### PR TITLE
octopus: qa/tasks/ragweed: always set ragweed_repo

### DIFF
--- a/qa/tasks/ragweed.py
+++ b/qa/tasks/ragweed.py
@@ -18,6 +18,33 @@ from teuthology.orchestra import run
 
 log = logging.getLogger(__name__)
 
+
+def get_ragweed_branches(config, client_conf):
+    """
+    figure out the ragweed branch according to the per-client settings
+
+    use force-branch is specified, and fall back to the ones deduced using ceph
+    branch under testing
+    """
+    force_branch = client_conf.get('force-branch', None)
+    if force_branch:
+        return [force_branch]
+    else:
+        S3_BRANCHES = ['master', 'nautilus', 'mimic',
+                       'luminous', 'kraken', 'jewel']
+        ceph_branch = config.get('branch')
+        suite_branch = config.get('suite_branch', ceph_branch)
+        if suite_branch in S3_BRANCHES:
+            branch = client_conf.get('branch', 'ceph-' + suite_branch)
+        else:
+            branch = client_conf.get('branch', suite_branch)
+        default_branch = client_conf.get('default-branch', None)
+        if default_branch:
+            return [branch, default_branch]
+        else:
+            return [branch]
+
+
 @contextlib.contextmanager
 def download(ctx, config):
     """
@@ -30,46 +57,21 @@ def download(ctx, config):
     assert isinstance(config, dict)
     log.info('Downloading ragweed...')
     testdir = teuthology.get_testdir(ctx)
-    s3_branches = [ 'master', 'nautilus', 'mimic', 'luminous', 'kraken', 'jewel' ]
     for (client, cconf) in config.items():
-        default_branch = ''
-        branch = cconf.get('force-branch', None)
-        if not branch:
-            default_branch = cconf.get('default-branch', None)
-            ceph_branch = ctx.config.get('branch')
-            suite_branch = ctx.config.get('suite_branch', ceph_branch)
-            ragweed_repo = ctx.config.get('ragweed_repo', teuth_config.ceph_git_base_url + 'ragweed.git')
-            if suite_branch in s3_branches:
-                branch = cconf.get('branch', 'ceph-' + suite_branch)
-            else:
-                branch = cconf.get('branch', suite_branch)
-        if not branch:
-            raise ValueError(
-                "Could not determine what branch to use for ragweed!")
-        else:
+        ragweed_repo = ctx.config.get('ragweed_repo',
+                                      teuth_config.ceph_git_base_url + 'ragweed.git')
+        for branch in get_ragweed_branches(ctx.config, cconf):
             log.info("Using branch '%s' for ragweed", branch)
-        sha1 = cconf.get('sha1')
-        try:
-            ctx.cluster.only(client).run(
-                args=[
-                    'git', 'clone',
-                    '-b', branch,
-                    ragweed_repo,
-                    '{tdir}/ragweed'.format(tdir=testdir),
-                    ],
-                )
-        except Exception as e:
-            if not default_branch:
-                raise e
-            ctx.cluster.only(client).run(
-                args=[
-                    'git', 'clone',
-                    '-b', default_branch,
-                    ragweed_repo,
-                    '{tdir}/ragweed'.format(tdir=testdir),
-                    ],
-                )
+            try:
+                ctx.cluster.only(client).sh(
+                    script=f'git clone -b {branch} {ragweed_repo} {testdir}/ragweed')
+                break
+            except Exception as e:
+                exc = e
+        else:
+            raise exc
 
+        sha1 = cconf.get('sha1')
         if sha1 is not None:
             ctx.cluster.only(client).run(
                 args=[


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46938

---

backport of https://github.com/ceph/ceph/pull/36367
parent tracker: https://tracker.ceph.com/issues/46771

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh