### PR TITLE
msg/async/ProtocolV2: allow rxbuf/txbuf get bigger in testing

### DIFF
--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -749,7 +749,7 @@ CtPtr ProtocolV2::read(CONTINUATION_RXBPTR_TYPE<ProtocolV2> &next,
       if (unlikely(pre_auth.enabled) && r >= 0) {
         pre_auth.rxbuf.append(*next.node);
 	ceph_assert(!cct->_conf->ms_die_on_bug ||
-		    pre_auth.rxbuf.length() < 1000000);
+		    pre_auth.rxbuf.length() < 10000000);
       }
       next.r = r;
       run_continuation(next);
@@ -759,7 +759,7 @@ CtPtr ProtocolV2::read(CONTINUATION_RXBPTR_TYPE<ProtocolV2> &next,
     if (unlikely(pre_auth.enabled) && r == 0) {
       pre_auth.rxbuf.append(*next.node);
       ceph_assert(!cct->_conf->ms_die_on_bug ||
-		  pre_auth.rxbuf.length() < 1000000);
+		  pre_auth.rxbuf.length() < 10000000);
     }
     next.r = r;
     return &next;
@@ -791,7 +791,7 @@ CtPtr ProtocolV2::write(const std::string &desc,
   if (unlikely(pre_auth.enabled)) {
     pre_auth.txbuf.append(buffer);
     ceph_assert(!cct->_conf->ms_die_on_bug ||
-		pre_auth.txbuf.length() < 1000000);
+		pre_auth.txbuf.length() < 10000000);
   }
 
   ssize_t r =


### PR DESCRIPTION
We have a kernel client test case that constructs huge auth tickets
to exercise the three related code paths in the kernel.  One of the
tickets is bigger than 1000000 bytes, as required for triggering the
third code path.

We haven't bumped into this assert earlier because the kernel client
is still on msgr v1.  However, "rbd map" and "rbd unmap" commands
started connecting to the cluster in commit 96f05a7956b3 ("rbd: delay
determination of default pool name") and that happens via msgr v2.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>