### PR TITLE
doc/mgr/administrator: add a more precise description for creating key

### DIFF
--- a/doc/mgr/administrator.rst
+++ b/doc/mgr/administrator.rst
@@ -14,8 +14,8 @@ First, create an authentication key for your daemon::
 
     ceph auth get-or-create mgr.$name mon 'allow profile mgr' osd 'allow *' mds 'allow *'
 
-Place that key into ``mgr data`` path, which for a cluster "ceph"
-and mgr $name "foo" would be ``/var/lib/ceph/mgr/ceph-foo``.
+Place that key as file named ``keyring`` into ``mgr data`` path, which for a cluster "ceph"
+and mgr $name "foo" would be ``/var/lib/ceph/mgr/ceph-foo`` respective ``/var/lib/ceph/mgr/ceph-foo/keyring``.
 
 Start the ceph-mgr daemon::
 


### PR DESCRIPTION
added a more precise description how to handle filename when creating key for mgr
