### PR TITLE
rgw: Set CURLOPT_NOBODY for HEAD request

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -557,6 +557,11 @@ int RGWHTTPClient::init_request(rgw_http_req_data *_req_data)
       h = curl_slist_append(h, "Expect:");
     }
   }
+
+  if (method == "HEAD") {
+    curl_easy_setopt(easy_handle, CURLOPT_NOBODY, 1L);
+  }
+
   if (h) {
     curl_easy_setopt(easy_handle, CURLOPT_HTTPHEADER, (void *)h);
   }


### PR DESCRIPTION
Set "CURLOPT_NOBODY" for HEAD request so that libcurl doesn't throw error when there is no body in the response.

Signed-off-by: Soumya Koduri <skoduri@redhat.com>