### PR TITLE
 mgr/cephadm, Add --image to `ceph orch redeploy <what>` 

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -358,6 +358,13 @@ class HostCache():
                 r.append(dd)
         return r
 
+    def get_daemon(self, daemon_name: str) -> orchestrator.DaemonDescription:
+        for _, dm in self.daemons.items():
+            for _, dd in dm.items():
+                if dd.name() == daemon_name:
+                    return dd
+        raise orchestrator.OrchestratorError(f'Unable to find {daemon_name} daemon(s)')
+
     def get_daemons_with_volatile_status(self) -> Iterator[Tuple[str, Dict[str, orchestrator.DaemonDescription]]]:
         def alter(host, dd_orig: orchestrator.DaemonDescription) -> orchestrator.DaemonDescription:
             dd = copy(dd_orig)

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -206,12 +206,12 @@ class TestCephadm(object):
         with with_host(cephadm_module, 'test'):
             with with_daemon(cephadm_module, RGWSpec(service_id='myrgw.foobar'), CephadmOrchestrator.add_rgw, 'test') as daemon_id:
 
-                c = cephadm_module.daemon_action('redeploy', 'rgw', daemon_id)
-                assert wait(cephadm_module, c) == [f"Deployed rgw.{daemon_id} on host 'test'"]
+                c = cephadm_module.daemon_action('redeploy', 'rgw.' + daemon_id)
+                assert wait(cephadm_module, c) == f"Deployed rgw.{daemon_id} on host 'test'"
 
                 for what in ('start', 'stop', 'restart'):
-                    c = cephadm_module.daemon_action(what, 'rgw', daemon_id)
-                    assert wait(cephadm_module, c) == [what + f" rgw.{daemon_id} from host 'test'"]
+                    c = cephadm_module.daemon_action(what, 'rgw.' + daemon_id)
+                    assert wait(cephadm_module, c) == what + f" rgw.{daemon_id} from host 'test'"
 
                 # Make sure, _check_daemons does a redeploy due to monmap change:
                 cephadm_module._store['_ceph_get/mon_map'] = {

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -307,17 +307,12 @@ class CephadmUpgrade:
                     return
                 logger.info('Upgrade: Redeploying %s.%s' %
                             (d.daemon_type, d.daemon_id))
-                ret, out, err = self.mgr.check_mon_command({
-                    'prefix': 'config set',
-                    'name': 'container_image',
-                    'value': target_name,
-                    'who': name_to_config_section(daemon_type + '.' + d.daemon_id),
-                })
                 self.mgr._daemon_action(
                     d.daemon_type,
                     d.daemon_id,
                     d.hostname,
-                    'redeploy'
+                    'redeploy',
+                    image=target_name
                 )
                 return
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -963,13 +963,13 @@ class Orchestrator(object):
         #assert action in ["start", "stop", "reload, "restart", "redeploy"]
         raise NotImplementedError()
 
-    def daemon_action(self, action, daemon_type, daemon_id):
-        # type: (str, str, str) -> Completion[List[str]]
+    def daemon_action(self, action: str, daemon_name: str, image: Optional[str]=None) -> Completion[str]:
         """
         Perform an action (start/stop/reload) on a daemon.
 
         :param action: one of "start", "stop", "restart", "redeploy", "reconfig"
-        :param name: name of daemon
+        :param daemon_name: name of daemon
+        :param image: Container image when redeploying that daemon
         :rtype: Completion
         """
         #assert action in ["start", "stop", "reload, "restart", "redeploy"]

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -313,7 +313,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         pass
 
     @deferred_write("daemon_action")
-    def daemon_action(self, action, daemon_type, daemon_id):
+    def daemon_action(self, action, daemon_name, image=None):
         pass
 
     @deferred_write("Adding NFS service")


### PR DESCRIPTION
This makes it possible to deploy a specific daemon with a new container image.

relates to: 

* https://github.com/SUSE/doc-ses/issues/399
* https://github.com/ceph/ceph/pull/35808#discussion_r459933159

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
