### PR TITLE
crush: do not malloc for empty bucket and avoid member variables after memset() with 0

### DIFF
--- a/src/crush/builder.c
+++ b/src/crush/builder.c
@@ -339,10 +339,6 @@ crush_make_tree_bucket(int hash, int type, int size,
 	bucket->h.size = size;
 
 	if (size == 0) {
-		bucket->h.items = NULL;
-		bucket->h.weight = 0;
-		bucket->node_weights = NULL;
-		bucket->num_nodes = 0;
 		/* printf("size 0 depth 0 nodes 0\n"); */
 		return bucket;
 	}
@@ -572,7 +568,6 @@ crush_make_straw_bucket(struct crush_map *map,
         if (!bucket->straws)
                 goto err;
 
-        bucket->h.weight = 0;
 	for (i=0; i<size; i++) {
 		bucket->h.items[i] = items[i];
 		bucket->h.weight += weights[i];
@@ -618,7 +613,6 @@ crush_make_straw2_bucket(struct crush_map *map,
         if (!bucket->item_weights)
                 goto err;
 
-        bucket->h.weight = 0;
 	for (i=0; i<size; i++) {
 		bucket->h.items[i] = items[i];
 		bucket->h.weight += weights[i];

--- a/src/crush/builder.c
+++ b/src/crush/builder.c
@@ -209,6 +209,10 @@ crush_make_uniform_bucket(int hash, int type, int size,
 
 	bucket->h.weight = size * item_weight;
 	bucket->item_weight = item_weight;
+
+	if (size == 0) {
+		return bucket;
+	}
 	bucket->h.items = malloc(sizeof(__s32)*size);
 
         if (!bucket->h.items)
@@ -244,6 +248,10 @@ crush_make_list_bucket(int hash, int type, int size,
 	bucket->h.hash = hash;
 	bucket->h.type = type;
 	bucket->h.size = size;
+
+	if (size == 0) {
+		return bucket;
+	}
 
 	bucket->h.items = malloc(sizeof(__s32)*size);
         if (!bucket->h.items)
@@ -605,6 +613,10 @@ crush_make_straw2_bucket(struct crush_map *map,
 	bucket->h.hash = hash;
 	bucket->h.type = type;
 	bucket->h.size = size;
+
+	if (size == 0) {
+		return bucket;
+	}
 
         bucket->h.items = malloc(sizeof(__s32)*size);
         if (!bucket->h.items)


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
