### PR TITLE
librbd: fix possible use after free error while shuting down exclusive lock

### DIFF
--- a/src/librbd/ExclusiveLock.cc
+++ b/src/librbd/ExclusiveLock.cc
@@ -140,6 +140,7 @@ template <typename I>
 void ExclusiveLock<I>::shut_down(Context *on_shut_down) {
   ldout(m_image_ctx.cct, 10) << dendl;
 
+  auto ref = ceph::ref_t<ExclusiveLock<I>>(this);
   on_shut_down = create_context_callback<Context>(on_shut_down, this);
 
   ML<I>::shut_down(on_shut_down);


### PR DESCRIPTION
after enable >1 op threads for librbd, when shuting down the exclusive lock
the on_shut_down context could be completed in another thread sooner before
the caller, which results the following memory corruption:

[ RUN      ] TestMirroring.AioGetInfo
==1425426== Thread 52 tp_librbd:
==1425426== Invalid read of size 1
==1425426==    at 0x54C8F64: Mutex::Lock(bool) (Mutex.cc:92)
==1425426==    by 0x6E22B7: Locker (Mutex.h:115)
==1425426==    by 0x6E22B7: librbd::ExclusiveLock<librbd::ImageCtx>::handle_peer_notification(int) (ExclusiveLock.cc:134)
==1425426==    by 0x6E2658: librbd::ExclusiveLock<librbd::ImageCtx>::shut_down(Context*) (ExclusiveLock.cc:129)
==1425426==    by 0x6001A7: librbd::image::CloseRequest<librbd::ImageCtx>::send_shut_down_exclusive_lock() (CloseRequest.cc:165)
==1425426==    by 0x6004EA: librbd::image::CloseRequest<librbd::ImageCtx>::handle_shut_down_io_queue(int) (CloseRequest.cc:138)
==1425426==    by 0x4B7AF8: Context::complete(int) (Context.h:70)
==1425426==    by 0x54D553: ContextWQ::process(Context*) (WorkQueue.h:616)
==1425426==    by 0x550260D: ThreadPool::worker(ThreadPool::WorkThread*) (WorkQueue.cc:120)
==1425426==    by 0x550374F: ThreadPool::WorkThread::entry() (WorkQueue.h:453)
==1425426==    by 0x4E3DDD4: start_thread (in /usr/lib64/libpthread-2.17.so)
==1425426==    by 0x10120EAC: clone (in /usr/lib64/libc-2.17.so)
==1425426==  Address 0x303b914d is 45 bytes inside a block of size 456 free'd
==1425426==    at 0x4C2B1CD: operator delete(void*) (vg_replace_malloc.c:576)
==1425426==    by 0x4DD171: RefCountedObject::put() const (RefCountedObj.h:60)
==1425426==    by 0x600DAA: librbd::image::CloseRequest<librbd::ImageCtx>::handle_shut_down_exclusive_lock(int) (CloseRequest.cc:184)
==1425426==    by 0x4B7AF8: Context::complete(int) (Context.h:70)
==1425426==    by 0x4B7AF8: Context::complete(int) (Context.h:70)
==1425426==    by 0x5A044B: librbd::ManagedLock<librbd::ImageCtx>::complete_shutdown(int) (ManagedLock.cc:843)
==1425426==    by 0x50C059: operator() (function_template.hpp:760)
==1425426==    by 0x50C059: FunctionContext::finish(int) (Context.h:493)
==1425426==    by 0x4B7AF8: Context::complete(int) (Context.h:70)
==1425426==    by 0x5A0C43: librbd::ManagedLock<librbd::ImageCtx>::wait_for_tracked_ops(int) (ManagedLock.cc:818)
==1425426==    by 0x5A0EFB: librbd::ManagedLock<librbd::ImageCtx>::handle_shutdown(int) (ManagedLock.cc:764)
==1425426==    by 0x4B7AF8: Context::complete(int) (Context.h:70)
==1425426==    by 0x54D553: ContextWQ::process(Context*) (WorkQueue.h:616)

Signed-off-by: luo.runbing <luo.runbing@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
