### PR TITLE
qa/tasks/workunit: allow passing optional args to workunit

### DIFF
--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -5,6 +5,7 @@ import logging
 import pipes
 import os
 import re
+import shlex
 
 from tasks.util import get_remote_for_role
 from tasks.util.workunit import get_refspec_after_overrides
@@ -59,6 +60,14 @@ def task(ctx, config):
               FOO: bar
               BAZ: quux
             timeout: 3h
+
+    You can also pass optional arguments to the found workunits:
+
+        tasks:
+        - workunit:
+            clients:
+              all:
+                - test-ceph-helpers.sh test_get_config
 
     This task supports roles that include a ceph cluster, e.g.::
 
@@ -368,9 +377,12 @@ def _run_tests(ctx, refspec, role, tests, env, basedir,
     try:
         assert isinstance(tests, list)
         for spec in tests:
-            log.info('Running workunits matching %s on %s...', spec, role)
-            prefix = '{spec}/'.format(spec=spec)
-            to_run = [w for w in workunits if w == spec or w.startswith(prefix)]
+            dir_or_fname, *optional_args = shlex.split(spec)
+            log.info('Running workunits matching %s on %s...', dir_or_fname, role)
+            # match executables named "foo" or "foo/*" with workunit named
+            # "foo"
+            to_run = [w for w in workunits
+                      if os.path.commonpath([w, dir_or_fname]) == dir_or_fname]
             if not to_run:
                 raise RuntimeError('Spec did not match any workunits: {spec!r}'.format(spec=spec))
             for workunit in to_run:
@@ -409,7 +421,7 @@ def _run_tests(ctx, refspec, role, tests, env, basedir,
                 ])
                 remote.run(
                     logger=log.getChild(role),
-                    args=args,
+                    args=args + optional_args,
                     label="workunit test {workunit}".format(workunit=workunit)
                 )
                 if cleanup:

--- a/qa/workunits/rados/test_python.sh
+++ b/qa/workunits/rados/test_python.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -ex
 
 ceph osd pool create rbd
-${PYTHON:-python3} -m nose -v $(dirname $0)/../../../src/test/pybind/test_rados.py $@
+${PYTHON:-python3} -m nose -v $(dirname $0)/../../../src/test/pybind/test_rados.py "$@"
 exit 0


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
