### PR TITLE
octopus: rbd: librbd: race when disabling object map with overlapping in-flight writes

### DIFF
--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -8,6 +8,7 @@
 #include "include/fs_types.h"
 #include "include/rados/librados_fwd.hpp"
 #include "include/rbd/object_map_types.h"
+#include "common/AsyncOpTracker.h"
 #include "common/bit_vector.hpp"
 #include "common/RWLock.h"
 #include "common/RefCountedObj.h"
@@ -102,6 +103,7 @@ public:
         return false;
       }
 
+      m_async_op_tracker.start_op();
       UpdateOperation update_operation(start_object_no, end_object_no,
                                        new_state, current_state, parent_trace,
                                        ignore_enoent,
@@ -150,6 +152,7 @@ private:
   mutable ceph::shared_mutex m_lock;
   ceph::BitVector<2> m_object_map;
 
+  AsyncOpTracker m_async_op_tracker;
   UpdateGuard *m_update_guard = nullptr;
 
   void detained_aio_update(UpdateOperation &&update_operation);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46150

---

backport of https://github.com/ceph/ceph/pull/35658
parent tracker: https://tracker.ceph.com/issues/46083

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh