### PR TITLE
rgw: RGWRESTOp no longer tracks separate error code

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1638,7 +1638,7 @@ int RGWDeleteMultiObj_ObjStore::get_params()
 void RGWRESTOp::send_response()
 {
   if (!flusher.did_start()) {
-    set_req_state_err(s, http_ret);
+    set_req_state_err(s, get_ret());
     dump_errno(s);
     end_header(s, this);
   }

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -542,10 +542,8 @@ public:
 
 class RGWRESTOp : public RGWOp {
 protected:
-  int http_ret;
   RGWRESTFlusher flusher;
 public:
-  RGWRESTOp() : http_ret(0) {}
   void init(rgw::sal::RGWRadosStore *store, struct req_state *s,
             RGWHandler *dialect_handler) override {
     RGWOp::init(store, s, dialect_handler);

--- a/src/rgw/rgw_rest_bucket.cc
+++ b/src/rgw/rgw_rest_bucket.cc
@@ -48,7 +48,7 @@ void RGWOp_Bucket_Info::execute()
   op_state.set_bucket_name(bucket);
   op_state.set_fetch_stats(fetch_stats);
 
-  http_ret = RGWBucketAdminOp::info(store, op_state, flusher);
+  op_ret = RGWBucketAdminOp::info(store, op_state, flusher);
 }
 
 class RGWOp_Get_Policy : public RGWRESTOp {
@@ -78,7 +78,7 @@ void RGWOp_Get_Policy::execute()
   op_state.set_bucket_name(bucket);
   op_state.set_object(object);
 
-  http_ret = RGWBucketAdminOp::get_policy(store, op_state, flusher);
+  op_ret = RGWBucketAdminOp::get_policy(store, op_state, flusher);
 }
 
 class RGWOp_Check_Bucket_Index : public RGWRESTOp {
@@ -112,7 +112,7 @@ void RGWOp_Check_Bucket_Index::execute()
   op_state.set_fix_index(fix_index);
   op_state.set_check_objects(check_objects);
 
-  http_ret = RGWBucketAdminOp::check_index(store, op_state, flusher, s->yield);
+  op_ret = RGWBucketAdminOp::check_index(store, op_state, flusher, s->yield);
 }
 
 class RGWOp_Bucket_Link : public RGWRESTOp {
@@ -155,7 +155,7 @@ void RGWOp_Bucket_Link::execute()
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
   }
-  http_ret = RGWBucketAdminOp::link(store, op_state);
+  op_ret = RGWBucketAdminOp::link(store, op_state);
 }
 
 class RGWOp_Bucket_Unlink : public RGWRESTOp {
@@ -193,7 +193,7 @@ void RGWOp_Bucket_Unlink::execute()
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
   }
-  http_ret = RGWBucketAdminOp::unlink(store, op_state);
+  op_ret = RGWBucketAdminOp::unlink(store, op_state);
 }
 
 class RGWOp_Bucket_Remove : public RGWRESTOp {
@@ -226,11 +226,6 @@ void RGWOp_Bucket_Remove::execute()
   }
 
   op_ret = bucket->remove_bucket(delete_children, string(), string(), true, &s->info, s->yield);
-  if (op_ret < 0) {
-    ldpp_dout(this, 0) << "remove_bucket returned ret=" << op_ret << dendl;
-    return;
-  }
-  http_ret = op_ret;
 }
 
 class RGWOp_Set_Bucket_Quota : public RGWRESTOp {
@@ -255,7 +250,7 @@ void RGWOp_Set_Bucket_Quota::execute()
   std::string uid_str;
   RESTArgs::get_string(s, "uid", uid_str, &uid_str, &uid_arg_existed);
   if (! uid_arg_existed) {
-    http_ret = -EINVAL;
+    op_ret = -EINVAL;
     return;
   }
   rgw_user uid(uid_str);
@@ -263,7 +258,7 @@ void RGWOp_Set_Bucket_Quota::execute()
   std::string bucket;
   RESTArgs::get_string(s, "bucket", bucket, &bucket, &bucket_arg_existed);
   if (! bucket_arg_existed) {
-    http_ret = -EINVAL;
+    op_ret = -EINVAL;
     return;
   }
 
@@ -278,8 +273,8 @@ void RGWOp_Set_Bucket_Quota::execute()
   RGWQuotaInfo quota;
   if (!use_http_params) {
     bool empty;
-    http_ret = rgw_rest_get_json_input(store->ctx(), s, quota, QUOTA_INPUT_MAX_LEN, &empty);
-    if (http_ret < 0) {
+    op_ret = rgw_rest_get_json_input(store->ctx(), s, quota, QUOTA_INPUT_MAX_LEN, &empty);
+    if (op_ret < 0) {
       if (!empty)
         return;
       /* was probably chunked input, but no content provided, configure via http params */
@@ -289,8 +284,8 @@ void RGWOp_Set_Bucket_Quota::execute()
   if (use_http_params) {
     RGWBucketInfo bucket_info;
     map<string, bufferlist> attrs;
-    http_ret = store->getRados()->get_bucket_info(store->svc(), uid.tenant, bucket, bucket_info, NULL, s->yield, &attrs);
-    if (http_ret < 0) {
+    op_ret = store->getRados()->get_bucket_info(store->svc(), uid.tenant, bucket, bucket_info, NULL, s->yield, &attrs);
+    if (op_ret < 0) {
       return;
     }
     RGWQuotaInfo *old_quota = &bucket_info.quota;
@@ -307,7 +302,7 @@ void RGWOp_Set_Bucket_Quota::execute()
   op_state.set_bucket_name(bucket);
   op_state.set_quota(quota);
 
-  http_ret = RGWBucketAdminOp::set_quota(store, op_state);
+  op_ret = RGWBucketAdminOp::set_quota(store, op_state);
 }
 
 class RGWOp_Sync_Bucket : public RGWRESTOp {
@@ -339,7 +334,7 @@ void RGWOp_Sync_Bucket::execute()
   op_state.set_tenant(tenant);
   op_state.set_sync_bucket(sync_bucket);
 
-  http_ret = RGWBucketAdminOp::sync_bucket(store, op_state);
+  op_ret = RGWBucketAdminOp::sync_bucket(store, op_state);
 }
 
 class RGWOp_Object_Remove: public RGWRESTOp {
@@ -369,7 +364,7 @@ void RGWOp_Object_Remove::execute()
   op_state.set_bucket_name(bucket);
   op_state.set_object(object);
 
-  http_ret = RGWBucketAdminOp::remove_object(store, op_state);
+  op_ret = RGWBucketAdminOp::remove_object(store, op_state);
 }
 
 

--- a/src/rgw/rgw_rest_config.cc
+++ b/src/rgw/rgw_rest_config.cc
@@ -31,18 +31,18 @@
 #define dout_subsys ceph_subsys_rgw
 
 void RGWOp_ZoneGroupMap_Get::execute() {
-  http_ret = zonegroup_map.read(g_ceph_context, store->svc()->sysobj);
-  if (http_ret < 0) {
+  op_ret = zonegroup_map.read(g_ceph_context, store->svc()->sysobj);
+  if (op_ret < 0) {
     dout(5) << "failed to read zone_group map" << dendl;
   }
 }
 
 void RGWOp_ZoneGroupMap_Get::send_response() {
-  set_req_state_err(s, http_ret);
+  set_req_state_err(s, op_ret);
   dump_errno(s);
   end_header(s);
 
-  if (http_ret < 0)
+  if (op_ret < 0)
     return;
 
   if (old_format) {
@@ -61,11 +61,11 @@ void RGWOp_ZoneGroupMap_Get::send_response() {
 void RGWOp_ZoneConfig_Get::send_response() {
   const RGWZoneParams& zone_params = store->svc()->zone->get_zone_params();
 
-  set_req_state_err(s, http_ret);
+  set_req_state_err(s, op_ret);
   dump_errno(s);
   end_header(s);
 
-  if (http_ret < 0)
+  if (op_ret < 0)
     return;
 
   encode_json("zone_params", zone_params, s->formatter);

--- a/src/rgw/rgw_rest_metadata.cc
+++ b/src/rgw/rgw_rest_metadata.cc
@@ -57,13 +57,13 @@ void RGWOp_Metadata_Get::execute() {
   auto meta_mgr = store->ctl()->meta.mgr;
 
   /* Get keys */
-  http_ret = meta_mgr->get(metadata_key, s->formatter, s->yield);
-  if (http_ret < 0) {
-    dout(5) << "ERROR: can't get key: " << cpp_strerror(http_ret) << dendl;
+  op_ret = meta_mgr->get(metadata_key, s->formatter, s->yield);
+  if (op_ret < 0) {
+    dout(5) << "ERROR: can't get key: " << cpp_strerror(op_ret) << dendl;
     return;
   }
 
-  http_ret = 0;
+  op_ret = 0;
 }
 
 void RGWOp_Metadata_Get_Myself::execute() {
@@ -105,7 +105,7 @@ void RGWOp_Metadata_List::execute() {
     max_entries = (unsigned)strict_strtol(max_entries_str.c_str(), 10, &err);
     if (!err.empty()) {
       dout(5) << "Error parsing max-entries " << max_entries_str << dendl;
-      http_ret = -EINVAL;
+      op_ret = -EINVAL;
       return;
     }
   }
@@ -123,9 +123,9 @@ void RGWOp_Metadata_List::execute() {
      marker = "3:bf885d8f:root::sorry_janefonda_665:head";
   */
 
-  http_ret = store->ctl()->meta.mgr->list_keys_init(metadata_key, marker, &handle);
-  if (http_ret < 0) {
-    dout(5) << "ERROR: can't get key: " << cpp_strerror(http_ret) << dendl;
+  op_ret = store->ctl()->meta.mgr->list_keys_init(metadata_key, marker, &handle);
+  if (op_ret < 0) {
+    dout(5) << "ERROR: can't get key: " << cpp_strerror(op_ret) << dendl;
     return;
   }
 
@@ -144,9 +144,9 @@ void RGWOp_Metadata_List::execute() {
   do {
     list<string> keys;
     left = (max_entries_specified ? max_entries - count : max);
-    http_ret = meta_mgr->list_keys_next(handle, left, keys, &truncated);
-    if (http_ret < 0) {
-      dout(5) << "ERROR: lists_keys_next(): " << cpp_strerror(http_ret)
+    op_ret = meta_mgr->list_keys_next(handle, left, keys, &truncated);
+    if (op_ret < 0) {
+      dout(5) << "ERROR: lists_keys_next(): " << cpp_strerror(op_ret)
 	      << dendl;
       return;
     }
@@ -173,7 +173,7 @@ void RGWOp_Metadata_List::execute() {
   }
   meta_mgr->list_keys_complete(handle);
 
-  http_ret = 0;
+  op_ret = 0;
 }
 
 int RGWOp_Metadata_Put::get_data(bufferlist& bl) {
@@ -238,13 +238,13 @@ void RGWOp_Metadata_Put::execute() {
   bufferlist bl;
   string metadata_key;
 
-  http_ret = get_data(bl);
-  if (http_ret < 0) {
+  op_ret = get_data(bl);
+  if (op_ret < 0) {
     return;
   }
 
-  http_ret = do_aws4_auth_completion();
-  if (http_ret < 0) {
+  op_ret = do_aws4_auth_completion();
+  if (op_ret < 0) {
     return;
   }
   
@@ -258,29 +258,29 @@ void RGWOp_Metadata_Put::execute() {
     bool parsed = string_to_sync_type(mode_string,
                                       sync_type);
     if (!parsed) {
-      http_ret = -EINVAL;
+      op_ret = -EINVAL;
       return;
     }
   }
 
-  http_ret = store->ctl()->meta.mgr->put(metadata_key, bl, s->yield, sync_type,
+  op_ret = store->ctl()->meta.mgr->put(metadata_key, bl, s->yield, sync_type,
 				  &ondisk_version);
-  if (http_ret < 0) {
-    dout(5) << "ERROR: can't put key: " << cpp_strerror(http_ret) << dendl;
+  if (op_ret < 0) {
+    dout(5) << "ERROR: can't put key: " << cpp_strerror(op_ret) << dendl;
     return;
   }
   // translate internal codes into return header
-  if (http_ret == STATUS_NO_APPLY)
+  if (op_ret == STATUS_NO_APPLY)
     update_status = "skipped";
-  else if (http_ret == STATUS_APPLIED)
+  else if (op_ret == STATUS_APPLIED)
     update_status = "applied";
 }
 
 void RGWOp_Metadata_Put::send_response() {
-  int http_return_code = http_ret;
-  if ((http_ret == STATUS_NO_APPLY) || (http_ret == STATUS_APPLIED))
-    http_return_code = STATUS_NO_CONTENT;
-  set_req_state_err(s, http_return_code);
+  int op_return_code = op_ret;
+  if ((op_ret == STATUS_NO_APPLY) || (op_ret == STATUS_APPLIED))
+    op_return_code = STATUS_NO_CONTENT;
+  set_req_state_err(s, op_return_code);
   dump_errno(s);
   stringstream ver_stream;
   ver_stream << "ver:" << ondisk_version.ver
@@ -294,12 +294,12 @@ void RGWOp_Metadata_Delete::execute() {
   string metadata_key;
 
   frame_metadata_key(s, metadata_key);
-  http_ret = store->ctl()->meta.mgr->remove(metadata_key, s->yield);
-  if (http_ret < 0) {
-    dout(5) << "ERROR: can't remove key: " << cpp_strerror(http_ret) << dendl;
+  op_ret = store->ctl()->meta.mgr->remove(metadata_key, s->yield);
+  if (op_ret < 0) {
+    dout(5) << "ERROR: can't remove key: " << cpp_strerror(op_ret) << dendl;
     return;
   }
-  http_ret = 0;
+  op_ret = 0;
 }
 
 RGWOp *RGWHandler_Metadata::op_get() {

--- a/src/rgw/rgw_rest_realm.cc
+++ b/src/rgw/rgw_rest_realm.cc
@@ -31,12 +31,12 @@ class RGWOp_Period_Base : public RGWRESTOp {
 // reply with the period object on success
 void RGWOp_Period_Base::send_response()
 {
-  set_req_state_err(s, http_ret, error_stream.str());
+  set_req_state_err(s, op_ret, error_stream.str());
   dump_errno(s);
 
-  if (http_ret < 0) {
+  if (op_ret < 0) {
     if (!s->err.message.empty()) {
-      ldout(s->cct, 4) << "Request failed with " << http_ret
+      ldout(s->cct, 4) << "Request failed with " << op_ret
           << ": " << s->err.message << dendl;
     }
     end_header(s);
@@ -73,8 +73,8 @@ void RGWOp_Period_Get::execute()
   period.set_id(period_id);
   period.set_epoch(epoch);
 
-  http_ret = period.init(store->ctx(), store->svc()->sysobj, realm_id, realm_name);
-  if (http_ret < 0)
+  op_ret = period.init(store->ctx(), store->svc()->sysobj, realm_id, realm_name);
+  if (op_ret < 0)
     ldout(store->ctx(), 5) << "failed to read period" << dendl;
 }
 
@@ -101,8 +101,8 @@ void RGWOp_Period_Post::execute()
   // decode the period from input
   const auto max_size = cct->_conf->rgw_max_put_param_size;
   bool empty;
-  http_ret = rgw_rest_get_json_input(cct, s, period, max_size, &empty);
-  if (http_ret < 0) {
+  op_ret = rgw_rest_get_json_input(cct, s, period, max_size, &empty);
+  if (op_ret < 0) {
     lderr(cct) << "failed to decode period" << dendl;
     return;
   }
@@ -111,7 +111,7 @@ void RGWOp_Period_Post::execute()
   if (period.get_realm() != store->svc()->zone->get_realm().get_id()) {
     error_stream << "period with realm id " << period.get_realm()
         << " doesn't match current realm " << store->svc()->zone->get_realm().get_id() << std::endl;
-    http_ret = -EINVAL;
+    op_ret = -EINVAL;
     return;
   }
 
@@ -119,25 +119,25 @@ void RGWOp_Period_Post::execute()
   // period that we haven't restarted with yet. we also don't want to modify
   // the objects in use by RGWRados
   RGWRealm realm(period.get_realm());
-  http_ret = realm.init(cct, store->svc()->sysobj);
-  if (http_ret < 0) {
+  op_ret = realm.init(cct, store->svc()->sysobj);
+  if (op_ret < 0) {
     lderr(cct) << "failed to read current realm: "
-        << cpp_strerror(-http_ret) << dendl;
+        << cpp_strerror(-op_ret) << dendl;
     return;
   }
 
   RGWPeriod current_period;
-  http_ret = current_period.init(cct, store->svc()->sysobj, realm.get_id());
-  if (http_ret < 0) {
+  op_ret = current_period.init(cct, store->svc()->sysobj, realm.get_id());
+  if (op_ret < 0) {
     lderr(cct) << "failed to read current period: "
-        << cpp_strerror(-http_ret) << dendl;
+        << cpp_strerror(-op_ret) << dendl;
     return;
   }
 
   // if period id is empty, handle as 'period commit'
   if (period.get_id().empty()) {
-    http_ret = period.commit(store, realm, current_period, error_stream);
-    if (http_ret < 0) {
+    op_ret = period.commit(store, realm, current_period, error_stream);
+    if (op_ret < 0) {
       lderr(cct) << "master zone failed to commit period" << dendl;
     }
     return;
@@ -147,26 +147,26 @@ void RGWOp_Period_Post::execute()
   if (period.get_master_zone() == store->svc()->zone->get_zone_params().get_id()) {
     ldout(cct, 10) << "master zone rejecting period id="
         << period.get_id() << " epoch=" << period.get_epoch() << dendl;
-    http_ret = -EINVAL; // XXX: error code
+    op_ret = -EINVAL; // XXX: error code
     return;
   }
 
   // write the period to rados
-  http_ret = period.store_info(false);
-  if (http_ret < 0) {
+  op_ret = period.store_info(false);
+  if (op_ret < 0) {
     lderr(cct) << "failed to store period " << period.get_id() << dendl;
     return;
   }
   // set as latest epoch
-  http_ret = period.update_latest_epoch(period.get_epoch());
-  if (http_ret == -EEXIST) {
+  op_ret = period.update_latest_epoch(period.get_epoch());
+  if (op_ret == -EEXIST) {
     // already have this epoch (or a more recent one)
     ldout(cct, 4) << "already have epoch >= " << period.get_epoch()
         << " for period " << period.get_id() << dendl;
-    http_ret = 0;
+    op_ret = 0;
     return;
   }
-  if (http_ret < 0) {
+  if (op_ret < 0) {
     lderr(cct) << "failed to set latest epoch" << dendl;
     return;
   }
@@ -189,19 +189,19 @@ void RGWOp_Period_Post::execute()
       lderr(cct) << "discarding period " << period.get_id()
           << " with realm epoch " << period.get_realm_epoch() << " too far in "
           "the future from current epoch " << current_epoch << dendl;
-      http_ret = -ENOENT; // XXX: error code
+      op_ret = -ENOENT; // XXX: error code
       return;
     }
     // attach a copy of the period into the period history
     auto cursor = period_history->attach(RGWPeriod{period});
     if (!cursor) {
       // we're missing some history between the new period and current_period
-      http_ret = cursor.get_error();
+      op_ret = cursor.get_error();
       lderr(cct) << "failed to collect the periods between current period "
           << current_period.get_id() << " (realm epoch " << current_epoch
           << ") and the new period " << period.get_id()
           << " (realm epoch " << period.get_realm_epoch()
-          << "): " << cpp_strerror(-http_ret) << dendl;
+          << "): " << cpp_strerror(-op_ret) << dendl;
       return;
     }
     if (cursor.has_next()) {
@@ -211,8 +211,8 @@ void RGWOp_Period_Post::execute()
       return;
     }
     // set as current period
-    http_ret = realm.set_current_period(period);
-    if (http_ret < 0) {
+    op_ret = realm.set_current_period(period);
+    if (op_ret < 0) {
       lderr(cct) << "failed to update realm's current period" << dendl;
       return;
     }
@@ -223,10 +223,10 @@ void RGWOp_Period_Post::execute()
     return;
   }
   // reflect the period into our local objects
-  http_ret = period.reflect();
-  if (http_ret < 0) {
+  op_ret = period.reflect();
+  if (op_ret < 0) {
     lderr(cct) << "failed to update local objects: "
-        << cpp_strerror(-http_ret) << dendl;
+        << cpp_strerror(-op_ret) << dendl;
     return;
   }
   ldout(cct, 4) << "period epoch " << period.get_epoch()
@@ -280,18 +280,18 @@ void RGWOp_Realm_Get::execute()
 
   // read realm
   realm.reset(new RGWRealm(id, name));
-  http_ret = realm->init(g_ceph_context, store->svc()->sysobj);
-  if (http_ret < 0)
+  op_ret = realm->init(g_ceph_context, store->svc()->sysobj);
+  if (op_ret < 0)
     lderr(store->ctx()) << "failed to read realm id=" << id
         << " name=" << name << dendl;
 }
 
 void RGWOp_Realm_Get::send_response()
 {
-  set_req_state_err(s, http_ret);
+  set_req_state_err(s, op_ret);
   dump_errno(s);
 
-  if (http_ret < 0) {
+  if (op_ret < 0) {
     end_header(s);
     return;
   }
@@ -324,17 +324,17 @@ void RGWOp_Realm_List::execute()
     RGWRealm realm(store->ctx(), store->svc()->sysobj);
     [[maybe_unused]] int ret = realm.read_default_id(default_id);
   }
-  http_ret = store->svc()->zone->list_realms(realms);
-  if (http_ret < 0)
+  op_ret = store->svc()->zone->list_realms(realms);
+  if (op_ret < 0)
     lderr(store->ctx()) << "failed to list realms" << dendl;
 }
 
 void RGWOp_Realm_List::send_response()
 {
-  set_req_state_err(s, http_ret);
+  set_req_state_err(s, op_ret);
   dump_errno(s);
 
-  if (http_ret < 0) {
+  if (op_ret < 0) {
     end_header(s);
     return;
   }

--- a/src/rgw/rgw_rest_usage.cc
+++ b/src/rgw/rgw_rest_usage.cc
@@ -53,7 +53,7 @@ void RGWOp_Usage_Get::execute() {
     }
   }
 
-  http_ret = RGWUsage::show(store->getRados(), uid, bucket_name, start, end, show_entries, show_summary, &categories, flusher);
+  op_ret = RGWUsage::show(store->getRados(), uid, bucket_name, start, end, show_entries, show_summary, &categories, flusher);
 }
 
 class RGWOp_Usage_Delete : public RGWRESTOp {
@@ -88,12 +88,12 @@ void RGWOp_Usage_Delete::execute() {
     bool remove_all;
     RESTArgs::get_bool(s, "remove-all", false, &remove_all);
     if (!remove_all) {
-      http_ret = -EINVAL;
+      op_ret = -EINVAL;
       return;
     }
   }
 
-  http_ret = RGWUsage::trim(store->getRados(), uid, bucket_name, start, end);
+  op_ret = RGWUsage::trim(store->getRados(), uid, bucket_name, start, end);
 }
 
 RGWOp *RGWHandler_Usage::op_get()

--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -42,7 +42,7 @@ void RGWOp_User_List::execute()
 
   op_state.max_entries = max_entries;
   op_state.marker = marker;
-  http_ret = RGWUserAdminOp_User::list(store, op_state, flusher);
+  op_ret = RGWUserAdminOp_User::list(store, op_state, flusher);
 }
 
 class RGWOp_User_Info : public RGWRESTOp {
@@ -74,7 +74,7 @@ void RGWOp_User_Info::execute()
   // end up initializing anonymous user, for which keys.init will eventually
   // return -EACESS
   if (uid_str.empty() && access_key_str.empty()){
-    http_ret=-EINVAL;
+    op_ret=-EINVAL;
     return;
   }
 
@@ -89,7 +89,7 @@ void RGWOp_User_Info::execute()
   op_state.set_fetch_stats(fetch_stats);
   op_state.set_sync_stats(sync_stats);
 
-  http_ret = RGWUserAdminOp_User::info(store, op_state, flusher);
+  op_ret = RGWUserAdminOp_User::info(store, op_state, flusher);
 }
 
 class RGWOp_User_Create : public RGWRESTOp {
@@ -152,7 +152,7 @@ void RGWOp_User_Create::execute()
 
   if (!s->user->get_info().system && system) {
     ldout(s->cct, 0) << "cannot set system flag by non-system user" << dendl;
-    http_ret = -EINVAL;
+    op_ret = -EINVAL;
     return;
   }
 
@@ -173,7 +173,7 @@ void RGWOp_User_Create::execute()
     int ret = rgw_parse_op_type_list(op_mask_str, &op_mask);
     if (ret < 0) {
       ldout(s->cct, 0) << "failed to parse op_mask: " << ret << dendl;
-      http_ret = -EINVAL;
+      op_ret = -EINVAL;
       return;
     }
     op_state.set_op_mask(op_mask);
@@ -212,7 +212,7 @@ void RGWOp_User_Create::execute()
     target_rule.from_str(default_placement_str);
     if (!store->svc()->zone->get_zone_params().valid_placement(target_rule)) {
       ldout(s->cct, 0) << "NOTICE: invalid dest placement: " << target_rule.to_str() << dendl;
-      http_ret = -EINVAL;
+      op_ret = -EINVAL;
       return;
     }
     op_state.set_default_placement(target_rule);
@@ -230,7 +230,7 @@ void RGWOp_User_Create::execute()
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
   }
-  http_ret = RGWUserAdminOp_User::create(store, op_state, flusher);
+  op_ret = RGWUserAdminOp_User::create(store, op_state, flusher);
 }
 
 class RGWOp_User_Modify : public RGWRESTOp {
@@ -289,7 +289,7 @@ void RGWOp_User_Modify::execute()
 
   if (!s->user->get_info().system && system) {
     ldout(s->cct, 0) << "cannot set system flag by non-system user" << dendl;
-    http_ret = -EINVAL;
+    op_ret = -EINVAL;
     return;
   }
 
@@ -326,7 +326,7 @@ void RGWOp_User_Modify::execute()
     uint32_t op_mask;
     if (rgw_parse_op_type_list(op_mask_str, &op_mask) < 0) {
         ldout(s->cct, 0) << "failed to parse op_mask" << dendl;
-        http_ret = -EINVAL;
+        op_ret = -EINVAL;
         return;
     }   
     op_state.set_op_mask(op_mask);
@@ -343,7 +343,7 @@ void RGWOp_User_Modify::execute()
     int ret = rgw_parse_op_type_list(op_mask_str, &op_mask);
     if (ret < 0) {
       ldout(s->cct, 0) << "failed to parse op_mask: " << ret << dendl;
-      http_ret = -EINVAL;
+      op_ret = -EINVAL;
       return;
     }
     op_state.set_op_mask(op_mask);
@@ -354,7 +354,7 @@ void RGWOp_User_Modify::execute()
     target_rule.from_str(default_placement_str);
     if (!store->svc()->zone->get_zone_params().valid_placement(target_rule)) {
       ldout(s->cct, 0) << "NOTICE: invalid dest placement: " << target_rule.to_str() << dendl;
-      http_ret = -EINVAL;
+      op_ret = -EINVAL;
       return;
     }
     op_state.set_default_placement(target_rule);
@@ -372,7 +372,7 @@ void RGWOp_User_Modify::execute()
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
   }
-  http_ret = RGWUserAdminOp_User::modify(store, op_state, flusher);
+  op_ret = RGWUserAdminOp_User::modify(store, op_state, flusher);
 }
 
 class RGWOp_User_Remove : public RGWRESTOp {
@@ -413,7 +413,7 @@ void RGWOp_User_Remove::execute()
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
   }
-  http_ret = RGWUserAdminOp_User::remove(store, op_state, flusher, s->yield);
+  op_ret = RGWUserAdminOp_User::remove(store, op_state, flusher, s->yield);
 }
 
 class RGWOp_Subuser_Create : public RGWRESTOp {
@@ -489,7 +489,7 @@ void RGWOp_Subuser_Create::execute()
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
   }
-  http_ret = RGWUserAdminOp_Subuser::create(store, op_state, flusher);
+  op_ret = RGWUserAdminOp_Subuser::create(store, op_state, flusher);
 }
 
 class RGWOp_Subuser_Modify : public RGWRESTOp {
@@ -556,7 +556,7 @@ void RGWOp_Subuser_Modify::execute()
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
   }
-  http_ret = RGWUserAdminOp_Subuser::modify(store, op_state, flusher);
+  op_ret = RGWUserAdminOp_Subuser::modify(store, op_state, flusher);
 }
 
 class RGWOp_Subuser_Remove : public RGWRESTOp {
@@ -599,7 +599,7 @@ void RGWOp_Subuser_Remove::execute()
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
   }
-  http_ret = RGWUserAdminOp_Subuser::remove(store, op_state, flusher);
+  op_ret = RGWUserAdminOp_Subuser::remove(store, op_state, flusher);
 }
 
 class RGWOp_Key_Create : public RGWRESTOp {
@@ -655,7 +655,7 @@ void RGWOp_Key_Create::execute()
     op_state.set_key_type(key_type);
   }
 
-  http_ret = RGWUserAdminOp_Key::create(store, op_state, flusher);
+  op_ret = RGWUserAdminOp_Key::create(store, op_state, flusher);
 }
 
 class RGWOp_Key_Remove : public RGWRESTOp {
@@ -702,7 +702,7 @@ void RGWOp_Key_Remove::execute()
     op_state.set_key_type(key_type);
   }
 
-  http_ret = RGWUserAdminOp_Key::remove(store, op_state, flusher);
+  op_ret = RGWUserAdminOp_Key::remove(store, op_state, flusher);
 }
 
 class RGWOp_Caps_Add : public RGWRESTOp {
@@ -740,7 +740,7 @@ void RGWOp_Caps_Add::execute()
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
   }
-  http_ret = RGWUserAdminOp_Caps::add(store, op_state, flusher);
+  op_ret = RGWUserAdminOp_Caps::add(store, op_state, flusher);
 }
 
 class RGWOp_Caps_Remove : public RGWRESTOp {
@@ -778,7 +778,7 @@ void RGWOp_Caps_Remove::execute()
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
   }
-  http_ret = RGWUserAdminOp_Caps::remove(store, op_state, flusher);
+  op_ret = RGWUserAdminOp_Caps::remove(store, op_state, flusher);
 }
 
 struct UserQuotas {
@@ -826,7 +826,7 @@ void RGWOp_Quota_Info::execute()
   RESTArgs::get_string(s, "quota-type", quota_type, &quota_type);
 
   if (uid_str.empty()) {
-    http_ret = -EINVAL;
+    op_ret = -EINVAL;
     return;
   }
 
@@ -837,26 +837,26 @@ void RGWOp_Quota_Info::execute()
   bool show_user = show_all || (quota_type == "user");
 
   if (!(show_all || show_bucket || show_user)) {
-    http_ret = -EINVAL;
+    op_ret = -EINVAL;
     return;
   }
 
   op_state.set_user_id(uid);
 
   RGWUser user;
-  http_ret = user.init(store, op_state);
-  if (http_ret < 0)
+  op_ret = user.init(store, op_state);
+  if (op_ret < 0)
     return;
 
   if (!op_state.has_existing_user()) {
-    http_ret = -ERR_NO_SUCH_USER;
+    op_ret = -ERR_NO_SUCH_USER;
     return;
   }
 
   RGWUserInfo info;
   string err_msg;
-  http_ret = user.info(info, &err_msg);
-  if (http_ret < 0)
+  op_ret = user.info(info, &err_msg);
+  if (op_ret < 0)
     return;
 
   flusher.start(0);
@@ -945,7 +945,7 @@ void RGWOp_Quota_Set::execute()
   RESTArgs::get_string(s, "quota-type", quota_type, &quota_type);
 
   if (uid_str.empty()) {
-    http_ret = -EINVAL;
+    op_ret = -EINVAL;
     return;
   }
 
@@ -957,7 +957,7 @@ void RGWOp_Quota_Set::execute()
 
   if (!(set_all || set_bucket || set_user)) {
     ldout(store->ctx(), 20) << "invalid quota type" << dendl;
-    http_ret = -EINVAL;
+    op_ret = -EINVAL;
     return;
   }
 
@@ -972,21 +972,21 @@ void RGWOp_Quota_Set::execute()
 
   if (use_http_params && set_all) {
     ldout(store->ctx(), 20) << "quota type was not specified, can't set all quotas via http headers" << dendl;
-    http_ret = -EINVAL;
+    op_ret = -EINVAL;
     return;
   }
 
   op_state.set_user_id(uid);
 
   RGWUser user;
-  http_ret = user.init(store, op_state);
-  if (http_ret < 0) {
-    ldout(store->ctx(), 20) << "failed initializing user info: " << http_ret << dendl;
+  op_ret = user.init(store, op_state);
+  if (op_ret < 0) {
+    ldout(store->ctx(), 20) << "failed initializing user info: " << op_ret << dendl;
     return;
   }
 
   if (!op_state.has_existing_user()) {
-    http_ret = -ERR_NO_SUCH_USER;
+    op_ret = -ERR_NO_SUCH_USER;
     return;
   }
 
@@ -994,7 +994,7 @@ void RGWOp_Quota_Set::execute()
   if (set_all) {
     UserQuotas quotas;
 
-    if ((http_ret = rgw_rest_get_json_input(store->ctx(), s, quotas, QUOTA_INPUT_MAX_LEN, NULL)) < 0) {
+    if ((op_ret = rgw_rest_get_json_input(store->ctx(), s, quotas, QUOTA_INPUT_MAX_LEN, NULL)) < 0) {
       ldout(store->ctx(), 20) << "failed to retrieve input" << dendl;
       return;
     }
@@ -1006,8 +1006,8 @@ void RGWOp_Quota_Set::execute()
 
     if (!use_http_params) {
       bool empty;
-      http_ret = rgw_rest_get_json_input(store->ctx(), s, quota, QUOTA_INPUT_MAX_LEN, &empty);
-      if (http_ret < 0) {
+      op_ret = rgw_rest_get_json_input(store->ctx(), s, quota, QUOTA_INPUT_MAX_LEN, &empty);
+      if (op_ret < 0) {
         ldout(store->ctx(), 20) << "failed to retrieve input" << dendl;
         if (!empty)
           return;
@@ -1020,9 +1020,9 @@ void RGWOp_Quota_Set::execute()
     if (use_http_params) {
       RGWUserInfo info;
       string err_msg;
-      http_ret = user.info(info, &err_msg);
-      if (http_ret < 0) {
-        ldout(store->ctx(), 20) << "failed to get user info: " << http_ret << dendl;
+      op_ret = user.info(info, &err_msg);
+      if (op_ret < 0) {
+        ldout(store->ctx(), 20) << "failed to get user info: " << op_ret << dendl;
         return;
       }
       RGWQuotaInfo *old_quota;
@@ -1051,9 +1051,9 @@ void RGWOp_Quota_Set::execute()
   }
 
   string err;
-  http_ret = user.modify(op_state, &err);
-  if (http_ret < 0) {
-    ldout(store->ctx(), 20) << "failed updating user info: " << http_ret << ": " << err << dendl;
+  op_ret = user.modify(op_state, &err);
+  if (op_ret < 0) {
+    ldout(store->ctx(), 20) << "failed updating user info: " << op_ret << ": " << err << dendl;
     return;
   }
 }


### PR DESCRIPTION
RGWOp_Bucket_Remove::execute() was storing failures from bucket->remove_bucket() in op_ret, but left http_ret=0 so we responded to the client with '200 OK'

to avoid bugs like this, remove the extra http_ret variable and only use the op_ret from RGWOp

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
