### PR TITLE
msg/async/rdma: Hash the RoCE interrupts to different cores

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -1415,6 +1415,13 @@ options:
   level: advanced
   default: ib
   with_legacy: true
+- name: ms_async_rdma_support_hash_irqs
+  type: bool
+  level: advanced
+  default: true
+  flags:
+  - startup
+  desc: hash CQ interrupts to different queues
 - name: ms_dpdk_port_id
   type: int
   level: advanced

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -629,7 +629,14 @@ Infiniband::CompletionQueue::~CompletionQueue()
 
 int Infiniband::CompletionQueue::init()
 {
-  cq = ibv_create_cq(infiniband.device->ctxt, queue_depth, this, channel->get_channel(), 0);
+  int comp_vector = 0;
+  bool hash_irqs = cct->_conf.get_val<bool>("ms_async_rdma_support_hash_irqs");
+  if (hash_irqs && cct->_conf->name.is_osd()) {
+    comp_vector = std::stoi(cct->_conf->name.get_id()) %
+                  infiniband.device->ctxt->num_comp_vectors;
+  }
+  cq = ibv_create_cq(infiniband.device->ctxt, queue_depth, this,
+                     channel->get_channel(), comp_vector);
   if (!cq) {
     lderr(cct) << __func__ << " failed to create receive completion queue: "
       << cpp_strerror(errno) << dendl;


### PR DESCRIPTION
The CQ interrupts are hashed to different cores to avoid the
single-core bottleneck. Use a script to bind the queue interrupt
to the NUMA node where the OSD is located to reduce the latency.

Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>
Signed-off-by: luo rixin <luorixin@huawei.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
