### PR TITLE
octopus: ceph-volume: run flake8 in python3

### DIFF
--- a/src/ceph-volume/tox.ini
+++ b/src/ceph-volume/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py3, flake8
+envlist = py36, py3, py3-flake8
 skip_missing_interpreters = true
 
 [testenv]
@@ -9,7 +9,7 @@ deps=
 install_command=./tox_install_command.sh {opts} {packages}
 commands=py.test -v {posargs:ceph_volume/tests} --ignore=ceph_volume/tests/functional
 
-[testenv:flake8]
+[testenv:py3-flake8]
 deps=flake8
 commands=flake8 {posargs:ceph_volume}
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46911

---

backport of https://github.com/ceph/ceph/pull/36565
parent tracker: https://tracker.ceph.com/issues/46897

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh