### PR TITLE
octopus: test/rbd-mirror: pool watcher registration error might result in race

### DIFF
--- a/src/tools/rbd_mirror/PoolWatcher.cc
+++ b/src/tools/rbd_mirror/PoolWatcher.cc
@@ -178,10 +178,12 @@ void PoolWatcher<I>::handle_register_watcher(int r) {
     std::swap(on_init_finish, m_on_init_finish);
   } else if (r == -ENOENT) {
     dout(5) << "mirroring directory does not exist" << dendl;
-    schedule_refresh_images(30);
+    {
+      std::lock_guard locker{m_lock};
+      std::swap(on_init_finish, m_on_init_finish);
+    }
 
-    std::lock_guard locker{m_lock};
-    std::swap(on_init_finish, m_on_init_finish);
+    schedule_refresh_images(30);
   } else {
     derr << "unexpected error registering mirroring directory watch: "
          << cpp_strerror(r) << dendl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46982

---

backport of https://github.com/ceph/ceph/pull/36479
parent tracker: https://tracker.ceph.com/issues/46669

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh