### PR TITLE
doc/cephadm: Remove shell alias

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -130,9 +130,9 @@ command.  There are several ways to do this:
 
     # cephadm shell
 
-* It may be helpful to create an alias::
+* To execute ``ceph`` commands, you can also run commands like so::
 
-    # alias ceph='cephadm shell -- ceph'
+    # cephadm shell -- ceph -s
 
 * You can install the ``ceph-common`` package, which contains all of the
   ceph commands, including ``ceph``, ``rbd``, ``mount.ceph`` (for mounting


### PR DESCRIPTION
Turns out, the alias doesn't work for files.

Fixes: https://tracker.ceph.com/issues/46701

Fixes:

```
$ ceph orch apply -i myfile.yaml
ERROR: no such file or directory: myfile.yaml
```

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>
Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
