### PR TITLE
rgwlc:  fix conditional decode of legacy lc op structures

### DIFF
--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1043,7 +1043,7 @@ struct cls_rgw_lc_get_next_entry_ret {
 
   void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(2, bl);
-    if (struct_v < 1) {
+    if (struct_v < 2) {
       std::pair<std::string, int> oe;
       decode(oe, bl);
       entry = {oe.first, 0 /* start */, uint32_t(oe.second)};
@@ -1109,7 +1109,7 @@ struct cls_rgw_lc_rm_entry_op {
 
   void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(2, bl);
-    if (struct_v < 1) {
+    if (struct_v < 2) {
       std::pair<std::string, int> oe;
       decode(oe, bl);
       entry = {oe.first, 0 /* start */, uint32_t(oe.second)};
@@ -1133,7 +1133,7 @@ struct cls_rgw_lc_set_entry_op {
 
   void decode(ceph::buffer::list::const_iterator& bl) {
     DECODE_START(2, bl);
-    if (struct_v < 1) {
+    if (struct_v < 2) {
       std::pair<std::string, int> oe;
       decode(oe, bl);
       entry = {oe.first, 0 /* start */, uint32_t(oe.second)};


### PR DESCRIPTION
Fixes the case where an upgraded radosgw operates on an unupgraded
OSD, so likely these cases do not execute.

Fixes: https://tracker.ceph.com/issues/46838

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
