### PR TITLE
octopus: rgw: fix boost::asio::async_write() does not return error...

### DIFF
--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -69,6 +69,10 @@ class StreamIO : public rgw::asio::ClientIO {
                                           yield[ec]);
     if (ec) {
       ldout(cct, 4) << "write_data failed: " << ec.message() << dendl;
+      if (ec==boost::asio::error::broken_pipe) {
+        boost::system::error_code ec_ignored;
+        stream.lowest_layer().shutdown(tcp::socket::shutdown_both, ec_ignored);
+      }
       throw rgw::io::Exception(ec.value(), std::system_category());
     }
     return bytes;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46518

---

backport of https://github.com/ceph/ceph/pull/35904
parent tracker: https://tracker.ceph.com/issues/46332

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh