### PR TITLE
cephadm: properly remove `osd-activate` container

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1987,7 +1987,6 @@ def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
                     p = os.path.join(data_dir, n)
                     f.write('[ ! -L {p} ] || chown {uid}:{gid} {p}\n'.format(p=p, uid=uid, gid=gid))
             else:
-                f.write('# LVM OSDs use ceph-volume lvm activate:\n')
                 prestart = CephContainer(
                     image=args.image,
                     entrypoint='/usr/sbin/ceph-volume',
@@ -2001,12 +2000,12 @@ def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
                     bind_mounts=get_container_binds(fsid, daemon_type, daemon_id),
                     cname='ceph-%s-%s.%s-activate' % (fsid, daemon_type, daemon_id),
                 )
-                f.write(' '.join(prestart.run_cmd()) + '\n')
+                _write_container_cmd_to_bash(f, prestart, 'LVM OSDs use ceph-volume lvm activate')
         elif daemon_type == NFSGanesha.daemon_type:
             # add nfs to the rados grace db
             nfs_ganesha = NFSGanesha.init(fsid, daemon_id)
             prestart = nfs_ganesha.get_rados_grace_container('add')
-            f.write(' '.join(prestart.run_cmd()) + '\n')
+            _write_container_cmd_to_bash(f, prestart)
         elif daemon_type == CephIscsi.daemon_type:
             f.write(' '.join(CephIscsi.configfs_mount_umount(data_dir, mount=True)) + '\n')
             ceph_iscsi = CephIscsi.init(fsid, daemon_id)
@@ -2039,12 +2038,12 @@ def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
                 cname='ceph-%s-%s.%s-deactivate' % (fsid, daemon_type,
                                                     daemon_id),
             )
-            f.write(' '.join(poststop.run_cmd()) + '\n')
+            _write_container_cmd_to_bash(f, poststop)
         elif daemon_type == NFSGanesha.daemon_type:
             # remove nfs from the rados grace db
             nfs_ganesha = NFSGanesha.init(fsid, daemon_id)
             poststop = nfs_ganesha.get_rados_grace_container('remove')
-            f.write(' '.join(poststop.run_cmd()) + '\n')
+            _write_container_cmd_to_bash(f, poststop)
         elif daemon_type == CephIscsi.daemon_type:
             # make sure we also stop the tcmu container
             ceph_iscsi = CephIscsi.init(fsid, daemon_id)


### PR DESCRIPTION

Othwerise we end up with being unable to create
new containers, due to the name being already used

Fixes: https://tracker.ceph.com/issues/47170

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
