### PR TITLE
mgr: cephadm remove ceph.target as well.

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4327,26 +4327,54 @@ def command_rm_cluster():
              verbose_on_failure=False)
 
     # cluster units
-    for unit_name in ['ceph-%s.target' % args.fsid]:
-        call(['systemctl', 'stop', unit_name],
-             verbose_on_failure=False)
-        call(['systemctl', 'reset-failed', unit_name],
-             verbose_on_failure=False)
-        call(['systemctl', 'disable', unit_name],
+    call(['systemctl', 'stop', 'ceph-%s.target' % args.fsid],
+         verbose_on_failure=False)
+    call(['systemctl', 'reset-failed', 'ceph-%s.target' % args.fsid],
+         verbose_on_failure=False)
+    call(['systemctl', 'disable', 'ceph-%s.target' % args.fsid],
              verbose_on_failure=False)
 
+    #
     slice_name = 'system-%s.slice' % (('ceph-%s' % args.fsid).replace('-',
                                                                       '\\x2d'))
     call(['systemctl', 'stop', slice_name],
          verbose_on_failure=False)
 
     # rm units
-    call_throws(['rm', '-f', args.unit_dir +
-                             '/ceph-%s@.service' % args.fsid])
-    call_throws(['rm', '-f', args.unit_dir +
-                             '/ceph-%s.target' % args.fsid])
+    call_throws(['rm', '-f', 
+                 args.unit_dir + '/ceph-%s@.service' % args.fsid])
+    call_throws(['rm', '-f',
+                 args.unit_dir + '/ceph-%s.target' % args.fsid])
     call_throws(['rm', '-rf',
-                  args.unit_dir + '/ceph-%s.target.wants' % args.fsid])
+                 args.unit_dir + '/ceph-%s.target.wants' % args.fsid])
+
+    # Are their other fsids on this host?
+    other_fsids_found=False
+    for item in list_daemons():
+        if "fsid" in item and item["fsid"]!=args.fsid:
+            # another fsid exists
+            other_fsids_found=True
+            break
+
+    # no, remove the extra targets.
+    if not other_fsids_found:
+        for name in [
+                'ceph-crash.service',
+                'ceph-mds.target',
+                'ceph-mgr.target',
+                'ceph-mon.target',
+                'ceph-osd.target',
+                'ceph.target',
+                ]:
+            call(['systemctl', 'stop', name],
+                 verbose_on_failure=False)
+            call(['systemctl', 'reset-failed', name],
+                 verbose_on_failure=False)
+            call(['systemctl', 'disable', name],
+                 verbose_on_failure=False)
+            call_throws(['rm', '-f', 
+                         args.unit_dir + '/'+name])
+
     # rm data
     call_throws(['rm', '-rf', args.data_dir + '/' + args.fsid])
     # rm logs


### PR DESCRIPTION
Delete the "ceph.target" when removing ceph.

Fixes: https://tracker.ceph.com/issues/46655
Signed-off-by: Harley Gorrell <harley@panix.com>
