### PR TITLE
nautilus: rgw: ordered bucket listing code clean-up

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2560,10 +2560,7 @@ int RGWRados::Bucket::List::list_objects_ordered(
             next_marker = prefix_key;
             (*common_prefixes)[prefix_key] = true;
 
-            int marker_delim_pos = cur_marker.name.find(
-	      params.delim, cur_prefix.size());
-
-            skip_after_delim = cur_marker.name.substr(0, marker_delim_pos);
+            skip_after_delim = obj.name.substr(0, delim_pos);
             skip_after_delim.append(after_delim_s);
 
             ldout(cct, 20) << "skip_after_delim=" << skip_after_delim << dendl;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2467,6 +2467,15 @@ int RGWRados::Bucket::List::list_objects_ordered(
     }
     prev_marker = cur_marker;
 
+    if (skip_after_delim > cur_marker.name) {
+      cur_marker = skip_after_delim;
+
+      ldout(cct, 20) << "setting cur_marker="
+		     << cur_marker.name
+		     << "[" << cur_marker.instance << "]"
+		     << dendl;
+    }
+
     std::map<string, rgw_bucket_dir_entry> ent_map;
     int r = store->cls_bucket_list_ordered(target->get_bucket_info(),
 					   shard_id,
@@ -2551,6 +2560,14 @@ int RGWRados::Bucket::List::list_objects_ordered(
             next_marker = prefix_key;
             (*common_prefixes)[prefix_key] = true;
 
+            int marker_delim_pos = cur_marker.name.find(
+	      params.delim, cur_prefix.size());
+
+            skip_after_delim = cur_marker.name.substr(0, marker_delim_pos);
+            skip_after_delim.append(after_delim_s);
+
+            ldout(cct, 20) << "skip_after_delim=" << skip_after_delim << dendl;
+
             count++;
           }
 
@@ -2569,24 +2586,6 @@ int RGWRados::Bucket::List::list_objects_ordered(
       result->emplace_back(std::move(entry));
       count++;
     } // eiter for loop
-
-    if (!params.delim.empty()) {
-      int marker_delim_pos = cur_marker.name.find(params.delim, cur_prefix.size());
-      if (marker_delim_pos >= 0) {
-        skip_after_delim = cur_marker.name.substr(0, marker_delim_pos);
-        skip_after_delim.append(after_delim_s);
-
-        ldout(cct, 20) << "skip_after_delim=" << skip_after_delim << dendl;
-
-        if (skip_after_delim > cur_marker.name) {
-          cur_marker = skip_after_delim;
-          ldout(cct, 20) << "setting cur_marker="
-                         << cur_marker.name
-                         << "[" << cur_marker.instance << "]"
-                         << dendl;
-        }
-      }
-    }
 
     ldout(cct, 20) << "RGWRados::Bucket::List::" << __func__ <<
       " INFO end of outer loop, truncated=" << truncated <<


### PR DESCRIPTION
rgw: ordered bucket listing code clean-up

As a result of an earlier bug-fix, the code for ordered bucket listing is now more complex than it needs to be. This reverts that fix and applies a cleaner one.

This change is not applicable to octopus or later because the ordered bucket listing code underwent a significant change in between. Specifically much of the delimiter filtering logic was moved to cls/osd code.

Fixes: https://tracker.ceph.com/issues/47487

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>