### PR TITLE
octopus: rgw: replace '+' with "%20" in canonical query string for s3 v4 auth.

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -497,7 +497,7 @@ std::string get_v4_canonical_qs(const req_info& info, const bool using_qs)
   }
   if (params->find_first_of('+') != std::string::npos) {
     copy_params = *params;
-    boost::replace_all(copy_params, "+", " ");
+    boost::replace_all(copy_params, "+", "%20");
     params = &copy_params;
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47321

---

backport of https://github.com/ceph/ceph/pull/35551
parent tracker: https://tracker.ceph.com/issues/45983

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh