### PR TITLE
octopus: ceph-volume: fix lvm functional tests

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
@@ -34,7 +34,7 @@ changedir=
   centos8-bluestore-mixed_type_explicit: {toxinidir}/centos8/bluestore/mixed-type-explicit
   centos8-bluestore-mixed_type_dmcrypt_explicit: {toxinidir}/centos8/bluestore/mixed-type-dmcrypt-explicit
 commands=
-  git clone -b {env:CEPH_ANSIBLE_BRANCH:master} --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
+  git clone -b {env:CEPH_ANSIBLE_BRANCH:master} --single-branch {env:CEPH_ANSIBLE_CLONE:"https://github.com/ceph/ceph-ansible.git"} {envdir}/tmp/ceph-ansible
   python -m pip install -r {envdir}/tmp/ceph-ansible/tests/requirements.txt
 
   # bash {toxinidir}/../scripts/vagrant_up.sh {env:VAGRANT_UP_FLAGS:""} {posargs:--provider=virtualbox}

--- a/src/ceph-volume/ceph_volume/tests/functional/group_vars/bluestore_lvm
+++ b/src/ceph-volume/ceph_volume/tests/functional/group_vars/bluestore_lvm
@@ -11,6 +11,9 @@ osd_scenario: lvm
 ceph_origin: 'repository'
 ceph_repository: 'dev'
 copy_admin_key: false
+pv_devices:
+  - /dev/vdb
+  - /dev/vdc
 lvm_volumes:
   - data: data-lv1
     data_vg: test_group

--- a/src/ceph-volume/ceph_volume/tests/functional/group_vars/bluestore_lvm_dmcrypt
+++ b/src/ceph-volume/ceph_volume/tests/functional/group_vars/bluestore_lvm_dmcrypt
@@ -12,6 +12,9 @@ osd_scenario: lvm
 ceph_origin: 'repository'
 ceph_repository: 'dev'
 copy_admin_key: false
+pv_devices:
+  - /dev/vdb
+  - /dev/vdc
 lvm_volumes:
   - data: data-lv1
     data_vg: test_group

--- a/src/ceph-volume/ceph_volume/tests/functional/group_vars/filestore_lvm
+++ b/src/ceph-volume/ceph_volume/tests/functional/group_vars/filestore_lvm
@@ -11,6 +11,9 @@ osd_scenario: lvm
 ceph_origin: 'repository'
 ceph_repository: 'dev'
 copy_admin_key: false
+pv_devices:
+  - /dev/vdb
+  - /dev/vdc
 # test-volume is created by tests/functional/lvm_setup.yml from /dev/sda
 lvm_volumes:
   - data: data-lv1

--- a/src/ceph-volume/ceph_volume/tests/functional/group_vars/filestore_lvm_dmcrypt
+++ b/src/ceph-volume/ceph_volume/tests/functional/group_vars/filestore_lvm_dmcrypt
@@ -12,6 +12,9 @@ osd_scenario: lvm
 ceph_origin: 'repository'
 ceph_repository: 'dev'
 copy_admin_key: false
+pv_devices:
+  - /dev/vdb
+  - /dev/vdc
 # test-volume is created by tests/functional/lvm_setup.yml from /dev/sda
 lvm_volumes:
   - data: data-lv1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_bluestore.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_bluestore.yml
@@ -114,8 +114,8 @@
         suffix: sparse
       register: tmpdir
 
-    - name: create a 5GB sparse file
-      command: fallocate -l 5G {{ tmpdir.path }}/sparse.file
+    - name: create a 1GB sparse file
+      command: fallocate -l 1G {{ tmpdir.path }}/sparse.file
 
     - name: find an empty loop device
       command: losetup -f

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_filestore.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_filestore.yml
@@ -135,8 +135,8 @@
         suffix: sparse
       register: tmpdir
 
-    - name: create a 5GB sparse file
-      command: fallocate -l 5G {{ tmpdir.path }}/sparse.file
+    - name: create a 1GB sparse file
+      command: fallocate -l 1G {{ tmpdir.path }}/sparse.file
 
     - name: find an empty loop device
       command: losetup -f

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -32,7 +32,7 @@ changedir=
   centos8-filestore-prepare_activate: {toxinidir}/xenial/filestore/prepare_activate
   centos8-bluestore-prepare_activate: {toxinidir}/xenial/bluestore/prepare_activate
 commands=
-  git clone -b {env:CEPH_ANSIBLE_BRANCH:master} --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
+  git clone -b {env:CEPH_ANSIBLE_BRANCH:master} --single-branch {env:CEPH_ANSIBLE_CLONE:"https://github.com/ceph/ceph-ansible.git"} {envdir}/tmp/ceph-ansible
   pip install -r {envdir}/tmp/ceph-ansible/tests/requirements.txt
 
   bash {toxinidir}/../scripts/vagrant_up.sh {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46148

---

backport of https://github.com/ceph/ceph/pull/35595
parent tracker: https://tracker.ceph.com/issues/46131

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh