### PR TITLE
doc: Update rbd-kubernetes.rst

### DIFF
--- a/doc/rbd/rbd-kubernetes.rst
+++ b/doc/rbd/rbd-kubernetes.rst
@@ -188,11 +188,16 @@ pool created above, the following YAML file can be used after ensuring that the
         parameters:
            clusterID: b9127830-b0cc-4e34-aa47-9d1a2e9949a8
            pool: kubernetes
+           imageFeatures: layering
            csi.storage.k8s.io/provisioner-secret-name: csi-rbd-secret
            csi.storage.k8s.io/provisioner-secret-namespace: default
+           csi.storage.k8s.io/controller-expand-secret-name: csi-rbd-secret
+           csi.storage.k8s.io/controller-expand-secret-namespace: default
            csi.storage.k8s.io/node-stage-secret-name: csi-rbd-secret
            csi.storage.k8s.io/node-stage-secret-namespace: default
+           csi.storage.k8s.io/fstype: ext4
         reclaimPolicy: Delete
+        allowVolumeExpansion: true
         mountOptions:
            - discard
         EOF


### PR DESCRIPTION
Signed-off-by: shaohq

add required fields according to ceph-csi:canary, also tested on ceph-csi:v3.0.0 and ceph-csi:v3.1.0.  Or ceph-csi can create rbd for volume, but pod cannot mount the volume.
The modification was made by referring to https://github.com/ceph/ceph-csi/blob/master/examples/rbd/storageclass.yaml


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
