### PR TITLE
mgr/cephadm: remove keyring during daemon post-remove

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2038,14 +2038,14 @@ To check that the host is reachable:
         Remove a daemon
         """
         (daemon_type, daemon_id) = name.split('.', 1)
+        daemon = orchestrator.DaemonDescription(
+            daemon_type=daemon_type,
+            daemon_id=daemon_id,
+            hostname=host)
 
-        with set_exception_subject('service', orchestrator.DaemonDescription(
-                daemon_type=daemon_type,
-                daemon_id=daemon_id,
-                hostname=host,
-        ).service_id(), overwrite=True):
+        with set_exception_subject('service', daemon.service_id(), overwrite=True):
 
-            self.cephadm_services[daemon_type].pre_remove(daemon_id)
+            self.cephadm_services[daemon_type].pre_remove(daemon)
 
             args = ['--name', name, '--force']
             self.log.info('Removing daemon %s from %s' % (name, host))
@@ -2056,7 +2056,7 @@ To check that the host is reachable:
                 self.cache.rm_daemon(host, name)
             self.cache.invalidate_host_daemons(host)
 
-            self.cephadm_services[daemon_type].post_remove(daemon_id)
+            self.cephadm_services[daemon_type].post_remove(daemon)
 
             return "Removed {} from host '{}'".format(name, host)
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2055,6 +2055,9 @@ To check that the host is reachable:
                 # remove item from cache
                 self.cache.rm_daemon(host, name)
             self.cache.invalidate_host_daemons(host)
+
+            self.cephadm_services[daemon_type].post_remove(daemon_id)
+
             return "Removed {} from host '{}'".format(name, host)
 
     def _config_fn(self, service_type) -> Optional[Callable[[ServiceSpec], None]]:

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -294,6 +294,10 @@ class CephService(CephadmService):
         daemon_id: str = daemon.daemon_id
         host: str = daemon.hostname
 
+        if daemon_id == 'mon':
+            # do not remove the mon keyring
+            return
+
         entity = self.get_auth_entity(daemon_id, host=host)
 
         logger.info(f'Remove keyring: {entity}')

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -216,7 +216,13 @@ class CephadmService(metaclass=ABCMeta):
         """
         Called before the daemon is removed.
         """
-        pass
+        logger.debug(f'Pre remove daemon {self.TYPE}.{daemon_id}')
+
+    def post_remove(self, daemon_id: str) -> None:
+        """
+        Called after the daemon is removed.
+        """
+        logger.debug(f'Post remove daemon {self.TYPE}.{daemon_id}')
 
 
 class CephService(CephadmService):
@@ -354,6 +360,7 @@ class MonService(CephService):
             'Removing %s would break mon quorum (new quorum %s, new mons %s)' % (mon_id, new_quorum, new_mons))
 
     def pre_remove(self, daemon_id: str) -> None:
+        super().pre_remove(daemon_id)
         self._check_safe_to_destroy(daemon_id)
 
         # remove mon from quorum before we destroy the daemon

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -212,17 +212,19 @@ class CephadmService(metaclass=ABCMeta):
         logger.info(out)
         return HandleCommandResult(r.retval, out, r.stderr)
 
-    def pre_remove(self, daemon_id: str) -> None:
+    def pre_remove(self, daemon: DaemonDescription) -> None:
         """
         Called before the daemon is removed.
         """
-        logger.debug(f'Pre remove daemon {self.TYPE}.{daemon_id}')
+        assert self.TYPE == daemon.daemon_type
+        logger.debug(f'Pre remove daemon {self.TYPE}.{daemon.daemon_id}')
 
-    def post_remove(self, daemon_id: str) -> None:
+    def post_remove(self, daemon: DaemonDescription) -> None:
         """
         Called after the daemon is removed.
         """
-        logger.debug(f'Post remove daemon {self.TYPE}.{daemon_id}')
+        assert self.TYPE == daemon.daemon_type
+        logger.debug(f'Post remove daemon {self.TYPE}.{daemon.daemon_id}')
 
 
 class CephService(CephadmService):
@@ -359,8 +361,10 @@ class MonService(CephService):
         raise OrchestratorError(
             'Removing %s would break mon quorum (new quorum %s, new mons %s)' % (mon_id, new_quorum, new_mons))
 
-    def pre_remove(self, daemon_id: str) -> None:
-        super().pre_remove(daemon_id)
+    def pre_remove(self, daemon: DaemonDescription) -> None:
+        super().pre_remove(daemon)
+
+        daemon_id: str = daemon.daemon_id
         self._check_safe_to_destroy(daemon_id)
 
         # remove mon from quorum before we destroy the daemon


### PR DESCRIPTION
Remove keyrings during a daemon post-remove action.

After:
- [x] #36935

Fixes: https://tracker.ceph.com/issues/47298
Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
