### PR TITLE
nautilus: mon: store mon updates in ceph context for future MonMap instantiation

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -11,3 +11,9 @@
   to be warned again if additional repairs are performed you can provide a value
   to the command and specify the value of ``mon_osd_warn_num_repaired``.
   This command will be replaced in future releases by the health mute/unmute feature.
+
+* It is now possible to specify the initial monitor to contact for Ceph tools
+  and daemons using the ``mon_host_override`` config option or
+  ``--mon-host-override <ip>`` command-line switch. This generally should only
+  be used for debugging and only affects initial communication with Ceph's
+  monitor cluster.

--- a/doc/rados/configuration/ceph-conf.rst
+++ b/doc/rados/configuration/ceph-conf.rst
@@ -65,6 +65,11 @@ configuration, they may need to be stored locally on the node and set
 in a local configuration file.  These options include:
 
   - ``mon_host``, the list of monitors for the cluster
+  - ``mon_host_override``, the list of monitors for the cluster to
+    **initially** contact when beginning a new instance of communication with the
+    Ceph cluster.  This overrides the known monitor list derived from MonMap
+    updates sent to older Ceph instances (like librados cluster handles).  It is
+    expected this option is primarily useful for debugging.
   - ``mon_dns_serv_name`` (default: `ceph-mon`), the name of the DNS
     SRV record to check to identify the cluster monitors via DNS
   - ``mon_data``, ``osd_data``, ``mds_data``, ``mgr_data``, and

--- a/qa/standalone/mon/mon-handle-forward.sh
+++ b/qa/standalone/mon/mon-handle-forward.sh
@@ -33,18 +33,18 @@ function run() {
         run_mon $dir b --public-addr $MONB || return 1
     )
 
-    timeout 360 ceph --mon-host $MONA mon stat || return 1
+    timeout 360 ceph --mon-host-override $MONA mon stat || return 1
     # check that MONB is indeed a peon
     ceph --admin-daemon $(get_asok_path mon.b) mon_status |
        grep '"peon"' || return 1
     # when the leader ( MONA ) is used, there is no message forwarding
-    ceph --mon-host $MONA osd pool create POOL1 12
+    ceph --mon-host-override $MONA osd pool create POOL1 12
     CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.a) log flush || return 1
     grep 'mon_command(.*"POOL1"' $dir/mon.a.log || return 1
     CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.b) log flush || return 1
     grep 'mon_command(.*"POOL1"' $dir/mon.b.log && return 1
     # when the peon ( MONB ) is used, the message is forwarded to the leader
-    ceph --mon-host $MONB osd pool create POOL2 12
+    ceph --mon-host-override $MONB osd pool create POOL2 12
     CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.b) log flush || return 1
     grep 'forward_request.*mon_command(.*"POOL2"' $dir/mon.b.log || return 1
     CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.a) log flush || return 1

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -42,6 +42,9 @@
 #include "common/PluginRegistry.h"
 #include "common/valgrind.h"
 #include "include/spinlock.h"
+#ifndef WITH_SEASTAR
+#include "mon/MonMap.h"
+#endif
 
 using ceph::bufferlist;
 using ceph::HeartbeatMap;
@@ -950,5 +953,14 @@ void CephContext::notify_post_fork()
   ceph::spin_unlock(&_fork_watchers_lock);
   for (auto &&t : _fork_watchers)
     t->handle_post_fork();
+}
+
+void CephContext::set_mon_addrs(const MonMap& mm) {
+  std::vector<entity_addrvec_t> mon_addrs;
+  for (auto& i : mm.mon_info) {
+    mon_addrs.push_back(i.second.public_addrs);
+  }
+
+  set_mon_addrs(mon_addrs);
 }
 #endif	// WITH_SEASTAR

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -29,6 +29,7 @@
 
 #include "common/cmdparse.h"
 #include "common/code_environment.h"
+#include "msg/msg_types.h"
 #ifdef WITH_SEASTAR
 #include "crimson/common/config_proxy.h"
 #include "crimson/common/perf_counters_collection.h"
@@ -47,6 +48,7 @@ class CephContextHook;
 class CephContextObs;
 class CryptoHandler;
 class CryptoRandom;
+class MonMap;
 
 namespace ceph {
   class PluginRegistry;
@@ -242,6 +244,21 @@ public:
   void notify_pre_fork();
   void notify_post_fork();
 
+  /**
+   * update CephContext with a copy of the passed in MonMap mon addrs
+   *
+   * @param mm MonMap to extract and update mon addrs
+   */
+  void set_mon_addrs(const MonMap& mm);
+  void set_mon_addrs(const std::vector<entity_addrvec_t>& in) {
+    auto ptr = std::make_shared<std::vector<entity_addrvec_t>>(in);
+    atomic_store_explicit(&_mon_addrs, std::move(ptr), std::memory_order_relaxed);
+  }
+  std::shared_ptr<std::vector<entity_addrvec_t>> get_mon_addrs() const {
+    auto ptr = atomic_load_explicit(&_mon_addrs, std::memory_order_relaxed);
+    return ptr;
+  }
+
 private:
 
 
@@ -258,6 +275,8 @@ private:
   std::string _set_gid_string;
 
   int _crypto_inited;
+
+  std::shared_ptr<std::vector<entity_addrvec_t>> _mon_addrs;
 
   /* libcommon service thread.
    * SIGHUP wakes this thread, which then reopens logfiles */

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -419,6 +419,12 @@ std::vector<Option> get_global_options() {
     .set_flag(Option::FLAG_STARTUP)
     .add_service("common"),
 
+    Option("mon_host_override", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_description("monitor(s) to use overriding the MonMap")
+    .set_flag(Option::FLAG_NO_MON_UPDATE)
+    .set_flag(Option::FLAG_STARTUP)
+    .add_service("common"),
+
     Option("mon_dns_srv_name", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("ceph-mon")
     .set_description("name of DNS SRV record to check for monitor addresses")

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -402,6 +402,8 @@ void MonClient::handle_monmap(MMonMap *m)
     }
   }
 
+  cct->set_mon_addrs(monmap);
+
   sub.got("monmap", monmap.get_epoch());
   map_cond.Signal();
   want_monmap = false;

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -449,9 +449,29 @@ void MonMap::_add_ambiguous_addr(const string& name,
   }
 }
 
+int
+MonMap::init_with_addrs(const std::vector<entity_addrvec_t>& addrs,
+                        bool for_mkfs,
+                        std::string_view prefix)
+{
+  char id = 'a';
+  for (auto& addr : addrs) {
+    string name{prefix};
+    name += id++;
+    if (addr.v.size() == 1) {
+      _add_ambiguous_addr(name, addr.front(), 0, for_mkfs);
+    } else {
+      // they specified an addrvec, so let's assume they also specified
+      // the addr *type* and *port*.  (we could possibly improve this?)
+      add(name, addr, 0);
+    }
+  }
+  return 0;
+}
+
 int MonMap::init_with_ips(const std::string& ips,
 			  bool for_mkfs,
-			  const std::string &prefix)
+			  std::string_view prefix)
 {
   vector<entity_addrvec_t> addrs;
   if (!parse_ip_port_vec(
@@ -461,27 +481,12 @@ int MonMap::init_with_ips(const std::string& ips,
   }
   if (addrs.empty())
     return -ENOENT;
-  for (unsigned i=0; i<addrs.size(); i++) {
-    char n[2];
-    n[0] = 'a' + i;
-    n[1] = 0;
-    string name;
-    name = prefix;
-    name += n;
-    if (addrs[i].v.size() == 1) {
-      _add_ambiguous_addr(name, addrs[i].front(), 0, for_mkfs);
-    } else {
-      // they specified an addrvec, so let's assume they also specified
-      // the addr *type* and *port*.  (we could possibly improve this?)
-      add(name, addrs[i], 0);
-    }
-  }
-  return 0;
+  return init_with_addrs(addrs, for_mkfs, prefix);
 }
 
 int MonMap::init_with_hosts(const std::string& hostlist,
 			    bool for_mkfs,
-			    const std::string& prefix)
+			    std::string_view prefix)
 {
   // maybe they passed us a DNS-resolvable name
   char *hosts = resolve_addrs(hostlist.c_str());
@@ -497,19 +502,8 @@ int MonMap::init_with_hosts(const std::string& hostlist,
     return -EINVAL;
   if (addrs.empty())
     return -ENOENT;
-  for (unsigned i=0; i<addrs.size(); i++) {
-    char n[2];
-    n[0] = 'a' + i;
-    n[1] = 0;
-    string name = prefix;
-    name += n;
-    if (addrs[i].v.size() == 1) {
-      _add_ambiguous_addr(name, addrs[i].front(), 0, for_mkfs);
-    } else {
-      // they specified an addrvec, so let's assume they also specified
-      // the addr *type* and *port*.  (we could possibly improve this?)
-      add(name, addrs[i], 0);
-    }
+  if (!init_with_addrs(addrs, for_mkfs, prefix)) {
+    return -EINVAL;
   }
   calc_legacy_ranks();
   return 0;
@@ -795,6 +789,13 @@ int MonMap::init_with_dns_srv(CephContext* cct,
 int MonMap::build_initial(CephContext *cct, bool for_mkfs, ostream& errout)
 {
   const auto& conf = cct->_conf;
+
+  // cct?
+  auto addrs = cct->get_mon_addrs();
+  if (addrs != nullptr && (addrs->size() > 0)) {
+    return init_with_addrs(*addrs, for_mkfs, "noname-");
+  }
+
   // file?
   if (const auto monmap = conf.get_val<std::string>("monmap");
       !monmap.empty()) {

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -790,6 +790,21 @@ int MonMap::build_initial(CephContext *cct, bool for_mkfs, ostream& errout)
 {
   const auto& conf = cct->_conf;
 
+  // mon_host_override?
+  auto mon_host_override = conf.get_val<std::string>("mon_host_override");
+  if (!mon_host_override.empty()) {
+    lgeneric_dout(cct, 1) << "Using mon_host_override " << mon_host_override << dendl;
+    auto ret = init_with_ips(mon_host_override, for_mkfs, "noname-");
+    if (ret == -EINVAL) {
+      ret = init_with_hosts(mon_host_override, for_mkfs, "noname-");
+    }
+    if (ret < 0) {
+      errout << "unable to parse addrs in '" << mon_host_override << "'"
+	     << std::endl;
+    }
+    return ret;
+  }
+
   // cct?
   auto addrs = cct->get_mon_addrs();
   if (addrs != nullptr && (addrs->size() > 0)) {

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -437,6 +437,18 @@ public:
   static void generate_test_instances(list<MonMap*>& o);
 protected:
   /**
+   * build a monmap from a list of entity_addrvec_t's
+   *
+   * Give mons dummy names.
+   *
+   * @param addrs  list of entity_addrvec_t's
+   * @param prefix prefix to prepend to generated mon names
+   * @return 0 for success, -errno on error
+   */
+  int init_with_addrs(const std::vector<entity_addrvec_t>& addrs,
+        bool for_mkfs,
+        std::string_view prefix);
+  /**
    * build a monmap from a list of ips
    *
    * Give mons dummy names.
@@ -447,7 +459,7 @@ protected:
    */
   int init_with_ips(const std::string& ips,
 		    bool for_mkfs,
-		    const std::string &prefix);
+		    std::string_view prefix);
   /**
    * build a monmap from a list of hostnames
    *
@@ -459,7 +471,7 @@ protected:
    */
   int init_with_hosts(const std::string& hostlist,
 		      bool for_mkfs,
-		      const std::string& prefix);
+		      std::string_view prefix);
   int init_with_config_file(const ConfigProxy& conf, std::ostream& errout);
 #if WITH_SEASTAR
   seastar::future<> read_monmap(const std::string& monmap);

--- a/src/test/libcephfs/CMakeLists.txt
+++ b/src/test/libcephfs/CMakeLists.txt
@@ -9,6 +9,7 @@ if(${WITH_CEPHFS})
     acl.cc
     main.cc
     deleg.cc
+    monconfig.cc
   )
   target_link_libraries(ceph_test_libcephfs
     ceph-common

--- a/src/test/libcephfs/monconfig.cc
+++ b/src/test/libcephfs/monconfig.cc
@@ -1,0 +1,99 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "gtest/gtest.h"
+#include "include/cephfs/libcephfs.h"
+#include "common/ceph_context.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+class MonConfig : public ::testing::Test
+{
+  protected:
+    struct ceph_mount_info *ca;
+
+    void SetUp() override {
+      ASSERT_EQ(0, ceph_create(&ca, NULL));
+      ASSERT_EQ(0, ceph_conf_read_file(ca, NULL));
+      ASSERT_EQ(0, ceph_conf_parse_env(ca, NULL));
+    }
+
+    void TearDown() override {
+      ceph_shutdown(ca);
+    }
+
+    // Helper to remove/unset all possible mon information from ConfigProxy
+    void clear_mon_config(CephContext *cct) {
+      auto& conf = cct->_conf;
+      // Clear safe_to_start_threads, allowing updates to config values
+      conf._clear_safe_to_start_threads();
+      ASSERT_EQ(0, conf.set_val("monmap", "", nullptr));
+      ASSERT_EQ(0, conf.set_val("mon_host", "", nullptr));
+      ASSERT_EQ(0, conf.set_val("mon_dns_srv_name", "", nullptr));
+      conf.set_safe_to_start_threads();
+    }
+
+    // Helper to test basic operation on a mount
+    void use_mount(struct ceph_mount_info *mnt, string name_prefix) {
+      char name[20];
+      snprintf(name, sizeof(name), "%s.%d", name_prefix.c_str(), getpid());
+      int fd = ceph_open(mnt, name, O_CREAT|O_RDWR, 0644);
+      ASSERT_LE(0, fd);
+
+      ceph_close(mnt, fd);
+    }
+};
+
+TEST_F(MonConfig, MonAddrsMissing) {
+  CephContext *cct;
+
+  // Test mount failure when there is no known mon config source
+  cct = ceph_get_mount_context(ca);
+  ASSERT_NE(nullptr, cct);
+  clear_mon_config(cct);
+
+  ASSERT_EQ(-ENOENT, ceph_mount(ca, NULL));
+}
+
+TEST_F(MonConfig, MonAddrsInConfigProxy) {
+  // Test a successful mount with default mon config source in ConfigProxy
+  ASSERT_EQ(0, ceph_mount(ca, NULL));
+
+  use_mount(ca, "foo");
+}
+
+TEST_F(MonConfig, MonAddrsInCct) {
+  struct ceph_mount_info *cb;
+  CephContext *cct;
+
+  // Perform mount to bootstrap mon addrs in CephContext
+  ASSERT_EQ(0, ceph_mount(ca, NULL));
+
+  // Reuse bootstrapped CephContext, clearing ConfigProxy mon addr sources
+  cct = ceph_get_mount_context(ca);
+  ASSERT_NE(nullptr, cct);
+  clear_mon_config(cct);
+  ASSERT_EQ(0, ceph_create_with_context(&cb, cct));
+
+  // Test a successful mount with only mon values in CephContext
+  ASSERT_EQ(0, ceph_mount(cb, NULL));
+
+  use_mount(ca, "bar");
+  use_mount(cb, "bar");
+
+  ceph_shutdown(cb);
+}


### PR DESCRIPTION
backport trackers: 

* https://tracker.ceph.com/issues/47013
* https://tracker.ceph.com/issues/47600

---

backport of:

* https://github.com/ceph/ceph/pull/36533
* https://github.com/ceph/ceph/pull/37202

parent trackers:

* https://tracker.ceph.com/issues/46645
* https://tracker.ceph.com/issues/47180

---

backport of #36533 was staged using ceph-backport.sh version 15.1.1.389
backport of #37202 was further cherry-picked