### PR TITLE
doc/rados: remove upgrade auth disable

### DIFF
--- a/doc/rados/configuration/common.rst
+++ b/doc/rados/configuration/common.rst
@@ -89,10 +89,6 @@ authentication in the ``[global]`` section of your Ceph configuration file. ::
 
 Additionally, you should enable message signing. See `Cephx Config Reference`_ for details.
 
-.. important:: When upgrading, we recommend expressly disabling authentication
-   first, then perform the upgrade. Once the upgrade is complete, re-enable
-   authentication.
-
 .. _Cephx Config Reference: ../auth-config-ref
 
 


### PR DESCRIPTION
This commit removes a recommendation to disable
authentication before performing an upgrade.

Fixes: https://tracker.ceph.com/issues/30630
Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
