### PR TITLE
blk: use choose_fd for all filehandle refences

### DIFF
--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -64,6 +64,8 @@
 #define  WRITE_LIFE_MAX  	1
 #endif
 
+bool const BUFFEREDFD = true;		// to be used in the buffered parameter
+bool const DIRECTFD = false;
 
 /// track in-flight io
 struct IOContext {

--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -82,9 +82,23 @@ KernelDevice::KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, ai
   }
 }
 
+inline int KernelDevice::choose_fd(bool buffered, int write_hint) const
+{
+#if defined(F_SET_FILE_RW_HINT)
+  assert(write_hint >= WRITE_LIFE_NOT_SET && write_hint < WRITE_LIFE_MAX);
+  if (!enable_wrt)
+    write_hint = WRITE_LIFE_NOT_SET;
+#else
+  // Without WRITE_LIFE capabilities, only one file is used.
+  // And rocksdb sets this value also to > 0.
+  write_hint = WRITE_LIFE_NOT_SET;
+#endif
+  return buffered ? fd_buffereds[write_hint] : fd_directs[write_hint];
+}
+
 int KernelDevice::_lock()
 {
-  dout(10) << __func__ << " " << fd_directs[WRITE_LIFE_NOT_SET] << dendl;
+  dout(10) << __func__ << " " << choose_fd(DIRECTFD ,WRITE_LIFE_NOT_SET) << dendl;
   utime_t sleeptime;
   sleeptime.set_from_double(cct->_conf->bdev_flock_retry_interval);
 
@@ -92,7 +106,7 @@ int KernelDevice::_lock()
   // read some information and close it. Then a failure occurs here.
   // So we need to try again here.
   for (int i = 0; i < cct->_conf->bdev_flock_retry + 1; i++) {
-    int r = ::flock(fd_directs[WRITE_LIFE_NOT_SET], LOCK_EX | LOCK_NB);
+    int r = ::flock(choose_fd(DIRECTFD, WRITE_LIFE_NOT_SET), LOCK_EX | LOCK_NB);
     if (r < 0 && errno == EAGAIN) {
       dout(1) << __func__ << " flock busy on " << path << dendl;    
       sleeptime.sleep();
@@ -158,7 +172,7 @@ int KernelDevice::open(const string& p)
 
   // disable readahead as it will wreak havoc on our mix of
   // directio/aio and buffered io.
-  r = posix_fadvise(fd_buffereds[WRITE_LIFE_NOT_SET], 0, 0, POSIX_FADV_RANDOM);
+  r = posix_fadvise(choose_fd(BUFFEREDFD,WRITE_LIFE_NOT_SET), 0, 0, POSIX_FADV_RANDOM);
   if (r) {
     r = -r;
     derr << __func__ << " posix_fadvise got: " << cpp_strerror(r) << dendl;
@@ -175,7 +189,7 @@ int KernelDevice::open(const string& p)
   }
 
   struct stat st;
-  r = ::fstat(fd_directs[WRITE_LIFE_NOT_SET], &st);
+  r = ::fstat(choose_fd(DIRECTFD, WRITE_LIFE_NOT_SET), &st);
   if (r < 0) {
     r = -errno;
     derr << __func__ << " fstat got " << cpp_strerror(r) << dendl;
@@ -195,8 +209,8 @@ int KernelDevice::open(const string& p)
 
 
   {
-    BlkDev blkdev_direct(fd_directs[WRITE_LIFE_NOT_SET]);
-    BlkDev blkdev_buffered(fd_buffereds[WRITE_LIFE_NOT_SET]);
+    BlkDev blkdev_direct(choose_fd(DIRECTFD, WRITE_LIFE_NOT_SET));
+    BlkDev blkdev_buffered(choose_fd(BUFFEREDFD, WRITE_LIFE_NOT_SET));
 
     if (S_ISBLK(st.st_mode)) {
       int64_t s;
@@ -330,14 +344,14 @@ int KernelDevice::collect_metadata(const string& prefix, map<string,string> *pm)
   }
 
   struct stat st;
-  int r = ::fstat(fd_buffereds[WRITE_LIFE_NOT_SET], &st);
+  int r = ::fstat(choose_fd(BUFFEREDFD, WRITE_LIFE_NOT_SET), &st);
   if (r < 0)
     return -errno;
   if (S_ISBLK(st.st_mode)) {
     (*pm)[prefix + "access_mode"] = "blk";
 
     char buffer[1024] = {0};
-    BlkDev blkdev{fd_buffereds[WRITE_LIFE_NOT_SET]};
+    BlkDev blkdev{choose_fd(BUFFEREDFD, WRITE_LIFE_NOT_SET)};
     if (r = blkdev.partition(buffer, sizeof(buffer)); r) {
       (*pm)[prefix + "partition_path"] = "unknown";
     } else {
@@ -398,14 +412,6 @@ bool KernelDevice::get_thin_utilization(uint64_t *total, uint64_t *avail) const
   return get_vdo_utilization(vdo_fd, total, avail);
 }
 
-int KernelDevice::choose_fd(bool buffered, int write_hint) const
-{
-  assert(write_hint >= WRITE_LIFE_NOT_SET && write_hint < WRITE_LIFE_MAX);
-  if (!enable_wrt)
-    write_hint = WRITE_LIFE_NOT_SET;
-  return buffered ? fd_buffereds[write_hint] : fd_directs[write_hint];
-}
-
 int KernelDevice::flush()
 {
   // protect flush with a mutex.  note that we are not really protecting
@@ -437,7 +443,7 @@ int KernelDevice::flush()
     _exit(1);
   }
   utime_t start = ceph_clock_now();
-  int r = ::fdatasync(fd_directs[WRITE_LIFE_NOT_SET]);
+  int r = ::fdatasync(choose_fd(DIRECTFD ,WRITE_LIFE_NOT_SET));
   utime_t end = ceph_clock_now();
   utime_t dur = end - start;
   if (r < 0) {
@@ -860,7 +866,7 @@ int KernelDevice::_sync_write(uint64_t off, bufferlist &bl, bool buffered, int w
 #ifdef HAVE_SYNC_FILE_RANGE
   if (buffered) {
     // initiate IO and wait till it completes
-    auto r = ::sync_file_range(fd_buffereds[WRITE_LIFE_NOT_SET], off, len, SYNC_FILE_RANGE_WRITE|SYNC_FILE_RANGE_WAIT_AFTER|SYNC_FILE_RANGE_WAIT_BEFORE);
+    auto r = ::sync_file_range(choose_fd(BUFFEREDFD, WRITE_LIFE_NOT_SET), off, len, SYNC_FILE_RANGE_WRITE|SYNC_FILE_RANGE_WAIT_AFTER|SYNC_FILE_RANGE_WAIT_BEFORE);
     if (r < 0) {
       r = -errno;
       derr << __func__ << " sync_file_range error: " << cpp_strerror(r) << dendl;
@@ -1008,7 +1014,7 @@ int KernelDevice::discard(uint64_t offset, uint64_t len)
 	       << " 0x" << std::hex << offset << "~" << len << std::dec
 	       << dendl;
 
-      r = BlkDev{fd_directs[WRITE_LIFE_NOT_SET]}.discard((int64_t)offset, (int64_t)len);
+      r = BlkDev{choose_fd(DIRECTFD, WRITE_LIFE_NOT_SET)}.discard((int64_t)offset, (int64_t)len);
   }
   return r;
 }
@@ -1027,7 +1033,7 @@ int KernelDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
   auto start1 = mono_clock::now();
 
   auto p = ceph::buffer::ptr_node::create(ceph::buffer::create_small_page_aligned(len));
-  int r = ::pread(buffered ? fd_buffereds[WRITE_LIFE_NOT_SET] : fd_directs[WRITE_LIFE_NOT_SET],
+  int r = ::pread(choose_fd(buffered, WRITE_LIFE_NOT_SET),
 		  p->c_str(), len, off);
   auto age = cct->_conf->bdev_debug_aio_log_age;
   if (mono_clock::now() - start1 >= make_timespan(age)) {
@@ -1073,7 +1079,7 @@ int KernelDevice::aio_read(
   if (aio && dio) {
     ceph_assert(is_valid_io(off, len));
     _aio_log_start(ioc, off, len);
-    ioc->pending_aios.push_back(aio_t(ioc, fd_directs[WRITE_LIFE_NOT_SET]));
+    ioc->pending_aios.push_back(aio_t(ioc, choose_fd(DIRECTFD, WRITE_LIFE_NOT_SET)));
     ++ioc->num_pending;
     aio_t& aio = ioc->pending_aios.back();
     bufferptr p = ceph::buffer::create_small_page_aligned(len);
@@ -1101,7 +1107,7 @@ int KernelDevice::direct_read_unaligned(uint64_t off, uint64_t len, char *buf)
   int r = 0;
 
   auto start1 = mono_clock::now();
-  r = ::pread(fd_directs[WRITE_LIFE_NOT_SET], p.c_str(), aligned_len, aligned_off);
+  r = ::pread(choose_fd(DIRECTFD, WRITE_LIFE_NOT_SET), p.c_str(), aligned_len, aligned_off);
   auto age = cct->_conf->bdev_debug_aio_log_age;
   if (mono_clock::now() - start1 >= make_timespan(age)) {
     derr << __func__ << " stalled read "
@@ -1155,7 +1161,7 @@ int KernelDevice::read_random(uint64_t off, uint64_t len, char *buf,
     char *t = buf;
     uint64_t left = len;
     while (left > 0) {
-      r = ::pread(fd_buffereds[WRITE_LIFE_NOT_SET], t, left, off);
+      r = ::pread(choose_fd(BUFFEREDFD, WRITE_LIFE_NOT_SET), t, left, off);
       if (r < 0) {
 	r = -errno;
         derr << __func__ << " 0x" << std::hex << off << "~" << left
@@ -1175,7 +1181,7 @@ int KernelDevice::read_random(uint64_t off, uint64_t len, char *buf,
     }
   } else {
     //direct and aligned read
-    r = ::pread(fd_directs[WRITE_LIFE_NOT_SET], buf, len, off);
+    r = ::pread(choose_fd(DIRECTFD, WRITE_LIFE_NOT_SET), buf, len, off);
     if (mono_clock::now() - start1 >= make_timespan(age)) {
       derr << __func__ << " stalled read "
 	   << " 0x" << std::hex << off << "~" << len << std::dec
@@ -1209,7 +1215,7 @@ int KernelDevice::invalidate_cache(uint64_t off, uint64_t len)
 	  << dendl;
   ceph_assert(off % block_size == 0);
   ceph_assert(len % block_size == 0);
-  int r = posix_fadvise(fd_buffereds[WRITE_LIFE_NOT_SET], off, len, POSIX_FADV_DONTNEED);
+  int r = posix_fadvise(choose_fd(BUFFEREDFD, WRITE_LIFE_NOT_SET), off, len, POSIX_FADV_DONTNEED);
   if (r) {
     r = -r;
     derr << __func__ << " 0x" << std::hex << off << "~" << len << std::dec


### PR DESCRIPTION
This is a leading part of the changes to implement bluestore on
FreeBSD. Without this invalid indexing in the descriptor arrays
will occur.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
