### PR TITLE
rpm: enable WITH_BOOST_CONTEXT for s390x

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1164,7 +1164,7 @@ ${CMAKE} .. \
 %if 0%{with ocf}
     -DWITH_OCF=ON \
 %endif
-%ifarch aarch64 armv7hl mips mipsel ppc ppc64 ppc64le %{ix86} x86_64
+%ifarch aarch64 armv7hl mips mipsel ppc ppc64 ppc64le %{ix86} x86_64 s390x
     -DWITH_BOOST_CONTEXT=ON \
 %else
     -DWITH_BOOST_CONTEXT=OFF \


### PR DESCRIPTION
We've upgraded to Boost version 1.73 (#35787), and this version provides working support for boost::context for s390x. Enable this in the RPM packaging.

Fixes: https://tracker.ceph.com/issues/47304