### PR TITLE
mgr/cephadm: Prevent unnecessary SSH reconfiguration

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -645,6 +645,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         if ssh_config_fname:
             self.validate_ssh_config_fname(ssh_config_fname)
             ssh_options += ['-F', ssh_config_fname]
+        self.ssh_config = ssh_config
 
         # identity
         ssh_key = self.get_store("ssh_identity_key")
@@ -741,6 +742,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         """
         if inbuf is None or len(inbuf) == 0:
             return -errno.EINVAL, "", "empty ssh config provided"
+        if inbuf == self.ssh_config:
+            return 0, "value unchanged", ""
         self.set_store("ssh_config", inbuf)
         self.log.info('Set ssh_config')
         self._reconfig_ssh()
@@ -808,6 +811,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
     def _set_priv_key(self, inbuf=None):
         if inbuf is None or len(inbuf) == 0:
             return -errno.EINVAL, "", "empty private ssh key provided"
+        if inbuf == self.ssh_key:
+            return 0, "value unchanged", ""
         self.set_store("ssh_identity_key", inbuf)
         self.log.info('Set ssh private key')
         self._reconfig_ssh()
@@ -819,6 +824,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
     def _set_pub_key(self, inbuf=None):
         if inbuf is None or len(inbuf) == 0:
             return -errno.EINVAL, "", "empty public ssh key provided"
+        if inbuf == self.ssh_pub:
+            return 0, "value unchanged", ""
         self.set_store("ssh_identity_pub", inbuf)
         self.log.info('Set ssh public key')
         self._reconfig_ssh()
@@ -855,6 +862,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         'Set user for SSHing to cluster hosts, passwordless sudo will be needed for non-root users')
     def set_ssh_user(self, user):
         current_user = self.ssh_user
+        if user == current_user:
+            return 0, "value unchanged", ""
 
         self.set_store('ssh_user', user)
         self._reconfig_ssh()


### PR DESCRIPTION
When `set-user`, `set-pub-key` or `set-priv-key` are called "two" times with the same value, we can ignore the "second" call:

```
# ceph cephadm set-pub-key -i pub_key 
# ceph cephadm set-pub-key -i pub_key 
value already set
```

This will prevent unnecessary SSH reconfiguration and connections reset.

Signed-off-by: Ricardo Marques <rimarques@suse.com>


---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
