### PR TITLE
octopus: cephfs: client: fix extra open ref decrease

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8922,7 +8922,6 @@ int Client::_open(Inode *in, int flags, mode_t mode, Fh **fhp,
 	ldout(cct, 8) << "Unable to get caps after open of inode " << *in <<
 			  " . Denying open: " <<
 			  cpp_strerror(result) << dendl;
-	in->put_open_ref(cmode);
       } else {
 	put_cap_ref(in, need);
       }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46786

---

backport of https://github.com/ceph/ceph/pull/36233
parent tracker: https://tracker.ceph.com/issues/46664

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh