### PR TITLE
crimson/common: read conf file in async

### DIFF
--- a/src/common/ConfUtils.cc
+++ b/src/common/ConfUtils.cc
@@ -136,7 +136,7 @@ int ConfFile::parse_file(const std::string &fname,
   std::ifstream ifs{fname};
   const std::string buffer{std::istreambuf_iterator<char>(ifs),
 			   std::istreambuf_iterator<char>()};
-  if (load_from_buffer(buffer, warnings)) {
+  if (parse_buffer(buffer, warnings)) {
     return 0;
   } else {
     return -EINVAL;
@@ -247,8 +247,9 @@ struct IniGrammer : qi::grammar<Iterator, ConfFile(), Skipper>
 };
 }
 
-bool ConfFile::load_from_buffer(std::string_view buf, std::ostream* err)
+bool ConfFile::parse_buffer(std::string_view buf, std::ostream* err)
 {
+  assert(err);
   if (int err_pos = check_utf8(buf.data(), buf.size()); err_pos > 0) {
     *err << "parse error: invalid UTF-8 found at line "
 	 << std::count(buf.begin(), std::next(buf.begin(), err_pos), '\n') + 1;
@@ -271,7 +272,7 @@ int ConfFile::parse_bufferlist(ceph::bufferlist *bl,
   if (!warnings) {
     warnings = &oss;
   }
-  return load_from_buffer({bl->c_str(), bl->length()}, warnings) ? 0 : -EINVAL;
+  return parse_buffer({bl->c_str(), bl->length()}, warnings) ? 0 : -EINVAL;
 }
 
 int ConfFile::read(const std::string& section_name,

--- a/src/common/ConfUtils.h
+++ b/src/common/ConfUtils.h
@@ -70,6 +70,7 @@ public:
   ConfFile(const std::vector<conf_section_t>& sections);
   int parse_file(const std::string &fname, std::ostream *warnings);
   int parse_bufferlist(ceph::bufferlist *bl, std::ostream *warnings);
+  bool parse_buffer(std::string_view buf, std::ostream* warning);
   int read(const std::string& section, std::string_view key,
 	   std::string &val) const;
   static std::string normalize_key_name(std::string_view key);
@@ -80,8 +81,6 @@ public:
   void check_old_style_section_names(const std::vector<std::string>& prefixes,
 				     std::ostream& os);
 
-private:
-  bool load_from_buffer(std::string_view buf, std::ostream* warning);
 };
 
 std::ostream &operator<<(std::ostream& oss, const ConfFile& cf);

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -121,7 +121,9 @@ public:
   int parse_config_files(ConfigValues& values, const ConfigTracker& tracker,
 			 const char *conf_files,
 			 std::ostream *warnings, int flags);
-
+  int parse_buffer(ConfigValues& values, const ConfigTracker& tracker,
+		   const char* buf, size_t len,
+		   std::ostream *warnings);
   // Absorb config settings from the environment
   void parse_env(unsigned entity_type,
 		 ConfigValues& values, const ConfigTracker& tracker,
@@ -312,11 +314,12 @@ public:  // for global_init
   // for those want to reexpand special meta, e.g, $pid
   bool finalize_reexpand_meta(ConfigValues& values,
 			      const ConfigTracker& tracker);
-private:
+
   std::list<std::string> get_conffile_paths(const ConfigValues& values,
 					    const char *conf_files,
 					    std::ostream *warnings,
 					    int flags) const;
+private:
   static std::string get_cluster_name(const char* conffile_path);
   // The configuration file we read, or NULL if we haven't read one.
   ConfFile cf;

--- a/src/crimson/common/config_proxy.cc
+++ b/src/crimson/common/config_proxy.cc
@@ -46,5 +46,18 @@ void ConfigProxy::show_config(ceph::Formatter* f) const {
   get_config().show_config(*values, f);
 }
 
+seastar::future<> ConfigProxy::parse_config_files(const std::string& conf_files)
+{
+  return do_change([this, conf_files](ConfigValues& values) {
+    const char* conf_file_paths =
+      conf_files.empty() ? nullptr : conf_files.c_str();
+      get_config().parse_config_files(values,
+                                      obs_mgr,
+                                      conf_file_paths,
+                                      &std::cerr,
+                                      CODE_ENVIRONMENT_DAEMON);
+  });
+}
+
 ConfigProxy::ShardedConfig ConfigProxy::sharded_conf;
 }

--- a/src/crimson/common/config_proxy.cc
+++ b/src/crimson/common/config_proxy.cc
@@ -3,6 +3,20 @@
 
 #include "config_proxy.h"
 
+#if __has_include(<filesystem>)
+#include <filesystem>
+#else
+#include <experimental/filesystem>
+#endif
+
+#include "crimson/common/buffer_io.h"
+
+#if defined(__cpp_lib_filesystem)
+namespace fs = std::filesystem;
+#elif defined(__cpp_lib_experimental_filesystem)
+namespace fs = std::experimental::filesystem;
+#endif
+
 namespace crimson::common {
 
 ConfigProxy::ConfigProxy(const EntityName& name, std::string_view cluster)
@@ -48,14 +62,36 @@ void ConfigProxy::show_config(ceph::Formatter* f) const {
 
 seastar::future<> ConfigProxy::parse_config_files(const std::string& conf_files)
 {
-  return do_change([this, conf_files](ConfigValues& values) {
-    const char* conf_file_paths =
-      conf_files.empty() ? nullptr : conf_files.c_str();
-      get_config().parse_config_files(values,
-                                      obs_mgr,
-                                      conf_file_paths,
-                                      &std::cerr,
-                                      CODE_ENVIRONMENT_DAEMON);
+  auto conffile_paths =
+    get_config().get_conffile_paths(*values,
+                                    conf_files.empty() ? nullptr : conf_files.c_str(),
+                                    &std::cerr,
+                                    CODE_ENVIRONMENT_DAEMON);
+  return seastar::do_with(std::move(conffile_paths), [this] (auto& paths) {
+    return seastar::repeat([path=paths.begin(), e=paths.end(), this]() mutable {
+      if (path == e) {
+        // tried all conffile, none of them works
+        return seastar::make_ready_future<seastar::stop_iteration>(
+          seastar::stop_iteration::yes);
+      }
+      return crimson::read_file(*path++).then([this](auto&& buf) {
+        return do_change([buf=std::move(buf), this](ConfigValues& values) {
+          if (get_config().parse_buffer(values, obs_mgr, buf.get(), buf.size(), &std::cerr)) {
+            throw std::invalid_argument("parse error");
+          }
+        }).then([] {
+          // this one works!
+	  return seastar::make_ready_future<seastar::stop_iteration>(
+            seastar::stop_iteration::yes);
+        });
+      }).handle_exception_type([] (const fs::filesystem_error&) {
+        return seastar::make_ready_future<seastar::stop_iteration>(
+          seastar::stop_iteration::no);
+      }).handle_exception_type([] (const std::invalid_argument&) {
+        return seastar::make_ready_future<seastar::stop_iteration>(
+         seastar::stop_iteration::no);
+      });
+    });
   });
 }
 

--- a/src/crimson/common/config_proxy.h
+++ b/src/crimson/common/config_proxy.h
@@ -179,17 +179,7 @@ public:
     });
   }
 
-  seastar::future<> parse_config_files(const std::string& conf_files) {
-    return do_change([this, conf_files](ConfigValues& values) {
-      const char* conf_file_paths =
-	conf_files.empty() ? nullptr : conf_files.c_str();
-      get_config().parse_config_files(values,
-				      obs_mgr,
-				      conf_file_paths,
-				      &std::cerr,
-				      CODE_ENVIRONMENT_DAEMON);
-      });
-  }
+  seastar::future<> parse_config_files(const std::string& conf_files);
 
   using ShardedConfig = seastar::sharded<ConfigProxy>;
 

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -133,7 +133,7 @@ int main(int argc, char* argv[])
     usage(argv[0]);
     return EXIT_SUCCESS;
   }
-  std::string cluster_name;
+  std::string cluster_name{"ceph"};
   std::string conf_file_list;
   // ceph_argparse_early_args() could _exit(), while local_conf() won't ready
   // until it's started. so do the boilerplate-settings parsing here.

--- a/src/test/cli/ceph-conf/env-vs-args.t
+++ b/src/test/cli/ceph-conf/env-vs-args.t
@@ -2,9 +2,9 @@
   $ env CEPH_CONF=from-env ceph-conf -s foo bar
   did not load config file, using default settings.
   .* \-1 Errors while parsing config file! (re)
-  .* \-1 parse_file: filesystem error: .* file.size: (No such file or directory )?\[from-env\] (re)
+  .* \-1 can't open from-env: \(2\) (No such file or directory)? (re)
   .* \-1 Errors while parsing config file! (re)
-  .* \-1 parse_file: filesystem error: .* file.size: (No such file or directory )?\[from-env\] (re)
+  .* \-1 can't open from-env: \(2\) (No such file or directory)? (re)
   [1]
 
 # command-line arguments should override environment


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
