### PR TITLE
mgr/cephadm: fixup broken type annotation

### DIFF
--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -22,8 +22,8 @@ def name_to_config_section(name: str) -> str:
     else:
         return 'mon'
 
-def name_to_auth_entity(daemon_type,  # type: str
-                        daemon_id,    # type: str
+def name_to_auth_entity(daemon_type: str,
+                        daemon_id: str,
                         host = ""     # type  Optional[str] = ""
                         ):
     """

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -22,9 +22,10 @@ def name_to_config_section(name: str) -> str:
     else:
         return 'mon'
 
+
 def name_to_auth_entity(daemon_type: str,
                         daemon_id: str,
-                        host = ""     # type  Optional[str] = ""
+                        host: Optional[str] = None
                         ):
     """
     Map from daemon names/host to ceph entity names (as seen in config)
@@ -32,7 +33,7 @@ def name_to_auth_entity(daemon_type: str,
     if daemon_type in ['rgw', 'rbd-mirror', 'nfs', "iscsi"]:
         return 'client.' + daemon_type + "." + daemon_id
     elif daemon_type == 'crash':
-        if host == "":
+        if not host:
             raise OrchestratorError("Host not provided to generate <crash> auth entity name")
         return 'client.' + daemon_type + "." + host
     elif daemon_type == 'mon':

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -2,9 +2,11 @@ import logging
 import re
 import json
 from functools import wraps
-from typing import Optional, Callable, TypeVar, List
+from typing import TYPE_CHECKING, Optional, Callable, TypeVar, List
 from orchestrator import OrchestratorError
 
+if TYPE_CHECKING:
+    from mgr_module import MgrModule
 
 T = TypeVar('T')
 logger = logging.getLogger(__name__)
@@ -26,7 +28,7 @@ def name_to_config_section(name: str) -> str:
 def name_to_auth_entity(daemon_type: str,
                         daemon_id: str,
                         host: Optional[str] = None
-                        ):
+                        ) -> str:
     """
     Map from daemon names/host to ceph entity names (as seen in config)
     """
@@ -44,6 +46,7 @@ def name_to_auth_entity(daemon_type: str,
         return daemon_type + "." + daemon_id
     else:
         raise OrchestratorError("unknown auth entity name")
+
 
 def forall_hosts(f: Callable[..., T]) -> Callable[..., List[T]]:
     @wraps(f)
@@ -73,10 +76,10 @@ def forall_hosts(f: Callable[..., T]) -> Callable[..., List[T]]:
         assert CephadmOrchestrator.instance is not None
         return CephadmOrchestrator.instance._worker_pool.map(do_work, vals)
 
-
     return forall_hosts_wrapper
 
-def get_cluster_health(mgr):
+
+def get_cluster_health(mgr: "MgrModule") -> str:
     # check cluster health
     ret, out, err = mgr.check_mon_command({
         'prefix': 'health',


### PR DESCRIPTION
fix broken type annotation in `cephadm/utils.py`

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
