### PR TITLE
WIP/rgw: Support MetadataLog over FIFO and Omap backends

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7246,6 +7246,17 @@ std::vector<Option> get_rgw_options() {
 	"but will default to FIFO if there isn't an existing log. Either of "
 	"the explicit options will cause startup to fail if the other log is "
 	"still around."),
+
+   Option("rgw_md_log_backing", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("auto")
+    .set_enum_allowed( { "auto", "fifo", "omap" } )
+    .set_description("Backing store for the RGW metadata sync log")
+    .set_long_description(
+        "Whether to use the older OMAP backing store or the high performance "
+	"FIFO based backing store. Auto uses whatever already exists "
+	"but will default to FIFO if there isn't an existing log. Either of "
+	"the explicit options will cause startup to fail if the other log is "
+	"still around."),
   });
 }
 

--- a/src/rgw/cls_fifo_legacy.cc
+++ b/src/rgw/cls_fifo_legacy.cc
@@ -39,7 +39,7 @@
 #include "cls_fifo_legacy.h"
 
 namespace rgw::cls::fifo {
-static constexpr auto dout_subsys = ceph_subsys_rgw;
+static constexpr auto dout_subsys = ceph_subsys_objclass;
 namespace cb = ceph::buffer;
 namespace fifo = rados::cls::fifo;
 
@@ -109,6 +109,7 @@ int get_meta(lr::IoCtx& ioctx, const std::string& oid,
   return r;
 };
 
+namespace {
 void update_meta(lr::ObjectWriteOperation* op, const fifo::objv& objv,
 		 const fifo::update& update)
 {
@@ -175,6 +176,27 @@ int push_part(lr::IoCtx& ioctx, const std::string& oid, std::string_view tag,
   return retval;
 }
 
+void push_part(lr::IoCtx& ioctx, const std::string& oid, std::string_view tag,
+	       std::deque<cb::list> data_bufs, std::uint64_t tid,
+	       lr::AioCompletion* c)
+{
+  lr::ObjectWriteOperation op;
+  fifo::op::push_part pp;
+
+  pp.tag = tag;
+  pp.data_bufs = data_bufs;
+  pp.total_len = 0;
+
+  for (const auto& bl : data_bufs)
+    pp.total_len += bl.length();
+
+  cb::list in;
+  encode(pp, in);
+  op.exec(fifo::op::CLASS, fifo::op::PUSH_PART, in);
+  auto r = ioctx.aio_operate(oid, c, &op, lr::OPERATION_RETURNVEC);
+  ceph_assert(r >= 0);
+}
+
 void trim_part(lr::ObjectWriteOperation* op,
 	       std::optional<std::string_view> tag,
 	       std::uint64_t ofs, bool exclusive)
@@ -232,6 +254,70 @@ int list_part(lr::IoCtx& ioctx, const std::string& oid,
   return r;
 }
 
+struct list_entry_completion : public lr::ObjectOperationCompletion {
+  CephContext* cct;
+  int* r_out;
+  std::vector<fifo::part_list_entry>* entries;
+  bool* more;
+  bool* full_part;
+  std::string* ptag;
+  std::uint64_t tid;
+
+  list_entry_completion(CephContext* cct, int* r_out, std::vector<fifo::part_list_entry>* entries,
+			bool* more, bool* full_part, std::string* ptag,
+			std::uint64_t tid)
+    : cct(cct), r_out(r_out), entries(entries), more(more),
+      full_part(full_part), ptag(ptag), tid(tid) {}
+  virtual ~list_entry_completion() = default;
+  void handle_completion(int r, bufferlist& bl) override {
+    if (r >= 0) try {
+	fifo::op::list_part_reply reply;
+	auto iter = bl.cbegin();
+	decode(reply, iter);
+	if (entries) *entries = std::move(reply.entries);
+	if (more) *more = reply.more;
+	if (full_part) *full_part = reply.full_part;
+	if (ptag) *ptag = reply.tag;
+      } catch (const cb::error& err) {
+	lderr(cct)
+	  << __PRETTY_FUNCTION__ << ":" << __LINE__
+	  << " decode failed: " << err.what()
+	  << " tid=" << tid << dendl;
+	r = from_error_code(err.code());
+      } else if (r < 0) {
+      lderr(cct)
+	<< __PRETTY_FUNCTION__ << ":" << __LINE__
+	<< " fifo::op::LIST_PART failed r=" << r << " tid=" << tid
+	<< dendl;
+    }
+    if (r_out) *r_out = r;
+  }
+};
+
+lr::ObjectReadOperation list_part(CephContext* cct,
+				  std::optional<std::string_view> tag,
+				  std::uint64_t ofs,
+				  std::uint64_t max_entries,
+				  int* r_out,
+				  std::vector<fifo::part_list_entry>* entries,
+				  bool* more, bool* full_part,
+				  std::string* ptag, std::uint64_t tid)
+{
+  lr::ObjectReadOperation op;
+  fifo::op::list_part lp;
+
+  lp.tag = tag;
+  lp.ofs = ofs;
+  lp.max_entries = max_entries;
+
+  cb::list in;
+  encode(lp, in);
+  op.exec(fifo::op::CLASS, fifo::op::LIST_PART, in,
+	  new list_entry_completion(cct, r_out, entries, more, full_part,
+				    ptag, tid));
+  return op;
+}
+
 int get_part_info(lr::IoCtx& ioctx, const std::string& oid,
 		  fifo::part_header* header,
 		  std::uint64_t tid, optional_yield y)
@@ -264,29 +350,131 @@ int get_part_info(lr::IoCtx& ioctx, const std::string& oid,
   return r;
 }
 
-static void complete(lr::AioCompletion* c_, int r)
+struct partinfo_completion : public lr::ObjectOperationCompletion {
+  CephContext* cct;
+  int* rp;
+  fifo::part_header* h;
+  std::uint64_t tid;
+  partinfo_completion(CephContext* cct, int* rp, fifo::part_header* h,
+		      std::uint64_t tid) :
+    cct(cct), rp(rp), h(h), tid(tid) {
+  }
+  virtual ~partinfo_completion() = default;
+  void handle_completion(int r, bufferlist& bl) override {
+    if (r >= 0) try {
+	fifo::op::get_part_info_reply reply;
+	auto iter = bl.cbegin();
+	decode(reply, iter);
+	if (h) *h = std::move(reply.header);
+      } catch (const cb::error& err) {
+	r = from_error_code(err.code());
+	lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " decode failed: " << err.what()
+		   << " tid=" << tid << dendl;
+      } else {
+      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " fifo::op::GET_PART_INFO failed r=" << r << " tid=" << tid
+		 << dendl;
+    }
+    if (rp) {
+      *rp = r;
+    }
+  }
+};
+
+template<typename T>
+struct Completion {
+private:
+  lr::AioCompletion* _cur = nullptr;
+  lr::AioCompletion* _super;
+public:
+
+  using Ptr = std::unique_ptr<T>;
+
+  lr::AioCompletion* cur() const {
+    return _cur;
+  }
+  lr::AioCompletion* super() const {
+    return _super;
+  }
+
+  Completion(lr::AioCompletion* super) : _super(super) {
+    super->pc->get();
+  }
+
+  ~Completion() {
+    if (_super) {
+      _super->pc->put();
+    }
+    if (_cur)
+      _cur->release();
+    _super = nullptr;
+    _cur = nullptr;
+  }
+
+  // The only times that aio_operate can return an error are:
+  // 1. The completion contains a null pointer. This should just
+  //    crash, and in our case it does.
+  // 2. An attempt is made to write to a snapshot. RGW doesn't use
+  //    snapshots, so we don't care.
+  //
+  // So we will just assert that initiating an Aio operation succeeds
+  // and not worry about recovering.
+  static lr::AioCompletion* call(Ptr&& p) {
+    p->_cur = lr::Rados::aio_create_completion(static_cast<void*>(p.get()),
+					       &cb);
+    auto c = p->_cur;
+    p.release();
+    return c;
+  }
+  static void complete(Ptr&& p, int r) {
+    auto c = p->_super->pc;
+    p->_super = nullptr;
+    c->lock.lock();
+    c->rval = r;
+    c->complete = true;
+    c->lock.unlock();
+
+    auto cb_complete = c->callback_complete;
+    auto cb_complete_arg = c->callback_complete_arg;
+    if (cb_complete)
+      cb_complete(c, cb_complete_arg);
+
+    auto cb_safe = c->callback_safe;
+    auto cb_safe_arg = c->callback_safe_arg;
+    if (cb_safe)
+      cb_safe(c, cb_safe_arg);
+
+    c->lock.lock();
+    c->callback_complete = nullptr;
+    c->callback_safe = nullptr;
+    c->cond.notify_all();
+    c->put_unlock();
+  }
+
+  static void cb(lr::completion_t, void* arg) {
+    auto t = static_cast<T*>(arg);
+    auto r = t->_cur->get_return_value();
+    t->_cur->release();
+    t->_cur = nullptr;
+    t->handle(Ptr(t), r);
+  }
+};
+
+lr::ObjectReadOperation get_part_info(CephContext* cct,
+				      fifo::part_header* header,
+				      std::uint64_t tid, int* r = 0)
 {
-  auto c = c_->pc;
-  c->lock.lock();
-  c->rval = r;
-  c->complete = true;
-  c->lock.unlock();
+  lr::ObjectReadOperation op;
+  fifo::op::get_part_info gpi;
 
-  auto cb_complete = c->callback_complete;
-  auto cb_complete_arg = c->callback_complete_arg;
-  if (cb_complete)
-    cb_complete(c, cb_complete_arg);
-
-  auto cb_safe = c->callback_safe;
-  auto cb_safe_arg = c->callback_safe_arg;
-  if (cb_safe)
-    cb_safe(c, cb_safe_arg);
-
-  c->lock.lock();
-  c->callback_complete = NULL;
-  c->callback_safe = NULL;
-  c->cond.notify_all();
-  c->put_unlock();
+  cb::list in;
+  cb::list bl;
+  encode(gpi, in);
+  op.exec(fifo::op::CLASS, fifo::op::GET_PART_INFO, in,
+	  new partinfo_completion(cct, r, header, tid));
+  return op;
+}
 }
 
 std::optional<marker> FIFO::to_marker(std::string_view s)
@@ -385,11 +573,8 @@ int FIFO::_update_meta(const fifo::update& update,
   return r;
 }
 
-struct Updater {
+struct Updater : public Completion<Updater> {
   FIFO* fifo;
-  lr::AioCompletion* super;
-  lr::AioCompletion* cur = lr::Rados::aio_create_completion(
-    static_cast<void*>(this), &FIFO::update_callback);
   fifo::update update;
   fifo::objv version;
   bool reread = false;
@@ -398,92 +583,74 @@ struct Updater {
   Updater(FIFO* fifo, lr::AioCompletion* super,
 	  const fifo::update& update, fifo::objv version,
 	  bool* pcanceled, std::uint64_t tid)
-    : fifo(fifo), super(super), update(update), version(version),
-      pcanceled(pcanceled), tid(tid) {
-    super->pc->get();
-  }
-  ~Updater() {
-    cur->release();
-  }
-};
+    : Completion(super), fifo(fifo), update(update), version(version),
+      pcanceled(pcanceled) {}
 
-void FIFO::update_callback(lr::completion_t, void* arg)
-{
-  std::unique_ptr<Updater> updater(static_cast<Updater*>(arg));
-  auto cct = updater->fifo->cct;
-  auto tid = updater->tid;
-  ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		 << " entering: tid=" << tid << dendl;
-  if (!updater->reread) {
-    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		   << " handling async update_meta: tid="
-		   << tid << dendl;
-    int r = updater->cur->get_return_value();
+  void handle(Ptr&& p, int r) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " entering: tid=" << tid << dendl;
+    if (reread)
+      handle_reread(std::move(p), r);
+    else
+      handle_update(std::move(p), r);
+  }
+
+  void handle_update(Ptr&& p, int r) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " handling async update_meta: tid="
+			 << tid << dendl;
     if (r < 0 && r != -ECANCELED) {
-      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+      lderr(fifo->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
 		 << " update failed: r=" << r << " tid=" << tid << dendl;
-      complete(updater->super, r);
+      complete(std::move(p), r);
       return;
     }
     bool canceled = (r == -ECANCELED);
     if (!canceled) {
-      int r = updater->fifo->apply_update(&updater->fifo->info,
-					  updater->version,
-					  updater->update, tid);
+      int r = fifo->apply_update(&fifo->info, version, update, tid);
       if (r < 0) {
-	ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		       << " update failed, marking canceled: r=" << r << " tid="
-		       << tid << dendl;
+	ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			     << " update failed, marking canceled: r=" << r
+			     << " tid=" << tid << dendl;
 	canceled = true;
       }
     }
     if (canceled) {
-      updater->cur->release();
-      updater->cur = lr::Rados::aio_create_completion(
-	arg, &FIFO::update_callback);
-      updater->reread = true;
-      auto r = updater->fifo->read_meta(tid, updater->cur);
-      if (r < 0) {
-	lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		   << " failed dispatching read_meta: r=" << r << " tid="
-		   << tid << dendl;
-	complete(updater->super, r);
-      } else {
-	updater.release();
-      }
+      reread = true;
+      fifo->read_meta(tid, call(std::move(p)));
       return;
     }
-    if (updater->pcanceled)
-      *updater->pcanceled = false;
-    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		   << " completing: tid=" << tid << dendl;
-    complete(updater->super, 0);
-    return;
+    if (pcanceled)
+      *pcanceled = false;
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " completing: tid=" << tid << dendl;
+    complete(std::move(p), 0);
   }
 
-  ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		 << " handling async read_meta: tid="
-		 << tid << dendl;
-  int r = updater->cur->get_return_value();
-  if (r < 0 && updater->pcanceled) {
-    *updater->pcanceled = false;
-  } else if (r >= 0 && updater->pcanceled) {
-    *updater->pcanceled = true;
+  void handle_reread(Ptr&& p, int r) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " handling async read_meta: tid="
+			 << tid << dendl;
+    if (r < 0 && pcanceled) {
+      *pcanceled = false;
+    } else if (r >= 0 && pcanceled) {
+      *pcanceled = true;
+    }
+    if (r < 0) {
+      lderr(fifo->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		       << " failed dispatching read_meta: r=" << r << " tid="
+		       << tid << dendl;
+    } else {
+      ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			   << " completing: tid=" << tid << dendl;
+    }
+    complete(std::move(p), r);
   }
-  if (r < 0) {
-    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-	       << " failed dispatching read_meta: r=" << r << " tid="
-	       << tid << dendl;
-  } else {
-    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		   << " completing: tid=" << tid << dendl;
-  }
-  complete(updater->super, r);
-}
+};
 
-int FIFO::_update_meta(const fifo::update& update,
-		       fifo::objv version, bool* pcanceled,
-		       std::uint64_t tid, lr::AioCompletion* c)
+void FIFO::_update_meta(const fifo::update& update,
+			fifo::objv version, bool* pcanceled,
+			std::uint64_t tid, lr::AioCompletion* c)
 {
   ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
 		 << " entering: tid=" << tid << dendl;
@@ -491,15 +658,8 @@ int FIFO::_update_meta(const fifo::update& update,
   update_meta(&op, info.version, update);
   auto updater = std::make_unique<Updater>(this, c, update, version, pcanceled,
 					   tid);
-  auto r = ioctx.aio_operate(oid, updater->cur, &op);
-  if (r < 0) {
-    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-	       << " failed dispatching update_meta: r=" << r << " tid="
-	       << tid << dendl;
-  } else {
-    updater.release();
-  }
-  return r;
+  auto r = ioctx.aio_operate(oid, Updater::call(std::move(updater)), &op);
+  assert(r >= 0);
 }
 
 int FIFO::create_part(int64_t part_num, std::string_view tag, std::uint64_t tid,
@@ -806,6 +966,209 @@ int FIFO::_prepare_new_head(std::uint64_t tid, optional_yield y)
   return 0;
 }
 
+struct NewPartPreparer : public Completion<NewPartPreparer> {
+  FIFO* f;
+  std::vector<fifo::journal_entry> jentries;
+  int i = 0;
+  std::int64_t new_head_part_num;
+  bool canceled = false;
+  uint64_t tid;
+
+  NewPartPreparer(FIFO* f, lr::AioCompletion* super,
+		  std::vector<fifo::journal_entry> jentries,
+		  std::int64_t new_head_part_num,
+		  std::uint64_t tid)
+    : Completion(super), f(f), jentries(std::move(jentries)),
+      new_head_part_num(new_head_part_num), tid(tid) {}
+
+  void handle(Ptr&& p, int r) {
+    ldout(f->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		      << " entering: tid=" << tid << dendl;
+    if (r < 0) {
+      lderr(f->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		    << " _update_meta failed:  r=" << r
+		    << " tid=" << tid << dendl;
+      complete(std::move(p), r);
+      return;
+    }
+
+    if (canceled) {
+      std::unique_lock l(f->m);
+      auto iter = f->info.journal.find(jentries.front().part_num);
+      auto max_push_part_num = f->info.max_push_part_num;
+      auto head_part_num = f->info.head_part_num;
+      auto version = f->info.version;
+      auto found = (iter != f->info.journal.end());
+      l.unlock();
+      if ((max_push_part_num >= jentries.front().part_num &&
+	   head_part_num >= new_head_part_num)) {
+	ldout(f->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			  << " raced, but journaled and processed: i=" << i
+			  << " tid=" << tid << dendl;
+	complete(std::move(p), 0);
+	return;
+      }
+      if (i >= MAX_RACE_RETRIES) {
+	complete(std::move(p), -ECANCELED);
+	return;
+      }
+      if (!found) {
+	++i;
+	f->_update_meta(fifo::update{}
+			.journal_entries_add(jentries),
+                        version, &canceled, tid, call(std::move(p)));
+	return;
+      } else {
+	ldout(f->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			  << " raced, journaled but not processed: i=" << i
+			  << " tid=" << tid << dendl;
+	canceled = false;
+      }
+      // Fall through. We still need to process the journal.
+    }
+    f->process_journal(tid, super());
+    return;
+  }
+};
+
+void FIFO::_prepare_new_part(bool is_head, std::uint64_t tid,
+			     lr::AioCompletion* c)
+{
+  std::unique_lock l(m);
+  std::vector jentries = { info.next_journal_entry(generate_tag()) };
+  if (info.journal.find(jentries.front().part_num) != info.journal.end()) {
+    l.unlock();
+    ldout(cct, 5) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		  << " new part journaled, but not processed: tid="
+		  << tid << dendl;
+    process_journal(tid, c);
+    return;
+  }
+  std::int64_t new_head_part_num = info.head_part_num;
+  auto version = info.version;
+
+  if (is_head) {
+    auto new_head_jentry = jentries.front();
+    new_head_jentry.op = fifo::journal_entry::Op::set_head;
+    new_head_part_num = jentries.front().part_num;
+    jentries.push_back(std::move(new_head_jentry));
+  }
+  l.unlock();
+
+  auto n = std::make_unique<NewPartPreparer>(this, c, jentries,
+					     new_head_part_num, tid);
+  auto np = n.get();
+  _update_meta(fifo::update{}.journal_entries_add(jentries), version,
+	       &np->canceled, tid, NewPartPreparer::call(std::move(n)));
+}
+
+struct NewHeadPreparer : public Completion<NewHeadPreparer> {
+  FIFO* f;
+  int i = 0;
+  bool newpart;
+  std::int64_t new_head_num;
+  bool canceled = false;
+  std::uint64_t tid;
+
+  NewHeadPreparer(FIFO* f, lr::AioCompletion* super,
+		  bool newpart, std::int64_t new_head_num, std::uint64_t tid)
+    : Completion(super), f(f), newpart(newpart), new_head_num(new_head_num),
+      tid(tid) {}
+
+  void handle(Ptr&& p, int r) {
+    if (newpart)
+      handle_newpart(std::move(p), r);
+    else
+      handle_update(std::move(p), r);
+  }
+
+  void handle_newpart(Ptr&& p, int r) {
+    if (r < 0) {
+      lderr(f->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		    << " _prepare_new_part failed: r=" << r
+		    << " tid=" << tid << dendl;
+      complete(std::move(p), r);
+      return;
+    }
+    std::unique_lock l(f->m);
+    if (f->info.max_push_part_num < new_head_num) {
+      l.unlock();
+      lderr(f->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		    << " _prepare_new_part failed: r=" << r
+		    << " tid=" << tid << dendl;
+      complete(std::move(p), -EIO);
+    } else {
+      l.unlock();
+      complete(std::move(p), 0);
+    }
+  }
+
+  void handle_update(Ptr&& p, int r) {
+    std::unique_lock l(f->m);
+    auto head_part_num = f->info.head_part_num;
+    auto version = f->info.version;
+    l.unlock();
+
+    if (r < 0) {
+      lderr(f->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		    << " _update_meta failed: r=" << r
+		    << " tid=" << tid << dendl;
+      complete(std::move(p), r);
+      return;
+    }
+    if (canceled) {
+      if (i >= MAX_RACE_RETRIES) {
+	lderr(f->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		      << " canceled too many times, giving up: tid=" << tid << dendl;
+	complete(std::move(p), -ECANCELED);
+	return;
+      }
+
+      // Raced, but there's still work to do!
+      if (head_part_num < new_head_num) {
+	canceled = false;
+	++i;
+	ldout(f->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			  << " updating head: i=" << i << " tid=" << tid << dendl;
+	f->_update_meta(fifo::update{}.head_part_num(new_head_num),
+			version, &this->canceled, tid, call(std::move(p)));
+	return;
+      }
+    }
+    ldout(f->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " succeeded : i=" << i << " tid=" << tid << dendl;
+    complete(std::move(p), 0);
+    return;
+  }
+};
+
+void FIFO::_prepare_new_head(std::uint64_t tid, lr::AioCompletion* c)
+{
+  ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " entering: tid=" << tid << dendl;
+  std::unique_lock l(m);
+  int64_t new_head_num = info.head_part_num + 1;
+  auto max_push_part_num = info.max_push_part_num;
+  auto version = info.version;
+  l.unlock();
+
+  if (max_push_part_num < new_head_num) {
+    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " need new part: tid=" << tid << dendl;
+    auto n = std::make_unique<NewHeadPreparer>(this, c, true, new_head_num,
+					       tid);
+    _prepare_new_part(true, tid, NewHeadPreparer::call(std::move(n)));
+  } else {
+    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " updating head: tid=" << tid << dendl;
+    auto n = std::make_unique<NewHeadPreparer>(this, c, false, new_head_num,
+					       tid);
+    auto np = n.get();
+    _update_meta(fifo::update{}.head_part_num(new_head_num), version,
+		 &np->canceled, tid, NewHeadPreparer::call(std::move(n)));
+  }
+}
+
 int FIFO::push_entries(const std::deque<cb::list>& data_bufs,
 		       std::uint64_t tid, optional_yield y)
 {
@@ -823,6 +1186,18 @@ int FIFO::push_entries(const std::deque<cb::list>& data_bufs,
 	       << " push_part failed: r=" << r << " tid=" << tid << dendl;
   }
   return r;
+}
+
+void FIFO::push_entries(const std::deque<cb::list>& data_bufs,
+			std::uint64_t tid, lr::AioCompletion* c)
+{
+  std::unique_lock l(m);
+  auto head_part_num = info.head_part_num;
+  auto tag = info.head_tag;
+  const auto part_oid = info.part_oid(head_part_num);
+  l.unlock();
+
+  push_part(ioctx, part_oid, tag, data_bufs, tid, c);
 }
 
 int FIFO::trim_part(int64_t part_num, uint64_t ofs,
@@ -845,10 +1220,10 @@ int FIFO::trim_part(int64_t part_num, uint64_t ofs,
   return 0;
 }
 
-int FIFO::trim_part(int64_t part_num, uint64_t ofs,
-		    std::optional<std::string_view> tag,
-		    bool exclusive, std::uint64_t tid,
-		    lr::AioCompletion* c)
+void FIFO::trim_part(int64_t part_num, uint64_t ofs,
+		     std::optional<std::string_view> tag,
+		     bool exclusive, std::uint64_t tid,
+		     lr::AioCompletion* c)
 {
   ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
 		 << " entering: tid=" << tid << dendl;
@@ -858,12 +1233,7 @@ int FIFO::trim_part(int64_t part_num, uint64_t ofs,
   l.unlock();
   rgw::cls::fifo::trim_part(&op, tag, ofs, exclusive);
   auto r = ioctx.aio_operate(part_oid, c, &op);
-  if (r < 0) {
-    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-	       << " failed scheduling trim_part: r=" << r
-	       << " tid=" << tid << dendl;
-  }
-  return r;
+  ceph_assert(r >= 0);
 }
 
 int FIFO::open(lr::IoCtx ioctx, std::string oid, std::unique_ptr<FIFO>* fifo,
@@ -960,54 +1330,42 @@ int FIFO::read_meta(optional_yield y) {
   return read_meta(tid, y);
 }
 
-struct Reader {
+struct Reader : public Completion<Reader> {
   FIFO* fifo;
   cb::list bl;
-  lr::AioCompletion* super;
   std::uint64_t tid;
-  lr::AioCompletion* cur = lr::Rados::aio_create_completion(
-    static_cast<void*>(this), &FIFO::read_callback);
   Reader(FIFO* fifo, lr::AioCompletion* super, std::uint64_t tid)
-    : fifo(fifo), super(super), tid(tid) {
-    super->pc->get();
-  }
-  ~Reader() {
-    cur->release();
+    : Completion(super), fifo(fifo), tid(tid) {}
+
+  void handle(Ptr&& p, int r) {
+    auto cct = fifo->cct;
+    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " entering: tid=" << tid << dendl;
+    if (r >= 0) try {
+	fifo::op::get_meta_reply reply;
+	auto iter = bl.cbegin();
+	decode(reply, iter);
+	std::unique_lock l(fifo->m);
+	if (reply.info.version.same_or_later(fifo->info.version)) {
+	  fifo->info = std::move(reply.info);
+	  fifo->part_header_size = reply.part_header_size;
+	  fifo->part_entry_overhead = reply.part_entry_overhead;
+	}
+      } catch (const cb::error& err) {
+	lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " failed to decode response err=" << err.what()
+		   << " tid=" << tid << dendl;
+	r = from_error_code(err.code());
+      } else {
+      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " read_meta failed r=" << r
+		 << " tid=" << tid << dendl;
+    }
+    complete(std::move(p), r);
   }
 };
 
-void FIFO::read_callback(lr::completion_t, void* arg)
-{
-  std::unique_ptr<Reader> reader(static_cast<Reader*>(arg));
-  auto cct = reader->fifo->cct;
-  auto tid = reader->tid;
-  ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		 << " entering: tid=" << tid << dendl;
-  auto r = reader->cur->get_return_value();
-  if (r >= 0) try {
-      fifo::op::get_meta_reply reply;
-      auto iter = reader->bl.cbegin();
-      decode(reply, iter);
-      std::unique_lock l(reader->fifo->m);
-      if (reply.info.version.same_or_later(reader->fifo->info.version)) {
-	reader->fifo->info = std::move(reply.info);
-	reader->fifo->part_header_size = reply.part_header_size;
-	reader->fifo->part_entry_overhead = reply.part_entry_overhead;
-      }
-    } catch (const cb::error& err) {
-      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		 << " failed to decode response err=" << err.what()
-		 << " tid=" << tid << dendl;
-      r = from_error_code(err.code());
-    } else {
-    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-	       << " read_meta failed r=" << r
-	       << " tid=" << tid << dendl;
-  }
-  complete(reader->super, r);
-}
-
-int FIFO::read_meta(std::uint64_t tid, lr::AioCompletion* c)
+void FIFO::read_meta(std::uint64_t tid, lr::AioCompletion* c)
 {
   ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
 		 << " entering: tid=" << tid << dendl;
@@ -1016,16 +1374,10 @@ int FIFO::read_meta(std::uint64_t tid, lr::AioCompletion* c)
   cb::list in;
   encode(gm, in);
   auto reader = std::make_unique<Reader>(this, c, tid);
-  auto r = ioctx.aio_exec(oid, reader->cur, fifo::op::CLASS,
-			  fifo::op::GET_META, in, &reader->bl);
-  if (r < 0) {
-    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-	       << " failed scheduling read_meta r=" << r
-	       << " tid=" << tid << dendl;
-  } else {
-    reader.release();
-  }
-  return r;
+  auto rp = reader.get();
+  auto r = ioctx.aio_exec(oid, Reader::call(std::move(reader)), fifo::op::CLASS,
+			  fifo::op::GET_META, in, &rp->bl);
+  assert(r >= 0);
 }
 
 const fifo::info& FIFO::meta() const {
@@ -1038,6 +1390,10 @@ std::pair<std::uint32_t, std::uint32_t> FIFO::get_part_layout_info() const {
 
 int FIFO::push(const cb::list& bl, optional_yield y) {
   return push(std::vector{ bl }, y);
+}
+
+void FIFO::push(const cb::list& bl, lr::AioCompletion* c) {
+  push(std::vector{ bl }, c);
 }
 
 int FIFO::push(const std::vector<cb::list>& data_bufs, optional_yield y)
@@ -1151,6 +1507,167 @@ int FIFO::push(const std::vector<cb::list>& data_bufs, optional_yield y)
     return -ECANCELED;
   }
   return 0;
+}
+
+struct Pusher : public Completion<Pusher> {
+  FIFO* f;
+  std::deque<cb::list> remaining;
+  std::deque<cb::list> batch;
+  int i = 0;
+  std::uint64_t tid;
+  bool new_heading = false;
+
+  void prep_then_push(Ptr&& p, const unsigned successes) {
+    std::unique_lock l(f->m);
+    auto max_part_size = f->info.params.max_part_size;
+    auto part_entry_overhead = f->part_entry_overhead;
+    l.unlock();
+
+    ldout(f->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		      << " preparing push: remaining=" << remaining.size()
+		      << " batch=" << batch.size() << " i=" << i
+		      << " tid=" << tid << dendl;
+
+    uint64_t batch_len = 0;
+    if (successes > 0) {
+      if (successes == batch.size()) {
+	batch.clear();
+      } else  {
+	batch.erase(batch.begin(), batch.begin() + successes);
+	for (const auto& b : batch) {
+	  batch_len +=  b.length() + part_entry_overhead;
+	}
+      }
+    }
+
+    if (batch.empty() && remaining.empty()) {
+      complete(std::move(p), 0);
+      return;
+    }
+
+    while (!remaining.empty() &&
+	   (remaining.front().length() + batch_len <= max_part_size)) {
+
+      /* We can send entries with data_len up to max_entry_size,
+	 however, we want to also account the overhead when
+	 dealing with multiple entries. Previous check doesn't
+	 account for overhead on purpose. */
+      batch_len += remaining.front().length() + part_entry_overhead;
+      batch.push_back(std::move(remaining.front()));
+      remaining.pop_front();
+    }
+    ldout(f->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		      << " prepared push: remaining=" << remaining.size()
+		      << " batch=" << batch.size() << " i=" << i
+		      << " batch_len=" << batch_len
+		      << " tid=" << tid << dendl;
+    push(std::move(p));
+  }
+
+  void push(Ptr&& p) {
+    f->push_entries(batch, tid, call(std::move(p)));
+  }
+
+  void new_head(Ptr&& p) {
+    new_heading = true;
+    f->_prepare_new_head(tid, call(std::move(p)));
+  }
+
+  void handle(Ptr&& p, int r) {
+    if (!new_heading) {
+      if (r == -ERANGE) {
+	ldout(f->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		       << " need new head tid=" << tid << dendl;
+	new_head(std::move(p));
+	return;
+      }
+      if (r < 0) {
+	lderr(f->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		      << " push_entries failed: r=" << r
+		      << " tid=" << tid << dendl;
+	complete(std::move(p), r);
+	return;
+      }
+      i = 0; // We've made forward progress, so reset the race counter!
+      prep_then_push(std::move(p), r);
+    } else {
+      if (r < 0) {
+	lderr(f->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		      << " prepare_new_head failed: r=" << r
+		      << " tid=" << tid << dendl;
+	complete(std::move(p), r);
+	return;
+      }
+      new_heading = false;
+      handle_new_head(std::move(p), r);
+    }
+  }
+
+  void handle_new_head(Ptr&& p, int r) {
+    if (r == -ECANCELED) {
+      if (p->i == MAX_RACE_RETRIES) {
+	lderr(f->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		      << " canceled too many times, giving up: tid=" << tid << dendl;
+	complete(std::move(p), -ECANCELED);
+	return;
+      }
+      ++p->i;
+    } else if (r) {
+      complete(std::move(p), r);
+      return;
+    }
+
+    if (p->batch.empty()) {
+      prep_then_push(std::move(p), 0);
+      return;
+    } else {
+      push(std::move(p));
+      return;
+    }
+  }
+
+  Pusher(FIFO* f, std::deque<cb::list>&& remaining,
+	 std::uint64_t tid, lr::AioCompletion* super)
+    : Completion(super), f(f), remaining(std::move(remaining)),
+      tid(tid) {}
+};
+
+void FIFO::push(const std::vector<cb::list>& data_bufs,
+		lr::AioCompletion* c)
+{
+  std::unique_lock l(m);
+  auto tid = ++next_tid;
+  auto max_entry_size = info.params.max_entry_size;
+  auto need_new_head = info.need_new_head();
+  l.unlock();
+  ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " entering: tid=" << tid << dendl;
+  auto p = std::make_unique<Pusher>(this, std::deque(data_bufs.begin(), data_bufs.end()),
+				    tid, c);
+  // Validate sizes
+  for (const auto& bl : data_bufs) {
+    if (bl.length() > max_entry_size) {
+      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " entry bigger than max_entry_size tid=" << tid << dendl;
+      Pusher::complete(std::move(p), -E2BIG);
+      return;
+    }
+  }
+
+  if (data_bufs.empty() ) {
+    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " empty push, returning success tid=" << tid << dendl;
+    Pusher::complete(std::move(p), 0);
+    return;
+  }
+
+  if (need_new_head) {
+    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " need new head tid=" << tid << dendl;
+    p->new_head(std::move(p));
+  } else {
+    p->prep_then_push(std::move(p), 0);
+  }
 }
 
 int FIFO::list(int max_entries,
@@ -1340,157 +1857,115 @@ int FIFO::trim(std::string_view markstr, bool exclusive, optional_yield y)
   return 0;
 }
 
-struct Trimmer {
+struct Trimmer : public Completion<Trimmer> {
   FIFO* fifo;
   std::int64_t part_num;
   std::uint64_t ofs;
   std::int64_t pn;
   bool exclusive;
-  lr::AioCompletion* super;
   std::uint64_t tid;
-  lr::AioCompletion* cur = lr::Rados::aio_create_completion(
-    static_cast<void*>(this), &FIFO::trim_callback);
   bool update = false;
   bool canceled = false;
   int retries = 0;
 
   Trimmer(FIFO* fifo, std::int64_t part_num, std::uint64_t ofs, std::int64_t pn,
 	  bool exclusive, lr::AioCompletion* super, std::uint64_t tid)
-    : fifo(fifo), part_num(part_num), ofs(ofs), pn(pn), exclusive(exclusive),
-      super(super), tid(tid) {
-    super->pc->get();
-  }
-  ~Trimmer() {
-    cur->release();
+    : Completion(super), fifo(fifo), part_num(part_num), ofs(ofs), pn(pn),
+      exclusive(exclusive), tid(tid) {}
+
+  void handle(Ptr&& p, int r) {
+    auto cct = fifo->cct;
+    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " entering: tid=" << tid << dendl;
+    if (r == -ENOENT) {
+      r = 0;
+    }
+
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << (update ? " update_meta " : " trim ") << "failed: r="
+		 << r << " tid=" << tid << dendl;
+      complete(std::move(p), r);
+      return;
+    }
+
+    if (!update) {
+      ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		     << " handling preceding trim callback: tid=" << tid << dendl;
+      retries = 0;
+      if (pn < part_num) {
+	ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		       << " pn=" << pn << " tid=" << tid << dendl;
+	std::unique_lock l(fifo->m);
+	const auto max_part_size = fifo->info.params.max_part_size;
+	l.unlock();
+	fifo->trim_part(pn++, max_part_size, std::nullopt,
+			false, tid, call(std::move(p)));
+	return;
+      }
+
+      std::unique_lock l(fifo->m);
+      const auto tail_part_num = fifo->info.tail_part_num;
+      l.unlock();
+      update = true;
+      canceled = tail_part_num < part_num;
+      fifo->trim_part(part_num, ofs, std::nullopt, exclusive, tid,
+		      call(std::move(p)));
+      return;
+    }
+
+    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " handling update-needed callback: tid=" << tid << dendl;
+    std::unique_lock l(fifo->m);
+    auto tail_part_num = fifo->info.tail_part_num;
+    auto objv = fifo->info.version;
+    l.unlock();
+    if ((tail_part_num < part_num) &&
+	canceled) {
+      if (retries > MAX_RACE_RETRIES) {
+	lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " canceled too many times, giving up: tid=" << tid << dendl;
+	complete(std::move(p), -EIO);
+	return;
+      }
+      ++retries;
+      fifo->_update_meta(fifo::update{}
+			 .tail_part_num(part_num), objv, &canceled,
+                         tid, call(std::move(p)));
+    } else {
+      complete(std::move(p), 0);
+    }
   }
 };
 
-void FIFO::trim_callback(lr::completion_t, void* arg)
-{
-  std::unique_ptr<Trimmer> trimmer(static_cast<Trimmer*>(arg));
-  auto cct = trimmer->fifo->cct;
-  auto tid = trimmer->tid;
-  ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		 << " entering: tid=" << tid << dendl;
-  int r = trimmer->cur->get_return_value();
-  if (r == -ENOENT) {
-    r = 0;
-  }
-
-  if (r < 0) {
-    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-	       << " trim failed: r=" << r << " tid=" << tid << dendl;
-    complete(trimmer->super, r);
-    return;
-  }
-
-  if (!trimmer->update) {
-    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		   << " handling preceding trim callback: tid=" << tid << dendl;
-    trimmer->retries = 0;
-    if (trimmer->pn < trimmer->part_num) {
-      std::unique_lock l(trimmer->fifo->m);
-      const auto max_part_size = trimmer->fifo->info.params.max_part_size;
-      l.unlock();
-      trimmer->cur->release();
-      trimmer->cur = lr::Rados::aio_create_completion(arg, &FIFO::trim_callback);
-      r = trimmer->fifo->trim_part(trimmer->pn++, max_part_size, std::nullopt,
-				   false, tid, trimmer->cur);
-      if (r < 0) {
-	lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		   << " trim failed: r=" << r << " tid=" << tid << dendl;
-	complete(trimmer->super, r);
-      } else {
-	trimmer.release();
-      }
-      return;
-    }
-
-    std::unique_lock l(trimmer->fifo->m);
-    const auto tail_part_num = trimmer->fifo->info.tail_part_num;
-    l.unlock();
-    trimmer->cur->release();
-    trimmer->cur = lr::Rados::aio_create_completion(arg, &FIFO::trim_callback);
-    trimmer->update = true;
-    trimmer->canceled = tail_part_num < trimmer->part_num;
-    r = trimmer->fifo->trim_part(trimmer->part_num, trimmer->ofs,
-				 std::nullopt, trimmer->exclusive, tid, trimmer->cur);
-    if (r < 0) {
-      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		 << " failed scheduling trim: r=" << r << " tid=" << tid << dendl;
-      complete(trimmer->super, r);
-    } else {
-      trimmer.release();
-    }
-    return;
-  }
-
-  ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		 << " handling update-needed callback: tid=" << tid << dendl;
-  std::unique_lock l(trimmer->fifo->m);
-  auto tail_part_num = trimmer->fifo->info.tail_part_num;
-  auto objv = trimmer->fifo->info.version;
-  l.unlock();
-  if ((tail_part_num < trimmer->part_num) &&
-      trimmer->canceled) {
-    if (trimmer->retries > MAX_RACE_RETRIES) {
-      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		 << " canceled too many times, giving up: tid=" << tid << dendl;
-      complete(trimmer->super, -EIO);
-      return;
-    }
-    trimmer->cur->release();
-    trimmer->cur = lr::Rados::aio_create_completion(arg,
-						    &FIFO::trim_callback);
-    ++trimmer->retries;
-    r = trimmer->fifo->_update_meta(fifo::update{}
-				    .tail_part_num(trimmer->part_num),
-			            objv, &trimmer->canceled,
-                                    tid, trimmer->cur);
-    if (r < 0) {
-      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		 << " failed scheduling _update_meta: r="
-		 << r << " tid=" << tid << dendl;
-      complete(trimmer->super, r);
-    } else {
-      trimmer.release();
-    }
-  } else {
-    complete(trimmer->super, 0);
-  }
-}
-
-int FIFO::trim(std::string_view markstr, bool exclusive, lr::AioCompletion* c) {
+void FIFO::trim(std::string_view markstr, bool exclusive,
+		lr::AioCompletion* c) {
   auto marker = to_marker(markstr);
-  if (!marker) {
-    return -EINVAL;
-  }
+  auto realmark = marker.value_or(::rgw::cls::fifo::marker{});
   std::unique_lock l(m);
   const auto max_part_size = info.params.max_part_size;
   const auto pn = info.tail_part_num;
   const auto part_oid = info.part_oid(pn);
   auto tid = ++next_tid;
   l.unlock();
-  auto trimmer = std::make_unique<Trimmer>(this, marker->num, marker->ofs, pn, exclusive, c,
-					   tid);
+  ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " entering: tid=" << tid << dendl;
+  auto trimmer = std::make_unique<Trimmer>(this, realmark.num, realmark.ofs,
+					   pn, exclusive, c, tid);
+  if (!marker) {
+    Trimmer::complete(std::move(trimmer), -EINVAL);
+  }
   ++trimmer->pn;
   auto ofs = marker->ofs;
   if (pn < marker->num) {
+    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " pn=" << pn << " tid=" << tid << dendl;
     ofs = max_part_size;
   } else {
     trimmer->update = true;
   }
-  auto r = trim_part(pn, ofs, std::nullopt, exclusive,
-		     tid, trimmer->cur);
-  if (r < 0) {
-    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-	       << " failed scheduling trim_part: r="
-	       << r << " tid=" << tid << dendl;
-    complete(trimmer->super, r);
-  } else {
-    trimmer.release();
-  }
-  return r;
+  trim_part(pn, ofs, std::nullopt, exclusive,
+	    tid, Trimmer::call(std::move(trimmer)));
 }
 
 int FIFO::get_part_info(int64_t part_num,
@@ -1508,5 +1983,522 @@ int FIFO::get_part_info(int64_t part_num,
 	       << r << " tid=" << tid << dendl;
   }
   return r;
+}
+
+void FIFO::get_part_info(int64_t part_num,
+			 fifo::part_header* header,
+			 lr::AioCompletion* c)
+{
+  std::unique_lock l(m);
+  const auto part_oid = info.part_oid(part_num);
+  auto tid = ++next_tid;
+  l.unlock();
+  auto op = rgw::cls::fifo::get_part_info(cct, header, tid);
+  auto r = ioctx.aio_operate(part_oid, c, &op, nullptr);
+  ceph_assert(r >= 0);
+}
+
+struct InfoGetter : Completion<InfoGetter> {
+  FIFO* fifo;
+  fifo::part_header header;
+  fu2::function<void(int r, fifo::part_header&&)> f;
+  std::uint64_t tid;
+  bool headerread = false;
+
+  InfoGetter(FIFO* fifo, fu2::function<void(int r, fifo::part_header&&)> f,
+	     std::uint64_t tid, lr::AioCompletion* super)
+    : Completion(super), fifo(fifo), f(std::move(f)), tid(tid) {}
+  void handle(Ptr&& p, int r) {
+    if (!headerread) {
+      if (r < 0) {
+	lderr(fifo->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " read_meta failed: r="
+			 << r << " tid=" << tid << dendl;
+	if (f)
+	  f(r, {});
+	complete(std::move(p), r);
+	return;
+      }
+
+      auto info = fifo->meta();
+      auto hpn = info.head_part_num;
+      if (hpn < 0) {
+	ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			     << " no head, returning empty partinfo r="
+			     << r << " tid=" << tid << dendl;
+	if (f)
+	  f(0, {});
+	complete(std::move(p), r);
+	return;
+      }
+      headerread = true;
+      auto op = rgw::cls::fifo::get_part_info(fifo->cct, &header, tid);
+      std::unique_lock l(fifo->m);
+      auto oid = fifo->info.part_oid(hpn);
+      l.unlock();
+      r = fifo->ioctx.aio_operate(oid, call(std::move(p)), &op,
+				  nullptr);
+      ceph_assert(r >= 0);
+      return;
+    }
+
+    if (r < 0) {
+      lderr(fifo->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		       << " get_part_info failed: r="
+		       << r << " tid=" << tid << dendl;
+    }
+
+    if (f)
+      f(r, std::move(header));
+    complete(std::move(p), r);
+    return;
+  }
+};
+
+void FIFO::get_head_info(fu2::unique_function<void(int r,
+						   fifo::part_header&&)> f,
+			 lr::AioCompletion* c)
+{
+  std::unique_lock l(m);
+  auto tid = ++next_tid;
+  l.unlock();
+  auto ig = std::make_unique<InfoGetter>(this, std::move(f), tid, c);
+  read_meta(tid, InfoGetter::call(std::move(ig)));
+}
+
+struct JournalProcessor : public Completion<JournalProcessor> {
+private:
+  FIFO* const fifo;
+
+  std::vector<fifo::journal_entry> processed;
+  std::multimap<std::int64_t, fifo::journal_entry> journal;
+  std::multimap<std::int64_t, fifo::journal_entry>::iterator iter;
+  std::int64_t new_tail;
+  std::int64_t new_head;
+  std::int64_t new_max;
+  int race_retries = 0;
+  bool first_pp = true;
+  bool canceled = false;
+  std::uint64_t tid;
+
+  enum {
+    entry_callback,
+    pp_callback,
+  } state;
+
+  void create_part(Ptr&& p, int64_t part_num,
+		   std::string_view tag) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " entering: tid=" << tid << dendl;
+    state = entry_callback;
+    lr::ObjectWriteOperation op;
+    op.create(false); /* We don't need exclusivity, part_init ensures
+			 we're creating from the  same journal entry. */
+    std::unique_lock l(fifo->m);
+    part_init(&op, tag, fifo->info.params);
+    auto oid = fifo->info.part_oid(part_num);
+    l.unlock();
+    auto r = fifo->ioctx.aio_operate(oid, call(std::move(p)), &op);
+    ceph_assert(r >= 0);
+    return;
+  }
+
+  void remove_part(Ptr&& p, int64_t part_num,
+		   std::string_view tag) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " entering: tid=" << tid << dendl;
+    state = entry_callback;
+    lr::ObjectWriteOperation op;
+    op.remove();
+    std::unique_lock l(fifo->m);
+    auto oid = fifo->info.part_oid(part_num);
+    l.unlock();
+    auto r = fifo->ioctx.aio_operate(oid, call(std::move(p)), &op);
+    ceph_assert(r >= 0);
+    return;
+  }
+
+  void finish_je(Ptr&& p, int r,
+		 const fifo::journal_entry& entry) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " entering: tid=" << tid << dendl;
+
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " finishing entry: entry=" << entry
+			 << " tid=" << tid << dendl;
+
+    if (entry.op == fifo::journal_entry::Op::remove && r == -ENOENT)
+      r = 0;
+
+    if (r < 0) {
+      lderr(fifo->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		       << " processing entry failed: entry=" << entry
+		       << " r=" << r << " tid=" << tid << dendl;
+      complete(std::move(p), r);
+      return;
+    } else {
+      switch (entry.op) {
+      case fifo::journal_entry::Op::unknown:
+      case fifo::journal_entry::Op::set_head:
+	// Can't happen. Filtered out in process.
+	complete(std::move(p), -EIO);
+	return;
+
+      case fifo::journal_entry::Op::create:
+	if (entry.part_num > new_max) {
+	  new_max = entry.part_num;
+	}
+	break;
+      case fifo::journal_entry::Op::remove:
+	if (entry.part_num >= new_tail) {
+	  new_tail = entry.part_num + 1;
+	}
+	break;
+      }
+      processed.push_back(entry);
+    }
+    ++iter;
+    process(std::move(p));
+  }
+
+  void postprocess(Ptr&& p) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " entering: tid=" << tid << dendl;
+    if (processed.empty()) {
+      ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			   << " nothing to update any more: race_retries="
+			   << race_retries << " tid=" << tid << dendl;
+      complete(std::move(p), 0);
+      return;
+    }
+    pp_run(std::move(p), 0, false);
+  }
+
+public:
+
+  JournalProcessor(FIFO* fifo, std::uint64_t tid, lr::AioCompletion* super)
+    : Completion(super), fifo(fifo), tid(tid) {
+    std::unique_lock l(fifo->m);
+    journal = fifo->info.journal;
+    iter = journal.begin();
+    new_tail = fifo->info.tail_part_num;
+    new_head = fifo->info.head_part_num;
+    new_max = fifo->info.max_push_part_num;
+  }
+
+  void pp_run(Ptr&& p, int r, bool canceled) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " entering: tid=" << tid << dendl;
+    std::optional<int64_t> tail_part_num;
+    std::optional<int64_t> head_part_num;
+    std::optional<int64_t> max_part_num;
+
+    if (r < 0) {
+      lderr(fifo->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		       << " failed, r=: " << r << " tid=" << tid << dendl;
+      complete(std::move(p), r);
+    }
+
+
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " postprocessing: race_retries="
+			 << race_retries << " tid=" << tid << dendl;
+
+    if (!first_pp && r == 0 && !canceled) {
+      ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			   << " nothing to update any more: race_retries="
+			   << race_retries << " tid=" << tid << dendl;
+      complete(std::move(p), 0);
+      return;
+    }
+
+    first_pp = false;
+
+    if (canceled) {
+      if (race_retries >= MAX_RACE_RETRIES) {
+	lderr(fifo->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " canceled too many times, giving up: tid="
+			 << tid << dendl;
+	complete(std::move(p), -ECANCELED);
+	return;
+      }
+      ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			   << " update canceled, retrying: race_retries="
+			   << race_retries << " tid=" << tid << dendl;
+
+      ++race_retries;
+
+      std::vector<fifo::journal_entry> new_processed;
+      std::unique_lock l(fifo->m);
+      for (auto& e : processed) {
+	auto jiter = fifo->info.journal.find(e.part_num);
+	/* journal entry was already processed */
+	if (jiter == fifo->info.journal.end() ||
+	    !(jiter->second == e)) {
+	  continue;
+	}
+	new_processed.push_back(e);
+      }
+      processed = std::move(new_processed);
+    }
+
+    std::unique_lock l(fifo->m);
+    auto objv = fifo->info.version;
+    if (new_tail > fifo->info.tail_part_num) {
+      tail_part_num = new_tail;
+    }
+
+    if (new_head > fifo->info.head_part_num) {
+      head_part_num = new_head;
+    }
+
+    if (new_max > fifo->info.max_push_part_num) {
+      max_part_num = new_max;
+    }
+    l.unlock();
+
+    if (processed.empty() &&
+	!tail_part_num &&
+	!max_part_num) {
+      /* nothing to update anymore */
+      ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			   << " nothing to update any more: race_retries="
+			   << race_retries << " tid=" << tid << dendl;
+      complete(std::move(p), 0);
+      return;
+    }
+    state = pp_callback;
+    fifo->_update_meta(fifo::update{}
+		       .tail_part_num(tail_part_num)
+		       .head_part_num(head_part_num)
+		       .max_push_part_num(max_part_num)
+		       .journal_entries_rm(processed),
+                       objv, &this->canceled, tid, call(std::move(p)));
+    return;
+  }
+
+  JournalProcessor(const JournalProcessor&) = delete;
+  JournalProcessor& operator =(const JournalProcessor&) = delete;
+  JournalProcessor(JournalProcessor&&) = delete;
+  JournalProcessor& operator =(JournalProcessor&&) = delete;
+
+  void process(Ptr&& p) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " entering: tid=" << tid << dendl;
+    while (iter != journal.end()) {
+      ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			   << " processing entry: entry=" << *iter
+			   << " tid=" << tid << dendl;
+      const auto entry = iter->second;
+      switch (entry.op) {
+      case fifo::journal_entry::Op::create:
+	create_part(std::move(p), entry.part_num, entry.part_tag);
+	return;
+      case fifo::journal_entry::Op::set_head:
+	if (entry.part_num > new_head) {
+	  new_head = entry.part_num;
+	}
+	processed.push_back(entry);
+	++iter;
+	continue;
+      case fifo::journal_entry::Op::remove:
+	remove_part(std::move(p), entry.part_num, entry.part_tag);
+	return;
+      default:
+	lderr(fifo->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " unknown journaled op: entry=" << entry << " tid="
+			 << tid << dendl;
+	complete(std::move(p), -EIO);
+	return;
+      }
+    }
+    postprocess(std::move(p));
+    return;
+  }
+
+  void handle(Ptr&& p, int r) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " entering: tid=" << tid << dendl;
+    switch (state) {
+    case entry_callback:
+      finish_je(std::move(p), r, iter->second);
+      return;
+    case pp_callback:
+      auto c = canceled;
+      canceled = false;
+      pp_run(std::move(p), r, c);
+      return;
+    }
+
+    abort();
+  }
+
+};
+
+void FIFO::process_journal(std::uint64_t tid, lr::AioCompletion* c) {
+  auto p = std::make_unique<JournalProcessor>(this, tid, c);
+  p->process(std::move(p));
+}
+
+struct Lister : Completion<Lister> {
+  FIFO* f;
+  std::vector<list_entry> result;
+  bool more = false;
+  std::int64_t part_num;
+  std::uint64_t ofs;
+  int max_entries;
+  int r_out = 0;
+  std::vector<fifo::part_list_entry> entries;
+  bool part_more = false;
+  bool part_full = false;
+  std::vector<list_entry>* entries_out;
+  bool* more_out;
+  std::uint64_t tid;
+
+  bool read = false;
+
+  void complete(Ptr&& p, int r) {
+    if (r >= 0) {
+      if (more_out) *more_out = more;
+      if (entries_out) *entries_out = std::move(result);
+    }
+    Completion::complete(std::move(p), r);
+  }
+
+public:
+  Lister(FIFO* f, std::int64_t part_num, std::uint64_t ofs, int max_entries,
+	 std::vector<list_entry>* entries_out, bool* more_out,
+	 std::uint64_t tid, lr::AioCompletion* super)
+    : Completion(super), f(f), part_num(part_num), ofs(ofs), max_entries(max_entries),
+      entries_out(entries_out), more_out(more_out), tid(tid) {
+    result.reserve(max_entries);
+  }
+
+  Lister(const Lister&) = delete;
+  Lister& operator =(const Lister&) = delete;
+  Lister(Lister&&) = delete;
+  Lister& operator =(Lister&&) = delete;
+
+  void handle(Ptr&& p, int r) {
+    if (read)
+      handle_read(std::move(p), r);
+    else
+      handle_list(std::move(p), r);
+  }
+
+  void list(Ptr&& p) {
+    if (max_entries > 0) {
+      part_more = false;
+      part_full = false;
+      entries.clear();
+
+      std::unique_lock l(f->m);
+      auto part_oid = f->info.part_oid(part_num);
+      l.unlock();
+
+      read = false;
+      auto op = list_part(f->cct, {}, ofs, max_entries, &r_out,
+			  &entries, &part_more, &part_full,
+			  nullptr, tid);
+      f->ioctx.aio_operate(part_oid, call(std::move(p)), &op, nullptr);
+    } else {
+      complete(std::move(p), 0);
+    }
+  }
+
+  void handle_read(Ptr&& p, int r) {
+    read = false;
+    if (r >= 0) r = r_out;
+    r_out = 0;
+
+    if (r < 0) {
+      complete(std::move(p), r);
+      return;
+    }
+
+    if (part_num < f->info.tail_part_num) {
+      /* raced with trim? restart */
+      max_entries += result.size();
+      result.clear();
+      part_num = f->info.tail_part_num;
+      ofs = 0;
+      list(std::move(p));
+      return;
+    }
+    /* assuming part was not written yet, so end of data */
+    more = false;
+    complete(std::move(p), 0);
+    return;
+  }
+
+  void handle_list(Ptr&& p, int r) {
+    if (r >= 0) r = r_out;
+    r_out = 0;
+    std::unique_lock l(f->m);
+    auto part_oid = f->info.part_oid(part_num);
+    l.unlock();
+    if (r == -ENOENT) {
+      read = true;
+      f->read_meta(tid, call(std::move(p)));
+      return;
+    }
+    if (r < 0) {
+      complete(std::move(p), r);
+      return;
+    }
+
+    more = part_full || part_more;
+    for (auto& entry : entries) {
+      list_entry e;
+      e.data = std::move(entry.data);
+      e.marker = marker{part_num, entry.ofs}.to_string();
+      e.mtime = entry.mtime;
+      result.push_back(std::move(e));
+    }
+    max_entries -= entries.size();
+    entries.clear();
+    if (max_entries > 0 && part_more) {
+      list(std::move(p));
+      return;
+    }
+
+    if (!part_full) { /* head part is not full */
+      complete(std::move(p), 0);
+      return;
+    }
+    ++part_num;
+    ofs = 0;
+    list(std::move(p));
+  }
+};
+
+void FIFO::list(int max_entries,
+		std::optional<std::string_view> markstr,
+		std::vector<list_entry>* out,
+		bool* more,
+		lr::AioCompletion* c) {
+  std::unique_lock l(m);
+  auto tid = ++next_tid;
+  std::int64_t part_num = info.tail_part_num;
+  l.unlock();
+  std::uint64_t ofs = 0;
+  std::optional<::rgw::cls::fifo::marker> marker;
+
+  if (markstr) {
+    marker = to_marker(*markstr);
+    if (marker) {
+      part_num = marker->num;
+      ofs = marker->ofs;
+    }
+  }
+
+  auto ls = std::make_unique<Lister>(this, part_num, ofs, max_entries, out,
+				     more, tid, c);
+  if (markstr && !marker) {
+    auto l = ls.get();
+    l->complete(std::move(ls), -EINVAL);
+  } else {
+    ls->list(std::move(ls));
+  }
 }
 }

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7729,7 +7729,7 @@ next:
 
     // trim until -ENODATA
     do {
-      ret = meta_log->trim(shard_id, marker);
+      ret = meta_log->trim(shard_id, marker, true);
     } while (ret == 0);
     if (ret < 0 && ret != -ENODATA) {
       cerr << "ERROR: meta_log->trim(): " << cpp_strerror(-ret) << std::endl;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7618,26 +7618,22 @@ next:
 
     formatter->open_array_section("entries");
     for (; i < g_ceph_context->_conf->rgw_md_log_max_shards; i++) {
-      void *handle;
-      list<cls_log_entry> entries;
+      std::vector<cls_log_entry> entries;
 
-      meta_log->init_list_entries(i, {}, {}, marker, &handle);
       bool truncated;
       do {
-	  int ret = meta_log->list_entries(handle, 1000, entries, NULL, &truncated);
+	int ret = meta_log->list_entries(i, 1000, marker, entries, &marker,
+					 &truncated);
         if (ret < 0) {
           cerr << "ERROR: meta_log->list_entries(): " << cpp_strerror(-ret) << std::endl;
           return -ret;
         }
 
-        for (list<cls_log_entry>::iterator iter = entries.begin(); iter != entries.end(); ++iter) {
-          cls_log_entry& entry = *iter;
+        for (const auto& entry : entries) {
           store->ctl()->meta.mgr->dump_log_entry(entry, formatter.get());
         }
         formatter->flush(cout);
       } while (truncated);
-
-      meta_log->complete_list_entries(handle);
 
       if (specified_shard_id)
         break;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7729,7 +7729,7 @@ next:
 
     // trim until -ENODATA
     do {
-      ret = meta_log->trim(shard_id, {}, {}, {}, marker);
+      ret = meta_log->trim(shard_id, marker);
     } while (ret == 0);
     if (ret < 0 && ret != -ENODATA) {
       cerr << "ERROR: meta_log->trim(): " << cpp_strerror(-ret) << std::endl;

--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -465,12 +465,7 @@ public:
       pc->cond.notify_all();
       pc->put_unlock();
     } else {
-      r = fifos[index]->trim(marker, false, c);
-      if (r < 0) {
-	lderr(cct) << __PRETTY_FUNCTION__
-		   << ": unable to trim FIFO: " << get_oid(index)
-		   << ": " << cpp_strerror(-r) << dendl;
-      }
+      fifos[index]->trim(marker, false, c);
     }
     return r;
   }

--- a/src/rgw/rgw_mdlog.h
+++ b/src/rgw/rgw_mdlog.h
@@ -150,6 +150,8 @@ public:
     return fmt::format("{}{}", prefix, id);
   }
 
+  int init();
+
   int add_entry(const std::string& hash_key, const std::string& section,
 		const std::string& key, ceph::bufferlist& bl);
   int get_shard_id(std::string_view hash_key);

--- a/src/rgw/rgw_mdlog.h
+++ b/src/rgw/rgw_mdlog.h
@@ -80,6 +80,7 @@ class RGWMetadataLogInfoCompletion : public RefCountedObject {
 
 class RGWMetadataLog {
   CephContext *cct;
+  rgw::sal::RGWRadosStore* store;
   const std::string prefix;
 
   struct Svc {
@@ -99,10 +100,11 @@ class RGWMetadataLog {
   void mark_modified(int shard_id);
 public:
   RGWMetadataLog(CephContext *cct,
+		 rgw::sal::RGWRadosStore* store,
                  RGWSI_Zone *_zone_svc,
                  RGWSI_Cls *_cls_svc,
                  const std::string& period)
-    : cct(cct),
+    : cct(cct), store(store),
       prefix(make_prefix(period)) {
     svc.zone = _zone_svc;
     svc.cls = _cls_svc;
@@ -145,6 +147,7 @@ public:
   int unlock(int shard_id, std::string& zone_id, string& owner_id);
 
   bc::flat_set<int> read_clear_modified();
+  RGWCoroutine* purge_cr();
 };
 
 struct LogStatusDump {

--- a/src/rgw/rgw_mdlog.h
+++ b/src/rgw/rgw_mdlog.h
@@ -109,10 +109,8 @@ public:
   }
 
 
-  void get_shard_oid(int id, std::string& oid) const {
-    char buf[16];
-    snprintf(buf, sizeof(buf), "%d", id);
-    oid = prefix + buf;
+  std::string get_shard_oid(int id) const {
+    return fmt::format("{}{}", prefix, id);
   }
 
   int add_entry(const std::string& hash_key, const std::string& section,
@@ -124,8 +122,6 @@ public:
   struct LogListCtx {
     int cur_shard;
     std::string marker;
-    ceph::real_time from_time;
-    ceph::real_time end_time;
 
     std::string cur_oid;
 
@@ -134,13 +130,10 @@ public:
     LogListCtx() : cur_shard(0), done(false) {}
   };
 
-  void init_list_entries(int shard_id, ceph::real_time from_time,
-			 ceph::real_time end_time,
-			 const std::string& marker, void **handle);
-  void complete_list_entries(void *handle);
-  int list_entries(void *handle,
+  int list_entries(int shard,
                    int max_entries,
-                   std::list<cls_log_entry>& entries,
+		   std::string_view marker,
+                   std::vector<cls_log_entry>& entries,
 		   std::string *out_marker,
 		   bool *truncated);
 

--- a/src/rgw/rgw_mdlog.h
+++ b/src/rgw/rgw_mdlog.h
@@ -116,7 +116,7 @@ public:
   int add_entry(const std::string& hash_key, const std::string& section,
 		const std::string& key, ceph::bufferlist& bl);
   int get_shard_id(const std::string& hash_key, int *shard_id);
-  int store_entries_in_shard(std::list<cls_log_entry>& entries, int shard_id,
+  int store_entries_in_shard(std::vector<cls_log_entry>& entries, int shard_id,
 			     librados::AioCompletion *completion);
 
   struct LogListCtx {
@@ -137,15 +137,12 @@ public:
 		   std::string *out_marker,
 		   bool *truncated);
 
-  int trim(int shard_id, ceph::real_time from_time, ceph::real_time end_time,
-	   const std::string& start_marker, const std::string& end_marker);
+  int trim(int shard_id, std::string_view marker);
   int get_info(int shard_id, RGWMetadataLogInfo *info);
   int get_info_async(int shard_id, RGWMetadataLogInfoCompletion *completion);
   int lock_exclusive(int shard_id, ceph::timespan duration, std::string& zone_id,
 		     std::string& owner_id);
   int unlock(int shard_id, std::string& zone_id, string& owner_id);
-
-  int update_shards(std::list<int>& shards);
 
   bc::flat_set<int> read_clear_modified();
 };

--- a/src/rgw/rgw_mdlog.h
+++ b/src/rgw/rgw_mdlog.h
@@ -18,8 +18,13 @@
 
 #include <list>
 #include <string>
+#include <string_view>
 
 #include <boost/container/flat_set.hpp>
+
+#undef FMT_HEADER_ONLY
+#define FMT_HEADER_ONLY 1
+#include <fmt/format.h>
 
 #include "common/Formatter.h"
 #include "common/ceph_mutex.h"
@@ -32,7 +37,7 @@
 
 namespace bc = boost::container;
 
-#define META_LOG_OBJ_PREFIX "meta.log."
+inline constexpr auto META_LOG_OBJ_PREFIX = "meta.log."sv;
 
 struct RGWMetadataLogInfo {
   std::string marker;
@@ -84,8 +89,8 @@ class RGWMetadataLog {
 
   static std::string make_prefix(const std::string& period) {
     if (period.empty())
-      return META_LOG_OBJ_PREFIX;
-    return META_LOG_OBJ_PREFIX + period + ".";
+      return string(META_LOG_OBJ_PREFIX);
+    return fmt::format("{}{}.", META_LOG_OBJ_PREFIX, period);
   }
 
   ceph::shared_mutex lock = ceph::make_shared_mutex("RGWMetaLog::lock");

--- a/src/rgw/rgw_mdlog.h
+++ b/src/rgw/rgw_mdlog.h
@@ -115,7 +115,7 @@ public:
 
   int add_entry(const std::string& hash_key, const std::string& section,
 		const std::string& key, ceph::bufferlist& bl);
-  int get_shard_id(const std::string& hash_key, int *shard_id);
+  int get_shard_id(std::string_view hash_key);
   int store_entries_in_shard(std::vector<cls_log_entry>& entries, int shard_id,
 			     librados::AioCompletion *completion);
 

--- a/src/rgw/rgw_mdlog.h
+++ b/src/rgw/rgw_mdlog.h
@@ -110,6 +110,8 @@ public:
   virtual int trim(int shard_id, std::string_view marker, bool exclusive) { return 0; };
   virtual int trim(int shard_id, std::string_view marker, librados::AioCompletion* c, bool exclusive) { return 0; };
   virtual std::string_view max_marker() { return NULL; };
+  static int remove(CephContext* cct, std::string prefix,
+	       		     librados::Rados* rados, const rgw_pool& log_pool);
 };
 
 class RGWMetadataLog {
@@ -138,19 +140,19 @@ public:
 		 rgw::sal::RGWRadosStore* store,
                  RGWSI_Zone *_zone_svc,
                  RGWSI_Cls *_cls_svc,
-                 const std::string& period);
-/*    : cct(cct), store(store),
+                 const std::string& period)
+    : cct(cct), store(store),
       prefix(make_prefix(period)) {
     svc.zone = _zone_svc;
     svc.cls = _cls_svc;
-  }*/
+  }
 
 
   std::string get_shard_oid(int id) const {
     return fmt::format("{}{}", prefix, id);
   }
 
-  int init();
+  int init(librados::Rados* lr);
 
   int add_entry(const std::string& hash_key, const std::string& section,
 		const std::string& key, ceph::bufferlist& bl);

--- a/src/rgw/rgw_mdlog.h
+++ b/src/rgw/rgw_mdlog.h
@@ -148,6 +148,8 @@ public:
 
   bc::flat_set<int> read_clear_modified();
   RGWCoroutine* purge_cr();
+  RGWCoroutine* master_trim_cr(int shard_id, const std::string& marker,
+	       			std::string* last_trim);
   RGWCoroutine* peer_trim_cr(int shard_id, std::string marker, bool exclusive);
 };
 

--- a/src/rgw/rgw_mdlog.h
+++ b/src/rgw/rgw_mdlog.h
@@ -79,6 +79,39 @@ class RGWMetadataLogInfoCompletion : public RefCountedObject {
   }
 };
 
+class RGWMetadataLogBE {
+protected:
+  CephContext* const cct;
+private:
+  std::string prefix;
+ 
+public:
+  using entries = std::variant<std::list<cls_log_entry>,
+			       std::vector<ceph::buffer::list>>;
+
+  RGWMetadataLogBE(CephContext* const cct, std::string prefix);
+  virtual ~RGWMetadataLogBE();
+
+  std::string get_shard_oid(int id) const {
+    return fmt::format("{}{}", prefix, id);
+  }
+
+  virtual int push(int index, std::vector<cls_log_entry>& items, librados::AioCompletion *&completion) { return 0; };
+  virtual int push(int index, ceph::real_time now,
+		   const std::string& section,
+		   const std::string& key,
+		   ceph::buffer::list& bl) { return 0; };
+  virtual int list(int index, int max_entries,
+		   std::vector<cls_log_entry>& items,
+		   std::string_view marker,
+		   std::string* out_marker, bool* truncated) { return 0; };
+  virtual int get_info(int index, RGWMetadataLogInfo *info) { return 0; };
+  virtual int get_info_async(int index, RGWMetadataLogInfoCompletion *completion) { return 0; };
+  virtual int trim(int shard_id, std::string_view marker, bool exclusive) { return 0; };
+  virtual int trim(int shard_id, std::string_view marker, librados::AioCompletion* c, bool exclusive) { return 0; };
+  virtual std::string_view max_marker() { return NULL; };
+};
+
 class RGWMetadataLog {
   CephContext *cct;
   rgw::sal::RGWRadosStore* store;
@@ -99,17 +132,18 @@ class RGWMetadataLog {
   bc::flat_set<int> modified_shards;
 
   void mark_modified(int shard_id);
+  std::unique_ptr<RGWMetadataLogBE> be;
 public:
   RGWMetadataLog(CephContext *cct,
 		 rgw::sal::RGWRadosStore* store,
                  RGWSI_Zone *_zone_svc,
                  RGWSI_Cls *_cls_svc,
-                 const std::string& period)
-    : cct(cct), store(store),
+                 const std::string& period);
+/*    : cct(cct), store(store),
       prefix(make_prefix(period)) {
     svc.zone = _zone_svc;
     svc.cls = _cls_svc;
-  }
+  }*/
 
 
   std::string get_shard_oid(int id) const {
@@ -153,6 +187,7 @@ public:
   RGWCoroutine* master_trim_cr(int shard_id, const std::string& marker,
 	       			std::string* last_trim);
   RGWCoroutine* peer_trim_cr(int shard_id, std::string marker, bool exclusive);
+  std::string_view max_marker() const;
 };
 
 class RGWMetadataLogTrimCR : public RGWSimpleCoroutine {
@@ -165,8 +200,6 @@ class RGWMetadataLogTrimCR : public RGWSimpleCoroutine {
   std::string *last_trim_marker;
 
  public:
-  static constexpr const char* max_marker = "99999999";
-
   RGWMetadataLogTrimCR(CephContext *cct,
                        RGWMetadataLog *mdlog, const int shard_id,
                        const std::string& marker, bool exclusive,

--- a/src/rgw/rgw_mdlog.h
+++ b/src/rgw/rgw_mdlog.h
@@ -148,6 +148,7 @@ public:
 
   bc::flat_set<int> read_clear_modified();
   RGWCoroutine* purge_cr();
+  RGWCoroutine* peer_trim_cr(int shard_id, std::string marker, bool exclusive);
 };
 
 struct LogStatusDump {

--- a/src/rgw/rgw_mdlog.h
+++ b/src/rgw/rgw_mdlog.h
@@ -122,6 +122,7 @@ class RGWMetadataLog {
   struct Svc {
     RGWSI_Zone *zone{nullptr};
     RGWSI_Cls *cls{nullptr};
+    RGWSI_RADOS *rados{nullptr};
   } svc;
 
   static std::string make_prefix(const std::string& period) {
@@ -135,24 +136,20 @@ class RGWMetadataLog {
 
   void mark_modified(int shard_id);
   std::unique_ptr<RGWMetadataLogBE> be;
+
+  int init(librados::Rados* lr);
+
 public:
   RGWMetadataLog(CephContext *cct,
 		 rgw::sal::RGWRadosStore* store,
                  RGWSI_Zone *_zone_svc,
                  RGWSI_Cls *_cls_svc,
-                 const std::string& period)
-    : cct(cct), store(store),
-      prefix(make_prefix(period)) {
-    svc.zone = _zone_svc;
-    svc.cls = _cls_svc;
-  }
-
+		 RGWSI_RADOS *_rados_svc,
+                 const std::string& period);
 
   std::string get_shard_oid(int id) const {
     return fmt::format("{}{}", prefix, id);
   }
-
-  int init(librados::Rados* lr);
 
   int add_entry(const std::string& hash_key, const std::string& section,
 		const std::string& key, ceph::bufferlist& bl);

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -12,6 +12,7 @@
 #include "rgw_tools.h"
 #include "rgw_mdlog.h"
 #include "rgw_sal.h"
+#include "rgw_sync.h"
 
 #include "rgw_cr_rados.h"
 
@@ -253,6 +254,43 @@ bc::flat_set<int> RGWMetadataLog::read_clear_modified()
   modified_shards.clear();
   return m;
 }
+
+
+/// purge all log shards for the given mdlog
+class PurgeLogShardsCR : public RGWShardCollectCR {
+  rgw::sal::RGWRadosStore *const store;
+  rgw_raw_obj obj;
+  std::size_t i = 0;
+  std::vector<std::string> oids;
+
+  static constexpr int max_concurrent = 16;
+
+ public:
+  PurgeLogShardsCR(rgw::sal::RGWRadosStore *store, const rgw_pool& pool,
+		   std::vector<std::string>&& oids)
+    : RGWShardCollectCR(store->ctx(), max_concurrent),
+      store(store), obj(pool, ""), oids(std::move(oids)) {}
+
+  bool spawn_next() override {
+    if (i == oids.size()) {
+      return false;
+    }
+    obj.oid = oids[i++];
+    spawn(new RGWRadosRemoveCR(store, obj), false);
+    return true;
+  }
+};
+
+RGWCoroutine* RGWMetadataLog::purge_cr()
+{
+  std::vector<std::string> oids;
+  for (auto i = 0; i < cct->_conf->rgw_md_log_max_shards; ++i)
+    oids.push_back(get_shard_oid(i));
+
+  return new PurgeLogShardsCR(store, svc.zone->get_zone_params().log_pool,
+			      std::move(oids));
+}
+
 
 obj_version& RGWMetadataObject::get_version()
 {

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -24,9 +24,16 @@
 
 #include "include/ceph_assert.h"
 
+#include "cls_fifo_legacy.h" 
+#include "cls/fifo/cls_fifo_types.h"
+
+#include "common/async/librados_completion.h"
+
 #include <boost/asio/yield.hpp>
 
 #define dout_subsys ceph_subsys_rgw
+
+namespace bs = boost::system;
 
 const std::string RGWMetadataLogHistory::oid = "meta.history";
 
@@ -137,12 +144,223 @@ int RGWMetadataLogTrimCR::request_complete()
     return r;
   }
   // nothing left to trim, update last_trim_marker
-  if (last_trim_marker && *last_trim_marker < marker && marker != max_marker) {
+  if (last_trim_marker && *last_trim_marker < marker &&
+	 marker != mdlog->max_marker()) {
     *last_trim_marker = marker;
     r = 0;
   }
   return r;
 }
+
+RGWMetadataLogBE::RGWMetadataLogBE(CephContext* const cct, std::string prefix)
+    : cct(cct), prefix(prefix) {}
+RGWMetadataLogBE::~RGWMetadataLogBE() {}
+
+class RGWMetadataLogOmap final : public RGWMetadataLogBE {
+  RGWSI_Cls& cls;
+  std::vector<std::string> oids;
+public:
+  RGWMetadataLogOmap(CephContext* cct, std::string prefix, RGWSI_Cls& cls)
+    : RGWMetadataLogBE(cct, prefix), cls(cls) {
+    auto num_shards = cct->_conf->rgw_md_log_max_shards;
+    oids.reserve(num_shards);
+    for (auto i = 0; i < num_shards; ++i) {
+      oids.push_back(RGWMetadataLogBE::get_shard_oid(i));
+    }
+  }
+  ~RGWMetadataLogOmap() override = default;
+  static int exists(CephContext* cct, RGWSI_Cls& cls, std::string prefix,
+		    bool* exists, bool* has_entries) {
+    auto num_shards = cct->_conf->rgw_md_log_max_shards;
+    std::string out_marker;
+    bool truncated = false;
+    std::list<cls_log_entry> log_entries;
+    const cls_log_header empty_info;
+    *exists = false;
+    *has_entries = false;
+    for (auto i = 0; i < num_shards; ++i) {
+      auto oid = fmt::format("{}{}", prefix, i);
+      cls_log_header info;
+      auto r = cls.timelog.info(oid, &info, null_yield);
+      if (r < 0 && r != -ENOENT) {
+	lderr(cct) << __PRETTY_FUNCTION__
+		   << ": failed to get info " << oid << ": " << cpp_strerror(-r)
+		   << dendl;
+	return r;
+      } else if ((r == -ENOENT) || (info == empty_info)) {
+	continue;
+      }
+      *exists = true;
+      r = cls.timelog.list(oid, {}, {}, 100, log_entries, "", &out_marker,
+			   &truncated, null_yield);
+      if (r < 0) {
+	lderr(cct) << __PRETTY_FUNCTION__
+		   << ": failed to list " << oid << ": " << cpp_strerror(-r)
+		   << dendl;
+	return r;
+      } else if (!log_entries.empty()) {
+	*has_entries = true;
+	break; // No reason to continue, once we have both existence
+	       // AND non-emptiness
+      }
+    }
+    return 0;
+  }
+  int push(int index, std::vector<cls_log_entry>& items, librados::AioCompletion *&completion) override {
+    std::list<cls_log_entry> lentries(std::move_iterator(items.begin()),
+				      std::move_iterator(items.end()));
+
+    auto r = cls.timelog.add(oids[index], lentries,
+			     completion, false, null_yield);
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": failed to push to " << oids[index] << cpp_strerror(-r)
+		 << dendl;
+    }
+    return r;
+  }
+  int push(int index, ceph::real_time now,
+	   const std::string& section,
+	   const std::string& key,
+	   ceph::buffer::list& bl) override {
+    auto r = cls.timelog.add(oids[index], now, section, key, bl, null_yield);
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": failed to push to " << oids[index]
+		 << cpp_strerror(-r) << dendl;
+    }
+    return r;
+  }
+  int list(int index, int max_entries,
+	   std::vector<cls_log_entry>& e,
+	   std::string_view marker,
+	   std::string* out_marker, bool* truncated) override {
+    std::list<cls_log_entry> lentries;
+    auto r = cls.timelog.list(oids[index], {}, {},
+			      max_entries, lentries,
+			      string(marker),
+			      out_marker, truncated, null_yield);
+    e.clear();
+    std::move(lentries.begin(), lentries.end(), std::back_inserter(e));
+
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": failed to list " << oids[index]
+		 << cpp_strerror(-r) << dendl;
+      return r;
+    }
+    return 0;
+  }
+  int get_info(int index, RGWMetadataLogInfo *info) override {
+    cls_log_header header;
+    auto r = cls.timelog.info(oids[index], &header, null_yield);
+    if (r == -ENOENT) r = 0;
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": failed to get info from " << oids[index]
+		 << cpp_strerror(-r) << dendl;
+    } else {
+      info->marker = header.max_marker;
+      info->last_update = header.max_time.to_real_time();
+    }
+    return r;
+  }
+  int get_info_async(int index, RGWMetadataLogInfoCompletion *completion) override {
+    return cls.timelog.info_async(completion->get_io_obj(), oids[index],
+                                       &completion->get_header(),
+                                       completion->get_completion());
+  }
+  int trim(int index, std::string_view marker, bool exclusive) override {
+    string m = string(marker);
+    int r = 0;
+
+    if (!exclusive) {
+      r = cls.timelog.trim(oids[index], {}, {},
+			      {}, m, nullptr, null_yield);
+    } else {
+      // Extract timestamp from marker .. needed only for OMAP
+      ceph::real_time stable;
+      int sec, usec;
+      char keyext[256];
+
+      int ret = sscanf(m.c_str(), "1_%d.%d_%255s", &sec, &usec, keyext);
+
+      if (ret < 0) {
+        ldout(cct, 0) << "ERROR: scanning marker ret = " << ret << dendl;
+        return -1;
+      } else {
+        stable = utime_t(sec, usec).to_real_time();
+        // can only trim -up to- master's first timestamp, so subtract a second.
+        // (this is why we use timestamps instead of markers for the peers)
+        stable -= std::chrono::seconds(1);
+      }
+
+      r = cls.timelog.trim(oids[index], {}, stable,
+  			      {}, {}, nullptr,
+  			      null_yield);
+    }
+
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": failed to trim " << oids[index]
+		 << cpp_strerror(-r) << dendl;
+    }
+    return r;
+  }
+  int trim(int index, std::string_view marker,
+	   librados::AioCompletion* c, bool exclusive) override {
+    string m = string(marker);
+
+    int r = 0;
+
+    if (!exclusive) {
+      r = cls.timelog.trim(oids[index], {}, {},
+			      {}, m, c, null_yield);
+    } else {
+      // Extract timestamp from marker .. needed only for OMAP
+      ceph::real_time stable;
+      int sec, usec;
+      char keyext[256];
+
+      int ret = sscanf(m.c_str(), "1_%d.%d_%255s", &sec, &usec, keyext);
+
+      if (ret < 0) {
+        ldout(cct, 0) << "ERROR: scanning marker ret = " << ret << dendl;
+        return -1;
+      } else {
+        stable = utime_t(sec, usec).to_real_time();
+        // can only trim -up to- master's first timestamp, so subtract a second.
+        // (this is why we use timestamps instead of markers for the peers)
+        stable -= std::chrono::seconds(1);
+      }
+
+      r = cls.timelog.trim(oids[index], {}, stable,
+			    {}, {}, c, null_yield);
+    }
+
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": failed to get trim " << oids[index]
+		 << cpp_strerror(-r) << dendl;
+    }
+    return r;
+  }
+  std::string_view max_marker() override {
+    return "99999999"sv;
+  }
+};
+
+RGWMetadataLog::RGWMetadataLog(CephContext *cct,
+		 rgw::sal::RGWRadosStore* store,
+                 RGWSI_Zone *_zone_svc,
+                 RGWSI_Cls *_cls_svc,
+                 const std::string& period)
+    : cct(cct), store(store),
+      prefix(make_prefix(period)) {
+    svc.zone = _zone_svc;
+    svc.cls = _cls_svc;
+    be = std::make_unique<RGWMetadataLogOmap>(cct, prefix, *svc.cls);
+  }
 
 int RGWMetadataLog::add_entry(const string& hash_key, const string& section,
 			      const string& key, bufferlist& bl) {
@@ -154,7 +372,7 @@ int RGWMetadataLog::add_entry(const string& hash_key, const string& section,
 					hash_key);
   mark_modified(shard_id);
   real_time now = real_clock::now();
-  return svc.cls->timelog.add(oid, now, section, key, bl, null_yield);
+  return be->push(shard_id, now, section, key, (ceph::buffer::list &)bl);
 }
 
 int RGWMetadataLog::get_shard_id(std::string_view hash_key)
@@ -165,13 +383,14 @@ int RGWMetadataLog::get_shard_id(std::string_view hash_key)
   return shard_id;
 }
 
+std::string_view RGWMetadataLog::max_marker() const {
+  return be->max_marker();
+}
+
 int RGWMetadataLog::store_entries_in_shard(std::vector<cls_log_entry>& entries, int shard_id, librados::AioCompletion *completion)
 {
   mark_modified(shard_id);
-  auto oid = rgw_shard_name(prefix, shard_id);
-  std::list<cls_log_entry> lentries(std::move_iterator(entries.begin()),
-				    std::move_iterator(entries.end()));
-  return svc.cls->timelog.add(oid, lentries, completion, false, null_yield);
+  return be->push(shard_id, entries, completion);
 }
 
 int RGWMetadataLog::list_entries(int shard,
@@ -188,12 +407,7 @@ int RGWMetadataLog::list_entries(int shard,
 
   auto oid = get_shard_oid(shard);
   std::string next_marker;
-  std::list<cls_log_entry> lentries;
-  int ret = svc.cls->timelog.list(oid, {}, {},
-                                  max_entries, lentries, string(marker),
-                                  &next_marker, truncated, null_yield);
-  entries.clear();
-  std::move(lentries.begin(), lentries.end(), std::back_inserter(entries));
+  int ret = be->list(shard, max_entries, entries, marker, &next_marker, truncated);
   if ((ret < 0) && (ret != -ENOENT))
     return ret;
 
@@ -209,18 +423,7 @@ int RGWMetadataLog::list_entries(int shard,
 
 int RGWMetadataLog::get_info(int shard_id, RGWMetadataLogInfo *info)
 {
-  auto oid = get_shard_oid(shard_id);
-
-  cls_log_header header;
-
-  int ret = svc.cls->timelog.info(oid, &header, null_yield);
-  if ((ret < 0) && (ret != -ENOENT))
-    return ret;
-
-  info->marker = header.max_marker;
-  info->last_update = header.max_time.to_real_time();
-
-  return 0;
+  return be->get_info(shard_id, info);
 }
 
 static void _mdlog_info_completion(librados::completion_t cb, void *arg)
@@ -244,77 +447,19 @@ RGWMetadataLogInfoCompletion::~RGWMetadataLogInfoCompletion()
 
 int RGWMetadataLog::get_info_async(int shard_id, RGWMetadataLogInfoCompletion *completion)
 {
-  auto oid = get_shard_oid(shard_id);
-
   completion->get(); // hold a ref until the completion fires
-
-  return svc.cls->timelog.info_async(completion->get_io_obj(), oid,
-                                     &completion->get_header(),
-                                     completion->get_completion());
+  return be->get_info_async(shard_id, completion);
 }
 
 int RGWMetadataLog::trim(int shard_id, std::string_view marker, bool exclusive)
 {
-  auto oid = get_shard_oid(shard_id);
-
-  if (!exclusive) {
-    return svc.cls->timelog.trim(oid, {}, {}, {},
-                                 string(marker), nullptr, null_yield);
-  }
-
-  string m = string(marker);
-
-  // Extract timestamp from marker .. needed only for OMAP
-  ceph::real_time stable;
-  int sec, usec;
-  char keyext[256];
-
-  int ret = sscanf(m.c_str(), "1_%d.%d_%255s", &sec, &usec, keyext);
-
-  if (ret < 0) {
-    ldout(cct, 0) << "ERROR: scanning marker ret = " << ret << dendl;
-    return -1;
-  } else {
-    stable = utime_t(sec, usec).to_real_time();
-    // can only trim -up to- master's first timestamp, so subtract a second.
-    // (this is why we use timestamps instead of markers for the peers)
-    stable -= std::chrono::seconds(1);
-  }
-
-  return svc.cls->timelog.trim(oid, {}, stable, {}, {},
-                               nullptr, null_yield);
+  return be->trim(shard_id, marker, exclusive);
 }
 
 int RGWMetadataLog::trim(int shard_id, std::string_view marker,
 	                 librados::AioCompletion* c, bool exclusive)
 {
-  auto oid = get_shard_oid(shard_id);
-  if (!exclusive) {
-    return svc.cls->timelog.trim(oid, {}, {}, {},
-                                 string(marker), c, null_yield);
-  }
-
-  string m = string(marker);
-
-  // Extract timestamp from marker .. needed only for OMAP
-  ceph::real_time stable;
-  int sec, usec;
-  char keyext[256];
-
-  int ret = sscanf(m.c_str(), "1_%d.%d_%255s", &sec, &usec, keyext);
-
-  if (ret < 0) {
-    ldout(cct, 0) << "ERROR: scanning marker ret = " << ret << dendl;
-    return -1;
-  } else {
-    stable = utime_t(sec, usec).to_real_time();
-    // can only trim -up to- master's first timestamp, so subtract a second.
-    // (this is why we use timestamps instead of markers for the peers)
-    stable -= std::chrono::seconds(1);
-  }
-
-  return svc.cls->timelog.trim(oid, {}, stable, {}, {},
-                               c, null_yield);
+  return be->trim(shard_id, marker, c, exclusive);
 }
 
 int RGWMetadataLog::lock_exclusive(int shard_id, timespan duration, string& zone_id, string& owner_id) {

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -152,10 +152,6 @@ int RGWMetadataLogTrimCR::request_complete()
   return r;
 }
 
-RGWMetadataLogBE::RGWMetadataLogBE(CephContext* const cct, std::string prefix)
-    : cct(cct), prefix(prefix) {}
-RGWMetadataLogBE::~RGWMetadataLogBE() {}
-
 class RGWMetadataLogOmap final : public RGWMetadataLogBE {
   RGWSI_Cls& cls;
   std::vector<std::string> oids;
@@ -350,20 +346,300 @@ public:
   }
 };
 
-RGWMetadataLog::RGWMetadataLog(CephContext *cct,
-		 rgw::sal::RGWRadosStore* store,
-                 RGWSI_Zone *_zone_svc,
-                 RGWSI_Cls *_cls_svc,
-                 const std::string& period)
-    : cct(cct), store(store),
-      prefix(make_prefix(period)) {
-    svc.zone = _zone_svc;
-    svc.cls = _cls_svc;
-//    be = std::make_unique<RGWMetadataLogOmap>(cct, prefix, *svc.cls);
+class RGWMetadataLogFIFO final : public RGWMetadataLogBE {
+  std::vector<std::unique_ptr<rgw::cls::fifo::FIFO>> fifos;
+public:
+  RGWMetadataLogFIFO(CephContext* cct, std::string prefix,
+		     librados::Rados* rados, const rgw_pool& log_pool)
+    : RGWMetadataLogBE(cct, prefix) {
+    librados::IoCtx ioctx;
+    auto shards = cct->_conf->rgw_md_log_max_shards;
+    auto r = rgw_init_ioctx(rados, log_pool.name, ioctx,
+			    true, false);
+    if (r < 0) {
+      throw bs::system_error(ceph::to_error_code(r));
+    }
+    fifos.resize(shards);
+    for (auto i = 0; i < shards; ++i) {
+      r = rgw::cls::fifo::FIFO::create(ioctx, get_shard_oid(i),
+				       &fifos[i], null_yield);
+      if (r < 0) {
+	throw bs::system_error(ceph::to_error_code(r));
+      }
+    }
+    ceph_assert(fifos.size() == unsigned(shards));
+    ceph_assert(std::none_of(fifos.cbegin(), fifos.cend(),
+			     [](const auto& p) {
+			       return p == nullptr;
+			     }));
+  }
+  ~RGWMetadataLogFIFO() override = default;
+  static int exists(CephContext* cct, std::string prefix, librados::Rados* rados,
+		    const rgw_pool& log_pool, bool* exists, bool* has_entries) {
+    auto num_shards = cct->_conf->rgw_md_log_max_shards;
+    librados::IoCtx ioctx;
+    auto r = rgw_init_ioctx(rados, log_pool.name, ioctx,
+			    false, false);
+    if (r < 0) {
+      if (r == -ENOENT) {
+	return 0;
+      } else {
+	lderr(cct) << __PRETTY_FUNCTION__
+		   << ": rgw_init_ioctx failed: " << log_pool.name
+		   << ": " << cpp_strerror(-r) << dendl;
+	return r;
+      }
+    }
+    *exists = false;
+    *has_entries = false;
+    for (auto i = 0; i < num_shards; ++i) {
+      std::unique_ptr<rgw::cls::fifo::FIFO> fifo;
+      auto oid = fmt::format("{}{}", prefix, i);
+      std::vector<rgw::cls::fifo::list_entry> log_entries;
+      bool more = false;
+      auto r = rgw::cls::fifo::FIFO::open(ioctx, oid,
+					  &fifo, null_yield);
+      if (r == -ENOENT || r == -ENODATA) {
+	continue;
+      } else if (r < 0) {
+	lderr(cct) << __PRETTY_FUNCTION__
+		   << ": unable to open FIFO: " << log_pool << "/" << oid
+		   << ": " << cpp_strerror(-r) << dendl;
+	return r;
+      }
+      *exists = true;
+      r = fifo->list(1, nullopt, &log_entries, &more,
+		     null_yield);
+
+      if ((r < 0) && (r != -ENOENT)) {
+	lderr(cct) << __PRETTY_FUNCTION__
+		   << ": unable to list entries: " << log_pool << "/" << oid
+		   << ": " << cpp_strerror(-r) << dendl;
+      } else if (!log_entries.empty()) {
+	*has_entries = true;
+	break;
+      }
+    }
+    return r;
+  }
+  int push(int index, std::vector<cls_log_entry>& items, librados::AioCompletion *&completion) override {
+    std::vector<ceph::buffer::list> c;
+    for (const auto& bs : items) {
+
+      bufferlist bl;
+      encode(bs, bl);
+
+      c.push_back(std::move(bl));
+    }
+
+    auto r = fifos[index]->push(c, completion);
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": unable to push to FIFO: " << get_shard_oid(index)
+		 << ": " << cpp_strerror(-r) << dendl;
+    }
+    return r;
+  }
+  int push(int index, ceph::real_time now,
+	   const std::string& section,
+	   const std::string& key,
+	   ceph::buffer::list& bl) override {
+    cls_log_entry entry;
+    utime_t t(now);
+
+    entry.timestamp = t;
+    entry.section = section;
+    entry.name = key;
+    entry.data = bl;
+
+    bufferlist ble;
+    encode(entry, ble);
+
+    auto r = fifos[index]->push(std::move(ble), null_yield);
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": unable to push to FIFO: " << get_shard_oid(index)
+		 << ": " << cpp_strerror(-r) << dendl;
+    }
+    return r;
+  }
+  int list(int index, int max_entries,
+	   std::vector<cls_log_entry>& e,
+	   std::string_view marker,
+	   std::string* out_marker, bool* truncated) override {
+    std::vector<rgw::cls::fifo::list_entry> log_entries;
+    bool more = false;
+    auto r = fifos[index]->list(max_entries, marker,
+		   		&log_entries, &more,
+				null_yield);
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": unable to list FIFO: " << get_shard_oid(index)
+		 << ": " << cpp_strerror(-r) << dendl;
+      return r;
+    }
+    for (const auto& entry : log_entries) {
+      auto liter = entry.data.cbegin();
+      cls_log_entry log_entry;
+      try {
+        decode(log_entry, liter);
+      } catch (const buffer::error& err) {
+	lderr(cct) << __PRETTY_FUNCTION__
+		   << ": failed to decode metadata changes log entry: "
+		   << err.what() << dendl;
+	return -EIO;
+      }
+      e.push_back(std::move(log_entry));
+    }
+    if (truncated)
+      *truncated = more;
+    if (out_marker && !log_entries.empty()) {
+      *out_marker = log_entries.back().marker;
+    }
+    return 0;
   }
 
+  int get_info(int index, RGWMetadataLogInfo *info) override {
+    auto& fifo = fifos[index];
+    auto r = fifo->read_meta(null_yield);
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": unable to get FIFO metadata: " << get_shard_oid(index)
+		 << ": " << cpp_strerror(-r) << dendl;
+      return r;
+    }
+    auto m = fifo->meta();
+    auto p = m.head_part_num;
+    if (p < 0) {
+      info->marker = rgw::cls::fifo::marker{}.to_string();
+      info->last_update = ceph::real_clock::zero();
+      return 0;
+    }
+    rgw::cls::fifo::part_info h;
+    r = fifo->get_part_info(p, &h, null_yield);
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": unable to get part info: " << get_shard_oid(index) << "/" << p
+		 << ": " << cpp_strerror(-r) << dendl;
+      return r;
+    }
+    info->marker = rgw::cls::fifo::marker{p, h.last_ofs}.to_string();
+    info->last_update = h.max_time;
+    return 0;
+  }
 
-int RGWMetadataLog::init()
+  int get_info_async(int index,
+		     RGWMetadataLogInfoCompletion *completion) override {
+    auto& fifo = fifos[index];
+    auto c = completion->get_completion();
+    auto r = fifo->get_head_info([completion](int p,
+					      rgw::cls::fifo::part_info* h) {
+      if (h) {
+	completion->get_header().max_marker =
+	  rgw::cls::fifo::marker{p, h->last_ofs}.to_string();
+	completion->get_header().max_time = utime_t(h->max_time);
+      } else {
+	completion->get_header().max_marker =
+	  rgw::cls::fifo::marker{}.to_string();
+	completion->get_header().max_time = utime_t{};
+      }
+    }, c);
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": unable to get head info: " << get_shard_oid(index) << "/"
+		 << ": " << cpp_strerror(-r) << dendl;
+    }
+    return r;
+  }
+
+  int trim(int index, std::string_view marker, bool exclusive) override {
+    auto r = fifos[index]->trim(marker, exclusive, null_yield);
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": unable to trim FIFO: " << get_shard_oid(index)
+		 << ": " << cpp_strerror(-r) << dendl;
+    }
+    return r;
+  }
+  int trim(int index, std::string_view marker,
+	   librados::AioCompletion* c, bool exclusive) override {
+    int r = 0;
+    if (marker == rgw::cls::fifo::marker(0, 0).to_string()) {
+      auto pc = c->pc;
+      pc->get();
+      pc->lock.lock();
+      pc->rval = 0;
+      pc->complete = true;
+      pc->lock.unlock();
+      auto cb_complete = pc->callback_complete;
+      auto cb_complete_arg = pc->callback_complete_arg;
+      if (cb_complete)
+	cb_complete(pc, cb_complete_arg);
+
+      auto cb_safe = pc->callback_safe;
+      auto cb_safe_arg = pc->callback_safe_arg;
+      if (cb_safe)
+	cb_safe(pc, cb_safe_arg);
+
+      pc->lock.lock();
+      pc->callback_complete = NULL;
+      pc->callback_safe = NULL;
+      pc->cond.notify_all();
+      pc->put_unlock();
+    } else {
+      r = fifos[index]->trim(marker, exclusive, c);
+      if (r < 0) {
+	lderr(cct) << __PRETTY_FUNCTION__
+		   << ": unable to trim FIFO: " << get_shard_oid(index)
+		   << ": " << cpp_strerror(-r) << dendl;
+      }
+    }
+    return r;
+  }
+  std::string_view max_marker() override {
+    static const std::string mm =
+      rgw::cls::fifo::marker::max().to_string();
+    return std::string_view(mm);
+  }
+};
+
+RGWMetadataLogBE::RGWMetadataLogBE(CephContext* const cct, std::string prefix)
+    : cct(cct), prefix(prefix) {}
+RGWMetadataLogBE::~RGWMetadataLogBE() {}
+
+int RGWMetadataLogBE::remove(CephContext* cct, std::string prefix,
+	       		     librados::Rados* rados, const rgw_pool& log_pool)
+{
+  auto num_shards = cct->_conf->rgw_md_log_max_shards;
+  librados::IoCtx ioctx;
+  auto r = rgw_init_ioctx(rados, log_pool.name, ioctx,
+			  false, false);
+  if (r < 0) {
+    if (r == -ENOENT) {
+      return 0;
+    } else {
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": rgw_init_ioctx failed: " << log_pool.name
+		 << ": " << cpp_strerror(-r) << dendl;
+      return r;
+    }
+  }
+  for (auto i = 0; i < num_shards; ++i) {
+    std::unique_ptr<rgw::cls::fifo::FIFO> fifo;
+    auto oid = fmt::format("{}{}", prefix, i);
+    librados::ObjectWriteOperation op;
+    op.remove();
+    auto r = rgw_rados_operate(ioctx, oid, &op, null_yield);
+    if (r < 0 && r != -ENOENT) {
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": remove failed: " << log_pool.name << "/" << oid
+		 << ": " << cpp_strerror(-r) << dendl;
+    }
+  }
+  return 0;
+}
+
+int RGWMetadataLog::init(librados::Rados* lr)
 {
   if (be) { // already initialized
     return 0;
@@ -381,12 +657,12 @@ int RGWMetadataLog::init()
 	       << cpp_strerror(-r) << dendl;
   }
   bool fifoexists = false, fifohasentries = false;
-  /*r = RGWMetadataLogFIFO::exists(cct, prefix, lr, log_pool, &fifoexists, &fifohasentries);
+  r = RGWMetadataLogFIFO::exists(cct, prefix, lr, log_pool, &fifoexists, &fifohasentries);
   if (r < 0) {
     lderr(cct) << __PRETTY_FUNCTION__
 	       << ": Error when checking for existing FIFO datalog backend: "
 	       << cpp_strerror(-r) << dendl;
-  }*/
+  }
 
   bool has_entries = omaphasentries || fifohasentries;
   bool remove = false;
@@ -429,7 +705,7 @@ int RGWMetadataLog::init()
     remove = true;
   }
 
-/*  if (remove) {
+  if (remove) {
     r = RGWMetadataLogBE::remove(cct, prefix, lr, log_pool);
     if (r < 0) {
       lderr(cct) << __PRETTY_FUNCTION__
@@ -439,13 +715,13 @@ int RGWMetadataLog::init()
     }
     omapexists = false;
     fifoexists = false;
-  } */
+  }
 
   try {
     if (backing == "omap" || (backing == "auto" && omapexists)) {
       be = std::make_unique<RGWMetadataLogOmap>(cct, prefix, *svc.cls);
     } else if (backing != "omap") {
-  //    be = std::make_unique<RGWMetadataLogFIFO>(cct, prefix, lr, log_pool);
+      be = std::make_unique<RGWMetadataLogFIFO>(cct, prefix, lr, log_pool);
     }
   } catch (bs::system_error& e) {
     lderr(cct) << __PRETTY_FUNCTION__

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -105,6 +105,45 @@ void RGWMetadataLogData::decode_json(JSONObj *obj) {
 }
 
 
+RGWMetadataLogTrimCR::RGWMetadataLogTrimCR(CephContext *cct,
+					     RGWMetadataLog *_mdlog,
+                                             const int _shard_id,
+                                             const std::string& _marker,
+					     bool _exclusive,
+					     std::string *_last_trim_marker)
+  : RGWSimpleCoroutine(cct), mdlog(_mdlog), shard_id(_shard_id),
+    marker(_marker), exclusive(_exclusive), last_trim_marker(_last_trim_marker)
+{
+  set_description() << "MetadataLog trim oid=" <<  shard_id
+      << " marker=" << marker;
+}
+
+int RGWMetadataLogTrimCR::send_request()
+{
+  set_status() << "sending request";
+
+  cn = stack->create_completion_notifier();
+
+  return mdlog->trim(shard_id, marker, cn->completion(), exclusive);
+}
+
+int RGWMetadataLogTrimCR::request_complete()
+{
+  int r = cn->completion()->get_return_value();
+
+  set_status() << "request complete; ret=" << r;
+
+  if (r != -ENODATA) {
+    return r;
+  }
+  // nothing left to trim, update last_trim_marker
+  if (last_trim_marker && *last_trim_marker < marker && marker != max_marker) {
+    *last_trim_marker = marker;
+    r = 0;
+  }
+  return r;
+}
+
 int RGWMetadataLog::add_entry(const string& hash_key, const string& section,
 			      const string& key, bufferlist& bl) {
   if (!svc.zone->need_to_log_metadata())
@@ -214,12 +253,68 @@ int RGWMetadataLog::get_info_async(int shard_id, RGWMetadataLogInfoCompletion *c
                                      completion->get_completion());
 }
 
-int RGWMetadataLog::trim(int shard_id, std::string_view marker)
+int RGWMetadataLog::trim(int shard_id, std::string_view marker, bool exclusive)
 {
   auto oid = get_shard_oid(shard_id);
 
-  return svc.cls->timelog.trim(oid, {}, {}, {},
-                               string(marker), nullptr, null_yield);
+  if (!exclusive) {
+    return svc.cls->timelog.trim(oid, {}, {}, {},
+                                 string(marker), nullptr, null_yield);
+  }
+
+  string m = string(marker);
+
+  // Extract timestamp from marker .. needed only for OMAP
+  ceph::real_time stable;
+  int sec, usec;
+  char keyext[256];
+
+  int ret = sscanf(m.c_str(), "1_%d.%d_%255s", &sec, &usec, keyext);
+
+  if (ret < 0) {
+    ldout(cct, 0) << "ERROR: scanning marker ret = " << ret << dendl;
+    return -1;
+  } else {
+    stable = utime_t(sec, usec).to_real_time();
+    // can only trim -up to- master's first timestamp, so subtract a second.
+    // (this is why we use timestamps instead of markers for the peers)
+    stable -= std::chrono::seconds(1);
+  }
+
+  return svc.cls->timelog.trim(oid, {}, stable, {}, {},
+                               nullptr, null_yield);
+}
+
+int RGWMetadataLog::trim(int shard_id, std::string_view marker,
+	                 librados::AioCompletion* c, bool exclusive)
+{
+  auto oid = get_shard_oid(shard_id);
+  if (!exclusive) {
+    return svc.cls->timelog.trim(oid, {}, {}, {},
+                                 string(marker), c, null_yield);
+  }
+
+  string m = string(marker);
+
+  // Extract timestamp from marker .. needed only for OMAP
+  ceph::real_time stable;
+  int sec, usec;
+  char keyext[256];
+
+  int ret = sscanf(m.c_str(), "1_%d.%d_%255s", &sec, &usec, keyext);
+
+  if (ret < 0) {
+    ldout(cct, 0) << "ERROR: scanning marker ret = " << ret << dendl;
+    return -1;
+  } else {
+    stable = utime_t(sec, usec).to_real_time();
+    // can only trim -up to- master's first timestamp, so subtract a second.
+    // (this is why we use timestamps instead of markers for the peers)
+    stable -= std::chrono::seconds(1);
+  }
+
+  return svc.cls->timelog.trim(oid, {}, stable, {}, {},
+                               c, null_yield);
 }
 
 int RGWMetadataLog::lock_exclusive(int shard_id, timespan duration, string& zone_id, string& owner_id) {
@@ -294,37 +389,12 @@ RGWCoroutine* RGWMetadataLog::purge_cr()
 RGWCoroutine* RGWMetadataLog::master_trim_cr(int shard_id, const std::string& marker,
 	       				      std::string* last_trim)
 {
-  auto oid = get_shard_oid(shard_id);
-    
-  return new RGWSyncLogTrimCR(store, oid, marker, last_trim);
+  return new RGWMetadataLogTrimCR(cct, this, shard_id, marker, false, last_trim);
 }
 
 RGWCoroutine* RGWMetadataLog::peer_trim_cr(int shard_id, std::string marker, bool exclusive)
 {
-  // Extract timestamp from marker
-  auto oid = get_shard_oid(shard_id);
-
-  if (!exclusive) {
-  	return new RGWRadosTimelogTrimCR(store, oid, {}, {}, {}, marker);
-  }
-
-  ceph::real_time stable;
-  int sec, usec;
-  char keyext[256];
-
-  int ret = sscanf(marker.c_str(), "1_%d.%d_%255s", &sec, &usec, keyext);
-
-  if (ret < 0) {
-    ldout(cct, 0) << "ERROR: scanning marker ret = " << ret << dendl;
-    return NULL;
-  } else {
-    stable = utime_t(sec, usec).to_real_time();
-    // can only trim -up to- master's first timestamp, so subtract a second.
-    // (this is why we use timestamps instead of markers for the peers)
-    stable -= std::chrono::seconds(1);
-  }
-
-  return new RGWRadosTimelogTrimCR(store, oid, {}, stable, "", "");
+  return new RGWMetadataLogTrimCR(cct, this, shard_id, marker, exclusive, NULL);
 }
 
 obj_version& RGWMetadataObject::get_version()

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -134,8 +134,8 @@ int RGWMetadataLog::store_entries_in_shard(list<cls_log_entry>& entries, int sha
   return svc.cls->timelog.add(oid, entries, completion, false, null_yield);
 }
 
-void RGWMetadataLog::init_list_entries(int shard_id, const real_time& from_time, const real_time& end_time, 
-                                       const string& marker, void **handle)
+void RGWMetadataLog::init_list_entries(int shard_id, ceph::real_time from_time, ceph::real_time end_time, 
+				       const string& marker, void **handle)
 {
   LogListCtx *ctx = new LogListCtx();
 
@@ -232,7 +232,7 @@ int RGWMetadataLog::get_info_async(int shard_id, RGWMetadataLogInfoCompletion *c
                                      completion->get_completion());
 }
 
-int RGWMetadataLog::trim(int shard_id, const real_time& from_time, const real_time& end_time,
+int RGWMetadataLog::trim(int shard_id, ceph::real_time from_time, ceph::real_time end_time,
                          const string& start_marker, const string& end_marker)
 {
   string oid;
@@ -258,22 +258,23 @@ int RGWMetadataLog::unlock(int shard_id, string& zone_id, string& owner_id) {
 
 void RGWMetadataLog::mark_modified(int shard_id)
 {
-  lock.get_read();
+  std::shared_lock l(lock);
   if (modified_shards.find(shard_id) != modified_shards.end()) {
-    lock.unlock();
+    l.unlock();
     return;
   }
-  lock.unlock();
+  l.unlock();
 
   std::unique_lock wl{lock};
   modified_shards.insert(shard_id);
 }
 
-void RGWMetadataLog::read_clear_modified(set<int> &modified)
+bc::flat_set<int> RGWMetadataLog::read_clear_modified()
 {
   std::unique_lock wl{lock};
-  modified.swap(modified_shards);
+  auto m = std::move(modified_shards);
   modified_shards.clear();
+  return m;
 }
 
 obj_version& RGWMetadataObject::get_version()
@@ -302,7 +303,8 @@ public:
 
   string get_type() override { return string(); }
 
-  RGWMetadataObject *get_meta_obj(JSONObj *jo, const obj_version& objv, const ceph::real_time& mtime) {
+  RGWMetadataObject *get_meta_obj(JSONObj *jo, const obj_version& objv,
+				  const ceph::real_time& mtime) override {
     return new RGWMetadataObject;
   }
 
@@ -324,7 +326,7 @@ public:
              RGWObjVersionTracker *objv_tracker,
              optional_yield y,
              RGWMDLogStatus op_type,
-             std::function<int()> f) {
+             std::function<int()> f) override {
     return -ENOTSUP;
   }
 

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -241,7 +241,7 @@ int RGWMetadataLog::trim(int shard_id, ceph::real_time from_time, ceph::real_tim
   return svc.cls->timelog.trim(oid, from_time, end_time, start_marker,
                                end_marker, nullptr, null_yield);
 }
-  
+
 int RGWMetadataLog::lock_exclusive(int shard_id, timespan duration, string& zone_id, string& owner_id) {
   string oid;
   get_shard_oid(shard_id, oid);
@@ -618,7 +618,7 @@ int RGWMetadataManager::find_handler(const string& metadata_key, RGWMetadataHand
     return 0;
   }
 
-  map<string, RGWMetadataHandler *>::iterator iter = handlers.find(type);
+  auto iter = handlers.find(type);
   if (iter == handlers.end())
     return -ENOENT;
 
@@ -839,7 +839,7 @@ void RGWMetadataManager::dump_log_entry(cls_log_entry& entry, Formatter *f)
     decode(log_data, iter);
 
     encode_json("data", log_data, f);
-  } catch (buffer::error& err) {
+  } catch (ceph::buffer::error& err) {
     lderr(cct) << "failed to decode log entry: " << entry.section << ":" << entry.name<< " ts=" << entry.timestamp << dendl;
   }
   f->close_section();
@@ -847,8 +847,7 @@ void RGWMetadataManager::dump_log_entry(cls_log_entry& entry, Formatter *f)
 
 void RGWMetadataManager::get_sections(list<string>& sections)
 {
-  for (map<string, RGWMetadataHandler *>::iterator iter = handlers.begin(); iter != handlers.end(); ++iter) {
+  for (auto iter = handlers.begin(); iter != handlers.end(); ++iter) {
     sections.push_back(iter->first);
   }
 }
-

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -614,12 +614,24 @@ int RGWMetadataLogBE::remove(CephContext* cct, std::string prefix,
   return 0;
 }
 
-int RGWMetadataLog::init(librados::Rados* lr)
-{
-  if (be) { // already initialized
-    return 0;
+RGWMetadataLog::RGWMetadataLog(CephContext *cct,
+		 rgw::sal::RGWRadosStore* store,
+                 RGWSI_Zone *_zone_svc,
+                 RGWSI_Cls *_cls_svc,
+		 RGWSI_RADOS *_rados_svc,
+                 const std::string& period)
+    : cct(cct), store(store),
+      prefix(make_prefix(period)) {
+    svc.zone = _zone_svc;
+    svc.cls = _cls_svc;
+    svc.rados = _rados_svc;
+
+    init(svc.rados->get_rados_handle());
+   // be = std::make_unique<RGWMetadataLogOmap>(cct, prefix, *svc.cls);
   }
 
+int RGWMetadataLog::init(librados::Rados* lr)
+{
   auto backing = cct->_conf.get_val<std::string>("rgw_md_log_backing");
   ceph_assert(backing == "auto" || backing == "fifo" || backing == "omap");
 

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -243,13 +243,13 @@ public:
     e.clear();
     std::move(lentries.begin(), lentries.end(), std::back_inserter(e));
 
-    if (r < 0) {
+    if ((r < 0) && (r != -ENOENT)) {
       lderr(cct) << __PRETTY_FUNCTION__
 		 << ": failed to list " << oids[index]
 		 << cpp_strerror(-r) << dendl;
       return r;
     }
-    return 0;
+    return r;
   }
   int get_info(int index, RGWMetadataLogInfo *info) override {
     cls_log_header header;
@@ -359,8 +359,104 @@ RGWMetadataLog::RGWMetadataLog(CephContext *cct,
       prefix(make_prefix(period)) {
     svc.zone = _zone_svc;
     svc.cls = _cls_svc;
-    be = std::make_unique<RGWMetadataLogOmap>(cct, prefix, *svc.cls);
+//    be = std::make_unique<RGWMetadataLogOmap>(cct, prefix, *svc.cls);
   }
+
+
+int RGWMetadataLog::init()
+{
+  if (be) { // already initialized
+    return 0;
+  }
+
+  auto backing = cct->_conf.get_val<std::string>("rgw_md_log_backing");
+  ceph_assert(backing == "auto" || backing == "fifo" || backing == "omap");
+
+  auto log_pool = svc.zone->get_zone_params().log_pool;
+  bool omapexists = false, omaphasentries = false;
+  auto r = RGWMetadataLogOmap::exists(cct, *svc.cls, prefix, &omapexists, &omaphasentries);
+  if (r < 0) {
+    lderr(cct) << __PRETTY_FUNCTION__
+	       << ": Error when checking for existing Omap datalog backend: "
+	       << cpp_strerror(-r) << dendl;
+  }
+  bool fifoexists = false, fifohasentries = false;
+  /*r = RGWMetadataLogFIFO::exists(cct, prefix, lr, log_pool, &fifoexists, &fifohasentries);
+  if (r < 0) {
+    lderr(cct) << __PRETTY_FUNCTION__
+	       << ": Error when checking for existing FIFO datalog backend: "
+	       << cpp_strerror(-r) << dendl;
+  }*/
+
+  bool has_entries = omaphasentries || fifohasentries;
+  bool remove = false;
+
+  if (omapexists && fifoexists) {
+    if (has_entries) {
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": Both Omap and FIFO backends exist, cannot continue."
+		 << dendl;
+      return -EINVAL;
+    }
+    ldout(cct, 0)
+      << __PRETTY_FUNCTION__
+      << ": Both Omap and FIFO backends exist, but are empty. Will remove."
+      << dendl;
+    remove = true;
+  }
+  if (backing == "omap" && fifoexists) {
+    if (has_entries) {
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": Omap requested, but FIFO backend exists, cannot continue."
+		 << dendl;
+      return -EINVAL;
+    }
+    ldout(cct, 0) << __PRETTY_FUNCTION__
+		  << ": Omap requested, FIFO exists, but is empty. Deleting."
+		  << dendl;
+    remove = true;
+  }
+  if ((backing == "fifo") && omapexists) {
+    if (has_entries) {
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": FIFO requested, but Omap backend exists, cannot continue."
+		 << dendl;
+      return -EINVAL;
+    }
+    ldout(cct, 0) << __PRETTY_FUNCTION__
+		  << ": FIFO requested, Omap exists, but is empty. Deleting."
+		  << dendl;
+    remove = true;
+  }
+
+/*  if (remove) {
+    r = RGWMetadataLogBE::remove(cct, prefix, lr, log_pool);
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": remove failed, cannot continue."
+		 << dendl;
+      return r;
+    }
+    omapexists = false;
+    fifoexists = false;
+  } */
+
+  try {
+    if (backing == "omap" || (backing == "auto" && omapexists)) {
+      be = std::make_unique<RGWMetadataLogOmap>(cct, prefix, *svc.cls);
+    } else if (backing != "omap") {
+  //    be = std::make_unique<RGWMetadataLogFIFO>(cct, prefix, lr, log_pool);
+    }
+  } catch (bs::system_error& e) {
+    lderr(cct) << __PRETTY_FUNCTION__
+	       << ": Error when starting backend: "
+	       << e.what() << dendl;
+    return ceph::from_error_code(e.code());
+  }
+
+  ceph_assert(be);
+  return 0;
+}
 
 int RGWMetadataLog::add_entry(const string& hash_key, const string& section,
 			      const string& key, bufferlist& bl) {

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -104,33 +104,31 @@ void RGWMetadataLogData::decode_json(JSONObj *obj) {
 }
 
 
-int RGWMetadataLog::add_entry(const string& hash_key, const string& section, const string& key, bufferlist& bl) {
+int RGWMetadataLog::add_entry(const string& hash_key, const string& section,
+			      const string& key, bufferlist& bl) {
   if (!svc.zone->need_to_log_metadata())
     return 0;
 
-  string oid;
-  int shard_id;
-
-  rgw_shard_name(prefix, cct->_conf->rgw_md_log_max_shards, hash_key, oid, &shard_id);
+  auto [oid, shard_id] = rgw_shard_name(prefix,
+					cct->_conf->rgw_md_log_max_shards,
+					hash_key);
   mark_modified(shard_id);
   real_time now = real_clock::now();
   return svc.cls->timelog.add(oid, now, section, key, bl, null_yield);
 }
 
-int RGWMetadataLog::get_shard_id(const string& hash_key, int *shard_id)
+int RGWMetadataLog::get_shard_id(std::string_view hash_key)
 {
-  string oid;
-
-  rgw_shard_name(prefix, cct->_conf->rgw_md_log_max_shards, hash_key, oid, shard_id);
-  return 0;
+  auto [oid, shard_id] = rgw_shard_name(prefix,
+					cct->_conf->rgw_md_log_max_shards,
+					hash_key);
+  return shard_id;
 }
 
 int RGWMetadataLog::store_entries_in_shard(std::vector<cls_log_entry>& entries, int shard_id, librados::AioCompletion *completion)
 {
-  string oid;
-
   mark_modified(shard_id);
-  rgw_shard_name(prefix, shard_id, oid);
+  auto oid = rgw_shard_name(prefix, shard_id);
   std::list<cls_log_entry> lentries(std::move_iterator(entries.begin()),
 				    std::move_iterator(entries.end()));
   return svc.cls->timelog.add(oid, lentries, completion, false, null_yield);
@@ -496,10 +494,10 @@ int RGWMetadataHandler_GenericMetaBE::mutate(const string& entry,
   });
 }
 
-int RGWMetadataHandler_GenericMetaBE::get_shard_id(const string& entry, int *shard_id)
+int RGWMetadataHandler_GenericMetaBE::get_shard_id(const string& entry)
 {
   return be_handler->call([&](RGWSI_MetaBackend_Handler::Op *op) {
-    return op->get_shard_id(entry, shard_id);
+    return op->get_shard_id(entry);
   });
 }
 
@@ -732,14 +730,14 @@ int RGWMetadataManager::mutate(const string& metadata_key,
   return handler->mutate(entry, mtime, objv_tracker, y, op_type, f);
 }
 
-int RGWMetadataManager::get_shard_id(const string& section, const string& entry, int *shard_id)
+int RGWMetadataManager::get_shard_id(const string& section, const string& entry)
 {
   RGWMetadataHandler *handler = get_handler(section);
   if (!handler) {
     return -EINVAL;
   }
 
-  return handler->get_shard_id(entry, shard_id);
+  return handler->get_shard_id(entry);
 }
 
 struct list_keys_handle {

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -134,48 +134,31 @@ int RGWMetadataLog::store_entries_in_shard(list<cls_log_entry>& entries, int sha
   return svc.cls->timelog.add(oid, entries, completion, false, null_yield);
 }
 
-void RGWMetadataLog::init_list_entries(int shard_id, ceph::real_time from_time, ceph::real_time end_time, 
-				       const string& marker, void **handle)
-{
-  LogListCtx *ctx = new LogListCtx();
-
-  ctx->cur_shard = shard_id;
-  ctx->from_time = from_time;
-  ctx->end_time  = end_time;
-  ctx->marker    = marker;
-
-  get_shard_oid(ctx->cur_shard, ctx->cur_oid);
-
-  *handle = (void *)ctx;
-}
-
-void RGWMetadataLog::complete_list_entries(void *handle) {
-  LogListCtx *ctx = static_cast<LogListCtx *>(handle);
-  delete ctx;
-}
-
-int RGWMetadataLog::list_entries(void *handle,
+int RGWMetadataLog::list_entries(int shard,
 				 int max_entries,
-				 list<cls_log_entry>& entries,
+				 std::string_view marker,
+				 std::vector<cls_log_entry>& entries,
 				 string *last_marker,
 				 bool *truncated) {
-  LogListCtx *ctx = static_cast<LogListCtx *>(handle);
 
   if (!max_entries) {
     *truncated = false;
     return 0;
   }
 
+  auto oid = get_shard_oid(shard);
   std::string next_marker;
-  int ret = svc.cls->timelog.list(ctx->cur_oid, ctx->from_time, ctx->end_time,
-                                  max_entries, entries, ctx->marker,
+  std::list<cls_log_entry> lentries;
+  int ret = svc.cls->timelog.list(oid, {}, {},
+                                  max_entries, lentries, string(marker),
                                   &next_marker, truncated, null_yield);
+  entries.clear();
+  std::move(lentries.begin(), lentries.end(), std::back_inserter(entries));
   if ((ret < 0) && (ret != -ENOENT))
     return ret;
 
-  ctx->marker = std::move(next_marker);
   if (last_marker) {
-    *last_marker = ctx->marker;
+    *last_marker = next_marker;
   }
 
   if (ret == -ENOENT)
@@ -186,8 +169,7 @@ int RGWMetadataLog::list_entries(void *handle,
 
 int RGWMetadataLog::get_info(int shard_id, RGWMetadataLogInfo *info)
 {
-  string oid;
-  get_shard_oid(shard_id, oid);
+  auto oid = get_shard_oid(shard_id);
 
   cls_log_header header;
 
@@ -222,8 +204,7 @@ RGWMetadataLogInfoCompletion::~RGWMetadataLogInfoCompletion()
 
 int RGWMetadataLog::get_info_async(int shard_id, RGWMetadataLogInfoCompletion *completion)
 {
-  string oid;
-  get_shard_oid(shard_id, oid);
+  auto oid = get_shard_oid(shard_id);
 
   completion->get(); // hold a ref until the completion fires
 
@@ -235,23 +216,20 @@ int RGWMetadataLog::get_info_async(int shard_id, RGWMetadataLogInfoCompletion *c
 int RGWMetadataLog::trim(int shard_id, ceph::real_time from_time, ceph::real_time end_time,
                          const string& start_marker, const string& end_marker)
 {
-  string oid;
-  get_shard_oid(shard_id, oid);
+  auto oid = get_shard_oid(shard_id);
 
   return svc.cls->timelog.trim(oid, from_time, end_time, start_marker,
                                end_marker, nullptr, null_yield);
 }
 
 int RGWMetadataLog::lock_exclusive(int shard_id, timespan duration, string& zone_id, string& owner_id) {
-  string oid;
-  get_shard_oid(shard_id, oid);
+  auto oid = get_shard_oid(shard_id);
 
   return svc.cls->lock.lock_exclusive(svc.zone->get_zone_params().log_pool, oid, duration, zone_id, owner_id);
 }
 
 int RGWMetadataLog::unlock(int shard_id, string& zone_id, string& owner_id) {
-  string oid;
-  get_shard_oid(shard_id, oid);
+  auto oid = get_shard_oid(shard_id);
 
   return svc.cls->lock.unlock(svc.zone->get_zone_params().log_pool, oid, zone_id, owner_id);
 }
@@ -825,7 +803,7 @@ string RGWMetadataManager::get_marker(void *handle)
   return h->handler->get_marker(h->handle);
 }
 
-void RGWMetadataManager::dump_log_entry(cls_log_entry& entry, Formatter *f)
+void RGWMetadataManager::dump_log_entry(const cls_log_entry& entry, Formatter *f)
 {
   f->open_object_section("entry");
   f->dump_string("id", entry.id);

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -291,6 +291,14 @@ RGWCoroutine* RGWMetadataLog::purge_cr()
 			      std::move(oids));
 }
 
+RGWCoroutine* RGWMetadataLog::master_trim_cr(int shard_id, const std::string& marker,
+	       				      std::string* last_trim)
+{
+  auto oid = get_shard_oid(shard_id);
+    
+  return new RGWSyncLogTrimCR(store, oid, marker, last_trim);
+}
+
 RGWCoroutine* RGWMetadataLog::peer_trim_cr(int shard_id, std::string marker, bool exclusive)
 {
   // Extract timestamp from marker

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -398,7 +398,8 @@ public:
       std::vector<rgw::cls::fifo::list_entry> log_entries;
       bool more = false;
       auto r = rgw::cls::fifo::FIFO::open(ioctx, oid,
-					  &fifo, null_yield);
+					  &fifo, null_yield,
+					  std::nullopt, true);
       if (r == -ENOENT || r == -ENODATA) {
 	continue;
       } else if (r < 0) {
@@ -432,13 +433,8 @@ public:
       c.push_back(std::move(bl));
     }
 
-    auto r = fifos[index]->push(c, completion);
-    if (r < 0) {
-      lderr(cct) << __PRETTY_FUNCTION__
-		 << ": unable to push to FIFO: " << get_shard_oid(index)
-		 << ": " << cpp_strerror(-r) << dendl;
-    }
-    return r;
+    fifos[index]->push(std::move(c), completion);
+    return 0;
   }
   int push(int index, ceph::real_time now,
 	   const std::string& section,
@@ -455,13 +451,8 @@ public:
     bufferlist ble;
     encode(entry, ble);
 
-    auto r = fifos[index]->push(std::move(ble), null_yield);
-    if (r < 0) {
-      lderr(cct) << __PRETTY_FUNCTION__
-		 << ": unable to push to FIFO: " << get_shard_oid(index)
-		 << ": " << cpp_strerror(-r) << dendl;
-    }
-    return r;
+    fifos[index]->push(std::move(ble), null_yield);
+    return 0;
   }
   int list(int index, int max_entries,
 	   std::vector<cls_log_entry>& e,
@@ -532,24 +523,13 @@ public:
 		     RGWMetadataLogInfoCompletion *completion) override {
     auto& fifo = fifos[index];
     auto c = completion->get_completion();
-    auto r = fifo->get_head_info([completion](int p,
-					      rgw::cls::fifo::part_info* h) {
-      if (h) {
-	completion->get_header().max_marker =
-	  rgw::cls::fifo::marker{p, h->last_ofs}.to_string();
-	completion->get_header().max_time = utime_t(h->max_time);
-      } else {
-	completion->get_header().max_marker =
-	  rgw::cls::fifo::marker{}.to_string();
-	completion->get_header().max_time = utime_t{};
-      }
+    rgw::cls::fifo::part_info h;
+    fifo->get_head_info([completion](int p, rgw::cls::fifo::part_info&& h) {
+      completion->get_header().max_marker =
+	  rgw::cls::fifo::marker{p, h.last_ofs}.to_string();
+      completion->get_header().max_time = utime_t(h.max_time);
     }, c);
-    if (r < 0) {
-      lderr(cct) << __PRETTY_FUNCTION__
-		 << ": unable to get head info: " << get_shard_oid(index) << "/"
-		 << ": " << cpp_strerror(-r) << dendl;
-    }
-    return r;
+    return 0;
   }
 
   int trim(int index, std::string_view marker, bool exclusive) override {
@@ -587,12 +567,7 @@ public:
       pc->cond.notify_all();
       pc->put_unlock();
     } else {
-      r = fifos[index]->trim(marker, exclusive, c);
-      if (r < 0) {
-	lderr(cct) << __PRETTY_FUNCTION__
-		   << ": unable to trim FIFO: " << get_shard_oid(index)
-		   << ": " << cpp_strerror(-r) << dendl;
-      }
+      fifos[index]->trim(marker, exclusive, c);
     }
     return r;
   }
@@ -653,14 +628,14 @@ int RGWMetadataLog::init(librados::Rados* lr)
   auto r = RGWMetadataLogOmap::exists(cct, *svc.cls, prefix, &omapexists, &omaphasentries);
   if (r < 0) {
     lderr(cct) << __PRETTY_FUNCTION__
-	       << ": Error when checking for existing Omap datalog backend: "
+	       << ": Error when checking for existing Omap mdlog backend: "
 	       << cpp_strerror(-r) << dendl;
   }
   bool fifoexists = false, fifohasentries = false;
   r = RGWMetadataLogFIFO::exists(cct, prefix, lr, log_pool, &fifoexists, &fifohasentries);
   if (r < 0) {
     lderr(cct) << __PRETTY_FUNCTION__
-	       << ": Error when checking for existing FIFO datalog backend: "
+	       << ": Error when checking for existing FIFO mdlog backend: "
 	       << cpp_strerror(-r) << dendl;
   }
 
@@ -719,8 +694,10 @@ int RGWMetadataLog::init(librados::Rados* lr)
 
   try {
     if (backing == "omap" || (backing == "auto" && omapexists)) {
+      ldout(cct, 20) << __func__ << " Configuring omap for metadata log backing." << dendl;
       be = std::make_unique<RGWMetadataLogOmap>(cct, prefix, *svc.cls);
     } else if (backing != "omap") {
+      ldout(cct, 20) << __func__ << " Configuring fifo for metadata log backing." << dendl;
       be = std::make_unique<RGWMetadataLogFIFO>(cct, prefix, lr, log_pool);
     }
   } catch (bs::system_error& e) {

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -291,6 +291,33 @@ RGWCoroutine* RGWMetadataLog::purge_cr()
 			      std::move(oids));
 }
 
+RGWCoroutine* RGWMetadataLog::peer_trim_cr(int shard_id, std::string marker, bool exclusive)
+{
+  // Extract timestamp from marker
+  auto oid = get_shard_oid(shard_id);
+
+  if (!exclusive) {
+  	return new RGWRadosTimelogTrimCR(store, oid, {}, {}, {}, marker);
+  }
+
+  ceph::real_time stable;
+  int sec, usec;
+  char keyext[256];
+
+  int ret = sscanf(marker.c_str(), "1_%d.%d_%255s", &sec, &usec, keyext);
+
+  if (ret < 0) {
+    ldout(cct, 0) << "ERROR: scanning marker ret = " << ret << dendl;
+    return NULL;
+  } else {
+    stable = utime_t(sec, usec).to_real_time();
+    // can only trim -up to- master's first timestamp, so subtract a second.
+    // (this is why we use timestamps instead of markers for the peers)
+    stable -= std::chrono::seconds(1);
+  }
+
+  return new RGWRadosTimelogTrimCR(store, oid, {}, stable, "", "");
+}
 
 obj_version& RGWMetadataObject::get_version()
 {

--- a/src/rgw/rgw_metadata.h
+++ b/src/rgw/rgw_metadata.h
@@ -254,7 +254,7 @@ public:
 
   string get_marker(void *handle);
 
-  void dump_log_entry(cls_log_entry& entry, Formatter *f);
+  void dump_log_entry(const cls_log_entry& entry, Formatter *f);
 
   void get_sections(list<string>& sections);
 

--- a/src/rgw/rgw_metadata.h
+++ b/src/rgw/rgw_metadata.h
@@ -90,8 +90,7 @@ public:
 
   virtual string get_marker(void *handle) = 0;
 
-  virtual int get_shard_id(const string& entry, int *shard_id) {
-    *shard_id = 0;
+  virtual int get_shard_id(const string& entry) {
     return 0;
   }
   virtual int attach(RGWMetadataManager *manager);
@@ -175,7 +174,7 @@ public:
 	     RGWMDLogStatus op_type,
 	     std::function<int()> f) override;
 
-  int get_shard_id(const string& entry, int *shard_id) override;
+  int get_shard_id(const string& entry) override;
 
   int list_keys_init(const std::string& marker, void **phandle) override;
   int list_keys_next(void *handle, int max, std::list<string>& keys, bool *truncated) override;
@@ -260,7 +259,7 @@ public:
 
   void parse_metadata_key(const string& metadata_key, string& type, string& entry);
 
-  int get_shard_id(const string& section, const string& key, int *shard_id);
+  int get_shard_id(const string& section, const string& key);
 };
 
 class RGWMetadataHandlerPut_SObj : public RGWMetadataHandler_GenericMetaBE::Put

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1332,10 +1332,10 @@ int RGWRados::init_complete()
 int RGWRados::init_svc(bool raw)
 {
   if (raw) {
-    return svc.init_raw(cct, use_cache, null_yield);
+    return svc.init_raw(cct, store, use_cache, null_yield);
   }
 
-  return svc.init(cct, use_cache, run_sync_thread, null_yield);
+  return svc.init(cct, store, use_cache, run_sync_thread, null_yield);
 }
 
 int RGWRados::init_ctl()

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -83,7 +83,7 @@ void RGWOp_MDLog_List::execute(optional_yield y) {
 
   RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls,
       period};
-  auto r = meta_log.init();
+  auto r = meta_log.init(store->svc()->rados->get_rados_handle());
   if (r < 0) {
     ldout(s->cct, 5) << "meta_log initialization failed." << dendl;
     op_ret = -EINVAL;
@@ -161,7 +161,7 @@ void RGWOp_MDLog_ShardInfo::execute(optional_yield y) {
     }
   }
   RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls, period};
-  auto r = meta_log.init();
+  auto r = meta_log.init(store->svc()->rados->get_rados_handle());
   if (r < 0) {
     ldout(s->cct, 5) << "meta_log initialization failed." << dendl;
     op_ret = -EINVAL;
@@ -233,7 +233,7 @@ void RGWOp_MDLog_Delete::execute(optional_yield y) {
     }
   }
   RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls, period};
-  auto r = meta_log.init();
+  auto r = meta_log.init(store->svc()->rados->get_rados_handle());
   if (r < 0) {
     ldout(s->cct, 5) << "meta_log initialization failed." << dendl;
     op_ret = -EINVAL;
@@ -279,7 +279,7 @@ void RGWOp_MDLog_Lock::execute(optional_yield y) {
   }
 
   RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls, period};
-  auto r = meta_log.init();
+  auto r = meta_log.init(store->svc()->rados->get_rados_handle());
   if (r < 0) {
     ldout(s->cct, 5) << "meta_log initialization failed." << dendl;
     op_ret = -EINVAL;
@@ -333,7 +333,7 @@ void RGWOp_MDLog_Unlock::execute(optional_yield y) {
   }
 
   RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls, period};
-  auto r = meta_log.init();
+  auto r = meta_log.init(store->svc()->rados->get_rados_handle());
   if (r < 0) {
     ldout(s->cct, 5) << "meta_log initialization failed." << dendl;
     op_ret = -EINVAL;

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -81,7 +81,8 @@ void RGWOp_MDLog_List::execute(optional_yield y) {
     }
   }
 
-  RGWMetadataLog meta_log{s->cct, store->svc()->zone, store->svc()->cls, period};
+  RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls,
+      period};
 
   op_ret = meta_log.list_entries(shard_id, max_entries, marker, entries,
                                    &last_marker, &truncated);
@@ -153,7 +154,7 @@ void RGWOp_MDLog_ShardInfo::execute(optional_yield y) {
       return;
     }
   }
-  RGWMetadataLog meta_log{s->cct, store->svc()->zone, store->svc()->cls, period};
+  RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls, period};
 
   op_ret = meta_log.get_info(shard_id, &info);
 }
@@ -219,7 +220,7 @@ void RGWOp_MDLog_Delete::execute(optional_yield y) {
       return;
     }
   }
-  RGWMetadataLog meta_log{s->cct, store->svc()->zone, store->svc()->cls, period};
+  RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls, period};
 
   op_ret = meta_log.trim(shard_id, marker);
 }
@@ -259,7 +260,7 @@ void RGWOp_MDLog_Lock::execute(optional_yield y) {
     return;
   }
 
-  RGWMetadataLog meta_log{s->cct, store->svc()->zone, store->svc()->cls, period};
+  RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls, period};
   unsigned dur;
   dur = (unsigned)strict_strtol(duration_str.c_str(), 10, &err);
   if (!err.empty() || dur <= 0) {
@@ -306,7 +307,7 @@ void RGWOp_MDLog_Unlock::execute(optional_yield y) {
     return;
   }
 
-  RGWMetadataLog meta_log{s->cct, store->svc()->zone, store->svc()->cls, period};
+  RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls, period};
   op_ret = meta_log.unlock(shard_id, zone_id, locker_id);
 }
 

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -83,6 +83,12 @@ void RGWOp_MDLog_List::execute(optional_yield y) {
 
   RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls,
       period};
+  auto r = meta_log.init();
+  if (r < 0) {
+    ldout(s->cct, 5) << "meta_log initialization failed." << dendl;
+    op_ret = -EINVAL;
+    return;
+  }
 
   op_ret = meta_log.list_entries(shard_id, max_entries, marker, entries,
                                    &last_marker, &truncated);
@@ -155,6 +161,12 @@ void RGWOp_MDLog_ShardInfo::execute(optional_yield y) {
     }
   }
   RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls, period};
+  auto r = meta_log.init();
+  if (r < 0) {
+    ldout(s->cct, 5) << "meta_log initialization failed." << dendl;
+    op_ret = -EINVAL;
+    return;
+  }
 
   op_ret = meta_log.get_info(shard_id, &info);
 }
@@ -221,6 +233,12 @@ void RGWOp_MDLog_Delete::execute(optional_yield y) {
     }
   }
   RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls, period};
+  auto r = meta_log.init();
+  if (r < 0) {
+    ldout(s->cct, 5) << "meta_log initialization failed." << dendl;
+    op_ret = -EINVAL;
+    return;
+  }
 
   op_ret = meta_log.trim(shard_id, marker, true);
 }
@@ -261,6 +279,13 @@ void RGWOp_MDLog_Lock::execute(optional_yield y) {
   }
 
   RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls, period};
+  auto r = meta_log.init();
+  if (r < 0) {
+    ldout(s->cct, 5) << "meta_log initialization failed." << dendl;
+    op_ret = -EINVAL;
+    return;
+  }
+
   unsigned dur;
   dur = (unsigned)strict_strtol(duration_str.c_str(), 10, &err);
   if (!err.empty() || dur <= 0) {
@@ -308,6 +333,13 @@ void RGWOp_MDLog_Unlock::execute(optional_yield y) {
   }
 
   RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls, period};
+  auto r = meta_log.init();
+  if (r < 0) {
+    ldout(s->cct, 5) << "meta_log initialization failed." << dendl;
+    op_ret = -EINVAL;
+    return;
+  }
+
   op_ret = meta_log.unlock(shard_id, zone_id, locker_id);
 }
 

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -221,7 +221,7 @@ void RGWOp_MDLog_Delete::execute(optional_yield y) {
   }
   RGWMetadataLog meta_log{s->cct, store->svc()->zone, store->svc()->cls, period};
 
-  op_ret = meta_log.trim(shard_id, {}, {}, {}, marker);
+  op_ret = meta_log.trim(shard_id, marker);
 }
 
 void RGWOp_MDLog_Lock::execute(optional_yield y) {

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -222,7 +222,7 @@ void RGWOp_MDLog_Delete::execute(optional_yield y) {
   }
   RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls, period};
 
-  op_ret = meta_log.trim(shard_id, marker);
+  op_ret = meta_log.trim(shard_id, marker, true);
 }
 
 void RGWOp_MDLog_Lock::execute(optional_yield y) {

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -82,13 +82,7 @@ void RGWOp_MDLog_List::execute(optional_yield y) {
   }
 
   RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls,
-      period};
-  auto r = meta_log.init(store->svc()->rados->get_rados_handle());
-  if (r < 0) {
-    ldout(s->cct, 5) << "meta_log initialization failed." << dendl;
-    op_ret = -EINVAL;
-    return;
-  }
+	  		  store->svc()->rados, period};
 
   op_ret = meta_log.list_entries(shard_id, max_entries, marker, entries,
                                    &last_marker, &truncated);
@@ -160,13 +154,8 @@ void RGWOp_MDLog_ShardInfo::execute(optional_yield y) {
       return;
     }
   }
-  RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls, period};
-  auto r = meta_log.init(store->svc()->rados->get_rados_handle());
-  if (r < 0) {
-    ldout(s->cct, 5) << "meta_log initialization failed." << dendl;
-    op_ret = -EINVAL;
-    return;
-  }
+  RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls,
+	  		  store->svc()->rados, period};
 
   op_ret = meta_log.get_info(shard_id, &info);
 }
@@ -232,13 +221,8 @@ void RGWOp_MDLog_Delete::execute(optional_yield y) {
       return;
     }
   }
-  RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls, period};
-  auto r = meta_log.init(store->svc()->rados->get_rados_handle());
-  if (r < 0) {
-    ldout(s->cct, 5) << "meta_log initialization failed." << dendl;
-    op_ret = -EINVAL;
-    return;
-  }
+  RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls,
+	  		  store->svc()->rados, period};
 
   op_ret = meta_log.trim(shard_id, marker, true);
 }
@@ -278,13 +262,8 @@ void RGWOp_MDLog_Lock::execute(optional_yield y) {
     return;
   }
 
-  RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls, period};
-  auto r = meta_log.init(store->svc()->rados->get_rados_handle());
-  if (r < 0) {
-    ldout(s->cct, 5) << "meta_log initialization failed." << dendl;
-    op_ret = -EINVAL;
-    return;
-  }
+  RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls,
+	  		  store->svc()->rados, period};
 
   unsigned dur;
   dur = (unsigned)strict_strtol(duration_str.c_str(), 10, &err);
@@ -332,13 +311,8 @@ void RGWOp_MDLog_Unlock::execute(optional_yield y) {
     return;
   }
 
-  RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls, period};
-  auto r = meta_log.init(store->svc()->rados->get_rados_handle());
-  if (r < 0) {
-    ldout(s->cct, 5) << "meta_log initialization failed." << dendl;
-    op_ret = -EINVAL;
-    return;
-  }
+  RGWMetadataLog meta_log{s->cct, store, store->svc()->zone, store->svc()->cls,
+	  		  store->svc()->rados, period};
 
   op_ret = meta_log.unlock(shard_id, zone_id, locker_id);
 }

--- a/src/rgw/rgw_rest_log.h
+++ b/src/rgw/rgw_rest_log.h
@@ -79,7 +79,7 @@ public:
 };
 
 class RGWOp_MDLog_List : public RGWRESTOp {
-  list<cls_log_entry> entries;
+  std::vector<cls_log_entry> entries;
   string last_marker;
   bool truncated;
 public:

--- a/src/rgw/rgw_service.cc
+++ b/src/rgw/rgw_service.cc
@@ -155,7 +155,7 @@ int RGWServices_Def::init(CephContext *cct,
       return r;
     }
 
-    r = mdlog->init_log();
+    r = mdlog->init_log(rados->get_rados_handle());
     if (r < 0) {
       ldout(cct, 0) << "ERROR: failed to init mdlog current log (" << cpp_strerror(-r) << dendl;
       return r;

--- a/src/rgw/rgw_service.cc
+++ b/src/rgw/rgw_service.cc
@@ -155,6 +155,12 @@ int RGWServices_Def::init(CephContext *cct,
       return r;
     }
 
+    r = mdlog->init_log();
+    if (r < 0) {
+      ldout(cct, 0) << "ERROR: failed to init mdlog current log (" << cpp_strerror(-r) << dendl;
+      return r;
+    }
+
     r = sync_modules->start(y);
     if (r < 0) {
       ldout(cct, 0) << "ERROR: failed to start sync modules service (" << cpp_strerror(-r) << dendl;

--- a/src/rgw/rgw_service.cc
+++ b/src/rgw/rgw_service.cc
@@ -155,12 +155,6 @@ int RGWServices_Def::init(CephContext *cct,
       return r;
     }
 
-    r = mdlog->init_log(rados->get_rados_handle());
-    if (r < 0) {
-      ldout(cct, 0) << "ERROR: failed to init mdlog current log (" << cpp_strerror(-r) << dendl;
-      return r;
-    }
-
     r = sync_modules->start(y);
     if (r < 0) {
       ldout(cct, 0) << "ERROR: failed to start sync modules service (" << cpp_strerror(-r) << dendl;

--- a/src/rgw/rgw_service.cc
+++ b/src/rgw/rgw_service.cc
@@ -44,6 +44,7 @@ RGWServices_Def::~RGWServices_Def()
 }
 
 int RGWServices_Def::init(CephContext *cct,
+			  rgw::sal::RGWRadosStore* store,
 			  bool have_cache,
                           bool raw,
 			  bool run_sync,
@@ -90,7 +91,7 @@ int RGWServices_Def::init(CephContext *cct,
                          bucket_sobj.get());
   cls->init(zone.get(), rados.get());
   config_key_rados->init(rados.get());
-  mdlog->init(rados.get(), zone.get(), sysobj.get(), cls.get());
+  mdlog->init(store, rados.get(), zone.get(), sysobj.get(), cls.get());
   meta->init(sysobj.get(), mdlog.get(), meta_bes);
   meta_be_sobj->init(sysobj.get(), mdlog.get());
   meta_be_otp->init(sysobj.get(), mdlog.get(), cls.get());
@@ -274,11 +275,13 @@ void RGWServices_Def::shutdown()
 }
 
 
-int RGWServices::do_init(CephContext *_cct, bool have_cache, bool raw, bool run_sync, optional_yield y)
+int RGWServices::do_init(CephContext *_cct, rgw::sal::RGWRadosStore *_store,
+			 bool have_cache, bool raw, bool run_sync, optional_yield y)
 {
   cct = _cct;
+  store = _store;
 
-  int r = _svc.init(cct, have_cache, raw, run_sync, y);
+  int r = _svc.init(cct, store, have_cache, raw, run_sync, y);
   if (r < 0) {
     return r;
   }

--- a/src/rgw/rgw_service.h
+++ b/src/rgw/rgw_service.h
@@ -108,7 +108,8 @@ struct RGWServices_Def
   RGWServices_Def();
   ~RGWServices_Def();
 
-  int init(CephContext *cct, bool have_cache, bool raw_storage, bool run_sync, optional_yield y);
+  int init(CephContext *cct, rgw::sal::RGWRadosStore* store,
+	   bool have_cache, bool raw_storage, bool run_sync, optional_yield y);
   void shutdown();
 };
 
@@ -118,6 +119,7 @@ struct RGWServices
   RGWServices_Def _svc;
 
   CephContext *cct;
+  rgw::sal::RGWRadosStore* store;
 
   RGWSI_Finisher *finisher{nullptr};
   RGWSI_Bucket *bucket{nullptr};
@@ -147,14 +149,17 @@ struct RGWServices
   RGWSI_SysObj_Core *core{nullptr};
   RGWSI_User *user{nullptr};
 
-  int do_init(CephContext *cct, bool have_cache, bool raw_storage, bool run_sync, optional_yield y);
+  int do_init(CephContext *cct, rgw::sal::RGWRadosStore* store, bool have_cache,
+	      bool raw_storage, bool run_sync, optional_yield y);
 
-  int init(CephContext *cct, bool have_cache, bool run_sync, optional_yield y) {
-    return do_init(cct, have_cache, false, run_sync, y);
+  int init(CephContext *cct, rgw::sal::RGWRadosStore* store, bool have_cache,
+	   bool run_sync, optional_yield y) {
+    return do_init(cct, store, have_cache, false, run_sync, y);
   }
 
-  int init_raw(CephContext *cct, bool have_cache, optional_yield y) {
-    return do_init(cct, have_cache, true, false, y);
+  int init_raw(CephContext *cct, rgw::sal::RGWRadosStore* store, bool have_cache,
+	       optional_yield y) {
+    return do_init(cct, store, have_cache, true, false, y);
   }
   void shutdown() {
     _svc.shutdown();

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -399,22 +399,14 @@ class RGWAsyncReadMDLogEntries : public RGWAsyncRadosRequest {
 
 protected:
   int _send_request() override {
-    real_time from_time;
-    real_time end_time;
-
-    void *handle;
-
-    mdlog->init_list_entries(shard_id, from_time, end_time, marker, &handle);
-
-    int ret = mdlog->list_entries(handle, max_entries, entries, &marker, &truncated);
-
-    mdlog->complete_list_entries(handle);
+    int ret = mdlog->list_entries(shard_id, max_entries, marker, entries, &marker,
+				  &truncated);
 
     return ret;
   }
 public:
-  string marker;
-  list<cls_log_entry> entries;
+  std::string marker;
+  std::vector<cls_log_entry> entries;
   bool truncated;
 
   RGWAsyncReadMDLogEntries(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RGWRadosStore *_store,
@@ -431,7 +423,7 @@ class RGWReadMDLogEntriesCR : public RGWSimpleCoroutine {
   string marker;
   string *pmarker;
   int max_entries;
-  list<cls_log_entry> *entries;
+  std::vector<cls_log_entry> *entries;
   bool *truncated;
 
   RGWAsyncReadMDLogEntries *req{nullptr};
@@ -439,7 +431,7 @@ class RGWReadMDLogEntriesCR : public RGWSimpleCoroutine {
 public:
   RGWReadMDLogEntriesCR(RGWMetaSyncEnv *_sync_env, RGWMetadataLog* mdlog,
                         int _shard_id, string*_marker, int _max_entries,
-                        list<cls_log_entry> *_entries, bool *_truncated)
+                        std::vector<cls_log_entry> *_entries, bool *_truncated)
     : RGWSimpleCoroutine(_sync_env->cct), sync_env(_sync_env), mdlog(mdlog),
       shard_id(_shard_id), pmarker(_marker), max_entries(_max_entries),
       entries(_entries), truncated(_truncated) {}
@@ -1411,8 +1403,8 @@ class RGWMetaSyncShardCR : public RGWCoroutine {
 
   RGWMetaSyncShardMarkerTrack *marker_tracker = nullptr;
 
-  list<cls_log_entry> log_entries;
-  list<cls_log_entry>::iterator log_iter;
+  std::vector<cls_log_entry> log_entries;
+  decltype(log_entries)::iterator log_iter;
   bool truncated = false;
 
   string mdlog_marker;

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -944,14 +944,8 @@ public:
 
             tn->log(20, SSTR("list metadata: section=" << *sections_iter << " key=" << *iter));
             string s = *sections_iter + ":" + *iter;
-            int shard_id;
 	    rgw::sal::RGWRadosStore *store = sync_env->store;
-            int ret = store->ctl()->meta.mgr->get_shard_id(*sections_iter, *iter, &shard_id);
-            if (ret < 0) {
-              tn->log(0, SSTR("ERROR: could not determine shard id for " << *sections_iter << ":" << *iter));
-              ret_status = ret;
-              break;
-            }
+            int shard_id = store->ctl()->meta.mgr->get_shard_id(*sections_iter, *iter);
             if (!entries_index->append(s, shard_id)) {
               break;
             }

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -2424,11 +2424,9 @@ int RGWCloneMetaLogCoroutine::state_receive_rest_response()
 
 int RGWCloneMetaLogCoroutine::state_store_mdlog_entries()
 {
-  list<cls_log_entry> dest_entries;
+  std::vector<cls_log_entry> dest_entries;
 
-  vector<rgw_mdlog_entry>::iterator iter;
-  for (iter = data.entries.begin(); iter != data.entries.end(); ++iter) {
-    rgw_mdlog_entry& entry = *iter;
+  for (auto& entry : data.entries) {
     ldpp_dout(sync_env->dpp, 20) << "entry: name=" << entry.name << dendl;
 
     cls_log_entry dest_entry;
@@ -2436,7 +2434,7 @@ int RGWCloneMetaLogCoroutine::state_store_mdlog_entries()
     dest_entry.section = entry.section;
     dest_entry.name = entry.name;
     dest_entry.timestamp = utime_t(entry.timestamp);
-  
+
     encode(entry.log_data, dest_entry.data);
 
     dest_entries.push_back(dest_entry);

--- a/src/rgw/rgw_tools.h
+++ b/src/rgw/rgw_tools.h
@@ -63,6 +63,13 @@ void rgw_shard_name(const string& prefix, unsigned max_shards, const string& key
 void rgw_shard_name(const string& prefix, unsigned max_shards, const string& section, const string& key, string& name);
 void rgw_shard_name(const string& prefix, unsigned shard_id, string& name);
 
+std::pair<std::string, int> rgw_shard_name(std::string_view prefix,
+					   unsigned max_shards,
+					   std::string_view key);
+std::string rgw_shard_name(std::string_view prefix, unsigned max_shards,
+			   std::string_view section, std::string_view key);
+std::string rgw_shard_name(std::string_view prefix, unsigned shard_id);
+
 struct rgw_name_to_flag {
   const char *type_name;
   uint32_t flag;

--- a/src/rgw/rgw_trim_mdlog.cc
+++ b/src/rgw/rgw_trim_mdlog.cc
@@ -20,33 +20,6 @@
 #undef dout_prefix
 #define dout_prefix (*_dout << "meta trim: ")
 
-/// purge all log shards for the given mdlog
-class PurgeLogShardsCR : public RGWShardCollectCR {
-  rgw::sal::RGWRadosStore *const store;
-  const RGWMetadataLog* mdlog;
-  const int num_shards;
-  rgw_raw_obj obj;
-  int i{0};
-
-  static constexpr int max_concurrent = 16;
-
- public:
-  PurgeLogShardsCR(rgw::sal::RGWRadosStore *store, const RGWMetadataLog* mdlog,
-                   const rgw_pool& pool, int num_shards)
-    : RGWShardCollectCR(store->ctx(), max_concurrent),
-      store(store), mdlog(mdlog), num_shards(num_shards), obj(pool, "")
-  {}
-
-  bool spawn_next() override {
-    if (i == num_shards) {
-      return false;
-    }
-    obj.oid = mdlog->get_shard_oid(i++);
-    spawn(new RGWRadosRemoveCR(store, obj), false);
-    return true;
-  }
-};
-
 using Cursor = RGWPeriodHistory::Cursor;
 
 /// purge mdlogs from the oldest up to (but not including) the given realm_epoch
@@ -91,9 +64,7 @@ int PurgePeriodLogsCR::operate()
           << " period=" << cursor.get_period().get_id() << dendl;
       yield {
         const auto mdlog = svc.mdlog->get_log(cursor.get_period().get_id());
-        const auto& pool = svc.zone->get_zone_params().log_pool;
-        auto num_shards = cct->_conf->rgw_md_log_max_shards;
-        call(new PurgeLogShardsCR(store, mdlog, pool, num_shards));
+        call(mdlog->purge_cr());
       }
       if (retcode < 0) {
         ldout(cct, 1) << "failed to remove log shards: "

--- a/src/rgw/rgw_trim_mdlog.cc
+++ b/src/rgw/rgw_trim_mdlog.cc
@@ -266,13 +266,15 @@ bool MetaMasterTrimShardCollectCR::spawn_next()
       continue;
     }
 
-    auto oid = mdlog->get_shard_oid(shard_id);
-
     ldout(cct, 10) << "trimming log shard " << shard_id
         << " at marker=" << stable
         << " last_trim=" << last_trim
         << " realm_epoch=" << sync_status.sync_info.realm_epoch << dendl;
-    spawn(new RGWSyncLogTrimCR(env.store, oid, stable, &last_trim), false);
+    RGWCoroutine* master_trim_cr = mdlog->master_trim_cr(shard_id, stable, &last_trim);
+    if (master_trim_cr) {
+      spawn(master_trim_cr, false);
+    }
+
     shard_id++;
     return true;
   }

--- a/src/rgw/rgw_trim_mdlog.cc
+++ b/src/rgw/rgw_trim_mdlog.cc
@@ -41,7 +41,7 @@ class PurgeLogShardsCR : public RGWShardCollectCR {
     if (i == num_shards) {
       return false;
     }
-    mdlog->get_shard_oid(i++, obj.oid);
+    obj.oid = mdlog->get_shard_oid(i++);
     spawn(new RGWRadosRemoveCR(store, obj), false);
     return true;
   }
@@ -294,7 +294,7 @@ bool MetaMasterTrimShardCollectCR::spawn_next()
       continue;
     }
 
-    mdlog->get_shard_oid(shard_id, oid);
+    auto oid = mdlog->get_shard_oid(shard_id);
 
     ldout(cct, 10) << "trimming log shard " << shard_id
         << " at marker=" << stable
@@ -496,8 +496,7 @@ int MetaPeerTrimShardCR::operate()
         << " at timestamp=" << stable
         << " last_trim=" << *last_trim << dendl;
     yield {
-      std::string oid;
-      mdlog->get_shard_oid(shard_id, oid);
+      auto oid = mdlog->get_shard_oid(shard_id);
       call(new RGWRadosTimelogTrimCR(env.store, oid, real_time{}, stable, "", ""));
     }
     if (retcode < 0 && retcode != -ENODATA) {

--- a/src/rgw/rgw_trim_mdlog.cc
+++ b/src/rgw/rgw_trim_mdlog.cc
@@ -205,17 +205,18 @@ struct MasterTrimEnv : public TrimEnv {
 };
 
 struct PeerTrimEnv : public TrimEnv {
-  /// last trim timestamp for each shard, only applies to current period's mdlog
-  std::vector<ceph::real_time> last_trim_timestamps;
+  /// last trim marker for each shard, only applies to current period's mdlog
+  std::vector<std::string> last_trim_markers;
+
 
   PeerTrimEnv(const DoutPrefixProvider *dpp, rgw::sal::RGWRadosStore *store, RGWHTTPManager *http, int num_shards)
     : TrimEnv(dpp, store, http, num_shards),
-      last_trim_timestamps(num_shards)
+      last_trim_markers(num_shards)
   {}
 
   void set_num_shards(int num_shards) {
     this->num_shards = num_shards;
-    last_trim_timestamps.resize(num_shards);
+    last_trim_markers.resize(num_shards);
   }
 };
 
@@ -384,14 +385,15 @@ class MetaPeerTrimShardCR : public RGWCoroutine {
   const std::string& period_id;
   const int shard_id;
   RGWMetadataLogInfo info;
-  ceph::real_time stable; //< safe timestamp to trim, according to master
-  ceph::real_time *last_trim; //< last trimmed timestamp, updated on trim
+  std::string stable; //< marker to trim, according to master
+  std::string *last_trim; //< last trimmed marker, updated on trim
   rgw_mdlog_shard_data result; //< result from master's mdlog listing
+  bool exclusive{true}; // if true, trims upto (not including) marker
 
  public:
   MetaPeerTrimShardCR(RGWMetaSyncEnv& env, RGWMetadataLog *mdlog,
                       const std::string& period_id, int shard_id,
-                      ceph::real_time *last_trim)
+                      std::string *last_trim)
     : RGWCoroutine(env.store->ctx()), env(env), mdlog(mdlog),
       period_id(period_id), shard_id(shard_id), last_trim(last_trim)
   {}
@@ -411,14 +413,14 @@ int MetaPeerTrimShardCR::operate()
           << ": " << cpp_strerror(retcode) << dendl;
       return set_cr_error(retcode);
     }
-    if (result.entries.empty()) {
-      // if there are no mdlog entries, we don't have a timestamp to compare. we
+    if (result.marker.empty()) {
+      // if there are no mdlog entries, we don't have a marker to compare. we
       // can't just trim everything, because there could be racing updates since
-      // this empty reply. query the mdlog shard info to read its max timestamp,
+      // this empty reply. query the mdlog shard info to read its marker,
       // then retry the listing to make sure it's still empty before trimming to
       // that
       ldpp_dout(env.dpp, 10) << "empty master mdlog shard " << shard_id
-          << ", reading last timestamp from shard info" << dendl;
+          << ", reading marker from shard info" << dendl;
       // read the mdlog shard info for the last timestamp
       yield call(create_read_remote_mdlog_shard_info_cr(&env, period_id, shard_id, &info));
       if (retcode < 0) {
@@ -427,11 +429,11 @@ int MetaPeerTrimShardCR::operate()
             << ": " << cpp_strerror(retcode) << dendl;
         return set_cr_error(retcode);
       }
-      if (ceph::real_clock::is_zero(info.last_update)) {
+      if (info.marker.empty()) {
         return set_cr_done(); // nothing to trim
       }
-      ldpp_dout(env.dpp, 10) << "got mdlog shard info with last update="
-          << info.last_update << dendl;
+      ldpp_dout(env.dpp, 10) << "got mdlog shard info with marker="
+          << info.marker << dendl;
       // re-read the master's first mdlog entry to make sure it hasn't changed
       yield call(create_list_remote_mdlog_shard_cr(&env, period_id, shard_id,
                                                    "", 1, &result));
@@ -442,33 +444,32 @@ int MetaPeerTrimShardCR::operate()
         return set_cr_error(retcode);
       }
       // if the mdlog is still empty, trim to max marker
-      if (result.entries.empty()) {
-        stable = info.last_update;
+      if (result.marker.empty()) {
+        stable = info.marker;
+	exclusive = false; // trim including marker
       } else {
-        stable = result.entries.front().timestamp;
-
-        // can only trim -up to- master's first timestamp, so subtract a second.
-        // (this is why we use timestamps instead of markers for the peers)
-        stable -= std::chrono::seconds(1);
+        stable = result.marker;
+	// the subtraction of '-1' will be done in Omap backend trim operation
       }
     } else {
-      stable = result.entries.front().timestamp;
-      stable -= std::chrono::seconds(1);
+      stable = result.marker;
     }
 
     if (stable <= *last_trim) {
       ldpp_dout(env.dpp, 10) << "skipping log shard " << shard_id
-          << " at timestamp=" << stable
+          << " at marker=" << stable
           << " last_trim=" << *last_trim << dendl;
       return set_cr_done();
     }
 
     ldpp_dout(env.dpp, 10) << "trimming log shard " << shard_id
-        << " at timestamp=" << stable
+        << " at marker=" << stable
         << " last_trim=" << *last_trim << dendl;
     yield {
-      auto oid = mdlog->get_shard_oid(shard_id);
-      call(new RGWRadosTimelogTrimCR(env.store, oid, real_time{}, stable, "", ""));
+      RGWCoroutine* peer_trim_cr = mdlog->peer_trim_cr(shard_id, stable, exclusive);
+      if (peer_trim_cr) {
+        call(peer_trim_cr);
+      }
     }
     if (retcode < 0 && retcode != -ENODATA) {
       ldpp_dout(env.dpp, 1) << "failed to trim mdlog shard " << shard_id
@@ -508,7 +509,7 @@ bool MetaPeerTrimShardCollectCR::spawn_next()
   if (shard_id >= env.num_shards) {
     return false;
   }
-  auto& last_trim = env.last_trim_timestamps[shard_id];
+  auto& last_trim = env.last_trim_markers[shard_id];
   spawn(new MetaPeerTrimShardCR(meta_env, mdlog, period_id, shard_id, &last_trim),
         false);
   shard_id++;

--- a/src/rgw/rgw_trim_mdlog.cc
+++ b/src/rgw/rgw_trim_mdlog.cc
@@ -270,10 +270,8 @@ bool MetaMasterTrimShardCollectCR::spawn_next()
         << " at marker=" << stable
         << " last_trim=" << last_trim
         << " realm_epoch=" << sync_status.sync_info.realm_epoch << dendl;
-    RGWCoroutine* master_trim_cr = mdlog->master_trim_cr(shard_id, stable, &last_trim);
-    if (master_trim_cr) {
-      spawn(master_trim_cr, false);
-    }
+
+    spawn(mdlog->master_trim_cr(shard_id, stable, &last_trim) , false);
 
     shard_id++;
     return true;
@@ -468,10 +466,7 @@ int MetaPeerTrimShardCR::operate()
         << " at marker=" << stable
         << " last_trim=" << *last_trim << dendl;
     yield {
-      RGWCoroutine* peer_trim_cr = mdlog->peer_trim_cr(shard_id, stable, exclusive);
-      if (peer_trim_cr) {
-        call(peer_trim_cr);
-      }
+      call(mdlog->peer_trim_cr(shard_id, stable, exclusive));
     }
     if (retcode < 0 && retcode != -ENODATA) {
       ldpp_dout(env.dpp, 1) << "failed to trim mdlog shard " << shard_id

--- a/src/rgw/services/svc_mdlog.cc
+++ b/src/rgw/services/svc_mdlog.cc
@@ -27,8 +27,11 @@ RGWSI_MDLog::RGWSI_MDLog(CephContext *cct, bool _run_sync) : RGWServiceInstance(
 RGWSI_MDLog::~RGWSI_MDLog() {
 }
 
-int RGWSI_MDLog::init(RGWSI_RADOS *_rados_svc, RGWSI_Zone *_zone_svc, RGWSI_SysObj *_sysobj_svc, RGWSI_Cls *_cls_svc)
+int RGWSI_MDLog::init(rgw::sal::RGWRadosStore* _store, RGWSI_RADOS *_rados_svc,
+		      RGWSI_Zone *_zone_svc, RGWSI_SysObj *_sysobj_svc,
+		      RGWSI_Cls *_cls_svc)
 {
+  store = _store;
   svc.zone = _zone_svc;
   svc.sysobj = _sysobj_svc;
   svc.mdlog = this;
@@ -380,7 +383,8 @@ RGWMetadataLog* RGWSI_MDLog::get_log(const std::string& period)
   // construct the period's log in place if it doesn't exist
   auto insert = md_logs.emplace(std::piecewise_construct,
                                 std::forward_as_tuple(period),
-                                std::forward_as_tuple(cct, svc.zone, svc.cls, period));
+                                std::forward_as_tuple(cct, store, svc.zone,
+						      svc.cls, period));
   return &insert.first->second;
 }
 

--- a/src/rgw/services/svc_mdlog.cc
+++ b/src/rgw/services/svc_mdlog.cc
@@ -59,6 +59,17 @@ int RGWSI_MDLog::do_start(optional_yield y)
   return 0;
 }
 
+int RGWSI_MDLog::init_log()
+{
+  auto& current_period = svc.zone->get_current_period();
+
+  current_log = get_log(current_period.get_id());
+
+  current_log->init();
+
+  return 0;
+}
+
 int RGWSI_MDLog::read_history(RGWMetadataLogHistory *state,
                               RGWObjVersionTracker *objv_tracker,
 			      optional_yield y) const
@@ -385,7 +396,10 @@ RGWMetadataLog* RGWSI_MDLog::get_log(const std::string& period)
                                 std::forward_as_tuple(period),
                                 std::forward_as_tuple(cct, store, svc.zone,
 						      svc.cls, period));
-  return &insert.first->second;
+
+  RGWMetadataLog* r = &insert.first->second;
+  r->init();
+  return r;
 }
 
 int RGWSI_MDLog::add_entry(const string& hash_key, const string& section, const string& key, bufferlist& bl)

--- a/src/rgw/services/svc_mdlog.cc
+++ b/src/rgw/services/svc_mdlog.cc
@@ -59,17 +59,6 @@ int RGWSI_MDLog::do_start(optional_yield y)
   return 0;
 }
 
-int RGWSI_MDLog::init_log(librados::Rados* lr)
-{
-  auto& current_period = svc.zone->get_current_period();
-
-  current_log = get_log(current_period.get_id());
-
-  current_log->init(lr);
-
-  return 0;
-}
-
 int RGWSI_MDLog::read_history(RGWMetadataLogHistory *state,
                               RGWObjVersionTracker *objv_tracker,
 			      optional_yield y) const
@@ -395,11 +384,9 @@ RGWMetadataLog* RGWSI_MDLog::get_log(const std::string& period)
   auto insert = md_logs.emplace(std::piecewise_construct,
                                 std::forward_as_tuple(period),
                                 std::forward_as_tuple(cct, store, svc.zone,
-						      svc.cls, period));
-
-  RGWMetadataLog* r = &insert.first->second;
-  r->init(store->svc()->rados->get_rados_handle());
-  return r;
+						      svc.cls, svc.rados,
+						      period));
+  return &insert.first->second;
 }
 
 int RGWSI_MDLog::add_entry(const string& hash_key, const string& section, const string& key, bufferlist& bl)

--- a/src/rgw/services/svc_mdlog.cc
+++ b/src/rgw/services/svc_mdlog.cc
@@ -390,10 +390,10 @@ int RGWSI_MDLog::add_entry(const string& hash_key, const string& section, const 
   return current_log->add_entry(hash_key, section, key, bl);
 }
 
-int RGWSI_MDLog::get_shard_id(const string& hash_key, int *shard_id)
+int RGWSI_MDLog::get_shard_id(const string& hash_key)
 {
   ceph_assert(current_log); // must have called init()
-  return current_log->get_shard_id(hash_key, shard_id);
+  return current_log->get_shard_id(hash_key);
 }
 
 int RGWSI_MDLog::pull_period(const std::string& period_id, RGWPeriod& period,
@@ -401,4 +401,3 @@ int RGWSI_MDLog::pull_period(const std::string& period_id, RGWPeriod& period,
 {
   return period_puller->pull(period_id, period, y);
 }
-

--- a/src/rgw/services/svc_mdlog.cc
+++ b/src/rgw/services/svc_mdlog.cc
@@ -59,13 +59,13 @@ int RGWSI_MDLog::do_start(optional_yield y)
   return 0;
 }
 
-int RGWSI_MDLog::init_log()
+int RGWSI_MDLog::init_log(librados::Rados* lr)
 {
   auto& current_period = svc.zone->get_current_period();
 
   current_log = get_log(current_period.get_id());
 
-  current_log->init();
+  current_log->init(lr);
 
   return 0;
 }
@@ -398,7 +398,7 @@ RGWMetadataLog* RGWSI_MDLog::get_log(const std::string& period)
 						      svc.cls, period));
 
   RGWMetadataLog* r = &insert.first->second;
-  r->init();
+  r->init(store->svc()->rados->get_rados_handle());
   return r;
 }
 

--- a/src/rgw/services/svc_mdlog.h
+++ b/src/rgw/services/svc_mdlog.h
@@ -53,7 +53,7 @@ class RGWSI_MDLog : public RGWServiceInstance
   std::unique_ptr<RGWPeriodPuller> period_puller;
   // maintains a connected history of periods
   std::unique_ptr<RGWPeriodHistory> period_history;
-
+  rgw::sal::RGWRadosStore* store;
 public:
   RGWSI_MDLog(CephContext *cct, bool run_sync);
   virtual ~RGWSI_MDLog();
@@ -66,8 +66,9 @@ public:
     RGWSI_Cls *cls{nullptr};
   } svc;
 
-  int init(RGWSI_RADOS *_rados_svc,
-           RGWSI_Zone *_zone_svc,
+  int init(rgw::sal::RGWRadosStore* _store,
+	   RGWSI_RADOS *_rados_svc,
+	   RGWSI_Zone *_zone_svc,
            RGWSI_SysObj *_sysobj_svc,
            RGWSI_Cls *_cls_svc);
 

--- a/src/rgw/services/svc_mdlog.h
+++ b/src/rgw/services/svc_mdlog.h
@@ -101,7 +101,7 @@ public:
 
   int add_entry(const string& hash_key, const string& section, const string& key, bufferlist& bl);
 
-  int get_shard_id(const string& hash_key, int *shard_id);
+  int get_shard_id(const string& hash_key);
 
   RGWPeriodHistory *get_period_history() {
     return period_history.get();
@@ -112,4 +112,3 @@ public:
   /// find or create the metadata log for the given period
   RGWMetadataLog* get_log(const std::string& period);
 };
-

--- a/src/rgw/services/svc_mdlog.h
+++ b/src/rgw/services/svc_mdlog.h
@@ -73,6 +73,7 @@ public:
            RGWSI_Cls *_cls_svc);
 
   int do_start(optional_yield y) override;
+  int init_log();
 
   // traverse all the way back to the beginning of the period history, and
   // return a cursor to the first period in a fully attached history

--- a/src/rgw/services/svc_mdlog.h
+++ b/src/rgw/services/svc_mdlog.h
@@ -73,7 +73,7 @@ public:
            RGWSI_Cls *_cls_svc);
 
   int do_start(optional_yield y) override;
-  int init_log();
+  int init_log(librados::Rados* lr);
 
   // traverse all the way back to the beginning of the period history, and
   // return a cursor to the first period in a fully attached history

--- a/src/rgw/services/svc_mdlog.h
+++ b/src/rgw/services/svc_mdlog.h
@@ -73,7 +73,6 @@ public:
            RGWSI_Cls *_cls_svc);
 
   int do_start(optional_yield y) override;
-  int init_log(librados::Rados* lr);
 
   // traverse all the way back to the beginning of the period history, and
   // return a cursor to the first period in a fully attached history

--- a/src/rgw/services/svc_meta_be.h
+++ b/src/rgw/services/svc_meta_be.h
@@ -22,7 +22,7 @@
 #include "rgw/rgw_service.h"
 #include "rgw/rgw_mdlog_types.h"
 
-class RGWMetadataLogData;
+struct RGWMetadataLogData;
 
 class RGWSI_MDLog;
 class RGWSI_Meta;

--- a/src/rgw/services/svc_meta_be.h
+++ b/src/rgw/services/svc_meta_be.h
@@ -167,8 +167,7 @@ public:
                    std::function<int(RGWSI_MetaBackend::Context *)> f) = 0;
 
   virtual int get_shard_id(RGWSI_MetaBackend::Context *ctx,
-			   const std::string& key,
-			   int *shard_id) = 0;
+			   const std::string& key) = 0;
 
   /* higher level */
   virtual int get(Context *ctx,
@@ -255,8 +254,8 @@ public:
       return be->list_get_marker(be_ctx, marker);
     }
 
-    int get_shard_id(const std::string& key, int *shard_id) {
-      return be->get_shard_id(be_ctx, key, shard_id);
+    int get_shard_id(const std::string& key) {
+      return be->get_shard_id(be_ctx, key);
     }
   };
 

--- a/src/rgw/services/svc_meta_be_sobj.cc
+++ b/src/rgw/services/svc_meta_be_sobj.cc
@@ -89,12 +89,10 @@ int RGWSI_MetaBackend_SObj::post_modify(RGWSI_MetaBackend::Context *_ctx,
 }
 
 int RGWSI_MetaBackend_SObj::get_shard_id(RGWSI_MetaBackend::Context *_ctx,
-					 const std::string& key,
-					 int *shard_id)
+					 const std::string& key)
 {
   auto ctx = static_cast<Context_SObj *>(_ctx);
-  *shard_id = mdlog_svc->get_shard_id(ctx->module->get_hash_key(key), shard_id);
-  return 0;
+  return mdlog_svc->get_shard_id(ctx->module->get_hash_key(key));
 }
 
 int RGWSI_MetaBackend_SObj::call(std::optional<RGWSI_MetaBackend_CtxParams> opt,

--- a/src/rgw/services/svc_meta_be_sobj.h
+++ b/src/rgw/services/svc_meta_be_sobj.h
@@ -168,8 +168,7 @@ public:
                       string *marker) override;
 
   int get_shard_id(RGWSI_MetaBackend::Context *ctx,
-		   const std::string& key,
-		   int *shard_id) override;
+		   const std::string& key) override;
 
   int call(std::optional<RGWSI_MetaBackend_CtxParams> opt,
            std::function<int(RGWSI_MetaBackend::Context *)> f) override;

--- a/src/test/rgw/test_cls_fifo_legacy.cc
+++ b/src/test/rgw/test_cls_fifo_legacy.cc
@@ -69,6 +69,8 @@ protected:
 };
 
 using LegacyClsFIFO = LegacyFIFO;
+using AioLegacyFIFO = LegacyFIFO;
+
 
 TEST_F(LegacyClsFIFO, TestCreate)
 {
@@ -577,8 +579,7 @@ TEST_F(LegacyFIFO, TestAioTrim)
     marker = result.front().marker;
     std::unique_ptr<R::AioCompletion> c(rados.aio_create_completion(nullptr,
 								    nullptr));
-    r = f->trim(*marker, false, c.get());
-    ASSERT_EQ(0, r);
+    f->trim(*marker, false, c.get());
     c->wait_for_complete();
     r = c->get_return_value();
     ASSERT_EQ(0, r);
@@ -644,4 +645,483 @@ TEST_F(LegacyFIFO, TestTrimExclusive) {
   std::tie(val, marker) = decode_entry<std::uint32_t>(result.front());
   ASSERT_EQ(result.size(), 1);
   ASSERT_EQ(max_entries - 1, val);
+}
+
+TEST_F(AioLegacyFIFO, TestPushListTrim)
+{
+  std::unique_ptr<RCf::FIFO> f;
+  auto r = RCf::FIFO::create(ioctx, fifo_id, &f, null_yield);
+  ASSERT_EQ(0, r);
+  static constexpr auto max_entries = 10u;
+  for (uint32_t i = 0; i < max_entries; ++i) {
+    cb::list bl;
+    encode(i, bl);
+    auto c = R::Rados::aio_create_completion();
+    f->push(bl, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    ASSERT_EQ(0, r);
+  }
+
+  std::optional<std::string> marker;
+  /* get entries one by one */
+  std::vector<RCf::list_entry> result;
+  bool more = false;
+  for (auto i = 0u; i < max_entries; ++i) {
+    auto c = R::Rados::aio_create_completion();
+    f->list(1, marker, &result, &more, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    ASSERT_EQ(0, r);
+
+    bool expected_more = (i != (max_entries - 1));
+    ASSERT_EQ(expected_more, more);
+    ASSERT_EQ(1, result.size());
+
+    std::uint32_t val;
+    std::tie(val, marker) = decode_entry<std::uint32_t>(result.front());
+
+    ASSERT_EQ(i, val);
+    result.clear();
+  }
+
+  /* get all entries at once */
+  std::string markers[max_entries];
+  std::uint32_t min_entry = 0;
+  auto c = R::Rados::aio_create_completion();
+  f->list(max_entries * 10, std::nullopt, &result, &more, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+
+  ASSERT_FALSE(more);
+  ASSERT_EQ(max_entries, result.size());
+  for (auto i = 0u; i < max_entries; ++i) {
+    std::uint32_t val;
+    std::tie(val, markers[i]) = decode_entry<std::uint32_t>(result[i]);
+    ASSERT_EQ(i, val);
+  }
+
+  /* trim one entry */
+  c = R::Rados::aio_create_completion();
+  f->trim(markers[min_entry], false, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+  ++min_entry;
+
+  c = R::Rados::aio_create_completion();
+  f->list(max_entries * 10, std::nullopt, &result, &more, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+  ASSERT_FALSE(more);
+  ASSERT_EQ(max_entries - min_entry, result.size());
+
+  for (auto i = min_entry; i < max_entries; ++i) {
+    std::uint32_t val;
+    std::tie(val, markers[i - min_entry]) =
+      decode_entry<std::uint32_t>(result[i - min_entry]);
+    EXPECT_EQ(i, val);
+  }
+}
+
+
+TEST_F(AioLegacyFIFO, TestPushTooBig)
+{
+  static constexpr auto max_part_size = 2048ull;
+  static constexpr auto max_entry_size = 128ull;
+
+  std::unique_ptr<RCf::FIFO> f;
+  auto r = RCf::FIFO::create(ioctx, fifo_id, &f, null_yield, std::nullopt,
+			     std::nullopt, false, max_part_size, max_entry_size);
+  ASSERT_EQ(0, r);
+
+  char buf[max_entry_size + 1];
+  memset(buf, 0, sizeof(buf));
+
+  cb::list bl;
+  bl.append(buf, sizeof(buf));
+
+  auto c = R::Rados::aio_create_completion();
+  f->push(bl, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  ASSERT_EQ(-E2BIG, r);
+  c->release();
+
+  c = R::Rados::aio_create_completion();
+  f->push(std::vector<cb::list>{}, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  EXPECT_EQ(0, r);
+}
+
+
+TEST_F(AioLegacyFIFO, TestMultipleParts)
+{
+  static constexpr auto max_part_size = 2048ull;
+  static constexpr auto max_entry_size = 128ull;
+  std::unique_ptr<RCf::FIFO> f;
+  auto r = RCf::FIFO::create(ioctx, fifo_id, &f, null_yield, std::nullopt,
+			     std::nullopt, false, max_part_size,
+			     max_entry_size);
+  ASSERT_EQ(0, r);
+
+  {
+    auto c = R::Rados::aio_create_completion();
+    f->get_head_info([&](int r, RCf::part_info&& p) {
+      ASSERT_TRUE(p.tag.empty());
+      ASSERT_EQ(0, p.magic);
+      ASSERT_EQ(0, p.min_ofs);
+      ASSERT_EQ(0, p.last_ofs);
+      ASSERT_EQ(0, p.next_ofs);
+      ASSERT_EQ(0, p.min_index);
+      ASSERT_EQ(0, p.max_index);
+      ASSERT_EQ(ceph::real_time{}, p.max_time);
+    }, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+  }
+
+  char buf[max_entry_size];
+  memset(buf, 0, sizeof(buf));
+  const auto [part_header_size, part_entry_overhead] =
+    f->get_part_layout_info();
+  const auto entries_per_part = ((max_part_size - part_header_size) /
+				 (max_entry_size + part_entry_overhead));
+  const auto max_entries = entries_per_part * 4 + 1;
+  /* push enough entries */
+  for (auto i = 0u; i < max_entries; ++i) {
+    cb::list bl;
+    *(int *)buf = i;
+    bl.append(buf, sizeof(buf));
+    auto c = R::Rados::aio_create_completion();
+    f->push(bl, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    EXPECT_EQ(0, r);
+  }
+
+  auto info = f->meta();
+  ASSERT_EQ(info.id, fifo_id);
+  /* head should have advanced */
+  ASSERT_GT(info.head_part_num, 0);
+
+  /* list all at once */
+  std::vector<RCf::list_entry> result;
+  bool more = false;
+  auto c = R::Rados::aio_create_completion();
+  f->list(max_entries, std::nullopt, &result, &more, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  EXPECT_EQ(0, r);
+  EXPECT_EQ(false, more);
+  ASSERT_EQ(max_entries, result.size());
+
+  for (auto i = 0u; i < max_entries; ++i) {
+    auto& bl = result[i].data;
+    ASSERT_EQ(i, *(int *)bl.c_str());
+  }
+
+  std::optional<std::string> marker;
+  /* get entries one by one */
+
+  for (auto i = 0u; i < max_entries; ++i) {
+    c = R::Rados::aio_create_completion();
+    f->list(1, marker, &result, &more, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    EXPECT_EQ(0, r);
+    ASSERT_EQ(result.size(), 1);
+    const bool expected_more = (i != (max_entries - 1));
+    ASSERT_EQ(expected_more, more);
+
+    std::uint32_t val;
+    std::tie(val, marker) = decode_entry<std::uint32_t>(result.front());
+
+    auto& entry = result.front();
+    auto& bl = entry.data;
+    ASSERT_EQ(i, *(int *)bl.c_str());
+    marker = entry.marker;
+  }
+
+  /* trim one at a time */
+  marker.reset();
+  for (auto i = 0u; i < max_entries; ++i) {
+    /* read single entry */
+    c = R::Rados::aio_create_completion();
+    f->list(1, marker, &result, &more, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    EXPECT_EQ(0, r);
+    ASSERT_EQ(result.size(), 1);
+    const bool expected_more = (i != (max_entries - 1));
+    ASSERT_EQ(expected_more, more);
+
+    marker = result.front().marker;
+    c = R::Rados::aio_create_completion();
+    f->trim(*marker, false, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    EXPECT_EQ(0, r);
+    ASSERT_EQ(result.size(), 1);
+
+    /* check tail */
+    info = f->meta();
+    ASSERT_EQ(info.tail_part_num, i / entries_per_part);
+
+    /* try to read all again, see how many entries left */
+    c = R::Rados::aio_create_completion();
+    f->list(max_entries, marker, &result, &more, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    EXPECT_EQ(0, r);
+    ASSERT_EQ(max_entries - i - 1, result.size());
+    ASSERT_EQ(false, more);
+  }
+
+  /* tail now should point at head */
+  info = f->meta();
+  ASSERT_EQ(info.head_part_num, info.tail_part_num);
+
+  /* check old tails are removed */
+  for (auto i = 0; i < info.tail_part_num; ++i) {
+    c = R::Rados::aio_create_completion();
+    RCf::part_info partinfo;
+    f->get_part_info(i, &partinfo, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    ASSERT_EQ(-ENOENT, r);
+  }
+  /* check current tail exists */
+  std::uint64_t next_ofs;
+  {
+    c = R::Rados::aio_create_completion();
+    RCf::part_info partinfo;
+    f->get_part_info(info.tail_part_num, &partinfo, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    next_ofs = partinfo.next_ofs;
+  }
+  ASSERT_EQ(0, r);
+
+  c = R::Rados::aio_create_completion();
+  f->get_head_info([&](int r, RCf::part_info&& p) {
+    ASSERT_EQ(next_ofs, p.next_ofs);
+  }, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+}
+
+TEST_F(AioLegacyFIFO, TestTwoPushers)
+{
+  static constexpr auto max_part_size = 2048ull;
+  static constexpr auto max_entry_size = 128ull;
+
+  std::unique_ptr<RCf::FIFO> f;
+  auto r = RCf::FIFO::create(ioctx, fifo_id, &f, null_yield, std::nullopt,
+			     std::nullopt, false, max_part_size,
+			     max_entry_size);
+  ASSERT_EQ(0, r);
+  char buf[max_entry_size];
+  memset(buf, 0, sizeof(buf));
+
+  auto [part_header_size, part_entry_overhead] = f->get_part_layout_info();
+  const auto entries_per_part = ((max_part_size - part_header_size) /
+				 (max_entry_size + part_entry_overhead));
+  const auto max_entries = entries_per_part * 4 + 1;
+  std::unique_ptr<RCf::FIFO> f2;
+  r = RCf::FIFO::open(ioctx, fifo_id, &f2, null_yield);
+  std::vector fifos{&f, &f2};
+
+  for (auto i = 0u; i < max_entries; ++i) {
+    cb::list bl;
+    *(int *)buf = i;
+    bl.append(buf, sizeof(buf));
+    auto& f = *fifos[i % fifos.size()];
+    auto c = R::Rados::aio_create_completion();
+    f->push(bl, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    ASSERT_EQ(0, r);
+  }
+
+  /* list all by both */
+  std::vector<RCf::list_entry> result;
+  bool more = false;
+  auto c = R::Rados::aio_create_completion();
+  f2->list(max_entries, std::nullopt, &result, &more, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(false, more);
+  ASSERT_EQ(max_entries, result.size());
+
+  c = R::Rados::aio_create_completion();
+  f2->list(max_entries, std::nullopt, &result, &more, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(false, more);
+  ASSERT_EQ(max_entries, result.size());
+
+  for (auto i = 0u; i < max_entries; ++i) {
+    auto& bl = result[i].data;
+    ASSERT_EQ(i, *(int *)bl.c_str());
+  }
+}
+
+TEST_F(AioLegacyFIFO, TestTwoPushersTrim)
+{
+  static constexpr auto max_part_size = 2048ull;
+  static constexpr auto max_entry_size = 128ull;
+  std::unique_ptr<RCf::FIFO> f1;
+  auto r = RCf::FIFO::create(ioctx, fifo_id, &f1, null_yield, std::nullopt,
+			     std::nullopt, false, max_part_size,
+			     max_entry_size);
+  ASSERT_EQ(0, r);
+
+  char buf[max_entry_size];
+  memset(buf, 0, sizeof(buf));
+
+  auto [part_header_size, part_entry_overhead] = f1->get_part_layout_info();
+  const auto entries_per_part = ((max_part_size - part_header_size) /
+				 (max_entry_size + part_entry_overhead));
+  const auto max_entries = entries_per_part * 4 + 1;
+
+  std::unique_ptr<RCf::FIFO> f2;
+  r = RCf::FIFO::open(ioctx, fifo_id, &f2, null_yield);
+  ASSERT_EQ(0, r);
+
+  /* push one entry to f2 and the rest to f1 */
+  for (auto i = 0u; i < max_entries; ++i) {
+    cb::list bl;
+    *(int *)buf = i;
+    bl.append(buf, sizeof(buf));
+    auto& f = (i < 1 ? f2 : f1);
+    auto c = R::Rados::aio_create_completion();
+    f->push(bl, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    ASSERT_EQ(0, r);
+  }
+
+  /* trim half by fifo1 */
+  auto num = max_entries / 2;
+  std::string marker;
+  std::vector<RCf::list_entry> result;
+  bool more = false;
+  auto c = R::Rados::aio_create_completion();
+  f1->list(num, std::nullopt, &result, &more, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(true, more);
+  ASSERT_EQ(num, result.size());
+
+  for (auto i = 0u; i < num; ++i) {
+    auto& bl = result[i].data;
+    ASSERT_EQ(i, *(int *)bl.c_str());
+  }
+
+  auto& entry = result[num - 1];
+  marker = entry.marker;
+  c = R::Rados::aio_create_completion();
+  f1->trim(marker, false, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+  /* list what's left by fifo2 */
+
+  const auto left = max_entries - num;
+  c = R::Rados::aio_create_completion();
+  f2->list(left, marker, &result, &more, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(left, result.size());
+  ASSERT_EQ(false, more);
+
+  for (auto i = num; i < max_entries; ++i) {
+    auto& bl = result[i - num].data;
+    ASSERT_EQ(i, *(int *)bl.c_str());
+  }
+}
+
+TEST_F(AioLegacyFIFO, TestPushBatch)
+{
+  static constexpr auto max_part_size = 2048ull;
+  static constexpr auto max_entry_size = 128ull;
+
+  std::unique_ptr<RCf::FIFO> f;
+  auto r = RCf::FIFO::create(ioctx, fifo_id, &f, null_yield, std::nullopt,
+			     std::nullopt, false, max_part_size,
+			     max_entry_size);
+  ASSERT_EQ(0, r);
+
+  char buf[max_entry_size];
+  memset(buf, 0, sizeof(buf));
+  auto [part_header_size, part_entry_overhead] = f->get_part_layout_info();
+  auto entries_per_part = ((max_part_size - part_header_size) /
+			   (max_entry_size + part_entry_overhead));
+  auto max_entries = entries_per_part * 4 + 1; /* enough entries to span multiple parts */
+  std::vector<cb::list> bufs;
+  for (auto i = 0u; i < max_entries; ++i) {
+    cb::list bl;
+    *(int *)buf = i;
+    bl.append(buf, sizeof(buf));
+    bufs.push_back(bl);
+  }
+  ASSERT_EQ(max_entries, bufs.size());
+
+  auto c = R::Rados::aio_create_completion();
+  f->push(bufs, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+
+  /* list all */
+
+  std::vector<RCf::list_entry> result;
+  bool more = false;
+  c = R::Rados::aio_create_completion();
+  f->list(max_entries, std::nullopt, &result, &more, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(false, more);
+  ASSERT_EQ(max_entries, result.size());
+  for (auto i = 0u; i < max_entries; ++i) {
+    auto& bl = result[i].data;
+    ASSERT_EQ(i, *(int *)bl.c_str());
+  }
+  auto& info = f->meta();
+  ASSERT_EQ(info.head_part_num, 4);
 }


### PR DESCRIPTION
this includes mdlog changes analogous to the datalog FIFO changes done in https://github.com/ceph/ceph/pull/35548. 

**Status of this PR and pending tasks (for reference)**

Most of the FIFO work is done except for the below issue - 

>>>
Unlike in OMAP, in case of FIFO, markers do not match across zones. So this breaks metadata incremental sync for FIFO, as the zones try to read the markers locally which cannot be compared to remote zone markers to do incremental sync.

This issue doesn't happen for Datalog where in zones save & compare remote marker to resume the data sync. If the same approach is used for MDLog as well (https://github.com/soumyakoduri/ceph/commit/6417e82c57926d8ce5b842d5b18e5616de46d3fa), it doesn't work if the primary MD server changes across multiple periods and thus breaks the sync.

This needs design changes (probably intrusive) in the way metadata markers are stored/handled.
<<<