### PR TITLE
rgwlc: fix clause counting in LCFilter_S3::decode_xml()

### DIFF
--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -184,9 +184,6 @@ class LCFilter
   bool has_multi_condition() const {
     if (obj_tags.count() > 1)
       return true;
-    else if (has_prefix() && has_tags())
-      return true;
-
     return false;
   }
 

--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -128,20 +128,21 @@ void LCFilter_S3::dump_xml(Formatter *f) const
 
 void LCFilter_S3::decode_xml(XMLObj *obj)
 {
+  /*
+   * The prior logic here looked for an And element, but did not
+   * structurally parse the Filter clause (and incorrectly rejected
+   * the base case where a Prefix and one Tag were supplied).  It
+   * could not reject generally malformed Filter syntax.
+   *
+   * Empty filters are allowed:
+   * https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html
+   */
   XMLObj *o = obj->find_first("And");
-  bool single_cond = false;
-  int num_conditions = 0;
-  // If there is an AND condition, every tag is a child of and
-  // else we only support single conditions and return false if we see multiple
-
   if (o == nullptr){
     o = obj;
-    single_cond = true;
   }
 
   RGWXMLDecoder::decode_xml("Prefix", prefix, o);
-  if (!prefix.empty())
-    num_conditions++;
   auto tags_iter = o->find("Tag");
   obj_tags.clear();
   while (auto tag_xml =tags_iter.get_next()){
@@ -149,11 +150,6 @@ void LCFilter_S3::decode_xml(XMLObj *obj)
     RGWXMLDecoder::decode_xml("Key", _key, tag_xml);
     RGWXMLDecoder::decode_xml("Value", _val, tag_xml);
     obj_tags.emplace_tag(std::move(_key), std::move(_val));
-    num_conditions++;
-  }
-
-  if (single_cond && num_conditions > 1) {
-    throw RGWXMLDecoder::err("Bad filter: badly formed multiple conditions");
   }
 }
 


### PR DESCRIPTION
The logic is not a structural parse, so remove the unreliable
logic to match And to Filter clauses.  Accept any number of tags
(including 1) after Prefix.

Empty Filter is allowed:
https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html

Fixes: https://tracker.ceph.com/issues/47472

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
