### PR TITLE
doc/mgr/orchestrator: Fix formatting and examples in create OSD

### DIFF
--- a/doc/mgr/orchestrator.rst
+++ b/doc/mgr/orchestrator.rst
@@ -156,25 +156,19 @@ Create OSDs on a set of devices on a single host::
 
     ceph orch daemon add osd <host>:device1,device2
 
-Example::
-=========
-or::
+Another way of doing it is using ``apply`` interface::
 
     ceph orch apply osd -i <json_file/yaml_file> [--dry-run]
-
 
 Where the ``json_file/yaml_file`` is a DriveGroup specification.
 For a more in-depth guide to DriveGroups please refer to :ref:`drivegroups`
 
-or::
-
-    ceph orch apply osd --all-available-devices [--dry-run]
-
-If the 'apply' method is used. You will be presented with a preview of what will happen.
+Along with ``apply`` interface if ``dry-run`` option is used, it will present a
+preview of what will happen.
 
 Example::
 
-    # ceph orch apply osd --all-available-devices
+    # ceph orch apply osd --all-available-devices --dry-run
     NAME                  HOST  DATA     DB WAL
     all-available-devices node1 /dev/vdb -  -
     all-available-devices node2 /dev/vdc -  -


### PR DESCRIPTION
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
