### PR TITLE
nautilus: mgr/diskprediction_local: Fix array size error

### DIFF
--- a/src/pybind/mgr/diskprediction_local/module.py
+++ b/src/pybind/mgr/diskprediction_local/module.py
@@ -167,7 +167,7 @@ class Module(MgrModule):
         else:
             self.log.error('unable to predict device due to health data records less than 6 days')
 
-        if predict_datas:
+        if len(predict_datas) >= 6:
             predicted_result = obj_predictor.predict(predict_datas)
         return predicted_result
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46716

---

backport of https://github.com/ceph/ceph/pull/36115
parent tracker: https://tracker.ceph.com/issues/46549

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh