### PR TITLE
nautilus: rgw: append obj: prevent tail from being GC'ed

### DIFF
--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -564,6 +564,7 @@ int AppendObjectProcessor::prepare()
     }
     cur_manifest = &astate->manifest;
     manifest.set_prefix(cur_manifest->get_prefix());
+    astate->keep_tail = true;
   }
   manifest.set_multipart_part_rule(store->ctx()->_conf->rgw_obj_stripe_size, cur_part_num);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46799

---

backport of https://github.com/ceph/ceph/pull/33511
parent tracker: https://tracker.ceph.com/issues/42670

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh