### PR TITLE
[DNM PENDING SQUASH AND COMMIT MESSAGE TWEAK] nautilus: rgw: s3: mark bucket encryption as not implemented

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3569,7 +3569,8 @@ RGWOp *RGWHandler_REST_Bucket_S3::get_obj_op(bool get_data)
 
 RGWOp *RGWHandler_REST_Bucket_S3::op_get()
 {
-  if (s->info.args.sub_resource_exists("encryption"))
+  if (s->info.args.sub_resource_exists("encryption") ||
+      s->info.args.sub_resource_exists("replication"))
     return nullptr;
 
   if (s->info.args.sub_resource_exists("logging"))
@@ -3625,7 +3626,8 @@ RGWOp *RGWHandler_REST_Bucket_S3::op_head()
 RGWOp *RGWHandler_REST_Bucket_S3::op_put()
 {
   if (s->info.args.sub_resource_exists("logging") ||
-      s->info.args.sub_resource_exists("encryption"))
+      s->info.args.sub_resource_exists("encryption") ||
+      s->info.args.sub_resource_exists("replication"))
     return nullptr;
   if (s->info.args.sub_resource_exists("versioning"))
     return new RGWSetBucketVersioning_ObjStore_S3;
@@ -3656,7 +3658,8 @@ RGWOp *RGWHandler_REST_Bucket_S3::op_put()
 RGWOp *RGWHandler_REST_Bucket_S3::op_delete()
 {
   if (s->info.args.sub_resource_exists("logging") ||
-      s->info.args.sub_resource_exists("encryption"))
+      s->info.args.sub_resource_exists("encryption") ||
+      s->info.args.sub_resource_exists("replication"))
     return nullptr;
 
   if (is_cors_op()) {

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3569,6 +3569,9 @@ RGWOp *RGWHandler_REST_Bucket_S3::get_obj_op(bool get_data)
 
 RGWOp *RGWHandler_REST_Bucket_S3::op_get()
 {
+  if (s->info.args.sub_resource_exists("encryption"))
+    return nullptr;
+
   if (s->info.args.sub_resource_exists("logging"))
     return new RGWGetBucketLogging_ObjStore_S3;
 
@@ -3621,8 +3624,9 @@ RGWOp *RGWHandler_REST_Bucket_S3::op_head()
 
 RGWOp *RGWHandler_REST_Bucket_S3::op_put()
 {
-  if (s->info.args.sub_resource_exists("logging"))
-    return NULL;
+  if (s->info.args.sub_resource_exists("logging") ||
+      s->info.args.sub_resource_exists("encryption"))
+    return nullptr;
   if (s->info.args.sub_resource_exists("versioning"))
     return new RGWSetBucketVersioning_ObjStore_S3;
   if (s->info.args.sub_resource_exists("website")) {
@@ -3651,6 +3655,10 @@ RGWOp *RGWHandler_REST_Bucket_S3::op_put()
 
 RGWOp *RGWHandler_REST_Bucket_S3::op_delete()
 {
+  if (s->info.args.sub_resource_exists("logging") ||
+      s->info.args.sub_resource_exists("encryption"))
+    return nullptr;
+
   if (is_cors_op()) {
     return new RGWDeleteCORS_ObjStore_S3;
   } else if(is_lc_op()) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46997

***

backport of #36264
parent tracker: https://tracker.ceph.com/issues/46263

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
