### PR TITLE
crimson/osd: accurately judge whether to do drop_recovery_read on recovering objs

### DIFF
--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -39,7 +39,9 @@ void RecoveryBackend::clean_up(ceph::os::Transaction& t,
   temp_contents.clear();
 
   for (auto& [soid, recovery_waiter] : recovering) {
-    if (recovery_waiter.obc && recovery_waiter.obc->obs.exists) {
+    if ((recovery_waiter.pi && recovery_waiter.pi->is_complete())
+	|| (!recovery_waiter.pi
+	  && recovery_waiter.obc && recovery_waiter.obc->obs.exists)) {
       recovery_waiter.obc->drop_recovery_read();
       recovery_waiter.interrupt(why);
     }

--- a/src/crimson/osd/recovery_backend.h
+++ b/src/crimson/osd/recovery_backend.h
@@ -125,7 +125,7 @@ protected:
     static constexpr const char* type_name = "WaitForObjectRecovery";
 
     crimson::osd::ObjectContextRef obc;
-    PullInfo pi;
+    std::optional<PullInfo> pi;
     std::map<pg_shard_t, PushInfo> pushing;
 
     seastar::future<> wait_for_readable() {

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -32,7 +32,11 @@ seastar::future<> ReplicatedRecoveryBackend::recover_object(
     return maybe_pull_missing_obj(soid, need).then([this, soid](bool pulled) {
       return load_obc_for_recovery(soid, pulled);
     }).then([this, soid, need, &pops, &shards] {
-      return prep_push(soid, need, &pops, shards);
+      if (!shards.empty()) {
+	return prep_push(soid, need, &pops, shards);
+      } else {
+	return seastar::now();
+      }
     }).handle_exception([this, soid](auto e) {
       auto recovery_waiter = recovering.find(soid);
       if (auto obc = recovery_waiter->second.obc; obc) {

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -58,7 +58,7 @@ seastar::future<> ReplicatedRecoveryBackend::recover_object(
       });
     }).then([this, soid] {
       auto& recovery = recovering.at(soid);
-      bool error = recovery.pi.recovery_progress.error;
+      bool error = recovery.pi->recovery_progress.error;
       if (!error) {
         auto push_info = recovery.pushing.begin();
         object_stat_sum_t stat = {};
@@ -66,7 +66,7 @@ seastar::future<> ReplicatedRecoveryBackend::recover_object(
           stat = push_info->second.stat;
         } else {
           // no push happened, take pull_info's stat
-          stat = recovery.pi.stat;
+          stat = recovery.pi->stat;
         }
         pg.get_recovery_handler()->on_global_recover(soid, stat, false);
         return seastar::make_ready_future<>();
@@ -92,7 +92,8 @@ ReplicatedRecoveryBackend::maybe_pull_missing_obj(
   }
   PullOp po;
   auto& recovery_waiter = recovering.at(soid);
-  auto& pi = recovery_waiter.pi;
+  recovery_waiter.pi = std::make_optional<RecoveryBackend::PullInfo>();
+  auto& pi = *recovery_waiter.pi;
   prepare_pull(po, pi, soid, need);
   auto msg = make_message<MOSDPGPull>();
   msg->from = pg.get_pg_whoami();
@@ -242,7 +243,7 @@ seastar::future<> ReplicatedRecoveryBackend::local_recover_delete(
     return seastar::make_ready_future<>();
   }).safe_then([this, soid, epoch_to_freeze, need] {
     auto& recovery_waiter = recovering[soid];
-    auto& pi = recovery_waiter.pi;
+    auto& pi = *recovery_waiter.pi;
     pi.recovery_info.soid = soid;
     pi.recovery_info.version = need;
     return on_local_recover_persist(soid, pi.recovery_info,
@@ -250,7 +251,7 @@ seastar::future<> ReplicatedRecoveryBackend::local_recover_delete(
   }, PGBackend::load_metadata_ertr::all_same_way(
       [this, soid, epoch_to_freeze, need] (auto e) {
       auto& recovery_waiter = recovering[soid];
-      auto& pi = recovery_waiter.pi;
+      auto& pi = *recovery_waiter.pi;
       pi.recovery_info.soid = soid;
       pi.recovery_info.version = need;
       return on_local_recover_persist(soid, pi.recovery_info,
@@ -633,7 +634,7 @@ seastar::future<bool> ReplicatedRecoveryBackend::_handle_pull_response(
 
   const hobject_t &hoid = pop.soid;
   auto& recovery_waiter = recovering[hoid];
-  auto& pi = recovery_waiter.pi;
+  auto& pi = *recovery_waiter.pi;
   if (pi.recovery_info.size == (uint64_t(-1))) {
     pi.recovery_info.size = pop.recovery_info.size;
     pi.recovery_info.copy_subset.intersection_of(
@@ -698,7 +699,7 @@ seastar::future<bool> ReplicatedRecoveryBackend::_handle_pull_response(
 
 	if (complete) {
 	  pi.stat.num_objects_recovered++;
-	  pg.get_recovery_handler()->on_local_recover(pop.soid, recovering[pop.soid].pi.recovery_info,
+	  pg.get_recovery_handler()->on_local_recover(pop.soid, recovering[pop.soid].pi->recovery_info,
 			      false, *t);
 	  return seastar::make_ready_future<bool>(true);
 	} else {
@@ -719,7 +720,7 @@ seastar::future<> ReplicatedRecoveryBackend::handle_pull_response(
   if (pop.version == eversion_t()) {
     // replica doesn't have it!
     pg.get_recovery_handler()->on_failed_recover({ m->from }, pop.soid,
-	get_recovering(pop.soid).pi.recovery_info.version);
+	get_recovering(pop.soid).pi->recovery_info.version);
     return seastar::make_exception_future<>(
 	std::runtime_error(fmt::format(
 	    "Error on pushing side {} when pulling obj {}",


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47313
Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
