### PR TITLE
mgr/dashboard: restore table footer size

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
@@ -252,12 +252,12 @@
   }
 
   .datatable-footer {
-    display: unset !important;
-
     .selected-count,
     .page-count {
       font-style: italic;
-      padding-left: 5px;
+      min-height: 2rem;
+      padding-left: 0.3rem;
+      padding-top: 0.3rem;
     }
   }
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47008
Signed-off-by: Alfonso Martínez <almartin@redhat.com>
NOW:
![Screenshot from 2020-08-18 14-22-44](https://user-images.githubusercontent.com/6780162/90515180-902af380-e162-11ea-87a4-8f56c138388b.png)

BEFORE:
![Screenshot from 2020-08-18 14-22-28](https://user-images.githubusercontent.com/6780162/90515210-9620d480-e162-11ea-9800-30ee714b4cc4.png)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
