### PR TITLE
cephadm: filter dangling images in get_last_local_ceph_image()

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1257,6 +1257,7 @@ def get_last_local_ceph_image():
     out, _, _ = call_throws(
         [container_path, 'images',
          '--filter', 'label=ceph=True',
+         '--filter', 'dangling=false',
          '--format', '{{.Repository}} {{.Tag}}'])
     for line in out.splitlines():
         if len(line.split()) == 2:


### PR DESCRIPTION
if `podman images --filter label=ceph=True --format {{.Repository}} {{.Tag}}`
returns something like following:

```
<none>                <none>
docker.io/ceph/ceph   v15
```

it will end up throwing an error:

```
    r = args.func()
  File "./cephadm", line 1147, in _infer_fsid
    return func()
  File "./cephadm", line 1184, in _infer_config
    return func()
  File "./cephadm", line 1230, in _infer_image
    return func()
  File "./cephadm", line 3283, in command_shell
    make_log_dir(args.fsid)
  File "./cephadm", line 1325, in make_log_dir
    uid, gid = extract_uid_gid()
  File "./cephadm", line 1913, in extract_uid_gid
    raise RuntimeError('uid/gid not found')
RuntimeError: uid/gid not found
```

adding `--filter dangling=false` can help to avoid this.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>

