### PR TITLE
rgw: Introduce S3Mirror capability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,6 +430,8 @@ endif (WITH_RADOSGW)
 #option for CephFS
 option(WITH_CEPHFS "CephFS is enabled" ON)
 
+option(WITH_RADOSGW_S3_MIRROR "Rados Gateway mirroring remote S3 bucket is enabled" ON)
+
 # Please specify 3.[0-7] if you want to build with a certain version of python3.
 set(WITH_PYTHON3 "3" CACHE STRING "build with specified python3 version")
 if(NOT WITH_PYTHON3 STREQUAL "3")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,9 @@ add_definitions(
 if(LINUX)
   add_definitions("-D_GNU_SOURCE")
 endif()
+if(WITH_RADOSGW_S3_MIRROR)
+  add_definitions("-DWITH_RADOSGW_S3_MIRROR")
+endif()
 
 add_compile_options(
   -Wall
@@ -927,4 +930,3 @@ if(DOXYGEN_FOUND)
     rgw
     COMMENT "Generate C++ documentation")
 endif()
-

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1456,6 +1456,13 @@ OPTION(rgw_expose_bucket, OPT_BOOL) // Return the bucket name in the 'Bucket' re
 
 OPTION(rgw_frontends, OPT_STR) // rgw front ends
 
+#ifdef WITH_RADOSGW_S3_MIRROR
+OPTION(mirror_s3_bucket, OPT_STR) // rgw remote bucket
+OPTION(mirror_s3_endpoint, OPT_STR) // rgw remote s3
+OPTION(mirror_s3_access_id, OPT_STR) // rgw remote id
+OPTION(mirror_s3_access_key, OPT_STR) // rgw remote secret
+#endif
+
 OPTION(rgw_user_quota_bucket_sync_interval, OPT_INT) // time period for accumulating modified buckets before syncing stats
 OPTION(rgw_user_quota_sync_interval, OPT_INT) // time period for accumulating modified buckets before syncing entire user stats
 OPTION(rgw_user_quota_sync_idle_users, OPT_BOOL) // whether stats for idle users be fully synced

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6525,6 +6525,40 @@ std::vector<Option> get_rgw_options() {
     .set_long_description(
         "A comma delimited list of default frontends configuration."),
 
+#ifdef WITH_RADOSGW_S3_MIRROR
+    Option("mirror_s3_endpoint", Option::TYPE_STR, Option::LEVEL_DEV)
+    .set_default("")
+    .set_description("Mirror S3 url endpoint")
+    .set_long_description("Url the points to an S3 endpoint that radosgw will mirror.")
+    .add_see_also("mirror_s3_bucket")
+    .add_see_also("mirror_s3_access_id")
+    .add_see_also("mirror_s3_access_key"),
+
+    Option("mirror_s3_bucket", Option::TYPE_STR, Option::LEVEL_DEV)
+    .set_default("")
+    .set_description("Mirror S3 bucket")
+    .set_long_description("The bucket from the mirror S3 endpoint that radosgw will mirror.")
+    .add_see_also("mirror_s3_endpoint")
+    .add_see_also("mirror_s3_access_id")
+    .add_see_also("mirror_s3_access_key"),
+
+    Option("mirror_s3_access_id", Option::TYPE_STR, Option::LEVEL_DEV)
+    .set_default("")
+    .set_description("Mirror S3 access ID")
+    .set_long_description("The ID by which the radosgw will connect to the mirror S3 endpoint")
+    .add_see_also("mirror_s3_bucket")
+    .add_see_also("mirror_s3_endpoint")
+    .add_see_also("mirror_s3_access_key"),
+
+    Option("mirror_s3_access_key", Option::TYPE_STR, Option::LEVEL_DEV)
+    .set_default("")
+    .set_description("Mirror S3 endpoint access secret")
+    .set_long_description("The access secret by which the radosgw will connect to the mirror S3 endpoint")
+    .add_see_also("mirror_s3_bucket")
+    .add_see_also("mirror_s3_access_id")
+    .add_see_also("mirror_s3_endpoint"),
+#endif
+
     Option("rgw_user_quota_bucket_sync_interval", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(180)
     .set_description("User quota bucket sync interval")

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -157,6 +157,11 @@ set(librgw_common_srcs
   rgw_datalog.cc
   cls_fifo_legacy.cc)
 
+if(WITH_RADOSGW_S3_MIRROR)
+  list(APPEND librgw_common_srcs rgw_s3_mirror.cc)
+  list(APPEND librgw_common_srcs rgw_s3_mirror_local.cc)
+endif()
+
 if(WITH_RADOSGW_AMQP_ENDPOINT)
   list(APPEND librgw_common_srcs rgw_amqp.cc)
 endif()
@@ -230,6 +235,9 @@ target_include_directories(rgw_a PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support
 target_include_directories(rgw_a SYSTEM PUBLIC "../rapidjson/include")
 target_include_directories(rgw_a SYSTEM PUBLIC "${CMAKE_SOURCE_DIR}/src/rgw")
 
+if(WITH_RADOSGW_S3_MIRROR)
+  find_package(AWSSDK REQUIRED COMPONENTS s3)
+endif()
 if(WITH_RADOSGW_AMQP_ENDPOINT)
   find_package(RabbitMQ REQUIRED)
 endif()
@@ -243,6 +251,7 @@ target_link_libraries(rgw_a
   cls_log_client cls_timeindex_client cls_version_client cls_cmpomap_client
   cls_user_client cls_rgw_gc_client cls_2pc_queue_client ceph-common common_utf8 global
   ${CURL_LIBRARIES}
+  ${AWSSDK_LINK_LIBRARIES}
   ${EXPAT_LIBRARIES}
   ${OPENLDAP_LIBRARIES} ${CRYPTO_LIBS}
   OATH::OATH)
@@ -322,7 +331,7 @@ target_link_libraries(radosgwd radosgw librados
   global
   ${FCGI_LIBRARY} ${LIB_RESOLV}
   ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${BLKID_LIBRARIES}
-  ${ALLOC_LIBS})
+  ${ALLOC_LIBS} ${AWSSDK_LINK_LIBRARIES})
 set_target_properties(radosgwd PROPERTIES OUTPUT_NAME radosgw)
 install(TARGETS radosgwd DESTINATION bin)
 
@@ -335,7 +344,8 @@ target_link_libraries(radosgw-admin ${rgw_libs} librados
   cls_log_client cls_timeindex_client neorados_cls_fifo
   cls_version_client cls_user_client
   global ${FCGI_LIBRARY} ${LIB_RESOLV}
-  ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${BLKID_LIBRARIES})
+  ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${BLKID_LIBRARIES}
+  ${AWSSDK_LINK_LIBRARIES})
 install(TARGETS radosgw-admin DESTINATION bin)
 
 set(radosgw_es_srcs
@@ -346,7 +356,8 @@ target_link_libraries(radosgw-es ${rgw_libs} librados
   cls_log_client cls_timeindex_client neorados_cls_fifo
   cls_version_client cls_user_client
   global ${FCGI_LIBRARY} ${LIB_RESOLV}
-  ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${BLKID_LIBRARIES})
+  ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${BLKID_LIBRARIES}
+  ${AWSSDK_LINK_LIBRARIES})
 install(TARGETS radosgw-es DESTINATION bin)
 
 set(radosgw_token_srcs
@@ -364,7 +375,8 @@ target_link_libraries(radosgw-object-expirer ${rgw_libs} librados
   cls_log_client cls_timeindex_client neorados_cls_fifo
   cls_version_client cls_user_client
   global ${FCGI_LIBRARY} ${LIB_RESOLV}
-  ${CURL_LIBRARIES} ${EXPAT_LIBRARIES})
+  ${CURL_LIBRARIES} ${EXPAT_LIBRARIES}
+  ${AWSSDK_LINK_LIBRARIES})
 install(TARGETS radosgw-object-expirer DESTINATION bin)
 
 set(librgw_srcs
@@ -387,6 +399,7 @@ target_link_libraries(rgw
   global
   ${LIB_RESOLV}
   ${CURL_LIBRARIES}
+  ${AWSSDK_LINK_LIBRARIES}
   ${EXPAT_LIBRARIES}
   PUBLIC
   dmclock::dmclock)

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -52,6 +52,10 @@
 
 #include "services/svc_zone.h"
 
+#ifdef WITH_RADOSGW_S3_MIRROR
+#include "rgw_s3_mirror.h"
+#endif
+
 #ifdef HAVE_SYS_PRCTL_H
 #include <sys/prctl.h>
 #endif
@@ -512,6 +516,13 @@ int radosgw_Main(int argc, const char **argv)
 
     fe_def_map[config->get_framework()].reset(config);
   }
+
+#ifdef WITH_RADOSGW_S3_MIRROR
+  if (g_conf()->mirror_s3_endpoint.compare("") != 0) {
+    S3Mirror::init(g_ceph_context, store, g_conf()->mirror_s3_endpoint, g_conf()->mirror_s3_access_id,
+                    g_conf()->mirror_s3_access_key, g_conf()->mirror_s3_bucket);
+  }
+#endif
 
   int fe_count = 0;
 

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -671,6 +671,9 @@ int radosgw_Main(int argc, const char **argv)
 #ifdef WITH_RADOSGW_AMQP_ENDPOINT
   rgw::amqp::shutdown();
 #endif
+#ifdef WITH_RADOSGW_S3_MIRROR
+  S3Mirror::shutdown();
+#endif
 #ifdef WITH_RADOSGW_KAFKA_ENDPOINT
   rgw::kafka::shutdown();
 #endif

--- a/src/rgw/rgw_s3_mirror.cc
+++ b/src/rgw/rgw_s3_mirror.cc
@@ -1,0 +1,1107 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020-2021 IBM Research Europe <koutsovasilis.panagiotis1@ibm.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License version 2, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "rgw_common.h"
+#include "global/global_context.h"
+#include <boost/algorithm/string/replace.hpp>
+#include "rgw_s3_mirror.h"
+#include "rgw_op.h"
+#include "rgw_acl.h"
+#include "rgw_acl_s3.h"
+#include "rgw_user.h"
+#include "rgw_sal.h"
+
+using namespace std;
+
+shared_ptr<S3Mirror> S3Mirror::instance = nullptr;
+
+int S3Mirror::remote_head_bucket(string bucket_name)
+{
+  Aws::S3::Model::HeadBucketRequest head_bucket_request;
+  head_bucket_request.SetBucket(bucket_name);
+
+  auto head_bucket_outcome = this->client.HeadBucket(head_bucket_request);
+
+  if (head_bucket_outcome.IsSuccess())
+    return 0;
+  
+  return -1;
+}
+
+// Creates the request bucket on the remote S3 endpoint
+int S3Mirror::remote_create_bucket(struct req_state* _req_state, bool dump_response)
+{
+  string bucket_name = _req_state->bucket_name;
+  Aws::S3::Model::CreateBucketRequest create_bucket_request;
+  create_bucket_request.SetBucket(bucket_name);
+
+  auto create_bucket_outcome = this->client.CreateBucket(create_bucket_request);
+
+  if (!create_bucket_outcome.IsSuccess())
+  {
+    auto err = create_bucket_outcome.GetError();
+    dout(20) << "S3Mirror remote_create_bucket: AWS Error " << 
+                err.GetExceptionName() << " " << err.GetMessage() << dendl;
+    return -1;
+  }
+
+  if (!dump_response)
+  {
+    return 0;
+  }
+  
+  auto create_bucket_result = create_bucket_outcome.GetResult();
+
+  set_req_state_err(_req_state, 0);
+  dump_errno(_req_state);
+  dump_header_if_nonempty(_req_state, "Location", create_bucket_result.GetLocation());
+  dump_content_length(_req_state, 0);
+  end_header(_req_state);
+
+  return S3MIRRORINTERCEPTED;
+}
+
+// Deletes the request object on the remote S3 endpoint
+int S3Mirror::remote_delete_object(struct req_state* _req_state, bool dump_response)
+{
+  string bucket_name = _req_state->bucket_name;
+  string object_name = _req_state->object->get_key().name;
+
+  Aws::S3::Model::DeleteObjectRequest delete_object_request;
+  delete_object_request.SetBucket(bucket_name);
+  delete_object_request.SetKey(object_name);
+
+  auto delete_object_outcome = this->client.DeleteObject(delete_object_request);
+
+  if (!delete_object_outcome.IsSuccess())
+  {
+    auto err = delete_object_outcome.GetError();
+    string exceptionName = err.GetExceptionName();
+    if (exceptionName.compare("NoSuchBucket") != 0) 
+    {
+      dout(20) << "S3Mirror remote_delete_object: AWS Error " << 
+                exceptionName << " " << err.GetMessage() << dendl;
+      return -1;
+    }
+  }
+
+  if (!dump_response)
+  {
+    return 0;
+  }
+
+  set_req_state_err(_req_state, STATUS_NO_CONTENT);
+  dump_errno(_req_state);
+  end_header(_req_state);
+
+  return S3MIRRORINTERCEPTED;
+}
+
+// Performs a head request of object on the remote S3 endpoint
+int S3Mirror::remote_head_object(struct req_state* _req_state, bool dump_response)
+{
+  string bucket_name = _req_state->bucket_name;
+  string object_name = _req_state->object->get_key().name;
+
+  Aws::S3::Model::HeadObjectRequest head_object_request;
+  head_object_request.SetBucket(bucket_name);
+  head_object_request.SetKey(object_name);
+
+  auto head_object_outcome = this->client.HeadObject(head_object_request);
+
+  if (!head_object_outcome.IsSuccess())
+  {
+    auto err = head_object_outcome.GetError();
+    dout(20) << "S3Mirror remote_head_object: AWS Error " << 
+                err.GetExceptionName() << " " << err.GetMessage() << dendl;
+    return -1;
+  }
+
+  if (!dump_response)
+  {
+    return 0;
+  }
+
+  auto head_object_result = head_object_outcome.GetResult();
+
+  set_req_state_err(_req_state, 0);
+  dump_errno(_req_state);
+  dump_header_if_nonempty(_req_state, "Cache-Control", head_object_result.GetCacheControl());
+  dump_header_if_nonempty(_req_state, "Content-Disposition", head_object_result.GetContentDisposition());
+  dump_header_if_nonempty(_req_state, "Content-Encoding", head_object_result.GetContentEncoding());
+  dump_header_if_nonempty(_req_state, "Content-Language", head_object_result.GetContentLanguage());
+  dump_content_length(_req_state, head_object_result.GetContentLength());
+  dump_header_if_nonempty(_req_state, "Content-Type", head_object_result.GetContentType());
+  dump_header_if_nonempty(_req_state, "ETag", head_object_result.GetETag());
+  auto medata = head_object_result.GetMetadata();
+  for (Aws::Map<Aws::String, Aws::String>::iterator it = medata.begin(); it != medata.end(); ++it)
+  {
+      dump_header(_req_state, it->first , it->second );
+  }
+
+  auto ceph_timepoint = ceph::real_clock::from_double(
+    chrono::system_clock::to_time_t(head_object_result.GetExpires().UnderlyingTimestamp())
+  );
+  dump_time_header(_req_state, "Expires", ceph_timepoint);
+  auto ceph_timepoint_last_modified = ceph::real_clock::from_double(
+    static_cast<double>(chrono::system_clock::to_time_t(head_object_result.GetLastModified().UnderlyingTimestamp()))
+  );
+  dump_time_header(_req_state, "Last-Modified", ceph_timepoint_last_modified);
+  end_header(_req_state);
+
+  return S3MIRRORINTERCEPTED;
+}
+
+// Copies the request object on the remote
+int S3Mirror::remote_copy_object(struct req_state *_req_state, string copysource, bool dump_response)
+{
+  Aws::S3::Model::CopyObjectRequest copy_object_request;
+  copy_object_request.SetCopySource(copysource.c_str());
+  copy_object_request.SetBucket(_req_state->bucket_name);
+  copy_object_request.SetKey(_req_state->object->get_key().name);
+  copy_object_request.SetMetadataDirective(Aws::S3::Model::MetadataDirective::COPY);
+  
+  auto copy_object_outcome = this->client.CopyObject(copy_object_request);
+  if (!copy_object_outcome.IsSuccess()) 
+  {
+    auto err = copy_object_outcome.GetError();
+    dout(20) << "S3Mirror intercept_copy_object_rgwop: AWS Error " << 
+                err.GetExceptionName() << " " << err.GetMessage() << dendl;
+    return -1;
+  }
+
+  if (!dump_response)
+  {
+    return 0;
+  }
+
+  auto copy_object_result = copy_object_outcome.GetResult().GetCopyObjectResultDetails();
+
+  set_req_state_err(_req_state, 0);
+  dump_errno(_req_state);
+  end_header(_req_state, nullptr, "application/xml", CHUNKED_TRANSFER_ENCODING);
+  dump_start(_req_state);
+  _req_state->formatter->open_object_section_in_ns("CopyObjectResult", XMLNS_AWS_S3);
+  auto ceph_timepoint_last_modified = ceph::real_clock::from_double(
+    static_cast<double>(chrono::system_clock::to_time_t(copy_object_result.GetLastModified().UnderlyingTimestamp()))
+  );
+  dump_time(_req_state, "LastModified", &ceph_timepoint_last_modified);
+  string etag = copy_object_result.GetETag();
+  _req_state->formatter->dump_string("ETag", std::move(etag));
+  _req_state->formatter->close_section();
+  rgw_flush_formatter_and_reset(_req_state, _req_state->formatter);
+
+  return S3MIRRORINTERCEPTED;
+}
+
+
+// helper function to parse the range of a blocking request. See below the remote_download_object for more info
+// on the "blocking request"
+static bool parse_http_range(struct req_state* _req_state, off_t &start, off_t &end, long long total)
+{
+  string defaultVal = "";
+  string rs(_req_state->info.env->get("HTTP_RANGE", defaultVal.c_str()));
+
+  if (rs == defaultVal)
+    return false;
+
+  string ofs_str;
+  string end_str;
+
+  size_t pos = rs.find("bytes=");
+  if (pos == string::npos) {
+    pos = 0;
+    while (isspace(rs[pos]))
+      pos++;
+    int end = pos;
+    while (isalpha(rs[end]))
+      end++;
+    if (strncasecmp(rs.c_str(), "bytes", end - pos) != 0)
+      return 0;
+    while (isspace(rs[end]))
+      end++;
+    if (rs[end] != '=')
+      return 0;
+    rs = rs.substr(end + 1);
+  } else {
+    rs = rs.substr(pos + 6); /* size of("bytes=")  */
+  }
+  pos = rs.find('-');
+  if (pos == string::npos)
+    goto done;
+
+  ofs_str = rs.substr(0, pos);
+  end_str = rs.substr(pos + 1);
+  if (end_str.length()) {
+    end = atoll(end_str.c_str());
+    if (end < 0)
+      goto done;
+  }
+  else {
+    end = total - 1;
+  }
+
+  if (ofs_str.length()) {
+    start = atoll(ofs_str.c_str());
+  } else { // RFC2616 suffix-byte-range-spec
+    start = -end;
+    end = -1;
+  }
+
+  if (end >= 0 && end < start)
+    goto done;
+
+  return true;
+
+done:
+  return false;
+}
+
+
+// helper function to dump the headers of a blocking request. See below the remote_download_object for more info
+// on the "blocking request"
+static void dump_request_headers(struct req_state *_req_state, std::shared_ptr<S3MirrorDownloadTask> download_task, 
+                                off_t &start, off_t &end, long long &content_size)
+{
+  string bucket_name = _req_state->bucket_name;
+  string object_name = _req_state->object->get_key().name;
+  long long content_length = download_task->content_length;
+  bool partial_content = parse_http_range(_req_state, start, end, content_length);
+
+  if (end > content_length - 1 || end == 0) 
+  {
+    end = content_length - 1;
+  }
+
+  if (partial_content) 
+  {
+    content_size = (end+1)-start;
+  }
+  else 
+  {
+    content_size = content_length;
+    start = 0;
+    end = content_length - 1;
+  }
+  
+  if (partial_content)
+  {
+    set_req_state_err(_req_state, STATUS_PARTIAL_CONTENT);
+  }
+  else 
+  {
+    set_req_state_err(_req_state, 0);
+  }
+  dump_errno(_req_state);
+  dump_time_header(_req_state, "Last-Modified", download_task->last_modified);
+  dump_content_length(_req_state, content_size);
+  dump_header_if_nonempty(_req_state, "ETag", download_task->etag);
+  dump_header_if_nonempty(_req_state, "Cache-Control", download_task->cache_control);
+  dump_header_if_nonempty(_req_state, "Content-Disposition", download_task->content_disposition);
+  dump_header_if_nonempty(_req_state, "Content-Encoding", download_task->content_encoding);
+  dump_header_if_nonempty(_req_state, "Content-Language", download_task->content_language);
+  dump_header_if_nonempty(_req_state, "Content-Type", download_task->content_type);
+  dump_range(_req_state, start, end, content_length);
+  dump_time_header(_req_state, "Expires", download_task->expires);
+  end_header(_req_state);
+}
+
+// Downloads an object from the remote S3 endpoint. Also in parallel serves all requests
+// and writes the object locally to the ceph cluster
+int S3Mirror::remote_download_object(struct req_state* _req_state, bool dump_response)
+{
+  bool existed = false;
+  string bucket_name = _req_state->bucket_name;
+  string object_name = _req_state->object->get_key().name;
+  string download_task_id = "download_" + bucket_name + "_" + object_name;
+
+  std::shared_ptr<S3MirrorDownloadTask> download_task = this->sync_map.find_or_create_task<S3MirrorDownloadTask>(download_task_id, existed);
+  download_task->refs++;
+  if (!existed) 
+  {
+    download_task->user_id = _req_state->user->get_id();
+
+    // Since we need to download the object we create 
+    // this thread which is responsible *only* for writing the 
+    // object variables through a head request, downloading the object
+    // and afterwards, when the object is "cold" write it locally
+    // and remove the task from the syncmap
+    std::thread([this, download_task, bucket_name, object_name, download_task_id]() {
+
+      // Do a headobjectrequest so we can in parallel supply the blocking requests
+      // with the necessary variables to dump the corresponding headers
+      Aws::S3::Model::HeadObjectRequest head_object_request;
+      head_object_request.SetBucket(bucket_name);
+      head_object_request.SetKey(object_name);
+
+      auto head_object_outcome = this->client.HeadObject(head_object_request);
+
+      if (!head_object_outcome.IsSuccess())
+      {
+        download_task->ret = -1;
+        download_task->completed = true;
+        auto err = head_object_outcome.GetError();
+        dout(20) << "S3Mirror remote_download_object AWS Error " << 
+                    err.GetExceptionName() << " " << err.GetMessage() << dendl;
+        this->sync_map.remove_task(download_task_id);
+        return;
+      }
+
+      // write the mandatory object variables so the blocking
+      // requests waiting practically the object of this task 
+      // can begin dumping the headers
+      auto head_object_result = head_object_outcome.GetResult();
+
+      const long long total_length = head_object_result.GetContentLength();
+
+      download_task->expires = ceph::real_clock::from_double(
+        static_cast<double>(chrono::system_clock::to_time_t(head_object_result.GetExpires().UnderlyingTimestamp()))
+      );
+      download_task->last_modified = ceph::real_clock::from_double(
+        static_cast<double>(chrono::system_clock::to_time_t(head_object_result.GetLastModified().UnderlyingTimestamp()))
+      );
+      download_task->etag = head_object_result.GetETag();
+      download_task->cache_control = head_object_result.GetCacheControl();
+      download_task->content_disposition = head_object_result.GetContentDisposition();
+      download_task->content_encoding = head_object_result.GetContentEncoding();
+      download_task->content_language = head_object_result.GetContentLanguage();
+      download_task->content_type = head_object_result.GetContentType();
+
+      download_task->customStreamBuf = make_shared<S3MirrorDownloadTask::CustomStreamBuffer>(total_length);
+      auto stream_buf = download_task->customStreamBuf;
+      if (stream_buf->get_buffer() == nullptr)
+      {
+        //OOM?!
+        dout(20) << "S3Mirror remote_download_object: Error OOM?! " << dendl;
+        download_task->ret = -1;
+        download_task->completed = true;
+        this->sync_map.remove_task(download_task_id);
+        return;
+      }
+      // allocate the iostream and get the actual object
+      // this "new" allocation is internally deallocated 
+      // by the aws sdk when the result is getting out of scope
+      // In our case, when the shared_ptr will destruct
+      download_task->ioStream = new std::basic_iostream<char, std::char_traits<char>>(stream_buf.get());
+
+      // *ALWAYS* write last the downloadTask->content_length
+      // the blocking requests rely on this to start dumping the headers
+      // and the body
+      download_task->content_length = total_length;
+      
+      Aws::S3::Model::GetObjectRequest get_object_request;
+      get_object_request.SetBucket(bucket_name);
+      get_object_request.SetKey(object_name);
+      auto _custom_iostream_fn = [download_task](){ return download_task->ioStream;};
+      get_object_request.SetResponseStreamFactory(_custom_iostream_fn);
+
+      auto get_object_outcome = this->client.GetObject(get_object_request);
+
+      if (!get_object_outcome.IsSuccess()) {
+        auto err = get_object_outcome.GetError();
+        dout(1) << "S3Mirror remote_download_object: AWS Error " << 
+                    err.GetExceptionName() << " " << err.GetMessage() << dendl;
+        download_task->ret = -1;
+        download_task->completed = true;
+        this->sync_map.remove_task(download_task_id);
+        return;
+      }
+      
+      // We need to get a hold of the result so that AWS SDK 
+      // won't clear our iostream at the end of this function. 
+      // This is the reason we dont explicitly delete the download_task-ioStream
+      // PS: these "ugly" const_casts are mandatory to get the result with ownership
+      download_task->result.push_back(
+              const_cast<Aws::S3::Model::GetObjectResult&&>(
+                const_cast<Aws::S3::Model::GetObjectOutcome&>(get_object_outcome).GetResultWithOwnership()
+              ));
+      download_task->completed = true;
+
+      // Consecutive time windows that task refs are 0 
+      // mean that the object of the task is cold and we will 
+      // write locally and the smart pointers will
+      // take care releasing the allocated memory
+      unsigned int zero_refs_window_counter = 0;
+      while(zero_refs_window_counter != this->consecutive_zero_refs_window) {
+        std::this_thread::sleep_for(std::chrono::seconds(this->interval_zero_refs_check));
+        if (download_task->refs.load(std::memory_order_relaxed) != 0)
+          zero_refs_window_counter = 0;
+        else
+          zero_refs_window_counter++;
+      }
+      
+      // Write the object locally to the ceph cluster 
+      this->local_put_object(bucket_name, object_name, stream_buf->get_buffer(), total_length, download_task->user_id);
+      this->sync_map.remove_task(download_task_id);
+
+    }).detach();
+  }
+  
+  // This request will block until the above thread supplies
+  // the object headers. Afterwards in a polling fashion it 
+  // the body of the request
+  {
+    
+    bool has_dumped_headers = false;
+    off_t start, end;
+    long long total_bytes_to_write = 0;
+
+    while (!download_task->completed)
+    {
+      // If this is true it means that headers are not ready yet
+      if (download_task->content_length == 0)
+        continue;
+      
+      // Dump the headers to the client
+      if (!has_dumped_headers)
+      {
+        has_dumped_headers = true;
+        dump_request_headers(_req_state, download_task, start, end, total_bytes_to_write);
+      }
+      
+      // stream_buf shouldn't be nullptr but lets check
+      auto stream_buf = download_task->customStreamBuf;
+      long long bytes_written;
+      if (stream_buf == nullptr || !(bytes_written = stream_buf->get_unsafe_length())) {
+        continue;
+      }
+      
+      // Dump the avalaible body bytes to the client
+      if (total_bytes_to_write > 0 && bytes_written >= start + total_bytes_to_write) {
+        int availableBytesToWrite = (bytes_written >= start + total_bytes_to_write) ? total_bytes_to_write : bytes_written - start;    
+        dump_body(_req_state, &(stream_buf->get_buffer()[start]), availableBytesToWrite);
+        start += availableBytesToWrite;
+        total_bytes_to_write -= availableBytesToWrite;
+      }
+
+      // If we are all done here break the loop
+      if (has_dumped_headers && total_bytes_to_write == 0) {
+        break;
+      }
+    }
+
+    // If something was unsuccessful return negative
+    // and let radosgw handle this
+    if (download_task->ret < 0)
+    {
+      download_task->refs--;
+      return -1;
+    }
+
+    // Need to check for headers and dump the body
+    // as there is a change the request arrived
+    // when the actual download task is completed
+    // and is still available because it is "hot"
+    if (download_task->content_length > 0 && !has_dumped_headers)
+    {
+      has_dumped_headers = true;
+      dump_request_headers(_req_state, download_task, start, end, total_bytes_to_write);
+    }
+
+    auto stream_buf = download_task->customStreamBuf;
+    long long bytes_written;
+    if (stream_buf == nullptr || !(bytes_written = stream_buf->get_unsafe_length())) {
+      dout(20) << "S3Mirror remote_download_object: Error download task " << 
+                  "completed but stream_buf null or empty" << dendl;
+      download_task->refs--;
+      return -1;
+    }
+
+    if (has_dumped_headers && total_bytes_to_write > 0 && bytes_written >= start + total_bytes_to_write) {
+      int availableBytesToWrite = (bytes_written >= start + total_bytes_to_write) ? total_bytes_to_write : bytes_written - start;    
+      dump_body(_req_state, &(stream_buf->get_buffer()[start]), availableBytesToWrite);
+      start += availableBytesToWrite;
+      total_bytes_to_write -= availableBytesToWrite;
+    }
+    
+    // If our start does not match end
+    // it means that we missed some bytes of the 
+    // client request so report back and let 
+    // radosgw handle this
+    if (start != end + 1) {
+      dout(20) << "S3Mirror remote_download_object Error missed bytes" << dendl;
+      download_task->refs--;
+      return -1;
+    }
+    
+    // At this point we are all set flush and complete
+    RESTFUL_IO(_req_state)->flush();
+    RESTFUL_IO(_req_state)->complete_request();
+  }
+
+  download_task->refs--;
+  return S3MIRRORINTERCEPTED;
+}
+
+/* Region
+ * 
+ * S3Mirror intercept functions on existing rgw ops
+ * 
+ */
+
+// Check if this request should be mirrored by the remote S3 endpoint
+bool S3Mirror::should_intercept_req_state(struct req_state *_req_state)
+{
+  // if S3Mirror: bypass header exists it means that we wont mirror any rgw op
+  map<string, string, ltstr_nocase> http_env_map = _req_state->info.env->get_map();
+  map<string, string, ltstr_nocase>::iterator mirror_http_header = http_env_map.find("HTTP_S3MIRROR");
+  if (mirror_http_header != http_env_map.end() && mirror_http_header->second.compare("bypass") == 0)
+  {
+    dout(20) << "S3Mirror: not intercepting req_state bypass http header found" << dendl;
+    return false;
+  }
+
+  if (_req_state->op_type == RGW_OP_LIST_BUCKETS) {
+    return true;
+  }
+
+  if (!_req_state->bucket_name.empty() && !this->bucket_to_listen.empty() && this->bucket_to_listen.compare(_req_state->bucket_name) != 0)
+  {
+    dout(20) << "S3Mirror: not intercepting req_state bucket_to_listen doesn't match bucket_name" << dendl;
+    return false;
+  }
+
+  dout(20) << "S3Mirror: will intercept req_state for op type " << _req_state->op_type << dendl;
+
+  return true;
+}
+
+// Intercept the errors of rgw_process_authenticated 
+// The errors of Interest are -ERR_NO_SUCH_BUCKET and -ENOENT
+// These mean that the bucket or object does not exist locally and S3Mirror
+// needs to intercept either by downloading the remote object or by 
+// serving the request on its own
+int S3Mirror::intercept_rgw_process_error(int rgw_error, struct req_state *_req_state)
+{
+  auto req_state_type = _req_state->op_type;
+  int ret;
+  bool create_bucket = false, fetch_object = false;
+
+  if (rgw_error != -ERR_NO_SUCH_BUCKET && rgw_error != -ENOENT)
+  {
+    return -1;
+  }
+
+  switch (req_state_type)
+  {
+  case RGW_OP_PUT_OBJ:
+  case RGW_OP_LIST_BUCKET:
+  case RGW_OP_STAT_BUCKET:
+    // For these ops we need to create the bucket locally
+    create_bucket = rgw_error == -ERR_NO_SUCH_BUCKET;
+    break;
+  case RGW_OP_GET_OBJ:
+    // For these ops we need to download the object from the remote
+    create_bucket = rgw_error == -ERR_NO_SUCH_BUCKET;
+    fetch_object = create_bucket || rgw_error == -ENOENT;
+    break;
+  case RGW_OP_DELETE_OBJ:
+    // No need to download anything delegate this to remote S3
+    // and dump the response
+    return this->remote_delete_object(_req_state, true);
+  case RGW_OP_COPY_OBJ:
+    {
+      // No need to download anything delegate this to remote S3
+      // and dump the response
+      string copy_source = _req_state->src_bucket_name + "/" + _req_state->src_object->get_key().name;
+      return this->remote_copy_object(_req_state, copy_source, true);
+    }
+  default:
+    return -1;
+  }
+
+  if (create_bucket)
+  {
+    // if the op requires the bucket present create it
+    ret = this->local_create_bucket(_req_state->bucket_name, _req_state->user->get_id());
+
+    if (ret < 0 && ret != -ERR_BUCKET_EXISTS)
+    {
+      dout(20) << "S3Mirror: couldn't create local bucket although remote exists " << ret << dendl;
+      return ret;
+    }
+  }
+
+  if (fetch_object)
+  {
+    if (req_state_type == RGW_OP_GET_OBJ && _req_state->op == OP_HEAD)
+    {
+      // No need to download anything delegate this to remote S3
+      // and dump the response
+      return this->remote_head_object(_req_state, true);
+    }
+    
+    // download the object from the remote S3 endpoint
+    ret = this->remote_download_object(_req_state);
+    
+    if (ret < 0)
+    {
+      dout(20) << "S3Mirror: couldn't fetch the remote file to ceph" << dendl;
+      return ret;
+    }
+  }
+
+  return ret;
+}
+
+// Intercept the RGW_OP_COPY_OBJ request
+// should be called only by rgw_op.cc
+int S3Mirror::intercept_copy_object_rgwop(struct req_state *_req_state, string copysource) 
+{
+  return this->remote_copy_object(_req_state, copysource);
+}
+
+// Intercept the RGW_OP_INIT_MULTIPART request
+// *should be called only by rgw_op.cc*
+// We supply the upload_id from the remote S3 so 
+// the following request of the client will supply
+// us a valid, in regard with the remote S3, upload_id 
+int S3Mirror::intercept_init_multipart_upload_rgwop(struct req_state *_req_state, string& upload_id)
+{
+  string default_content_type = "";
+  string content_type = string(_req_state->info.env->get("HTTP_CONTENT_TYPE", default_content_type.c_str()));
+
+  Aws::S3::Model::CreateMultipartUploadRequest multipart_upload_request;
+  multipart_upload_request.SetBucket(_req_state->bucket_name);
+  multipart_upload_request.SetKey(_req_state->object->get_key().name);
+  if (content_type != "")
+    multipart_upload_request.SetContentType(content_type);
+  
+  auto multipart_upload_outcome = this->client.CreateMultipartUpload(multipart_upload_request);
+
+  if (!multipart_upload_outcome.IsSuccess())
+  {
+    auto err = multipart_upload_outcome.GetError();
+    dout(20) << "S3Mirror intercept_init_multipart_upload_rgwop: AWS Error " << 
+                  err.GetExceptionName() << " " << err.GetMessage() << dendl;
+    return -1;
+  }
+
+  upload_id = multipart_upload_outcome.GetResult().GetUploadId();
+  return 0;
+}
+
+// Intercept the RGW_OP_ABORT_MULTIPART request
+// *should be called only by rgw_op.cc*
+// Propagate the abort multipart to the remote
+int S3Mirror::intercept_abort_multipart_rgwop(struct req_state *_req_state, string upload_id)
+{
+  std::shared_ptr<Aws::Client::AsyncCallerContext> context = 
+        Aws::MakeShared<Aws::Client::AsyncCallerContext>("cache:context");
+  context->SetUUID(_req_state->object->get_key().name);
+  
+  Aws::S3::Model::AbortMultipartUploadRequest abort_multi_upload_request;
+  abort_multi_upload_request.SetBucket(_req_state->bucket_name);
+  abort_multi_upload_request.SetKey(_req_state->object->get_key().name);
+  abort_multi_upload_request.SetUploadId(upload_id);
+  
+  dout(20) << "S3Mirror abort multipart upload " << _req_state->object->get_key().name << " object to remote" << dendl;
+  this->client.AbortMultipartUploadAsync(abort_multi_upload_request, S3Mirror::async_abort_multipart_finished, context);
+  return 0;
+}
+
+// Intercept the RGW_OP_COMPLETE_MULTIPART request
+// *should be called only by rgw_op.cc*
+// This will utilize the async s3 client as we dont 
+// need to wait for all the other async part uploads
+// to finish
+int S3Mirror::intercept_complete_multipart_rgwop(struct req_state *_req_state, string upload_id, map<uint32_t, RGWUploadPartInfo> &obj_parts)
+{
+  string bucket_name = _req_state->bucket_name;
+  string object_name = _req_state->object->get_key().name;
+  
+  auto multipart_upload_ptr = std::make_shared<Aws::S3::Model::CompleteMultipartUploadRequest>();
+  multipart_upload_ptr->SetBucket(bucket_name);
+  multipart_upload_ptr->SetKey(object_name);
+  multipart_upload_ptr->SetUploadId(upload_id);
+
+  auto completed_multipart_upload = std::make_shared<Aws::S3::Model::CompletedMultipartUpload>();
+      
+  for (auto obj_iter = obj_parts.begin(); obj_iter != obj_parts.end(); ++obj_iter) {
+    std::shared_ptr<Aws::S3::Model::CompletedPart> completedPart = std::make_shared<Aws::S3::Model::CompletedPart>();
+    completedPart->SetPartNumber(obj_iter->second.num);
+    completedPart->SetETag(obj_iter->second.etag);
+    completed_multipart_upload->AddParts(*completedPart);
+  }
+
+  multipart_upload_ptr->SetMultipartUpload(*completed_multipart_upload); 
+
+  // Need to introduce this in thread so we can wait for all the object parts to upload
+  // and then issue the multipart complete
+  std::thread([this, bucket_name, object_name, multipart_upload_ptr, completed_multipart_upload]() {
+      string complete_multipart_task_id = "partialupload_" + bucket_name + object_name + "#";
+      std::shared_ptr<S3MirrorTask> task = this->sync_map.findPrefix<S3MirrorTask>(complete_multipart_task_id);
+      while (task != nullptr) {
+        task->wait();
+        task = this->sync_map.findPrefix<S3MirrorTask>(complete_multipart_task_id);
+      }
+
+      std::shared_ptr<Aws::Client::AsyncCallerContext> context = Aws::MakeShared<Aws::Client::AsyncCallerContext>("PutObjectAllocationTag");
+      context->SetUUID(bucket_name + object_name);
+
+      this->client.CompleteMultipartUploadAsync(*multipart_upload_ptr, S3Mirror::async_complete_multipart_finished, context);
+
+  }).detach();
+
+  return 0;
+}
+
+// Intercept the RGW_OP_PUT_OBJ request
+// *should be called only by rgw_op.cc*
+// This will utilize the async s3 client as we dont 
+// want the client to blocking waiting for the object
+// to upload on the remote S3 endpoint
+int S3Mirror::intercept_put_object_rgwop(struct req_state *_req_state, string multipart_upload_id, 
+              string multipart_part_str, int multipart_part_num, long long content_length, 
+              shared_ptr<Aws::IOStream> aws_body) 
+{
+  auto context = Aws::MakeShared<Aws::Client::AsyncCallerContext>("cache:context");
+  
+  if (!multipart_part_str.empty()) 
+  {
+    //NOTE: I would love to use `supplied_md5_b64` but s3fs does something weird here
+    Aws::Utils::ByteBuffer part_md5(Aws::Utils::HashingUtils::CalculateMD5(*aws_body));
+    string part_md5_b64 = Aws::Utils::HashingUtils::Base64Encode(part_md5);
+
+    Aws::S3::Model::UploadPartRequest upload_part_request;
+    upload_part_request.SetBucket(_req_state->bucket_name);
+    upload_part_request.SetKey(_req_state->object->get_key().name);
+    upload_part_request.SetPartNumber(multipart_part_num);
+    upload_part_request.SetUploadId(multipart_upload_id.c_str());
+    upload_part_request.SetContentLength(content_length);
+    upload_part_request.SetContentMD5(part_md5_b64);
+    upload_part_request.SetBody(aws_body);
+    
+    string task_id = "partialupload_" + _req_state->bucket_name + _req_state->object->get_key().name + "#" + multipart_part_str;
+    bool existed = false;
+    std::shared_ptr<S3MirrorTask> part_upload_task = this->sync_map.find_or_create_task<S3MirrorTask>(task_id, existed);
+    context->SetUUID(task_id);
+    dout(20) << "S3Mirror uploading part " << multipart_part_str << " object to remote" << dendl;
+    this->client.UploadPartAsync(upload_part_request, S3Mirror::async_put_part_finished, context);
+  } 
+  else
+  {
+    Aws::S3::Model::PutObjectRequest put_object_request;
+    put_object_request.SetBucket(_req_state->bucket_name);
+    put_object_request.SetKey(_req_state->object->get_key().name);
+    put_object_request.SetContentLength(content_length);
+    put_object_request.SetBody(aws_body);
+
+    dout(20) << "S3Mirror uploading single object to remote" << dendl;
+    this->client.PutObjectAsync(put_object_request, S3Mirror::async_put_object_finished, context);
+  }
+  return 0;
+}
+
+// Intercept the RGW_OP_LIST_BUCKETS request
+// *should be called only by rgw_op.cc*
+int S3Mirror::intercept_list_buckets_rgwop(struct req_state *_req_state, rgw::sal::RGWBucketList &_bucket_list)
+{
+  auto list_buckets_outcome = this->client.ListBuckets();
+
+  if (!list_buckets_outcome.IsSuccess())
+  {
+    auto err = list_buckets_outcome.GetError();
+    dout(20) << "S3Mirror intercept_list_buckets_rgwop: AWS Error " << 
+                err.GetExceptionName() << " " << err.GetMessage() << dendl;
+    return -1;
+  }
+
+  for (Aws::S3::Model::Bucket const &_aws_bucket : list_buckets_outcome.GetResult().GetBuckets())
+  {
+      string aws_bucket_name = _aws_bucket.GetName();
+      
+      if (!this->bucket_to_listen.empty() && this->bucket_to_listen.compare(aws_bucket_name) != 0) {
+          continue;
+      }
+
+      struct RGWBucketEnt rgw_bucket_ent;
+      rgw_bucket_ent.bucket.name = aws_bucket_name;
+      rgw_bucket_ent.creation_time = ceph::real_clock::from_time_t(
+                                        chrono::system_clock::to_time_t(
+                                          _aws_bucket.GetCreationDate().UnderlyingTimestamp()
+                                        ));
+
+      _bucket_list.add(std::unique_ptr<rgw::sal::RGWBucket>(new rgw::sal::RGWRadosBucket(this->store, rgw_bucket_ent, _req_state->user.get())));
+  }
+
+  return 0;
+}
+
+// Intercept the RGW_OP_LIST_BUCKET request
+// *should be called only by rgw_op.cc*
+int S3Mirror::intercept_list_objects_rgwop(struct req_state *_req_state, int max, vector<rgw_bucket_dir_entry> &_result, map<string, bool> &common_prefixes, rgw::sal::RGWBucket::ListParams &params, bool &is_truncated, rgw_obj_key &next_marker)
+{
+  _result.clear();
+
+  Aws::S3::Model::ListObjectsRequest list_objects_request;
+  list_objects_request.SetBucket(_req_state->bucket_name);
+  list_objects_request.SetMaxKeys(max);
+
+  if (!params.prefix.empty()){
+    list_objects_request.SetPrefix(params.prefix);
+  }
+
+  if (!params.delim.empty()) {
+    list_objects_request.SetDelimiter(params.delim);
+  }
+
+  if (!params.marker.empty()) {
+    list_objects_request.SetMarker(params.marker.name);
+  }
+
+  auto list_objects_outcome = this->client.ListObjects(list_objects_request);
+
+  if (!list_objects_outcome.IsSuccess())
+  {
+    auto err = list_objects_outcome.GetError();
+    dout(20) << "S3Mirror remote_list_bucket_objects: AWS Error " << 
+                err.GetExceptionName() << " " << err.GetMessage() << dendl;
+    return -1;
+  }
+
+  auto list_objects_result = list_objects_outcome.GetResult();
+
+  for (Aws::S3::Model::Object const &_aws_object : list_objects_result.GetContents())
+  {
+    rgw_bucket_dir_entry rgw_dir_entry = rgw_bucket_dir_entry();
+    rgw_dir_entry.exists = true;
+
+    auto key = cls_rgw_obj_key();
+    key.name = _aws_object.GetKey();
+    rgw_dir_entry.key = key;
+
+    rgw_dir_entry.meta = rgw_bucket_dir_entry_meta();
+    auto time = static_cast<double>(chrono::system_clock::to_time_t(_aws_object.GetLastModified().UnderlyingTimestamp()));
+    rgw_dir_entry.meta.mtime = ceph::real_clock::from_double(time);
+    rgw_dir_entry.meta.etag = _aws_object.GetETag();
+    boost::replace_all(rgw_dir_entry.meta.etag,"\"","");
+    rgw_dir_entry.meta.size = rgw_dir_entry.meta.accounted_size = _aws_object.GetSize();
+    _result.push_back(rgw_dir_entry);
+  }
+
+  for (Aws::S3::Model::CommonPrefix const &_aws_common_prefix : list_objects_result.GetCommonPrefixes())
+  {
+      common_prefixes[_aws_common_prefix.GetPrefix()] = true;
+  }
+
+  is_truncated = list_objects_result.GetIsTruncated();
+
+  if (is_truncated)
+      next_marker = list_objects_result.GetNextMarker();
+
+  return 0;
+}
+
+// Intercept the RGW_OP_LIST_BUCKET (V2) request
+// *should be called only by rgw_op.cc*
+int S3Mirror::intercept_list_objects_rgwop_V2(struct req_state *_req_state, int max, vector<rgw_bucket_dir_entry> &_result, map<string, bool> &common_prefixes, rgw::sal::RGWBucket::ListParams &params, bool &is_truncated, rgw_obj_key &next_marker, bool continuation_token_exists)
+{
+  _result.clear();
+
+  Aws::S3::Model::ListObjectsV2Request list_objects_request;
+  list_objects_request.SetBucket(_req_state->bucket_name);
+  list_objects_request.SetMaxKeys(max);
+
+  if (!params.prefix.empty()){
+    list_objects_request.SetPrefix(params.prefix);
+  }
+
+  if (!params.delim.empty()) {
+    list_objects_request.SetDelimiter(params.delim);
+  }
+
+  if (!params.marker.empty()) {
+    if (!continuation_token_exists) {
+      list_objects_request.SetStartAfter(params.marker.name);
+    }
+    else {
+      list_objects_request.SetContinuationToken(params.marker.name);
+    }
+  }
+  
+  auto list_objects_outcome = this->client.ListObjectsV2(list_objects_request);
+
+  if (!list_objects_outcome.IsSuccess())
+  {
+    auto err = list_objects_outcome.GetError();
+    dout(20) << "S3Mirror intercept_list_objects_rgwop_V2: AWS Error " << 
+                err.GetExceptionName() << " " << err.GetMessage() << dendl;
+    return -1;
+  }
+
+  auto list_objects_result = list_objects_outcome.GetResult();
+
+  for (Aws::S3::Model::Object const &_aws_object : list_objects_result.GetContents())
+  {
+    string _aws_object_key = _aws_object.GetKey();
+    
+    rgw_bucket_dir_entry rgw_dir_entry = rgw_bucket_dir_entry();
+    rgw_dir_entry.exists = true;
+
+    auto key = cls_rgw_obj_key();
+    key.name = _aws_object_key;
+    rgw_dir_entry.key = key;
+
+    rgw_dir_entry.meta = rgw_bucket_dir_entry_meta();
+    auto time = static_cast<double>(chrono::system_clock::to_time_t(_aws_object.GetLastModified().UnderlyingTimestamp()));
+    rgw_dir_entry.meta.mtime = ceph::real_clock::from_double(time);
+    rgw_dir_entry.meta.etag = _aws_object.GetETag();
+    boost::replace_all(rgw_dir_entry.meta.etag,"\"","");
+    rgw_dir_entry.meta.size = rgw_dir_entry.meta.accounted_size = _aws_object.GetSize();
+
+    _result.push_back(rgw_dir_entry);
+  }
+
+  for (Aws::S3::Model::CommonPrefix const &commonPrefix : list_objects_result.GetCommonPrefixes())
+  {
+    common_prefixes[commonPrefix.GetPrefix()] = true;
+  }
+
+  is_truncated = list_objects_result.GetIsTruncated();
+
+  if (is_truncated)
+    next_marker.name = list_objects_result.GetNextContinuationToken();
+  
+  return 0;
+}
+
+/* Region
+ * 
+ * S3Mirror local ops
+ * 
+ */
+// Reads an object that is locally stored and uploads it to the remote S3 endpoint
+int S3Mirror::local_upload_to_remote(string _object_name, string _bucket_name, rgw_user user_id)
+{
+  int ret = 0;
+  
+  Aws::S3::Model::PutObjectRequest put_object_request;
+  put_object_request.SetBucket(_bucket_name);
+  put_object_request.SetKey(_object_name);
+
+  const shared_ptr<Aws::IOStream> data = Aws::MakeShared<Aws::StringStream>("putobj", stringstream::in | stringstream::out | stringstream::binary);
+
+  auto _user = this->store->get_user(user_id);
+  S3MirrorGetObjRequest req(this->cxt, this->store, std::move(_user), _bucket_name, _object_name, &data);
+  ret = do_process_request(this->store, &req);
+  if (ret < 0)
+  {
+    dout(20) << "S3Mirror local_upload_to_remote: " << ret << dendl;
+    return ret;
+  }
+
+  put_object_request.SetBody(data);
+
+  auto put_object_outcome = this->client.PutObject(put_object_request);
+
+  if (!put_object_outcome.IsSuccess())
+  {
+    auto err = put_object_outcome.GetError();
+    dout(20) << "S3Mirror local_upload_to_remote: AWS Error " << 
+                err.GetExceptionName() << " " << err.GetMessage() << dendl;
+    return -1;
+  }
+
+  return 0;
+}
+
+// Creates a bucket locally
+int S3Mirror::local_create_bucket(string _bucket_name, rgw_user user_id)
+{
+    auto _user = this->store->get_user(user_id);
+    S3MirrorCreateBucketRequest req(this->cxt, this->store, std::move(_user), _bucket_name);
+    int ret = do_process_request(this->store, &req);
+    if (ret < 0)
+    {
+      dout(20) << "S3Mirror local_create_bucket: " << ret << dendl;
+    }
+    return req.get_ret();
+}
+
+// Downloads an object from the remote S3 endpoint and writes it locally
+int S3Mirror::local_put_object(string _bucket_name, string _object_name, char * object_buffer, 
+                              long long object_length, rgw_user user_id) 
+{
+  auto _user = this->store->get_user(user_id);
+  S3MirrorPutObjRequest req(this->cxt, this->store, std::move(_user), _bucket_name, _object_name, object_buffer, object_length);
+  int ret = do_process_request(this->store, &req);
+  if (ret < 0)
+    dout(20) << "S3Mirror local_put_object: " << ret << dendl;
+  return ret;
+}
+
+/* Region
+ * 
+ * Async void function finishers for
+ * Aws S3 Client
+ * 
+ */
+void S3Mirror::async_put_object_finished(const Aws::S3::S3Client* s3Client, 
+              const Aws::S3::Model::PutObjectRequest& request, 
+              const Aws::S3::Model::PutObjectOutcome& outcome,
+              const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context)
+{
+  if (!outcome.IsSuccess()) {
+    auto err = outcome.GetError();
+    dout(20) << "S3Mirror async_put_object_finished: AWS Error " << 
+                err.GetExceptionName() << " " << err.GetMessage() << dendl;
+  }
+}
+
+void S3Mirror::async_complete_multipart_finished(const Aws::S3::S3Client* s3Client, 
+              const Aws::S3::Model::CompleteMultipartUploadRequest& request, 
+              const Aws::S3::Model::CompleteMultipartUploadOutcome& outcome,
+              const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context)
+{
+  if (!outcome.IsSuccess()) { 
+    auto err = outcome.GetError();
+    dout(20) << "S3Mirror async_complete_multipart_finished: AWS Error " << 
+                err.GetExceptionName() << " " << err.GetMessage() << dendl;
+  }
+}
+
+void S3Mirror::async_put_part_finished(const Aws::S3::S3Client* s3Client, 
+              const Aws::S3::Model::UploadPartRequest& request, 
+              const Aws::S3::Model::UploadPartOutcome& outcome,
+              const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context)
+{
+  int ret = 0;
+  if (!outcome.IsSuccess()) {
+    auto err = outcome.GetError();
+    dout(20) << "S3Mirror async_complete_multipart_finished: AWS Error " << 
+                err.GetExceptionName() << " " << err.GetMessage() << dendl;
+    ret = -1;
+  }
+
+  auto mirror = S3Mirror::getInstance();
+  if (mirror == nullptr)
+    return;
+
+  auto part_upload_task = mirror->sync_map.find<S3MirrorTask>(context->GetUUID());
+  part_upload_task->notify(ret);
+  mirror->sync_map.remove_task(context->GetUUID());
+}
+
+void S3Mirror::async_abort_multipart_finished(const Aws::S3::S3Client* s3Client, 
+              const Aws::S3::Model::AbortMultipartUploadRequest& request, 
+              const Aws::S3::Model::AbortMultipartUploadOutcome& outcome,
+              const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context)
+{
+  if (!outcome.IsSuccess()) { 
+    auto err = outcome.GetError();
+    dout(20) << "S3Mirror async_abort_multipart_finished: AWS Error " << 
+                err.GetExceptionName() << " " << err.GetMessage() << dendl;
+  }
+}

--- a/src/rgw/rgw_s3_mirror.h
+++ b/src/rgw/rgw_s3_mirror.h
@@ -1,0 +1,233 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020-2021 IBM Research Europe <koutsovasilis.panagiotis1@ibm.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License version 2, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef RGW_S3_MIRROR_H
+#define RGW_S3_MIRROR_H
+
+#include "rgw/rgw_sal.h"
+
+#include <aws/core/Aws.h>
+#include <aws/core/auth/AWSCredentials.h>
+#include <aws/s3/S3Client.h>
+#include <aws/s3/model/GetObjectRequest.h>
+#include <aws/s3/model/CreateBucketRequest.h>
+#include <aws/s3/model/DeleteBucketRequest.h>
+#include <aws/s3/model/DeleteObjectRequest.h>
+#include <aws/s3/model/DeleteObjectsRequest.h>
+#include <aws/s3/model/PutObjectRequest.h>
+#include <aws/s3/model/ListObjectsRequest.h>
+#include <aws/s3/model/ListObjectsV2Request.h>
+#include <aws/s3/model/HeadBucketRequest.h>
+#include <aws/s3/model/HeadObjectRequest.h>
+#include <aws/s3/model/MultipartUpload.h>
+#include <aws/s3/model/CreateMultipartUploadRequest.h>
+#include <aws/s3/model/CompleteMultipartUploadRequest.h>
+#include <aws/s3/model/AbortMultipartUploadRequest.h>
+#include <aws/s3/model/CopyObjectRequest.h>
+#include <aws/s3/model/Object.h>
+#include <aws/core/utils/HashingUtils.h>
+#include <aws/s3/model/Bucket.h>
+#include <aws/s3/model/CreateMultipartUploadRequest.h>
+#include <aws/s3/model/CompleteMultipartUploadRequest.h>
+#include <aws/s3/model/UploadPartRequest.h>
+
+#include "rgw_s3_mirror_local.h"
+#include "rgw_s3_mirror_sync_tasks.h"
+#include "rgw_sal_rados.h"
+
+#define dout_subsys ceph_subsys_rgw
+#define dout_context g_ceph_context
+
+using namespace std;
+
+// this return code means that S3Mirror 
+// has dumped the appropriate headers and
+// body to the request and radosgw shouldn't
+// do any further actions
+#define S3MIRRORINTERCEPTED -1989
+
+// class that holds the remote S3 endpoint, access_key, access_secret
+class S3MirrorRemoteCredentials
+{
+public:
+    string endpoint;
+    string access_key;
+    string access_secret;
+
+    S3MirrorRemoteCredentials() : endpoint(""), access_key(""), access_secret("") {}
+};
+
+// singleton class, *should be initialized only once from rgw_main.cc*
+class S3Mirror
+{
+private:
+  S3Mirror() = default;
+  S3Mirror(S3Mirror const &) = delete;
+  S3Mirror &operator=(S3Mirror const &) = delete;
+
+  rgw::sal::RGWRadosStore *store;
+  CephContext *cxt;
+
+  static Aws::S3::S3Client get_s3_client(string _endpoint, string _access_key, string _access_secret)
+  {
+    Aws::Client::ClientConfiguration config;
+    config.region = Aws::String("");
+    config.verifySSL = false;
+    config.connectTimeoutMs = 60000;
+    config.requestTimeoutMs = 10000;
+    config.maxConnections = 1024;
+    config.endpointOverride = Aws::String(_endpoint);
+
+    if (_endpoint.find("https://") != std::string::npos)
+    {
+      config.scheme = Aws::Http::Scheme::HTTPS;
+    }
+    else
+    {
+      config.scheme = Aws::Http::Scheme::HTTP;
+    }
+
+    if (_access_secret.compare("") != 0)
+    {
+      Aws::Auth::AWSCredentials credentials;
+      credentials.SetAWSAccessKeyId(_access_key);
+      credentials.SetAWSSecretKey(_access_secret);
+      return Aws::S3::S3Client(credentials, config, Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
+    }
+
+    return Aws::S3::S3Client(config, Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
+  }
+
+public:
+  Aws::S3::S3Client client;
+  string bucket_to_listen;
+  S3MirrorSyncMap sync_map;
+  S3MirrorRemoteCredentials credentials;
+  unsigned int consecutive_zero_refs_window;
+  unsigned int interval_zero_refs_check;
+  static std::shared_ptr<S3Mirror> instance;
+
+  static void init(CephContext *cxt, rgw::sal::RGWRadosStore *store, string _endpoint,
+                    string _access_key, string _access_secret, string _bucket_to_listen)
+  {
+    if (!instance)
+    {
+      if (_bucket_to_listen.empty())
+        return;
+
+      Aws::SDKOptions options;
+      Aws::InitAPI(options);
+      instance.reset(new S3Mirror());
+      instance->store = store;
+      instance->cxt = cxt;
+      instance->credentials.endpoint = _endpoint;
+      instance->credentials.access_key = _access_key;
+      instance->credentials.access_secret = _access_secret;
+      instance->bucket_to_listen = _bucket_to_listen;
+      instance->client = get_s3_client(_endpoint, _access_key, _access_secret);
+      instance->consecutive_zero_refs_window = 3;
+      instance->interval_zero_refs_check = 10;
+
+      // Let's check if the bucket on the remote exists
+      if (instance->remote_head_bucket(_bucket_to_listen) < 0)
+      {
+        instance = nullptr;
+        dout(20) << "S3Mirror remote bucket does not exist" << dendl;
+        return;        
+      }
+
+      dout(20) << "S3Mirror initialized" << dendl;
+    }
+  }
+
+  static std::shared_ptr<S3Mirror> getInstance()
+  {
+    return instance;
+  }
+
+  static std::shared_ptr<S3Mirror> getInstanceForRequest(struct req_state *_req_state)
+  {
+    if (instance != nullptr && instance->should_intercept_req_state(_req_state)) {
+      return instance;
+    }
+    return nullptr;
+  }
+
+  rgw::sal::RGWRadosStore *getStore()
+  {
+    return this->store;
+  }
+
+  CephContext *getContext()
+  {
+    return this->cxt;
+  }
+  
+  bool should_intercept_req_state(struct req_state *_req_state);
+
+  // intercepting functions of rgw ops and rgw_process
+  int intercept_list_buckets_rgwop(struct req_state *_req_state, rgw::sal::RGWBucketList &_bucket_list);
+  int intercept_list_objects_rgwop(struct req_state *_req_state, int max, vector<rgw_bucket_dir_entry> &_result, 
+                                  map<string, bool> &common_prefixes, rgw::sal::RGWBucket::ListParams &params, 
+                                  bool &is_truncated, rgw_obj_key &next_marker);
+  int intercept_list_objects_rgwop_V2(struct req_state *_req_state, int max, vector<rgw_bucket_dir_entry> &_result, 
+                                      map<string, bool> &common_prefixes, rgw::sal::RGWBucket::ListParams &params, 
+                                      bool &is_truncated, rgw_obj_key &next_marker, bool continuation_toke_exists);
+  int intercept_rgw_process_error(int rgw_error, struct req_state *_req_state);
+  int intercept_pre_process_req_state(struct req_state *_req_state);
+  int intercept_copy_object_rgwop(struct req_state *_req_state, string copysource);
+  int intercept_put_object_rgwop(struct req_state *_req_state, string multipart_upload_id, string multipart_part_str, 
+                                int multipart_part_num, long long contentLength, shared_ptr<Aws::IOStream> awsbody);
+  int intercept_init_multipart_upload_rgwop(struct req_state *_req_state, string& upload_id);
+  int intercept_complete_multipart_rgwop(struct req_state *_req_state, string upload_id, map<uint32_t, RGWUploadPartInfo> &obj_parts);
+  int intercept_abort_multipart_rgwop(struct req_state *_req_state, string upload_id);
+
+  // remote S3 endpoint ops
+  int remote_head_object(struct req_state *_req_state, bool dump_response=false);    
+  int remote_create_bucket(struct req_state* _req_state, bool dump_response=false);
+  int remote_delete_object(struct req_state *_req_state, bool dump_response = false);
+  int remote_download_object(struct req_state *_req_state, bool dump_response = false);
+  int remote_copy_object(struct req_state *_req_state, string copysource, bool dump_response = false);
+  int remote_head_bucket(string bucket_name);
+
+  // local Ceph ops
+  int local_create_bucket(string _bucket_name, rgw_user user_id);
+  int local_put_object(string _bucket_name, string _object_name, char* object_buffer, long long object_length, rgw_user user_id);
+  int local_upload_to_remote(string _object_name, string bucket_name, rgw_user user_id);
+
+  
+  // async completion handlers for S3 async ops
+  static void async_complete_multipart_finished(const Aws::S3::S3Client* client, 
+                                                const Aws::S3::Model::CompleteMultipartUploadRequest& request, 
+                                                const Aws::S3::Model::CompleteMultipartUploadOutcome& outcome, 
+                                                const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context);
+
+  static void async_put_part_finished(const Aws::S3::S3Client* client, const Aws::S3::Model::UploadPartRequest& request, 
+                                      const Aws::S3::Model::UploadPartOutcome& outcome, 
+                                      const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context);
+
+  static void async_put_object_finished(const Aws::S3::S3Client* client, const Aws::S3::Model::PutObjectRequest& request, 
+                                        const Aws::S3::Model::PutObjectOutcome& outcome, 
+                                        const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context);
+
+  static void async_abort_multipart_finished(const Aws::S3::S3Client* client, const Aws::S3::Model::AbortMultipartUploadRequest& request, 
+                                            const Aws::S3::Model::AbortMultipartUploadOutcome& outcome, 
+                                            const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context);
+
+  static void GetObjectAsyncFinished(const Aws::S3::S3Client* client, const Aws::S3::Model::GetObjectRequest& request, 
+                                      const Aws::S3::Model::GetObjectOutcome& outcome, 
+                                      const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context);
+};
+
+#endif

--- a/src/rgw/rgw_s3_mirror.h
+++ b/src/rgw/rgw_s3_mirror.h
@@ -118,6 +118,12 @@ public:
   unsigned int interval_zero_refs_check;
   static std::shared_ptr<S3Mirror> instance;
 
+  static void shutdown()
+  {
+    Aws::SDKOptions options;
+    Aws::ShutdownAPI(options);
+  }
+
   static void init(CephContext *cxt, rgw::sal::RGWRadosStore *store, string _endpoint,
                     string _access_key, string _access_secret, string _bucket_to_listen)
   {

--- a/src/rgw/rgw_s3_mirror_local.cc
+++ b/src/rgw/rgw_s3_mirror_local.cc
@@ -1,0 +1,251 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020-2021 IBM Research Europe <koutsovasilis.panagiotis1@ibm.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License version 2, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "rgw_s3_mirror_local.h"
+
+int RGWHandler_S3Mirror::authorize(const DoutPrefixProvider *dpp)
+{
+    /* TODO: handle
+     *  1. subusers
+     *  2. anonymous access
+     *  3. system access
+     *  4. ?
+     *
+     *  Much or all of this depends on handling the cached authorization
+     *  correctly (e.g., dealing with keystone) at mount time.
+     */
+    s->perm_mask = RGW_PERM_FULL_CONTROL;
+
+    // populate the owner info
+    s->owner.set_id(s->user->get_id());
+    s->owner.set_name(s->user->get_display_name());
+
+    return 0;
+}
+
+int RGWHandler_S3Mirror::init_from_header(rgw::sal::RGWRadosStore *store, struct req_state *s)
+{
+    string req;
+    string first;
+
+    const char *req_name = s->relative_uri.c_str();
+    const char *p;
+
+    /* skip request_params parsing, rgw_file should not be
+     * seeing any */
+    if (*req_name == '?')
+    {
+        p = req_name;
+    }
+    else
+    {
+        p = s->info.request_params.c_str();
+    }
+
+    s->info.args.set(p);
+    s->info.args.parse();
+
+    if (*req_name != '/')
+        return 0;
+
+    req_name++;
+
+    if (!*req_name)
+        return 0;
+
+    req = req_name;
+    int pos = req.find('/');
+    if (pos >= 0)
+    {
+        first = req.substr(0, pos);
+    }
+    else
+    {
+        first = req;
+    }
+    
+    if (s->bucket_name.empty())
+    {
+        s->bucket_name = move(first);
+        if (pos >= 0)
+        {
+            
+            // XXX ugh, another copy
+            string encoded_obj_str = req.substr(pos + 1);
+            s->object = store->get_object(rgw_obj_key(encoded_obj_str, s->info.args.get("versionId")));
+        }
+    }
+    else
+    {
+        s->object = store->get_object(rgw_obj_key(req_name, s->info.args.get("versionId")));
+    }
+    return 0;
+}
+
+int S3MirrorRequest::read_permissions(RGWOp *op)
+{
+    /* bucket and object ops */
+    int ret = rgw_build_bucket_policies(this->store, get_state());
+    if (ret < 0)
+    {
+        if (ret == -ENODATA)
+            ret = -EACCES;
+    }
+    else if (!only_bucket())
+    {
+        /* object ops */
+        ret = rgw_build_object_policies(store, get_state(),
+                                        op->prefetch_data());
+        if (ret < 0)
+        {
+            if (ret == -ENODATA)
+                ret = -EACCES;
+        }
+    }
+    return ret;
+}
+
+int do_process_request(rgw::sal::RGWRadosStore *store, S3MirrorRequest *req)
+{
+  S3MirrorIO io;
+  int ret = 0;
+
+  /*
+    * invariant: valid requests are derived from RGWOp--well-formed
+    * requests should have assigned RGWRequest::op in their descendant
+    * constructor--if not, the compiler can find it, at the cost of
+    * a runtime check
+    */
+  RGWOp *op = (req->op) ? req->op : dynamic_cast<RGWOp *>(req);
+  if (!op)
+  {
+      return -EINVAL;
+  }
+
+  io.init(req->cct);
+
+  RGWEnv &rgw_env = io.get_env();
+
+  /* XXX
+    * until major refactoring of req_state and req_info, we need
+    * to build their RGWEnv boilerplate from the RGWLibRequest,
+    * pre-staging any strings (HTTP_HOST) that provoke a crash when
+    * not found
+    */
+
+  /* XXX for now, use "";  could be a legit hostname, or, in future,
+    * perhaps a tenant (Yehuda) */
+  rgw_env.set("HTTP_HOST", "");
+
+  /* XXX and -then- bloat up req_state with string copies from it */
+  struct req_state rstate(req->cct, &rgw_env, req->id);
+  struct req_state *s = &rstate;
+
+  // XXX fix this
+  s->cio = &io;
+
+  RGWObjectCtx rados_ctx(store, s); // XXX holds map
+
+  auto sysobj_ctx = store->svc()->sysobj->init_obj_ctx();
+  s->sysobj_ctx = &sysobj_ctx;
+
+  /* XXX and -then- stash req_state pointers everywhere they are needed */
+  ret = req->init(rgw_env, &rados_ctx, &io, s);
+  if (ret < 0)
+  {
+      goto done;
+  }
+
+  /* req is-a RGWOp, currently initialized separately */
+  ret = req->op_init();
+  if (ret < 0)
+  {
+      goto done;
+  }
+
+  /* now expected by rgw_log_op() */
+  rgw_env.set("REQUEST_METHOD", s->info.method);
+  rgw_env.set("REQUEST_URI", s->info.request_uri);
+  rgw_env.set("QUERY_STRING", "");
+
+  try
+  {
+    /* XXX authorize does less here then in the REST path, e.g.,
+    * the user's info is cached, but still incomplete */
+    ret = req->authorize(op);
+    if (ret < 0)
+    {
+      goto done;
+    }
+
+    /* FIXME: remove this after switching all handlers to the new
+    * authentication infrastructure. */
+    if (!s->auth.identity)
+    {
+      s->auth.identity = rgw::auth::transform_old_authinfo(s);
+    }
+
+    ret = req->read_permissions(op);
+    if (ret < 0)
+    {
+      goto done;
+    }
+
+    ret = op->init_processing();
+    if (ret < 0)
+    {
+      goto done;
+    }
+
+    ret = op->verify_op_mask();
+    if (ret < 0)
+    {
+      goto done;
+    }
+
+    ret = op->verify_permission();
+    if (ret < 0)
+    {
+      if ((!s->system_request) && (!s->auth.identity->is_admin_of(s->user->get_id())))
+      {
+        goto done;
+      }
+    }
+
+    ret = op->verify_params();
+    if (ret < 0)
+    {
+      goto done;
+    }
+
+    op->pre_exec();
+    op->execute();
+    op->complete();
+  }
+  catch (const ceph::crypto::DigestException &e)
+  {
+      
+  }
+
+done:
+  try
+  {
+    io.complete_request();
+  }
+  catch (rgw::io::Exception &e)
+  {
+  }
+
+  return (ret < 0 ? ret : s->err.ret);
+}

--- a/src/rgw/rgw_s3_mirror_local.h
+++ b/src/rgw/rgw_s3_mirror_local.h
@@ -1,0 +1,462 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020-2021 IBM Research Europe <koutsovasilis.panagiotis1@ibm.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License version 2, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef RGW_S3_MIRROR_LOCAL_H
+#define RGW_S3_MIRROR_LOCAL_H
+
+#include <string.h>
+
+#include "rgw_client_io.h"
+#include "rgw_rest.h"
+#include "rgw_rest_s3.h"
+#include "rgw_acl_s3.h"
+#include "rgw_sal_rados.h"
+#include "rgw_request.h"
+#include "rgw_op.h"
+#include "rgw_common.h"
+#include "services/svc_zone_utils.h"
+
+#include <aws/core/Aws.h>
+
+#define dout_subsys ceph_subsys_rgw
+#define dout_context g_ceph_context
+
+using namespace std;
+
+static inline string make_uri(const string &bucket_name, const string &object_name)
+{
+    string uri("/");
+    uri.reserve(bucket_name.length() + object_name.length() + 2);
+    uri += bucket_name;
+    uri += "/";
+    uri += object_name;
+    return uri;
+}
+
+// S3MirrorIO is derived from RGWLibIO customized for the needs of S3Mirror
+class S3MirrorIO : public rgw::io::BasicClient,
+    public rgw::io::Accounter
+{
+    RGWUserInfo user_info;
+    RGWEnv env;
+
+public:
+    S3MirrorIO()
+    {
+        get_env().set("HTTP_HOST", "");
+    }
+    explicit S3MirrorIO(const RGWUserInfo &_user_info)
+        : user_info(_user_info) {}
+
+    int init_env(CephContext *cct) override
+    {
+        env.init(cct);
+        env.set("HTTP_S3MIRROR", "bypass"); //bypass the S3 Mirror interception
+        return 0;
+    }
+
+    const RGWUserInfo &get_user()
+    {
+        return user_info;
+    }
+
+    int set_uid(rgw::sal::RGWRadosStore *store, const rgw_user &uid);
+
+    int write_data(const char *buf, int len);
+    int read_data(char *buf, int len);
+    int send_status(int status, const char *status_name);
+    int send_100_continue();
+    int complete_header();
+    int send_content_length(uint64_t len);
+
+    RGWEnv &get_env() noexcept override
+    {
+        return env;
+    }
+
+    size_t complete_request() override
+    { /* XXX */
+        return 0;
+    };
+
+    void set_account(bool) override
+    {
+        return;
+    }
+
+    uint64_t get_bytes_sent() const override
+    {
+        return 0;
+    }
+
+    uint64_t get_bytes_received() const override
+    {
+        return 0;
+    }
+
+}; /* S3MirrorIO */
+
+// RGWRESTMgr_S3Mirror is derived from RGWRESTMgr_Lib customized for the needs of S3Mirror
+class RGWRESTMgr_S3Mirror : public RGWRESTMgr
+{
+public:
+    RGWRESTMgr_S3Mirror() {}
+    ~RGWRESTMgr_S3Mirror() override {}
+};
+
+// RGWHandler_S3Mirror is derived from RGWHandler_Lib customized for the needs of S3Mirror
+class RGWHandler_S3Mirror : public RGWHandler
+{
+    friend class RGWRESTMgr_S3Mirror;
+
+public:
+    int authorize(const DoutPrefixProvider *dpp) override;
+
+    RGWHandler_S3Mirror() {}
+    ~RGWHandler_S3Mirror() override {}
+    static int init_from_header(rgw::sal::RGWRadosStore *_store, struct req_state *s);
+};
+
+// S3MirrorRequest is derived from RGWLibRequest customized for the needs of S3Mirror
+class S3MirrorRequest : public RGWRequest,
+    public RGWHandler_S3Mirror
+{
+private:
+    std::unique_ptr<rgw::sal::RGWUser> tuser;
+public:
+    CephContext *cct;
+    rgw::sal::RGWRadosStore *store;
+    boost::optional<RGWSysObjectCtx> sysobj_ctx;
+
+    /* unambiguiously return req_state */
+    inline struct req_state *get_state() {
+        return this->RGWRequest::s;
+    }
+
+    S3MirrorRequest(CephContext *_cct, std::unique_ptr<rgw::sal::RGWUser> _user, rgw::sal::RGWRadosStore *_store)
+        : RGWRequest(_store->getRados()->get_new_req_id()), tuser(std::move(_user)),
+        cct(_cct), store(_store)
+    {
+    }
+
+    int postauth_init() override {
+        return 0;
+    }
+
+    /* descendant equivalent of *REST*::init_from_header(...):
+     * prepare request for execute()--should mean, fixup URI-alikes
+     * and any other expected stat vars in local req_state, for
+     * now */
+    virtual int header_init() = 0;
+
+    /* descendant initializer responsible to call RGWOp::init()--which
+     * descendants are required to inherit */
+    virtual int op_init() = 0;
+
+    using RGWHandler::init;
+
+    int init(const RGWEnv &rgw_env, RGWObjectCtx *rados_ctx,
+        S3MirrorIO *io, struct req_state *_s)
+    {
+
+        RGWRequest::init_state(_s);
+        RGWHandler::init(rados_ctx->get_store(), _s, io);
+
+        sysobj_ctx.emplace(store->svc()->sysobj);
+
+        get_state()->obj_ctx = rados_ctx;
+        get_state()->sysobj_ctx = &(sysobj_ctx.get());
+        get_state()->req_id = store->svc()->zone_utils->unique_id(id);
+        get_state()->trans_id = store->svc()->zone_utils->unique_trans_id(id);
+        get_state()->bucket_tenant = tuser->get_tenant();
+        get_state()->set_user(tuser);
+
+        int ret = header_init();
+        if (ret == 0)
+        {
+            ret = init_from_header(rados_ctx->get_store(), _s);
+        }
+        return ret;
+    }
+
+    virtual bool only_bucket() = 0;
+
+    int read_permissions(RGWOp *op) override;
+
+};
+
+// Request to write an object locally by reading an Aws::IOStream
+class S3MirrorPutObjRequest : public S3MirrorRequest,
+    public RGWPutObj /* RGWOp */
+{
+public:
+    const string &bucket_name;
+    const string &obj_name;
+    size_t bytes_written;
+    char * buffer;
+    uint64_t content_length;
+
+    S3MirrorPutObjRequest(CephContext *_cct, rgw::sal::RGWRadosStore *_store,
+        std::unique_ptr<rgw::sal::RGWUser> _user, const string &_bname, const string &_oname,
+        char * object_buffer, long long object_length)
+        : S3MirrorRequest(_cct, std::move(_user), _store), bucket_name(_bname), obj_name(_oname),
+        bytes_written(0), buffer(object_buffer), content_length(object_length)
+    {
+        op = this;
+    }
+
+    bool only_bucket() override {
+        return true;
+    }
+
+    int op_init() override
+    {
+        // assign store, s, and dialect_handler
+        RGWObjectCtx *rados_ctx = static_cast<RGWObjectCtx *>(get_state()->obj_ctx);
+        // framework promises to call op_init after parent init
+        ceph_assert(rados_ctx);
+        RGWOp::init(rados_ctx->get_store(), get_state(), this);
+        op = this; // assign self as op: REQUIRED
+
+        int rc = valid_s3_object_name(obj_name);
+        if (rc != 0)
+            return rc;
+
+        return 0;
+    }
+
+    int header_init() override
+    {
+        struct req_state *s = get_state();
+        s->info.method = "PUT";
+        s->op = OP_PUT;
+
+        /* XXX derp derp derp */
+        string uri = make_uri(bucket_name, obj_name);
+        s->relative_uri = uri;
+        s->info.request_uri = uri; // XXX
+        s->info.effective_uri = uri;
+        s->info.request_params = "";
+        s->info.domain = ""; /* XXX ? */
+
+        /* XXX required in RGWOp::execute() */
+        s->content_length = content_length;
+
+        return 0;
+    }
+
+    int get_params() override
+    {
+        struct req_state *s = get_state();
+        RGWAccessControlPolicy_S3 s3policy(s->cct);
+        /* we don't have (any) headers, so just create canned ACLs */
+        int ret = s3policy.create_canned(s->owner, s->bucket_owner, s->canned_acl);
+        policy = s3policy;
+        return ret;
+    }
+
+    int get_data(ceph::bufferlist &_bl) override
+    {
+      // std::this_thread::sleep_for(std::chrono::seconds(10));
+      struct req_state *s = get_state();
+      size_t cl;
+      uint64_t chunk_size = s->cct->_conf->rgw_max_chunk_size;
+      cl = content_length - ofs;
+      if (cl > chunk_size)
+        cl = chunk_size;
+
+      _bl.append(&(this->buffer[bytes_written]), cl);
+
+      bytes_written += cl;
+      return cl;
+    }
+
+    void send_response() override {}
+
+    int verify_params() override
+    {
+        if (content_length > cct->_conf->rgw_max_put_size)
+            return -ERR_TOO_LARGE;
+        return 0;
+    }
+
+    ceph::bufferlist *get_attr(const string &k)
+    {
+        auto iter = attrs.find(k);
+        return (iter != attrs.end()) ? &(iter->second) : nullptr;
+    }
+
+}; /* S3MirrorPutObjRequest */
+
+// Request to read a local object and write to an Aws::IOStream
+class S3MirrorGetObjRequest : public S3MirrorRequest,
+    public RGWGetObj /* RGWOp */
+{
+public:
+    const string &bucket_name;
+    const string &obj_name;
+    const shared_ptr<Aws::IOStream> *body_stream;
+    uint64_t content_length;
+
+    S3MirrorGetObjRequest(CephContext *_cct, rgw::sal::RGWRadosStore *_store,
+        std::unique_ptr<rgw::sal::RGWUser> _user, const string &_bname, const string &_oname,
+        const shared_ptr<Aws::IOStream> *_body_stream)
+        : S3MirrorRequest(_cct, std::move(_user), _store), bucket_name(_bname), obj_name(_oname),
+        body_stream(_body_stream)
+    {
+        op = this;
+
+        /* fixup RGWGetObj (already know range parameters) */
+        RGWGetObj::range_parsed = false;
+        RGWGetObj::get_data = true; // XXX
+        RGWGetObj::partial_content = false;
+    }
+
+    bool only_bucket() override {
+        return false;
+    }
+
+    int op_init() override
+    {
+        // assign store, s, and dialect_handler
+        RGWObjectCtx *rados_ctx = static_cast<RGWObjectCtx *>(get_state()->obj_ctx);
+        // framework promises to call op_init after parent init
+        ceph_assert(rados_ctx);
+        RGWOp::init(rados_ctx->get_store(), get_state(), this);
+        op = this; // assign self as op: REQUIRED
+        return 0;
+    }
+
+    int header_init() override
+    {
+
+        struct req_state *s = get_state();
+        s->info.method = "GET";
+        s->op = OP_GET;
+
+        /* XXX derp derp derp */
+        string uri = make_uri(bucket_name, obj_name);
+        s->relative_uri = uri;
+        s->info.request_uri = uri; // XXX
+        s->info.effective_uri = uri;
+        s->info.request_params = "";
+        s->info.domain = ""; /* XXX ? */
+
+        return 0;
+    }
+
+    int get_params() override
+    {
+        return 0;
+    }
+
+    int send_response_data(ceph::buffer::list &bl, off_t bl_off,
+        off_t bl_len) override
+    {
+        for (auto &bp : bl.buffers())
+        {
+            /* if for some reason bl_off indicates the start-of-data is not at
+            * the current buffer::ptr, skip it and account */
+            if (bl_off > bp.length())
+            {
+                bl_off -= bp.length();
+                continue;
+            }
+
+            (*this->body_stream)->write(bp.c_str(), bp.length());
+        }
+        return 0;
+    }
+
+    int send_response_data_error() override
+    {
+        /* S3 implementation just sends nothing--there is no side effect
+     * to simulate here */
+        return 0;
+    }
+}; /* S3MirrorGetObjRequest */
+
+
+// Request to create a bucket locally  
+class S3MirrorCreateBucketRequest : public S3MirrorRequest,
+    public RGWCreateBucket /* RGWOp */
+{
+public:
+    const string &bucket_name;
+
+    S3MirrorCreateBucketRequest(CephContext *_cct, rgw::sal::RGWRadosStore *_store,
+        std::unique_ptr<rgw::sal::RGWUser> _user, string &_bname)
+        : S3MirrorRequest(_cct, std::move(_user), _store), bucket_name(_bname)
+    {
+        op = this;
+    }
+
+    bool only_bucket() override {
+        return false;
+    }
+
+    int read_permissions(RGWOp *op_obj) override
+    {
+        /* we ARE a 'create bucket' request (cf. rgw_rest.cc, ll. 1305-6) */
+        return 0;
+    }
+
+    int op_init() override
+    {
+        // assign store, s, and dialect_handler
+        RGWObjectCtx *rados_ctx = static_cast<RGWObjectCtx *>(get_state()->obj_ctx);
+        // framework promises to call op_init after parent init
+        ceph_assert(rados_ctx);
+        RGWOp::init(rados_ctx->get_store(), get_state(), this);
+        op = this; // assign self as op: REQUIRED
+        return 0;
+    }
+
+    int header_init() override
+    {
+
+        struct req_state *s = get_state();
+        s->info.method = "PUT";
+        s->op = OP_PUT;
+
+        string uri = "/" + bucket_name;
+        /* XXX derp derp derp */
+        s->relative_uri = uri;
+        s->info.request_uri = uri; // XXX
+        s->info.effective_uri = uri;
+        s->info.request_params = "";
+        s->info.domain = ""; /* XXX ? */
+
+        return 0;
+    }
+
+    int get_params() override
+    {
+        struct req_state *s = get_state();
+        RGWAccessControlPolicy_S3 s3policy(s->cct);
+        /* we don't have (any) headers, so just create canned ACLs */
+        int ret = s3policy.create_canned(s->owner, s->bucket_owner, s->canned_acl);
+        policy = s3policy;
+        return ret;
+    }
+
+    void send_response() override
+    {
+        /* TODO: something (maybe) */
+    }
+}; /* S3MirrorCreateBucketRequest */
+
+int do_process_request(rgw::sal::RGWRadosStore *store, S3MirrorRequest *req);
+
+#endif

--- a/src/rgw/rgw_s3_mirror_sync_tasks.h
+++ b/src/rgw/rgw_s3_mirror_sync_tasks.h
@@ -1,0 +1,181 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020-2021 IBM Research Europe <koutsovasilis.panagiotis1@ibm.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License version 2, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <vector>
+#include <map>
+
+#include "rgw_sal.h"
+#include "common/ceph_time.h"
+
+#include <aws/core/Aws.h>
+
+// Base S3MirrorTask that is used only for synchronization between 
+// other tasks
+class S3MirrorTask
+{
+private:
+  std::mutex task_mutex;
+  std::condition_variable condVar;
+
+public:
+    bool completed = false;
+    int ret = 0;
+    
+    S3MirrorTask() {};
+    ~S3MirrorTask() {};
+
+    int wait() {
+        std::unique_lock<std::mutex> lck(task_mutex);
+        condVar.wait(lck, [this]{ return this->completed; });
+        return ret;
+    }
+
+    int waitfor(std::chrono::milliseconds dur, bool& cv_status) {
+        std::unique_lock<std::mutex> lck(task_mutex);
+        cv_status = condVar.wait_for(lck, dur, [this]{ return this->completed; });
+        return ret;
+    }
+
+    void notify(int ret) {
+        {
+            std::lock_guard<std::mutex> lck(task_mutex);
+            completed = true;
+            this->ret = ret;
+        }
+        condVar.notify_all();
+    }
+};
+
+// S3MirrorDownloadTask inherits S3MirrorTask and carries further variables 
+// that regard downloading an object through AWS S3 client
+class S3MirrorDownloadTask : public S3MirrorTask, public std::enable_shared_from_this<S3MirrorTask>
+{
+public:
+  class CustomStreamBuffer : public std::streambuf
+  {
+    private:
+      std::unique_ptr<char[]> bodybuffer;
+      long long length =0;
+    public:
+      CustomStreamBuffer(long long size) 
+      {
+        
+        bodybuffer.reset(new char[size]);
+
+        this->pubsetbuf(&(bodybuffer[0]), size);
+        this->setg(0, 0, 0);
+        this->setp(&(bodybuffer[0]), &(bodybuffer[size-1]));
+      }
+      
+      streamsize xsputn (const char* s, streamsize n) override {
+        memcpy(&(bodybuffer[length]), s, n);
+        length += n;
+        return n;
+      }
+
+      char *get_buffer() {
+        return &(bodybuffer[0]);
+      }
+
+      long long get_unsafe_length()
+      {
+        return length;
+      }
+  };
+  // necessary to write the object locally
+  rgw_user user_id;
+  // object hotness ref counter
+  std::atomic<int> refs = 0;
+  // vector with result to keep the iostream alive
+  std::vector<Aws::S3::Model::GetObjectResult> result;
+  std::shared_ptr<CustomStreamBuffer> customStreamBuf = nullptr;
+  std::basic_iostream<char, std::char_traits<char>>  *ioStream;
+  // S3 object properties to dump the headers
+  ceph::time_detail::real_clock::time_point expires;
+  ceph::time_detail::real_clock::time_point last_modified;
+  string etag = "";
+  string cache_control = "";
+  string content_disposition = "";
+  string content_encoding = "";
+  string content_language = "";
+  string content_type = "";
+  long long content_length = 0;
+};
+
+// S3MirrorSyncMap is used for searching existing S3MirrorTasks so 
+// future S3MirrorTasks can wait for them to finish 
+class S3MirrorSyncMap 
+{
+private:
+    std::shared_mutex download_lock;
+    std::map<string, std::shared_ptr<S3MirrorTask>> download_map;
+
+public:
+    template<typename T>
+    std::shared_ptr<T> find_or_create_task(string taskName, bool &existed)
+    {
+        std::unique_lock wl(download_lock);
+        auto iter = download_map.find(taskName);
+        if (iter != download_map.end())
+        { 
+            existed = true;
+            return std::static_pointer_cast<T>(iter->second);
+        }
+        existed = false;
+        auto tmpTask = std::make_shared<T>();
+        auto pair = download_map.insert(std::make_pair(taskName, std::move(tmpTask)));
+        existed = false;
+        return std::static_pointer_cast<T>(pair.first->second);
+    }
+
+    template<typename T>
+    std::shared_ptr<T> find(string taskName)
+    {
+        std::shared_lock rl(download_lock);
+        auto iter = download_map.find(taskName);
+        if (iter == download_map.end())
+        { 
+            return nullptr;
+        }
+
+        return std::static_pointer_cast<T>(iter->second);
+    }
+
+    template<typename T>
+    std::shared_ptr<T> findPrefix(string prefix)
+    {
+        std::shared_lock rl(download_lock);
+        auto iter = download_map.lower_bound(prefix);
+        if (iter == download_map.end())
+        { 
+            return nullptr;
+        }
+
+        return std::static_pointer_cast<T>(iter->second);
+    }
+
+    void remove_task(string taskName) 
+    {
+        std::unique_lock wl(download_lock);
+        std::map<string, std::shared_ptr<S3MirrorTask>>::iterator iter = download_map.find(taskName);
+        if (iter != download_map.end())
+        { 
+            download_map.erase(iter);
+        }
+    }
+
+};

--- a/src/rgw/rgw_s3_mirror_sync_tasks.h
+++ b/src/rgw/rgw_s3_mirror_sync_tasks.h
@@ -105,8 +105,8 @@ public:
   std::shared_ptr<CustomStreamBuffer> customStreamBuf = nullptr;
   std::basic_iostream<char, std::char_traits<char>>  *ioStream;
   // S3 object properties to dump the headers
-  ceph::time_detail::real_clock::time_point expires;
-  ceph::time_detail::real_clock::time_point last_modified;
+  real_clock::time_point expires;
+  real_clock::time_point last_modified;
   string etag = "";
   string cache_control = "";
   string content_disposition = "";


### PR DESCRIPTION
This PR implements S3Mirror capability for RadosGW. S3Mirror transforms Ceph, through RadosGW, to an intermediate cache that stands between a remote S3 COS and transparently serves the workload at hand. We found that having such an intermediate cache can significantly improve the data locality and by extension provide performance gains.

Some high-level key features of this PR are the following:

- Serve on the fly the clients when downloading objects from the remote S3 COS (cache-miss)
- Take action only when RadosGW reports an error because the object is missing (cache-miss)
- Asynchronously reflect changes to the remote S3 COS 
- Reflect changes to the remote S3 COS even if the object is not locally present, e.g. delete of an object 
- Introduce a simple hotness accounting mechanism downloaded objects before writing them locally. In this way can serve imminent short-term requests from in-memory and not thrash our OSDs because of increased concurrent writes and reads.

We validated the operation of this PR with TensorFlow2 (TF2) and [Resnet](https://github.com/tensorflow/models/tree/master/official/vision/image_classification/resnet):
```
1 epoch (cold cache): 3697s
2 epoch (hot cache): 1633s
3 epoch (hot cache): 1634s

1 epoch (no cache): 8738s
2 epoch (no cache): 8546s
3 epoch (no cache): 8774s
```

Except for the significant gains we observe for epochs 2+ because our cache is hot and contains locally all objects, we even observe significant gains for epoch 1, where the cache is cold. This happens because this PR does only a single request to fetch the object where the (TF2) built-in s3 access mechanism dissects and fetches the objects in multiple small chunks and the overhead of the HTTP request becomes measurable. On the contrary, when the objects are particularly small (in the scale of KB), as it for the case of [MLPerf Object Detection](https://github.com/mlperf/training/tree/master/object_detection), for the cold cache we observe an 8% overhead but again for the remaining training epochs, where the cache is hot, we do observe performance gains.

Moreover, this PR is cloud-computing ready as it is 100% compatible and tested with [Rook](https://rook.io/). This was done in the context of [Dataset Lifecycle Framework](https://github.com/IBM/dataset-lifecycle-framework) as a cache-plugin where Ceph, with this PR in place, is deployed on the fly and acts like the aforementioned intermediate cache.

Please have a look and provide feedback on this PR.

PS: this PR requires the [AWS Library](https://github.com/aws/aws-sdk-cpp) to be installed system-wide. We tried to introduce it as a git submodule and include it through the current CMake procedure of Ceph but the project is not compatible, as is (more details [here](https://github.com/aws/aws-sdk-cpp/issues/1294)). However, we are willing to try and support this if this PR is found to be interesting.

Signed-off: Panagiotis Koutsovasilis <<koutsovasilis.panagiotis1@ibm.com>>
Signed-off: Christian Pinto <<christian.pinto@ibm.com>>

**Acknowledgment**
This project has received funding from the European Union's Horizon 2020 research and innovation programme under grant agreement No 825061, [H2020 Evolve](https://www.evolve-h2020.eu/).
