### PR TITLE
nautilus: os/bluestore: enable more flexible bluefs space management by default.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4965,7 +4965,7 @@ std::vector<Option> get_global_options() {
     .set_description("log collection list operation if it's slower than this age (seconds)"),
 
     Option("bluestore_volume_selection_policy", Option::TYPE_STR, Option::LEVEL_DEV)
-    .set_default("rocksdb_original")
+    .set_default("use_some_extra")
     .set_enum_allowed({ "rocksdb_original", "use_some_extra" })
     .set_description("Determines bluefs volume selection policy")
     .set_long_description("Determines bluefs volume selection policy. 'use_some_extra' policy allows to override RocksDB level granularity and put high level's data to faster device even when the level doesn't completely fit there"),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47194

---

backport of https://github.com/ceph/ceph/pull/36750
parent tracker: https://tracker.ceph.com/issues/47053

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh