### PR TITLE
rgw: fix post upload file size check

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1379,10 +1379,6 @@ int RGWPostObj_ObjStore::verify_params()
   if (!s->length) {
     return -ERR_LENGTH_REQUIRED;
   }
-  off_t len = atoll(s->length);
-  if (len > (off_t)(s->cct->_conf->rgw_max_put_size)) {
-    return -ERR_TOO_LARGE;
-  }
 
   supplied_md5_b64 = s->info.env->get("HTTP_CONTENT_MD5");
 

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2770,9 +2770,11 @@ int RGWPostObj_ObjStore_S3::get_params()
 
 
   min_len = post_policy.min_length;
-  max_len = post_policy.max_length;
-
-
+  max_len = (off_t)(s->cct->_conf->rgw_max_put_size);
+  if (max_len > post_policy.max_length) {
+    ldout(s->cct, 20) << "INFO: reset max_len to post_policy.max_length, max_len=" << post_policy.max_length << dendl;
+    max_len = post_policy.max_length;
+  }
 
   return 0;
 }


### PR DESCRIPTION
fix https://tracker.ceph.com/issues/47430

post upload 5GB size file failed, because the content-length contain extra content such as AWSAccessKeyId , policy and signature

```
Content-Disposition: form-data; name="AWSAccessKeyId"

yly
--f743e4588d4eb6dac43de1d1a83f3cbc
Content-Disposition: form-data; name="x-amz-storage-class"

STANDARD
--f743e4588d4eb6dac43de1d1a83f3cbc
Content-Disposition: form-data; name="key"

ylypostobj-4G-2
--f743e4588d4eb6dac43de1d1a83f3cbc
Content-Disposition: form-data; name="signature"

kDWcl4jzBpoUY6AyCXVa3nmoWP0=
--f743e4588d4eb6dac43de1d1a83f3cbc
Content-Disposition: form-data; name="policy"

eyJjb25kaXRpb25zIjogW1sic3RhcnRzLXdpdGgiLCAiJENvbnRlbnQtVHlwZSIsICJpbWFnZS8iXSwgeyJ4LWFtei1zdG9yYWdlLWNsYXNzIjogIlNUQU5EQVJEIn0sIFsiY29udGVudC1sZW5ndGgtcmFuZ2UiLCAwLCAxMDAwMDAwMDAwMF0sIHsiYnVja2V0IjogInRlc3QzIn0sIHsia2V5IjogInlseXBvc3RvYmotNEctMiJ9XSwgImV4cGlyYXRpb24iOiAiMjAyMC0wOS0xMVQxMDozNzozMFoifQ==
--f743e4588d4eb6dac43de1d1a83f3cbc
Content-Disposition: form-data; name="Content-Type"
```

Signed-off-by: yuliyang_yewu <yuliyang_yewu@cmss.chinamobile.com>