### PR TITLE
rgw: rgw_sync_obj_etag_verify accounts for compressed multipart uploads

### DIFF
--- a/src/rgw/rgw_compression.cc
+++ b/src/rgw/rgw_compression.cc
@@ -5,29 +5,36 @@
 
 #define dout_subsys ceph_subsys_rgw
 
-int rgw_compression_info_from_attrset(map<string, bufferlist>& attrs,
+int rgw_compression_info_from_attr(const bufferlist& attr,
+                                   bool& need_decompress,
+                                   RGWCompressionInfo& cs_info)
+{
+  auto bliter = attr.cbegin();
+  try {
+    decode(cs_info, bliter);
+  } catch (buffer::error& err) {
+    return -EIO;
+  }
+  if (cs_info.blocks.size() == 0) {
+    return -EIO;
+  }
+  if (cs_info.compression_type != "none")
+    need_decompress = true;
+  else
+    need_decompress = false;
+  return 0;
+}
+
+int rgw_compression_info_from_attrset(const map<string, bufferlist>& attrs,
                                       bool& need_decompress,
-                                      RGWCompressionInfo& cs_info) {
-  map<string, bufferlist>::iterator value = attrs.find(RGW_ATTR_COMPRESSION);
-  if (value != attrs.end()) {
-    auto bliter = value->second.cbegin();
-    try {
-      decode(cs_info, bliter);
-    } catch (buffer::error& err) {
-      return -EIO;
-    }
-    if (cs_info.blocks.size() == 0) {
-      return -EIO;
-    }
-    if (cs_info.compression_type != "none")
-      need_decompress = true;
-    else
-      need_decompress = false;
-    return 0;
-  } else {
+                                      RGWCompressionInfo& cs_info)
+{
+  auto value = attrs.find(RGW_ATTR_COMPRESSION);
+  if (value == attrs.end()) {
     need_decompress = false;
     return 0;
   }
+  return rgw_compression_info_from_attr(value->second, need_decompress, cs_info);
 }
 
 //------------RGWPutObj_Compress---------------

--- a/src/rgw/rgw_compression.h
+++ b/src/rgw/rgw_compression.h
@@ -11,7 +11,12 @@
 #include "rgw_op.h"
 #include "rgw_compression_types.h"
 
-int rgw_compression_info_from_attrset(map<string, bufferlist>& attrs, bool& need_decompress, RGWCompressionInfo& cs_info);
+int rgw_compression_info_from_attr(const bufferlist& attr,
+                                   bool& need_decompress,
+                                   RGWCompressionInfo& cs_info);
+int rgw_compression_info_from_attrset(const map<string, bufferlist>& attrs,
+                                      bool& need_decompress,
+                                      RGWCompressionInfo& cs_info);
 
 class RGWGetObj_Decompress : public RGWGetObj_Filter
 {

--- a/src/rgw/rgw_etag_verifier.cc
+++ b/src/rgw/rgw_etag_verifier.cc
@@ -10,8 +10,7 @@ namespace rgw::putobj {
 int create_etag_verifier(CephContext* cct, DataProcessor* filter,
                          const bufferlist& manifest_bl,
                          const std::optional<RGWCompressionInfo>& compression,
-                         boost::optional<ETagVerifier_Atomic>& etag_verifier_atomic,
-                         boost::optional<ETagVerifier_MPU>& etag_verifier_mpu)
+                         etag_verifier_ptr& verifier)
 {
   RGWObjManifest manifest;
 
@@ -32,8 +31,7 @@ int create_etag_verifier(CephContext* cct, DataProcessor* filter,
 
   if (rule.part_size == 0) {
     /* Atomic object */
-    etag_verifier_atomic = boost::in_place(cct, filter);
-    filter = &*etag_verifier_atomic;
+    verifier.emplace<ETagVerifier_Atomic>(cct, filter);
     return 0;
   }
 
@@ -75,7 +73,7 @@ int create_etag_verifier(CephContext* cct, DataProcessor* filter,
     }
   }
 
-  etag_verifier_mpu = boost::in_place(cct, std::move(part_ofs), filter);
+  verifier.emplace<ETagVerifier_MPU>(cct, std::move(part_ofs), filter);
   return 0;
 }
 

--- a/src/rgw/rgw_etag_verifier.cc
+++ b/src/rgw/rgw_etag_verifier.cc
@@ -5,7 +5,9 @@
 
 #define dout_subsys ceph_subsys_rgw
 
-int RGWPutObj_ETagVerifier_Atomic::process(bufferlist&& in, uint64_t logical_offset)
+namespace rgw::putobj {
+
+int ETagVerifier_Atomic::process(bufferlist&& in, uint64_t logical_offset)
 {
   bufferlist out;
   if (in.length() > 0)
@@ -14,7 +16,7 @@ int RGWPutObj_ETagVerifier_Atomic::process(bufferlist&& in, uint64_t logical_off
   return Pipe::process(std::move(in), logical_offset);
 }
 
-void RGWPutObj_ETagVerifier_Atomic::calculate_etag()
+void ETagVerifier_Atomic::calculate_etag()
 {
   unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
   char calc_md5[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
@@ -30,7 +32,7 @@ void RGWPutObj_ETagVerifier_Atomic::calculate_etag()
           << dendl;
 }
 
-void RGWPutObj_ETagVerifier_MPU::process_end_of_MPU_part()
+void ETagVerifier_MPU::process_end_of_MPU_part()
 {
   unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
   char calc_md5_part[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
@@ -50,7 +52,7 @@ void RGWPutObj_ETagVerifier_MPU::process_end_of_MPU_part()
   next_part_index++;
 }
 
-int RGWPutObj_ETagVerifier_MPU::process(bufferlist&& in, uint64_t logical_offset)
+int ETagVerifier_MPU::process(bufferlist&& in, uint64_t logical_offset)
 {
   uint64_t bl_end = in.length() + logical_offset;
 
@@ -87,7 +89,7 @@ done:
   return Pipe::process(std::move(in), logical_offset);
 }
 
-void RGWPutObj_ETagVerifier_MPU::calculate_etag()
+void ETagVerifier_MPU::calculate_etag()
 {
   unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE], mpu_m[CEPH_CRYPTO_MD5_DIGESTSIZE];
   char final_etag_str[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 16];
@@ -109,3 +111,5 @@ void RGWPutObj_ETagVerifier_MPU::calculate_etag()
   calculated_etag = final_etag_str;
   ldout(cct, 20) << "MPU calculated ETag:" << calculated_etag << dendl;
 }
+
+} // namespace rgw::putobj

--- a/src/rgw/rgw_etag_verifier.h
+++ b/src/rgw/rgw_etag_verifier.h
@@ -18,12 +18,6 @@
 #include "rgw_putobj.h"
 #include "rgw_op.h"
 
-enum SourceObjType {
-  OBJ_TYPE_UNINIT, /* Object type is not initialised yet */
-  OBJ_TYPE_ATOMIC,
-  OBJ_TYPE_MPU, /* Object at source was created through MPU */
-};
-
 class RGWPutObj_ETagVerifier : public rgw::putobj::Pipe
 {
 protected:

--- a/src/rgw/rgw_etag_verifier.h
+++ b/src/rgw/rgw_etag_verifier.h
@@ -17,6 +17,7 @@
 
 #include "rgw_putobj.h"
 #include "rgw_op.h"
+#include "common/static_ptr.h"
 
 namespace rgw::putobj {
 
@@ -68,11 +69,16 @@ public:
 
 }; /* ETagVerifier_MPU */
 
-int create_etag_verifier(CephContext* cct, DataProcessor* filter,
+constexpr auto max_etag_verifier_size = std::max(
+    sizeof(ETagVerifier_Atomic),
+    sizeof(ETagVerifier_MPU)
+  );
+using etag_verifier_ptr = ceph::static_ptr<ETagVerifier, max_etag_verifier_size>;
+
+int create_etag_verifier(CephContext* cct, DataProcessor* next,
                          const bufferlist& manifest_bl,
                          const std::optional<RGWCompressionInfo>& compression,
-                         boost::optional<ETagVerifier_Atomic>& etag_verifier_atomic,
-                         boost::optional<ETagVerifier_MPU>& etag_verifier_mpu);
+                         etag_verifier_ptr& verifier);
 
 } // namespace rgw::putobj
 

--- a/src/rgw/rgw_etag_verifier.h
+++ b/src/rgw/rgw_etag_verifier.h
@@ -60,12 +60,15 @@ class RGWPutObj_ETagVerifier_MPU : public RGWPutObj_ETagVerifier
   void process_end_of_MPU_part();
 
 public:
-  RGWPutObj_ETagVerifier_MPU(CephContext* cct_, rgw::putobj::DataProcessor *next)
-    : RGWPutObj_ETagVerifier(cct_, next) {}
+  RGWPutObj_ETagVerifier_MPU(CephContext* cct,
+                             std::vector<uint64_t> part_ofs,
+                             rgw::putobj::DataProcessor *next)
+    : RGWPutObj_ETagVerifier(cct, next),
+      part_ofs(std::move(part_ofs))
+  {}
 
   int process(bufferlist&& data, uint64_t logical_offset) override;
   void calculate_etag() override;
-  void append_part_ofs(uint64_t ofs) { part_ofs.emplace_back(ofs); }
 
 }; /* RGWPutObj_ETagVerifier_MPU */
 

--- a/src/rgw/rgw_etag_verifier.h
+++ b/src/rgw/rgw_etag_verifier.h
@@ -68,6 +68,12 @@ public:
 
 }; /* ETagVerifier_MPU */
 
+int create_etag_verifier(CephContext* cct, DataProcessor* filter,
+                         const bufferlist& manifest_bl,
+                         const std::optional<RGWCompressionInfo>& compression,
+                         boost::optional<ETagVerifier_Atomic>& etag_verifier_atomic,
+                         boost::optional<ETagVerifier_MPU>& etag_verifier_mpu);
+
 } // namespace rgw::putobj
 
 #endif /* CEPH_RGW_ETAG_VERIFIER_H */

--- a/src/rgw/rgw_etag_verifier.h
+++ b/src/rgw/rgw_etag_verifier.h
@@ -18,7 +18,9 @@
 #include "rgw_putobj.h"
 #include "rgw_op.h"
 
-class RGWPutObj_ETagVerifier : public rgw::putobj::Pipe
+namespace rgw::putobj {
+
+class ETagVerifier : public rgw::putobj::Pipe
 {
 protected:
   CephContext* cct;
@@ -26,26 +28,26 @@ protected:
   string calculated_etag;
 
 public:
-  RGWPutObj_ETagVerifier(CephContext* cct_, rgw::putobj::DataProcessor *next)
+  ETagVerifier(CephContext* cct_, rgw::putobj::DataProcessor *next)
     : Pipe(next), cct(cct_) {}
 
   virtual void calculate_etag() = 0;
   string get_calculated_etag() { return calculated_etag;}
 
-}; /* RGWPutObj_ETagVerifier */
+}; /* ETagVerifier */
 
-class RGWPutObj_ETagVerifier_Atomic : public RGWPutObj_ETagVerifier
+class ETagVerifier_Atomic : public ETagVerifier
 {
 public:
-  RGWPutObj_ETagVerifier_Atomic(CephContext* cct_, rgw::putobj::DataProcessor *next)
-    : RGWPutObj_ETagVerifier(cct_, next) {}
+  ETagVerifier_Atomic(CephContext* cct_, rgw::putobj::DataProcessor *next)
+    : ETagVerifier(cct_, next) {}
 
   int process(bufferlist&& data, uint64_t logical_offset) override;
   void calculate_etag() override;
 
-}; /* RGWPutObj_ETagVerifier_Atomic */
+}; /* ETagVerifier_Atomic */
 
-class RGWPutObj_ETagVerifier_MPU : public RGWPutObj_ETagVerifier
+class ETagVerifier_MPU : public ETagVerifier
 {
   std::vector<uint64_t> part_ofs;
   uint64_t cur_part_index{0}, next_part_index{1};
@@ -54,16 +56,18 @@ class RGWPutObj_ETagVerifier_MPU : public RGWPutObj_ETagVerifier
   void process_end_of_MPU_part();
 
 public:
-  RGWPutObj_ETagVerifier_MPU(CephContext* cct,
+  ETagVerifier_MPU(CephContext* cct,
                              std::vector<uint64_t> part_ofs,
                              rgw::putobj::DataProcessor *next)
-    : RGWPutObj_ETagVerifier(cct, next),
+    : ETagVerifier(cct, next),
       part_ofs(std::move(part_ofs))
   {}
 
   int process(bufferlist&& data, uint64_t logical_offset) override;
   void calculate_etag() override;
 
-}; /* RGWPutObj_ETagVerifier_MPU */
+}; /* ETagVerifier_MPU */
+
+} // namespace rgw::putobj
 
 #endif /* CEPH_RGW_ETAG_VERIFIER_H */

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3284,8 +3284,7 @@ class RGWRadosPutObj : public RGWHTTPStreamRWRequest::ReceiveCB
   rgw::putobj::DataProcessor *filter;
   boost::optional<RGWPutObj_Compress>& compressor;
   bool try_etag_verify;
-  boost::optional<rgw::putobj::ETagVerifier_Atomic> etag_verifier_atomic;
-  boost::optional<rgw::putobj::ETagVerifier_MPU> etag_verifier_mpu;
+  rgw::putobj::etag_verifier_ptr etag_verifier;
   boost::optional<rgw::putobj::ChunkProcessor> buffering;
   CompressorRef& plugin;
   rgw::putobj::ObjectProcessor *processor;
@@ -3389,15 +3388,12 @@ public:
     if (try_etag_verify && src_attrs.find(RGW_ATTR_CRYPT_MODE) == src_attrs.end()) {
       ret = rgw::putobj::create_etag_verifier(cct, filter, manifest_bl,
                                               compression_info,
-                                              etag_verifier_atomic,
-                                              etag_verifier_mpu);
+                                              etag_verifier);
       if (ret < 0) {
         ldout(cct, 4) << "failed to initial etag verifier, "
             "disabling etag verification" << dendl;
-      } else if (etag_verifier_atomic) {
-        filter = &*etag_verifier_atomic;
-      } else if (etag_verifier_mpu) {
-        filter = &*etag_verifier_mpu;
+      } else {
+        filter = etag_verifier.get();
       }
     }
 
@@ -3469,12 +3465,9 @@ public:
   }
 
   std::string get_verifier_etag() {
-    if (etag_verifier_atomic) {
-      etag_verifier_atomic->calculate_etag();
-      return etag_verifier_atomic->get_calculated_etag();
-    } else if (etag_verifier_mpu) {
-      etag_verifier_mpu->calculate_etag();
-      return etag_verifier_mpu->get_calculated_etag();
+    if (etag_verifier) {
+      etag_verifier->calculate_etag();
+      return etag_verifier->get_calculated_etag();
     } else {
       return "";
     }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3283,6 +3283,7 @@ class RGWRadosPutObj : public RGWHTTPStreamRWRequest::ReceiveCB
   rgw_obj obj;
   rgw::putobj::DataProcessor *filter;
   boost::optional<RGWPutObj_Compress>& compressor;
+  bool try_etag_verify;
   boost::optional<RGWPutObj_ETagVerifier_Atomic> etag_verifier_atomic;
   boost::optional<RGWPutObj_ETagVerifier_MPU> etag_verifier_mpu;
   boost::optional<rgw::putobj::ChunkProcessor> buffering;
@@ -3291,6 +3292,7 @@ class RGWRadosPutObj : public RGWHTTPStreamRWRequest::ReceiveCB
   void (*progress_cb)(off_t, void *);
   void *progress_data;
   bufferlist extra_data_bl, manifest_bl;
+  std::optional<RGWCompressionInfo> compression_info;
   uint64_t extra_data_left{0};
   bool need_to_process_attrs{true};
   SourceObjType obj_type{OBJ_TYPE_UNINIT};
@@ -3310,6 +3312,7 @@ public:
                        cct(cct),
                        filter(p),
                        compressor(compressor),
+                       try_etag_verify(cct->_conf->rgw_sync_obj_etag_verify),
                        plugin(plugin),
                        processor(p),
                        progress_cb(_progress_cb),
@@ -3326,9 +3329,28 @@ public:
 
       JSONDecoder::decode_json("attrs", src_attrs, &jp);
 
-      src_attrs.erase(RGW_ATTR_COMPRESSION);
+      auto iter = src_attrs.find(RGW_ATTR_COMPRESSION);
+      if (iter != src_attrs.end()) {
+        const bufferlist bl = std::move(iter->second);
+        src_attrs.erase(iter); // don't preserve source compression info
+
+        if (try_etag_verify) {
+          // if we're trying to verify etags, we need to convert compressed
+          // ranges in the manifest back into logical multipart part offsets
+          RGWCompressionInfo info;
+          bool compressed = false;
+          int r = rgw_compression_info_from_attr(bl, compressed, info);
+          if (r < 0) {
+            ldout(cct, 4) << "failed to decode compression info, "
+                "disabling etag verification" << dendl;
+            try_etag_verify = false;
+          } else if (compressed) {
+            compression_info = std::move(info);
+          }
+        }
+      }
       /* We need the manifest to recompute the ETag for verification */
-      auto iter = src_attrs.find(RGW_ATTR_MANIFEST);
+      iter = src_attrs.find(RGW_ATTR_MANIFEST);
       if (iter != src_attrs.end()) {
         manifest_bl = std::move(iter->second);
         src_attrs.erase(iter);
@@ -3365,8 +3387,7 @@ public:
      * requested. We can enable simultaneous support once we have a mechanism
      * to know the sequence in which the filters must be applied.
      */
-    if (cct->_conf->rgw_sync_obj_etag_verify &&
-        src_attrs.find(RGW_ATTR_CRYPT_MODE) == src_attrs.end()) {
+    if (try_etag_verify && src_attrs.find(RGW_ATTR_CRYPT_MODE) == src_attrs.end()) {
 
       RGWObjManifest manifest;
 
@@ -3407,9 +3428,36 @@ public:
           part_ofs.push_back(cur_part_ofs);
         }
 
-        obj_type = OBJ_TYPE_MPU;
-        etag_verifier_mpu = boost::in_place(cct, std::move(part_ofs), filter);
-        filter = &*etag_verifier_mpu;
+        if (compression_info) {
+          // if the source object was compressed, the manifest is storing
+          // compressed part offsets. transform the compressed offsets back to
+          // their original offsets by finding the first block of each part
+          const auto& blocks = compression_info->blocks;
+          auto block = blocks.begin();
+          for (auto& ofs : part_ofs) {
+            // find the compression_block with new_ofs == ofs
+            constexpr auto less = [] (const compression_block& block, uint64_t ofs) {
+              return block.new_ofs < ofs;
+            };
+            block = std::lower_bound(block, blocks.end(), ofs, less);
+            if (block == blocks.end() || block->new_ofs != ofs) {
+              ldout(cct, 4) << "no match for compressed offset " << ofs
+                  << ", disabling etag verification" << dendl;
+              part_ofs.clear();
+              break;
+            }
+            ofs = block->old_ofs;
+            ldout(cct, 20) << "MPU Part uncompressed offset:" << ofs << dendl;
+          }
+        }
+
+        if (part_ofs.empty()) {
+          try_etag_verify = false;
+        } else {
+          obj_type = OBJ_TYPE_MPU;
+          etag_verifier_mpu = boost::in_place(cct, std::move(part_ofs), filter);
+          filter = &*etag_verifier_mpu;
+        }
       }
     }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3387,74 +3387,17 @@ public:
      * to know the sequence in which the filters must be applied.
      */
     if (try_etag_verify && src_attrs.find(RGW_ATTR_CRYPT_MODE) == src_attrs.end()) {
-
-      RGWObjManifest manifest;
-
-      auto miter = manifest_bl.cbegin();
-      try {
-        decode(manifest, miter);
-      } catch (buffer::error& err) {
-        ldout(cct, 0) << "ERROR: couldn't decode manifest" << dendl;
-        return -EIO;
-      }
-
-      RGWObjManifestRule rule;
-      bool found = manifest.get_rule(0, &rule);
-      if (!found) {
-        lderr(cct) << "ERROR: manifest->get_rule() could not find rule" << dendl;
-        return -EIO;
-      }
-
-      if (rule.part_size == 0) {
-        /* Atomic object */
-        etag_verifier_atomic = boost::in_place(cct, filter);
+      ret = rgw::putobj::create_etag_verifier(cct, filter, manifest_bl,
+                                              compression_info,
+                                              etag_verifier_atomic,
+                                              etag_verifier_mpu);
+      if (ret < 0) {
+        ldout(cct, 4) << "failed to initial etag verifier, "
+            "disabling etag verification" << dendl;
+      } else if (etag_verifier_atomic) {
         filter = &*etag_verifier_atomic;
-      } else {
-        uint64_t cur_part_ofs = UINT64_MAX;
-        std::vector<uint64_t> part_ofs;
-
-        /*
-         * We must store the offset of each part to calculate the ETAGs for each
-         * MPU part. These part ETags then become the input for the MPU object
-         * Etag.
-         */
-        for (auto mi = manifest.obj_begin(); mi != manifest.obj_end(); ++mi) {
-          if (cur_part_ofs == mi.get_part_ofs())
-            continue;
-          cur_part_ofs = mi.get_part_ofs();
-          ldout(cct, 20) << "MPU Part offset:" << cur_part_ofs << dendl;
-          part_ofs.push_back(cur_part_ofs);
-        }
-
-        if (compression_info) {
-          // if the source object was compressed, the manifest is storing
-          // compressed part offsets. transform the compressed offsets back to
-          // their original offsets by finding the first block of each part
-          const auto& blocks = compression_info->blocks;
-          auto block = blocks.begin();
-          for (auto& ofs : part_ofs) {
-            // find the compression_block with new_ofs == ofs
-            constexpr auto less = [] (const compression_block& block, uint64_t ofs) {
-              return block.new_ofs < ofs;
-            };
-            block = std::lower_bound(block, blocks.end(), ofs, less);
-            if (block == blocks.end() || block->new_ofs != ofs) {
-              ldout(cct, 4) << "no match for compressed offset " << ofs
-                  << ", disabling etag verification" << dendl;
-              part_ofs.clear();
-              break;
-            }
-            ofs = block->old_ofs;
-            ldout(cct, 20) << "MPU Part uncompressed offset:" << ofs << dendl;
-          }
-        }
-
-        if (part_ofs.empty()) {
-          try_etag_verify = false;
-        } else {
-          etag_verifier_mpu = boost::in_place(cct, std::move(part_ofs), filter);
-          filter = &*etag_verifier_mpu;
-        }
+      } else if (etag_verifier_mpu) {
+        filter = &*etag_verifier_mpu;
       }
     }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3391,9 +3391,8 @@ public:
         etag_verifier_atomic = boost::in_place(cct, filter);
         filter = &*etag_verifier_atomic;
       } else {
-        obj_type = OBJ_TYPE_MPU;
-        etag_verifier_mpu = boost::in_place(cct, filter);
         uint64_t cur_part_ofs = UINT64_MAX;
+        std::vector<uint64_t> part_ofs;
 
         /*
          * We must store the offset of each part to calculate the ETAGs for each
@@ -3405,8 +3404,11 @@ public:
             continue;
           cur_part_ofs = mi.get_part_ofs();
           ldout(cct, 20) << "MPU Part offset:" << cur_part_ofs << dendl;
-          etag_verifier_mpu->append_part_ofs(cur_part_ofs);
+          part_ofs.push_back(cur_part_ofs);
         }
+
+        obj_type = OBJ_TYPE_MPU;
+        etag_verifier_mpu = boost::in_place(cct, std::move(part_ofs), filter);
         filter = &*etag_verifier_mpu;
       }
     }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3295,7 +3295,6 @@ class RGWRadosPutObj : public RGWHTTPStreamRWRequest::ReceiveCB
   std::optional<RGWCompressionInfo> compression_info;
   uint64_t extra_data_left{0};
   bool need_to_process_attrs{true};
-  SourceObjType obj_type{OBJ_TYPE_UNINIT};
   uint64_t data_len{0};
   map<string, bufferlist> src_attrs;
   uint64_t ofs{0};
@@ -3408,7 +3407,6 @@ public:
 
       if (rule.part_size == 0) {
         /* Atomic object */
-        obj_type = OBJ_TYPE_ATOMIC;
         etag_verifier_atomic = boost::in_place(cct, filter);
         filter = &*etag_verifier_atomic;
       } else {
@@ -3454,7 +3452,6 @@ public:
         if (part_ofs.empty()) {
           try_etag_verify = false;
         } else {
-          obj_type = OBJ_TYPE_MPU;
           etag_verifier_mpu = boost::in_place(cct, std::move(part_ofs), filter);
           filter = &*etag_verifier_mpu;
         }
@@ -3528,20 +3525,16 @@ public:
     return data_len;
   }
 
-  string get_calculated_etag() {
-    if (obj_type == OBJ_TYPE_ATOMIC) {
+  std::string get_verifier_etag() {
+    if (etag_verifier_atomic) {
       etag_verifier_atomic->calculate_etag();
       return etag_verifier_atomic->get_calculated_etag();
-    } else if (obj_type == OBJ_TYPE_MPU) {
+    } else if (etag_verifier_mpu) {
       etag_verifier_mpu->calculate_etag();
       return etag_verifier_mpu->get_calculated_etag();
     } else {
       return "";
     }
-  }
-
-  SourceObjType get_obj_type() {
-    return obj_type;
   }
 };
 
@@ -4079,17 +4072,18 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
   }
 
   /* Perform ETag verification is we have computed the object's MD5 sum at our end */
-  if (cb.get_obj_type() != OBJ_TYPE_UNINIT) {
+  if (const auto& verifier_etag = cb.get_verifier_etag();
+      !verifier_etag.empty()) {
     string trimmed_etag = etag;
 
     /* Remove the leading and trailing double quotes from etag */
     trimmed_etag.erase(std::remove(trimmed_etag.begin(), trimmed_etag.end(),'\"'),
       trimmed_etag.end());
 
-    if (cb.get_calculated_etag().compare(trimmed_etag)) {
+    if (verifier_etag != trimmed_etag) {
       ret = -EIO;
       ldout(cct, 0) << "ERROR: source and destination objects don't match. Expected etag:"
-        << trimmed_etag << " Computed etag:" << cb.get_calculated_etag() << dendl;
+        << trimmed_etag << " Computed etag:" << verifier_etag << dendl;
       goto set_err_state;
     }
   }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3284,8 +3284,8 @@ class RGWRadosPutObj : public RGWHTTPStreamRWRequest::ReceiveCB
   rgw::putobj::DataProcessor *filter;
   boost::optional<RGWPutObj_Compress>& compressor;
   bool try_etag_verify;
-  boost::optional<RGWPutObj_ETagVerifier_Atomic> etag_verifier_atomic;
-  boost::optional<RGWPutObj_ETagVerifier_MPU> etag_verifier_mpu;
+  boost::optional<rgw::putobj::ETagVerifier_Atomic> etag_verifier_atomic;
+  boost::optional<rgw::putobj::ETagVerifier_MPU> etag_verifier_mpu;
   boost::optional<rgw::putobj::ChunkProcessor> buffering;
   CompressorRef& plugin;
   rgw::putobj::ObjectProcessor *processor;


### PR DESCRIPTION
the etag verifier for multipart uploads uses the manifest to get the logical offsets for each part. but when compression is enabled, those are offsets into the compressed data. use the source object's compression info to translate those compressed part offsets back to their original offsets

Fixes: https://tracker.ceph.com/issues/45992

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
