### PR TITLE
mgr/cephadm: customize blink_device_light cmd via j2

### DIFF
--- a/src/pybind/mgr/cephadm/template.py
+++ b/src/pybind/mgr/cephadm/template.py
@@ -1,7 +1,7 @@
 import copy
 from typing import Optional
 
-from jinja2 import Environment, PackageLoader, select_autoescape, StrictUndefined
+from jinja2 import Environment, PackageLoader, select_autoescape, StrictUndefined, Template
 from jinja2 import exceptions as j2_exceptions
 
 
@@ -43,6 +43,17 @@ class Jinja2Engine(TemplateEngine):
         except j2_exceptions.TemplateNotFound as e:
             raise TemplateNotFoundError(e.message)
 
+    def render_plain(self, source, context):
+        try:
+            template = self.env.from_string(source)
+            if context is None:
+                return template.render()
+            return template.render(context)
+        except j2_exceptions.UndefinedError as e:
+            raise UndefinedError(e.message)
+        except j2_exceptions.TemplateNotFound as e:
+            raise TemplateNotFoundError(e.message)
+
 
 class TemplateMgr:
     def __init__(self):
@@ -71,3 +82,4 @@ class TemplateMgr:
         if context is not None:
             ctx = {**ctx, **context}
         return self.engine.render(name, ctx)
+

--- a/src/pybind/mgr/cephadm/templates/lsmcli_blink_lights_cmd.j2
+++ b/src/pybind/mgr/cephadm/templates/lsmcli_blink_lights_cmd.j2
@@ -1,0 +1,1 @@
+lsmcli local-disk-{{ ident_fault }}-led-{{'on' if on else 'off'}} --path '{{ path or dev }}'

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -605,6 +605,16 @@ class TestCephadm(object):
             _run_cephadm.assert_called_with('test', 'osd', 'shell', [
                                             '--', 'lsmcli', f'local-disk-{fault_ident}-led-{on_off}', '--path', 'dev'], error_ok=True)
 
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm")
+    def test_blink_device_light_custom(self, _run_cephadm, cephadm_module):
+        _run_cephadm.return_value = '{}', '', 0
+        with with_host(cephadm_module, 'test'):
+            cephadm_module.set_store('lsmcli_blink_lights_cmd', 'echo hello')
+            c = cephadm_module.blink_device_light('ident', True, [('test', '', 'dev')])
+            assert wait(cephadm_module, c) == ['Set ident light for test: on']
+            _run_cephadm.assert_called_with('test', 'osd', 'shell', [
+                                            '--', 'echo', 'hello'], error_ok=True)
+
     @pytest.mark.parametrize(
         "spec, meth",
         [


### PR DESCRIPTION
Blink a device light. Calling something like:

    lsmcli local-disk-ident-led-on --path $path

If you must, you can customize this via:

    ceph config-key set mgr/cephadm/lsmcli_blink_lights_cmd '<my jinja2 template>'

where my jinja2 template is something like:

    lsmcli local-disk-{{ ident_fault }}-led-{{'on' if on else 'off'}} --path '{{ path or dev }}'

If this ever comes as a feature request in the tracker, I'm happy to add a documentation 
section for it. Till then I'd be happy to leave it out.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
