### PR TITLE
osdc: fix lingerOp stray

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -653,17 +653,17 @@ void Objecter::_linger_reconnect(LingerOp *info, bs::error_code ec)
 {
   ldout(cct, 10) << __func__ << " " << info->linger_id << " = " << ec 
 		 << " (last_error " << info->last_error << ")" << dendl;
+  std::unique_lock wl(info->watch_lock);
   if (ec) {
-    std::unique_lock wl(info->watch_lock);
     if (!info->last_error) {
       ec = _normalize_watch_error(ec);
-      info->last_error = ec;
       if (info->handle) {
 	boost::asio::defer(finish_strand, CB_DoWatchError(this, info, ec));
       }
     }
-    wl.unlock();
   }
+
+  info->last_error = ec;
 }
 
 void Objecter::_send_linger_ping(LingerOp *info)


### PR DESCRIPTION
   when linger ping failed with error, like ENOTCONN
   last_error set to error.
   after that, last_error will never recovery to succecss(0),
   even reconnecting successfully, which stops from sending linger ping to osd.
   as a result, this normal client ** can't receive notify message **
   after osd_client_watch_timeout goes away.

   Fixes: https://tracker.ceph.com/issues/47004

Signed-off-by: Song Shun <song.shun3@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
