### PR TITLE
ceph-volume: fix wrong type passed in terminal.warning()

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/simple/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/simple/activate.py
@@ -286,7 +286,7 @@ class Activate(object):
                 try:
                     self.activate(args)
                 except RuntimeError as e:
-                    terminal.warning(e)
+                    terminal.warning(e.message)
         else:
             if args.file:
                 json_config = args.file


### PR DESCRIPTION
`terminal.warning('{}'.format(e))` excepts an `str`

passing `e` means we pass a type `exceptions.RuntimeError` where it
needs an `str`.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1877672
Resolves: rhbz#1877672

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>