### PR TITLE
cephadm: remove py2 from tox tests

### DIFF
--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py3, mypy
+envlist = py3, mypy
 skipsdist=true
 
 [testenv]


### PR DESCRIPTION
cephadm is dependent on py3, and the presence of py2 in
tox is just going to throw more errors over time as py3
idioms are adopted. py2 is EOL, and older hosts should
have py3 available as an installation option anyway.

This patch just removes py2 from the tox test.

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>