### PR TITLE
os/bluestore: allow dynamic levels

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4687,11 +4687,11 @@ std::vector<Option> get_global_options() {
 
     Option("bluestore_volume_selection_policy", Option::TYPE_STR, Option::LEVEL_DEV)
     .set_default("use_some_extra")
-    .set_enum_allowed({ "rocksdb_original", "use_some_extra", "without_slow_dir" })
+    .set_enum_allowed({ "rocksdb_original", "use_some_extra", "fit_to_fast" })
     .set_description("Determines bluefs volume selection policy")
     .set_long_description("Determines bluefs volume selection policy. 'use_some_extra' policy allows to override RocksDB level "
                           "granularity and put high level's data to faster device even when the level doesn't completely fit there. "
-                          "'without_slow_dir' policy enables using 100% of faster disk capacity and allows the user to turn on "
+                          "'fit_to_fast' policy enables using 100% of faster disk capacity and allows the user to turn on "
                           "'level_compaction_dynamic_level_bytes' option in RocksDB options."),
 
     Option("bluestore_volume_selection_reserved_factor", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4687,9 +4687,12 @@ std::vector<Option> get_global_options() {
 
     Option("bluestore_volume_selection_policy", Option::TYPE_STR, Option::LEVEL_DEV)
     .set_default("use_some_extra")
-    .set_enum_allowed({ "rocksdb_original", "use_some_extra" })
+    .set_enum_allowed({ "rocksdb_original", "use_some_extra", "without_slow_dir" })
     .set_description("Determines bluefs volume selection policy")
-    .set_long_description("Determines bluefs volume selection policy. 'use_some_extra' policy allows to override RocksDB level granularity and put high level's data to faster device even when the level doesn't completely fit there"),
+    .set_long_description("Determines bluefs volume selection policy. 'use_some_extra' policy allows to override RocksDB level "
+                          "granularity and put high level's data to faster device even when the level doesn't completely fit there. "
+                          "'without_slow_dir' policy enables using 100% of faster disk capacity and allows the user to turn on "
+                          "'level_compaction_dynamic_level_bytes' option in RocksDB options."),
 
     Option("bluestore_volume_selection_reserved_factor", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
       .set_flag(Option::FLAG_STARTUP)

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -3594,3 +3594,10 @@ void OriginalVolumeSelector::dump(ostream& sout) {
     << ", slow_total:" << slow_total
     << std::endl;
 }
+
+// ===============================================
+// WithoutSlowDirVolumeSelector
+
+void WithoutSlowDirVolumeSelector::get_paths(const std::string& base, paths& res) const {
+  res.emplace_back(base, 1);  // size of the last db_path has no effect
+}

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -3596,8 +3596,8 @@ void OriginalVolumeSelector::dump(ostream& sout) {
 }
 
 // ===============================================
-// WithoutSlowDirVolumeSelector
+// FitToFastVolumeSelector
 
-void WithoutSlowDirVolumeSelector::get_paths(const std::string& base, paths& res) const {
+void FitToFastVolumeSelector::get_paths(const std::string& base, paths& res) const {
   res.emplace_back(base, 1);  // size of the last db_path has no effect
 }

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -637,4 +637,15 @@ public:
   void dump(std::ostream& sout) override;
 };
 
+class WithoutSlowDirVolumeSelector : public OriginalVolumeSelector {
+public:
+  WithoutSlowDirVolumeSelector(
+    uint64_t _wal_total,
+    uint64_t _db_total,
+    uint64_t _slow_total)
+    : OriginalVolumeSelector(_wal_total, _db_total, _slow_total) {}
+
+  void get_paths(const std::string& base, paths& res) const override;
+};
+
 #endif

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -637,9 +637,9 @@ public:
   void dump(std::ostream& sout) override;
 };
 
-class WithoutSlowDirVolumeSelector : public OriginalVolumeSelector {
+class FitToFastVolumeSelector : public OriginalVolumeSelector {
 public:
-  WithoutSlowDirVolumeSelector(
+  FitToFastVolumeSelector(
     uint64_t _wal_total,
     uint64_t _db_total,
     uint64_t _slow_total)

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5601,13 +5601,13 @@ int BlueStore::_open_bluefs(bool create, bool read_only)
   if (r < 0) {
     return r;
   }
-  RocksDBBlueFSVolumeSelector* vselector = nullptr;
+  BlueFSVolumeSelector* vselector = nullptr;
   if (bluefs_layout.shared_bdev == BlueFS::BDEV_SLOW) {
 
     string options = cct->_conf->bluestore_rocksdb_options;
 
     rocksdb::Options rocks_opts;
-    int r = RocksDBStore::ParseOptionsFromStringStatic(
+    r = RocksDBStore::ParseOptionsFromStringStatic(
       cct,
       options,
       rocks_opts,
@@ -5615,19 +5615,25 @@ int BlueStore::_open_bluefs(bool create, bool read_only)
     if (r < 0) {
       return r;
     }
-
-    double reserved_factor = cct->_conf->bluestore_volume_selection_reserved_factor;
-    vselector =
-      new RocksDBBlueFSVolumeSelector(
+    if (cct->_conf->bluestore_volume_selection_policy == "without_slow_dir") {
+      vselector = new WithoutSlowDirVolumeSelector(
         bluefs->get_block_device_size(BlueFS::BDEV_WAL) * 95 / 100,
         bluefs->get_block_device_size(BlueFS::BDEV_DB) * 95 / 100,
-        bluefs->get_block_device_size(BlueFS::BDEV_SLOW) * 95 / 100,
-        1024 * 1024 * 1024, //FIXME: set expected l0 size here
-        rocks_opts.max_bytes_for_level_base,
-        rocks_opts.max_bytes_for_level_multiplier,
-        reserved_factor,
-        cct->_conf->bluestore_volume_selection_reserved,
-        cct->_conf->bluestore_volume_selection_policy != "rocksdb_original");
+        bluefs->get_block_device_size(BlueFS::BDEV_SLOW) * 95 / 100);
+    } else {
+      double reserved_factor = cct->_conf->bluestore_volume_selection_reserved_factor;
+      vselector =
+        new RocksDBBlueFSVolumeSelector(
+          bluefs->get_block_device_size(BlueFS::BDEV_WAL) * 95 / 100,
+          bluefs->get_block_device_size(BlueFS::BDEV_DB) * 95 / 100,
+          bluefs->get_block_device_size(BlueFS::BDEV_SLOW) * 95 / 100,
+          1024 * 1024 * 1024, //FIXME: set expected l0 size here
+          rocks_opts.max_bytes_for_level_base,
+          rocks_opts.max_bytes_for_level_multiplier,
+          reserved_factor,
+          cct->_conf->bluestore_volume_selection_reserved,
+          cct->_conf->bluestore_volume_selection_policy == "use_some_extra");
+    }    
   }
   if (create) {
     bluefs->mkfs(fsid, bluefs_layout);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5615,7 +5615,7 @@ int BlueStore::_open_bluefs(bool create, bool read_only)
     if (r < 0) {
       return r;
     }
-    if (cct->_conf->bluestore_volume_selection_policy == "without_slow_dir") {
+    if (cct->_conf->bluestore_volume_selection_policy == "fit_to_fast") {
       vselector = new WithoutSlowDirVolumeSelector(
         bluefs->get_block_device_size(BlueFS::BDEV_WAL) * 95 / 100,
         bluefs->get_block_device_size(BlueFS::BDEV_DB) * 95 / 100,

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5616,7 +5616,7 @@ int BlueStore::_open_bluefs(bool create, bool read_only)
       return r;
     }
     if (cct->_conf->bluestore_volume_selection_policy == "fit_to_fast") {
-      vselector = new WithoutSlowDirVolumeSelector(
+      vselector = new FitToFastVolumeSelector(
         bluefs->get_block_device_size(BlueFS::BDEV_WAL) * 95 / 100,
         bluefs->get_block_device_size(BlueFS::BDEV_DB) * 95 / 100,
         bluefs->get_block_device_size(BlueFS::BDEV_SLOW) * 95 / 100);

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -8816,7 +8816,7 @@ TEST_P(StoreTestSpecificAUSize, SpilloverFixed3Test) {
 
   SetVal(g_conf(), "bluestore_block_db_create", "true");
   SetVal(g_conf(), "bluestore_block_db_size", "3221225472");
-  SetVal(g_conf(), "bluestore_volume_selection_policy", "without_slow_dir");
+  SetVal(g_conf(), "bluestore_volume_selection_policy", "fit_to_fast");
 
   g_conf().apply_changes(nullptr);
 


### PR DESCRIPTION
os/bluestore: This PR introduces option bluestore_volume_selection_policy=without_slow_dir which helps avoiding OSD spillover and enables the user to turn on dynamic levels in RocksDB options.

More information about the PR is included in attached document:
[rocksdb_in_ceph.pdf](https://github.com/ceph/ceph/files/5224089/rocksdb_in_ceph.pdf)

Signed-off-by: Kinga Karczewska <kkarczewska@cloudferro.com>
Signed-off-by: Kajetan Janiak <kjaniak@cloudferro.com>