### PR TITLE
octopus: ceph-volume: avoid format strings for now

### DIFF
--- a/src/ceph-volume/ceph_volume/drive_group/main.py
+++ b/src/ceph-volume/ceph_volume/drive_group/main.py
@@ -29,7 +29,6 @@ class Deploy(object):
     '''
 
     def __init__(self, argv):
-        logger.error(f'argv: {argv}')
         self.argv = argv
 
     def main(self):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47409

---

backport of https://github.com/ceph/ceph/pull/37039
parent tracker: https://tracker.ceph.com/issues/47354

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh