### PR TITLE
test/librados_test_stub: handle assert_version

### DIFF
--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -815,6 +815,11 @@ void ObjectOperation::assert_exists() {
   o->ops.push_back(std::bind(&TestIoCtxImpl::assert_exists, _1, _2, _4));
 }
 
+void ObjectOperation::assert_version(uint64_t ver) {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+  o->ops.push_back(std::bind(&TestIoCtxImpl::assert_version, _1, _2, ver));
+}
+
 void ObjectOperation::exec(const char *cls, const char *method,
                            bufferlist& inbl) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);

--- a/src/test/librados_test_stub/MockTestMemIoCtxImpl.h
+++ b/src/test/librados_test_stub/MockTestMemIoCtxImpl.h
@@ -68,6 +68,11 @@ public:
     return TestMemIoCtxImpl::assert_exists(oid, snap_id);
   }
 
+  MOCK_METHOD2(assert_version, int(const std::string &, uint64_t));
+  int do_assert_version(const std::string &oid, uint64_t ver) {
+    return TestMemIoCtxImpl::assert_version(oid, ver);
+  }
+
   MOCK_METHOD3(create, int(const std::string&, bool, const SnapContext &));
   int do_create(const std::string& oid, bool exclusive,
                 const SnapContext &snapc) {
@@ -213,6 +218,7 @@ public:
     ON_CALL(*this, aio_watch(_, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_aio_watch));
     ON_CALL(*this, aio_unwatch(_, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_aio_unwatch));
     ON_CALL(*this, assert_exists(_, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_assert_exists));
+    ON_CALL(*this, assert_version(_, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_assert_version));
     ON_CALL(*this, create(_, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_create));
     ON_CALL(*this, cmpext(_, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_cmpext));
     ON_CALL(*this, exec(_, _, _, _, _, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_exec));

--- a/src/test/librados_test_stub/NeoradosTestStub.cc
+++ b/src/test/librados_test_stub/NeoradosTestStub.cc
@@ -242,6 +242,12 @@ void Op::assert_exists() {
     &librados::TestIoCtxImpl::assert_exists, _1, _2, _4));
 }
 
+void Op::assert_version(uint64_t ver) {
+  auto o = *reinterpret_cast<librados::TestObjectOperationImpl**>(&impl);
+  o->ops.push_back(std::bind(
+          &librados::TestIoCtxImpl::assert_version, _1, _2, ver));
+}
+
 void Op::cmpext(uint64_t off, ceph::buffer::list&& cmp_bl, std::size_t* s) {
   auto o = *reinterpret_cast<librados::TestObjectOperationImpl**>(&impl);
   librados::ObjectOperationTestImpl op = std::bind(

--- a/src/test/librados_test_stub/TestIoCtxImpl.h
+++ b/src/test/librados_test_stub/TestIoCtxImpl.h
@@ -99,6 +99,7 @@ public:
   virtual int append(const std::string& oid, const bufferlist &bl,
                      const SnapContext &snapc) = 0;
   virtual int assert_exists(const std::string &oid, uint64_t snap_id) = 0;
+  virtual int assert_version(const std::string &oid, uint64_t ver) = 0;
 
   virtual int create(const std::string& oid, bool exclusive,
                      const SnapContext &snapc) = 0;

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.h
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.h
@@ -27,6 +27,7 @@ public:
              const SnapContext &snapc) override;
 
   int assert_exists(const std::string &oid, uint64_t snap_id) override;
+  int assert_version(const std::string &oid, uint64_t ver) override;
 
   int create(const std::string& oid, bool exclusive,
              const SnapContext &snapc) override;


### PR DESCRIPTION
This commits adds a proper handling in librados_test_stub of the assert_version API in RADOS.

This will be used for testing an upcoming librbd PR that will add assert_version support for ObjectDispatchInterface::write.