### PR TITLE
octopus: mgr/dashboard: Add hosts page unit tests

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -3,6 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import * as _ from 'lodash';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 import { ToastrModule } from 'ngx-toastr';
@@ -11,6 +12,8 @@ import { of } from 'rxjs';
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
 import { CoreModule } from '../../../core/core.module';
 import { HostService } from '../../../shared/api/host.service';
+import { ActionLabels } from '../../../shared/constants/app.constants';
+import { CdTableAction } from '../../../shared/models/cd-table-action';
 import { Permissions } from '../../../shared/models/permissions';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { SharedModule } from '../../../shared/shared.module';
@@ -93,30 +96,39 @@ describe('HostsComponent', () => {
     });
   }));
 
-  describe('getEditDisableDesc', () => {
-    it('should return message (not managed by Orchestrator)', () => {
+  describe('test edit button', () => {
+    let tableAction: CdTableAction;
+
+    beforeEach(() => {
+      tableAction = _.find(component.tableActions, { name: ActionLabels.EDIT });
+    });
+
+    it('should disable button and return message (not managed by Orchestrator)', () => {
       component.selection.add({
         sources: {
           ceph: true,
           orchestrator: false
         }
       });
+      expect(tableAction.disable(component.selection)).toBeTruthy();
       expect(component.getEditDisableDesc(component.selection)).toBe(
         'Host editing is disabled because the host is not managed by Orchestrator.'
       );
     });
 
-    it('should return undefined (no selection)', () => {
+    it('should disable button and return undefined (no selection)', () => {
+      expect(tableAction.disable(component.selection)).toBeTruthy();
       expect(component.getEditDisableDesc(component.selection)).toBeUndefined();
     });
 
-    it('should return undefined (managed by Orchestrator)', () => {
+    it('should enable button and return undefined (managed by Orchestrator)', () => {
       component.selection.add({
         sources: {
           ceph: false,
           orchestrator: true
         }
       });
+      expect(tableAction.disable(component.selection)).toBeFalsy();
       expect(component.getEditDisableDesc(component.selection)).toBeUndefined();
     });
   });


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46751

---

backport of https://github.com/ceph/ceph/pull/36007
parent tracker: https://tracker.ceph.com/issues/46448

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh