### PR TITLE
mgr/cephadm: guard _check_daemons

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -554,8 +554,8 @@ class EventStore():
         for k_s in unknowns:
             del self.events[k_s]
 
-    def get_for_service(self, name):
+    def get_for_service(self, name) -> List[OrchestratorEvent]:
         return self.events.get('service:' + name, [])
 
-    def get_for_daemon(self, name):
+    def get_for_daemon(self, name) -> List[OrchestratorEvent]:
         return self.events.get('daemon:' + name, [])

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -514,9 +514,27 @@ class EventStore():
         e = OrchestratorEvent(datetime.datetime.utcnow(), 'service', spec.service_name(), level, message)
         self.add(e)
 
+    def from_orch_error(self, e: OrchestratorError):
+        if e.event_subject is not None:
+            self.add(OrchestratorEvent(
+                datetime.datetime.utcnow(),
+                e.event_subject[0],
+                e.event_subject[1],
+                "ERROR",
+                str(e)
+            ))
+
+
     def for_daemon(self, daemon_name, level, message):
         e = OrchestratorEvent(datetime.datetime.utcnow(), 'daemon', daemon_name, level, message)
         self.add(e)
+
+    def for_daemon_from_exception(self, daemon_name, e: Exception):
+        self.for_daemon(
+            daemon_name,
+            "ERROR",
+            str(e)
+        )
 
     def cleanup(self) -> None:
         # Needs to be properly done, in case events are persistently stored.

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2128,9 +2128,13 @@ you may want to run:
                         reconfig=True)
                 except OrchestratorError as e:
                     self.events.from_orch_error(e)
+                    if dd.daemon_type in daemons_post:
+                        del daemons_post[dd.daemon_type]
                     # continue...
                 except Exception as e:
                     self.events.for_daemon_from_exception(dd.name(), e)
+                    if dd.daemon_type in daemons_post:
+                        del daemons_post[dd.daemon_type]
                     # continue...
 
         # do daemon post actions

--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -33,9 +33,6 @@ def match_glob(val, pat):
         assert pat in val
 
 
-def mon_command(*args, **kwargs):
-    return 0, '', ''
-
 @contextmanager
 def with_cephadm_module(module_options=None, store=None):
     """
@@ -43,11 +40,9 @@ def with_cephadm_module(module_options=None, store=None):
     :param store: Set the store before module.__init__ is called
     """
     with mock.patch("cephadm.module.CephadmOrchestrator.get_ceph_option", get_ceph_option),\
-             mock.patch("cephadm.module.CephadmOrchestrator.remote"), \
-             mock.patch("cephadm.services.osd.RemoveUtil._run_mon_cmd"), \
-             mock.patch("cephadm.module.CephadmOrchestrator.send_command"), \
-             mock.patch("cephadm.module.CephadmOrchestrator.get_osdmap"), \
-             mock.patch("cephadm.module.CephadmOrchestrator.mon_command", mon_command):
+            mock.patch("cephadm.services.osd.RemoveUtil._run_mon_cmd"), \
+            mock.patch("cephadm.module.CephadmOrchestrator.get_osdmap"), \
+            mock.patch("cephadm.module.CephadmOrchestrator.remote"):
 
         m = CephadmOrchestrator.__new__ (CephadmOrchestrator)
         if module_options is not None:

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -48,6 +48,25 @@ def assert_rm_daemon(cephadm: CephadmOrchestrator, prefix, host):
     match_glob(out, f"Removed {d_names}* from host '{host}'")
 
 
+@contextmanager
+def with_daemon(cephadm_module: CephadmOrchestrator, spec: ServiceSpec, meth, host: str):
+    spec.placement = PlacementSpec(hosts=[host], count=1)
+
+    c = meth(cephadm_module, spec)
+    [out] = wait(cephadm_module, c)
+    match_glob(out, f"Deployed {spec.service_name()}.* on host '{host}'")
+
+    dds = cephadm_module.cache.get_daemons_by_service(spec.service_name())
+    for dd in dds:
+        if dd.hostname == host:
+            yield dd.daemon_id
+            assert_rm_daemon(cephadm_module, spec.service_name(), host)
+            return
+
+    assert False, 'Daemon not found'
+
+
+
 class TestCephadm(object):
 
     def test_get_unique_name(self, cephadm_module):
@@ -164,30 +183,35 @@ class TestCephadm(object):
             )
         ])
     ))
-    def test_daemon_action(self, cephadm_module: CephadmOrchestrator):
-
+    def test_list_daemons(self, cephadm_module: CephadmOrchestrator):
         cephadm_module.service_cache_timeout = 10
         with with_host(cephadm_module, 'test'):
             c = cephadm_module.list_daemons(refresh=True)
-            wait(cephadm_module, c)
-            assert len(c.result) == 1
-            c = cephadm_module.daemon_action('redeploy', 'rgw', 'myrgw.foobar')
-            assert wait(cephadm_module, c) == ["Deployed rgw.myrgw.foobar on host 'test'"]
+            assert wait(cephadm_module, c)[0].name() == 'rgw.myrgw.foobar'
 
-            for what in ('start', 'stop', 'restart'):
-                c = cephadm_module.daemon_action(what, 'rgw', 'myrgw.foobar')
-                assert wait(cephadm_module, c) == [what + " rgw.myrgw.foobar from host 'test'"]
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
+    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _,__,___: None)
+    def test_daemon_action(self, cephadm_module: CephadmOrchestrator):
+        cephadm_module.service_cache_timeout = 10
+        with with_host(cephadm_module, 'test'):
+            with with_daemon(cephadm_module, RGWSpec(service_id='myrgw.foobar'), CephadmOrchestrator.add_rgw, 'test') as daemon_id:
 
-            # Make sure, _check_daemons does a redeploy due to monmap change:
-            cephadm_module._store['_ceph_get/mon_map'] = {
-                'modified': datetime.datetime.utcnow().strftime(CEPH_DATEFMT),
-                'fsid': 'foobar',
-            }
-            cephadm_module.notify('mon_map', None)
+                c = cephadm_module.daemon_action('redeploy', 'rgw', daemon_id)
+                assert wait(cephadm_module, c) == [f"Deployed rgw.{daemon_id} on host 'test'"]
 
-            cephadm_module._check_daemons()
+                for what in ('start', 'stop', 'restart'):
+                    c = cephadm_module.daemon_action(what, 'rgw', daemon_id)
+                    assert wait(cephadm_module, c) == [what + f" rgw.{daemon_id} from host 'test'"]
 
-            assert_rm_daemon(cephadm_module, 'rgw.myrgw.foobar', 'test')
+                # Make sure, _check_daemons does a redeploy due to monmap change:
+                cephadm_module._store['_ceph_get/mon_map'] = {
+                    'modified': datetime.datetime.utcnow().strftime(CEPH_DATEFMT),
+                    'fsid': 'foobar',
+                }
+                cephadm_module.notify('mon_map', None)
+
+                cephadm_module._check_daemons()
+
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
     def test_mon_add(self, cephadm_module):
@@ -442,13 +466,8 @@ class TestCephadm(object):
     @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _,__,___: None)
     def test_daemon_add(self, spec: ServiceSpec, meth, cephadm_module):
         with with_host(cephadm_module, 'test'):
-            spec.placement = PlacementSpec(hosts=['test'], count=1)
-
-            c = meth(cephadm_module, spec)
-            [out] = wait(cephadm_module, c)
-            match_glob(out, f"Deployed {spec.service_name()}.* on host 'test'")
-
-            assert_rm_daemon(cephadm_module, spec.service_name(), 'test')
+            with with_daemon(cephadm_module, spec, meth, 'test'):
+                pass
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.module.CephadmOrchestrator.rados", mock.MagicMock())

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -22,7 +22,7 @@ from ceph.deployment.inventory import Devices, Device
 from orchestrator import ServiceDescription, DaemonDescription, InventoryHost, \
     HostSpec, OrchestratorError
 from tests import mock
-from .fixtures import cephadm_module, wait, _run_cephadm, mon_command, match_glob, with_host, \
+from .fixtures import cephadm_module, wait, _run_cephadm, match_glob, with_host, \
     with_cephadm_module
 from cephadm.module import CephadmOrchestrator, CEPH_DATEFMT
 
@@ -212,6 +212,28 @@ class TestCephadm(object):
 
                 cephadm_module._check_daemons()
 
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
+    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _,__,___: None)
+    def test_daemon_action_fail(self, cephadm_module: CephadmOrchestrator):
+        cephadm_module.service_cache_timeout = 10
+        with with_host(cephadm_module, 'test'):
+            with with_daemon(cephadm_module, RGWSpec(service_id='myrgw.foobar'), CephadmOrchestrator.add_rgw, 'test') as daemon_id:
+                with mock.patch('ceph_module.BaseMgrModule._ceph_send_command') as _ceph_send_command:
+
+                    _ceph_send_command.side_effect = Exception("myerror")
+
+                    # Make sure, _check_daemons does a redeploy due to monmap change:
+                    cephadm_module._store['_ceph_get/mon_map'] = {
+                        'modified': datetime.datetime.utcnow().strftime(CEPH_DATEFMT),
+                        'fsid': 'foobar',
+                    }
+                    cephadm_module.notify('mon_map', None)
+
+                    cephadm_module._check_daemons()
+
+                    evs = [e.message for e in cephadm_module.events.get_for_daemon(f'rgw.{daemon_id}')]
+
+                    assert 'myerror' in ''.join(evs)
 
     @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
     def test_mon_add(self, cephadm_module):

--- a/src/pybind/mgr/tests/__init__.py
+++ b/src/pybind/mgr/tests/__init__.py
@@ -70,6 +70,8 @@ if 'UNITTEST' in os.environ:
                 self._store = {}
             return self._store.get(f'_ceph_get/{data_name}', mock.MagicMock())
 
+        def _ceph_send_command(self, ev, *args):
+            ev.complete(0, '', '')
 
         def __init__(self, *args):
             if not hasattr(self, '_store'):

--- a/src/pybind/mgr/tests/__init__.py
+++ b/src/pybind/mgr/tests/__init__.py
@@ -115,7 +115,7 @@ if 'UNITTEST' in os.environ:
 
 
         sys.modules.update({
-            'rados': mock.Mock(Error=MockRadosError, OSError=MockRadosError),
+            'rados': mock.MagicMock(Error=MockRadosError, OSError=MockRadosError),
             'rbd': mock.Mock(),
             'cephfs': mock.Mock(),
         })


### PR DESCRIPTION
Continue with other daemons, if one fails

Fixes: https://tracker.ceph.com/issues/46748
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
