### PR TITLE
nautilus: monclient: schedule first tick using mon_client_hunt_interval

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -863,11 +863,13 @@ void MonClient::_un_backoff()
 void MonClient::schedule_tick()
 {
   auto do_tick = make_lambda_context([this]() { tick(); });
-  if (_hunting()) {
+  if (!is_connected()) {
+    // start another round of hunting
     const auto hunt_interval = (cct->_conf->mon_client_hunt_interval *
 				reopen_interval_multiplier);
     timer.add_event_after(hunt_interval, do_tick);
   } else {
+    // keep in touch
     timer.add_event_after(cct->_conf->mon_client_ping_interval, do_tick);
   }
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46952

---

backport of https://github.com/ceph/ceph/pull/36065
parent tracker: https://tracker.ceph.com/issues/46445

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh