### PR TITLE
rgw/sts: adding code for "aws:TokenIssueTime" to be used

### DIFF
--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -743,6 +743,8 @@ void rgw::auth::RoleApplier::modify_request_state(const DoutPrefixProvider *dpp,
   string value = role.id + ":" + role_session_name;
   s->env.emplace(condition, value);
 
+  s->env.emplace("aws:TokenIssueTime", token_issued_at);
+
   s->token_claims.emplace_back("sts");
   for (auto& it : token_claims) {
     s->token_claims.emplace_back(it);

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -640,6 +640,7 @@ protected:
   string token_policy;
   string role_session_name;
   std::vector<string> token_claims;
+  string token_issued_at;
 
 public:
 
@@ -648,12 +649,14 @@ public:
                const rgw_user& user_id,
                const string& token_policy,
                const string& role_session_name,
-               const std::vector<string>& token_claims)
+               const std::vector<string>& token_claims,
+               const string& token_issued_at)
     : role(role),
       user_id(user_id),
       token_policy(token_policy),
       role_session_name(role_session_name),
-      token_claims(token_claims) {}
+      token_claims(token_claims),
+      token_issued_at(token_issued_at) {}
 
   uint32_t get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const override {
     return 0;
@@ -679,11 +682,12 @@ public:
     virtual ~Factory() {}
     virtual aplptr_t create_apl_role( CephContext* cct,
                                       const req_state* s,
-                                      const rgw::auth::RoleApplier::Role& role_name,
+                                      const rgw::auth::RoleApplier::Role& role,
                                       const rgw_user& user_id,
                                       const std::string& token_policy,
                                       const std::string& role_session,
-                                      const std::vector<string>& token_claims) const = 0;
+                                      const std::vector<string>& token_claims,
+                                      const std::string& token_issued_at) const = 0;
     };
 };
 

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -68,9 +68,10 @@ class STSAuthStrategy : public rgw::auth::Strategy,
                             const rgw_user& user_id,
                             const std::string& token_policy,
                             const std::string& role_session_name,
-                            const std::vector<string>& token_claims) const override {
+                            const std::vector<string>& token_claims,
+                            const std::string& token_issued_at) const override {
     auto apl = rgw::auth::add_sysreq(cct, ctl, s,
-      rgw::auth::RoleApplier(cct, role, user_id, token_policy, role_session_name, token_claims));
+      rgw::auth::RoleApplier(cct, role, user_id, token_policy, role_session_name, token_claims, token_issued_at));
     return aplptr_t(new decltype(apl)(std::move(apl)));
   }
 

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -5971,7 +5971,7 @@ rgw::auth::s3::STSEngine::authenticate(
                                             get_creds_info(token));
     return result_t::grant(std::move(apl), completer_factory(boost::none));
   } else if (token.acct_type == TYPE_ROLE) {
-    auto apl = role_apl_factory->create_apl_role(cct, s, r, user_id, token.policy, token.role_session, token.token_claims);
+    auto apl = role_apl_factory->create_apl_role(cct, s, r, user_id, token.policy, token.role_session, token.token_claims, token.issued_at);
     return result_t::grant(std::move(apl), completer_factory(token.secret_access_key));
   } else { // This is for all local users of type TYPE_RGW or TYPE_NONE
     string subuser;

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -89,6 +89,7 @@ int Credentials::generateCredentials(CephContext* cct,
   token.access_key_id = accessKeyId;
   token.secret_access_key = secretAccessKey;
   token.expiration = expiration;
+  token.issued_at = ceph::to_iso_8601(t);
 
   //Authorization info
   if (policy)

--- a/src/rgw/rgw_sts.h
+++ b/src/rgw/rgw_sts.h
@@ -130,11 +130,12 @@ struct SessionToken {
   uint32_t acct_type;
   string role_session;
   std::vector<string> token_claims;
+  string issued_at;
 
   SessionToken() {}
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(3, 1, bl);
+    ENCODE_START(4, 1, bl);
     encode(access_key_id, bl);
     encode(secret_access_key, bl);
     encode(expiration, bl);
@@ -147,11 +148,12 @@ struct SessionToken {
     encode(acct_type, bl);
     encode(role_session, bl);
     encode(token_claims, bl);
+    encode(issued_at, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(3, bl);
+    DECODE_START(4, bl);
     decode(access_key_id, bl);
     decode(secret_access_key, bl);
     decode(expiration, bl);
@@ -167,6 +169,9 @@ struct SessionToken {
     }
     if (struct_v >= 3) {
       decode(token_claims, bl);
+    }
+    if (struct_v >= 4) {
+      decode(issued_at, bl);
     }
     DECODE_FINISH(bl);
   }


### PR DESCRIPTION
in condition element of role policy to deny access to
temporary credentials.

Signed-off-by: Pritha Srivastava <prsrivas@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
