### PR TITLE
systemd: Support Graceful Reboot for AIO Node

### DIFF
--- a/systemd/ceph-fuse.target
+++ b/systemd/ceph-fuse.target
@@ -2,5 +2,6 @@
 Description=ceph target allowing to start/stop all ceph-fuse@.service instances at once
 PartOf=ceph.target
 Before=ceph.target
+
 [Install]
 WantedBy=remote-fs.target ceph.target

--- a/systemd/ceph-immutable-object-cache.target
+++ b/systemd/ceph-immutable-object-cache.target
@@ -2,5 +2,6 @@
 Description=ceph target allowing to start/stop all ceph-immutable-object-cache@.service instances at once
 PartOf=ceph.target
 Before=ceph.target
+
 [Install]
 WantedBy=multi-user.target ceph.target

--- a/systemd/ceph-mds.target
+++ b/systemd/ceph-mds.target
@@ -1,6 +1,9 @@
 [Unit]
 Description=ceph target allowing to start/stop all ceph-mds@.service instances at once
 PartOf=ceph.target
+After=ceph-mon.target
 Before=ceph.target
+Wants=ceph.target ceph-mon.target
+
 [Install]
 WantedBy=multi-user.target ceph.target

--- a/systemd/ceph-mds@.service.in
+++ b/systemd/ceph-mds@.service.in
@@ -1,8 +1,9 @@
 [Unit]
 Description=Ceph metadata server daemon
-After=network-online.target local-fs.target time-sync.target
-Wants=network-online.target local-fs.target time-sync.target
 PartOf=ceph-mds.target
+After=network-online.target local-fs.target time-sync.target
+Before=remote-fs-pre.target ceph-mds.target
+Wants=network-online.target local-fs.target time-sync.target remote-fs-pre.target ceph-mds.target
 
 [Service]
 Environment=CLUSTER=ceph

--- a/systemd/ceph-mgr.target
+++ b/systemd/ceph-mgr.target
@@ -1,6 +1,9 @@
 [Unit]
 Description=ceph target allowing to start/stop all ceph-mgr@.service instances at once
 PartOf=ceph.target
+After=ceph-mon.target
 Before=ceph.target
+Wants=ceph.target ceph-mon.target
+
 [Install]
 WantedBy=multi-user.target ceph.target

--- a/systemd/ceph-mgr@.service.in
+++ b/systemd/ceph-mgr@.service.in
@@ -1,8 +1,9 @@
 [Unit]
 Description=Ceph cluster manager daemon
-After=network-online.target local-fs.target time-sync.target
-Wants=network-online.target local-fs.target time-sync.target
 PartOf=ceph-mgr.target
+After=network-online.target local-fs.target time-sync.target
+Before=remote-fs-pre.target ceph-mgr.target
+Wants=network-online.target local-fs.target time-sync.target remote-fs-pre.target ceph-mgr.target
 
 [Service]
 Environment=CLUSTER=ceph
@@ -28,11 +29,9 @@ RestartSec=10
 RestrictSUIDSGID=true
 StartLimitBurst=3
 StartLimitInterval=30min
-
 # We need to disable this protection as some python libraries generate
 # dynamic code, like python-cffi, and require mmap calls to succeed
 MemoryDenyWriteExecute=false
-
 
 [Install]
 WantedBy=ceph-mgr.target

--- a/systemd/ceph-mon.target
+++ b/systemd/ceph-mon.target
@@ -2,5 +2,7 @@
 Description=ceph target allowing to start/stop all ceph-mon@.service instances at once
 PartOf=ceph.target
 Before=ceph.target
+Wants=ceph.target
+
 [Install]
 WantedBy=multi-user.target ceph.target

--- a/systemd/ceph-mon@.service.in
+++ b/systemd/ceph-mon@.service.in
@@ -1,13 +1,13 @@
 [Unit]
 Description=Ceph cluster monitor daemon
-
+PartOf=ceph-mon.target
 # According to:
 #   http://www.freedesktop.org/wiki/Software/systemd/NetworkTarget
 # these can be removed once ceph-mon will dynamically change network
 # configuration.
 After=network-online.target local-fs.target time-sync.target
-Wants=network-online.target local-fs.target time-sync.target
-PartOf=ceph-mon.target
+Before=remote-fs-pre.target ceph-mon.target
+Wants=network-online.target local-fs.target time-sync.target remote-fs-pre.target ceph-mon.target
 
 [Service]
 Environment=CLUSTER=ceph

--- a/systemd/ceph-osd.target
+++ b/systemd/ceph-osd.target
@@ -1,6 +1,9 @@
 [Unit]
 Description=ceph target allowing to start/stop all ceph-osd@.service instances at once
 PartOf=ceph.target
+After=ceph-mon.target
 Before=ceph.target
+Wants=ceph.target ceph-mon.target
+
 [Install]
 WantedBy=multi-user.target ceph.target

--- a/systemd/ceph-osd@.service.in
+++ b/systemd/ceph-osd@.service.in
@@ -1,8 +1,9 @@
 [Unit]
 Description=Ceph object storage daemon osd.%i
-After=network-online.target local-fs.target time-sync.target ceph-mon.target
-Wants=network-online.target local-fs.target time-sync.target
 PartOf=ceph-osd.target
+After=network-online.target local-fs.target time-sync.target
+Before=remote-fs-pre.target ceph-osd.target
+Wants=network-online.target local-fs.target time-sync.target remote-fs-pre.target ceph-osd.target
 
 [Service]
 Environment=CLUSTER=ceph

--- a/systemd/ceph-radosgw.target
+++ b/systemd/ceph-radosgw.target
@@ -1,6 +1,9 @@
 [Unit]
 Description=ceph target allowing to start/stop all ceph-radosgw@.service instances at once
 PartOf=ceph.target
+After=ceph-mon.target
 Before=ceph.target
+Wants=ceph.target ceph-mon.target
+
 [Install]
 WantedBy=multi-user.target ceph.target

--- a/systemd/ceph-radosgw@.service.in
+++ b/systemd/ceph-radosgw@.service.in
@@ -1,8 +1,9 @@
 [Unit]
 Description=Ceph rados gateway
-After=network-online.target local-fs.target time-sync.target
-Wants=network-online.target local-fs.target time-sync.target
 PartOf=ceph-radosgw.target
+After=network-online.target local-fs.target time-sync.target
+Before=remote-fs-pre.target ceph-radosgw.target
+Wants=network-online.target local-fs.target time-sync.target remote-fs-pre.target ceph-radosgw.target
 
 [Service]
 Environment=CLUSTER=ceph

--- a/systemd/ceph-rbd-mirror.target
+++ b/systemd/ceph-rbd-mirror.target
@@ -2,5 +2,6 @@
 Description=ceph target allowing to start/stop all ceph-rbd-mirror@.service instances at once
 PartOf=ceph.target
 Before=ceph.target
+
 [Install]
 WantedBy=multi-user.target ceph.target

--- a/systemd/ceph.target
+++ b/systemd/ceph.target
@@ -1,4 +1,5 @@
 [Unit]
 Description=ceph target allowing to start/stop all ceph*@.service instances at once
+
 [Install]
 WantedBy=multi-user.target

--- a/systemd/rbdmap.service.in
+++ b/systemd/rbdmap.service.in
@@ -1,9 +1,8 @@
 [Unit]
 Description=Map RBD devices
-
-After=network-online.target
+After=network-online.target ceph.target
 Before=remote-fs-pre.target
-Wants=network-online.target remote-fs-pre.target
+Wants=network-online.target remote-fs-pre.target ceph.target
 
 [Service]
 EnvironmentFile=-@SYSTEMD_ENV_FILE@


### PR DESCRIPTION
Ceph AIO installation with single/multiple node is not friendly for loopback mount, especially always get deadlock issue during graceful system reboot. 

We already have `rbdmap.service` with graceful system reboot friendly as below:

    [Unit]
    After=network-online.target
    Before=remote-fs-pre.target
    Wants=network-online.target remote-fs-pre.target
    
    [Service]
    ExecStart=/usr/bin/rbdmap map
    ExecReload=/usr/bin/rbdmap map
    ExecStop=/usr/bin/rbdmap unmap-all
    
This PR introduce:

  - `ceph-mon.target`: Ensure startup after `network-online.target` and before `remote-fs-pre.target`
  - `ceph-*.target`: Ensure startup after `ceph-mon.target` and before `remote-fs-pre.target`
  - `rbdmap.service`: Once all `_netdev` get unmount by `remote-fs.target`, ensure unmap all RBD BEFORE any Ceph components under `ceph.target` get stopped during shutdown
  
The logic is concept proof by <https://github.com/alvistack/ansible-role-ceph_common/tree/develop>; also works as expected with Ceph + Kubernetes deployment by <https://github.com/alvistack/ansible-collection-kubernetes/tree/develop>. No more deadlock happened during graceful system reboot, both AIO single/multiple no de with loopback mount.

Also see: 

  - <https://github.com/ceph/ceph/pull/36776> 
  - <https://github.com/etcd-io/etcd/pull/12259>
  - <https://github.com/cri-o/cri-o/pull/4128>
  - <https://github.com/kubernetes/release/pull/1504>

Fixes: https://tracker.ceph.com/issues/47528
Signed-off-by: Wong Hoi Sing Edison <hswong3i@gmail.com>



![image](https://user-images.githubusercontent.com/780562/93428317-ce4a3d00-f8f1-11ea-81d8-60c1430db1d0.png)

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
