### PR TITLE
mds: check auth undef subtree, adopt or not depend on config

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8487,6 +8487,11 @@ std::vector<Option> get_mds_options() {
      .set_flag(Option::FLAG_RUNTIME)
      .set_description("interval in seconds for sending ping messages to active MDSs.")
      .set_long_description("interval in seconds for rank 0 to send ping messages to all active MDSs."),
+    
+    Option("mds_adopt_homeless_subtree", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+     .set_default(false)
+     .set_flag(Option::FLAG_RUNTIME)
+     .set_description("adopt auth undef subtree"),
 
     Option("mds_metrics_update_interval", Option::TYPE_SECS, Option::LEVEL_ADVANCED)
      .set_default(2)

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1055,6 +1055,7 @@ class MDCache {
   void discard_delayed_resolve(mds_rank_t who);
   void maybe_resolve_finish();
   void disambiguate_my_imports();
+  void maybe_adopt_homeless_subtrees();
   void disambiguate_other_imports();
   void trim_unlinked_inodes();
 


### PR DESCRIPTION
mds: check auth undef subtree, adopt or not depend on config

In some unexpected situation, there are some auth-undef subtrees, these auth-undef subtrees cause assert when mds rejoining, we should check these auth-undef subtrees when resolve finishing, adopt or not depend on config

Fixs: https://tracker.ceph.com/issues/47594

Signed-off-by: redickwang <redickwang@tencent.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
