### PR TITLE
nautilus: mgr/dashboard: Allow editing iSCSI targets with initiators logged-in

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -359,35 +359,48 @@ class IscsiTarget(RESTController):
         deleted_groups = []
         for group_id in list(target_config['groups'].keys()):
             if IscsiTarget._group_deletion_required(target, new_target_iqn, new_target_controls,
-                                                    new_groups, group_id, new_clients,
-                                                    new_disks):
+                                                    new_groups, group_id):
                 deleted_groups.append(group_id)
                 IscsiClient.instance(gateway_name=gateway_name).delete_group(target_iqn,
                                                                              group_id)
+            else:
+                group = IscsiTarget._get_group(new_groups, group_id)
+
+                old_group_disks = set(target_config['groups'][group_id]['disks'].keys())
+                new_group_disks = {'{}/{}'.format(x['pool'], x['image']) for x in group['disks']}
+                local_deleted_disks = list(old_group_disks - new_group_disks)
+
+                old_group_members = set(target_config['groups'][group_id]['members'])
+                new_group_members = set(group['members'])
+                local_deleted_members = list(old_group_members - new_group_members)
+
+                if local_deleted_disks or local_deleted_members:
+                    IscsiClient.instance(gateway_name=gateway_name).update_group(
+                        target_iqn, group_id, local_deleted_members, local_deleted_disks)
             TaskManager.current_task().inc_progress(task_progress_inc)
         deleted_clients = []
         deleted_client_luns = []
         for client_iqn, client_config in target_config['clients'].items():
             if IscsiTarget._client_deletion_required(target, new_target_iqn, new_target_controls,
-                                                     new_clients, client_iqn,
-                                                     deleted_groups):
+                                                     new_clients, client_iqn):
                 deleted_clients.append(client_iqn)
                 IscsiClient.instance(gateway_name=gateway_name).delete_client(target_iqn,
                                                                               client_iqn)
             else:
                 for image_id in list(client_config.get('luns', {}).keys()):
                     if IscsiTarget._client_lun_deletion_required(target, client_iqn, image_id,
-                                                                 new_clients):
+                                                                 new_clients, new_groups):
                         deleted_client_luns.append((client_iqn, image_id))
                         IscsiClient.instance(gateway_name=gateway_name).delete_client_lun(
                             target_iqn, client_iqn, image_id)
             TaskManager.current_task().inc_progress(task_progress_inc)
         for image_id in target_config['disks']:
             if IscsiTarget._target_lun_deletion_required(target, new_target_iqn,
-                                                         new_target_controls,
-                                                         new_disks, image_id):
+                                                         new_target_controls, new_disks, image_id):
                 all_clients = target_config['clients'].keys()
-                not_deleted_clients = [c for c in all_clients if c not in deleted_clients]
+                not_deleted_clients = [c for c in all_clients if c not in deleted_clients
+                                       and not IscsiTarget._client_in_group(target['groups'], c)
+                                       and not IscsiTarget._client_in_group(new_groups, c)]
                 for client_iqn in not_deleted_clients:
                     client_image_ids = target_config['clients'][client_iqn]['luns'].keys()
                     for client_image_id in client_image_ids:
@@ -422,28 +435,12 @@ class IscsiTarget(RESTController):
 
     @staticmethod
     def _group_deletion_required(target, new_target_iqn, new_target_controls,
-                                 new_groups, group_id, new_clients, new_disks):
+                                 new_groups, group_id):
         if IscsiTarget._target_deletion_required(target, new_target_iqn, new_target_controls):
             return True
         new_group = IscsiTarget._get_group(new_groups, group_id)
         if not new_group:
             return True
-        old_group = IscsiTarget._get_group(target['groups'], group_id)
-        if new_group != old_group:
-            return True
-        # Check if any client inside this group has changed
-        for client_iqn in new_group['members']:
-            if IscsiTarget._client_deletion_required(target, new_target_iqn, new_target_controls,
-                                                     new_clients, client_iqn,
-                                                     []):
-                return True
-        # Check if any disk inside this group has changed
-        for disk in new_group['disks']:
-            image_id = '{}/{}'.format(disk['pool'], disk['image'])
-            if IscsiTarget._target_lun_deletion_required(target, new_target_iqn,
-                                                         new_target_controls,
-                                                         new_disks, image_id):
-                return True
         return False
 
     @staticmethod
@@ -455,29 +452,45 @@ class IscsiTarget(RESTController):
 
     @staticmethod
     def _client_deletion_required(target, new_target_iqn, new_target_controls,
-                                  new_clients, client_iqn, deleted_groups):
+                                  new_clients, client_iqn):
         if IscsiTarget._target_deletion_required(target, new_target_iqn, new_target_controls):
             return True
         new_client = IscsiTarget._get_client(new_clients, client_iqn)
         if not new_client:
             return True
-        # Check if client belongs to a groups that has been deleted
-        for group in target['groups']:
-            if group['group_id'] in deleted_groups and client_iqn in group['members']:
+        return False
+
+    @staticmethod
+    def _client_in_group(groups, client_iqn):
+        for group in groups:
+            if client_iqn in group['members']:
                 return True
         return False
 
     @staticmethod
-    def _client_lun_deletion_required(target, client_iqn, image_id, new_clients):
+    def _client_lun_deletion_required(target, client_iqn, image_id, new_clients, new_groups):
         new_client = IscsiTarget._get_client(new_clients, client_iqn)
         if not new_client:
             return True
+
+        # Disks inherited from groups must be considered
+        was_in_group = IscsiTarget._client_in_group(target['groups'], client_iqn)
+        is_in_group = IscsiTarget._client_in_group(new_groups, client_iqn)
+
+        if not was_in_group and is_in_group:
+            return True
+
+        if is_in_group:
+            return False
+
         new_lun = IscsiTarget._get_disk(new_client.get('luns', []), image_id)
         if not new_lun:
             return True
+
         old_client = IscsiTarget._get_client(target['clients'], client_iqn)
         if not old_client:
             return False
+
         old_lun = IscsiTarget._get_disk(old_client.get('luns', []), image_id)
         return new_lun != old_lun
 
@@ -648,15 +661,9 @@ class IscsiTarget(RESTController):
 
         target_config = config['targets'][target_iqn]
         target = IscsiTarget._config_to_target(target_iqn, config)
-        deleted_groups = []
-        for group_id in list(target_config['groups'].keys()):
-            if IscsiTarget._group_deletion_required(target, new_target_iqn, new_target_controls,
-                                                    new_groups, group_id, new_clients,
-                                                    new_disks):
-                deleted_groups.append(group_id)
         for client_iqn in list(target_config['clients'].keys()):
             if IscsiTarget._client_deletion_required(target, new_target_iqn, new_target_controls,
-                                                     new_clients, client_iqn, deleted_groups):
+                                                     new_clients, client_iqn):
                 client_info = IscsiClient.instance(gateway_name=gateway).get_clientinfo(target_iqn,
                                                                                         client_iqn)
                 if client_info.get('state', {}).get('LOGGED_IN', []):
@@ -782,8 +789,15 @@ class IscsiTarget(RESTController):
                     pool = lun['pool']
                     image = lun['image']
                     image_id = '{}/{}'.format(pool, image)
+                    # Disks inherited from groups must be considered
+                    group_disks = []
+                    for group in groups:
+                        if client_iqn in group['members']:
+                            group_disks = ['{}/{}'.format(x['pool'], x['image'])
+                                           for x in group['disks']]
                     if not target_config or client_iqn not in target_config['clients'] or \
-                            image_id not in target_config['clients'][client_iqn]['luns']:
+                            (image_id not in target_config['clients'][client_iqn]['luns']
+                             and image_id not in group_disks):
                         IscsiClient.instance(gateway_name=gateway_name).create_client_lun(
                             target_iqn, client_iqn, image_id)
                 TaskManager.current_task().inc_progress(task_progress_inc)
@@ -793,7 +807,14 @@ class IscsiTarget(RESTController):
                 image_ids = []
                 for disk in group['disks']:
                     image_ids.append('{}/{}'.format(disk['pool'], disk['image']))
-                if not target_config or group_id not in target_config['groups']:
+
+                if target_config and group_id in target_config['groups']:
+                    old_members = target_config['groups'][group_id]['members']
+                    old_disks = target_config['groups'][group_id]['disks'].keys()
+
+                if not target_config or group_id not in target_config['groups'] or \
+                        list(set(group['members']) - set(old_members)) or \
+                        list(set(image_ids) - set(old_disks)):
                     IscsiClient.instance(gateway_name=gateway_name).create_group(
                         target_iqn, group_id, members, image_ids)
                 TaskManager.current_task().inc_progress(task_progress_inc)

--- a/src/pybind/mgr/dashboard/services/iscsi_client.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_client.py
@@ -202,6 +202,15 @@ class IscsiClient(RestClient):
             'disks': ','.join(image_ids)
         })
 
+    @RestClient.api_put('/api/hostgroup/{target_iqn}/{group_name}')
+    def update_group(self, target_iqn, group_name, members, image_ids, request=None):
+        logger.debug("iSCSI[%s] Updating group: %s/%s", self.gateway_name, target_iqn, group_name)
+        return request({
+            'action': 'remove',
+            'members': ','.join(members),
+            'disks': ','.join(image_ids)
+        })
+
     @RestClient.api_delete('/api/hostgroup/{target_iqn}/{group_name}')
     def delete_group(self, target_iqn, group_name, request=None):
         logger.debug("iSCSI[%s] Deleting group: %s/%s", self.gateway_name, target_iqn, group_name)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47558

---

backport of https://github.com/ceph/ceph/pull/37087
parent tracker: https://tracker.ceph.com/issues/47393

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh