### PR TITLE
nautilus: mgr/dashboard: remove "This week/month/year" and "Today" time stamps of Grafana in dashboard

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
@@ -83,10 +83,6 @@ export class GrafanaComponent implements OnInit, OnChanges {
         value: 'from=now-1d%2Fd&to=now-1d%2Fd'
       },
       {
-        name: this.i18n('Today'),
-        value: 'from=now%2Fd&to=now%2Fd'
-      },
-      {
         name: this.i18n('Today so far'),
         value: 'from=now%2Fd&to=now'
       },
@@ -107,10 +103,6 @@ export class GrafanaComponent implements OnInit, OnChanges {
         value: 'from=now-1w%2Fw&to=now-1w%2Fw'
       },
       {
-        name: this.i18n('This week'),
-        value: 'from=now%2Fw&to=now%2Fw'
-      },
-      {
         name: this.i18n('This week so far'),
         value: 'from=now%2Fw&to=now'
       },
@@ -121,10 +113,6 @@ export class GrafanaComponent implements OnInit, OnChanges {
       {
         name: this.i18n('Previous month'),
         value: 'from=now-1M%2FM&to=now-1M%2FM'
-      },
-      {
-        name: this.i18n('This month'),
-        value: 'from=now%2FM&to=now%2FM'
       },
       {
         name: this.i18n('This month so far'),
@@ -149,10 +137,6 @@ export class GrafanaComponent implements OnInit, OnChanges {
       {
         name: this.i18n('Previous year'),
         value: 'from=now-1y%2Fy&to=now-1y%2Fy'
-      },
-      {
-        name: this.i18n('This year'),
-        value: 'from=now%2Fy&to=now%2Fy'
       },
       {
         name: this.i18n('This year so far'),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47122

---

backport of https://github.com/ceph/ceph/pull/36735
parent tracker: https://tracker.ceph.com/issues/47049

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh