### PR TITLE
octopus: mgr/dashboard: Remove useless tab in monitoring/alerts datatable details

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.html
@@ -3,13 +3,10 @@
           [hasDetails]="true"
           (updateSelection)="setExpandedRow($event)"
           [selectionType]="'single'">
-  <tabset cdTableDetail
-          *ngIf="expandedRow">
-    <tab i18n-heading
-         heading="Details">
-      <cd-table-key-value [data]="expandedRow"
-                          [renderObjects]="true"
-                          [hideKeys]="hideKeys"></cd-table-key-value>
-    </tab>
-  </tabset>
+  <cd-table-key-value cdTableDetail
+                      *ngIf="expandedRow"
+                      [data]="expandedRow"
+                      [renderObjects]="true"
+                      [hideKeys]="hideKeys">
+  </cd-table-key-value>
 </cd-table>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/rules-list/rules-list.component.spec.ts
@@ -2,8 +2,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
-import { TabsModule } from 'ngx-bootstrap/tabs';
-
 import { configureTestBed, i18nProviders } from '../../../../../testing/unit-test-helper';
 import { PrometheusService } from '../../../../shared/api/prometheus.service';
 import { SettingsService } from '../../../../shared/api/settings.service';
@@ -16,7 +14,7 @@ describe('RulesListComponent', () => {
 
   configureTestBed({
     declarations: [RulesListComponent],
-    imports: [HttpClientTestingModule, SharedModule, TabsModule.forRoot(), BrowserAnimationsModule],
+    imports: [HttpClientTestingModule, SharedModule, BrowserAnimationsModule],
     providers: [PrometheusService, SettingsService, i18nProviders]
   });
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46342

---

backport of https://github.com/ceph/ceph/pull/35828
parent tracker: https://tracker.ceph.com/issues/46249

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh