### PR TITLE
nautilus: ceph.in: ignore failures to flush stdout

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -1250,8 +1250,12 @@ def main():
                 except IOError as e:
                     if e.errno != errno.EPIPE:
                         raise e
+        try:
+            sys.stdout.flush()
+        except IOError as e:
+            if e.errno != errno.EPIPE:
+                raise e
 
-        sys.stdout.flush()
 
     # Block until command completion (currently scrub and deep_scrub only)
     if block:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47532

---

backport of https://github.com/ceph/ceph/pull/37143
parent tracker: https://tracker.ceph.com/issues/47442

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh