### PR TITLE
cls, rgw: drop the unused log_op from rgw_cls_obj_prepare_op.

### DIFF
--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -172,7 +172,7 @@ void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
 }
 
 void cls_rgw_bucket_prepare_op(ObjectWriteOperation& o, RGWModifyOp op, string& tag,
-                               const cls_rgw_obj_key& key, const string& locator, bool log_op,
+                               const cls_rgw_obj_key& key, const string& locator,
                                uint16_t bilog_flags, rgw_zone_set& zones_trace)
 {
   rgw_cls_obj_prepare_op call;
@@ -180,7 +180,6 @@ void cls_rgw_bucket_prepare_op(ObjectWriteOperation& o, RGWModifyOp op, string& 
   call.tag = tag;
   call.key = key;
   call.locator = locator;
-  call.log_op = log_op;
   call.bilog_flags = bilog_flags;
   call.zones_trace = zones_trace;
   bufferlist in;

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -356,7 +356,7 @@ void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
                                  const std::map<RGWObjCategory, rgw_bucket_category_stats>& stats);
 
 void cls_rgw_bucket_prepare_op(librados::ObjectWriteOperation& o, RGWModifyOp op, std::string& tag,
-                               const cls_rgw_obj_key& key, const std::string& locator, bool log_op,
+                               const cls_rgw_obj_key& key, const std::string& locator,
                                uint16_t bilog_op, rgw_zone_set& zones_trace);
 
 void cls_rgw_bucket_complete_op(librados::ObjectWriteOperation& o, RGWModifyOp op, std::string& tag,

--- a/src/cls/rgw/cls_rgw_ops.cc
+++ b/src/cls/rgw/cls_rgw_ops.cc
@@ -114,7 +114,10 @@ void rgw_cls_obj_prepare_op::dump(Formatter *f) const
   f->dump_string("name", key.name);
   f->dump_string("tag", tag);
   f->dump_string("locator", locator);
-  f->dump_bool("log_op", log_op);
+
+  // for legacy only
+  f->dump_bool("log_op", false);
+
   f->dump_int("bilog_flags", bilog_flags);
   encode_json("zones_trace", zones_trace, f);
 }

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -33,11 +33,10 @@ struct rgw_cls_obj_prepare_op
   cls_rgw_obj_key key;
   std::string tag;
   std::string locator;
-  bool log_op;
   uint16_t bilog_flags;
   rgw_zone_set zones_trace;
 
-  rgw_cls_obj_prepare_op() : op(CLS_RGW_OP_UNKNOWN), log_op(false), bilog_flags(0) {}
+  rgw_cls_obj_prepare_op() : op(CLS_RGW_OP_UNKNOWN), bilog_flags(0) {}
 
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(7, 5, bl);
@@ -45,7 +44,7 @@ struct rgw_cls_obj_prepare_op
     encode(c, bl);
     encode(tag, bl);
     encode(locator, bl);
-    encode(log_op, bl);
+    encode(bool{false} /* legacy: log_op */, bl);
     encode(key, bl);
     encode(bilog_flags, bl);
     encode(zones_trace, bl);
@@ -64,6 +63,8 @@ struct rgw_cls_obj_prepare_op
       decode(locator, bl);
     }
     if (struct_v >= 4) {
+      // just for legacy
+      bool log_op;
       decode(log_op, bl);
     }
     if (struct_v >= 5) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8154,7 +8154,7 @@ int RGWRados::cls_obj_prepare_op(BucketShard& bs, RGWModifyOp op, string& tag,
   ObjectWriteOperation o;
   cls_rgw_obj_key key(obj.key.get_index_key_name(), obj.key.instance);
   cls_rgw_guard_bucket_resharding(o, -ERR_BUSY_RESHARDING);
-  cls_rgw_bucket_prepare_op(o, op, tag, key, obj.key.get_loc(), svc.zone->get_zone().log_data, bilog_flags, zones_trace);
+  cls_rgw_bucket_prepare_op(o, op, tag, key, obj.key.get_loc(), bilog_flags, zones_trace);
   return bs.bucket_obj.operate(&o, y);
 }
 

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -71,11 +71,11 @@ void test_stats(librados::IoCtx& ioctx, string& oid, RGWObjCategory category, ui
 
 void index_prepare(librados::IoCtx& ioctx, string& oid, RGWModifyOp index_op,
                    string& tag, const cls_rgw_obj_key& key, string& loc,
-                   uint16_t bi_flags = 0, bool log_op = true)
+                   uint16_t bi_flags = 0)
 {
   ObjectWriteOperation op;
   rgw_zone_set zones_trace;
-  cls_rgw_bucket_prepare_op(op, index_op, tag, key, loc, log_op, bi_flags, zones_trace);
+  cls_rgw_bucket_prepare_op(op, index_op, tag, key, loc, bi_flags, zones_trace);
   ASSERT_EQ(0, ioctx.operate(oid, &op));
 }
 
@@ -400,7 +400,7 @@ TEST_F(cls_rgw, index_list)
     string loc = str_int("loc", i);
 
     index_prepare(ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, obj, loc,
-		  0 /* bi_flags */, false /* log_op */);
+		  0 /* bi_flags */);
 
     rgw_bucket_dir_entry_meta meta;
     meta.category = RGWObjCategory::None;
@@ -478,7 +478,7 @@ TEST_F(cls_rgw, index_list_delimited)
       const string obj = str_int(p, i);
 
       index_prepare(ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, obj, loc,
-		    0 /* bi_flags */, false /* log_op */);
+		    0 /* bi_flags */);
 
       index_complete(ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, epoch, obj, meta,
 		     0 /* bi_flags */, false /* log_op */);
@@ -493,7 +493,7 @@ TEST_F(cls_rgw, index_list_delimited)
       const string obj = p + str_int("f", i);
 
       index_prepare(ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, obj, loc,
-		    0 /* bi_flags */, false /* log_op */);
+		    0 /* bi_flags */);
 
       index_complete(ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, epoch, obj, meta,
 		     0 /* bi_flags */, false /* log_op */);


### PR DESCRIPTION
It's unnecessary as, after a change, BILog is not touched at the "prepare" stage of a modification to Bucket Index anymore. This commit preserves the exact marshalling compatibility.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
