### PR TITLE
[DNM] Attempt to make ok-to-stop fail for the current MGR.

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1875,7 +1875,6 @@ you may want to run:
                        daemon_spec: CephadmDaemonSpec,
                        reconfig=False,
                        osd_uuid_map: Optional[Dict[str, Any]] = None,
-                       redeploy=False,
                        ) -> str:
 
 

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -325,6 +325,21 @@ class MgrService(CephadmService):
 
         return self.mgr._create_daemon(daemon_spec)
 
+    def fail_over(self):
+        mgr_map = self.mgr.get('mgr_map')
+        num = len(mgr_map.get('standbys'))
+        if not num:
+            raise OrchestratorError('Need standby mgr daemon', event_kind_subject=('daemon', 'mgr' + self.mgr.get_mgr_id()))
+
+        self.mgr.events.for_daemon('mgr' + self.mgr.get_mgr_id(), 'Failing over to other MGR')
+        logger.info('Failing over to other MGR')
+
+        # fail over
+        ret, out, err = self.mgr.check_mon_command({
+            'prefix': 'mgr fail',
+            'who': self.mgr.get_mgr_id(),
+        })
+
 
 class MdsService(CephadmService):
     TYPE = 'mds'

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -163,7 +163,7 @@ class CephadmUpgrade:
             if not r.retval:
                 logger.info(f'Upgrade: {r.stdout}')
                 return True
-            logger.error('Upgrade: {r.stderr}')
+            logger.error(f'Upgrade: {r.stderr}')
 
             time.sleep(15)
             tries -= 1

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -3,7 +3,7 @@ import re
 import json
 from enum import Enum
 from functools import wraps
-from typing import Optional, Callable, TypeVar, List, NewType, TYPE_CHECKING
+from typing import Optional, Callable, TypeVar, List, NewType, TYPE_CHECKING, Iterator
 from orchestrator import OrchestratorError
 
 if TYPE_CHECKING:
@@ -103,3 +103,18 @@ def get_cluster_health(mgr: 'CephadmOrchestrator') -> str:
         raise OrchestratorError('failed to parse health status')
 
     return j['status']
+
+
+def reduced_powerset(l: List[T]) -> Iterator[List[T]]:
+    """
+    This is a subset of powerset(), aimed at searching
+    a usable subset for ok-to-stop [ids...]
+
+    >>> list(reduced_powerset([0,1,2]))
+    [[0, 1, 2], [0, 1], [0], [1], [2]]
+
+    """
+    for i in reversed(range(len(l) + 1)):
+        if i > 1:
+            yield l[0:i]
+    yield from map(lambda x: [x], l)

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -965,7 +965,7 @@ Usage:
         "name=name,type=CephString "
         "name=image,type=CephString,req=false",
         'Redeploy a daemon (with a specifc image)')
-    def _daemon_action_redeploy(self, name, image):
+    def _daemon_action_redeploy(self, name: str, image: Optional[str] = None) -> HandleCommandResult:
         if '.' not in name:
             raise OrchestratorError('%s is not a valid daemon name' % name)
         completion = self.daemon_action("redeploy", name, image=image)


### PR DESCRIPTION
I'm facing a problem that `ceph orch daemon redeploy <our own mgr>` really fails badly:
1. client sends `redeploy` to the mon
2. mon sends `redeploy` to the mgr
3. we synchonously call _create_daemon() with our own mgr. this never completes
4. the mon re-sends the command to the mgr as soon as it starts
5. goto 2.
and we're in an evil endless loop


I'm now trying to 1. ok-to-stop to always return False in this case and 2. call ok-to-stop from `orch daemon redeploy`
,but this makes some problems, as we then no longer failove the mgr thus never undeploy the active MGR.

Turns out this is really closely related to AdamKm's #36485 (preferring to remove standby daemons instead of active ones),
but that dosn't solve `orch daemon redeploy`. So for now, I think making ok-to-stop always false for our own mgr is the wrong idea
for that I should rely on #36485 instead. 

but how do I solve `daemon redeploy`? I think we _have_ to failover before redeploying our own mgr
I mean, self._create_daemon is the last call we ever execute. becuase then we're gone and another MGR takes over

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
