### PR TITLE
mds: make purge_queue delete objects asynchronously and keep accepting pushes

### DIFF
--- a/src/mds/PurgeQueue.cc
+++ b/src/mds/PurgeQueue.cc
@@ -98,8 +98,8 @@ void PurgeItem::decode(bufferlist::const_iterator &p)
   DECODE_FINISH(p);
 }
 
-// TODO: if Objecter has any slow requests, take that as a hint and
-// slow down our rate of purging (keep accepting pushes though)
+// if Objecter has any slow requests, take that as a hint and
+// slow down our rate of purging
 PurgeQueue::PurgeQueue(
       CephContext *cct_,
       mds_rank_t rank_,
@@ -495,102 +495,74 @@ bool PurgeQueue::_consume()
   return could_consume;
 }
 
-void PurgeQueue::_execute_item(
-    const PurgeItem &item,
-    uint64_t expire_to)
+class C_IO_PurgeItem_Commit : public Context {
+public:
+  C_IO_PurgeItem_Commit(PurgeQueue *pq, std::vector<PurgeItemCommitOp> ops, uint64_t expire_to)
+    : purge_queue(pq), ops_vec(std::move(ops)), expire_to(expire_to) {
+  }
+
+  void finish(int r) override {
+    purge_queue->_commit_ops(r, ops_vec, expire_to);
+  }
+
+private:
+  PurgeQueue *purge_queue;
+  std::vector<PurgeItemCommitOp> ops_vec;
+  uint64_t expire_to;
+};
+
+void PurgeQueue::_commit_ops(int r, const std::vector<PurgeItemCommitOp>& ops_vec, uint64_t expire_to)
 {
-  ceph_assert(ceph_mutex_is_locked_by_me(lock));
-
-  in_flight[expire_to] = item;
-  logger->set(l_pq_executing, in_flight.size());
-  files_high_water = std::max(files_high_water,
-                              static_cast<uint64_t>(in_flight.size()));
-  logger->set(l_pq_executing_high_water, files_high_water);
-  auto ops = _calculate_ops(item);
-  ops_in_flight += ops;
-  logger->set(l_pq_executing_ops, ops_in_flight);
-  ops_high_water = std::max(ops_high_water, ops_in_flight);
-  logger->set(l_pq_executing_ops_high_water, ops_high_water);
-
-  SnapContext nullsnapc;
-
-  C_GatherBuilder gather(cct);
-  if (item.action == PurgeItem::PURGE_FILE) {
-    if (item.size > 0) {
-      uint64_t num = Striper::get_num_objects(item.layout, item.size);
-      dout(10) << " 0~" << item.size << " objects 0~" << num
-               << " snapc " << item.snapc << " on " << item.ino << dendl;
-      filer.purge_range(item.ino, &item.layout, item.snapc,
-                        0, num, ceph::real_clock::now(), 0,
-                        gather.new_sub());
-    }
-
-    // remove the backtrace object if it was not purged
-    object_t oid = CInode::get_object_name(item.ino, frag_t(), "");
-    if (!gather.has_subs() || !item.layout.pool_ns.empty()) {
-      object_locator_t oloc(item.layout.pool_id);
-      dout(10) << " remove backtrace object " << oid
-               << " pool " << oloc.pool << " snapc " << item.snapc << dendl;
-      objecter->remove(oid, oloc, item.snapc,
-                            ceph::real_clock::now(), 0,
-                            gather.new_sub());
-    }
-
-    // remove old backtrace objects
-    for (const auto &p : item.old_pools) {
-      object_locator_t oloc(p);
-      dout(10) << " remove backtrace object " << oid
-               << " old pool " << p << " snapc " << item.snapc << dendl;
-      objecter->remove(oid, oloc, item.snapc,
-                            ceph::real_clock::now(), 0,
-                            gather.new_sub());
-    }
-  } else if (item.action == PurgeItem::PURGE_DIR) {
-    object_locator_t oloc(metadata_pool);
-    frag_vec_t leaves;
-    if (!item.fragtree.is_leaf(frag_t()))
-      item.fragtree.get_leaves(leaves);
-    leaves.push_back(frag_t());
-    for (const auto &leaf : leaves) {
-      object_t oid = CInode::get_object_name(item.ino, leaf, "");
-      dout(10) << " remove dirfrag " << oid << dendl;
-      objecter->remove(oid, oloc, nullsnapc,
-                       ceph::real_clock::now(),
-                       0, gather.new_sub());
-    }
-  } else if (item.action == PurgeItem::TRUNCATE_FILE) {
-    const uint64_t num = Striper::get_num_objects(item.layout, item.size);
-    dout(10) << " 0~" << item.size << " objects 0~" << num
-	     << " snapc " << item.snapc << " on " << item.ino << dendl;
-
-    // keep backtrace object
-    if (num > 1) {
-      filer.purge_range(item.ino, &item.layout, item.snapc,
-			1, num - 1, ceph::real_clock::now(),
-			0, gather.new_sub());
-    }
-    filer.zero(item.ino, &item.layout, item.snapc,
-	       0, item.layout.object_size,
-	       ceph::real_clock::now(),
-	       0, true, gather.new_sub());
-  } else {
-    derr << "Invalid item (action=" << item.action << ") in purge queue, "
-            "dropping it" << dendl;
-    ops_in_flight -= ops;
-    logger->set(l_pq_executing_ops, ops_in_flight);
-    ops_high_water = std::max(ops_high_water, ops_in_flight);
-    logger->set(l_pq_executing_ops_high_water, ops_high_water);
-    in_flight.erase(expire_to);
-    logger->set(l_pq_executing, in_flight.size());
-    files_high_water = std::max(files_high_water,
-                                static_cast<uint64_t>(in_flight.size()));
-    logger->set(l_pq_executing_high_water, files_high_water);
+  if (r < 0) {
+    derr << " r = " << r << dendl;
     return;
   }
+
+  SnapContext nullsnapc;
+  C_GatherBuilder gather(cct);
+
+  for (auto &op : ops_vec) {
+    dout(10) << op.item.get_type_str() << dendl;
+    if (op.type == PurgeItemCommitOp::PURGE_OP_RANGE) {
+      uint64_t first_obj = 0, num_obj = 0;
+      uint64_t num = Striper::get_num_objects(op.item.layout, op.item.size);
+      num_obj = num;
+
+      if (op.item.action == PurgeItem::TRUNCATE_FILE) {
+        first_obj = 1;
+        if (num > 1)
+          num_obj = num - 1;
+        else
+          continue;
+      }
+
+      filer.purge_range(op.item.ino, &op.item.layout, op.item.snapc,
+                        first_obj, num_obj, ceph::real_clock::now(), op.flags,
+                        gather.new_sub());
+    } else if (op.type == PurgeItemCommitOp::PURGE_OP_REMOVE) {
+      if (op.item.action == PurgeItem::PURGE_DIR) {
+        objecter->remove(op.oid, op.oloc, nullsnapc,
+                         ceph::real_clock::now(), op.flags,
+                         gather.new_sub());
+      } else {
+        objecter->remove(op.oid, op.oloc, op.item.snapc,
+                         ceph::real_clock::now(), op.flags,
+                         gather.new_sub());
+      }
+    } else if (op.type == PurgeItemCommitOp::PURGE_OP_ZERO) {
+      filer.zero(op.item.ino, &op.item.layout, op.item.snapc,
+                 0, op.item.layout.object_size, ceph::real_clock::now(), 0, true,
+                 gather.new_sub());
+    } else {
+      derr << "Invalid purge op: " << op.type << dendl;
+      ceph_abort();
+    }
+  }
+
   ceph_assert(gather.has_subs());
 
   gather.set_finisher(new C_OnFinisher(
-                      new LambdaContext([this, expire_to](int r){
+	              new LambdaContext([this, expire_to](int r) {
     std::lock_guard l(lock);
 
     if (r == -EBLOCKLISTED) {
@@ -608,12 +580,97 @@ void PurgeQueue::_execute_item(
     // expire_pos doesn't fall too far behind our progress when consuming
     // a very long queue.
     if (!readonly &&
-	(in_flight.empty() || journaler.write_head_needed())) {
+        (in_flight.empty() || journaler.write_head_needed())) {
       journaler.write_head(nullptr);
     }
   }), &finisher));
 
   gather.activate();
+}
+
+void PurgeQueue::_execute_item(
+    const PurgeItem &item,
+    uint64_t expire_to)
+{
+  ceph_assert(ceph_mutex_is_locked_by_me(lock));
+
+  in_flight[expire_to] = item;
+  logger->set(l_pq_executing, in_flight.size());
+  files_high_water = std::max(files_high_water,
+                              static_cast<uint64_t>(in_flight.size()));
+  logger->set(l_pq_executing_high_water, files_high_water);
+  auto ops = _calculate_ops(item);
+  ops_in_flight += ops;
+  logger->set(l_pq_executing_ops, ops_in_flight);
+  ops_high_water = std::max(ops_high_water, ops_in_flight);
+  logger->set(l_pq_executing_ops_high_water, ops_high_water);
+
+  std::vector<PurgeItemCommitOp> ops_vec;
+  auto submit_ops = [&]() {
+    finisher.queue(new C_IO_PurgeItem_Commit(this, std::move(ops_vec), expire_to));
+  };
+
+  if (item.action == PurgeItem::PURGE_FILE) {
+    if (item.size > 0) {
+      uint64_t num = Striper::get_num_objects(item.layout, item.size);
+      dout(10) << " 0~" << item.size << " objects 0~" << num
+               << " snapc " << item.snapc << " on " << item.ino << dendl;
+      ops_vec.emplace_back(item, PurgeItemCommitOp::PURGE_OP_RANGE, 0);
+    }
+
+    // remove the backtrace object if it was not purged
+    object_t oid = CInode::get_object_name(item.ino, frag_t(), "");
+    if (ops_vec.empty() || !item.layout.pool_ns.empty()) {
+      object_locator_t oloc(item.layout.pool_id);
+      dout(10) << " remove backtrace object " << oid
+               << " pool " << oloc.pool << " snapc " << item.snapc << dendl;
+      ops_vec.emplace_back(item, PurgeItemCommitOp::PURGE_OP_REMOVE, 0, oid, oloc);
+    }
+
+    // remove old backtrace objects
+    for (const auto &p : item.old_pools) {
+      object_locator_t oloc(p);
+      dout(10) << " remove backtrace object " << oid
+               << " old pool " << p << " snapc " << item.snapc << dendl;
+      ops_vec.emplace_back(item, PurgeItemCommitOp::PURGE_OP_REMOVE, 0, oid, oloc);
+    }
+  } else if (item.action == PurgeItem::PURGE_DIR) {
+    object_locator_t oloc(metadata_pool);
+    frag_vec_t leaves;
+    if (!item.fragtree.is_leaf(frag_t()))
+      item.fragtree.get_leaves(leaves);
+    leaves.push_back(frag_t());
+    for (const auto &leaf : leaves) {
+      object_t oid = CInode::get_object_name(item.ino, leaf, "");
+      dout(10) << " remove dirfrag " << oid << dendl;
+      ops_vec.emplace_back(item, PurgeItemCommitOp::PURGE_OP_REMOVE, 0, oid, oloc);
+    }
+  } else if (item.action == PurgeItem::TRUNCATE_FILE) {
+    const uint64_t num = Striper::get_num_objects(item.layout, item.size);
+    dout(10) << " 0~" << item.size << " objects 0~" << num
+	     << " snapc " << item.snapc << " on " << item.ino << dendl;
+
+    // keep backtrace object
+    if (num > 1) {
+      ops_vec.emplace_back(item, PurgeItemCommitOp::PURGE_OP_RANGE, 0);
+    }
+    ops_vec.emplace_back(item, PurgeItemCommitOp::PURGE_OP_ZERO, 0);
+  } else {
+    derr << "Invalid item (action=" << item.action << ") in purge queue, "
+            "dropping it" << dendl;
+    ops_in_flight -= ops;
+    logger->set(l_pq_executing_ops, ops_in_flight);
+    ops_high_water = std::max(ops_high_water, ops_in_flight);
+    logger->set(l_pq_executing_ops_high_water, ops_high_water);
+    in_flight.erase(expire_to);
+    logger->set(l_pq_executing, in_flight.size());
+    files_high_water = std::max(files_high_water,
+                                static_cast<uint64_t>(in_flight.size()));
+    logger->set(l_pq_executing_high_water, files_high_water);
+    return;
+  }
+
+  submit_ops();
 }
 
 void PurgeQueue::_execute_item_complete(

--- a/src/mds/PurgeQueue.h
+++ b/src/mds/PurgeQueue.h
@@ -94,6 +94,28 @@ enum {
   l_pq_last
 };
 
+struct PurgeItemCommitOp {
+public:
+  enum PurgeType : uint8_t {
+    PURGE_OP_RANGE = 0,
+    PURGE_OP_REMOVE = 1,
+    PURGE_OP_ZERO
+  };
+
+  PurgeItemCommitOp(PurgeItem _item, PurgeType _type, int _flags)
+    : item(_item), type(_type), flags(_flags) {}
+
+  PurgeItemCommitOp(PurgeItem _item, PurgeType _type, int _flags,
+                    object_t _oid, object_locator_t _oloc)
+    : item(_item), type(_type), flags(_flags), oid(_oid), oloc(_oloc) {}
+
+  PurgeItem item;
+  PurgeType type;
+  int flags;
+  object_t oid;
+  object_locator_t oloc;
+};
+
 /**
  * A persistent queue of PurgeItems.  This class both writes and reads
  * to the queue.  There is one of these per MDS rank.
@@ -130,6 +152,8 @@ public:
   // Submit one entry to the work queue.  Call back when it is persisted
   // to the queue (there is no callback for when it is executed)
   void push(const PurgeItem &pi, Context *completion);
+
+  void _commit_ops(int r, const std::vector<PurgeItemCommitOp>& ops_vec, uint64_t expire_to);
 
   // If the on-disk queue is empty and we are not currently processing
   // anything.


### PR DESCRIPTION

Signed-off-by: Yanhu Cao <gmayyyha@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
