### PR TITLE
common/BackTrace: do not use len for length of demangled symbol

### DIFF
--- a/src/common/BackTrace.cc
+++ b/src/common/BackTrace.cc
@@ -52,10 +52,10 @@ std::string BackTrace::demangle(const char* name)
     // only demangle a C++ mangled name
     if (mangled.compare(0, 2, "_Z") == 0) {
       // let __cxa_demangle do the malloc
-      size_t len = 0;
-      if (char* demangled = abi::__cxa_demangle(mangled.c_str(), nullptr, &len, &status)) {
+      char* demangled = abi::__cxa_demangle(mangled.c_str(), nullptr, nullptr, &status);
+      if (!status) {
         std::string full_name{OPEN};
-        full_name += std::string_view(demangled, len);
+        full_name += demangled;
         full_name += end;
         // buf could be reallocated, so free(demangled) instead
         free(demangled);


### PR DESCRIPTION
it turns out `len` is longer than the length of demangled symbol,
let's rely on the `\0` sentry in the returned char* string instead.

in this change, use `status` to tell if the demangle is successful or
not.

Fixes: https://tracker.ceph.com/issues/47552
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
