### PR TITLE
crimson/admin: use tell_result_t(unique_ptr<Formatter>)

### DIFF
--- a/src/crimson/admin/admin_socket.cc
+++ b/src/crimson/admin/admin_socket.cc
@@ -37,7 +37,7 @@ tell_result_t::tell_result_t(int ret, std::string&& err, ceph::bufferlist&& out)
   : ret{ret}, err(std::move(err)), out(std::move(out))
 {}
 
-tell_result_t::tell_result_t(Formatter* formatter)
+tell_result_t::tell_result_t(std::unique_ptr<Formatter> formatter)
 {
   formatter->flush(out);
 }
@@ -301,7 +301,7 @@ class VersionHook final : public AdminSocketHook {
     f->dump_string("release", ceph_release_to_str());
     f->dump_string("release_type", ceph_release_type());
     f->close_section();
-    return seastar::make_ready_future<tell_result_t>(f.get());
+    return seastar::make_ready_future<tell_result_t>(std::move(f));
   }
 };
 
@@ -322,7 +322,7 @@ class GitVersionHook final : public AdminSocketHook {
     f->open_object_section("version");
     f->dump_string("git_version", git_version_to_str());
     f->close_section();
-    return seastar::make_ready_future<tell_result_t>(f.get());
+    return seastar::make_ready_future<tell_result_t>(std::move(f));
   }
 };
 
@@ -349,7 +349,7 @@ class HelpHook final : public AdminSocketHook {
 	}
       }
       f->close_section();
-      return seastar::make_ready_future<tell_result_t>(f.get());
+      return seastar::make_ready_future<tell_result_t>(std::move(f));
     });
   }
 };
@@ -380,7 +380,7 @@ class GetdescsHook final : public AdminSocketHook {
         cmdnum++;
       }
       f->close_section();
-      return seastar::make_ready_future<tell_result_t>(f.get());
+      return seastar::make_ready_future<tell_result_t>(std::move(f));
     });
   }
 };
@@ -428,7 +428,7 @@ public:
     f->open_object_section("config_show");
     local_conf().show_config(f.get());
     f->close_section();
-    return seastar::make_ready_future<tell_result_t>(f.get());
+    return seastar::make_ready_future<tell_result_t>(std::move(f));
   }
 };
 
@@ -461,7 +461,7 @@ public:
     f->open_object_section("config_get");
     f->dump_string(var, conf_val);
     f->close_section();
-    return seastar::make_ready_future<tell_result_t>(f.get());
+    return seastar::make_ready_future<tell_result_t>(std::move(f));
   }
 };
 
@@ -492,7 +492,7 @@ public:
       f->open_object_section("config_set");
       f->dump_string("success", "");
       f->close_section();
-      return seastar::make_ready_future<tell_result_t>(f.get());
+      return seastar::make_ready_future<tell_result_t>(std::move(f));
     }).handle_exception_type([](std::invalid_argument& e) {
       return seastar::make_ready_future<tell_result_t>(
         tell_result_t{-EINVAL, e.what()});

--- a/src/crimson/admin/admin_socket.h
+++ b/src/crimson/admin/admin_socket.h
@@ -44,7 +44,7 @@ struct tell_result_t {
    * \param formatter the content of formatter will be flushed to the
    *        output buffer
    */
-  tell_result_t(Formatter* formatter);
+  tell_result_t(std::unique_ptr<Formatter> formatter);
 };
 
 /**

--- a/src/crimson/admin/osd_admin.cc
+++ b/src/crimson/admin/osd_admin.cc
@@ -47,7 +47,7 @@ public:
     f->open_object_section("status");
     osd.dump_status(f.get());
     f->close_section();
-    return seastar::make_ready_future<tell_result_t>(f.get());
+    return seastar::make_ready_future<tell_result_t>(std::move(f));
   }
 private:
   const crimson::osd::OSD& osd;
@@ -98,7 +98,7 @@ public:
     uint64_t seq = osd.send_pg_stats();
     unique_ptr<Formatter> f{Formatter::create(format, "json-pretty", "json-pretty")};
     f->dump_unsigned("stat_seq", seq);
-    return seastar::make_ready_future<tell_result_t>(tell_result_t(f.get()));
+    return seastar::make_ready_future<tell_result_t>(std::move(f));
   }
 
 private:
@@ -125,7 +125,7 @@ public:
     f->open_object_section("pgstate_history");
     osd.dump_pg_state_history(f.get());
     f->close_section();
-    return seastar::make_ready_future<tell_result_t>(f.get());
+    return seastar::make_ready_future<tell_result_t>(std::move(f));
   }
 private:
   const crimson::osd::OSD& osd;
@@ -183,7 +183,7 @@ public:
      }
    }
    f->close_section();
-   return seastar::make_ready_future<tell_result_t>(f.get());
+   return seastar::make_ready_future<tell_result_t>(std::move(f));
  }
 };
 template std::unique_ptr<AdminSocketHook> make_asok_hook<SeastarMetricsHook>();


### PR DESCRIPTION
to address the comment of

> Taking the `Formatter` by pointer was a bit confusing in the matter of
> lifetime control.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
