### PR TITLE
pybind/mgr/status: check get_metadata return

### DIFF
--- a/src/pybind/mgr/status/module.py
+++ b/src/pybind/mgr/status/module.py
@@ -30,7 +30,7 @@ class Module(MgrModule):
         },
     ]
 
-        
+
     def get_latest(self, daemon_type, daemon_name, stat):
         data = self.get_counter(daemon_type, daemon_name, stat)[stat]
         #self.log.error("get_latest {0} data={1}".format(stat, data))
@@ -113,6 +113,10 @@ class Module(MgrModule):
                             activity = "Reqs: " + mgr_util.format_dimless(rate, 5) + "/s"
 
                     metadata = self.get_metadata('mds', info['name'])
+                    if metadata is None:
+                        self.log.error("get_metadata for daemon {} returned nothing".format(info['name']))
+                        metadata = {}
+
                     mds_versions[metadata.get('ceph_version', "unknown")].append(info['name'])
                     if output_format in ('json', 'json-pretty'):
                         json_output['mdsmap'].append({
@@ -160,6 +164,10 @@ class Module(MgrModule):
                     activity = "Evts: " + mgr_util.format_dimless(events, 5) + "/s"
 
                 metadata = self.get_metadata('mds', daemon_info['name'])
+                if metadata is None:
+                    self.log.error("get_metadata for daemon {} returned nothing".format(info['name']))
+                    metadata = {}
+
                 mds_versions[metadata.get('ceph_version', "unknown")].append(daemon_info['name'])
 
                 if output_format in ('json', 'json-pretty'):
@@ -197,7 +205,7 @@ class Module(MgrModule):
             for pool_id in [metadata_pool_id] + data_pool_ids:
                 pool_type = "metadata" if pool_id == metadata_pool_id else "data"
                 stats = pool_stats[pool_id]
-                
+
                 if output_format in ('json', 'json-pretty'):
                     json_output['pools'].append({
                         'id': pool_id,
@@ -212,7 +220,7 @@ class Module(MgrModule):
                         mgr_util.format_bytes(stats['bytes_used'], 5),
                         mgr_util.format_bytes(stats['max_avail'], 5)
                     ])
-            
+
             if output_format in ('json', 'json-pretty'):
                 json_output['clients'].append({
                     'fs': mdsmap['fs_name'],
@@ -233,6 +241,10 @@ class Module(MgrModule):
         standby_table.right_padding_width = 2
         for standby in fsmap['standbys']:
             metadata = self.get_metadata('mds', standby['name'])
+            if metadata is None:
+                self.log.error("get_metadata for daemon {} returned nothing".format(info['name']))
+                metadata = {}
+
             mds_versions[metadata.get('ceph_version', "unknown")].append(standby['name'])
 
             if output_format in ('json', 'json-pretty'):


### PR DESCRIPTION
The mgr_module get_metadata function can return None. This adds a check
and log message if retrieving metadata information for an MDS fails.

Fixes: https://tracker.ceph.com/issues/46817

Signed-off-by: Jan Fajerski <jfajerski@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
