### PR TITLE
mds: revert the decode version

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -505,7 +505,7 @@ void FSMap::decode(bufferlist::const_iterator& p)
   // MDSMonitor to store an FSMap instead of an MDSMap was
   // 5, so anything older than 6 is decoded as an MDSMap,
   // and anything newer is decoded as an FSMap.
-  DECODE_START_LEGACY_COMPAT_LEN_16(8, 4, 4, p);
+  DECODE_START_LEGACY_COMPAT_LEN_16(7, 4, 4, p);
   if (struct_v < 6) {
     // Because the mon used to store an MDSMap where we now
     // store an FSMap, FSMap knows how to decode the legacy


### PR DESCRIPTION
Introduced in
https://github.com/ceph/ceph/commit/3fac3b1236c4918e9640e38fe7f5f59efc0a23b9,
the decode changes are reverted but the version number is not.

Fixes: https://tracker.ceph.com/issues/46926