### PR TITLE
mgr/dashboard: correct color names which are not defined

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.scss
@@ -10,8 +10,8 @@
 
 a {
   .dot {
-    background-color: bd.$color-primary;
-    border: 2px solid bd.$color-navbar-bg;
+    background-color: bd.$primary;
+    border: 2px solid bd.$secondary;
     border-radius: 50%;
     height: 11px;
     position: absolute;
@@ -21,7 +21,7 @@ a {
   }
 
   &:hover .dot {
-    background-color: bd.$color-solid-white;
-    border-color: bd.$color-primary;
+    background-color: bd.$white;
+    border-color: bd.$primary;
   }
 }


### PR DESCRIPTION
```
ERROR in Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
SassError: Undefined variable.
   ╷
13 │     background-color: bd.$color-primary;
   │                       ^^^^^^^^^^^^^^^^^
   ╵
  /ceph/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.scss 13:23  root stylesheet
```

Rename some color names that have been changed by the mentioned PR.

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
