### PR TITLE
ceph.in: ignore failures to flush stdout

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -1253,8 +1253,12 @@ def main():
                 except IOError as e:
                     if e.errno != errno.EPIPE:
                         raise e
+        try:
+            sys.stdout.flush()
+        except IOError as e:
+            if e.errno != errno.EPIPE:
+                raise e
 
-        sys.stdout.flush()
 
     # Block until command completion (currently scrub and deep_scrub only)
     if block:


### PR DESCRIPTION
Catch an IOError exception when flushing ceph stdout.

Fixes: https://tracker.ceph.com/issues/47442
Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>