### PR TITLE
octopus: mon: mark pgtemp messages as no_reply more consistenly in preprocess_…

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4050,6 +4050,7 @@ bool OSDMonitor::preprocess_pgtemp(MonOpRequestRef op)
   return true;
 
  ignore:
+  mon->no_reply(op);
   return true;
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47091

---

backport of https://github.com/ceph/ceph/pull/36593
parent tracker: https://tracker.ceph.com/issues/46914

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh