### PR TITLE
common/buffer: use homebrew BUF_OFFSETOF to replace offsetof()

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -2147,13 +2147,17 @@ buffer::list buffer::list::static_from_string(string& s) {
   // const makes me generally sad.
 }
 
+// buffer::raw is not a standard layout type.
+#define BUF_OFFSETOF(type, field)					\
+  (reinterpret_cast<std::uintptr_t>(&(((type*)1024)->field)) - 1024u)
+
 bool buffer::ptr_node::dispose_if_hypercombined(
   buffer::ptr_node* const delete_this)
 {
   // in case _raw is nullptr
   const std::uintptr_t bptr =
     (reinterpret_cast<std::uintptr_t>(delete_this->_raw) +
-     offsetof(buffer::raw, bptr_storage));
+     BUF_OFFSETOF(buffer::raw, bptr_storage));
   const bool is_hypercombined =
     reinterpret_cast<std::uintptr_t>(delete_this) == bptr;
   if (is_hypercombined) {


### PR DESCRIPTION
because buffer::raw is not a standard layout type. so `offsetof()`
does not always work. let's use a homebrew macro to calculate the
address of `bptr_storage`.

this change silences the warning like:
```
src/common/buffer.cc:2156:15: warning: ‘offsetof’ within non-standard-layout type ‘ceph::buffer::v15_2_0::raw’ is conditionally-supported [-Winvalid-offsetof]
 2156 |      offsetof(buffer::raw, bptr_storage));
```
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
