### PR TITLE
octopus: osd/OSD.cc: remove osd_lock for bench

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2709,7 +2709,6 @@ will start to track new ops received afterwards.";
   }
 
   else if (prefix == "bench") {
-    lock_guard l(osd_lock);
     int64_t count;
     int64_t bsize;
     int64_t osize, onum;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46722

---

backport of https://github.com/ceph/ceph/pull/36251
parent tracker: https://tracker.ceph.com/issues/43888

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh