### PR TITLE
octopus: doc/mgr/crash: Add missing command in rm example

### DIFF
--- a/doc/mgr/crash.rst
+++ b/doc/mgr/crash.rst
@@ -29,7 +29,7 @@ and will read from stdin.
 
 ::
 
-  ceph rm <crashid>
+  ceph crash rm <crashid>
 
 Remove a specific crash dump.
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46996

---

backport of https://github.com/ceph/ceph/pull/36228
parent tracker: https://tracker.ceph.com/issues/46676

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh