### PR TITLE
mgr/dashboard: replace assertDictContainsSubset() with assertLessEqual()

### DIFF
--- a/src/pybind/mgr/dashboard/tests/test_access_control.py
+++ b/src/pybind/mgr/dashboard/tests/test_access_control.py
@@ -389,7 +389,7 @@ class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
             uroles.sort()
             user = self.exec_cmd('ac-user-add-roles', username=username,
                                  roles=[role])
-            self.assertDictContainsSubset({'roles': uroles}, user)
+            self.assertLessEqual(uroles, user['roles'])
         self.validate_persistent_user(username, uroles)
         self.assertGreaterEqual(user['lastUpdate'], user_orig['lastUpdate'])
 
@@ -397,8 +397,8 @@ class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
         user_orig = self.test_create_user()
         user = self.exec_cmd('ac-user-add-roles', username="admin",
                              roles=['pool-manager', 'block-manager'])
-        self.assertDictContainsSubset(
-            {'roles': ['block-manager', 'pool-manager']}, user)
+        self.assertLessEqual(['block-manager', 'pool-manager'],
+                             user['roles'])
         self.validate_persistent_user('admin', ['block-manager',
                                                 'pool-manager'])
         self.assertGreaterEqual(user['lastUpdate'], user_orig['lastUpdate'])
@@ -425,14 +425,13 @@ class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
         user_orig = self.test_create_user()
         user = self.exec_cmd('ac-user-add-roles', username="admin",
                              roles=['pool-manager'])
-        self.assertDictContainsSubset(
-            {'roles': ['pool-manager']}, user)
+        self.assertLessEqual(['pool-manager'], user['roles'])
         self.validate_persistent_user('admin', ['pool-manager'])
         self.assertGreaterEqual(user['lastUpdate'], user_orig['lastUpdate'])
         user2 = self.exec_cmd('ac-user-set-roles', username="admin",
                               roles=['rgw-manager', 'block-manager'])
-        self.assertDictContainsSubset(
-            {'roles': ['block-manager', 'rgw-manager']}, user2)
+        self.assertLessEqual(['block-manager', 'rgw-manager'],
+                             user2['roles'])
         self.validate_persistent_user('admin', ['block-manager',
                                                 'rgw-manager'])
         self.assertGreaterEqual(user2['lastUpdate'], user['lastUpdate'])
@@ -459,8 +458,7 @@ class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
         self.test_add_user_roles()
         user = self.exec_cmd('ac-user-del-roles', username="admin",
                              roles=['pool-manager'])
-        self.assertDictContainsSubset(
-            {'roles': ['block-manager']}, user)
+        self.assertLessEqual(['block-manager'], user['roles'])
         self.validate_persistent_user('admin', ['block-manager'])
 
     def test_del_user_roles_not_existent_user(self):


### PR DESCRIPTION
to silence the warnings like

tests/test_access_control.py::AccessControlTest::test_show_all_users
  /usr/lib/python3.6/unittest/case.py:1126: DeprecationWarning: assertDictContainsSubset is deprecated
    DeprecationWarning)

as assertDictContainsSubset() method was deprecated, see also
https://dev.rbcafe.com/python/python-3.5.1/whatsnew/3.2.html#unittest

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
