### PR TITLE
osd: Got rid of global flag eio_errors_to_process

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -628,7 +628,6 @@ private:
 protected:
   OSDriver osdriver;
   SnapMapper snap_mapper;
-  bool eio_errors_to_process = false;
 
   virtual PGBackend *get_pgbackend() = 0;
   virtual const PGBackend* get_pgbackend() const = 0;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -12077,7 +12077,6 @@ void PrimaryLogPG::on_activate_complete()
 	  PeeringState::RequestBackfill())));
   } else {
     dout(10) << "activate all replicas clean, no recovery" << dendl;
-    eio_errors_to_process = false;
     queue_peering_event(
       PGPeeringEventRef(
 	std::make_shared<PGPeeringEvent>(
@@ -12440,7 +12439,6 @@ bool PrimaryLogPG::start_recovery_ops(
             PeeringState::RequestBackfill())));
     } else {
       dout(10) << "recovery done, no backfill" << dendl;
-      eio_errors_to_process = false;
       state_clear(PG_STATE_FORCED_BACKFILL);
       queue_peering_event(
         PGPeeringEventRef(
@@ -12454,7 +12452,6 @@ bool PrimaryLogPG::start_recovery_ops(
     state_clear(PG_STATE_FORCED_BACKFILL);
     state_clear(PG_STATE_FORCED_RECOVERY);
     dout(10) << "recovery done, backfill done" << dendl;
-    eio_errors_to_process = false;
     queue_peering_event(
       PGPeeringEventRef(
         std::make_shared<PGPeeringEvent>(
@@ -15109,23 +15106,15 @@ int PrimaryLogPG::rep_repair_primary_object(const hobject_t& soid, OpContext *ct
   waiting_for_unreadable_object[soid].push_back(op);
   op->mark_delayed("waiting for missing object");
 
-  if (!eio_errors_to_process) {
-    eio_errors_to_process = true;
-    ceph_assert(is_clean());
-    state_set(PG_STATE_REPAIR);
-    state_clear(PG_STATE_CLEAN);
-    queue_peering_event(
-        PGPeeringEventRef(
-	  std::make_shared<PGPeeringEvent>(
-	  get_osdmap_epoch(),
-	  get_osdmap_epoch(),
-	  PeeringState::DoRecovery())));
-  } else {
-    // A prior error must have already cleared clean state and queued recovery
-    // or a map change has triggered re-peering.
-    // Not inlining the recovery by calling maybe_kick_recovery(soid);
-    dout(5) << __func__<< ": Read error on " << soid << ", but already seen errors" << dendl;
-  }
+  ceph_assert(is_clean());
+  state_set(PG_STATE_REPAIR);
+  state_clear(PG_STATE_CLEAN);
+  queue_peering_event(
+      PGPeeringEventRef(
+	std::make_shared<PGPeeringEvent>(
+	get_osdmap_epoch(),
+	get_osdmap_epoch(),
+	PeeringState::DoRecovery())));
 
   return -EAGAIN;
 }


### PR DESCRIPTION
A cleanup for the process of EIO handling. I think the flag `eio_errors_to_process` had 3 purposes: 
1. No duplicative DoRecovery event will be scheduled on further `rep_repair_primary_object()` calls. 
2. No pg-log based recovery / backfill happening at the moment.  
3. According to David Zafman: "I didn't have confidence that DoRecovery() was initiated because the PG could be in backfill. Recovery can run simultaneously to backfill, so I played it safe and added this bool so that I could guarantee that recovery will happen."

For the first purpose, this flag is redundant in my eyes because before scheduling a recovery (namely, calling DoRecovery) we are checking the state of the PG and we can only schedule after moving from clean state to repair state. This actually applies to the second purpose too.
The third one is what I'm not sure about, personally I don't think such scenario is possible.

CC: @rzarzynski @neha-ojha @jdurgin @tchaikov 

Signed-off-by: Amnon Hanuhov <ahanukov@redhat.com>