### PR TITLE
mgr/dashboard: Strange iSCSI discovery auth behavior

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html
@@ -17,7 +17,8 @@
             <input id="user"
                    class="form-control"
                    formControlName="user"
-                   type="text">
+                   type="text"
+                   autocomplete="off">
             <span class="invalid-feedback"
                   *ngIf="discoveryForm.showError('user', formDir, 'required')"
                   i18n>This field is required.</span>
@@ -39,7 +40,8 @@
               <input id="password"
                      class="form-control"
                      formControlName="password"
-                     type="password">
+                     type="password"
+                     autocomplete="new-password">
 
               <span class="input-group-append">
                 <button type="button"
@@ -73,7 +75,8 @@
             <input id="mutual_user"
                    class="form-control"
                    formControlName="mutual_user"
-                   type="text">
+                   type="text"
+                   autocomplete="off">
 
             <span class="invalid-feedback"
                   *ngIf="discoveryForm.showError('mutual_user', formDir, 'required')"
@@ -96,7 +99,8 @@
               <input id="mutual_password"
                      class="form-control"
                      formControlName="mutual_password"
-                     type="password">
+                     type="password"
+                     autocomplete="new-password">
 
               <span class="input-group-append">
                 <button type="button"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
@@ -213,6 +213,7 @@
             <div class="cd-col-form-input">
               <input class="form-control"
                      type="text"
+                     autocomplete="off"
                      id="target_user"
                      name="target_user"
                      formControlName="user" />
@@ -274,6 +275,7 @@
             <div class="cd-col-form-input">
               <input class="form-control"
                      type="text"
+                     autocomplete="off"
                      id="target_mutual_user"
                      name="target_mutual_user"
                      formControlName="mutual_user" />
@@ -385,6 +387,7 @@
                       <input [id]="'user' + ii"
                              class="form-control"
                              formControlName="user"
+                             autocomplete="off"
                              type="text">
                       <span class="invalid-feedback"
                             *ngIf="initiator.showError('user', formDir, 'required')"
@@ -407,6 +410,7 @@
                         <input [id]="'password' + ii"
                                class="form-control"
                                formControlName="password"
+                               autocomplete="new-password"
                                type="password">
 
                         <span class="input-group-append">
@@ -442,6 +446,7 @@
                       <input [id]="'mutual_user' + ii"
                              class="form-control"
                              formControlName="mutual_user"
+                             autocomplete="off"
                              type="text">
 
                       <span class="invalid-feedback"
@@ -465,6 +470,7 @@
                         <input [id]="'mutual_password' + ii"
                                class="form-control"
                                formControlName="mutual_password"
+                               autocomplete="new-password"
                                type="password">
 
                         <span class="input-group-append">


### PR DESCRIPTION
Disable 'autocomplete' for the user and password form fields.

Before:
![scre](https://user-images.githubusercontent.com/1897962/89900129-9d386780-dbe3-11ea-815f-c9122c781054.gif)

![Bildschirmfoto vom 2020-08-12 11-52-22](https://user-images.githubusercontent.com/1897962/90002675-44280c80-dc93-11ea-92b1-d54623c83b0f.png)

Check the tracker issue for more examples.

Fixes: https://tracker.ceph.com/issues/46900

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
