### PR TITLE
nautilus: rgw: policy: reuse eval_principal to evaluate the policy principal

### DIFF
--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -963,12 +963,9 @@ ostream& operator <<(ostream& m, const Condition& c) {
 Effect Statement::eval(const Environment& e,
 		       boost::optional<const rgw::auth::Identity&> ida,
 		       uint64_t act, const ARN& res) const {
-  if (ida) {
-    if (!princ.empty() && !ida->is_identity(princ)) {
-      return Effect::Pass;
-    } else if (!noprinc.empty() && ida->is_identity(noprinc)) {
-      return Effect::Pass;
-    }
+
+  if (eval_principal(e, ida) == Effect::Deny) {
+    return Effect::Pass;
   }
 
   if (!resource.empty()) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46954

---

backport of https://github.com/ceph/ceph/pull/36303
parent tracker: https://tracker.ceph.com/issues/46078

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh