### PR TITLE
common/config: Make sure legacy_values are updated

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -386,6 +386,7 @@ int md_config_t::parse_config_files(ConfigValues& values,
   if (values.cluster.empty()) {
     values.cluster = get_cluster_name(conffile.c_str());
   }
+  update_legacy_vals(values);
   return 0;
 }
 
@@ -418,7 +419,6 @@ md_config_t::parse_buffer(ConfigValues& values,
     }
   }
   cf.check_old_style_section_names({"mds", "mon", "osd"}, cerr);
-  update_legacy_vals(values);
   return 0;
 }
 


### PR DESCRIPTION
Must be updated after final change to 'values'

Fixes: https://tracker.ceph.com/issues/47002

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
