### PR TITLE
common/bl, os/bluestore: eradicate bufferlist rebuilds caused by FileWriter of BlueFS

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1623,18 +1623,18 @@ static ceph::spinlock debug_lock;
     _carriage = &always_empty_bptr;
 
     while (len > 0) {
-      // partial?
-      if (off + len < curbuf->length()) {
+      // partial or the last (appendable) one?
+      if (const auto to_drop = off + len; to_drop < curbuf->length()) {
 	//cout << "keeping end of " << *curbuf << ", losing first " << off+len << std::endl;
 	if (claim_by) 
 	  claim_by->append(*curbuf, off, len);
-	curbuf->set_offset(off+len + curbuf->offset());    // ignore beginning big
-	curbuf->set_length(curbuf->length() - (len+off));
-	_len -= off+len;
+	curbuf->set_offset(to_drop + curbuf->offset());    // ignore beginning big
+	curbuf->set_length(curbuf->length() - to_drop);
+	_len -= to_drop;
 	//cout << " now " << *curbuf << std::endl;
 	break;
       }
-      
+
       // hose though the end
       unsigned howmuch = curbuf->length() - off;
       //cout << "discarding " << howmuch << " of " << *curbuf << std::endl;
@@ -1646,7 +1646,7 @@ static ceph::spinlock debug_lock;
       len -= howmuch;
       off = 0;
     }
-      
+
     // splice in *replace (implement me later?)
   }
 

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1562,7 +1562,7 @@ static ceph::spinlock debug_lock;
       // partial?
       if (off + len < curbuf->length()) {
 	//cout << "copying partial of " << *curbuf << std::endl;
-	_buffers.push_back(*ptr_node::create( *curbuf, off, len ).release());
+	_buffers.push_back(*ptr_node::create(*curbuf, off, len).release());
 	_len += len;
         _num += 1;
 	break;
@@ -1571,7 +1571,7 @@ static ceph::spinlock debug_lock;
       // through end
       //cout << "copying end (all?) of " << *curbuf << std::endl;
       unsigned howmuch = curbuf->length() - off;
-      _buffers.push_back(*ptr_node::create( *curbuf, off, howmuch ).release());
+      _buffers.push_back(*ptr_node::create(*curbuf, off, howmuch).release());
       _len += howmuch;
       _num += 1;
       len -= howmuch;
@@ -1610,8 +1610,8 @@ static ceph::spinlock debug_lock;
     }
     
     if (off) {
-      // add a reference to the front bit
-      //  insert it before curbuf (which we'll hose)
+      // add a reference to the front bit, insert it before curbuf (which
+      // we'll lose).
       //cout << "keeping front " << off << " of " << *curbuf << std::endl;
       _buffers.insert_after(curbuf_prev,
 			    *ptr_node::create(*curbuf, 0, off).release());
@@ -1624,23 +1624,23 @@ static ceph::spinlock debug_lock;
 
     while (len > 0) {
       // partial?
-      if (off + len < (*curbuf).length()) {
+      if (off + len < curbuf->length()) {
 	//cout << "keeping end of " << *curbuf << ", losing first " << off+len << std::endl;
 	if (claim_by) 
-	  claim_by->append( *curbuf, off, len );
-	(*curbuf).set_offset( off+len + (*curbuf).offset() );    // ignore beginning big
-	(*curbuf).set_length( (*curbuf).length() - (len+off) );
+	  claim_by->append(*curbuf, off, len);
+	curbuf->set_offset(off+len + curbuf->offset());    // ignore beginning big
+	curbuf->set_length(curbuf->length() - (len+off));
 	_len -= off+len;
 	//cout << " now " << *curbuf << std::endl;
 	break;
       }
       
       // hose though the end
-      unsigned howmuch = (*curbuf).length() - off;
+      unsigned howmuch = curbuf->length() - off;
       //cout << "discarding " << howmuch << " of " << *curbuf << std::endl;
       if (claim_by) 
-	claim_by->append( *curbuf, off, howmuch );
-      _len -= (*curbuf).length();
+	claim_by->append(*curbuf, off, howmuch);
+      _len -= curbuf->length();
       _num -= 1;
       curbuf = _buffers.erase_after_and_dispose(curbuf_prev);
       len -= howmuch;

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1286,15 +1286,6 @@ static ceph::spinlock debug_lock;
     bl.clear();
   }
 
-  void buffer::list::claim_append_piecewise(list& bl)
-  {
-    // steal the other guy's buffers
-    for (const auto& node : bl.buffers()) {
-      append(node, 0, node.length());
-    }
-    bl.clear();
-  }
-
   void buffer::list::append(char c)
   {
     // put what we can into the existing append_buffer.

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1382,6 +1382,7 @@ static ceph::spinlock debug_lock;
       _carriage = new_back;
       return { new_back->c_str(), &new_back->_len, &_len };
     } else {
+      ceph_assert(!_buffers.empty());
       if (unlikely(_carriage != &_buffers.back())) {
         auto bptr = ptr_node::create(*_carriage, _carriage->length(), 0);
 	_carriage = bptr.get();

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -2218,6 +2218,15 @@ MEMPOOL_DEFINE_OBJECT_FACTORY(buffer::raw_static, buffer_raw_static,
 			      buffer_meta);
 
 
+void ceph::buffer::list::page_aligned_appender::_refill(size_t len) {
+  const size_t alloc = \
+    std::max((size_t)min_alloc, (len + CEPH_PAGE_SIZE - 1) & CEPH_PAGE_MASK);
+  auto new_back = \
+    ptr_node::create(buffer::create_page_aligned(alloc));
+  new_back->set_length(0);   // unused, so far.
+  bl.push_back(std::move(new_back));
+}
+
 namespace ceph::buffer {
 inline namespace v15_2_0 {
 

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -1091,8 +1091,6 @@ struct error_code;
     void claim_append(list&& bl) {
       claim_append(bl);
     }
-    // only for bl is bufferlist::page_aligned_appender
-    void claim_append_piecewise(list& bl);
 
     // copy with explicit volatile-sharing semantics
     void share(const list& bl)

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -872,14 +872,6 @@ struct error_code;
       friend class list;
 
     public:
-      ~page_aligned_appender() {
-	flush();
-      }
-
-      void flush() {
-	// nop
-      }
-
       void append(const bufferlist& l) {
 	bl.append(l);
 	bl.obtain_contiguous_space(0);

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -844,39 +844,26 @@ struct error_code;
 		  "contiguous_filler should be no costlier than pointer");
 
     class page_aligned_appender {
-      bufferlist *pbl;
+      bufferlist& bl;
       unsigned min_alloc;
-      ptr buffer;
-      char *pos, *end;
 
       page_aligned_appender(list *l, unsigned min_pages)
-	: pbl(l),
-	  min_alloc(min_pages * CEPH_PAGE_SIZE),
-	  pos(nullptr), end(nullptr) {}
+	: bl(*l),
+	  min_alloc(min_pages * CEPH_PAGE_SIZE) {
+      }
+
+      void _refill(size_t len);
 
       template <class Func>
       void _append_common(size_t len, Func&& impl_f) {
-	while (len > 0) {
-	  if (!pos) {
-	    size_t alloc = (len + CEPH_PAGE_SIZE - 1) & CEPH_PAGE_MASK;
-	    if (alloc < min_alloc) {
-	      alloc = min_alloc;
-	    }
-	    buffer = create_page_aligned(alloc);
-	    pos = buffer.c_str();
-	    end = buffer.end_c_str();
-	  }
-	  size_t l = len;
-	  if (l > (size_t)(end - pos)) {
-	    l = end - pos;
-	  }
-	  impl_f(l, pos);
-	  pos += l;
-	  len -= l;
-	  if (pos == end) {
-	    pbl->append(buffer, 0, buffer.length());
-	    pos = end = nullptr;
-	  }
+	const auto free_in_last = bl.get_append_buffer_unused_tail_length();
+	const auto first_round = std::min(len, free_in_last);
+	if (first_round) {
+	  impl_f(first_round);
+	}
+	if (const auto second_round = len - first_round; second_round) {
+	  _refill(second_round);
+	  impl_f(second_round);
 	}
       }
 
@@ -888,26 +875,25 @@ struct error_code;
       }
 
       void flush() {
-	if (pos && pos != buffer.c_str()) {
-	  size_t len = pos - buffer.c_str();
-	  pbl->append(buffer, 0, len);
-	  buffer.set_length(buffer.length() - len);
-	  buffer.set_offset(buffer.offset() + len);
-	}
+	// nop
+      }
+
+      void append(const bufferlist& l) {
+	bl.append(l);
+	bl.obtain_contiguous_space(0);
       }
 
       void append(const char* buf, size_t entire_len) {
-	 _append_common(entire_len, [buf] (const size_t chunk_len,
-					   char* const dst) mutable {
-	  memcpy(dst, buf, chunk_len);
+	 _append_common(entire_len,
+			[buf, this] (const size_t chunk_len) mutable {
+	  bl.append(buf, chunk_len);
 	  buf += chunk_len;
 	});
       }
 
       void append_zero(size_t entire_len) {
-	_append_common(entire_len, [] (const size_t chunk_len,
-				       char* const dst) {
-	  memset(dst, '\0', chunk_len);
+	_append_common(entire_len, [this] (const size_t chunk_len) {
+	  bl.append_zero(chunk_len);
 	});
       }
 
@@ -935,6 +921,12 @@ struct error_code;
     // it allows to avoid conditionals on hot paths.
     static ptr always_empty_bptr;
     ptr_node& refill_append_space(const unsigned len);
+
+    // for page_aligned_appender; never ever expose this publicly!
+    // carriage / append_buffer is just an implementation's detail.
+    ptr& get_append_buffer() {
+      return *_carriage;
+    }
 
   public:
     // cons/des
@@ -1061,8 +1053,6 @@ struct error_code;
     void push_back(ptr_node&) = delete;
     void push_back(ptr_node&&) = delete;
     void push_back(std::unique_ptr<ptr_node, ptr_node::disposer> bp) {
-      if (bp->length() == 0)
-	return;
       _carriage = bp.get();
       _len += bp->length();
       _num += 1;

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -389,6 +389,8 @@ struct error_code;
     static ptr_node* copy_hypercombined(const ptr_node& copy_this);
 
   private:
+    friend list;
+
     template <class... Args>
     ptr_node(Args&&... args) : ptr(std::forward<Args>(args)...) {
     }
@@ -632,7 +634,7 @@ struct error_code;
     // track bufferptr we can modify (especially ::append() to). Not all bptrs
     // bufferlist holds have this trait -- if somebody ::push_back(const ptr&),
     // he expects it won't change.
-    ptr* _carriage;
+    ptr_node* _carriage;
     unsigned _len, _num;
 
     template <bool is_const>
@@ -919,7 +921,7 @@ struct error_code;
     // always_empty_bptr has no underlying raw but its _len is always 0.
     // This is useful for e.g. get_append_buffer_unused_tail_length() as
     // it allows to avoid conditionals on hot paths.
-    static ptr always_empty_bptr;
+    static ptr_node always_empty_bptr;
     ptr_node& refill_append_space(const unsigned len);
 
     // for page_aligned_appender; never ever expose this publicly!

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2775,8 +2775,6 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
     // Otherwise a costly rebuild could happen in e.g. `KernelDevice`.
     buffer_appender.append_zero(padding_len);
     buffer_appender.flush();
-    // FIXME: `splice` is currently broken at it always thrashes
-    // the `_carriage`. This will be fixed in a separated patch.
     buffer.splice(buffer.length() - padding_len, padding_len, &bl);
     // Deep copy the tail here. This allows to avoid costlier copy on
     // bufferlist rebuild in e.g. `KernelDevice` and minimizes number

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2759,9 +2759,7 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
     /* in case of inital allocation and need to zero, limited flush is unacceptable */
     bl.claim_append_piecewise(buffer);
   } else {
-    bufferlist t;
-    buffer.splice(0, length, &t);
-    bl.claim_append_piecewise(t);
+    buffer.splice(0, length, &bl);
     dout(20) << " leaving 0x" << std::hex << buffer.length() << std::dec
              << " unflushed" << dendl;
   }

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2630,6 +2630,7 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<ceph::mutex>& l,
   ceph_assert(!log_t.empty());
 
   // allocate some more space (before we run out)?
+  // BTW: this triggers `flush()` in the `page_aligned_appender` of `log_writer`.
   int64_t runway = log_writer->file->fnode.get_allocated() -
     log_writer->get_effective_write_pos();
   bool just_expanded_log = false;
@@ -2858,8 +2859,6 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
     bufferlist t;
     h->buffer.splice(0, length, &t);
     bl.claim_append_piecewise(t);
-    t.substr_of(h->buffer, length, h->buffer.length() - length);
-    h->buffer.swap(t);
     dout(20) << " leaving 0x" << std::hex << h->buffer.length() << std::dec
              << " unflushed" << dendl;
   }

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2777,6 +2777,8 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
     // Otherwise a costly rebuild could happen in e.g. `KernelDevice`.
     buffer_appender.append_zero(padding_len);
     buffer_appender.flush();
+    // FIXME: `splice` is currently broken at it always thrashes
+    // the `_carriage`. This will be fixed in a separated patch.
     buffer.splice(buffer.length() - padding_len, padding_len, &bl);
     // Deep copy the tail here. This allows to avoid costlier copy on
     // bufferlist rebuild in e.g. `KernelDevice` and minimizes number

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2753,13 +2753,11 @@ ceph::bufferlist BlueFS::FileWriter::flush_buffer(
 {
   ceph::bufferlist bl;
   if (partial) {
-    bl.claim_append_piecewise(tail_block);
+    tail_block.splice(0, tail_block.length(), &bl);
   }
-  if (length == bl.length() + buffer.length()) {
-    /* in case of inital allocation and need to zero, limited flush is unacceptable */
-    bl.claim_append_piecewise(buffer);
-  } else {
-    buffer.splice(0, length, &bl);
+  const auto remaining_len = length - bl.length();
+  buffer.splice(0, remaining_len, &bl);
+  if (buffer.length()) {
     dout(20) << " leaving 0x" << std::hex << buffer.length() << std::dec
              << " unflushed" << dendl;
   }

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2874,6 +2874,18 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
              << " and padding block with 0x" << (super.block_size - tail)
              << std::dec << dendl;
     h->tail_block.substr_of(bl, bl.length() - tail, tail);
+    //Because class page_aligned_appender, bl.append_zero will create a new ptr.
+    //This make rebuild for direct-io. We split ptr into two parts which make only rebuild size < 4k.
+    if (bl.get_num_buffers() == 1) {
+      bufferptr buf = bl.buffers().front();
+      if (length > super.block_size && buf.is_aligned(super.block_size) && !buf.is_n_align_sized(super.block_size)) {
+	bl.clear();
+	bufferptr tmp(buf, length - tail, tail);
+	buf.set_length(length - tail);
+	bl.append(buf);
+	bl.append(tmp);
+      }
+    }
     bl.append_zero(super.block_size - tail);
     length += super.block_size - tail;
   } else {

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -202,7 +202,6 @@ public:
     }
 
     uint64_t get_effective_write_pos() {
-      buffer_appender.flush();
       return pos + buffer.length();
     }
   };
@@ -557,7 +556,6 @@ public:
     ceph_assert(r == 0);
   }
   void try_flush(FileWriter *h) {
-    h->buffer_appender.flush();
     if (h->get_buffer_length() >= cct->_conf->bluefs_min_flush_size) {
       flush(h, true);
     }

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -197,6 +197,10 @@ public:
       buffer.claim_append(bl);
     }
 
+    void append_zero(size_t len) {
+      buffer_appender.append_zero(len);
+    }
+
     uint64_t get_effective_write_pos() {
       buffer_appender.flush();
       return pos + buffer.length();

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -148,9 +148,20 @@ public:
 
     FileRef file;
     uint64_t pos = 0;       ///< start offset for buffer
+  private:
     ceph::buffer::list buffer;      ///< new data to write (at end of file)
     ceph::buffer::list tail_block;  ///< existing partial block at end of file, if any
+  public:
+    unsigned get_buffer_length() const {
+      return buffer.length();
+    }
+    ceph::bufferlist flush_buffer(
+      CephContext* cct,
+      const bool partial,
+      const unsigned length,
+      const bluefs_super_t& super);
     ceph::buffer::list::page_aligned_appender buffer_appender;  //< for const char* only
+  public:
     int writer_type = 0;    ///< WRITER_*
     int write_hint = WRITE_LIFE_NOT_SET;
 
@@ -160,8 +171,8 @@ public:
 
     FileWriter(FileRef f)
       : file(std::move(f)),
-	buffer_appender(buffer.get_page_aligned_appender(
-			  g_conf()->bluefs_alloc_size / CEPH_PAGE_SIZE)) {
+       buffer_appender(buffer.get_page_aligned_appender(
+                         g_conf()->bluefs_alloc_size / CEPH_PAGE_SIZE)) {
       ++file->num_writers;
       iocv.fill(nullptr);
       dirty_devs.fill(false);
@@ -543,7 +554,7 @@ public:
   }
   void try_flush(FileWriter *h) {
     h->buffer_appender.flush();
-    if (h->buffer.length() >= cct->_conf->bluefs_min_flush_size) {
+    if (h->get_buffer_length() >= cct->_conf->bluefs_min_flush_size) {
       flush(h, true);
     }
   }

--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -250,7 +250,7 @@ class BlueRocksWritableFile : public rocksdb::WritableFile {
    * Get the size of valid data in the file.
    */
   uint64_t GetFileSize() override {
-    return h->file->fnode.size + h->buffer.length();;
+    return h->file->fnode.size + h->get_buffer_length();;
   }
 
   // For documentation, refer to RandomAccessFile::GetUniqueId()

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1606,29 +1606,81 @@ TEST(BufferList, is_n_page_sized) {
 
 TEST(BufferList, page_aligned_appender) {
   bufferlist bl;
-  auto a = bl.get_page_aligned_appender(5);
-  a.append("asdf", 4);
-  a.flush();
-  cout << bl << std::endl;
-  ASSERT_EQ(1u, bl.get_num_buffers());
-  a.append("asdf", 4);
-  for (unsigned n = 0; n < 3 * CEPH_PAGE_SIZE; ++n) {
-    a.append("x", 1);
+  {
+    auto a = bl.get_page_aligned_appender(5);
+    a.append("asdf", 4);
+    a.flush();
+    cout << bl << std::endl;
+    ASSERT_EQ(1u, bl.get_num_buffers());
+    ASSERT_TRUE(bl.contents_equal("asdf", 4));
+    a.append("asdf", 4);
+    for (unsigned n = 0; n < 3 * CEPH_PAGE_SIZE; ++n) {
+      a.append("x", 1);
+    }
+    a.flush();
+    cout << bl << std::endl;
+    ASSERT_EQ(1u, bl.get_num_buffers());
+    // verify the beginning
+    {
+      bufferlist t;
+      t.substr_of(bl, 0, 10);
+      ASSERT_TRUE(t.contents_equal("asdfasdfxx", 10));
+    }
+    for (unsigned n = 0; n < 3 * CEPH_PAGE_SIZE; ++n) {
+      a.append("y", 1);
+    }
+    a.flush();
+    cout << bl << std::endl;
+    ASSERT_EQ(2u, bl.get_num_buffers());
+
+    a.append_zero(42);
+    a.flush();
+    // ensure append_zero didn't introduce a fragmentation
+    ASSERT_EQ(2u, bl.get_num_buffers());
+    // verify the end is actually zeroed
+    {
+      bufferlist t;
+      t.substr_of(bl, bl.length() - 42, 42);
+      ASSERT_TRUE(t.is_zero());
+    }
+
+    // let's check whether appending a bufferlist directly to `bl`
+    // doesn't fragment further C string appends via appender.
+    {
+      const auto& initial_back = bl.back();
+      {
+        bufferlist src;
+        src.append("abc", 3);
+        bl.claim_append(src);
+        // surely the extra `ptr_node` taken from `src` must get
+        // reflected in the `bl` instance
+        ASSERT_EQ(3u, bl.get_num_buffers());
+      }
+
+      // moreover, the next C string-taking `append()` had to
+      // create anoter `ptr_node` instance but...
+      a.append("xyz", 3);
+      a.flush();
+      ASSERT_EQ(4u, bl.get_num_buffers());
+
+      // ... it should point to the same `buffer::raw` instance
+      // (to the same same block of memory).
+      ASSERT_EQ(bl.back().raw_c_str(), initial_back.raw_c_str());
+    }
+
+    // check whether it'll take the first byte only and whether
+    // the auto-flushing works.
+    for (unsigned n = 0; n < 10 * CEPH_PAGE_SIZE - 3; ++n) {
+      a.append("zasdf", 1);
+    }
   }
-  a.flush();
-  cout << bl << std::endl;
-  ASSERT_EQ(1u, bl.get_num_buffers());
-  for (unsigned n = 0; n < 3 * CEPH_PAGE_SIZE; ++n) {
-    a.append("y", 1);
+
+  // `flush()` should be called by automatically when destructing
+  // the appender.
+  {
+    cout << bl << std::endl;
+    ASSERT_EQ(6u, bl.get_num_buffers());
   }
-  a.flush();
-  cout << bl << std::endl;
-  ASSERT_EQ(2u, bl.get_num_buffers());
-  for (unsigned n = 0; n < 10 * CEPH_PAGE_SIZE; ++n) {
-    a.append("asdfasdfasdf", 1);
-  }
-  a.flush();
-  cout << bl << std::endl;
 }
 
 TEST(BufferList, rebuild_aligned_size_and_memory) {

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1973,27 +1973,6 @@ TEST(BufferList, claim_append) {
   EXPECT_EQ((unsigned)0, from.length());
 }
 
-TEST(BufferList, claim_append_piecewise) {
-  bufferlist bl, t, dst;
-  auto a = bl.get_page_aligned_appender(4);
-  for (uint32_t i = 0; i < (CEPH_PAGE_SIZE + CEPH_PAGE_SIZE - 1333); i++)
-    a.append("x", 1);
-  a.flush();
-  const char *p = bl.c_str();
-  t.claim_append(bl);
-
-  for (uint32_t i = 0; i < (CEPH_PAGE_SIZE + 1333); i++)
-    a.append("x", 1);
-  a.flush();
-  t.claim_append(bl);
-
-  EXPECT_FALSE(t.is_aligned_size_and_memory(CEPH_PAGE_SIZE, CEPH_PAGE_SIZE));
-  dst.claim_append_piecewise(t);
-  EXPECT_TRUE(dst.is_aligned_size_and_memory(CEPH_PAGE_SIZE, CEPH_PAGE_SIZE));
-  const char *p1 = dst.c_str();
-  EXPECT_TRUE(p == p1);
-}
-
 TEST(BufferList, begin) {
   bufferlist bl;
   bl.append("ABC");

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1681,6 +1681,16 @@ TEST(BufferList, page_aligned_appender) {
     cout << bl << std::endl;
     ASSERT_EQ(6u, bl.get_num_buffers());
   }
+
+  // Verify that `page_aligned_appender` does respect the carrying
+  // `_carriage` over multiple allocations. Although `append_zero()`
+  // is used here, this affects other members of the append family.
+  // This part would be crucial for e.g. `encode()`.
+  {
+    bl.append_zero(42);
+    cout << bl << std::endl;
+    ASSERT_EQ(6u, bl.get_num_buffers());
+  }
 }
 
 TEST(BufferList, rebuild_aligned_size_and_memory) {

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1609,7 +1609,6 @@ TEST(BufferList, page_aligned_appender) {
   {
     auto a = bl.get_page_aligned_appender(5);
     a.append("asdf", 4);
-    a.flush();
     cout << bl << std::endl;
     ASSERT_EQ(1u, bl.get_num_buffers());
     ASSERT_TRUE(bl.contents_equal("asdf", 4));
@@ -1617,7 +1616,6 @@ TEST(BufferList, page_aligned_appender) {
     for (unsigned n = 0; n < 3 * CEPH_PAGE_SIZE; ++n) {
       a.append("x", 1);
     }
-    a.flush();
     cout << bl << std::endl;
     ASSERT_EQ(1u, bl.get_num_buffers());
     // verify the beginning
@@ -1629,12 +1627,10 @@ TEST(BufferList, page_aligned_appender) {
     for (unsigned n = 0; n < 3 * CEPH_PAGE_SIZE; ++n) {
       a.append("y", 1);
     }
-    a.flush();
     cout << bl << std::endl;
     ASSERT_EQ(2u, bl.get_num_buffers());
 
     a.append_zero(42);
-    a.flush();
     // ensure append_zero didn't introduce a fragmentation
     ASSERT_EQ(2u, bl.get_num_buffers());
     // verify the end is actually zeroed
@@ -1660,7 +1656,6 @@ TEST(BufferList, page_aligned_appender) {
       // moreover, the next C string-taking `append()` had to
       // create anoter `ptr_node` instance but...
       a.append("xyz", 3);
-      a.flush();
       ASSERT_EQ(4u, bl.get_num_buffers());
 
       // ... it should point to the same `buffer::raw` instance
@@ -1675,8 +1670,6 @@ TEST(BufferList, page_aligned_appender) {
     }
   }
 
-  // `flush()` should be called by automatically when destructing
-  // the appender.
   {
     cout << bl << std::endl;
     ASSERT_EQ(6u, bl.get_num_buffers());


### PR DESCRIPTION
This is a continuation of the Jianpeng Ma's work in https://github.com/ceph/ceph/pull/36387. It eradicates the `bufferlist` rebuilds due to the zero padding around `FileWriter` of BlueFS. Most important changes:

* fixed and reworked `BlueFS::_flush_range`. Flushing the `FileWriter::buffer` has been dissected into a `FileWriter::flush_buffer()`,
* `page_aligned_appender` doesn't need manual `flush()` anymore,
* `page_aligned_appender` reuses `bufferlist::_carriage` machinery, enabling e.g. `encode()` to place the data in the same, contiguous memory block,
* fixed `_carriage` handling in `bufferlist::splice()`,
* dropped `bufferlist::claim_append_piecewise()` variant which enables renaming the plain `claim_append()`.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
