### PR TITLE
crimson/osd: fix unexpected connection markdown in heartbeat

### DIFF
--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -71,30 +71,26 @@ void Protocol::close(bool dispatch_reset,
   }
   set_write_state(write_state_t::drop);
   auto gate_closed = gate.close();
-  auto reset_dispatched = seastar::futurize_invoke([this, dispatch_reset, is_replace] {
-    if (dispatch_reset) {
-      dispatcher->ms_handle_reset(
-	  seastar::static_pointer_cast<SocketConnection>(conn.shared_from_this()),
-	  is_replace);
+
+  if (dispatch_reset) {
+    try {
+        dispatcher->ms_handle_reset(
+            seastar::static_pointer_cast<SocketConnection>(conn.shared_from_this()),
+            is_replace);
+    } catch (...) {
+      logger().error("{} got unexpected exception in ms_handle_reset() {}",
+                     conn, std::current_exception());
     }
-    return seastar::now();
-  }).handle_exception([this] (std::exception_ptr eptr) {
-    logger().error("{} ms_handle_reset caught exception: {}", conn, eptr);
-    ceph_abort("unexpected exception from ms_handle_reset()");
-  });
+  }
 
   // asynchronous operations
   assert(!close_ready.valid());
-  close_ready = seastar::when_all_succeed(
-    std::move(gate_closed).finally([this] {
-      if (socket) {
-        return socket->close();
-      }
+  close_ready = std::move(gate_closed).finally([this] {
+    if (socket) {
+      return socket->close();
+    } else {
       return seastar::now();
-    }),
-    std::move(reset_dispatched)
-  ).then_unpack([] {
-    return seastar::now();
+    }
   }).finally(std::move(cleanup));
 }
 

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -1591,6 +1591,12 @@ void ProtocolV2::execute_establishing(
   trigger_state(state_t::ESTABLISHING, write_state_t::delay, false);
   if (existing_conn) {
     existing_conn->protocol->close(dispatch_reset, std::move(accept_me));
+    if (unlikely(state != state_t::ESTABLISHING)) {
+      logger().warn("{} triggered {} during execute_establishing(), "
+                    "the accept event will not be delivered!",
+                    conn, get_state_name(state));
+      abort_protocol();
+    }
   } else {
     accept_me();
   }

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -402,7 +402,7 @@ void Heartbeat::Connection::replaced()
   racing_detected = true;
   logger().warn("Heartbeat::Connection::replaced(): {} racing", *this);
   assert(conn != replaced_conn);
-  assert(!conn->is_connected());
+  assert(conn->is_connected());
 }
 
 void Heartbeat::Connection::reset()

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -176,6 +176,11 @@ class Heartbeat::Connection {
       is_winner_side{is_winner_side} {
     connect();
   }
+  Connection(const Connection&) = delete;
+  Connection(Connection&&) = delete;
+  Connection& operator=(const Connection&) = delete;
+  Connection& operator=(Connection&&) = delete;
+
   ~Connection();
 
   bool matches(crimson::net::Connection* _conn) const;
@@ -235,7 +240,7 @@ class Heartbeat::Connection {
   crimson::net::ConnectionRef conn;
   bool is_connected = false;
 
- friend std::ostream& operator<<(std::ostream& os, const Connection c) {
+ friend std::ostream& operator<<(std::ostream& os, const Connection& c) {
    if (c.type == type_t::front) {
      return os << "con_front(osd." << c.peer << ")";
    } else {
@@ -393,6 +398,7 @@ class Heartbeat::Peer final : private Heartbeat::ConnectionListener {
   ~Peer();
   Peer(Peer&&) = delete;
   Peer(const Peer&) = delete;
+  Peer& operator=(Peer&&) = delete;
   Peer& operator=(const Peer&) = delete;
 
   void set_epoch(epoch_t epoch) { session.set_epoch(epoch); }


### PR DESCRIPTION
Pass reference when log Heartbeat::Connection instance, or the
destructor will be called incorrectly, and the conn be marked down
unexpectedly.

Also, the replacing conn is actually connected during replacement-reset
event.

Fixes: https://tracker.ceph.com/issues/47124

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
