### PR TITLE
ceph-volume: cache the return value of util.disk.get_devices

### DIFF
--- a/src/ceph-volume/ceph_volume/decorators.py
+++ b/src/ceph-volume/ceph_volume/decorators.py
@@ -73,6 +73,18 @@ def catches(catch=None, handler=None, exit=True):
 
     return decorate
 
+
+def memoize(func):
+    cache = func.cache = {}
+
+    @wraps(func)
+    def memoizer(*args, **kwargs):
+        key = str(args) + str(kwargs)
+        if key not in cache:
+            cache[key] = func(*args, **kwargs)
+        return cache[key]
+    return memoizer
+
 #
 # Decorator helpers
 #

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -4,6 +4,7 @@ import re
 import stat
 from ceph_volume import process
 from ceph_volume.api import lvm
+from ceph_volume.decorators import memoize
 from ceph_volume.util.system import get_file_contents
 
 
@@ -729,6 +730,7 @@ def get_block_devs_lsblk():
     return [re.split(r'\s+', line) for line in stdout]
 
 
+@memoize
 def get_devices(_sys_block_path='/sys/block'):
     """
     Captures all available block devices as reported by lsblk.
@@ -795,4 +797,5 @@ def get_devices(_sys_block_path='/sys/block'):
         metadata['locked'] = is_locked_raw_device(metadata['path'])
 
         device_facts[diskname] = metadata
+
     return device_facts


### PR DESCRIPTION
Calls to get_devices result in udev messages being
created because of the opening and closing of devices
in util.disk.is_locked_raw_device. In systems with large
numbers of devices race conditions can occur with udev
that cause unintended consequenses. This effect is magnified
when many devices are passed to a command likes `lvm batch` because
`get_devices` will be called for every device given, which then runs
`is_locked_raw_device` against every device on the system. These issues have
been observed in both https://bugzilla.redhat.com/show_bug.cgi?id=1822134
and https://bugzilla.redhat.com/show_bug.cgi?id=1878500.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1878500
Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1822134

Signed-off-by: Andrew Schoen <aschoen@redhat.com>