### PR TITLE
mgr/dashboard: Fix iSCSI backend unit-test

### DIFF
--- a/src/pybind/mgr/dashboard/tests/test_exceptions.py
+++ b/src/pybind/mgr/dashboard/tests/test_exceptions.py
@@ -88,6 +88,10 @@ class RESTControllerTest(ControllerTestCase):
         TaskManager.init()
         cls.setup_controllers([FooResource])
 
+    @classmethod
+    def tearDownClass(cls):
+        NotificationQueue.stop()
+
     def test_no_exception(self):
         self._get('/foo/no_exception/a/b')
         self.assertStatus(200)

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -16,6 +16,7 @@ from ..controllers.iscsi import Iscsi, IscsiTarget
 from ..services.iscsi_client import IscsiClient
 from ..services.orchestrator import OrchClient
 from ..rest_client import RequestException
+from ..tools import NotificationQueue, TaskManager
 
 
 class IscsiTestCli(unittest.TestCase, CLICommandTestMixin):
@@ -66,12 +67,18 @@ class IscsiTestController(ControllerTestCase, KVStoreMockMixin):
 
     @classmethod
     def setup_server(cls):
+        NotificationQueue.start_queue()
+        TaskManager.init()
         OrchClient.instance().available = lambda: False
         mgr.rados.side_effect = None
         # pylint: disable=protected-access
         Iscsi._cp_config['tools.authenticate.on'] = False
         IscsiTarget._cp_config['tools.authenticate.on'] = False
         cls.setup_controllers([Iscsi, IscsiTarget])
+
+    @classmethod
+    def tearDownClass(cls):
+        NotificationQueue.stop()
 
     def setUp(self):
         self.mock_kv_store()


### PR DESCRIPTION
This allows us to run iSCSI tests individually.

Fixes: https://tracker.ceph.com/issues/47391

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
