### PR TITLE
mon: use string_veiw to glimpse string and remove unused variable

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3268,7 +3268,6 @@ void Monitor::handle_command(MonOpRequestRef op)
     return;
   }
 
-  string module;
   string err;
 
   dout(0) << "handle_command " << *m << dendl;
@@ -3287,7 +3286,7 @@ void Monitor::handle_command(MonOpRequestRef op)
     return;
   }
 
-  module = fullcmd[0];
+  std::string_view module = fullcmd[0];
 
   // validate command is in leader map
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3268,8 +3268,6 @@ void Monitor::handle_command(MonOpRequestRef op)
     return;
   }
 
-  string err;
-
   dout(0) << "handle_command " << *m << dendl;
 
   string format;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5390,7 +5390,6 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	   prefix == "osd getcrushmap" ||
 	   prefix == "osd ls-tree" ||
 	   prefix == "osd info") {
-    string val;
 
     epoch_t epoch = 0;
     int64_t epochnum;


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
