### PR TITLE
mgr/dashboard: log in non-admin users successfully if the telemetry notification is shown

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/telemetry-notification/telemetry-notification.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/telemetry-notification/telemetry-notification.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 
-import { UserFormModel } from '../../../core/auth/user-form/user-form.model';
+import _ from 'lodash';
+
 import { MgrModuleService } from '../../api/mgr-module.service';
-import { UserService } from '../../api/user.service';
 import { NotificationType } from '../../enum/notification-type.enum';
 import { AuthStorageService } from '../../services/auth-storage.service';
 import { NotificationService } from '../../services/notification.service';
@@ -19,7 +19,6 @@ export class TelemetryNotificationComponent implements OnInit, OnDestroy {
   constructor(
     private mgrModuleService: MgrModuleService,
     private authStorageService: AuthStorageService,
-    private userService: UserService,
     private notificationService: NotificationService,
     private telemetryNotificationService: TelemetryNotificationService
   ) {}
@@ -30,16 +29,14 @@ export class TelemetryNotificationComponent implements OnInit, OnDestroy {
     });
 
     if (!this.isNotificationHidden()) {
-      const username = this.authStorageService.getUsername();
-      this.userService.get(username).subscribe((user: UserFormModel) => {
-        if (user.roles.includes('administrator')) {
-          this.mgrModuleService.getConfig('telemetry').subscribe((options) => {
-            if (!options['enabled']) {
-              this.telemetryNotificationService.setVisibility(true);
-            }
-          });
-        }
-      });
+      const configOptPermissions = this.authStorageService.getPermissions().configOpt;
+      if (_.every(Object.values(configOptPermissions))) {
+        this.mgrModuleService.getConfig('telemetry').subscribe((options) => {
+          if (!options['enabled']) {
+            this.telemetryNotificationService.setVisibility(true);
+          }
+        });
+      }
     }
   }
 


### PR DESCRIPTION
Getting the user object fails for a non-admin user. Check the permissions directory if the user is allowed to access the config options instead.

Fixes: https://tracker.ceph.com/issues/47331
Signed-off-by: Tatjana Dehler <tdehler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
