### PR TITLE
octopus: mds: optimize random threshold lookup for dentry load

### DIFF
--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -644,6 +644,7 @@ protected:
       bufferlist &bl,
       int pos,
       const std::set<snapid_t> *snaps,
+      double rand_threshold,
       bool *force_dirty);
 
   /**

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -5351,7 +5351,7 @@ void CInode::set_ephemeral_rand(bool yes)
   }
 }
 
-void CInode::maybe_ephemeral_rand(bool fresh)
+void CInode::maybe_ephemeral_rand(bool fresh, double threshold)
 {
   if (!mdcache->get_export_ephemeral_random_config()) {
     dout(15) << __func__ << " config false: cannot ephemeral random pin " << *this << dendl;
@@ -5373,7 +5373,13 @@ void CInode::maybe_ephemeral_rand(bool fresh)
     return;
   }
 
-  double threshold = get_ephemeral_rand();
+  /* not precomputed? */
+  if (threshold < 0.0) {
+    threshold = get_ephemeral_rand();
+  }
+  if (threshold <= 0.0) {
+    return;
+  }
   double n = ceph::util::generate_random_number(0.0, 1.0);
 
   dout(15) << __func__ << " rand " << n << " <?= " << threshold

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -938,7 +938,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
 
   double get_ephemeral_rand(bool inherit=true) const;
   void set_ephemeral_rand(bool yes);
-  void maybe_ephemeral_rand(bool fresh=false);
+  void maybe_ephemeral_rand(bool fresh=false, double threshold=-1.0);
   void setxattr_ephemeral_rand(double prob=0.0);
   bool is_ephemeral_rand() const {
     return state_test(STATE_RANDEPHEMERALPIN);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46637

---

backport of https://github.com/ceph/ceph/pull/35969
parent tracker: https://tracker.ceph.com/issues/46302

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh