### PR TITLE
mgr/cephadm: more rgw streamlining

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -497,9 +497,9 @@ For example, to deploy 2 rgw daemons serving the *myorg* realm and the *us-east-
 
    ceph orch apply rgw myorg us-east-1 --placement="2 myhost1 myhost2"
 
-Cephadm will wait for a healthy cluster and automatically create the supplied realm and zone if they do not exist before deploying the rgw daemon(s)
+Cephadm will wait for a healthy cluster before deploying any daemons. 
 
-Alternatively, the realm, zonegroup, and zone can be manually created using ``radosgw-admin`` commands:
+The realm, zonegroup, and zone can be manually created using ``radosgw-admin`` commands before the ``ceph orch apply rgw`` command is used :
 
 .. prompt:: bash #
 
@@ -515,7 +515,11 @@ Alternatively, the realm, zonegroup, and zone can be manually created using ``ra
 
 .. prompt:: bash #
 
-  radosgw-admin period update --rgw-realm=<realm-name> --commit
+  # radosgw-admin period update --rgw-realm=<realm-name> --commit
+
+Alternatively Cephadm will attempt to create these for you, the --zonegroup-name flag needs to be used to supply a zonegroup-name to be created with the realm-name and zone-name
+
+Cephadm will also automatically create a radosgw user ``dashboard`` if the dashboard is enabled and set the dashboard rgw api keys 
 
 See :ref:`orchestrator-cli-placement-spec` for details of the placement
 specification.

--- a/doc/mgr/orchestrator.rst
+++ b/doc/mgr/orchestrator.rst
@@ -411,7 +411,7 @@ The ``name`` parameter is an identifier of the group of instances:
 Creating/growing/shrinking/removing services::
 
     ceph orch apply mds <fs_name> [--placement=<placement>] [--dry-run]
-    ceph orch apply rgw <realm> <zone> [--subcluster=<subcluster>] [--port=<port>] [--ssl] [--placement=<placement>] [--dry-run]
+    ceph orch apply rgw <realm> <zone> [--zonegroup-name=<zonegroup>] [--subcluster=<subcluster>] [--port=<port>] [--ssl] [--placement=<placement>] [--dry-run]
     ceph orch apply nfs <name> <pool> [--namespace=<namespace>] [--placement=<placement>] [--dry-run]
     ceph orch rm <service_name> [--force]
 

--- a/qa/tasks/cephadm_cases/test_rgw_autocreation.py
+++ b/qa/tasks/cephadm_cases/test_rgw_autocreation.py
@@ -1,0 +1,64 @@
+import logging
+
+from tasks.mgr.mgr_test_case import MgrTestCase
+
+log = logging.getLogger(__name__)
+
+
+class TestCephadmRgwAutoCreation(MgrTestCase):
+    def _cmd(self, *args):
+        return self.mgr_cluster.mon_manager.raw_cluster_cmd(*args)
+
+    def _orch_cmd(self, *args):
+        return self._cmd("orch", *args)
+
+    def _sys_cmd(self, cmd):
+        cmd[0:0] = ['sudo']
+        ret = self.ctx.cluster.run(args=cmd, check_status=False, stdout=BytesIO(), stderr=BytesIO())
+        stdout = ret[0].stdout
+        if stdout:
+            return stdout.getvalue()
+
+    def setUp(self):
+        super(TestCephadmRgwAutoCreation, self).setUp()
+
+    def test_happypath(self):
+        # zone, zonegroup, realm, dashboard user, should be created succesfully
+
+        out = self._orch_cmd('ceph', 'orch', 'apply', 'rgw', 'test_realm', 'test_zone', '--zonegroup_name=test_group')
+
+        #wait for rgw deamon to show up in orch ps
+        wait_time = 10
+        while wait_time <= 60:
+            time.sleep(wait_time)
+            if expected_status in self._orch_cmd('ps', '--format', 'yaml'):
+                return
+            wait_time += 10
+        self.fail(fail_msg)
+
+        #check if realm was created
+        out = self._sys_cmd(['radosgw-admin', 'realm', 'list'])
+        self.assertNotIn('test_realm', out)
+
+        #check if zonegroup was created
+        out = self._sys_cmd(['radosgw-admin', 'zonegroup', 'list'])
+        self.assertNotIn('test_group', out)
+
+        #check if zone was created
+        out = self._sys_cmd(['radosgw-admin', 'zone', 'list'])
+        self.assertNotIn('test_zone', out)
+
+        #check if dashboard user was created
+        out = self._sys_cmd(['radosgw-admin', 'user', 'list'])
+        self.assertNotIn('dashboard', out)
+
+        #check if keys were set
+        out = self._cmd('dashboard', 'get-rgw-api-access-key')
+        if not out:
+            error
+
+        out = self._cmd('dashboard', 'get-rgw-api-secret-key')
+        if not out:
+            error
+
+        #clean up / delete evewrything 

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -100,8 +100,8 @@ class TestCephadm(object):
             assert wait(cephadm_module, cephadm_module.get_hosts()) == [HostSpec('test', 'test')]
         assert wait(cephadm_module, cephadm_module.get_hosts()) == []
 
-    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
-    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __, ___: None)
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
+    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __: None)
     def test_service_ls(self, cephadm_module):
         with with_host(cephadm_module, 'test'):
             c = cephadm_module.list_daemons(refresh=True)
@@ -184,8 +184,8 @@ class TestCephadm(object):
             c = cephadm_module.list_daemons()
             assert wait(cephadm_module, c)[0].name() == 'rgw.myrgw.foobar'
 
-    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
-    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __, ___: None)
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
+    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __: None)
     def test_daemon_action(self, cephadm_module: CephadmOrchestrator):
         cephadm_module.service_cache_timeout = 10
         with with_host(cephadm_module, 'test'):
@@ -210,8 +210,8 @@ class TestCephadm(object):
 
                 CephadmServe(cephadm_module)._check_daemons()
 
-    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
-    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __, ___: None)
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
+    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __: None)
     def test_daemon_action_fail(self, cephadm_module: CephadmOrchestrator):
         cephadm_module.service_cache_timeout = 10
         with with_host(cephadm_module, 'test'):
@@ -526,8 +526,8 @@ class TestCephadm(object):
             out = wait(cephadm_module, c)
             assert out == []
 
-    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
-    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __, ___: None)
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __: None)
     def test_rgw_update(self, cephadm_module):
         with with_host(cephadm_module, 'host1'):
             with with_host(cephadm_module, 'host2'):
@@ -581,9 +581,9 @@ class TestCephadm(object):
             (ServiceSpec('cephadm-exporter'), CephadmOrchestrator.add_cephadm_exporter),
         ]
     )
-    @mock.patch("cephadm.serve.CephadmServe._deploy_cephadm_binary", _deploy_cephadm_binary('test'))
-    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
-    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __, ___: None)
+    @mock.patch("cephadm.module.CephadmOrchestrator._deploy_cephadm_binary", _deploy_cephadm_binary('test'))
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __: None)
     def test_daemon_add(self, spec: ServiceSpec, meth, cephadm_module):
         unmanaged_spec = ServiceSpec.from_json(spec.to_json())
         unmanaged_spec.unmanaged = True
@@ -766,9 +766,9 @@ class TestCephadm(object):
             (ServiceSpec('cephadm-exporter'), CephadmOrchestrator.apply_cephadm_exporter),
         ]
     )
-    @mock.patch("cephadm.serve.CephadmServe._deploy_cephadm_binary", _deploy_cephadm_binary('test'))
-    @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
-    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __, ___: None)
+    @mock.patch("cephadm.module.CephadmOrchestrator._deploy_cephadm_binary", _deploy_cephadm_binary('test'))
+    @mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __: None)
     def test_apply_save(self, spec: ServiceSpec, meth, cephadm_module: CephadmOrchestrator):
         with with_host(cephadm_module, 'test'):
             with with_service(cephadm_module, spec, meth, 'test'):

--- a/src/pybind/mgr/cephadm/tests/test_migration.py
+++ b/src/pybind/mgr/cephadm/tests/test_migration.py
@@ -9,8 +9,8 @@ from cephadm.serve import CephadmServe
 from tests import mock
 
 
-@mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
-@mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __, ___: None)
+@mock.patch("cephadm.module.CephadmOrchestrator._run_cephadm", _run_cephadm('[]'))
+@mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __: None)
 def test_migrate_scheduler(cephadm_module: CephadmOrchestrator):
     with with_host(cephadm_module, 'host1', refresh_hosts=False):
         with with_host(cephadm_module, 'host2', refresh_hosts=False):

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1113,6 +1113,7 @@ Usage:
     def _apply_rgw(self,
                    realm_name: str,
                    zone_name: str,
+                   zonegroup_name: Optional[str] = None,
                    subcluster: Optional[str] = None,
                    port: Optional[int] = None,
                    ssl: bool = False,
@@ -1128,6 +1129,7 @@ Usage:
         spec = RGWSpec(
             rgw_realm=realm_name,
             rgw_zone=zone_name,
+            rgw_zonegroup=zonegroup_name,
             subcluster=subcluster,
             rgw_frontend_port=port,
             ssl=ssl,

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -632,6 +632,7 @@ class RGWSpec(ServiceSpec):
                  service_id: Optional[str] = None,
                  placement: Optional[PlacementSpec] = None,
                  rgw_realm: Optional[str] = None,
+                 rgw_zonegroup: Optional[str] = None,
                  rgw_zone: Optional[str] = None,
                  subcluster: Optional[str] = None,
                  rgw_frontend_port: Optional[int] = None,
@@ -661,6 +662,7 @@ class RGWSpec(ServiceSpec):
 
         self.rgw_realm = rgw_realm
         self.rgw_zone = rgw_zone
+        self.rgw_zonegroup = rgw_zonegroup
         self.subcluster = subcluster
         self.rgw_frontend_port = rgw_frontend_port
         self.rgw_frontend_ssl_certificate = rgw_frontend_ssl_certificate


### PR DESCRIPTION
IMPORTANT: some refactoring will be required when https://github.com/ceph/ceph/pull/38284 is merged.

**goal: make deploying a rgw service a one step process**

prior to this it was a multi step process to get everything setup

```
radosgw-admin realm create --rgw-realm=test_realm --default
radosgw-admin zonegroup create --rgw-zonegroup=default --rgw-realm=test_realm --master --default
radosgw-admin zone create --rgw-zonegroup=default --rgw-zone=test_zone --rgw-realm=test_realm --master --default
radosgw-admin period update --rgw-realm=test_realm --commit
ceph orch apply rgw test_realm test_zone 
radosgw-admin user create --uid=test_user --display-name=TEST_USER --system 
ceph dashboard set-rgw-api-access-key 
ceph dashboard set-rgw-api-secret-key
```

i have tried to automate this process as much as i can but the hard part is dealing with multiple realms and zones.

i believe this logic will prevent cephadm from messing with realms, zonegroups, and zone the the user has manually created
and will only create things when it's safe to do so. 

it will create a dashboard user if the keys arent set and a user doesnt exist.

this will streamline simple use cases (1 realm, 'default' zonegroup, multiple zone)
more complex use cases with multiple realms, zonegroups will need to be handled manually

this will also prevent invalid configs 
if zone_b exists in realm_b this would be raise an error ``ceph orch apply rgw realm_a zone_b``



_general info:_

realms contain zonegroups and zonegroups contain zones    realms(zonegroups(zones))

realms need a master zonegroup and zone, the first ones created are the masters usually

every realm, zonegroup, and zone have a name and these must be unique across the entire cluster (no 2 zones can have the same name for example)

commands like ``radosgw-admin zone list --rgw-zone=<zone>`` return all the zones in the cluster not just in a realm

to get zones just in a specific realms you need to get the period and extract it from the json it returns ``radosgw-admin period get --rgw-realm=test_realm`` 

the dashboard expects the zonegroup to be called 'default', bucket create requests contain a flag like this '--rgw-zonegroup=default' hard coded in 

dashboard only deals with one realm at a time. a user is connected to a realm

Related PRs:
#36162
#36496 

Fixes:
https://tracker.ceph.com/issues/43681
https://tracker.ceph.com/issues/44926
https://tracker.ceph.com/issues/44605

Signed-off-by: Daniel-Pivonka <dpivonka@redhat.com>