### PR TITLE
octopus: mgr: PyModuleRegistry::unregister_client() can run endlessly

### DIFF
--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -193,7 +193,8 @@ public:
     auto itp = clients.equal_range(std::string(name));
     for (auto it = itp.first; it != itp.second; ++it) {
       if (it->second == addrs) {
-        it = clients.erase(it);
+        clients.erase(it);
+        return;
       }
     }
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47462

---

backport of https://github.com/ceph/ceph/pull/36987
parent tracker: https://tracker.ceph.com/issues/47329

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh