### PR TITLE
octopus: mgr/dashboard: Auto close table column dropdown on click outside

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -107,7 +107,7 @@
     <!-- show hide columns -->
     <div class="widget-toolbar">
       <div dropdown
-           [autoClose]="false"
+           [insideClick]="true"
            class="dropdown tc_menuitem tc_menuitem_cluster">
         <a dropdownToggle
            class="btn btn-light dropdown-toggle tc_columnBtn"


### PR DESCRIPTION
This is a manually fix, since the original code includes a big refactor that can't be backported.

---
backport tracker: https://tracker.ceph.com/issues/46091

---

backport of https://github.com/ceph/ceph/pull/35505
parent tracker: https://tracker.ceph.com/issues/45566

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh