### PR TITLE
nautilus: librbd: Align rbd_write_zeroes declarations

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -979,7 +979,7 @@ CEPH_RBD_API ssize_t rbd_writesame(rbd_image_t image, uint64_t ofs, size_t len,
                                    const char *buf, size_t data_len,
                                    int op_flags);
 CEPH_RBD_API ssize_t rbd_write_zeroes(rbd_image_t image, uint64_t ofs,
-                                      uint64_t len, int zero_flags,
+                                      size_t len, int zero_flags,
                                       int op_flags);
 CEPH_RBD_API ssize_t rbd_compare_and_write(rbd_image_t image, uint64_t ofs,
                                            size_t len, const char *cmp_buf,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47023

---

backport of https://github.com/ceph/ceph/pull/36688
parent tracker: https://tracker.ceph.com/issues/46928

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh