### PR TITLE
mgr/dashboard: Allow editing iSCSI targets with initiators logged-in

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -384,35 +384,48 @@ class IscsiTarget(RESTController):
         deleted_groups = []
         for group_id in list(target_config['groups'].keys()):
             if IscsiTarget._group_deletion_required(target, new_target_iqn, new_target_controls,
-                                                    new_groups, group_id, new_clients,
-                                                    new_disks):
+                                                    new_groups, group_id):
                 deleted_groups.append(group_id)
                 IscsiClient.instance(gateway_name=gateway_name).delete_group(target_iqn,
                                                                              group_id)
+            else:
+                group = IscsiTarget._get_group(new_groups, group_id)
+
+                old_group_disks = set(target_config['groups'][group_id]['disks'].keys())
+                new_group_disks = {'{}/{}'.format(x['pool'], x['image']) for x in group['disks']}
+                local_deleted_disks = list(old_group_disks - new_group_disks)
+
+                old_group_members = set(target_config['groups'][group_id]['members'])
+                new_group_members = set(group['members'])
+                local_deleted_members = list(old_group_members - new_group_members)
+
+                if local_deleted_disks or local_deleted_members:
+                    IscsiClient.instance(gateway_name=gateway_name).update_group(
+                        target_iqn, group_id, local_deleted_members, local_deleted_disks)
             TaskManager.current_task().inc_progress(task_progress_inc)
         deleted_clients = []
         deleted_client_luns = []
         for client_iqn, client_config in target_config['clients'].items():
             if IscsiTarget._client_deletion_required(target, new_target_iqn, new_target_controls,
-                                                     new_clients, client_iqn,
-                                                     deleted_groups):
+                                                     new_clients, client_iqn):
                 deleted_clients.append(client_iqn)
                 IscsiClient.instance(gateway_name=gateway_name).delete_client(target_iqn,
                                                                               client_iqn)
             else:
                 for image_id in list(client_config.get('luns', {}).keys()):
                     if IscsiTarget._client_lun_deletion_required(target, client_iqn, image_id,
-                                                                 new_clients):
+                                                                 new_clients, new_groups):
                         deleted_client_luns.append((client_iqn, image_id))
                         IscsiClient.instance(gateway_name=gateway_name).delete_client_lun(
                             target_iqn, client_iqn, image_id)
             TaskManager.current_task().inc_progress(task_progress_inc)
         for image_id in target_config['disks']:
             if IscsiTarget._target_lun_deletion_required(target, new_target_iqn,
-                                                         new_target_controls,
-                                                         new_disks, image_id):
+                                                         new_target_controls, new_disks, image_id):
                 all_clients = target_config['clients'].keys()
-                not_deleted_clients = [c for c in all_clients if c not in deleted_clients]
+                not_deleted_clients = [c for c in all_clients if c not in deleted_clients
+                                       and not IscsiTarget._client_in_group(target['groups'], c)
+                                       and not IscsiTarget._client_in_group(new_groups, c)]
                 for client_iqn in not_deleted_clients:
                     client_image_ids = target_config['clients'][client_iqn]['luns'].keys()
                     for client_image_id in client_image_ids:
@@ -447,28 +460,12 @@ class IscsiTarget(RESTController):
 
     @staticmethod
     def _group_deletion_required(target, new_target_iqn, new_target_controls,
-                                 new_groups, group_id, new_clients, new_disks):
+                                 new_groups, group_id):
         if IscsiTarget._target_deletion_required(target, new_target_iqn, new_target_controls):
             return True
         new_group = IscsiTarget._get_group(new_groups, group_id)
         if not new_group:
             return True
-        old_group = IscsiTarget._get_group(target['groups'], group_id)
-        if new_group != old_group:
-            return True
-        # Check if any client inside this group has changed
-        for client_iqn in new_group['members']:
-            if IscsiTarget._client_deletion_required(target, new_target_iqn, new_target_controls,
-                                                     new_clients, client_iqn,
-                                                     []):
-                return True
-        # Check if any disk inside this group has changed
-        for disk in new_group['disks']:
-            image_id = '{}/{}'.format(disk['pool'], disk['image'])
-            if IscsiTarget._target_lun_deletion_required(target, new_target_iqn,
-                                                         new_target_controls,
-                                                         new_disks, image_id):
-                return True
         return False
 
     @staticmethod
@@ -480,29 +477,45 @@ class IscsiTarget(RESTController):
 
     @staticmethod
     def _client_deletion_required(target, new_target_iqn, new_target_controls,
-                                  new_clients, client_iqn, deleted_groups):
+                                  new_clients, client_iqn):
         if IscsiTarget._target_deletion_required(target, new_target_iqn, new_target_controls):
             return True
         new_client = IscsiTarget._get_client(new_clients, client_iqn)
         if not new_client:
             return True
-        # Check if client belongs to a groups that has been deleted
-        for group in target['groups']:
-            if group['group_id'] in deleted_groups and client_iqn in group['members']:
+        return False
+
+    @staticmethod
+    def _client_in_group(groups, client_iqn):
+        for group in groups:
+            if client_iqn in group['members']:
                 return True
         return False
 
     @staticmethod
-    def _client_lun_deletion_required(target, client_iqn, image_id, new_clients):
+    def _client_lun_deletion_required(target, client_iqn, image_id, new_clients, new_groups):
         new_client = IscsiTarget._get_client(new_clients, client_iqn)
         if not new_client:
             return True
+
+        # Disks inherited from groups must be considered
+        was_in_group = IscsiTarget._client_in_group(target['groups'], client_iqn)
+        is_in_group = IscsiTarget._client_in_group(new_groups, client_iqn)
+
+        if not was_in_group and is_in_group:
+            return True
+
+        if is_in_group:
+            return False
+
         new_lun = IscsiTarget._get_disk(new_client.get('luns', []), image_id)
         if not new_lun:
             return True
+
         old_client = IscsiTarget._get_client(target['clients'], client_iqn)
         if not old_client:
             return False
+
         old_lun = IscsiTarget._get_disk(old_client.get('luns', []), image_id)
         return new_lun != old_lun
 
@@ -673,15 +686,9 @@ class IscsiTarget(RESTController):
 
         target_config = config['targets'][target_iqn]
         target = IscsiTarget._config_to_target(target_iqn, config)
-        deleted_groups = []
-        for group_id in list(target_config['groups'].keys()):
-            if IscsiTarget._group_deletion_required(target, new_target_iqn, new_target_controls,
-                                                    new_groups, group_id, new_clients,
-                                                    new_disks):
-                deleted_groups.append(group_id)
         for client_iqn in list(target_config['clients'].keys()):
             if IscsiTarget._client_deletion_required(target, new_target_iqn, new_target_controls,
-                                                     new_clients, client_iqn, deleted_groups):
+                                                     new_clients, client_iqn):
                 client_info = IscsiClient.instance(gateway_name=gateway).get_clientinfo(target_iqn,
                                                                                         client_iqn)
                 if client_info.get('state', {}).get('LOGGED_IN', []):
@@ -807,8 +814,15 @@ class IscsiTarget(RESTController):
                     pool = lun['pool']
                     image = lun['image']
                     image_id = '{}/{}'.format(pool, image)
+                    # Disks inherited from groups must be considered
+                    group_disks = []
+                    for group in groups:
+                        if client_iqn in group['members']:
+                            group_disks = ['{}/{}'.format(x['pool'], x['image'])
+                                           for x in group['disks']]
                     if not target_config or client_iqn not in target_config['clients'] or \
-                            image_id not in target_config['clients'][client_iqn]['luns']:
+                            (image_id not in target_config['clients'][client_iqn]['luns']
+                             and image_id not in group_disks):
                         IscsiClient.instance(gateway_name=gateway_name).create_client_lun(
                             target_iqn, client_iqn, image_id)
                 TaskManager.current_task().inc_progress(task_progress_inc)
@@ -818,7 +832,14 @@ class IscsiTarget(RESTController):
                 image_ids = []
                 for disk in group['disks']:
                     image_ids.append('{}/{}'.format(disk['pool'], disk['image']))
-                if not target_config or group_id not in target_config['groups']:
+
+                if target_config and group_id in target_config['groups']:
+                    old_members = target_config['groups'][group_id]['members']
+                    old_disks = target_config['groups'][group_id]['disks'].keys()
+
+                if not target_config or group_id not in target_config['groups'] or \
+                        list(set(group['members']) - set(old_members)) or \
+                        list(set(image_ids) - set(old_disks)):
                     IscsiClient.instance(gateway_name=gateway_name).create_group(
                         target_iqn, group_id, members, image_ids)
                 TaskManager.current_task().inc_progress(task_progress_inc)

--- a/src/pybind/mgr/dashboard/services/iscsi_client.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_client.py
@@ -205,6 +205,15 @@ class IscsiClient(RestClient):
             'disks': ','.join(image_ids)
         })
 
+    @RestClient.api_put('/api/hostgroup/{target_iqn}/{group_name}')
+    def update_group(self, target_iqn, group_name, members, image_ids, request=None):
+        logger.debug("iSCSI[%s] Updating group: %s/%s", self.gateway_name, target_iqn, group_name)
+        return request({
+            'action': 'remove',
+            'members': ','.join(members),
+            'disks': ','.join(image_ids)
+        })
+
     @RestClient.api_delete('/api/hostgroup/{target_iqn}/{group_name}')
     def delete_group(self, target_iqn, group_name, request=None):
         logger.debug("[%s] Deleting group: %s/%s", self.gateway_name, target_iqn, group_name)


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47393

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
