### PR TITLE
octopus: pybind/cephfs: fix custom exception raised by cephfs.pyx

### DIFF
--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -269,6 +269,10 @@ class ObjectNotEmpty(OSError):
 class NotDirectory(OSError):
     pass
 
+class DiskQuotaExceeded(OSError):
+    pass
+
+
 IF UNAME_SYSNAME == "FreeBSD":
     cdef errno_to_exception =  {
         errno.EPERM      : PermissionError,
@@ -282,6 +286,7 @@ IF UNAME_SYSNAME == "FreeBSD":
         errno.ERANGE     : OutOfRange,
         errno.EWOULDBLOCK: WouldBlock,
         errno.ENOTEMPTY  : ObjectNotEmpty,
+        errno.EDQUOT     : DiskQuotaExceeded,
     }
 ELSE:
     cdef errno_to_exception =  {
@@ -296,7 +301,8 @@ ELSE:
         errno.ERANGE     : OutOfRange,
         errno.EWOULDBLOCK: WouldBlock,
         errno.ENOTEMPTY  : ObjectNotEmpty,
-        errno.ENOTDIR    : NotDirectory
+        errno.ENOTDIR    : NotDirectory,
+        errno.EDQUOT     : DiskQuotaExceeded,
     }
 
 

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -431,3 +431,12 @@ def test_futimens():
 
     cephfs.close(fd)
     cephfs.unlink(b'/file-1')
+
+@with_setup(setup_test)
+def test_disk_quota_exceeeded_error():
+    cephfs.mkdir("/dir-1", 0o755)
+    cephfs.setxattr("/dir-1", "ceph.quota.max_bytes", b"5", 0)
+    fd = cephfs.open(b'/dir-1/file-1', 'w', 0o755)
+    assert_raises(libcephfs.DiskQuotaExceeded, cephfs.write, fd, b"abcdeghiklmnopqrstuvwxyz", 0)
+    cephfs.close(fd)
+    cephfs.unlink(b"/dir-1/file-1")


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46463

---

backport of https://github.com/ceph/ceph/pull/35934
parent tracker: https://tracker.ceph.com/issues/46360

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh