### PR TITLE
common/buffer: return memcopy count for rebuid_align* api.

### DIFF
--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -878,9 +878,11 @@ int KernelDevice::write(
     return 0;
   }
 
-  if ((!buffered || bl.get_num_buffers() >= IOV_MAX) &&
-      bl.rebuild_aligned_size_and_memory(block_size, block_size, IOV_MAX)) {
-    dout(20) << __func__ << " rebuilding buffer to be aligned" << dendl;
+  if ((!buffered || bl.get_num_buffers() >= IOV_MAX)) {
+    unsigned copy_count = bl.rebuild_aligned_size_and_memory(block_size, block_size, IOV_MAX);
+    if (copy_count) {
+      dout(20) << __func__ << " rebuilding buffer(len=" << len <<  "to be aligned(memcopy=" << copy_count << dendl;
+    }
   }
   dout(40) << "data: ";
   bl.hexdump(*_dout);
@@ -907,10 +909,13 @@ int KernelDevice::aio_write(
     return 0;
   }
 
-  if ((!buffered || bl.get_num_buffers() >= IOV_MAX) &&
-      bl.rebuild_aligned_size_and_memory(block_size, block_size, IOV_MAX)) {
-    dout(20) << __func__ << " rebuilding buffer to be aligned" << dendl;
+  if ((!buffered || bl.get_num_buffers() >= IOV_MAX)) {
+    unsigned copy_count = bl.rebuild_aligned_size_and_memory(block_size, block_size, IOV_MAX);
+    if (copy_count) {
+      dout(20) << __func__ << " rebuilding buffer(len=" << len <<  "to be aligned(memcopy=" << copy_count << dendl;
+    }
   }
+
   dout(40) << "data: ";
   bl.hexdump(*_dout);
   *_dout << dendl;

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1198,16 +1198,16 @@ static ceph::spinlock debug_lock;
     invalidate_crc();
   }
 
-  bool buffer::list::rebuild_aligned(unsigned align)
+  unsigned buffer::list::rebuild_aligned(unsigned align)
   {
     return rebuild_aligned_size_and_memory(align, align);
   }
   
-  bool buffer::list::rebuild_aligned_size_and_memory(unsigned align_size,
+  unsigned buffer::list::rebuild_aligned_size_and_memory(unsigned align_size,
 						    unsigned align_memory,
 						    unsigned max_buffers)
   {
-    bool had_to_rebuild = false;
+    unsigned memcopy_count = 0;
 
     if (max_buffers && _num > max_buffers && _len > (max_buffers * align_size)) {
       align_size = round_up_to(round_up_to(_len, max_buffers) / max_buffers, align_size);
@@ -1252,16 +1252,16 @@ static ceph::spinlock debug_lock;
         unaligned.rebuild(
           ptr_node::create(
             buffer::create_aligned(unaligned._len, align_memory)));
-        had_to_rebuild = true;
+        memcopy_count += unaligned._len;
       }
       _buffers.insert_after(p_prev, *ptr_node::create(unaligned._buffers.front()).release());
       _num += 1;
       ++p_prev;
     }
-    return had_to_rebuild;
+    return memcopy_count;
   }
   
-  bool buffer::list::rebuild_page_aligned()
+  unsigned buffer::list::rebuild_page_aligned()
   {
    return  rebuild_aligned(CEPH_PAGE_SIZE);
   }

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -1054,13 +1054,13 @@ struct error_code;
     bool is_contiguous() const;
     void rebuild();
     void rebuild(std::unique_ptr<ptr_node, ptr_node::disposer> nb);
-    bool rebuild_aligned(unsigned align);
+    unsigned  rebuild_aligned(unsigned align);
     // max_buffers = 0 mean don't care _buffers.size(), other
     // must make _buffers.size() <= max_buffers after rebuilding.
-    bool rebuild_aligned_size_and_memory(unsigned align_size,
+    unsigned rebuild_aligned_size_and_memory(unsigned align_size,
 					 unsigned align_memory,
 					 unsigned max_buffers = 0);
-    bool rebuild_page_aligned();
+    unsigned rebuild_page_aligned();
 
     void reserve(size_t prealloc);
 


### PR DESCRIPTION
we want get the memcopy_count for bufferlist rebuild and print this.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
