### PR TITLE
common/bl: implement the raw_tls to workaround multithread allocation costs of tcmalloc

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1529,8 +1529,9 @@ static ceph::spinlock debug_lock;
     // make a new buffer.  fill out a complete page, factoring in the
     // raw_combined overhead.
     size_t need = round_up_to(len, sizeof(size_t)) + sizeof(raw_combined);
-    size_t alen = round_up_to(need, CEPH_BUFFER_ALLOC_UNIT) -
-      sizeof(raw_combined);
+    size_t alen = round_up_to(need,
+      _carriage == &always_empty_bptr ? 512 : CEPH_BUFFER_ALLOC_UNIT) -
+        sizeof(raw_combined);
     auto new_back = \
       ptr_node::create(RawT::create(alen, 0, get_mempool()));
     new_back->set_length(0);   // unused, so far.

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -906,6 +906,7 @@ struct error_code;
     // This is useful for e.g. get_append_buffer_unused_tail_length() as
     // it allows to avoid conditionals on hot paths.
     static ptr always_empty_bptr;
+    template <class RawT>
     ptr_node& refill_append_space(const unsigned len);
 
   public:
@@ -1110,7 +1111,10 @@ struct error_code;
     }
 
     void append(char c);
+    template <class RawT>
     void append(const char *data, unsigned len);
+    void append(const char *data, unsigned len);
+    void append_tls(const char *data, unsigned len);
     void append(std::string s) {
       append(s.data(), s.length());
     }
@@ -1133,7 +1137,10 @@ struct error_code;
     void append(const ptr& bp, unsigned off, unsigned len);
     void append(const list& bl);
     void append(std::istream& in);
+    template <class RawT>
     contiguous_filler append_hole(unsigned len);
+    contiguous_filler append_hole(unsigned len);
+    contiguous_filler append_hole_tls(unsigned len);
     void append_zero(unsigned len);
     void prepend_zero(unsigned len);
 

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -71,7 +71,7 @@ namespace ceph {
 template<class T>
 inline void encode_raw(const T& t, bufferlist& bl)
 {
-  bl.append((char*)&t, sizeof(t));
+  bl.append_tls((char*)&t, sizeof(t));
 }
 template<class T>
 inline void decode_raw(T& t, bufferlist::const_iterator &p)
@@ -185,7 +185,7 @@ inline void encode(std::string_view s, bufferlist& bl, uint64_t features=0)
   __u32 len = s.length();
   encode(len, bl);
   if (len)
-    bl.append(s.data(), len);
+    bl.append_tls(s.data(), len);
 }
 inline void encode(const std::string& s, bufferlist& bl, uint64_t features=0)
 {
@@ -201,7 +201,7 @@ inline void decode(std::string& s, bufferlist::const_iterator& p)
 
 inline void encode_nohead(std::string_view s, bufferlist& bl)
 {
-  bl.append(s.data(), s.length());
+  bl.append_tls(s.data(), s.length());
 }
 inline void encode_nohead(const std::string& s, bufferlist& bl)
 {
@@ -675,7 +675,7 @@ inline std::enable_if_t<!traits::supported>
 {
   using counter_encode_t = ceph_le32;
   unsigned n = 0;
-  auto filler = bl.append_hole(sizeof(counter_encode_t));
+  auto filler = bl.append_hole_tls(sizeof(counter_encode_t));
   for (const auto& item : ls) {
     // we count on our own because of buggy std::list::size() implementation
     // which doesn't follow the O(1) complexity constraint C++11 has brought.
@@ -1306,7 +1306,7 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
   __u8 struct_v = v;                                         \
   __u8 struct_compat = compat;		                     \
   ceph_le32 struct_len;				             \
-  auto filler = (bl).append_hole(sizeof(struct_v) +	     \
+  auto filler = (bl).append_hole_tls(sizeof(struct_v) +	     \
     sizeof(struct_compat) + sizeof(struct_len));	     \
   const auto starting_bl_len = (bl).length();		     \
   using ::ceph::encode;					     \

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1391,6 +1391,24 @@ TEST(BufferList, append_bench) {
   }
 }
 
+TEST(BufferList, append_hole_bench) {
+  constexpr size_t targeted_bl_size = 1048576/4;
+
+  for (size_t step = 2048; step <= 16384; step *= 2) {
+    const utime_t start = ceph_clock_now();
+    constexpr size_t rounds = 80000;
+    for (size_t r = 0; r < rounds; ++r) {
+      ceph::bufferlist bl;
+      while (bl.length() < targeted_bl_size) {
+	bl.append_hole(step);
+      }
+    }
+    cout << rounds << " fills of buffer len " << targeted_bl_size
+	 << " with " << step << " byte long append_hole in "
+	 << (ceph_clock_now() - start) << std::endl;
+  }
+}
+
 TEST(BufferList, operator_assign_rvalue) {
   bufferlist from;
   {

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1350,7 +1350,7 @@ TEST(BufferList, BenchAlloc) {
 }
 
 TEST(BufferList, append_bench_with_size_hint) {
-  std::array<char, 1048576> src = { 0, };
+  std::array<char, 1048576/ 4> src = { 0, };
 
   for (size_t step = 4; step <= 16384; step *= 4) {
     const utime_t start = ceph_clock_now();
@@ -1371,7 +1371,7 @@ TEST(BufferList, append_bench_with_size_hint) {
 }
 
 TEST(BufferList, append_bench) {
-  std::array<char, 1048576> src = { 0, };
+  std::array<char, 1048576/4> src = { 0, };
 
   for (size_t step = 4; step <= 16384; step *= 4) {
     const utime_t start = ceph_clock_now();


### PR DESCRIPTION
Sending this just to the record. The changeset was intended to minimize the cost of multithread allocation / freeing observed in MDS while profiling for the IO-500 contest. `raw_tls` was an alternative to converting almost every data struct to the effective-but-viral `denc` library. It significantly reduced the CPU usage MDS got bottlenecked in another place.

DNM.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
