### PR TITLE
pybind/mgr: pytest: Unconditionally mock the rados objects

### DIFF
--- a/src/pybind/mgr/cephadm/__init__.py
+++ b/src/pybind/mgr/cephadm/__init__.py
@@ -2,6 +2,5 @@ import os
 
 if 'UNITTEST' in os.environ:
     import tests
-    tests.mock_ceph_modules()  # type: ignore
 
 from .module import CephadmOrchestrator

--- a/src/pybind/mgr/dashboard/__init__.py
+++ b/src/pybind/mgr/dashboard/__init__.py
@@ -38,12 +38,10 @@ else:
     os.environ['PATH'] = '{}:{}'.format(os.path.abspath('../../../../build/bin'),
                                         os.environ['PATH'])
 
-    from tests import mock, mock_ceph_modules  # type: ignore
+    from tests import mock  # type: ignore
 
     mgr = mock.Mock()
     mgr.get_frontend_path.side_effect = lambda: os.path.abspath("./frontend/dist")
-
-    mock_ceph_modules()
 
 # DO NOT REMOVE: required for ceph-mgr to load a module
 from .module import Module, StandbyModule  # noqa: F401

--- a/src/pybind/mgr/mds_autoscaler/__init__.py
+++ b/src/pybind/mgr/mds_autoscaler/__init__.py
@@ -2,6 +2,5 @@ import os
 
 if 'UNITTEST' in os.environ:
     import tests
-    tests.mock_ceph_modules()  # type: ignore
 
 from .module import MDSAutoscaler

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -1,8 +1,12 @@
+import os
+
+if 'UNITTEST' in os.environ:
+    import tests
+
 import cephfs
 import contextlib
 import datetime
 import errno
-import os
 import socket
 import time
 import logging

--- a/src/pybind/mgr/tests/__init__.py
+++ b/src/pybind/mgr/tests/__init__.py
@@ -190,3 +190,6 @@ if 'UNITTEST' in os.environ:
             'rbd': mock.Mock(),
             'cephfs': mock.Mock(),
         })
+
+    # Unconditionally mock the rados objects when we're imported
+    mock_ceph_modules()  # type: ignore

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -28,8 +28,6 @@ addopts =
 [testenv]
 setenv =
     UNITTEST = true
-    PYTHONPATH = ../../../build/lib/cython_modules/lib.3/
-    LD_LIBRARY_PATH = ../../../build/lib
 deps =
     cython
     -rrequirements.txt


### PR DESCRIPTION
Always call `mock_ceph_modules()`. Otherwise we'd need to
split the tox run between modules that need to call
`mock_ceph_modules()` and those that don't

Fixes: https://tracker.ceph.com/issues/47141
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
