### PR TITLE
octopus: mgr/dashboard: fix regression in delete OSD modal

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -82,8 +82,7 @@
                  class="custom-control-input"
                  name="preserve"
                  id="preserve"
-                 formControlName="preserve"
-                 autofocus>
+                 formControlName="preserve">
           <label class="custom-control-label"
                  for="preserve"
                  i18n>Preserve OSD ID(s) for replacement.</label>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46794

---

backport of https://github.com/ceph/ceph/pull/35985
parent tracker: https://tracker.ceph.com/issues/46413

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh