### PR TITLE
Revert "mgr/osd_support: remove module and all traces"

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1641,6 +1641,7 @@ fi
 %{_datadir}/ceph/mgr/mds_autoscaler
 %{_datadir}/ceph/mgr/orchestrator
 %{_datadir}/ceph/mgr/osd_perf_query
+%{_datadir}/ceph/mgr/osd_support
 %{_datadir}/ceph/mgr/pg_autoscaler
 %{_datadir}/ceph/mgr/progress
 %{_datadir}/ceph/mgr/prometheus

--- a/debian/ceph-mgr-modules-core.install
+++ b/debian/ceph-mgr-modules-core.install
@@ -8,6 +8,7 @@ usr/share/ceph/mgr/iostat
 usr/share/ceph/mgr/localpool
 usr/share/ceph/mgr/orchestrator
 usr/share/ceph/mgr/osd_perf_query
+usr/share/ceph/mgr/osd_support
 usr/share/ceph/mgr/pg_autoscaler
 usr/share/ceph/mgr/progress
 usr/share/ceph/mgr/prometheus

--- a/src/pybind/mgr/osd_support/__init__.py
+++ b/src/pybind/mgr/osd_support/__init__.py
@@ -1,0 +1,1 @@
+from .module import OSDSupport

--- a/src/pybind/mgr/osd_support/module.py
+++ b/src/pybind/mgr/osd_support/module.py
@@ -1,0 +1,19 @@
+from mgr_module import MgrModule
+
+
+class OSDSupport(MgrModule):
+    # Kept to keep upgrades from older point releases working.
+    # This module can be removed as soon as we no longer
+    # support upgrades from old octopus point releases.
+
+    # On the other hand, if you find a use for this module,
+    # Feel free to use it!
+
+    COMMANDS = []
+
+    MODULE_OPTIONS: []
+
+    NATIVE_OPTIONS: []
+
+    def __init__(self, *args, **kwargs):
+        super(OSDSupport, self).__init__(*args, **kwargs)


### PR DESCRIPTION
This reverts commit a55c1dd0fac826978edf22e448c3456e7634cbc3.

Kept to keep upgrades from older point releases working.
This module can be removed as soon as we no longer
support upgrades from old octopus point releases.

Revert "build/debian: remove osd_support"

This reverts commit 8ff2824beb78dfd03710e94302f038ea70fb4561.

Fixes: https://tracker.ceph.com/issues/47109
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
