### PR TITLE
rgw: Add a configurable request summary to rgw logs

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -757,6 +757,15 @@ Logging Settings
 :Type: Boolean
 :Default: ``false``
 
+``rgw log request summary``
+
+:Description: Log additional info about individual rgw requests.
+              The additional log line includes the HTTP Method,
+              target, content_length, and owner for each rgw request.
+
+:Type: Boolean
+:Default: ``false``
+
 
 ``rgw usage max shards``
 

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1555,3 +1555,4 @@ OPTION(debug_allow_any_pool_priority, OPT_BOOL)
 OPTION(rgw_gc_max_deferred_entries_size, OPT_U64) // GC deferred entries size in queue head
 OPTION(rgw_gc_max_queue_size, OPT_U64) // GC max queue size
 OPTION(rgw_gc_max_deferred, OPT_U64) // GC max number of deferred entries
+OPTION(rgw_log_request_summary, OPT_BOOL)  // Log target, owner, content-length, latency and method for individual requests

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7144,6 +7144,14 @@ std::vector<Option> get_rgw_options() {
 	"but will default to FIFO if there isn't an existing log. Either of "
 	"the explicit options will cause startup to fail if the other log is "
 	"still around."),
+
+    Option("rgw_log_request_summary", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("Log additional info about individual rgw requests")
+    .set_long_description(
+        "Additional logging information includes a line with HTTP Method, "
+        "target, content_length, and owner for each rgw request."),
+
   });
 }
 

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -316,6 +316,18 @@ done:
     handler->put_op(op);
   rest->put_handler(handler);
 
+  if (s->cct->_conf->rgw_log_request_summary) {
+    dout(1) << "request summary: req=" << hex << req << dec
+            << " op_status=" << op_ret
+            << " http_status=" << s->err.http_ret
+            << " latency=" << s->time_elapsed()
+            << " op_method=" << s->info.method
+            << " op_target=" << s->info.request_uri
+            << " op_content_length=" << s->content_length
+            << " op_owner=" << s->user->get_id()
+            << dendl;
+  }
+
   dout(1) << "====== req done req=" << hex << req << dec
 	  << " op status=" << op_ret
 	  << " http_status=" << s->err.http_ret


### PR DESCRIPTION
Add a config variables that enables additional
logging that includes a line with HTTP Method,
target, content_length, and owner for each rgw request.

Signed-off-by: Ali Maredia <amaredia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
