### PR TITLE
nautilus: rgw: Add bucket name to bucket stats error logging

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1491,7 +1491,7 @@ static int bucket_stats(RGWRados *store, const std::string& tenant_name, const s
   string max_marker;
   int ret = store->get_bucket_stats(bucket_info, RGW_NO_SHARD, &bucket_ver, &master_ver, stats, &max_marker);
   if (ret < 0) {
-    cerr << "error getting bucket stats ret=" << ret << std::endl;
+    cerr << "error getting bucket stats bucket=" << bucket.name << " ret=" << ret << std::endl;
     return ret;
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47244

---

backport of https://github.com/ceph/ceph/pull/34653
parent tracker: https://tracker.ceph.com/issues/47216

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh