### PR TITLE
mgr/cephadm: mgr or mds scale-down should prefer non-active daemons

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2135,6 +2135,12 @@ you may want to run:
             # These daemon types require additional configs after creation
             if dd.daemon_type in ['grafana', 'iscsi', 'prometheus', 'alertmanager', 'nfs']:
                 daemons_post[dd.daemon_type].append(dd)
+            
+            if self.cephadm_services[dd.daemon_type].get_active_daemon(
+               self.cache.get_daemons_by_service(dd.service_name())).daemon_id == dd.daemon_id:
+                dd.is_active = True
+            else:
+                dd.is_active = False
 
             deps = self._calc_daemon_deps(dd.daemon_type, dd.daemon_id)
             last_deps, last_config = self.cache.get_daemon_last_config_deps(

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -114,7 +114,8 @@ class TestCephadm(object):
                         'daemon_type': 'mds',
                         'hostname': 'test',
                         'status': 1,
-                        'status_desc': 'starting'}
+                        'status_desc': 'starting',
+                        'is_active': False}
                 ]
 
                 with with_service(cephadm_module, ServiceSpec('rgw', 'r.z'), CephadmOrchestrator.apply_rgw, 'test'):

--- a/src/pybind/mgr/cephadm/tests/test_spec.py
+++ b/src/pybind/mgr/cephadm/tests/test_spec.py
@@ -122,7 +122,8 @@ def test_spec_octopus(spec_json):
         "status_desc": "running",
         "last_refresh": "2020-04-03T15:31:48.725856",
         "created": "2020-04-02T19:23:08.829543",
-        "started": "2020-04-03T07:29:16.932838" 
+        "started": "2020-04-03T07:29:16.932838",
+        "is_active": false 
     },
     {
         "hostname": "ceph-001",
@@ -136,7 +137,8 @@ def test_spec_octopus(spec_json):
         "status_desc": "running",
         "last_refresh": "2020-04-03T15:31:48.725903",
         "created": "2020-04-02T19:23:11.390694",
-        "started": "2020-04-03T07:29:16.910897" 
+        "started": "2020-04-03T07:29:16.910897",
+        "is_active": false 
     },
     {
         "hostname": "ceph-001",
@@ -150,7 +152,8 @@ def test_spec_octopus(spec_json):
         "status_desc": "running",
         "last_refresh": "2020-04-03T15:31:48.725950",
         "created": "2020-04-02T19:23:52.025088",
-        "started": "2020-04-03T07:29:16.847972" 
+        "started": "2020-04-03T07:29:16.847972",
+        "is_active": false 
     },
     {
         "hostname": "ceph-001",
@@ -164,7 +167,8 @@ def test_spec_octopus(spec_json):
         "status_desc": "running",
         "last_refresh": "2020-04-03T15:31:48.725807",
         "created": "2020-04-02T19:22:18.648584",
-        "started": "2020-04-03T07:29:16.856153" 
+        "started": "2020-04-03T07:29:16.856153",
+        "is_active": false 
     },
     {
         "hostname": "ceph-001",
@@ -178,7 +182,8 @@ def test_spec_octopus(spec_json):
         "status_desc": "running",
         "last_refresh": "2020-04-03T15:31:48.725715",
         "created": "2020-04-02T19:22:13.863300",
-        "started": "2020-04-03T07:29:17.206024" 
+        "started": "2020-04-03T07:29:17.206024",
+        "is_active": false 
     },
     {
         "hostname": "ceph-001",
@@ -192,7 +197,8 @@ def test_spec_octopus(spec_json):
         "status_desc": "running",
         "last_refresh": "2020-04-03T15:31:48.725996",
         "created": "2020-04-02T19:23:53.880197",
-        "started": "2020-04-03T07:29:16.880044" 
+        "started": "2020-04-03T07:29:16.880044",
+        "is_active": false 
     },
     {
         "hostname": "ceph-001",
@@ -206,7 +212,8 @@ def test_spec_octopus(spec_json):
         "status_desc": "running",
         "last_refresh": "2020-04-03T15:31:48.726088",
         "created": "2020-04-02T20:35:02.991435",
-        "started": "2020-04-03T07:29:19.373956" 
+        "started": "2020-04-03T07:29:19.373956",
+        "is_active": false 
     },
     {
         "hostname": "ceph-001",
@@ -220,7 +227,8 @@ def test_spec_octopus(spec_json):
         "status_desc": "running",
         "last_refresh": "2020-04-03T15:31:48.726134",
         "created": "2020-04-02T20:35:17.142272",
-        "started": "2020-04-03T07:29:19.374002" 
+        "started": "2020-04-03T07:29:19.374002",
+        "is_active": false 
     },
     {
         "hostname": "ceph-001",
@@ -234,14 +242,16 @@ def test_spec_octopus(spec_json):
         "status_desc": "running",
         "last_refresh": "2020-04-03T15:31:48.726042",
         "created": "2020-04-02T19:24:10.281163",
-        "started": "2020-04-03T07:29:16.926292" 
+        "started": "2020-04-03T07:29:16.926292",
+        "is_active": false 
     },
     {
         "hostname": "ceph-001",
         "daemon_id": "default-rgw-realm.eu-central-1.1.ceph-001.ytywjo",
         "daemon_type": "rgw",
         "status": 1,
-        "status_desc": "starting" 
+        "status_desc": "starting",
+        "is_active": false 
     }
 ]""")
 )

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1200,7 +1200,8 @@ class DaemonDescription(object):
                  last_configured=None,
                  osdspec_affinity=None,
                  last_deployed=None,
-                 events: Optional[List['OrchestratorEvent']] = None):
+                 events: Optional[List['OrchestratorEvent']] = None,
+                 is_active: bool=False):
 
         # Host is at the same granularity as InventoryHost
         self.hostname: str = hostname
@@ -1242,6 +1243,8 @@ class DaemonDescription(object):
         self.osdspec_affinity: Optional[str] = osdspec_affinity
 
         self.events: List[OrchestratorEvent] = events or []
+        
+        self.is_active = is_active
 
     def name(self):
         return '%s.%s' % (self.daemon_type, self.daemon_id)
@@ -1318,6 +1321,7 @@ class DaemonDescription(object):
         out['status_desc'] = self.status_desc
         if self.daemon_type == 'osd':
             out['osdspec_affinity'] = self.osdspec_affinity
+        out['is_active'] = self.is_active
 
         for k in ['last_refresh', 'created', 'started', 'last_deployed',
                   'last_configured']:

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -251,6 +251,7 @@ daemon_id: ubuntu
 hostname: ubuntu
 status: 1
 status_desc: starting
+is_active: false
 events:
 - 2020-06-10T10:08:22.933241 daemon:crash.ubuntu [INFO] "Deployed crash.ubuntu on
   host 'ubuntu'"


### PR DESCRIPTION
~~When placing daemons during a mgr/mds scale-down, give preference
to the host with the active daemon so the active daemon is not
picked for removal~~

When removing daemons during a mgr/mds scale-down, prefer to remove
standby daemons so the active daemon is not killed

Fixes: https://tracker.ceph.com/issues/44252
Signed-off-by: Adam King <adking@redhat.com>