### PR TITLE
python-common: allow generic alias assignment for drivegroup keys

### DIFF
--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -145,6 +145,8 @@ class DriveGroupSpec(ServiceSpec):
         "journal_size", "unmanaged", "filter_logic", "preview_only"
     ]
 
+    _aliases = {'encryption': 'encrypted'}
+
     def __init__(self,
                  placement=None,  # type: Optional[PlacementSpec]
                  service_id=None,  # type: str
@@ -259,6 +261,9 @@ class DriveGroupSpec(ServiceSpec):
 
     @classmethod
     def _drive_group_spec_from_json(cls, json_drive_group: dict) -> dict:
+        # replace key with alias key if an alias is present. Otherwise don't replace
+        json_drive_group = {k.replace(k, cls._aliases.get(k, k)): v for k, v in json_drive_group.items()}
+
         for applied_filter in list(json_drive_group.keys()):
             if applied_filter not in cls._supported_features:
                 raise DriveGroupValidationError(

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -262,7 +262,8 @@ class DriveGroupSpec(ServiceSpec):
     @classmethod
     def _drive_group_spec_from_json(cls, json_drive_group: dict) -> dict:
         # replace key with alias key if an alias is present. Otherwise don't replace
-        json_drive_group = {k.replace(k, cls._aliases.get(k, k)): v for k, v in json_drive_group.items()}
+        json_drive_group = {k.replace(k, cls._aliases.get(k, k)): v
+                            for k, v in json_drive_group.items()}
 
         for applied_filter in list(json_drive_group.keys()):
             if applied_filter not in cls._supported_features:

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -18,7 +18,9 @@ from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection, \
                 'service_type': 'osd',
                 'service_id': 'testing_drivegroup',
                 'placement': {'host_pattern': 'hostname'},
-                'data_devices': {'paths': ['/dev/sda']}
+                'data_devices': {'paths': ['/dev/sda']},
+                'encrypted': True,
+                'encryption': True,
             }
         ]
     ),
@@ -27,6 +29,7 @@ def test_DriveGroup(test_input):
     dg = [DriveGroupSpec.from_json(inp) for inp in test_input][0]
     assert dg.placement.filter_matching_hostspecs([HostSpec('hostname')]) == ['hostname']
     assert dg.service_id == 'testing_drivegroup'
+    assert dg.encrypted is True
     assert all([isinstance(x, Device) for x in dg.data_devices.paths])
     assert dg.data_devices.paths[0].path == '/dev/sda'
 
@@ -43,6 +46,7 @@ placement:
   host_pattern: '*'
 data_devices:
   limit: 1
+encrypted: true
 """),
 
         yaml.safe_load("""
@@ -53,13 +57,13 @@ placement:
 data_devices:
   all: True
 filter_logic: XOR
+encrypted: true
 """)
     )
 ])
 def test_DriveGroup_fail(test_input):
     with pytest.raises(ServiceSpecValidationError):
         DriveGroupSpec.from_json(test_input)
-
 
 
 def test_drivegroup_pattern():


### PR DESCRIPTION



## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
