### PR TITLE
librbd: expose internal plugin API to plugin libraries

### DIFF
--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -167,27 +167,12 @@ set(librbd_internal_srcs
   operation/SnapshotLimitRequest.cc
   operation/SparsifyRequest.cc
   operation/TrimRequest.cc
+  plugin/Api.cc
   trash/MoveRequest.cc
   trash/RemoveRequest.cc
   watcher/Notifier.cc
   watcher/RewatchRequest.cc
   ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc)
-
-add_custom_target(librbd_plugins)
-set(librbd_plugins_dir ${CEPH_INSTALL_PKGLIBDIR}/librbd)
-
-set(rbd_plugin_parent_cache_srcs
-  cache/ParentCacheObjectDispatch.cc
-  plugin/ParentCache.cc)
-add_library(librbd_plugin_parent_cache SHARED ${rbd_plugin_parent_cache_srcs})
-target_link_libraries(librbd_plugin_parent_cache PRIVATE
-  ceph_immutable_object_cache_lib)
-set_target_properties(librbd_plugin_parent_cache PROPERTIES
-  OUTPUT_NAME ceph_librbd_parent_cache
-  VERSION 1.0.0
-  SOVERSION 1)
-install(TARGETS librbd_plugin_parent_cache DESTINATION ${librbd_plugins_dir})
-add_dependencies(librbd_plugins librbd_plugin_parent_cache)
 
 if(WITH_EVENTTRACE)
   list(APPEND librbd_internal_srcs ../common/EventTrace.cc)
@@ -227,6 +212,24 @@ if(WITH_RBD_RWL)
   target_link_libraries(rbd_internal
     PUBLIC blk)
 endif()
+
+add_custom_target(librbd_plugins)
+set(librbd_plugins_dir ${CEPH_INSTALL_PKGLIBDIR}/librbd)
+
+set(rbd_plugin_parent_cache_srcs
+  cache/ParentCacheObjectDispatch.cc
+  plugin/ParentCache.cc)
+add_library(librbd_plugin_parent_cache SHARED
+  ${rbd_plugin_parent_cache_srcs})
+target_link_libraries(librbd_plugin_parent_cache PRIVATE
+  ceph_immutable_object_cache_lib
+  librados)
+set_target_properties(librbd_plugin_parent_cache PROPERTIES
+  OUTPUT_NAME ceph_librbd_parent_cache
+  VERSION 1.0.0
+  SOVERSION 1)
+install(TARGETS librbd_plugin_parent_cache DESTINATION ${librbd_plugins_dir})
+add_dependencies(librbd_plugins librbd_plugin_parent_cache)
 
 add_library(librbd ${CEPH_SHARED}
   librbd.cc)

--- a/src/librbd/PluginRegistry.cc
+++ b/src/librbd/PluginRegistry.cc
@@ -5,6 +5,7 @@
 #include "include/Context.h"
 #include "common/dout.h"
 #include "librbd/ImageCtx.h"
+#include "librbd/plugin/Api.h"
 #include <boost/tokenizer.hpp>
 
 #define dout_subsys ceph_subsys_rbd
@@ -15,7 +16,12 @@
 namespace librbd {
 
 template <typename I>
-PluginRegistry<I>::PluginRegistry(I* image_ctx) : m_image_ctx(image_ctx) {
+PluginRegistry<I>::PluginRegistry(I* image_ctx)
+  : m_image_ctx(image_ctx), m_plugin_api(std::make_unique<plugin::Api<I>>()) {
+}
+
+template <typename I>
+PluginRegistry<I>::~PluginRegistry() {
 }
 
 template <typename I>
@@ -41,7 +47,7 @@ void PluginRegistry<I>::init(const std::string& plugins, Context* on_finish) {
 
     m_plugin_hook_points.emplace_back();
     auto hook_points = &m_plugin_hook_points.back();
-    plugin->init(m_image_ctx, hook_points, ctx);
+    plugin->init(m_image_ctx, *m_plugin_api, hook_points, ctx);
   }
 
   gather_ctx->activate();

--- a/src/librbd/PluginRegistry.cc
+++ b/src/librbd/PluginRegistry.cc
@@ -35,7 +35,7 @@ void PluginRegistry<I>::init(const std::string& plugins, Context* on_finish) {
       plugin_registry->get_with_load("librbd", "librbd_" + token));
     if (plugin == nullptr) {
       lderr(cct) << "failed to load plugin: " << token << dendl;
-      ctx->complete(-ENOENT);
+      ctx->complete(-ENOSYS);
       break;
     }
 

--- a/src/librbd/PluginRegistry.h
+++ b/src/librbd/PluginRegistry.h
@@ -5,6 +5,7 @@
 #define CEPH_LIBRBD_PLUGIN_REGISTRY_H
 
 #include "librbd/plugin/Types.h"
+#include <memory>
 #include <string>
 #include <list>
 
@@ -14,10 +15,13 @@ namespace librbd {
 
 struct ImageCtx;
 
+namespace plugin { template <typename> struct Api; }
+
 template <typename ImageCtxT>
 class PluginRegistry {
 public:
   PluginRegistry(ImageCtxT* image_ctx);
+  ~PluginRegistry();
 
   void init(const std::string& plugins, Context* on_finish);
 
@@ -25,6 +29,8 @@ private:
   typedef std::list<plugin::HookPoints> PluginHookPoints;
 
   ImageCtxT* m_image_ctx;
+  std::unique_ptr<plugin::Api<ImageCtxT>> m_plugin_api;
+
   std::string m_plugins;
 
   PluginHookPoints m_plugin_hook_points;

--- a/src/librbd/cache/ParentCacheObjectDispatch.h
+++ b/src/librbd/cache/ParentCacheObjectDispatch.h
@@ -14,6 +14,8 @@ namespace librbd {
 
 class ImageCtx;
 
+namespace plugin { template <typename> struct Api; }
+
 namespace cache {
 
 template <typename ImageCtxT = ImageCtx>
@@ -23,11 +25,13 @@ class ParentCacheObjectDispatch : public io::ObjectDispatchInterface {
   typedef typename TypeTraits::CacheClient CacheClient;
 
 public:
-  static ParentCacheObjectDispatch* create(ImageCtxT* image_ctx) {
-    return new ParentCacheObjectDispatch(image_ctx);
+  static ParentCacheObjectDispatch* create(ImageCtxT* image_ctx,
+                                           plugin::Api<ImageCtxT>& plugin_api) {
+    return new ParentCacheObjectDispatch(image_ctx, plugin_api);
   }
 
-  ParentCacheObjectDispatch(ImageCtxT* image_ctx);
+  ParentCacheObjectDispatch(ImageCtxT* image_ctx,
+                            plugin::Api<ImageCtxT>& plugin_api);
   ~ParentCacheObjectDispatch() override;
 
   io::ObjectDispatchLayer get_dispatch_layer() const override {
@@ -129,6 +133,7 @@ private:
   void create_cache_session(Context* on_finish, bool is_reconnect);
 
   ImageCtxT* m_image_ctx;
+  plugin::Api<ImageCtxT>& m_plugin_api;
 
   ceph::mutex m_lock;
   CacheClient *m_cache_client = nullptr;

--- a/src/librbd/image/OpenRequest.cc
+++ b/src/librbd/image/OpenRequest.cc
@@ -549,6 +549,8 @@ Context* OpenRequest<I>::handle_init_plugin_registry(int *result) {
   if (*result < 0) {
     lderr(cct) << "failed to initialize plugin registry: "
                << cpp_strerror(*result) << dendl;
+    send_close_image(*result);
+    return nullptr;
   }
 
   return send_init_cache(result);

--- a/src/librbd/plugin/Api.cc
+++ b/src/librbd/plugin/Api.cc
@@ -1,0 +1,23 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/plugin/Api.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/io/Utils.h"
+
+namespace librbd {
+namespace plugin {
+
+template <typename I>
+void Api<I>::read_parent(
+    I *image_ctx, uint64_t object_no, const Extents &extents,
+    librados::snap_t snap_id, const ZTracer::Trace &trace,
+    ceph::bufferlist* data, Context* on_finish) {
+  io::util::read_parent<I>(image_ctx, object_no, extents, snap_id, trace, data,
+                           on_finish);
+}
+
+} // namespace plugin
+} // namespace librbd
+
+template class librbd::plugin::Api<librbd::ImageCtx>;

--- a/src/librbd/plugin/Api.h
+++ b/src/librbd/plugin/Api.h
@@ -1,0 +1,39 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_PLUGIN_API_H
+#define CEPH_LIBRBD_PLUGIN_API_H
+
+#include "include/common_fwd.h"
+#include "include/int_types.h"
+#include "include/rados/librados.hpp"
+#include "librbd/io/Types.h"
+
+namespace ZTracer { struct Trace; }
+
+namespace librbd {
+
+struct ImageCtx;
+
+namespace plugin {
+
+template <typename ImageCtxT>
+struct Api {
+  using Extents = librbd::io::Extents;
+
+  Api() {}
+  virtual ~Api() {}
+
+  virtual void read_parent(
+      ImageCtxT *image_ctx, uint64_t object_no, const Extents &extents,
+      librados::snap_t snap_id, const ZTracer::Trace &trace,
+      ceph::bufferlist* data, Context* on_finish);
+
+};
+
+} // namespace plugin
+} // namespace librbd
+
+extern template class librbd::plugin::Api<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_PLUGIN_API_H

--- a/src/librbd/plugin/ParentCache.cc
+++ b/src/librbd/plugin/ParentCache.cc
@@ -33,7 +33,7 @@ namespace librbd {
 namespace plugin {
 
 template <typename I>
-void ParentCache<I>::init(I* image_ctx, HookPoints* hook_points,
+void ParentCache<I>::init(I* image_ctx, Api<I>& api, HookPoints* hook_points,
                           Context* on_finish) {
   m_image_ctx = image_ctx;
   bool parent_cache_enabled = m_image_ctx->config.template get_val<bool>(
@@ -46,7 +46,8 @@ void ParentCache<I>::init(I* image_ctx, HookPoints* hook_points,
   auto cct = m_image_ctx->cct;
   ldout(cct, 5) << dendl;
 
-  auto parent_cache = cache::ParentCacheObjectDispatch<I>::create(m_image_ctx);
+  auto parent_cache = cache::ParentCacheObjectDispatch<I>::create(
+    m_image_ctx, api);
   on_finish = new LambdaContext([this, on_finish, parent_cache](int r) {
       if (r < 0) {
         // the object dispatcher will handle cleanup if successfully initialized

--- a/src/librbd/plugin/ParentCache.h
+++ b/src/librbd/plugin/ParentCache.h
@@ -19,7 +19,7 @@ public:
   ParentCache(CephContext* cct) : Interface<ImageCtxT>(cct) {
   }
 
-  void init(ImageCtxT* image_ctx, HookPoints* hook_points,
+  void init(ImageCtxT* image_ctx, Api<ImageCtxT>& api, HookPoints* hook_points,
             Context* on_finish) override;
 
 private:

--- a/src/librbd/plugin/Types.h
+++ b/src/librbd/plugin/Types.h
@@ -12,6 +12,8 @@ struct Context;
 namespace librbd {
 namespace plugin {
 
+template <typename> struct Api;
+
 struct HookPoints {
   // TODO later commits will add support for exclusive-lock hook points
 };
@@ -21,8 +23,8 @@ struct Interface : public ceph::Plugin {
   Interface(CephContext* cct) : Plugin(cct) {
   }
 
-  virtual void init(ImageCtxT* image_ctx, HookPoints* hook_points,
-                    Context* on_finish) = 0;
+  virtual void init(ImageCtxT* image_ctx, Api<ImageCtxT>& api,
+                    HookPoints* hook_points, Context* on_finish) = 0;
 };
 
 } // namespace plugin


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
