### PR TITLE
test/librados: fix endian bugs in checksum test cases

### DIFF
--- a/src/test/librados/c_read_operations.cc
+++ b/src/test/librados/c_read_operations.cc
@@ -381,7 +381,7 @@ TEST_F(CReadOpsTest, Checksum) {
 
   {
     rados_read_op_t op = rados_create_read_op();
-    uint64_t init_value = -1;
+    ceph_le64 init_value = init_le64(-1);
     rados_read_op_checksum(op, LIBRADOS_CHECKSUM_TYPE_XXHASH64,
 			   reinterpret_cast<char *>(&init_value),
 			   sizeof(init_value), 0, len, 0, NULL, 0, NULL);
@@ -390,8 +390,8 @@ TEST_F(CReadOpsTest, Checksum) {
   }
 
   {
-    uint32_t init_value = -1;
-    uint32_t crc[2];
+    ceph_le32 init_value = init_le32(-1);
+    ceph_le32 crc[2];
     rados_read_op_t op = rados_create_read_op();
     rados_read_op_checksum(op, LIBRADOS_CHECKSUM_TYPE_CRC32C,
 			   reinterpret_cast<char *>(&init_value),
@@ -407,7 +407,7 @@ TEST_F(CReadOpsTest, Checksum) {
   }
 
   {
-    uint32_t init_value = -1;
+    ceph_le32 init_value = init_le32(-1);
     int rval;
     rados_read_op_t op = rados_create_read_op();
     rados_read_op_checksum(op, LIBRADOS_CHECKSUM_TYPE_XXHASH32,
@@ -419,8 +419,8 @@ TEST_F(CReadOpsTest, Checksum) {
   }
 
   {
-    uint32_t init_value = -1;
-    uint32_t crc[3];
+    ceph_le32 init_value = init_le32(-1);
+    ceph_le32 crc[3];
     int rval;
     rados_read_op_t op = rados_create_read_op();
     rados_read_op_checksum(op, LIBRADOS_CHECKSUM_TYPE_CRC32C,

--- a/src/test/librados/io.cc
+++ b/src/test/librados/io.cc
@@ -111,8 +111,8 @@ TEST_F(LibRadosIo, Checksum) {
 
   uint32_t expected_crc = ceph_crc32c(-1, reinterpret_cast<const uint8_t*>(buf),
                                       sizeof(buf));
-  uint32_t init_value = -1;
-  uint32_t crc[2];
+  ceph_le32 init_value = init_le32(-1);
+  ceph_le32 crc[2];
   ASSERT_EQ(0, rados_checksum(ioctx, "foo", LIBRADOS_CHECKSUM_TYPE_CRC32C,
 			      reinterpret_cast<char*>(&init_value),
 			      sizeof(init_value), sizeof(buf), 0, 0,

--- a/src/test/librados/misc_cxx.cc
+++ b/src/test/librados/misc_cxx.cc
@@ -707,11 +707,11 @@ public:
 
 typedef ::testing::Types<
     LibRadosChecksumParams<LIBRADOS_CHECKSUM_TYPE_XXHASH32,
-			   Checksummer::xxhash32, uint32_t>,
+			   Checksummer::xxhash32, ceph_le32>,
     LibRadosChecksumParams<LIBRADOS_CHECKSUM_TYPE_XXHASH64,
-			   Checksummer::xxhash64, uint64_t>,
+			   Checksummer::xxhash64, ceph_le64>,
     LibRadosChecksumParams<LIBRADOS_CHECKSUM_TYPE_CRC32C,
-			   Checksummer::crc32c, uint32_t>
+			   Checksummer::crc32c, ceph_le32>
   > LibRadosChecksumTypes;
 
 TYPED_TEST_SUITE(LibRadosChecksum, LibRadosChecksumTypes);


### PR DESCRIPTION
We're seeing test failures when running rados/test.sh in Teuthology
on a big-endian platform (IBM Z).  These are all related to calls
to the checksum operations, which expect little-endian inputs and
outputs, but are in many places called with native-endian types
from the test code.

One test case, LibRadosAio::RoundTrip3 in aio.cc, already uses
ceph_le types to address this problem, and this test actually
completes successfully on IBM Z.  This patch changes the other
test case performing checksum operations accordingly.

With this patch in place, rados/test.sh now completed successfully.

Fixes: https://tracker.ceph.com/issues/47516

Signed-off-by: Ulrich Weigand <ulrich.weigand@de.ibm.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
