### PR TITLE
librbd/rwl: discard cache

### DIFF
--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -42,8 +42,10 @@ set(librbd_internal_srcs
   cache/ImageWriteback.cc
   cache/ObjectCacherObjectDispatch.cc
   cache/ObjectCacherWriteback.cc
+  cache/pwl/DiscardRequest.cc
   cache/pwl/InitRequest.cc
   cache/pwl/ShutdownRequest.cc
+  cache/Utils.cc
   cache/WriteAroundObjectDispatch.cc
   crypto/BlockCrypto.cc
   crypto/CryptoContextPool.cc
@@ -222,6 +224,8 @@ target_include_directories(rbd_internal PRIVATE ${OPENSSL_INCLUDE_DIR})
 if(WITH_RBD_RWL)
   target_link_libraries(rbd_internal
     PUBLIC blk)
+  target_link_libraries(rbd_internal PRIVATE
+    StdFilesystem::filesystem)
 endif()
 
 add_custom_target(librbd_plugins)

--- a/src/librbd/cache/Utils.cc
+++ b/src/librbd/cache/Utils.cc
@@ -1,0 +1,24 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/cache/pwl/DiscardRequest.h"
+#include "librbd/cache/Utils.h"
+#include "include/Context.h"
+
+namespace librbd {
+namespace cache {
+namespace util {
+
+template <typename I>
+void discard_cache(I &image_ctx, Context *ctx) {
+  cache::pwl::DiscardRequest<I> *req = cache::pwl::DiscardRequest<I>::create(
+    image_ctx, ctx);
+  req->send();
+}
+
+} // namespace util
+} // namespace cache
+} // namespace librbd
+
+template void librbd::cache::util::discard_cache(
+  librbd::ImageCtx &image_ctx, Context *ctx);

--- a/src/librbd/cache/Utils.h
+++ b/src/librbd/cache/Utils.h
@@ -6,7 +6,11 @@
 
 #include "acconfig.h"
 
+class Context;
+
 namespace librbd {
+
+struct ImageCtx;
 
 namespace cache {
 namespace util {
@@ -19,6 +23,9 @@ bool is_pwl_enabled(T& image_ctx) {
   return false;
 #endif // WITH_RBD_RWL
 }
+
+template <typename T = librbd::ImageCtx>
+void discard_cache(T &image_ctx, Context *ctx);
 
 } // namespace util
 } // namespace cache

--- a/src/librbd/cache/WriteLogImageDispatch.cc
+++ b/src/librbd/cache/WriteLogImageDispatch.cc
@@ -218,7 +218,6 @@ bool WriteLogImageDispatch<I>::list_snaps(
   return false;
 }
 
-
 template <typename I>
 bool WriteLogImageDispatch<I>::preprocess_length(
     io::AioCompletion* aio_comp, io::Extents &image_extents) const {
@@ -228,6 +227,12 @@ bool WriteLogImageDispatch<I>::preprocess_length(
     return true;
   }
   return false;
+}
+
+template <typename I>
+bool WriteLogImageDispatch<I>::invalidate_cache(Context* on_finish) {
+  m_image_cache->invalidate(on_finish);
+  return true;
 }
 
 } // namespace io

--- a/src/librbd/cache/WriteLogImageDispatch.h
+++ b/src/librbd/cache/WriteLogImageDispatch.h
@@ -86,6 +86,8 @@ public:
     io::DispatchResult* dispatch_result, Context** on_finish,
     Context* on_dispatched) override;
 
+  bool invalidate_cache(Context* on_finish) override;
+
 private:
   ImageCtxT* m_image_ctx;
   pwl::AbstractWriteLog<ImageCtx> *m_image_cache;

--- a/src/librbd/cache/pwl/DiscardRequest.cc
+++ b/src/librbd/cache/pwl/DiscardRequest.cc
@@ -62,6 +62,7 @@ void DiscardRequest<I>::send() {
 #endif
 }
 
+#if defined(WITH_RBD_RWL)
 template <typename I>
 void DiscardRequest<I>::delete_image_cache_file() {
   CephContext *cct = m_image_ctx.cct;
@@ -146,6 +147,8 @@ void DiscardRequest<I>::handle_remove_feature_bit(int r) {
   }
   finish();
 }
+
+#endif // WITH_RBD_RWL
 
 template <typename I>
 void DiscardRequest<I>::finish() {

--- a/src/librbd/cache/pwl/DiscardRequest.cc
+++ b/src/librbd/cache/pwl/DiscardRequest.cc
@@ -1,0 +1,167 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "common/dout.h"
+#include "common/errno.h"
+#include "common/hostname.h"
+#include "librbd/asio/ContextWQ.h"
+#include "librbd/cache/pwl/DiscardRequest.h"
+
+#if defined(WITH_RBD_RWL)
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
+
+#include "librbd/cache/pwl/ImageCacheState.h"
+#endif // WITH_RBD_RWL
+
+#include "librbd/cache/Types.h"
+#include "librbd/io/ImageDispatcherInterface.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Utils.h"
+
+
+#define dout_subsys ceph_subsys_rbd_pwl
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::cache::pwl:DiscardRequest: " \
+                           << this << " " << __func__ << ": "
+
+namespace librbd {
+namespace cache {
+namespace pwl {
+
+using librbd::util::create_async_context_callback;
+using librbd::util::create_context_callback;
+
+template <typename I>
+DiscardRequest<I>* DiscardRequest<I>::create(
+    I &image_ctx,
+    Context *on_finish) {
+  return new DiscardRequest(image_ctx, on_finish);
+}
+
+template <typename I>
+DiscardRequest<I>::DiscardRequest(
+    I &image_ctx,
+    Context *on_finish)
+  : m_image_ctx(image_ctx),
+    m_on_finish(create_async_context_callback(image_ctx, on_finish)),
+    m_error_result(0) {
+}
+
+template <typename I>
+void DiscardRequest<I>::send() {
+#if defined(WITH_RBD_RWL)
+  delete_image_cache_file();
+#else
+  finish();
+#endif
+}
+
+template <typename I>
+void DiscardRequest<I>::delete_image_cache_file() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << dendl;
+
+  m_cache_state = ImageCacheState<I>::get_image_cache_state(&m_image_ctx);
+  if (!m_cache_state) {
+    remove_feature_bit();
+    return;
+  }
+  if (m_cache_state->present &&
+      !m_cache_state->host.compare(ceph_get_short_hostname()) &&
+      fs::exists(m_cache_state->path)) {
+    fs::remove(m_cache_state->path);
+  }
+
+  remove_image_cache_state();
+}
+
+template <typename I>
+void DiscardRequest<I>::remove_image_cache_state() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << dendl;
+
+  using klass = DiscardRequest<I>;
+  Context *ctx = create_context_callback<klass, &klass::handle_remove_image_cache_state>(
+    this);
+
+  m_cache_state->clear_image_cache_state(ctx);
+}
+
+template <typename I>
+void DiscardRequest<I>::handle_remove_image_cache_state(int r) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "failed to remove the image cache state: " << cpp_strerror(r)
+               << dendl;
+    save_result(r);
+    finish();
+    return;
+  }
+
+  remove_feature_bit();
+}
+
+template <typename I>
+void DiscardRequest<I>::remove_feature_bit() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << dendl;
+
+  if (!(m_image_ctx.features &&RBD_FEATURE_DIRTY_CACHE)) {
+    finish();
+    return;
+  }
+  uint64_t new_features = m_image_ctx.features & ~RBD_FEATURE_DIRTY_CACHE;
+  uint64_t features_mask = RBD_FEATURE_DIRTY_CACHE;
+  ldout(cct, 10) << "old_features=" << m_image_ctx.features
+                 << ", new_features=" << new_features
+                 << ", features_mask=" << features_mask
+                 << dendl;
+
+  int r = librbd::cls_client::set_features(&m_image_ctx.md_ctx, m_image_ctx.header_oid,
+                                           new_features, features_mask);
+  m_image_ctx.features &= ~RBD_FEATURE_DIRTY_CACHE;
+  using klass = DiscardRequest<I>;
+  Context *ctx = create_context_callback<klass, &klass::handle_remove_feature_bit>(
+    this);
+  ctx->complete(r);
+}
+
+template <typename I>
+void DiscardRequest<I>::handle_remove_feature_bit(int r) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "failed to remove the feature bit: " << cpp_strerror(r)
+               << dendl;
+    save_result(r);
+  }
+  finish();
+}
+
+template <typename I>
+void DiscardRequest<I>::finish() {
+#if defined(WITH_RBD_RWL)
+  if (m_cache_state) {
+    delete m_cache_state;
+    m_cache_state = nullptr;
+  }
+#endif // WITH_RBD_RWL
+
+  m_on_finish->complete(m_error_result);
+  delete this;
+}
+
+} // namespace pwl
+} // namespace cache
+} // namespace librbd
+
+template class librbd::cache::pwl::DiscardRequest<librbd::ImageCtx>;

--- a/src/librbd/cache/pwl/DiscardRequest.h
+++ b/src/librbd/cache/pwl/DiscardRequest.h
@@ -1,0 +1,86 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_CACHE_PWL_SHUTDOWN_REQUEST_H
+#define CEPH_LIBRBD_CACHE_PWL_SHUTDOWN_REQUEST_H
+
+class Context;
+
+namespace librbd {
+
+class ImageCtx;
+
+namespace cache {
+
+namespace pwl {
+
+template<typename>
+class ImageCacheState;
+
+template <typename ImageCtxT = ImageCtx>
+class DiscardRequest {
+public:
+  static DiscardRequest* create(
+      ImageCtxT &image_ctx,
+      Context *on_finish);
+
+  void send();
+
+private:
+
+  /**
+   * @verbatim
+   *
+   * Shutdown request goes through the following state machine:
+   *
+   * <start>
+   *    |
+   *    v
+   * REMOVE_IMAGE_CACHE_FILE
+   *    |
+   *    v
+   * REMOVE_IMAGE_CACHE_STATE
+   *    |
+   *    v
+   * REMOVE_IMAGE_FEATURE_BIT
+   *    |
+   *    v
+   * <finish>
+   *
+   * @endverbatim
+   */
+
+  DiscardRequest(ImageCtxT &image_ctx,
+    Context *on_finish);
+
+  ImageCtxT &m_image_ctx;
+  ImageCacheState<ImageCtxT>* m_cache_state;
+  Context *m_on_finish;
+
+  int m_error_result;
+
+  void delete_image_cache_file();
+
+  void remove_image_cache_state();
+  void handle_remove_image_cache_state(int r);
+
+  void remove_feature_bit();
+  void handle_remove_feature_bit(int r);
+
+  void finish();
+
+  void save_result(int result) {
+    if (m_error_result == 0 && result < 0) {
+      m_error_result = result;
+    }
+  }
+
+};
+
+} // namespace pwl
+} // namespace cache
+} // namespace librbd
+
+extern template class librbd::cache::pwl::DiscardRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_CACHE_PWL_SHUTDOWN_REQUEST_H

--- a/src/librbd/cache/pwl/ImageCacheState.cc
+++ b/src/librbd/cache/pwl/ImageCacheState.cc
@@ -96,7 +96,7 @@ void ImageCacheState<I>::dump(ceph::Formatter *f) const {
 }
 
 template <typename I>
-ImageCacheState<I>* ImageCacheState<I>::get_image_cache_state(
+ImageCacheState<I>* ImageCacheState<I>::create_image_cache_state(
     I* image_ctx, int &r) {
   std::string cache_state_str;
   ImageCacheState<I>* cache_state = nullptr;
@@ -148,6 +148,24 @@ ImageCacheState<I>* ImageCacheState<I>::get_image_cache_state(
         break;
       default:
 	r = -EINVAL;
+    }
+  }
+  return cache_state;
+}
+
+template <typename I>
+ImageCacheState<I>* ImageCacheState<I>::get_image_cache_state(I* image_ctx) {
+  ImageCacheState<I>* cache_state = nullptr;
+  string cache_state_str;
+  cls_client::metadata_get(&image_ctx->md_ctx, image_ctx->header_oid,
+			   IMAGE_CACHE_STATE, &cache_state_str);
+  if (!cache_state_str.empty()) {
+    JSONFormattable f;
+    bool success = get_json_format(cache_state_str, &f);
+    if (!success) {
+      cache_state = new ImageCacheState<I>(image_ctx);
+    } else {
+      cache_state = new ImageCacheState<I>(image_ctx, f);
     }
   }
   return cache_state;

--- a/src/librbd/cache/pwl/ImageCacheState.h
+++ b/src/librbd/cache/pwl/ImageCacheState.h
@@ -47,8 +47,11 @@ public:
 
   void dump(ceph::Formatter *f) const;
 
+  static ImageCacheState<ImageCtxT>* create_image_cache_state(
+    ImageCtxT* image_ctx, int &r);
+
   static ImageCacheState<ImageCtxT>* get_image_cache_state(
-      ImageCtxT* image_ctx, int &r);
+    ImageCtxT* image_ctx);
 
   bool is_valid();
 };

--- a/src/librbd/cache/pwl/InitRequest.cc
+++ b/src/librbd/cache/pwl/InitRequest.cc
@@ -58,7 +58,7 @@ void InitRequest<I>::get_image_cache_state() {
   ldout(cct, 10) << dendl;
 
   int r;
-  auto cache_state = ImageCacheState<I>::get_image_cache_state(&m_image_ctx, r);
+  auto cache_state = ImageCacheState<I>::create_image_cache_state(&m_image_ctx, r);
 
   if (r < 0 || !cache_state) {
     save_result(r);

--- a/src/librbd/exclusive_lock/ImageDispatch.h
+++ b/src/librbd/exclusive_lock/ImageDispatch.h
@@ -99,6 +99,10 @@ public:
     return false;
   }
 
+  bool invalidate_cache(Context* on_finish) override {
+    return false;
+  }
+
 private:
   typedef std::list<Context*> Contexts;
   typedef std::unordered_set<uint64_t> Tids;

--- a/src/librbd/exclusive_lock/PreReleaseRequest.cc
+++ b/src/librbd/exclusive_lock/PreReleaseRequest.cc
@@ -198,11 +198,10 @@ void PreReleaseRequest<I>::send_invalidate_cache() {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 10) << dendl;
 
-  std::shared_lock owner_lock{m_image_ctx.owner_lock};
   Context *ctx = create_context_callback<
       PreReleaseRequest<I>,
       &PreReleaseRequest<I>::handle_invalidate_cache>(this);
-  m_image_ctx.io_object_dispatcher->invalidate_cache(ctx);
+  m_image_ctx.io_image_dispatcher->invalidate_cache(ctx);
 }
 
 template <typename I>

--- a/src/librbd/io/Dispatcher.h
+++ b/src/librbd/io/Dispatcher.h
@@ -10,6 +10,7 @@
 #include "common/dout.h"
 #include "common/AsyncOpTracker.h"
 #include "librbd/Utils.h"
+#include "librbd/io/DispatcherInterface.h"
 #include "librbd/io/Types.h"
 #include <map>
 
@@ -32,7 +33,7 @@ public:
     : m_image_ctx(image_ctx),
       m_lock(ceph::make_shared_mutex(
         librbd::util::unique_lock_name("librbd::io::Dispatcher::lock",
-				       this))) {
+                                       this))) {
   }
 
   virtual ~Dispatcher() {
@@ -152,6 +153,65 @@ protected:
 
   virtual bool send_dispatch(Dispatch* dispatch,
                              DispatchSpec* dispatch_spec) = 0;
+
+protected:
+  struct C_LayerIterator : public Context {
+    Dispatcher* dispatcher;
+    Context* on_finish;
+    DispatchLayer dispatch_layer;
+
+    C_LayerIterator(Dispatcher* dispatcher,
+                    DispatchLayer start_layer,
+                    Context* on_finish)
+    : dispatcher(dispatcher), on_finish(on_finish), dispatch_layer(start_layer) {
+    }
+
+    void complete(int r) override {
+      while (true) {
+        dispatcher->m_lock.lock_shared();
+        auto it = dispatcher->m_dispatches.upper_bound(dispatch_layer);
+        if (it == dispatcher->m_dispatches.end()) {
+          dispatcher->m_lock.unlock_shared();
+          Context::complete(r);
+          return;
+        }
+
+        auto& dispatch_meta = it->second;
+        auto dispatch = dispatch_meta.dispatch;
+
+        // prevent recursive locking back into the dispatcher while handling IO
+        dispatch_meta.async_op_tracker->start_op();
+        dispatcher->m_lock.unlock_shared();
+
+        // next loop should start after current layer
+        dispatch_layer = dispatch->get_dispatch_layer();
+
+        auto handled = execute(dispatch, this);
+        dispatch_meta.async_op_tracker->finish_op();
+
+        if (handled) {
+          break;
+        }
+      }
+    }
+
+    void finish(int r) override {
+      on_finish->complete(0);
+    }
+    virtual bool execute(Dispatch* dispatch,
+                         Context* on_finish) = 0;
+  };
+
+  struct C_InvalidateCache : public C_LayerIterator {
+    C_InvalidateCache(Dispatcher* dispatcher, DispatchLayer start_layer, Context* on_finish)
+      : C_LayerIterator(dispatcher, start_layer, on_finish) {
+    }
+
+    bool execute(Dispatch* dispatch,
+                 Context* on_finish) override {
+      return dispatch->invalidate_cache(on_finish);
+    }
+  };
 
 private:
   void shut_down_dispatch(DispatchMeta& dispatch_meta,

--- a/src/librbd/io/ImageDispatch.cc
+++ b/src/librbd/io/ImageDispatch.cc
@@ -6,6 +6,7 @@
 #include "librbd/ImageCtx.h"
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/ImageRequest.h"
+#include "librbd/io/ObjectDispatcherInterface.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
@@ -164,6 +165,16 @@ bool ImageDispatch<I>::list_snaps(
     *m_image_ctx, aio_comp, std::move(image_extents), std::move(snap_ids),
     list_snaps_flags, snapshot_delta, parent_trace);
   req.send();
+  return true;
+}
+
+template <typename I>
+bool ImageDispatch<I>::invalidate_cache(Context* on_finish) {
+  auto cct = m_image_ctx->cct;
+  ldout(cct, 20) << dendl;
+
+  std::shared_lock owner_lock{m_image_ctx->owner_lock};
+  m_image_ctx->io_object_dispatcher->invalidate_cache(on_finish);
   return true;
 }
 

--- a/src/librbd/io/ImageDispatch.h
+++ b/src/librbd/io/ImageDispatch.h
@@ -81,6 +81,8 @@ public:
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 
+  bool invalidate_cache(Context* on_finish) override;
+
 private:
   ImageCtxT* m_image_ctx;
 

--- a/src/librbd/io/ImageDispatchInterface.h
+++ b/src/librbd/io/ImageDispatchInterface.h
@@ -79,6 +79,7 @@ struct ImageDispatchInterface {
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;
 
+  virtual bool invalidate_cache(Context* on_finish) = 0;
 };
 
 } // namespace io

--- a/src/librbd/io/ImageDispatcher.cc
+++ b/src/librbd/io/ImageDispatcher.cc
@@ -6,8 +6,6 @@
 #include "common/AsyncOpTracker.h"
 #include "common/dout.h"
 #include "librbd/ImageCtx.h"
-#include "librbd/Utils.h"
-#include "librbd/io/AsyncOperation.h"
 #include "librbd/io/ImageDispatch.h"
 #include "librbd/io/ImageDispatchInterface.h"
 #include "librbd/io/ImageDispatchSpec.h"
@@ -194,6 +192,17 @@ ImageDispatcher<I>::ImageDispatcher(I* image_ctx)
 
   m_write_block_dispatch = new WriteBlockImageDispatch<I>(image_ctx);
   this->register_dispatch(m_write_block_dispatch);
+}
+
+template <typename I>
+void ImageDispatcher<I>::invalidate_cache(Context* on_finish) {
+  auto image_ctx = this->m_image_ctx;
+  auto cct = image_ctx->cct;
+  ldout(cct, 5) << dendl;
+
+  auto ctx = new C_InvalidateCache(
+      this, IMAGE_DISPATCH_LAYER_NONE, on_finish);
+  ctx->complete(0);
 }
 
 template <typename I>

--- a/src/librbd/io/ImageDispatcher.h
+++ b/src/librbd/io/ImageDispatcher.h
@@ -30,6 +30,8 @@ class ImageDispatcher : public Dispatcher<ImageCtxT, ImageDispatcherInterface> {
 public:
   ImageDispatcher(ImageCtxT* image_ctx);
 
+  void invalidate_cache(Context* on_finish) override;
+
   void shut_down(Context* on_finish) override;
 
   void apply_qos_schedule_tick_min(uint64_t tick) override;
@@ -51,6 +53,8 @@ protected:
 private:
   struct SendVisitor;
   struct PreprocessVisitor;
+
+  using typename Dispatcher<ImageCtxT, ImageDispatcherInterface>::C_InvalidateCache;
 
   std::atomic<uint64_t> m_next_tid{0};
 

--- a/src/librbd/io/ImageDispatcherInterface.h
+++ b/src/librbd/io/ImageDispatcherInterface.h
@@ -27,6 +27,8 @@ public:
 
   virtual void unblock_writes() = 0;
   virtual void wait_on_writes_unblocked(Context *on_unblocked) = 0;
+
+  virtual void invalidate_cache(Context* on_finish) = 0;
 };
 
 } // namespace io

--- a/src/librbd/io/ObjectDispatcher.cc
+++ b/src/librbd/io/ObjectDispatcher.cc
@@ -21,71 +21,9 @@ namespace librbd {
 namespace io {
 
 template <typename I>
-struct ObjectDispatcher<I>::C_LayerIterator : public Context {
-  ObjectDispatcher* object_dispatcher;
-  Context* on_finish;
-
-  ObjectDispatchLayer object_dispatch_layer = OBJECT_DISPATCH_LAYER_NONE;
-
-  C_LayerIterator(ObjectDispatcher* object_dispatcher,
-                Context* on_finish)
-    : object_dispatcher(object_dispatcher), on_finish(on_finish) {
-  }
-
-  void complete(int r) override {
-    while (true) {
-      object_dispatcher->m_lock.lock_shared();
-      auto it = object_dispatcher->m_dispatches.upper_bound(
-        object_dispatch_layer);
-      if (it == object_dispatcher->m_dispatches.end()) {
-        object_dispatcher->m_lock.unlock_shared();
-        Context::complete(r);
-        return;
-      }
-
-      auto& object_dispatch_meta = it->second;
-      auto object_dispatch = object_dispatch_meta.dispatch;
-
-      // prevent recursive locking back into the dispatcher while handling IO
-      object_dispatch_meta.async_op_tracker->start_op();
-      object_dispatcher->m_lock.unlock_shared();
-
-      // next loop should start after current layer
-      object_dispatch_layer = object_dispatch->get_dispatch_layer();
-
-      auto handled = execute(object_dispatch, this);
-      object_dispatch_meta.async_op_tracker->finish_op();
-
-      if (handled) {
-        break;
-      }
-    }
-  }
-
-  void finish(int r) override {
-    on_finish->complete(0);
-  }
-
-  virtual bool execute(ObjectDispatchInterface* object_dispatch,
-                       Context* on_finish) = 0;
-};
-
-template <typename I>
-struct ObjectDispatcher<I>::C_InvalidateCache : public C_LayerIterator {
-  C_InvalidateCache(ObjectDispatcher* object_dispatcher, Context* on_finish)
-    : C_LayerIterator(object_dispatcher, on_finish) {
-  }
-
-  bool execute(ObjectDispatchInterface* object_dispatch,
-               Context* on_finish) override {
-    return object_dispatch->invalidate_cache(on_finish);
-  }
-};
-
-template <typename I>
 struct ObjectDispatcher<I>::C_ResetExistenceCache : public C_LayerIterator {
   C_ResetExistenceCache(ObjectDispatcher* object_dispatcher, Context* on_finish)
-    : C_LayerIterator(object_dispatcher, on_finish) {
+    : C_LayerIterator(object_dispatcher, OBJECT_DISPATCH_LAYER_NONE, on_finish) {
   }
 
   bool execute(ObjectDispatchInterface* object_dispatch,
@@ -201,7 +139,8 @@ void ObjectDispatcher<I>::invalidate_cache(Context* on_finish) {
   ldout(cct, 5) << dendl;
 
   on_finish = util::create_async_context_callback(*image_ctx, on_finish);
-  auto ctx = new C_InvalidateCache(this, on_finish);
+  auto ctx = new C_InvalidateCache(
+    this, OBJECT_DISPATCH_LAYER_NONE, on_finish);
   ctx->complete(0);
 }
 

--- a/src/librbd/io/ObjectDispatcher.h
+++ b/src/librbd/io/ObjectDispatcher.h
@@ -38,13 +38,15 @@ public:
       uint64_t object_no,
       SnapshotSparseBufferlist* snapshot_sparse_bufferlist) override;
 
+  using typename Dispatcher<ImageCtxT, ObjectDispatcherInterface>::C_LayerIterator;
+
+  using typename Dispatcher<ImageCtxT, ObjectDispatcherInterface>::C_InvalidateCache;
+
 protected:
   bool send_dispatch(ObjectDispatchInterface* object_dispatch,
                      ObjectDispatchSpec* object_dispatch_spec) override;
 
 private:
-  struct C_LayerIterator;
-  struct C_InvalidateCache;
   struct C_ResetExistenceCache;
   struct SendVisitor;
 

--- a/src/librbd/io/QosImageDispatch.h
+++ b/src/librbd/io/QosImageDispatch.h
@@ -100,6 +100,10 @@ public:
     return false;
   }
 
+  bool invalidate_cache(Context* on_finish) override {
+    return false;
+  }
+
 private:
   ImageCtxT* m_image_ctx;
 

--- a/src/librbd/io/QueueImageDispatch.h
+++ b/src/librbd/io/QueueImageDispatch.h
@@ -87,6 +87,10 @@ public:
     return false;
   }
 
+  bool invalidate_cache(Context* on_finish) override {
+    return false;
+  }
+
 private:
   ImageCtxT* m_image_ctx;
 

--- a/src/librbd/io/RefreshImageDispatch.h
+++ b/src/librbd/io/RefreshImageDispatch.h
@@ -83,6 +83,10 @@ public:
     return false;
   }
 
+  bool invalidate_cache(Context* on_finish) override {
+    return false;
+  }
+
 private:
   ImageCtxT* m_image_ctx;
 

--- a/src/librbd/io/WriteBlockImageDispatch.h
+++ b/src/librbd/io/WriteBlockImageDispatch.h
@@ -119,6 +119,10 @@ private:
                   Context** on_finish, Context* on_dispatched);
   void flush_io(Context* on_finish);
 
+  bool invalidate_cache(Context* on_finish) override {
+    return false;
+  }
+
   void handle_blocked_writes(int r);
 
 };

--- a/src/librbd/migration/ImageDispatch.h
+++ b/src/librbd/migration/ImageDispatch.h
@@ -81,6 +81,10 @@ public:
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 
+  bool invalidate_cache(Context* on_finish) override {
+    return false;
+  }
+
 private:
   ImageCtxT* m_image_ctx;
   std::unique_ptr<FormatInterface> m_format;

--- a/src/librbd/operation/ResizeRequest.cc
+++ b/src/librbd/operation/ResizeRequest.cc
@@ -225,8 +225,7 @@ void ResizeRequest<I>::send_invalidate_cache() {
 
   // need to invalidate since we're deleting objects, and
   // ObjectCacher doesn't track non-existent objects
-  std::shared_lock owner_locker{image_ctx.owner_lock};
-  image_ctx.io_object_dispatcher->invalidate_cache(create_context_callback<
+  image_ctx.io_image_dispatcher->invalidate_cache(create_context_callback<
     ResizeRequest<I>, &ResizeRequest<I>::handle_invalidate_cache>(this));
 }
 

--- a/src/librbd/operation/SnapshotRollbackRequest.cc
+++ b/src/librbd/operation/SnapshotRollbackRequest.cc
@@ -379,18 +379,17 @@ Context *SnapshotRollbackRequest<I>::send_invalidate_cache() {
   CephContext *cct = image_ctx.cct;
   ldout(cct, 5) << this << " " << __func__ << dendl;
 
-  std::shared_lock owner_lock{image_ctx.owner_lock};
   if(m_object_map != nullptr) {
     Context *ctx = create_context_callback<
       SnapshotRollbackRequest<I>,
       &SnapshotRollbackRequest<I>::handle_invalidate_cache>(this, m_object_map);
-    image_ctx.io_object_dispatcher->invalidate_cache(ctx);
+    image_ctx.io_image_dispatcher->invalidate_cache(ctx);
   }
   else {
     Context *ctx = create_context_callback<
       SnapshotRollbackRequest<I>,
       &SnapshotRollbackRequest<I>::handle_invalidate_cache>(this);
-    image_ctx.io_object_dispatcher->invalidate_cache(ctx);
+    image_ctx.io_image_dispatcher->invalidate_cache(ctx);
   }
   return nullptr;
 }

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -52,6 +52,7 @@
       group snap remove (... rm)        Remove a snapshot from a group.
       group snap rename                 Rename group's snapshot.
       group snap rollback               Rollback group to snapshot.
+      image-cache invalidate            Discard existing / dirty image cache
       image-meta get                    Image metadata get the value associated
                                         with the key.
       image-meta list (image-meta ls)   Image metadata list keys with values.
@@ -1021,6 +1022,23 @@
     --namespace arg      namespace name
     --group arg          group name
     --snap arg           snapshot name
+  
+  rbd help image-cache invalidate
+  usage: rbd image-cache invalidate [--pool <pool>] [--namespace <namespace>] 
+                                    [--image <image>] [--image-id <image-id>] 
+                                    <image-spec> 
+  
+  Discard existing / dirty image cache
+  
+  Positional arguments
+    <image-spec>         image specification
+                         (example: [<pool-name>/[<namespace>/]]<image-name>)
+  
+  Optional arguments
+    -p [ --pool ] arg    pool name
+    --namespace arg      namespace name
+    --image arg          image name
+    --image-id arg       image id
   
   rbd help image-meta get
   usage: rbd image-meta get [--pool <pool>] [--namespace <namespace>] 

--- a/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
@@ -144,7 +144,7 @@ public:
 
   void expect_invalidate_cache(MockTestImageCtx &mock_image_ctx,
                                int r) {
-    EXPECT_CALL(*mock_image_ctx.io_object_dispatcher, invalidate_cache(_))
+    EXPECT_CALL(*mock_image_ctx.io_image_dispatcher, invalidate_cache(_))
       .WillOnce(CompleteContext(r, mock_image_ctx.image_ctx->op_work_queue));
   }
 

--- a/src/test/librbd/mock/io/MockImageDispatch.h
+++ b/src/test/librbd/mock/io/MockImageDispatch.h
@@ -87,6 +87,10 @@ public:
     return false;
   }
 
+  bool invalidate_cache(Context* on_finish) override {
+    return false;
+  }
+
 };
 
 } // namespace io

--- a/src/test/librbd/mock/io/MockImageDispatcher.h
+++ b/src/test/librbd/mock/io/MockImageDispatcher.h
@@ -23,6 +23,7 @@ public:
 
   MOCK_METHOD1(register_dispatch, void(ImageDispatchInterface*));
   MOCK_METHOD2(shut_down_dispatch, void(ImageDispatchLayer, Context*));
+  MOCK_METHOD1(invalidate_cache, void(Context *));
 
   MOCK_METHOD1(send, void(ImageDispatchSpec*));
   MOCK_METHOD3(finish, void(int r, ImageDispatchLayer, uint64_t));

--- a/src/test/librbd/operation/test_mock_ResizeRequest.cc
+++ b/src/test/librbd/operation/test_mock_ResizeRequest.cc
@@ -146,7 +146,7 @@ public:
 
   void expect_invalidate_cache(MockImageCtx &mock_image_ctx,
                                int r) {
-    EXPECT_CALL(*mock_image_ctx.io_object_dispatcher, invalidate_cache(_))
+    EXPECT_CALL(*mock_image_ctx.io_image_dispatcher, invalidate_cache(_))
                    .WillOnce(CompleteContext(r, mock_image_ctx.image_ctx->op_work_queue));
     expect_op_work_queue(mock_image_ctx);
   }

--- a/src/test/librbd/operation/test_mock_SnapshotRollbackRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotRollbackRequest.cc
@@ -187,7 +187,7 @@ public:
 
   void expect_invalidate_cache(MockOperationImageCtx &mock_image_ctx,
                                int r) {
-    EXPECT_CALL(*mock_image_ctx.io_object_dispatcher, invalidate_cache(_))
+    EXPECT_CALL(*mock_image_ctx.io_image_dispatcher, invalidate_cache(_))
                    .WillOnce(CompleteContext(r, mock_image_ctx.image_ctx->op_work_queue));
   }
 

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -4538,6 +4538,8 @@ TEST_F(TestLibRBD, TestPendingAio)
 				 false, features));
   ASSERT_EQ(0, rbd_open(ioctx, name.c_str(), &image, NULL));
 
+  ASSERT_EQ(0, rbd_invalidate_cache(image));
+
   char test_data[TEST_IO_SIZE];
   for (size_t i = 0; i < TEST_IO_SIZE; ++i) {
     test_data[i] = (char) (rand() % (126 - 33) + 33);

--- a/src/tools/rbd/CMakeLists.txt
+++ b/src/tools/rbd/CMakeLists.txt
@@ -25,6 +25,7 @@ set(rbd_srcs
   action/Flatten.cc
   action/Ggate.cc
   action/Group.cc
+  action/ImageCache.cc
   action/ImageMeta.cc
   action/Import.cc
   action/Info.cc

--- a/src/tools/rbd/action/ImageCache.cc
+++ b/src/tools/rbd/action/ImageCache.cc
@@ -1,0 +1,71 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "tools/rbd/ArgumentTypes.h"
+#include "tools/rbd/Shell.h"
+#include "tools/rbd/Utils.h"
+#include "include/types.h"
+#include "include/rbd_types.h"
+#include "include/stringify.h"
+#include "common/errno.h"
+#include "common/Formatter.h"
+#include <iostream>
+#include <boost/program_options.hpp>
+
+namespace rbd {
+namespace action {
+namespace image_cache {
+
+namespace at = argument_types;
+namespace po = boost::program_options;
+
+void get_arguments(po::options_description *positional,
+                   po::options_description *options) {
+  at::add_image_spec_options(positional, options,
+				at::ARGUMENT_MODIFIER_NONE);
+  at::add_image_id_option(options);
+}
+
+int execute_discard(const po::variables_map &vm,
+                    const std::vector<std::string> &ceph_global_init_args) {
+  size_t arg_index = 0;
+  std::string pool_name;
+  std::string namespace_name;
+  std::string image_name;
+  int r = utils::get_pool_image_snapshot_names(
+    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, &pool_name, &namespace_name,
+    &image_name, nullptr, true, utils::SNAPSHOT_PRESENCE_NONE,
+    utils::SPEC_VALIDATION_NONE);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::Rados rados;
+  librados::IoCtx io_ctx;
+  librbd::Image image;
+  r = utils::init_and_open_image(pool_name, namespace_name, image_name, "",
+                                 "", false, &rados, &io_ctx, &image);
+  if (r < 0) {
+    std::cerr << "rbd: failed to open image " << image_name << ": "
+              << cpp_strerror(r) << std::endl;
+    return r;
+  }
+
+  r = image.invalidate_cache();
+  if (r < 0) {
+    std::cerr << "rbd: failed to discard the cache of image " << image_name << ": "
+              << cpp_strerror(r) << std::endl;
+    return r;
+  }
+
+  image.close();
+  return 0;
+}
+
+Shell::Action action_discard(
+  {"image-cache", "invalidate"}, {}, "Discard existing / dirty image cache", "",
+  &get_arguments, &execute_discard);
+
+} // namespace image_cache
+} // namespace action
+} // namespace rbd


### PR DESCRIPTION
Add an rbd command to discard RWL cache if the cache is corrupted or not needed. 

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
