### PR TITLE
octopus: mds: don't recover files after normal session close

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -799,11 +799,12 @@ void Server::_session_logged(Session *session, uint64_t state_seq, bool open, ve
   } else if (session->is_closing() ||
 	     session->is_killing()) {
     // kill any lingering capabilities, leases, requests
+    bool killing = session->is_killing();
     while (!session->caps.empty()) {
       Capability *cap = session->caps.front();
       CInode *in = cap->get_inode();
       dout(20) << " killing capability " << ccap_string(cap->issued()) << " on " << *in << dendl;
-      mds->locker->remove_client_cap(in, cap, true);
+      mds->locker->remove_client_cap(in, cap, killing);
     }
     while (!session->leases.empty()) {
       ClientLease *r = session->leases.front();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47087

---

backport of https://github.com/ceph/ceph/pull/36673
parent tracker: https://tracker.ceph.com/issues/46984

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh