### PR TITLE
octopus: tools/osdmaptool.cc: add ability to clean_temps

### DIFF
--- a/doc/man/8/osdmaptool.rst
+++ b/doc/man/8/osdmaptool.rst
@@ -131,6 +131,10 @@ Options
 
    clears pg_temp and primary_temp variables.
 
+.. option:: --clean-temps
+
+   clean pg_temps.
+
 .. option:: --health
 
    dump health checks

--- a/src/test/cli/osdmaptool/help.t
+++ b/src/test/cli/osdmaptool/help.t
@@ -16,6 +16,7 @@
      --mark-out <osdid>      mark an osd as out (but do not persist)
      --with-default-pool     include default pool when creating map
      --clear-temp            clear pg_temp and primary_temp
+     --clean-temps           clean pg_temps
      --test-random           do random placements
      --test-map-pg <pgid>    map a pgid to osds
      --test-map-object <objectname> [--pool <poolid>] map an object to osds


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47251

---

backport of https://github.com/ceph/ceph/pull/36832
parent tracker: https://tracker.ceph.com/issues/47159

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh