### PR TITLE
octopus: mgr/dashboard: Proper format iSCSI target portals

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-list/iscsi-target-list.component.ts
@@ -18,6 +18,7 @@ import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { FinishedTask } from '../../../shared/models/finished-task';
 import { Permission } from '../../../shared/models/permissions';
 import { Task } from '../../../shared/models/task';
+import { JoinPipe } from '../../../shared/pipes/join.pipe';
 import { NotAvailablePipe } from '../../../shared/pipes/not-available.pipe';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { TaskListService } from '../../../shared/services/task-list.service';
@@ -59,6 +60,7 @@ export class IscsiTargetListComponent extends ListWithDetails implements OnInit,
     private authStorageService: AuthStorageService,
     private i18n: I18n,
     private iscsiService: IscsiService,
+    private joinPipe: JoinPipe,
     private taskListService: TaskListService,
     private notAvailablePipe: NotAvailablePipe,
     private modalService: BsModalService,
@@ -105,11 +107,13 @@ export class IscsiTargetListComponent extends ListWithDetails implements OnInit,
       {
         name: this.i18n('Portals'),
         prop: 'cdPortals',
+        pipe: this.joinPipe,
         flexGrow: 2
       },
       {
         name: this.i18n('Images'),
         prop: 'cdImages',
+        pipe: this.joinPipe,
         flexGrow: 2
       },
       {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46970

---

backport of https://github.com/ceph/ceph/pull/36585
parent tracker: https://tracker.ceph.com/issues/46908

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh