### PR TITLE
octopus: rbd: librbd: flush all queued object IO from simple scheduler

### DIFF
--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -73,6 +73,7 @@ set(librbd_internal_srcs
   io/AioCompletion.cc
   io/AsyncOperation.cc
   io/CopyupRequest.cc
+  io/FlushTracker.cc
   io/ImageDispatchSpec.cc
   io/ImageRequest.cc
   io/ImageRequestWQ.cc

--- a/src/librbd/io/FlushTracker.cc
+++ b/src/librbd/io/FlushTracker.cc
@@ -1,0 +1,125 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/io/FlushTracker.h"
+#include "common/dout.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Utils.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::io::FlushTracker: " << this \
+                           << " " << __func__ << ": "
+
+namespace librbd {
+namespace io {
+
+template <typename I>
+FlushTracker<I>::FlushTracker(I* image_ctx)
+  : m_image_ctx(image_ctx),
+    m_lock(ceph::make_shared_mutex(
+      util::unique_lock_name("librbd::io::FlushTracker::m_lock", this))) {
+}
+
+template <typename I>
+FlushTracker<I>::~FlushTracker() {
+  std::unique_lock locker{m_lock};
+  ceph_assert(m_flush_contexts.empty());
+}
+
+template <typename I>
+void FlushTracker<I>::shut_down() {
+  auto cct = m_image_ctx->cct;
+  ldout(cct, 20) << dendl;
+
+  std::unique_lock locker{m_lock};
+  Contexts flush_ctxs;
+  for (auto& [flush_tid, ctxs] : m_flush_contexts) {
+    flush_ctxs.insert(flush_ctxs.end(), ctxs.begin(), ctxs.end());
+  }
+  locker.unlock();
+
+  for (auto ctx : flush_ctxs) {
+    ctx->complete(0);
+  }
+}
+
+template <typename I>
+uint64_t FlushTracker<I>::start_io(uint64_t tid) {
+  auto cct = m_image_ctx->cct;
+
+  std::unique_lock locker{m_lock};
+  auto [it, inserted] = m_tid_to_flush_tid.insert({tid, ++m_next_flush_tid});
+  auto flush_tid = it->second;
+  m_in_flight_flush_tids.insert(flush_tid);
+  locker.unlock();
+
+  ldout(cct, 20) << "tid=" << tid << ", flush_tid=" << flush_tid << dendl;
+  return flush_tid;
+}
+
+template <typename I>
+void FlushTracker<I>::finish_io(uint64_t tid) {
+  auto cct = m_image_ctx->cct;
+
+  std::unique_lock locker{m_lock};
+  auto tid_to_flush_tid_it = m_tid_to_flush_tid.find(tid);
+  if (tid_to_flush_tid_it == m_tid_to_flush_tid.end()) {
+    return;
+  }
+
+  auto flush_tid = tid_to_flush_tid_it->second;
+  m_tid_to_flush_tid.erase(tid_to_flush_tid_it);
+  m_in_flight_flush_tids.erase(flush_tid);
+
+  ldout(cct, 20) << "tid=" << tid << ", flush_tid=" << flush_tid << dendl;
+  auto oldest_flush_tid = std::numeric_limits<uint64_t>::max();
+  if (!m_in_flight_flush_tids.empty()) {
+    oldest_flush_tid = *m_in_flight_flush_tids.begin();
+  }
+
+  // all flushes tagged before the oldest tid should be completed
+  Contexts flush_ctxs;
+  auto flush_contexts_it = m_flush_contexts.begin();
+  while (flush_contexts_it != m_flush_contexts.end()) {
+    if (flush_contexts_it->first >= oldest_flush_tid) {
+      ldout(cct, 20) << "pending IOs: [" << m_in_flight_flush_tids << "], "
+                     << "pending flushes=" << m_flush_contexts << dendl;
+      break;
+    }
+
+    auto& ctxs = flush_contexts_it->second;
+    flush_ctxs.insert(flush_ctxs.end(), ctxs.begin(), ctxs.end());
+    flush_contexts_it = m_flush_contexts.erase(flush_contexts_it);
+  }
+  locker.unlock();
+
+  if (!flush_ctxs.empty()) {
+    ldout(cct, 20) << "completing flushes: " << flush_ctxs << dendl;
+    for (auto ctx : flush_ctxs) {
+      ctx->complete(0);
+    }
+  }
+}
+
+template <typename I>
+void FlushTracker<I>::flush(Context* on_finish) {
+  auto cct = m_image_ctx->cct;
+
+  std::unique_lock locker{m_lock};
+  if (m_in_flight_flush_tids.empty()) {
+    locker.unlock();
+    on_finish->complete(0);
+    return;
+  }
+
+  auto flush_tid = *m_in_flight_flush_tids.rbegin();
+  m_flush_contexts[flush_tid].push_back(on_finish);
+  ldout(cct, 20) << "flush_tid=" << flush_tid << ", ctx=" << on_finish << ", "
+                 << "flush_contexts=" << m_flush_contexts << dendl;
+}
+
+} // namespace io
+} // namespace librbd
+
+template class librbd::io::FlushTracker<librbd::ImageCtx>;

--- a/src/librbd/io/FlushTracker.h
+++ b/src/librbd/io/FlushTracker.h
@@ -1,0 +1,61 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_IO_FLUSH_TRACKER_H
+#define CEPH_LIBRBD_IO_FLUSH_TRACKER_H
+
+#include "include/int_types.h"
+#include "common/ceph_mutex.h"
+#include <atomic>
+#include <list>
+#include <map>
+#include <set>
+#include <unordered_map>
+
+struct Context;
+
+namespace librbd {
+
+struct ImageCtx;
+
+namespace io {
+
+struct AioCompletion;
+
+template <typename ImageCtxT>
+class FlushTracker {
+public:
+  FlushTracker(ImageCtxT* image_ctx);
+  ~FlushTracker();
+
+  void shut_down();
+
+  uint64_t start_io(uint64_t tid);
+  void finish_io(uint64_t tid);
+
+  void flush(Context* on_finish);
+
+private:
+  typedef std::list<Context*> Contexts;
+  typedef std::map<uint64_t, Contexts> FlushContexts;
+  typedef std::set<uint64_t> Tids;
+  typedef std::unordered_map<uint64_t, uint64_t> TidToFlushTid;
+
+  ImageCtxT* m_image_ctx;
+
+  std::atomic<uint32_t> m_next_flush_tid{0};
+
+  mutable ceph::shared_mutex m_lock;
+  TidToFlushTid m_tid_to_flush_tid;
+
+  Tids m_in_flight_flush_tids;
+  FlushContexts m_flush_contexts;
+
+};
+
+} // namespace io
+} // namespace librbd
+
+extern template class librbd::io::FlushTracker<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_IO_FLUSH_TRACKER_H

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.cc
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.cc
@@ -7,6 +7,7 @@
 #include "common/errno.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/Utils.h"
+#include "librbd/io/FlushTracker.h"
 #include "librbd/io/ObjectDispatchSpec.h"
 #include "librbd/io/ObjectDispatcher.h"
 #include "librbd/io/Utils.h"
@@ -174,6 +175,7 @@ template <typename I>
 SimpleSchedulerObjectDispatch<I>::SimpleSchedulerObjectDispatch(
     I* image_ctx)
   : m_image_ctx(image_ctx),
+    m_flush_tracker(new FlushTracker<I>(image_ctx)),
     m_lock(ceph::make_mutex(librbd::util::unique_lock_name(
       "librbd::io::SimpleSchedulerObjectDispatch::lock", this))),
     m_max_delay(image_ctx->config.template get_val<uint64_t>(
@@ -190,6 +192,7 @@ SimpleSchedulerObjectDispatch<I>::SimpleSchedulerObjectDispatch(
 
 template <typename I>
 SimpleSchedulerObjectDispatch<I>::~SimpleSchedulerObjectDispatch() {
+  delete m_flush_tracker;
 }
 
 template <typename I>
@@ -206,6 +209,7 @@ void SimpleSchedulerObjectDispatch<I>::shut_down(Context* on_finish) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 5) << dendl;
 
+  m_flush_tracker->shut_down();
   on_finish->complete(0);
 }
 
@@ -260,6 +264,15 @@ bool SimpleSchedulerObjectDispatch<I>::write(
   std::lock_guard locker{m_lock};
   if (try_delay_write(object_no, object_off, std::move(data), snapc, op_flags,
                       *object_dispatch_flags, on_dispatched)) {
+
+    auto dispatch_seq = ++m_dispatch_seq;
+    m_flush_tracker->start_io(dispatch_seq);
+    *on_finish = new LambdaContext(
+      [this, dispatch_seq, ctx=*on_finish](int r) {
+        ctx->complete(r);
+        m_flush_tracker->finish_io(dispatch_seq);
+      });
+
     *dispatch_result = DISPATCH_RESULT_COMPLETE;
     return true;
   }
@@ -316,10 +329,15 @@ bool SimpleSchedulerObjectDispatch<I>::flush(
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << dendl;
 
-  std::lock_guard locker{m_lock};
-  dispatch_all_delayed_requests();
+  {
+    std::lock_guard locker{m_lock};
+    dispatch_all_delayed_requests();
+  }
 
-  return false;
+  *dispatch_result = DISPATCH_RESULT_CONTINUE;
+  m_flush_tracker->flush(on_dispatched);
+
+  return true;
 }
 
 template <typename I>
@@ -403,24 +421,30 @@ void SimpleSchedulerObjectDispatch<I>::register_in_flight_request(
   auto it = res.first;
 
   auto dispatch_seq = ++m_dispatch_seq;
+  m_flush_tracker->start_io(dispatch_seq);
+
   it->second->set_dispatch_seq(dispatch_seq);
   *on_finish = new LambdaContext(
     [this, object_no, dispatch_seq, start_time, ctx=*on_finish](int r) {
       ctx->complete(r);
 
-      std::lock_guard locker{m_lock};
+      std::unique_lock locker{m_lock};
       if (m_latency_stats && start_time != utime_t()) {
         auto latency = ceph_clock_now() - start_time;
         m_latency_stats->add(latency.to_nsec());
       }
+
       auto it = m_requests.find(object_no);
       if (it == m_requests.end() ||
           it->second->get_dispatch_seq() != dispatch_seq) {
         ldout(m_image_ctx->cct, 20) << "already dispatched" << dendl;
-        return;
+      } else {
+        dispatch_delayed_requests(it->second);
+        m_requests.erase(it);
       }
-      dispatch_delayed_requests(it->second);
-      m_requests.erase(it);
+      locker.unlock();
+
+      m_flush_tracker->finish_io(dispatch_seq);
     });
 }
 

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.h
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.h
@@ -22,6 +22,7 @@ class ImageCtx;
 
 namespace io {
 
+template <typename> class FlushTracker;
 class LatencyStats;
 
 /**
@@ -175,6 +176,8 @@ private:
   typedef std::map<uint64_t, ObjectRequestsRef> Requests;
 
   ImageCtxT *m_image_ctx;
+
+  FlushTracker<ImageCtxT>* m_flush_tracker;
 
   ceph::mutex m_lock;
   SafeTimer *m_timer;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46711

---

backport of https://github.com/ceph/ceph/pull/36242
parent tracker: https://tracker.ceph.com/issues/46668

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh