### PR TITLE
mgr/dashbaord: Fix bogus type annotations

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/prometheus.py
+++ b/src/pybind/mgr/dashboard/controllers/prometheus.py
@@ -3,6 +3,12 @@ from __future__ import absolute_import
 
 from datetime import datetime
 import json
+
+try:
+    from typing import Any
+except ImportError:  # pragma: no cover
+    pass  # Just for type checking
+
 import requests
 
 from . import Controller, ApiController, BaseController, RESTController, Endpoint
@@ -27,12 +33,13 @@ class PrometheusReceiver(BaseController):
 
 class PrometheusRESTController(RESTController):
     def prometheus_proxy(self, method, path, params=None, payload=None):
-        # type (str, str, dict, dict)
+        # type: (str, str, dict, dict) -> Any
         return self._proxy(self._get_api_url(Settings.PROMETHEUS_API_HOST),
                            method, path, 'Prometheus', params, payload)
 
     def alert_proxy(self, method, path, params=None, payload=None):
-        # type (str, str, dict, dict)
+        # type: (str, str, dict, dict) -> Any
+        i:int = "s"
         return self._proxy(self._get_api_url(Settings.ALERTMANAGER_API_HOST),
                            method, path, 'Alertmanager', params, payload)
 
@@ -40,7 +47,7 @@ class PrometheusRESTController(RESTController):
         return host.rstrip('/') + '/api/v1'
 
     def _proxy(self, base_url, method, path, api_name, params=None, payload=None):
-        # type (str, str, str, str, dict, dict)
+        # type: (str, str, str, str, dict, dict) -> Any
         try:
             response = requests.request(method, base_url + path, params=params, json=payload)
         except Exception:

--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -16,7 +16,7 @@ from ..services.rgw_client import RgwClient
 from ..tools import json_str_to_object, str_to_bool
 
 try:
-    from typing import List
+    from typing import List, Optional
 except ImportError:  # pragma: no cover
     pass  # Just for type checking
 
@@ -167,7 +167,7 @@ class RgwBucket(RgwRESTController):
 
     @staticmethod
     def strip_tenant_from_bucket_name(bucket_name):
-        # type (str) -> str
+        # type: (str) -> str
         """
         >>> RgwBucket.strip_tenant_from_bucket_name('tenant/bucket-name')
         'bucket-name'
@@ -178,7 +178,7 @@ class RgwBucket(RgwRESTController):
 
     @staticmethod
     def get_s3_bucket_name(bucket_name, tenant=None):
-        # type (str, str) -> str
+        # type: (str, Optional[str]) -> str
         """
         >>> RgwBucket.get_s3_bucket_name('bucket-name', 'tenant')
         'tenant:bucket-name'


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
