### PR TITLE
test/cls: make sure that the ceph mtime is formatable

### DIFF
--- a/src/test/cls_fifo/bench_cls_fifo.cc
+++ b/src/test/cls_fifo/bench_cls_fifo.cc
@@ -443,7 +443,8 @@ int main(int argc, char* argv[])
     }
     if (op & LIST) {
       for (const auto& entry : entries) {
-	fmt::print(std::cout, "{}\t{}\n", entry.marker, entry.mtime);
+	fmt::print(std::cout, "{}\t{}\n", entry.marker, 
+		   ceph::real_clock::to_time_t(entry.mtime));
       }
       if (more) {
 	fmt::print(std::cout, "...");


### PR DESCRIPTION
Clang complains it cannot find a way to actually convert 
the ceph::real_time to something it knows.

/usr/local/include/fmt/core.h:1016:5: error: static_assert failed due to requirement 'formattable' "Cannot format argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#formatting-user-defined-types"
    static_assert(
    ^
/usr/local/include/fmt/core.h:1217:32: note: in instantiation of member function 'fmt::v6::internal::arg_mapper<fmt::v6::basic_format_context<std::__1::back_insert_iterator<fmt::v6::internal::buffer<char> >, char> >::map' requested here
  return arg_mapper<Context>().map(val);
                               ^
/usr/local/include/fmt/core.h:1354:25: note: in instantiation of function template specialization 'fmt::v6::internal::make_arg<true, fmt::v6::basic_format_context<std::__1::back_insert_iterator<fmt::v6::internal::buffer<char> >, char>, fmt::v6::internal::type::int_type, std::__1::chrono::time_point<ceph::time_detail::real_clock, std::__1::chrono::duration<unsigned long, std::__1::ratio<1, 1000000000> > >, 0>' requested here
        data_{internal::make_arg<
                        ^
/usr/local/include/fmt/core.h:1656:10: note: in instantiation of member function 'fmt::v6::format_arg_store<fmt::v6::basic_format_context<std::__1::back_insert_iterator<fmt::v6::internal::buffer<char> >, char>, const std::__1::chrono::time_point<ceph::time_detail::real_clock, std::__1::chrono::duration<unsigned long, std::__1::ratio<1, 1000000000> > > >::format_arg_store' requested here
  return {args...};
         ^
/usr/local/include/fmt/ostream.h:162:20: note: in instantiation of function template specialization 'fmt::v6::internal::make_args_checked<const std::__1::chrono::time_point<ceph::time_detail::real_clock, std::__1::chrono::duration<unsigned long, std::__1::ratio<1, 1000000000> > > &, char [4], char>' requested here
         internal::make_args_checked<Args...>(format_str, args...));
                   ^
/home/jenkins/workspace/ceph-master-compile/src/test/cls_fifo/bench_cls_fifo.cc:447:7: note: in instantiation of function template specialization 'fmt::v6::print<char [4], const std::__1::chrono::time_point<ceph::time_detail::real_clock, std::__1::chrono::duration<unsigned long, std::__1::ratio<1, 1000000000> > > &, char>' requested here
        fmt::print(std::cout, "{}\n", entry.mtime);
             ^
1 error generated.



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>