### PR TITLE
rpm: on SUSE, podman is required for cephadm to work

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -384,10 +384,13 @@ Summary:        Utility to bootstrap Ceph clusters
 Requires:       lvm2
 %if 0%{?suse_version}
 Requires:       apparmor-abstractions
+Requires:       podman
 %endif
 Requires:       python%{python3_pkgversion}
+%if ! 0%{?suse_version}
 %if 0%{?weak_deps}
 Recommends:     podman
+%endif
 %endif
 %description -n cephadm
 Utility to bootstrap a Ceph cluster and manage Ceph daemons deployed 


### PR DESCRIPTION
On SUSE, cephadm is tested with podman only.

Fixes: https://tracker.ceph.com/issues/47305
Signed-off-by: Nathan Cutler <ncutler@suse.com>
