### PR TITLE
ceph-bluestore-tool list-objects operation

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -21,6 +21,7 @@ set(common_srcs
   FastCDC.cc
   Finisher.cc
   FixedCDC.cc
+  formatter_filter.cc
   Formatter.cc
   Graylog.cc
   HTMLFormatter.cc

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -12,6 +12,7 @@
 #include <stdarg.h>
 #include <sstream>
 #include <map>
+#include <functional>
 
 namespace ceph {
 
@@ -307,5 +308,300 @@ namespace ceph {
 
   std::string fixed_to_string(int64_t num, int scale);
   std::string fixed_u_to_string(uint64_t num, int scale);
+
+
+  /**
+   * @class Trimmer
+   *
+   * Trimmer is a transform for @ref Formatter that eliminates unwanted sections of data structure.
+   *
+   * Trimmer treats incoming sequence of @ref Formatter calls as tree.
+   * Pairs of @ref Formatter::open_array_section / @ref Formatter::open_object_section and
+   * @ref Formatter::close_section form branches of tree, and functions @ref Formatter.dump* form leaves.
+   * Both branches and leaves are named, and identified by path leading to them.
+   * Trimmer treats branches and leaves equally.
+   * Rules that exclude branches are the same as ones that exclude leaves.
+   *
+   * Trimmer preserves tree paths. When some branch is excluded
+   * but a far subbranch is included then Trimmer reconstructs missing path.
+   *
+   * Example (XML):
+   * Rule "-a.b, +a.b.c2.d" transforms
+   * <a><b><c0>X</c0><c1>Y</c1><c2><d>Z</d></c2></b></a>
+   * into
+   * <a><b><c2><d>Z</d></c2></b></a> .
+   *
+   * Rule is defined as sequence of paths. Each path can either be inclusion or exclustion,
+   * denoted by prefix "+" or prefix "-", respectively. Lack of prefix means inclusion.
+   * Rules are applied in sequence. Next rule always overrides previous rule.
+   * So, exclusion of specialized path is countered by inclusion of more general path specified later.
+   */
+  class Trimmer {
+  public:
+    virtual ~Trimmer() {}
+    /**
+     * @brief
+     * Creates Trimmer instance
+     *
+     * @retval newly created Trimmer
+     */
+    static Trimmer* create();
+    /**
+     * @brief
+     * Sets up rule for trimming data tree
+     *
+     * Sets up tree filtering behaviour for all @ref Formatters obtained by @ref attach.
+     * @c stencil is a comma "," separated list of multipart branches.
+     * Each multipart branch is prefixed with "+" or "-" that denote inclusion and exclustion respectively.
+     * Lack of prefix is considered to be inclusion "+".
+     * Branches are separated by dot ".".
+     * Example: "+objects,-objects.id".
+     *
+     * If error in parsing @c stencil occurs, @c error contains human-readable,
+     * possibly multiline text containing problem description.
+     *
+     * A Trimmer configured with @ref setup can be used multiple times
+     * as long as previous @ref attach are paired with @ref detach.
+     *
+     * @param stencil[in] Tree-trimming rule.
+     * @param error[out] Error description
+     *
+     * @retval true - @c stencil successfully parsed, @c error is empty.
+     * @retval false - @c stencil invalid, @c contains error.
+     */
+    virtual bool setup(std::string_view stencil, std::string& error) = 0;
+    /**
+     * @brief
+     * Connects formatter for processing
+     *
+     * Prepares Trimmer for transforming @ref ceph::Formatter operations.
+     * Returned @ref Formatter is input that should recieve structuralized data to be formatted.
+     * Only one @ref Formatter can be connected at any time.
+     * One has to @ref detach before calling @ref attach again.
+     *
+     * @param sink[in] Formatter that is used by Trimmer as output
+     *
+     * @retval Formatter input, stream data into this.
+     *
+     * @note Returned formatter is an internal object, do not delete it.
+     */
+    virtual Formatter* attach(Formatter* sink) = 0;
+    /**
+     * @brief
+     * Disconnects formatter
+     *
+     * Complementary operation to @ref attach.
+     * After it is called, it is illegal to use @ref Formatter obtained by previous call to @ref attach.
+     */
+    virtual void detach() = 0;
+  };
+
+
+  /**
+   * @class Buffer
+   *
+   * Buffer is a @ref Formatter transform that either passes input unchanged or eliminates it completely
+   * Formatting data streamed to input is stored (copied) into internal buffers.
+   * When @ref unbuffer is called, stored formatter input is sent to output.
+   * After that @ref Buffer ceases its buffering behaviour until @ref attach is called again.
+   */
+  class Buffer {
+  public:
+    virtual ~Buffer() {};
+    /**
+     * @brief
+     * Creates Buffer instance
+     *
+     * @retval newly created Buffer
+     */
+    static Buffer* create();
+    /**
+     * @brief
+     * Connects formatter for processing
+     *
+     * Prepares Buffer for incoming @ref ceph::Formatter operations.
+     * Returned @ref Formatter is input that should recieve structuralized data to be formatted.
+     * Only one @ref Formatter can be connected at any time.
+     * One has to @ref detach before calling @ref attach again.
+     *
+     * @param sink[in] Formatter that will recieve data on @ref unbuffer
+     *
+     * @retval Formatter input, stream data into this.
+     *
+     * @note Returned formatter is an internal object, do not delete it.
+     */
+    virtual Formatter* attach(Formatter* sink) = 0;
+    /**
+     * @brief
+     * Disconnects formatter
+     *
+     * Complementary operation to @ref attach. Deletes any stored formatter data.
+     * After it is called, it is illegal to use @ref Formatter obtained by previous call to @ref attach.
+     */
+    virtual void detach() = 0;
+    /**
+     * @brief
+     * Disconnects formatter
+     *
+     * Complementary operation to @ref attach. Deletes any stored formatter data.
+     * After it is called, it is illegal to use @ref Formatter obtained by previous call to @ref attach.
+     */
+    virtual void unbuffer() = 0;
+  };
+
+  /**
+   * @class Filter
+   *
+   * Filter is a @ref Formatter transform that checks if data/structure matches selected condition.
+   * Input data passes unchanged to output immediatelly.
+   *
+   * Examples:
+   * 1) .object.size > 1000
+   * 2) .object.name has "osdmap" && exists .object.shards
+   * 3) (.object.shards.shard.offset + .object.shards.shard.len) % 0x1000 != 0
+   *
+   * Filter treats incoming sequence of @ref Formatter calls as tree.
+   * Pairs of @ref Formatter::open_array_section / @ref Formatter::open_object_section and
+   * @ref Formatter::close_section form branches of tree, and functions @ref Formatter.dump* form leaves.
+   * Both branches and leaves are named, and identified by path leading to them.
+   *
+   * ::Condition::
+   * Condition is an expression that is formed by combining values from tree,
+   * operators and constants to give boolean result.
+   * When condition is met @ref on_match function is immediatelly called.
+   *
+   * ::Expressions::
+   * expression := literal |
+   *               number |
+   *               variable |
+   *               '(' expression ')' |
+   *               left_operator expression |
+   *               expression binary_operator expression
+   *
+   * literal := '"' in-literal '"'
+   * in-literal := |
+   *              {single_character} in-literal |
+   *              '\"' in-literal
+   *
+   * number := [0-9]* |
+   *          '0x' [0-9a-f]*
+   *
+   * variable := branch |
+   *            variable branch
+   *
+   * branch := '.' [_a-zA-Z0-9]*
+   *
+   * left_operator := 'exists' | '-' | '!'
+   *
+   * binary_operator := '==' | '!=' | '>=' | '<=' | '<' | '>' |
+   *                    '&&' | '||' | 'has' | '+' | '-' |
+   *                    '*' | '/' | '%'
+   *
+   * ::Variables::
+   * Variables used in expressions are obtained from processed tree.
+   * Names of variables are equal to branch paths. If path is leading to a leaf
+   * (data put by @ref Formatter::dump* function) dumped value is stored as variable value.
+   * If path is leading to a branch, variable does not have any value, but is marked as present.
+   * Operator 'exists' is used to test if branch exists in tree.
+   *
+   * ::Condition matching::
+   * A condition can be constructed using multiple variables.
+   * When tree is processed current branch path is tracked. When branch path equals to any variable
+   * that is part of condition, value is snapshot into variable.
+   * Each time value of any variable changes, condition is evaluated.
+   * If result of condition is true (after possible convertion to bool) @ref on_match function is called.
+   * Each time setting variables makes condition true, @ref on_match will be invoked.
+   *
+   * ::Operators::
+   * Boolean operators: == != && || !
+   * Aritmetic operators: + - * / %
+   * Relational operators: >= <= < > == !=
+   * Substring operator: has
+   *   A 'has' B is true iff B is a substring of A.
+   * Structure inspection: exists
+   *   'exists' A is true iff branch/leaf A exists in tree.
+   *
+   * ::Operator priorities::
+   * (highest) 0: ! % / * exists has
+   *           1: + -
+   *           2: < > <= >= != ==
+   * (lowest)  3: && ||
+   * When operands between arguments are of same priority, left is evaluated first.
+   *
+   * ::Data types::
+   * There are 3 data types used in expression evaluation: boolean, string, integer(signed 64bit).
+   * Initial types are from variables are string and integer.
+   * String type is used when @ref dump_string, @ref dump_float, @ref dump_stream or @ref dump_format_va are used.
+   * Integer type is used when @ref dump_unsigned or @ref dump_int are used.
+   * Boolean type is used when @ref dump_bool is used.
+   *
+   * ::Conversions::
+   * When type of argument is not consistent with used unary operator,
+   * or types of arguments are different for binary operators,
+   * then conversion is performed. For binary operators right argument is converted into type of left argument.
+   *
+   * Integer to string conversion does signed 64 bit print into string.
+   * String to integer conversion allows for optional '0x' hex interpretation.
+   * Integer to boolean conversion maps 0->0, *->1.
+   * Boolean to integer conversion maps 0->0, 1->1.
+   */
+  class Filter {
+  public:
+    virtual ~Filter() {};
+    /**
+     * @brief
+     * Creates Filter instance
+     *
+     * @retval newly created Filter
+     */
+    static Filter* create();
+    /**
+     * @brief
+     * Sets up matching condition
+     *
+     * Sets up condition that is used to validate if passed @ref Formatter structured data
+     * adheres to required specification. Grammar for it is described in @ref class Filter.
+     *
+     * A Filter configured with @ref setup can be used multiple times
+     * as long as previous @ref attach are paired with @ref detach.
+     *
+     * @param condition[in] Formatter-matching rule.
+     * @param error[out] Error description
+     *
+     * @retval true - @c condition successfully parsed, @c error is empty.
+     * @retval false - @c condition invalid, @c contains error.
+     */
+    virtual bool setup(const std::string& condition,
+		       std::string& error) = 0;
+    /**
+     * @brief
+     * Connects formatter for pattern matching
+     *
+     * Prepares Filter to sniff passing @ref ceph::Formatter operations.
+     *
+     * Returned @ref Formatter is input. Any action on input is passed to sink (output) immediately.
+     * Filter inspects passing data, and if it matches condition @c on_match is called.
+     * Function @c on_match can be called multiple times, if values passing through Filter keep
+     * matching condition.
+     * Only one @ref Formatter can be connected at any time.
+     * Call @ref detach before calling @ref attach again.
+     *
+     * @param sink[in] Formatter that is used by Filter as output
+     * @param on_match[in] function to call when condition matches
+     *
+     * @retval Formatter input, stream structuralized data into this.
+     *
+     * @note Returned formatter is an internal object, do not delete it.
+     */
+    virtual Formatter* attach(Formatter* sink, std::function<void()> on_match) = 0;
+    /**
+     * @brief
+     * Disconnects formatter
+     *
+     * Complementary operation to @ref attach.
+     * After it is called, it is illegal to use @ref Formatter obtained by previous call to @ref attach.
+     */
+    virtual void detach() = 0;
+  };
 }
 #endif

--- a/src/common/formatter_filter.cc
+++ b/src/common/formatter_filter.cc
@@ -1,0 +1,1574 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <boost/program_options/variables_map.hpp>
+#include <boost/program_options/parsers.hpp>
+
+#include <stdio.h>
+#include <string.h>
+#include <iostream>
+#include <time.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include "global/global_init.h"
+#include "common/ceph_argparse.h"
+#include "include/stringify.h"
+#include "common/errno.h"
+#include "common/safe_io.h"
+
+#include "os/bluestore/BlueFS.h"
+#include "os/bluestore/BlueStore.h"
+#include "common/admin_socket.h"
+#include "common/url_escape.h"
+
+#include "formatter_filter.h"
+/*
+  expression:= literal ||
+               number ||
+	       variable ||
+	       ( expression ) ||
+	       LOP expression ||
+               expression OP expression ||
+	       expression ROP
+term
+
+
+OP term OP OP term OP expression
+3             4  3             2
+reduce
+              shift
+                 shift         reduce
+                 reduce
+              reduce
+
+literal -> expression
+number -> expression
+variable -> expression
+( expression ) -> expression
+LOP expression -> expression
+expression OP expression -> expression
+
+! == != > < >= <=
+&& ||
+has
++ - * / %
+
+Variables are set when encountered in formatter, and never unset.
+Condition is checked every time a variable is set.
+*/
+
+
+namespace ceph {
+namespace formatter_filter {
+
+  operator_spec_t operators[op_last] =
+    {
+      {"==", 2, true, false},
+      {"!=", 2, true, false},
+      {">=", 2, true, false},
+      {"<=", 2, true, false},
+      {">", 2, true, false},
+      {"<", 2, true, false},
+      {"&&", 3, true, false},
+      {"||", 3, true, false},
+      {"has", 0, true, false},
+      {"exists", 0, false, true},
+      {"+", 1, true, false},
+      {"-", 1, true, true},
+      {"*", 0, true, false},
+      {"/", 0, true, false},
+      {"%", 0, true, false},
+      {"!", 0, false, true}
+    };
+
+  /* splits input into stream of tokens */
+  void TokenSplitter::parse_one() {
+    skip_whitespace();
+    if (left.empty()) {
+      token = eEnd;
+      return;
+    }
+    peeked = left;
+    switch (peeked.front()) {
+    case '"':
+      {
+	//literal
+	token_literal.clear();
+	peeked = peeked.substr(1);
+	while (!peeked.empty()) {
+	  switch (peeked.front()) {
+	  case '"':
+	    token = eLiteral;
+	    peeked = peeked.substr(1);
+	    return;
+	  case '\\':
+	    peeked = peeked.substr(1);
+	    if (peeked.empty()) {
+	      token = eError;
+	      return;
+	    }
+	    token_literal.push_back(peeked.front());
+	    peeked = peeked.substr(1);
+	    break;
+	  default:
+	    token_literal.push_back(peeked.front());
+	    peeked = peeked.substr(1);
+	    break;
+	  }
+	}
+	token = eError;
+	break;
+      }
+    case '0' ... '9':
+      {
+	//number
+	char* endptr;
+	int64_t v = strtoll(&peeked[0],  &endptr, 0);
+	if (endptr == &peeked.front()) {
+	  /* this is actually possible, if input is "0x" */
+	  token = eError;
+	  break;
+	}
+	token = eNumber;
+	token_number = v;
+	peeked = left.substr(endptr - &peeked.front());
+	break;
+      }
+    case '(':
+      {
+	token = eLeftBracket;
+	peeked = left.substr(1);
+	break;
+      }
+    case ')':
+      {
+	token = eRightBracket;
+	peeked = left.substr(1);
+	break;
+      }
+    case '.':
+      {
+	//variable
+	size_t cnt = 0;
+	while (cnt < peeked.size()) {
+	  switch (peeked[cnt]) {
+	  case 'A' ... 'Z':
+	  case 'a' ... 'z':
+	  case '0' ... '9':
+	  case '_':
+	  case '.':
+	    {
+	      cnt++;
+	      continue;
+	    }
+	  default:
+	    break;
+	  }
+	  break;
+	}
+	token_variable = peeked.substr(0, cnt);
+	peeked = peeked.substr(cnt);
+	token = eVariable;
+	break;
+      }
+    default:
+      {
+	//this must be operator
+	std::string_view cand;
+	for (size_t i = 1; i <= std::min<size_t>(6, left.size()); i++) {
+	  std::string_view cand_n = left.substr(0, i);
+	  if (possibly_operator(cand_n) < 1) {
+	    //longer will not be operator
+	    break;
+	  };
+	  cand = cand_n;
+	}
+	auto [op, prio] = get_operator(cand);
+	if (op != op_last) {
+	  token_op = op;
+	  token_op_prio = prio;
+	  token = eOperator;
+	  peeked = peeked.substr(cand.size());
+	} else {
+	  token = eError;
+	}
+      }
+    }
+  }
+
+  token_t TokenSplitter::peek() {
+    parse_one();
+    return token;
+  }
+  void TokenSplitter::consume() {
+    ceph_assert(left != peeked);
+    left = peeked;
+  }
+  std::string TokenSplitter::get_variable() {
+    ceph_assert(token == eVariable);
+    return token_variable;
+  }
+  uint64_t TokenSplitter::get_number() {
+    ceph_assert(token == eNumber);
+    return token_number;
+  }
+  std::string TokenSplitter::get_literal() {
+    ceph_assert(token == eLiteral);
+    return token_literal;
+  }
+  operator_t TokenSplitter::get_operator() {
+    ceph_assert(token == eOperator);
+    return token_op;
+  }
+  int8_t TokenSplitter::get_operator_prio() {
+    ceph_assert(token == eOperator);
+    return token_op_prio;
+  }
+  void TokenSplitter::skip_whitespace() {
+    while (!left.empty() &&
+	   (left.front() == ' ' ||
+	    left.front() == '\n' ||
+	    left.front() == '\t')) {
+      left = left.substr(1);
+    }
+  }
+  std::tuple<operator_t, uint8_t> TokenSplitter::get_operator(std::string_view cand) {
+    for (size_t i = 0; i < op_last; i++) {
+      if (cand == operators[i].name) {
+	operator_t op = static_cast<operator_t>(i);
+	return std::make_tuple(op, operators[i].prio);
+      }
+    }
+    return std::make_tuple(op_last, 255);
+  }
+  size_t TokenSplitter::possibly_operator(std::string_view cand) {
+    size_t cnt = 0;
+    for (size_t i = 0; i < op_last; i++) {
+      if (cand == operators[i].name.substr(0, cand.size())) {
+	cnt++;
+      }
+    }
+    return cnt;
+  }
+  void TokenSplitter::set_input(std::string_view str) {
+    input = str;
+    left = str;
+    token = eError;
+  }
+
+  bool TokenSplitter::show_error(std::ostream& out,
+				 const std::string& error)
+  {
+    size_t consumed = input.size() - left.size();
+    std::string_view s = input.substr(0, consumed + 20);
+    out << s << std::endl;
+    out << std::string(consumed, ' ') << "^ " << error << std::endl;
+    return true;
+  }
+
+
+  Exp::Value Exp::cast_to(variant_t target, const Value& right) {
+    if (right.index() == einv) {
+      return right;
+    }
+    switch (target) {
+    case einv:
+      return inv();
+    case eint:
+      switch (right.index()) {
+      case eint:
+	return right;
+      case estring:
+	{
+	  const std::string& str = *std::get<pstring>(right);
+	  char* endptr;
+	  int64_t v = strtoll(str.c_str(),  &endptr, 0);
+	  if (*endptr != '\0') {
+	    return Value{inv()};
+	  }
+	  return Value{v};
+	}
+      case ebool:
+	return Value{int64_t(std::get<bool>(right) ? 1 : 0) };
+      }
+    case estring:
+      switch (right.index()) {
+      case eint:
+	{
+	  //std::string* p = new std::string;
+	  std::string p = std::to_string(std::get<int64_t>(right));
+	  pstring pp = std::make_shared<std::string>(p);
+	  return Value{pp};
+	}
+      case estring:
+	return right;
+      case ebool:
+	{
+	  //	  std::string* p = new std::string;
+	  std::string p = std::get<bool>(right) ? "1"s : "0"s;
+	  pstring pp = std::make_shared<std::string>(p);
+	  return Value{pp};
+	}
+      }
+    case ebool:
+      switch (right.index()) {
+      case eint:
+	return Value{std::get<int64_t>(right) != 0 ? true : false};
+      case estring:
+	{
+	  std::string& s = *std::get<pstring>(right);
+	  if (s == "0" || s == "false")
+	    return Value{false};
+	  if (s == "1" || s == "true")
+	    return Value{true};
+	  return Value{inv()};
+	}
+      case ebool:
+	return right;
+      }
+    }
+    return {inv()};
+  }
+
+
+  class ExpLiteral : public Exp {
+  public:
+    ExpLiteral(const std::string& literal)
+      : literal(std::make_shared<std::string>(literal)) {};
+    Value get_value() override {
+      return {literal};
+    }
+  private:
+    pstring literal;
+  };
+
+  class ExpNumber : public Exp {
+  public:
+    ExpNumber(uint64_t value)
+      : value(value) {};
+    Value get_value() override {
+      return {(int64_t)value};
+    }
+  private:
+    uint64_t value;
+  };
+
+  class ExpVariable : public Exp {
+  public:
+    ExpVariable(std::shared_ptr<std::string>& value)
+      : value(value) {};
+    Value get_value() override {
+      if (!value) {
+	return {inv()};
+      } else {
+	return {value};
+      }
+    }
+  private:
+    std::shared_ptr<std::string>& value;
+  };
+
+
+
+  class BinaryExp : public Exp {
+    ExpRef left;
+    ExpRef right;
+    operator_t op;
+  public:
+    BinaryExp(ExpRef left, operator_t op, ExpRef right)
+      :left(left), right(right), op(op) {}
+
+    Value get_value() override
+    {
+      switch (op) {
+      case eq:
+      case neq:
+      case gt:
+      case le:
+      case lt:
+      case ge:
+	{
+	  Value l = left->get_value();
+	  Value r = cast_to(static_cast<variant_t>(l.index()), right->get_value());
+	  switch (op) {
+	  case eq:
+	  case neq:
+	    {
+	      bool b = false;
+	      switch (r.index()) {
+	      case einv:
+		return r;
+	      case eint:
+		b = std::get<int64_t>(l) == std::get<int64_t>(r);
+		break;
+	      case estring:
+		b = *std::get<pstring>(l) == *std::get<pstring>(r);
+		break;
+	      case ebool:
+		b = std::get<bool>(l) == std::get<bool>(r);
+		break;
+	      }
+	      if (op == neq) b = !b;
+	      return Value{b};
+	    }
+	  case gt:
+	  case le:
+	    {
+	      bool b = false;
+	      switch (r.index()) {
+	      case einv:
+		return r;
+	      case eint:
+		b = std::get<int64_t>(l) > std::get<int64_t>(r);
+		break;
+	      case estring:
+		b = *std::get<pstring>(l) > *std::get<pstring>(r);
+		break;
+	      case ebool:
+		b = std::get<bool>(l) > std::get<bool>(r);
+		break;
+	      }
+	      if (op == le) b = !b;
+	      return Value{b};
+	    }
+	  case lt:
+	  case ge:
+	    {
+	      bool b = false;
+	      switch (r.index()) {
+	      case einv:
+		return r;
+	      case eint:
+		b = std::get<int64_t>(l) < std::get<int64_t>(r);
+		break;
+	      case estring:
+		b = *std::get<pstring>(l) < *std::get<pstring>(r);
+		break;
+	      case ebool:
+		b = std::get<bool>(l) < std::get<bool>(r);
+		break;
+	      }
+	      if (op == ge) b = !b;
+	      return Value{b};
+	    }
+	  default:
+	    ceph_assert(false);
+	  }
+	}
+      case _or:
+      case _and:
+	{
+	  Value l = cast_to(ebool, left->get_value());
+	  Value r = cast_to(ebool, right->get_value());
+	  if (l.index() == einv || r.index() == einv) {
+	    return inv();
+	  }
+	  ceph_assert(l.index() == ebool);
+	  ceph_assert(r.index() == ebool);
+	  switch (op) {
+	  case _or:
+	    return std::get<bool>(l) || std::get<bool>(r);
+	  case _and:
+	    return std::get<bool>(l) && std::get<bool>(r);
+	  default:
+	    ceph_assert(false);
+	  }
+	}
+      case plus:
+      case minus:
+      case mult:
+      case div:
+      case mod:
+	{
+	  Value L = cast_to(eint, left->get_value());
+	  Value R = cast_to(eint, right->get_value());
+	  if (L.index() == einv || R.index() == einv) {
+	    return inv();
+	  }
+	  ceph_assert(L.index() == eint);
+	  ceph_assert(R.index() == eint);
+	  int64_t l = std::get<int64_t>(L);
+	  int64_t r = std::get<int64_t>(R);
+	  switch (op) {
+	  case plus:
+	    return l + r;
+	  case minus:
+	    return l - r;
+	  case mult:
+	    return l * r;
+	  case div:
+	    if (r == 0) {
+	      return inv();
+	    }
+	    return l / r;
+	  case mod:
+	    if (r == 0) {
+	      return inv();
+	    }
+	    return l % r;
+	  default:
+	    ceph_assert(false);
+	  }
+	  break;
+	}
+      case has:
+	{
+	  Value l = cast_to(estring, left->get_value());
+	  Value r = cast_to(estring, right->get_value());
+	  if (l.index() == einv || r.index() == einv) {
+	    return false;
+	  }
+	  ceph_assert(l.index() == estring);
+	  ceph_assert(r.index() == estring);
+	  const std::string& L = *std::get<pstring>(l);
+	  const std::string& R = *std::get<pstring>(r);
+	  bool b = L.find(R) != std::string::npos;
+	  return b;
+	}
+      default:
+	{
+	  ceph_assert(false);
+	}
+      }
+      return inv();
+    }
+  };
+
+  class UnaryExp : public Exp {
+    operator_t op;
+    ExpRef right;
+  public:
+    UnaryExp(operator_t op, ExpRef right)
+      :op(op), right(right) {}
+
+    Value get_value() override
+    {
+      switch (op) {
+      case exists:
+	{
+	  return right->get_value().index() != einv;
+	}
+      case neg:
+	{
+	  Value r = cast_to(ebool, right->get_value());
+	  if (r.index() == einv) {
+	    return inv();
+	  }
+	  return !std::get<bool>(r);
+	}
+      default:
+	{
+	  ceph_assert(false);
+	}
+      }
+    }
+  };
+
+  bool isUnary(operator_t op) {
+    return operators[op].is_unary;
+  }
+
+  bool isBinary(operator_t op) {
+    return operators[op].is_binary;
+  }
+
+
+  //must read at least one token and form expression
+  //return true if reading expression succeded
+  bool parse_expression(TokenSplitter& token_src,
+			VariableMap& vars,
+			std::string& error,
+			ExpRef *exp_result,
+			uint8_t left_op_prio = 255)
+  {
+    bool res = false;
+    ExpRef left;
+    error = "dupa";
+    //mandatory consumption of token into expression
+    token_t t = token_src.peek();
+    switch (t) {
+    case eLiteral:
+      left.reset(new ExpLiteral(token_src.get_literal()));
+      token_src.consume();
+      res = true;
+      break;
+    case eNumber:
+      left.reset(new ExpNumber(token_src.get_number()));
+      token_src.consume();
+      res = true;
+      break;
+    case eVariable:
+      left.reset(new ExpVariable(vars[token_src.get_variable()]));
+      token_src.consume();
+      res = true;
+      break;
+    case eLeftBracket:
+      {
+	token_src.consume();
+	//"shift"
+	if (!parse_expression(token_src, vars, error, &left) ) {
+	  //pass error from inside
+	  break;
+	}
+	token_t t1 = token_src.peek();
+	if (t1 != eRightBracket) {
+	  error = ") missing";
+	  break;
+	}
+	token_src.consume();
+	//"reduce"
+	res = true;
+	break;
+      }
+    case eRightBracket:
+      error = ") unexpected";
+      break;
+    case eOperator:
+      {
+	//must be unary operator
+	operator_t op = token_src.get_operator();
+	if (!isUnary(op)) {
+	  error = "expected unary operator";
+	  break;
+	}
+	uint8_t prio = token_src.get_operator_prio();
+	token_src.consume();
+	ExpRef exp;
+	//shift
+	res = parse_expression(token_src, vars, error, &exp, prio);
+	//reduce
+	if (res)
+	  left = std::make_shared<UnaryExp>(op, exp);
+	break;
+      }
+    case eEnd:
+      error = "unexpected end of input";
+      return false;
+    case eError:
+      error = "unrecognized input";
+      return false;
+    }
+
+    //greedy part
+    if (res) {
+      while (true) {
+	t = token_src.peek();
+	if (t == eEnd) {
+	  error = "";
+	  break;
+	}
+	if (t == eOperator) {
+	  operator_t op = token_src.get_operator();
+	  if (!isBinary(op)) {
+	    error = "binary operator expected";
+	    //error
+	    break;
+	  }
+	  uint8_t prio = token_src.get_operator_prio();
+	  if (prio < left_op_prio) {
+	    token_src.consume();
+	    ExpRef right;
+	    //shift
+	    res = parse_expression(token_src, vars, error, &right, prio);
+	    if (!res) {
+	      //if fail, inherit error from nested
+	      break;
+	    }
+	    left = std::make_shared<BinaryExp>(left, op, right);
+	    //reduce
+	    continue;
+	  } else {
+	    break;
+	  }
+	} else {
+	  //this is not operator, so we exit greedy part
+	  //if this is problem, outer expression will handle it
+	  ceph_assert(res == true);
+	  break;
+	}
+      }
+    }
+    if (res) {
+      *exp_result = left;
+    }
+    return res;
+  }
+
+bool parse(TokenSplitter& token_src,
+	   VariableMap& vars,
+	   std::string& error,
+	   ExpRef *exp_result)
+{
+  bool res = parse_expression(token_src, vars, error, exp_result);
+  if (!res) {
+    return false;
+  }
+  token_t t = token_src.peek();
+  if (t != eEnd) {
+    error = "extra token at end of input";
+    return false;
+  }
+  error = "";
+  return true;
+}
+
+
+class BufferImpl final: public Buffer, public Formatter {
+  Formatter* sink;
+  std::vector<std::function<void()>> stack;
+  std::string dump_stream_name;
+  std::stringstream dump_stream_stream;
+  bool dump_stream_is = false;
+public:
+  virtual ~BufferImpl() {};
+  Formatter* attach(Formatter* sink) override {
+    detach();
+    this->sink = sink;
+    return this;
+  }
+  void detach() override {
+    reset_buffer();
+    sink = nullptr;
+  }
+  /* function to dump all buffered formats */
+  void unbuffer() override {
+    for (auto f: stack) {
+      f();
+    }
+    stack.clear();
+  }
+
+private:
+  void reset_buffer() {
+    dump_stream_is = false;
+    dump_stream_stream.str("");
+    dump_stream_name.clear();
+    stack.clear();
+  }
+  static void list_helper(Formatter* f,
+			  const char *name, const char *ns, bool quoted, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    f->dump_format_va(name, ns, quoted, fmt, ap);
+    va_end(ap);
+  }
+  void push(std::function<void()> f) {
+    maybe_dump_stream();
+    stack.push_back(std::move(f));
+  }
+  void maybe_dump_stream() {
+    if (unlikely(dump_stream_is)) {
+      Formatter* f = sink;
+      std::string name = dump_stream_name;
+      std::string data = dump_stream_stream.str();
+      push([f, name, data](){f->dump_stream(name.c_str()) << data;});
+      dump_stream_is = false;
+      dump_stream_stream.str("");
+    }
+  }
+
+  //formatter functions
+  void enable_line_break() override {
+    Formatter* f = sink;
+    push([f](){f->enable_line_break();});
+  }
+  void flush(std::ostream& os) override {
+    maybe_dump_stream();
+    sink->flush(os);
+  }
+  void reset() override {
+    maybe_dump_stream();
+    sink->reset();
+    }
+  void set_status(int status, const char* status_name) override {
+    sink->set_status(status, status_name);
+  }
+  void output_header() override {
+    Formatter* f = sink;
+    push([f](){f->output_header();});
+  }
+  void output_footer() override {
+    Formatter* f = sink;
+    push([f](){f->output_footer();});
+  }
+  void open_array_section(const char *name) override {
+    Formatter* f = sink;
+    std::string _name(name);
+    push([f, _name](){f->open_array_section(_name.c_str());});
+  }
+  void open_array_section_in_ns(const char *name, const char *ns) override {
+    Formatter* f = sink;
+    std::string _name(name);
+    std::string _ns(ns);
+    push([f, _name, _ns](){f->open_array_section_in_ns(_name.c_str(), _ns.c_str());});    
+  }
+  void open_object_section(const char *name) override {
+    Formatter* f = sink;
+    std::string _name(name);
+    push([f, _name](){f->open_object_section(_name.c_str());});
+  }
+  void open_object_section_in_ns(const char *name, const char *ns) override {
+    Formatter* f = sink;
+    std::string _name(name);
+    std::string _ns(ns);
+    push([f, _name, _ns](){f->open_object_section_in_ns(_name.c_str(), _ns.c_str());});    
+  }
+  void close_section() override {
+    Formatter* f = sink;
+    push([f](){f->close_section();});
+  }
+  void dump_unsigned(const char *name, uint64_t u) override {
+    std::string _name(name);
+    Formatter* f = sink;
+    push([f, _name, u](){f->dump_unsigned(_name.c_str(), u);});
+  }
+  void dump_int(const char *name, int64_t s) override {
+    std::string _name(name);
+    Formatter* f = sink;
+    push([f, _name, s](){f->dump_int(_name.c_str(), s);});
+  }
+  void dump_float(const char *name, double d) override {
+    std::string _name(name);
+    Formatter* f = sink;
+    push([f, _name, d](){f->dump_float(_name.c_str(), d);});
+  }
+  void dump_string(const char *name, std::string_view s) override {
+    std::string _name(name);
+    std::string _s(s);
+    Formatter* f = sink;
+    push([f, _name, _s](){f->dump_string(_name.c_str(), _s);});
+  }
+  std::ostream& dump_stream(const char *name) override {
+    dump_stream_name = name;
+    dump_stream_is = true;
+    return dump_stream_stream;
+  }
+  void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap) override {
+    Formatter* f = sink;
+    char* _buf;
+    int r = vasprintf(&_buf, fmt, ap);
+    ceph_assert(r >= 0);
+    std::string _name(name);
+    if (ns != nullptr) {
+      std::string _ns(ns);
+      push([f, _name, _ns, quoted, _buf]() {
+	  list_helper(f, _name.c_str(), _ns.c_str(), quoted, "%s", _buf);
+	  free(_buf);
+	});
+    } else {
+      push([f, _name, quoted, _buf]() {
+	  list_helper(f, _name.c_str(), nullptr, quoted, "%s", _buf);
+	  free(_buf);
+	});
+    }
+  }
+  int get_len() const override {
+    //can't suspend getting len
+    return sink->get_len();
+  }
+  void write_raw_data(const char *data) override {
+    Formatter* f = sink;
+    std::string _data(data);
+    push([f, _data](){f->write_raw_data(_data.c_str());});
+  }
+  void open_array_section_with_attrs(const char *name, const FormatterAttrs& attrs) override {
+    Formatter* f = sink;
+    std::string _name(name);
+    FormatterAttrs _attrs(attrs);
+    push([f, _name, _attrs](){f->open_array_section_with_attrs(_name.c_str(), _attrs);});    
+  }
+  void open_object_section_with_attrs(const char *name, const FormatterAttrs& attrs) override {
+    Formatter* f = sink;
+    std::string _name(name);
+    FormatterAttrs _attrs(attrs);
+    push([f, _name, _attrs](){f->open_object_section_with_attrs(_name.c_str(), _attrs);});        
+  }
+  void dump_string_with_attrs(const char *name, std::string_view s, const FormatterAttrs& attrs) override {
+    Formatter* f = sink;
+    std::string _name(name);
+    std::string _s(s);
+    FormatterAttrs _attrs(attrs);
+    push([f, _name, _s, _attrs](){f->dump_string_with_attrs(_name.c_str(), _s, _attrs);});
+  }
+};
+
+
+
+class FilterImpl final: public Filter, public Formatter {
+  ExpRef exp;
+  VariableMap vars;
+  std::function<void()> on_match;
+  Formatter* sink = nullptr;
+  std::string path;
+  std::vector<size_t> path_sizes;
+  std::string dump_stream_name;
+  std::stringstream dump_stream_stream;
+  bool dump_stream_is = false;
+
+public:
+  virtual ~FilterImpl() {
+  };
+  bool setup(const std::string& condition,
+	     std::string& error) override {
+    TokenSplitter token_source;
+    token_source.set_input(condition);
+    bool res = parse(token_source, vars, error, &exp);
+    if (!res) {
+      stringstream ss;
+      token_source.show_error(ss, error);
+      error = ss.str();
+    } else {
+      error = "";
+    }
+    return res;
+  }
+  Formatter* attach(Formatter* sink, std::function<void()> on_match) override {
+    reset_filter();
+    this->sink = sink;
+    this->on_match = on_match;
+    return this;
+  }
+  void detach() override {
+    reset_filter();
+    sink = nullptr;
+  }
+  void reset_filter() {
+    for (auto& v : vars) {
+      v.second.reset();
+    }
+    path.clear();
+    path_sizes.clear();
+    dump_stream_is = false;
+    dump_stream_name.clear();
+    dump_stream_stream.str("");
+  }
+
+private:
+  void enter(const char* name) {
+    maybe_dump_stream();
+    size_t l = path.length();
+    path_sizes.push_back(l);
+    path.push_back('.');
+    path.append(name);
+    auto it = vars.find(path);
+    if (it != vars.end()) {
+      it->second.reset(new std::string(""));
+      check();
+    }
+  }
+  void leave() {
+    maybe_dump_stream();
+    if (path_sizes.size() > 0) {
+      size_t l = path_sizes.back();
+      path_sizes.pop_back();
+      path.resize(l);
+    }
+  }
+  void check() {
+    Exp::Value v = Exp::cast_to(Exp::ebool, exp->get_value());
+    if (v.index() == Exp::ebool) {
+      if (std::get<bool>(v)) {
+	on_match();
+      }
+    }
+  }
+  VariableMap::iterator var_it(const char* name) {
+    maybe_dump_stream();
+    size_t l = path.length();
+    path.push_back('.');
+    path.append(name);
+    auto it = vars.find(path);
+    path.resize(l);
+    return it;
+  }
+  void maybe_dump_stream() {
+    if (unlikely(dump_stream_is)) {
+      sink->dump_stream(dump_stream_name.c_str()) << dump_stream_stream.str();
+      dump_stream_is = false;
+      dump_stream_stream.str("");
+    }
+  }
+
+  //Formatter methods
+  void enable_line_break() override {
+    sink->enable_line_break();
+  }
+  void flush(std::ostream& os) override {
+    sink->flush(os);
+  }
+  void reset() override {
+    sink->reset();
+  }
+  void set_status(int status, const char* status_name) override {
+    sink->set_status(status, status_name);
+  }
+  void output_header() override {
+    sink->output_header();
+  }
+  void output_footer() override {
+    sink->output_footer();
+  }
+  void open_array_section(const char *name) override {
+    enter(name);
+    sink->open_array_section(name);
+  }
+  void open_array_section_in_ns(const char *name, const char *ns) override {
+    enter(name);
+    sink->open_array_section_in_ns(name, ns);
+  }
+  void open_object_section(const char *name) override {
+    enter(name);
+    sink->open_object_section(name);
+  }
+  void open_object_section_in_ns(const char *name, const char *ns) override {
+    enter(name);
+    sink->open_object_section_in_ns(name, ns);
+  }
+  void close_section() override {
+    leave();
+    sink->close_section();
+  }
+  void dump_unsigned(const char *name, uint64_t u) override {
+    auto it = var_it(name);
+    if (it != vars.end()) {
+      it->second.reset(new std::string(to_string(u)));
+      check();
+    }
+    sink->dump_unsigned(name, u);
+  }
+  void dump_int(const char *name, int64_t s) override {
+    auto it = var_it(name);
+    if (it != vars.end()) {
+      it->second.reset(new std::string(to_string(s)));
+      check();
+    }
+    sink->dump_int(name, s);
+  }
+  void dump_float(const char *name, double d) override {
+    auto it = var_it(name);
+    if (it != vars.end()) {
+      it->second.reset(new std::string(to_string(d)));
+      check();
+    }
+    sink->dump_float(name, d);
+  }
+  void dump_string(const char *name, std::string_view s) override {
+    auto it = var_it(name);
+    if (it != vars.end()) {
+      it->second.reset(new std::string(s));
+      check();
+    }
+    sink->dump_string(name, s);
+  }
+  std::ostream& dump_stream(const char *name) override {
+    dump_stream_name = name;
+    dump_stream_is = true;
+    return dump_stream_stream;
+  }
+  void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap) override {
+    auto it = var_it(name);
+    if (it != vars.end()) {
+      char* buf;
+      int r = vasprintf(&buf, fmt, ap);
+      ceph_assert(r >= 0);
+      it->second.reset(new std::string(buf));
+      check();
+    }
+    sink->dump_format_va(name, ns, quoted, fmt, ap);
+  }
+  int get_len() const override {
+    return sink->get_len();
+  }
+  void write_raw_data(const char *data) override {
+    maybe_dump_stream();
+    //cannot be filtered
+    sink->write_raw_data(data);
+  }
+  void open_array_section_with_attrs(const char *name, const FormatterAttrs& attrs) override {
+    enter(name);
+    sink->open_array_section_with_attrs(name, attrs);
+  }
+  void open_object_section_with_attrs(const char *name, const FormatterAttrs& attrs) override {
+    enter(name);
+    sink->open_object_section_with_attrs(name, attrs);
+  }
+  void dump_string_with_attrs(const char *name, std::string_view s, const FormatterAttrs& attrs) override {
+    auto it = var_it(name);
+    if (it != vars.end()) {
+      it->second.reset(new std::string(s));
+      check();
+    }
+    sink->dump_string_with_attrs(name, s, attrs);
+  }
+};
+
+
+
+/*
+Rule: "-a,+a.b.c,+a.d,-a.d.e.f.g,-a.h.i"
+gives tree:
+  -a -> ^b -> +c
+     -> +d -> ^e -> ^f -> -g
+     -> ^h -> -i
+Legend:
+  + in
+  - out
+  ^ maybe
+
+When going through (^maybe) down, scope opening action is pushed for delayed resolve.
+At some point it might be flushed on (+in).
+When going through (^maybe) up, either scope close action is ignored (and corresponding opening action popped),
+or scope close action is executed.
+This translates to the following:
+- if close action at (^maybe) can pop opening action, then ignore close action,
+- otherwise emit close action
+*/
+
+class TrimmerImpl : public ceph::Trimmer, public Formatter {
+  typedef enum {
+    in,   //when this branch/element and all below are to be passed to output
+    out,  //when this branch/element and all below are to be erased from output
+    maybe //when this branch/element is undecided
+          //if some element deeper will be IN, then it also will be IN
+          //if no element deeper will be IN, then this is deleted
+  } shape;
+  struct stencil {
+    shape action = in;
+    std::map<std::string, stencil> pattern;
+    stencil* up = nullptr;
+    void dump(ostringstream& ss, const std::string& prev) {
+      ss << prev;
+      switch (action) {
+      case in:
+	ss << " in";
+	break;
+      case out:
+	ss << " out";
+	break;
+      case maybe:
+	ss << " maybe";
+	break;
+      }
+      ss << std::endl;
+
+      for (auto& x: pattern) {
+	x.second.dump(ss, prev + " " + x.first);
+      }
+    }
+  };
+  stencil* root; /// < root for stencil
+  stencil* current; /// < current location in stencil pattern
+  Formatter* sink;
+  std::vector<std::function<void()>> maybe_stack;
+  size_t extra_depth = 0; /// < branch depth after last pattern shape was selected
+  std::stringstream stream_devnull; /// < null stringstream to dump to if not selected
+
+public:
+  virtual ~TrimmerImpl() {
+    if (root) {
+      delete root;
+    }
+  };
+  bool setup(std::string_view def, std::string& error) override {
+    //split stencil by ","
+    if (root) {
+      delete root;
+    }
+    root = new stencil;
+    std::string_view path;
+
+    root->action = in;
+    stencil* curr = root;
+
+    while (!def.empty()) {
+      size_t pos = def.find(",");
+      if (pos != std::string_view::npos) {
+	path = def.substr(0,pos);
+	def = def.substr(pos+1);
+      } else {
+	path = def;
+	def = std::string_view();
+      }
+      if (path.empty()) {
+	continue;
+      }
+      curr = root;
+      shape sh = in;
+      if (path.front() == '-') {
+	sh = out;
+	path = path.substr(1);
+      } else if (path.front() == '+') {
+	path = path.substr(1);
+      }
+      if (!path.empty()) {
+	if (path.front() == '.') {
+	  //ignore leading '.'
+	  path = path.substr(1);
+	}
+      }
+
+      //1. When added rule is longer then existing tree,
+      //types of branches bridging the gap between last branch and rule branch:
+      //rule  last   action
+      // +in  +in    do nothing, there is no reason to extend
+      // +in  -out   extend with +in
+      //-out  +in    extend with ^maybe
+      //-out  -out   do nothing, there is no reason to extend
+      //2. Delete any branches that go deeper then just defined branch.
+
+      if (sh == in && root->action == out) {
+	root->action = maybe;
+      }
+      while (!path.empty()) {
+	std::string level;
+	pos = path.find('.');
+	if (pos != std::string_view::npos) {
+	  level = std::string(path.substr(0, pos));
+	  path = path.substr(pos+1);
+	} else {
+	  level = std::string(path);
+	  path = std::string_view();
+	}
+
+	if (!level.empty()) {
+	  auto it = curr->pattern.find(level);
+	  if (it == curr->pattern.end()) {
+	    //when we make deeper tree, we inherit action
+	    auto& n = curr->pattern[level];
+	    ceph_assert(! (sh == in && curr->action == out));
+	    if (curr->action == maybe && sh == in) {
+	      n.action = maybe;
+	    } else {
+	      n.action = curr->action;
+	    }
+	    n.up = curr;
+	  } else {
+	    //found this branch
+	    //if it is -out and we are +in then we need to change to ^maybe
+	    if (it->second.action == out && sh == in) {
+	      it->second.action = maybe;
+	    }
+	  }
+	  curr = &curr->pattern[level];
+	}
+      }
+      curr->action = sh;
+      //if there was some specialization of this path, it does not matter now
+      curr->pattern.clear();
+    }
+    return true;
+  }
+  Formatter* attach(Formatter* sink) override {
+    detach();
+    this->sink = sink;
+    return this;
+  }
+  virtual void detach() override {
+    reset_trimmer();
+    sink = nullptr;
+  }
+
+  void reset_trimmer() {
+    current = root;
+    extra_depth = 0;
+  }
+
+  void push(std::function<void()> f) {
+    maybe_stack.push_back(std::move(f));
+  }
+
+  void flush_maybes() {
+    for (auto f: maybe_stack) {
+      f();
+    }
+    maybe_stack.clear();
+  }
+
+  bool pop_maybe() {
+    if (maybe_stack.empty()) {
+      return false;
+    } else {
+      maybe_stack.pop_back();
+      return true;
+    }
+  }
+
+  static char* capture(const char* name) {
+    if (name == nullptr) {
+      return nullptr;
+    } else {
+      return strdup(name);
+    }
+  }
+
+  bool qualify(const char* name) {
+    if (extra_depth > 0) {
+      return current->action == in;
+    }
+    auto it = current->pattern.find(name);
+    if (it == current->pattern.end()) {
+      //no specialization for that name
+      return current->action == in;
+    } else {
+      //there is specialization for that name
+      if (it->second.action == in) {
+	flush_maybes();
+      }
+      return it->second.action == in;
+    }
+  }
+
+  shape enter(const char* name) {
+    if (extra_depth > 0) {
+      extra_depth++;
+      //if we are in ^maybe mode, it means ^out
+      if (current->action == in) {
+	return in;
+      } else {
+	return out;
+      }
+    }
+    auto it = current->pattern.find(name);
+    if (it == current->pattern.end()) {
+      //no specialization for that name
+      extra_depth++;
+      //if we are in ^maybe mode, it means ^out
+      if (current->action == in) {
+	return in;
+      } else {
+	return out;
+      }
+    } else {
+      //there is specialization for that name
+      if (current->action == maybe) {
+	//if we just left ^maybe land we need to flush stacked opening actions
+	current = &it->second;
+	if (current->action == in) {
+	  flush_maybes();
+	}
+	return current->action;
+      } else {
+	current = &it->second;
+	return current->action;
+      }
+    }
+  }
+  /* true - emit, false - ignore */
+  bool leave() {
+    if (extra_depth > 0) {
+      extra_depth--;
+      //if we are in ^maybe mode, it means ^out
+      return current->action == in;
+    }
+    bool result = false;
+    //if we are at ^maybe we have to choose
+    switch (current->action) {
+    case maybe:
+      result = !pop_maybe();
+      break;
+    case in:
+      result = true;
+      break;
+    case out:
+      result = false;
+      break;
+    }
+    if (current->up != nullptr) {
+      current = current->up;
+    } else {
+      //this basically means someone went below root
+      //we ignore it, but we can self-check
+      ceph_assert(current == root);
+    }
+    return result;
+  }
+
+  void enable_line_break() override {
+    sink->enable_line_break();
+  }
+  void flush(std::ostream& os) override {
+    sink->flush(os);
+  }
+  void reset() override {
+    sink->reset();
+  }
+
+  void set_status(int status, const char* status_name) override {
+    sink->set_status(status, status_name);
+  }
+  void output_header() override {
+    sink->output_header();
+  }
+  void output_footer() override {
+    sink->output_footer();
+  }
+
+  void open_array_section(const char *name) override {
+    switch (enter(name)) {
+    case maybe:
+      {
+	Formatter* f = sink;
+	char* _name = capture(name);
+	push([f, _name](){f->open_array_section(_name); free(_name);});
+      }
+      break;
+    case in:
+      sink->open_array_section(name);
+      break;
+    case out:
+      break;
+    }
+  }
+  void open_array_section_in_ns(const char *name, const char *ns) override {
+    switch (enter(name)) {
+    case maybe:
+      {
+	Formatter* f = sink;
+	char* _name = capture(name);
+	char* _ns = capture(ns);
+	push([f, _name, _ns](){f->open_array_section_in_ns(_name, _ns); free(_name); free(_ns);});
+      }
+      break;
+    case in:
+      sink->open_array_section_in_ns(name, ns);
+      break;
+    case out:
+      break;
+    }
+  }
+  void open_object_section(const char *name) override {
+    switch (enter(name)) {
+    case maybe:
+      {
+	Formatter* f = sink;
+	char* _name = capture(name);
+	push([f, _name](){f->open_object_section(_name); free(_name); });
+      }
+      break;
+    case in:
+      sink->open_object_section(name);
+      break;
+    case out:
+      break;
+    }
+  }
+  void open_object_section_in_ns(const char *name, const char *ns) override {
+    switch (enter(name)) {
+    case maybe:
+      {
+	Formatter* f = sink;
+	char* _name = capture(name);
+	char* _ns = capture(ns);
+	push([f, _name, _ns](){f->open_object_section_in_ns(_name, _ns); free(_name); free(_ns);});
+      }
+      break;
+    case in:
+      sink->open_object_section_in_ns(name, ns);
+      break;
+    case out:
+      break;
+    }
+  }
+  void close_section() override {
+    if (leave()) {
+      sink->close_section();
+    }
+  }
+  void dump_unsigned(const char *name, uint64_t u) override {
+    if (qualify(name)) {
+      sink->dump_unsigned(name, u);
+    }
+  }
+  void dump_int(const char *name, int64_t s) override {
+    if (qualify(name)) {
+      sink->dump_int(name, s);
+    }
+  }
+  void dump_float(const char *name, double d) override {
+    if (qualify(name)) {
+      sink->dump_float(name, d);
+    }
+  }
+  void dump_string(const char *name, std::string_view s) override {
+    if (qualify(name)) {
+      sink->dump_string(name, s);
+    }
+  }
+  std::ostream& dump_stream(const char *name) override {
+    if (qualify(name)) {
+      return sink->dump_stream(name);
+    } else {
+      //provide null stream to dump data
+      stream_devnull.str("");
+      return stream_devnull;
+    }
+  }
+  void dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap) override {
+    if (qualify(name)) {
+      sink->dump_format_va(name, ns, quoted, fmt, ap);
+    }
+  };
+  int get_len() const override {
+    return sink->get_len();
+  }
+  void write_raw_data(const char *data) override {
+    if (current->action == in || true) {
+      sink->write_raw_data(data);
+    }
+  }
+  void open_array_section_with_attrs(const char *name, const FormatterAttrs& attrs) override {
+    switch (enter(name)) {
+    case maybe:
+      {
+	Formatter* f = sink;
+	char* _name = capture(name);
+	FormatterAttrs _attrs(attrs);
+	push([f, _name, _attrs](){f->open_array_section_with_attrs(_name, _attrs); free(_name);});
+      }
+      break;
+    case in:
+      sink->open_array_section_with_attrs(name, attrs);
+      break;
+    case out:
+      break;
+    }
+  }
+  void open_object_section_with_attrs(const char *name, const FormatterAttrs& attrs) override {
+    switch (enter(name)) {
+    case maybe:
+      {
+	Formatter* f = sink;
+	char* _name = capture(name);
+	FormatterAttrs _attrs(attrs);
+	push([f, _name, _attrs](){f->open_object_section_with_attrs(_name, _attrs); free(_name);});
+      }
+      break;
+    case in:
+      sink->open_object_section_with_attrs(name, attrs);
+      break;
+    case out:
+      break;
+    }
+  }
+  void dump_string_with_attrs(const char *name, std::string_view s, const FormatterAttrs& attrs) override {
+    if (qualify(name)) {
+      sink->dump_string_with_attrs(name, s, attrs);
+    }
+  }
+};
+
+} /*namespace formatter_filter*/
+
+Filter* Filter::create() {
+  return new formatter_filter::FilterImpl();
+}
+
+Buffer* Buffer::create() {
+  return new formatter_filter::BufferImpl();
+}
+
+Trimmer* Trimmer::create() {
+  return new formatter_filter::TrimmerImpl();
+}
+
+} /*namespace ceph*/

--- a/src/common/formatter_filter.h
+++ b/src/common/formatter_filter.h
@@ -1,0 +1,157 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#ifndef FORMATTER_FILTER_H
+#define FORMATTER_FILTER_H
+
+#include <boost/program_options/variables_map.hpp>
+#include <boost/program_options/parsers.hpp>
+
+#include <stdio.h>
+#include <string.h>
+#include <iostream>
+#include <time.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include "global/global_init.h"
+#include "common/ceph_argparse.h"
+#include "include/stringify.h"
+#include "common/errno.h"
+#include "common/safe_io.h"
+
+#include "os/bluestore/BlueFS.h"
+#include "os/bluestore/BlueStore.h"
+#include "common/admin_socket.h"
+#include "common/url_escape.h"
+#include "common/formatter_filter.h"
+
+namespace ceph {
+namespace formatter_filter {
+
+struct filter_branch {
+  typedef enum {branch_in, branch_out} branch_handling;
+  std::map<std::string, filter_branch> branches;
+  branch_handling action;
+  bool is_leaf() {
+    return branches.size() == 0;
+  }
+  bool is_in() {
+    return action == branch_in;
+  }
+};
+
+using VariableMap = std::map<std::string, std::shared_ptr<std::string>>;
+
+typedef enum {
+  op_first = 0,
+  eq = op_first,  //==
+  neq, //!=
+  ge,  //>=
+  le,  //<=
+  gt,  //>
+  lt,  //<
+  _and, // &&
+  _or,  // ||
+  has, // "has"
+  exists, // "exists"
+  plus, // +
+  minus, // -
+  mult, // *
+  div, // /
+  mod, // %
+  neg, // !
+  op_last
+} operator_t;
+
+typedef enum {
+  eLeft,
+  eRight,
+  eBi
+} assoc_t;
+
+struct operator_spec_t {
+  std::string name;
+  uint8_t prio;
+  bool is_binary;
+  bool is_unary;
+};
+
+typedef enum {
+  eLiteral,
+  eNumber,
+  eVariable,
+  eOperator,
+  eLeftBracket,
+  eRightBracket,
+  eEnd,
+  eError
+} token_t;
+
+class Exp {
+public:
+  Exp() {}
+  virtual ~Exp() {}
+  class inv {};
+  using pstring = std::shared_ptr<std::string>;
+  using Value = std::variant<inv,
+			     int64_t,
+			     pstring,
+			     bool>;
+  typedef enum {
+    einv,
+    eint,
+    estring,
+    ebool
+  } variant_t;
+  static_assert(std::is_same_v<inv, std::variant_alternative_t<einv, Value>>);
+  static_assert(std::is_same_v<int64_t, std::variant_alternative_t<eint, Value>>);
+  static_assert(std::is_same_v<pstring, std::variant_alternative_t<estring, Value>>);
+  static_assert(std::is_same_v<bool, std::variant_alternative_t<ebool, Value>>);
+
+  virtual Value get_value() = 0;
+  static Value cast_to(variant_t target, const Value& right);
+};
+using ExpRef = std::shared_ptr<Exp>;
+
+
+
+class TokenSplitter {
+public:
+  void set_input(std::string_view str);
+  token_t peek();
+  void consume();
+  std::string get_variable();
+  std::string get_literal();
+  uint64_t get_number();
+  operator_t get_operator();
+  int8_t get_operator_prio();
+
+  bool show_error(std::ostream&out,
+		  const std::string& error);
+private:
+  std::string_view input; //whole passed input
+  std::string_view left; //input not consumed yet
+  std::string_view peeked; //input after consuming peeked token
+
+  token_t token;
+  operator_t token_op;
+  uint8_t token_op_prio;
+  std::string token_literal;
+  uint64_t token_number;
+  std::string token_variable;
+
+  std::string error;
+  void parse_one();
+  void skip_whitespace();
+  std::tuple<operator_t, uint8_t> get_operator(std::string_view cand);
+  size_t possibly_operator(std::string_view cand);
+};
+
+bool parse(TokenSplitter& token_src,
+	   VariableMap& vars,
+	   std::string& error,
+	   ExpRef *exp_result);
+
+} /*namespace formatting_filter*/
+} /*namespace ceph*/
+
+#endif

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -103,7 +103,8 @@ add_dependencies(os crypto_plugins)
 
 if(WITH_BLUESTORE)
   add_executable(ceph-bluestore-tool
-    bluestore/bluestore_tool.cc)
+    bluestore/bluestore_tool.cc
+    bluestore/bluestore_dump.cc)
   target_link_libraries(ceph-bluestore-tool
     os global)
   install(TARGETS ceph-bluestore-tool

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -415,6 +415,23 @@ static int get_key_object(const S& key, ghobject_t *oid)
   return 0;
 }
 
+int BlueStore::objkey_to_oid(const std::string& key, ghobject_t *oid)
+{
+  return get_key_object(key, oid);
+}
+
+int BlueStore::extentkey_to_oid(const std::string& key, ghobject_t *oid, uint32_t *offset)
+{
+  if (key.size() <= sizeof(uint32_t) + 1)
+    return -9;
+  if (*key.rbegin() != EXTENT_SHARD_KEY_SUFFIX)
+    return -10;
+  int key_len = key.size() - sizeof(uint32_t) - 1;
+  const char *p = key.data() + key_len;
+  _key_decode_u32(p, offset);
+  return get_key_object(key.substr(0, key_len), oid);
+}
+
 template<typename S>
 static void get_object_key(CephContext *cct, const ghobject_t& oid, S *key)
 {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2705,6 +2705,9 @@ public:
 
   int dump_bluefs_sizes(ostream& out);
 
+  static int objkey_to_oid(const std::string& key, ghobject_t *oid);
+  static int extentkey_to_oid(const std::string& key, ghobject_t *oid, uint32_t *offset);
+
 public:
   int statfs(struct store_statfs_t *buf,
              osd_alert_list_t* alerts = nullptr) override;

--- a/src/os/bluestore/bluestore_dump.cc
+++ b/src/os/bluestore/bluestore_dump.cc
@@ -1,0 +1,438 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <boost/program_options/variables_map.hpp>
+#include <boost/program_options/parsers.hpp>
+
+#include <stdio.h>
+#include <string.h>
+#include <iostream>
+#include <time.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include "global/global_init.h"
+#include "common/ceph_argparse.h"
+#include "include/stringify.h"
+#include "common/errno.h"
+#include "common/safe_io.h"
+
+#include "os/bluestore/BlueFS.h"
+#include "os/bluestore/BlueStore.h"
+#include "common/admin_socket.h"
+#include "common/url_escape.h"
+namespace po = boost::program_options;
+
+#include "bluestore_dump.h"
+
+void Dump::dump(const bluestore_blob_t& t)
+{
+  f->open_array_section("extents");
+  for(auto& e: t.get_extents()) {
+    f->open_object_section("extent");
+    if ((int64_t)e.offset != -1)
+      f->dump_format_unquoted("o", "0x%x", e.offset);
+    else
+      f->dump_int("o", -1);
+    f->dump_format_unquoted("l", "0x%x", e.length);
+    f->close_section();
+  }
+  f->close_section();
+  f->dump_format_unquoted("flags", "%d(%s)", t.flags, bluestore_blob_t::get_flags_string(t.flags).c_str());
+  if (t.is_compressed()) {
+    f->dump_unsigned("logical_length", t.get_logical_length());
+    f->dump_unsigned("compressed_length", t.get_compressed_payload_length());
+  }
+  if (t.has_csum()) {
+    f->open_object_section("csum");
+    f->dump_format_unquoted("type", "%d(%s)", t.csum_type, Checksummer::get_csum_type_string(t.csum_type));
+    f->dump_int("order", t.csum_chunk_order);
+    char str[t.csum_data.length()*2+1];
+    for (size_t i = 0; i < t.csum_data.length(); i++)
+      sprintf(&str[i*2], "%2.2x", *(unsigned char*)(t.csum_data.c_str()+i));
+    f->dump_format_unquoted("data", "%s", str);
+    f->close_section();
+  }
+  if (t.has_unused()) {
+    f->dump_unsigned("unused", t.unused);
+  }
+}
+
+
+void Dump::dump(bluestore_onode_t& t)
+{
+  f->dump_unsigned("nid", t.nid);
+  f->dump_unsigned("size", t.size);
+  f->open_object_section("attrs");
+  for (auto p = t.attrs.begin(); p != t.attrs.end(); ++p) {
+    f->open_object_section("attr");
+    f->dump_string("name", p->first.c_str());  // it's not quite std::string
+    f->dump_string("val", url_escape(std::string(p->second.c_str(), p->second.length())));
+    f->close_section();
+  }
+  f->close_section();
+  f->dump_format_unquoted("flags", "%d(%s)", t.flags, t.get_flags_string().c_str());
+  f->open_array_section("extent_map_shards");
+  for(auto& e: t.extent_map_shards) {
+    f->open_object_section("shard");
+    f->dump_format_unquoted("offset", "0x%x", e.offset);
+    f->dump_unsigned("bytes", e.bytes);
+    f->close_section();
+  }
+  f->close_section();
+  f->dump_unsigned("expected_object_size", t.expected_object_size);
+  f->dump_unsigned("expected_write_size", t.expected_write_size);
+  f->dump_unsigned("alloc_hint_flags", t.alloc_hint_flags);
+}
+
+void Dump::dump(const bluestore_blob_use_tracker_t& t)
+{
+  f->dump_int("au_size", t.au_size);
+  if (t.au_size) {
+    f->dump_int("num_au", t.num_au);
+    if (!t.num_au) {
+      f->dump_int("total_bytes", t.total_bytes);
+    } else {
+      f->open_array_section("bytes_per_au");
+      for (size_t i = 0; i < t.num_au; ++i) {
+	f->dump_int("bytes", t.bytes_per_au[i]);
+      }
+      f->close_section();
+    }
+  }
+}
+
+
+//equivalent to BlueStore::ExtentMap::decode_spanning_blobs
+int Dump::decode_spanning_blobs(std::map<int16_t, bluestore_blob_t>& spanning_blobs,
+				bufferptr::const_iterator& p)
+{
+  __u8 struct_v;
+  denc(struct_v, p);
+  f->dump_int("v", struct_v);
+  ceph_assert(struct_v == 1 || struct_v == 2); //AKAK - cannot be asserts!
+
+  unsigned n;
+  denc_varint(n, p);
+  f->dump_int("blobs_cnt", n);
+
+  f->open_array_section("blobs");
+  while (n--) {
+    decltype(BlueStore::Blob::id) blob_id; //int16_t
+    denc_varint(blob_id, p);
+    f->open_object_section("a_blob");
+    f->dump_int("blob_id", blob_id);
+
+    bluestore_blob_t bluestore_blob;
+    denc(bluestore_blob, p, struct_v);
+    spanning_blobs[blob_id] = bluestore_blob;
+
+    f->open_object_section("bluestore_blob");
+    dump(bluestore_blob);
+    f->close_section();
+
+    uint64_t shared_blob_id = 0;
+    if (bluestore_blob.is_shared()) {
+      denc(shared_blob_id, p);
+      f->dump_int("shared_blob_id", shared_blob_id);
+      //AK maybe? ceph_assert(shared_blob_id != 0);
+    }
+    bluestore_blob_use_tracker_t bluestore_blob_use_tracker;
+    if (struct_v > 1) {
+      bluestore_blob_use_tracker.decode(p);
+      f->open_object_section("blob_tracker");
+      dump(bluestore_blob_use_tracker);
+      f->close_section();
+    } else {
+      //legacy AKAK - TODO - not converted
+      bluestore_extent_ref_map_t legacy_ref_map;
+      legacy_ref_map.decode(p);
+      f->open_object_section("legacy_ref_map");
+      legacy_ref_map.dump(f);
+      f->close_section();
+    }
+    f->close_section();//a_blob
+  }
+  f->close_section();//blobs
+  return 0;
+}
+
+#define BLOBID_FLAG_CONTIGUOUS 0x1  // this extent starts at end of previous
+#define BLOBID_FLAG_ZEROOFFSET 0x2  // blob_offset is 0
+#define BLOBID_FLAG_SAMELENGTH 0x4  // length matches previous extent
+#define BLOBID_FLAG_SPANNING   0x8  // has spanning blob id
+#define BLOBID_SHIFT_BITS        4
+
+std::string Dump::blob_flags_to_string(uint8_t flags)
+{
+  stringstream o;
+  if (flags & BLOBID_FLAG_CONTIGUOUS)
+  {
+    o << "cont";
+    if (flags & ~BLOBID_FLAG_CONTIGUOUS)
+      o << "+";
+  }
+  if (flags & BLOBID_FLAG_ZEROOFFSET)
+  {
+    o << "zeroofs";
+    if (flags & ~(BLOBID_FLAG_CONTIGUOUS|BLOBID_FLAG_ZEROOFFSET))
+      o << "+";
+  }
+  if (flags & BLOBID_FLAG_SAMELENGTH)
+  {
+    o << "samelen";
+    if (flags & ~(BLOBID_FLAG_CONTIGUOUS|BLOBID_FLAG_ZEROOFFSET|BLOBID_FLAG_SAMELENGTH))
+      o << "+";
+  }
+  if (flags & BLOBID_FLAG_SPANNING)
+  {
+    o << "spanning";
+  }
+  return o.str();
+}
+
+
+unsigned Dump::decode_some(const bufferlist& bl)
+{
+
+  ceph_assert(bl.get_num_buffers() <= 1);
+  auto p = bl.front().begin_deep();
+  __u8 struct_v;
+  denc(struct_v, p);
+  f->dump_int("v", struct_v);
+
+  // Version 2 differs from v1 in blob's ref_map
+  // serialization only. Hence there is no specific
+  // handling at ExtentMap level below.
+  ceph_assert(struct_v == 1 || struct_v == 2); //AKAK - cannot be asserts!
+
+  uint32_t num;
+  denc_varint(num, p);
+  f->dump_int("extents_cnt", num);
+  uint64_t pos = 0;
+  uint64_t prev_len = 0;
+  unsigned n = 0;
+
+  bluestore_blob_t blob;
+
+  f->open_array_section("extents");
+  while (!p.end()) {
+    f->open_object_section("extent");
+    BlueStore::Extent le;
+    uint64_t blobid;
+    denc_varint(blobid, p);
+    uint8_t flags = blobid & ((1 << BLOBID_SHIFT_BITS) - 1);
+    f->dump_format_unquoted("flags", "%d(%s)", flags, blob_flags_to_string(flags).c_str());
+    f->dump_int("blob_id", blobid >> BLOBID_SHIFT_BITS);
+    if ((blobid & BLOBID_FLAG_CONTIGUOUS) == 0) {
+      uint64_t gap;
+      denc_varint_lowz(gap, p);
+      f->dump_int("gap", gap);
+      pos += gap;
+    }
+    le.logical_offset = pos;
+    if ((blobid & BLOBID_FLAG_ZEROOFFSET) == 0) {
+      denc_varint_lowz(le.blob_offset, p);
+      f->dump_int("offset", le.blob_offset);
+    } else {
+      le.blob_offset = 0;
+    }
+    if ((blobid & BLOBID_FLAG_SAMELENGTH) == 0) {
+      denc_varint_lowz(prev_len, p);
+      f->dump_int("length", prev_len);
+    }
+    le.length = prev_len;
+    //std::string blob_source;
+    if (blobid & BLOBID_FLAG_SPANNING) {
+      uint64_t defined_blob_id = blobid >> BLOBID_SHIFT_BITS;
+
+      //AK using blobs defined as spanning blobs
+      //blob_source = "spanning:" + to_string(defined_blob_id);
+      f->dump_int("spanning_blob", defined_blob_id);
+    } else {
+      blobid >>= BLOBID_SHIFT_BITS;
+      if (blobid) {
+	//AK will use locally defined blobs
+	//AK here we assume this (blobid - 1) is already created
+	f->dump_format_unquoted("__uses_local_blob","(%d)", blobid - 1);
+      } else {
+	//AK blob defined right here, blob_id provided
+	uint64_t shared_blob_id;
+	denc(blob, p, struct_v);
+	f->open_object_section("blob");
+	f->dump_format_unquoted("__defines_local_blob","(%d)", n);
+	dump(blob);
+	if (blob.is_shared()) {
+	  //AK it uses shared_blob. I wonder if we double check it somehow
+	  denc(shared_blob_id, p);
+	  f->dump_int("shared_blob_id", shared_blob_id);
+	}
+	f->close_section();
+      }
+      // we build ref_map dynamically for non-spanning blobs
+      ///cout << blob_source << " " << to_string(blob) << " #" << to_string(le) << std::endl;
+    }
+    pos += prev_len;
+    ++n;
+    f->close_section(); //extent
+  }
+  f->close_section(); //extents
+  ceph_assert(n == num);
+  return num;
+}
+
+
+bool Dump::dump_object(const bufferlist& v)
+{
+  std::map<int16_t, bluestore_blob_t> spanning_blobs;
+  size_t v_size = v.length();
+  auto p = v.front().begin_deep();
+
+  bluestore_onode_t bo;
+  bo.decode(p);
+  f->open_object_section("object");
+  f->open_object_section("bluestore_onode_t");
+  dump(bo);
+  f->close_section();
+
+  f->open_object_section("spanning_blobs");
+  decode_spanning_blobs(spanning_blobs, p);
+  f->close_section();
+
+  if(bo.extent_map_shards.empty()) {
+    bufferlist inline_bl;
+    denc(inline_bl, p);
+    f->open_object_section("extents");
+    decode_some(inline_bl);
+    f->close_section();
+  } else {
+    f->open_array_section("extent_map_shards");
+    for (auto& x: bo.extent_map_shards) {
+      f->open_object_section("extent");
+      f->dump_format_unquoted("offset", "0x%x", x.offset);
+      f->dump_int("bytes", x.bytes);
+      f->close_section();
+    }
+    f->close_section();
+  }
+  f->close_section(); //Onode
+
+  //TODO - improve on error with decoding size
+  ceph_assert(p.get_offset() == v_size);
+  return true;
+}
+
+
+bool Dump::dump_object(const std::string& key, const bufferlist& v)
+{
+  ghobject_t oid;
+  int r = BlueStore::objkey_to_oid(key, &oid);
+  if (r != 0) {
+    cout << "failed to decode '" + url_escape(key) + "' error code=" + std::to_string(r) << std::endl;
+    return false;
+  }
+  f->open_object_section("object");
+  f->open_object_section("id");
+  f->dump_string("hobj", oid.hobj.to_str());
+  f->dump_int("shard", oid.shard_id);
+  if (oid.generation != ghobject_t::NO_GEN)
+    f->dump_unsigned("gen", oid.generation);
+  else
+    f->dump_int("gen", -1);
+  f->close_section();
+  dump_object(v);
+  f->close_section();
+  return true;
+}
+
+
+bool Dump::dump_extent(const std::string& key, const bufferlist& v)
+{
+  ghobject_t oid;
+  uint32_t offset;
+  int r = BlueStore::extentkey_to_oid(key, &oid, &offset);
+  if (r != 0) {
+    cerr << "failed to decode '" + url_escape(key) + "' error code=" + std::to_string(r) << std::endl;
+    return false;
+  }
+  f->open_object_section("extent");
+  f->open_object_section("id");
+  f->dump_string("hobj", oid.hobj.to_str());
+  f->dump_int("shard", oid.shard_id);
+  if (oid.generation != ghobject_t::NO_GEN)
+    f->dump_unsigned("gen", oid.generation);
+  else
+    f->dump_int("gen", -1);
+  f->close_section();
+  f->dump_unsigned("offset", offset);
+
+  decode_some(v);
+  f->close_section();
+  return true;
+}
+
+
+int Dump::list_objects(const std::string& format,
+		       const std::string& selector,
+		       const std::string& trimmer) {
+  KeyValueDB::Iterator obj_it = db->get_iterator("O");
+  obj_it->seek_to_first();
+  shared_ptr<Formatter> actual_formatter(Formatter::create(format));
+  if (actual_formatter.get() == nullptr) {
+    std::cout << "Invalid format '" << format << "'" << std::endl;
+    return -1;
+  }
+  shared_ptr<Filter> ff;
+  shared_ptr<Buffer> bf;
+  shared_ptr<Trimmer> tf;
+  Formatter* buffer;
+  bool matched;
+
+  if (!selector.empty()) {
+    std::string error;
+    ff.reset(Filter::create());
+    bool b = ff->setup(selector, error);
+    if (!b) {
+      std::cout << error << std::endl;
+      return -1;
+    }
+    bf.reset(Buffer::create());
+  }
+
+  if (!trimmer.empty()) {
+    std::string error;
+    tf.reset(Trimmer::create());
+    bool b = tf->setup(trimmer, error);
+    if (!b) {
+      std::cout << error << std::endl;
+      return -1;
+    }
+  }
+
+  for(; obj_it->valid(); obj_it->next()) {
+    f = &*actual_formatter;
+    if (!trimmer.empty()) {
+      f = tf->attach(f);
+    }
+    if (!selector.empty()) {
+      matched = false;
+      buffer = bf->attach(f);
+      f = ff->attach(buffer, [&](){matched = true;});
+    }
+    std::string key = obj_it->key();
+    ghobject_t oid;
+    bool is_oid = *key.rbegin() == 'o';
+    if (is_oid)
+      dump_object(key, obj_it->value());
+    else
+      dump_extent(key, obj_it->value());
+    if (!selector.empty()) {
+      if (matched) {
+	bf->unbuffer();
+	actual_formatter->flush(cout);
+      }
+    } else {
+      actual_formatter->flush(cout);
+    }
+  }
+  return 0;
+}

--- a/src/os/bluestore/bluestore_dump.h
+++ b/src/os/bluestore/bluestore_dump.h
@@ -1,0 +1,45 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <boost/program_options/variables_map.hpp>
+#include <boost/program_options/parsers.hpp>
+
+#include <stdio.h>
+#include <string.h>
+#include <iostream>
+#include <time.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include "global/global_init.h"
+#include "common/ceph_argparse.h"
+#include "include/stringify.h"
+#include "common/errno.h"
+#include "common/safe_io.h"
+
+#include "os/bluestore/BlueFS.h"
+#include "os/bluestore/BlueStore.h"
+#include "common/admin_socket.h"
+#include "common/url_escape.h"
+
+class Dump {
+public:
+  Dump(KeyValueDB *db)
+    :db(db) {};
+
+  int list_objects(const std::string& format,
+		   const std::string& selector,
+		   const std::string& trimmer);
+private:
+  bool dump_extent(const std::string& key, const bufferlist& v);
+  bool dump_object(const std::string& key, const bufferlist& v);
+  bool dump_object(const bufferlist& v);
+  unsigned decode_some(const bufferlist& bl);
+  std::string blob_flags_to_string(uint8_t flags);
+  int decode_spanning_blobs(std::map<int16_t, bluestore_blob_t>& spanning_blobs,
+			    bufferptr::const_iterator& p);
+  void dump(const bluestore_blob_use_tracker_t& t);
+  void dump(bluestore_onode_t& t);
+  void dump(const bluestore_blob_t& t);
+  KeyValueDB* db;
+  Formatter* f = nullptr;
+};

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -293,7 +293,7 @@ void PGBackend::rollforward(
   ldpp_dout(dpp, 20) << __func__ << ": entry=" << entry << dendl;
   if (!entry.can_rollback())
     return;
-  Trimmer trimmer(entry.soid, this, t);
+  ::Trimmer trimmer(entry.soid, this, t);
   entry.mod_desc.visit(&trimmer);
 }
 
@@ -303,7 +303,7 @@ void PGBackend::trim(
 {
   if (!entry.can_rollback())
     return;
-  Trimmer trimmer(entry.soid, this, t);
+  ::Trimmer trimmer(entry.soid, this, t);
   entry.mod_desc.visit(&trimmer);
 }
 

--- a/src/test/formatter.cc
+++ b/src/test/formatter.cc
@@ -15,10 +15,13 @@
 #include "gtest/gtest.h"
 #include "common/Formatter.h"
 #include "common/HTMLFormatter.h"
+#include "common/formatter_filter.h"
 
 #include <sstream>
 #include <string>
 
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/linear_congruential.hpp>
 using namespace ceph;
 using std::ostringstream;
 
@@ -352,3 +355,584 @@ TEST(HtmlFormatter, DumpFormatNameSpaceTest) {
   fmt.flush(oss2);
   ASSERT_EQ(oss2.str(),"<li>foo: bar</li>");
 }
+
+using namespace ceph::formatter_filter;
+TEST(FormatterFilter, TokenTypes) {
+  TokenSplitter tok;
+  tok.set_input("! ) (.variable!>=  has \"text\"  0x1111 777   ");
+  token_t t;
+  t = tok.peek();
+  ASSERT_EQ(t, eOperator);
+  ASSERT_EQ(tok.get_operator(), neg);
+  tok.consume();
+
+  t = tok.peek();
+  ASSERT_EQ(t, eRightBracket);
+  tok.consume();
+
+  t = tok.peek();
+  ASSERT_EQ(t, eLeftBracket);
+  tok.consume();
+
+  t = tok.peek();
+  ASSERT_EQ(t, eVariable);
+  ASSERT_EQ(tok.get_variable(), ".variable");
+  tok.consume();
+
+  t = tok.peek();
+  ASSERT_EQ(t, eOperator);
+  ASSERT_EQ(tok.get_operator(), neg);
+  tok.consume();
+
+  t = tok.peek();
+  ASSERT_EQ(t, eOperator);
+  ASSERT_EQ(tok.get_operator(), ge);
+  tok.consume();
+
+  t = tok.peek();
+  ASSERT_EQ(t, eOperator);
+  ASSERT_EQ(tok.get_operator(), has);
+  tok.consume();
+
+  t = tok.peek();
+  ASSERT_EQ(t, eLiteral);
+  ASSERT_EQ(tok.get_literal(), "text");
+  tok.consume();
+
+  t = tok.peek();
+  ASSERT_EQ(t, eNumber);
+  ASSERT_EQ(tok.get_number(), 0x1111);
+  tok.consume();
+
+  t = tok.peek();
+  ASSERT_EQ(t, eNumber);
+  ASSERT_EQ(tok.get_number(), 777);
+  tok.consume();
+
+  t = tok.peek();
+  ASSERT_EQ(t, eEnd);
+}
+
+TEST(FormatterFilter, ErrorMessages) {
+  TokenSplitter token_src;
+  VariableMap vars;
+  std::string error;
+  ExpRef exp;
+  bool b;
+  token_src.set_input("(1 + .var");
+  b = parse(token_src, vars, error, &exp);
+  EXPECT_EQ(b, false);
+  token_src.show_error(std::cout, error);
+
+  token_src.set_input("(1 + + .var)");
+  b = parse(token_src, vars, error, &exp);
+  EXPECT_EQ(b, false);
+  token_src.show_error(std::cout, error);
+
+  token_src.set_input("(1 + .var))");
+  b = parse(token_src, vars, error, &exp);
+  EXPECT_EQ(b, false);
+  token_src.show_error(std::cout, error);
+
+  token_src.set_input("has b");
+  b = parse(token_src, vars, error, &exp);
+  EXPECT_EQ(b, false);
+  token_src.show_error(std::cout, error);
+}
+
+
+TEST(FormatterFilter, Expressions_basic) {
+  TokenSplitter token_src;
+  token_src.set_input("1 + .var");
+  VariableMap vars;
+  std::string error;
+  ExpRef exp;
+  bool b = parse(token_src, vars, error, &exp);
+  ASSERT_EQ(b, true);
+  auto it = vars.find(".var");
+  ASSERT_NE(it, vars.end());
+  ASSERT_NE(exp.get(), nullptr);
+  Exp::Value v = exp->get_value();
+  ASSERT_EQ(v.index(), Exp::einv);
+  vars[".var"].reset(new string("1"));
+  v = exp->get_value();
+  ASSERT_EQ(v.index(), Exp::eint);
+  ASSERT_EQ(std::get<int64_t>(v), 2);
+}
+
+TEST(FormatterFilter, Expressions_more) {
+  TokenSplitter token_src;
+  token_src.set_input("(1 + .var)*.var");
+  VariableMap vars;
+  std::string error;
+  ExpRef exp;
+  bool b = parse(token_src, vars, error, &exp);
+  if (!b) token_src.show_error(std::cout, error);
+  ASSERT_EQ(b, true);
+  {
+  vars[".var"].reset(new string("1"));
+  Exp::Value v = exp->get_value();
+  ASSERT_EQ(v.index(), Exp::eint);
+  ASSERT_EQ(std::get<int64_t>(v), 2);
+  }
+  {
+  vars[".var"].reset(new string("2"));
+  Exp::Value v = exp->get_value();
+  ASSERT_EQ(v.index(), Exp::eint);
+  ASSERT_EQ(std::get<int64_t>(v), 6);
+  }
+  {
+  vars[".var"].reset();
+  Exp::Value v = exp->get_value();
+  ASSERT_EQ(v.index(), Exp::einv);
+  }
+}
+
+TEST(FormatterFilter, Expressions_priority) {
+  TokenSplitter token_src;
+  VariableMap vars;
+  std::string error;
+  ExpRef exp;
+  bool b;
+  Exp::Value v;
+  token_src.set_input("1 + 2 * 3");
+  b = parse(token_src, vars, error, &exp);
+  if (!b) token_src.show_error(std::cout, error);
+  ASSERT_EQ(b, true);
+  v = exp->get_value();
+  ASSERT_EQ(v.index(), Exp::eint);
+  ASSERT_EQ(std::get<int64_t>(v), 7);
+
+  token_src.set_input("1+2*3+4*5+6*7");
+  b = parse(token_src, vars, error, &exp);
+  if (!b) token_src.show_error(std::cout, error);
+  ASSERT_EQ(b, true);
+  v = exp->get_value();
+  ASSERT_EQ(v.index(), Exp::eint);
+  ASSERT_EQ(std::get<int64_t>(v), 1+2*3+4*5+6*7);
+
+  token_src.set_input("6 == 2 * 3");
+  b = parse(token_src, vars, error, &exp);
+  if (!b) token_src.show_error(std::cout, error);
+  ASSERT_EQ(b, true);
+  v = exp->get_value();
+  ASSERT_EQ(v.index(), Exp::ebool);
+  ASSERT_EQ(std::get<bool>(v), true);
+
+  token_src.set_input("(2 < 1) == (1 == 2)");
+  b = parse(token_src, vars, error, &exp);
+  if (!b) token_src.show_error(std::cout, error);
+  ASSERT_EQ(b, true);
+  v = exp->get_value();
+  ASSERT_EQ(v.index(), Exp::ebool);
+  ASSERT_EQ(std::get<bool>(v), true);
+
+  token_src.set_input("2 < 1 * 3 && 1 + 1 == 2");
+  b = parse(token_src, vars, error, &exp);
+  if (!b) token_src.show_error(std::cout, error);
+  ASSERT_EQ(b, true);
+  v = exp->get_value();
+  ASSERT_EQ(v.index(), Exp::ebool);
+  ASSERT_EQ(std::get<bool>(v), true);
+}
+
+TEST(FormatterFilter, Expressions_has) {
+  TokenSplitter token_src;
+  VariableMap vars;
+  std::string error;
+  ExpRef exp;
+  bool b;
+  Exp::Value v;
+  token_src.set_input("\"abcdefgh\" has \"def\"");
+  b = parse(token_src, vars, error, &exp);
+  if (!b) token_src.show_error(std::cout, error);
+  ASSERT_EQ(b, true);
+  v = exp->get_value();
+  ASSERT_EQ(v.index(), Exp::ebool);
+  ASSERT_EQ(std::get<bool>(v), true);
+
+  token_src.set_input("\"ab1234cdefgh\" has (2+2)");
+  b = parse(token_src, vars, error, &exp);
+  if (!b) token_src.show_error(std::cout, error);
+  ASSERT_EQ(b, true);
+  v = exp->get_value();
+  ASSERT_EQ(v.index(), Exp::ebool);
+  ASSERT_EQ(std::get<bool>(v), true);
+
+}
+
+TEST(FormatterFilter, Expressions_exists) {
+  TokenSplitter token_src;
+  VariableMap vars;
+  std::string error;
+  ExpRef exp;
+  bool b;
+  Exp::Value v;
+  token_src.set_input("exists .var");
+  b = parse(token_src, vars, error, &exp);
+  if (!b) token_src.show_error(std::cout, error);
+  ASSERT_EQ(b, true);
+  v = exp->get_value();
+  ASSERT_EQ(v.index(), Exp::ebool);
+  ASSERT_EQ(std::get<bool>(v), false);
+
+  vars[".var"].reset(new string(""));
+  v = exp->get_value();
+  ASSERT_EQ(v.index(), Exp::ebool);
+  ASSERT_EQ(std::get<bool>(v), true);
+
+  exp.reset();
+  vars.clear();
+  token_src.set_input("1 + .var");
+  b = parse(token_src, vars, error, &exp);
+  if (!b) token_src.show_error(std::cout, error);
+  ASSERT_EQ(b, true);
+  v = exp->get_value();
+  ASSERT_EQ(v.index(), Exp::einv);
+
+  token_src.set_input("exists (1 + .var)");
+  b = parse(token_src, vars, error, &exp);
+  if (!b) token_src.show_error(std::cout, error);
+  ASSERT_EQ(b, true);
+  v = exp->get_value();
+  ASSERT_EQ(v.index(), Exp::ebool);
+  ASSERT_EQ(std::get<bool>(v), false);
+
+  vars[".var"].reset(new string("aaa"));
+  v = exp->get_value();
+  ASSERT_EQ(v.index(), Exp::ebool);
+  ASSERT_EQ(std::get<bool>(v), false);
+
+  vars[".var"].reset(new string("1"));
+  v = exp->get_value();
+  ASSERT_EQ(v.index(), Exp::ebool);
+  ASSERT_EQ(std::get<bool>(v), true);
+}
+
+TEST(FormatterFilter, Expressions_all_ops) {
+  TokenSplitter token_src;
+  VariableMap vars;
+  std::string error;
+  ExpRef exp;
+  bool b;
+  Exp::Value v;
+  token_src.set_input("1 == 2 != 3 >= 4 <= 5 > 6 < 7 && 8 || 9 has exists 10 + 11 - 12 * 13 / 14 % !15");
+  b = parse(token_src, vars, error, &exp);
+  if (!b) token_src.show_error(std::cout, error);
+  ASSERT_EQ(b, true);
+  v = exp->get_value();
+}
+
+TEST(FormatterFilter, basic) {
+  ostringstream oss;
+  std::string error;
+  Filter* ff = Filter::create();
+  bool b = ff->setup(".foo.bar.int == 111", error);
+  ASSERT_EQ(b, true);
+  JSONFormatter fmt(false);
+  bool matched = false;
+  Formatter* f = ff->attach(&fmt, [&matched]() { matched = true;} );
+  f->open_object_section("foo");
+  f->open_object_section("bar");
+  f->dump_int("int", 111);
+  f->dump_unsigned("unsigned", 0x8000000000000001llu);
+  f->dump_float("float", 1.234);
+  f->close_section();
+  f->dump_string("string", "str");
+  f->close_section();
+  f->flush(oss);
+  ASSERT_EQ(matched, true);
+  ff->detach();
+  ASSERT_EQ(oss.str(), "{\"bar\":{\"int\":111,\
+\"unsigned\":9223372036854775809,\"float\":1.234},\
+\"string\":\"str\"}");
+  delete ff;
+}
+
+TEST(BufferingFilter, basic) {
+  ostringstream oss;
+  JSONFormatter fmt(false);
+  std::unique_ptr<Buffer> ff(Buffer::create());
+  Formatter* f = ff->attach(&fmt);
+  f->open_object_section("foo");
+  f->open_object_section("bar");
+  f->dump_int("int", 0xf00000000000ll);
+  f->dump_unsigned("unsigned", 0x8000000000000001llu);
+  f->dump_float("float", 1.234);
+  f->close_section();
+  f->dump_string("string", "str");
+  f->close_section();
+  ff->unbuffer();
+  f->flush(oss);
+  ff->detach();
+  ASSERT_EQ(oss.str(), "{\"bar\":{\"int\":263882790666240,\
+\"unsigned\":9223372036854775809,\"float\":1.234},\
+\"string\":\"str\"}");
+};
+
+TEST(FilterTrimmer, basic_1) {
+  ostringstream oss;
+  JSONFormatter fmt(false);
+  std::string error;
+  std::unique_ptr<ceph::Trimmer> trimmer(ceph::Trimmer::create());
+  bool b = trimmer->setup("-foo.bar.float", error);
+  ASSERT_EQ(b, true);
+  Formatter* f(trimmer->attach(&fmt));
+  f->open_object_section("foo");
+  f->open_object_section("bar");
+  f->dump_int("int", 0xf00000000000ll);
+  f->dump_unsigned("unsigned", 0x8000000000000001llu);
+  f->dump_float("float", 1.234);
+  f->close_section();
+  f->dump_string("string", "str");
+  f->close_section();
+  f->flush(oss);
+  trimmer->detach();
+  ASSERT_EQ(oss.str(), "{\"bar\":{\"int\":263882790666240,\
+\"unsigned\":9223372036854775809},\
+\"string\":\"str\"}");
+};
+
+TEST(FilterTrimmer, basic_2) {
+  ostringstream oss;
+  XMLFormatter fmt(false);
+  std::string error;
+  std::unique_ptr<ceph::Trimmer> trimmer(ceph::Trimmer::create());
+  bool b = trimmer->setup("-foo,+foo.bar.float", error);
+  ASSERT_EQ(b, true);
+  Formatter* f(trimmer->attach(&fmt));
+  f->open_object_section("foo");
+  f->open_object_section("bar");
+  f->dump_int("int", 0xf00000000000ll);
+  f->dump_unsigned("unsigned", 0x8000000000000001llu);
+  f->dump_float("float", 1.234);
+  f->close_section();
+  f->dump_string("string", "str");
+  f->close_section();
+  f->flush(oss);
+  ASSERT_EQ(oss.str(), "<foo><bar><float>1.234</float></bar></foo>");
+};
+
+
+
+/*
+1. make random tree A
+2. make +/- rule R that matches this tree
+3. make tree B by interpreting rule R - copying parts A to B or deleting from B
+4. stream tree A through filter R
+5. stream tree B
+6. 4 and 5 must match
+ */
+TEST(FilterTrimmer, big) {
+  boost::rand48 rng;
+
+  auto R = [&](size_t min, size_t max) {
+    return boost::uniform_int<>(min, max)(rng);
+  };
+
+  auto random_id = [&]() {
+    std::string n;
+    size_t s = R(1,7);
+    for (size_t i = 0; i < s; i++) {
+      if (R(0,1)) {
+	n.push_back(R('a', 'z'));
+      } else {
+	n.push_back(R('A', 'Z'));
+      }
+    }
+    return n;
+  };
+
+  auto unique_random_id = [&](std::set<std::string>& ids) {
+    while (true) {
+      std::string n = random_id();
+      if (ids.count(n) == 0) {
+	ids.emplace(n);
+	return n;
+      }
+    }
+  };
+
+  struct T {
+    std::string value; //if value!="" branches must be empty
+    std::map<std::string, T> branches;
+    bool support_only = false;
+    void dump(size_t depth) const {
+      if (value != "") {
+	std::cout << std::string(depth * 2, ' ') << ":" << value << std::endl;
+      } else {
+	for (auto& t : branches) {
+	  std::cout << std::string(depth * 2, ' ') <<
+	    "(" << t.second.support_only << ")" << t.first << std::endl;
+	  t.second.dump(depth + 1);
+	}
+      }
+    }
+    void set_support(bool b) {
+      support_only = b;
+      for (auto& t : branches) {
+	t.second.set_support(b);
+      }
+    }
+    bool prune_support() {
+      bool b = support_only;
+      for (auto it = branches.begin(); it != branches.end(); ) {
+	bool b1 = it->second.prune_support();
+	if (b1 == true) {
+	  it = branches.erase(it);
+	} else {
+	  it ++;
+	}
+	b = b && b1;
+      }
+      return b;
+    }
+  };
+
+  std::set<std::string> used_ids;
+
+  std::function<void(size_t, T&)>
+  produce_tree = [&](size_t depth, T& t) {
+    ssize_t elems = depth == 0 ? 1 : 6 - depth * 2 + R(0, 4);
+    bool is_leaf = depth < 2 ? false : R(0, 3) == 0;
+
+    if (is_leaf) {
+      t.value = random_id();
+      return;
+    }
+    for (ssize_t i = 0; i < elems; i++) {
+      std::string branch = unique_random_id(used_ids);
+      T& x = t.branches[branch];
+      produce_tree(depth + 1, x);
+    }
+  };
+
+  std::function<void(const T&, std::vector<std::string>& path)>
+  select_path = [&](const T& t, std::vector<std::string>& path) {
+    std::string s;
+    if (R(0,3) > 0) {
+      size_t br = t.branches.size();
+      if (br != 0) {
+	size_t pos = R(0, br - 1);
+	auto it = t.branches.begin();
+	while (pos > 0) {
+	  it++;
+	  pos--;
+	};
+	path.push_back(it->first);
+	select_path(it->second, path);
+      }
+    }
+  };
+
+  auto copy = [&](const T& src, T& dst, const std::vector<std::string>& path) {
+    const T* s = &src;
+    T* d = &dst;
+    //first check if anything gets copied
+    bool matched = true;
+    for (size_t i = 0; i < path.size(); i++) {
+      auto it = s->branches.find(path[i]);
+      if (it == s->branches.end()) {
+	matched = false;
+	break;
+      }
+      s = &it->second;
+    }
+    if (!matched) {
+      return;
+    }
+    s = &src;
+    for (auto& p : path) {
+      auto it = s->branches.find(p);
+      ceph_assert(it != s->branches.end());
+      auto itd = d->branches.find(p);
+      if (itd == d->branches.end()) {
+	d = &d->branches[p];
+	d->support_only = true;
+      } else {
+	d = &d->branches[p];
+      }
+      s = &it->second;
+    }
+    *d = *s;
+    d->set_support(false);
+  };
+
+  auto cut = [&](T& dst, const std::vector<std::string>& path) {
+    T* d = &dst;
+    if (path.size() == 0) {
+      d->branches.clear();
+    }
+    for (size_t i = 0; i < path.size(); i++) {
+      auto it = d->branches.find(path[i]);
+      if (it == d->branches.end()) {
+	break;
+      }
+      if (i == path.size() - 1) {
+	d->branches.erase(it);
+	break;
+      }
+      d = &it->second;
+    }
+  };
+
+  std::function<void(const T&, Formatter*)>
+  print_tree = [&](const T& t, Formatter* f) {
+    for (auto const& [n, b]: t.branches) {
+      if (b.value != "") {
+	f->dump_string(n.c_str(), b.value);
+      } else {
+	f->open_object_section(n.c_str());
+	print_tree(b, f);
+	f->close_section();
+      }
+    }
+  };
+
+  for (size_t i = 0; i < 10000; i++) {
+    T t;
+    T manual;
+    produce_tree(0,t);
+    //default +
+    manual = t;
+    size_t rct = R(1,5);
+    std::string rule;
+    for (size_t j = 0; j < rct; j++) {
+      std::vector<std::string> path;
+      select_path(t, path);
+
+      std::string r;
+      for (auto& x: path) {
+	r = r + "." + x;
+      }
+      if (!rule.empty()) {
+	rule += ",";
+      }
+
+      if (R(0, 2) > 0) {
+	copy(t, manual, path);
+	rule += "+" + r;
+      } else {
+	cut(manual, path);
+	rule += "-" + r;
+      }
+    }
+    manual.prune_support();
+    std::unique_ptr<Formatter> f_actual(new XMLFormatter(false));
+    ASSERT_NE(f_actual.get(), nullptr);
+    print_tree(manual, &*f_actual);
+    stringstream manual_ss;
+    f_actual->flush(manual_ss);
+    std::unique_ptr<ceph::Trimmer> trimmer(ceph::Trimmer::create());
+    std::string error;
+    bool b = trimmer->setup(rule, error);
+    ASSERT_EQ(b, true);
+    Formatter* f = trimmer->attach(f_actual.get());
+    ASSERT_NE(f, nullptr);
+    print_tree(t, f);
+    stringstream trimmed_ss;
+    f->flush(trimmed_ss);
+    EXPECT_EQ(manual_ss.str(), trimmed_ss.str());
+    trimmer->detach();
+  }
+};


### PR DESCRIPTION
Adding list-objects operation to ceph-bluestore-tool. 
It list in detail content of Onode "O" prefixes in RocksDB.
It allows to inspect in detail state of object internal metadata.

Options for filtering objects and reducing output tree are also available "--select", "--trim".