### PR TITLE
nautilus: mds: fix mds forwarding request 'no_available_op_found'

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -9418,7 +9418,9 @@ void MDCache::request_finish(MDRequestRef& mdr)
 
 void MDCache::request_forward(MDRequestRef& mdr, mds_rank_t who, int port)
 {
-  mdr->mark_event("forwarding request");
+  CachedStackStringStream css;
+  *css << "forwarding request to mds." << who;
+  mdr->mark_event(css->strv());
   if (mdr->client_request && mdr->client_request->get_source().is_client()) {
     dout(7) << "request_forward " << *mdr << " to mds." << who << " req "
             << *mdr->client_request << dendl;

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -366,6 +366,7 @@ MClientRequest::const_ref MDRequestImpl::release_client_request()
   msg_lock.lock();
   MClientRequest::const_ref req;
   req.swap(client_request);
+  client_request = req;
   msg_lock.unlock();
   return req;
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46633

---

backport of https://github.com/ceph/ceph/pull/36107
parent tracker: https://tracker.ceph.com/issues/46543

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh