### PR TITLE
mgr/dashboard: Fix favicon white circle

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/favicon.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/favicon.service.ts
@@ -48,19 +48,22 @@ export class FaviconService implements OnDestroy {
       // Draw Original Favicon as Background
       context.drawImage(img, 0, 0, faviconSize, faviconSize);
 
-      // Cut notification circle area
-      context.save();
-      context.globalCompositeOperation = 'destination-out';
-      context.beginPath();
-      context.arc(canvas.width - radius, radius, radius + 2, 0, 2 * Math.PI);
-      context.fill();
-      context.restore();
+      if (Color[status]) {
+        // Cut notification circle area
+        context.save();
+        context.globalCompositeOperation = 'destination-out';
+        context.beginPath();
+        context.arc(canvas.width - radius, radius, radius + 2, 0, 2 * Math.PI);
+        context.fill();
+        context.restore();
 
-      // Draw Notification Circle
-      context.beginPath();
-      context.arc(canvas.width - radius, radius, radius, 0, 2 * Math.PI);
-      context.fillStyle = Color[status] || 'transparent';
-      context.fill();
+        // Draw Notification Circle
+        context.beginPath();
+        context.arc(canvas.width - radius, radius, radius, 0, 2 * Math.PI);
+
+        context.fillStyle = Color[status];
+        context.fill();
+      }
 
       // Replace favicon
       favicon.setAttribute('href', canvas.toDataURL('image/png'));


### PR DESCRIPTION
A white circle was displayed when the user logged out.

Fixes: https://tracker.ceph.com/issues/46919

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
