### PR TITLE
octopus: qa/*/mon/mon-last-epoch-clean.sh: mark osd out instead of down

### DIFF
--- a/qa/standalone/mon/mon-last-epoch-clean.sh
+++ b/qa/standalone/mon/mon-last-epoch-clean.sh
@@ -226,7 +226,7 @@ function TEST_mon_last_clean_epoch() {
   # - all pools have floor equal to lec
 
   while kill $osd_pid ; do sleep 1 ; done
-  ceph osd down 2
+  ceph osd out 2
   sleep 5 # seriously, just to make sure things settle; we may not need this.
 
   # generate some maps


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47346

---

backport of https://github.com/ceph/ceph/pull/36999
parent tracker: https://tracker.ceph.com/issues/47309

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh