### PR TITLE
mon: validate crush-failure-domain

### DIFF
--- a/qa/standalone/mon/osd-erasure-code-profile.sh
+++ b/qa/standalone/mon/osd-erasure-code-profile.sh
@@ -222,6 +222,17 @@ function TEST_profile_k_sanity() {
         m=1 || return 1
 }
 
+function TEST_invalid_crush_failure_domain() {
+    local dir=$1
+
+    run_mon $dir a || return 1
+
+    local profile=ec_profile
+    local crush_failure_domain=invalid_failure_domain
+
+    ! ceph osd erasure-code-profile set $profile k=4 m=2 crush-failure-domain=$crush_failure_domain 2>&1 || return 1
+}
+
 main osd-erasure-code-profile "$@"
 
 # Local Variables:

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -10919,6 +10919,18 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     err = parse_erasure_code_profile(profile, &profile_map, &ss);
     if (err)
       goto reply;
+    if (auto found = profile_map.find("crush-failure-domain");
+	found != profile_map.end()) {
+      const auto& failure_domain = found->second;
+      int failure_domain_type = osdmap.crush->get_type_id(failure_domain);
+      if (failure_domain_type < 0) {
+	ss << "erasure-code-profile " << profile_map
+	  << " contains an invalid failure-domain " << std::quoted(failure_domain);
+	err = -EINVAL;
+	goto reply;
+      }
+    }
+
     if (profile_map.find("plugin") == profile_map.end()) {
       ss << "erasure-code-profile " << profile_map
 	 << " must contain a plugin entry" << std::endl;


### PR DESCRIPTION
While creating erasure-coded profile make sure
that user is specifying valid crush-failure-domain.

Fixes: https://tracker.ceph.com/issues/47452

Signed-off-by: Prashant Dhange <pdhange@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
