### PR TITLE
octopus: mds: do not submit omap_rm_keys if the dir is the basedir of merge

### DIFF
--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2231,10 +2231,11 @@ void CDir::_omap_commit(int op_prio)
   };
 
   if (state_test(CDir::STATE_FRAGMENTING)) {
+    assert(committed_version == 0);
     for (auto p = items.begin(); p != items.end(); ) {
       CDentry *dn = p->second;
       ++p;
-      if (!dn->is_dirty() && dn->get_linkage()->is_null())
+      if (dn->get_linkage()->is_null())
 	continue;
       write_one(dn);
     }

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2212,7 +2212,7 @@ void CDir::_omap_commit(int op_prio)
       op.priority = op_prio;
 
       // don't create new dirfrag blindly
-      if (!is_new() && !state_test(CDir::STATE_FRAGMENTING))
+      if (!is_new())
 	op.stat(NULL, (ceph::real_time*) NULL, NULL);
 
       if (!to_set.empty())
@@ -2230,7 +2230,7 @@ void CDir::_omap_commit(int op_prio)
     }
   };
 
-  if (state_test(CDir::STATE_FRAGMENTING)) {
+  if (state_test(CDir::STATE_FRAGMENTING) && is_new()) {
     assert(committed_version == 0);
     for (auto p = items.begin(); p != items.end(); ) {
       CDentry *dn = p->second;
@@ -2251,7 +2251,7 @@ void CDir::_omap_commit(int op_prio)
   op.priority = op_prio;
 
   // don't create new dirfrag blindly
-  if (!is_new() && !state_test(CDir::STATE_FRAGMENTING))
+  if (!is_new())
     op.stat(NULL, (ceph::real_time*)NULL, NULL);
 
   /*

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -11995,6 +11995,8 @@ void MDCache::_fragment_logged(MDRequestRef& mdr)
   for (const auto& dir : info.resultfrags) {
     dout(10) << " storing result frag " << *dir << dendl;
 
+    dir->mark_new(mdr->ls);
+
     // freeze and store them too
     dir->auth_pin(this);
     dir->state_set(CDir::STATE_FRAGMENTING);


### PR DESCRIPTION
backport trackers: 

* https://tracker.ceph.com/issues/46520
* https://tracker.ceph.com/issues/47316

---

backport of 

* https://github.com/ceph/ceph/pull/35848
* https://github.com/ceph/ceph/pull/36902

parent trackers: 

* https://tracker.ceph.com/issues/46273
* https://tracker.ceph.com/issues/47201

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh