### PR TITLE
nautilus: qa: Fix traceback during fs cleanup between tests

### DIFF
--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -64,6 +64,8 @@ class CephFSTestCase(CephTestCase):
     def setUp(self):
         super(CephFSTestCase, self).setUp()
 
+        self.config_set('mon', 'mon_allow_pool_delete', True)
+
         if len(self.mds_cluster.mds_ids) < self.MDSS_REQUIRED:
             raise case.SkipTest("Only have {0} MDSs, require {1}".format(
                 len(self.mds_cluster.mds_ids), self.MDSS_REQUIRED


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46948

---

backport of https://github.com/ceph/ceph/pull/36155
parent tracker: https://tracker.ceph.com/issues/46597

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh