### PR TITLE
nautilus: mds: resolve SIGSEGV in waiting for uncommitted fragments

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -11985,10 +11985,13 @@ void MDCache::rollback_uncommitted_fragment(dirfrag_t basedirfrag, frag_vec_t&& 
   }
 }
 
-void MDCache::wait_for_uncommitted_fragments(MDSGather *gather)
+void MDCache::wait_for_uncommitted_fragments(MDSContext* finisher)
 {
-  for (auto& p : uncommitted_fragments)
-    p.second.waiters.push_back(gather->new_sub());
+  MDSGatherBuilder gather(g_ceph_context, finisher);
+  for (auto& p : uncommitted_fragments) {
+    p.second.waiters.push_back(gather.new_sub());
+  }
+  gather.activate();
 }
 
 void MDCache::rollback_uncommitted_fragments()

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1254,7 +1254,7 @@ public:
   bool is_any_uncommitted_fragment() const {
     return !uncommitted_fragments.empty();
   }
-  void wait_for_uncommitted_fragments(MDSGather *gather);
+  void wait_for_uncommitted_fragments(MDSContext* finisher);
   void rollback_uncommitted_fragments();
 
   void split_dir(CDir *dir, int byn);

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1918,9 +1918,7 @@ void MDSRank::rejoin_done()
 
   if (mdcache->is_any_uncommitted_fragment()) {
     dout(1) << " waiting for uncommitted fragments" << dendl;
-    MDSGatherBuilder gather(g_ceph_context, new C_MDS_VoidFn(this, &MDSRank::rejoin_done));
-    mdcache->wait_for_uncommitted_fragments(gather.get());
-    gather.activate();
+    mdcache->wait_for_uncommitted_fragments(new C_MDS_VoidFn(this, &MDSRank::rejoin_done));
     return;
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46943

---

backport of https://github.com/ceph/ceph/pull/36358
parent tracker: https://tracker.ceph.com/issues/46765

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh