### PR TITLE
octopus: mgr/dashboard: redirect to original URL after successful login

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
+import * as _ from 'lodash';
 import { BsModalService } from 'ngx-bootstrap/modal';
 
 import { AuthService } from '../../../shared/api/auth.service';
@@ -15,11 +16,13 @@ import { AuthStorageService } from '../../../shared/services/auth-storage.servic
 export class LoginComponent implements OnInit {
   model = new Credentials();
   isLoginActive = false;
+  returnUrl: string;
 
   constructor(
     private authService: AuthService,
     private authStorageService: AuthStorageService,
     private bsModalService: BsModalService,
+    private route: ActivatedRoute,
     private router: Router
   ) {}
 
@@ -64,7 +67,8 @@ export class LoginComponent implements OnInit {
 
   login() {
     this.authService.login(this.model).subscribe(() => {
-      this.router.navigate(['']);
+      const url = _.get(this.route.snapshot.queryParams, 'returnUrl', '/');
+      this.router.navigate([url]);
     });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.spec.ts
@@ -1,6 +1,6 @@
 import { Component, NgZone } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { Router, Routes } from '@angular/router';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, Routes } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { configureTestBed } from '../../../testing/unit-test-helper';
@@ -11,6 +11,8 @@ describe('AuthGuardService', () => {
   let service: AuthGuardService;
   let authStorageService: AuthStorageService;
   let ngZone: NgZone;
+  let route: ActivatedRouteSnapshot;
+  let state: RouterStateSnapshot;
 
   @Component({ selector: 'cd-login', template: '' })
   class LoginComponent {}
@@ -34,16 +36,19 @@ describe('AuthGuardService', () => {
   });
 
   it('should allow the user if loggedIn', () => {
+    route = null;
+    state = { url: '/', root: null };
     spyOn(authStorageService, 'isLoggedIn').and.returnValue(true);
-    expect(service.canActivate()).toBe(true);
+    expect(service.canActivate(route, state)).toBe(true);
   });
 
   it('should prevent user if not loggedIn and redirect to login page', fakeAsync(() => {
     const router = TestBed.get(Router);
+    state = { url: '/pool', root: null };
     ngZone.run(() => {
-      expect(service.canActivate()).toBe(false);
+      expect(service.canActivate(route, state)).toBe(false);
     });
     tick();
-    expect(router.url).toBe('/login');
+    expect(router.url).toBe('/login?returnUrl=%2Fpool');
   }));
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.ts
@@ -1,5 +1,11 @@
 import { Injectable } from '@angular/core';
-import { CanActivate, CanActivateChild, Router } from '@angular/router';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  CanActivateChild,
+  Router,
+  RouterStateSnapshot
+} from '@angular/router';
 
 import { AuthStorageService } from './auth-storage.service';
 
@@ -9,15 +15,15 @@ import { AuthStorageService } from './auth-storage.service';
 export class AuthGuardService implements CanActivate, CanActivateChild {
   constructor(private router: Router, private authStorageService: AuthStorageService) {}
 
-  canActivate() {
+  canActivate(_route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
     if (this.authStorageService.isLoggedIn()) {
       return true;
     }
-    this.router.navigate(['/login']);
+    this.router.navigate(['/login'], { queryParams: { returnUrl: state.url } });
     return false;
   }
 
-  canActivateChild(): boolean {
-    return this.canActivate();
+  canActivateChild(childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
+    return this.canActivate(childRoute, state);
   }
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47155

---

backport of https://github.com/ceph/ceph/pull/36582
parent tracker: https://tracker.ceph.com/issues/45067

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh