### PR TITLE
[RFC] ServiceSpec validation health check

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -128,6 +128,7 @@ class SpecStore():
 
     def save(self, spec):
         # type: (ServiceSpec) -> None
+        spec.validate()
         if spec.preview_only:
             self.spec_preview[spec.service_name()] = spec
             return None

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -3,7 +3,8 @@ import random
 from typing import List, Optional, Callable, Iterable, Tuple, TypeVar, Set
 
 import orchestrator
-from ceph.deployment.service_spec import PlacementSpec, HostPlacementSpec, ServiceSpec
+from ceph.deployment.service_spec import PlacementSpec, HostPlacementSpec, \
+        ServiceSpec, ServiceSpecValidationError
 from orchestrator._interface import DaemonDescription
 from orchestrator import OrchestratorValidationError
 
@@ -67,7 +68,10 @@ class HostAssignment(object):
         self.daemons = get_daemons_func(self.service_name)
 
     def validate(self):
-        self.spec.validate()
+        try:
+            self.spec.validate()
+        except Exception as e:
+            raise ServiceSpecValidationError(str(e))
 
         if self.spec.placement.count == 0:
             raise OrchestratorValidationError(

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -58,8 +58,6 @@ class DeviceSelection(object):
         #: Matches all devices. Can only be used for data devices
         self.all = all
 
-        self.validate()
-
     def validate(self):
         # type: () -> None
         props = [self.model, self.vendor, self.size, self.rotational]  # type: List[Any]

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -131,7 +131,6 @@ class HostPlacementSpec(namedtuple('HostPlacementSpec', ['hostname', 'network', 
             except ValueError as e:
                 # logging?
                 raise e
-        host_spec.validate()
         return host_spec
 
     def validate(self):
@@ -160,8 +159,6 @@ class PlacementSpec(object):
 
         #: fnmatch patterns to select hosts. Can also be a single host.
         self.host_pattern = host_pattern  # type: Optional[str]
-
-        self.validate()
 
     def is_empty(self):
         return self.label is None and \
@@ -244,7 +241,6 @@ class PlacementSpec(object):
                                   isinstance(host, str) else
                                   HostPlacementSpec.from_json(host))
         _cls = cls(**c)
-        _cls.validate()
         return _cls
 
     def to_json(self):
@@ -497,7 +493,6 @@ class ServiceSpec(object):
                 continue
             args.update({k: v})
         _cls = cls(**args)
-        _cls.validate()
         return _cls
 
     def service_name(self):

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -74,7 +74,8 @@ def test_drive_selection():
     assert spec.data_devices.paths[0].path == '/dev/sda'
 
     with pytest.raises(DriveGroupValidationError, match='exclusive'):
-        DeviceSelection(paths=['/dev/sda'], rotational=False)
+        ds = DeviceSelection(paths=['/dev/sda'], rotational=False)
+        ds.validate()
 
 
 def test_ceph_volume_command_0():

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -62,7 +62,8 @@ def test_parse_placement_specs(test_input, expected):
 )
 def test_parse_placement_specs_raises(test_input):
     with pytest.raises(ServiceSpecValidationError):
-        PlacementSpec.from_string(test_input)
+        ps = PlacementSpec.from_string(test_input)
+        ps.validate()
 
 @pytest.mark.parametrize("test_input",
                          # wrong subnet


### PR DESCRIPTION
report a health check error when a ServiceSpec contained in the spec store fails validation

```
$ ceph -s
  cluster:
    id:     85c196c3-e837-4c32-8aa6-cd0c2e6870d6
    health: HEALTH_WARN
            1 service spec(s) are not valid
            10 stray daemons(s) not managed by cephadm
 
  services:
    mon: 3 daemons, quorum a,b,c (age 17h)
    mgr: x(active, since 7m)
    mds: a:1 {0=a=up:active} 3 up:standby
    osd: 3 osds: 3 up (since 17h), 3 in (since 17h)
 
  data:
    pools:   3 pools, 65 pgs
    objects: 23 objects, 111 KiB
    usage:   6.0 GiB used, 297 GiB / 303 GiB avail
    pgs:     65 active+clean
 
$ ceph health detail
HEALTH_WARN 1 service spec(s) are not valid; 10 stray daemons(s) not managed by cephadm
[WRN] CEPHADM_SPEC_VALIDATE: 1 service spec(s) are not valid
    ServiceSpec nfs.foo is not valid: Cannot add NFS: No Pool specified
[WRN] CEPHADM_STRAY_DAEMON: 10 stray daemons(s) not managed by cephadm
    stray daemon mds.a on host host3 not managed by cephadm
    stray daemon mds.b on host host3 not managed by cephadm
    stray daemon mds.c on host host3 not managed by cephadm
    stray daemon mgr.x on host host3 not managed by cephadm
    stray daemon mon.a on host host3 not managed by cephadm
    stray daemon mon.b on host host3 not managed by cephadm
    stray daemon mon.c on host host3 not managed by cephadm
    stray daemon osd.0 on host host3 not managed by cephadm
    stray daemon osd.1 on host host3 not managed by cephadm
    stray daemon osd.2 on host host3 not managed by cephadm
```

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
