### PR TITLE
Enable per-RBD image monitoring 

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -500,6 +500,13 @@ on your preferred hosts, proceed with the following steps.
       [security]
       allow_embedding = true
 
+Enabling RBD-Image monitoring
+"""""""""""""""""""""""""""""
+
+Due to performance reasons, monitoring of RBD images is disabled by default. For
+more information please see :ref:`prometheus-rbd-io-statistics`. If disabled,
+the overview and details dashboards will stay empty in Grafana and the metrics
+will not be visible in Prometheus.
 
 Configuring Dashboard
 """""""""""""""""""""

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.html
@@ -143,6 +143,17 @@
         <cd-rbd-configuration-table [data]="selection['configuration']"></cd-rbd-configuration-table>
       </ng-template>
     </li>
+
+    <li ngbNavItem="performance">
+      <a ngbNavLink
+         i18n>Performance</a>
+      <ng-template ngbNavContent>
+        <cd-grafana [grafanaPath]="rbdDashboardUrl"
+                    uid="YhCYGcuZz"
+                    grafanaStyle="one">
+        </cd-grafana>
+      </ng-template>
+    </li>
   </ul>
 
   <div [ngbNavOutlet]="nav"></div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, TemplateRef, ViewChild } from '@angular/core';
+import { Component, Input, OnChanges, TemplateRef, ViewChild } from '@angular/core';
 
 import { NgbNav } from '@ng-bootstrap/ng-bootstrap';
 
@@ -9,7 +9,7 @@ import { RbdFormModel } from '../rbd-form/rbd-form.model';
   templateUrl: './rbd-details.component.html',
   styleUrls: ['./rbd-details.component.scss']
 })
-export class RbdDetailsComponent {
+export class RbdDetailsComponent implements OnChanges {
   @Input()
   selection: RbdFormModel;
   @Input()
@@ -20,4 +20,12 @@ export class RbdDetailsComponent {
 
   @ViewChild(NgbNav, { static: true })
   nav: NgbNav;
+
+  rbdDashboardUrl: string;
+
+  ngOnChanges() {
+    if (this.selection) {
+      this.rbdDashboardUrl = `rbd-details?var-Pool=${this.selection['pool_name']}&var-Image=${this.selection['name']}`;
+    }
+  }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.spec.ts
@@ -88,7 +88,7 @@ describe('RbdTrashMoveModalComponent', () => {
       component.moveImage();
       const req = httpTesting.expectOne('api/block/image/foo%2Fbar/move_trash');
       req.flush(null);
-      expect(req.request.body.delay).toBeGreaterThan(86390);
+      expect(req.request.body.delay).toBeGreaterThan(76390);
     });
   });
 });


### PR DESCRIPTION
The Grafana per RBD graphs have already been added and backported down to nautilus, though, Ceph Dashboard does not yet integrate them.

![localhost_4200_](https://user-images.githubusercontent.com/9606095/93076981-79f05480-f688-11ea-915a-bd5dd6601409.png)
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>

