### PR TITLE
mgr/dashboard: Improving notification sidebar card spacing

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.html
@@ -1,9 +1,9 @@
 <ng-template #tasksTpl>
   <!-- Executing -->
   <div *ngFor="let executingTask of executingTasks; trackBy:trackByFn">
-    <div class="card tc_task border-0 mb-3">
+    <div class="card tc_task border-0">
       <div class="row no-gutters">
-        <div class="col-md-3 text-center">
+        <div class="col-md-2 text-center">
           <span [ngClass]="[icons.stack, icons.large2x]"
                 class="text-info">
             <i [ngClass]="[icons.stack2x, icons.circle]"></i>
@@ -11,7 +11,7 @@
           </span>
         </div>
         <div class="col-md-9">
-          <div class="card-body p-0">
+          <div class="card-body p-1">
             <h6 class="card-title bold">{{ executingTask.description }}</h6>
 
             <div class="mb-1">
@@ -54,16 +54,16 @@
     <hr>
 
     <div *ngFor="let notification of notifications; let i = index">
-      <div class="card tc_notification border-0 mb-3">
+      <div class="card tc_notification border-0">
         <div class="row no-gutters">
-          <div class="col-md-3 text-center">
-            <span [ngClass]="[icons.stack, icons.large2x, notification.textClass]">
+          <div class="col-md-2 text-center">
+            <span [ngClass]="[icons.stack, icons.large2x,  notification.textClass]">
               <i [ngClass]="[icons.circle, icons.stack2x]"></i>
               <i [ngClass]="[icons.stack1x, icons.inverse, notification.iconClass]"></i>
             </span>
           </div>
-          <div class="col-md-9">
-            <div class="card-body p-0">
+          <div class="col-md-10">
+            <div class="card-body p-1">
               <button class="btn btn-link float-right mt-0 pt-0"
                       title="Remove notification"
                       i18n-title
@@ -114,7 +114,9 @@
             tabindex="-1"
             type="button"
             (click)="closeSidebar()">
-      <span>×</span>
+      <span>
+        <i [ngClass]="icons.close"></i>
+      </span>
     </button>
   </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.scss
@@ -22,6 +22,10 @@
   height: 100%;
 }
 
+.card-body {
+  padding-left: 5px;
+}
+
 ngx-simplebar {
   height: calc(100% - 42.2px);
 }
@@ -44,4 +48,8 @@ table {
 .row {
   margin-left: 0;
   margin-right: 0;
+}
+
+.fa-times {
+  margin-right: 10px;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/icons.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/icons.enum.ts
@@ -61,6 +61,7 @@ export enum Icons {
   clearFilters = 'fa fa-window-close', // Clear filters, solid x
   download = 'fa fa-download', // Download
   upload = 'fa fa-upload', // Upload
+  close = 'fa fa-times', // Close
 
   /* Icons for special effect */
   large = 'fa fa-lg', // icon becomes 33% larger


### PR DESCRIPTION
There were some unnecessary spacings in the notification sidebar cards. This commit is a cleanup for taking care of that spaces.

**Before:**
![oldnot](https://user-images.githubusercontent.com/53651462/91942220-30167e80-ed18-11ea-8f74-6be9ceab58c2.png)

**After:**
![newnot](https://user-images.githubusercontent.com/53651462/91942236-39075000-ed18-11ea-8d4a-bb6999ebd1f2.png)

Fixes: https://tracker.ceph.com/issues/47262

Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
