### PR TITLE
octopus: mds: revert the decode version

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -497,7 +497,7 @@ void FSMap::decode(bufferlist::const_iterator& p)
   // MDSMonitor to store an FSMap instead of an MDSMap was
   // 5, so anything older than 6 is decoded as an MDSMap,
   // and anything newer is decoded as an FSMap.
-  DECODE_START_LEGACY_COMPAT_LEN_16(8, 4, 4, p);
+  DECODE_START_LEGACY_COMPAT_LEN_16(7, 4, 4, p);
   if (struct_v < 6) {
     // Because the mon used to store an MDSMap where we now
     // store an FSMap, FSMap knows how to decode the legacy


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47016

---

backport of https://github.com/ceph/ceph/pull/36617
parent tracker: https://tracker.ceph.com/issues/46926

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh