### PR TITLE
mgr/dashboard: Creating a new Login Page Legal Links Component

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.html
@@ -1,4 +1,5 @@
-<div *ngIf="isLoginActive">
+<div class="container"
+     *ngIf="isLoginActive">
   <form name="loginForm"
         (ngSubmit)="login()"
         #loginForm="ngForm"

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/login-layout/login-layout.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/login-layout/login-layout.component.html
@@ -11,10 +11,21 @@
     <div class="container">
       <div class="row full-height vertical-align">
         <div class="col-sm-12 col-md-6 d-sm-block">
+          <router-outlet></router-outlet>
+        </div>
+        <div class="col-sm-12 col-md-6 d-sm-block">
           <img src="assets/Ceph_Ceph_Logo_with_text_white.svg"
                alt="Ceph"
-               class="img-fluid mb-5">
-          <router-outlet></router-outlet>
+               class="img-fluid">
+          <ul class="list-inline">
+            <li class="list-inline-item p-3"
+                *ngFor="let docItem of docItems">
+              <cd-doc section="{{ docItem.section }}"
+                      docText="{{ docItem.text }}"
+                      noSubscribe="true"
+                      i18n-docText></cd-doc>
+            </li>
+          </ul>
         </div>
       </div>
     </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/login-layout/login-layout.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/login-layout/login-layout.component.scss
@@ -29,4 +29,17 @@
     min-height: 100vh;
     width: 100vw;
   }
+
+  .list-inline {
+    margin-bottom: 20%;
+    margin-left: 20%;
+  }
+
+  a {
+    color: bd.$fg-color-over-dark-bg;
+
+    &:hover {
+      color: bd.$fg-hover-color-over-dark-bg;
+    }
+  }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/login-layout/login-layout.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/layouts/login-layout/login-layout.component.ts
@@ -5,4 +5,10 @@ import { Component } from '@angular/core';
   templateUrl: './login-layout.component.html',
   styleUrls: ['./login-layout.component.scss']
 })
-export class LoginLayoutComponent {}
+export class LoginLayoutComponent {
+  docItems: any[] = [
+    { section: 'help', text: $localize`Help` },
+    { section: 'security', text: $localize`Security` },
+    { section: 'trademarks', text: $localize`Trademarks` }
+  ];
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/doc/doc.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/doc/doc.component.ts
@@ -10,14 +10,19 @@ import { DocService } from '../../../shared/services/doc.service';
 export class DocComponent implements OnInit {
   @Input() section: string;
   @Input() docText = $localize`documentation`;
+  @Input() noSubscribe: boolean;
 
   docUrl: string;
 
   constructor(private docService: DocService) {}
 
   ngOnInit() {
-    this.docService.subscribeOnce(this.section, (url: string) => {
-      this.docUrl = url;
-    });
+    if (this.noSubscribe) {
+      this.docUrl = this.docService.urlGenerator(this.section);
+    } else {
+      this.docService.subscribeOnce(this.section, (url: string) => {
+        this.docUrl = url;
+      });
+    }
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/doc.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/doc.service.spec.ts
@@ -21,7 +21,7 @@ describe('DocService', () => {
   });
 
   it('should return full URL', () => {
-    expect(service.urlGenerator('foo', 'iscsi')).toBe(
+    expect(service.urlGenerator('iscsi', 'foo')).toBe(
       'http://docs.ceph.com/docs/foo/mgr/dashboard/#enabling-iscsi-management'
     );
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/doc.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/doc.service.ts
@@ -23,8 +23,9 @@ export class DocService {
     });
   }
 
-  urlGenerator(release: string, section: string): string {
+  urlGenerator(section: string, release = 'master'): string {
     const domain = `http://docs.ceph.com/docs/${release}/`;
+    const domainCeph = `https://ceph.io/`;
 
     const sections = {
       iscsi: `${domain}mgr/dashboard/#enabling-iscsi-management`,
@@ -35,7 +36,10 @@ export class DocService {
       dashboard: `${domain}mgr/dashboard`,
       grafana: `${domain}mgr/dashboard/#enabling-the-embedding-of-grafana-dashboards`,
       orch: `${domain}mgr/orchestrator`,
-      pgs: `http://ceph.com/pgcalc`,
+      pgs: `${domainCeph}pgcalc`,
+      help: `${domainCeph}help/`,
+      security: `${domainCeph}security/`,
+      trademarks: `${domainCeph}legal-page/trademarks/`,
       'dashboard-landing-page-status': `${domain}mgr/dashboard/#dashboard-landing-page-status`,
       'dashboard-landing-page-performance': `${domain}mgr/dashboard/#dashboard-landing-page-performance`,
       'dashboard-landing-page-capacity': `${domain}mgr/dashboard/#dashboard-landing-page-capacity`
@@ -52,7 +56,7 @@ export class DocService {
     return this.releaseData$
       .pipe(
         filter((value) => !!value),
-        map((release) => this.urlGenerator(release, section)),
+        map((release) => this.urlGenerator(section, release)),
         first()
       )
       .subscribe(next, error);

--- a/src/pybind/mgr/dashboard/frontend/src/styles/defaults/_bootstrap-defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/defaults/_bootstrap-defaults.scss
@@ -34,6 +34,9 @@ $danger: $red;
 $light: $gray-100;
 $dark: #777;
 
+$fg-color-over-dark-bg: $white;
+$fg-hover-color-over-dark-bg: $gray-500;
+
 $theme-colors: (
   'accent': #ef5c55
 );


### PR DESCRIPTION
A new component which has some of the doc links that can be shown in the login page like security, trademarks etc and can add new links easily.  Also did some cleanup on the login.component.html file.

![login_upstream_align](https://user-images.githubusercontent.com/53651462/93450292-6bf23c00-f8f3-11ea-98b4-d3daeb37a1e0.png)


Fixes: https://tracker.ceph.com/issues/47454

Signed-off-by: nizamial09 <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
