### PR TITLE
common/options: change the default value of option osd_async_recovery_min_cost from 100 to 10

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,6 +1,9 @@
 >=16.0.0
 --------
 
+* The default value for the option ``osd_async_recovery_min_cost`` is now 10
+  as compared to 100.
+
 * The ``ceph df`` command now lists the number of pgs in each pool.
 
 * Monitors now have config option ``mon_allow_pool_size_one``, which is disabled

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3389,7 +3389,7 @@ std::vector<Option> get_global_options() {
     .set_description("Approximate missing objects above which to force auth_log_shard to be primary temporarily"),
 
     Option("osd_async_recovery_min_cost", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(100)
+    .set_default(10)
     .set_description("A mixture measure of number of current log entries difference "
                      "and historical missing objects,  above which we switch to use "
                      "asynchronous recovery when appropriate"),


### PR DESCRIPTION
common/options: change the default value of option osd_async_recovery_min_cost from 100 to 10
While testing different RGW workloads we do not see async recovery benefits
specifically in EC pools with the default async recovery cost 100.
We changed the value from 100 to 10 and we saw a good amount of async recovery
activity during pgs recovery.

Fixes: https://tracker.ceph.com/issues/47223
Signed-off-by: Vikhyat Umrao <vikhyat@redhat.com>


