### PR TITLE
mgr/cephadm: Introduce tox and autopep8

### DIFF
--- a/src/pybind/mgr/requirements-fix.txt
+++ b/src/pybind/mgr/requirements-fix.txt
@@ -1,0 +1,1 @@
+autopep8; python_version >= '3'

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -1,7 +1,29 @@
 [tox]
-envlist = py3, mypy
+envlist =
+    py3,
+    mypy,
+    test,
+    fix
 skipsdist = true
 requires = cython
+
+[flake8]
+max-line-length = 100
+exclude =
+    .tox,
+    .vagrant,
+    __pycache__,
+    *.pyc,
+    templates,
+    .eggs
+
+[autopep8]
+addopts =
+    --max-line-length {[flake8]max-line-length}
+    --exclude "{[flake8]exclude}"
+    --in-place
+    --recursive
+    --ignore-local-config
 
 [testenv]
 setenv =
@@ -27,7 +49,8 @@ deps =
     cython
     -rrequirements.txt
     mypy==0.782
-commands = mypy --config-file=../../mypy.ini \
+commands =
+    mypy --config-file=../../mypy.ini \
            cephadm/module.py \
            mgr_module.py \
            dashboard/module.py \
@@ -38,3 +61,16 @@ commands = mypy --config-file=../../mypy.ini \
            rook/module.py \
            test_orchestrator/module.py \
            volumes/__init__.py
+
+[testenv:test]
+setenv = {[testenv]setenv}
+deps = {[testenv]deps}
+commands = {[testenv]commands}
+
+[testenv:fix]
+basepython = python3
+deps = -rrequirements-fix.txt
+commands =
+    python --version
+    autopep8 {[autopep8]addopts} {posargs: \
+        cephadm/}


### PR DESCRIPTION
This PR introduces tox and autopep8 to format the Python code according to PEP8. It does NOT include any lint related things.

The Python code of the cephadm mgr module can be formated using `tox -e fix` from the `src/pybind/mgr`directory. This should be done by every developer before commiting a PR. Thus the code formatting keeps consistent.

Superseds: https://github.com/ceph/ceph/pull/36325

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
