### PR TITLE
nautilus: mgr: Add missing states to PG_STATES in mgr_module.py.

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -14,6 +14,7 @@ import rados
 import re
 import time
 
+# Full list of strings in "osd_types.cc:pg_state_string()"
 PG_STATES = [
     "active",
     "clean",
@@ -44,7 +45,10 @@ PG_STATES = [
     "snaptrim_wait",
     "snaptrim_error",
     "creating",
-    "unknown"]
+    "unknown",
+    "premerge",
+    "failed_repair",
+]
 
 
 class CPlusPlusHandler(logging.Handler):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46937

---

backport of https://github.com/ceph/ceph/pull/36399
parent tracker: https://tracker.ceph.com/issues/46808

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh