### PR TITLE
octopus: crush/CrushWrapper: rebuild reverse maps after rebuilding crush map

### DIFF
--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -1331,6 +1331,7 @@ public:
       crush->max_devices = name_map.rbegin()->first + 1;
     }
     have_uniform_rules = !has_legacy_rule_ids();
+    build_rmaps();
   }
   int bucket_set_alg(int id, int alg);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46595

---

backport of https://github.com/ceph/ceph/pull/36103
parent tracker: https://tracker.ceph.com/issues/44311

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh