### PR TITLE
qa/workunits/mon: fixed excessively large pool PG count

### DIFF
--- a/qa/workunits/mon/rbd_snaps_ops.sh
+++ b/qa/workunits/mon/rbd_snaps_ops.sh
@@ -19,8 +19,8 @@ expect()
 }
 
 ceph osd pool delete test test --yes-i-really-really-mean-it || true
-expect 'ceph osd pool create test 256 256' 0
-expect 'rbd --pool=test pool init' 0
+expect 'ceph osd pool create test 8 8' 0
+expect 'ceph osd pool application enable test rbd'
 expect 'ceph osd pool mksnap test snapshot' 0
 expect 'ceph osd pool rmsnap test snapshot' 0
 
@@ -28,7 +28,7 @@ expect 'rbd --pool=test --rbd_validate_pool=false create --size=102400 image' 0
 expect 'rbd --pool=test snap create image@snapshot' 22
 
 expect 'ceph osd pool delete test test --yes-i-really-really-mean-it' 0
-expect 'ceph osd pool create test 256 256' 0
+expect 'ceph osd pool create test 8 8' 0
 expect 'rbd --pool=test pool init' 0
 expect 'rbd --pool=test create --size=102400 image' 0
 expect 'rbd --pool=test snap create image@snapshot' 0
@@ -45,13 +45,13 @@ expect 'ceph osd pool delete test test --yes-i-really-really-mean-it' 0
 
 ceph osd pool delete test-foo test-foo --yes-i-really-really-mean-it || true
 expect 'ceph osd pool create test-foo 8' 0
-expect 'rbd pool init test-foo'
+expect 'ceph osd pool application enable test-foo rbd'
 expect 'rbd --pool test-foo create --size 1024 image' 0
 expect 'rbd --pool test-foo snap create image@snapshot' 0
 
 ceph osd pool delete test-bar test-bar --yes-i-really-really-mean-it || true
 expect 'ceph osd pool create test-bar 8' 0
-expect 'rbd pool init test-bar'
+expect 'ceph osd pool application enable test-bar rbd'
 expect 'rados cppool test-foo test-bar --yes-i-really-mean-it' 0
 expect 'rbd --pool test-bar snap rm image@snapshot' 95
 expect 'ceph osd pool delete test-foo test-foo --yes-i-really-really-mean-it' 0


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47405
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
