### PR TITLE
octopus: cephfs: client: fix directory inode can not call release callback

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4381,10 +4381,12 @@ void Client::trim_caps(MetaSession *s, uint64_t max)
 	  all = false;
         }
       }
+      if (in->ll_ref == 1 && in->ino != MDS_INO_ROOT) {
+         _schedule_ino_release_callback(in.get());
+      }
       if (all && in->ino != MDS_INO_ROOT) {
         ldout(cct, 20) << __func__ << " counting as trimmed: " << *in << dendl;
 	trimmed++;
-	_schedule_ino_release_callback(in.get());
       }
     }
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46516

---

backport of https://github.com/ceph/ceph/pull/35327
parent tracker: https://tracker.ceph.com/issues/46355

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh