### PR TITLE
mds: add " (blacklisted)" to session reject error string

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -598,7 +598,12 @@ void Server::handle_client_session(const cref_t<MClientSession> &m)
 
       if (blocklisted) {
 	dout(10) << "rejecting blocklisted client " << addr << dendl;
-	send_reject_message("blocklisted");
+	// This goes on the wire and the "blacklisted" substring is
+	// depended upon by the kernel client for detecting whether it
+	// has been blocklisted.  If mounted with recover_session=clean
+	// (since 5.4), it tries to automatically recover itself from
+	// blocklisting.
+	send_reject_message("blocklisted (blacklisted)");
 	session->clear();
 	break;
       }


### PR DESCRIPTION
mds: add " (blacklisted)" to session reject error string

Commit dfd01d765304 ("blacklist -> blocklist") introduced a
regression for recover_session=clean mode of the kernel client.
Unfortunately, one of the ways it detects blocklisting is by
parsing the error string in the session reject message:

3320                 if (err_str && strnstr(*p, "blacklisted", len))
3321                         *blacklisted = true;

Add a suitable substring to restore the functionality.  ceph-fuse
doesn't care, as it just logs this string.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>