### PR TITLE
octopus: common/admin_socket: always validate the parameters

### DIFF
--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -531,19 +531,19 @@ AdminSocket::find_matched_hook(std::string& prefix,
   // hook takes the same lock that was held during calls to
   // register/unregister, and set in_hook to allow unregister to wait for us
   // before removing this hook.
-  auto p = hooks.find(prefix);
-  if (p == hooks.cend()) {
+  auto [hooks_begin, hooks_end] = hooks.equal_range(prefix);
+  if (hooks_begin == hooks_end) {
     return {ENOENT, nullptr};
   }
   // make sure one of the registered commands with this prefix validates.
   stringstream errss;
-  if (!validate_cmd(m_cct, p->second.desc, cmdmap, errss)) {
-    if (p->first != prefix) {
-      return {EINVAL, nullptr};
+  for (auto hook = hooks_begin; hook != hooks_end; ++hook) {
+    if (validate_cmd(m_cct, hook->second.desc, cmdmap, errss)) {
+      in_hook = true;
+      return {0, hook->second.hook};
     }
   }
-  in_hook = true;
-  return {0, p->second.hook};
+  return {EINVAL, nullptr};
 }
 
 void AdminSocket::queue_tell_command(cref_t<MCommand> m)

--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -492,32 +492,20 @@ void AdminSocket::execute_command(
 
   Formatter *f = Formatter::create(format, "json-pretty", "json-pretty");
 
-  std::unique_lock l(lock);
-  decltype(hooks)::iterator p;
-  p = hooks.find(prefix);
-  if (p == hooks.cend()) {
+  auto [retval, hook] = find_matched_hook(prefix, cmdmap);
+  switch (retval) {
+  case ENOENT:
     lderr(m_cct) << "AdminSocket: request '" << cmdvec
 		 << "' not defined" << dendl;
     delete f;
     return on_finish(-EINVAL, "unknown command prefix "s + prefix, empty);
+  case EINVAL:
+    delete f;
+    return on_finish(-EINVAL, "invalid command json", empty);
+  default:
+    assert(retval == 0);
   }
 
-  // make sure one of the registered commands with this prefix validates.
-  while (!validate_cmd(m_cct, p->second.desc, cmdmap, errss)) {
-    ++p;
-    if (p->first != prefix) {
-      delete f;
-      return on_finish(-EINVAL, "invalid command json", empty);
-    }
-  }
-
-  // Drop lock to avoid cycles in cases where the hook takes
-  // the same lock that was held during calls to register/unregister,
-  // and set in_hook to allow unregister to wait for us before
-  // removing this hook.
-  in_hook = true;
-  auto hook = p->second.hook;
-  l.unlock();
   hook->call_async(
     prefix, cmdmap, f, inbl,
     [f, on_finish](int r, const std::string& err, bufferlist& out) {
@@ -529,9 +517,33 @@ void AdminSocket::execute_command(
       on_finish(r, err, out);
     });
 
-  l.lock();
+  std::unique_lock l(lock);
   in_hook = false;
   in_hook_cond.notify_all();
+}
+
+std::pair<int, AdminSocketHook*>
+AdminSocket::find_matched_hook(std::string& prefix,
+			       const cmdmap_t& cmdmap)
+{
+  std::unique_lock l(lock);
+  // Drop lock after done with the lookup to avoid cycles in cases where the
+  // hook takes the same lock that was held during calls to
+  // register/unregister, and set in_hook to allow unregister to wait for us
+  // before removing this hook.
+  auto p = hooks.find(prefix);
+  if (p == hooks.cend()) {
+    return {ENOENT, nullptr};
+  }
+  // make sure one of the registered commands with this prefix validates.
+  stringstream errss;
+  if (!validate_cmd(m_cct, p->second.desc, cmdmap, errss)) {
+    if (p->first != prefix) {
+      return {EINVAL, nullptr};
+    }
+  }
+  in_hook = true;
+  return {0, p->second.hook};
 }
 
 void AdminSocket::queue_tell_command(cref_t<MCommand> m)

--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -207,6 +207,11 @@ private:
       : hook(hook), desc(desc), help(help) {}
   };
 
+  /// find the first hook which matches the given prefix and cmdmap
+  std::pair<int, AdminSocketHook*> find_matched_hook(
+    std::string& prefix,
+    const cmdmap_t& cmdmap);
+
   std::multimap<std::string, hook_info, std::less<>> hooks;
 
   friend class AdminSocketTest;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47466

---

backport of https://github.com/ceph/ceph/pull/37098
parent tracker: https://tracker.ceph.com/issues/47179

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh