### PR TITLE
librbd: flush op was not properly waiting for queued IO

### DIFF
--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -1600,7 +1600,9 @@ void Journal<I>::transition_state(State state, int r) {
   }
 
   if (is_steady_state()) {
-    Contexts wait_for_state_contexts(std::move(m_wait_for_state_contexts));
+    auto wait_for_state_contexts(std::move(m_wait_for_state_contexts));
+    m_wait_for_state_contexts.clear();
+
     for (auto ctx : wait_for_state_contexts) {
       ctx->complete(m_error_result);
     }

--- a/src/librbd/io/QueueImageDispatch.cc
+++ b/src/librbd/io/QueueImageDispatch.cc
@@ -8,6 +8,7 @@
 #include "librbd/ImageCtx.h"
 #include "librbd/Utils.h"
 #include "librbd/io/AioCompletion.h"
+#include "librbd/io/FlushTracker.h"
 #include "librbd/io/ImageDispatchSpec.h"
 
 #define dout_subsys ceph_subsys_rbd
@@ -20,13 +21,19 @@ namespace io {
 
 template <typename I>
 QueueImageDispatch<I>::QueueImageDispatch(I* image_ctx)
-  : m_image_ctx(image_ctx) {
+  : m_image_ctx(image_ctx), m_flush_tracker(new FlushTracker<I>(image_ctx)) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 5) << "ictx=" << image_ctx << dendl;
 }
 
 template <typename I>
+QueueImageDispatch<I>::~QueueImageDispatch() {
+  delete m_flush_tracker;
+}
+
+template <typename I>
 void QueueImageDispatch<I>::shut_down(Context* on_finish) {
+  m_flush_tracker->shut_down();
   on_finish->complete(0);
 }
 
@@ -39,7 +46,7 @@ bool QueueImageDispatch<I>::read(
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << "tid=" << tid << dendl;
 
-  return enqueue(dispatch_result, on_dispatched);
+  return enqueue(true, tid, dispatch_result, on_dispatched);
 }
 
 template <typename I>
@@ -51,7 +58,7 @@ bool QueueImageDispatch<I>::write(
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << "tid=" << tid << dendl;
 
-  return enqueue(dispatch_result, on_dispatched);
+  return enqueue(false, tid, dispatch_result, on_dispatched);
 }
 
 template <typename I>
@@ -63,7 +70,7 @@ bool QueueImageDispatch<I>::discard(
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << "tid=" << tid << dendl;
 
-  return enqueue(dispatch_result, on_dispatched);
+  return enqueue(false, tid, dispatch_result, on_dispatched);
 }
 
 template <typename I>
@@ -75,7 +82,7 @@ bool QueueImageDispatch<I>::write_same(
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << "tid=" << tid << dendl;
 
-  return enqueue(dispatch_result, on_dispatched);
+  return enqueue(false, tid, dispatch_result, on_dispatched);
 }
 
 template <typename I>
@@ -88,7 +95,7 @@ bool QueueImageDispatch<I>::compare_and_write(
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << "tid=" << tid << dendl;
 
-  return enqueue(dispatch_result, on_dispatched);
+  return enqueue(false, tid, dispatch_result, on_dispatched);
 }
 
 template <typename I>
@@ -104,14 +111,29 @@ bool QueueImageDispatch<I>::flush(
     return false;
   }
 
-  return enqueue(dispatch_result, on_dispatched);
+  *dispatch_result = DISPATCH_RESULT_CONTINUE;
+  m_flush_tracker->flush(on_dispatched);
+  return true;
+}
+
+template <typename I>
+void QueueImageDispatch<I>::handle_finished(int r, uint64_t tid) {
+  auto cct = m_image_ctx->cct;
+  ldout(cct, 20) << "tid=" << tid << dendl;
+
+  m_flush_tracker->finish_io(tid);
 }
 
 template <typename I>
 bool QueueImageDispatch<I>::enqueue(
-    DispatchResult* dispatch_result, Context* on_dispatched) {
+    bool read_op, uint64_t tid, DispatchResult* dispatch_result,
+    Context* on_dispatched) {
   if (!m_image_ctx->non_blocking_aio) {
     return false;
+  }
+
+  if (!read_op) {
+    m_flush_tracker->start_io(tid);
   }
 
   *dispatch_result = DISPATCH_RESULT_CONTINUE;

--- a/src/librbd/io/QueueImageDispatch.h
+++ b/src/librbd/io/QueueImageDispatch.h
@@ -23,11 +23,13 @@ struct ImageCtx;
 namespace io {
 
 struct AioCompletion;
+template <typename> class FlushTracker;
 
 template <typename ImageCtxT>
 class QueueImageDispatch : public ImageDispatchInterface {
 public:
   QueueImageDispatch(ImageCtxT* image_ctx);
+  ~QueueImageDispatch();
 
   ImageDispatchLayer get_dispatch_layer() const override {
     return IMAGE_DISPATCH_LAYER_QUEUE;
@@ -69,13 +71,15 @@ public:
       std::atomic<uint32_t>* image_dispatch_flags,
       DispatchResult* dispatch_result, Context* on_dispatched) override;
 
-  void handle_finished(int r, uint64_t tid) override {
-  }
+  void handle_finished(int r, uint64_t tid) override;
 
 private:
   ImageCtxT* m_image_ctx;
 
-  bool enqueue(DispatchResult* dispatch_result, Context* on_dispatched);
+  FlushTracker<ImageCtxT>* m_flush_tracker;
+
+  bool enqueue(bool read_op, uint64_t tid, DispatchResult* dispatch_result,
+               Context* on_dispatched);
 
 };
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
