### PR TITLE
doc:Improve installation process with ceph-deploy

### DIFF
--- a/doc/install/ceph-deploy/quick-start-preflight.rst
+++ b/doc/install/ceph-deploy/quick-start-preflight.rst
@@ -32,6 +32,11 @@ For Debian and Ubuntu distributions, perform the following steps:
 
 	echo deb https://download.ceph.com/debian-{ceph-stable-release}/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
 
+#. Add the Ceph source, replace ``{ceph-stable-release}`` with a stable Ceph release (e.g.,``luminous``.)::
+
+	export CEPH_DEPLOY_REPO_URL=https://download.ceph.com/debian-{ceph-stable-release}
+	export CEPH_DEPLOY_GPG_URL=https://download.ceph.com/keys/release.asc
+
 #. Update your repository and install ``ceph-deploy``::
 
 	sudo apt update


### PR DESCRIPTION
doc:Improve installation process with ceph-deploy

    When I install ceph luminous version with ceph-deploy, If I do not use this step, when installing ceph with ceph-deploy: "install node1 node2 node3", the version I installed is still mimic. 
    My Linux version is Ubuntu18.04, and I exchange sources.list with Chinese tsinghua.edu.cn. And the Ceph mirror I used is "http://mirrors.ustc.edu.cn/ceph/ ". So I think it's necessary to add this step.

Signed-off-by: ZhenLiu94 <zhenliu94@163.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
