### PR TITLE
octopus: rgw: fix double slash (//) killing the gateway

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4863,7 +4863,7 @@ bool RGWHandler_REST_S3Website::web_dir() const {
 
   if (subdir_name.empty()) {
     return false;
-  } else if (subdir_name.back() == '/') {
+  } else if (subdir_name.back() == '/' && subdir_name.size() > 1) {
     subdir_name.pop_back();
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46966

---

backport of https://github.com/ceph/ceph/pull/35792
parent tracker: https://tracker.ceph.com/issues/41225

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh