### PR TITLE
octopus: rbd: immutable-object-cache: fixed crashes on start up

### DIFF
--- a/doc/rbd/rbd-persistent-cache.rst
+++ b/doc/rbd/rbd-persistent-cache.rst
@@ -71,6 +71,10 @@ not enough capacity it will delete some cold cache files.
 
 Here are some important cache options correspond to the following settings:
 
+- ``immutable_object_cache_sock`` The path to the domain socket used for
+  communication between librbd clients and the ceph-immutable-object-cache
+  daemon.
+
 - ``immutable_object_cache_path`` The immutable object cache data directory.
 
 - ``immutable_object_cache_max_size`` The max size for immutable cache.

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7596,7 +7596,7 @@ static std::vector<Option> get_rbd_mirror_options() {
 static std::vector<Option> get_immutable_object_cache_options() {
   return std::vector<Option>({
     Option("immutable_object_cache_path", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("/tmp")
+    .set_default("/tmp/ceph_immutable_object_cache")
     .set_description("immutable object cache data dir"),
 
     Option("immutable_object_cache_sock", Option::TYPE_STR, Option::LEVEL_ADVANCED)

--- a/src/tools/immutable_object_cache/CacheController.h
+++ b/src/tools/immutable_object_cache/CacheController.h
@@ -23,15 +23,15 @@ class CacheController {
 
   void handle_signal(int sinnum);
 
-  void run();
+  int run();
 
   void handle_request(CacheSession* session, ObjectCacheRequest* msg);
 
  private:
-  CacheServer *m_cache_server;
+  CacheServer *m_cache_server = nullptr;
   std::vector<const char*> m_args;
   CephContext *m_cct;
-  ObjectCacheStore *m_object_cache_store;
+  ObjectCacheStore *m_object_cache_store = nullptr;
 };
 
 }  // namespace immutable_obj_cache

--- a/src/tools/immutable_object_cache/CacheServer.cc
+++ b/src/tools/immutable_object_cache/CacheServer.cc
@@ -53,20 +53,22 @@ int CacheServer::start_accept() {
   boost::system::error_code ec;
   m_acceptor.open(m_local_path.protocol(), ec);
   if (ec) {
-    ldout(cct, 1) << "m_acceptor open fails: " << ec.message() << dendl;
-    return -1;
+    lderr(cct) << "failed to open domain socket: " << ec.message() << dendl;
+    return -ec.value();
   }
 
   m_acceptor.bind(m_local_path, ec);
   if (ec) {
-    ldout(cct, 1) << "m_acceptor bind fails: " << ec.message() << dendl;
-    return -1;
+    lderr(cct) << "failed to bind to domain socket '"
+               << m_local_path << "': " << ec.message() << dendl;
+    return -ec.value();
   }
 
   m_acceptor.listen(boost::asio::socket_base::max_connections, ec);
   if (ec) {
-    ldout(cct, 1) << "m_acceptor listen fails: " << ec.message() << dendl;
-    return -1;
+    lderr(cct) << "failed to listen on domain socket: " << ec.message()
+               << dendl;
+    return -ec.value();
   }
 
   accept();

--- a/src/tools/immutable_object_cache/main.cc
+++ b/src/tools/immutable_object_cache/main.cc
@@ -67,7 +67,10 @@ int main(int argc, const char **argv) {
     goto cleanup;
   }
 
-  cachectl->run();
+  r = cachectl->run();
+  if (r < 0) {
+    goto cleanup;
+  }
 
  cleanup:
   unregister_async_signal_handler(SIGHUP, sighup_handler);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46721

---

backport of https://github.com/ceph/ceph/pull/36158
parent tracker: https://tracker.ceph.com/issues/45169

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh