### PR TITLE
cmake: make crimson libraries static to prevent cmake error

### DIFF
--- a/src/crimson/os/CMakeLists.txt
+++ b/src/crimson/os/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(crimson-os
+add_library(crimson-os STATIC
   futurized_store.cc
   ${PROJECT_SOURCE_DIR}/src/os/Transaction.cc)
 add_subdirectory(cyanstore)

--- a/src/crimson/os/cyanstore/CMakeLists.txt
+++ b/src/crimson/os/cyanstore/CMakeLists.txt
@@ -1,6 +1,7 @@
-add_library(crimson-cyanstore
+add_library(crimson-cyanstore STATIC
   cyan_store.cc
   cyan_collection.cc
   cyan_object.cc)
 target_link_libraries(crimson-cyanstore
-  crimson)
+  crimson
+  crimson-os)

--- a/src/crimson/os/seastore/CMakeLists.txt
+++ b/src/crimson/os/seastore/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(crimson-seastore
+add_library(crimson-seastore STATIC
   cached_extent.cc
   seastore_types.cc
   segment_manager/ephemeral.cc
@@ -18,4 +18,6 @@ add_library(crimson-seastore
   ../../../test/crimson/seastore/test_block.cc
 	)
 target_link_libraries(crimson-seastore
-  crimson)
+  crimson
+  crimson-os)
+

--- a/src/test/crimson/seastore/CMakeLists.txt
+++ b/src/test/crimson/seastore/CMakeLists.txt
@@ -24,7 +24,7 @@ target_link_libraries(
 add_executable(unittest_seastore_journal
   test_seastore_journal.cc)
 add_ceph_test(unittest_seastore_journal
-  unittest_seastore_cache)
+  unittest_seastore_journal)
 target_link_libraries(
   unittest_seastore_journal
   crimson::gtest

--- a/src/test/crimson/seastore/CMakeLists.txt
+++ b/src/test/crimson/seastore/CMakeLists.txt
@@ -6,7 +6,9 @@ add_ceph_unittest(unittest_transaction_manager)
 target_link_libraries(
   unittest_transaction_manager
   ${CMAKE_DL_LIBS}
-  crimson-seastore)
+  crimson-seastore
+  crimson-os
+  crimson-common)
 
 add_executable(unittest_btree_lba_manager
   test_btree_lba_manager.cc
@@ -15,7 +17,9 @@ add_ceph_unittest(unittest_btree_lba_manager)
 target_link_libraries(
   unittest_btree_lba_manager
   ${CMAKE_DL_LIBS}
-  crimson-seastore)
+  crimson-seastore
+  crimson-os
+  crimson-common)
 
 add_executable(unittest_seastore_journal
   test_seastore_journal.cc)
@@ -24,7 +28,9 @@ add_ceph_test(unittest_seastore_journal
 target_link_libraries(
   unittest_seastore_journal
   crimson::gtest
-  crimson-seastore)
+  crimson-seastore
+  crimson-os
+  crimson-common)
 
 add_executable(unittest_seastore_cache
   test_block.cc
@@ -34,6 +40,8 @@ add_ceph_test(unittest_seastore_cache
 target_link_libraries(
   unittest_seastore_cache
   crimson::gtest
-  crimson-seastore)
+  crimson-seastore
+  crimson-os
+  crimson-common)
 
 add_subdirectory(onode_tree)

--- a/src/test/crimson/seastore/onode_tree/CMakeLists.txt
+++ b/src/test/crimson/seastore/onode_tree/CMakeLists.txt
@@ -3,4 +3,6 @@ add_executable(test-seastore-onode-tree-node
 add_ceph_unittest(test-seastore-onode-tree-node)
 target_link_libraries(test-seastore-onode-tree-node
   crimson-seastore
-  GTest::Main)
+  GTest::Main
+  crimson-os
+  crimson-common)


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47209

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
