### PR TITLE
qa/tasks/cephadm.py: add ceph logs directory in job's info.yaml

### DIFF
--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -10,6 +10,7 @@ import os
 import json
 import re
 import uuid
+import yaml
 
 from io import BytesIO, StringIO
 import toml
@@ -158,6 +159,16 @@ def ceph_log(ctx, config):
     cluster_name = config['cluster']
     fsid = ctx.ceph[cluster_name].fsid
 
+    # Add logs directory to job's info log file
+    with open(os.path.join(ctx.archive, 'info.yaml'), 'r+') as info_file:
+        info_yaml = yaml.safe_load(info_file)
+        info_file.seek(0)
+        if 'archive' not in info_yaml:
+            info_yaml['archive'] = {'log': '/var/log/ceph'}
+        else:
+            info_yaml['archive']['log'] = '/var/log/ceph'
+        yaml.safe_dump(info_yaml, info_file, default_flow_style=False)
+
     try:
         yield
 
@@ -265,6 +276,16 @@ def ceph_crash(ctx, config):
     cluster_name = config['cluster']
     fsid = ctx.ceph[cluster_name].fsid
 
+    # Add logs directory to job's info log file
+    with open(os.path.join(ctx.archive, 'info.yaml'), 'r+') as info_file:
+        info_yaml = yaml.safe_load(info_file)
+        info_file.seek(0)
+        if 'archive' not in info_yaml:
+            info_yaml['archive'] = {'crash': '/var/lib/ceph/%s/crash' % fsid}
+        else:
+            info_yaml['archive']['crash'] = '/var/lib/ceph/%s/crash' % fsid
+        yaml.safe_dump(info_yaml, info_file, default_flow_style=False)
+
     try:
         yield
 
@@ -307,7 +328,7 @@ def ceph_bootstrap(ctx, config, registry):
     first_mon = ctx.ceph[cluster_name].first_mon
     first_mon_role = ctx.ceph[cluster_name].first_mon_role
     mons = ctx.ceph[cluster_name].mons
-    
+
     ctx.cluster.run(args=[
         'sudo', 'mkdir', '-p', '/etc/ceph',
         ]);
@@ -469,7 +490,7 @@ def ceph_bootstrap(ctx, config, registry):
                 ctx.daemons.get_daemon(type_, id_, cluster).stop()
             except Exception:
                 log.exception(f'Failed to stop "{role}"')
-                raise 
+                raise
 
         # clean up /etc/ceph
         ctx.cluster.run(args=[
@@ -1128,7 +1149,7 @@ def task(ctx, config):
     if cluster_name not in ctx.ceph:
         ctx.ceph[cluster_name] = argparse.Namespace()
         ctx.ceph[cluster_name].bootstrapped = False
- 
+
     # image
     teuth_defaults = teuth_config.get('defaults', {})
     cephadm_defaults = teuth_defaults.get('cephadm', {})
@@ -1248,9 +1269,9 @@ def registries_add_mirror_to_docker_io(conf, mirror):
 
 def add_mirror_to_cluster(ctx, mirror):
     log.info('Adding local image mirror %s' % mirror)
-    
+
     registries_conf = '/etc/containers/registries.conf'
-    
+
     for remote in ctx.cluster.remotes.keys():
         try:
             config = teuthology.get_file(


### PR DESCRIPTION
This PR adds the file path of ceph log directories to the job's
info.yaml log file. The motivation behind this is, in case of job
timeout, the logs would still be tranferred to teuthology host
before nuking test machines using these ceph log directory paths in
job's info.yaml log file.

Signed-off-by: Shraddha Agrawal <shraddha.agrawal000@gmail.com>

related: [#1546](https://github.com/ceph/teuthology/pull/1546)
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
