### PR TITLE
mds: distribute dirfrags for ephemeral distributed directory

### DIFF
--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -363,8 +363,8 @@ class CephFSTestCase(CephTestCase):
                     if filtered == test:
                         # Confirm export_pin in output is correct:
                         for s in subtrees:
-                            if s['export_pin'] >= 0:
-                                self.assertTrue(s['export_pin'] == s['auth_first'])
+                            if s['export_pin_target'] >= 0:
+                                self.assertTrue(s['export_pin_target'] == s['auth_first'])
                         return subtrees
                     if action is not None:
                         action()
@@ -384,7 +384,9 @@ class CephFSTestCase(CephTestCase):
             with contextutil.safe_while(sleep=5, tries=20) as proceed:
                 while proceed():
                     subtrees = self._get_subtrees(status=status, rank=rank, path=path)
-                    subtrees = list(filter(lambda s: s['distributed_ephemeral_pin'] == True, subtrees))
+                    subtrees = list(filter(lambda s: s['distributed_ephemeral_pin'] == True and
+                                                     s['auth_first'] == s['export_pin_target'],
+                                           subtrees))
                     log.info(f"len={len(subtrees)} {subtrees}")
                     if len(subtrees) >= count:
                         return subtrees
@@ -396,7 +398,9 @@ class CephFSTestCase(CephTestCase):
             with contextutil.safe_while(sleep=5, tries=20) as proceed:
                 while proceed():
                     subtrees = self._get_subtrees(status=status, rank=rank, path=path)
-                    subtrees = list(filter(lambda s: s['random_ephemeral_pin'] == True, subtrees))
+                    subtrees = list(filter(lambda s: s['random_ephemeral_pin'] == True and
+                                                     s['auth_first'] == s['export_pin_target'],
+                                           subtrees))
                     log.info(f"len={len(subtrees)} {subtrees}")
                     if len(subtrees) >= count:
                         return subtrees

--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -659,12 +659,10 @@ class TestSubvolumeGroups(TestVolumesHelper):
         group = "pinme"
         self._fs_cmd("subvolumegroup", "create", self.volname, group)
         self._fs_cmd("subvolumegroup", "pin", self.volname, group, "distributed", "True")
-        # (no effect on distribution) pin the group directory to 0 so rank 0 has all subtree bounds visible
-        self._fs_cmd("subvolumegroup", "pin", self.volname, group, "export", "0")
         subvolumes = self._generate_random_subvolume_name(10)
         for subvolume in subvolumes:
             self._fs_cmd("subvolume", "create", self.volname, subvolume, "--group_name", group)
-        self._wait_distributed_subtrees(10, status=status)
+        self._wait_distributed_subtrees(2 * 2, status=status, rank="all")
 
         # remove subvolumes
         for subvolume in subvolumes:

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8113,6 +8113,12 @@ std::vector<Option> get_mds_options() {
     .set_description("allow ephemeral distributed pinning of the loaded subtrees")
     .set_long_description("pin the immediate child directories of the loaded directory inode based on the consistent hash of the child's inode number. "),
 
+    Option("mds_export_ephemeral_distributed_factor", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(2.0)
+    .set_min_max(1.0, 100.0)
+    .set_flag(Option::FLAG_RUNTIME)
+    .set_description("multiple of max_mds for splitting and distributing directory"),
+
     Option("mds_bal_sample_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(3.0)
     .set_description("interval in seconds between balancer ticks"),

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -439,10 +439,7 @@ public:
            (int)get_frag_size() > g_conf()->mds_bal_split_size;
   }
   bool should_split_fast() const;
-  bool should_merge() const {
-    return get_frag() != frag_t() &&
-	   (int)get_frag_size() < g_conf()->mds_bal_merge_size;
-  }
+  bool should_merge() const;
 
   mds_authority_t authority() const override;
   mds_authority_t get_dir_auth() const { return dir_auth; }
@@ -546,6 +543,9 @@ public:
   void finish_waiting(uint64_t mask, int result = 0);    // ditto
 
   // -- import/export --
+  mds_rank_t get_export_pin(bool inherit=true) const;
+  bool is_exportable(mds_rank_t dest) const;
+
   void encode_export(ceph::buffer::list& bl);
   void finish_export();
   void abort_export() {

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -1052,24 +1052,22 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
     return !projected_parent.empty();
   }
 
-  mds_rank_t get_export_pin(bool inherit=true, bool ephemeral=true) const;
+  mds_rank_t get_export_pin(bool inherit=true) const;
+  void check_pin_policy(mds_rank_t target);
   void set_export_pin(mds_rank_t rank);
   void queue_export_pin(mds_rank_t target);
   void maybe_export_pin(bool update=false);
 
-  void check_pin_policy();
+  void set_ephemeral_pin(bool dist, bool rand);
+  void clear_ephemeral_pin(bool dist, bool rand);
 
-  void set_ephemeral_dist(bool yes);
-  void maybe_ephemeral_dist(bool update=false);
-  void maybe_ephemeral_dist_children(bool update=false);
   void setxattr_ephemeral_dist(bool val=false);
   bool is_ephemeral_dist() const {
     return state_test(STATE_DISTEPHEMERALPIN);
   }
 
-  double get_ephemeral_rand(bool inherit=true) const;
-  void set_ephemeral_rand(bool yes);
-  void maybe_ephemeral_rand(bool fresh=false, double threshold=-1.0);
+  double get_ephemeral_rand() const;
+  void maybe_ephemeral_rand(double threshold=-1.0);
   void setxattr_ephemeral_rand(double prob=0.0);
   bool is_ephemeral_rand() const {
     return state_test(STATE_RANDEPHEMERALPIN);
@@ -1082,13 +1080,6 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   bool is_ephemerally_pinned() const {
     return state_test(STATE_DISTEPHEMERALPIN) ||
            state_test(STATE_RANDEPHEMERALPIN);
-  }
-  bool is_exportable(mds_rank_t dest) const;
-
-  void maybe_pin() {
-    maybe_export_pin();
-    maybe_ephemeral_dist();
-    maybe_ephemeral_rand();
   }
 
   void print(std::ostream& out) override;

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -92,7 +92,10 @@ void MDBalancer::handle_conf_change(const std::set<std::string>& changed, const 
 
 void MDBalancer::handle_export_pins(void)
 {
-  auto &q = mds->mdcache->export_pin_queue;
+  const mds_rank_t max_mds = mds->mdsmap->get_max_mds();
+  auto mdcache = mds->mdcache;
+
+  auto &q = mdcache->export_pin_queue;
   auto it = q.begin();
   dout(20) << "export_pin_queue size=" << q.size() << dendl;
   while (it != q.end()) {
@@ -100,26 +103,47 @@ void MDBalancer::handle_export_pins(void)
     CInode *in = *cur;
     ceph_assert(in->is_dir());
 
-    in->check_pin_policy();
     mds_rank_t export_pin = in->get_export_pin(false);
-    if (export_pin >= mds->mdsmap->get_max_mds()) {
+    in->check_pin_policy(export_pin);
+
+    if (export_pin >= max_mds) {
       dout(20) << " delay export_pin=" << export_pin << " on " << *in << dendl;
       in->state_clear(CInode::STATE_QUEUEDEXPORTPIN);
       q.erase(cur);
 
       in->state_set(CInode::STATE_DELAYEDEXPORTPIN);
-      mds->mdcache->export_pin_delayed_queue.insert(in);
+      mdcache->export_pin_delayed_queue.insert(in);
       continue;
-    } else {
-      dout(20) << " executing export_pin=" << export_pin << " on " << *in << dendl;
     }
+
+    dout(20) << " executing export_pin=" << export_pin << " on " << *in << dendl;
+    unsigned min_frag_bits = 0;
+    mds_rank_t target = MDS_RANK_NONE;
+    if (export_pin >= 0)
+      target = export_pin;
+    else if (export_pin == MDS_RANK_EPHEMERAL_RAND)
+      target = mdcache->hash_into_rank_bucket(in->ino());
+    else if (export_pin == MDS_RANK_EPHEMERAL_DIST)
+      min_frag_bits = mdcache->get_ephemeral_dist_frag_bits();
 
     bool remove = true;
     for (auto&& dir : in->get_dirfrags()) {
       if (!dir->is_auth())
 	continue;
 
-      if (export_pin == MDS_RANK_NONE) {
+      if (export_pin == MDS_RANK_EPHEMERAL_DIST) {
+	if (dir->get_frag().bits() < min_frag_bits) {
+	  if (!dir->state_test(CDir::STATE_CREATING) &&
+	      !dir->is_frozen() && !dir->is_freezing()) {
+	    queue_split(dir, true);
+	  }
+	  remove = false;
+	  continue;
+	}
+	target = mdcache->hash_into_rank_bucket(in->ino(), dir->get_frag());
+      }
+
+      if (target == MDS_RANK_NONE) {
 	if (dir->state_test(CDir::STATE_AUXSUBTREE)) {
 	  if (dir->is_frozen() || dir->is_freezing()) {
 	    // try again later
@@ -130,7 +154,7 @@ void MDBalancer::handle_export_pins(void)
 	  dir->state_clear(CDir::STATE_AUXSUBTREE);
 	  mds->mdcache->try_subtree_merge(dir);
 	}
-      } else if (export_pin == mds->get_nodeid()) {
+      } else if (target == mds->get_nodeid()) {
         if (dir->state_test(CDir::STATE_AUXSUBTREE)) {
           ceph_assert(dir->is_subtree_root());
         } else if (dir->state_test(CDir::STATE_CREATING) ||
@@ -151,7 +175,7 @@ void MDBalancer::handle_export_pins(void)
          * be sent back by the importer.
          */
         if (dir->get_num_head_items() > 0) {
-	  mds->mdcache->migrator->export_dir(dir, export_pin);
+	  mds->mdcache->migrator->export_dir(dir, target);
         }
 	remove = false;
       }
@@ -163,7 +187,7 @@ void MDBalancer::handle_export_pins(void)
     }
   }
 
-  std::vector<CDir *> authsubs = mds->mdcache->get_auth_subtrees();
+  std::vector<CDir*> authsubs = mdcache->get_auth_subtrees();
   bool print_auth_subtrees = true;
 
   if (authsubs.size() > AUTH_TREES_THRESHOLD &&
@@ -175,18 +199,20 @@ void MDBalancer::handle_export_pins(void)
 
   for (auto &cd : authsubs) {
     mds_rank_t export_pin = cd->inode->get_export_pin();
+    cd->inode->check_pin_policy(export_pin);
 
-    if (print_auth_subtrees) {
-      dout(25) << "auth tree " << *cd << " export_pin=" << export_pin <<
-		  dendl;
+    if (export_pin == MDS_RANK_EPHEMERAL_DIST) {
+      export_pin = mdcache->hash_into_rank_bucket(cd->ino(), cd->get_frag());
+    } else if (export_pin == MDS_RANK_EPHEMERAL_RAND) {
+      export_pin = mdcache->hash_into_rank_bucket(cd->ino());
     }
 
-    if (export_pin >= 0 && export_pin < mds->mdsmap->get_max_mds()) {
-      if (export_pin == mds->get_nodeid()) {
-        cd->get_inode()->check_pin_policy();
-      } else {
-        mds->mdcache->migrator->export_dir(cd, export_pin);
-      }
+    if (print_auth_subtrees)
+      dout(25) << "auth tree " << *cd << " export_pin=" << export_pin << dendl;
+
+    if (export_pin >= 0 && export_pin != mds->get_nodeid() &&
+	export_pin < mds->mdsmap->get_max_mds()) {
+      mdcache->migrator->export_dir(cd, export_pin);
     }
   }
 }
@@ -521,10 +547,10 @@ void MDBalancer::queue_split(const CDir *dir, bool fast)
   dout(10) << __func__ << " enqueuing " << *dir
                        << " (fast=" << fast << ")" << dendl;
 
-  const dirfrag_t frag = dir->dirfrag();
+  const dirfrag_t df = dir->dirfrag();
 
-  auto callback = [this, frag](int r) {
-    if (split_pending.erase(frag) == 0) {
+  auto callback = [this, df](int r) {
+    if (split_pending.erase(df) == 0) {
       // Someone beat me to it.  This can happen in the fast splitting
       // path, because we spawn two contexts, one with mds->timer and
       // one with mds->queue_waiter.  The loser can safely just drop
@@ -532,27 +558,32 @@ void MDBalancer::queue_split(const CDir *dir, bool fast)
       return;
     }
 
-    CDir *split_dir = mds->mdcache->get_dirfrag(frag);
-    if (!split_dir) {
-      dout(10) << "drop split on " << frag << " because not in cache" << dendl;
+    auto mdcache = mds->mdcache;
+
+    CDir *dir = mdcache->get_dirfrag(df);
+    if (!dir) {
+      dout(10) << "drop split on " << df << " because not in cache" << dendl;
       return;
     }
-    if (!split_dir->is_auth()) {
-      dout(10) << "drop split on " << frag << " because non-auth" << dendl;
+    if (!dir->is_auth()) {
+      dout(10) << "drop split on " << df << " because non-auth" << dendl;
       return;
     }
 
     // Pass on to MDCache: note that the split might still not
     // happen if the checks in MDCache::can_fragment fail.
-    dout(10) << __func__ << " splitting " << *split_dir << dendl;
-    mds->mdcache->split_dir(split_dir, g_conf()->mds_bal_split_bits);
+    dout(10) << __func__ << " splitting " << *dir << dendl;
+    int bits = g_conf()->mds_bal_split_bits;
+    if (dir->inode->is_ephemeral_dist()) {
+      unsigned min_frag_bits = mdcache->get_ephemeral_dist_frag_bits();
+      if (df.frag.bits() + bits < min_frag_bits)
+	bits = min_frag_bits - df.frag.bits();
+    }
+    mdcache->split_dir(dir, bits);
   };
 
-  bool is_new = false;
-  if (split_pending.count(frag) == 0) {
-    split_pending.insert(frag);
-    is_new = true;
-  }
+  auto ret = split_pending.insert(df);
+  bool is_new = ret.second;
 
   if (fast) {
     // Do the split ASAP: enqueue it in the MDSRank waiters which are
@@ -579,7 +610,8 @@ void MDBalancer::queue_merge(CDir *dir)
     // starting one), and this context is the only one that erases it.
     merge_pending.erase(frag);
 
-    CDir *dir = mds->mdcache->get_dirfrag(frag);
+    auto mdcache = mds->mdcache;
+    CDir *dir = mdcache->get_dirfrag(frag);
     if (!dir) {
       dout(10) << "drop merge on " << frag << " because not in cache" << dendl;
       return;
@@ -595,8 +627,12 @@ void MDBalancer::queue_merge(CDir *dir)
 
     CInode *diri = dir->get_inode();
 
+    unsigned min_frag_bits = 0;
+    if (diri->is_ephemeral_dist())
+      min_frag_bits = mdcache->get_ephemeral_dist_frag_bits();
+
     frag_t fg = dir->get_frag();
-    while (fg != frag_t()) {
+    while (fg.bits() > min_frag_bits) {
       frag_t sibfg = fg.get_sibling();
       auto&& [complete, sibs] = diri->get_dirfrags_under(sibfg);
       if (!complete) {
@@ -619,7 +655,7 @@ void MDBalancer::queue_merge(CDir *dir)
     }
 
     if (fg != dir->get_frag())
-      mds->mdcache->merge_dir(diri, fg);
+      mdcache->merge_dir(diri, fg);
   };
 
   if (merge_pending.count(frag) == 0) {

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -212,6 +212,9 @@ class MDCache {
 
   void advance_stray();
 
+  unsigned get_ephemeral_dist_frag_bits() const {
+    return export_ephemeral_dist_frag_bits;
+  }
   bool get_export_ephemeral_distributed_config(void) const {
     return export_ephemeral_distributed_config;
   }
@@ -232,7 +235,7 @@ class MDCache {
     stray_manager.eval_stray(dn);
   }
 
-  mds_rank_t hash_into_rank_bucket(inodeno_t ino);
+  mds_rank_t hash_into_rank_bucket(inodeno_t ino, frag_t fg=0);
 
   void maybe_eval_stray(CInode *in, bool delay=false);
   void clear_dirty_bits_for_stray(CInode* diri);
@@ -991,8 +994,7 @@ class MDCache {
   /* Because exports may fail, this set lets us keep track of inodes that need exporting. */
   std::set<CInode *> export_pin_queue;
   std::set<CInode *> export_pin_delayed_queue;
-  std::set<CInode *> rand_ephemeral_pins;
-  std::set<CInode *> dist_ephemeral_pins;
+  std::set<CInode *> export_ephemeral_pins;
 
   OpenFileTable open_file_table;
 
@@ -1308,6 +1310,7 @@ class MDCache {
 
   bool export_ephemeral_distributed_config;
   bool export_ephemeral_random_config;
+  unsigned export_ephemeral_dist_frag_bits;
 
   // File size recovery
   RecoveryQueue recovery_queue;

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2944,11 +2944,13 @@ void MDSRank::command_get_subtrees(Formatter *f)
     {
       f->dump_bool("is_auth", dir->is_auth());
       f->dump_int("auth_first", dir->get_dir_auth().first);
-      f->dump_int("auth_second", dir->get_dir_auth().second);
-      f->dump_int("export_pin", dir->inode->get_export_pin(false, false));
-      f->dump_bool("distributed_ephemeral_pin", dir->inode->is_ephemeral_dist());
-      f->dump_bool("random_ephemeral_pin", dir->inode->is_ephemeral_rand());
-      f->dump_int("ephemeral_pin", mdcache->hash_into_rank_bucket(dir->inode->ino()));
+      f->dump_int("auth_second", dir->get_dir_auth().second); {
+	mds_rank_t export_pin = dir->inode->get_export_pin(false);
+	f->dump_int("export_pin", export_pin >= 0 ? export_pin : -1);
+	f->dump_bool("distributed_ephemeral_pin", export_pin == MDS_RANK_EPHEMERAL_DIST);
+	f->dump_bool("random_ephemeral_pin", export_pin == MDS_RANK_EPHEMERAL_RAND);
+      }
+      f->dump_int("export_pin_target", dir->get_export_pin(false));
       f->open_object_section("dir");
       dir->dump(f);
       f->close_section();

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -790,7 +790,7 @@ void Migrator::export_dir(CDir *dir, mds_rank_t dest)
   ceph_assert(dest != mds->get_nodeid());
    
   CDir* parent = dir->inode->get_projected_parent_dir();
-  if (!mds->is_stopping() && !dir->inode->is_exportable(dest) && dir->get_num_head_items() > 0) {
+  if (!mds->is_stopping() && !dir->is_exportable(dest) && dir->get_num_head_items() > 0) {
     dout(7) << "Cannot export to mds." << dest << " " << *dir << ": dir is export pinned" << dendl;
     return;
   } else if (!(mds->is_active() || mds->is_stopping())) {
@@ -3472,7 +3472,6 @@ void Migrator::decode_import_dir(bufferlist::const_iterator& blp,
     dir->verify_fragstat();
 #endif
 
-  dir->inode->maybe_ephemeral_dist();
   dir->inode->maybe_export_pin();
 
   dout(7) << " done " << *dir << dendl;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -6022,8 +6022,7 @@ public:
       get_mds()->locker->share_inode_max_size(newi);
     } else if (newi->is_dir()) {
       // We do this now so that the linkages on the new directory are stable.
-      newi->maybe_ephemeral_dist();
-      newi->maybe_ephemeral_rand(true);
+      newi->maybe_ephemeral_rand();
     }
 
     // hit pop

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -566,10 +566,8 @@ void EMetaBlob::fullbit::update_inode(MDSRank *mds, CInode *in)
   if (in->is_dir()) {
     if (is_export_ephemeral_random()) {
       dout(15) << "random ephemeral pin on " << *in << dendl;
-      in->set_ephemeral_rand(true);
-      in->maybe_ephemeral_rand(true);
+      in->set_ephemeral_pin(false, true);
     }
-    in->maybe_ephemeral_dist();
     in->maybe_export_pin();
     if (!(in->dirfragtree == dirfragtree)) {
       dout(10) << "EMetaBlob::fullbit::update_inode dft " << in->dirfragtree << " -> "

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -71,7 +71,9 @@
 #define MDS_INO_STRAY_INDEX(i) (((unsigned (i)) - MDS_INO_STRAY_OFFSET) % NUM_STRAY)
 
 typedef int32_t mds_rank_t;
-constexpr mds_rank_t MDS_RANK_NONE = -1;
+constexpr mds_rank_t MDS_RANK_NONE		= -1;
+constexpr mds_rank_t MDS_RANK_EPHEMERAL_DIST	= -2;
+constexpr mds_rank_t MDS_RANK_EPHEMERAL_RAND	= -3;
 
 BOOST_STRONG_TYPEDEF(uint64_t, mds_gid_t)
 extern const mds_gid_t MDS_GID_NONE;


### PR DESCRIPTION
Instead of distribute individual dir inodes inside the ephemeral
distributed dir. Distributing dirfrags can limit number of subtrees
created by the ephemeral dist pin.

This patch also unifies codes that handle export pin and ephemeral pin.

Fixes: https://tracker.ceph.com/issues/46696
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
