### PR TITLE
mon: define paxos services indexes using enum and cleanups

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -203,7 +203,6 @@ Monitor::Monitor(CephContext* cct_, string nm, MonitorDBStore *s,
   timecheck_rounds_since_clean(0),
   timecheck_event(NULL),
 
-  paxos_service(PAXOS_NUM),
   admin_hook(NULL),
   routed_request_tid(0),
   op_tracker(cct, g_conf().get_val<bool>("mon_enable_op_tracker"), 1)
@@ -286,7 +285,6 @@ Monitor::~Monitor()
 {
   op_tracker.on_shutdown();
 
-  paxos_service.clear();
   delete config_key_service;
   delete paxos;
   ceph_assert(session_map.sessions.empty());

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -26,6 +26,7 @@
 #include <errno.h>
 #include <cmath>
 #include <string>
+#include <array>
 
 #include "include/types.h"
 #include "include/health.h"
@@ -637,7 +638,7 @@ public:
   /**
    * Vector holding the Services serviced by this Monitor.
    */
-  std::vector<std::unique_ptr<PaxosService>> paxos_service;
+  std::array<std::unique_ptr<PaxosService>, PAXOS_NUM> paxos_service;
 
   class MDSMonitor *mdsmon() {
     return (class MDSMonitor *)paxos_service[PAXOS_MDSMAP].get();

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -35,21 +35,6 @@
 #define PAXOS_CONFIG     8
 #define PAXOS_NUM        9
 
-inline const char *get_paxos_name(int p) {
-  switch (p) {
-  case PAXOS_MDSMAP: return "mdsmap";
-  case PAXOS_MONMAP: return "monmap";
-  case PAXOS_OSDMAP: return "osdmap";
-  case PAXOS_LOG: return "logm";
-  case PAXOS_AUTH: return "auth";
-  case PAXOS_MGR: return "mgr";
-  case PAXOS_MGRSTAT: return "mgrstat";
-  case PAXOS_HEALTH: return "health";
-  case PAXOS_CONFIG: return "config";
-  default: ceph_abort(); return 0;
-  }
-}
-
 #define CEPH_MON_ONDISK_MAGIC "ceph mon volume v012"
 
 extern const std::string CONFIG_PREFIX;

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -24,16 +24,19 @@
 #include "common/bit_str.h"
 #include "common/ceph_releases.h"
 
-#define PAXOS_MDSMAP     0
-#define PAXOS_OSDMAP     1
-#define PAXOS_LOG        2
-#define PAXOS_MONMAP     3
-#define PAXOS_AUTH       4
-#define PAXOS_MGR        5
-#define PAXOS_MGRSTAT    6
-#define PAXOS_HEALTH     7
-#define PAXOS_CONFIG     8
-#define PAXOS_NUM        9
+// use as paxos_service index
+enum {
+  PAXOS_MDSMAP,
+  PAXOS_OSDMAP,
+  PAXOS_LOG,
+  PAXOS_MONMAP,
+  PAXOS_AUTH,
+  PAXOS_MGR,
+  PAXOS_MGRSTAT,
+  PAXOS_HEALTH,
+  PAXOS_CONFIG,
+  PAXOS_NUM
+};
 
 #define CEPH_MON_ONDISK_MAGIC "ceph mon volume v012"
 


### PR DESCRIPTION
1. remove unused function
2. define paxos services indexes using enum
3. define paxos_service with fixed array size

Signed-off-by: Changcheng Liu <changcheng.liu@aliyun.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
