### PR TITLE
cephfs-mirror: handle blocklisted mirror instances

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8785,6 +8785,12 @@ std::vector<Option> get_cephfs_mirror_options() {
     .set_description("")
     .set_long_description(""),
 
+    Option("cephfs_mirror_restart_mirror_on_blocklist_interval", Option::TYPE_SECS, Option::LEVEL_ADVANCED)
+    .set_default(30)
+    .set_min(0)
+    .set_description("")
+    .set_long_description(""),
+
     });
 }
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8778,6 +8778,13 @@ std::vector<Option> get_cephfs_mirror_options() {
     .set_default("random")
     .set_description("policy for choosing directories to mirror snapshots")
     .set_long_description("policy used by cephfs-mirror daemon to choose directories for snapshot mirroring"),
+
+    Option("cephfs_mirror_mirror_action_update_interval", Option::TYPE_SECS, Option::LEVEL_ADVANCED)
+    .set_default(2)
+    .set_min(1)
+    .set_description("")
+    .set_long_description(""),
+
     });
 }
 

--- a/src/tools/cephfs_mirror/ClusterWatcher.h
+++ b/src/tools/cephfs_mirror/ClusterWatcher.h
@@ -26,10 +26,10 @@ public:
     }
 
     virtual void handle_mirroring_enabled(const FilesystemSpec &spec) = 0;
-    virtual void handle_mirroring_disabled(const std::string &fs_name) = 0;
+    virtual void handle_mirroring_disabled(const Filesystem &filesystem) = 0;
 
-    virtual void handle_peers_added(const std::string &fs_name, const Peer &peer) = 0;
-    virtual void handle_peers_removed(const std::string &fs_name, const Peer &peer) = 0;
+    virtual void handle_peers_added(const Filesystem &filesystem, const Peer &peer) = 0;
+    virtual void handle_peers_removed(const Filesystem &filesystem, const Peer &peer) = 0;
   };
 
   ClusterWatcher(CephContext *cct, MonClient *monc, Listener &listener);
@@ -57,18 +57,11 @@ public:
   void shutdown();
 
 private:
-  struct StringCmp {
-    using is_transparent = void;
-    bool operator()(std::string_view a, std::string_view b) const {
-      return a < b;
-    }
-  };
-
   ceph::mutex m_lock = ceph::make_mutex("cephfs::mirror::cluster_watcher");
   MonClient *m_monc;
   Listener &m_listener;
 
-  std::map<std::string, Peers, StringCmp> m_filesystem_peers;
+  std::map<Filesystem, Peers> m_filesystem_peers;
 
   void handle_fsmap(const cref_t<MFSMap> &m);
 };

--- a/src/tools/cephfs_mirror/FSMirror.cc
+++ b/src/tools/cephfs_mirror/FSMirror.cc
@@ -423,6 +423,8 @@ void FSMirror::mirror_status(Formatter *f) {
   f->open_object_section("status");
   if (m_init_failed) {
     f->dump_string("state", "failed");
+  } else if (is_blocklisted(locker)) {
+    f->dump_string("state", "blocklisted");
   } else {
     f->open_object_section("peers");
     for ([[maybe_unused]] auto &[peer, peer_replayer] : m_peer_replayers) {

--- a/src/tools/cephfs_mirror/FSMirror.cc
+++ b/src/tools/cephfs_mirror/FSMirror.cc
@@ -96,10 +96,14 @@ FSMirror::FSMirror(CephContext *cct, std::string_view fs_name, uint64_t pool_id,
 FSMirror::~FSMirror() {
   dout(20) << dendl;
 
-  std::scoped_lock locker(m_lock);
-  delete m_instance_watcher;
-  delete m_mirror_watcher;
-  m_cluster.reset();
+  {
+    std::scoped_lock locker(m_lock);
+    delete m_instance_watcher;
+    delete m_mirror_watcher;
+    m_cluster.reset();
+  }
+  // outside the lock so that in-progress commands can acquire
+  // lock and finish executing.
   delete m_asok_hook;
 }
 

--- a/src/tools/cephfs_mirror/FSMirror.cc
+++ b/src/tools/cephfs_mirror/FSMirror.cc
@@ -360,19 +360,19 @@ void FSMirror::handle_shutdown_instance_watcher(int r) {
   }
 }
 
-void FSMirror::handle_acquire_directory(string_view dir_name) {
-  dout(5) << ": dir_name=" << dir_name << dendl;
+void FSMirror::handle_acquire_directory(string_view dir_path) {
+  dout(5) << ": dir_path=" << dir_path << dendl;
 
   std::scoped_lock locker(m_lock);
-  m_directories.emplace(dir_name);
+  m_directories.emplace(dir_path);
   m_cond.notify_all();
 }
 
-void FSMirror::handle_release_directory(string_view dir_name) {
-  dout(5) << ": dir_name=" << dir_name << dendl;
+void FSMirror::handle_release_directory(string_view dir_path) {
+  dout(5) << ": dir_path=" << dir_path << dendl;
 
   std::scoped_lock locker(m_lock);
-  auto it = m_directories.find(dir_name);
+  auto it = m_directories.find(dir_path);
   if (it != m_directories.end()) {
     m_directories.erase(it);
   }

--- a/src/tools/cephfs_mirror/FSMirror.cc
+++ b/src/tools/cephfs_mirror/FSMirror.cc
@@ -426,6 +426,8 @@ void FSMirror::mirror_status(Formatter *f) {
   } else if (is_blocklisted(locker)) {
     f->dump_string("state", "blocklisted");
   } else {
+    // dump rados addr for blocklist test
+    f->dump_string("rados_inst", m_addrs);
     f->open_object_section("peers");
     for ([[maybe_unused]] auto &[peer, peer_replayer] : m_peer_replayers) {
       peer.dump(f);

--- a/src/tools/cephfs_mirror/FSMirror.h
+++ b/src/tools/cephfs_mirror/FSMirror.h
@@ -47,12 +47,12 @@ private:
       : fs_mirror(fs_mirror) {
     }
 
-    void acquire_directory(string_view dir_name) override {
-      fs_mirror->handle_acquire_directory(dir_name);
+    void acquire_directory(string_view dir_path) override {
+      fs_mirror->handle_acquire_directory(dir_path);
     }
 
-    void release_directory(string_view dir_name) override {
-      fs_mirror->handle_release_directory(dir_name);
+    void release_directory(string_view dir_path) override {
+      fs_mirror->handle_release_directory(dir_path);
     }
   };
 
@@ -115,8 +115,8 @@ private:
   void shutdown_instance_watcher();
   void handle_shutdown_instance_watcher(int r);
 
-  void handle_acquire_directory(string_view dir_name);
-  void handle_release_directory(string_view dir_name);
+  void handle_acquire_directory(string_view dir_path);
+  void handle_release_directory(string_view dir_path);
 };
 
 } // namespace mirror

--- a/src/tools/cephfs_mirror/FSMirror.h
+++ b/src/tools/cephfs_mirror/FSMirror.h
@@ -47,6 +47,15 @@ public:
     return is_blocklisted(locker);
   }
 
+  Peers get_peers() {
+    Peers peers;
+    std::scoped_lock locker(m_lock);
+    for ([[maybe_unused]] auto &[peer, peer_replayer] : m_peer_replayers) {
+      peers.emplace(peer);
+    }
+    return peers;
+  }
+
   // admin socket helpers
   void mirror_status(Formatter *f);
 

--- a/src/tools/cephfs_mirror/FSMirror.h
+++ b/src/tools/cephfs_mirror/FSMirror.h
@@ -37,6 +37,11 @@ public:
     return m_stopping;
   }
 
+  bool is_failed() {
+    std::scoped_lock locker(m_lock);
+    return m_init_failed;
+  }
+
   // admin socket helpers
   void mirror_status(Formatter *f);
 

--- a/src/tools/cephfs_mirror/FSMirror.h
+++ b/src/tools/cephfs_mirror/FSMirror.h
@@ -42,10 +42,27 @@ public:
     return m_init_failed;
   }
 
+  bool is_blocklisted() {
+    std::scoped_lock locker(m_lock);
+    return is_blocklisted(locker);
+  }
+
   // admin socket helpers
   void mirror_status(Formatter *f);
 
 private:
+  bool is_blocklisted(const std::scoped_lock<ceph::mutex> &locker) const {
+    bool blocklisted = false;
+    if (m_instance_watcher) {
+      blocklisted = m_instance_watcher->is_blocklisted();
+    }
+    if (m_mirror_watcher) {
+      blocklisted |= m_mirror_watcher->is_blocklisted();
+    }
+
+    return blocklisted;
+  }
+
   struct SnapListener : public InstanceWatcher::Listener {
     FSMirror *fs_mirror;
 

--- a/src/tools/cephfs_mirror/FSMirror.h
+++ b/src/tools/cephfs_mirror/FSMirror.h
@@ -32,7 +32,8 @@ public:
   void add_peer(const Peer &peer);
   void remove_peer(const Peer &peer);
 
-  bool is_stopping() const {
+  bool is_stopping() {
+    std::scoped_lock locker(m_lock);
     return m_stopping;
   }
 

--- a/src/tools/cephfs_mirror/FSMirror.h
+++ b/src/tools/cephfs_mirror/FSMirror.h
@@ -22,7 +22,7 @@ class MirrorAdminSocketHook;
 
 class FSMirror {
 public:
-  FSMirror(CephContext *cct, std::string_view fs_name, uint64_t pool_id,
+  FSMirror(CephContext *cct, const Filesystem &filesystem, uint64_t pool_id,
            std::vector<const char*> args, ContextWQ *work_queue);
   ~FSMirror();
 
@@ -90,7 +90,7 @@ private:
     }
   };
 
-  std::string m_fs_name;
+  Filesystem m_filesystem;
   uint64_t m_pool_id;
   std::vector<const char *> m_args;
   ContextWQ *m_work_queue;

--- a/src/tools/cephfs_mirror/InstanceWatcher.cc
+++ b/src/tools/cephfs_mirror/InstanceWatcher.cc
@@ -82,23 +82,23 @@ void InstanceWatcher::handle_notify(uint64_t notify_id, uint64_t handle,
                                     uint64_t notifier_id, bufferlist& bl) {
   dout(20) << dendl;
 
-  std::string dir_name;
+  std::string dir_path;
   std::string mode;
   try {
     JSONDecoder jd(bl);
-    JSONDecoder::decode_json("dir_name", dir_name, &jd.parser, true);
+    JSONDecoder::decode_json("dir_path", dir_path, &jd.parser, true);
     JSONDecoder::decode_json("mode", mode, &jd.parser, true);
   } catch (const JSONDecoder::err &e) {
     derr << ": failed to decode notify json: " << e.what() << dendl;
   }
 
-  dout(20) << ": notifier_id=" << notifier_id << ", dir_name=" << dir_name
+  dout(20) << ": notifier_id=" << notifier_id << ", dir_path=" << dir_path
            << ", mode=" << mode << dendl;
 
   if (mode == "acquire") {
-    m_listener.acquire_directory(dir_name);
+    m_listener.acquire_directory(dir_path);
   } else if (mode == "release") {
-    m_listener.release_directory(dir_name);
+    m_listener.release_directory(dir_path);
   } else {
     derr << ": unknown mode" << dendl;
   }

--- a/src/tools/cephfs_mirror/InstanceWatcher.cc
+++ b/src/tools/cephfs_mirror/InstanceWatcher.cc
@@ -107,6 +107,10 @@ void InstanceWatcher::handle_notify(uint64_t notify_id, uint64_t handle,
   acknowledge_notify(notify_id, handle, outbl);
 }
 
+void InstanceWatcher::handle_rewatch_complete(int r) {
+  dout(20) << ": r=" << r << dendl;
+}
+
 void InstanceWatcher::create_instance() {
   dout(20) << dendl;
 

--- a/src/tools/cephfs_mirror/InstanceWatcher.cc
+++ b/src/tools/cephfs_mirror/InstanceWatcher.cc
@@ -108,7 +108,17 @@ void InstanceWatcher::handle_notify(uint64_t notify_id, uint64_t handle,
 }
 
 void InstanceWatcher::handle_rewatch_complete(int r) {
-  dout(20) << ": r=" << r << dendl;
+  dout(5) << ": r=" << r << dendl;
+
+  if (r == -EBLOCKLISTED) {
+    dout(0) << ": client blocklisted" <<dendl;
+    std::scoped_lock locker(m_lock);
+    m_blocklisted = true;
+  } else if (r == -ENOENT) {
+    derr << ": mirroring object deleted" << dendl;
+  } else if (r < 0) {
+    derr << ": rewatch error: " << cpp_strerror(r) << dendl;
+  }
 }
 
 void InstanceWatcher::create_instance() {

--- a/src/tools/cephfs_mirror/InstanceWatcher.h
+++ b/src/tools/cephfs_mirror/InstanceWatcher.h
@@ -44,6 +44,11 @@ public:
                      uint64_t notifier_id, bufferlist& bl) override;
   void handle_rewatch_complete(int r) override;
 
+  bool is_blocklisted() {
+    std::scoped_lock locker(m_lock);
+    return m_blocklisted;
+  }
+
 private:
   librados::IoCtx &m_ioctx;
   Listener &m_listener;
@@ -52,6 +57,8 @@ private:
   ceph::mutex m_lock;
   Context *m_on_init_finish = nullptr;
   Context *m_on_shutdown_finish = nullptr;
+
+  bool m_blocklisted = false;
 
   void create_instance();
   void handle_create_instance(int r);

--- a/src/tools/cephfs_mirror/InstanceWatcher.h
+++ b/src/tools/cephfs_mirror/InstanceWatcher.h
@@ -42,6 +42,7 @@ public:
 
   void handle_notify(uint64_t notify_id, uint64_t handle,
                      uint64_t notifier_id, bufferlist& bl) override;
+  void handle_rewatch_complete(int r) override;
 
 private:
   librados::IoCtx &m_ioctx;

--- a/src/tools/cephfs_mirror/InstanceWatcher.h
+++ b/src/tools/cephfs_mirror/InstanceWatcher.h
@@ -25,8 +25,8 @@ public:
     virtual ~Listener() {
     }
 
-    virtual void acquire_directory(string_view dir_name) = 0;
-    virtual void release_directory(string_view dir_name) = 0;
+    virtual void acquire_directory(string_view dir_path) = 0;
+    virtual void release_directory(string_view dir_path) = 0;
   };
 
   static InstanceWatcher *create(librados::IoCtx &ioctx,

--- a/src/tools/cephfs_mirror/Mirror.h
+++ b/src/tools/cephfs_mirror/Mirror.h
@@ -42,6 +42,7 @@ private:
   struct C_EnableMirroring;
   struct C_DisableMirroring;
   struct C_PeerUpdate;
+  struct C_RestartMirroring;
 
   struct ClusterListener : ClusterWatcher::Listener {
     Mirror *mirror;
@@ -68,6 +69,11 @@ private:
   };
 
   struct MirrorAction {
+    MirrorAction(uint64_t pool_id) :
+      pool_id(pool_id) {
+    }
+
+    uint64_t pool_id; // for restarting blocklisted mirror instance
     bool action_in_progress = false;
     std::list<Context *> action_ctxs;
     std::unique_ptr<FSMirror> fs_mirror;
@@ -92,6 +98,8 @@ private:
   std::unique_ptr<ClusterWatcher> m_cluster_watcher;
   std::map<Filesystem, MirrorAction> m_mirror_actions;
 
+  utime_t m_last_blocklist_check;
+
   int init_mon_client();
 
   // called via listener
@@ -102,8 +110,9 @@ private:
 
   // mirror enable callback
   void enable_mirroring(const Filesystem &filesystem, uint64_t local_pool_id,
-                        Context *on_finish);
+                        Context *on_finish, bool is_restart=false);
   void handle_enable_mirroring(const Filesystem &filesystem, int r);
+  void handle_enable_mirroring(const Filesystem &filesystem, const Peers &peers, int r);
 
   // mirror disable callback
   void disable_mirroring(const Filesystem &filesystem, Context *on_finish);

--- a/src/tools/cephfs_mirror/MirrorWatcher.cc
+++ b/src/tools/cephfs_mirror/MirrorWatcher.cc
@@ -83,6 +83,20 @@ void MirrorWatcher::handle_notify(uint64_t notify_id, uint64_t handle,
   acknowledge_notify(notify_id, handle, outbl);
 }
 
+void MirrorWatcher::handle_rewatch_complete(int r) {
+  dout(5) << ": r=" << r << dendl;
+
+  if (r == -EBLOCKLISTED) {
+    dout(0) << ": client blocklisted" <<dendl;
+    std::scoped_lock locker(m_lock);
+    m_blocklisted = true;
+  } else if (r == -ENOENT) {
+    derr << ": mirroring object deleted" << dendl;
+  } else if (r < 0) {
+    derr << ": rewatch error: " << cpp_strerror(r) << dendl;
+  }
+}
+
 void MirrorWatcher::register_watcher() {
   dout(20) << dendl;
 

--- a/src/tools/cephfs_mirror/MirrorWatcher.h
+++ b/src/tools/cephfs_mirror/MirrorWatcher.h
@@ -20,7 +20,7 @@ namespace mirror {
 // watch for notifications via cephfs_mirror object (in metadata
 // pool). this is used sending keepalived with keepalive payload
 // being the rados instance address (used by the manager module
-// to blacklist when needed).
+// to blocklist when needed).
 
 class MirrorWatcher : public Watcher {
 public:

--- a/src/tools/cephfs_mirror/MirrorWatcher.h
+++ b/src/tools/cephfs_mirror/MirrorWatcher.h
@@ -38,6 +38,12 @@ public:
 
   void handle_notify(uint64_t notify_id, uint64_t handle,
                      uint64_t notifier_id, bufferlist& bl) override;
+  void handle_rewatch_complete(int r) override;
+
+  bool is_blocklisted() {
+    std::scoped_lock locker(m_lock);
+    return m_blocklisted;
+  }
 
 private:
   librados::IoCtx &m_ioctx;
@@ -49,6 +55,8 @@ private:
 
   Context *m_on_init_finish = nullptr;
   Context *m_on_shutdown_finish = nullptr;
+
+  bool m_blocklisted = false;
 
   void register_watcher();
   void handle_register_watcher(int r);

--- a/src/tools/cephfs_mirror/Types.cc
+++ b/src/tools/cephfs_mirror/Types.cc
@@ -6,8 +6,13 @@
 namespace cephfs {
 namespace mirror {
 
+std::ostream& operator<<(std::ostream& out, const Filesystem &filesystem) {
+  out << "{fscid=" << filesystem.fscid << ", fs_name=" << filesystem.fs_name << "}";
+  return out;
+}
+
 std::ostream& operator<<(std::ostream& out, const FilesystemSpec &spec) {
-  out << "{fs_name=" << spec.fs_name << ", pool_id=" << spec.pool_id << "}";
+  out << "{filesystem=" << spec.filesystem << ", pool_id=" << spec.pool_id << "}";
   return out;
 }
 

--- a/src/tools/cephfs_mirror/Watcher.h
+++ b/src/tools/cephfs_mirror/Watcher.h
@@ -81,7 +81,7 @@ private:
   mutable ceph::shared_mutex m_lock;
   State m_state;
   bool m_watch_error = false;
-  bool m_watch_blacklisted = false;
+  bool m_watch_blocklisted = false;
   uint64_t m_watch_handle;
   WatchCtx m_watch_ctx;
   Context *m_unregister_watch_ctx = nullptr;

--- a/src/tools/cephfs_mirror/watcher/RewatchRequest.cc
+++ b/src/tools/cephfs_mirror/watcher/RewatchRequest.cc
@@ -53,8 +53,8 @@ void RewatchRequest::unwatch() {
 void RewatchRequest::handle_unwatch(int r) {
   dout(20) << ": r=" << r << dendl;
 
-  if (r == -EBLACKLISTED) {
-    derr << ": client blacklisted" << dendl;
+  if (r == -EBLOCKLISTED) {
+    derr << ": client blocklisted" << dendl;
     finish(r);
     return;
   } else if (r < 0) {


### PR DESCRIPTION
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
