### PR TITLE
octopus: mgr/dashboard: Datatable catches select events from other datatables

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -685,8 +685,8 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
     // https://github.com/swimlane/ngx-datatable/issues/899
     if (_.has($event, 'selected')) {
       this.selection.selected = $event['selected'];
-      this.updateSelection.emit(_.clone(this.selection));
     }
+    this.updateSelection.emit(_.clone(this.selection));
   }
 
   toggleColumn($event: any) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -681,8 +681,12 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
   }
 
   onSelect($event: any) {
-    this.selection.selected = $event['selected'];
-    this.updateSelection.emit(_.clone(this.selection));
+    // Ensure we do not process DOM 'select' events.
+    // https://github.com/swimlane/ngx-datatable/issues/899
+    if (_.has($event, 'selected')) {
+      this.selection.selected = $event['selected'];
+      this.updateSelection.emit(_.clone(this.selection));
+    }
   }
 
   toggleColumn($event: any) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47199

---

backport of https://github.com/ceph/ceph/pull/36590
parent tracker: https://tracker.ceph.com/issues/46903

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh