### PR TITLE
octopus: mds: standy-replay mds remained in the "resolve" state after resta…

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1690,8 +1690,6 @@ void MDSRank::replay_start()
   if (is_standby_replay())
     standby_replaying = true;
 
-  calc_recovery_set();
-
   // Check if we need to wait for a newer OSD map before starting
   Context *fin = new C_IO_Wrapper(this, new C_MDS_BootStart(this, MDS_BOOT_INITIAL));
   bool const ready = objecter->wait_for_map(
@@ -1859,6 +1857,8 @@ void MDSRank::resolve_start()
   dout(1) << "resolve_start" << dendl;
 
   reopen_log();
+
+  calc_recovery_set();
 
   mdcache->resolve_start(new C_MDS_VoidFn(this, &MDSRank::resolve_done));
   finish_contexts(g_ceph_context, waiting_for_resolve);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47089

---

backport of https://github.com/ceph/ceph/pull/36632
parent tracker: https://tracker.ceph.com/issues/46976

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh