### PR TITLE
crimson/osd: avoid accessing WaitForObjectRecovery::pi when no pulling occurred

### DIFF
--- a/src/crimson/osd/recovery_backend.h
+++ b/src/crimson/osd/recovery_backend.h
@@ -152,6 +152,9 @@ protected:
     void set_pulled() {
       pulled.set_value();
     }
+    void set_push_failed(pg_shard_t shard, std::exception_ptr e) {
+      pushes.at(shard).set_exception(e);
+    }
     void interrupt(const std::string& why) {
       readable.set_exception(std::system_error(
 	    std::make_error_code(std::errc::interrupted), why));

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -245,19 +245,17 @@ seastar::future<> ReplicatedRecoveryBackend::local_recover_delete(
     }
     return seastar::make_ready_future<>();
   }).safe_then([this, soid, epoch_to_freeze, need] {
-    auto& recovery_waiter = recovering[soid];
-    auto& pi = *recovery_waiter.pi;
-    pi.recovery_info.soid = soid;
-    pi.recovery_info.version = need;
-    return on_local_recover_persist(soid, pi.recovery_info,
+    ObjectRecoveryInfo recovery_info;
+    recovery_info.soid = soid;
+    recovery_info.version = need;
+    return on_local_recover_persist(soid, recovery_info,
 	                            true, epoch_to_freeze);
   }, PGBackend::load_metadata_ertr::all_same_way(
       [this, soid, epoch_to_freeze, need] (auto e) {
-      auto& recovery_waiter = recovering[soid];
-      auto& pi = *recovery_waiter.pi;
-      pi.recovery_info.soid = soid;
-      pi.recovery_info.version = need;
-      return on_local_recover_persist(soid, pi.recovery_info,
+      ObjectRecoveryInfo recovery_info;
+      recovery_info.soid = soid;
+      recovery_info.version = need;
+      return on_local_recover_persist(soid, recovery_info,
 				      true, epoch_to_freeze);
     })
   );

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -62,25 +62,24 @@ seastar::future<> ReplicatedRecoveryBackend::recover_object(
       });
     }).then([this, soid] {
       auto& recovery = recovering.at(soid);
-      bool error = recovery.pi->recovery_progress.error;
-      if (!error) {
-        auto push_info = recovery.pushing.begin();
-        object_stat_sum_t stat = {};
-        if (push_info != recovery.pushing.end()) {
-          stat = push_info->second.stat;
-        } else {
-          // no push happened, take pull_info's stat
-          stat = recovery.pi->stat;
-        }
-        pg.get_recovery_handler()->on_global_recover(soid, stat, false);
-        return seastar::make_ready_future<>();
+      auto push_info = recovery.pushing.begin();
+      object_stat_sum_t stat = {};
+      if (push_info != recovery.pushing.end()) {
+	stat = push_info->second.stat;
       } else {
-	if (recovery.obc)
-	  recovery.obc->drop_recovery_read();
-	recovering.erase(soid);
-	return seastar::make_exception_future<>(
-	    std::runtime_error(fmt::format("Errors during pushing for {}", soid)));
+	// no push happened, take pull_info's stat
+	assert(recovery.pi);
+	stat = recovery.pi->stat;
       }
+      pg.get_recovery_handler()->on_global_recover(soid, stat, false);
+      return seastar::make_ready_future<>();
+    }).handle_exception([this, soid](auto e) {
+      auto& recovery = recovering.at(soid);
+      if (recovery.obc)
+	recovery.obc->drop_recovery_read();
+      recovering.erase(soid);
+      return seastar::make_exception_future<>(
+	  std::runtime_error(fmt::format("Errors during pushing for {}", soid)));
     });
   });
 }
@@ -865,7 +864,7 @@ seastar::future<bool> ReplicatedRecoveryBackend::_handle_push_reply(
       return seastar::make_ready_future<bool>(true);
     }().handle_exception([recovering_iter, &pi, peer] (auto e) {
       pi.recovery_progress.error = true;
-      recovering_iter->second.set_pushed(peer);
+      recovering_iter->second.set_push_failed(peer, e);
       return seastar::make_ready_future<bool>(true);
     });
   }


### PR DESCRIPTION
1. recover_delete uses WaitForObjectRecovery::pi to create RecoveryInfo;
2. recover_object checking WaitForObjectRecovery::pi's recovery_progress
   even if there had been no pulling

Fixes: https://tracker.ceph.com/issues/47357
Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
