### PR TITLE
nautilus: client: static dirent for readdir is not thread-safe

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8380,7 +8380,7 @@ static int _readdir_single_dirent_cb(void *p, struct dirent *de,
 struct dirent *Client::readdir(dir_result_t *d)
 {
   int ret;
-  static struct dirent de;
+  auto& de = d->de;
   single_readdir sr;
   sr.de = &de;
   sr.stx = NULL;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -222,6 +222,7 @@ struct dir_result_t {
   frag_t buffer_frag;
 
   vector<dentry> buffer;
+  struct dirent de;
 };
 
 class Client : public Dispatcher, public md_config_obs_t {


### PR DESCRIPTION
https://tracker.ceph.com/issues/46856