### PR TITLE
crimson/osd: errorator omap_get_values() ops

### DIFF
--- a/src/crimson/os/alienstore/alien_store.h
+++ b/src/crimson/os/alienstore/alien_store.h
@@ -64,23 +64,23 @@ public:
   get_attrs_ertr::future<attrs_t> get_attrs(CollectionRef c,
                                      const ghobject_t& oid) final;
 
-  seastar::future<omap_values_t> omap_get_values(
+  read_errorator::future<omap_values_t> omap_get_values(
     CollectionRef c,
     const ghobject_t& oid,
     const omap_keys_t& keys) final;
+
+  /// Retrieves paged set of values > start (if present)
+  read_errorator::future<std::tuple<bool, omap_values_t>> omap_get_values(
+    CollectionRef c,           ///< [in] collection
+    const ghobject_t &oid,     ///< [in] oid
+    const std::optional<std::string> &start ///< [in] start, empty for begin
+    ) final; ///< @return <done, values> values.empty() iff done
 
   seastar::future<std::tuple<std::vector<ghobject_t>, ghobject_t>> list_objects(
     CollectionRef c,
     const ghobject_t& start,
     const ghobject_t& end,
     uint64_t limit) const final;
-
-  /// Retrieves paged set of values > start (if present)
-  seastar::future<std::tuple<bool, omap_values_t>> omap_get_values(
-    CollectionRef c,           ///< [in] collection
-    const ghobject_t &oid,     ///< [in] oid
-    const std::optional<std::string> &start ///< [in] start, empty for begin
-    ) final; ///< @return <done, values> values.empty() iff done
 
   seastar::future<CollectionRef> create_new_collection(const coll_t& cid) final;
   seastar::future<CollectionRef> open_collection(const coll_t& cid) final;

--- a/src/crimson/os/cyanstore/cyan_store.h
+++ b/src/crimson/os/cyanstore/cyan_store.h
@@ -100,23 +100,23 @@ public:
     CollectionRef c,
     const ghobject_t& oid);
 
-  seastar::future<omap_values_t> omap_get_values(
+  read_errorator::future<omap_values_t> omap_get_values(
     CollectionRef c,
     const ghobject_t& oid,
     const omap_keys_t& keys) final;
+
+  /// Retrieves paged set of values > start (if present)
+  read_errorator::future<std::tuple<bool, omap_values_t>> omap_get_values(
+    CollectionRef c,           ///< [in] collection
+    const ghobject_t &oid,     ///< [in] oid
+    const std::optional<std::string> &start ///< [in] start, empty for begin
+    ) final; ///< @return <done, values> values.empty() iff done
 
   seastar::future<std::tuple<std::vector<ghobject_t>, ghobject_t>> list_objects(
     CollectionRef c,
     const ghobject_t& start,
     const ghobject_t& end,
     uint64_t limit) const final;
-
-  /// Retrieves paged set of values > start (if present)
-  seastar::future<std::tuple<bool, omap_values_t>> omap_get_values(
-    CollectionRef c,           ///< [in] collection
-    const ghobject_t &oid,     ///< [in] oid
-    const std::optional<std::string> &start ///< [in] start, empty for begin
-    ) final; ///< @return <done, values> values.empty() iff done
 
   seastar::future<ceph::bufferlist> omap_get_header(
     CollectionRef c,

--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -118,16 +118,16 @@ public:
 
   using omap_values_t = std::map<std::string, bufferlist, std::less<>>;
   using omap_keys_t = std::set<std::string>;
-  virtual seastar::future<omap_values_t> omap_get_values(
-                                         CollectionRef c,
-                                         const ghobject_t& oid,
-                                         const omap_keys_t& keys) = 0;
+  virtual read_errorator::future<omap_values_t> omap_get_values(
+    CollectionRef c,
+    const ghobject_t& oid,
+    const omap_keys_t& keys) = 0;
   virtual seastar::future<std::tuple<std::vector<ghobject_t>, ghobject_t>> list_objects(
     CollectionRef c,
     const ghobject_t& start,
     const ghobject_t& end,
     uint64_t limit) const = 0;
-  virtual seastar::future<std::tuple<bool, omap_values_t>> omap_get_values(
+  virtual read_errorator::future<std::tuple<bool, omap_values_t>> omap_get_values(
     CollectionRef c,           ///< [in] collection
     const ghobject_t &oid,     ///< [in] oid
     const std::optional<std::string> &start ///< [in] start, empty for begin

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -163,18 +163,6 @@ seastar::future<struct stat> SeaStore::stat(
   return seastar::make_ready_future<struct stat>(st);
 }
 
-seastar::future<SeaStore::omap_values_t>
-SeaStore::omap_get_values(CollectionRef ch,
-                           const ghobject_t& oid,
-                           const omap_keys_t& keys)
-{
-  auto c = static_cast<SeastoreCollection*>(ch.get());
-  logger().debug("{} {} {}",
-                __func__, c->get_cid(), oid);
-  return seastar::make_ready_future<omap_values_t>();
-}
-
-
 seastar::future<ceph::bufferlist> omap_get_header(
   CollectionRef c,
   const ghobject_t& oid)
@@ -182,12 +170,26 @@ seastar::future<ceph::bufferlist> omap_get_header(
   return seastar::make_ready_future<bufferlist>();
 }
 
-seastar::future<std::tuple<bool, SeaStore::omap_values_t>>
+auto
 SeaStore::omap_get_values(
-    CollectionRef ch,
-    const ghobject_t &oid,
-    const std::optional<string> &start
-  ) {
+  CollectionRef ch,
+  const ghobject_t& oid,
+  const omap_keys_t& keys)
+  -> read_errorator::future<omap_values_t>
+{
+  auto c = static_cast<SeastoreCollection*>(ch.get());
+  logger().debug("{} {} {}",
+                __func__, c->get_cid(), oid);
+  return seastar::make_ready_future<omap_values_t>();
+}
+
+auto
+SeaStore::omap_get_values(
+  CollectionRef ch,
+  const ghobject_t &oid,
+  const std::optional<string> &start)
+  -> read_errorator::future<std::tuple<bool, SeaStore::omap_values_t>>
+{
   auto c = static_cast<SeastoreCollection*>(ch.get());
   logger().debug(
     "{} {} {}",

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -69,10 +69,17 @@ public:
     CollectionRef c,
     const ghobject_t& oid) final;
 
-  seastar::future<omap_values_t> omap_get_values(
+  read_errorator::future<omap_values_t> omap_get_values(
     CollectionRef c,
     const ghobject_t& oid,
     const omap_keys_t& keys) final;
+
+  /// Retrieves paged set of values > start (if present)
+  read_errorator::future<std::tuple<bool, omap_values_t>> omap_get_values(
+    CollectionRef c,           ///< [in] collection
+    const ghobject_t &oid,     ///< [in] oid
+    const std::optional<std::string> &start ///< [in] start, empty for begin
+    ) final; ///< @return <done, values> values.empty() iff done
 
   seastar::future<bufferlist> omap_get_header(
     CollectionRef c,
@@ -83,13 +90,6 @@ public:
     const ghobject_t& start,
     const ghobject_t& end,
     uint64_t limit) const final;
-
-  /// Retrieves paged set of values > start (if present)
-  seastar::future<std::tuple<bool, omap_values_t>> omap_get_values(
-    CollectionRef c,           ///< [in] collection
-    const ghobject_t &oid,     ///< [in] oid
-    const std::optional<std::string> &start ///< [in] start, empty for begin
-    ) final; ///< @return <done, values> values.empty() iff done
 
   seastar::future<CollectionRef> create_new_collection(const coll_t& cid) final;
   seastar::future<CollectionRef> open_collection(const coll_t& cid) final;

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -143,13 +143,13 @@ public:
     uint64_t len);
 
   // OMAP
-  seastar::future<> omap_get_keys(
+  ll_read_errorator::future<> omap_get_keys(
     const ObjectState& os,
     OSDOp& osd_op) const;
-  seastar::future<> omap_get_vals(
+  ll_read_errorator::future<> omap_get_vals(
     const ObjectState& os,
     OSDOp& osd_op) const;
-  seastar::future<> omap_get_vals_by_keys(
+  ll_read_errorator::future<> omap_get_vals_by_keys(
     const ObjectState& os,
     OSDOp& osd_op) const;
   seastar::future<> omap_set_vals(


### PR DESCRIPTION
* os/alienstore: do not panic if retval is less than 0. instead,
  translate ENOENT to enoent and other erros to input_output_error
* os/FuturizedStore: errorator omap_get_values() variants, so
  they return errorator::future<> instead of plain seastar::future<>
* os/seastore: update accordingly.
* osd/pg_backend: use enodata for OI without omap in it. better
  performance, and better readability this way.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
