### PR TITLE
mgr/cephadm: Verify non-empty list in get_active_daemon functions

### DIFF
--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -61,7 +61,10 @@ class GrafanaService(CephadmService):
 
     def get_active_daemon(self, daemon_descrs: List[DaemonDescription]) -> DaemonDescription:
         # Use the least-created one as the active daemon
-        return daemon_descrs[-1]
+        if daemon_descrs:
+            return daemon_descrs[-1]
+        # if empty list provided, return empty Daemon Desc
+        return DaemonDescription()
 
     def config_dashboard(self, daemon_descrs: List[DaemonDescription]):
         # TODO: signed cert
@@ -141,7 +144,10 @@ class AlertmanagerService(CephadmService):
 
     def get_active_daemon(self, daemon_descrs: List[DaemonDescription]) -> DaemonDescription:
         # TODO: if there are multiple daemons, who is the active one?
-        return daemon_descrs[0]
+        if daemon_descrs:
+            return daemon_descrs[0]
+        # if empty list provided, return empty Daemon Desc
+        return DaemonDescription()
 
     def config_dashboard(self, daemon_descrs: List[DaemonDescription]):
         dd = self.get_active_daemon(daemon_descrs)
@@ -231,7 +237,10 @@ class PrometheusService(CephadmService):
 
     def get_active_daemon(self, daemon_descrs: List[DaemonDescription]) -> DaemonDescription:
         # TODO: if there are multiple daemons, who is the active one?
-        return daemon_descrs[0]
+        if daemon_descrs:
+            return daemon_descrs[0]
+        # if empty list provided, return empty Daemon Desc
+        return DaemonDescription()
 
     def config_dashboard(self, daemon_descrs: List[DaemonDescription]):
         dd = self.get_active_daemon(daemon_descrs)


### PR DESCRIPTION
The get_active_daemon functions for monitoring stack daemons
were just returning the first or last daemon in the given list
without checking the list actually contained any daemons

Fixes: https://tracker.ceph.com/issues/47171

Signed-off-by: Adam King <adking@redhat.com>