### PR TITLE
octopus: cephfs: client: use non-static dirent for thread-safety

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8432,7 +8432,7 @@ static int _readdir_single_dirent_cb(void *p, struct dirent *de,
 struct dirent *Client::readdir(dir_result_t *d)
 {
   int ret;
-  static struct dirent de;
+  auto& de = d->de;
   single_readdir sr;
   sr.de = &de;
   sr.stx = NULL;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -221,6 +221,7 @@ struct dir_result_t {
   frag_t buffer_frag;
 
   vector<dentry> buffer;
+  struct dirent de;
 };
 
 class Client : public Dispatcher, public md_config_obs_t {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46855

---

backport of https://github.com/ceph/ceph/pull/36503
parent tracker: https://tracker.ceph.com/issues/46832

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh