### PR TITLE
cephadm: fix iSCSI unit.run file

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -481,6 +481,9 @@ class CephIscsi(object):
         tcmu_container = get_container(self.fsid, self.daemon_type, self.daemon_id)
         tcmu_container.entrypoint = "/usr/bin/tcmu-runner"
         tcmu_container.cname = self.get_container_name(desc='tcmu')
+        # remove extra container args for tcmu container.
+        # extra args could cause issue with forking service type
+        tcmu_container.container_args = []
         return tcmu_container
 
 ##################################
@@ -1773,8 +1776,10 @@ def get_container_mounts(fsid, daemon_type, daemon_id,
 def get_container(fsid, daemon_type, daemon_id,
                   privileged=False,
                   ptrace=False,
-                  container_args=[]):
-    # type: (str, str, Union[int, str], bool, bool, List[str]) -> CephContainer
+                  container_args=None):
+    # type: (str, str, Union[int, str], bool, bool, Optional[List[str]]) -> CephContainer
+    if container_args is None:
+        container_args = []
     if daemon_type in ['mon', 'osd']:
         # mon and osd need privileged in order for libudev to query devices
         privileged = True


### PR DESCRIPTION
Current unit.run file generated for iSCSI when using podman
tries to have two containers use the same conmon pidfile and
cidfile for both containers which is invalid
Fixes: https://tracker.ceph.com/issues/47291

Signed-off-by: Adam King <adking@redhat.com>

Current generated iSCSI unit.run with master branch code while using podman:
![image](https://user-images.githubusercontent.com/47704447/92147464-3163ac00-ede9-11ea-9544-e5286c451402.png)

generated iSCSI unit.run with these changes while using podman:
![image](https://user-images.githubusercontent.com/47704447/92149609-3bd37500-edec-11ea-923a-c4db2dd74581.png)
