### PR TITLE
common/ceph_time: move operator<<() into ceph::details namespace

### DIFF
--- a/src/common/ceph_time.h
+++ b/src/common/ceph_time.h
@@ -51,6 +51,7 @@ namespace ceph {
 
     // A concrete duration, unsigned. The timespan Ceph thinks in.
     typedef std::chrono::duration<rep, std::nano> timespan;
+    std::ostream& operator<<(std::ostream& m, const timespan& t);
 
 
     // Like the above but signed.
@@ -299,6 +300,15 @@ namespace ceph {
       }
     };
 
+    template<typename Clock,
+	     typename std::enable_if<!Clock::is_steady>::type* = nullptr>
+    std::ostream& operator<<(std::ostream& m,
+			     const std::chrono::time_point<Clock>& t);
+    template<typename Clock,
+	     typename std::enable_if<Clock::is_steady>::type* = nullptr>
+    std::ostream& operator<<(std::ostream& m,
+			     const std::chrono::time_point<Clock>& t);
+
     // So that our subtractions produce negative spans rather than
     // arithmetic underflow.
     namespace {
@@ -440,15 +450,7 @@ namespace ceph {
     }
   }
 
-  std::ostream& operator<<(std::ostream& m, const timespan& t);
-  template<typename Clock,
-	   typename std::enable_if<!Clock::is_steady>::type* = nullptr>
-  std::ostream& operator<<(std::ostream& m,
-			   const std::chrono::time_point<Clock>& t);
-  template<typename Clock,
-	   typename std::enable_if<Clock::is_steady>::type* = nullptr>
-  std::ostream& operator<<(std::ostream& m,
-			   const std::chrono::time_point<Clock>& t);
+  using time_detail::operator<<;
 
   // The way std::chrono handles the return type of subtraction is not
   // wonderful. The difference of two unsigned types SHOULD be signed.


### PR DESCRIPTION
in bench_cls_fifo.cc, we use

fmt::print(std::cout, "{}\t{}\n", entry.marker, entry.mtime)

to print out the `entry.mtime` using libfmt, but clang fails to compile
like:

fmt/core.h:1016:5: error: static_assert failed due to requirement 'formattable' "Cannot format argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/lat\
est/api.html#formatting-user-defined-types"
    static_assert(
    ^
...
src/test/cls_fifo/bench_cls_fifo.cc:447:7: note: in instantiation of function template specialization 'fmt::v6::print<char [7], const std::__cxx11::basic_string<char,
std::char_traits<ch\
ar>, std::allocator<char> > &, const std::chrono::time_point<ceph::time_detail::real_clock, std::chrono::duration<unsigned long, std::ratio<1, 1000000000> > > &, char>' requested here
        fmt::print(std::cout, "{}\t{}\n", entry.marker, entry.mtime);
             ^

it's due to ADL. instead of looking up in the `ceph` namespace where the alias
of `ceph::real_clock` is defined for `operator<<`, Clang tries to find it in
`ceph::time_detail`. and it fails. as the `operator<<` templates are defined in
`ceph` namespace.

in this change, `operator<<` templates are defined in `ceph::time_detail`, and
they are exposed using `using` in `ceph` namespace, to make sure the ADL can
also find them if the compiler thinks that the alias belong to the namespace
where they are defined.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
