### PR TITLE
pg_autoscaler: Allows idle pools to give up PGs and active pools to retrieve them

### DIFF
--- a/src/pybind/mgr/pg_autoscaler/__init__.py
+++ b/src/pybind/mgr/pg_autoscaler/__init__.py
@@ -1,1 +1,1 @@
-from .module import PgAutoscaler, effective_target_ratio
+from .module import PgAutoscaler, effective_target_ratio, nearest_power_of_two

--- a/src/pybind/mgr/pg_autoscaler/tests/test_autoscaler.py
+++ b/src/pybind/mgr/pg_autoscaler/tests/test_autoscaler.py
@@ -1,4 +1,4 @@
-from pg_autoscaler import effective_target_ratio
+from pg_autoscaler import effective_target_ratio, PgAutoscaler, nearest_power_of_two
 from pytest import approx
 
 def check_simple_ratio(target_ratio, tot_ratio):
@@ -32,3 +32,27 @@ def test_total_bytes():
     assert etr == approx(0.0)
     etr = effective_target_ratio(1, 1, 10, 10)
     assert etr == approx(0.0)
+
+def test_pg_move():
+    pool_stats = {'rd': 30, 'wr': 50}
+    pool_id = 5
+    final_pg_target = 50
+    old_values = {1: {'total_requests': 0, 'potential_moved': 0, 'current_moved': 0, 'potential_add': 0,
+                      'current_add': 0}}
+    old_values, final_pg_target = PgAutoscaler.check_pool_activity(1, pool_stats, pool_id, final_pg_target, old_values)
+    assert old_values[pool_id]['total_requests'] == pool_stats['rd'] + pool_stats['wr']
+    PgAutoscaler.check_pool_activity(1, pool_stats, pool_id, final_pg_target, old_values)
+    assert old_values[pool_id]['potential_moved'] == 1
+    assert old_values[1]['potential_add'] == 1
+    old_values = {1: {'total_requests': 0, 'potential_moved': 0, 'current_moved': 0, 'potential_add': 64,
+                      'current_add': 0}, 5: {'total_requests': 0, 'potential_moved': 32, 'current_moved': 0,
+                      'potential_add': 0, 'current_add': 0}, 6: {'total_requests': 0, 'potential_moved': 32,
+                      'current_moved': 0, 'potential_add': 0, 'current_add': 0}}
+    final_pg_target = 64
+    test_target = final_pg_target
+    old_values, final_pg_target = PgAutoscaler.check_pool_activity(0, pool_stats, 1, test_target, old_values)
+    assert test_target + 64 == final_pg_target
+    final_pg_target = 64
+    old_values, final_pg_target1 = PgAutoscaler.check_pool_activity(0, pool_stats, pool_id, final_pg_target, old_values)
+    assert test_target - 32 == final_pg_target1
+


### PR DESCRIPTION
pg_autoscaler: Allows idle pools to give up PGs and active pools to retrieve them

This allows PGs that have been assigned to pools with a large percentage of space occupied to be reallocated
to other pools that are smaller but more active

Fixes: https://tracker.ceph.com/issues/46841

Signed-off-by: Tyler <tyler_sheehan@student.uml.edu>


-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
