### PR TITLE
 qa: Move fs creation/removal to CephFSTestCase class 

### DIFF
--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -209,6 +209,9 @@ class CephFSTestCase(CephTestCase):
 
         for m, md in zip(self.mounts, self._orig_mount_details):
             md.restore(m)
+        if self.fs is not None:
+            self.fs.destroy()
+            self.fs = None
 
         for subsys, key in self.configs_set:
             self.mds_cluster.clear_ceph_conf(subsys, key)

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -588,6 +588,9 @@ class Filesystem(MDSCluster):
         log.info('Destroying file system ' + self.name +  ' and related '
                  'pools')
 
+        if self.name is None and self.metadata_pool_name is None and self.data_pool_name is None:
+            return
+
         # make sure no MDSs are attached to given FS.
         self.mon_manager.raw_cluster_cmd('fs', 'fail', self.name)
         self.mon_manager.raw_cluster_cmd(

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -185,15 +185,6 @@ class TestVolumes(CephFSTestCase):
     def _enable_multi_fs(self):
         self._fs_cmd("flag", "set", "enable_multiple", "true", "--yes-i-really-mean-it")
 
-    def _create_or_reuse_test_volume(self):
-        result = json.loads(self._fs_cmd("volume", "ls"))
-        if len(result) == 0:
-            self.vol_created = True
-            self.volname = self._generate_random_volume_name()
-            self._fs_cmd("volume", "create", self.volname)
-        else:
-            self.volname = result[0]['name']
-
     def  _get_subvolume_group_path(self, vol_name, group_name):
         args = ("subvolumegroup", "getpath", vol_name, group_name)
         path = self._fs_cmd(*args)
@@ -224,9 +215,6 @@ class TestVolumes(CephFSTestCase):
         args = tuple(args)
         snap_md = self._fs_cmd(*args)
         return snap_md
-
-    def _delete_test_volume(self):
-        self._fs_cmd("volume", "rm", self.volname, "--yes-i-really-mean-it")
 
     def _do_subvolume_pool_and_namespace_update(self, subvolume, pool=None, pool_namespace=None, subvolume_group=None):
         subvolpath = self._get_subvolume_path(self.volname, subvolume, group_name=subvolume_group)
@@ -346,11 +334,8 @@ class TestVolumes(CephFSTestCase):
 
     def setUp(self):
         super(TestVolumes, self).setUp()
-        self.volname = None
-        self.vol_created = False
+        self.volname = self.fs.name
         self._enable_multi_fs()
-        self._create_or_reuse_test_volume()
-        self.config_set('mon', 'mon_allow_pool_delete', True)
         self.volume_start = random.randint(1, (1<<20))
         self.subvolume_start = random.randint(1, (1<<20))
         self.group_start = random.randint(1, (1<<20))
@@ -358,8 +343,6 @@ class TestVolumes(CephFSTestCase):
         self.clone_start = random.randint(1, (1<<20))
 
     def tearDown(self):
-        if self.vol_created:
-            self._delete_test_volume()
         super(TestVolumes, self).tearDown()
 
     def test_connection_expiration(self):


### PR DESCRIPTION
There is no functional change with this patch. It's
re-org of the code.

The 'CephFSTestCase' class creates the filesystem based on
'REQUIRE_FILESYSTEM' flag in setUp. The 'TestVolume' class
which inherits 'CephFSTestCase' also has the code to create
filesystem which never gets executed. This patch removes this
redundant and dead code.

Also the 'CephFSTestCase' class doesn't cleanup the filesystem
created in setUp in the corresponding tearDown function but
instead cleans up any existing filesystems in setUp prior to
new filesystem creation. Though there is no functional impact,
cleaning it up in tearDown is neat. This patch does the same.
It also retains the filesysytem clean up code in setUp as is
which helps running the test suit on cluster with existing
filesystems.

Fixes: https://tracker.ceph.com/issues/46769
Signed-off-by: Kotresh HR <khiremat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
