### PR TITLE
octopus: mds: do not raise "client failing to respond to cap release" when client working set is reasonable

### DIFF
--- a/qa/tasks/ceph_test_case.py
+++ b/qa/tasks/ceph_test_case.py
@@ -6,6 +6,8 @@ from teuthology.orchestra.run import CommandFailedError
 
 log = logging.getLogger(__name__)
 
+class TestTimeoutError(RuntimeError):
+    pass
 
 class CephTestCase(unittest.TestCase):
     """
@@ -172,7 +174,7 @@ class CephTestCase(unittest.TestCase):
                 raise RuntimeError("wait_until_equal: forbidden value {0} seen".format(val))
             else:
                 if elapsed >= timeout:
-                    raise RuntimeError("Timed out after {0} seconds waiting for {1} (currently {2})".format(
+                    raise TestTimeoutError("Timed out after {0} seconds waiting for {1} (currently {2})".format(
                         elapsed, expect_val, val
                     ))
                 else:
@@ -191,7 +193,7 @@ class CephTestCase(unittest.TestCase):
                 return
             else:
                 if elapsed >= timeout:
-                    raise RuntimeError("Timed out after {0}s".format(elapsed))
+                    raise TestTimeoutError("Timed out after {0}s".format(elapsed))
                 else:
                     log.debug("wait_until_true: waiting (timeout={0})...".format(timeout))
                 time.sleep(period)

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -484,13 +484,14 @@ class CephFSMount(object):
             n = {count}
             abs_path = "{abs_path}"
 
-            if not os.path.exists(os.path.dirname(abs_path)):
-                os.makedirs(os.path.dirname(abs_path))
+            if not os.path.exists(abs_path):
+                os.makedirs(abs_path)
 
             handles = []
             for i in range(0, n):
-                fname = "{{0}}_{{1}}".format(abs_path, i)
-                handles.append(open(fname, 'w'))
+                fname = "file_"+str(i)
+                path = os.path.join(abs_path, fname)
+                handles.append(open(path, 'w'))
 
             while True:
                 time.sleep(1)

--- a/qa/tasks/cephfs/test_client_limits.py
+++ b/qa/tasks/cephfs/test_client_limits.py
@@ -42,16 +42,14 @@ class TestClientLimits(CephFSTestCase):
         # ask the client to trim the caps.
         cache_memory_limit = "1K"
 
-        self.set_conf('mds', 'mds_cache_memory_limit', cache_memory_limit)
-        self.set_conf('mds', 'mds_recall_max_caps', open_files/2)
-        self.set_conf('mds', 'mds_recall_warning_threshold', open_files)
-        self.fs.mds_fail_restart()
-        self.fs.wait_for_daemons()
+        self.config_set('mds', 'mds_cache_memory_limit', cache_memory_limit)
+        self.config_set('mds', 'mds_recall_max_caps', int(open_files/2))
+        self.config_set('mds', 'mds_recall_warning_threshold', open_files)
 
-        mds_min_caps_per_client = int(self.fs.get_config("mds_min_caps_per_client"))
-        mds_max_caps_per_client = int(self.fs.get_config("mds_max_caps_per_client"))
-        mds_recall_warning_decay_rate = float(self.fs.get_config("mds_recall_warning_decay_rate"))
-        self.assertTrue(open_files >= mds_min_caps_per_client)
+        mds_min_caps_per_client = int(self.config_get('mds', "mds_min_caps_per_client"))
+        mds_max_caps_per_client = int(self.config_get('mds', "mds_max_caps_per_client"))
+        mds_recall_warning_decay_rate = float(self.config_get('mds', "mds_recall_warning_decay_rate"))
+        self.assertGreaterEqual(open_files, mds_min_caps_per_client)
 
         mount_a_client_id = self.mount_a.get_global_id()
         path = "subdir" if use_subdir else "."
@@ -239,11 +237,9 @@ class TestClientLimits(CephFSTestCase):
         That the MDS will not let a client sit above mds_max_caps_per_client caps.
         """
 
-        mds_min_caps_per_client = int(self.fs.get_config("mds_min_caps_per_client"))
+        mds_min_caps_per_client = int(self.config_get('mds', "mds_min_caps_per_client"))
         mds_max_caps_per_client = 2*mds_min_caps_per_client
-        self.set_conf('mds', 'mds_max_caps_per_client', mds_max_caps_per_client)
-        self.fs.mds_fail_restart()
-        self.fs.wait_for_daemons()
+        self.config_set('mds', 'mds_max_caps_per_client', mds_max_caps_per_client)
 
         self.mount_a.create_n_files("foo/", 3*mds_max_caps_per_client, sync=True)
 

--- a/qa/tasks/cephfs/test_client_limits.py
+++ b/qa/tasks/cephfs/test_client_limits.py
@@ -54,7 +54,7 @@ class TestClientLimits(CephFSTestCase):
         self.assertTrue(open_files >= mds_min_caps_per_client)
 
         mount_a_client_id = self.mount_a.get_global_id()
-        path = "subdir/mount_a" if use_subdir else "mount_a"
+        path = "subdir" if use_subdir else "."
         open_proc = self.mount_a.open_n_background(path, open_files)
 
         # Client should now hold:

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8188,6 +8188,11 @@ std::vector<Option> get_mds_options() {
     .set_default(100)
     .set_description("minimum number of capabilities a client may hold"),
 
+    Option("mds_min_caps_working_set", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(10000)
+    .set_flag(Option::FLAG_RUNTIME)
+    .set_description("number of capabilities a client may hold without cache pressure warnings generated"),
+
     Option("mds_max_caps_per_client", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(1_M)
     .set_description("maximum number of capabilities a client may hold"),

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -358,6 +358,10 @@ public:
     return info.completed_flushes.count(tid);
   }
 
+  uint64_t get_num_caps() const {
+    return caps.size();
+  }
+
   unsigned get_num_completed_flushes() const { return info.completed_flushes.size(); }
   unsigned get_num_trim_flushes_warnings() const {
     return num_trim_flushes_warnings;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46859

---

backport of https://github.com/ceph/ceph/pull/36501
parent tracker: https://tracker.ceph.com/issues/46830

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh