### PR TITLE
common/buffer.cc: Implement dynamic alen in refill_append_space

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -48,6 +48,10 @@ using namespace ceph;
 #define CEPH_BUFFER_ALLOC_UNIT  4096u
 #define CEPH_BUFFER_APPEND_SIZE (CEPH_BUFFER_ALLOC_UNIT - sizeof(raw_combined))
 
+// 256K is the maximum "small" object size in tcmalloc above which allocations come from
+// the central heap.  For now let's keep this below that threshold.
+#define CEPH_BUFFER_ALLOC_UNIT_MAX std::size_t { 256*1024 }
+
 #ifdef BUFFER_DEBUG
 static ceph::spinlock debug_lock;
 # define bdout { std::lock_guard<ceph::spinlock> lg(debug_lock); std::cout
@@ -1324,8 +1328,14 @@ static ceph::spinlock debug_lock;
     // make a new buffer.  fill out a complete page, factoring in the
     // raw_combined overhead.
     size_t need = round_up_to(len, sizeof(size_t)) + sizeof(raw_combined);
-    size_t alen = round_up_to(need, CEPH_BUFFER_ALLOC_UNIT) -
-      sizeof(raw_combined);
+    size_t alen = round_up_to(need, CEPH_BUFFER_ALLOC_UNIT);
+    if (_carriage == &_buffers.back()) {
+      size_t nlen = round_up_to(_carriage->raw_length(), CEPH_BUFFER_ALLOC_UNIT) * 2;
+      nlen = std::min(nlen, CEPH_BUFFER_ALLOC_UNIT_MAX);
+      alen = std::max(alen, nlen);
+    }
+    alen -= sizeof(raw_combined);
+
     auto new_back = \
       ptr_node::create(raw_combined::create(alen, 0, get_mempool()));
     new_back->set_length(0);   // unused, so far.

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1349,6 +1349,22 @@ TEST(BufferList, BenchAlloc) {
   bench_bufferlist_alloc(4, 100000, 16);
 }
 
+/*
+ * append_bench tests now have multiple variants:
+ *
+ * Version 1 tests allocate a single bufferlist during loop iteration.
+ * Ultimately very little memory is utilized since the bufferlist immediately
+ * drops out of scope. This was the original variant of these tests but showed
+ * unexpected performance characteristics that appears to be tied to tcmalloc
+ * and/or kernel behavior depending on the bufferlist size and step size.
+ *
+ * Version 2 tests allocate a configurable number of bufferlists that are
+ * replaced round-robin during loop iteration.  Version 2 tests are designed
+ * to better mimic performance when multiple bufferlists are in memory at the
+ * same time.  During testing this showed more consistent and seemingly
+ * accurate behavior across bufferlist and step sizes.
+ */
+
 TEST(BufferList, append_bench_with_size_hint) {
   std::array<char, 1048576> src = { 0, };
 
@@ -1370,12 +1386,39 @@ TEST(BufferList, append_bench_with_size_hint) {
   }
 }
 
-TEST(BufferList, append_bench) {
+TEST(BufferList, append_bench_with_size_hint2) {
   std::array<char, 1048576> src = { 0, };
+  constexpr size_t rounds = 4000;
+  constexpr int conc_bl = 400;
+  std::vector<ceph::bufferlist*> bls(conc_bl);
 
+  for (int i = 0; i < conc_bl; i++) {
+    bls[i] = new ceph::bufferlist;
+  }
   for (size_t step = 4; step <= 16384; step *= 4) {
     const utime_t start = ceph_clock_now();
+    for (size_t r = 0; r < rounds; ++r) {
+      delete bls[r % conc_bl];
+      bls[r % conc_bl] = new ceph::bufferlist(std::size(src));
+      for (auto iter = std::begin(src);
+           iter != std::end(src);
+           iter = std::next(iter, step)) {
+        bls[r % conc_bl]->append(&*iter, step);
+      }
+    }
+    cout << rounds << " fills of buffer len " << src.size()
+         << " with " << step << " byte appends in "
+         << (ceph_clock_now() - start) << std::endl;
+  }
+  for (int i = 0; i < conc_bl; i++) {
+    delete bls[i];
+  }
+}
 
+TEST(BufferList, append_bench) {
+  std::array<char, 1048576> src = { 0, };
+  for (size_t step = 4; step <= 16384; step *= 4) {
+    const utime_t start = ceph_clock_now();
     constexpr size_t rounds = 4000;
     for (size_t r = 0; r < rounds; ++r) {
       ceph::bufferlist bl;
@@ -1388,6 +1431,80 @@ TEST(BufferList, append_bench) {
     cout << rounds << " fills of buffer len " << src.size()
 	 << " with " << step << " byte appends in "
 	 << (ceph_clock_now() - start) << std::endl;
+  }
+}
+
+TEST(BufferList, append_bench2) {
+  std::array<char, 1048576> src = { 0, };
+  constexpr size_t rounds = 4000;
+  constexpr int conc_bl = 400;
+  std::vector<ceph::bufferlist*> bls(conc_bl);
+
+  for (int i = 0; i < conc_bl; i++) {
+    bls[i] = new ceph::bufferlist;
+  }
+  for (size_t step = 4; step <= 16384; step *= 4) {
+    const utime_t start = ceph_clock_now();
+    for (size_t r = 0; r < rounds; ++r) {
+      delete bls[r % conc_bl];
+      bls[r % conc_bl] = new ceph::bufferlist;
+      for (auto iter = std::begin(src);
+	   iter != std::end(src);
+	   iter = std::next(iter, step)) {
+	bls[r % conc_bl]->append(&*iter, step);
+      }
+    }
+    cout << rounds << " fills of buffer len " << src.size()
+	 << " with " << step << " byte appends in "
+	 << (ceph_clock_now() - start) << std::endl;
+  }
+  for (int i = 0; i < conc_bl; i++) {
+    delete bls[i];
+  }
+}
+
+TEST(BufferList, append_hole_bench) {
+  constexpr size_t targeted_bl_size = 1048576;
+
+  for (size_t step = 512; step <= 65536; step *= 2) {
+    const utime_t start = ceph_clock_now();
+    constexpr size_t rounds = 80000;
+    for (size_t r = 0; r < rounds; ++r) {
+      ceph::bufferlist bl;
+      while (bl.length() < targeted_bl_size) {
+	bl.append_hole(step);
+      }
+    }
+    cout << rounds << " fills of buffer len " << targeted_bl_size
+	 << " with " << step << " byte long append_hole in "
+	 << (ceph_clock_now() - start) << std::endl;
+  }
+}
+
+TEST(BufferList, append_hole_bench2) {
+  constexpr size_t targeted_bl_size = 1048576;
+  constexpr size_t rounds = 80000;
+  constexpr int conc_bl = 400;
+  std::vector<ceph::bufferlist*> bls(conc_bl);
+
+  for (int i = 0; i < conc_bl; i++) {
+    bls[i] = new ceph::bufferlist;
+  }
+  for (size_t step = 512; step <= 65536; step *= 2) {
+    const utime_t start = ceph_clock_now();
+    for (size_t r = 0; r < rounds; ++r) {
+      delete bls[r % conc_bl];
+      bls[r % conc_bl] = new ceph::bufferlist;
+      while (bls[r % conc_bl]->length() < targeted_bl_size) {
+	bls[r % conc_bl]->append_hole(step);
+      }
+    }
+    cout << rounds << " fills of buffer len " << targeted_bl_size
+	 << " with " << step << " byte long append_hole in "
+	 << (ceph_clock_now() - start) << std::endl;
+  }
+  for (int i = 0; i < conc_bl; i++) {
+    delete bls[i];
   }
 }
 


### PR DESCRIPTION
This is the first PR that @rzarzynski and I developed in our effort to improve bufferlist append and append_hole performance.  It does not include the per-thread ring buffer, but rather only implements the dynamic append length changes and @rzarzynski's new append_hole benchmark for testing.

So far these changes appear to help dramatically in microbenchmarks and appear to help reduce tcmalloc overhead in real tests, though it's been difficult so far to tease out performance gains in our target code (MDS dirlump encoding during journaling) due to other bottlenecks.  In any event, I have not yet seen any cases where this appears to hurt performance in any way.

### append_bench (4000 fills of buffer len 1048576):
append size (bytes) | master | dynamic_alen | dynamic_alen + ring_buffer
-- | -- | -- | --
4 | 12.858250 | 12.193041 | 11.174737
16 | 4.886555 | 4.427386 | 3.342223
64 | 2.409864 | 1.994269 | 1.031621
256 | 1.844059 | 1.416273 | 0.413652
1024 | 1.761385 | 0.349366 | 0.368927
4096 | 1.727695 | 0.331894 | 0.344841
16384 | 1.533571 | 0.244583 | 0.269231

### append_hole_bench (80000 fills of buffer len 1048576):
append_hole size (bytes) | master | dynamic_alen | dynamic_alen + ring_buffer
-- | -- | -- | --
512 | 32.345912 | 2.337284 | 1.497456
1024 | 37.694357 | 0.856610 | 0.824889
2048 | 11.371681 | 0.487344 | 0.478096
4096 | 29.341005 | 0.288370 | 0.296215
8192 | 14.060870 | 0.175921 | 0.191394
16384 | 7.106426 | **0.910349** | 0.150365
32768 | 3.636371 | **0.874957** | 0.111889
65536 | 2.177889 | **0.843771** | 0.084226

* After significant testing, tcmalloc appears to have unexpected slowdowns at different request sizes depending on CEPH_BUFFER_ALLOC_UNIT_BASE and CEPH_BUFFER_ALLOC_UNIT_MAX.  This even happens when using the ring_buffer if the max ring buffer allocation unit is 32-64k and the buffer length is set to 4MB or higher allowing large allocations to come from the central heap (these should not touch tcmalloc's own per-thread cache).  It is not yet clear what tcmalloc is doing in these situations, but allocating from the ring buffer is consistently fast but may run out of space in practice.  Ultimately there will be a trade-off between how much per-thread ring-buffer cache we allocate and at what request size we fallback to tcmalloc's central heap.

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [X] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
