### PR TITLE
octopus: librbd:  global and pool-level config overrides require image refresh to apply

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7467,6 +7467,12 @@ static std::vector<Option> get_rbd_options() {
     Option("rbd_rwl_path", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("/tmp")
     .set_description("location of the persistent write back cache in a DAX-enabled filesystem on persistent memory"),
+
+    Option("rbd_config_pool_override_update_timestamp", Option::TYPE_UINT,
+           Option::LEVEL_DEV)
+    .set_default(0)
+    .set_description("timestamp of last update to pool-level config overrides"),
+
   });
 }
 

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(rbd_types STATIC
 set(librbd_internal_srcs
   AsyncObjectThrottle.cc
   AsyncRequest.cc
+  ConfigWatcher.cc
   DeepCopyRequest.cc
   ExclusiveLock.cc
   ImageCtx.cc

--- a/src/librbd/ConfigWatcher.cc
+++ b/src/librbd/ConfigWatcher.cc
@@ -1,0 +1,116 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/ConfigWatcher.h"
+#include "common/config_obs.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "librbd/api/Config.h"
+#include <deque>
+#include <string>
+#include <vector>
+#include <boost/algorithm/string/predicate.hpp>
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::ConfigWatcher: " \
+                           << __func__ << ": "
+
+namespace librbd {
+
+template <typename I>
+struct ConfigWatcher<I>::Observer : public md_config_obs_t {
+  ConfigWatcher<I>* m_config_watcher;
+
+  std::deque<std::string> m_config_key_strs;
+  mutable std::vector<const char*> m_config_keys;
+
+  Observer(CephContext* cct, ConfigWatcher<I>* config_watcher)
+    : m_config_watcher(config_watcher) {
+    const std::string rbd_key_prefix("rbd_");
+    auto& schema = cct->_conf.get_schema();
+    for (auto& pair : schema) {
+      // watch all "rbd_" keys for simplicity
+      if (!boost::starts_with(pair.first, rbd_key_prefix)) {
+        continue;
+      }
+
+      m_config_key_strs.emplace_back(pair.first);
+    }
+
+    m_config_keys.reserve(m_config_key_strs.size());
+    for (auto& key : m_config_key_strs) {
+      m_config_keys.emplace_back(key.c_str());
+    }
+    m_config_keys.emplace_back(nullptr);
+  }
+
+  const char** get_tracked_conf_keys() const override {
+    ceph_assert(!m_config_keys.empty());
+    return &m_config_keys[0];
+  }
+
+  void handle_conf_change(const ConfigProxy& conf,
+                          const std::set <std::string> &changed) override {
+    m_config_watcher->handle_global_config_change(changed);
+  }
+};
+
+template <typename I>
+ConfigWatcher<I>::ConfigWatcher(I& image_ctx)
+  : m_image_ctx(image_ctx) {
+}
+
+template <typename I>
+ConfigWatcher<I>::~ConfigWatcher() {
+  ceph_assert(m_observer == nullptr);
+}
+
+template <typename I>
+void ConfigWatcher<I>::init() {
+  auto cct = m_image_ctx.cct;
+  ldout(cct, 10) << dendl;
+
+  m_observer = new Observer(cct, this);
+  cct->_conf.add_observer(m_observer);
+}
+
+template <typename I>
+void ConfigWatcher<I>::shut_down() {
+  auto cct = m_image_ctx.cct;
+  ldout(cct, 10) << dendl;
+
+  ceph_assert(m_observer != nullptr);
+  cct->_conf.remove_observer(m_observer);
+
+  delete m_observer;
+  m_observer = nullptr;
+}
+
+template <typename I>
+void ConfigWatcher<I>::handle_global_config_change(
+    std::set<std::string> changed_keys) {
+
+  {
+    // ignore any global changes that are being overridden
+    std::shared_lock image_locker{m_image_ctx.image_lock};
+    for (auto& key : m_image_ctx.config_overrides) {
+      changed_keys.erase(key);
+    }
+  }
+  if (changed_keys.empty()) {
+    return;
+  }
+
+  auto cct = m_image_ctx.cct;
+  ldout(cct, 10) << "changed_keys=" << changed_keys << dendl;
+
+  // refresh the image to pick up any global config overrides
+  m_image_ctx.state->handle_update_notification();
+}
+
+} // namespace librbd
+
+template class librbd::ConfigWatcher<librbd::ImageCtx>;

--- a/src/librbd/ConfigWatcher.h
+++ b/src/librbd/ConfigWatcher.h
@@ -1,0 +1,47 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_CONFIG_WATCHER_H
+#define CEPH_LIBRBD_CONFIG_WATCHER_H
+
+#include <set>
+#include <string>
+
+struct Context;
+
+namespace librbd {
+
+struct ImageCtx;
+
+template <typename ImageCtxT>
+class ConfigWatcher {
+public:
+  static ConfigWatcher* create(ImageCtxT& image_ctx) {
+    return new ConfigWatcher(image_ctx);
+  }
+
+  ConfigWatcher(ImageCtxT& image_ctx);
+  ~ConfigWatcher();
+
+  ConfigWatcher(const ConfigWatcher&) = delete;
+  ConfigWatcher& operator=(const ConfigWatcher&) = delete;
+
+  void init();
+  void shut_down();
+
+private:
+  struct Observer;
+
+  ImageCtxT& m_image_ctx;
+
+  Observer* m_observer = nullptr;
+
+  void handle_global_config_change(std::set<std::string> changed);
+
+};
+
+} // namespace librbd
+
+extern template class librbd::ConfigWatcher<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_CONFIG_WATCHER_H

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -727,6 +727,8 @@ public:
                                 bool thread_safe) {
     ldout(cct, 20) << __func__ << dendl;
 
+    std::unique_lock image_locker(image_lock);
+
     // reset settings back to global defaults
     for (auto& key : config_overrides) {
       std::string value;
@@ -764,6 +766,8 @@ public:
         }
       }
     }
+
+    image_locker.unlock();
 
 #define ASSIGN_OPTION(param, type)              \
     param = config.get_val<type>("rbd_"#param)

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -158,6 +158,7 @@ public:
   }
 
   ImageCtx::~ImageCtx() {
+    ceph_assert(config_watcher == nullptr);
     ceph_assert(image_watcher == NULL);
     ceph_assert(exclusive_lock == NULL);
     ceph_assert(object_map == NULL);

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -42,6 +42,7 @@ class SafeTimer;
 
 namespace librbd {
 
+  template <typename> class ConfigWatcher;
   template <typename> class ExclusiveLock;
   template <typename> class ImageState;
   template <typename> class ImageWatcher;
@@ -109,6 +110,8 @@ namespace librbd {
     cls::rbd::SnapshotNamespace snap_namespace;
     std::string snap_name;
     IoCtx data_ctx, md_ctx;
+
+    ConfigWatcher<ImageCtx> *config_watcher = nullptr;
     ImageWatcher<ImageCtx> *image_watcher;
     Journal<ImageCtx> *journal;
 

--- a/src/librbd/api/Config.cc
+++ b/src/librbd/api/Config.cc
@@ -36,7 +36,8 @@ static std::set<std::string_view> EXCLUDE_OPTIONS {
     "rbd_tracing",
     "rbd_validate_names",
     "rbd_validate_pool",
-    "rbd_mirror_pool_replayers_refresh_interval"
+    "rbd_mirror_pool_replayers_refresh_interval",
+    "rbd_config_pool_override_update_timestamp"
   };
 static std::set<std::string_view> EXCLUDE_IMAGE_OPTIONS {
     "rbd_default_clone_format",

--- a/src/librbd/image/CloseRequest.cc
+++ b/src/librbd/image/CloseRequest.cc
@@ -4,6 +4,7 @@
 #include "librbd/image/CloseRequest.h"
 #include "common/dout.h"
 #include "common/errno.h"
+#include "librbd/ConfigWatcher.h"
 #include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageState.h"
@@ -34,6 +35,13 @@ CloseRequest<I>::CloseRequest(I *image_ctx, Context *on_finish)
 
 template <typename I>
 void CloseRequest<I>::send() {
+  if (m_image_ctx->config_watcher != nullptr) {
+    m_image_ctx->config_watcher->shut_down();
+
+    delete m_image_ctx->config_watcher;
+    m_image_ctx->config_watcher = nullptr;
+  }
+
   send_block_image_watcher();
 }
 

--- a/src/librbd/image/OpenRequest.cc
+++ b/src/librbd/image/OpenRequest.cc
@@ -5,6 +5,7 @@
 #include "common/dout.h"
 #include "common/errno.h"
 #include "cls/rbd/cls_rbd_client.h"
+#include "librbd/ConfigWatcher.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/Utils.h"
 #include "librbd/cache/ObjectCacherObjectDispatch.h"
@@ -499,6 +500,9 @@ void OpenRequest<I>::send_refresh() {
 
   CephContext *cct = m_image_ctx->cct;
   ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  m_image_ctx->config_watcher = ConfigWatcher<I>::create(*m_image_ctx);
+  m_image_ctx->config_watcher->init();
 
   using klass = OpenRequest<I>;
   RefreshRequest<I> *req = RefreshRequest<I>::create(

--- a/src/test/librados_test_stub/TestRadosClient.cc
+++ b/src/test/librados_test_stub/TestRadosClient.cc
@@ -169,6 +169,8 @@ int TestRadosClient::mon_command(const std::vector<std::string>& cmd,
       return 0;
     } else if ((*j_it)->get_data() == "config-key rm") {
       return 0;
+    } else if ((*j_it)->get_data() == "config set") {
+      return 0;
     } else if ((*j_it)->get_data() == "df") {
       std::stringstream str;
       str << R"({"pools": [)";

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(rbd_test_mock PUBLIC
 set(unittest_librbd_srcs
   test_main.cc
   test_mock_fixture.cc
+  test_mock_ConfigWatcher.cc
   test_mock_DeepCopyRequest.cc
   test_mock_ExclusiveLock.cc
   test_mock_Journal.cc

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -318,6 +318,7 @@ struct MockImageCtx {
   bool cache;
 
   ConfigProxy config;
+  std::set<std::string> config_overrides;
 };
 
 } // namespace librbd

--- a/src/test/librbd/mock/MockImageState.h
+++ b/src/test/librbd/mock/MockImageState.h
@@ -30,6 +30,8 @@ struct MockImageState {
 
   MOCK_METHOD2(register_update_watcher, int(UpdateWatchCtx *, uint64_t *));
   MOCK_METHOD2(unregister_update_watcher, void(uint64_t, Context *));  
+
+  MOCK_METHOD0(handle_update_notification, void());
 };
 
 } // namespace librbd

--- a/src/test/librbd/test_mock_ConfigWatcher.cc
+++ b/src/test/librbd/test_mock_ConfigWatcher.cc
@@ -1,0 +1,100 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_mock_fixture.h"
+#include "test/librbd/test_support.h"
+#include "include/rbd_types.h"
+#include "common/ceph_mutex.h"
+#include "librbd/ConfigWatcher.h"
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include <list>
+
+namespace librbd {
+namespace {
+
+struct MockTestImageCtx : public MockImageCtx {
+  MockTestImageCtx(ImageCtx &image_ctx) : MockImageCtx(image_ctx) {
+  }
+};
+
+} // anonymous namespace
+} // namespace librbd
+
+#include "librbd/ConfigWatcher.cc"
+
+namespace librbd {
+
+using ::testing::Invoke;
+
+class TestMockConfigWatcher : public TestMockFixture {
+public:
+  typedef ConfigWatcher<MockTestImageCtx> MockConfigWatcher;
+
+  librbd::ImageCtx *m_image_ctx;
+
+  ceph::mutex m_lock = ceph::make_mutex("m_lock");
+  ceph::condition_variable m_cv;
+  bool m_refreshed = false;
+
+  void SetUp() override {
+    TestMockFixture::SetUp();
+
+    ASSERT_EQ(0, open_image(m_image_name, &m_image_ctx));
+  }
+
+  void expect_update_notification(MockTestImageCtx& mock_image_ctx) {
+    EXPECT_CALL(*mock_image_ctx.state, handle_update_notification())
+      .WillOnce(Invoke([this]() {
+          std::unique_lock locker{m_lock};
+          m_refreshed = true;
+          m_cv.notify_all();
+        }));
+  }
+
+  void wait_for_update_notification() {
+    std::unique_lock locker{m_lock};
+    m_cv.wait(locker, [this] {
+        if (m_refreshed) {
+          m_refreshed = false;
+          return true;
+        }
+        return false;
+      });
+  }
+};
+
+TEST_F(TestMockConfigWatcher, GlobalConfig) {
+  MockTestImageCtx mock_image_ctx(*m_image_ctx);
+
+  MockConfigWatcher mock_config_watcher(mock_image_ctx);
+  mock_config_watcher.init();
+
+  expect_update_notification(mock_image_ctx);
+  mock_image_ctx.cct->_conf.set_val("rbd_cache", "false");
+  mock_image_ctx.cct->_conf.set_val("rbd_cache", "true");
+  mock_image_ctx.cct->_conf.apply_changes(nullptr);
+  wait_for_update_notification();
+
+  mock_config_watcher.shut_down();
+}
+
+TEST_F(TestMockConfigWatcher, IgnoreOverriddenGlobalConfig) {
+  MockTestImageCtx mock_image_ctx(*m_image_ctx);
+
+  MockConfigWatcher mock_config_watcher(mock_image_ctx);
+  mock_config_watcher.init();
+
+  EXPECT_CALL(*mock_image_ctx.state, handle_update_notification())
+    .Times(0);
+  mock_image_ctx.config_overrides.insert("rbd_cache");
+  mock_image_ctx.cct->_conf.set_val("rbd_cache", "false");
+  mock_image_ctx.cct->_conf.set_val("rbd_cache", "true");
+  mock_image_ctx.cct->_conf.apply_changes(nullptr);
+
+  mock_config_watcher.shut_down();
+
+  ASSERT_FALSE(m_refreshed);
+}
+
+} // namespace librbd


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46945

---

backport of https://github.com/ceph/ceph/pull/36309
parent tracker: https://tracker.ceph.com/issues/46694

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh