### PR TITLE
compressor: fix compile error for QAT

### DIFF
--- a/src/compressor/CMakeLists.txt
+++ b/src/compressor/CMakeLists.txt
@@ -22,6 +22,11 @@ if(HAVE_BROTLI)
   add_subdirectory(brotli)
 endif()
 
+add_library(compressor STATIC ${compressor_srcs})
+if(HAVE_QATZIP)
+  target_link_libraries(compressor PRIVATE ${QATZIP_LIBRARIES})
+endif()
+
 set(ceph_compressor_libs
     ceph_snappy
     ceph_zlib

--- a/src/compressor/QatAccel.cc
+++ b/src/compressor/QatAccel.cc
@@ -113,7 +113,7 @@ int QatAccel::decompress(bufferlist::const_iterator &p,
     if (rc == QZ_DATA_ERROR) {
       if (!joint) {
         tmp.append(cur_ptr.c_str(), cur_ptr.length());
-        p.advance(remaining);
+        p += remaining;
         joint = true;
       }
       read_more = true;
@@ -133,7 +133,7 @@ int QatAccel::decompress(bufferlist::const_iterator &p,
       read_more = false;
     }
 
-    p.advance(remaining);
+    p += remaining;
     remaining -= len;
     dst.append(ptr, 0, out_len);
   }

--- a/src/compressor/QatAccel.h
+++ b/src/compressor/QatAccel.h
@@ -16,6 +16,7 @@
 #define CEPH_QATACCEL_H
 
 #include <qatzip.h>
+#include <boost/optional.hpp>
 #include "include/buffer.h"
 
 class QatAccel {

--- a/src/compressor/lz4/CMakeLists.txt
+++ b/src/compressor/lz4/CMakeLists.txt
@@ -5,7 +5,7 @@ set(lz4_sources
 )
 
 add_library(ceph_lz4 SHARED ${lz4_sources})
-target_link_libraries(ceph_lz4 PRIVATE LZ4::LZ4)
+target_link_libraries(ceph_lz4 PRIVATE LZ4::LZ4 compressor)
 set_target_properties(ceph_lz4 PROPERTIES
   VERSION 2.0.0
   SOVERSION 2

--- a/src/compressor/snappy/CMakeLists.txt
+++ b/src/compressor/snappy/CMakeLists.txt
@@ -5,7 +5,7 @@ set(snappy_sources
 )
 
 add_library(ceph_snappy SHARED ${snappy_sources})
-target_link_libraries(ceph_snappy PRIVATE snappy::snappy)
+target_link_libraries(ceph_snappy PRIVATE snappy::snappy compressor)
 set_target_properties(ceph_snappy PROPERTIES
   VERSION 2.0.0
   SOVERSION 2

--- a/src/compressor/zlib/CMakeLists.txt
+++ b/src/compressor/zlib/CMakeLists.txt
@@ -49,7 +49,7 @@ else(HAVE_INTEL_SSE4_1 AND HAVE_BETTER_YASM_ELF64 AND (NOT APPLE))
 endif(HAVE_INTEL_SSE4_1 AND HAVE_BETTER_YASM_ELF64 AND (NOT APPLE))
 
 add_library(ceph_zlib SHARED ${zlib_sources})
-target_link_libraries(ceph_zlib ZLIB::ZLIB)
+target_link_libraries(ceph_zlib ZLIB::ZLIB compressor)
 target_include_directories(ceph_zlib SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/isa-l/include")
 set_target_properties(ceph_zlib PROPERTIES
   VERSION 2.0.0


### PR DESCRIPTION
With '-DWITH_QATZIP=ON', Ceph could not be compiled successfully because
of the change of bufferptr API and QATzip library link.

Signed-off-by: Qiaowei Ren <qiaowei.ren@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
