### PR TITLE
mgr/dashboard: display devices' health information within a tabset

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/smart-list/smart-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/smart-list/smart-list.component.html
@@ -8,75 +8,91 @@
     dashboard.</cd-alert-panel>
 
   <ng-container *ngIf="!error && !incompatible">
-    <cd-alert-panel *ngIf="!(data | keyvalue).length"
+    <cd-alert-panel *ngIf="isEmpty(data)"
                     type="info"
                     i18n>No SMART data available.</cd-alert-panel>
 
-    <ng-container *ngFor="let device of data | keyvalue">
+    <ng-container *ngIf="!isEmpty(data)">
       <ul ngbNav
           #nav="ngbNav"
           class="nav-tabs">
-        <li ngbNavItem>
-          <a ngbNavLink
-             i18n>{{ device.value.device }} ({{ device.value.identifier }})</a>
+        <li ngbNavItem
+            *ngFor="let device of data | keyvalue">
+          <a ngbNavLink>{{ device.value.device }} ({{ device.value.identifier }})</a>
           <ng-template ngbNavContent>
-
             <ng-container *ngIf="device.value.error; else noError">
               <cd-alert-panel id="alert-error"
                               type="warning">{{ device.value.userMessage }}</cd-alert-panel>
             </ng-container>
 
             <ng-template #noError>
-              <!-- HDD/NVMe self test -->
-              <ng-container *ngIf="device.value.info.smart_status.passed; else selfTestFailed">
-                <cd-alert-panel id="alert-self-test-passed"
-                                size="slim"
-                                type="info"
-                                i18n-title
-                                title="SMART overall-health self-assessment test result"
-                                i18n>passed</cd-alert-panel>
-              </ng-container>
-              <ng-template #selfTestFailed>
-                <cd-alert-panel id="alert-self-test-failed"
-                                size="slim"
-                                type="warning"
-                                i18n-title
-                                title="SMART overall-health self-assessment test result"
-                                i18n>failed</cd-alert-panel>
+              <cd-alert-panel *ngIf="isEmpty(device.value.info?.smart_status); else hasSmartStatus"
+                              id="alert-self-test-unknown"
+                              size="slim"
+                              type="warning"
+                              i18n-title
+                              title="SMART overall-health self-assessment test result"
+                              i18n>unknown</cd-alert-panel>
+              <ng-template #hasSmartStatus>
+                <!-- HDD/NVMe self test -->
+                <ng-container *ngIf="device.value.info.smart_status.passed; else selfTestFailed">
+                  <cd-alert-panel id="alert-self-test-passed"
+                                  size="slim"
+                                  type="info"
+                                  i18n-title
+                                  title="SMART overall-health self-assessment test result"
+                                  i18n>passed</cd-alert-panel>
+                </ng-container>
+                <ng-template #selfTestFailed>
+                  <cd-alert-panel id="alert-self-test-failed"
+                                  size="slim"
+                                  type="warning"
+                                  i18n-title
+                                  title="SMART overall-health self-assessment test result"
+                                  i18n>failed</cd-alert-panel>
+                </ng-template>
               </ng-template>
             </ng-template>
 
-            <ul ngbNav
-                #innerNav="ngbNav"
-                class="nav-tabs">
-              <li ngbNavItem>
-                <a ngbNavLink
-                   i18n>Device Information</a>
-                <ng-template ngbNavContent>
-                  <cd-table-key-value [renderObjects]="true"
-                                      [data]="device.value.info"></cd-table-key-value>
-                </ng-template>
-              </li>
-              <li ngbNavItem>
-                <a ngbNavLink
-                   i18n>SMART</a>
-                <ng-template ngbNavContent>
-                  <cd-table *ngIf="device.value.smart.attributes"
-                            [data]="device.value.smart.attributes.table"
-                            updateSelectionOnRefresh="never"
-                            [columns]="smartDataColumns"></cd-table>
-                  <cd-table-key-value *ngIf="device.value.smart.nvmeData"
-                                      [renderObjects]="true"
-                                      [data]="device.value.smart.nvmeData"
-                                      updateSelectionOnRefresh="never"></cd-table-key-value>
-                  <cd-alert-panel *ngIf="!device.value.smart.attributes && !device.value.smart.nvmeData"
-                                  type="info"
-                                  i18n>No SMART data available for this device.</cd-alert-panel>
-                </ng-template>
-              </li>
-            </ul>
+            <ng-container *ngIf="!isEmpty(device.value.info) || !isEmpty(device.value.smart)">
+              <ul ngbNav
+                  #innerNav="ngbNav"
+                  class="nav-tabs">
+                <li [ngbNavItem]="1">
+                  <a ngbNavLink
+                     i18n>Device Information</a>
+                  <ng-template ngbNavContent>
+                    <cd-table-key-value *ngIf="!isEmpty(device.value.info)"
+                                        [renderObjects]="true"
+                                        [data]="device.value.info"></cd-table-key-value>
+                    <cd-alert-panel *ngIf="isEmpty(device.value.info)"
+                                    id="alert-device-info-unavailable"
+                                    type="info"
+                                    i18n>No device information available for this device.</cd-alert-panel>
+                  </ng-template>
+                </li>
+                <li [ngbNavItem]="2">
+                  <a ngbNavLink
+                     i18n>SMART</a>
+                  <ng-template ngbNavContent>
+                    <cd-table *ngIf="device.value.smart?.attributes"
+                              [data]="device.value.smart.attributes.table"
+                              updateSelectionOnRefresh="never"
+                              [columns]="smartDataColumns"></cd-table>
+                    <cd-table-key-value *ngIf="device.value.smart?.nvmeData"
+                                        [renderObjects]="true"
+                                        [data]="device.value.smart.nvmeData"
+                                        updateSelectionOnRefresh="never"></cd-table-key-value>
+                    <cd-alert-panel *ngIf="!device.value.smart?.attributes && !device.value.smart?.nvmeData"
+                                    id="alert-device-smart-data-unavailable"
+                                    type="info"
+                                    i18n>No SMART data available for this device.</cd-alert-panel>
+                  </ng-template>
+                </li>
+              </ul>
 
-            <div [ngbNavOutlet]="innerNav"></div>
+              <div [ngbNavOutlet]="innerNav"></div>
+            </ng-container>
           </ng-template>
         </li>
       </ul>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/smart-list/smart-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/smart-list/smart-list.component.ts
@@ -1,5 +1,6 @@
-import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { Component, Input, OnChanges, OnInit, SimpleChanges, ViewChild } from '@angular/core';
 
+import { NgbNav } from '@ng-bootstrap/ng-bootstrap';
 import _ from 'lodash';
 
 import { HostService } from '../../../shared/api/host.service';
@@ -19,6 +20,9 @@ import {
   styleUrls: ['./smart-list.component.scss']
 })
 export class SmartListComponent implements OnInit, OnChanges {
+  @ViewChild('innerNav')
+  nav: NgbNav;
+
   @Input()
   osdId: number = null;
   @Input()
@@ -139,6 +143,10 @@ smartmontools is required to successfully retrieve data.`;
         }
       });
     }
+  }
+
+  isEmpty(value: any) {
+    return _.isEmpty(value);
   }
 
   ngOnInit() {


### PR DESCRIPTION
Wrap all devices' health information within a tabset
instead of displaying them from top to bottom.

Add more guard in the HTML template to prevent referencing undefined
variables.

Fixes: https://tracker.ceph.com/issues/47494
Fixes: https://tracker.ceph.com/issues/43177

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


Now:
![FireShot Capture 003 - Ceph - 192 168 2 106](https://user-images.githubusercontent.com/1691518/93749905-4df74500-fc2d-11ea-87ff-61373b41c24c.png)

[Before](https://tracker.ceph.com/attachments/download/4629/bug.png)



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
