### PR TITLE
doc/dev: fix broken link and fix the codeblocks' formatting

### DIFF
--- a/doc/dev/developer_guide/tests-integration-tests.rst
+++ b/doc/dev/developer_guide/tests-integration-tests.rst
@@ -24,7 +24,7 @@ installed on any machine running those platforms.
 
 Teuthology has a `list of platforms that it supports
 <https://github.com/ceph/ceph/tree/master/qa/distros/supported>`_ (as
-of December 2017 the list consisted of "CentOS 7.2" and "Ubuntu 16.04").  It
+of September 2020 the list consisted of "RHEL/CentOS 8" and "Ubuntu 18.04").  It
 expects to be provided pre-built Ceph packages for these platforms.
 Teuthology deploys these platforms on machines (bare-metal or
 cloud-provisioned), installs the packages on them, and deploys Ceph

--- a/doc/dev/developer_guide/tests-integration-tests.rst
+++ b/doc/dev/developer_guide/tests-integration-tests.rst
@@ -494,7 +494,6 @@ this is rarely useful, however, because there is no way to control which
 test will be first.
 
 .. _ceph/qa sub-directory: https://github.com/ceph/ceph/tree/master/qa
-.. _Integration testing: testing-integration-tests
 .. _Sepia Lab: https://wiki.sepia.ceph.com/doku.php
 .. _teuthology repository: https://github.com/ceph/teuthology
 .. _teuthology framework: https://github.com/ceph/teuthology

--- a/doc/dev/developer_guide/tests-integration-tests.rst
+++ b/doc/dev/developer_guide/tests-integration-tests.rst
@@ -3,7 +3,7 @@
 Testing - Integration Tests
 ===========================
 
-Ceph has two types of tests: `make check`_ tests and integration tests.
+Ceph has two types of tests: :ref:`make check <make-check>` tests and integration tests.
 When a test requires multiple machines, root access or lasts for a
 longer time (for example, to simulate a realistic Ceph deployment), it
 is deemed to be an integration test. Integration tests are organized into
@@ -495,7 +495,6 @@ test will be first.
 
 .. _ceph/qa sub-directory: https://github.com/ceph/ceph/tree/master/qa
 .. _Integration testing: testing-integration-tests
-.. _make check:
 .. _Sepia Lab: https://wiki.sepia.ceph.com/doku.php
 .. _teuthology repository: https://github.com/ceph/teuthology
 .. _teuthology framework: https://github.com/ceph/teuthology

--- a/doc/dev/developer_guide/tests-integration-tests.rst
+++ b/doc/dev/developer_guide/tests-integration-tests.rst
@@ -185,9 +185,11 @@ so-called "teuthology machine" from which tests suites are triggered using the
 ``teuthology-suite`` command.
 
 A detailed and up-to-date description of each `teuthology-suite`_ option is
-available by running the following command on the teuthology machine::
+available by running the following command on the teuthology machine
 
-   $ teuthology-suite --help
+.. prompt:: bash $
+
+   teuthology-suite --help
 
 .. _teuthology-suite: http://docs.ceph.com/teuthology/docs/teuthology.suite.html
 
@@ -209,7 +211,8 @@ Let us first examine a standalone test, or "singleton".
 Here is a commented example using the integration test
 `rados/singleton/all/admin-socket.yaml
 <https://github.com/ceph/ceph/blob/master/qa/suites/rados/singleton/all/admin-socket.yaml>`_
-::
+
+.. code-block:: yaml
 
       roles:
       - - mon.a
@@ -267,9 +270,11 @@ the parameter is a set of commands to be sent to the admin socket of
 ``osd.0``. The task verifies that each of them returns on success (i.e.
 exit code zero).
 
-This test can be run with::
+This test can be run with
 
-    $ teuthology-suite --machine-type smithi --suite rados/singleton/all/admin-socket.yaml fs/ext4.yaml
+.. prompt:: bash $
+
+   teuthology-suite --machine-type smithi --suite rados/singleton/all/admin-socket.yaml fs/ext4.yaml
 
 Test descriptions
 -----------------
@@ -325,7 +330,9 @@ subdirectories below the directory containing the operator.
 For example, the `ceph-deploy suite
 <https://github.com/ceph/ceph/tree/jewel/qa/suites/ceph-deploy/>`_ is
 defined by the ``suites/ceph-deploy/`` tree, which consists of the files and
-subdirectories in the following structure::
+subdirectories in the following structure
+
+.. code-block:: none
 
   directory: ceph-deploy/basic
       file: %
@@ -361,14 +368,18 @@ By using symlinks instead of copying, a single file can appear in multiple
 suites. This eases the maintenance of the test framework as a whole.
 
 All the tests generated from the ``suites/ceph-deploy/`` directory tree
-(also known as the "ceph-deploy suite") can be run with::
+(also known as the "ceph-deploy suite") can be run with
 
-  $ teuthology-suite --machine-type smithi --suite ceph-deploy
+.. prompt:: bash $
+
+   teuthology-suite --machine-type smithi --suite ceph-deploy
 
 An individual test from the `ceph-deploy suite`_ can be run by adding the
-``--filter`` option::
+``--filter`` option
 
-  $ teuthology-suite \
+.. prompt:: bash $
+
+   teuthology-suite \
       --machine-type smithi \
       --suite ceph-deploy/basic \
       --filter 'ceph-deploy/basic/{distros/ubuntu_16.04.yaml tasks/ceph-deploy.yaml}'
@@ -386,7 +397,9 @@ For even greater flexibility in sharing yaml files between suites, the
 special file plus (``+``) can be used to concatenate files within a
 directory. For instance, consider the `suites/rbd/thrash
 <https://github.com/ceph/ceph/tree/master/qa/suites/rbd/thrash>`_
-tree::
+tree
+
+.. code-block:: none
 
   directory: rbd/thrash
     file: %
@@ -416,21 +429,27 @@ a 2x2 matrix:
 * rbd/thrash/{clusters/fixed-2.yaml workloads/rbd_api_tests.yaml}
 
 The ``clusters/fixed-2.yaml`` file is shared among many suites to
-define the following ``roles``::
+define the following ``roles``
+
+.. code-block:: yaml
 
   roles:
   - [mon.a, mon.c, osd.0, osd.1, osd.2, client.0]
   - [mon.b, osd.3, osd.4, osd.5, client.1]
 
 The ``rbd/thrash`` suite as defined above, consisting of two tests,
-can be run with::
+can be run with
 
-  $ teuthology-suite --machine-type smithi --suite rbd/thrash
+.. prompt:: bash $
+
+   teuthology-suite --machine-type smithi --suite rbd/thrash
 
 A single test from the rbd/thrash suite can be run by adding the
-``--filter`` option::
+``--filter`` option
 
-  $ teuthology-suite \
+.. prompt:: bash $
+
+   teuthology-suite \
       --machine-type smithi \
       --suite rbd/thrash \
       --filter 'rbd/thrash/{clusters/fixed-2.yaml clusters/openstack.yaml workloads/rbd_api_tests_copy_on_read.yaml}'
@@ -441,16 +460,20 @@ Filtering tests by their description
 When a few jobs fail and need to be run again, the ``--filter`` option
 can be used to select tests with a matching description. For instance, if the
 ``rados`` suite fails the `all/peer.yaml <https://github.com/ceph/ceph/blob/master/qa/suites/rados/singleton/all/peer.yaml>`_ test, the following will only
-run the tests that contain this file::
+run the tests that contain this file
 
-  teuthology-suite --machine-type smithi --suite rados --filter all/peer.yaml
+.. prompt:: bash $
+
+   teuthology-suite --machine-type smithi --suite rados --filter all/peer.yaml
 
 The ``--filter-out`` option does the opposite (it matches tests that do `not`
 contain a given string), and can be combined with the ``--filter`` option.
 
 Both ``--filter`` and ``--filter-out`` take a comma-separated list of strings
 (which means the comma character is implicitly forbidden in filenames found in
-the `ceph/qa sub-directory`_). For instance::
+the `ceph/qa sub-directory`_). For instance
+
+.. prompt:: bash $
 
   teuthology-suite --machine-type smithi --suite rados --filter all/peer.yaml,all/rest-api.yaml
 
@@ -478,9 +501,11 @@ All integration tests are required to be run before a Ceph release is
 published. When merely verifying whether a contribution can be merged without
 risking a trivial regression, it is enough to run a subset. The ``--subset``
 option can be used to reduce the number of tests that are triggered. For
-instance::
+instance
 
-  teuthology-suite --machine-type smithi --suite rados --subset 0/4000
+.. prompt:: bash $
+
+   teuthology-suite --machine-type smithi --suite rados --subset 0/4000
 
 will run as few tests as possible. The tradeoff in this case is that
 not all combinations of test variations will together,

--- a/doc/dev/developer_guide/tests-integration-tests.rst
+++ b/doc/dev/developer_guide/tests-integration-tests.rst
@@ -328,19 +328,20 @@ teuthology to construct a test matrix from yaml facets found in
 subdirectories below the directory containing the operator.
 
 For example, the `ceph-deploy suite
-<https://github.com/ceph/ceph/tree/jewel/qa/suites/ceph-deploy/>`_ is
+<https://github.com/ceph/ceph/tree/master/qa/suites/ceph-deploy/>`_ is
 defined by the ``suites/ceph-deploy/`` tree, which consists of the files and
 subdirectories in the following structure
 
 .. code-block:: none
 
-  directory: ceph-deploy/basic
-      file: %
-      directory: distros
-         file: centos_7.0.yaml
-         file: ubuntu_16.04.yaml
-      directory: tasks
-         file: ceph-deploy.yaml
+  qa/suites/ceph-deploy
+  ├── %
+  ├── distros
+  │   ├── centos_latest.yaml
+  │   └── ubuntu_latest.yaml
+  └── tasks
+      ├── ceph-admin-commands.yaml
+      └── rbd_import_export.yaml
 
 This is interpreted as a 2x1 matrix consisting of two tests:
 
@@ -401,15 +402,16 @@ tree
 
 .. code-block:: none
 
-  directory: rbd/thrash
-    file: %
-    directory: clusters
-      file: +
-      file: fixed-2.yaml
-      file: openstack.yaml
-    directory: workloads
-      file: rbd_api_tests_copy_on_read.yaml
-      file: rbd_api_tests.yaml
+  qa/suites/rbd/thrash
+  ├── %
+  ├── clusters
+  │   ├── +
+  │   ├── fixed-2.yaml
+  │   └── openstack.yaml
+  └── workloads
+      ├── rbd_api_tests_copy_on_read.yaml
+      ├── rbd_api_tests.yaml
+      └── rbd_fsx_rate_limit.yaml
 
 This creates two tests:
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
