### PR TITLE
mon/PGMap: add pg count for pools in the ceph df command

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,6 +1,8 @@
 >=16.0.0
 --------
 
+* The ``ceph df`` command now lists the number of pgs in each pool.
+
 * Monitors now have config option ``mon_allow_pool_size_one``, which is disabled
   by default. However, if enabled, user now have to pass the
   ``--yes-i-really-mean-it`` flag to ``osd pool set size 1``, if they are really

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -762,6 +762,7 @@ void PGMapDigest::dump_pool_stats_full(
   } else {
     tbl.define_column("POOL", TextTable::LEFT, TextTable::LEFT);
     tbl.define_column("ID", TextTable::LEFT, TextTable::RIGHT);
+    tbl.define_column("PGS", TextTable::LEFT, TextTable::RIGHT);
     tbl.define_column("STORED", TextTable::LEFT, TextTable::RIGHT);
     if (verbose) {
       tbl.define_column("(DATA)", TextTable::LEFT, TextTable::RIGHT);
@@ -793,6 +794,7 @@ void PGMapDigest::dump_pool_stats_full(
       continue;
 
     const string& pool_name = osd_map.get_pool_name(pool_id);
+    auto pool_pg_num = osd_map.get_pg_num(pool_id);
     const pool_stat_t &stat = pg_pool_sum.at(pool_id);
 
     const pg_pool_t *pool = osd_map.get_pg_pool(pool_id);
@@ -816,7 +818,8 @@ void PGMapDigest::dump_pool_stats_full(
       f->open_object_section("stats");
     } else {
       tbl << pool_name
-          << pool_id;
+          << pool_id
+          << pool_pg_num;
     }
     float raw_used_rate = osd_map.pool_raw_used_rate(pool_id);
     bool per_pool = use_per_pool_stats();


### PR DESCRIPTION
mon/PGMap: add pg count for pools in the ceph df command
Fixes: https://tracker.ceph.com/issues/46663

Signed-off-by: Vikhyat Umrao <vikhyat@redhat.com>
