### PR TITLE
octopus: pybind/mgr/volumes: add global lock debug

### DIFF
--- a/src/pybind/mgr/volumes/fs/operations/lock.py
+++ b/src/pybind/mgr/volumes/fs/operations/lock.py
@@ -1,6 +1,9 @@
 from contextlib import contextmanager
+import logging
 from threading import Lock
 from typing import Dict
+
+log = logging.getLogger(__name__)
 
 # singleton design pattern taken from http://www.aleax.it/5ep.html
 
@@ -33,5 +36,8 @@ class GlobalLock(object):
 
     @contextmanager
     def lock_op(self):
+        log.debug("entering global lock")
         with self._shared_state['lock']:
+            log.debug("acquired global lock")
             yield
+        log.debug("exited global lock")


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47151

---

backport of https://github.com/ceph/ceph/pull/36805
parent tracker: https://tracker.ceph.com/issues/47149

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh