### PR TITLE
octopus: rgw: stop realm reloader before store shutdown

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -600,10 +600,11 @@ int radosgw_Main(int argc, const char **argv)
   // add a watcher to respond to realm configuration changes
   RGWPeriodPusher pusher(store);
   RGWFrontendPauser pauser(fes, implicit_tenant_context, &pusher);
-  RGWRealmReloader reloader(store, service_map_meta, &pauser);
+  std::optional<RGWRealmReloader> reloader(std::in_place, store,
+                                           service_map_meta, &pauser);
 
   RGWRealmWatcher realm_watcher(g_ceph_context, store->svc()->zone->get_realm());
-  realm_watcher.add_watcher(RGWRealmNotify::Reload, reloader);
+  realm_watcher.add_watcher(RGWRealmNotify::Reload, *reloader);
   realm_watcher.add_watcher(RGWRealmNotify::ZonesNeedPeriod, pusher);
 
 #if defined(HAVE_SYS_PRCTL_H)
@@ -615,6 +616,8 @@ int radosgw_Main(int argc, const char **argv)
   wait_shutdown();
 
   derr << "shutting down" << dendl;
+
+  reloader.reset(); // stop the realm reloader
 
   for (list<RGWFrontend *>::iterator liter = fes.begin(); liter != fes.end();
        ++liter) {

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -600,8 +600,8 @@ int radosgw_Main(int argc, const char **argv)
   // add a watcher to respond to realm configuration changes
   RGWPeriodPusher pusher(store);
   RGWFrontendPauser pauser(fes, implicit_tenant_context, &pusher);
-  std::optional<RGWRealmReloader> reloader(std::in_place, store,
-                                           service_map_meta, &pauser);
+  auto reloader = std::make_unique<RGWRealmReloader>(store,
+						     service_map_meta, &pauser);
 
   RGWRealmWatcher realm_watcher(g_ceph_context, store->svc()->zone->get_realm());
   realm_watcher.add_watcher(RGWRealmNotify::Reload, *reloader);


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/46471
* https://tracker.ceph.com/issues/47114

---

backport of

* https://github.com/ceph/ceph/pull/35525
* https://github.com/ceph/ceph/pull/36521

parent trackers:

* https://tracker.ceph.com/issues/45969
* https://tracker.ceph.com/issues/47113

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh

---

To Do:

- [x] #36521 merged
- [x] #36521 cherry-picked into this PR
- [x] check if #36521 gets a tracker ticket and backport tickets (if so, link octopus backport ticket to this PR)
- [x] remove DNM, queue for testing