### PR TITLE
cls: replace __le{32,64} types by their Ceph counterparts

### DIFF
--- a/src/cls/fifo/cls_fifo.cc
+++ b/src/cls/fifo/cls_fifo.cc
@@ -34,12 +34,12 @@ static constexpr auto CLS_FIFO_MAX_PART_HEADER_SIZE = 512;
 static std::uint32_t part_entry_overhead;
 
 struct entry_header_pre {
-  __le64 magic;
-  __le64 pre_size;
-  __le64 header_size;
-  __le64 data_size;
-  __le64 index;
-  __le32 reserved;
+  ceph_le64 magic;
+  ceph_le64 pre_size;
+  ceph_le64 header_size;
+  ceph_le64 data_size;
+  ceph_le64 index;
+  ceph_le32 reserved;
 } __attribute__ ((packed));
 
 struct entry_header {


### PR DESCRIPTION
`__le*` types are not available on FreeBSD, so that is fixed.

And replacing `__le*` with `ceph_le*` is possible as long as
the variables are not using in kernel related parts.
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>