### PR TITLE
rbd-nbd: add --legacy and make --try-netlink as deprecated

### DIFF
--- a/doc/man/8/rbd-nbd.rst
+++ b/doc/man/8/rbd-nbd.rst
@@ -37,11 +37,11 @@ Options
 .. option:: --nbds_max *limit*
 
    Override the parameter of NBD kernel module when modprobe, used to
-   limit the count of nbd device.
+   limit the count of nbd device (ignored unless --legacy specified).
 
 .. option:: --max_part *limit*
 
-    Override for module param nbds_max.
+   Override for module param nbds_max.
 
 .. option:: --exclusive
 
@@ -57,6 +57,9 @@ Options
    Specify timeout for the kernel to wait for a new rbd-nbd process is
    attached after the old process is detached. The default is 30
    second.
+
+.. option:: --legacy
+   Use the NBD ioctl interface (old kernels) instead of the default netlink interface.
 
 Image and snap specs
 ====================


### PR DESCRIPTION
Currently in nbd.ko module for the first time when loading, it
will add and initialize nbds_max(16 as default) nbd devices
defautly, and the udev service will try to open/close the
/dev/nbdX to do some sanity check.

And if we do the map at the same time we will hit error, such the
device is alredy in use, but it is actually not.

Fixes: https://tracker.ceph.com/issues/47560
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
