### PR TITLE
test/osd/RadosModel: check retval of read op

### DIFF
--- a/src/test/osd/Object.cc
+++ b/src/test/osd/Object.cc
@@ -82,28 +82,23 @@ void VarLenGenerator::get_ranges_map(
 }
 
 void ObjectDesc::iterator::adjust_stack() {
-  while (!stack.empty() && pos >= stack.front().second.next) {
-    ceph_assert(pos == stack.front().second.next);
-    size = stack.front().second.size;
-    current = stack.front().first;
-    stack.pop_front();
+  while (!stack.empty() && pos >= stack.top().second.next) {
+    ceph_assert(pos == stack.top().second.next);
+    size = stack.top().second.size;
+    current = stack.top().first;
+    stack.pop();
   }
 
   if (stack.empty()) {
     cur_valid_till = std::numeric_limits<uint64_t>::max();
   } else {
-    cur_valid_till = stack.front().second.next;
+    cur_valid_till = stack.top().second.next;
   }
 
   while (current != layers.end() && !current->covers(pos)) {
     uint64_t next = current->next(pos);
     if (next < cur_valid_till) {
-      stack.push_front(
-	make_pair(
-	  current,
-	  StackState{next, size}
-	  )
-	);
+      stack.emplace(current, StackState{next, size});
       cur_valid_till = next;
     }
 

--- a/src/test/osd/Object.h
+++ b/src/test/osd/Object.h
@@ -5,6 +5,7 @@
 #include <list>
 #include <map>
 #include <set>
+#include <stack>
 #include <random>
 
 #ifndef OBJECT_H
@@ -369,14 +370,16 @@ public:
 	  std::numeric_limits<uint64_t>::max();
       }
     };
-    std::list<ContState> layers;
+    // from latest to earliest
+    using layers_t = std::vector<ContState>;
+    layers_t layers;
 
     struct StackState {
       const uint64_t next;
       const uint64_t size;
     };
-    std::list<std::pair<std::list<ContState>::iterator, StackState> > stack;
-    std::list<ContState>::iterator current;
+    std::stack<std::pair<layers_t::iterator, StackState> > stack;
+    layers_t::iterator current;
 
     explicit iterator(ObjectDesc &obj) :
       pos(0),

--- a/src/test/osd/Object.h
+++ b/src/test/osd/Object.h
@@ -10,6 +10,7 @@
 #ifndef OBJECT_H
 #define OBJECT_H
 
+/// describes an object
 class ContDesc {
 public:
   int objnum;
@@ -78,6 +79,10 @@ public:
       _ret.push_back(ret);
       return _ret;
     }
+    /// walk through given @c bl
+    ///
+    /// @param[out] off the offset of the first byte which does not match
+    /// @returns true if @c bl matches with the content, false otherwise
     virtual bool check_bl_advance(bufferlist &bl, uint64_t *off = nullptr) {
       uint64_t _off = 0;
       for (bufferlist::iterator i = bl.begin();
@@ -407,6 +412,7 @@ public:
       return pos >= size;
     }
 
+    // advance @c pos to given position
     void seek(uint64_t _pos) {
       if (_pos < pos) {
 	ceph_abort();
@@ -424,6 +430,9 @@ public:
       ceph_assert(pos == _pos);
     }
 
+    // grab the bytes in the range of [pos, pos+s), and advance @c pos
+    //
+    // @returns the bytes in the specified range
     bufferlist gen_bl_advance(uint64_t s) {
       bufferlist ret;
       while (s > 0) {
@@ -447,6 +456,11 @@ public:
       return ret;
     }
 
+    // compare the range of [pos, pos+bl.length()) with given @c bl, and
+    // advance @pos if all bytes in the range match
+    //
+    // @param error_at the offset of the first byte which does not match
+    // @returns true if all bytes match, false otherwise
     bool check_bl_advance(bufferlist &bl, uint64_t *error_at = nullptr) {
       uint64_t off = 0;
       while (off < bl.length()) {

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -104,16 +104,15 @@ public:
 
 class TestOp {
 public:
-  int num;
+  const int num;
   RadosTestContext *context;
   TestOpStat *stat;
-  bool done;
+  bool done = false;
   TestOp(int n, RadosTestContext *context,
 	 TestOpStat *stat = 0)
     : num(n),
       context(context),
-      stat(stat),
-      done(false)
+      stat(stat)
   {}
 
   virtual ~TestOp() {};
@@ -752,19 +751,19 @@ public:
 
 class WriteOp : public TestOp {
 public:
-  string oid;
+  const string oid;
   ContDesc cont;
   set<librados::AioCompletion *> waiting;
-  librados::AioCompletion *rcompletion;
-  uint64_t waiting_on;
-  uint64_t last_acked_tid;
+  librados::AioCompletion *rcompletion = nullptr;
+  uint64_t waiting_on = 0;
+  uint64_t last_acked_tid = 0;
 
   librados::ObjectReadOperation read_op;
   librados::ObjectWriteOperation write_op;
   bufferlist rbuffer;
 
-  bool do_append;
-  bool do_excl;
+  const bool do_append;
+  const bool do_excl;
 
   WriteOp(int n,
 	  RadosTestContext *context,
@@ -773,8 +772,8 @@ public:
 	  bool do_excl,
 	  TestOpStat *stat = 0)
     : TestOp(n, context, stat),
-      oid(oid), rcompletion(NULL), waiting_on(0), 
-      last_acked_tid(0), do_append(do_append),
+      oid(oid),
+      do_append(do_append),
       do_excl(do_excl)
   {}
 		

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -779,9 +779,9 @@ public:
 		
   void _begin() override
   {
-    std::lock_guard state_locker{context->state_lock};
-    done = 0;
+    assert(!done);
     stringstream acc;
+    std::lock_guard state_locker{context->state_lock};
     acc << context->prefix << "OID: " << oid << " snap " << context->current_snap << std::endl;
     string prefix = acc.str();
 

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -799,11 +799,11 @@ public:
       uint64_t prev_length = found && old_value.has_contents() ?
 	old_value.most_recent_gen()->get_length(old_value.most_recent()) :
 	0;
-      bool requires;
-      int r = context->io_ctx.pool_requires_alignment2(&requires);
+      bool requires_alignment;
+      int r = context->io_ctx.pool_requires_alignment2(&requires_alignment);
       ceph_assert(r == 0);
       uint64_t alignment = 0;
-      if (requires) {
+      if (requires_alignment) {
         r = context->io_ctx.pool_required_alignment2(&alignment);
         ceph_assert(r == 0);
         ceph_assert(alignment != 0);

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -827,7 +827,8 @@ public:
 
     waiting_on = ranges.size();
     ContentsGenerator::iterator gen_pos = cont_gen->get_iterator(cont);
-    uint64_t tid = 1;
+    // assure that tid is greater than last_acked_tid
+    uint64_t tid = last_acked_tid + 1;
     for (auto [offset, len] : ranges) {
       gen_pos.seek(offset);
       bufferlist to_write = gen_pos.gen_bl_advance(len);
@@ -838,7 +839,7 @@ public:
 		<< " to " << len + offset << " tid " << tid << std::endl;
       auto cb_arg =
 	new pair<TestOp*, TestOp::CallbackInfo*>(this,
-						 new TestOp::CallbackInfo(tid));
+						 new TestOp::CallbackInfo(tid++));
       librados::AioCompletion *completion =
 	context->rados.aio_create_completion((void*) cb_arg, &write_callback);
       waiting.insert(completion);
@@ -848,12 +849,11 @@ public:
       } else {
 	op.write(offset, to_write);
       }
-      if (do_excl && tid == 1)
+      if (do_excl && cb_arg->second->id == last_acked_tid + 1)
 	op.assert_exists();
       context->io_ctx.aio_operate(
 	context->prefix+oid, completion,
 	&op);
-      ++tid;
     }
 
     bufferlist contbl;
@@ -861,7 +861,7 @@ public:
     pair<TestOp*, TestOp::CallbackInfo*> *cb_arg =
       new pair<TestOp*, TestOp::CallbackInfo*>(
 	this,
-	new TestOp::CallbackInfo(++tid));
+	new TestOp::CallbackInfo(tid++));
     librados::AioCompletion *completion = context->rados.aio_create_completion(
       (void*) cb_arg, &write_callback);
     waiting.insert(completion);
@@ -876,7 +876,7 @@ public:
     cb_arg =
       new pair<TestOp*, TestOp::CallbackInfo*>(
 	this,
-	new TestOp::CallbackInfo(++tid));
+	new TestOp::CallbackInfo(tid++));
     rcompletion = context->rados.aio_create_completion(
          (void*) cb_arg, &write_callback);
     waiting_on++;
@@ -1006,7 +1006,8 @@ public:
 
     waiting_on = ranges.size();
     ContentsGenerator::iterator gen_pos = cont_gen->get_iterator(cont);
-    uint64_t tid = 1;
+    // assure that tid is greater than last_acked_tid
+    uint64_t tid = last_acked_tid + 1;
     for (auto [offset, len] : ranges) {
       gen_pos.seek(offset);
       bufferlist to_write = gen_pos.gen_bl_advance(len);
@@ -1017,7 +1018,7 @@ public:
 		<< " to " << offset + len << " tid " << tid << std::endl;
       auto cb_arg =
 	new pair<TestOp*, TestOp::CallbackInfo*>(this,
-						 new TestOp::CallbackInfo(tid));
+						 new TestOp::CallbackInfo(tid++));
       librados::AioCompletion *completion =
 	context->rados.aio_create_completion((void*) cb_arg,
 					     &write_callback);
@@ -1029,7 +1030,6 @@ public:
       context->io_ctx.aio_operate(
 	context->prefix+oid, completion,
 	&op);
-      ++tid;
     }
 
     bufferlist contbl;
@@ -1037,7 +1037,7 @@ public:
     pair<TestOp*, TestOp::CallbackInfo*> *cb_arg =
       new pair<TestOp*, TestOp::CallbackInfo*>(
 	this,
-	new TestOp::CallbackInfo(++tid));
+	new TestOp::CallbackInfo(tid++));
     librados::AioCompletion *completion = context->rados.aio_create_completion(
       (void*) cb_arg, &write_callback);
     waiting.insert(completion);
@@ -1050,7 +1050,7 @@ public:
     cb_arg =
       new pair<TestOp*, TestOp::CallbackInfo*>(
 	this,
-	new TestOp::CallbackInfo(++tid));
+	new TestOp::CallbackInfo(tid++));
     rcompletion = context->rados.aio_create_completion(
          (void*) cb_arg, &write_callback);
     waiting_on++;

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -389,8 +389,7 @@ public:
       new_obj.attrs.erase(*i);
     }
     new_obj.dirty = true;
-    pool_obj_cont[current_snap].erase(oid);
-    pool_obj_cont[current_snap].insert(pair<string,ObjectDesc>(oid, new_obj));
+    pool_obj_cont[current_snap].insert_or_assign(oid, new_obj);
   }
 
   void remove_object_header(const string &oid)
@@ -398,8 +397,7 @@ public:
     ObjectDesc new_obj = get_most_recent(oid);
     new_obj.header = bufferlist();
     new_obj.dirty = true;
-    pool_obj_cont[current_snap].erase(oid);
-    pool_obj_cont[current_snap].insert(pair<string,ObjectDesc>(oid, new_obj));
+    pool_obj_cont[current_snap].insert_or_assign(oid, new_obj);
   }
 
 
@@ -409,8 +407,7 @@ public:
     new_obj.header = bl;
     new_obj.exists = true;
     new_obj.dirty = true;
-    pool_obj_cont[current_snap].erase(oid);
-    pool_obj_cont[current_snap].insert(pair<string,ObjectDesc>(oid, new_obj));
+    pool_obj_cont[current_snap].insert_or_assign(oid, new_obj);
   }
 
   void update_object_attrs(const string &oid, const map<string, ContDesc> &attrs)
@@ -423,8 +420,7 @@ public:
     }
     new_obj.exists = true;
     new_obj.dirty = true;
-    pool_obj_cont[current_snap].erase(oid);
-    pool_obj_cont[current_snap].insert(pair<string,ObjectDesc>(oid, new_obj));
+    pool_obj_cont[current_snap].insert_or_assign(oid, new_obj);
   }
 
   void update_object(ContentsGenerator *cont_gen,
@@ -435,14 +431,12 @@ public:
     new_obj.dirty = true;
     new_obj.update(cont_gen,
 		   contents);
-    pool_obj_cont[current_snap].erase(oid);
-    pool_obj_cont[current_snap].insert(pair<string,ObjectDesc>(oid, new_obj));
+    pool_obj_cont[current_snap].insert_or_assign(oid, new_obj);
   }
 
   void update_object_full(const string &oid, const ObjectDesc &contents)
   {
-    pool_obj_cont[current_snap].erase(oid);
-    pool_obj_cont[current_snap].insert(pair<string,ObjectDesc>(oid, contents));
+    pool_obj_cont[current_snap].insert_or_assign(oid, contents);
     pool_obj_cont[current_snap][oid].dirty = true;
   }
 
@@ -450,8 +444,7 @@ public:
   {
     ObjectDesc new_obj = get_most_recent(oid);
     new_obj.dirty = false;
-    pool_obj_cont[current_snap].erase(oid);
-    pool_obj_cont[current_snap].insert(pair<string,ObjectDesc>(oid, new_obj));
+    pool_obj_cont[current_snap].insert_or_assign(oid, new_obj);
   }
 
   void update_object_version(const string &oid, uint64_t version,
@@ -481,8 +474,7 @@ public:
   {
     ceph_assert(!get_watch_context(oid));
     ObjectDesc new_obj;
-    pool_obj_cont[current_snap].erase(oid);
-    pool_obj_cont[current_snap].insert(pair<string,ObjectDesc>(oid, new_obj));
+    pool_obj_cont[current_snap].insert_or_assign(oid, new_obj);
   }
 
   bool find_object(const string &oid, ObjectDesc *contents, int snap = -1) const


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47061
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
