### PR TITLE
mgr/dashboard: Created a Download and Copy-to-Clipboard option for the logs

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
@@ -6,6 +6,7 @@ import { RouterModule } from '@angular/router';
 import { TreeModule } from '@circlon/angular-tree-component';
 import {
   NgbDatepickerModule,
+  NgbDropdownModule,
   NgbNavModule,
   NgbPopoverModule,
   NgbTimepickerModule,
@@ -69,7 +70,8 @@ import { TelemetryComponent } from './telemetry/telemetry.component';
     NgBootstrapFormValidationModule,
     CephSharedModule,
     NgbDatepickerModule,
-    NgbPopoverModule
+    NgbPopoverModule,
+    NgbDropdownModule
   ],
   declarations: [
     HostsComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
@@ -11,6 +11,19 @@
       <ng-template ngbNavContent>
         <div class="card bg-light mb-3"
              *ngIf="clog">
+          <div class="btn-group"
+               role="group"
+               (click)="logToText(clog)"
+               *ngIf="clog.length">
+            <cd-download-button [objectItem]="clog"
+                                [textItem]="logText"
+                                fileName="cluster_log">
+            </cd-download-button>
+            <button type="button"
+                    class="btn btn-light"
+                    [cdCopy2ClipboardButton]="logText"
+                    [byId]="false"></button>
+          </div>
           <div class="card-body">
             <p *ngFor="let line of clog">
               <span class="timestamp">{{ line.stamp | cdDate }}</span>
@@ -29,6 +42,19 @@
       <ng-template ngbNavContent>
         <div class="card bg-light mb-3"
              *ngIf="audit_log">
+          <div class="btn-group"
+               role="group"
+               (click)="logToText(audit_log)"
+               *ngIf="audit_log.length">
+            <cd-download-button [objectItem]="audit_log"
+                                [textItem]="logText"
+                                fileName="audit_log">
+            </cd-download-button>
+            <button type="button"
+                    class="btn btn-light"
+                    [cdCopy2ClipboardButton]="logText"
+                    [byId]="false"></button>
+          </div>
           <div class="card-body">
             <p *ngFor="let line of audit_log">
               <span class="timestamp">{{ line.stamp | cdDate }}</span>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.scss
@@ -5,6 +5,12 @@ p {
 }
 
 .card {
+  .btn-group {
+    margin-top: -45px;
+    position: absolute;
+    right: 0;
+  }
+
   div p {
     display: flex;
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.ts
@@ -16,6 +16,7 @@ export class LogsComponent implements OnInit, OnDestroy {
   clog: Array<any>;
   audit_log: Array<any>;
   icons = Icons;
+  logText: string;
 
   interval: number;
   priorities: Array<{ name: string; value: string }> = [
@@ -135,5 +136,19 @@ export class LogsComponent implements OnInit, OnDestroy {
     this.filterLogs();
 
     return false;
+  }
+
+  logToText(log: object) {
+    this.logText = '';
+    for (const line of Object.keys(log)) {
+      this.logText =
+        this.logText +
+        this.datePipe.transform(log[line].stamp, 'medium') +
+        '\t' +
+        log[line].priority +
+        '\t' +
+        log[line].message +
+        '\n';
+    }
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
@@ -262,17 +262,16 @@
             </div>
             <div class="form-group row">
               <div class="cd-col-form-offset">
-                <button type="button"
-                        class="btn btn-light mr-2"
-                        title="Download"
-                        (click)="download(report, 'telemetry_report.json')"
-                        i18n-title>
-                  <i class="fa fa-download"></i>
-                </button>
-                <button type="button"
-                        class="btn btn-light"
-                        cdCopy2ClipboardButton="report">
-                </button>
+                <div class="btn-group"
+                     role="group">
+                  <cd-download-button [objectItem]="report"
+                                      fileName="telemetry_report">
+                  </cd-download-button>
+                  <button type="button"
+                          class="btn btn-light"
+                          cdCopy2ClipboardButton="report">
+                  </button>
+                </div>
               </div>
             </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.spec.ts
@@ -4,15 +4,14 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { DownloadButtonComponent } from 'app/shared/components/download-button/download-button.component';
 import _ from 'lodash';
 import { ToastrModule } from 'ngx-toastr';
 import { of as observableOf } from 'rxjs';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { MgrModuleService } from '../../../shared/api/mgr-module.service';
-import { TelemetryService } from '../../../shared/api/telemetry.service';
 import { LoadingPanelComponent } from '../../../shared/components/loading-panel/loading-panel.component';
-import { TextToDownloadService } from '../../../shared/services/text-to-download.service';
 import { SharedModule } from '../../../shared/shared.module';
 import { TelemetryComponent } from './telemetry.component';
 
@@ -20,7 +19,6 @@ describe('TelemetryComponent', () => {
   let component: TelemetryComponent;
   let fixture: ComponentFixture<TelemetryComponent>;
   let mgrModuleService: MgrModuleService;
-  let telemetryService: TelemetryService;
   let options: any;
   let configs: any;
   let httpTesting: HttpTestingController;
@@ -58,7 +56,7 @@ describe('TelemetryComponent', () => {
         ToastrModule.forRoot()
       ]
     },
-    [LoadingPanelComponent]
+    [LoadingPanelComponent, DownloadButtonComponent]
   );
 
   describe('configForm', () => {
@@ -135,16 +133,10 @@ describe('TelemetryComponent', () => {
   });
 
   describe('previewForm', () => {
-    const reportText = {
-      testA: 'testA',
-      testB: 'testB'
-    };
-
     beforeEach(() => {
       fixture = TestBed.createComponent(TelemetryComponent);
       component = fixture.componentInstance;
       fixture.detectChanges();
-      telemetryService = TestBed.inject(TelemetryService);
       httpTesting = TestBed.inject(HttpTestingController);
       router = TestBed.inject(Router);
       spyOn(router, 'navigate');
@@ -152,16 +144,6 @@ describe('TelemetryComponent', () => {
 
     it('should create', () => {
       expect(component).toBeTruthy();
-    });
-
-    it('should call TextToDownloadService download function', () => {
-      spyOn(telemetryService, 'getReport').and.returnValue(observableOf(reportText));
-      component.ngOnInit();
-
-      const downloadSpy = spyOn(TestBed.inject(TextToDownloadService), 'download');
-      const filename = 'reportText.json';
-      component.download(reportText, filename);
-      expect(downloadSpy).toHaveBeenCalledWith(JSON.stringify(reportText, null, 2), filename);
     });
 
     it('should submit', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
@@ -14,7 +14,6 @@ import { CdFormGroup } from '../../../shared/forms/cd-form-group';
 import { CdValidators } from '../../../shared/forms/cd-validators';
 import { NotificationService } from '../../../shared/services/notification.service';
 import { TelemetryNotificationService } from '../../../shared/services/telemetry-notification.service';
-import { TextToDownloadService } from '../../../shared/services/text-to-download.service';
 
 @Component({
   selector: 'cd-telemetry',
@@ -49,7 +48,6 @@ export class TelemetryComponent extends CdForm implements OnInit {
     private notificationService: NotificationService,
     private router: Router,
     private telemetryService: TelemetryService,
-    private textToDownloadService: TextToDownloadService,
     private telemetryNotificationService: TelemetryNotificationService
   ) {
     super();
@@ -162,10 +160,6 @@ export class TelemetryComponent extends CdForm implements OnInit {
         this.configForm.setErrors({ cdSubmitButton: true });
       }
     );
-  }
-
-  download(report: object, fileName: string) {
-    this.textToDownloadService.download(JSON.stringify(report, null, 2), fileName);
   }
 
   disableModule(message: string = null, followUpFunc: Function = null) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
@@ -26,6 +26,7 @@ import { ConfirmationModalComponent } from './confirmation-modal/confirmation-mo
 import { CriticalConfirmationModalComponent } from './critical-confirmation-modal/critical-confirmation-modal.component';
 import { DateTimePickerComponent } from './date-time-picker/date-time-picker.component';
 import { DocComponent } from './doc/doc.component';
+import { DownloadButtonComponent } from './download-button/download-button.component';
 import { FormModalComponent } from './form-modal/form-modal.component';
 import { GrafanaComponent } from './grafana/grafana.component';
 import { HelperComponent } from './helper/helper.component';
@@ -87,7 +88,8 @@ import { UsageBarComponent } from './usage-bar/usage-bar.component';
     TelemetryNotificationComponent,
     OrchestratorDocPanelComponent,
     DateTimePickerComponent,
-    DocComponent
+    DocComponent,
+    DownloadButtonComponent
   ],
   providers: [],
   exports: [
@@ -110,7 +112,8 @@ import { UsageBarComponent } from './usage-bar/usage-bar.component';
     TelemetryNotificationComponent,
     OrchestratorDocPanelComponent,
     DateTimePickerComponent,
-    DocComponent
+    DocComponent,
+    DownloadButtonComponent
   ]
 })
 export class ComponentsModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/download-button/download-button.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/download-button/download-button.component.html
@@ -1,0 +1,23 @@
+<div ngbDropdown
+     placement="bottom-right">
+  <button type="button"
+          [title]="title"
+          class="btn btn-light dropdown-toggle-split"
+          ngbDropdownToggle>
+    <i [ngClass]="[icons.download]"></i>
+  </button>
+  <div ngbDropdownMenu>
+    <button ngbDropdownItem
+            (click)="download('json')"
+            *ngIf="objectItem">
+      <i [ngClass]="[icons.json]"></i>
+      <span>JSON</span>
+    </button>
+    <button ngbDropdownItem
+            (click)="download()"
+            *ngIf="textItem">
+      <i [ngClass]="[icons.text]"></i>
+      <span>Text</span>
+    </button>
+  </div>
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/download-button/download-button.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/download-button/download-button.component.spec.ts
@@ -1,0 +1,39 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { configureTestBed } from '../../../../testing/unit-test-helper';
+import { TextToDownloadService } from '../../services/text-to-download.service';
+import { DownloadButtonComponent } from './download-button.component';
+
+describe('DownloadButtonComponent', () => {
+  let component: DownloadButtonComponent;
+  let fixture: ComponentFixture<DownloadButtonComponent>;
+
+  configureTestBed({
+    declarations: [DownloadButtonComponent],
+    providers: [TextToDownloadService]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DownloadButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should call download function', () => {
+    component.objectItem = {
+      testA: 'testA',
+      testB: 'testB'
+    };
+    const downloadSpy = spyOn(TestBed.inject(TextToDownloadService), 'download');
+    component.fileName = `${'reportText.json'}_${new Date().toLocaleDateString()}`;
+    component.download('json');
+    expect(downloadSpy).toHaveBeenCalledWith(
+      JSON.stringify(component.objectItem, null, 2),
+      `${component.fileName}.json`
+    );
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/download-button/download-button.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/download-button/download-button.component.ts
@@ -1,0 +1,31 @@
+import { Component, Input } from '@angular/core';
+
+import { Icons } from '../../enum/icons.enum';
+import { TextToDownloadService } from '../../services/text-to-download.service';
+
+@Component({
+  selector: 'cd-download-button',
+  templateUrl: './download-button.component.html',
+  styleUrls: ['./download-button.component.scss']
+})
+export class DownloadButtonComponent {
+  @Input() objectItem: object;
+  @Input() textItem: string;
+  @Input() fileName: any;
+  @Input() title = $localize`Download`;
+
+  icons = Icons;
+  constructor(private textToDownloadService: TextToDownloadService) {}
+
+  download(format?: string) {
+    this.fileName = `${this.fileName}_${new Date().toLocaleDateString()}`;
+    if (format === 'json') {
+      this.textToDownloadService.download(
+        JSON.stringify(this.objectItem, null, 2),
+        `${this.fileName}.json`
+      );
+    } else {
+      this.textToDownloadService.download(this.textItem, `${this.fileName}.txt`);
+    }
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/copy2clipboard-button.directive.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/copy2clipboard-button.directive.ts
@@ -9,6 +9,8 @@ import { ToastrService } from 'ngx-toastr';
 export class Copy2ClipboardButtonDirective implements OnInit {
   @Input()
   private cdCopy2ClipboardButton: string;
+  @Input()
+  byId = true;
 
   constructor(
     private elementRef: ElementRef,
@@ -33,7 +35,7 @@ export class Copy2ClipboardButtonDirective implements OnInit {
   onClick() {
     try {
       const browser = detect();
-      const text = this.getText();
+      const text = this.byId ? this.getText() : this.cdCopy2ClipboardButton;
       const toastrFn = () => {
         this.toastr.success('Copied text to the clipboard successfully.');
       };

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/icons.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/icons.enum.ts
@@ -62,6 +62,8 @@ export enum Icons {
   download = 'fa fa-download', // Download
   upload = 'fa fa-upload', // Upload
   close = 'fa fa-times', // Close
+  json = 'fa fa-file-code-o', // JSON file
+  text = 'fa fa-file-text', // Text file
 
   /* Icons for special effect */
   large = 'fa fa-lg', // icon becomes 33% larger


### PR DESCRIPTION
I've created a Download-button component which can be used to download .json and .txt file (either or both). This component is also now used in the telemetry component where it downloads the report.json file.

Added a Download and Copy-to-Clipboard button for the Cluster and Audit Logs in the Log section. Also added a flag in the current Copy2ClipboardButton directive to indicate the incoming string is actually a log.

**Sample log files**
[audit_log_16_09_2020.log](https://github.com/ceph/ceph/files/5232629/audit_log_16_09_2020.log)
[cluster_log_16_09_2020.log](https://github.com/ceph/ceph/files/5232630/cluster_log_16_09_2020.log)

![log_download](https://user-images.githubusercontent.com/71764184/96453169-b723a580-1237-11eb-8022-8a37a39aba0e.png)


Fixes: https://tracker.ceph.com/issues/47498
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
