### PR TITLE
mgr/cephadm: Fix race between host_add and _apply_all_specs

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -85,7 +85,7 @@ class Inventory:
                 else:
                     yield h
 
-    def spec_from_dict(self, info):
+    def spec_from_dict(self, info) -> HostSpec:
         hostname = info['hostname']
         return HostSpec(
             hostname,
@@ -94,8 +94,8 @@ class Inventory:
             status='Offline' if hostname in self.mgr.offline_hosts else info.get('status', ''),
         )
 
-    def all_specs(self) -> Iterator[HostSpec]:
-        return map(self.spec_from_dict, self._inventory.values())
+    def all_specs(self) -> List[HostSpec]:
+        return list(map(self.spec_from_dict, self._inventory.values()))
 
     def save(self):
         self.mgr.set_store('inventory', json.dumps(self._inventory))

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -434,6 +434,16 @@ class HostCache():
             return True
         return False
 
+    def host_had_daemon_refresh(self, host: str) -> bool:
+        """
+        ... at least once.
+        """
+        if host in self.last_daemon_update:
+            return True
+        if host not in self.daemons:
+            return False
+        return bool(self.daemons[host])
+
     def host_needs_device_refresh(self, host):
         # type: (str) -> bool
         if host in self.mgr.offline_hosts:
@@ -512,7 +522,7 @@ class HostCache():
         We're not checking for `host_needs_daemon_refresh`, as this might never be
         False for all hosts.
         """
-        return all((h in self.last_daemon_update or h in self.mgr.offline_hosts)
+        return all((self.host_had_daemon_refresh(h) or h in self.mgr.offline_hosts)
                    for h in self.get_hosts())
 
     def schedule_daemon_action(self, host: str, daemon_name: str, action: str):

--- a/src/pybind/mgr/cephadm/migrations.py
+++ b/src/pybind/mgr/cephadm/migrations.py
@@ -91,7 +91,7 @@ class Migrations:
         def convert_to_explicit(spec: ServiceSpec) -> None:
             placements = HostAssignment(
                 spec=spec,
-                get_hosts_func=self.mgr._get_hosts,
+                hosts=self.mgr.inventory.all_specs(),
                 get_daemons_func=self.mgr.cache.get_daemons_by_service
             ).place()
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1228,6 +1228,20 @@ To check that the host is reachable:
                         code, '\n'.join(err)))
             return out, err, code
 
+    def _hosts_with_daemon_inventory(self) -> List[HostSpec]:
+        """
+        Returns all hosts that went through _refresh_host_daemons().
+
+        This mitigates a potential race, where new host was added *after*
+        ``_refresh_host_daemons()`` was called, but *before*
+        ``_apply_all_specs()`` was called. thus we end up with a hosts
+        where daemons might be running, but we have not yet detected them.
+        """
+        return [
+            h for h in self.inventory.all_specs()
+            if self.cache.host_had_daemon_refresh(h.hostname)
+        ]
+
     def _add_host(self, spec):
         # type: (HostSpec) -> str
         """
@@ -2071,6 +2085,8 @@ To check that the host is reachable:
         Schedule a service.  Deploy new daemons or remove old ones, depending
         on the target label and count specified in the placement.
         """
+        self.migration.verify_no_migration()
+
         daemon_type = spec.service_type
         service_name = spec.service_name()
         if spec.unmanaged:
@@ -2111,7 +2127,7 @@ To check that the host is reachable:
 
         ha = HostAssignment(
             spec=spec,
-            hosts=self.inventory.all_specs(),
+            hosts=self._hosts_with_daemon_inventory(),
             get_daemons_func=self.cache.get_daemons_by_service,
             filter_new_host=matches_network if daemon_type == 'mon' else None,
         )
@@ -2352,8 +2368,6 @@ To check that the host is reachable:
         return self._add_daemon('mgr', spec, self.mgr_service.create)
 
     def _apply(self, spec: GenericSpec) -> str:
-        self.migration.verify_no_migration()
-
         if spec.service_type == 'host':
             return self._add_host(cast(HostSpec, spec))
 
@@ -2372,7 +2386,7 @@ To check that the host is reachable:
 
         ha = HostAssignment(
             spec=spec,
-            hosts=self.inventory.all_specs(),
+            hosts=self._hosts_with_daemon_inventory(),
             get_daemons_func=self.cache.get_daemons_by_service,
         )
         ha.validate()
@@ -2426,7 +2440,7 @@ To check that the host is reachable:
 
         HostAssignment(
             spec=spec,
-            hosts=self.inventory.all_specs(),
+            hosts=self.inventory.all_specs(),  # All hosts, even those without daemon refresh
             get_daemons_func=self.cache.get_daemons_by_service,
         ).validate()
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2114,7 +2114,7 @@ To check that the host is reachable:
 
         ha = HostAssignment(
             spec=spec,
-            get_hosts_func=self._get_hosts,
+            hosts=self.inventory.all_specs(),
             get_daemons_func=self.cache.get_daemons_by_service,
             filter_new_host=matches_network if daemon_type == 'mon' else None,
         )
@@ -2375,7 +2375,7 @@ To check that the host is reachable:
 
         ha = HostAssignment(
             spec=spec,
-            get_hosts_func=self._get_hosts,
+            hosts=self.inventory.all_specs(),
             get_daemons_func=self.cache.get_daemons_by_service,
         )
         ha.validate()
@@ -2429,7 +2429,7 @@ To check that the host is reachable:
 
         HostAssignment(
             spec=spec,
-            get_hosts_func=self._get_hosts,
+            hosts=self.inventory.all_specs(),
             get_daemons_func=self.cache.get_daemons_by_service,
         ).validate()
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1228,9 +1228,6 @@ To check that the host is reachable:
                         code, '\n'.join(err)))
             return out, err, code
 
-    def _get_hosts(self, label: Optional[str] = '', as_hostspec: bool = False) -> List:
-        return list(self.inventory.filter_by_label(label=label, as_hostspec=as_hostspec))
-
     def _add_host(self, spec):
         # type: (HostSpec) -> str
         """

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -55,15 +55,15 @@ class HostAssignment(object):
 
     def __init__(self,
                  spec,  # type: ServiceSpec
-                 get_hosts_func,  # type: Callable
+                 hosts: List[orchestrator.HostSpec],
                  get_daemons_func,  # type: Callable[[str],List[orchestrator.DaemonDescription]]
                  filter_new_host=None,  # type: Optional[Callable[[str],bool]]
                  scheduler=None,  # type: Optional[BaseScheduler]
                  ):
-        assert spec and get_hosts_func and get_daemons_func
+        assert spec and get_daemons_func
         self.spec = spec  # type: ServiceSpec
         self.scheduler = scheduler if scheduler else SimpleScheduler(self.spec)
-        self.hosts: List[orchestrator.HostSpec] = get_hosts_func(as_hostspec=True)
+        self.hosts: List[orchestrator.HostSpec] = hosts
         self.filter_new_host = filter_new_host
         self.service_name = spec.service_name()
         self.daemons = get_daemons_func(self.service_name)

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -107,7 +107,8 @@ class OSDService(CephService):
 
     def prepare_drivegroup(self, drive_group: DriveGroupSpec) -> List[Tuple[str, DriveSelection]]:
         # 1) use fn_filter to determine matching_hosts
-        matching_hosts = drive_group.placement.filter_matching_hosts(self.mgr._get_hosts)
+        matching_hosts = drive_group.placement.filter_matching_hostspecs(
+            self.mgr.inventory.all_specs())
         # 2) Map the inventory to the InventoryHost object
         host_ds_map = []
 
@@ -205,7 +206,7 @@ class OSDService(CephService):
         if not osdspecs:
             self.mgr.log.debug("No OSDSpecs found")
             return []
-        return sum([spec.placement.filter_matching_hosts(self.mgr._get_hosts) for spec in osdspecs], [])
+        return sum([spec.placement.filter_matching_hostspecs(self.mgr.inventory.all_specs()) for spec in osdspecs], [])
 
     def resolve_osdspecs_for_host(self, host: str, specs: Optional[List[DriveGroupSpec]] = None):
         matching_specs = []
@@ -214,7 +215,7 @@ class OSDService(CephService):
             specs = [cast(DriveGroupSpec, spec) for (sn, spec) in self.mgr.spec_store.spec_preview.items()
                      if spec.service_type == 'osd']
         for spec in specs:
-            if host in spec.placement.filter_matching_hosts(self.mgr._get_hosts):
+            if host in spec.placement.filter_matching_hostspecs(self.mgr.inventory.all_specs()):
                 self.mgr.log.debug(f"Found OSDSpecs for host: <{host}> -> <{spec}>")
                 matching_specs.append(spec)
         return matching_specs

--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -114,9 +114,11 @@ def wait(m, c):
 
 
 @contextmanager
-def with_host(m: CephadmOrchestrator, name):
+def with_host(m: CephadmOrchestrator, name, refresh_hosts=True):
     # type: (CephadmOrchestrator, str) -> None
     wait(m, m.add_host(HostSpec(hostname=name)))
+    if refresh_hosts:
+        m._refresh_hosts_and_daemons()
     yield
     wait(m, m.remove_host(name))
 

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -747,7 +747,7 @@ class TestCephadm(object):
             return '{}', None, 0
         with mock.patch("remoto.Connection", side_effect=[Connection(), Connection(), Connection()]):
             with mock.patch("remoto.process.check", _check):
-                with with_host(cephadm_module, 'test'):
+                with with_host(cephadm_module, 'test', refresh_hosts=False):
                     code, out, err = cephadm_module.check_host('test')
                     # First should succeed.
                     assert err is None
@@ -856,7 +856,7 @@ class TestCephadm(object):
                                  True
                              ])
     def test_upgrade_run(self, use_repo_digest, cephadm_module: CephadmOrchestrator):
-        with with_host(cephadm_module, 'test'):
+        with with_host(cephadm_module, 'test', refresh_hosts=False):
             cephadm_module.set_container_image('global', 'image')
             if use_repo_digest:
                 cephadm_module.use_repo_digest = True

--- a/src/pybind/mgr/cephadm/tests/test_migration.py
+++ b/src/pybind/mgr/cephadm/tests/test_migration.py
@@ -1,18 +1,21 @@
 import json
 from datetime import datetime
 
+import pytest
+
 from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, HostPlacementSpec
 from cephadm import CephadmOrchestrator
 from cephadm.inventory import SPEC_STORE_PREFIX, DATEFMT
 from cephadm.tests.fixtures import _run_cephadm, cephadm_module, wait, with_host
+from orchestrator import OrchestratorError
 from tests import mock
 
 
 @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
 @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __, ___: None)
 def test_migrate_scheduler(cephadm_module: CephadmOrchestrator):
-    with with_host(cephadm_module, 'host1'):
-        with with_host(cephadm_module, 'host2'):
+    with with_host(cephadm_module, 'host1', refresh_hosts=False):
+        with with_host(cephadm_module, 'host2', refresh_hosts=False):
 
             # emulate the old scheduler:
             c = cephadm_module.apply_rgw(
@@ -20,7 +23,19 @@ def test_migrate_scheduler(cephadm_module: CephadmOrchestrator):
             )
             assert wait(cephadm_module, c) == 'Scheduled rgw.r.z update...'
 
+            # with pytest.raises(OrchestratorError, match="cephadm migration still ongoing. Please wait, until the migration is complete."):
             cephadm_module._apply_all_services()
+
+            cephadm_module.migration_current = 0
+            cephadm_module.migration.migrate()
+            # assert we need all daemons.
+            assert cephadm_module.migration_current == 0
+
+            cephadm_module._refresh_hosts_and_daemons()
+            cephadm_module.migration.migrate()
+
+            cephadm_module._apply_all_services()
+
             out = {o.hostname for o in wait(cephadm_module, cephadm_module.list_daemons())}
             assert out == {'host1', 'host2'}
 
@@ -29,17 +44,12 @@ def test_migrate_scheduler(cephadm_module: CephadmOrchestrator):
             )
             assert wait(cephadm_module, c) == 'Scheduled rgw.r.z update...'
 
-            cephadm_module.migration_current = 0
-            cephadm_module.migration.migrate()
-
-            # assert we need all daemons.
-            assert cephadm_module.migration_current == 0
-
             # Sorry, for this hack, but I need to make sure, Migration thinks,
             # we have updated all daemons already.
             cephadm_module.cache.last_daemon_update['host1'] = datetime.now()
             cephadm_module.cache.last_daemon_update['host2'] = datetime.now()
 
+            cephadm_module.migration_current = 0
             cephadm_module.migration.migrate()
             assert cephadm_module.migration_current == 2
 

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -3,7 +3,7 @@ import fnmatch
 import re
 from collections import namedtuple, OrderedDict
 from functools import wraps
-from typing import Optional, Dict, Any, List, Union, Callable, Iterator
+from typing import Optional, Dict, Any, List, Union, Callable, Iterable
 
 import yaml
 
@@ -191,7 +191,7 @@ class PlacementSpec(object):
     def filter_matching_hosts(self, _get_hosts_func: Callable) -> List[str]:
         return self.filter_matching_hostspecs(_get_hosts_func(as_hostspec=True))
 
-    def filter_matching_hostspecs(self, hostspecs: Iterator[HostSpec]) -> List[str]:
+    def filter_matching_hostspecs(self, hostspecs: Iterable[HostSpec]) -> List[str]:
         if self.hosts:
             all_hosts = [hs.hostname for hs in hostspecs]
             return [h.hostname for h in self.hosts if h.hostname in all_hosts]
@@ -205,7 +205,7 @@ class PlacementSpec(object):
             # get_host_selection_size
             return []
 
-    def get_host_selection_size(self, hostspecs: Iterator[HostSpec]):
+    def get_host_selection_size(self, hostspecs: Iterable[HostSpec]):
         if self.count:
             return self.count
         return len(self.filter_matching_hostspecs(hostspecs))

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -188,6 +188,7 @@ class PlacementSpec(object):
             self.hosts = [HostPlacementSpec.parse(x, require_network=False)  # type: ignore
                           for x in hosts if x]
 
+    # deprecated
     def filter_matching_hosts(self, _get_hosts_func: Callable) -> List[str]:
         return self.filter_matching_hostspecs(_get_hosts_func(as_hostspec=True))
 


### PR DESCRIPTION
This mitigates a potential race, where new host was added *after*
``_refresh_host_daemons()`` was called, but *before*
``_apply_all_specs()`` was called. thus we end up with a hosts
where daemons might be running, but we have not yet detected them.

Imagine:

1. the initial MGR was deployed manually
2. `serve()` is called
3. `_refresh_hosts_and_daemons()` is called
4. `add_host()` is called with the initial host
5. `apply_all_specs()` now deploys an additional MGR on the initial host

Fixes: https://tracker.ceph.com/issues/45093

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
