### PR TITLE
mgr/dashboard: Fix host attributes like labels are not returned

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/host.py
+++ b/src/pybind/mgr/dashboard/controllers/host.py
@@ -46,7 +46,7 @@ def merge_hosts_by_hostname(ceph_hosts, orch_hosts):
     for host in hosts:
         hostname = host['hostname']
         if hostname in orch_hosts_map:
-            host = merge_dicts(host, orch_hosts_map[hostname])
+            host.update(orch_hosts_map[hostname])
             host['sources']['orchestrator'] = True
             orch_hosts_map.pop(hostname)
 

--- a/src/pybind/mgr/dashboard/tests/test_host.py
+++ b/src/pybind/mgr/dashboard/tests/test_host.py
@@ -163,27 +163,37 @@ class TestHosts(unittest.TestCase):
         fake_client = mock.Mock()
         fake_client.available.return_value = True
         fake_client.hosts.list.return_value = [
-            HostSpec('node1'), HostSpec('node2')
+            HostSpec('node1', labels=['foo', 'bar']),
+            HostSpec('node2', labels=['bar'])
         ]
         instance.return_value = fake_client
 
         hosts = get_hosts()
         self.assertEqual(len(hosts), 3)
-        check_sources = {
+        checks = {
             'localhost': {
-                'ceph': True,
-                'orchestrator': False
+                'sources': {
+                    'ceph': True,
+                    'orchestrator': False
+                },
+                'labels': []
             },
             'node1': {
-                'ceph': True,
-                'orchestrator': True
+                'sources': {
+                    'ceph': True,
+                    'orchestrator': True
+                },
+                'labels': ['bar', 'foo']
             },
             'node2': {
-                'ceph': False,
-                'orchestrator': True
+                'sources': {
+                    'ceph': False,
+                    'orchestrator': True
+                },
+                'labels': ['bar']
             }
         }
         for host in hosts:
             hostname = host['hostname']
-            sources = host['sources']
-            self.assertDictEqual(sources, check_sources[hostname])
+            self.assertDictEqual(host['sources'], checks[hostname]['sources'])
+            self.assertListEqual(host['labels'], checks[hostname]['labels'])


### PR DESCRIPTION
The problem only happens when a host is reported both from Ceph and the
Orchestrator. There is an error on merging Ceph hosts with Orchestrator
hosts. The unit test is refined to test this case.

Fixes: https://tracker.ceph.com/issues/46761
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
