### PR TITLE
octopus: qa/workunits/mon: fixed excessively large pool PG count

### DIFF
--- a/qa/workunits/mon/rbd_snaps_ops.sh
+++ b/qa/workunits/mon/rbd_snaps_ops.sh
@@ -19,8 +19,8 @@ expect()
 }
 
 ceph osd pool delete test test --yes-i-really-really-mean-it || true
-expect 'ceph osd pool create test 256 256' 0
-expect 'rbd --pool=test pool init' 0
+expect 'ceph osd pool create test 8 8' 0
+expect 'ceph osd pool application enable test rbd'
 expect 'ceph osd pool mksnap test snapshot' 0
 expect 'ceph osd pool rmsnap test snapshot' 0
 
@@ -28,7 +28,7 @@ expect 'rbd --pool=test --rbd_validate_pool=false create --size=102400 image' 0
 expect 'rbd --pool=test snap create image@snapshot' 22
 
 expect 'ceph osd pool delete test test --yes-i-really-really-mean-it' 0
-expect 'ceph osd pool create test 256 256' 0
+expect 'ceph osd pool create test 8 8' 0
 expect 'rbd --pool=test pool init' 0
 expect 'rbd --pool=test create --size=102400 image' 0
 expect 'rbd --pool=test snap create image@snapshot' 0
@@ -45,13 +45,13 @@ expect 'ceph osd pool delete test test --yes-i-really-really-mean-it' 0
 
 ceph osd pool delete test-foo test-foo --yes-i-really-really-mean-it || true
 expect 'ceph osd pool create test-foo 8' 0
-expect 'rbd pool init test-foo'
+expect 'ceph osd pool application enable test-foo rbd'
 expect 'rbd --pool test-foo create --size 1024 image' 0
 expect 'rbd --pool test-foo snap create image@snapshot' 0
 
 ceph osd pool delete test-bar test-bar --yes-i-really-really-mean-it || true
 expect 'ceph osd pool create test-bar 8' 0
-expect 'rbd pool init test-bar'
+expect 'ceph osd pool application enable test-bar rbd'
 expect 'rados cppool test-foo test-bar --yes-i-really-mean-it' 0
 expect 'rbd --pool test-bar snap rm image@snapshot' 95
 expect 'ceph osd pool delete test-foo test-foo --yes-i-really-really-mean-it' 0


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47460

---

backport of https://github.com/ceph/ceph/pull/37107
parent tracker: https://tracker.ceph.com/issues/47405

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh