### PR TITLE
osd: Introduce new PGOpQueueable class for recovery push/reply messages.

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1565,6 +1565,7 @@ protected:
   friend class ceph::osd::scheduler::PGOpItem;
   friend class ceph::osd::scheduler::PGPeeringItem;
   friend class ceph::osd::scheduler::PGRecovery;
+  friend class ceph::osd::scheduler::PGRecoveryMsg;
   friend class ceph::osd::scheduler::PGDelete;
 
   class ShardedOpWQ

--- a/src/osd/scheduler/OpSchedulerItem.cc
+++ b/src/osd/scheduler/OpSchedulerItem.cc
@@ -85,4 +85,14 @@ void PGDelete::run(
   osd->dequeue_delete(sdata, pg.get(), epoch_queued, handle);
 }
 
+void PGRecoveryMsg::run(
+  OSD *osd,
+  OSDShard *sdata,
+  PGRef& pg,
+  ThreadPool::TPHandle &handle)
+{
+  osd->dequeue_op(pg, op, handle);
+  pg->unlock();
+}
+
 }


### PR DESCRIPTION
Introduce a new PGopQueueable class called PGRecoveryMsg to be used for
background recovery specific messages - MOSDPGPush and MOSDPGPushReply.
Earlier the above was categorized into the PGOpItem class leading to the
scheduler (for e.g. dmclock) giving higher importance to recovery IO
compared to client IO regardless of the weightage given to client IO.
This resulted in the poor performance of client IO.
    
This new class helps the existing and future (e.g. dmclock) IO schedulers
to schedule either client or recovery specific IO operations based on the
scheduling algorithm being employed and try to meet the QoS requirements.

Enqueue recovery specific ops received via MOSDPGPush or MOSDPGPushReply
messages as PGRecoveryMsg item. Messages with CEPH_MSG_PRIO_HIGH or
higher priority are given higher importance.

Fixes: https://tracker.ceph.com/issues/47344
Signed-off-by: Sridhar Seshasayee <sseshasa@redhat.com>

## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
