### PR TITLE
octopus: mgr/dashboard: Configure overflow of popover in health page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/info-card/info-card-popover.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/info-card/info-card-popover.scss
@@ -8,6 +8,7 @@
     max-width: 100%;
     max-height: 19vh;
     font-size: 12px;
+    overflow: auto;
   }
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46788

---

backport of https://github.com/ceph/ceph/pull/36231
parent tracker: https://tracker.ceph.com/issues/46657

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh