### PR TITLE
crimson/osd: pass the the cause by string_view

### DIFF
--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -30,7 +30,7 @@ hobject_t RecoveryBackend::get_temp_recovery_object(
 }
 
 void RecoveryBackend::clean_up(ceph::os::Transaction& t,
-			       const std::string& why)
+			       std::string_view why)
 {
   for (auto& soid : temp_contents) {
     t.remove(pg.get_collection_ref()->get_cid(),

--- a/src/crimson/osd/recovery_backend.h
+++ b/src/crimson/osd/recovery_backend.h
@@ -155,16 +155,16 @@ protected:
     void set_push_failed(pg_shard_t shard, std::exception_ptr e) {
       pushes.at(shard).set_exception(e);
     }
-    void interrupt(const std::string& why) {
+    void interrupt(std::string_view why) {
       readable.set_exception(std::system_error(
-	    std::make_error_code(std::errc::interrupted), why));
+        std::make_error_code(std::errc::interrupted), why.data()));
       recovered.set_exception(std::system_error(
-	    std::make_error_code(std::errc::interrupted), why));
+        std::make_error_code(std::errc::interrupted), why.data()));
       pulled.set_exception(std::system_error(
-	    std::make_error_code(std::errc::interrupted), why));
+        std::make_error_code(std::errc::interrupted), why.data()));
       for (auto& [pg_shard, pr] : pushes) {
-	pr.set_exception(std::system_error(
-	      std::make_error_code(std::errc::interrupted), why));
+        pr.set_exception(std::system_error(
+          std::make_error_code(std::errc::interrupted), why.data()));
       }
     }
     void stop();
@@ -184,6 +184,6 @@ protected:
   void clear_temp_obj(const hobject_t &oid) {
     temp_contents.erase(oid);
   }
-  void clean_up(ceph::os::Transaction& t, const std::string& why);
+  void clean_up(ceph::os::Transaction& t, std::string_view why);
   virtual seastar::future<> on_stop() = 0;
 };


### PR DESCRIPTION
in future, string_view can be used almost every where string can be
used. in this change, `const char*` is instead passed to the constructor
of system_error, as we can ensure that the string_view instances are
always constructed from a `const char*` ended with `\0`.

we need this change for two reasons:

* better performance
* prefer for the world where string_view rules.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
