### PR TITLE
build: Use fmt as a header only library everywhere

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -310,6 +310,7 @@ else()
   add_subdirectory(fmt)
   include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/fmt/include")
 endif()
+add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-DFMT_HEADER_ONLY>)
 
 if(WITH_SEASTAR)
   find_package(c-ares 1.13.0 QUIET)
@@ -407,9 +408,7 @@ set(ceph_common_deps
   Boost::program_options
   Boost::date_time
   Boost::iostreams
-  fmt::fmt
   StdFilesystem::filesystem
-  fmt::fmt
   ${BLKID_LIBRARIES}
   ${Backtrace_LIBRARIES}
   ${BLKIN_LIBRARIES}

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -49,7 +49,6 @@ target_compile_definitions(crimson-alienstore PRIVATE -DWITH_SEASTAR -DWITH_ALIE
 target_include_directories(crimson-alienstore PRIVATE
   $<TARGET_PROPERTY:Seastar::seastar,INTERFACE_INCLUDE_DIRECTORIES>)
 target_link_libraries(crimson-alienstore
-  fmt::fmt
   kv
   heap_profiler
   ${BLKID_LIBRARIES}

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -45,7 +45,6 @@ target_link_libraries(crimson-osd
   crimson-common
   crimson-os
   crimson
-  fmt::fmt
   dmclock::dmclock)
 set_target_properties(crimson-osd PROPERTIES
   POSITION_INDEPENDENT_CODE ${EXE_LINKER_USE_PIE})

--- a/src/neorados/CMakeLists.txt
+++ b/src/neorados/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(libneorados STATIC
   $<TARGET_OBJECTS:neorados_api_obj>
   $<TARGET_OBJECTS:neorados_objs>)
 target_link_libraries(libneorados PRIVATE
-  osdc ceph-common cls_lock_client fmt::fmt
+  osdc ceph-common cls_lock_client
   ${BLKID_LIBRARIES} ${CRYPTO_LIBS} ${EXTRALIBS})
 
 # if(ENABLE_SHARED)

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -29,10 +29,6 @@
 #include "rgw_multi.h"
 #include "rgw_sal.h"
 
-// this seems safe to use, at least for now--arguably, we should
-// prefer header-only fmt, in general
-#undef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY 1
 #include "fmt/format.h"
 
 #include "services/svc_sys_obj.h"

--- a/src/test/neorados/CMakeLists.txt
+++ b/src/test/neorados/CMakeLists.txt
@@ -17,12 +17,12 @@ target_link_libraries(ceph_test_neorados_completions Boost::system pthread
 
 add_executable(ceph_test_neorados_op_speed op_speed.cc)
 target_link_libraries(ceph_test_neorados_op_speed
-  libneorados fmt::fmt ${unittest_libs})
+  libneorados ${unittest_libs})
 
 add_library(neoradostest-support common_tests.cc)
 target_link_libraries(neoradostest-support
-  libneorados fmt::fmt)
+  libneorados)
 
 add_executable(ceph_test_neorados_list_pool list_pool.cc)
 target_link_libraries(ceph_test_neorados_list_pool
-  libneorados neoradostest-support global fmt::fmt ${unittest_libs})
+  libneorados neoradostest-support global ${unittest_libs})


### PR DESCRIPTION
As suggested in a review elsewhere.

