### PR TITLE
octopus: rbd: librbd: don't resend async_complete if watcher is unregistered

### DIFF
--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -160,12 +160,13 @@ void ImageWatcher<I>::handle_async_complete(const AsyncRequestId &request,
 			   << cpp_strerror(ret_val) << dendl;
     if (ret_val == -ETIMEDOUT && !is_unregistered()) {
       schedule_async_complete(request, r);
+      m_async_op_tracker.finish_op();
+      return;
     }
-  } else {
-    std::unique_lock async_request_locker{m_async_request_lock};
-    m_async_pending.erase(request);
   }
 
+  std::unique_lock async_request_locker{m_async_request_lock};
+  m_async_pending.erase(request);
   m_async_op_tracker.finish_op();
 }
 

--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -88,6 +88,9 @@ void ImageWatcher<I>::unregister_watch(Context *on_finish) {
 
   cancel_async_requests();
 
+  on_finish = new LambdaContext([this, on_finish](int r) {
+    m_async_op_tracker.wait_for_ops(on_finish);
+  });
   auto ctx = new LambdaContext([this, on_finish](int r) {
     m_task_finisher->cancel_all(on_finish);
   });
@@ -129,6 +132,7 @@ int ImageWatcher<I>::notify_async_progress(const AsyncRequestId &request,
 template <typename I>
 void ImageWatcher<I>::schedule_async_complete(const AsyncRequestId &request,
                                               int r) {
+  m_async_op_tracker.start_op();
   auto ctx = new LambdaContext(
     boost::bind(&ImageWatcher<I>::notify_async_complete, this, request, r));
   m_task_finisher->queue(ctx);
@@ -154,13 +158,15 @@ void ImageWatcher<I>::handle_async_complete(const AsyncRequestId &request,
   if (ret_val < 0) {
     lderr(m_image_ctx.cct) << this << " failed to notify async complete: "
 			   << cpp_strerror(ret_val) << dendl;
-    if (ret_val == -ETIMEDOUT) {
+    if (ret_val == -ETIMEDOUT && !is_unregistered()) {
       schedule_async_complete(request, r);
     }
   } else {
     std::unique_lock async_request_locker{m_async_request_lock};
     m_async_pending.erase(request);
   }
+
+  m_async_op_tracker.finish_op();
 }
 
 template <typename I>

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -5,6 +5,7 @@
 #define CEPH_LIBRBD_IMAGE_WATCHER_H
 
 #include "cls/rbd/cls_rbd_types.h"
+#include "common/AsyncOpTracker.h"
 #include "common/ceph_mutex.h"
 #include "include/Context.h"
 #include "include/rbd/librbd.hpp"
@@ -170,6 +171,8 @@ private:
 
   ceph::mutex m_owner_client_id_lock;
   watch_notify::ClientId m_owner_client_id;
+
+  AsyncOpTracker m_async_op_tracker;
 
   void handle_register_watch(int r);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46719

---

backport of https://github.com/ceph/ceph/pull/35981
parent tracker: https://tracker.ceph.com/issues/45268

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh