### PR TITLE
nautilus: ceph-volume: fix simple activate when legacy osd

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/simple/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/simple/activate.py
@@ -286,7 +286,7 @@ class Activate(object):
                 try:
                     self.activate(args)
                 except RuntimeError as e:
-                    terminal.warning(e)
+                    terminal.warning(e.message)
         else:
             if args.file:
                 json_config = args.file

--- a/src/ceph-volume/ceph_volume/devices/simple/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/simple/activate.py
@@ -169,6 +169,12 @@ class Activate(object):
 
         # XXX there is no support for LVM here
         data_device = self.get_device(data_uuid)
+
+        if not data_device:
+            raise RuntimeError("osd fsid {} doesn't exist, this file will "
+                "be skipped, consider cleaning legacy "
+                "json file {}".format(osd_metadata['fsid'], args.json_config))
+
         journal_device = self.get_device(osd_metadata.get('journal', {}).get('uuid'))
         block_device = self.get_device(osd_metadata.get('block', {}).get('uuid'))
         block_db_device = self.get_device(osd_metadata.get('block.db', {}).get('uuid'))
@@ -277,7 +283,10 @@ class Activate(object):
             for json_config in json_configs:
                 mlogger.info('activating OSD specified in {}'.format(json_config))
                 args.json_config = json_config
-                self.activate(args)
+                try:
+                    self.activate(args)
+                except RuntimeError as e:
+                    terminal.warning(e)
         else:
             if args.file:
                 json_config = args.file


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47504

---

backport of https://github.com/ceph/ceph/pull/37093
parent tracker: https://tracker.ceph.com/issues/47493

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh