### PR TITLE
octopus: mgr/zabbix: indent the output of "zabbix config-show"

### DIFF
--- a/src/pybind/mgr/zabbix/module.py
+++ b/src/pybind/mgr/zabbix/module.py
@@ -404,7 +404,7 @@ class Module(MgrModule):
 
     def handle_command(self, inbuf, command):
         if command['prefix'] == 'zabbix config-show':
-            return 0, json.dumps(self.config, index=4, sort_keys=True), ''
+            return 0, json.dumps(self.config, indent=4, sort_keys=True), ''
         elif command['prefix'] == 'zabbix config-set':
             key = command['key']
             value = command['value']


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47426

---

backport of https://github.com/ceph/ceph/pull/37105
parent tracker: https://tracker.ceph.com/issues/47404

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh