### PR TITLE
mgr/dashboard: fix security scopes of some NFS-Ganesha endpoints

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/nfsganesha.py
+++ b/src/pybind/mgr/dashboard/controllers/nfsganesha.py
@@ -233,7 +233,7 @@ class NFSGaneshaExports(RESTController):
             ganesha_conf.reload_daemons(export.daemons)
 
 
-@ApiController('/nfs-ganesha/daemon')
+@ApiController('/nfs-ganesha/daemon', Scope.NFS_GANESHA)
 @ControllerDoc(group="NFS-Ganesha")
 class NFSGaneshaService(RESTController):
 
@@ -268,17 +268,20 @@ class NFSGaneshaService(RESTController):
         return result
 
 
-@UiApiController('/nfs-ganesha')
+@UiApiController('/nfs-ganesha', Scope.NFS_GANESHA)
 class NFSGaneshaUi(BaseController):
     @Endpoint('GET', '/cephx/clients')
+    @ReadPermission
     def cephx_clients(self):
         return [client for client in CephX.list_clients()]
 
     @Endpoint('GET', '/fsals')
+    @ReadPermission
     def fsals(self):
         return Ganesha.fsals_available()
 
     @Endpoint('GET', '/lsdir')
+    @ReadPermission
     def lsdir(self, root_dir=None, depth=1):  # pragma: no cover
         if root_dir is None:
             root_dir = "/"
@@ -299,13 +302,16 @@ class NFSGaneshaUi(BaseController):
         return {'paths': paths}
 
     @Endpoint('GET', '/cephfs/filesystems')
+    @ReadPermission
     def filesystems(self):
         return CephFS.list_filesystems()
 
     @Endpoint('GET', '/rgw/buckets')
+    @ReadPermission
     def buckets(self, user_id=None):
         return RgwClient.instance(user_id).get_buckets()
 
     @Endpoint('GET', '/clusters')
+    @ReadPermission
     def clusters(self):
         return Ganesha.get_ganesha_clusters()


### PR DESCRIPTION
Apply NFS_GANESHA scope to these endpoints:
- `/api/nfs-ganesha/daemon`.
- `/ui-api/nfs-ganesha/*`.

Otherwise, any valid users can access them.

Fixes: https://tracker.ceph.com/issues/47356
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
