### PR TITLE
octopus: cls/rgw: preserve olh entry's name on last unlink

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1795,7 +1795,9 @@ static int rgw_bucket_unlink_instance(cls_method_context_t hctx, bufferlist *in,
       olh.update(next_key, next.is_delete_marker());
       olh.update_log(CLS_RGW_OLH_OP_LINK_OLH, op.op_tag, next_key, next.is_delete_marker());
     } else {
-      /* next_key is empty */
+      // next_key is empty, but we need to preserve its name in case this entry
+      // gets resharded, because this key is used for hash placement
+      next_key.name = dest_key.name;
       olh.update(next_key, false);
       olh.update_log(CLS_RGW_OLH_OP_UNLINK_OLH, op.op_tag, next_key, false);
       olh.set_exists(false);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46949

---

backport of https://github.com/ceph/ceph/pull/36015
parent tracker: https://tracker.ceph.com/issues/46456

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh