### PR TITLE
client: remove the unecessary client_lock for objector->write()

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -13684,8 +13684,6 @@ int Client::ll_read_block(Inode *in, uint64_t blockid,
   C_SaferCond onfinish;
   bufferlist bl;
 
-  std::scoped_lock lock(client_lock);
-
   objecter->read(oid,
 		 object_locator_t(layout->pool_id),
 		 offset,
@@ -13695,10 +13693,7 @@ int Client::ll_read_block(Inode *in, uint64_t blockid,
 		 CEPH_OSD_FLAG_READ,
                  &onfinish);
 
-  client_lock.unlock();
   int r = onfinish.wait();
-  client_lock.lock();
-
   if (r >= 0) {
       bl.begin().copy(bl.length(), buf);
       r = bl.length();
@@ -13744,7 +13739,6 @@ int Client::ll_write_block(Inode *in, uint64_t blockid,
   fakesnap.seq = snapseq;
 
   /* lock just in time */
-  client_lock.lock();
   objecter->write(oid,
 		  object_locator_t(layout->pool_id),
 		  offset,
@@ -13755,7 +13749,6 @@ int Client::ll_write_block(Inode *in, uint64_t blockid,
 		  0,
 		  onsafe.get());
 
-  client_lock.unlock();
   if (nullptr != onsafe) {
     r = onsafe->wait();
   }

--- a/src/client/RWRef.h
+++ b/src/client/RWRef.h
@@ -167,7 +167,7 @@ public:
        * If the current state is not the same as "require"
        * then update the state and we are the first writer.
        *
-       * Or we are there already has one writer running or
+       * Or if there already has one writer running or
        * finished, it will let user to choose to continue
        * or just break.
        */


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47325
Signed-off-by: Xiubo Li <xiubli@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
