### PR TITLE
nautilus: mds: After restarting an mds, its standy-replay mds remained in the "resolve" state

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1683,8 +1683,6 @@ void MDSRank::replay_start()
   if (is_standby_replay())
     standby_replaying = true;
 
-  calc_recovery_set();
-
   // Check if we need to wait for a newer OSD map before starting
   Context *fin = new C_IO_Wrapper(this, new C_MDS_BootStart(this, MDS_BOOT_INITIAL));
   bool const ready = objecter->wait_for_map(
@@ -1852,6 +1850,8 @@ void MDSRank::resolve_start()
   dout(1) << "resolve_start" << dendl;
 
   reopen_log();
+
+  calc_recovery_set();
 
   mdcache->resolve_start(new C_MDS_VoidFn(this, &MDSRank::resolve_done));
   finish_contexts(g_ceph_context, waiting_for_resolve);


### PR DESCRIPTION
https://tracker.ceph.com/issues/47090