### PR TITLE
qa/tasks/ragweed: always set ragweed_repo

### DIFF
--- a/qa/tasks/ragweed.py
+++ b/qa/tasks/ragweed.py
@@ -17,6 +17,33 @@ from teuthology.orchestra import run
 
 log = logging.getLogger(__name__)
 
+
+def get_ragweed_branches(config, client_conf):
+    """
+    figure out the ragweed branch according to the per-client settings
+
+    use force-branch is specified, and fall back to the ones deduced using ceph
+    branch under testing
+    """
+    force_branch = client_conf.get('force-branch', None)
+    if force_branch:
+        return [force_branch]
+    else:
+        S3_BRANCHES = ['master', 'nautilus', 'mimic',
+                       'luminous', 'kraken', 'jewel']
+        ceph_branch = config.get('branch')
+        suite_branch = config.get('suite_branch', ceph_branch)
+        if suite_branch in S3_BRANCHES:
+            branch = client_conf.get('branch', 'ceph-' + suite_branch)
+        else:
+            branch = client_conf.get('branch', suite_branch)
+        default_branch = client_conf.get('default-branch', None)
+        if default_branch:
+            return [branch, default_branch]
+        else:
+            return [branch]
+
+
 @contextlib.contextmanager
 def download(ctx, config):
     """
@@ -29,46 +56,21 @@ def download(ctx, config):
     assert isinstance(config, dict)
     log.info('Downloading ragweed...')
     testdir = teuthology.get_testdir(ctx)
-    s3_branches = [ 'master', 'nautilus', 'mimic', 'luminous', 'kraken', 'jewel' ]
     for (client, cconf) in config.items():
-        default_branch = ''
-        branch = cconf.get('force-branch', None)
-        if not branch:
-            default_branch = cconf.get('default-branch', None)
-            ceph_branch = ctx.config.get('branch')
-            suite_branch = ctx.config.get('suite_branch', ceph_branch)
-            ragweed_repo = ctx.config.get('ragweed_repo', teuth_config.ceph_git_base_url + 'ragweed.git')
-            if suite_branch in s3_branches:
-                branch = cconf.get('branch', 'ceph-' + suite_branch)
-            else:
-                branch = cconf.get('branch', suite_branch)
-        if not branch:
-            raise ValueError(
-                "Could not determine what branch to use for ragweed!")
-        else:
+        ragweed_repo = ctx.config.get('ragweed_repo',
+                                      teuth_config.ceph_git_base_url + 'ragweed.git')
+        for branch in get_ragweed_branches(ctx.config, cconf):
             log.info("Using branch '%s' for ragweed", branch)
-        sha1 = cconf.get('sha1')
-        try:
-            ctx.cluster.only(client).run(
-                args=[
-                    'git', 'clone',
-                    '-b', branch,
-                    ragweed_repo,
-                    '{tdir}/ragweed'.format(tdir=testdir),
-                    ],
-                )
-        except Exception as e:
-            if not default_branch:
-                raise e
-            ctx.cluster.only(client).run(
-                args=[
-                    'git', 'clone',
-                    '-b', default_branch,
-                    ragweed_repo,
-                    '{tdir}/ragweed'.format(tdir=testdir),
-                    ],
-                )
+            try:
+                ctx.cluster.only(client).sh(
+                    script=f'git clone -b {branch} {ragweed_repo} {testdir}/ragweed')
+                break
+            except Exception as e:
+                exc = e
+        else:
+            raise exc
 
+        sha1 = cconf.get('sha1')
         if sha1 is not None:
             ctx.cluster.only(client).run(
                 args=[


### PR DESCRIPTION
* extract get_ragweed_branch() out of download() task, for better
  readablity.
* use a loop for retry when the first clone fails
* drop the `raise ValueError()` clause as it never happens. we could use
  an assert() here, but i don't think it is necessary anyway.
* use sh() instead of run() for better readablity.
* always set ragweed_repo. before this change this variable is
  unbounded if `force-branch` is set.

Fixes: https://tracker.ceph.com/issues/46771
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
