### PR TITLE
octopus: mgr/dashboard/api: increase API health timeout

### DIFF
--- a/qa/tasks/mgr/dashboard/helper.py
+++ b/qa/tasks/mgr/dashboard/helper.py
@@ -21,6 +21,9 @@ class DashboardTestCase(MgrTestCase):
     # Display full error diffs
     maxDiff = None
 
+    # Increased x3 (20 -> 60)
+    TIMEOUT_HEALTH_CLEAR = 60
+
     MGRS_REQUIRED = 2
     MDSS_REQUIRED = 1
     REQUIRE_FILESYSTEM = True
@@ -186,7 +189,7 @@ class DashboardTestCase(MgrTestCase):
         super(DashboardTestCase, self).setUp()
         if not self._loggedin and self.AUTO_AUTHENTICATE:
             self.login('admin', 'admin')
-        self.wait_for_health_clear(20)
+        self.wait_for_health_clear(self.TIMEOUT_HEALTH_CLEAR)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46895

---

backport of https://github.com/ceph/ceph/pull/36157
parent tracker: https://tracker.ceph.com/issues/46601

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh