### PR TITLE
octopus: osd/OSDCap: rbd profile permits use of "rbd_info"

### DIFF
--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -332,6 +332,8 @@ void OSDCapGrant::expand_profile()
 
   if (profile.name == "rbd") {
     // RBD read-write grant
+    profile_grants.emplace_back(OSDCapMatch(string(), "rbd_info"),
+                                OSDCapSpec(osd_rwxa_t(OSD_CAP_R)));
     profile_grants.emplace_back(OSDCapMatch(string(), "rbd_children"),
                                 OSDCapSpec(osd_rwxa_t(OSD_CAP_CLS_R)));
     profile_grants.emplace_back(OSDCapMatch(string(), "rbd_mirroring"),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46322

---

backport of https://github.com/ceph/ceph/pull/35699
parent tracker: https://tracker.ceph.com/issues/46139

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh