### PR TITLE
mds/FSMap: check parse_role return before filtering

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -1022,6 +1022,7 @@ int FSMap::parse_role(
     const std::vector<string> &filter) const
 {
   int r = parse_role(role_str, role, ss);
+  if (r < 0) return r;
 
   string_view fs_name = get_filesystem(role->fscid)->mds_map.get_fs_name();
 


### PR DESCRIPTION
If parse_role fails, then the fscid value is invalid.

This was caught in testing cephtool. Funnily enough, the command
rmfailed normally fails:

    2020-09-06T00:05:51.020 INFO:tasks.workunit.client.0.smithi036.stderr:/home/ubuntu/cephtest/clone.client.0/qa/workunits/cephtool/test.sh:35: expect_false:  set -x
    2020-09-06T00:05:51.020 INFO:tasks.workunit.client.0.smithi036.stderr:/home/ubuntu/cephtest/clone.client.0/qa/workunits/cephtool/test.sh:36: expect_false:  ceph mds rmfailed 0
    2020-09-06T00:05:51.318 INFO:tasks.workunit.client.0.smithi036.stderr:Error EPERM: WARNING: this can make your filesystem inaccessible! Add --yes-i-really-mean-it if you are sure you wish to continue.
    2020-09-06T00:05:51.321 INFO:tasks.workunit.client.0.smithi036.stderr:/home/ubuntu/cephtest/clone.client.0/qa/workunits/cephtool/test.sh:36: expect_false:  return 0
    2020-09-06T00:05:51.322 INFO:tasks.workunit.client.0.smithi036.stderr:/home/ubuntu/cephtest/clone.client.0/qa/workunits/cephtool/test.sh:989: test_mon_mds:  ceph mds rmfailed 0 --yes-i-really-mean-it
    2020-09-06T00:05:51.631 INFO:tasks.workunit.client.0.smithi036.stderr:Error EINVAL: Rank '0' not foundinvalid role '0'
    2020-09-06T00:05:51.634 INFO:tasks.workunit.client.0.smithi036.stderr:/home/ubuntu/cephtest/clone.client.0/qa/workunits/cephtool/test.sh:990: test_mon_mds:  set -e

From: /ceph/teuthology-archive/teuthology-2020-09-14_07:01:01-rados-master-distro-basic-smithi/5434134/teuthology.log

The change in 811e48d6ffd841ecd93a57eb00c6aceae476f4f8 causes an abort because
this failure is not caught in the parse_role hook.

Fixes: https://tracker.ceph.com/issues/47444
Fixes: 811e48d6ffd841ecd93a57eb00c6aceae476f4f8
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>

Related PR; #32581 

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
