### PR TITLE
osd: pass pg_log_t by lvalue reference

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1364,7 +1364,6 @@ void OSDMap::get_blocklist(std::set<entity_addr_t> *bl) const
 
 void OSDMap::set_max_osd(int m)
 {
-  int o = max_osd;
   max_osd = m;
   osd_state.resize(max_osd, 0);
   osd_weight.resize(max_osd, CEPH_OSD_OUT);

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -356,7 +356,7 @@ void PGLog::rewind_divergent_log(eversion_t newhead,
   dirty_big_info = true;
 }
 
-void PGLog::merge_log(pg_info_t &oinfo, pg_log_t &olog, pg_shard_t fromosd,
+void PGLog::merge_log(pg_info_t &oinfo, pg_log_t&& olog, pg_shard_t fromosd,
                       pg_info_t &info, LogEntryHandler *rollbacker,
                       bool &dirty_info, bool &dirty_big_info)
 {
@@ -399,7 +399,7 @@ void PGLog::merge_log(pg_info_t &oinfo, pg_log_t &olog, pg_shard_t fromosd,
 
     // splice into our log.
     log.log.splice(log.log.begin(),
-		   olog.log, from, to);
+		   std::move(olog.log), from, to);
 
     info.log_tail = log.tail = olog.tail;
     changed = true;

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -1245,7 +1245,7 @@ public:
                             bool &dirty_big_info);
 
   void merge_log(pg_info_t &oinfo,
-		 pg_log_t &olog,
+		 pg_log_t&& olog,
 		 pg_shard_t from,
 		 pg_info_t &info, LogEntryHandler *rollbacker,
 		 bool &dirty_info, bool &dirty_big_info);

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -1577,14 +1577,14 @@ public:
   void rewind_divergent_log(ObjectStore::Transaction& t, eversion_t newhead);
   void merge_log(
     ObjectStore::Transaction& t, pg_info_t &oinfo,
-    pg_log_t &olog, pg_shard_t from);
+    pg_log_t&& olog, pg_shard_t from);
 
   void proc_primary_info(ObjectStore::Transaction &t, const pg_info_t &info);
   void proc_master_log(ObjectStore::Transaction& t, pg_info_t &oinfo,
-		       pg_log_t &olog, pg_missing_t& omissing,
+		       pg_log_t&& olog, pg_missing_t&& omissing,
 		       pg_shard_t from);
   void proc_replica_log(pg_info_t &oinfo, const pg_log_t &olog,
-			pg_missing_t& omissing, pg_shard_t from);
+			pg_missing_t&& omissing, pg_shard_t from);
 
   void calc_min_last_complete_ondisk() {
     eversion_t min = last_complete_ondisk;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4705,10 +4705,10 @@ public:
     return it->second.need;
   }
 
-  void claim(pg_missing_set& o) {
+  void claim(pg_missing_set&& o) {
     static_assert(!TrackChanges, "Can't use claim with TrackChanges");
-    missing.swap(o.missing);
-    rmissing.swap(o.rmissing);
+    missing = std::move(o.missing);
+    rmissing = std::move(o.rmissing);
   }
 
   /*

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -289,7 +289,7 @@ public:
     bool dirty_info = false;
     bool dirty_big_info = false;
     merge_log(
-      oinfo, olog, pg_shard_t(1, shard_id_t(0)), info,
+      oinfo, std::move(olog), pg_shard_t(1, shard_id_t(0)), info,
       &h, dirty_info, dirty_big_info);
 
     ASSERT_EQ(info.last_update, oinfo.last_update);
@@ -890,7 +890,7 @@ TEST_F(PGLogTest, merge_log) {
     EXPECT_FALSE(dirty_big_info);
 
     TestHandler h(remove_snap);
-    merge_log(oinfo, olog, fromosd, info, &h,
+    merge_log(oinfo, std::move(olog), fromosd, info, &h,
               dirty_info, dirty_big_info);
 
     EXPECT_FALSE(missing.have_missing());
@@ -940,7 +940,7 @@ TEST_F(PGLogTest, merge_log) {
     EXPECT_FALSE(dirty_big_info);
 
     TestHandler h(remove_snap);
-    merge_log(oinfo, olog, fromosd, info, &h,
+    merge_log(oinfo, std::move(olog), fromosd, info, &h,
               dirty_info, dirty_big_info);
 
     EXPECT_FALSE(missing.have_missing());
@@ -1045,7 +1045,7 @@ TEST_F(PGLogTest, merge_log) {
     EXPECT_FALSE(dirty_big_info);
 
     TestHandler h(remove_snap);
-    merge_log(oinfo, olog, fromosd, info, &h,
+    merge_log(oinfo, std::move(olog), fromosd, info, &h,
               dirty_info, dirty_big_info);
 
     EXPECT_FALSE(missing.have_missing());
@@ -1154,7 +1154,7 @@ TEST_F(PGLogTest, merge_log) {
     EXPECT_FALSE(dirty_big_info);
 
     TestHandler h(remove_snap);
-    merge_log(oinfo, olog, fromosd, info, &h,
+    merge_log(oinfo, std::move(olog), fromosd, info, &h,
               dirty_info, dirty_big_info);
 
     /* When the divergent entry is a DELETE and the authoritative
@@ -1273,7 +1273,7 @@ TEST_F(PGLogTest, merge_log) {
 
     TestHandler h(remove_snap);
     missing.may_include_deletes = false;
-    merge_log(oinfo, olog, fromosd, info, &h,
+    merge_log(oinfo, std::move(olog), fromosd, info, &h,
               dirty_info, dirty_big_info);
 
     /* When the divergent entry is a DELETE and the authoritative
@@ -1375,7 +1375,7 @@ TEST_F(PGLogTest, merge_log) {
 
     TestHandler h(remove_snap);
     missing.may_include_deletes = false;
-    merge_log(oinfo, olog, fromosd, info, &h,
+    merge_log(oinfo, std::move(olog), fromosd, info, &h,
               dirty_info, dirty_big_info);
 
     EXPECT_FALSE(missing.have_missing());

--- a/src/test/osd/types.cc
+++ b/src/test/osd/types.cc
@@ -996,7 +996,7 @@ TEST(pg_missing_t, claim)
   pg_missing_t other;
   EXPECT_FALSE(other.have_missing());
 
-  other.claim(missing);
+  other.claim(std::move(missing));
   EXPECT_TRUE(other.have_missing());
 }
 


### PR DESCRIPTION
for better readability, as we intent to relinquish the ownership to the
callee.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
