### PR TITLE
nautilus: mds: kcephfs parse dirfrag's ndist is always 0

### DIFF
--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -554,7 +554,7 @@ private:
 
   // for giving to clients
   void get_dist_spec(std::set<mds_rank_t>& ls, mds_rank_t auth) {
-    if (is_rep()) {
+    if (is_auth()) {
       list_replicas(ls);
       if (!ls.empty()) 
 	ls.insert(auth);


### PR DESCRIPTION
https://tracker.ceph.com/issues/47017