### PR TITLE
octopus: mgr/dashboard: Fix host attributes like labels are not returned

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/host.py
+++ b/src/pybind/mgr/dashboard/controllers/host.py
@@ -46,7 +46,7 @@ def merge_hosts_by_hostname(ceph_hosts, orch_hosts):
     for host in hosts:
         hostname = host['hostname']
         if hostname in orch_hosts_map:
-            host = merge_dicts(host, orch_hosts_map[hostname])
+            host.update(orch_hosts_map[hostname])
             host['sources']['orchestrator'] = True
             orch_hosts_map.pop(hostname)
 

--- a/src/pybind/mgr/dashboard/tests/test_host.py
+++ b/src/pybind/mgr/dashboard/tests/test_host.py
@@ -163,27 +163,37 @@ class TestHosts(unittest.TestCase):
         fake_client = mock.Mock()
         fake_client.available.return_value = True
         fake_client.hosts.list.return_value = [
-            HostSpec('node1'), HostSpec('node2')
+            HostSpec('node1', labels=['foo', 'bar']),
+            HostSpec('node2', labels=['bar'])
         ]
         instance.return_value = fake_client
 
         hosts = get_hosts()
         self.assertEqual(len(hosts), 3)
-        check_sources = {
+        checks = {
             'localhost': {
-                'ceph': True,
-                'orchestrator': False
+                'sources': {
+                    'ceph': True,
+                    'orchestrator': False
+                },
+                'labels': []
             },
             'node1': {
-                'ceph': True,
-                'orchestrator': True
+                'sources': {
+                    'ceph': True,
+                    'orchestrator': True
+                },
+                'labels': ['bar', 'foo']
             },
             'node2': {
-                'ceph': False,
-                'orchestrator': True
+                'sources': {
+                    'ceph': False,
+                    'orchestrator': True
+                },
+                'labels': ['bar']
             }
         }
         for host in hosts:
             hostname = host['hostname']
-            sources = host['sources']
-            self.assertDictEqual(sources, check_sources[hostname])
+            self.assertDictEqual(host['sources'], checks[hostname]['sources'])
+            self.assertListEqual(host['labels'], checks[hostname]['labels'])


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46944

---

backport of https://github.com/ceph/ceph/pull/36427
parent tracker: https://tracker.ceph.com/issues/46761

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh