### PR TITLE
mgr_module.py: make keyword style argument passing explicit

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -651,15 +651,17 @@ class argdesc(object):
     valid() will later be called with input to validate against it,
     and will store the validated value in self.instance.val for extraction.
     """
-    def __init__(self, t, name=None, n=1, req=True, **kwargs):
+    def __init__(self, t, name=None, n=1, req=True, kw=False, **kwargs):
         if isinstance(t, basestring):
             self.t = CephPrefix
             self.typeargs = {'prefix': t}
             self.req = True
+            self.kw = False
         else:
             self.t = t
             self.typeargs = kwargs
             self.req = req in (True, 'True', 'true')
+            self.kw = kw in (True, 'True', 'true')
 
         self.name = name
         self.N = (n in ['n', 'N'])

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -290,6 +290,7 @@ class CLICommand(object):
         if not self.args:
             return
         args = self.args.split(" ")
+        kwargs_switch = False
         for arg in args:
             arg_desc = arg.strip().split(",")
             arg_d = {}
@@ -299,6 +300,12 @@ class CLICommand(object):
                     arg_d[k] = v
                 else:
                     self.args_dict[v] = arg_d
+                if k == 'kw' and v == 'true':
+                    kwargs_switch = True
+                else:
+                    if kwargs_switch:
+                        # we saw a kwarg earlier and now a positional
+                        logging.warn('Found positional argument after kwarg')
 
     def __call__(self, func):
         self.func = func

--- a/src/pybind/mgr/snap_schedule/module.py
+++ b/src/pybind/mgr/snap_schedule/module.py
@@ -47,10 +47,10 @@ class Module(MgrModule):
         return -errno.EINVAL, "", "Unknown command"
 
     @CLIReadCommand('fs snap-schedule status',
-                    'name=path,type=CephString,req=false '
-                    'name=subvol,type=CephString,req=false '
-                    'name=fs,type=CephString,req=false '
-                    'name=format,type=CephString,req=false',
+                    'name=path,type=CephString,req=false,kw=true '
+                    'name=subvol,type=CephString,req=false,kw=true '
+                    'name=fs,type=CephString,req=false,kw=true '
+                    'name=format,type=CephString,req=false,kw=true',
                     'List current snapshot schedules')
     def snap_schedule_get(self, path='/', subvol=None, fs=None, format='plain'):
         use_fs = fs if fs else self.default_fs
@@ -65,10 +65,10 @@ class Module(MgrModule):
 
     @CLIReadCommand('fs snap-schedule list',
                     'name=path,type=CephString '
-                    'name=recursive,type=CephString,req=false '
-                    'name=subvol,type=CephString,req=false '
-                    'name=fs,type=CephString,req=false '
-                    'name=format,type=CephString,req=false',
+                    'name=recursive,type=CephString,req=false,kw=true '
+                    'name=subvol,type=CephString,req=false,kw=true '
+                    'name=fs,type=CephString,req=false,kw=true '
+                    'name=format,type=CephString,req=false,kw=true',
                     'Get current snapshot schedule for <path>')
     def snap_schedule_list(self, path, subvol=None, recursive=False, fs=None,
                            format='plain'):
@@ -88,9 +88,9 @@ class Module(MgrModule):
     @CLIWriteCommand('fs snap-schedule add',
                      'name=path,type=CephString '
                      'name=snap-schedule,type=CephString '
-                     'name=start,type=CephString,req=false '
-                     'name=fs,type=CephString,req=false '
-                     'name=subvol,type=CephString,req=false',
+                     'name=start,type=CephString,req=false,kw=true '
+                     'name=fs,type=CephString,req=false,kw=true '
+                     'name=subvol,type=CephString,req=false,kw=true',
                      'Set a snapshot schedule for <path>')
     def snap_schedule_add(self,
                           path,
@@ -120,10 +120,10 @@ class Module(MgrModule):
 
     @CLIWriteCommand('fs snap-schedule remove',
                      'name=path,type=CephString '
-                     'name=repeat,type=CephString,req=false '
-                     'name=start,type=CephString,req=false '
-                     'name=subvol,type=CephString,req=false '
-                     'name=fs,type=CephString,req=false',
+                     'name=repeat,type=CephString,req=false,kw=true '
+                     'name=start,type=CephString,req=false,kw=true '
+                     'name=subvol,type=CephString,req=false,kw=true '
+                     'name=fs,type=CephString,req=false,kw=true',
                      'Remove a snapshot schedule for <path>')
     def snap_schedule_rm(self,
                          path,
@@ -144,9 +144,9 @@ class Module(MgrModule):
     @CLIWriteCommand('fs snap-schedule retention add',
                      'name=path,type=CephString '
                      'name=retention-spec-or-period,type=CephString '
-                     'name=retention-count,type=CephString,req=false '
-                     'name=fs,type=CephString,req=false '
-                     'name=subvol,type=CephString,req=false',
+                     'name=retention-count,type=CephString,req=false,kw=true '
+                     'name=fs,type=CephString,req=false,kw=true '
+                     'name=subvol,type=CephString,req=false,kw=true',
                      'Set a retention specification for <path>')
     def snap_schedule_retention_add(self,
                                     path,
@@ -169,9 +169,9 @@ class Module(MgrModule):
     @CLIWriteCommand('fs snap-schedule retention remove',
                      'name=path,type=CephString '
                      'name=retention-spec-or-period,type=CephString '
-                     'name=retention-count,type=CephString,req=false '
-                     'name=fs,type=CephString,req=false '
-                     'name=subvol,type=CephString,req=false',
+                     'name=retention-count,type=CephString,req=false,kw=true '
+                     'name=fs,type=CephString,req=false,kw=true '
+                     'name=subvol,type=CephString,req=false,kw=true',
                      'Remove a retention specification for <path>')
     def snap_schedule_retention_rm(self,
                                    path,
@@ -193,10 +193,10 @@ class Module(MgrModule):
 
     @CLIWriteCommand('fs snap-schedule activate',
                      'name=path,type=CephString '
-                     'name=repeat,type=CephString,req=false '
-                     'name=start,type=CephString,req=false '
-                     'name=subvol,type=CephString,req=false '
-                     'name=fs,type=CephString,req=false',
+                     'name=repeat,type=CephString,req=false,kw=true '
+                     'name=start,type=CephString,req=false,kw=true '
+                     'name=subvol,type=CephString,req=false,kw=true '
+                     'name=fs,type=CephString,req=false,kw=true',
                      'Activate a snapshot schedule for <path>')
     def snap_schedule_activate(self,
                                path,
@@ -216,10 +216,10 @@ class Module(MgrModule):
 
     @CLIWriteCommand('fs snap-schedule deactivate',
                      'name=path,type=CephString '
-                     'name=repeat,type=CephString,req=false '
-                     'name=start,type=CephString,req=false '
-                     'name=subvol,type=CephString,req=false '
-                     'name=fs,type=CephString,req=false',
+                     'name=repeat,type=CephString,req=false,kw=true '
+                     'name=start,type=CephString,req=false,kw=true '
+                     'name=subvol,type=CephString,req=false,kw=true '
+                     'name=fs,type=CephString,req=false,kw=true',
                      'Deactivate a snapshot schedule for <path>')
     def snap_schedule_deactivate(self,
                                  path,


### PR DESCRIPTION
This PR changes the recent addition to CLICommand to support kwargs style passing. With this a module author has to explicitly mark arguments that can be passed with a keyword.

 

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
