### PR TITLE
mds: fix kcephfs parse dirfrag's ndist is always 0

### DIFF
--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -447,7 +447,7 @@ public:
 
   // for giving to clients
   void get_dist_spec(std::set<mds_rank_t>& ls, mds_rank_t auth) {
-    if (is_rep()) {
+    if (is_auth()) {
       list_replicas(ls);
       if (!ls.empty()) 
 	ls.insert(auth);


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/46891
Signed-off-by: Yanhu Cao <gmayyyha@gmail.com>

