### PR TITLE
luminous: rgw: conduct necessary checking of website configuration

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3554,6 +3554,13 @@ int RGWHandler_REST_S3Website::retarget(RGWOp* op, RGWOp** new_op) {
 
   rgw_obj_key new_obj;
   s->bucket_info.website_conf.get_effective_key(s->object.name, &new_obj.name, web_dir());
+  bool get_res = s->bucket_info.website_conf.get_effective_key(s->object.name, &new_obj.name, web_dir());
+  if (!get_res) {
+    s->err.message = "The IndexDocument Suffix is not configurated or not well formed!";
+    ldout(s->cct, 5) << s->err.message << dendl;
+    return -EINVAL;
+  }
+
   ldout(s->cct, 10) << "retarget get_effective_key " << s->object << " -> "
 		    << new_obj << dendl;
 

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1016,6 +1016,21 @@ int RGWSetBucketWebsite_ObjStore_S3::get_params()
     return -EINVAL;
   }
 
+  if (website_conf.is_redirect_all && website_conf.redirect_all.hostname.empty()) {
+    s->err.message = "A host name must be provided to redirect all requests (e.g. \"example.com\").";
+    ldout(s->cct, 5) << s->err.message << dendl;
+    return -EINVAL;
+  } else if (!website_conf.is_redirect_all && !website_conf.is_set_index_doc) {
+    s->err.message = "A value for IndexDocument Suffix must be provided if RedirectAllRequestsTo is empty";
+    ldout(s->cct, 5) << s->err.message << dendl;
+    return -EINVAL;
+  } else if (!website_conf.is_redirect_all && website_conf.is_set_index_doc &&
+             website_conf.index_doc_suffix.empty()) {
+    s->err.message = "The IndexDocument Suffix is not well formed";
+    ldout(s->cct, 5) << s->err.message << dendl;
+    return -EINVAL;
+  }
+
   return 0;
 }
 

--- a/src/rgw/rgw_website.cc
+++ b/src/rgw/rgw_website.cc
@@ -106,8 +106,11 @@ bool RGWBucketWebsiteConf::should_redirect(const string& key, const int http_err
   return true;
 }
 
-void RGWBucketWebsiteConf::get_effective_key(const string& key, string *effective_key, bool is_file) const
+bool RGWBucketWebsiteConf::get_effective_key(const string& key, string *effective_key, bool is_file) const
 {
+  if (index_doc_suffix.empty()) {
+    return false;
+  }
 
   if (key.empty()) {
     *effective_key = index_doc_suffix;
@@ -118,4 +121,6 @@ void RGWBucketWebsiteConf::get_effective_key(const string& key, string *effectiv
   } else {
     *effective_key = key;
   }
+
+  return true;
 }

--- a/src/rgw/rgw_website.h
+++ b/src/rgw/rgw_website.h
@@ -178,10 +178,14 @@ struct RGWBucketWebsiteConf
   std::string subdir_marker;
   std::string listing_css_doc;
   bool listing_enabled;
+  bool is_redirect_all;
+  bool is_set_index_doc;
   RGWBWRoutingRules routing_rules;
 
   RGWBucketWebsiteConf()
     : listing_enabled(false) {
+    is_redirect_all = false;
+    is_set_index_doc = false;
   }
 
   void encode(bufferlist& bl) const {

--- a/src/rgw/rgw_website.h
+++ b/src/rgw/rgw_website.h
@@ -222,7 +222,7 @@ struct RGWBucketWebsiteConf
                        const int http_error_code,
                        RGWBWRoutingRule *redirect);
 
-  void get_effective_key(const std::string& key,
+  bool get_effective_key(const std::string& key,
                          std::string *effective_key, bool is_file) const;
 
   const std::string& get_index_doc() const {

--- a/src/rgw/rgw_xml_enc.cc
+++ b/src/rgw/rgw_xml_enc.cc
@@ -114,11 +114,13 @@ void decode_xml_obj(list<RGWBWRoutingRule>& l, XMLObj *obj)
 void RGWBucketWebsiteConf::decode_xml(XMLObj *obj) {
   XMLObj *o = obj->find_first("RedirectAllRequestsTo");
   if (o) {
+    is_redirect_all = true;
     RGWXMLDecoder::decode_xml("HostName", redirect_all.hostname, o, true);
     RGWXMLDecoder::decode_xml("Protocol", redirect_all.protocol, o);
   } else {
     o = obj->find_first("IndexDocument");
     if (o) {
+      is_set_index_doc = true;
       RGWXMLDecoder::decode_xml("Suffix", index_doc_suffix, o);
     }
     o = obj->find_first("ErrorDocument");


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/41497

---

backport of https://github.com/ceph/ceph/pull/28904
parent tracker: https://tracker.ceph.com/issues/40678

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh