### PR TITLE
nautilus: pybind: volume_client handle purge of directory names encoded in utf-8

### DIFF
--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -562,6 +562,9 @@ vc.disconnect()
         self.mount_a.run_shell(["touch", os.path.join(mount_path, "noperms")])
         self.mount_a.run_shell(["chmod", "0000", os.path.join(mount_path, "noperms")])
 
+        # A folder with non-ascii characters
+        self.mount_a.run_shell(["mkdir", os.path.join(mount_path, u"f\u00F6n")])
+
         self._volume_client_python(self.mount_b, dedent("""
             vp = VolumePath("{group_id}", u"{volume_id}")
             vc.delete_volume(vp)

--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -770,7 +770,7 @@ class CephFSVolumeClient(object):
             return
 
         def rmtree(root_path):
-            log.debug("rmtree {0}".format(root_path))
+            log.debug(u"rmtree {0}".format(root_path))
             dir_handle = self.fs.opendir(root_path)
             d = self.fs.readdir(dir_handle)
             while d:


### PR DESCRIPTION
https://tracker.ceph.com/issues/45997