### PR TITLE
octopus: cephfs: libcephfs: ignore restoring the open files limit 

### DIFF
--- a/src/msg/async/Stack.cc
+++ b/src/msg/async/Stack.cc
@@ -117,7 +117,9 @@ NetworkStack::NetworkStack(CephContext *c, const string &t): type(t), started(fa
 
   for (unsigned worker_id = 0; worker_id < num_workers; ++worker_id) {
     Worker *w = create_worker(cct, type, worker_id);
-    w->center.init(InitEventNumber, worker_id, type);
+    int ret = w->center.init(InitEventNumber, worker_id, type);
+    if (ret)
+      throw std::system_error(-ret, std::generic_category());
     workers.push_back(w);
   }
 }

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -2017,7 +2017,13 @@ TEST(LibCephFS, ShutdownRace)
 
   for (int i = 0; i < nthreads; ++i)
     threads[i].join();
-  ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &rold), 0);
+  /*
+   * Let's just ignore restoring the open files limit,
+   * the kernel will defer releasing the file descriptors
+   * and then the process will be possibly reachthe open
+   * files limit. More detail, please see tracer#43039
+   */
+//  ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &rold), 0);
 }
 
 static void get_current_time_utimbuf(struct utimbuf *utb)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47021

---

backport of https://github.com/ceph/ceph/pull/36515
parent tracker: https://tracker.ceph.com/issues/43039

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh