### PR TITLE
monitoring: Use null yaxes min for OSD read latency

### DIFF
--- a/monitoring/grafana/dashboards/osd-device-details.json
+++ b/monitoring/grafana/dashboards/osd-device-details.json
@@ -126,7 +126,7 @@
           "label": "Read (-) / Write (+)",
           "logBase": 1,
           "max": null,
-          "min": "0",
+          "min": null,
           "show": true
         },
         {


### PR DESCRIPTION
According to seriesOverrides that negative-Y for read param there shouldn't be a minimum for yaxes

Fixes: https://tracker.ceph.com/issues/47323
Signed-off-by: Seena Fallah <seenafallah@gmail.com>