### PR TITLE
rbd-mirror: peer setup can still race and fail creation of peer 

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -238,6 +238,7 @@ peer_add()
     local cluster=$1 ; shift
     local pool=$1 ; shift
     local client_cluster=$1 ; shift
+    local remote_cluster="${client_cluster##*@}"
 
     local uuid_var_name
     if [ -n "$1" ]; then
@@ -257,6 +258,9 @@ peer_add()
         if [ $error_code -eq 17 ]; then
             # raced with a remote heartbeat ping -- remove and retry
             sleep $s
+            peer_uuid=$(rbd mirror pool info --cluster ${cluster} --pool ${pool} --format xml | \
+                xmlstarlet sel -t -v "//peers/peer[site_name='${remote_cluster}']/uuid")
+
             rbd --cluster ${cluster} --pool ${pool} mirror pool peer remove ${peer_uuid}
         else
             test $error_code -eq 0

--- a/src/tools/rbd/action/MirrorPool.cc
+++ b/src/tools/rbd/action/MirrorPool.cc
@@ -818,8 +818,7 @@ int get_mirror_image_status(
 void get_peer_bootstrap_create_arguments(po::options_description *positional,
                                          po::options_description *options) {
   at::add_pool_options(positional, options, false);
-  options->add_options()
-    (SITE_NAME.c_str(), po::value<std::string>(), "local site name");
+  add_site_name_optional(options);
 }
 
 int execute_peer_bootstrap_create(
@@ -871,8 +870,7 @@ int execute_peer_bootstrap_create(
 void get_peer_bootstrap_import_arguments(po::options_description *positional,
                                          po::options_description *options) {
   at::add_pool_options(positional, options, false);
-  options->add_options()
-    (SITE_NAME.c_str(), po::value<std::string>(), "local site name");
+  add_site_name_optional(options);
   positional->add_options()
     ("token-path", po::value<std::string>(),
      "bootstrap token file (or '-' for stdin)");


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
