### PR TITLE
octopus: mds: dump granular cap info in mds_sessions

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -778,7 +778,7 @@ protected:
   void _sync_write_commit(Inode *in);
 
   void dump_mds_requests(Formatter *f);
-  void dump_mds_sessions(Formatter *f);
+  void dump_mds_sessions(Formatter *f, bool cap_dump=false);
 
   int make_request(MetaRequest *req, const UserPerm& perms,
 		   InodeRef *ptarget = 0, bool *pcreated = 0,

--- a/src/client/MetaSession.cc
+++ b/src/client/MetaSession.cc
@@ -5,6 +5,7 @@
 #include "messages/MClientCapRelease.h"
 
 #include "MetaSession.h"
+#include "Inode.h"
 
 #include "common/Formatter.h"
 
@@ -21,7 +22,7 @@ const char *MetaSession::get_state_name() const
   }
 }
 
-void MetaSession::dump(Formatter *f) const
+void MetaSession::dump(Formatter *f, bool cap_dump) const
 {
   f->dump_int("mds", mds_num);
   f->dump_object("addrs", addrs);
@@ -31,6 +32,13 @@ void MetaSession::dump(Formatter *f) const
   f->dump_stream("last_cap_renew_request") << last_cap_renew_request;
   f->dump_unsigned("cap_renew_seq", cap_renew_seq);
   f->dump_int("num_caps", caps.size());
+  if (cap_dump) {
+    f->open_array_section("caps");
+    for (const auto& cap : caps) {
+      f->dump_object("cap", *cap);
+    }
+    f->close_section();
+  }
   f->dump_string("state", get_state_name());
 }
 

--- a/src/client/MetaSession.h
+++ b/src/client/MetaSession.h
@@ -66,7 +66,7 @@ struct MetaSession {
 
   const char *get_state_name() const;
 
-  void dump(Formatter *f) const;
+  void dump(Formatter *f, bool cap_dump=false) const;
 
   void enqueue_cap_release(inodeno_t ino, uint64_t cap_id, ceph_seq_t iseq,
       ceph_seq_t mseq, epoch_t osd_barrier);

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -333,11 +333,15 @@ void MDSDaemon::set_up_admin_socket()
                                      asok_hook,
                                      "dump snapshots");
   ceph_assert(r == 0);
-  r = admin_socket->register_command("session ls name=filters,type=CephString,n=N,req=false",
+  r = admin_socket->register_command("session ls "
+				     "name=cap_dump,type=CephBool,req=false "
+		                     "name=filters,type=CephString,n=N,req=false ",
 				     asok_hook,
 				     "List client sessions based on a filter");
   ceph_assert(r == 0);
-  r = admin_socket->register_command("client ls name=filters,type=CephString,n=N,req=false",
+  r = admin_socket->register_command("client ls "
+				     "name=cap_dump,type=CephBool,req=false "
+		                     "name=filters,type=CephString,n=N,req=false ",
 				     asok_hook,
 				     "List client sessions based on a filter");
   ceph_assert(r == 0);
@@ -353,7 +357,7 @@ void MDSDaemon::set_up_admin_socket()
 				     asok_hook,
 				     "Evict a client session by id");
   ceph_assert(r == 0);
-  r = admin_socket->register_command("session ls",
+  r = admin_socket->register_command("session ls name=cap_dump,type=CephBool,req=false",
 				     asok_hook,
 				     "Enumerate connected CephFS clients");
   ceph_assert(r == 0);

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2506,14 +2506,17 @@ void MDSRankDispatcher::handle_asok_command(
   } else if (command == "session ls" ||
 	     command == "client ls") {
     std::lock_guard l(mds_lock);
+    bool cap_dump = false;
     std::vector<std::string> filter_args;
+    cmd_getval(cmdmap, "cap_dump", cap_dump);
     cmd_getval(cmdmap, "filters", filter_args);
+
     SessionFilter filter;
     r = filter.parse(filter_args, &ss);
     if (r != 0) {
       goto out;
     }
-    dump_sessions(filter, f);
+    dump_sessions(filter, f, cap_dump);
   } else if (command == "session evict" ||
 	     command == "client evict") {
     std::lock_guard l(mds_lock);
@@ -2772,7 +2775,7 @@ void MDSRankDispatcher::evict_clients(
   gather.activate();
 }
 
-void MDSRankDispatcher::dump_sessions(const SessionFilter &filter, Formatter *f) const
+void MDSRankDispatcher::dump_sessions(const SessionFilter &filter, Formatter *f, bool cap_dump) const
 {
   // Dump sessions, decorated with recovery/replay status
   f->open_array_section("sessions");
@@ -2785,7 +2788,9 @@ void MDSRankDispatcher::dump_sessions(const SessionFilter &filter, Formatter *f)
       continue;
     }
 
-    f->dump_object("session", *s);
+    f->open_object_section("session");
+    s->dump(f, cap_dump);
+    f->close_section();
   }
   f->close_section(); // sessions
 }

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -648,7 +648,7 @@ public:
   const char** get_tracked_conf_keys() const override final;
   void handle_conf_change(const ConfigProxy& conf, const std::set<std::string>& changed) override;
 
-  void dump_sessions(const SessionFilter &filter, Formatter *f) const;
+  void dump_sessions(const SessionFilter &filter, Formatter *f, bool cap_dump=false) const;
   void evict_clients(const SessionFilter &filter,
 		     std::function<void(int,const std::string&,bufferlist&)> on_finish);
 

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -571,13 +571,20 @@ void SessionMapStore::decode_legacy(bufferlist::const_iterator& p)
   }
 }
 
-void Session::dump(Formatter *f) const
+void Session::dump(Formatter *f, bool cap_dump) const
 {
   f->dump_int("id", info.inst.name.num());
   f->dump_object("entity", info.inst);
   f->dump_string("state", get_state_name());
   f->dump_int("num_leases", leases.size());
   f->dump_int("num_caps", caps.size());
+  if (cap_dump) {
+    f->open_array_section("caps");
+    for (const auto& cap : caps) {
+      f->dump_object("cap", *cap);
+    }
+    f->close_section();
+  }
   if (is_open() || is_stale()) {
     f->dump_unsigned("request_load_avg", get_load_avg());
   }

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -117,7 +117,7 @@ public:
     }
   }
 
-  void dump(Formatter *f) const;
+  void dump(Formatter *f, bool cap_dump=false) const;
   void push_pv(version_t pv)
   {
     ceph_assert(projected.empty() || projected.back() != pv);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47085

NOTE: the master PR (see below) has 2 commits, but the first one is omitted here because it changes code that was removed (in octopus) by https://github.com/ceph/ceph/pull/37341 

---

backport of https://github.com/ceph/ceph/pull/36459
parent tracker: https://tracker.ceph.com/issues/46985

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh