### PR TITLE
octopus: mgr: Add missing states to PG_STATES in mgr_module.py.

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -16,6 +16,7 @@ import re
 import time
 from mgr_util import profile_method
 
+# Full list of strings in "osd_types.cc:pg_state_string()"
 PG_STATES = [
     "active",
     "clean",
@@ -46,7 +47,12 @@ PG_STATES = [
     "snaptrim_wait",
     "snaptrim_error",
     "creating",
-    "unknown"]
+    "unknown",
+    "premerge",
+    "failed_repair",
+    "laggy",
+    "wait",
+]
 
 
 class CommandResult(object):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46936

---

backport of https://github.com/ceph/ceph/pull/36399
parent tracker: https://tracker.ceph.com/issues/46808

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh