### PR TITLE
Revert "rgw: replace '+' with "%20" in canonical query string for s3 v4 auth."

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -498,7 +498,7 @@ std::string get_v4_canonical_qs(const req_info& info, const bool using_qs)
   }
   if (params->find_first_of('+') != std::string::npos) {
     copy_params = *params;
-    boost::replace_all(copy_params, "+", "%20");
+    boost::replace_all(copy_params, "+", " ");
     params = &copy_params;
   }
 


### PR DESCRIPTION
Reverts ceph/ceph#35551

https://tracker.ceph.com/issues/47306