### PR TITLE
librbd: Align rbd_write_zeroes declarations

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -1109,7 +1109,7 @@ CEPH_RBD_API ssize_t rbd_writesame(rbd_image_t image, uint64_t ofs, size_t len,
                                    const char *buf, size_t data_len,
                                    int op_flags);
 CEPH_RBD_API ssize_t rbd_write_zeroes(rbd_image_t image, uint64_t ofs,
-                                      uint64_t len, int zero_flags,
+                                      size_t len, int zero_flags,
                                       int op_flags);
 CEPH_RBD_API ssize_t rbd_compare_and_write(rbd_image_t image, uint64_t ofs,
                                            size_t len, const char *cmp_buf,


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/46928
Signed-off-by: Corey Bryant corey.bryant@canonical.com