### PR TITLE
osdc: Implement truncate throttle

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3863,6 +3863,11 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description(""),
 
+    Option("osdc_max_truncate_ops", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(8192)
+    .set_min(128)
+    .set_description("maximum number of truncate operations performed in parallel"),
+
     Option("osd_discard_disconnected_ops", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description(""),

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -137,7 +137,8 @@ public:
 MDCache::MDCache(MDSRank *m, PurgeQueue &purge_queue_) :
   mds(m),
   open_file_table(m),
-  filer(m->objecter, m->finisher),
+  trunc_work_queue(m->objecter, m->finisher),
+  filer(m->objecter, m->finisher, &trunc_work_queue),
   stray_manager(m, purge_queue_),
   recovery_queue(m),
   trim_counter(g_conf().get_val<double>("mds_cache_trim_decay_rate"))
@@ -290,6 +291,7 @@ bool MDCache::shutdown()
     show_subtrees();
     //dump();
   }
+  trunc_work_queue.set_stopping();
   return true;
 }
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1139,6 +1139,7 @@ class MDCache {
 
   std::unique_ptr<PerfCounters> logger;
 
+  TruncWorkQueue trunc_work_queue;
   Filer filer;
   bool exceeded_size_limit = false;
   std::array<xlist<ClientLease*>, client_lease_pools> client_leases{};


### PR DESCRIPTION
The throttle can ensure mds will not send the flooding of truncate ops.

Signed-off-by: Alice Zheng <alice.zheng@bigtera.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
