### PR TITLE
nautilus: mon/OSDMonitor: only take in osd into consideration when trimming osd…

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2090,7 +2090,7 @@ epoch_t OSDMonitor::get_min_last_epoch_clean() const
   // don't trim past the oldest reported osd epoch
   for (auto& osd_epoch : osd_epochs) {
     if (osd_epoch.second < floor &&
-        osdmap.is_out(osd_epoch.first)) {
+        osdmap.is_in(osd_epoch.first)) {
       floor = osd_epoch.second;
     }
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47296

---

backport of https://github.com/ceph/ceph/pull/36977
parent tracker: https://tracker.ceph.com/issues/47290

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh