### PR TITLE
Update librados-intro.rst

### DIFF
--- a/doc/rados/api/librados-intro.rst
+++ b/doc/rados/api/librados-intro.rst
@@ -451,7 +451,7 @@ binding converts C++-based errors into exceptions.
 .. code-block:: java
 
 	import com.ceph.rados.Rados;
-	import com.ceph.rados.RadosException;
+	import com.ceph.rados.exceptions.RadosException;
 	
 	import java.io.File;
 	
@@ -883,7 +883,7 @@ Java-Example
 .. code-block:: java
 
 	import com.ceph.rados.Rados;
-	import com.ceph.rados.RadosException;
+	import com.ceph.rados.exceptions.RadosException;
 
 	import java.io.File;
 	import com.ceph.rados.IoCTX;


### PR DESCRIPTION
[librados]: [Updated incorrect package path for Java in librados intro doc.]


Updated proper package path for RadosException class in Java API.

As per Rados java https://github.com/ceph/phprados.git , RadosException package path is "com.ceph.rados.exceptions.RadosException" not "com.ceph.rados.RadosException"

Signed-off-by: Vutukuri Sathvik <7vik.sathvik@gmail.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"


This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
