### PR TITLE
octopus: qa/tasks/nfs: Test mounting of export created with nfs command

### DIFF
--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -378,6 +378,7 @@ class TestNFS(MgrTestCase):
         check_pseudo_path('invalidpath')
         check_pseudo_path('/')
         check_pseudo_path('//')
+        self._cmd('fs', 'volume', 'rm', self.fs_name, '--yes-i-really-mean-it')
         self._test_delete_cluster()
 
     def test_cluster_info(self):
@@ -459,7 +460,6 @@ class TestNFS(MgrTestCase):
                 raise
         self._cmd('fs', 'volume', 'rm', fs_name, '--yes-i-really-mean-it')
         self._test_delete_cluster()
-        time.sleep(30)
 
     def test_cluster_set_user_config_with_non_existing_clusterid(self):
         '''

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -12,9 +12,7 @@ log = logging.getLogger(__name__)
 
 # TODO Add test for cluster update when ganesha can be deployed on multiple ports.
 class TestNFS(MgrTestCase):
-    def _cmd(self, *args, stdin=''):
-        if stdin:
-            return self.mgr_cluster.mon_manager.raw_cluster_cmd(*args, stdin=stdin)
+    def _cmd(self, *args):
         return self.mgr_cluster.mon_manager.raw_cluster_cmd(*args)
 
     def _nfs_cmd(self, *args):
@@ -60,10 +58,6 @@ class TestNFS(MgrTestCase):
          },
          "clients": []
         }
-
-    def _check_port_status(self):
-        log.info("NETSTAT")
-        self._sys_cmd(['netstat', '-tnlp'])
 
     def _check_nfs_server_status(self):
         res = self._sys_cmd(['systemctl', 'status', 'nfs-server'])


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47147

---

backport of https://github.com/ceph/ceph/pull/36684
parent tracker: https://tracker.ceph.com/issues/46989

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh