### PR TITLE
octopus: blk:BlockDevice.cc: use pending_aios instead of iovec size as ios num

### DIFF
--- a/src/os/bluestore/BlockDevice.cc
+++ b/src/os/bluestore/BlockDevice.cc
@@ -64,9 +64,7 @@ uint64_t IOContext::get_num_ios() const
   // that to the bytes value.
   uint64_t ios = 0;
 #if defined(HAVE_LIBAIO) || defined(HAVE_POSIXAIO)
-  for (auto& p : pending_aios) {
-    ios += p.iov.size();
-  }
+  ios += pending_aios.size();
 #endif
 #ifdef HAVE_SPDK
   ios += total_nseg;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46629

---

backport of https://github.com/ceph/ceph/pull/35315
parent tracker: https://tracker.ceph.com/issues/46626

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh