### PR TITLE
mds: introduce ceph.mirror.info vxattr

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -11728,7 +11728,7 @@ int Client::_getxattr(Inode *in, const char *name, void *value, size_t size,
     if (vxattr->flags & VXATTR_RSTAT) {
       flags |= CEPH_STAT_RSTAT;
     }
-    r = _getattr(in, flags, perms, true);
+    r = _getattr(in, flags | CEPH_STAT_CAP_XATTR, perms, true);
     if (r != 0) {
       // Error from getattr!
       return r;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -11821,8 +11821,12 @@ int Client::_listxattr(Inode *in, char *name, size_t size,
   }
 
   r = 0;
-  for (const auto& p : in->xattrs) {
-    size_t this_len = p.first.length() + 1;
+  for ([[maybe_unused]] const auto &[xattr_name, xattr_value_bl] : in->xattrs) {
+    if (xattr_name.rfind("ceph.", 0) == 0) {
+      continue;
+    }
+
+    size_t this_len = xattr_name.length() + 1;
     r += this_len;
     if (len_only)
       continue;
@@ -11832,7 +11836,7 @@ int Client::_listxattr(Inode *in, char *name, size_t size,
       goto out;
     }
 
-    memcpy(name, p.first.c_str(), this_len);
+    memcpy(name, xattr_name.c_str(), this_len);
     name += this_len;
     size -= this_len;
   }

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12266,6 +12266,21 @@ size_t Client::_vxattrcb_snap_btime(Inode *in, char *val, size_t size)
       (long unsigned)in->snap_btime.nsec());
 }
 
+bool Client::_vxattrcb_mirror_info_exists(Inode *in)
+{
+  // checking one of the xattrs would suffice
+  return in->xattrs.count("ceph.mirror.info.cluster_id") != 0;
+}
+
+size_t Client::_vxattrcb_mirror_info(Inode *in, char *val, size_t size)
+{
+  return snprintf(val, size, "cluster_id=%.*s fs_id=%.*s",
+                  in->xattrs["ceph.mirror.info.cluster_id"].length(),
+                  in->xattrs["ceph.mirror.info.cluster_id"].c_str(),
+                  in->xattrs["ceph.mirror.info.fs_id"].length(),
+                  in->xattrs["ceph.mirror.info.fs_id"].c_str());
+}
+
 #define CEPH_XATTR_NAME(_type, _name) "ceph." #_type "." #_name
 #define CEPH_XATTR_NAME2(_type, _name, _name2) "ceph." #_type "." #_name "." #_name2
 
@@ -12345,6 +12360,13 @@ const Client::VXattr Client::_dir_vxattrs[] = {
     getxattr_cb: &Client::_vxattrcb_snap_btime,
     readonly: true,
     exists_cb: &Client::_vxattrcb_snap_btime_exists,
+    flags: 0,
+  },
+  {
+    name: "ceph.mirror.info",
+    getxattr_cb: &Client::_vxattrcb_mirror_info,
+    readonly: false,
+    exists_cb: &Client::_vxattrcb_mirror_info_exists,
     flags: 0,
   },
   { name: "" }     /* Required table terminator */

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1294,6 +1294,9 @@ private:
   bool _vxattrcb_snap_btime_exists(Inode *in);
   size_t _vxattrcb_snap_btime(Inode *in, char *val, size_t size);
 
+  bool _vxattrcb_mirror_info_exists(Inode *in);
+  size_t _vxattrcb_mirror_info(Inode *in, char *val, size_t size);
+
   static const VXattr *_get_vxattrs(Inode *in);
   static const VXattr *_match_vxattr(Inode *in, const char *name);
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -6012,6 +6012,11 @@ void Server::handle_client_setxattr(MDRequestRef& mdr)
     return;
   }
 
+  if (!is_allowed_ceph_xattr(name)) {
+    respond_to_request(mdr, -EINVAL);
+    return;
+  }
+
   CInode *cur = rdlock_path_pin_ref(mdr, true);
   if (!cur)
     return;
@@ -6102,6 +6107,11 @@ void Server::handle_client_removexattr(MDRequestRef& mdr)
       return;
 
     handle_remove_vxattr(mdr, cur);
+    return;
+  }
+
+  if (!is_allowed_ceph_xattr(name)) {
+    respond_to_request(mdr, -EINVAL);
     return;
   }
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5821,8 +5821,8 @@ void Server::handle_client_setxattr(MDRequestRef& mdr)
   const cref_t<MClientRequest> &req = mdr->client_request;
   string name(req->get_path2());
 
-  // magic ceph.* namespace?
-  if (name.compare(0, 5, "ceph.") == 0) {
+  // is a ceph virtual xattr?
+  if (is_ceph_vxattr(name)) {
     // can't use rdlock_path_pin_ref because we need to xlock snaplock/policylock
     CInode *cur = try_get_auth_inode(mdr, req->get_filepath().get_ino());
     if (!cur)
@@ -5923,7 +5923,8 @@ void Server::handle_client_removexattr(MDRequestRef& mdr)
   const cref_t<MClientRequest> &req = mdr->client_request;
   std::string name(req->get_path2());
 
-  if (name.compare(0, 5, "ceph.") == 0) {
+  // is a ceph virtual xattr?
+  if (is_ceph_vxattr(name)) {
     // can't use rdlock_path_pin_ref because we need to xlock snaplock/policylock
     CInode *cur = try_get_auth_inode(mdr, req->get_filepath().get_ino());
     if (!cur)

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -417,6 +417,15 @@ private:
            xattr_name == "ceph.dir.pin.distributed"sv;
   }
 
+  static bool is_allowed_ceph_xattr(std::string_view xattr_name) {
+    // not a ceph xattr -- allow!
+    if (xattr_name.rfind("ceph.", 0) != 0) {
+      return true;
+    }
+
+    return xattr_name == "ceph.mirror.info";
+  }
+
   void reply_client_request(MDRequestRef& mdr, const ref_t<MClientReply> &reply);
   void flush_session(Session *session, MDSGatherBuilder& gather);
 

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -326,6 +326,21 @@ private:
     }
   };
 
+  struct MirrorXattrInfo : XattrInfo {
+    std::string cluster_id;
+    std::string fs_id;
+
+    static const std::string MIRROR_INFO_REGEX;
+    static const std::string CLUSTER_ID;
+    static const std::string FS_ID;
+
+    MirrorXattrInfo(std::string_view cluster_id,
+                    std::string_view fs_id)
+      : cluster_id(cluster_id),
+        fs_id(fs_id) {
+    }
+  };
+
   struct XattrOp {
     int op;
     std::string xattr_name;
@@ -381,6 +396,16 @@ private:
                                 const XattrOp &xattr_op);
   void default_removexattr_handler(CInode *cur, InodeStoreBase::xattr_map_ptr xattrs,
                                    const XattrOp &xattr_op);
+
+  // mirror info xattr handler
+  int parse_mirror_info_xattr(const std::string &name, const std::string &value,
+                              std::string &cluster_id, std::string &fs_id);
+  int mirror_info_xattr_validate(CInode *cur, const InodeStoreBase::xattr_map_const_ptr xattrs,
+                                 XattrOp *xattr_op);
+  void mirror_info_setxattr_handler(CInode *cur, InodeStoreBase::xattr_map_ptr xattrs,
+                                    const XattrOp &xattr_op);
+  void mirror_info_removexattr_handler(CInode *cur, InodeStoreBase::xattr_map_ptr xattrs,
+                                       const XattrOp &xattr_op);
 
   static bool is_ceph_vxattr(std::string_view xattr_name) {
     return xattr_name.rfind("ceph.dir.layout", 0) == 0 ||

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -318,6 +318,16 @@ private:
   friend class ServerLogContext;
   friend class Batch_Getattr_Lookup;
 
+  static bool is_ceph_vxattr(std::string_view xattr_name) {
+    return xattr_name.rfind("ceph.dir.layout", 0) == 0 ||
+           xattr_name.rfind("ceph.file.layout", 0) == 0 ||
+           xattr_name.rfind("ceph.quota", 0) == 0 ||
+           xattr_name == "ceph.dir.subvolume"sv ||
+           xattr_name == "ceph.dir.pin"sv ||
+           xattr_name == "ceph.dir.pin.random"sv ||
+           xattr_name == "ceph.dir.pin.distributed"sv;
+  }
+
   void reply_client_request(MDRequestRef& mdr, const ref_t<MClientReply> &reply);
   void flush_session(Session *session, MDSGatherBuilder& gather);
 

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -34,6 +34,11 @@ def setup_test():
     cephfs.closedir(d)
 
     cephfs.chdir(b"/")
+    _, ret_buf = cephfs.listxattr("/")
+    print(f'ret_buf={ret_buf}')
+    xattrs = ret_buf.decode('utf-8').split('\x00')
+    for xattr in xattrs[:-1]:
+        cephfs.removexattr("/", xattr)
 
 @with_setup(setup_test)
 def test_conf_get():

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -3,6 +3,7 @@ from nose.tools import assert_raises, assert_equal, assert_greater, with_setup
 import cephfs as libcephfs
 import fcntl
 import os
+import random
 import time
 import stat
 import uuid
@@ -145,6 +146,47 @@ def test_xattr():
     ret_val, ret_buff = cephfs.listxattr("/")
     assert_equal(9, ret_val)
     assert_equal("user.big\x00", ret_buff.decode('utf-8'))
+
+@with_setup(setup_test)
+def test_ceph_mirror_xattr():
+    def gen_mirror_xattr():
+        cluster_id = str(uuid.uuid4())
+        fs_id = random.randint(1, 10)
+        mirror_xattr = f'cluster_id={cluster_id} fs_id={fs_id}'
+        return mirror_xattr.encode('utf-8')
+
+    mirror_xattr_enc_1 = gen_mirror_xattr()
+
+    # mirror xattr is only allowed on root
+    cephfs.mkdir('/d0', 0o755)
+    assert_raises(libcephfs.InvalidValue, cephfs.setxattr,
+                  '/d0', 'ceph.mirror.info', mirror_xattr_enc_1, os.XATTR_CREATE)
+    cephfs.rmdir('/d0')
+
+    cephfs.setxattr('/', 'ceph.mirror.info', mirror_xattr_enc_1, os.XATTR_CREATE)
+    assert_equal(mirror_xattr_enc_1, cephfs.getxattr('/', 'ceph.mirror.info'))
+
+    # setting again with XATTR_CREATE should fail
+    assert_raises(libcephfs.ObjectExists, cephfs.setxattr,
+                  '/', 'ceph.mirror.info', mirror_xattr_enc_1, os.XATTR_CREATE)
+
+    # ceph.mirror.info should not show up in listing
+    ret_val, _ = cephfs.listxattr("/")
+    assert_equal(0, ret_val)
+
+    mirror_xattr_enc_2 = gen_mirror_xattr()
+
+    cephfs.setxattr('/', 'ceph.mirror.info', mirror_xattr_enc_2, os.XATTR_REPLACE)
+    assert_equal(mirror_xattr_enc_2, cephfs.getxattr('/', 'ceph.mirror.info'))
+
+    cephfs.removexattr('/', 'ceph.mirror.info')
+    # ceph.mirror.info is already removed
+    assert_raises(libcephfs.NoData, cephfs.getxattr, '/', 'ceph.mirror.info')
+    # removing again should throw error
+    assert_raises(libcephfs.NoData, cephfs.removexattr, "/", "ceph.mirror.info")
+
+    # check mirror info xattr format
+    assert_raises(libcephfs.InvalidValue, cephfs.setxattr, '/', 'ceph.mirror.info', b"unknown", 0)
 
 @with_setup(setup_test)
 def test_fxattr():


### PR DESCRIPTION
This virtual extended attribute is to be used when setting up
a filesystem for mirroring. The idea is to prevent multiple
ceph clusters adding a same remote ceph cluster as a peer for
a filesystem.

Adding a peer is configured via an interface exposed by manager
module ("mirroring" plugin). This extended attribute is set on
the remote filesystems root directory by the manager plugin
thereby preventing other clusters adding the filesystem as a
peer.

Note that this extended attribute is a constraint to be set only
on the root directory. Technically, filesystems in multiple
ceph clusters can mirror distinct directories to a filesystem
in the remote cluster. When supporting this, the path constraint
can be removed for setting the extended attribute on directories.

Signed-off-by: Venky Shankar <vshankar@redhat.com>