### PR TITLE
librbd/cache: Fix pwl_path read issue

### DIFF
--- a/src/librbd/cache/pwl/ImageCacheState.cc
+++ b/src/librbd/cache/pwl/ImageCacheState.cc
@@ -53,10 +53,10 @@ ImageCacheState<I>::ImageCacheState(
   present = (bool)f["present"];
   empty = (bool)f["empty"];
   clean = (bool)f["clean"];
-  host = (string)f["rwl_host"];
-  path = (string)f["rwl_path"];
+  host = (string)f["pwl_host"];
+  path = (string)f["pwl_path"];
   uint64_t pwl_size;
-  std::istringstream iss(f["rwl_size"]);
+  std::istringstream iss(f["pwl_size"]);
   iss >> pwl_size;
   size = pwl_size;
 

--- a/src/test/librbd/cache/test_mock_ReplicatedWriteLog.cc
+++ b/src/test/librbd/cache/test_mock_ReplicatedWriteLog.cc
@@ -156,9 +156,9 @@ TEST_F(TestMockCacheReplicatedWriteLog, init_state_json_write) {
 
   JSONFormattable f;
   string strf = "{ \"present\": \"1\", \"empty\": \"0\", \"clean\": \"0\", \
-                   \"rwl_host\": \"testhost\", \
-                   \"rwl_path\": \"/tmp\", \
-                   \"rwl_size\": \"1024\" }";
+                   \"pwl_host\": \"testhost\", \
+                   \"pwl_path\": \"/tmp\", \
+                   \"pwl_size\": \"1024\" }";
   get_jf(strf, &f);
   MockImageCacheStateRWL image_cache_state(&mock_image_ctx, f);
 


### PR DESCRIPTION
... in ImageCacheState

Signed-off-by: Mahati Chamarthy <mahati.chamarthy@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
