### PR TITLE
octopus: rgw: RGWObjVersionTracker tracks version over increments

### DIFF
--- a/src/rgw/rgw_cache.cc
+++ b/src/rgw/rgw_cache.cc
@@ -176,6 +176,9 @@ void ObjectCache::put(const string& name, ObjectCacheInfo& info, rgw_cache_entry
     cache_info->gen = entry.gen;
   }
 
+  // put() must include the latest version if we're going to keep caching it
+  target.flags &= ~CACHE_FLAG_OBJV;
+
   target.flags |= info.flags;
 
   if (info.flags & CACHE_FLAG_META)

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1056,10 +1056,7 @@ struct RGWObjVersionTracker {
   void prepare_op_for_read(librados::ObjectReadOperation *op);
   void prepare_op_for_write(librados::ObjectWriteOperation *op);
 
-  void apply_write() {
-    read_version = write_version;
-    write_version = obj_version();
-  }
+  void apply_write();
 
   void clear() {
     read_version = obj_version();

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -184,6 +184,20 @@ void RGWObjVersionTracker::prepare_op_for_write(ObjectWriteOperation *op)
   }
 }
 
+void RGWObjVersionTracker::apply_write()
+{
+  const bool checked = (read_version.ver != 0);
+  const bool incremented = (write_version.ver == 0);
+
+  if (checked && incremented) {
+    // apply cls_version_inc() so our next operation can recheck it
+    ++read_version.ver;
+  } else {
+    read_version = write_version;
+  }
+  write_version = obj_version();
+}
+
 RGWObjState::RGWObjState() {
 }
 


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/47319
* https://tracker.ceph.com/issues/47687

---

backport of 

* https://github.com/ceph/ceph/pull/36502
* https://github.com/ceph/ceph/pull/37054

parent trackers:

* https://tracker.ceph.com/issues/46849
* https://tracker.ceph.com/issues/47306

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh