### PR TITLE
nautilus: mds: fix nullptr dereference in MDCache::finish_rollback

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -3553,7 +3553,7 @@ MDSlaveUpdate* MDCache::get_uncommitted_slave(metareqid_t reqid, mds_rank_t mast
 }
 
 void MDCache::finish_rollback(metareqid_t reqid, MDRequestRef& mdr) {
-  auto p = resolve_need_rollback.find(mdr->reqid);
+  auto p = resolve_need_rollback.find(reqid);
   ceph_assert(p != resolve_need_rollback.end());
   if (mds->is_resolve()) {
     finish_uncommitted_slave(reqid, false);


### PR DESCRIPTION
introduced by commit 4940ab62e0d
"mds: preserve ESlaveUpdate::OP_PREPARE logevent before doing commit"

Fixes: https://tracker.ceph.com/issues/46533
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>
(cherry picked from commit 6715514aa577842942a1221a0f25924c53e03834)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
