### PR TITLE
nautilus: pybind/mgr/restful: use dict.items() for py3 compatible

### DIFF
--- a/src/pybind/mgr/restful/common.py
+++ b/src/pybind/mgr/restful/common.py
@@ -34,7 +34,7 @@ POOL_ARGS = POOL_PROPERTIES + [x for x,_ in POOL_QUOTA_PROPERTIES]
 def humanify_command(command):
     out = [command['prefix']]
 
-    for arg, val in command.iteritems():
+    for arg, val in command.items():
         if arg != 'prefix':
             out.append("%s=%s" % (str(arg), str(val)))
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46981

---

backport of https://github.com/ceph/ceph/pull/29356
parent tracker: https://tracker.ceph.com/issues/46980

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh