### PR TITLE
rgw: support obj encryption stack on compression

### DIFF
--- a/src/rgw/rgw_compression.h
+++ b/src/rgw/rgw_compression.h
@@ -42,6 +42,9 @@ class RGWPutObj_Compress : public rgw::putobj::Pipe
   CompressorRef compressor;
   boost::optional<int32_t> compressor_message;
   std::vector<compression_block> blocks;
+  uint64_t compressed_ofs{0};
+  off_t in_len{0};
+  off_t out_len{0};
 public:
   RGWPutObj_Compress(CephContext* cct_, CompressorRef compressor,
                      rgw::putobj::DataProcessor *next)


### PR DESCRIPTION
add implementation for obj encryption stack on compression. Compressing first and then encrypting.

Fixes: https://tracker.ceph.com/issues/19988

Signed-off-by: Dai Zhiwei daizhiwei3@huawei.com
Signed-off-by: luo rixin luorixin@huawei.com
