### PR TITLE
crimson/osd: don't reset osd_op_params.clean_regions. Clean-up OpsExecuter

### DIFF
--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -697,6 +697,7 @@ OpsExecuter::execute_osd_op(OSDOp& osd_op)
     });
   case CEPH_OSD_OP_CREATE:
     return do_write_op([&osd_op] (auto& backend, auto& os, auto& txn) {
+      osd_op_params = osd_op_params_t();
       return backend.create(os, osd_op, txn);
     }, true);
   case CEPH_OSD_OP_WRITE:
@@ -720,10 +721,12 @@ OpsExecuter::execute_osd_op(OSDOp& osd_op)
     return osd_op_errorator::now();
   case CEPH_OSD_OP_SETXATTR:
     return do_write_op([&osd_op] (auto& backend, auto& os, auto& txn) {
+      osd_op_params = osd_op_params_t();
       return backend.setxattr(os, osd_op, txn);
     }, true);
   case CEPH_OSD_OP_DELETE:
     return do_write_op([] (auto& backend, auto& os, auto& txn) {
+      osd_op_params = osd_op_params_t();
       return backend.remove(os, txn);
     }, true);
   case CEPH_OSD_OP_CALL:
@@ -773,6 +776,7 @@ OpsExecuter::execute_osd_op(OSDOp& osd_op)
     }
 #endif
     return do_write_op([&osd_op] (auto& backend, auto& os, auto& txn) {
+      osd_op_params = osd_op_params_t();
       return backend.omap_set_header(os, osd_op, txn);
     }, true);
   case CEPH_OSD_OP_OMAPRMKEYRANGE:
@@ -782,12 +786,14 @@ OpsExecuter::execute_osd_op(OSDOp& osd_op)
     }
 #endif
     return do_write_op([&osd_op] (auto& backend, auto& os, auto& txn) {
+      osd_op_params = osd_op_params_t();
       return backend.omap_remove_range(os, osd_op, txn);
     }, true);
 
   // watch/notify
   case CEPH_OSD_OP_WATCH:
     return do_write_op([this, &osd_op] (auto& backend, auto& os, auto& txn) {
+      osd_op_params = osd_op_params_t();
       return do_op_watch(osd_op, os, txn);
     }, false);
   case CEPH_OSD_OP_NOTIFY:

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -697,36 +697,30 @@ OpsExecuter::execute_osd_op(OSDOp& osd_op)
     });
   case CEPH_OSD_OP_CREATE:
     return do_write_op([&osd_op] (auto& backend, auto& os, auto& txn) {
-      osd_op_params = osd_op_params_t();
       return backend.create(os, osd_op, txn);
     }, true);
   case CEPH_OSD_OP_WRITE:
     return do_write_op([this, &osd_op] (auto& backend, auto& os, auto& txn) {
-      osd_op_params = osd_op_params_t();
       return backend.write(os, osd_op, txn, *osd_op_params);
     }, true);
   case CEPH_OSD_OP_WRITEFULL:
     return do_write_op([this, &osd_op] (auto& backend, auto& os, auto& txn) {
-      osd_op_params = osd_op_params_t();
       return backend.writefull(os, osd_op, txn, *osd_op_params);
     }, true);
   case CEPH_OSD_OP_TRUNCATE:
     return do_write_op([this, &osd_op] (auto& backend, auto& os, auto& txn) {
       // FIXME: rework needed. Move this out to do_write_op(), introduce
       // do_write_op_no_user_modify()...
-      osd_op_params = osd_op_params_t();
       return backend.truncate(os, osd_op, txn, *osd_op_params);
     }, true);
   case CEPH_OSD_OP_SETALLOCHINT:
     return osd_op_errorator::now();
   case CEPH_OSD_OP_SETXATTR:
     return do_write_op([&osd_op] (auto& backend, auto& os, auto& txn) {
-      osd_op_params = osd_op_params_t();
       return backend.setxattr(os, osd_op, txn);
     }, true);
   case CEPH_OSD_OP_DELETE:
     return do_write_op([] (auto& backend, auto& os, auto& txn) {
-      osd_op_params = osd_op_params_t();
       return backend.remove(os, txn);
     }, true);
   case CEPH_OSD_OP_CALL:
@@ -766,7 +760,6 @@ OpsExecuter::execute_osd_op(OSDOp& osd_op)
     }
 #endif
     return do_write_op([this, &osd_op] (auto& backend, auto& os, auto& txn) {
-      osd_op_params = osd_op_params_t();
       return backend.omap_set_vals(os, osd_op, txn, *osd_op_params);
     }, true);
   case CEPH_OSD_OP_OMAPSETHEADER:
@@ -776,7 +769,6 @@ OpsExecuter::execute_osd_op(OSDOp& osd_op)
     }
 #endif
     return do_write_op([&osd_op] (auto& backend, auto& os, auto& txn) {
-      osd_op_params = osd_op_params_t();
       return backend.omap_set_header(os, osd_op, txn);
     }, true);
   case CEPH_OSD_OP_OMAPRMKEYRANGE:
@@ -786,14 +778,12 @@ OpsExecuter::execute_osd_op(OSDOp& osd_op)
     }
 #endif
     return do_write_op([&osd_op] (auto& backend, auto& os, auto& txn) {
-      osd_op_params = osd_op_params_t();
       return backend.omap_remove_range(os, osd_op, txn);
     }, true);
 
   // watch/notify
   case CEPH_OSD_OP_WATCH:
     return do_write_op([this, &osd_op] (auto& backend, auto& os, auto& txn) {
-      osd_op_params = osd_op_params_t();
       return do_op_watch(osd_op, os, txn);
     }, false);
   case CEPH_OSD_OP_NOTIFY:

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -182,8 +182,8 @@ public:
   osd_op_errorator::future<> execute_osd_op(class OSDOp& osd_op);
   seastar::future<> execute_pg_op(class OSDOp& osd_op);
 
-  template <typename Func>
-  osd_op_errorator::future<> submit_changes(Func&& f) &&;
+  template <typename Func, typename MutFunc>
+  osd_op_errorator::future<> flush_changes(Func&& func, MutFunc&& mut_func) &&;
 
   const auto& get_message() const {
     return *msg;
@@ -207,7 +207,7 @@ auto OpsExecuter::with_effect_on_obc(
   using context_t = std::decay_t<Context>;
   // the language offers implicit conversion to pointer-to-function for
   // lambda only when it's closureless. We enforce this restriction due
-  // the fact that `submit_changes()` std::moves many executer's parts.
+  // the fact that `flush_changes()` std::moves many executer's parts.
   using allowed_effect_func_t =
     seastar::future<> (*)(context_t&&, ObjectContextRef);
   static_assert(std::is_convertible_v<EffectFunc, allowed_effect_func_t>,
@@ -233,30 +233,44 @@ auto OpsExecuter::with_effect_on_obc(
   return std::forward<MainFunc>(main_func)(ctx_ref);
 }
 
-template <typename Func>
-OpsExecuter::osd_op_errorator::future<> OpsExecuter::submit_changes(Func&& f) && {
+template <typename Func,
+          typename MutFunc>
+OpsExecuter::osd_op_errorator::future<> OpsExecuter::flush_changes(
+  Func&& func,
+  MutFunc&& mut_func) &&
+{
   assert(obc);
-  if (!osd_op_params) {
-    osd_op_params = osd_op_params_t();
+  const bool want_mutate = !txn.empty();
+  if (want_mutate) {
+    if (!osd_op_params) {
+      osd_op_params = osd_op_params_t();
+    }
+    osd_op_params->req = std::move(msg);
+    osd_op_params->at_version = pg.next_version();
+    osd_op_params->pg_trim_to = pg.get_pg_trim_to();
+    osd_op_params->min_last_complete_ondisk = pg.get_min_last_complete_ondisk();
+    osd_op_params->last_complete = pg.get_info().last_complete;
+    if (user_modify) {
+      osd_op_params->user_at_version = osd_op_params->at_version.version;
+    }
   }
-  osd_op_params->req = std::move(msg);
-  eversion_t at_version = pg.next_version();
-
-  osd_op_params->at_version = at_version;
-  osd_op_params->pg_trim_to = pg.get_pg_trim_to();
-  osd_op_params->min_last_complete_ondisk = pg.get_min_last_complete_ondisk();
-  osd_op_params->last_complete = pg.get_info().last_complete;
-  if (user_modify)
-    osd_op_params->user_at_version = at_version.version;
   if (__builtin_expect(op_effects.empty(), true)) {
-    return std::forward<Func>(f)(std::move(txn), std::move(obc), std::move(*osd_op_params));
-  }
-  return std::forward<Func>(f)(std::move(txn), std::move(obc), std::move(*osd_op_params)).safe_then([this] {
-    // let's do the cleaning of `op_effects` in destructor
-    return crimson::do_for_each(op_effects, [] (auto& op_effect) {
-      return op_effect->execute();
+    return want_mutate ? std::forward<MutFunc>(mut_func)(std::move(txn),
+                                                         std::move(obc),
+                                                         std::move(*osd_op_params))
+                       : std::forward<Func>(func)(std::move(obc));
+  } else {
+    return (want_mutate ? std::forward<MutFunc>(mut_func)(std::move(txn),
+                                                          std::move(obc),
+                                                          std::move(*osd_op_params))
+                        : std::forward<Func>(func)(std::move(obc))
+    ).safe_then([this] {
+      // let's do the cleaning of `op_effects` in destructor
+      return crimson::do_for_each(op_effects, [] (auto& op_effect) {
+        return op_effect->execute();
+      });
     });
-  });
+  }
 }
 
 } // namespace crimson::osd

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -152,6 +152,9 @@ private:
   template <class Func>
   auto do_write_op(Func&& f, bool um) {
     ++num_write;
+    if (!osd_op_params) {
+      osd_op_params.emplace();
+    }
     user_modify = um;
     return std::forward<Func>(f)(backend, obc->obs, txn);
   }

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -242,9 +242,8 @@ OpsExecuter::osd_op_errorator::future<> OpsExecuter::flush_changes(
   assert(obc);
   const bool want_mutate = !txn.empty();
   if (want_mutate) {
-    if (!osd_op_params) {
-      osd_op_params = osd_op_params_t();
-    }
+    // osd_op_params are instantiated by every wr-like operation.
+    assert(osd_op_params);
     osd_op_params->req = std::move(msg);
     osd_op_params->at_version = pg.next_version();
     osd_op_params->pg_trim_to = pg.get_pg_trim_to();

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -606,26 +606,23 @@ seastar::future<Ref<MOSDOpReply>> PG::do_osd_ops(
       "do_osd_ops: {} - object {} all operations successful",
       *m,
       obc->obs.oi.soid);
-    return std::move(*ox).submit_changes([this, m, &op_info]
-      (auto&& txn, auto&& obc, auto&& osd_op_p) -> osd_op_errorator::future<> {
-	// XXX: the entire lambda could be scheduled conditionally. ::if_then()?
-	if (txn.empty()) {
-	  logger().debug(
-	    "do_osd_ops: {} - object {} txn is empty, bypassing mutate",
-	    *m,
-	    obc->obs.oi.soid);
-          return osd_op_errorator::now();
-        } else {
-	  logger().debug(
-	    "do_osd_ops: {} - object {} submitting txn",
-	    *m,
-	    obc->obs.oi.soid);
-	   return submit_transaction(op_info,
-                                     m->ops,
-                                     std::move(obc),
-                                     std::move(txn),
-                                     std::move(osd_op_p));
-	 }
+    return std::move(*ox).flush_changes(
+      [this, m] (auto&& obc) -> osd_op_errorator::future<> {
+	logger().debug(
+	  "do_osd_ops: {} - object {} txn is empty, bypassing mutate",
+	  *m,
+	  obc->obs.oi.soid);
+        return osd_op_errorator::now();
+      },
+      [this, m, &op_info] (auto&& txn,
+			   auto&& obc,
+			   auto&& osd_op_p) -> osd_op_errorator::future<> {
+	logger().debug(
+	  "do_osd_ops: {} - object {} submitting txn",
+	  *m,
+	  obc->obs.oi.soid);
+	return submit_transaction(
+          op_info, m->ops, std::move(obc), std::move(txn), std::move(osd_op_p));
       });
   }).safe_then([this,
                 m,


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
