### PR TITLE
nautilus: mds: fix incorrect check for if dirfrag is being fragmented

### DIFF
--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2198,7 +2198,7 @@ void CDir::_omap_commit(int op_prio)
       op.priority = op_prio;
 
       // don't create new dirfrag blindly
-      if (!is_new() && !state_test(CDir::STATE_FRAGMENTING))
+      if (!is_new())
 	op.stat(NULL, (ceph::real_time*) NULL, NULL);
 
       if (!to_set.empty())
@@ -2216,7 +2216,7 @@ void CDir::_omap_commit(int op_prio)
     }
   };
 
-  if (state_test(CDir::STATE_FRAGMENTING)) {
+  if (state_test(CDir::STATE_FRAGMENTING) && is_new()) {
     assert(committed_version == 0);
     for (auto p = items.begin(); p != items.end(); ) {
       CDentry *dn = p->second;
@@ -2237,7 +2237,7 @@ void CDir::_omap_commit(int op_prio)
   op.priority = op_prio;
 
   // don't create new dirfrag blindly
-  if (!is_new() && !state_test(CDir::STATE_FRAGMENTING))
+  if (!is_new())
     op.stat(NULL, (ceph::real_time*)NULL, NULL);
 
   /*

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -11676,6 +11676,8 @@ void MDCache::_fragment_logged(MDRequestRef& mdr)
     CDir *dir = *p;
     dout(10) << " storing result frag " << *dir << dendl;
 
+    dir->mark_new(mdr->ls);
+
     // freeze and store them too
     dir->auth_pin(this);
     dir->state_set(CDir::STATE_FRAGMENTING);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47317

---

backport of https://github.com/ceph/ceph/pull/36902
parent tracker: https://tracker.ceph.com/issues/47201

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh