### PR TITLE
mgr/devicehealth: device_health_metrics pool gets created even without any OSDs in the cluster

### DIFF
--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -144,6 +144,7 @@ class Module(MgrModule):
         # other
         self.run = True
         self.event = Event()
+        self.has_device_pool = False
 
     def is_valid_daemon_name(self, who):
         l = who.split('.')
@@ -220,6 +221,37 @@ class Module(MgrModule):
                     self.get_module_option(opt['name']))
             self.log.debug(' %s = %s', opt['name'], getattr(self, opt['name']))
 
+    def notify(self, notify_type, notify_id):
+       # create device_health_metrics pool if it doesn't exist
+       if notify_type == "osd_map" and self.enable_monitoring:
+            if not self.has_device_pool:
+                self.create_device_pool()
+                self.has_device_pool = True
+
+    def create_device_pool(self):
+        self.log.debug('create %s pool' % self.pool_name)
+        # create pool
+        result = CommandResult('')
+        self.send_command(result, 'mon', '', json.dumps({
+            'prefix': 'osd pool create',
+            'format': 'json',
+            'pool': self.pool_name,
+            'pg_num': 1,
+            'pg_num_min': 1,
+        }), '')
+        r, outb, outs = result.wait()
+        assert r == 0
+        # set pool application
+        result = CommandResult('')
+        self.send_command(result, 'mon', '', json.dumps({
+            'prefix': 'osd pool application enable',
+            'format': 'json',
+            'pool': self.pool_name,
+            'app': 'mgr_devicehealth',
+        }), '')
+        r, outb, outs = result.wait()
+        assert r == 0
+
     def serve(self):
         self.log.info("Starting")
         self.config_notify()
@@ -273,44 +305,23 @@ class Module(MgrModule):
         self.event.set()
 
     def open_connection(self, create_if_missing=True):
-        pools = self.rados.list_pools()
-        is_pool = False
-        for pool in pools:
-            if pool == self.pool_name:
-                is_pool = True
-                break
-        if not is_pool:
+        osdmap = self.get("osd_map")
+        assert osdmap is not None
+        if len(osdmap['osds']) == 0:
+            return None
+        if not self.has_device_pool:
             if not create_if_missing:
                 return None
-            self.log.debug('create %s pool' % self.pool_name)
-            # create pool
-            result = CommandResult('')
-            self.send_command(result, 'mon', '', json.dumps({
-                'prefix': 'osd pool create',
-                'format': 'json',
-                'pool': self.pool_name,
-                'pg_num': 1,
-                'pg_num_min': 1,
-            }), '')
-            r, outb, outs = result.wait()
-            assert r == 0
-
-            # set pool application
-            result = CommandResult('')
-            self.send_command(result, 'mon', '', json.dumps({
-                'prefix': 'osd pool application enable',
-                'format': 'json',
-                'pool': self.pool_name,
-                'app': 'mgr_devicehealth',
-            }), '')
-            r, outb, outs = result.wait()
-            assert r == 0
-
+            if self.enable_monitoring:
+                self.create_device_pool()
+                self.has_device_pool = True
         ioctx = self.rados.open_ioctx(self.pool_name)
         return ioctx
 
     def scrape_daemon(self, daemon_type, daemon_id):
         ioctx = self.open_connection()
+        if not ioctx:
+            return 0, "", ""
         raw_smart_data = self.do_scrape_daemon(daemon_type, daemon_id)
         if raw_smart_data:
             for device, raw_data in raw_smart_data.items():
@@ -324,6 +335,8 @@ class Module(MgrModule):
         osdmap = self.get("osd_map")
         assert osdmap is not None
         ioctx = self.open_connection()
+        if not ioctx:
+            return 0, "", ""
         did_device = {}
         ids = []
         for osd in osdmap['osds']:
@@ -356,6 +369,8 @@ class Module(MgrModule):
                     'device ' + devid + ' not claimed by any active daemons')
         (daemon_type, daemon_id) = daemons[0].split('.')
         ioctx = self.open_connection()
+        if not ioctx:
+            return 0, "", ""
         raw_smart_data = self.do_scrape_daemon(daemon_type, daemon_id,
                                                devid=devid)
         if raw_smart_data:


### PR DESCRIPTION
This patch checks if the cluster has any OSD before the 'device_health_metrics'
pool creation by devicehealth, which prevents the cluster entering HEALTH_WARN
immediately after bootstrap.
   
Fixes: https://tracker.ceph.com/issues/46743

Signed-off-by: Sunny Kumar <sunkumar@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
