### PR TITLE
nautilus: mgr/devicehealth: fix daemon filtering before scraping device

### DIFF
--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -351,7 +351,7 @@ class Module(MgrModule):
         r = self.get("device " + devid)
         if not r or 'device' not in r.keys():
             return -errno.ENOENT, '', 'device ' + devid + ' not found'
-        daemons = [d for d in r['device'].get('daemons', []) if not d.startswith('osd.')]
+        daemons = [d for d in r['device'].get('daemons', []) if d.startswith('osd.')]
         if not daemons:
             return (-errno.EAGAIN, '',
                     'device ' + devid + ' not claimed by any active OSD daemons')


### PR DESCRIPTION
Scraping health metrics of mon devices was introduced in Nautilus, then
disabled (only in Nautilus) since the 'tell' mechanism of mons was not
reliable.
This commit fixes a bug when filtering the daemons on the device to be
scrapped (and allows scraping osd devices solely).

When:
$ ceph device scrape-health-metrics seagate_123
Error EAGAIN: device seagate_123 not claimed by any active OSD daemons

But:
$ ceph device ls
DEVICE        	HOST:DEV     	DAEMONS	  LIFE EXPECTANCY
seagate_123	hostname:sdc	osd.1

See:
Introducing the feature in Nautilus:
PR: https://github.com/ceph/ceph/pull/24151
commit: 8d786003a44313c85c038cbdc9bd9875da197ab1

Disabling the feature in Nautilus:
PR: https://github.com/ceph/ceph/pull/31446
commit: d592e56e74d94c6a05b9240fcb0031868acefbab

This issue exists only in Nautilus and does not require fixes in any other branch.

Fixes: https://tracker.ceph.com/issues/46871

Signed-off-by: Yaarit Hatuka <yaarit@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
