### PR TITLE
mgr/dashboard: Speed improvements of pool details

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.html
@@ -9,7 +9,7 @@
          i18n>Details</a>
       <ng-template ngbNavContent>
         <cd-table-key-value [renderObjects]="true"
-                            [data]="filterNonPoolData(selection)"
+                            [data]="poolDetails"
                             [autoReload]="false">
         </cd-table-key-value>
       </ng-template>
@@ -19,7 +19,7 @@
       <a ngbNavLink
          i18n>Performance Details</a>
       <ng-template ngbNavContent>
-        <cd-grafana [grafanaPath]="'ceph-pool-detail?var-pool_name='+ selection['pool_name']"
+        <cd-grafana grafanaPath="ceph-pool-detail?var-pool_name={{selection.pool_name}}"
                     uid="-xyV8KCiz"
                     grafanaStyle="three">
         </cd-grafana>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
@@ -8,7 +8,7 @@ import _ from 'lodash';
 import { ToastrModule } from 'ngx-toastr';
 import { of } from 'rxjs';
 
-import { configureTestBed, expectItemTasks } from '../../../../testing/unit-test-helper';
+import { configureTestBed, expectItemTasks, Mocks } from '../../../../testing/unit-test-helper';
 import { ConfigurationService } from '../../../shared/api/configuration.service';
 import { PoolService } from '../../../shared/api/pool.service';
 import { CriticalConfirmationModalComponent } from '../../../shared/components/critical-confirmation-modal/critical-confirmation-modal.component';
@@ -29,18 +29,8 @@ describe('PoolListComponent', () => {
   let fixture: ComponentFixture<PoolListComponent>;
   let poolService: PoolService;
 
-  const createPool = (name: string, id: number): Pool => {
-    return _.merge(new Pool(name), {
-      pool: id,
-      pg_num: 256,
-      pg_placement_num: 256,
-      pg_num_target: 256,
-      pg_placement_num_target: 256
-    });
-  };
-
   const getPoolList = (): Pool[] => {
-    return [createPool('a', 0), createPool('b', 1), createPool('c', 2)];
+    return [Mocks.getPool('a', 0), Mocks.getPool('b', 1), Mocks.getPool('c', 2)];
   };
 
   configureTestBed({
@@ -141,13 +131,15 @@ describe('PoolListComponent', () => {
 
   describe('pool deletion', () => {
     let taskWrapper: TaskWrapperService;
+    let modalRef: any;
 
     const setSelectedPool = (poolName: string) =>
       (component.selection.selected = [{ pool_name: poolName }]);
 
     const callDeletion = () => {
       component.deletePoolModal();
-      const deletion: CriticalConfirmationModalComponent = component.modalRef.componentInstance;
+      expect(modalRef).toBeTruthy();
+      const deletion: CriticalConfirmationModalComponent = modalRef && modalRef.componentInstance;
       deletion.submitActionObservable();
     };
 
@@ -168,9 +160,10 @@ describe('PoolListComponent', () => {
 
     beforeEach(() => {
       spyOn(TestBed.inject(ModalService), 'show').and.callFake((deletionClass, initialState) => {
-        return {
+        modalRef = {
           componentInstance: Object.assign(new deletionClass(), initialState)
         };
+        return modalRef;
       });
       spyOn(poolService, 'delete').and.stub();
       taskWrapper = TestBed.inject(TaskWrapperService);
@@ -299,7 +292,7 @@ describe('PoolListComponent', () => {
 
     const getPoolData = (o: object) => [
       _.merge(
-        _.merge(createPool('a', 0), {
+        _.merge(Mocks.getPool('a', 0), {
           cdIsBinary: true,
           pg_status: '',
           stats: {
@@ -319,7 +312,7 @@ describe('PoolListComponent', () => {
     ];
 
     beforeEach(() => {
-      pool = createPool('a', 0);
+      pool = Mocks.getPool('a', 0);
     });
 
     it('transforms pools data correctly', () => {
@@ -451,7 +444,7 @@ describe('PoolListComponent', () => {
 
     it('should select correct existing cache tier', () => {
       setSelectionTiers([0]);
-      expect(component.cacheTiers).toEqual([createPool('a', 0)]);
+      expect(component.cacheTiers).toEqual([Mocks.getPool('a', 0)]);
     });
 
     it('should not select cache tier if id is invalid', () => {
@@ -468,7 +461,7 @@ describe('PoolListComponent', () => {
       setSelectionTiers([0, 1, 2]);
       expect(component.cacheTiers).toEqual(getPoolList());
       setSelectionTiers([0]);
-      expect(component.cacheTiers).toEqual([createPool('a', 0)]);
+      expect(component.cacheTiers).toEqual([Mocks.getPool('a', 0)]);
       setSelectionTiers([]);
       expect(component.cacheTiers).toEqual([]);
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
 
-import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import _ from 'lodash';
 
 import { ConfigurationService } from '../../../shared/api/configuration.service';
@@ -52,7 +51,6 @@ export class PoolListComponent extends ListWithDetails implements OnInit {
   pools: Pool[];
   columns: CdTableColumn[];
   selection = new CdTableSelection();
-  modalRef: NgbModalRef;
   executingTasks: ExecutingTask[] = [];
   permissions: Permissions;
   tableActions: CdTableAction[];
@@ -222,7 +220,7 @@ export class PoolListComponent extends ListWithDetails implements OnInit {
 
   deletePoolModal() {
     const name = this.selection.first().pool_name;
-    this.modalRef = this.modalService.show(CriticalConfirmationModalComponent, {
+    this.modalService.show(CriticalConfirmationModalComponent, {
       itemDescription: 'Pool',
       itemNames: [name],
       submitActionObservable: () =>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/cd-helper.class.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/cd-helper.class.spec.ts
@@ -1,0 +1,66 @@
+import { CdHelperClass } from './cd-helper.class';
+
+class MockClass {
+  n = 42;
+  o = {
+    x: 'something',
+    y: [1, 2, 3],
+    z: true
+  };
+  b: boolean;
+}
+
+describe('CdHelperClass', () => {
+  describe('updateChanged', () => {
+    let old: MockClass;
+    let used: MockClass;
+    let structure = {
+      n: 42,
+      o: {
+        x: 'something',
+        y: [1, 2, 3],
+        z: true
+      }
+    } as any;
+
+    beforeEach(() => {
+      old = new MockClass();
+      used = new MockClass();
+      structure = {
+        n: 42,
+        o: {
+          x: 'something',
+          y: [1, 2, 3],
+          z: true
+        }
+      };
+    });
+
+    it('should not update anything', () => {
+      CdHelperClass.updateChanged(used, structure);
+      expect(used).toEqual(old);
+    });
+
+    it('should only change n', () => {
+      CdHelperClass.updateChanged(used, { n: 17 });
+      expect(used.n).not.toEqual(old.n);
+      expect(used.n).toBe(17);
+    });
+
+    it('should update o on change of o.y', () => {
+      CdHelperClass.updateChanged(used, structure);
+      structure.o.y.push(4);
+      expect(used.o.y).toEqual(old.o.y);
+      CdHelperClass.updateChanged(used, structure);
+      expect(used.o.y).toEqual([1, 2, 3, 4]);
+    });
+
+    it('should change b, o and n', () => {
+      structure.o.x.toUpperCase();
+      structure.n++;
+      structure.b = true;
+      CdHelperClass.updateChanged(used, structure);
+      expect(used).toEqual(structure);
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/cd-helper.class.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/classes/cd-helper.class.ts
@@ -1,0 +1,19 @@
+import * as _ from 'lodash';
+
+export class CdHelperClass {
+  /**
+   * Simple way to only update variables if they have really changed and not just the reference
+   *
+   * @param componentThis - In order to update the variables if necessary
+   * @param change - The variable name (attribute of the object) is followed by the current value
+   *                 it would update even if it equals
+   */
+  static updateChanged(componentThis: any, change: { [publicVarName: string]: any }) {
+    Object.keys(change).forEach((publicVarName) => {
+      const data = change[publicVarName];
+      if (!_.isEqual(data, componentThis[publicVarName])) {
+        componentThis[publicVarName] = data;
+      }
+    });
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
@@ -5,10 +5,12 @@ import { By } from '@angular/platform-browser';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 
 import { NgbModal, NgbNav, NgbNavItem } from '@ng-bootstrap/ng-bootstrap';
+import _ from 'lodash';
 import { configureTestSuite } from 'ng-bullet';
 import { of } from 'rxjs';
 
 import { InventoryDevice } from '../app/ceph/cluster/inventory/inventory-devices/inventory-device.model';
+import { Pool } from '../app/ceph/pool/pool';
 import { OrchestratorService } from '../app/shared/api/orchestrator.service';
 import { TableActionsComponent } from '../app/shared/datatable/table-actions/table-actions.component';
 import { Icons } from '../app/shared/enum/icons.enum';
@@ -382,6 +384,17 @@ export class Mocks {
   ): CrushNode {
     return { name, type, type_id, id, children, device_class };
   }
+
+  static getPool = (name: string, id: number): Pool => {
+    return _.merge(new Pool(name), {
+      pool: id,
+      type: 'replicated',
+      pg_num: 256,
+      pg_placement_num: 256,
+      pg_num_target: 256,
+      pg_placement_num_target: 256
+    });
+  };
 
   /**
    * Create the following test crush map:


### PR DESCRIPTION
Now all variables that are shown in a listing that trigger a
more complex render cycle will only be updated if pool properties have
changed and not only the time series data, which isn't shown anymore,
as it can be seen graphically enhanced in the pool listing.

The pool detail component now uses the `onPush` change detection
strategy, to only call `ngOnChanges` if one of the input variables
have changed.

The function that only updates variables if they have changed is
now available through a helper class in order to provide this
useful functionality through out the dashboard.

Fixes: https://tracker.ceph.com/issues/46375
Signed-off-by: Stephan Müller <smueller@suse.com>


---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
