### PR TITLE
crimson/osd: support "dump_pgstate_history" command and update legacy conf vars

### DIFF
--- a/src/common/config.h
+++ b/src/common/config.h
@@ -124,6 +124,7 @@ public:
   int parse_buffer(ConfigValues& values, const ConfigTracker& tracker,
 		   const char* buf, size_t len,
 		   std::ostream *warnings);
+  void update_legacy_vals(ConfigValues& values);
   // Absorb config settings from the environment
   void parse_env(unsigned entity_type,
 		 ConfigValues& values, const ConfigTracker& tracker,
@@ -294,7 +295,6 @@ private:
   void assign_member(member_ptr_t ptr, const Option::value_t &val);
 
 
-  void update_legacy_vals(ConfigValues& values);
   void update_legacy_val(ConfigValues& values,
 			 const Option &opt,
 			 member_ptr_t member);

--- a/src/crimson/admin/admin_socket.cc
+++ b/src/crimson/admin/admin_socket.cc
@@ -397,8 +397,9 @@ public:
 				      ceph::bufferlist&&) const final
   {
     std::vector<std::string> argv;
-    [[maybe_unused]] bool found = cmd_getval(cmdmap, "injected_args", argv);
-    assert(found);
+    if (!cmd_getval(cmdmap, "injected_args", argv)) {
+      return seastar::make_ready_future<tell_result_t>();
+    }
     const std::string args = boost::algorithm::join(argv, " ");
     return local_conf().inject_args(args).then([] {
       return seastar::make_ready_future<tell_result_t>();

--- a/src/crimson/admin/osd_admin.cc
+++ b/src/crimson/admin/osd_admin.cc
@@ -34,7 +34,7 @@ std::unique_ptr<AdminSocketHook> make_asok_hook(Args&&... args)
  */
 class OsdStatusHook : public AdminSocketHook {
 public:
-  explicit OsdStatusHook(crimson::osd::OSD& osd) :
+  explicit OsdStatusHook(const crimson::osd::OSD& osd) :
     AdminSocketHook{"status", "", "OSD status"},
     osd(osd)
   {}
@@ -49,10 +49,10 @@ public:
     return seastar::make_ready_future<tell_result_t>(f.get());
   }
 private:
-  crimson::osd::OSD& osd;
+  const crimson::osd::OSD& osd;
 };
 template std::unique_ptr<AdminSocketHook>
-make_asok_hook<OsdStatusHook>(crimson::osd::OSD& osd);
+make_asok_hook<OsdStatusHook>(const crimson::osd::OSD& osd);
 
 /**
  * An OSD admin hook: send beacon

--- a/src/crimson/admin/osd_admin.h
+++ b/src/crimson/admin/osd_admin.h
@@ -12,6 +12,7 @@ class AssertAlwaysHook;
 class FlushPgStatsHook;
 class OsdStatusHook;
 class SendBeaconHook;
+class DumpPGStateHistory;
 
 template<class Hook, class... Args>
 std::unique_ptr<AdminSocketHook> make_asok_hook(Args&&... args);

--- a/src/crimson/common/config_proxy.cc
+++ b/src/crimson/common/config_proxy.cc
@@ -76,7 +76,11 @@ seastar::future<> ConfigProxy::parse_config_files(const std::string& conf_files)
       }
       return crimson::read_file(*path++).then([this](auto&& buf) {
         return do_change([buf=std::move(buf), this](ConfigValues& values) {
-          if (get_config().parse_buffer(values, obs_mgr, buf.get(), buf.size(), &std::cerr)) {
+          if (get_config().parse_buffer(values, obs_mgr,
+                                        buf.get(), buf.size(),
+                                        &std::cerr) == 0) {
+            get_config().update_legacy_vals(values);
+          } else {
             throw std::invalid_argument("parse error");
           }
         }).then([] {

--- a/src/crimson/common/config_proxy.cc
+++ b/src/crimson/common/config_proxy.cc
@@ -3,19 +3,9 @@
 
 #include "config_proxy.h"
 
-#if __has_include(<filesystem>)
 #include <filesystem>
-#else
-#include <experimental/filesystem>
-#endif
 
 #include "crimson/common/buffer_io.h"
-
-#if defined(__cpp_lib_filesystem)
-namespace fs = std::filesystem;
-#elif defined(__cpp_lib_experimental_filesystem)
-namespace fs = std::experimental::filesystem;
-#endif
 
 namespace crimson::common {
 
@@ -88,7 +78,7 @@ seastar::future<> ConfigProxy::parse_config_files(const std::string& conf_files)
 	  return seastar::make_ready_future<seastar::stop_iteration>(
             seastar::stop_iteration::yes);
         });
-      }).handle_exception_type([] (const fs::filesystem_error&) {
+      }).handle_exception_type([] (const std::filesystem::filesystem_error&) {
         return seastar::make_ready_future<seastar::stop_iteration>(
           seastar::stop_iteration::no);
       }).handle_exception_type([] (const std::invalid_argument&) {

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -427,7 +427,7 @@ seastar::future<> OSD::start_asok_admin()
   return asok->start(asok_path).then([this] {
     return seastar::when_all_succeed(
       asok->register_admin_commands(),
-      asok->register_command(make_asok_hook<OsdStatusHook>(*this)),
+      asok->register_command(make_asok_hook<OsdStatusHook>(std::as_const(*this))),
       asok->register_command(make_asok_hook<SendBeaconHook>(*this)),
       asok->register_command(make_asok_hook<FlushPgStatsHook>(*this)),
       asok->register_command(make_asok_hook<DumpPGStateHistory>(std::as_const(*this))));

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -429,7 +429,8 @@ seastar::future<> OSD::start_asok_admin()
       asok->register_admin_commands(),
       asok->register_command(make_asok_hook<OsdStatusHook>(*this)),
       asok->register_command(make_asok_hook<SendBeaconHook>(*this)),
-      asok->register_command(make_asok_hook<FlushPgStatsHook>(*this)));
+      asok->register_command(make_asok_hook<FlushPgStatsHook>(*this)),
+      asok->register_command(make_asok_hook<DumpPGStateHistory>(std::as_const(*this))));
   }).then_unpack([] {
     return seastar::now();
   });
@@ -491,6 +492,20 @@ void OSD::dump_status(Formatter* f) const
   f->dump_unsigned("oldest_map", superblock.oldest_map);
   f->dump_unsigned("newest_map", superblock.newest_map);
   f->dump_unsigned("num_pgs", pg_map.get_pgs().size());
+}
+
+void OSD::dump_pg_state_history(Formatter* f) const
+{
+  f->open_array_section("pgs");
+  for (auto [pgid, pg] : pg_map.get_pgs()) {
+    f->open_object_section("pg");
+    f->dump_stream("pg") << pgid;
+    const auto& peering_state = pg->get_peering_state();
+    f->dump_string("currently", peering_state.get_current_state());
+    peering_state.dump_history(f);
+    f->close_section();
+  }
+  f->close_section();
 }
 
 void OSD::print(std::ostream& out) const

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -135,7 +135,7 @@ public:
   seastar::future<> stop();
 
   void dump_status(Formatter*) const;
-
+  void dump_pg_state_history(Formatter*) const;
   void print(std::ostream&) const;
 
   seastar::future<> send_incremental_map(crimson::net::Connection* conn,


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
