### PR TITLE
nautilus: rgw: hold reloader using unique_ptr

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -565,8 +565,8 @@ int main(int argc, const char **argv)
   // add a watcher to respond to realm configuration changes
   RGWPeriodPusher pusher(store);
   RGWFrontendPauser pauser(fes, implicit_tenant_context, &pusher);
-  std::optional<RGWRealmReloader> reloader(std::in_place, store,
-                                           service_map_meta, &pauser);
+  auto reloader = std::make_unique<RGWRealmReloader>(store,
+						     service_map_meta, &pauser);
 
   RGWRealmWatcher realm_watcher(g_ceph_context, store->svc.zone->get_realm());
   realm_watcher.add_watcher(RGWRealmNotify::Reload, *reloader);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47115

---

backport of https://github.com/ceph/ceph/pull/36521
parent tracker: https://tracker.ceph.com/issues/47113

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh