### PR TITLE
crimson/osd: construct log_keys_debug when reading pglog entries

### DIFF
--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -1660,8 +1660,8 @@ public:
     ) {
     return read_log_and_missing_crimson(
       store, ch, info,
-      log, missing, pgmeta_oid,
-      this);
+      log, (pg_log_debug ? &log_keys_debug : nullptr),
+      missing, pgmeta_oid, this);
   }
 
   template <typename missing_type>
@@ -1670,6 +1670,7 @@ public:
     crimson::os::CollectionRef ch;
     const pg_info_t &info;
     IndexedLog &log;
+    std::set<std::string>* log_keys_debug = NULL;
     missing_type &missing;
     ghobject_t pgmeta_oid;
     const DoutPrefixProvider *dpp;
@@ -1727,6 +1728,8 @@ public:
 	  ceph_assert(last_e.version.epoch <= e.version.epoch);
 	}
 	entries.push_back(e);
+	if (log_keys_debug)
+	  log_keys_debug->insert(e.get_key_name());
       }
     }
 
@@ -1767,6 +1770,7 @@ public:
     crimson::os::CollectionRef ch,
     const pg_info_t &info,
     IndexedLog &log,
+    std::set<std::string>* log_keys_debug,
     missing_type &missing,
     ghobject_t pgmeta_oid,
     const DoutPrefixProvider *dpp = nullptr
@@ -1775,7 +1779,8 @@ public:
 		       << ch->get_cid()
 		       << " " << pgmeta_oid << dendl;
     return (new FuturizedStoreLogReader<missing_type>{
-      store, ch, info, log, missing, pgmeta_oid, dpp})->start();
+      store, ch, info, log, log_keys_debug,
+      missing, pgmeta_oid, dpp})->start();
   }
 
 #endif


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47226
Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
