### PR TITLE
octopus: mgr/dashboard: increase Grafana iframe height to avoid scroll bar

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.html
@@ -19,7 +19,7 @@
        *ngIf="permissions.grafana.read">
     <cd-grafana [grafanaPath]="'host-details?var-ceph_hosts=' + selectedHostname"
                 uid="rtOg0AiWz"
-                grafanaStyle="three">
+                grafanaStyle="four">
     </cd-grafana>
   </tab>
   <tab heading="Device health"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.html
@@ -62,7 +62,7 @@
        heading="Performance Details">
     <cd-grafana [grafanaPath]="'osd-device-details?var-osd=osd.' + osd['id']"
                 uid="CrAHE0iZz"
-                grafanaStyle="GrafanaStyles.two">
+                grafanaStyle="three">
     </cd-grafana>
   </tab>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -44,7 +44,7 @@
        heading="Overall Performance">
     <cd-grafana [grafanaPath]="'osd-overview?'"
                 uid="lo02I1Aiz"
-                grafanaStyle="three">
+                grafanaStyle="four">
     </cd-grafana>
   </tab>
 </tabset>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-details/pool-details.component.html
@@ -14,7 +14,7 @@
     <cd-grafana [grafanaPath]="'ceph-pool-detail?var-pool_name='
                 + selection['pool_name']"
                 uid="-xyV8KCiz"
-                grafanaStyle="one">
+                grafanaStyle="three">
     </cd-grafana>
   </tab>
   <tab *ngIf="selection.type === 'replicated'"

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.scss
@@ -16,6 +16,10 @@
   height: 900px;
 }
 
+.grafana_four {
+  height: 1160px;
+}
+
 .timepicker {
   label {
     font-weight: 700;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
@@ -154,7 +154,8 @@ export class GrafanaComponent implements OnInit, OnChanges {
     this.styles = {
       one: 'grafana_one',
       two: 'grafana_two',
-      three: 'grafana_three'
+      three: 'grafana_three',
+      four: 'grafana_four'
     };
 
     this.settingsService.ifSettingConfigured('api/grafana/url', (url) => {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47414

---

backport of https://github.com/ceph/ceph/pull/34777
parent tracker: https://tracker.ceph.com/issues/44966

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh