### PR TITLE
nautilus: mon/PGMap: add pg count for pools in the ceph df command

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,17 +1,7 @@
->= 14.2.11
+>= 14.2.12
 ----------
 
-* RGW: The ``radosgw-admin`` sub-commands dealing with orphans --
-  ``radosgw-admin orphans find``, ``radosgw-admin orphans finish``,
-  ``radosgw-admin orphans list-jobs`` -- have been deprecated. They
-  have not been actively maintained and they store intermediate
-  results on the cluster, which could fill a nearly-full cluster.
-  They have been replaced by a tool, currently considered
-  experimental, ``rgw-orphan-list``.
-
-* Now when noscrub and/or nodeep-scrub flags are set globally or per pool,
-  scheduled scrubs of the type disabled will be aborted. All user initiated
-  scrubs are NOT interrupted.
+* The ``ceph df`` command now lists the number of pgs in each pool.
 
 * Monitors now have a config option ``mon_osd_warn_num_repaired``, 10 by default.
   If any OSD has repaired more than this many I/O errors in stored data a

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -759,6 +759,7 @@ void PGMapDigest::dump_pool_stats_full(
   } else {
     tbl.define_column("POOL", TextTable::LEFT, TextTable::LEFT);
     tbl.define_column("ID", TextTable::LEFT, TextTable::RIGHT);
+    tbl.define_column("PGS", TextTable::LEFT, TextTable::RIGHT);
     tbl.define_column("STORED", TextTable::LEFT, TextTable::RIGHT);
     tbl.define_column("OBJECTS", TextTable::LEFT, TextTable::RIGHT);
     tbl.define_column("USED", TextTable::LEFT, TextTable::RIGHT);
@@ -782,6 +783,7 @@ void PGMapDigest::dump_pool_stats_full(
       continue;
 
     const string& pool_name = osd_map.get_pool_name(pool_id);
+    auto pool_pg_num = osd_map.get_pg_num(pool_id);
     const pool_stat_t &stat = pg_pool_sum.at(pool_id);
 
     const pg_pool_t *pool = osd_map.get_pg_pool(pool_id);
@@ -805,7 +807,8 @@ void PGMapDigest::dump_pool_stats_full(
       f->open_object_section("stats");
     } else {
       tbl << pool_name
-          << pool_id;
+          << pool_id
+          << pool_pg_num;
     }
     float raw_used_rate = osd_map.pool_raw_used_rate(pool_id);
     bool per_pool = use_per_pool_stats();


### PR DESCRIPTION
https://tracker.ceph.com/issues/47257

---

nautilus: mon/PGMap: add pg count for pools in the ceph df command
Fixes: https://tracker.ceph.com/issues/46663

Signed-off-by: Vikhyat Umrao <vikhyat@redhat.com>
(cherry picked from commit 9ffbffbe6cd1d8dafb1dd88cbc1ce644afc7a915)

 Conflicts:
	PendingReleaseNotes
        - Taking only release notes line for this commit
