### PR TITLE
cephadm: Add --container-init

### DIFF
--- a/doc/man/8/cephadm.rst
+++ b/doc/man/8/cephadm.rst
@@ -77,6 +77,7 @@ Synopsis
 |                           [--registry-username REGISTRY_USERNAME]
 |                           [--registry-password REGISTRY_PASSWORD]
 |                           [--registry-json REGISTRY_JSON]
+|                           [--container-init]
 
 
 
@@ -84,6 +85,7 @@ Synopsis
 |                        [--config-json CONFIG_JSON] [--keyring KEYRING]
 |                        [--key KEY] [--osd-fsid OSD_FSID] [--skip-firewalld]
 |                        [--tcp-ports TCP_PORTS] [--reconfig] [--allow-ptrace]
+|                        [--container-init]
 
 | **cephadm** **check-host** [-h] [--expect-hostname EXPECT_HOSTNAME]
 
@@ -235,6 +237,8 @@ Arguments:
 * [--registry-username REGISTRY_USERNAME] username of account to login to on custom registry
 * [--registry-password REGISTRY_PASSWORD] password of account to login to on custom registry
 * [--registry-json REGISTRY_JSON] JSON file containing registry login info (see registry-login command documentation)
+* [--container-init]              Run podman/docker with `--init`
+
 
 ceph-volume
 -----------
@@ -284,6 +288,7 @@ Arguments:
 * [--tcp-ports                List of tcp ports to open in the host firewall
 * [--reconfig]                Reconfigure a previously deployed daemon
 * [--allow-ptrace]            Allow SYS_PTRACE on daemon container
+* [--container-init]          Run podman/docker with `--init`
 
 
 enter

--- a/doc/man/8/cephadm.rst
+++ b/doc/man/8/cephadm.rst
@@ -28,6 +28,7 @@ Synopsis
 | **cephadm** **adopt** [-h] --name NAME --style STYLE [--cluster CLUSTER]
 |                       [--legacy-dir LEGACY_DIR] [--config-json CONFIG_JSON]
 |                       [--skip-firewalld] [--skip-pull]
+|                       [--container-init]
 
 | **cephadm** **rm-daemon** [-h] --name NAME --fsid FSID [--force]
 |                           [--force-delete-data]

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2942,6 +2942,9 @@ def command_bootstrap():
         cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_username', args.registry_username, '--force'])
         cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_password', args.registry_password, '--force'])
 
+    if args.container_init:
+        cli(['config', 'set', 'mgr', 'mgr/cephadm/container_init', args.container_init, '--force'])
+
     if not args.skip_dashboard:
         # Configure SSL port (cephadm only allows to configure dashboard SSL port)
         # if the user does not want to use SSL he can change this setting once the cluster is up
@@ -5297,6 +5300,10 @@ def _get_parser():
         '--force-start',
         action='store_true',
         help="start newly adoped daemon, even if it wasn't running previously")
+    parser_adopt.add_argument(
+        '--container-init',
+        action='store_true',
+        help='Run podman/docker with `--init`')
 
     parser_rm_daemon = subparsers.add_parser(
         'rm-daemon', help='remove daemon instance')

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1839,6 +1839,7 @@ def get_container(fsid, daemon_type, daemon_id,
         envs=envs,
         privileged=privileged,
         ptrace=ptrace,
+        init=args.container_init,
     )
 
 
@@ -2295,8 +2296,10 @@ class CephContainer:
                  envs=None,
                  privileged=False,
                  ptrace=False,
-                 bind_mounts=None):
-        # type: (str, str, List[str], Dict[str, str], str, List[str], Optional[List[str]], bool, bool, Optional[List[List[str]]]) -> None
+                 bind_mounts=None,
+                 init=False,
+                 ):
+        # type: (str, str, List[str], Dict[str, str], str, List[str], Optional[List[str]], bool, bool, Optional[List[List[str]]], bool) -> None
         self.image = image
         self.entrypoint = entrypoint
         self.args = args
@@ -2307,6 +2310,7 @@ class CephContainer:
         self.privileged = privileged
         self.ptrace = ptrace
         self.bind_mounts = bind_mounts if bind_mounts else []
+        self.init = init
 
     def run_cmd(self):
         # type: () -> List[str]
@@ -2325,6 +2329,7 @@ class CephContainer:
                     '--group-add=disk']
         if self.ptrace:
             priv.append('--cap-add=SYS_PTRACE')
+        init = ['--init'] if self.init else []
         vols = sum(
             [['-v', '%s:%s' % (host_dir, container_dir)]
              for host_dir, container_dir in self.volume_mounts.items()], [])
@@ -2345,7 +2350,7 @@ class CephContainer:
             '--net=host',
             '--ipc=host',
         ] + self.container_args + priv + \
-        cname + envs + \
+        cname + init + envs + \
         vols + binds + entrypoint + \
         [
             self.image
@@ -5573,6 +5578,10 @@ def _get_parser():
     parser_bootstrap.add_argument(
         '--registry-json',
         help='json file with custom registry login info (URL, Username, Password)')
+    parser_bootstrap.add_argument(
+        '--container-init',
+        action='store_true',
+        help='Run podman/docker with `--init`')
 
     parser_deploy = subparsers.add_parser(
         'deploy', help='deploy a daemon')
@@ -5616,6 +5625,10 @@ def _get_parser():
         '--allow-ptrace',
         action='store_true',
         help='Allow SYS_PTRACE on daemon container')
+    parser_deploy.add_argument(
+        '--container-init',
+        action='store_true',
+        help='Run podman/docker with `--init`')
 
     parser_check_host = subparsers.add_parser(
         'check-host', help='check host configuration')

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -206,6 +206,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                          'at runtime.',
         },
         {
+            'name': 'container_init',
+            'type': 'bool',
+            'default': False,
+            'desc': 'Run podman/docker with `--init`',
+        },
+        {
             'name': 'prometheus_alerts_path',
             'type': 'str',
             'default': '/etc/prometheus/ceph/ceph_default_alerts.yml',
@@ -280,6 +286,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.warn_on_stray_daemons = True
             self.warn_on_failed_host_check = True
             self.allow_ptrace = False
+            self.container_init = False
             self.prometheus_alerts_path = ''
             self.migration_current = None
             self.config_dashboard = True
@@ -1118,6 +1125,10 @@ you may want to run:
 
             if not no_fsid:
                 final_args += ['--fsid', self._cluster_fsid]
+
+            if self.container_init:
+                final_args += ['--container-init']
+
             final_args += args
 
             self.log.debug('args: %s' % (' '.join(final_args)))


### PR DESCRIPTION
cephadm: Add --container-image

The kernel treats any process with PID 1 different. Especially
it does not generate a core dump. Call podman / docker with
--init in order to get core dumps.

In addition, we can now properly reap zombies processes.

Fixes: https://tracker.ceph.com/issues/44231
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

cephadm: Add --container-image

The kernel treats any process with PID 1 different. Especially
it does not generate a core dump. Call podman / docker with
--init in order to get core dumps.

In addition, we can now properly reap zombies processes.


"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
