### PR TITLE
octopus: mgr/dashboard: Fix for CrushMap viewer items getting compressed vertically

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.scss
@@ -1,0 +1,7 @@
+::ng-deep tree-root {
+  tree-viewport {
+    div:first-child {
+      height: unset !important;
+    }
+  }
+}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46933

---

backport of https://github.com/ceph/ceph/pull/36445
parent tracker: https://tracker.ceph.com/issues/46826

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh