### PR TITLE
ceph-volume: simple scan should ignore tmpfs

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/simple/scan.py
+++ b/src/ceph-volume/ceph_volume/devices/simple/scan.py
@@ -375,8 +375,11 @@ class Scan(object):
             self.encryption_metadata = encryption.legacy_encrypted(args.osd_path)
             self.is_encrypted = self.encryption_metadata['encrypted']
 
-            device = Device(self.encryption_metadata['device'])
-            if not device.is_ceph_disk_member:
-                terminal.warning("Ignoring %s because it's not a ceph-disk created osd." % path)
+            if self.encryption_metadata['device'] != "tmpfs":
+                device = Device(self.encryption_metadata['device'])
+                if not device.is_ceph_disk_member:
+                    terminal.warning("Ignoring %s because it's not a ceph-disk created osd." % path)
+                else:
+                    self.scan(args)
             else:
-                self.scan(args)
+                terminal.warning("Ignoring %s because it's not a ceph-disk created osd." % path)


### PR DESCRIPTION
When simple scan is ran against a ceph-volume
OSD, util.encryption.legacy_encrypted returns
tmpfs. We want to avoid creating a Device
object with tmpfs and ignore the OSD as it's
not a ceph-disk created OSD.

Resolves: rhbz#1872983

Signed-off-by: Andrew Schoen <aschoen@redhat.com>