### PR TITLE
crimson: extract read_file()

### DIFF
--- a/src/crimson/auth/KeyRing.cc
+++ b/src/crimson/auth/KeyRing.cc
@@ -13,20 +13,10 @@
 #include "common/buffer_seastar.h"
 #include "auth/KeyRing.h"
 #include "include/denc.h"
+#include "crimson/common/buffer_io.h"
 #include "crimson/common/config_proxy.h"
 
 namespace crimson::auth {
-
-seastar::future<seastar::temporary_buffer<char>> read_file(const std::string& path)
-{
-  return seastar::open_file_dma(path, seastar::open_flags::ro).then([] (seastar::file f) {
-    return f.size().then([f = std::move(f)](size_t s) {
-      return seastar::do_with(seastar::make_file_input_stream(f), [s](seastar::input_stream<char>& in) {
-        return in.read_exactly(s);
-      });
-    });
-  });
-}
 
 seastar::future<KeyRing*> load_from_keyring(KeyRing* keyring)
 {

--- a/src/crimson/common/buffer_io.cc
+++ b/src/crimson/common/buffer_io.cc
@@ -37,4 +37,18 @@ seastar::future<> write_file(ceph::buffer::list&& bl,
   });
 }
 
+seastar::future<seastar::temporary_buffer<char>>
+read_file(const seastar::sstring fn)
+{
+  return seastar::open_file_dma(fn, seastar::open_flags::ro).then(
+    [] (seastar::file f) {
+    return f.size().then([f = std::move(f)](size_t s) {
+      return seastar::do_with(seastar::make_file_input_stream(f),
+			      [s](seastar::input_stream<char>& in) {
+        return in.read_exactly(s);
+      });
+    });
+  });
+}
+
 }

--- a/src/crimson/common/buffer_io.cc
+++ b/src/crimson/common/buffer_io.cc
@@ -9,7 +9,7 @@
 
 #include "include/buffer.h"
 
-namespace ceph::buffer {
+namespace crimson {
 
 seastar::future<> write_file(ceph::buffer::list&& bl,
                              seastar::sstring fn,

--- a/src/crimson/common/buffer_io.h
+++ b/src/crimson/common/buffer_io.h
@@ -16,4 +16,6 @@ namespace crimson {
                                   seastar::file_permissions::user_write |
                                   seastar::file_permissions::group_read |
                                   seastar::file_permissions::others_read));
+  seastar::future<seastar::temporary_buffer<char>>
+  read_file(const seastar::sstring fn);
 }

--- a/src/crimson/common/buffer_io.h
+++ b/src/crimson/common/buffer_io.h
@@ -8,7 +8,7 @@
 
 #include "include/buffer_fwd.h"
 
-namespace ceph::buffer {
+namespace crimson {
   seastar::future<> write_file(ceph::buffer::list&& bl,
                                seastar::sstring fn,
                                seastar::file_permissions= // 0644

--- a/src/crimson/os/cyanstore/cyan_store.cc
+++ b/src/crimson/os/cyanstore/cyan_store.cc
@@ -71,12 +71,12 @@ seastar::future<> CyanStore::umount()
       ceph_assert(ch);
       ch->encode(bl);
       std::string fn = fmt::format("{}/{}", path, col);
-      return ceph::buffer::write_file(std::move(bl), fn);
+      return crimson::write_file(std::move(bl), fn);
     }).then([&collections, this] {
       ceph::bufferlist bl;
       ceph::encode(collections, bl);
       std::string fn = fmt::format("{}/collections", path);
-      return ceph::buffer::write_file(std::move(bl), fn);
+      return crimson::write_file(std::move(bl), fn);
     });
   });
 }
@@ -110,7 +110,7 @@ seastar::future<> CyanStore::mkfs(uuid_d new_osd_fsid)
     ceph::bufferlist bl;
     std::set<coll_t> collections;
     ceph::encode(collections, bl);
-    return ceph::buffer::write_file(std::move(bl), fn);
+    return crimson::write_file(std::move(bl), fn);
   }).then([this] {
     return write_meta("type", "memstore");
   });

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -98,7 +98,7 @@ seastar::future<> make_keyring()
       keyring.encode_plaintext(bl);
       const auto permissions = (seastar::file_permissions::user_read |
                               seastar::file_permissions::user_write);
-      return ceph::buffer::write_file(std::move(bl), path, permissions);
+      return crimson::write_file(std::move(bl), path, permissions);
     }
   }).handle_exception_type([path](const fs::filesystem_error& e) {
     seastar::fprint(std::cerr, "FATAL: writing new keyring to %s: %s\n", path, e.what());


### PR DESCRIPTION
the intention of this change is to pave the road to have synchronized version of `md_config_t::parse_config_files()` and probably other functions we want to share with classic OSD.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
