### PR TITLE
doc/cephadm: remove ssh user limitation troubleshooting

### DIFF
--- a/doc/cephadm/troubleshooting.rst
+++ b/doc/cephadm/troubleshooting.rst
@@ -139,7 +139,6 @@ Things users can do:
     
      [root@mon1 ~]# ssh -F config -i key root@mon1
 
-4. There is a limitation right now: the ssh user is always `root`.
 
 
 


### PR DESCRIPTION
#35606 removed this limitation

issue noticed here: https://github.com/ceph/ceph/pull/36330#discussion_r471314000

Signed-off-by: Daniel-Pivonka <dpivonka@redhat.com>

