### PR TITLE
rgw: add check for ACL when create existing bucket

### DIFF
--- a/src/rgw/rgw_acl.cc
+++ b/src/rgw/rgw_acl.cc
@@ -15,6 +15,64 @@
 
 #define dout_subsys ceph_subsys_rgw
 
+bool operator==(const ACLPermission& lhs, const ACLPermission& rhs) {
+  return lhs.flags == rhs.flags;
+}
+bool operator!=(const ACLPermission& lhs, const ACLPermission& rhs) {
+  return !(lhs == rhs);
+}
+
+bool operator==(const ACLGranteeType& lhs, const ACLGranteeType& rhs) {
+  return lhs.type == rhs.type;
+}
+bool operator!=(const ACLGranteeType& lhs, const ACLGranteeType& rhs) {
+  return lhs.type != rhs.type;
+}
+
+bool operator==(const ACLGrant& lhs, const ACLGrant& rhs) {
+  return lhs.type == rhs.type && lhs.id == rhs.id
+      && lhs.email == rhs.email && lhs.permission == rhs.permission
+      && lhs.name == rhs.name && lhs.group == rhs.group
+      && lhs.url_spec == rhs.url_spec;
+}
+bool operator!=(const ACLGrant& lhs, const ACLGrant& rhs) {
+  return !(lhs == rhs);
+}
+
+bool operator==(const ACLReferer& lhs, const ACLReferer& rhs) {
+  return lhs.url_spec == rhs.url_spec && lhs.perm == rhs.perm;
+}
+bool operator!=(const ACLReferer& lhs, const ACLReferer& rhs) {
+  return !(lhs == rhs);
+}
+
+bool operator==(const RGWAccessControlList& lhs,
+                const RGWAccessControlList& rhs) {
+  return lhs.acl_user_map == rhs.acl_user_map
+      && lhs.acl_group_map == rhs.acl_group_map
+      && lhs.referer_list == rhs.referer_list
+      && lhs.grant_map == rhs.grant_map;
+}
+bool operator!=(const RGWAccessControlList& lhs,
+                const RGWAccessControlList& rhs) {
+  return !(lhs == rhs);
+}
+
+bool operator==(const ACLOwner& lhs, const ACLOwner& rhs) {
+  return lhs.id == rhs.id && lhs.display_name == rhs.display_name;
+}
+bool operator!=(const ACLOwner& lhs, const ACLOwner& rhs) {
+  return !(lhs == rhs);
+}
+
+bool operator==(const RGWAccessControlPolicy& lhs,
+                const RGWAccessControlPolicy& rhs) {
+  return lhs.acl == rhs.acl && lhs.owner == rhs.owner;
+}
+bool operator!=(const RGWAccessControlPolicy& lhs,
+                const RGWAccessControlPolicy& rhs) {
+  return !(lhs == rhs);
+}
 
 void RGWAccessControlList::_add_grant(ACLGrant *grant)
 {

--- a/src/rgw/rgw_acl.h
+++ b/src/rgw/rgw_acl.h
@@ -68,6 +68,9 @@ public:
   }
   void dump(Formatter *f) const;
   static void generate_test_instances(list<ACLPermission*>& o);
+
+  friend bool operator==(const ACLPermission& lhs, const ACLPermission& rhs);
+  friend bool operator!=(const ACLPermission& lhs, const ACLPermission& rhs);
 };
 WRITE_CLASS_ENCODER(ACLPermission)
 
@@ -94,6 +97,9 @@ public:
   }
   void dump(Formatter *f) const;
   static void generate_test_instances(list<ACLGranteeType*>& o);
+
+  friend bool operator==(const ACLGranteeType& lhs, const ACLGranteeType& rhs);
+  friend bool operator!=(const ACLGranteeType& lhs, const ACLGranteeType& rhs);
 };
 WRITE_CLASS_ENCODER(ACLGranteeType)
 
@@ -204,6 +210,9 @@ public:
     url_spec = _url_spec;
     permission.set_permissions(perm);
   }
+
+  friend bool operator==(const ACLGrant& lhs, const ACLGrant& rhs);
+  friend bool operator!=(const ACLGrant& lhs, const ACLGrant& rhs);
 };
 WRITE_CLASS_ENCODER(ACLGrant)
 
@@ -254,6 +263,9 @@ struct ACLReferer {
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
+
+  friend bool operator==(const ACLReferer& lhs, const ACLReferer& rhs);
+  friend bool operator!=(const ACLReferer& lhs, const ACLReferer& rhs);
 
 private:
   boost::optional<std::string_view> get_http_host(const std::string_view url) const {
@@ -359,6 +371,9 @@ public:
     grant.set_canon(id, name, RGW_PERM_FULL_CONTROL);
     add_grant(&grant);
   }
+
+  friend bool operator==(const RGWAccessControlList& lhs, const RGWAccessControlList& rhs);
+  friend bool operator!=(const RGWAccessControlList& lhs, const RGWAccessControlList& rhs);
 };
 WRITE_CLASS_ENCODER(RGWAccessControlList)
 
@@ -396,6 +411,9 @@ public:
   rgw_user& get_id() { return id; }
   const rgw_user& get_id() const { return id; }
   string& get_display_name() { return display_name; }
+
+  friend bool operator==(const ACLOwner& lhs, const ACLOwner& rhs);
+  friend bool operator!=(const ACLOwner& lhs, const ACLOwner& rhs);
 };
 WRITE_CLASS_ENCODER(ACLOwner)
 
@@ -467,6 +485,9 @@ public:
 
   virtual bool compare_group_name(string& id, ACLGroupTypeEnum group) { return false; }
   bool is_public() const;
+
+  friend bool operator==(const RGWAccessControlPolicy& lhs, const RGWAccessControlPolicy& rhs);
+  friend bool operator!=(const RGWAccessControlPolicy& lhs, const RGWAccessControlPolicy& rhs);
 };
 WRITE_CLASS_ENCODER(RGWAccessControlPolicy)
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3046,7 +3046,6 @@ void RGWCreateBucket::execute()
 {
   buffer::list aclbl;
   buffer::list corsbl;
-  bool existed;
   string bucket_name = rgw_make_bucket_entry_name(s->bucket_tenant, s->bucket_name);
   rgw_raw_obj obj(store->svc()->zone->get_zone_params().domain_root, bucket_name);
 
@@ -3169,11 +3168,10 @@ void RGWCreateBucket::execute()
    * recover from a partial create by retrying it. */
   ldpp_dout(this, 20) << "rgw_create_bucket returned ret=" << op_ret << " bucket=" << s->bucket.get() << dendl;
 
-  if (op_ret && op_ret != -EEXIST)
+  if (op_ret)
     return;
 
-  existed = (op_ret == -EEXIST);
-
+  const bool existed = s->bucket_exists;
   if (existed) {
     /* bucket already existed, might have raced with another bucket creation, or
      * might be partial bucket creation that never completed. Read existing bucket

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3161,7 +3161,7 @@ void RGWCreateBucket::execute()
   op_ret = store->create_bucket(*s->user, tmp_bucket, zonegroup_id,
 				placement_rule,
 				info.swift_ver_location,
-				pquota_info, attrs, info, ep_objv,
+				pquota_info, policy, attrs, info, ep_objv,
 				true, obj_lock_enabled, &s->bucket_exists, s->info,
 				&s->bucket);
 
@@ -6892,7 +6892,7 @@ int RGWBulkUploadOp::handle_dir(const std::string_view path)
   op_ret = store->create_bucket(*s->user, new_bucket,
                                 store->get_zonegroup().get_id(),
                                 placement_rule, swift_ver_location,
-                                pquota_info, attrs,
+                                pquota_info, policy, attrs,
                                 out_info, ep_objv,
                                 true, false, &bucket_exists,
 				info, &bucket);

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -61,6 +61,7 @@ class RGWStore : public DoutPrefixProvider {
                             rgw_placement_rule& placement_rule,
                             std::string& swift_ver_location,
                             const RGWQuotaInfo * pquota_info,
+                            const RGWAccessControlPolicy& policy,
 			    RGWAttrs& attrs,
                             RGWBucketInfo& info,
                             obj_version& ep_objv,

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -829,6 +829,7 @@ int RGWRadosStore::create_bucket(RGWUser& u, const rgw_bucket& b,
 				 rgw_placement_rule& placement_rule,
 				 string& swift_ver_location,
 				 const RGWQuotaInfo * pquota_info,
+				 const RGWAccessControlPolicy& policy,
 				 RGWAttrs& attrs,
 				 RGWBucketInfo& info,
 				 obj_version& ep_objv,
@@ -844,7 +845,6 @@ int RGWRadosStore::create_bucket(RGWUser& u, const rgw_bucket& b,
   rgw_bucket *pmaster_bucket;
   uint32_t *pmaster_num_shards;
   real_time creation_time;
-  RGWAccessControlPolicy old_policy(ctx());
   std::unique_ptr<RGWBucket> bucket;
   obj_version objv, *pobjv = NULL;
 
@@ -854,19 +854,19 @@ int RGWRadosStore::create_bucket(RGWUser& u, const rgw_bucket& b,
     return ret;
 
   if (ret != -ENOENT) {
+    RGWAccessControlPolicy old_policy(ctx());
     *existed = true;
     if (swift_ver_location.empty()) {
       swift_ver_location = bucket->get_info().swift_ver_location;
     }
     placement_rule.inherit_from(bucket->get_info().placement_rule);
+
+    // don't allow changes to the acl policy
     int r = rgw_op_get_bucket_policy_from_attr(this, u, bucket->get_attrs(),
 					       &old_policy);
-    if (r >= 0)  {
-      if (old_policy.get_owner().get_id().compare(u.get_id()) != 0) {
-	bucket_out->swap(bucket);
-	ret = -EEXIST;
-	return ret;
-      }
+    if (r >= 0 && old_policy != policy) {
+      bucket_out->swap(bucket);
+      return -EEXIST;
     }
   } else {
     bucket = std::unique_ptr<RGWBucket>(new RGWRadosBucket(this, b, &u));

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -925,6 +925,7 @@ int RGWRadosStore::create_bucket(RGWUser& u, const rgw_bucket& b,
 				    pmaster_bucket, pmaster_num_shards, exclusive);
     if (ret == -EEXIST) {
       *existed = true;
+      ret = 0;
     } else if (ret != 0) {
       return ret;
     }

--- a/src/rgw/rgw_sal_rados.h
+++ b/src/rgw/rgw_sal_rados.h
@@ -239,6 +239,7 @@ class RGWRadosStore : public RGWStore {
                             rgw_placement_rule& placement_rule,
                             std::string& swift_ver_location,
                             const RGWQuotaInfo * pquota_info,
+                            const RGWAccessControlPolicy& policy,
 			    RGWAttrs& attrs,
                             RGWBucketInfo& info,
                             obj_version& ep_objv,


### PR DESCRIPTION
some cleanups for https://github.com/ceph/ceph/pull/35170:
* use composition of `operator==()`s to avoid having to encode buffers for comparison
* adds `operator!=()`s
* changes the `create_bucket()` policy argument from an optional pointer to a const reference
* moves the acl owner comparison into `operator==()`

Fixes: https://tracker.ceph.com/issues/47028

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
