### PR TITLE
client: make the send_to_auth display of mds_requests more accurate

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1523,6 +1523,7 @@ mds_rank_t Client::choose_target_mds(MetaRequest *req, Inode** phash_diri)
 	if (phash_diri)
 	  *phash_diri = in;
       } else if (in->auth_cap) {
+	req->send_to_auth = true;
 	mds = in->auth_cap->session->mds_num;
       }
       if (mds >= 0) {


### PR DESCRIPTION
e.g.
getfattr -n ceph.dir.rbytes /mnt/fuse/dir01
```c
"request": {
        "tid": 30363,
        "op": "getattr",
...
        "mds": 0,
        "resend_mds": -1,
        "send_to_auth": 1,
        "sent_on_mseq": 0,
...
    }
```