### PR TITLE
octopus: rbd-mirror: peer setup can still race and fail creation of peer 

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -238,6 +238,7 @@ peer_add()
     local cluster=$1 ; shift
     local pool=$1 ; shift
     local client_cluster=$1 ; shift
+    local remote_cluster="${client_cluster##*@}"
 
     local uuid_var_name
     if [ -n "$1" ]; then
@@ -257,6 +258,9 @@ peer_add()
         if [ $error_code -eq 17 ]; then
             # raced with a remote heartbeat ping -- remove and retry
             sleep $s
+            peer_uuid=$(rbd mirror pool info --cluster ${cluster} --pool ${pool} --format xml | \
+                xmlstarlet sel -t -v "//peers/peer[site_name='${remote_cluster}']/uuid")
+
             rbd --cluster ${cluster} --pool ${pool} mirror pool peer remove ${peer_uuid}
         else
             test $error_code -eq 0

--- a/src/tools/rbd/action/MirrorPool.cc
+++ b/src/tools/rbd/action/MirrorPool.cc
@@ -818,8 +818,7 @@ int get_mirror_image_status(
 void get_peer_bootstrap_create_arguments(po::options_description *positional,
                                          po::options_description *options) {
   at::add_pool_options(positional, options, false);
-  options->add_options()
-    (SITE_NAME.c_str(), po::value<std::string>(), "local site name");
+  add_site_name_optional(options);
 }
 
 int execute_peer_bootstrap_create(
@@ -871,8 +870,7 @@ int execute_peer_bootstrap_create(
 void get_peer_bootstrap_import_arguments(po::options_description *positional,
                                          po::options_description *options) {
   at::add_pool_options(positional, options, false);
-  options->add_options()
-    (SITE_NAME.c_str(), po::value<std::string>(), "local site name");
+  add_site_name_optional(options);
   positional->add_options()
     ("token-path", po::value<std::string>(),
      "bootstrap token file (or '-' for stdin)");


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47082

---

backport of https://github.com/ceph/ceph/pull/36707
parent tracker: https://tracker.ceph.com/issues/47007

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh