### PR TITLE
mgr/cephadm: call ok-to-stop before restart|redeploy

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1651,22 +1651,14 @@ To check that the host is reachable:
 
     @trivial_completion
     def service_action(self, action, service_name) -> List[str]:
-        args = []
-        for host, dm in self.cache.daemons.items():
-            for name, d in dm.items():
-                if d.matches_service(service_name):
-                    args.append((d.daemon_type, d.daemon_id,
-                                 d.hostname, action))
+        if action == 'stop':
+            raise OrchestratorError("Unable to stop all daemons of a service. Too dangerous.")
+        dds: List[DaemonDescription] = self.cache.get_daemons_by_service(service_name)
         self.log.info('%s service %s' % (action.capitalize(), service_name))
-        return self._daemon_actions(args)
-
-    @forall_hosts
-    def _daemon_actions(self, daemon_type, daemon_id, host, action) -> str:
-        with set_exception_subject('daemon', DaemonDescription(
-            daemon_type=daemon_type,
-            daemon_id=daemon_id
-        ).name()):
-            return self._daemon_action(daemon_type, daemon_id, host, action)
+        return [
+            self._schedule_daemon_action(dd.name(), action)
+            for dd in dds
+        ]
 
     def _daemon_action(self, daemon_type, daemon_id, host, action, image=None):
         daemon_spec: CephadmDaemonSpec = CephadmDaemonSpec(

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1669,6 +1669,11 @@ To check that the host is reachable:
 
         self._daemon_action_set_image(action, image, daemon_type, daemon_id)
 
+        if action in ['restart', 'redeploy']:
+            ok_to_stop = self.cephadm_services[daemon_type].ok_to_stop([daemon_id])
+            if not ok_to_stop:
+                raise OrchestratorError(f'Daemon is not OK to stop: {ok_to_stop.stderr}')
+
         if action == 'redeploy':
             if self.daemon_is_self(daemon_type, daemon_id):
                 self.mgr_service.fail_over()

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -101,6 +101,9 @@ class HandleCommandResult(namedtuple('HandleCommandResult', ['retval', 'stdout',
         """
         return super(HandleCommandResult, cls).__new__(cls, retval, stdout, stderr)
 
+    def __bool__(self):
+        return self.retval == 0
+
 
 class MonCommandFailed(RuntimeError): pass
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -924,7 +924,7 @@ class Orchestrator(object):
         Perform an action (start/stop/reload) on a service (i.e., all daemons
         providing the logical service).
 
-        :param action: one of "start", "stop", "restart", "redeploy", "reconfig"
+        :param action: one of "start", "restart", "redeploy", "reconfig"
         :param service_name: service_type + '.' + service_id
                             (e.g. "mon", "mgr", "mds.mycephfs", "rgw.realm.zone", ...)
         :rtype: Completion

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -986,7 +986,7 @@ Usage:
 
     @_cli_write_command(
         'orch',
-        "name=action,type=CephChoices,strings=start|stop|restart|redeploy|reconfig "
+        "name=action,type=CephChoices,strings=start|restart|redeploy|reconfig "
         "name=service_name,type=CephString",
         'Start, stop, restart, redeploy, or reconfig an entire service (i.e. all daemons)')
     def _service_action(self, action, service_name):


### PR DESCRIPTION
mgr/cephadm: call ok-to-stop before restart|redeploy

e.g. make sure `ceph orch restart osd` is safe as it can get

https://tracker.ceph.com/issues/45465

Also:

* make `ceph orch {restart|...}` asynchronous
* remove support for`ceph orch stop osd`


Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
