### PR TITLE
common/config: refactor md_config_t::parse_config_files()

### DIFF
--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -738,8 +738,7 @@ int main(int argc, const char **argv)
     ipaddrs = monmap.get_addrs(g_conf()->name.get_id());
 
     // print helpful warning if the conf file doesn't match
-    std::vector <std::string> my_sections;
-    g_conf().get_my_sections(my_sections);
+    std::vector<std::string> my_sections = g_conf().get_my_sections();
     std::string mon_addr_str;
     if (g_conf().get_val_from_conf_file(my_sections, "mon addr",
 				       mon_addr_str, true) == 0) {

--- a/src/common/ConfUtils.h
+++ b/src/common/ConfUtils.h
@@ -73,6 +73,13 @@ public:
   int read(const std::string& section, std::string_view key,
 	   std::string &val) const;
   static std::string normalize_key_name(std::string_view key);
+  // print warnings to os if any old-style section name is found
+  //
+  // consider a section name as old-style name if it starts with any of the
+  // given prefixes, but does not follow with a "."
+  void check_old_style_section_names(const std::vector<std::string>& prefixes,
+				     std::ostream& os);
+
 private:
   bool load_from_buffer(std::string_view buf, std::ostream* warning);
 };

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -401,29 +401,8 @@ int md_config_t::parse_config_files(ConfigValues& values,
       }
     }
   }
-
-  // Warn about section names that look like old-style section names
-  std::deque < std::string > old_style_section_names;
-  for (auto& [name, section] : cf) {
-    if (((name.find("mds") == 0) || (name.find("mon") == 0) ||
-	 (name.find("osd") == 0)) && (name.size() > 3) && (name[3] != '.')) {
-      old_style_section_names.push_back(name);
-    }
-  }
-  if (!old_style_section_names.empty()) {
-    ostringstream oss;
-    cerr << "ERROR! old-style section name(s) found: ";
-    string sep;
-    for (std::deque < std::string >::const_iterator os = old_style_section_names.begin();
-	 os != old_style_section_names.end(); ++os) {
-      cerr << sep << *os;
-      sep = ", ";
-    }
-    cerr << ". Please use the new style section names that include a period.";
-  }
-
+  cf.check_old_style_section_names({"mds", "mon", "osd"}, cerr);
   update_legacy_vals(values);
-
   return 0;
 }
 

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -396,8 +396,7 @@ int md_config_t::parse_config_files(ConfigValues& values,
     }
   }
 
-  std::vector <std::string> my_sections;
-  _get_my_sections(values, my_sections);
+  std::vector<std::string> my_sections = get_my_sections(values);
   for (const auto &i : schema) {
     const auto &opt = i.second;
     std::string val;
@@ -1316,20 +1315,12 @@ void md_config_t::get_all_keys(std::vector<std::string> *keys) const {
  * looking. The lowest priority section is the one we look in only if all
  * others had nothing.  This should always be the global section.
  */
-void md_config_t::get_my_sections(const ConfigValues& values,
-				  std::vector <std::string> &sections) const
+std::vector <std::string>
+md_config_t::get_my_sections(const ConfigValues& values) const
 {
-  _get_my_sections(values, sections);
-}
-
-void md_config_t::_get_my_sections(const ConfigValues& values,
-				   std::vector <std::string> &sections) const
-{
-  sections.push_back(values.name.to_str());
-
-  sections.push_back(values.name.get_type_name().data());
-
-  sections.push_back("global");
+  return {values.name.to_str(),
+	  values.name.get_type_name().data(),
+	  "global"};
 }
 
 // Return a list of all sections

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -317,7 +317,7 @@ private:
 					    const char *conf_files,
 					    std::ostream *warnings,
 					    int flags) const;
-
+  static std::string get_cluster_name(const char* conffile_path);
   // The configuration file we read, or NULL if we haven't read one.
   ConfFile cf;
 public:

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -205,8 +205,7 @@ public:
   void get_all_keys(std::vector<std::string> *keys) const;
 
   // Return a list of all the sections that the current entity is a member of.
-  void get_my_sections(const ConfigValues& values,
-		       std::vector <std::string> &sections) const;
+  std::vector<std::string> get_my_sections(const ConfigValues& values) const;
 
   // Return a list of all sections
   int get_all_sections(std::vector <std::string> &sections) const;
@@ -264,9 +263,6 @@ private:
 
   void _show_config(const ConfigValues& values,
 		    std::ostream *out, ceph::Formatter *f) const;
-
-  void _get_my_sections(const ConfigValues& values,
-			std::vector<std::string> &sections) const;
 
   int _get_val_from_conf_file(const std::vector<std::string> &sections,
 			      const std::string_view key, std::string &out) const;

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -317,6 +317,11 @@ public:  // for global_init
   bool finalize_reexpand_meta(ConfigValues& values,
 			      const ConfigTracker& tracker);
 private:
+  std::list<std::string> get_conffile_paths(const ConfigValues& values,
+					    const char *conf_files,
+					    std::ostream *warnings,
+					    int flags) const;
+
   // The configuration file we read, or NULL if we haven't read one.
   ConfFile cf;
 public:

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -317,10 +317,6 @@ public:  // for global_init
   bool finalize_reexpand_meta(ConfigValues& values,
 			      const ConfigTracker& tracker);
 private:
-
-  /// expand all metavariables in config structure.
-  void expand_all_meta();
-
   // The configuration file we read, or NULL if we haven't read one.
   ConfFile cf;
 public:

--- a/src/common/config_proxy.h
+++ b/src/common/config_proxy.h
@@ -170,9 +170,9 @@ public:
     std::lock_guard l{lock};
     return config.diff(values, f, name);
   }
-  void get_my_sections(std::vector <std::string> &sections) const {
+  std::vector<std::string> get_my_sections() const {
     std::lock_guard l{lock};
-    config.get_my_sections(values, sections);
+    return config.get_my_sections(values);
   }
   int get_all_sections(std::vector<std::string>& sections) const {
     std::lock_guard l{lock};

--- a/src/tools/ceph_conf.cc
+++ b/src/tools/ceph_conf.cc
@@ -117,11 +117,10 @@ static int list_sections(const std::string &prefix,
 static int lookup(const std::deque<std::string> &sections,
 		  const std::string &key, bool resolve_search)
 {
-  std::vector <std::string> my_sections;
-  for (deque<string>::const_iterator s = sections.begin(); s != sections.end(); ++s) {
-    my_sections.push_back(*s);
+  std::vector<std::string> my_sections{sections.begin(), sections.end()};
+  for (auto& section : g_conf().get_my_sections()) {
+    my_sections.push_back(section);
   }
-  g_conf().get_my_sections(my_sections);
   std::string val;
   int ret = g_conf().get_val_from_conf_file(my_sections, key.c_str(), val, true);
   if (ret == -ENOENT)


### PR DESCRIPTION
the original intention was to appease the stall detector of seastar, as it sometimes warns that it takes too long while reading / parsing the conf file while crimson-osd starts. the only blocking call in that code path is the call reading the conf file from the disk.

but along the way of refactoring the code, i think before having an async version of `md_config_t::parse_config_files()`, it's still beneficial to get the refacory changes into master. as they help to improve the readability and the code quality in general.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
