### PR TITLE
librbd: task finisher should distinguish quiesce tasks with different ID

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -1411,9 +1411,11 @@ CEPH_RBD_API int rbd_quiesce_watch(rbd_image_t image,
  * Notify quiesce is complete
  *
  * @param image the image to notify
+ * @param handle which watch is complete
  * @param r the return code
  */
-CEPH_RADOS_API void rbd_quiesce_complete(rbd_image_t image, int r);
+CEPH_RADOS_API void rbd_quiesce_complete(rbd_image_t image, uint64_t handle,
+                                         int r);
 
 /**
  * Unregister a quiesce/unquiesce watcher.

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -794,7 +794,7 @@ public:
 
   int quiesce_watch(QuiesceWatchCtx *ctx, uint64_t *handle);
   int quiesce_unwatch(uint64_t handle);
-  void quiesce_complete(int r);
+  void quiesce_complete(uint64_t handle, int r);
 
 private:
   friend class RBD;

--- a/src/librbd/ImageState.h
+++ b/src/librbd/ImageState.h
@@ -57,7 +57,7 @@ public:
   int unregister_quiesce_watcher(uint64_t handle);
   void notify_quiesce(Context *on_finish);
   void notify_unquiesce(Context *on_finish);
-  void quiesce_complete(int r);
+  void quiesce_complete(uint64_t handle, int r);
 
 private:
   enum State {

--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -713,29 +713,25 @@ Context *ImageWatcher<I>::prepare_quiesce_request(
 
   return new LambdaContext(
     [this, request, timeout](int r) {
-      if (r < 0) {
-        std::unique_lock async_request_locker{m_async_request_lock};
-        m_async_pending.erase(request);
-      } else {
-        auto unquiesce_ctx = new LambdaContext(
-          [this, request](int r) {
-            if (r == 0) {
-              ldout(m_image_ctx.cct, 10) << this << " quiesce request "
-                                         << request << " timed out" << dendl;
-            }
+      auto unquiesce_ctx = new LambdaContext(
+        [this, request](int r) {
+          if (r == 0) {
+            ldout(m_image_ctx.cct, 10) << this << " quiesce request "
+                                       << request << " timed out" << dendl;
+          }
 
-            auto on_finish = new LambdaContext(
-              [this, request](int r) {
-                std::unique_lock async_request_locker{m_async_request_lock};
-                m_async_pending.erase(request);
-              });
+          auto on_finish = new LambdaContext(
+            [this, request](int r) {
+              std::unique_lock async_request_locker{m_async_request_lock};
+              m_async_pending.erase(request);
+            });
 
-            m_image_ctx.state->notify_unquiesce(on_finish);
-          });
+          m_image_ctx.state->notify_unquiesce(on_finish);
+        });
 
-        m_task_finisher->add_event_after(Task(TASK_CODE_QUIESCE, request),
-                                         timeout, unquiesce_ctx);
-      }
+      m_task_finisher->add_event_after(Task(TASK_CODE_QUIESCE, request),
+                                       timeout, unquiesce_ctx);
+
       auto ctx = remove_async_request(request);
       ceph_assert(ctx != nullptr);
       ctx = new C_ResponseMessage(static_cast<C_NotifyAck *>(ctx));

--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -750,12 +750,16 @@ Context *ImageWatcher<I>::prepare_unquiesce_request(const AsyncRequestId &reques
     std::unique_lock async_request_locker{m_async_request_lock};
     bool found = m_async_pending.erase(request);
     if (!found) {
+      ldout(m_image_ctx.cct, 20) << this << " " << request
+                                 << ": not found in pending" << dendl;
       return nullptr;
     }
   }
 
   bool canceled = m_task_finisher->cancel(Task(TASK_CODE_QUIESCE, request));
   if (!canceled) {
+    ldout(m_image_ctx.cct, 20) << this << " " << request
+                               << ": timer task not found" << dendl;
     return nullptr;
   }
 

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -100,7 +100,8 @@ private:
       if (m_task_code != rhs.m_task_code) {
         return m_task_code < rhs.m_task_code;
       } else if ((m_task_code == TASK_CODE_ASYNC_REQUEST ||
-                  m_task_code == TASK_CODE_ASYNC_PROGRESS) &&
+                  m_task_code == TASK_CODE_ASYNC_PROGRESS ||
+                  m_task_code == TASK_CODE_QUIESCE) &&
                  m_async_request_id != rhs.m_async_request_id) {
         return m_async_request_id < rhs.m_async_request_id;
       }

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -3071,9 +3071,9 @@ namespace librbd {
     return r;
   }
 
-  void Image::quiesce_complete(int r) {
+  void Image::quiesce_complete(uint64_t handle, int r) {
     ImageCtx *ictx = (ImageCtx *)ctx;
-    ictx->state->quiesce_complete(r);
+    ictx->state->quiesce_complete(handle, r);
   }
 
 } // namespace librbd
@@ -7238,8 +7238,8 @@ extern "C" int rbd_quiesce_unwatch(rbd_image_t image, uint64_t handle)
   return r;
 }
 
-extern "C" void rbd_quiesce_complete(rbd_image_t image, int r)
+extern "C" void rbd_quiesce_complete(rbd_image_t image, uint64_t handle, int r)
 {
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
-  ictx->state->quiesce_complete(r);
+  ictx->state->quiesce_complete(handle, r);
 }

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -8210,7 +8210,6 @@ TEST_F(TestLibRBD, QuiesceWatch)
   uint64_t size = 2 << 20;
   ASSERT_EQ(0, create_image(ioctx, name.c_str(), size, &order));
 
-  uint64_t handle1, handle2;
   rbd_image_t image1, image2;
   ASSERT_EQ(0, rbd_open(ioctx, name.c_str(), &image1, NULL));
   ASSERT_EQ(0, rbd_open(ioctx, name.c_str(), &image2, NULL));
@@ -8226,6 +8225,7 @@ TEST_F(TestLibRBD, QuiesceWatch)
     }
 
     rbd_image_t &image;
+    uint64_t handle = 0;
     size_t quiesce_count = 0;
     size_t unquiesce_count = 0;
 
@@ -8238,7 +8238,7 @@ TEST_F(TestLibRBD, QuiesceWatch)
     void handle_quiesce() {
       ASSERT_EQ(quiesce_count, unquiesce_count);
       quiesce_count++;
-      rbd_quiesce_complete(image, 0);
+      rbd_quiesce_complete(image, handle, 0);
     }
     void handle_unquiesce() {
       std::unique_lock locker(lock);
@@ -8254,9 +8254,11 @@ TEST_F(TestLibRBD, QuiesceWatch)
   } watcher1(image1), watcher2(image2);
 
   ASSERT_EQ(0, rbd_quiesce_watch(image1, Watcher::quiesce_cb,
-                                 Watcher::unquiesce_cb, &watcher1, &handle1));
+                                 Watcher::unquiesce_cb, &watcher1,
+                                 &watcher1.handle));
   ASSERT_EQ(0, rbd_quiesce_watch(image2, Watcher::quiesce_cb,
-                                 Watcher::unquiesce_cb, &watcher2, &handle2));
+                                 Watcher::unquiesce_cb, &watcher2,
+                                 &watcher2.handle));
 
   ASSERT_EQ(0, rbd_snap_create(image1, "snap1"));
   ASSERT_EQ(1U, watcher1.quiesce_count);
@@ -8270,7 +8272,7 @@ TEST_F(TestLibRBD, QuiesceWatch)
   ASSERT_EQ(2U, watcher2.quiesce_count);
   ASSERT_TRUE(watcher2.wait_for_unquiesce(2U));
 
-  ASSERT_EQ(0, rbd_quiesce_unwatch(image1, handle1));
+  ASSERT_EQ(0, rbd_quiesce_unwatch(image1, watcher1.handle));
 
   ASSERT_EQ(0, rbd_snap_create(image1, "snap3"));
   ASSERT_EQ(2U, watcher1.quiesce_count);
@@ -8278,7 +8280,7 @@ TEST_F(TestLibRBD, QuiesceWatch)
   ASSERT_EQ(3U, watcher2.quiesce_count);
   ASSERT_TRUE(watcher2.wait_for_unquiesce(3U));
 
-  ASSERT_EQ(0, rbd_quiesce_unwatch(image2, handle2));
+  ASSERT_EQ(0, rbd_quiesce_unwatch(image2, watcher2.handle));
 
   ASSERT_EQ(0, rbd_snap_remove(image1, "snap1"));
   ASSERT_EQ(0, rbd_snap_remove(image1, "snap2"));
@@ -8306,6 +8308,7 @@ TEST_F(TestLibRBD, QuiesceWatchPP)
 
     struct Watcher : public librbd::QuiesceWatchCtx {
       librbd::Image &image;
+      uint64_t handle = 0;
       size_t quiesce_count = 0;
       size_t unquiesce_count = 0;
 
@@ -8318,7 +8321,7 @@ TEST_F(TestLibRBD, QuiesceWatchPP)
       void handle_quiesce() override {
         ASSERT_EQ(quiesce_count, unquiesce_count);
         quiesce_count++;
-        image.quiesce_complete(0);
+        image.quiesce_complete(handle, 0);
       }
       void handle_unquiesce() override {
         std::unique_lock locker(lock);
@@ -8332,10 +8335,9 @@ TEST_F(TestLibRBD, QuiesceWatchPP)
                            [this, c]() { return unquiesce_count >= c; });
       }
     } watcher1(image1), watcher2(image2);
-    uint64_t handle1, handle2;
 
-    ASSERT_EQ(0, image1.quiesce_watch(&watcher1, &handle1));
-    ASSERT_EQ(0, image2.quiesce_watch(&watcher2, &handle2));
+    ASSERT_EQ(0, image1.quiesce_watch(&watcher1, &watcher1.handle));
+    ASSERT_EQ(0, image2.quiesce_watch(&watcher2, &watcher2.handle));
 
     ASSERT_EQ(0, image1.snap_create("snap1"));
     ASSERT_EQ(1U, watcher1.quiesce_count);
@@ -8349,7 +8351,7 @@ TEST_F(TestLibRBD, QuiesceWatchPP)
     ASSERT_EQ(2U, watcher2.quiesce_count);
     ASSERT_TRUE(watcher2.wait_for_unquiesce(2U));
 
-    ASSERT_EQ(0, image1.quiesce_unwatch(handle1));
+    ASSERT_EQ(0, image1.quiesce_unwatch(watcher1.handle));
 
     ASSERT_EQ(0, image1.snap_create("snap3"));
     ASSERT_EQ(2U, watcher1.quiesce_count);
@@ -8357,7 +8359,7 @@ TEST_F(TestLibRBD, QuiesceWatchPP)
     ASSERT_EQ(3U, watcher2.quiesce_count);
     ASSERT_TRUE(watcher2.wait_for_unquiesce(3U));
 
-    ASSERT_EQ(0, image2.quiesce_unwatch(handle2));
+    ASSERT_EQ(0, image2.quiesce_unwatch(watcher2.handle));
 
     ASSERT_EQ(0, image1.snap_remove("snap1"));
     ASSERT_EQ(0, image1.snap_remove("snap2"));
@@ -8386,6 +8388,7 @@ TEST_F(TestLibRBD, QuiesceWatchError)
     struct Watcher : public librbd::QuiesceWatchCtx {
       librbd::Image &image;
       int r;
+      uint64_t handle;
       size_t quiesce_count = 0;
       size_t unquiesce_count = 0;
 
@@ -8395,9 +8398,14 @@ TEST_F(TestLibRBD, QuiesceWatchError)
       Watcher(librbd::Image &image, int r) : image(image), r(r) {
       }
 
+      void reset_counters() {
+        quiesce_count = 0;
+        unquiesce_count = 0;
+      }
+
       void handle_quiesce() override {
         quiesce_count++;
-        image.quiesce_complete(r);
+        image.quiesce_complete(handle, r);
       }
 
       void handle_unquiesce() override {
@@ -8406,45 +8414,60 @@ TEST_F(TestLibRBD, QuiesceWatchError)
         cv.notify_one();
       }
 
-      bool wait_for_unquiesce(size_t c) {
+      bool wait_for_unquiesce() {
         std::unique_lock locker(lock);
         return cv.wait_for(locker, seconds(60),
-                           [this, c]() { return unquiesce_count >= c; });
+                           [this]() {
+                             return quiesce_count == unquiesce_count;
+                           });
       }
-    } watcher1(image1, -EINVAL), watcher2(image2, 0);
-    uint64_t handle1, handle2;
+    } watcher10(image1, -EINVAL), watcher11(image1, 0), watcher20(image2, 0);
 
-    ASSERT_EQ(0, image1.quiesce_watch(&watcher1, &handle1));
-    ASSERT_EQ(0, image2.quiesce_watch(&watcher2, &handle2));
+    ASSERT_EQ(0, image1.quiesce_watch(&watcher10, &watcher10.handle));
+    ASSERT_EQ(0, image1.quiesce_watch(&watcher11, &watcher11.handle));
+    ASSERT_EQ(0, image2.quiesce_watch(&watcher20, &watcher20.handle));
 
     ASSERT_EQ(-EINVAL, image1.snap_create("snap1"));
-    ASSERT_LT(0U, watcher1.quiesce_count);
-    ASSERT_EQ(0U, watcher1.unquiesce_count);
-    ASSERT_EQ(1U, watcher2.quiesce_count);
-    ASSERT_TRUE(watcher2.wait_for_unquiesce(1U));
+    ASSERT_GT(watcher10.quiesce_count, 0U);
+    ASSERT_EQ(watcher10.unquiesce_count, 0U);
+    ASSERT_GT(watcher11.quiesce_count, 0U);
+    ASSERT_TRUE(watcher11.wait_for_unquiesce());
+    ASSERT_GT(watcher20.quiesce_count, 0U);
+    ASSERT_TRUE(watcher20.wait_for_unquiesce());
 
     PrintProgress prog_ctx;
-    watcher1.quiesce_count = 0;
+    watcher10.reset_counters();
+    watcher11.reset_counters();
+    watcher20.reset_counters();
     ASSERT_EQ(0, image2.snap_create2("snap2",
                                      RBD_SNAP_CREATE_IGNORE_QUIESCE_ERROR,
                                      prog_ctx));
-    ASSERT_LT(0U, watcher1.quiesce_count);
-    ASSERT_EQ(0U, watcher1.unquiesce_count);
-    ASSERT_EQ(2U, watcher2.quiesce_count);
-    ASSERT_TRUE(watcher2.wait_for_unquiesce(2U));
+    ASSERT_GT(watcher10.quiesce_count, 0U);
+    ASSERT_EQ(watcher10.unquiesce_count, 0U);
+    ASSERT_GT(watcher11.quiesce_count, 0U);
+    ASSERT_TRUE(watcher11.wait_for_unquiesce());
+    ASSERT_GT(watcher20.quiesce_count, 0U);
+    ASSERT_TRUE(watcher20.wait_for_unquiesce());
 
-    ASSERT_EQ(0, image1.quiesce_unwatch(handle1));
+    ASSERT_EQ(0, image1.quiesce_unwatch(watcher10.handle));
 
+    watcher11.reset_counters();
+    watcher20.reset_counters();
     ASSERT_EQ(0, image1.snap_create("snap3"));
-    ASSERT_EQ(3U, watcher2.quiesce_count);
-    ASSERT_TRUE(watcher2.wait_for_unquiesce(3U));
+    ASSERT_GT(watcher11.quiesce_count, 0U);
+    ASSERT_TRUE(watcher11.wait_for_unquiesce());
+    ASSERT_GT(watcher20.quiesce_count, 0U);
+    ASSERT_TRUE(watcher20.wait_for_unquiesce());
 
+    ASSERT_EQ(0, image1.quiesce_unwatch(watcher11.handle));
+
+    watcher20.reset_counters();
     ASSERT_EQ(0, image2.snap_create2("snap4", RBD_SNAP_CREATE_SKIP_QUIESCE,
                                      prog_ctx));
-    ASSERT_EQ(3U, watcher2.quiesce_count);
-    ASSERT_EQ(3U, watcher2.unquiesce_count);
+    ASSERT_EQ(watcher20.quiesce_count, 0U);
+    ASSERT_EQ(watcher20.unquiesce_count, 0U);
 
-    ASSERT_EQ(0, image2.quiesce_unwatch(handle2));
+    ASSERT_EQ(0, image2.quiesce_unwatch(watcher20.handle));
 
     ASSERT_EQ(0, image1.snap_remove("snap2"));
     ASSERT_EQ(0, image1.snap_remove("snap3"));
@@ -8517,10 +8540,10 @@ TEST_F(TestLibRBD, QuiesceWatchTimeout)
 
     std::cerr << "test quiesce is not long enough to time out" << std::endl;
 
-    thread quiesce1([&image, &watcher]() {
+    thread quiesce1([&image, &watcher, handle]() {
       watcher.wait_for_quiesce_count(1);
       sleep(8);
-      image.quiesce_complete(0);
+      image.quiesce_complete(handle, 0);
     });
 
     ASSERT_EQ(0, image.snap_create("snap1"));
@@ -8532,13 +8555,13 @@ TEST_F(TestLibRBD, QuiesceWatchTimeout)
     std::cerr << "test quiesce is timed out" << std::endl;
 
     bool timed_out = false;
-    thread quiesce2([&image, &watcher, &timed_out]() {
+    thread quiesce2([&image, &watcher, handle, &timed_out]() {
       watcher.wait_for_quiesce_count(2);
       for (int i = 0; !timed_out && i < 60; i++) {
         std::cerr << "waiting for timed out ... " << i << std::endl;
         sleep(1);
       }
-      image.quiesce_complete(0);
+      image.quiesce_complete(handle, 0);
     });
 
     ASSERT_EQ(-ETIMEDOUT, image.snap_create("snap2"));
@@ -8548,9 +8571,9 @@ TEST_F(TestLibRBD, QuiesceWatchTimeout)
     watcher.wait_for_unquiesce_count(2);
     ASSERT_EQ(2U, watcher.unquiesce_count);
 
-    thread quiesce3([&image, &watcher]() {
+    thread quiesce3([&image, handle, &watcher]() {
       watcher.wait_for_quiesce_count(3);
-      image.quiesce_complete(0);
+      image.quiesce_complete(handle, 0);
     });
 
     std::cerr << "test retry succeeds" << std::endl;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47068
Signed-off-by: Mykola Golub <mgolub@suse.com>