### PR TITLE
cephadm: don't add `ceph-volume lvm activate` for adopted simple OSDs

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1964,25 +1964,29 @@ def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
         if daemon_type == 'osd':
             # osds have a pre-start step
             assert osd_fsid
-            f.write('# Simple OSDs need chown on startup:\n')
-            for n in ['block', 'block.db', 'block.wal']:
-                p = os.path.join(data_dir, n)
-                f.write('[ ! -L {p} ] || chown {uid}:{gid} {p}\n'.format(p=p, uid=uid, gid=gid))
-            f.write('# LVM OSDs use ceph-volume lvm activate:\n')
-            prestart = CephContainer(
-                image=args.image,
-                entrypoint='/usr/sbin/ceph-volume',
-                args=[
-                    'lvm', 'activate',
-                    str(daemon_id), osd_fsid,
-                    '--no-systemd'
-                ],
-                privileged=True,
-                volume_mounts=get_container_mounts(fsid, daemon_type, daemon_id),
-                bind_mounts=get_container_binds(fsid, daemon_type, daemon_id),
-                cname='ceph-%s-%s.%s-activate' % (fsid, daemon_type, daemon_id),
-            )
-            f.write(' '.join(prestart.run_cmd()) + '\n')
+            simple_fn = os.path.join('/etc/ceph/osd',
+                                     '%s-%s.json.adopted-by-cephadm' % (daemon_id, osd_fsid))
+            if os.path.exists(simple_fn):
+                f.write('# Simple OSDs need chown on startup:\n')
+                for n in ['block', 'block.db', 'block.wal']:
+                    p = os.path.join(data_dir, n)
+                    f.write('[ ! -L {p} ] || chown {uid}:{gid} {p}\n'.format(p=p, uid=uid, gid=gid))
+            else:
+                f.write('# LVM OSDs use ceph-volume lvm activate:\n')
+                prestart = CephContainer(
+                    image=args.image,
+                    entrypoint='/usr/sbin/ceph-volume',
+                    args=[
+                        'lvm', 'activate',
+                        str(daemon_id), osd_fsid,
+                        '--no-systemd'
+                    ],
+                    privileged=True,
+                    volume_mounts=get_container_mounts(fsid, daemon_type, daemon_id),
+                    bind_mounts=get_container_binds(fsid, daemon_type, daemon_id),
+                    cname='ceph-%s-%s.%s-activate' % (fsid, daemon_type, daemon_id),
+                )
+                f.write(' '.join(prestart.run_cmd()) + '\n')
         elif daemon_type == NFSGanesha.daemon_type:
             # add nfs to the rados grace db
             nfs_ganesha = NFSGanesha.init(fsid, daemon_id)


### PR DESCRIPTION
This changes the logic in deploy_daemon_units() to add either `chown` calls for simple (ceph-disk style) OSDs, or to add `ceph-volume lvm activate` calls for LVM OSDs, rather than always adding both.  When I was working on https://github.com/ceph/ceph/pull/34703, I'd originally added an "osd_simple" flag to figure out what type of OSD was being adopted/deployed, but passing that around was kinda ugly, so was removed from that PR.  This time around I'm checking if /etc/ceph/osd/$OSD_ID-$OSD_FSID.json.adopted-by-cephadm exists, which seems pretty safe IMO.  My only concern with this method is: what happens if someone adopts a simple OSD, then later wants to migrate it to LVM.  Presumably that's a destroy and recreate, keeping the same OSD ID? If that's true, then the JSON file probably still exists, so the subsequent create will do the wrong thing, i.e. will add `chown` calls, not `ceph-volume lvm activate` calls.  Any/all feedback appreciated...

Fixes: https://tracker.ceph.com/issues/46833
Signed-off-by: Tim Serong <tserong@suse.com>