### PR TITLE
mgr: Add missing states to PG_STATES in mgr_module.py.

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -15,6 +15,7 @@ import re
 import time
 from mgr_util import profile_method
 
+# Full list of strings in "osd_types.cc:pg_state_string()"
 PG_STATES = [
     "active",
     "clean",
@@ -45,7 +46,12 @@ PG_STATES = [
     "snaptrim_wait",
     "snaptrim_error",
     "creating",
-    "unknown"]
+    "unknown",
+    "premerge",
+    "failed_repair",
+    "laggy",
+    "wait",
+]
 
 
 class CommandResult(object):


### PR DESCRIPTION
While waiting for an osd to add, I noticed grafana missing some scrapes.
Looking at the logs, I found the "laggy" state was missing causing an error.

Adds the "laggy" state, and some others which also appeared to be missing.
