### PR TITLE
mgr/cephadm: only deploy 3 mons by default when there are 4 hosts

### DIFF
--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -122,7 +122,29 @@ class HostAssignment(object):
         # If we don't have <count> the list of candidates is definitive.
         if count is None:
             logger.debug('Provided hosts: %s' % candidates)
+            # if asked to place even number of mons, deploy 1 less
+            if self.spec.service_type == 'mon' and (len(candidates) % 2) == 0:
+                logger.info("deploying %s monitor(s) instead of %s so monitors may achieve consensus" % (
+                    len(candidates) - 1, len(candidates)))
+                return candidates[0:len(candidates)-1]
             return candidates
+
+        # if asked to place even number of mons, deploy 1 less
+        if self.spec.service_type == 'mon':
+            # if count >= number of candidates then number of candidates
+            # is determining factor in how many mons will be placed
+            if count >= len(candidates):
+                if (len(candidates) % 2) == 0:
+                    logger.info("deploying %s monitor(s) instead of %s so monitors may achieve consensus" % (
+                        len(candidates) - 1, len(candidates)))
+                    count = len(candidates) - 1
+            # if count < number of candidates then count is determining
+            # factor in how many mons will get placed
+            else:
+                if (count % 2) == 0:
+                    logger.info(
+                        "deploying %s monitor(s) instead of %s so monitors may achieve consensus" % (count - 1, count))
+                    count = count - 1
 
         # prefer hosts that already have services.
         # this avoids re-assigning to _new_ hosts

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -89,12 +89,12 @@ def get_result(key, results):
 def mk_spec_and_host(spec_section, hosts, explicit_key, explicit, count):
 
     if spec_section == 'hosts':
-        mk_spec = lambda: ServiceSpec('mon', placement=PlacementSpec(
+        mk_spec = lambda: ServiceSpec('mgr', placement=PlacementSpec(
                     hosts=explicit,
                     count=count,
                 ))
     elif spec_section == 'label':
-        mk_spec = lambda: ServiceSpec('mon', placement=PlacementSpec(
+        mk_spec = lambda: ServiceSpec('mgr', placement=PlacementSpec(
             label='mylabel',
             count=count,
         ))
@@ -105,7 +105,7 @@ def mk_spec_and_host(spec_section, hosts, explicit_key, explicit, count):
             '12': '[1-2]',
             '123': '*',
         }[explicit_key]
-        mk_spec = lambda: ServiceSpec('mon', placement=PlacementSpec(
+        mk_spec = lambda: ServiceSpec('mgr', placement=PlacementSpec(
                     host_pattern=pattern,
                     count=count,
                 ))
@@ -162,17 +162,17 @@ def run_scheduler_test(results, mk_spec, hosts, get_daemons_func, key_elems):
 #       |   |   | |     |
 test_explicit_scheduler_results = [
     (k("*   *   0 *"), error(ServiceSpecValidationError, 'num/count must be > 1')),
-    (k("*   e   N l"), error(OrchestratorValidationError, 'Cannot place <ServiceSpec for service_name=mon>: No matching hosts for label mylabel')),
-    (k("*   e   N p"), error(OrchestratorValidationError, 'Cannot place <ServiceSpec for service_name=mon>: No matching hosts')),
+    (k("*   e   N l"), error(OrchestratorValidationError, 'Cannot place <ServiceSpec for service_name=mgr>: No matching hosts for label mylabel')),
+    (k("*   e   N p"), error(OrchestratorValidationError, 'Cannot place <ServiceSpec for service_name=mgr>: No matching hosts')),
     (k("*   e   N h"), error(OrchestratorValidationError, 'placement spec is empty: no hosts, no label, no pattern, no count')),
     (k("*   e   * *"), none),
-    (k("1   12  * h"), error(OrchestratorValidationError, "Cannot place <ServiceSpec for service_name=mon> on 2: Unknown hosts")),
-    (k("1   123 * h"), error(OrchestratorValidationError, "Cannot place <ServiceSpec for service_name=mon> on 2, 3: Unknown hosts")),
+    (k("1   12  * h"), error(OrchestratorValidationError, "Cannot place <ServiceSpec for service_name=mgr> on 2: Unknown hosts")),
+    (k("1   123 * h"), error(OrchestratorValidationError, "Cannot place <ServiceSpec for service_name=mgr> on 2, 3: Unknown hosts")),
     (k("1   *   * *"), exactly('1')),
     (k("12  1   * *"), exactly('1')),
     (k("12  12  1 *"), one_of('1', '2')),
     (k("12  12  * *"), exactly('1', '2')),
-    (k("12  123 * h"), error(OrchestratorValidationError, "Cannot place <ServiceSpec for service_name=mon> on 3: Unknown hosts")),
+    (k("12  123 * h"), error(OrchestratorValidationError, "Cannot place <ServiceSpec for service_name=mgr> on 3: Unknown hosts")),
     (k("12  123 1 *"), one_of('1', '2', '3')),
     (k("12  123 * *"), two_of('1', '2', '3')),
     (k("123 1   * *"), exactly('1')),
@@ -237,9 +237,9 @@ def test_explicit_scheduler(host_key, hosts,
 #       |   |   | |     |   |
 test_scheduler_daemons_results = [
     (k("*   1   * *   *"), exactly('1')),
-    (k("1   123 * *   h"), error(OrchestratorValidationError, 'Cannot place <ServiceSpec for service_name=mon> on 2, 3: Unknown hosts')),
+    (k("1   123 * *   h"), error(OrchestratorValidationError, 'Cannot place <ServiceSpec for service_name=mgr> on 2, 3: Unknown hosts')),
     (k("1   123 * *   *"), exactly('1')),
-    (k("12  123 * *   h"), error(OrchestratorValidationError, 'Cannot place <ServiceSpec for service_name=mon> on 3: Unknown hosts')),
+    (k("12  123 * *   h"), error(OrchestratorValidationError, 'Cannot place <ServiceSpec for service_name=mgr> on 3: Unknown hosts')),
     (k("12  123 N *   *"), exactly('1', '2')),
     (k("12  123 1 *   *"), one_of('1', '2')),
     (k("12  123 2 *   *"), exactly('1', '2')),
@@ -304,7 +304,7 @@ def test_scheduler_daemons(host_key, hosts,
                            spec_section_key, spec_section):
     mk_spec, hosts = mk_spec_and_host(spec_section, hosts, explicit_key, explicit, count)
     dds = [
-        DaemonDescription('mon', d, d)
+        DaemonDescription('mgr', d, d)
         for d in daemons
     ]
     run_scheduler_test(
@@ -330,7 +330,7 @@ class NodeAssignmentTest(NamedTuple):
     [
         # just hosts
         NodeAssignmentTest(
-            'mon',
+            'mgr',
             PlacementSpec(hosts=['smithi060:[v2:172.21.15.60:3301,v1:172.21.15.60:6790]=c']),
             ['smithi060'],
             [],
@@ -338,12 +338,12 @@ class NodeAssignmentTest(NamedTuple):
         ),
         # all_hosts
         NodeAssignmentTest(
-            'mon',
+            'mgr',
             PlacementSpec(host_pattern='*'),
             'host1 host2 host3'.split(),
             [
-                DaemonDescription('mon', 'a', 'host1'),
-                DaemonDescription('mon', 'b', 'host2'),
+                DaemonDescription('mgr', 'a', 'host1'),
+                DaemonDescription('mgr', 'b', 'host2'),
             ],
             ['host1', 'host2', 'host3']
         ),
@@ -358,59 +358,59 @@ class NodeAssignmentTest(NamedTuple):
         ),
         # count + partial host list
         NodeAssignmentTest(
-            'mon',
+            'mgr',
             PlacementSpec(count=3, hosts=['host3']),
             'host1 host2 host3'.split(),
             [
-                DaemonDescription('mon', 'a', 'host1'),
-                DaemonDescription('mon', 'b', 'host2'),
+                DaemonDescription('mgr', 'a', 'host1'),
+                DaemonDescription('mgr', 'b', 'host2'),
             ],
             ['host3']
         ),
         # count 1 + partial host list
         NodeAssignmentTest(
-            'mon',
+            'mgr',
             PlacementSpec(count=1, hosts=['host3']),
             'host1 host2 host3'.split(),
             [
-                DaemonDescription('mon', 'a', 'host1'),
-                DaemonDescription('mon', 'b', 'host2'),
+                DaemonDescription('mgr', 'a', 'host1'),
+                DaemonDescription('mgr', 'b', 'host2'),
             ],
             ['host3']
         ),
         # count + partial host list + existing
         NodeAssignmentTest(
-            'mon',
+            'mgr',
             PlacementSpec(count=2, hosts=['host3']),
             'host1 host2 host3'.split(),
             [
-                DaemonDescription('mon', 'a', 'host1'),
+                DaemonDescription('mgr', 'a', 'host1'),
             ],
             ['host3']
         ),
         # count + partial host list + existing (deterministic)
         NodeAssignmentTest(
-            'mon',
+            'mgr',
             PlacementSpec(count=2, hosts=['host1']),
             'host1 host2'.split(),
             [
-                DaemonDescription('mon', 'a', 'host1'),
+                DaemonDescription('mgr', 'a', 'host1'),
             ],
             ['host1']
         ),
         # count + partial host list + existing (deterministic)
         NodeAssignmentTest(
-            'mon',
+            'mgr',
             PlacementSpec(count=2, hosts=['host1']),
             'host1 host2'.split(),
             [
-                DaemonDescription('mon', 'a', 'host2'),
+                DaemonDescription('mgr', 'a', 'host2'),
             ],
             ['host1']
         ),
         # label only
         NodeAssignmentTest(
-            'mon',
+            'mgr',
             PlacementSpec(label='foo'),
             'host1 host2 host3'.split(),
             [],
@@ -418,11 +418,11 @@ class NodeAssignmentTest(NamedTuple):
         ),
         # host_pattern
         NodeAssignmentTest(
-            'mon',
-            PlacementSpec(host_pattern='mon*'),
-            'monhost1 monhost2 datahost'.split(),
+            'mgr',
+            PlacementSpec(host_pattern='mgr*'),
+            'mgrhost1 mgrhost2 datahost'.split(),
             [],
-            ['monhost1', 'monhost2']
+            ['mgrhost1', 'mgrhost2']
         ),
     ])
 def test_node_assignment(service_type, placement, hosts, daemons, expected):
@@ -453,7 +453,7 @@ class NodeAssignmentTest2(NamedTuple):
     [
         # just count
         NodeAssignmentTest2(
-            'mon',
+            'mgr',
             PlacementSpec(count=1),
             'host1 host2 host3'.split(),
             [],
@@ -463,7 +463,7 @@ class NodeAssignmentTest2(NamedTuple):
 
         # hosts + (smaller) count
         NodeAssignmentTest2(
-            'mon',
+            'mgr',
             PlacementSpec(count=1, hosts='host1 host2'.split()),
             'host1 host2'.split(),
             [],
@@ -472,28 +472,28 @@ class NodeAssignmentTest2(NamedTuple):
         ),
         # hosts + (smaller) count, existing
         NodeAssignmentTest2(
-            'mon',
+            'mgr',
             PlacementSpec(count=1, hosts='host1 host2 host3'.split()),
             'host1 host2 host3'.split(),
-            [DaemonDescription('mon', 'mon.a', 'host1'),],
+            [DaemonDescription('mgr', 'mgr.a', 'host1'),],
             1,
             ['host1', 'host2', 'host3'],
         ),
         # hosts + (smaller) count, (more) existing
         NodeAssignmentTest2(
-            'mon',
+            'mgr',
             PlacementSpec(count=1, hosts='host1 host2 host3'.split()),
             'host1 host2 host3'.split(),
             [
-                DaemonDescription('mon', 'a', 'host1'),
-                DaemonDescription('mon', 'b', 'host2'),
+                DaemonDescription('mgr', 'a', 'host1'),
+                DaemonDescription('mgr', 'b', 'host2'),
             ],
             1,
             ['host1', 'host2']
         ),
         # count + partial host list
         NodeAssignmentTest2(
-            'mon',
+            'mgr',
             PlacementSpec(count=2, hosts=['host3']),
             'host1 host2 host3'.split(),
             [],
@@ -502,7 +502,7 @@ class NodeAssignmentTest2(NamedTuple):
         ),
         # label + count
         NodeAssignmentTest2(
-            'mon',
+            'mgr',
             PlacementSpec(count=1, label='foo'),
             'host1 host2 host3'.split(),
             [],
@@ -524,7 +524,7 @@ def test_node_assignment2(service_type, placement, hosts,
     [
         # hosts + (smaller) count, (more) existing
         NodeAssignmentTest2(
-            'mon',
+            'mgr',
             PlacementSpec(count=3, hosts='host3'.split()),
             'host1 host2 host3'.split(),
             [],
@@ -533,7 +533,7 @@ def test_node_assignment2(service_type, placement, hosts,
         ),
         # count + partial host list
         NodeAssignmentTest2(
-            'mon',
+            'mgr',
             PlacementSpec(count=2, hosts=['host3']),
             'host1 host2 host3'.split(),
             [],
@@ -577,27 +577,27 @@ class NodeAssignmentTestBadSpec(NamedTuple):
     [
         # unknown host
         NodeAssignmentTestBadSpec(
-            'mon',
+            'mgr',
             PlacementSpec(hosts=['unknownhost']),
             ['knownhost'],
             [],
-            "Cannot place <ServiceSpec for service_name=mon> on unknownhost: Unknown hosts"
+            "Cannot place <ServiceSpec for service_name=mgr> on unknownhost: Unknown hosts"
         ),
         # unknown host pattern
         NodeAssignmentTestBadSpec(
-            'mon',
+            'mgr',
             PlacementSpec(host_pattern='unknownhost'),
             ['knownhost'],
             [],
-            "Cannot place <ServiceSpec for service_name=mon>: No matching hosts"
+            "Cannot place <ServiceSpec for service_name=mgr>: No matching hosts"
         ),
         # unknown label
         NodeAssignmentTestBadSpec(
-            'mon',
+            'mgr',
             PlacementSpec(label='unknownlabel'),
             [],
             [],
-            "Cannot place <ServiceSpec for service_name=mon>: No matching hosts for label unknownlabel"
+            "Cannot place <ServiceSpec for service_name=mgr>: No matching hosts for label unknownlabel"
         ),
     ])
 def test_bad_specs(service_type, placement, hosts, daemons, expected):

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -756,3 +756,115 @@ def test_active_assignment(service_type, placement, hosts, daemons, expected):
         hosts=[HostSpec(h) for h in hosts],
         get_daemons_func=lambda _: daemons).place()
     assert sorted([h.hostname for h in hosts]) in expected
+
+class OddMonsTest(NamedTuple):
+    service_type: str
+    placement: PlacementSpec
+    hosts: List[str]
+    daemons: List[DaemonDescription]
+    expected_count: int
+
+
+@pytest.mark.parametrize("service_type,placement,hosts,daemons,expected_count",
+                         [
+                             OddMonsTest(
+                                 'mon',
+                                 PlacementSpec(count=5),
+                                 'host1 host2 host3 host4'.split(),
+                                 [],
+                                 3
+                             ),
+                             OddMonsTest(
+                                 'mon',
+                                 PlacementSpec(count=4),
+                                 'host1 host2 host3 host4 host5'.split(),
+                                 [],
+                                 3
+                             ),
+                             OddMonsTest(
+                                 'mon',
+                                 PlacementSpec(count=5),
+                                 'host1 host2 host3 host4 host5'.split(),
+                                 [],
+                                 5
+                             ),
+                             OddMonsTest(
+                                 'mon',
+                                 PlacementSpec(hosts='host1 host2 host3 host4'.split()),
+                                 'host1 host2 host3 host4 host5'.split(),
+                                 [],
+                                 3
+                             ),
+                             OddMonsTest(
+                                 'mon',
+                                 PlacementSpec(hosts='host1 host2 host3 host4 host5'.split()),
+                                 'host1 host2 host3 host4 host5'.split(),
+                                 [],
+                                 5
+                             ),
+                             OddMonsTest(
+                                 'mon',
+                                 PlacementSpec(host_pattern='*'),
+                                 'host1 host2 host3 host4'.split(),
+                                 [],
+                                 3
+                             ),
+                             OddMonsTest(
+                                 'mon',
+                                 PlacementSpec(count=5, hosts='host1 host2 host3 host4'.split()),
+                                 'host1 host2 host3 host4 host5'.split(),
+                                 [],
+                                 3
+                             ),
+                             OddMonsTest(
+                                 'mon',
+                                 PlacementSpec(count=2, hosts='host1 host2 host3'.split()),
+                                 'host1 host2 host3 host4 host5'.split(),
+                                 [],
+                                 1
+                             ),
+                             OddMonsTest(
+                                 'mon',
+                                 PlacementSpec(count=5),
+                                 'host1 host2 host3 host4'.split(),
+                                 [
+                                     DaemonDescription('mon', 'a', 'host1'),
+                                     DaemonDescription('mon', 'b', 'host2'),
+                                     DaemonDescription('mon', 'c', 'host3'),
+                                 ],
+                                 3
+                             ),
+                            OddMonsTest(
+                                'mon',
+                                PlacementSpec(count=5),
+                                'host1 host2 host3 host4'.split(),
+                                [
+                                   DaemonDescription('mon', 'a', 'host1'),
+                                   DaemonDescription('mon', 'b', 'host2'),
+                                ],
+                                3
+                            ),
+                            OddMonsTest(
+                                'mon',
+                                PlacementSpec(hosts='host1 host2 host3 host4'.split()),
+                                'host1 host2 host3 host4 host5'.split(),
+                                [
+                                   DaemonDescription('mon', 'a', 'host1'),
+                                   DaemonDescription('mon', 'b', 'host2'),
+                                   DaemonDescription('mon', 'c', 'host3'),
+                                ],
+                                3
+                            ),
+
+                         ])
+def test_odd_mons(service_type, placement, hosts, daemons, expected_count):
+
+    spec = ServiceSpec(service_type=service_type,
+                       service_id=None,
+                       placement=placement)
+
+    hosts = HostAssignment(
+        spec=spec,
+        hosts=[HostSpec(h) for h in hosts],
+        get_daemons_func=lambda _: daemons).place()
+    assert len(hosts) == expected_count


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47234

Signed-off-by: Adam King <adking@redhat.com>