### PR TITLE
nautilus: ceph-volume: fix journal size argument not work

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
@@ -351,8 +351,6 @@ class MixedType(MixedStrategy):
         else:
             journal_vg = self.common_vg
 
-        journal_size = prepare.get_journal_size(lv_format=False)
-
         # create 1 vg per data device first, mapping them to the device path,
         # when the lv gets created later, it can create as many as needed (or
         # even just 1)
@@ -371,7 +369,7 @@ class MixedType(MixedStrategy):
                 'osd-data', data_uuid, vg=data_vg, extents=data_lv_extents)
             journal_uuid = system.generate_uuid()
             journal_lv = lvm.create_lv(
-                'osd-journal', journal_uuid, vg=journal_vg, size=journal_size)
+                'osd-journal', journal_uuid, vg=journal_vg, size=self.journal_size)
 
             command = ['--filestore', '--data']
             command.append('%s/%s' % (data_vg.name, data_lv.name))

--- a/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
@@ -1,5 +1,6 @@
 import argparse
 import pytest
+import os
 from ceph_volume import exceptions
 from ceph_volume.util import arg_validators
 
@@ -9,7 +10,8 @@ class TestOSDPath(object):
     def setup(self):
         self.validator = arg_validators.OSDPath()
 
-    def test_is_not_root(self):
+    def test_is_not_root(self, monkeypatch):
+        monkeypatch.setattr(os, 'getuid', lambda: 100)
         with pytest.raises(exceptions.SuperUserError):
             self.validator('')
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47283

---

backport of https://github.com/ceph/ceph/pull/36847
parent tracker: https://tracker.ceph.com/issues/41374

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh