### PR TITLE
doc: fix up and acting explaination

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -291,6 +291,7 @@ John Wilkins <jwilkins@redhat.com> <jowilk@redhat.com>
 John Wilkins <jwilkins@redhat.com> <jowilki@redhat.com>
 John Wilkins <jwilkins@redhat.com> <jowilkin@redhat.com>
 Johnu George <johnugeo@cisco.com> <johnugeorge109@gmail.com>
+Jonas Jelten <jj@sft.lol> <jj@stusta.net>
 Jonas Keidel <jonas@jonas-keidel.de>
 Jordan Dorne <jordan.dorne@gmail.com>
 Josh Durgin <jdurgin@redhat.com>

--- a/doc/rados/operations/monitoring-osd-pg.rst
+++ b/doc/rados/operations/monitoring-osd-pg.rst
@@ -109,9 +109,15 @@ requires three replicas of a placement group, CRUSH may assign them to
 ``osd.1``, ``osd.2`` and ``osd.3`` respectively. CRUSH actually seeks a
 pseudo-random placement that will take into account failure domains you set in
 your `CRUSH map`_, so you will rarely see placement groups assigned to nearest
-neighbor OSDs in a large cluster. We refer to the set of OSDs that should
-contain the replicas of a particular placement group as the **Acting Set**. In
-some cases, an OSD in the Acting Set is ``down`` or otherwise not able to
+neighbor OSDs in a large cluster.
+
+Ceph processes a client request using the **Acting Set**, which is the set of
+OSDs that will actually handle the requests since they have a full and working
+version of a placement group shard. The set of OSDs that should contain a shard
+of a particular placement group as the **Up Set**, i.e. where data is
+moved/copied to (or planned to be).
+
+In some cases, an OSD in the Acting Set is ``down`` or otherwise not able to
 service requests for objects in the placement group. When these situations
 arise, don't panic. Common examples include:
 
@@ -122,12 +128,10 @@ arise, don't panic. Common examples include:
 - An OSD in the Acting Set is ``down`` or unable to service requests, 
   and another OSD has temporarily assumed its duties.
 
-Ceph processes a client request using the **Up Set**, which is the set of OSDs
-that will actually handle the requests. In most cases, the Up Set and the Acting
-Set are virtually identical. When they are not, it may indicate that Ceph is
-migrating data, an OSD is recovering, or that there is a problem (i.e., Ceph
-usually echoes a "HEALTH WARN" state with a "stuck stale" message in such
-scenarios).
+In most cases, the Up Set and the Acting Set are identical. When they are not,
+it may indicate that Ceph is migrating the PG (it's remapped), an OSD is
+recovering, or that there is a problem (i.e., Ceph usually echoes a "HEALTH
+WARN" state with a "stuck stale" message in such scenarios).
 
 To retrieve a list of placement groups, execute:: 
 


### PR DESCRIPTION
This fixes the main documentation of the up and acting sets, since it was confusing, and wrong.

[Currently](https://github.com/ceph/ceph/blob/0cb56e0f13dc57167271ec7f20f11421416196a2/doc/rados/operations/monitoring-osd-pg.rst#pg-sets), there's this sentence:
> Ceph processes a client request using the Up Set, which is the set of OSDs that will actually handle the requests.

That's not true, the actual processing is the acting set.

This is explained correctly in the [pg-concepts](https://github.com/ceph/ceph/blob/41d3fdc554ce920a631c7c6699a383134173fcff/doc/rados/operations/pg-concepts.rst) document (but also not that comprehensible).

Fixes https://tracker.ceph.com/issues/48718

## Checklist
- [x] Updates documentation if necessary
- [x] References tracker ticket 

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>