### PR TITLE
rbd: add DIRTY_CACHE in IMPLICIT_ENABLE

### DIFF
--- a/src/include/rbd/features.h
+++ b/src/include/rbd/features.h
@@ -95,7 +95,8 @@
                                        RBD_FEATURE_FAST_DIFF   | \
                                        RBD_FEATURE_OPERATIONS  | \
                                        RBD_FEATURE_MIGRATING   | \
-                                       RBD_FEATURE_NON_PRIMARY)
+                                       RBD_FEATURE_NON_PRIMARY | \
+                                       RBD_FEATURE_DIRTY_CACHE)
 
 /// features that cannot be controlled by the user
 #define RBD_FEATURES_INTERNAL         (RBD_FEATURE_OPERATIONS | \


### PR DESCRIPTION
Add DIRTY_CACHE IN RBD_FEATURES_IMPLICIT_ENABLE, so that when creating
images, it won't create an image with the DIRTY_CACHE feature.

Signed-off-by: Li, Xiaoyan <xiaoyan.li@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
