### PR TITLE
mgr/dashboard: adjust cross button color in table filter chips

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
@@ -83,6 +83,10 @@
   .filter-chips {
     float: right;
     padding: 0 8px;
+
+    .badge-remove {
+      color: bd.$white;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/46986
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>

This might occur because of changes in https://github.com/ceph/ceph/pull/35954

Before:
![Screenshot_20200817_104134](https://user-images.githubusercontent.com/1691518/90355116-0570c880-e07e-11ea-907a-b5cafecf3e5f.png)

After:
![Screenshot_20200817_113622](https://user-images.githubusercontent.com/1691518/90355121-06a1f580-e07e-11ea-8d73-aa60d63d8c28.png)



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
