### PR TITLE
nautilus: qa/tests: moved "mon.c" into second part of upgrades...

### DIFF
--- a/qa/suites/upgrade/luminous-x/stress-split/2-partial-upgrade/firsthalf.yaml
+++ b/qa/suites/upgrade/luminous-x/stress-split/2-partial-upgrade/firsthalf.yaml
@@ -6,7 +6,6 @@ tasks:
 - install.upgrade:
     mon.a:
     mon.b:
-    mon.c:
 - print: "**** done install.upgrade of first 3 nodes"
 - ceph.restart:
     daemons: [mon.a,mon.b,mgr.x,osd.0,osd.1,osd.2,osd.3,osd.4,osd.5,osd.6,osd.7]

--- a/qa/suites/upgrade/luminous-x/stress-split/5-finish-upgrade.yaml
+++ b/qa/suites/upgrade/luminous-x/stress-split/5-finish-upgrade.yaml
@@ -2,6 +2,7 @@ tasks:
 - install.upgrade:
     osd.8:
     client.0:
+    mon.c:
 - ceph.restart:
     daemons: [mon.c, osd.8, osd.9, osd.10, osd.11]
     wait-for-healthy: false

--- a/qa/suites/upgrade/mimic-x/stress-split/2-partial-upgrade/firsthalf.yaml
+++ b/qa/suites/upgrade/mimic-x/stress-split/2-partial-upgrade/firsthalf.yaml
@@ -6,9 +6,8 @@ tasks:
 - install.upgrade:
     mon.a:
     mon.b:
-    mon.c:
 - print: "**** done install.upgrade first 3 nodes"
 - ceph.restart:
-    daemons: [mon.a,mon.b,mon.c,mgr.x,osd.0,osd.1,osd.2,osd.3,osd.4,osd.5,osd.6,osd.7]
+    daemons: [mon.a,mon.b,mgr.x,osd.0,osd.1,osd.2,osd.3,osd.4,osd.5,osd.6,osd.7]
     mon-health-to-clog: false
 - print: "**** done ceph.restart all mons and 2/3 of osds"

--- a/qa/suites/upgrade/mimic-x/stress-split/5-finish-upgrade.yaml
+++ b/qa/suites/upgrade/mimic-x/stress-split/5-finish-upgrade.yaml
@@ -2,8 +2,9 @@ tasks:
 - install.upgrade:
     osd.8:
     client.0:
+    mon.c:
 - ceph.restart:
-    daemons: [osd.8, osd.9, osd.10, osd.11]
+    daemons: [mon.c, osd.8, osd.9, osd.10, osd.11]
     wait-for-healthy: false
     wait-for-osds-up: true
 - exec:


### PR DESCRIPTION
...from 2-partial-upgrade/firsthalf.yaml to 5-finish-upgrade.yaml to replicate https://tracker.ceph.com/issues/47153

Fixes: https://tracker.ceph.com/issues/47153
Signed-off-by: Yuri Weinstein <yweinste@redhat.com>
