### PR TITLE
cmake: do not check OFED_PREFIX anymore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,8 +466,6 @@ if(WITH_REENTRANT_STRSIGNAL)
   set(HAVE_REENTRANT_STRSIGNAL 1 CACHE INTERNAL "Reentrant strsignal is supported.")
 endif()
 
-set(HAVE_LIBROCKSDB 1)
-
 # -lz link into kv
 find_package(ZLIB REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,11 +76,6 @@ if(WIN32)
   add_definitions(-include winsock_wrapper.h)
 endif()
 
-if(OFED_PREFIX)
-  include_directories(SYSTEM ${OFED_PREFIX}/include)
-  link_directories(${OFED_PREFIX}/lib)
-endif()
-
 if(FREEBSD)
   include_directories(SYSTEM /usr/local/include)
   link_directories(/usr/local/lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,9 +71,9 @@ include_directories(
 
 if(WIN32)
   include_directories(
-  ${PROJECT_SOURCE_DIR}/src/include/win32)
+    ${PROJECT_SOURCE_DIR}/src/include/win32)
   # Boost complains if winsock2.h (or windows.h) is included before asio.hpp.
-  add_definitions(-include winsock_wrapper.h)
+  add_compile_options(-include winsock_wrapper.h)
 endif()
 
 if(FREEBSD)

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ defaulted to ON. To build without the RADOS Gateway:
 Another example below is building with debugging and alternate locations 
 for a couple of external dependencies:
 
-	cmake -DLEVELDB_PREFIX="/opt/hyperleveldb" -DOFED_PREFIX="/opt/ofed" \
-	-DCMAKE_INSTALL_PREFIX=/opt/accelio -DCMAKE_C_FLAGS="-O0 -g3 -gdwarf-4" \
+	cmake -DLEVELDB_PREFIX="/opt/hyperleveldb" \
+	-DCMAKE_INSTALL_PREFIX=/opt/ceph -DCMAKE_C_FLAGS="-O0 -g3 -gdwarf-4" \
 	..
 
 To view an exhaustive list of -D options, you can invoke `cmake` with:

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -205,9 +205,6 @@
 /* Define to 1 if you have fdatasync. */
 #cmakedefine HAVE_FDATASYNC 1
 
-/* Defined if you have librocksdb enabled */
-#cmakedefine HAVE_LIBROCKSDB
-
 /* Define to 1 if you have the <valgrind/helgrind.h> header file. */
 #cmakedefine HAVE_VALGRIND_HELGRIND_H 1
 

--- a/src/kv/KeyValueDB.cc
+++ b/src/kv/KeyValueDB.cc
@@ -6,9 +6,7 @@
 #include "LevelDBStore.h"
 #endif
 #include "MemDB.h"
-#ifdef HAVE_LIBROCKSDB
 #include "RocksDBStore.h"
-#endif
 
 using std::map;
 using std::string;
@@ -23,12 +21,9 @@ KeyValueDB *KeyValueDB::create(CephContext *cct, const string& type,
     return new LevelDBStore(cct, dir);
   }
 #endif
-#ifdef HAVE_LIBROCKSDB
   if (type == "rocksdb") {
     return new RocksDBStore(cct, dir, options, p);
   }
-#endif
-
   if ((type == "memdb") && 
     cct->check_experimental_feature_enabled("memdb")) {
     return new MemDB(cct, dir, p);
@@ -43,12 +38,9 @@ int KeyValueDB::test_init(const string& type, const string& dir)
     return LevelDBStore::_test_init(dir);
   }
 #endif
-#ifdef HAVE_LIBROCKSDB
   if (type == "rocksdb") {
     return RocksDBStore::_test_init(dir);
   }
-#endif
-
   if (type == "memdb") {
     return MemDB::_test_init(dir);
   }


### PR DESCRIPTION
OFED_PREFIX was added to compile with xio messenger for supporting RDMA
using the Accelio and/or MLNX_OFED package. but xio messenger was removed in
in cc9a9142fd41ee5c98792c6f6d2e5504

let remove the leftover in CMakeLists

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
