### PR TITLE
mgr/dashboard: table detail rows overflow

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.scss
@@ -1,0 +1,7 @@
+table {
+  table-layout: fixed;
+}
+
+table td {
+  word-wrap: break-word;
+}


### PR DESCRIPTION
Added word-wrap to the rgw-bucket-details table rows to fix overflow of values

Before: 
![Screenshot from 2020-09-16 11-34-30](https://user-images.githubusercontent.com/66050535/93302776-24e34880-f818-11ea-847f-3526756f57ba.png)

After:
![Screenshot from 2020-09-16 11-33-03](https://user-images.githubusercontent.com/66050535/93302807-2dd41a00-f818-11ea-8887-889dcce6f025.png)

Fixes:https://tracker.ceph.com/issues/47434
Signed-off-by: Aashish Sharma <aasharma@redhat.com>


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
