### PR TITLE
doc/dev/macos.rst: disable features not supported on osx

### DIFF
--- a/doc/dev/macos.rst
+++ b/doc/dev/macos.rst
@@ -18,21 +18,30 @@ then, under the source directory of Ceph::
 
   mkdir build
   cd build
+  export PKG_CONFIG_PATH=/usr/local/Cellar/nss/3.48/lib/pkgconfig:/usr/local/Cellar/openssl/1.0.2t/lib/pkgconfig
   cmake .. -DBOOST_J=4 \
     -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang \
     -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ \
     -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/opt/llvm/lib" \
     -DENABLE_GIT_VERSION=OFF \
-    -DWITH_MANPAGE=OFF \
-    -DWITH_LIBCEPHFS=OFF \
-    -DWITH_XFS=OFF \
-    -DWITH_KRBD=OFF \
-    -DWITH_LTTNG=OFF \
+    -DSNAPPY_ROOT_DIR=/usr/local/Cellar/snappy/1.1.7_1 \
     -DWITH_BABELTRACE=OFF \
     -DWITH_BLUESTORE=OFF \
+    -DWITH_CCACHE=OFF \
+    -DWITH_CEPHFS=OFF \
+    -DWITH_KRBD=OFF \
+    -DWITH_LIBCEPHFS=OFF \
+    -DWITH_LTTNG=OFF \
+    -DWITH_LZ4=OFF \
+    -DWITH_MANPAGE=ON \
+    -DWITH_MGR=OFF \
+    -DWITH_MGR_DASHBOARD_FRONTEND=OFF \
     -DWITH_RADOSGW=OFF \
+    -DWITH_RDMA=OFF \
     -DWITH_SPDK=OFF \
-    -DSNAPPY_ROOT_DIR=/usr/local/Cellar/snappy/1.1.7_1
+    -DWITH_SYSTEMD=OFF \
+    -DWITH_TESTS=OFF \
+    -DWITH_XFS=OFF
 
 The paths to ``nss`` and ``snappy`` might vary if newer versions of the packages are installed.
 


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
