### PR TITLE
common: remove log_early configuration option

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1342,7 +1342,7 @@ class CephManager:
         testdir = teuthology.get_testdir(self.ctx)
         prefix = ['sudo', 'adjust-ulimits', 'ceph-coverage',
                   f'{testdir}/archive/coverage', 'timeout', '120', 'ceph',
-                  '--cluster', self.cluster, '--log-early']
+                  '--cluster', self.cluster]
         kwargs['args'] = prefix + list(kwargs['args'])
         return self.controller.run(**kwargs)
 

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -667,9 +667,6 @@ int md_config_t::parse_argv(ConfigValues& values,
     else if (ceph_argparse_flag(args, i, "--no-mon-config", (char*)NULL)) {
       values.no_mon_config = true;
     }
-    else if (ceph_argparse_flag(args, i, "--log-early", (char*)NULL)) {
-      values.log_early = true;
-    }
     else if (ceph_argparse_flag(args, i, "--mon-config", (char*)NULL)) {
       values.no_mon_config = false;
     }

--- a/src/common/config_values.h
+++ b/src/common/config_values.h
@@ -28,7 +28,6 @@ public:
   std::string cluster;
   ceph::logging::SubsystemMap subsys;
   bool no_mon_config = false;
-  bool log_early = false;
   // Set of configuration options that have changed since the last
   // apply_changes
   using changed_set_t = std::set<std::string>;

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -169,11 +169,6 @@ void global_pre_init(
   // command line (as passed by caller)
   conf.parse_argv(args);
 
-  if (conf->log_early &&
-      !cct->_log->is_started()) {
-    cct->_log->start();
-  }
-
   if (!cct->_log->is_started()) {
     cct->_log->start();
   }

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -80,8 +80,7 @@ public:
   {
     int ret;
 
-    if (cct->_conf->log_early &&
-	!cct->_log->is_started()) {
+    if (!cct->_log->is_started()) {
       cct->_log->start();
     }
 

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -212,8 +212,7 @@ int librados::RadosClient::connect()
     return -EISCONN;
   state = CONNECTING;
 
-  if (cct->_conf->log_early &&
-      !cct->_log->is_started()) {
+  if (!cct->_log->is_started()) {
     cct->_log->start();
   }
 


### PR DESCRIPTION
1. remove unnecessary check condition.
2. remove log_early configuration option

Signed-off-by: Changcheng Liu <changcheng.liu@aliyun.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
