### PR TITLE
octopus: mds: fix nullptr dereference in MDCache::finish_rollback

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -3587,7 +3587,7 @@ MDSlaveUpdate* MDCache::get_uncommitted_slave(metareqid_t reqid, mds_rank_t mast
 }
 
 void MDCache::finish_rollback(metareqid_t reqid, MDRequestRef& mdr) {
-  auto p = resolve_need_rollback.find(mdr->reqid);
+  auto p = resolve_need_rollback.find(reqid);
   ceph_assert(p != resolve_need_rollback.end());
   if (mds->is_resolve()) {
     finish_uncommitted_slave(reqid, false);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46636

---

backport of https://github.com/ceph/ceph/pull/36097
parent tracker: https://tracker.ceph.com/issues/46533

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh