### PR TITLE
octopus: rgw: Swift API anonymous access should 401

### DIFF
--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -58,7 +58,7 @@ public:
    * with the reason. */
   virtual uint32_t get_perm_mask() const = 0;
 
-  virtual bool is_anonymous() const final {
+  virtual bool is_anonymous() const {
     /* If the identity owns the anonymous account (rgw_user), it's considered
      * the anonymous identity. On error throws rgw::auth::Exception storing
      * the reason. */
@@ -498,7 +498,6 @@ public:
       is_admin(acct_privilege_t::IS_ADMIN_ACCT == level),
       acct_type(acct_type) {
     }
-    bool is_anon() const {return (acct_name.compare(RGW_USER_ANON_ID) == 0);}
   };
 
   using aclspec_t = rgw::auth::Identity::aclspec_t;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47348

---

backport of https://github.com/ceph/ceph/pull/35984
parent tracker: https://tracker.ceph.com/issues/46295

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh