### PR TITLE
librbd: support assembling results of multiple object extents

### DIFF
--- a/src/librbd/cache/ObjectCacherObjectDispatch.h
+++ b/src/librbd/cache/ObjectCacherObjectDispatch.h
@@ -42,9 +42,8 @@ public:
   void shut_down(Context* on_finish) override;
 
   bool read(
-      uint64_t object_no, const io::Extents &extents, IOContext io_context,
+      uint64_t object_no, io::ReadExtents* extents, IOContext io_context,
       int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
-      ceph::bufferlist* read_data, io::Extents* extent_map,
       uint64_t* version, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;

--- a/src/librbd/cache/ObjectCacherWriteback.cc
+++ b/src/librbd/cache/ObjectCacherWriteback.cc
@@ -135,7 +135,7 @@ void ObjectCacherWriteback::read(const object_t& oid, uint64_t object_no,
   aio_comp->set_request_count(1);
 
   auto req_comp = new io::ReadResult::C_ObjectReadRequest(
-    aio_comp, off, len, {{0, len}});
+    aio_comp, {{off, len, {{0, len}}}});
 
   auto io_context = m_ictx->duplicate_data_io_context();
   if (snapid != CEPH_NOSNAP) {
@@ -147,9 +147,8 @@ void ObjectCacherWriteback::read(const object_t& oid, uint64_t object_no,
   op_flags &= ~READ_FLAGS_MASK;
 
   auto req = io::ObjectDispatchSpec::create_read(
-    m_ictx, io::OBJECT_DISPATCH_LAYER_CACHE, object_no, {{off, len}},
-    io_context, op_flags, read_flags, trace, &req_comp->bl,
-    &req_comp->extent_map, nullptr, req_comp);
+    m_ictx, io::OBJECT_DISPATCH_LAYER_CACHE, object_no, &req_comp->extents,
+    io_context, op_flags, read_flags, trace, nullptr, req_comp);
   req->send();
 }
 

--- a/src/librbd/cache/ParentCacheObjectDispatch.h
+++ b/src/librbd/cache/ParentCacheObjectDispatch.h
@@ -44,9 +44,8 @@ public:
   }
 
   bool read(
-      uint64_t object_no, const io::Extents &extents, IOContext io_context,
+      uint64_t object_no, io::ReadExtents* extents, IOContext io_context,
       int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
-      ceph::bufferlist* read_data, io::Extents* extent_map,
       uint64_t* version, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
@@ -132,10 +131,9 @@ private:
   int read_object(std::string file_path, ceph::bufferlist* read_data,
                   uint64_t offset, uint64_t length, Context *on_finish);
   void handle_read_cache(ceph::immutable_obj_cache::ObjectCacheRequest* ack,
-                         uint64_t object_no, uint64_t read_off,
-                         uint64_t read_len, IOContext io_context,
+                         uint64_t object_no, io::ReadExtents* extents,
+                         IOContext io_context,
                          const ZTracer::Trace &parent_trace,
-                         ceph::bufferlist* read_data,
                          io::DispatchResult* dispatch_result,
                          Context* on_dispatched);
   int handle_register_client(bool reg);

--- a/src/librbd/cache/WriteAroundObjectDispatch.cc
+++ b/src/librbd/cache/WriteAroundObjectDispatch.cc
@@ -57,14 +57,17 @@ void WriteAroundObjectDispatch<I>::shut_down(Context* on_finish) {
 
 template <typename I>
 bool WriteAroundObjectDispatch<I>::read(
-    uint64_t object_no, const io::Extents &extents, IOContext io_context,
+    uint64_t object_no, io::ReadExtents* extents, IOContext io_context,
     int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
-    ceph::bufferlist* read_data, io::Extents* extent_map, uint64_t* version,
-    int* object_dispatch_flags, io::DispatchResult* dispatch_result,
-    Context** on_finish, Context* on_dispatched) {
-  auto [object_off, object_len] = extents.front();
-  return dispatch_unoptimized_io(object_no, object_off, object_len,
-                                 dispatch_result, on_dispatched);
+    uint64_t* version, int* object_dispatch_flags,
+    io::DispatchResult* dispatch_result, Context** on_finish,
+    Context* on_dispatched) {
+  bool handled = false;
+  for (auto& extent: *extents) {
+    handled |= dispatch_unoptimized_io(object_no, extent.offset, extent.length,
+                                       dispatch_result, on_dispatched);
+  }
+  return handled;
 }
 
 template <typename I>

--- a/src/librbd/cache/WriteAroundObjectDispatch.h
+++ b/src/librbd/cache/WriteAroundObjectDispatch.h
@@ -42,9 +42,8 @@ public:
   void shut_down(Context* on_finish) override;
 
   bool read(
-      uint64_t object_no, const io::Extents &extents, IOContext io_context,
+      uint64_t object_no, io::ReadExtents* extents, IOContext io_context,
       int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
-      ceph::bufferlist* read_data, io::Extents* extent_map,
       uint64_t* version, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;

--- a/src/librbd/crypto/CryptoObjectDispatch.h
+++ b/src/librbd/crypto/CryptoObjectDispatch.h
@@ -32,10 +32,9 @@ public:
   void shut_down(Context* on_finish) override;
 
   bool read(
-      uint64_t object_no, const io::Extents &extents,
-      IOContext io_context, int op_flags, int read_flags,
-      const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-      io::Extents* extent_map, uint64_t* version, int* object_dispatch_flags,
+      uint64_t object_no, io::ReadExtents* extents, IOContext io_context,
+      int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
+      uint64_t* version, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;
 

--- a/src/librbd/io/ObjectDispatch.cc
+++ b/src/librbd/io/ObjectDispatch.cc
@@ -33,19 +33,18 @@ void ObjectDispatch<I>::shut_down(Context* on_finish) {
 
 template <typename I>
 bool ObjectDispatch<I>::read(
-    uint64_t object_no, const Extents &extents, IOContext io_context,
+    uint64_t object_no, ReadExtents* extents, IOContext io_context,
     int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
-    ceph::bufferlist* read_data, Extents* extent_map, uint64_t* version,
-    int* object_dispatch_flags, DispatchResult* dispatch_result,
-    Context** on_finish, Context* on_dispatched) {
+    uint64_t* version, int* object_dispatch_flags,
+    DispatchResult* dispatch_result, Context** on_finish,
+    Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << "object_no=" << object_no << " " << extents << dendl;
+  ldout(cct, 20) << "object_no=" << object_no << " " << *extents << dendl;
 
   *dispatch_result = DISPATCH_RESULT_COMPLETE;
   auto req = new ObjectReadRequest<I>(m_image_ctx, object_no, extents,
                                       io_context, op_flags, read_flags,
-                                      parent_trace, read_data, extent_map,
-                                      version, on_dispatched);
+                                      parent_trace, version, on_dispatched);
   req->send();
   return true;
 }

--- a/src/librbd/io/ObjectDispatch.h
+++ b/src/librbd/io/ObjectDispatch.h
@@ -33,9 +33,8 @@ public:
   void shut_down(Context* on_finish) override;
 
   bool read(
-      uint64_t object_no, const Extents &extents, IOContext io_context,
+      uint64_t object_no, ReadExtents* extents, IOContext io_context,
       int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
-      ceph::bufferlist* read_data, Extents* extent_map,
       uint64_t* version, int* object_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;

--- a/src/librbd/io/ObjectDispatchInterface.h
+++ b/src/librbd/io/ObjectDispatchInterface.h
@@ -34,10 +34,9 @@ struct ObjectDispatchInterface {
   virtual void shut_down(Context* on_finish) = 0;
 
   virtual bool read(
-      uint64_t object_no, const Extents &extents,
-      IOContext io_context, int op_flags, int read_flags,
-      const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-      Extents* extent_map, uint64_t* version, int* object_dispatch_flags,
+      uint64_t object_no, ReadExtents* extents, IOContext io_context,
+      int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
+      uint64_t* version, int* object_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) = 0;
 

--- a/src/librbd/io/ObjectDispatchSpec.h
+++ b/src/librbd/io/ObjectDispatchSpec.h
@@ -43,17 +43,14 @@ public:
   };
 
   struct ReadRequest : public RequestBase {
-    const Extents extents;
+    ReadExtents* extents;
     int read_flags;
-    ceph::bufferlist* read_data;
-    Extents* extent_map;
     uint64_t* version;
 
-    ReadRequest(uint64_t object_no, const Extents &extents,
-                int read_flags, ceph::bufferlist* read_data,
-                Extents* extent_map, uint64_t* version)
+    ReadRequest(uint64_t object_no, ReadExtents* extents, int read_flags,
+                uint64_t* version)
       : RequestBase(object_no), extents(extents), read_flags(read_flags),
-        read_data(read_data), extent_map(extent_map), version(version) {
+        version(version) {
     }
   };
 
@@ -170,15 +167,13 @@ public:
   template <typename ImageCtxT>
   static ObjectDispatchSpec* create_read(
       ImageCtxT* image_ctx, ObjectDispatchLayer object_dispatch_layer,
-      uint64_t object_no, const Extents &extents, IOContext io_context,
+      uint64_t object_no, ReadExtents* extents, IOContext io_context,
       int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
-      ceph::bufferlist* read_data, Extents* extent_map, uint64_t* version,
-      Context* on_finish) {
+      uint64_t* version, Context* on_finish) {
     return new ObjectDispatchSpec(image_ctx->io_object_dispatcher,
                                   object_dispatch_layer,
                                   ReadRequest{object_no, extents,
-                                              read_flags, read_data, extent_map,
-                                              version},
+                                              read_flags, version},
                                   io_context, op_flags, parent_trace,
                                   on_finish);
   }

--- a/src/librbd/io/ObjectDispatcher.cc
+++ b/src/librbd/io/ObjectDispatcher.cc
@@ -109,8 +109,7 @@ struct ObjectDispatcher<I>::SendVisitor : public boost::static_visitor<bool> {
     return object_dispatch->read(
       read.object_no, read.extents, object_dispatch_spec->io_context,
       object_dispatch_spec->op_flags, read.read_flags,
-      object_dispatch_spec->parent_trace,
-      read.read_data, read.extent_map, read.version,
+      object_dispatch_spec->parent_trace, read.version,
       &object_dispatch_spec->object_dispatch_flags,
       &object_dispatch_spec->dispatch_result,
       &object_dispatch_spec->dispatcher_ctx.on_finish,

--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -93,20 +93,19 @@ template <typename ImageCtxT = ImageCtx>
 class ObjectReadRequest : public ObjectRequest<ImageCtxT> {
 public:
   static ObjectReadRequest* create(
-      ImageCtxT *ictx, uint64_t objectno, const Extents &extents,
+      ImageCtxT *ictx, uint64_t objectno, ReadExtents* extents,
       IOContext io_context, int op_flags, int read_flags,
-      const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-      Extents* extent_map, uint64_t* version, Context *completion) {
+      const ZTracer::Trace &parent_trace, uint64_t* version,
+      Context *completion) {
     return new ObjectReadRequest(ictx, objectno, extents, io_context, op_flags,
-                                 read_flags, parent_trace, read_data,
-                                 extent_map, version, completion);
+                                 read_flags, parent_trace, version, completion);
   }
 
   ObjectReadRequest(
-      ImageCtxT *ictx, uint64_t objectno, const Extents &extents,
+      ImageCtxT *ictx, uint64_t objectno, ReadExtents* extents,
       IOContext io_context, int op_flags, int read_flags,
-      const ZTracer::Trace &parent_trace, ceph::bufferlist* read_data,
-      Extents* extent_map, uint64_t* version, Context *completion);
+      const ZTracer::Trace &parent_trace, uint64_t* version,
+      Context *completion);
 
   void send() override;
 
@@ -136,16 +135,9 @@ private:
    * @endverbatim
    */
 
-  const Extents m_extents;
-
-  typedef std::pair<ceph::bufferlist, Extents> ExtentResult;
-  typedef std::vector<ExtentResult> ExtentResults;
-  ExtentResults m_extent_results;
+  ReadExtents* m_extents;
   int m_op_flags;
   int m_read_flags;
-
-  ceph::bufferlist* m_read_data;
-  Extents* m_extent_map;
   uint64_t* m_version;
 
   void read_object();

--- a/src/librbd/io/ReadResult.h
+++ b/src/librbd/io/ReadResult.h
@@ -38,18 +38,23 @@ public:
 
   struct C_ObjectReadRequest : public Context {
     AioCompletion *aio_completion;
-    uint64_t object_off;
-    uint64_t object_len;
-    LightweightBufferExtents buffer_extents;
+    ReadExtents extents;
 
-    bufferlist bl;
-    Extents extent_map;
-
-    C_ObjectReadRequest(AioCompletion *aio_completion, uint64_t object_off,
-                        uint64_t object_len,
-                        LightweightBufferExtents&& buffer_extents);
+    C_ObjectReadRequest(AioCompletion *aio_completion, ReadExtents&& extents);
 
     void finish(int r) override;
+  };
+
+  struct C_ObjectReadMergedExtents : public Context {
+      CephContext* cct;
+      ReadExtents* extents;
+      Context *on_finish;
+      bufferlist bl;
+
+      C_ObjectReadMergedExtents(CephContext* cct, ReadExtents* extents,
+                                Context* on_finish);
+
+      void finish(int r) override;
   };
 
   ReadResult();

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.cc
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.cc
@@ -219,18 +219,18 @@ void SimpleSchedulerObjectDispatch<I>::shut_down(Context* on_finish) {
 
 template <typename I>
 bool SimpleSchedulerObjectDispatch<I>::read(
-    uint64_t object_no, const Extents &extents, IOContext io_context,
+    uint64_t object_no, ReadExtents* extents, IOContext io_context,
     int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
-    ceph::bufferlist* read_data, Extents* extent_map, uint64_t* version,
-    int* object_dispatch_flags, DispatchResult* dispatch_result,
-    Context** on_finish, Context* on_dispatched) {
+    uint64_t* version, int* object_dispatch_flags,
+    DispatchResult* dispatch_result, Context** on_finish,
+    Context* on_dispatched) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " " << extents
                  << dendl;
 
   std::lock_guard locker{m_lock};
-  for (auto [object_off, object_len] : extents) {
-    if (intersects(object_no, object_off, object_len)) {
+  for (auto& extent : *extents) {
+    if (intersects(object_no, extent.offset, extent.length)) {
       dispatch_delayed_requests(object_no);
       break;
     }

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.h
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.h
@@ -49,9 +49,8 @@ public:
   void shut_down(Context* on_finish) override;
 
   bool read(
-      uint64_t object_no, const Extents &extents, IOContext io_context,
+      uint64_t object_no, ReadExtents* extents, IOContext io_context,
       int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
-      ceph::bufferlist* read_data, Extents* extent_map,
       uint64_t* version, int* object_dispatch_flags,
       DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override;

--- a/src/librbd/io/Types.h
+++ b/src/librbd/io/Types.h
@@ -197,6 +197,45 @@ using striper::LightweightObjectExtents;
 typedef std::pair<uint64_t,uint64_t> Extent;
 typedef std::vector<Extent> Extents;
 
+struct ReadExtent {
+    const uint64_t offset;
+    const uint64_t length;
+    const LightweightBufferExtents buffer_extents;
+    ceph::bufferlist bl;
+    Extents extent_map;
+
+    ReadExtent(uint64_t offset,
+               uint64_t length) : offset(offset), length(length) {};
+    ReadExtent(uint64_t offset,
+               uint64_t length,
+               const LightweightBufferExtents&& buffer_extents)
+               : offset(offset),
+                 length(length),
+                 buffer_extents(buffer_extents) {}
+    ReadExtent(uint64_t offset,
+               uint64_t length,
+               const LightweightBufferExtents&& buffer_extents,
+               ceph::bufferlist&& bl,
+               Extents&& extent_map) : offset(offset),
+                                       length(length),
+                                       buffer_extents(buffer_extents),
+                                       bl(bl),
+                                       extent_map(extent_map) {};
+
+    friend inline std::ostream& operator<<(
+            std::ostream& os,
+            const ReadExtent &extent) {
+      os << "offset=" << extent.offset << ", "
+         << "length=" << extent.length << ", "
+         << "buffer_extents=" << extent.buffer_extents << ", "
+         << "bl.length=" << extent.bl.length() << ", "
+         << "extent_map=" << extent.extent_map;
+      return os;
+    }
+};
+
+typedef std::vector<ReadExtent> ReadExtents;
+
 typedef std::map<uint64_t, uint64_t> ExtentMap;
 
 } // namespace io

--- a/src/librbd/io/Utils.h
+++ b/src/librbd/io/Utils.h
@@ -30,14 +30,18 @@ bool assemble_write_same_extent(const LightweightObjectExtent &object_extent,
                                 bool force_write);
 
 template <typename ImageCtxT = librbd::ImageCtx>
-void read_parent(ImageCtxT *image_ctx, uint64_t object_no, const Extents &extents,
-                 librados::snap_t snap_id, const ZTracer::Trace &trace,
-                 ceph::bufferlist* data, Context* on_finish);
+void read_parent(ImageCtxT *image_ctx, uint64_t object_no,
+                 ReadExtents* extents, librados::snap_t snap_id,
+                 const ZTracer::Trace &trace, Context* on_finish);
 
 template <typename ImageCtxT = librbd::ImageCtx>
 int clip_request(ImageCtxT *image_ctx, Extents *image_extents);
 
 uint64_t extents_length(Extents &extents);
+
+void unsparsify(CephContext* cct, ceph::bufferlist* bl,
+                const Extents& extent_map, uint64_t bl_off,
+                uint64_t out_bl_len);
 
 } // namespace util
 } // namespace io

--- a/src/librbd/journal/ObjectDispatch.h
+++ b/src/librbd/journal/ObjectDispatch.h
@@ -37,9 +37,8 @@ public:
   void shut_down(Context* on_finish) override;
 
   bool read(
-      uint64_t object_no, const io::Extents &extents, IOContext io_context,
+      uint64_t object_no, io::ReadExtents* extents, IOContext io_context,
       int op_flags, int read_flags, const ZTracer::Trace &parent_trace,
-      ceph::bufferlist* read_data, io::Extents* extent_map,
       uint64_t* version, int* object_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) {

--- a/src/librbd/plugin/Api.cc
+++ b/src/librbd/plugin/Api.cc
@@ -10,10 +10,10 @@ namespace plugin {
 
 template <typename I>
 void Api<I>::read_parent(
-    I *image_ctx, uint64_t object_no, const Extents &extents,
+    I *image_ctx, uint64_t object_no, io::ReadExtents* extents,
     librados::snap_t snap_id, const ZTracer::Trace &trace,
-    ceph::bufferlist* data, Context* on_finish) {
-  io::util::read_parent<I>(image_ctx, object_no, extents, snap_id, trace, data,
+    Context* on_finish) {
+  io::util::read_parent<I>(image_ctx, object_no, extents, snap_id, trace,
                            on_finish);
 }
 

--- a/src/librbd/plugin/Api.h
+++ b/src/librbd/plugin/Api.h
@@ -25,9 +25,9 @@ struct Api {
   virtual ~Api() {}
 
   virtual void read_parent(
-      ImageCtxT *image_ctx, uint64_t object_no, const Extents &extents,
+      ImageCtxT *image_ctx, uint64_t object_no, io::ReadExtents* extents,
       librados::snap_t snap_id, const ZTracer::Trace &trace,
-      ceph::bufferlist* data, Context* on_finish);
+      Context* on_finish);
 
 };
 

--- a/src/osdc/Striper.cc
+++ b/src/osdc/Striper.cc
@@ -425,6 +425,12 @@ void Striper::StripedReadResult::add_partial_sparse_result(
   ldout(cct, 10) << "add_partial_sparse_result(" << this << ") " << bl.length()
 		 << " covering " << bl_map << " (offset " << bl_off << ")"
 		 << " to " << buffer_extents << dendl;
+
+  if (bl_map.empty()) {
+    add_partial_result(cct, bl, buffer_extents);
+    return;
+  }
+
   auto s = bl_map.cbegin();
   for (auto& be : buffer_extents) {
     ::add_partial_sparse_result(cct, &partial, &total_intended_len, bl, &s,
@@ -433,12 +439,18 @@ void Striper::StripedReadResult::add_partial_sparse_result(
 }
 
 void Striper::StripedReadResult::add_partial_sparse_result(
-    CephContext *cct, ceph::buffer::list& bl,
+    CephContext *cct, ceph::buffer::list&& bl,
     const std::vector<std::pair<uint64_t, uint64_t>>& bl_map, uint64_t bl_off,
     const striper::LightweightBufferExtents& buffer_extents) {
   ldout(cct, 10) << "add_partial_sparse_result(" << this << ") " << bl.length()
 		 << " covering " << bl_map << " (offset " << bl_off << ")"
 		 << " to " << buffer_extents << dendl;
+
+  if (bl_map.empty()) {
+    add_partial_result(cct, std::move(bl), buffer_extents);
+    return;
+  }
+
   auto s = bl_map.cbegin();
   for (auto& be : buffer_extents) {
     ::add_partial_sparse_result(cct, &partial, &total_intended_len, bl, &s,

--- a/src/osdc/Striper.h
+++ b/src/osdc/Striper.h
@@ -106,7 +106,7 @@
 	const std::map<uint64_t, uint64_t>& bl_map, uint64_t bl_off,
 	const std::vector<std::pair<uint64_t,uint64_t> >& buffer_extents);
       void add_partial_sparse_result(
-	  CephContext *cct, ceph::buffer::list& bl,
+	  CephContext *cct, ceph::buffer::list&& bl,
 	  const std::vector<std::pair<uint64_t, uint64_t>>& bl_map,
           uint64_t bl_off,
           const striper::LightweightBufferExtents& buffer_extents);

--- a/src/test/librbd/io/test_mock_SimpleSchedulerObjectDispatch.cc
+++ b/src/test/librbd/io/test_mock_SimpleSchedulerObjectDispatch.cc
@@ -131,9 +131,10 @@ TEST_F(TestMockIoSimpleSchedulerObjectDispatch, Read) {
 
   C_SaferCond cond;
   Context *on_finish = &cond;
+  io::ReadExtents extents = {{0, 4096}, {8192, 4096}};
   ASSERT_FALSE(mock_simple_scheduler_object_dispatch.read(
-      0, {{0, 4096}}, mock_image_ctx.get_data_io_context(), 0, 0, {}, nullptr,
-      nullptr, nullptr, nullptr, nullptr, &on_finish, nullptr));
+      0, &extents, mock_image_ctx.get_data_io_context(), 0, 0, {}, nullptr,
+      nullptr, nullptr, &on_finish, nullptr));
   ASSERT_EQ(on_finish, &cond); // not modified
   on_finish->complete(0);
   ASSERT_EQ(0, cond.wait());

--- a/src/test/librbd/mock/io/MockObjectDispatch.h
+++ b/src/test/librbd/mock/io/MockObjectDispatch.h
@@ -24,18 +24,17 @@ public:
 
   MOCK_METHOD1(shut_down, void(Context*));
 
-  MOCK_METHOD8(execute_read,
-               bool(uint64_t, const Extents&, IOContext io_context,
-                    ceph::bufferlist*, Extents*, uint64_t*,
+  MOCK_METHOD6(execute_read,
+               bool(uint64_t, ReadExtents*, IOContext io_context, uint64_t*,
                     DispatchResult*, Context*));
   bool read(
-      uint64_t object_no, const Extents& extents, IOContext io_context,
+      uint64_t object_no, ReadExtents* extents, IOContext io_context,
       int op_flags, int read_flags, const ZTracer::Trace& parent_trace,
-      ceph::bufferlist* read_data, Extents* extent_map, uint64_t* version,
-      int* dispatch_flags, DispatchResult* dispatch_result,
-      Context** on_finish, Context* on_dispatched) {
-    return execute_read(object_no, extents, io_context, read_data, extent_map,
-                        version, dispatch_result, on_dispatched);
+      uint64_t* version, int* dispatch_flags,
+      DispatchResult* dispatch_result, Context** on_finish,
+      Context* on_dispatched) {
+    return execute_read(object_no, extents, io_context, version,
+                        dispatch_result, on_dispatched);
   }
 
   MOCK_METHOD9(execute_discard,


### PR DESCRIPTION
Previous PR extended the read API of object dispatch to support multiple extents.
However, the striper feeding on the output of this API assumes the result matches a single (object_off, object_len) extent.
This PR modifies the striper to take into account the possible multiple object extents that were requested by the read API.

@dillaman I finally decided to go with this instead of using SparseBufferList since the striper code already handles the unsparsifying functionality that was needed. It just needed a little change to handle multiple extents.