### PR TITLE
octopus: mds: fix kcephfs parse dirfrag's ndist is always 0

### DIFF
--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -421,7 +421,7 @@ public:
 
   // for giving to clients
   void get_dist_spec(std::set<mds_rank_t>& ls, mds_rank_t auth) {
-    if (is_rep()) {
+    if (is_auth()) {
       list_replicas(ls);
       if (!ls.empty()) 
 	ls.insert(auth);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47018

---

backport of https://github.com/ceph/ceph/pull/36552
parent tracker: https://tracker.ceph.com/issues/46891

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh