### PR TITLE
librbd: flush all incomplete in-flight IOs upon image close

### DIFF
--- a/src/librbd/image/CloseRequest.h
+++ b/src/librbd/image/CloseRequest.h
@@ -33,14 +33,15 @@ private:
    * BLOCK_IMAGE_WATCHER (skip if R/O)
    *    |
    *    v
-   * SHUT_DOWN_UPDATE_WATCHERS  . .
-   *    |                         . (exclusive lock disabled)
-   *    v                         v
-   * SHUT_DOWN_EXCLUSIVE_LOCK   FLUSH
-   *    |                         .
-   *    |     . . . . . . . . . . .
-   *    |     .
-   *    v     v
+   * SHUT_DOWN_UPDATE_WATCHERS
+   *    |
+   *    v
+   * FLUSH
+   *    |
+   *    v (skip if disabled)
+   * SHUT_DOWN_EXCLUSIVE_LOCK
+   *    |
+   *    v
    * UNREGISTER_IMAGE_WATCHER (skip if R/O)
    *    |
    *    v
@@ -82,11 +83,11 @@ private:
   void send_shut_down_update_watchers();
   void handle_shut_down_update_watchers(int r);
 
-  void send_shut_down_exclusive_lock();
-  void handle_shut_down_exclusive_lock(int r);
-
   void send_flush();
   void handle_flush(int r);
+
+  void send_shut_down_exclusive_lock();
+  void handle_shut_down_exclusive_lock(int r);
 
   void send_unregister_image_watcher();
   void handle_unregister_image_watcher(int r);

--- a/src/librbd/io/QueueImageDispatch.cc
+++ b/src/librbd/io/QueueImageDispatch.cc
@@ -107,10 +107,6 @@ bool QueueImageDispatch<I>::flush(
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << "tid=" << tid << dendl;
 
-  if (flush_source != FLUSH_SOURCE_USER) {
-    return false;
-  }
-
   *dispatch_result = DISPATCH_RESULT_CONTINUE;
   m_flush_tracker->flush(on_dispatched);
   return true;


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/46875
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
