### PR TITLE
octopus: mgr/dashboard: table detail rows overflow

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.scss
@@ -1,0 +1,7 @@
+table {
+  table-layout: fixed;
+}
+
+table td {
+  word-wrap: break-word;
+}


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47569

---

backport of https://github.com/ceph/ceph/pull/37183
parent tracker: https://tracker.ceph.com/issues/47434

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh