### PR TITLE
nautilus: rgw: dump transitions in RGWLifecycleConfiguration::dump()

### DIFF
--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -1694,6 +1694,17 @@ void lc_op::dump(Formatter *f) const
   if (obj_tags) {
     f->dump_object("obj_tags", *obj_tags);
   }
+  f->open_object_section("transitions");
+  for(auto& [storage_class, transition] : transitions) {
+    f->dump_object(storage_class.c_str(), transition);
+  }
+  f->close_section();
+
+  f->open_object_section("noncur_transitions");  
+  for (auto& [storage_class, transition] : noncur_transitions) {
+    f->dump_object(storage_class.c_str(), transition);
+  }
+  f->close_section();
 }
 
 void LCFilter::dump(Formatter *f) const
@@ -1717,6 +1728,17 @@ void LCRule::dump(Formatter *f) const
   f->dump_object("noncur_expiration", noncur_expiration);
   f->dump_object("mp_expiration", mp_expiration);
   f->dump_object("filter", filter);
+  f->open_object_section("transitions");  
+  for (auto& [storage_class, transition] : transitions) {
+    f->dump_object(storage_class.c_str(), transition);
+  }
+  f->close_section();
+
+  f->open_object_section("noncur_transitions");  
+  for (auto& [storage_class, transition] : noncur_transitions) {
+    f->dump_object(storage_class.c_str(), transition);
+  }
+  f->close_section();
   f->dump_bool("dm_expiration", dm_expiration);
 }
 

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -152,7 +152,11 @@ public:
     decode(storage_class, bl);
     DECODE_FINISH(bl);
   }
-  void dump(Formatter *f) const;
+  void dump(Formatter *f) const {  
+    f->dump_string("days", days);
+    f->dump_string("date", date);
+    f->dump_string("storage_class", storage_class);
+  }
 };
 WRITE_CLASS_ENCODER(LCTransition)
 
@@ -369,6 +373,14 @@ struct transition_action
   boost::optional<ceph::real_time> date;
   string storage_class;
   transition_action() : days(0) {}
+  void dump(Formatter *f) const {
+    if (!date) {
+      f->dump_int("days", days);
+    } else {
+      utime_t ut(*date);
+      f->dump_stream("date") << ut;
+    }
+  }
 };
 
 /* XXX why not LCRule? */


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47186

---

backport of https://github.com/ceph/ceph/pull/36092
parent tracker: https://tracker.ceph.com/issues/46647

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh