### PR TITLE
vstart_runner: don't quit running testsuite on a test failure

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -1341,6 +1341,7 @@ def clear_old_log():
 class LogStream(object):
     def __init__(self):
         self.buffer = ""
+        self.omit_result_lines = False
 
     def _del_result_lines(self):
         """
@@ -1348,8 +1349,9 @@ class LogStream(object):
         vstart_runner.py will do it for itself since it runs tests in a
         testsuite one by one.
         """
-        self.buffer = re.sub('-'*70+'\nran [0-9]* test in [0-9.]*s\n*',
-                             '', self.buffer, flags=re.I)
+        if self.omit_result_lines:
+            self.buffer = re.sub('-'*70+'\nran [0-9]* test in [0-9.]*s\n*',
+                                 '', self.buffer, flags=re.I)
         self.buffer = re.sub('failed \(failures=[0-9]*\)\n', '', self.buffer,
                              flags=re.I)
         self.buffer = self.buffer.replace('OK\n', '')


### PR DESCRIPTION
Add an option that makes it possible to not to quit running testsuite on
a test failure. This way user can get a better idea on the current state
of the testsuite and test its own patch more effectively and easily.
    




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>