### PR TITLE
librbd: support writing with version assertion on object dispatch

### DIFF
--- a/src/librbd/cache/ObjectCacherObjectDispatch.h
+++ b/src/librbd/cache/ObjectCacherObjectDispatch.h
@@ -58,7 +58,8 @@ public:
 
   bool write(
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
-      const ::SnapContext &snapc, int op_flags,
+      const ::SnapContext &snapc, int op_flags, int write_flags,
+      std::optional<uint64_t> assert_version,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;

--- a/src/librbd/cache/ObjectCacherWriteback.cc
+++ b/src/librbd/cache/ObjectCacherWriteback.cc
@@ -197,7 +197,7 @@ ceph_tid_t ObjectCacherWriteback::write(const object_t& oid,
 
   auto req = io::ObjectDispatchSpec::create_write(
     m_ictx, io::OBJECT_DISPATCH_LAYER_CACHE, object_no, off, std::move(bl_copy),
-    snapc, 0, journal_tid, trace, ctx);
+    snapc, 0, 0, std::nullopt, journal_tid, trace, ctx);
   req->object_dispatch_flags = (
     io::OBJECT_DISPATCH_FLAG_FLUSH |
     io::OBJECT_DISPATCH_FLAG_WILL_RETRY_ON_ERROR);

--- a/src/librbd/cache/ParentCacheObjectDispatch.h
+++ b/src/librbd/cache/ParentCacheObjectDispatch.h
@@ -58,7 +58,8 @@ public:
 
   bool write(
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
-      const ::SnapContext &snapc, int op_flags,
+      const ::SnapContext &snapc, int op_flags, int write_flags,
+      std::optional<uint64_t> assert_version,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) {

--- a/src/librbd/cache/WriteAroundObjectDispatch.cc
+++ b/src/librbd/cache/WriteAroundObjectDispatch.cc
@@ -85,7 +85,8 @@ bool WriteAroundObjectDispatch<I>::discard(
 template <typename I>
 bool WriteAroundObjectDispatch<I>::write(
     uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
-    const ::SnapContext &snapc, int op_flags,
+    const ::SnapContext &snapc, int op_flags, int write_flags,
+    std::optional<uint64_t> assert_version,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context**on_finish, Context* on_dispatched) {

--- a/src/librbd/cache/WriteAroundObjectDispatch.h
+++ b/src/librbd/cache/WriteAroundObjectDispatch.h
@@ -58,7 +58,8 @@ public:
 
   bool write(
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
-      const ::SnapContext &snapc, int op_flags,
+      const ::SnapContext &snapc, int op_flags, int write_flags,
+      std::optional<uint64_t> assert_version,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context**on_finish, Context* on_dispatched) override;

--- a/src/librbd/crypto/CryptoObjectDispatch.cc
+++ b/src/librbd/crypto/CryptoObjectDispatch.cc
@@ -141,7 +141,8 @@ bool CryptoObjectDispatch<I>::read(
 template <typename I>
 bool CryptoObjectDispatch<I>::write(
     uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
-    const ::SnapContext &snapc, int op_flags,
+    const ::SnapContext &snapc, int op_flags, int write_flags,
+    std::optional<uint64_t> assert_version,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
@@ -188,7 +189,7 @@ bool CryptoObjectDispatch<I>::write_same(
   *dispatch_result = io::DISPATCH_RESULT_COMPLETE;
   auto req = io::ObjectDispatchSpec::create_write(
           m_image_ctx, io::OBJECT_DISPATCH_LAYER_NONE, object_no,
-          object_off, std::move(ws_data), snapc, op_flags, 0,
+          object_off, std::move(ws_data), snapc, op_flags, 0, std::nullopt, 0,
           parent_trace, ctx);
   req->send();
   return true;

--- a/src/librbd/crypto/CryptoObjectDispatch.h
+++ b/src/librbd/crypto/CryptoObjectDispatch.h
@@ -48,7 +48,8 @@ public:
 
   bool write(
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
-      const ::SnapContext &snapc, int op_flags,
+      const ::SnapContext &snapc, int op_flags, int write_flags,
+      std::optional<uint64_t> assert_version,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -579,8 +579,8 @@ ObjectDispatchSpec *ImageWriteRequest<I>::create_object_request(
 
   auto req = ObjectDispatchSpec::create_write(
     &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.object_no,
-    object_extent.offset, std::move(bl), snapc, m_op_flags, journal_tid,
-    this->m_trace, on_finish);
+    object_extent.offset, std::move(bl), snapc, m_op_flags, 0, std::nullopt,
+    journal_tid, this->m_trace, on_finish);
   return req;
 }
 
@@ -811,8 +811,8 @@ ObjectDispatchSpec *ImageWriteSameRequest<I>::create_object_request(
   }
   req = ObjectDispatchSpec::create_write(
     &image_ctx, OBJECT_DISPATCH_LAYER_NONE, object_extent.object_no,
-    object_extent.offset, std::move(bl), snapc, m_op_flags, journal_tid,
-    this->m_trace, on_finish);
+    object_extent.offset, std::move(bl), snapc, m_op_flags, 0, std::nullopt,
+    journal_tid, this->m_trace, on_finish);
   return req;
 }
 

--- a/src/librbd/io/ObjectDispatch.cc
+++ b/src/librbd/io/ObjectDispatch.cc
@@ -71,7 +71,8 @@ bool ObjectDispatch<I>::discard(
 template <typename I>
 bool ObjectDispatch<I>::write(
     uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
-    const ::SnapContext &snapc, int op_flags,
+    const ::SnapContext &snapc, int op_flags, int write_flags,
+    std::optional<uint64_t> assert_version,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
@@ -82,6 +83,7 @@ bool ObjectDispatch<I>::write(
   *dispatch_result = DISPATCH_RESULT_COMPLETE;
   auto req = new ObjectWriteRequest<I>(m_image_ctx, object_no, object_off,
                                        std::move(data), snapc, op_flags,
+                                       write_flags, assert_version,
                                        parent_trace, on_dispatched);
   req->send();
   return true;

--- a/src/librbd/io/ObjectDispatch.h
+++ b/src/librbd/io/ObjectDispatch.h
@@ -50,7 +50,8 @@ public:
 
   bool write(
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
-      const ::SnapContext &snapc, int op_flags,
+      const ::SnapContext &snapc, int op_flags, int write_flags,
+      std::optional<uint64_t> assert_version,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;

--- a/src/librbd/io/ObjectDispatchInterface.h
+++ b/src/librbd/io/ObjectDispatchInterface.h
@@ -49,7 +49,8 @@ struct ObjectDispatchInterface {
 
   virtual bool write(
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
-      const ::SnapContext &snapc, int op_flags,
+      const ::SnapContext &snapc, int op_flags, int write_flags,
+      std::optional<uint64_t> assert_version,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context**on_finish, Context* on_dispatched) = 0;

--- a/src/librbd/io/ObjectDispatchSpec.h
+++ b/src/librbd/io/ObjectDispatchSpec.h
@@ -83,12 +83,16 @@ public:
 
   struct WriteRequest : public WriteRequestBase {
     ceph::bufferlist data;
+    int write_flags;
+    std::optional<uint64_t> assert_version;
 
     WriteRequest(uint64_t object_no, uint64_t object_off,
                  ceph::bufferlist&& data, const ::SnapContext& snapc,
+                 int write_flags, std::optional<uint64_t> assert_version,
                  uint64_t journal_tid)
       : WriteRequestBase(object_no, object_off, snapc, journal_tid),
-        data(std::move(data)) {
+        data(std::move(data)), write_flags(write_flags),
+        assert_version(assert_version) {
     }
   };
 
@@ -182,12 +186,14 @@ public:
   static ObjectDispatchSpec* create_write(
       ImageCtxT* image_ctx, ObjectDispatchLayer object_dispatch_layer,
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
-      const ::SnapContext &snapc, int op_flags, uint64_t journal_tid,
+      const ::SnapContext &snapc, int op_flags, int write_flags,
+      std::optional<uint64_t> assert_version, uint64_t journal_tid,
       const ZTracer::Trace &parent_trace, Context *on_finish) {
     return new ObjectDispatchSpec(image_ctx->io_object_dispatcher,
                                   object_dispatch_layer,
                                   WriteRequest{object_no, object_off,
                                                std::move(data), snapc,
+                                               write_flags, assert_version,
                                                journal_tid},
                                   op_flags, parent_trace, on_finish);
   }

--- a/src/librbd/io/ObjectDispatcher.cc
+++ b/src/librbd/io/ObjectDispatcher.cc
@@ -129,7 +129,8 @@ struct ObjectDispatcher<I>::SendVisitor : public boost::static_visitor<bool> {
   bool operator()(ObjectDispatchSpec::WriteRequest& write) const {
     return object_dispatch->write(
       write.object_no, write.object_off, std::move(write.data), write.snapc,
-      object_dispatch_spec->op_flags, object_dispatch_spec->parent_trace,
+      object_dispatch_spec->op_flags, write.write_flags, write.assert_version,
+      object_dispatch_spec->parent_trace,
       &object_dispatch_spec->object_dispatch_flags, &write.journal_tid,
       &object_dispatch_spec->dispatch_result,
       &object_dispatch_spec->dispatcher_ctx.on_finish,

--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -38,6 +38,7 @@ public:
   static ObjectRequest* create_write(
       ImageCtxT *ictx, uint64_t object_no, uint64_t object_off,
       ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
+      int write_flags, std::optional<uint64_t> assert_version,
       const ZTracer::Trace &parent_trace, Context *completion);
   static ObjectRequest* create_discard(
       ImageCtxT *ictx, uint64_t object_no, uint64_t object_off,
@@ -265,11 +266,13 @@ public:
   ObjectWriteRequest(
       ImageCtxT *ictx, uint64_t object_no, uint64_t object_off,
       ceph::bufferlist&& data, const ::SnapContext &snapc, int op_flags,
+      int write_flags, std::optional<uint64_t> assert_version,
       const ZTracer::Trace &parent_trace, Context *completion)
     : AbstractObjectWriteRequest<ImageCtxT>(ictx, object_no, object_off,
                                             data.length(), snapc, "write",
                                             parent_trace, completion),
-      m_write_data(std::move(data)), m_op_flags(op_flags) {
+      m_write_data(std::move(data)), m_op_flags(op_flags),
+      m_write_flags(write_flags), m_assert_version(assert_version) {
   }
 
   bool is_empty_write_op() const override {
@@ -286,6 +289,8 @@ protected:
 private:
   ceph::bufferlist m_write_data;
   int m_op_flags;
+  int m_write_flags;
+  std::optional<uint64_t> m_assert_version;
 };
 
 template <typename ImageCtxT = ImageCtx>

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.cc
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.cc
@@ -162,7 +162,7 @@ void SimpleSchedulerObjectDispatch<I>::ObjectRequests::dispatch_delayed_requests
     auto req = ObjectDispatchSpec::create_write(
         image_ctx, OBJECT_DISPATCH_LAYER_SCHEDULER,
         m_object_no, offset, std::move(merged_requests.data), m_snapc,
-        m_op_flags, 0, {}, ctx);
+        m_op_flags, 0, std::nullopt, 0, {}, ctx);
 
     req->object_dispatch_flags = m_object_dispatch_flags;
     req->send();
@@ -256,13 +256,21 @@ bool SimpleSchedulerObjectDispatch<I>::discard(
 template <typename I>
 bool SimpleSchedulerObjectDispatch<I>::write(
     uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
-    const ::SnapContext &snapc, int op_flags,
+    const ::SnapContext &snapc, int op_flags, int write_flags,
+    std::optional<uint64_t> assert_version,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
                  << object_off << "~" << data.length() << dendl;
+
+  // don't try to batch assert version writes
+  if (assert_version.has_value() ||
+      (write_flags & OBJECT_WRITE_FLAG_CREATE_EXCLUSIVE) != 0) {
+    dispatch_delayed_requests(object_no);
+    return false;
+  }
 
   std::lock_guard locker{m_lock};
   if (try_delay_write(object_no, object_off, std::move(data), snapc, op_flags,

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.h
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.h
@@ -66,7 +66,8 @@ public:
 
   bool write(
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
-      const ::SnapContext &snapc, int op_flags,
+      const ::SnapContext &snapc, int op_flags, int write_flags,
+      std::optional<uint64_t> assert_version,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;

--- a/src/librbd/io/Types.h
+++ b/src/librbd/io/Types.h
@@ -100,6 +100,10 @@ enum ObjectDispatchLayer {
 };
 
 enum {
+  OBJECT_WRITE_FLAG_CREATE_EXCLUSIVE            = 1UL << 0
+};
+
+enum {
   OBJECT_DISCARD_FLAG_DISABLE_CLONE_REMOVE      = 1UL << 0,
   OBJECT_DISCARD_FLAG_DISABLE_OBJECT_MAP_UPDATE = 1UL << 1
 };

--- a/src/librbd/journal/ObjectDispatch.cc
+++ b/src/librbd/journal/ObjectDispatch.cc
@@ -107,7 +107,8 @@ bool ObjectDispatch<I>::discard(
 template <typename I>
 bool ObjectDispatch<I>::write(
     uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
-    const ::SnapContext &snapc, int op_flags,
+    const ::SnapContext &snapc, int op_flags, int write_flags,
+    std::optional<uint64_t> assert_version,
     const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
     uint64_t* journal_tid, io::DispatchResult* dispatch_result,
     Context** on_finish, Context* on_dispatched) {

--- a/src/librbd/journal/ObjectDispatch.h
+++ b/src/librbd/journal/ObjectDispatch.h
@@ -56,7 +56,8 @@ public:
 
   bool write(
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
-      const ::SnapContext &snapc, int op_flags,
+      const ::SnapContext &snapc, int op_flags, int write_flags,
+      std::optional<uint64_t> assert_version,
       const ZTracer::Trace &parent_trace, int* object_dispatch_flags,
       uint64_t* journal_tid, io::DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override;

--- a/src/librbd/operation/FlattenRequest.cc
+++ b/src/librbd/operation/FlattenRequest.cc
@@ -56,8 +56,8 @@ public:
 
     bufferlist bl;
     auto req = new io::ObjectWriteRequest<I>(&image_ctx, m_object_no, 0,
-                                             std::move(bl), m_snapc, 0, {},
-                                             this);
+                                             std::move(bl), m_snapc, 0, 0,
+                                             std::nullopt, {}, this);
     if (!req->has_parent()) {
       // stop early if the parent went away - it just means
       // another flatten finished first or the image was resized

--- a/src/librbd/operation/MigrateRequest.cc
+++ b/src/librbd/operation/MigrateRequest.cc
@@ -118,8 +118,8 @@ private:
     if (is_within_overlap_bounds()) {
       bufferlist bl;
       auto req = new io::ObjectWriteRequest<I>(&image_ctx, m_object_no, 0,
-                                               std::move(bl), m_snapc, 0, {},
-                                               ctx);
+                                               std::move(bl), m_snapc, 0, 0,
+                                               std::nullopt, {}, ctx);
 
       ldout(cct, 20) << "copyup object req " << req << ", object_no "
                      << m_object_no << dendl;

--- a/src/test/librbd/cache/test_mock_ParentCacheObjectDispatch.cc
+++ b/src/test/librbd/cache/test_mock_ParentCacheObjectDispatch.cc
@@ -313,7 +313,7 @@ TEST_F(TestMockParentCacheObjectDispatch, test_disble_interface) {
 
   ASSERT_EQ(mock_parent_image_cache->discard(0, 0, 0, *temp_snapc, 0, *temp_trace, temp_op_flags,
             temp_journal_tid, temp_dispatch_result, temp_on_finish, temp_on_dispatched), false);
-  ASSERT_EQ(mock_parent_image_cache->write(0, 0, std::move(temp_bl), *temp_snapc, 0,
+  ASSERT_EQ(mock_parent_image_cache->write(0, 0, std::move(temp_bl), *temp_snapc, 0, 0, std::nullopt,
             *temp_trace, temp_op_flags, temp_journal_tid, temp_dispatch_result,
             temp_on_finish, temp_on_dispatched), false);
   ASSERT_EQ(mock_parent_image_cache->write_same(0, 0, 0, std::move(buffer_extents),

--- a/src/test/librbd/cache/test_mock_WriteAroundObjectDispatch.cc
+++ b/src/test/librbd/cache/test_mock_WriteAroundObjectDispatch.cc
@@ -72,9 +72,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, WriteThrough) {
   MockContext finish_ctx;
   MockContext dispatch_ctx;
   Context* finish_ctx_ptr = &finish_ctx;
-  ASSERT_FALSE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
-                                     nullptr, nullptr, &dispatch_result,
-                                     &finish_ctx_ptr, &dispatch_ctx));
+  ASSERT_FALSE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
+                                     std::nullopt, {}, nullptr, nullptr,
+                                     &dispatch_result, &finish_ctx_ptr,
+                                     &dispatch_ctx));
   ASSERT_EQ(finish_ctx_ptr, &finish_ctx);
 }
 
@@ -95,9 +96,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, WriteThroughUntilFlushed) {
   MockContext finish_ctx;
   MockContext dispatch_ctx;
   Context* finish_ctx_ptr = &finish_ctx;
-  ASSERT_FALSE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
-                                     nullptr, nullptr, &dispatch_result,
-                                     &finish_ctx_ptr, &dispatch_ctx));
+  ASSERT_FALSE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
+                                     std::nullopt, {}, nullptr, nullptr,
+                                     &dispatch_result, &finish_ctx_ptr,
+                                     &dispatch_ctx));
   ASSERT_EQ(finish_ctx_ptr, &finish_ctx);
 
   ASSERT_FALSE(object_dispatch.flush(io::FLUSH_SOURCE_USER, {}, nullptr,
@@ -107,9 +109,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, WriteThroughUntilFlushed) {
   expect_context_complete(dispatch_ctx, 0);
   expect_context_complete(finish_ctx, 0);
 
-  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
-                                     nullptr, nullptr, &dispatch_result,
-                                     &finish_ctx_ptr, &dispatch_ctx));
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
+                                    std::nullopt, {}, nullptr, nullptr,
+                                    &dispatch_result, &finish_ctx_ptr,
+                                    &dispatch_ctx));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
   ASSERT_NE(finish_ctx_ptr, &finish_ctx);
   ASSERT_EQ(0, dispatch_ctx.wait());
@@ -138,9 +141,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, DispatchIO) {
   expect_context_complete(dispatch_ctx, 0);
   expect_context_complete(finish_ctx, 0);
 
-  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
-                                    nullptr, nullptr, &dispatch_result,
-                                    &finish_ctx_ptr, &dispatch_ctx));
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
+                                    std::nullopt, {}, nullptr, nullptr,
+                                    &dispatch_result, &finish_ctx_ptr,
+                                    &dispatch_ctx));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
   ASSERT_NE(finish_ctx_ptr, &finish_ctx);
 
@@ -170,9 +174,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, BlockedIO) {
   expect_context_complete(dispatch_ctx1, 0);
   expect_context_complete(finish_ctx1, 0);
 
-  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
-                                    nullptr, nullptr, &dispatch_result,
-                                    &finish_ctx_ptr1, &dispatch_ctx1));
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0,  0,
+                                    std::nullopt,{}, nullptr, nullptr,
+                                    &dispatch_result, &finish_ctx_ptr1,
+                                    &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
   ASSERT_NE(finish_ctx_ptr1, &finish_ctx1);
 
@@ -183,9 +188,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, BlockedIO) {
   expect_context_complete(dispatch_ctx2, 0);
   expect_context_complete(finish_ctx2, 0);
 
-  ASSERT_TRUE(object_dispatch.write(0, 4096, std::move(data), {}, 0, {},
-                                    nullptr, nullptr, &dispatch_result,
-                                    &finish_ctx_ptr2, &dispatch_ctx2));
+  ASSERT_TRUE(object_dispatch.write(0, 4096, std::move(data), {}, 0, 0,
+                                    std::nullopt, {}, nullptr, nullptr,
+                                    &dispatch_result, &finish_ctx_ptr2,
+                                    &dispatch_ctx2));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
   ASSERT_NE(finish_ctx_ptr2, &finish_ctx2);
 
@@ -193,9 +199,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, BlockedIO) {
   MockContext dispatch_ctx3;
   Context* finish_ctx_ptr3 = &finish_ctx3;
 
-  ASSERT_TRUE(object_dispatch.write(0, 1024, std::move(data), {}, 0,
-                                    {}, nullptr, nullptr, &dispatch_result,
-                                    &finish_ctx_ptr3, &dispatch_ctx3));
+  ASSERT_TRUE(object_dispatch.write(0, 1024, std::move(data), {}, 0, 0,
+                                    std::nullopt, {}, nullptr, nullptr,
+                                    &dispatch_result, &finish_ctx_ptr3,
+                                    &dispatch_ctx3));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
   ASSERT_NE(finish_ctx_ptr3, &finish_ctx3);
 
@@ -235,9 +242,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, QueuedIO) {
   expect_context_complete(dispatch_ctx1, 0);
   expect_context_complete(finish_ctx1, 0);
 
-  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
-                                    nullptr, nullptr, &dispatch_result,
-                                    &finish_ctx_ptr1, &dispatch_ctx1));
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
+                                    std::nullopt, {}, nullptr, nullptr,
+                                    &dispatch_result, &finish_ctx_ptr1,
+                                    &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
   ASSERT_NE(finish_ctx_ptr1, &finish_ctx1);
 
@@ -245,9 +253,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, QueuedIO) {
   MockContext dispatch_ctx2;
   Context* finish_ctx_ptr2 = &finish_ctx2;
 
-  ASSERT_TRUE(object_dispatch.write(0, 8192, std::move(data), {}, 0, {},
-                                    nullptr, nullptr, &dispatch_result,
-                                    &finish_ctx_ptr2, &dispatch_ctx2));
+  ASSERT_TRUE(object_dispatch.write(0, 8192, std::move(data), {}, 0, 0,
+                                    std::nullopt, {}, nullptr, nullptr,
+                                    &dispatch_result, &finish_ctx_ptr2,
+                                    &dispatch_ctx2));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
   ASSERT_NE(finish_ctx_ptr2, &finish_ctx2);
   ASSERT_EQ(0, dispatch_ctx1.wait());
@@ -283,9 +292,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, BlockedAndQueuedIO) {
   expect_context_complete(dispatch_ctx1, 0);
   expect_context_complete(finish_ctx1, 0);
 
-  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
-                                    nullptr, nullptr, &dispatch_result,
-                                    &finish_ctx_ptr1, &dispatch_ctx1));
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
+                                    std::nullopt, {}, nullptr, nullptr,
+                                    &dispatch_result, &finish_ctx_ptr1,
+                                    &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
   ASSERT_NE(finish_ctx_ptr1, &finish_ctx1);
 
@@ -296,9 +306,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, BlockedAndQueuedIO) {
   expect_context_complete(dispatch_ctx2, 0);
   expect_context_complete(finish_ctx2, 0);
 
-  ASSERT_TRUE(object_dispatch.write(0, 4096, std::move(data), {}, 0, {},
-                                    nullptr, nullptr, &dispatch_result,
-                                    &finish_ctx_ptr2, &dispatch_ctx2));
+  ASSERT_TRUE(object_dispatch.write(0, 4096, std::move(data), {}, 0, 0,
+                                    std::nullopt, {}, nullptr, nullptr,
+                                    &dispatch_result, &finish_ctx_ptr2,
+                                    &dispatch_ctx2));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
   ASSERT_NE(finish_ctx_ptr2, &finish_ctx2);
 
@@ -306,9 +317,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, BlockedAndQueuedIO) {
   MockContext dispatch_ctx3;
   Context* finish_ctx_ptr3 = &finish_ctx3;
 
-  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0,
-                                    {}, nullptr, nullptr, &dispatch_result,
-                                    &finish_ctx_ptr3, &dispatch_ctx3));
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
+                                    std::nullopt, {}, nullptr, nullptr,
+                                    &dispatch_result, &finish_ctx_ptr3,
+                                    &dispatch_ctx3));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
   ASSERT_NE(finish_ctx_ptr3, &finish_ctx3);
 
@@ -368,9 +380,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, FlushQueuedOnInFlightIO) {
   expect_context_complete(dispatch_ctx1, 0);
   expect_context_complete(finish_ctx1, 0);
 
-  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
-                                    nullptr, nullptr, &dispatch_result,
-                                    &finish_ctx_ptr1, &dispatch_ctx1));
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
+                                    std::nullopt, {}, nullptr, nullptr,
+                                    &dispatch_result, &finish_ctx_ptr1,
+                                    &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
   ASSERT_NE(finish_ctx_ptr1, &finish_ctx1);
   ASSERT_EQ(0, dispatch_ctx1.wait());
@@ -413,9 +426,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, FlushQueuedOnQueuedIO) {
   expect_context_complete(dispatch_ctx1, 0);
   expect_context_complete(finish_ctx1, 0);
 
-  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
-                                    nullptr, nullptr, &dispatch_result,
-                                    &finish_ctx_ptr1, &dispatch_ctx1));
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
+                                    std::nullopt, {}, nullptr, nullptr,
+                                    &dispatch_result, &finish_ctx_ptr1,
+                                    &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
   ASSERT_NE(finish_ctx_ptr1, &finish_ctx1);
   ASSERT_EQ(0, dispatch_ctx1.wait());
@@ -424,9 +438,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, FlushQueuedOnQueuedIO) {
   MockContext dispatch_ctx2;
   Context* finish_ctx_ptr2 = &finish_ctx2;
 
-  ASSERT_TRUE(object_dispatch.write(0, 8192, std::move(data), {}, 0, {},
-                                    nullptr, nullptr, &dispatch_result,
-                                    &finish_ctx_ptr2, &dispatch_ctx2));
+  ASSERT_TRUE(object_dispatch.write(0, 8192, std::move(data), {}, 0, 0,
+                                    std::nullopt, {}, nullptr, nullptr,
+                                    &dispatch_result, &finish_ctx_ptr2,
+                                    &dispatch_ctx2));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
   ASSERT_NE(finish_ctx_ptr2, &finish_ctx2);
   ASSERT_EQ(0, dispatch_ctx1.wait());
@@ -477,9 +492,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, FlushError) {
   expect_context_complete(dispatch_ctx1, 0);
   expect_context_complete(finish_ctx1, 0);
 
-  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
-                                    nullptr, nullptr, &dispatch_result,
-                                    &finish_ctx_ptr1, &dispatch_ctx1));
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
+                                    std::nullopt, {}, nullptr, nullptr,
+                                    &dispatch_result, &finish_ctx_ptr1,
+                                    &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
   ASSERT_NE(finish_ctx_ptr1, &finish_ctx1);
   ASSERT_EQ(0, dispatch_ctx1.wait());
@@ -547,9 +563,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, UnoptimizedIOInFlightIO) {
   expect_context_complete(dispatch_ctx1, 0);
   expect_context_complete(finish_ctx1, 0);
 
-  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
-                                    nullptr, nullptr, &dispatch_result,
-                                    &finish_ctx_ptr1, &dispatch_ctx1));
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
+                                    std::nullopt, {}, nullptr, nullptr,
+                                    &dispatch_result, &finish_ctx_ptr1,
+                                    &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
   ASSERT_NE(finish_ctx_ptr1, &finish_ctx1);
   ASSERT_EQ(0, dispatch_ctx1.wait());
@@ -593,9 +610,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, UnoptimizedIOBlockedIO) {
   expect_context_complete(dispatch_ctx1, 0);
   expect_context_complete(finish_ctx1, 0);
 
-  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, {},
-                                    nullptr, nullptr, &dispatch_result,
-                                    &finish_ctx_ptr1, &dispatch_ctx1));
+  ASSERT_TRUE(object_dispatch.write(0, 0, std::move(data), {}, 0, 0,
+                                    std::nullopt, {}, nullptr, nullptr,
+                                    &dispatch_result, &finish_ctx_ptr1,
+                                    &dispatch_ctx1));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
   ASSERT_NE(finish_ctx_ptr1, &finish_ctx1);
   ASSERT_EQ(0, dispatch_ctx1.wait());
@@ -604,9 +622,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, UnoptimizedIOBlockedIO) {
   MockContext finish_ctx2;
   MockContext dispatch_ctx2;
   Context* finish_ctx_ptr2 = &finish_ctx2;
-  ASSERT_TRUE(object_dispatch.write(0, 4096, std::move(data), {}, 0, {},
-                                    nullptr, nullptr, &dispatch_result,
-                                    &finish_ctx_ptr2, &dispatch_ctx2));
+  ASSERT_TRUE(object_dispatch.write(0, 4096, std::move(data), {}, 0, 0,
+                                    std::nullopt, {}, nullptr, nullptr,
+                                    &dispatch_result, &finish_ctx_ptr2,
+                                    &dispatch_ctx2));
   ASSERT_EQ(io::DISPATCH_RESULT_CONTINUE, dispatch_result);
   ASSERT_NE(finish_ctx_ptr2, &finish_ctx2);
 
@@ -649,9 +668,10 @@ TEST_F(TestMockCacheWriteAroundObjectDispatch, FUA) {
   MockContext dispatch_ctx;
   Context* finish_ctx_ptr = &finish_ctx;
   ASSERT_FALSE(object_dispatch.write(0, 0, std::move(data), {},
-                                     LIBRADOS_OP_FLAG_FADVISE_FUA, {},
-                                     nullptr, nullptr, &dispatch_result,
-                                     &finish_ctx_ptr, &dispatch_ctx));
+                                     LIBRADOS_OP_FLAG_FADVISE_FUA, 0,
+                                     std::nullopt, {}, nullptr, nullptr,
+                                     &dispatch_result, &finish_ctx_ptr,
+                                     &dispatch_ctx));
   ASSERT_EQ(finish_ctx_ptr, &finish_ctx);
 }
 

--- a/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
+++ b/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
@@ -163,8 +163,8 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, Read) {
 TEST_F(TestMockCryptoCryptoObjectDispatch, Write) {
   expect_encrypt();
   ASSERT_TRUE(mock_crypto_object_dispatch->write(
-        0, 0, std::move(data), mock_image_ctx->snapc, 0, {}, nullptr, nullptr,
-        &dispatch_result, &on_finish, on_dispatched));
+        0, 0, std::move(data), mock_image_ctx->snapc, 0, 0, std::nullopt, {},
+        nullptr, nullptr, &dispatch_result, &on_finish, on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_CONTINUE);
   ASSERT_EQ(on_finish, &finished_cond); // not modified
   on_finish->complete(0);

--- a/src/test/librbd/io/test_mock_SimpleSchedulerObjectDispatch.cc
+++ b/src/test/librbd/io/test_mock_SimpleSchedulerObjectDispatch.cc
@@ -171,7 +171,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Write) {
   C_SaferCond cond;
   Context *on_finish = &cond;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt, {},
       &object_dispatch_flags, nullptr, nullptr, &on_finish, nullptr));
   ASSERT_NE(on_finish, &cond);
   on_finish->complete(0);
@@ -256,7 +256,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteDelayed) {
   C_SaferCond cond1;
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt, {},
       &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
@@ -268,7 +268,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteDelayed) {
   Context *on_finish2 = &cond2;
   C_SaferCond on_dispatched;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt, {},
       &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
       &on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
@@ -303,7 +303,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteDelayedFlush) {
   C_SaferCond cond1;
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt, {},
       &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
@@ -315,7 +315,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteDelayedFlush) {
   Context *on_finish2 = &cond2;
   C_SaferCond on_dispatched;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt, {},
       &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
       &on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
@@ -359,7 +359,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteMerged) {
   C_SaferCond cond1;
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt, {},
       &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
@@ -374,8 +374,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteMerged) {
   Context *on_finish2 = &cond2;
   C_SaferCond on_dispatched2;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
-      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt,
+      {}, &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
       &on_dispatched2));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish2, &cond2);
@@ -388,8 +388,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteMerged) {
   Context *on_finish3 = &cond3;
   C_SaferCond on_dispatched3;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
-      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish3,
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt,
+      {}, &object_dispatch_flags, nullptr, &dispatch_result, &on_finish3,
       &on_dispatched3));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish3, &cond3);
@@ -401,8 +401,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteMerged) {
   Context *on_finish4 = &cond4;
   C_SaferCond on_dispatched4;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
-      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish4,
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt,
+      {},&object_dispatch_flags, nullptr, &dispatch_result, &on_finish4,
       &on_dispatched4));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish4, &cond4);
@@ -414,8 +414,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteMerged) {
   Context *on_finish5 = &cond5;
   C_SaferCond on_dispatched5;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
-      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish5,
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt,
+      {}, &object_dispatch_flags, nullptr, &dispatch_result, &on_finish5,
       &on_dispatched5));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish5, &cond5);
@@ -427,8 +427,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteMerged) {
   Context *on_finish6 = &cond6;
   C_SaferCond on_dispatched6;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
-      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish6,
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt,
+      {}, &object_dispatch_flags, nullptr, &dispatch_result, &on_finish6,
       &on_dispatched6));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish6, &cond6);
@@ -475,7 +475,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteNonSequential) {
   C_SaferCond cond1;
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt, {},
       &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
@@ -490,8 +490,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteNonSequential) {
   Context *on_finish2 = &cond2;
   C_SaferCond on_dispatched2;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
-      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt,
+      {}, &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
       &on_dispatched2));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish2, &cond2);
@@ -506,8 +506,9 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, WriteNonSequential) {
   C_SaferCond cond3;
   Context *on_finish3 = &cond3;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
-      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish3, nullptr));
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt,
+      {}, &object_dispatch_flags, nullptr, &dispatch_result, &on_finish3,
+      nullptr));
   ASSERT_NE(on_finish3, &cond3);
 
   on_finish1->complete(0);
@@ -538,7 +539,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Mixed) {
   C_SaferCond cond1;
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt, {},
       &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
@@ -554,8 +555,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Mixed) {
   Context *on_finish2 = &cond2;
   C_SaferCond on_dispatched2;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
-      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt,
+      {}, &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
       &on_dispatched2));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish2, &cond2);
@@ -570,8 +571,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Mixed) {
   Context *on_finish3 = &cond3;
   C_SaferCond on_dispatched3;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
-      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish3,
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt,
+      {}, &object_dispatch_flags, nullptr, &dispatch_result, &on_finish3,
       &on_dispatched3));
   ASSERT_NE(on_finish3, &cond3);
 
@@ -600,8 +601,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Mixed) {
   Context *on_finish5 = &cond5;
   C_SaferCond on_dispatched5;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
-      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish5,
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt,
+      {}, &object_dispatch_flags, nullptr, &dispatch_result, &on_finish5,
       &on_dispatched5));
   ASSERT_NE(on_finish5, &cond5);
   ASSERT_NE(timer_task, nullptr);
@@ -630,8 +631,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Mixed) {
   Context *on_finish7 = &cond7;
   C_SaferCond on_dispatched7;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      0, object_off, std::move(data), mock_image_ctx.snapc, 0, {},
-      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish7,
+      0, object_off, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt,
+      {}, &object_dispatch_flags, nullptr, &dispatch_result, &on_finish7,
       &on_dispatched7));
   ASSERT_NE(on_finish7, &cond7);
   ASSERT_NE(timer_task, nullptr);
@@ -693,8 +694,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, DispatchQueue) {
   C_SaferCond cond1;
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      object_no, 0, std::move(data), mock_image_ctx.snapc, 0, {},
-      &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
+      object_no, 0, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt,
+      {}, &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
   Context *timer_task = nullptr;
@@ -706,8 +707,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, DispatchQueue) {
   Context *on_finish2 = &cond2;
   C_SaferCond on_dispatched2;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      object_no, 0, std::move(data), mock_image_ctx.snapc, 0, {},
-      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
+      object_no, 0, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt,
+      {}, &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
       &on_dispatched2));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish2, &cond2);
@@ -720,8 +721,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, DispatchQueue) {
   C_SaferCond cond3;
   Context *on_finish3 = &cond3;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      object_no, 0, std::move(data), mock_image_ctx.snapc, 0, {},
-      &object_dispatch_flags, nullptr, nullptr, &on_finish3, nullptr));
+      object_no, 0, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt,
+      {}, &object_dispatch_flags, nullptr, nullptr, &on_finish3, nullptr));
   ASSERT_NE(on_finish3, &cond3);
 
   data.clear();
@@ -729,8 +730,8 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, DispatchQueue) {
   Context *on_finish4 = &cond4;
   C_SaferCond on_dispatched4;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      object_no, 0, std::move(data), mock_image_ctx.snapc, 0, {},
-      &object_dispatch_flags, nullptr, &dispatch_result, &on_finish4,
+      object_no, 0, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt,
+      {}, &object_dispatch_flags, nullptr, &dispatch_result, &on_finish4,
       &on_dispatched4));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_NE(on_finish4, &cond4);
@@ -776,7 +777,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Timer) {
   C_SaferCond cond1;
   Context *on_finish1 = &cond1;
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.write(
-      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt, {},
       &object_dispatch_flags, nullptr, nullptr, &on_finish1, nullptr));
   ASSERT_NE(on_finish1, &cond1);
 
@@ -789,7 +790,7 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Timer) {
   Context *on_finish2 = &cond2;
   C_SaferCond on_dispatched;
   ASSERT_TRUE(mock_simple_scheduler_object_dispatch.write(
-      0, 0, std::move(data), mock_image_ctx.snapc, 0, {},
+      0, 0, std::move(data), mock_image_ctx.snapc, 0, 0, std::nullopt, {},
       &object_dispatch_flags, nullptr, &dispatch_result, &on_finish2,
       &on_dispatched));
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);

--- a/src/test/librbd/mock/io/MockObjectDispatch.h
+++ b/src/test/librbd/mock/io/MockObjectDispatch.h
@@ -52,18 +52,20 @@ public:
                            dispatch_result, on_dispatched);
   }
 
-  MOCK_METHOD8(execute_write,
+  MOCK_METHOD10(execute_write,
                bool(uint64_t, uint64_t, const ceph::bufferlist&,
-                    const ::SnapContext &, int*, uint64_t*, DispatchResult*,
-                    Context *));
+                    const ::SnapContext &, int, std::optional<uint64_t>, int*,
+                    uint64_t*, DispatchResult*, Context *));
   bool write(
       uint64_t object_no, uint64_t object_off, ceph::bufferlist&& data,
-      const ::SnapContext &snapc, int op_flags,
+      const ::SnapContext &snapc, int op_flags, int write_flags,
+      std::optional<uint64_t> assert_version,
       const ZTracer::Trace &parent_trace, int* dispatch_flags,
       uint64_t* journal_tid, DispatchResult* dispatch_result,
       Context** on_finish, Context* on_dispatched) override {
-    return execute_write(object_no, object_off, data, snapc, dispatch_flags,
-                         journal_tid, dispatch_result, on_dispatched);
+    return execute_write(object_no, object_off, data, snapc, write_flags,
+                         assert_version, dispatch_flags, journal_tid,
+                         dispatch_result, on_dispatched);
   }
 
   MOCK_METHOD10(execute_write_same,


### PR DESCRIPTION
This commit extends the object dispatch write function to support RADOS object version assertion.
In addition, we add a write flag which allows to assert that an object exists before writing.

This is required by the planned crypto layer to support unaligned (relative to the crypto segment size) writes.
Writing of unaligned data with encryption requires a read-modify-write procedure as follows:

1. Possibly reading + decrypting the head and tail of the extent to be written.
2. Updating the plaintext data with the data to be written.
3. Re-encrypting and writing with a checked write (using the version returned in (1)).
This new API is to support (3) above.

The only real implementation for this is in the CORE layer.