### PR TITLE
octopus: mgr/dashboard: Host delete action should be disabled if not managed by Orchestrator

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -112,7 +112,7 @@ describe('HostsComponent', () => {
       });
       expect(tableAction.disable(component.selection)).toBeTruthy();
       expect(component.getEditDisableDesc(component.selection)).toBe(
-        'Host editing is disabled because the host is not managed by Orchestrator.'
+        'Host editing is disabled because the selected host is not managed by Orchestrator.'
       );
     });
 
@@ -130,6 +130,46 @@ describe('HostsComponent', () => {
       });
       expect(tableAction.disable(component.selection)).toBeFalsy();
       expect(component.getEditDisableDesc(component.selection)).toBeUndefined();
+    });
+  });
+
+  describe('getDeleteDisableDesc', () => {
+    it('should return message (not managed by Orchestrator)', () => {
+      component.selection.add({
+        sources: {
+          ceph: false,
+          orchestrator: true
+        }
+      });
+      component.selection.add({
+        sources: {
+          ceph: true,
+          orchestrator: false
+        }
+      });
+      expect(component.getDeleteDisableDesc(component.selection)).toBe(
+        'Host deletion is disabled because a selected host is not managed by Orchestrator.'
+      );
+    });
+
+    it('should return undefined (no selection)', () => {
+      expect(component.getDeleteDisableDesc(component.selection)).toBeUndefined();
+    });
+
+    it('should return undefined (managed by Orchestrator)', () => {
+      component.selection.add({
+        sources: {
+          ceph: false,
+          orchestrator: true
+        }
+      });
+      component.selection.add({
+        sources: {
+          ceph: false,
+          orchestrator: true
+        }
+      });
+      expect(component.getDeleteDisableDesc(component.selection)).toBeUndefined();
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -107,7 +107,10 @@ export class HostsComponent extends ListWithDetails implements OnInit {
             () => this.deleteAction()
           );
         },
-        disable: () => !this.selection.hasSelection
+        disable: (selection: CdTableSelection) =>
+          !selection.hasSelection ||
+          !selection.selected.every((selected) => selected.sources.orchestrator),
+        disableDesc: this.getDeleteDisableDesc.bind(this)
       }
     ];
   }
@@ -191,7 +194,9 @@ export class HostsComponent extends ListWithDetails implements OnInit {
 
   getEditDisableDesc(selection: CdTableSelection): string | undefined {
     if (selection && selection.hasSingleSelection && !selection.first().sources.orchestrator) {
-      return this.i18n('Host editing is disabled because the host is not managed by Orchestrator.');
+      return this.i18n(
+        'Host editing is disabled because the selected host is not managed by Orchestrator.'
+      );
     }
     return undefined;
   }
@@ -210,6 +215,19 @@ export class HostsComponent extends ListWithDetails implements OnInit {
           })
       }
     });
+  }
+
+  getDeleteDisableDesc(selection: CdTableSelection): string | undefined {
+    if (
+      selection &&
+      selection.hasSelection &&
+      !selection.selected.every((selected) => selected.sources.orchestrator)
+    ) {
+      return this.i18n(
+        'Host deletion is disabled because a selected host is not managed by Orchestrator.'
+      );
+    }
+    return undefined;
   }
 
   getHosts(context: CdTableFetchDataContext) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46345

---

backport of https://github.com/ceph/ceph/pull/35745
parent tracker: https://tracker.ceph.com/issues/46146

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh