### PR TITLE
nautilus: mgr/dashboard/api: reduce amount of daemon logs

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -902,6 +902,7 @@ def exec_test():
     create_cluster = False
     create_cluster_only = False
     ignore_missing_binaries = False
+    opt_verbose = True
 
     args = sys.argv[1:]
     flags = [a for a in args if a.startswith("-")]
@@ -915,6 +916,8 @@ def exec_test():
             create_cluster_only = True
         elif f == "--ignore-missing-binaries":
             ignore_missing_binaries = True
+        elif '--no-verbose' == f:
+            opt_verbose = False
         else:
             log.error("Unknown option '{0}'".format(f))
             sys.exit(-1)
@@ -958,10 +961,16 @@ def exec_test():
         vstart_env["OSD"] = "4"
         vstart_env["MGR"] = max(max_required_mgr, 1).__str__()
 
-        args = [os.path.join(SRC_PREFIX, "vstart.sh"), "-n", "-d",
-                    "--nolockdep"]
+        args = [
+            os.path.join(SRC_PREFIX, "vstart.sh"),
+            "-n",
+            "--nolockdep",
+        ]
         if require_memstore:
             args.append("--memstore")
+
+        if opt_verbose:
+            args.append("-d")
 
         remote.run(args, env=vstart_env)
 

--- a/src/pybind/mgr/dashboard/run-backend-api-tests.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-tests.sh
@@ -71,7 +71,7 @@ on_tests_error() {
     if [[ -n "$JENKINS_HOME" ]]; then
         CEPH_OUT_DIR=${CEPH_OUT_DIR:-"$BUILD_DIR"/out}
         MGR_LOG_FILES=$(find "$CEPH_OUT_DIR" -iname "mgr.*.log" | tr '\n' ' ')
-        MGR_LOG_FILE_LAST_LINES=60000
+        MGR_LOG_FILE_LAST_LINES=1000
         for mgr_log_file in ${MGR_LOG_FILES[@]}; do
             printf "\n\nDisplaying last ${MGR_LOG_FILE_LAST_LINES} lines of: $mgr_log_file\n\n"
             tail -n ${MGR_LOG_FILE_LAST_LINES} $mgr_log_file
@@ -120,7 +120,7 @@ run_teuthology_tests() {
     export COVERAGE_FILE=.coverage.mgr.dashboard
     find . -iname "*${COVERAGE_FILE}*" -type f -delete
 
-    python ../qa/tasks/vstart_runner.py --ignore-missing-binaries $OPTIONS $TEST_CASES
+    python ../qa/tasks/vstart_runner.py --ignore-missing-binaries --no-verbose $OPTIONS $TEST_CASES
 
     deactivate
     cd $CURR_DIR


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47000

---

backport of https://github.com/ceph/ceph/pull/36605
parent tracker: https://tracker.ceph.com/issues/46920

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh