### PR TITLE
nautilus: qa: ignore expected mds failover message

### DIFF
--- a/qa/suites/fs/basic_functional/tasks/cap-flush.yaml
+++ b/qa/suites/fs/basic_functional/tasks/cap-flush.yaml
@@ -1,4 +1,7 @@
-
+overrides:
+  ceph:
+    log-ignorelist:
+      - Replacing daemon mds.a
 tasks:
   - cephfs_test_runner:
       modules:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47246

---

backport of https://github.com/ceph/ceph/pull/36887
parent tracker: https://tracker.ceph.com/issues/47202

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh