### PR TITLE
tools/osdmaptool.cc: add ability to clean_temps

### DIFF
--- a/doc/man/8/osdmaptool.rst
+++ b/doc/man/8/osdmaptool.rst
@@ -131,6 +131,10 @@ Options
 
    clears pg_temp and primary_temp variables.
 
+.. option:: --clean-temps
+
+   clean pg_temps.
+
 .. option:: --health
 
    dump health checks

--- a/src/test/cli/osdmaptool/help.t
+++ b/src/test/cli/osdmaptool/help.t
@@ -16,6 +16,7 @@
      --mark-out <osdid>      mark an osd as out (but do not persist)
      --with-default-pool     include default pool when creating map
      --clear-temp            clear pg_temp and primary_temp
+     --clean-temps           clean pg_temps
      --test-random           do random placements
      --test-map-pg <pgid>    map a pgid to osds
      --test-map-object <objectname> [--pool <poolid>] map an object to osds


### PR DESCRIPTION
This is particularly useful for debugging purposes when clean_temps()
takes abnormally high amount of time due to flaws in crush rules etc.

Fixes: https://tracker.ceph.com/issues/47159
Signed-off-by: Neha Ojha <nojha@redhat.com>
