### PR TITLE
nautilus: mds/CInode: Optimize only pinned by subtrees check

### DIFF
--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -600,6 +600,9 @@ public:
         ls.push_back(dir);
     }
   }
+  int get_num_subtree_roots() const {
+    return num_subtree_roots;
+  }
 
   CDir *get_or_open_dirfrag(MDCache *mdcache, frag_t fg);
   CDir *add_dirfrag(CDir *dir);

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6706,9 +6706,7 @@ std::pair<bool, uint64_t> MDCache::trim(uint64_t count)
       if (!diri->is_auth()) {
 	if (dir->get_num_ref() > 1)  // only subtree pin
 	  continue;
-	list<CDir*> ls;
-	diri->get_subtree_dirfrags(ls);
-	if (diri->get_num_ref() > (int)ls.size()) // only pinned by subtrees
+	if (diri->get_num_ref() > diri->get_num_subtree_roots())
 	  continue;
 
 	// don't trim subtree root if its auth MDS is recovering.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46784

---

backport of https://github.com/ceph/ceph/pull/36288
parent tracker: https://tracker.ceph.com/issues/46727

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh