### PR TITLE
cephadm: Fix error bootstraping with '--registry-json'

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2910,9 +2910,9 @@ def command_bootstrap():
                 cli(['orch', 'apply', t])
 
     if args.registry_url and args.registry_username and args.registry_password:
-        cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_url', args.registry_url])
-        cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_username', args.registry_username])
-        cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_password', args.registry_password])
+        cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_url', args.registry_url, '--force'])
+        cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_username', args.registry_username, '--force'])
+        cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_password', args.registry_password, '--force'])
 
     if not args.skip_dashboard:
         logger.info('Enabling the dashboard module...')


### PR DESCRIPTION
We need to force setting registry auth options because these options are unknown before the mgr first starts and registers them.

Fixes: https://tracker.ceph.com/issues/46777

Signed-off-by: Ricardo Marques <rimarques@suse.com>


---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
