### PR TITLE
mon: allow overriding the initial mon_host

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -128,6 +128,12 @@
   contain alphanumeric and ``-``, ``_`` and ``.`` characters. Some commands
   or CephX credentials may not work with old FSs with non-conformant names.
 
+* It is now possible to specify the initial monitor to contact for Ceph tools
+  and daemons using the ``mon_host_override`` config option or
+  ``--mon-host-override <ip>`` command-line switch. This generally should only
+  be used for debugging and only affects initial communication with Ceph's
+  monitor cluster.
+
 * `blacklist` has been replaced with `blocklist` throughout.  The following commands have changed:
 
   - ``ceph osd blacklist ...`` are now ``ceph osd blocklist ...``

--- a/doc/rados/configuration/ceph-conf.rst
+++ b/doc/rados/configuration/ceph-conf.rst
@@ -67,6 +67,11 @@ configuration, they may need to be stored locally on the node and set
 in a local configuration file.  These options include:
 
   - ``mon_host``, the list of monitors for the cluster
+  - ``mon_host_override``, the list of monitors for the cluster to
+    **initially** contact when beginning a new instance of communication with the
+    Ceph cluster.  This overrides the known monitor list derived from MonMap
+    updates sent to older Ceph instances (like librados cluster handles).  It is
+    expected this option is primarily useful for debugging.
   - ``mon_dns_serv_name`` (default: `ceph-mon`), the name of the DNS
     SRV record to check to identify the cluster monitors via DNS
   - ``mon_data``, ``osd_data``, ``mds_data``, ``mgr_data``, and

--- a/qa/standalone/mon/mon-handle-forward.sh
+++ b/qa/standalone/mon/mon-handle-forward.sh
@@ -33,18 +33,18 @@ function run() {
         run_mon $dir b --public-addr $MONB || return 1
     )
 
-    timeout 360 ceph --mon-host $MONA mon stat || return 1
+    timeout 360 ceph --mon-host-override $MONA mon stat || return 1
     # check that MONB is indeed a peon
     ceph --admin-daemon $(get_asok_path mon.b) mon_status |
        grep '"peon"' || return 1
     # when the leader ( MONA ) is used, there is no message forwarding
-    ceph --mon-host $MONA osd pool create POOL1 12
+    ceph --mon-host-override $MONA osd pool create POOL1 12
     CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.a) log flush || return 1
     grep 'mon_command(.*"POOL1"' $dir/mon.a.log || return 1
     CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.b) log flush || return 1
     grep 'mon_command(.*"POOL1"' $dir/mon.b.log && return 1
     # when the peon ( MONB ) is used, the message is forwarded to the leader
-    ceph --mon-host $MONB osd pool create POOL2 12
+    ceph --mon-host-override $MONB osd pool create POOL2 12
     CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.b) log flush || return 1
     grep 'forward_request.*mon_command(.*"POOL2"' $dir/mon.b.log || return 1
     CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.a) log flush || return 1

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -429,6 +429,12 @@ std::vector<Option> get_global_options() {
     .set_flag(Option::FLAG_STARTUP)
     .add_service("common"),
 
+    Option("mon_host_override", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_description("monitor(s) to use overriding the MonMap")
+    .set_flag(Option::FLAG_NO_MON_UPDATE)
+    .set_flag(Option::FLAG_STARTUP)
+    .add_service("common"),
+
     Option("mon_dns_srv_name", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("ceph-mon")
     .set_description("name of DNS SRV record to check for monitor addresses")

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -820,6 +820,21 @@ int MonMap::build_initial(CephContext *cct, bool for_mkfs, ostream& errout)
 {
   const auto& conf = cct->_conf;
 
+  // mon_host_override?
+  auto mon_host_override = conf.get_val<std::string>("mon_host_override");
+  if (!mon_host_override.empty()) {
+    lgeneric_dout(cct, 1) << "Using mon_host_override " << mon_host_override << dendl;
+    auto ret = init_with_ips(mon_host_override, for_mkfs, "noname-");
+    if (ret == -EINVAL) {
+      ret = init_with_hosts(mon_host_override, for_mkfs, "noname-");
+    }
+    if (ret < 0) {
+      errout << "unable to parse addrs in '" << mon_host_override << "'"
+	     << std::endl;
+    }
+    return ret;
+  }
+
   // cct?
   auto addrs = cct->get_mon_addrs();
   if (addrs != nullptr && (addrs->size() > 0)) {


### PR DESCRIPTION
This overrides what the CephContext believes to be the current quorum of
monitors (retrieved from other instances of the MonClient), introduced
by [1]. Tests need to be able to target a specific monitor for
exercising forwarding and other things.

[1] 731e2db9fb4611f767446a3c8e778a097ce70d35
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
