### PR TITLE
crimson/admin: Add a hook for Seastar metrics

### DIFF
--- a/src/crimson/admin/osd_admin.cc
+++ b/src/crimson/admin/osd_admin.cc
@@ -9,6 +9,7 @@
 #include <seastar/core/do_with.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/thread.hh>
+#include <seastar/core/scollectd_api.hh>
 
 #include "common/config.h"
 #include "crimson/admin/admin_socket.h"
@@ -156,5 +157,35 @@ public:
   }
 };
 template std::unique_ptr<AdminSocketHook> make_asok_hook<AssertAlwaysHook>();
+
+/**
+* A Seastar admin hook: fetching the values of configured metrics
+*/
+class SeastarMetricsHook : public AdminSocketHook {
+public:
+ SeastarMetricsHook()  :
+   AdminSocketHook("perf dump_seastar",
+      "",
+      "dump current configured seastar metrics and their values")
+ {}
+ seastar::future<tell_result_t> call(const cmdmap_t& cmdmap,
+             std::string_view format,
+             ceph::bufferlist&& input) const final
+ {
+   std::unique_ptr<Formatter> f{Formatter::create(format, "json-pretty", "json-pretty")};
+   f->open_object_section("perf_dump_seastar");
+   for (const auto& mf : seastar::scollectd::get_value_map()) {
+     for (const auto& m : mf.second) {
+       if (m.second && m.second->is_enabled()) {
+         auto& metric_function = m.second->get_function();
+         f->dump_float(m.second->get_id().full_name(), metric_function().d());
+       }
+     }
+   }
+   f->close_section();
+   return seastar::make_ready_future<tell_result_t>(f.get());
+ }
+};
+template std::unique_ptr<AdminSocketHook> make_asok_hook<SeastarMetricsHook>();
 
 } // namespace crimson::admin

--- a/src/crimson/admin/osd_admin.h
+++ b/src/crimson/admin/osd_admin.h
@@ -13,6 +13,8 @@ class FlushPgStatsHook;
 class OsdStatusHook;
 class SendBeaconHook;
 class DumpPGStateHistory;
+class SeastarMetricsHook;
+
 
 template<class Hook, class... Args>
 std::unique_ptr<AdminSocketHook> make_asok_hook(Args&&... args);

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -430,7 +430,8 @@ seastar::future<> OSD::start_asok_admin()
       asok->register_command(make_asok_hook<OsdStatusHook>(std::as_const(*this))),
       asok->register_command(make_asok_hook<SendBeaconHook>(*this)),
       asok->register_command(make_asok_hook<FlushPgStatsHook>(*this)),
-      asok->register_command(make_asok_hook<DumpPGStateHistory>(std::as_const(*this))));
+      asok->register_command(make_asok_hook<DumpPGStateHistory>(std::as_const(*this))),
+      asok->register_command(make_asok_hook<SeastarMetricsHook>()));
   }).then_unpack([] {
     return seastar::now();
   });


### PR DESCRIPTION
This PR adds a new admin socket hook/command which extracts real-time metrics from the Seastar reactor.
In the future, this can be integrated with CBT.

Signed-off-by: Amnon Hanuhov <ahanukov@redhat.com>