### PR TITLE
rgw: Make sure 'target' is available before proceeding

### DIFF
--- a/src/rgw/services/svc_sys_obj_cache.cc
+++ b/src/rgw/services/svc_sys_obj_cache.cc
@@ -567,17 +567,16 @@ int RGWSI_SysObj_Cache_ASocketHook::call(
     svc->asocket.call_list(filter, f);
     f->close_section();
     return 0;
-  } else if (command == "cache inspect"sv) {
-    const auto& target = boost::get<std::string>(cmdmap.at("target"));
-    if (svc->asocket.call_inspect(target, f)) {
-      return 0;
-    } else {
-      ss << "Unable to find entry "s + target + ".\n";
+  } else if (command == "cache inspect"sv || command == "cache erase"sv) {
+    if (cmdmap.find("target") == cmdmap.cend())
+    {
+      ss << "No target specified\n";
       return -ENOENT;
     }
-  } else if (command == "cache erase"sv) {
     const auto& target = boost::get<std::string>(cmdmap.at("target"));
-    if (svc->asocket.call_erase(target)) {
+    if (command == "cache inspect"sv && svc->asocket.call_inspect(target, f)) {
+      return 0;
+    } else if (command == "cache erase"sv && svc->asocket.call_erase(target)) {
       return 0;
     } else {
       ss << "Unable to find entry "s + target + ".\n";


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47179

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
