### PR TITLE
nautilus: qa/tasks/vstart_runner: use parent's umount methods

### DIFF
--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -248,6 +248,9 @@ class FuseMount(CephFSMount):
         return self.client_remote.run(args=["ls", "-d", self.mountpoint], check_status=False, cwd=self.test_dir, timeout=(15*60)).exitstatus == 0
 
     def umount(self):
+        if not self.is_mounted():
+            return
+
         try:
             log.info('Running fusermount -u on {name}...'.format(name=self.client_remote.name))
             self.client_remote.run(

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -70,6 +70,9 @@ class KernelMount(CephFSMount):
         self.mounted = True
 
     def umount(self, force=False):
+        if not self.is_mounted():
+            return
+
         log.debug('Unmounting client client.{id}...'.format(id=self.client_id))
 
         cmd=['sudo', 'umount', self.mountpoint]

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -482,10 +482,6 @@ class LocalFuseMount(FuseMount):
         log.info("I think my launching pid was {0}".format(self.fuse_daemon.subproc.pid))
         return path
 
-    def umount(self):
-        if self.is_mounted():
-            super(LocalFuseMount, self).umount()
-
     def mount(self, mount_path=None, mount_fs_name=None, mountpoint=None):
         if mountpoint is not None:
             self.mountpoint = mountpoint


### PR DESCRIPTION
https://tracker.ceph.com/issues/47178

Skips https://github.com/ceph/ceph/pull/33711/commits/64680a7e6466c38b918bf338dc03bc9f2f3b36b8 as XFSTests is not in nautilus.