### PR TITLE
octopus: mgr/dashboard: right-align dropdown menu of column filters

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -34,7 +34,7 @@
           {{ selectedFilter.column.name }}
         </a>
         <ul *dropdownMenu
-            class="dropdown-menu px-1"
+            class="dropdown-menu dropdown-menu-right px-1"
             role="menu">
           <li *ngFor="let filter of columnFilters"
               role="menuitem">
@@ -53,7 +53,7 @@
            {{ selectedFilter.value ? selectedFilter.value.formatted: 'Any' }}
         </a>
         <ul *dropdownMenu
-            class="dropdown-menu px-1"
+            class="dropdown-menu dropdown-menu-right px-1"
             role="menu">
           <li *ngFor="let option of selectedFilter.options"
               role="menuitem">


### PR DESCRIPTION
When the value of a filter is too long, the text of value will run out
of the viewport. Right-aligning the menu makes the text visible.

**NOTE: This change can't be backported from master because in master we had
switched the bootstrap library to ng-bootstrap and the menu is already
right-aligned in the master.**

Fixes: https://tracker.ceph.com/issues/44458
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>

**Before**
![before](https://user-images.githubusercontent.com/1691518/88908004-eacfde80-d28b-11ea-9d16-aef1cd03dd45.png)

**After**
![after](https://user-images.githubusercontent.com/1691518/88908011-edcacf00-d28b-11ea-93c4-f056c40c4b57.png)




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
