### PR TITLE
rgwlc:  fix (post-parallel) non-current expiration

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -352,12 +352,19 @@ static bool obj_has_expired(CephContext *cct, ceph::real_time mtime, int days,
     cmp = days*cct->_conf->rgw_lc_debug_interval;
     base_time = ceph_clock_now();
   }
-  timediff = base_time - ceph::real_clock::to_time_t(mtime);
+  auto tt_mtime = ceph::real_clock::to_time_t(mtime);
+  timediff = base_time - tt_mtime;
 
   if (expire_time) {
     *expire_time = mtime + make_timespan(cmp);
   }
-  ldout(cct, 20) << __func__ << "(): mtime=" << mtime << " days=" << days << " base_time=" << base_time << " timediff=" << timediff << " cmp=" << cmp << dendl;
+
+  ldout(cct, 20) << __func__ << __func__
+		 << "(): mtime=" << mtime << " days=" << days
+		 << " base_time=" << base_time << " timediff=" << timediff
+		 << " cmp=" << cmp
+		 << " is_expired=" << (timediff >= cmp) 
+		 << dendl;
 
   return (timediff >= cmp);
 }
@@ -530,7 +537,7 @@ struct lc_op_ctx {
   op_env env;
   rgw_bucket_dir_entry o;
   boost::optional<std::string> next_key_name;
-  ceph::real_time dm_effective_mtime;
+  ceph::real_time effective_mtime;
 
   rgw::sal::RGWRadosStore *store;
   RGWBucketInfo& bucket_info;
@@ -544,9 +551,10 @@ struct lc_op_ctx {
 
   lc_op_ctx(op_env& env, rgw_bucket_dir_entry& o,
 	    boost::optional<std::string> next_key_name,
-	    ceph::real_time dem,
+	    ceph::real_time effective_mtime,
 	    const DoutPrefixProvider *dpp, WorkQ* wq)
     : cct(env.store->ctx()), env(env), o(o), next_key_name(next_key_name),
+      effective_mtime(effective_mtime),
       store(env.store), bucket_info(env.bucket_info), op(env.op), ol(env.ol),
       obj(env.bucket_info.bucket, o.key), rctx(env.store), dpp(dpp), wq(wq)
     {}
@@ -631,7 +639,7 @@ class LCOpRule {
 
   op_env env;
   boost::optional<std::string> next_key_name;
-  ceph::real_time dm_effective_mtime;
+  ceph::real_time effective_mtime;
 
   std::vector<shared_ptr<LCOpFilter> > filters; // n.b., sharing ovhd
   std::vector<shared_ptr<LCOpAction> > actions;
@@ -641,6 +649,10 @@ public:
 
   boost::optional<std::string> get_next_key_name() {
     return next_key_name;
+  }
+
+  std::vector<shared_ptr<LCOpAction>>& get_actions() {
+    return actions;
   }
 
   void build();
@@ -1101,10 +1113,8 @@ public:
 
 class LCOpAction_NonCurrentExpiration : public LCOpAction {
 protected:
-  ceph::real_time mtime;
 public:
   LCOpAction_NonCurrentExpiration(op_env& env)
-    : mtime(env.ol.get_prev_obj().meta.mtime)
     {}
 
   bool check(lc_op_ctx& oc, ceph::real_time *exp_time) override {
@@ -1117,11 +1127,13 @@ public:
     }
 
     int expiration = oc.op.noncur_expiration;
-    bool is_expired = obj_has_expired(oc.cct, mtime, expiration, exp_time);
+    bool is_expired = obj_has_expired(oc.cct, oc.effective_mtime, expiration,
+				      exp_time);
 
     ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": is_expired="
 		      << is_expired << " "
 		      << oc.wq->thr_name() << dendl;
+
     return is_expired &&
       pass_object_lock_check(oc.store->getRados(),
 			     oc.bucket_info, oc.obj, oc.rctx);
@@ -1313,7 +1325,7 @@ protected:
   }
 
   ceph::real_time get_effective_mtime(lc_op_ctx& oc) override {
-    return oc.dm_effective_mtime;
+    return oc.effective_mtime;
   }
 public:
   LCOpAction_NonCurrentTransition(op_env& env,
@@ -1362,14 +1374,14 @@ void LCOpRule::build()
 void LCOpRule::update()
 {
   next_key_name = env.ol.next_key_name();
-  dm_effective_mtime = env.ol.get_prev_obj().meta.mtime;
+  effective_mtime = env.ol.get_prev_obj().meta.mtime;
 }
 
 int LCOpRule::process(rgw_bucket_dir_entry& o,
 		      const DoutPrefixProvider *dpp,
 		      WorkQ* wq)
 {
-  lc_op_ctx ctx(env, o, next_key_name, dm_effective_mtime, dpp, wq);
+  lc_op_ctx ctx(env, o, next_key_name, effective_mtime, dpp, wq);
   shared_ptr<LCOpAction> *selected = nullptr; // n.b., req'd by sharing
   real_time exp;
 


### PR DESCRIPTION
Object mtime had been lifted correctly into LCOpRule for
DMExpiration and, apparently, NonCurrentTransition, but not
for NonCurrentExpiration.

Some additional debug statements added at level 20.

Fixes: https://tracker.ceph.com/issues/47308

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
