### PR TITLE
octopus: mgr/volumes/nfs: Check if orchestrator spec service_id is valid

### DIFF
--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -29,7 +29,8 @@ def available_clusters(mgr):
     completion = mgr.describe_service(service_type='nfs')
     mgr._orchestrator_wait([completion])
     orchestrator.raise_if_exception(completion)
-    return [cluster.spec.service_id.replace('ganesha-', '', 1) for cluster in completion.result]
+    return [cluster.spec.service_id.replace('ganesha-', '', 1) for cluster in completion.result
+            if cluster.spec.service_id]
 
 
 def export_cluster_checker(func):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47601

---

backport of https://github.com/ceph/ceph/pull/37214
parent tracker: https://tracker.ceph.com/issues/47512

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh