### PR TITLE
mimic: ceph-volume: add ceph.osdspec_affinity tag

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -947,6 +947,7 @@ class Volume(object):
                 'type': type_,
                 'osd_fsid': self.tags['ceph.osd_fsid'],
                 'cluster_fsid': self.tags['ceph.cluster_fsid'],
+                'osdspec_affinity': self.tags.get('ceph.osdspec_affinity', ''),
             }
             type_uuid = '{}_uuid'.format(type_)
             report[type_uuid] = self.tags['ceph.{}'.format(type_uuid)]

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -294,6 +294,7 @@ class Prepare(object):
             'ceph.cluster_fsid': cluster_fsid,
             'ceph.cluster_name': conf.cluster,
             'ceph.crush_device_class': crush_device_class,
+            'ceph.osdspec_affinity': prepare_utils.get_osdspec_affinity()
         }
         if self.args.filestore:
             #TODO: allow auto creation of journal on passed device, only works

--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -399,6 +399,10 @@ def get_monmap(osd_id):
     ])
 
 
+def get_osdspec_affinity():
+    return os.environ.get('CEPH_VOLUME_OSDSPEC_AFFINITY', '')
+
+
 def osd_mkfs_bluestore(osd_id, fsid, keyring=None, wal=False, db=False):
     """
     Create the files for the OSD to function. A normal call will look like:
@@ -450,15 +454,14 @@ def osd_mkfs_bluestore(osd_id, fsid, keyring=None, wal=False, db=False):
         )
         system.chown(db)
 
+    if get_osdspec_affinity():
+        base_command.extend(['--osdspec-affinity', get_osdspec_affinity()])
+
     command = base_command + supplementary_command
 
     _, _, returncode = process.call(command, stdin=keyring, show_command=True)
     if returncode != 0:
         raise RuntimeError('Command failed with exit code %s: %s' % (returncode, ' '.join(command)))
-
-
-def get_osdspec_affinity():
-    return os.environ.get('CEPH_VOLUME_OSDSPEC_AFFINITY', '')
 
 
 def osd_mkfs_filestore(osd_id, fsid, keyring):
@@ -490,6 +493,9 @@ def osd_mkfs_filestore(osd_id, fsid, keyring):
         '-i', osd_id,
         '--monmap', monmap,
     ]
+
+    if get_osdspec_affinity():
+        command.extend(['--osdspec-affinity', get_osdspec_affinity()])
 
     if __release__ != 'luminous':
         # goes through stdin

--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -457,6 +457,10 @@ def osd_mkfs_bluestore(osd_id, fsid, keyring=None, wal=False, db=False):
         raise RuntimeError('Command failed with exit code %s: %s' % (returncode, ' '.join(command)))
 
 
+def get_osdspec_affinity():
+    return os.environ.get('CEPH_VOLUME_OSDSPEC_AFFINITY', '')
+
+
 def osd_mkfs_filestore(osd_id, fsid, keyring):
     """
     Create the files for the OSD to function. A normal call will look like:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/45482

---

backport of https://github.com/ceph/ceph/pull/34436
parent tracker: https://tracker.ceph.com/issues/44929

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh