### PR TITLE
crimson/osd: add_recovery(oid) before recover_object(oid)

### DIFF
--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -258,10 +258,10 @@ std::optional<crimson::osd::blocking_future<>> PGRecovery::recover_missing(
   const hobject_t &soid, eversion_t need)
 {
   if (pg->get_peering_state().get_missing_loc().is_deleted(soid)) {
-    return pg->get_recovery_backend()->get_recovering(soid).make_blocking_future(
+    return pg->get_recovery_backend()->add_recovering(soid).make_blocking_future(
 	pg->get_recovery_backend()->recover_delete(soid, need));
   } else {
-    return pg->get_recovery_backend()->get_recovering(soid).make_blocking_future(
+    return pg->get_recovery_backend()->add_recovering(soid).make_blocking_future(
       pg->get_recovery_backend()->recover_object(soid, need).handle_exception(
 	[=, soid = std::move(soid)] (auto e) {
 	on_failed_recover({ pg->get_pg_whoami() }, soid, need);
@@ -277,7 +277,7 @@ size_t PGRecovery::prep_object_replica_deletes(
   std::vector<crimson::osd::blocking_future<>> *in_progress)
 {
   in_progress->push_back(
-    pg->get_recovery_backend()->get_recovering(soid).make_blocking_future(
+    pg->get_recovery_backend()->add_recovering(soid).make_blocking_future(
       pg->get_recovery_backend()->push_delete(soid, need).then([=] {
 	object_stat_sum_t stat_diff;
 	stat_diff.num_objects_recovered = 1;
@@ -295,7 +295,7 @@ size_t PGRecovery::prep_object_replica_pushes(
   std::vector<crimson::osd::blocking_future<>> *in_progress)
 {
   in_progress->push_back(
-    pg->get_recovery_backend()->get_recovering(soid).make_blocking_future(
+    pg->get_recovery_backend()->add_recovering(soid).make_blocking_future(
       pg->get_recovery_backend()->recover_object(soid, need).handle_exception(
 	[=, soid = std::move(soid)] (auto e) {
 	on_failed_recover({ pg->get_pg_whoami() }, soid, need);

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -433,6 +433,7 @@ void PGRecovery::enqueue_push(
 {
   logger().debug("{}: target={} obj={} v={}",
                  __func__, target, obj, v);
+  pg->get_recovery_backend()->add_recovering(obj);
   std::ignore = pg->get_recovery_backend()->recover_object(obj, v).\
   handle_exception([] (auto) {
     ceph_abort_msg("got exception on backfill's push");

--- a/src/crimson/osd/recovery_backend.h
+++ b/src/crimson/osd/recovery_backend.h
@@ -50,8 +50,14 @@ public:
       coll{coll},
       backend{backend} {}
   virtual ~RecoveryBackend() {}
+  WaitForObjectRecovery& add_recovering(const hobject_t& soid) {
+    auto [it, added] = recovering.emplace(soid, WaitForObjectRecovery{});
+    assert(added);
+    return it->second;
+  }
   WaitForObjectRecovery& get_recovering(const hobject_t& soid) {
-    return recovering[soid];
+    assert(is_recovering(soid));
+    return recovering.at(soid);
   }
   void remove_recovering(const hobject_t& soid) {
     recovering.erase(soid);

--- a/src/crimson/osd/recovery_backend.h
+++ b/src/crimson/osd/recovery_backend.h
@@ -62,10 +62,10 @@ public:
   void remove_recovering(const hobject_t& soid) {
     recovering.erase(soid);
   }
-  bool is_recovering(const hobject_t& soid) {
+  bool is_recovering(const hobject_t& soid) const {
     return recovering.count(soid) != 0;
   }
-  uint64_t total_recovering() {
+  uint64_t total_recovering() const {
     return recovering.size();
   }
 

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -23,10 +23,9 @@ seastar::future<> ReplicatedRecoveryBackend::recover_object(
   eversion_t need)
 {
   logger().debug("{}: {}, {}", __func__, soid, need);
-  [[maybe_unused]] auto [r, added] =
-    recovering.emplace(soid, WaitForObjectRecovery{});
+  // always add_recovering(soid) before recover_object(soid)
+  assert(is_recovering(soid));
   // start tracking the recovery of soid
-  assert(added);
   return seastar::do_with(std::map<pg_shard_t, PushOp>(), get_shards_to_push(soid),
     [this, soid, need](auto& pops, auto& shards) {
     return maybe_pull_missing_obj(soid, need).then([this, soid](bool pulled) {


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
