### PR TITLE
common: remove data_dir_option in func global_init

### DIFF
--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -91,8 +91,7 @@ int main(int argc, const char **argv)
   }
 
   auto cct = global_init(NULL, args,
-			 CEPH_ENTITY_TYPE_MDS, CODE_ENVIRONMENT_DAEMON,
-			 0, "mds_data");
+			 CEPH_ENTITY_TYPE_MDS, CODE_ENVIRONMENT_DAEMON, 0);
   ceph_heap_profiler_init();
 
   int numa_node = g_conf().get_val<int64_t>("mds_numa_node");

--- a/src/ceph_mgr.cc
+++ b/src/ceph_mgr.cc
@@ -58,8 +58,7 @@ int main(int argc, const char **argv)
     { "keyring", "$mgr_data/keyring" }
   };
   auto cct = global_init(&defaults, args, CEPH_ENTITY_TYPE_MGR,
-			 CODE_ENVIRONMENT_DAEMON, 0,
-			 "mgr_data");
+			 CODE_ENVIRONMENT_DAEMON, 0);
 
   pick_addresses(g_ceph_context, CEPH_PICK_ADDRESS_PUBLIC);
 

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -310,7 +310,7 @@ int main(int argc, const char **argv)
 
   auto cct = global_init(&defaults, args,
 			 CEPH_ENTITY_TYPE_MON, CODE_ENVIRONMENT_DAEMON,
-			 flags, "mon_data");
+			 flags);
   ceph_heap_profiler_init();
 
   std::string val;

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -137,8 +137,7 @@ int main(int argc, const char **argv)
   auto cct = global_init(
     &defaults,
     args, CEPH_ENTITY_TYPE_OSD,
-    CODE_ENVIRONMENT_DAEMON,
-    0, "osd_data");
+    CODE_ENVIRONMENT_DAEMON, 0);
   ceph_heap_profiler_init();
 
   Preforker forker;

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -174,8 +174,7 @@ boost::intrusive_ptr<CephContext>
 global_init(const std::map<std::string,std::string> *defaults,
 	    std::vector < const char* >& args,
 	    uint32_t module_type, code_environment_t code_env,
-	    int flags,
-	    const char *data_dir_option, bool run_pre_init)
+	    int flags, bool run_pre_init)
 {
   // Ensure we're not calling the global init functions multiple times.
   static bool first_run = true;

--- a/src/global/global_init.h
+++ b/src/global/global_init.h
@@ -35,9 +35,7 @@ global_init(
   std::vector < const char* >& args,
   uint32_t module_type,
   code_environment_t code_env,
-  int flags,
-  const char *data_dir_option = 0,
-  bool run_pre_init = true);
+  int flags, bool run_pre_init = true);
 
 // just the first half; enough to get config parsed but doesn't start up the
 // cct or log.

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -209,8 +209,7 @@ int radosgw_Main(int argc, const char **argv)
   flags |= CINIT_FLAG_DEFER_DROP_PRIVILEGES;
 
   auto cct = global_init(&defaults, args, CEPH_ENTITY_TYPE_CLIENT,
-			 CODE_ENVIRONMENT_DAEMON,
-			 flags, "rgw_data");
+			 CODE_ENVIRONMENT_DAEMON, flags);
 
   // First, let's determine which frontends are configured.
   list<string> frontends;

--- a/src/rgw/rgw_object_expirer.cc
+++ b/src/rgw/rgw_object_expirer.cc
@@ -66,7 +66,7 @@ int main(const int argc, const char **argv)
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_DAEMON,
-			 CINIT_FLAG_UNPRIVILEGED_DAEMON_DEFAULTS, "rgw_data");
+			 CINIT_FLAG_UNPRIVILEGED_DAEMON_DEFAULTS);
 
   for (std::vector<const char *>::iterator i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {


### PR DESCRIPTION
data_dir_option parameter isn't used. Align with commit 85f2315b

Signed-off-by: Changcheng Liu <changcheng.liu@aliyun.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
