### PR TITLE
octopus: mds/CInode: Optimize only pinned by subtrees check

### DIFF
--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -575,6 +575,9 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
     get_subtree_dirfrags(v);
     return v;
   }
+  int get_num_subtree_roots() const {
+    return num_subtree_roots;
+  }
 
   CDir *get_or_open_dirfrag(MDCache *mdcache, frag_t fg);
   CDir *add_dirfrag(CDir *dir);

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6819,9 +6819,9 @@ std::pair<bool, uint64_t> MDCache::trim(uint64_t count)
       }
     } else if (!diri->is_auth() && dir->get_num_ref() <= 1) {
       // only subtree pin
-      auto&& ls = diri->get_subtree_dirfrags();
-      if (diri->get_num_ref() > (int)ls.size()) // only pinned by subtrees
+      if (diri->get_num_ref() > diri->get_num_subtree_roots()) {
         continue;
+      }
 
       // don't trim subtree root if its auth MDS is recovering.
       // This simplify the cache rejoin code.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46783

---

backport of https://github.com/ceph/ceph/pull/36288
parent tracker: https://tracker.ceph.com/issues/46727

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh