### PR TITLE
mgr/dashboard/api: move/create OSD histogram in separate endpoint

### DIFF
--- a/qa/tasks/mgr/dashboard/test_osd.py
+++ b/qa/tasks/mgr/dashboard/test_osd.py
@@ -51,6 +51,12 @@ class OsdTest(DashboardTestCase):
         self.assertStatus(200)
         self.assert_in_and_not_none(data, ['osd_metadata'])
 
+    def test_histogram(self):
+        data = self._get('/api/osd/0/histogram')
+        self.assertStatus(200)
+        self.assert_in_and_not_none(data['osd'], ['op_w_latency_in_bytes_histogram',
+                                                               'op_r_latency_out_bytes_histogram'])    
+
     def test_scrub(self):
         self._post('/api/osd/0/scrub?deep=False')
         self.assertStatus(200)

--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -120,6 +120,22 @@ class Osd(RESTController):
             'osd_metadata': mgr.get_metadata('osd', svc_id),
         }
 
+    @RESTController.Resource('GET')
+    @handle_send_command_error('osd')
+    def histogram(self, svc_id):
+        # type: (int) -> Dict[str, Any]
+        """
+        :return: Returns the histogram data.
+        """
+        try:
+            histogram = CephService.send_command(
+                'osd', srv_spec=svc_id, prefix='perf histogram dump')
+        except SendCommandError as e:  # pragma: no cover - the handling is too obvious
+            raise DashboardException(
+                component='osd', http_status_code=400, msg=str(e))
+
+        return histogram
+
     def set(self, svc_id, device_class):  # pragma: no cover
         old_device_class = CephService.send_command('mon', 'osd crush get-device-class',
                                                     ids=[svc_id])


### PR DESCRIPTION
Added a separate endpoint for osd/histogram - api/osd/{svc_id}/histogram

Fixes:https://tracker.ceph.com/issues/46898
Signed-off-by:Aashish Sharma <aasharma@redhat.com>

## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
