### PR TITLE
test: fix ambiguous reference to _1

### DIFF
--- a/src/test/librados_test_stub/TestRadosClient.cc
+++ b/src/test/librados_test_stub/TestRadosClient.cc
@@ -292,7 +292,7 @@ void TestRadosClient::flush_aio_operations(AioCompletionImpl *c) {
 int TestRadosClient::aio_watch_flush(AioCompletionImpl *c) {
   c->get();
   Context *ctx = new LambdaContext(std::bind(
-    &TestRadosClient::finish_aio_completion, this, c, _1));
+    &TestRadosClient::finish_aio_completion, this, c, std::placeholders::_1));
   get_watch_notify()->aio_flush(this, ctx);
   return 0;
 }


### PR DESCRIPTION
FreeBSD/Clang/lib complains:
/home/jenkins/workspace/ceph-master/src/test/librados_test_stub/TestRadosClient.cc:295:55: error: reference to '_1' is ambiguous
    &TestRadosClient::finish_aio_completion, this, c, _1));
                                                      ^
/usr/local/include/boost/bind/placeholders.hpp:46:38: note: candidate found by name lookup is 'boost::placeholders::_1'
BOOST_STATIC_CONSTEXPR boost::arg<1> _1;
                                     ^
/usr/include/c++/v1/functional:2448:46: note: candidate found by name lookup is 'std::__1::placeholders::_1'
/* _LIBCPP_INLINE_VAR */ constexpr __ph<1>   _1{};




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>