### PR TITLE
common: add constructor for WorkQueue with time_t

### DIFF
--- a/src/common/WorkQueue.h
+++ b/src/common/WorkQueue.h
@@ -24,6 +24,8 @@ struct ThreadPool {
 
 #else
 
+#include <time.h>
+
 #include <atomic>
 #include <list>
 #include <set>
@@ -79,6 +81,9 @@ protected:
     ceph::timespan timeout_interval;
     ceph::timespan suicide_interval;
     WorkQueue_(std::string n, ceph::timespan ti, ceph::timespan sti)
+      : name(std::move(n)), timeout_interval(ti), suicide_interval(sti)
+    { }
+    WorkQueue_(std::string n, time_t ti, time_t sti)
       : name(std::move(n)), timeout_interval(ti), suicide_interval(sti)
     { }
     virtual ~WorkQueue_() {}


### PR DESCRIPTION
Otherwise clang/FreeBSD complains:

In file included from /home/jenkins/workspace/ceph-master-compile/src/os/ObjectStore.h:26:
/home/jenkins/workspace/ceph-master-compile/src/common/WorkQueue.h:150:9: error: no matching constructor for initialization of 'ThreadPool::WorkQueue_'
      : WorkQueue_(std::move(n), ti, sti), pool(p) {
        ^          ~~~~~~~~~~~~~~~~~~~~~
/home/jenkins/workspace/ceph-master-compile/src/common/WorkQueue.h:81:5: note: candidate constructor not viable: no known conversion from 'time_t' (aka 'long') to 'ceph::timespan' (aka 'duration<unsigned long, ratio<1LL, 1000000000LL> >') for 2nd argument
    WorkQueue_(std::string n, ceph::timespan ti, ceph::timespan sti)
    ^
/home/jenkins/workspace/ceph-master-compile/src/common/WorkQueue.h:77:10: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 3 were provided
  struct WorkQueue_ {
         ^
1 warning and 1 error generated.




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>