### PR TITLE
[DNM CHANGES REQUESTED] nautilus: mds: reduce memory usage of open file table prefetch

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2816,7 +2816,7 @@ void Client::send_reconnect(MetaSession *session)
 	       << " wants " << ccap_string(in->caps_wanted())
 	       << dendl;
       filepath path;
-      in->make_long_path(path);
+      in->make_short_path(path);
       ldout(cct, 10) << "    path " << path << dendl;
 
       bufferlist flockbl;

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -95,9 +95,19 @@ void Inode::make_long_path(filepath& p)
     dn->dir->parent_inode->make_long_path(p);
     p.push_dentry(dn->name);
   } else if (snapdir_parent) {
-    snapdir_parent->make_nosnap_relative_path(p);
-    string empty;
-    p.push_dentry(empty);
+    make_nosnap_relative_path(p);
+  } else
+    p = filepath(ino);
+}
+
+void Inode::make_short_path(filepath& p)
+{
+  if (!dentries.empty()) {
+    Dentry *dn = get_first_parent();
+    ceph_assert(dn->dir && dn->dir->parent_inode);
+    p = filepath(dn->name, dn->dir->parent_inode->ino);
+  } else if (snapdir_parent) {
+    make_nosnap_relative_path(p);
   } else
     p = filepath(ino);
 }

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -237,6 +237,7 @@ struct Inode {
   }
 
   void make_long_path(filepath& p);
+  void make_short_path(filepath& p);
   void make_nosnap_relative_path(filepath& p);
 
   void get();

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7996,6 +7996,11 @@ std::vector<Option> get_mds_options() {
     .set_default(10.0)
     .set_description("rate of decay for export targets communicated to clients"),
 
+    Option("mds_oft_prefetch_dirfrags", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .set_description("prefetch dirfrags recorded in open file table on startup")
+    .set_flag(Option::FLAG_STARTUP),
+
     Option("mds_replay_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(1.0)
     .set_description("time in seconds between replay of updates to journal by standby replay MDS"),

--- a/src/mds/Anchor.cc
+++ b/src/mds/Anchor.cc
@@ -18,21 +18,24 @@
 
 void Anchor::encode(bufferlist &bl) const
 {
-  ENCODE_START(1, 1, bl);
+  ENCODE_START(2, 1, bl);
   encode(ino, bl);
   encode(dirino, bl);
   encode(d_name, bl);
   encode(d_type, bl);
+  encode(frags, bl);
   ENCODE_FINISH(bl);
 }
 
 void Anchor::decode(bufferlist::const_iterator &bl)
 {
-  DECODE_START(1, bl);
+  DECODE_START(2, bl);
   decode(ino, bl);
   decode(dirino, bl);
   decode(d_name, bl);
   decode(d_type, bl);
+  if (struct_v >= 2)
+    decode(frags, bl);
   DECODE_FINISH(bl);
 }
 

--- a/src/mds/Anchor.h
+++ b/src/mds/Anchor.h
@@ -32,6 +32,7 @@ public:
   inodeno_t dirino;
   std::string d_name;
   __u8 d_type = 0;
+  std::set<frag_t> frags;
 
   int omap_idx = -1;	// stored in which omap object
 
@@ -43,13 +44,13 @@ public:
   void decode(bufferlist::const_iterator &bl);
   void dump(Formatter *f) const;
   static void generate_test_instances(list<Anchor*>& ls);
+  bool operator==(const Anchor &r) const {
+    return ino == r.ino && dirino == r.dirino &&
+	   d_name == r.d_name && d_type == r.d_type &&
+	   frags == r.frags;
+  }
 };
 WRITE_CLASS_ENCODER(Anchor)
-
-inline bool operator==(const Anchor &l, const Anchor &r) {
-  return l.ino == r.ino && l.dirino == r.dirino &&
-	 l.d_name == r.d_name && l.d_type == r.d_type;
-}
 
 ostream& operator<<(ostream& out, const Anchor &a);
 

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -2972,9 +2972,9 @@ void CInode::set_mds_caps_wanted(mempool::mds_co::compact_map<int32_t,int32_t>& 
   mds_caps_wanted.swap(m);
   if (old_empty != (bool)mds_caps_wanted.empty()) {
     if (old_empty)
-      adjust_num_caps_wanted(1);
+      adjust_num_caps_notable(1);
     else
-      adjust_num_caps_wanted(-1);
+      adjust_num_caps_notable(-1);
   }
 }
 
@@ -2984,23 +2984,23 @@ void CInode::set_mds_caps_wanted(mds_rank_t mds, int32_t wanted)
   if (wanted) {
     mds_caps_wanted[mds] = wanted;
     if (old_empty)
-      adjust_num_caps_wanted(1);
+      adjust_num_caps_notable(1);
   } else if (!old_empty) {
     mds_caps_wanted.erase(mds);
     if (mds_caps_wanted.empty())
-      adjust_num_caps_wanted(-1);
+      adjust_num_caps_notable(-1);
   }
 }
 
-void CInode::adjust_num_caps_wanted(int d)
+void CInode::adjust_num_caps_notable(int d)
 {
-  if (!num_caps_wanted && d > 0)
+  if (!num_caps_notable && d > 0)
     mdcache->open_file_table.add_inode(this);
-  else if (num_caps_wanted > 0 && num_caps_wanted == -d)
+  else if (num_caps_notable > 0 && num_caps_notable == -d)
     mdcache->open_file_table.remove_inode(this);
 
-  num_caps_wanted +=d;
-  ceph_assert(num_caps_wanted >= 0);
+  num_caps_notable +=d;
+  ceph_assert(num_caps_notable >= 0);
 }
 
 Capability *CInode::add_client_cap(client_t client, Session *session, SnapRealm *conrealm)
@@ -3046,8 +3046,8 @@ void CInode::remove_client_cap(client_t client)
   if (client == loner_cap)
     loner_cap = -1;
 
-  if (cap->wanted())
-    adjust_num_caps_wanted(-1);
+  if (cap->is_wanted_notable())
+    adjust_num_caps_notable(-1);
 
   client_caps.erase(it);
   if (client_caps.empty()) {

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -630,7 +630,7 @@ protected:
   mempool_cap_map client_caps;         // client -> caps
   mempool::mds_co::compact_map<int32_t, int32_t>      mds_caps_wanted;     // [auth] mds -> caps wanted
   int replica_caps_wanted = 0; // [replica] what i've requested from auth
-  int num_caps_wanted = 0;
+  int num_caps_notable = 0;
 
 public:
   mempool::mds_co::set<client_t> client_snap_caps;
@@ -733,7 +733,7 @@ public:
     clear_file_locks();
     ceph_assert(num_projected_xattrs == 0);
     ceph_assert(num_projected_srnodes == 0);
-    ceph_assert(num_caps_wanted == 0);
+    ceph_assert(num_caps_notable == 0);
     ceph_assert(num_subtree_roots == 0);
     ceph_assert(num_exporting_dirs == 0);
   }
@@ -1036,8 +1036,8 @@ public:
     }
   }
 
-  int get_num_caps_wanted() const { return num_caps_wanted; }
-  void adjust_num_caps_wanted(int d);
+  int get_num_caps_notable() const { return num_caps_notable; }
+  void adjust_num_caps_notable(int d);
 
   Capability *add_client_cap(client_t client, Session *session, SnapRealm *conrealm=0);
   void remove_client_cap(client_t client);

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -242,6 +242,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   static const int STATE_QUEUEDEXPORTPIN	= (1<<17);
   static const int STATE_TRACKEDBYOFT		= (1<<18);  // tracked by open file table
   static const int STATE_DELAYEDEXPORTPIN	= (1<<19);
+  static const int STATE_CLIENTWRITEABLE	= (1<<22);
+
   // orphan inode needs notification of releasing reference
   static const int STATE_ORPHAN =	STATE_NOTIFYREF;
 
@@ -1061,6 +1063,11 @@ public:
   bool is_any_caps_wanted() const;
   int get_caps_wanted(int *ploner = 0, int *pother = 0, int shift = 0, int mask = -1) const;
   bool issued_caps_need_gather(SimpleLock *lock);
+
+  // client writeable
+  bool is_clientwriteable() const { return state & STATE_CLIENTWRITEABLE; }
+  void mark_clientwriteable();
+  void clear_clientwriteable();
 
   // -- authority --
   mds_authority_t authority() const override;

--- a/src/mds/Capability.cc
+++ b/src/mds/Capability.cc
@@ -215,15 +215,12 @@ void Capability::maybe_clear_notable()
 void Capability::set_wanted(int w) {
   CInode *in = get_inode();
   if (in) {
-    if (!_wanted && w) {
-      in->adjust_num_caps_wanted(1);
-    } else if (_wanted && !w) {
-      in->adjust_num_caps_wanted(-1);
-    }
     if (!is_wanted_notable(_wanted) && is_wanted_notable(w)) {
+      in->adjust_num_caps_notable(1);
       if (!is_notable())
 	mark_notable();
     } else if (is_wanted_notable(_wanted) && !is_wanted_notable(w)) {
+      in->adjust_num_caps_notable(-1);
       maybe_clear_notable();
     }
   }

--- a/src/mds/Capability.h
+++ b/src/mds/Capability.h
@@ -247,6 +247,9 @@ public:
   static bool is_wanted_notable(int wanted) {
     return wanted & (CEPH_CAP_ANY_WR|CEPH_CAP_FILE_WR|CEPH_CAP_FILE_RD);
   }
+  bool is_wanted_notable() const {
+    return is_wanted_notable(wanted());
+  }
   bool is_notable() const { return state & STATE_NOTABLE; }
 
   bool is_stale() const;

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2450,6 +2450,12 @@ bool Locker::calc_new_client_ranges(CInode *in, uint64_t size, bool *max_increas
     it = pi->client_ranges.erase(it);
     updated = true;
   }
+  if (updated) {
+    if (pi->client_ranges.empty())
+      in->clear_clientwriteable();
+    else
+      in->mark_clientwriteable();
+  }
   return updated;
 }
 
@@ -3403,7 +3409,7 @@ bool Locker::_do_cap_update(CInode *in, Capability *cap,
   // increase or zero max_size?
   uint64_t size = m->get_size();
   bool change_max = false;
-  uint64_t old_max = latest->client_ranges.count(client) ? latest->client_ranges[client].range.last : 0;
+  uint64_t old_max = latest->get_client_range(client);
   uint64_t new_max = old_max;
   
   if (in->is_file()) {
@@ -3520,10 +3526,13 @@ bool Locker::_do_cap_update(CInode *in, Capability *cap,
       cr.range.first = 0;
       cr.range.last = new_max;
       cr.follows = in->first - 1;
+      in->mark_clientwriteable();
       if (cap)
 	cap->mark_clientwriteable();
     } else {
       pi.inode.client_ranges.erase(client);
+      if (pi.inode.client_ranges.empty())
+	in->clear_clientwriteable();
       if (cap)
 	cap->clear_clientwriteable();
     }

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -5055,6 +5055,9 @@ void Locker::file_eval(ScatterLock *lock, bool *need_issue)
 	    << " on " << *lock->get_parent() << dendl;
     simple_sync(lock, need_issue);
   }
+  else if (in->state_test(CInode::STATE_NEEDSRECOVER)) {
+    mds->mdcache->queue_file_recover(in);
+  }
 }
 
 

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2374,9 +2374,7 @@ uint64_t Locker::calc_new_max_size(CInode::mempool_inode *pi, uint64_t size)
   return round_up_to(new_max, pi->get_layout_size_increment());
 }
 
-void Locker::calc_new_client_ranges(CInode *in, uint64_t size, bool update,
-				    CInode::mempool_inode::client_range_map *new_ranges,
-				    bool *max_increased)
+bool Locker::check_client_ranges(CInode *in, uint64_t size)
 {
   auto latest = in->get_projected_inode();
   uint64_t ms;
@@ -2387,30 +2385,72 @@ void Locker::calc_new_client_ranges(CInode *in, uint64_t size, bool update,
     ms = 0;
   }
 
-  // increase ranges as appropriate.
-  // shrink to 0 if no WR|BUFFER caps issued.
+  auto it = latest->client_ranges.begin();
   for (auto &p : in->client_caps) {
     if ((p.second.issued() | p.second.wanted()) & CEPH_CAP_ANY_FILE_WR) {
-      client_writeable_range_t& nr = (*new_ranges)[p.first];
-      nr.range.first = 0;
-      if (latest->client_ranges.count(p.first)) {
-	client_writeable_range_t& oldr = latest->client_ranges[p.first];
-	if (ms > oldr.range.last)
-	  *max_increased = true;
-	nr.range.last = std::max(ms, oldr.range.last);
-	nr.follows = oldr.follows;
-      } else {
-	*max_increased = true;
-	nr.range.last = ms;
-	nr.follows = in->first - 1;
-      }
-      if (update)
-	p.second.mark_clientwriteable();
-    } else {
-      if (update)
-	p.second.clear_clientwriteable();
+      if (it == latest->client_ranges.end())
+	return true;
+      if (it->first != p.first)
+	return true;
+      if (ms > it->second.range.last)
+	return true;
+      ++it;
     }
   }
+  return it != latest->client_ranges.end();
+}
+
+bool Locker::calc_new_client_ranges(CInode *in, uint64_t size, bool *max_increased)
+{
+  auto pi = in->get_projected_inode();
+  uint64_t ms;
+  if (pi->has_layout()) {
+    ms = calc_new_max_size(pi, size);
+  } else {
+    // Layout-less directories like ~mds0/, have zero size
+    ms = 0;
+  }
+
+  bool updated = false;
+
+  // increase ranges as appropriate.
+  // shrink to 0 if no WR|BUFFER caps issued.
+  auto it = pi->client_ranges.begin();
+  for (auto &p : in->client_caps) {
+    if ((p.second.issued() | p.second.wanted()) & CEPH_CAP_ANY_FILE_WR) {
+      while (it != pi->client_ranges.end() && it->first < p.first) {
+	it = pi->client_ranges.erase(it);
+	updated = true;
+      }
+
+      if (it != pi->client_ranges.end() && it->first == p.first) {
+	if (ms > it->second.range.last) {
+	  it->second.range.last = ms;
+	  updated = true;
+	  if (max_increased)
+	    *max_increased = true;
+	}
+      } else {
+	it = pi->client_ranges.emplace_hint(it, std::piecewise_construct,
+					    std::forward_as_tuple(p.first),
+					    std::forward_as_tuple());
+	it->second.range.last = ms;
+	it->second.follows = in->first - 1;
+	updated = true;
+	if (max_increased)
+	  *max_increased = true;
+      }
+      p.second.mark_clientwriteable();
+      ++it;
+    } else {
+      p.second.clear_clientwriteable();
+    }
+  }
+  while (it != pi->client_ranges.end()) {
+    it = pi->client_ranges.erase(it);
+    updated = true;
+  }
+  return updated;
 }
 
 bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
@@ -2421,11 +2461,8 @@ bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
   ceph_assert(in->is_file());
 
   CInode::mempool_inode *latest = in->get_projected_inode();
-  CInode::mempool_inode::client_range_map new_ranges;
   uint64_t size = latest->size;
   bool update_size = new_size > 0;
-  bool update_max = false;
-  bool max_increased = false;
 
   if (update_size) {
     new_size = size = std::max(size, new_size);
@@ -2434,28 +2471,8 @@ bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
       update_size = false;
   }
 
-  int can_update = 1;
-  if (in->is_frozen()) {
-    can_update = -1;
-  } else if (!force_wrlock && !in->filelock.can_wrlock(in->get_loner())) {
-    // lock?
-    if (in->filelock.is_stable()) {
-      if (in->get_target_loner() >= 0)
-	file_excl(&in->filelock);
-      else
-	simple_lock(&in->filelock);
-    }
-    if (!in->filelock.can_wrlock(in->get_loner()))
-      can_update = -2;
-  }
-
-  calc_new_client_ranges(in, std::max(new_max_size, size), can_update > 0,
-			 &new_ranges, &max_increased);
-
-  if (max_increased || latest->client_ranges != new_ranges)
-    update_max = true;
-
-  if (!update_size && !update_max) {
+  bool new_ranges = check_client_ranges(in, std::max(new_max_size, size));
+  if (!update_size && !new_ranges) {
     dout(20) << "check_inode_max_size no-op on " << *in << dendl;
     return false;
   }
@@ -2464,16 +2481,25 @@ bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
 	   << " update_size " << update_size
 	   << " on " << *in << dendl;
 
-  if (can_update < 0) {
-    auto cms = new C_MDL_CheckMaxSize(this, in, new_max_size, new_size, new_mtime);
-    if (can_update == -1) {
-      dout(10) << "check_inode_max_size frozen, waiting on " << *in << dendl;
-      in->add_waiter(CInode::WAIT_UNFREEZE, cms);
-    } else {
-      in->filelock.add_waiter(SimpleLock::WAIT_STABLE, cms);
-      dout(10) << "check_inode_max_size can't wrlock, waiting on " << *in << dendl;
-    }
+  if (in->is_frozen()) {
+    dout(10) << "check_inode_max_size frozen, waiting on " << *in << dendl;
+    in->add_waiter(CInode::WAIT_UNFREEZE,
+		   new C_MDL_CheckMaxSize(this, in, new_max_size, new_size, new_mtime));
     return false;
+  } else if (!force_wrlock && !in->filelock.can_wrlock(in->get_loner())) {
+    // lock?
+    if (in->filelock.is_stable()) {
+      if (in->get_target_loner() >= 0)
+	file_excl(&in->filelock);
+      else
+	simple_lock(&in->filelock);
+    }
+    if (!in->filelock.can_wrlock(in->get_loner())) {
+      dout(10) << "check_inode_max_size can't wrlock, waiting on " << *in << dendl;
+      in->filelock.add_waiter(SimpleLock::WAIT_STABLE,
+			      new C_MDL_CheckMaxSize(this, in, new_max_size, new_size, new_mtime));
+      return false;
+    }
   }
 
   MutationRef mut(new MutationImpl());
@@ -2482,9 +2508,12 @@ bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
   auto &pi = in->project_inode();
   pi.inode.version = in->pre_dirty();
 
-  if (update_max) {
-    dout(10) << "check_inode_max_size client_ranges " << pi.inode.client_ranges << " -> " << new_ranges << dendl;
-    pi.inode.client_ranges = new_ranges;
+  bool max_increased = false;
+  if (new_ranges &&
+      calc_new_client_ranges(in, std::max(new_max_size, size), &max_increased)) {
+    dout(10) << "check_inode_max_size client_ranges "
+	     << in->get_previous_projected_inode()->client_ranges
+	     <<  " -> " << pi.inode.client_ranges << dendl;
   }
 
   if (update_size) {

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -259,9 +259,9 @@ protected:
 private:
   uint64_t calc_new_max_size(CInode::mempool_inode *pi, uint64_t size);
 public:
-  void calc_new_client_ranges(CInode *in, uint64_t size, bool update,
-			      CInode::mempool_inode::client_range_map* new_ranges,
-			      bool *max_increased);
+  bool check_client_ranges(CInode *in, uint64_t size);
+  bool calc_new_client_ranges(CInode *in, uint64_t size,
+			      bool *max_increased=nullptr);
   bool check_inode_max_size(CInode *in, bool force_wrlock=false,
                             uint64_t newmax=0, uint64_t newsize=0,
 			    utime_t mtime=utime_t());

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -325,6 +325,8 @@ void MDCache::remove_inode(CInode *o)
 
   o->clear_scatter_dirty();
 
+  o->clear_clientwriteable();
+
   o->item_open_file.remove_myself();
 
   if (o->state_test(CInode::STATE_QUEUEDEXPORTPIN))
@@ -6341,16 +6343,18 @@ void MDCache::identify_files_to_recover()
     }
     
     bool recover = false;
-    for (map<client_t,client_writeable_range_t>::iterator p = in->inode.client_ranges.begin();
-	 p != in->inode.client_ranges.end();
-	 ++p) {
-      Capability *cap = in->get_client_cap(p->first);
-      if (cap) {
-	cap->mark_clientwriteable();
-      } else {
-	dout(10) << " client." << p->first << " has range " << p->second << " but no cap on " << *in << dendl;
-	recover = true;
-	break;
+    const auto& client_ranges = in->get_projected_inode()->client_ranges;
+    if (!client_ranges.empty()) {
+      in->mark_clientwriteable();
+      for (auto& p : client_ranges) {
+	Capability *cap = in->get_client_cap(p.first);
+	if (cap) {
+	  cap->mark_clientwriteable();
+	} else {
+	  dout(10) << " client." << p.first << " has range " << p.second << " but no cap on " << *in << dendl;
+	  recover = true;
+	  break;
+	}
       }
     }
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -9085,7 +9085,9 @@ void MDCache::kick_open_ino_peers(mds_rank_t who)
 }
 
 void MDCache::open_ino(inodeno_t ino, int64_t pool, MDSContext* fin,
-		       bool want_replica, bool want_xlocked)
+		       bool want_replica, bool want_xlocked,
+		       vector<inode_backpointer_t> *ancestors_hint,
+		       mds_rank_t auth_hint)
 {
   dout(10) << "open_ino " << ino << " pool " << pool << " want_replica "
 	   << want_replica << dendl;
@@ -9118,8 +9120,10 @@ void MDCache::open_ino(inodeno_t ino, int64_t pool, MDSContext* fin,
     info.tid = ++open_ino_last_tid;
     info.pool = pool >= 0 ? pool : default_file_layout.pool_id;
     info.waiters.push_back(fin);
-    if (mds->is_rejoin() &&
-	open_file_table.get_ancestors(ino, info.ancestors, info.auth_hint)) {
+    if (auth_hint != MDS_RANK_NONE)
+      info.auth_hint = auth_hint;
+    if (ancestors_hint) {
+      info.ancestors = std::move(*ancestors_hint);
       info.fetch_backtrace = false;
       info.checking = mds->get_nodeid();
       _open_ino_traverse_dir(ino, info, 0);

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -5405,19 +5405,43 @@ bool MDCache::process_imported_caps()
     return true;
   }
 
-  for (auto p = cap_imports.begin(); p != cap_imports.end(); ++p) {
-    CInode *in = get_inode(p->first);
+  for (auto& p : cap_imports) {
+    CInode *in = get_inode(p.first);
     if (in) {
       ceph_assert(in->is_auth());
-      cap_imports_missing.erase(p->first);
+      cap_imports_missing.erase(p.first);
       continue;
     }
-    if (cap_imports_missing.count(p->first) > 0)
+    if (cap_imports_missing.count(p.first) > 0)
       continue;
 
+    uint64_t parent_ino = 0;
+    std::string_view d_name;
+    for (auto& q : p.second) {
+      for (auto& r : q.second) {
+	auto &icr = r.second;
+	if (icr.capinfo.pathbase &&
+	    icr.path.length() > 0 &&
+	    icr.path.find('/') == string::npos) {
+	  parent_ino = icr.capinfo.pathbase;
+	  d_name = icr.path;
+	  break;
+	}
+      }
+      if (parent_ino)
+	break;
+    }
+
+    dout(10) << "  opening missing ino " << p.first << dendl;
     cap_imports_num_opening++;
-    dout(10) << "  opening missing ino " << p->first << dendl;
-    open_ino(p->first, (int64_t)-1, new C_MDC_RejoinOpenInoFinish(this, p->first), false);
+    auto fin = new C_MDC_RejoinOpenInoFinish(this, p.first);
+    if (parent_ino) {
+      vector<inode_backpointer_t> ancestors;
+      ancestors.push_back(inode_backpointer_t(parent_ino, string{d_name}, 0));
+      open_ino(p.first, (int64_t)-1, fin, false, false, &ancestors);
+    } else {
+      open_ino(p.first, (int64_t)-1, fin, false);
+    }
     if (!(cap_imports_num_opening % 1000))
       mds->heartbeat_reset();
   }

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1095,7 +1095,9 @@ protected:
 public:
   void kick_open_ino_peers(mds_rank_t who);
   void open_ino(inodeno_t ino, int64_t pool, MDSContext *fin,
-		bool want_replica=true, bool want_xlocked=false);
+		bool want_replica=true, bool want_xlocked=false,
+		vector<inode_backpointer_t> *ancestors_hint=nullptr,
+		mds_rank_t auth_hint=MDS_RANK_NONE);
   
   // -- find_ino_peer --
   struct find_ino_peer_info_t {

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -1703,6 +1703,8 @@ void Migrator::finish_export_inode(CInode *in, mds_rank_t peer,
 
   in->clear_dirty_parent();
 
+  in->clear_clientwriteable();
+
   in->clear_file_locks();
 
   // waiters
@@ -2826,6 +2828,7 @@ void Migrator::import_reverse(CDir *dir)
 
 	in->clear_dirty_parent();
 
+	in->clear_clientwriteable();
 	in->state_clear(CInode::STATE_NEEDSRECOVER);
 
 	in->authlock.clear_gather();
@@ -3183,6 +3186,9 @@ void Migrator::decode_import_inode(CDentry *dn, bufferlist::const_iterator& blp,
 
   if (in->inode.is_dirty_rstat())
     in->mark_dirty_rstat();
+
+  if (!in->get_inode().client_ranges.empty())
+    in->mark_clientwriteable();
   
   // clear if dirtyscattered, since we're going to journal this
   //  but not until we _actually_ finish the import...

--- a/src/mds/OpenFileTable.cc
+++ b/src/mds/OpenFileTable.cc
@@ -989,8 +989,13 @@ void OpenFileTable::_open_ino_finish(inodeno_t ino, int r)
   num_opening_inodes--;
   if (num_opening_inodes == 0) {
     if (prefetch_state == DIR_INODES)  {
-      prefetch_state = DIRFRAGS;
-      _prefetch_dirfrags();
+      if (g_conf().get_val<bool>("mds_oft_prefetch_dirfrags")) {
+	prefetch_state = DIRFRAGS;
+	_prefetch_dirfrags();
+      } else {
+	prefetch_state = FILE_INODES;
+	_prefetch_inodes();
+      }
     } else if (prefetch_state == FILE_INODES) {
       prefetch_state = DONE;
       logseg_destroyed_inos.clear();

--- a/src/mds/OpenFileTable.cc
+++ b/src/mds/OpenFileTable.cc
@@ -936,23 +936,19 @@ void OpenFileTable::load(MDSContext *onload)
 		      new C_OnFinisher(c, mds->finisher));
 }
 
-bool OpenFileTable::get_ancestors(inodeno_t ino, vector<inode_backpointer_t>& ancestors,
-				  mds_rank_t& auth_hint)
+void OpenFileTable::_get_ancestors(const Anchor& parent,
+				   vector<inode_backpointer_t>& ancestors,
+				   mds_rank_t& auth_hint)
 {
-  auto p = loaded_anchor_map.find(ino);
-  if (p == loaded_anchor_map.end())
-    return false;
-
-  inodeno_t dirino = p->second.dirino;
-  if (dirino == inodeno_t(0))
-    return false;
+  inodeno_t dirino = parent.dirino;
+  std::string_view d_name = parent.d_name;
 
   bool first = true;
   ancestors.clear();
   while (true) {
-    ancestors.push_back(inode_backpointer_t(dirino, p->second.d_name, 0));
+    ancestors.push_back(inode_backpointer_t(dirino, string{d_name}, 0));
 
-    p = loaded_anchor_map.find(dirino);
+    auto p = loaded_anchor_map.find(dirino);
     if (p == loaded_anchor_map.end())
       break;
 
@@ -960,12 +956,12 @@ bool OpenFileTable::get_ancestors(inodeno_t ino, vector<inode_backpointer_t>& an
       auth_hint = p->second.auth;
 
     dirino = p->second.dirino;
+    d_name = p->second.d_name;
     if (dirino == inodeno_t(0))
       break;
 
     first = false;
   }
-  return true;
 }
 
 class C_OFT_OpenInoFinish: public MDSContext {
@@ -1117,7 +1113,16 @@ void OpenFileTable::_prefetch_inodes()
       continue;
 
     num_opening_inodes++;
-    mdcache->open_ino(it.first, pool, new C_OFT_OpenInoFinish(this, it.first), false);
+
+    auto fin = new C_OFT_OpenInoFinish(this, it.first);
+    if (it.second.dirino != inodeno_t(0)) {
+      vector<inode_backpointer_t> ancestors;
+      mds_rank_t auth_hint = MDS_RANK_NONE;
+      _get_ancestors(it.second, ancestors, auth_hint);
+      mdcache->open_ino(it.first, pool, fin, false, false, &ancestors, auth_hint);
+    } else {
+      mdcache->open_ino(it.first, pool, fin, false);
+    }
 
     if (!(num_opening_inodes % 1000))
       mds->heartbeat_reset();

--- a/src/mds/OpenFileTable.cc
+++ b/src/mds/OpenFileTable.cc
@@ -31,14 +31,25 @@ static ostream& _prefix(std::ostream *_dout, MDSRank *mds) {
   return *_dout << "mds." << mds->get_nodeid() << ".openfiles ";
 }
 
-void OpenFileTable::get_ref(CInode *in)
+void OpenFileTable::get_ref(CInode *in, frag_t fg)
 {
   do {
     auto p = anchor_map.find(in->ino());
+    if (!in->is_dir()) {
+      ceph_assert(fg == -1U);
+      ceph_assert(p == anchor_map.end());
+    }
+
     if (p != anchor_map.end()) {
       ceph_assert(in->state_test(CInode::STATE_TRACKEDBYOFT));
       ceph_assert(p->second.nref > 0);
       p->second.nref++;
+
+      if (fg != -1U) {
+	auto ret = p->second.frags.insert(fg);
+	ceph_assert(ret.second);
+	dirty_items.emplace(in->ino(), (int)DIRTY_UNDEF);
+      }
       break;
     }
 
@@ -51,6 +62,9 @@ void OpenFileTable::get_ref(CInode *in)
     ceph_assert(ret.second == true);
     in->state_set(CInode::STATE_TRACKEDBYOFT);
 
+    if (fg != -1U)
+      ret.first->second.frags.insert(fg);
+
     auto ret1 = dirty_items.emplace(in->ino(), (int)DIRTY_NEW);
     if (!ret1.second) {
       int omap_idx = ret1.first->second;
@@ -59,10 +73,11 @@ void OpenFileTable::get_ref(CInode *in)
     }
 
     in = pin;
+    fg = -1U;
   } while (in);
 }
 
-void OpenFileTable::put_ref(CInode *in)
+void OpenFileTable::put_ref(CInode *in, frag_t fg)
 {
   do {
     ceph_assert(in->state_test(CInode::STATE_TRACKEDBYOFT));
@@ -70,8 +85,18 @@ void OpenFileTable::put_ref(CInode *in)
     ceph_assert(p != anchor_map.end());
     ceph_assert(p->second.nref > 0);
 
+    if (!in->is_dir()) {
+      ceph_assert(fg == -1U);
+      ceph_assert(p->second.nref == 1);
+    }
+
     if (p->second.nref > 1) {
       p->second.nref--;
+      if (fg != -1U) {
+	auto ret = p->second.frags.erase(fg);
+	ceph_assert(ret);
+	dirty_items.emplace(in->ino(), (int)DIRTY_UNDEF);
+      }
       break;
     }
 
@@ -83,6 +108,11 @@ void OpenFileTable::put_ref(CInode *in)
     } else {
       ceph_assert(p->second.dirino == inodeno_t(0));
       ceph_assert(p->second.d_name == "");
+    }
+
+    if (fg != -1U) {
+      ceph_assert(p->second.frags.size() == 1);
+      ceph_assert(*p->second.frags.begin() == fg);
     }
 
     int omap_idx = p->second.omap_idx;
@@ -101,27 +131,19 @@ void OpenFileTable::put_ref(CInode *in)
     }
 
     in = pin;
+    fg = -1U;
   } while (in);
 }
 
 void OpenFileTable::add_inode(CInode *in)
 {
   dout(10) << __func__ << " " << *in << dendl;
-  if (!in->is_dir()) {
-    auto p = anchor_map.find(in->ino());
-    ceph_assert(p == anchor_map.end());
-  }
   get_ref(in);
 }
 
 void OpenFileTable::remove_inode(CInode *in)
 {
   dout(10) << __func__ << " " << *in << dendl;
-  if (!in->is_dir()) {
-    auto p = anchor_map.find(in->ino());
-    ceph_assert(p != anchor_map.end());
-    ceph_assert(p->second.nref == 1);
-  }
   put_ref(in);
 }
 
@@ -130,10 +152,7 @@ void OpenFileTable::add_dirfrag(CDir *dir)
   dout(10) << __func__ << " " << *dir << dendl;
   ceph_assert(!dir->state_test(CDir::STATE_TRACKEDBYOFT));
   dir->state_set(CDir::STATE_TRACKEDBYOFT);
-  auto ret = dirfrags.insert(dir->dirfrag());
-  ceph_assert(ret.second);
-  get_ref(dir->get_inode());
-  dirty_items.emplace(dir->ino(), (int)DIRTY_UNDEF);
+  get_ref(dir->get_inode(), dir->get_frag());
 }
 
 void OpenFileTable::remove_dirfrag(CDir *dir)
@@ -141,11 +160,7 @@ void OpenFileTable::remove_dirfrag(CDir *dir)
   dout(10) << __func__ << " " << *dir << dendl;
   ceph_assert(dir->state_test(CDir::STATE_TRACKEDBYOFT));
   dir->state_clear(CDir::STATE_TRACKEDBYOFT);
-  auto p = dirfrags.find(dir->dirfrag());
-  ceph_assert(p != dirfrags.end());
-  dirfrags.erase(p);
-  dirty_items.emplace(dir->ino(), (int)DIRTY_UNDEF);
-  put_ref(dir->get_inode());
+  put_ref(dir->get_inode(), dir->get_frag());
 }
 
 void OpenFileTable::notify_link(CInode *in)
@@ -422,33 +437,14 @@ void OpenFileTable::commit(MDSContext *c, uint64_t log_seq, int op_prio)
   }
 
   for (auto& it : dirty_items) {
-    frag_vec_t frags;
     auto p = anchor_map.find(it.first);
-    if (p != anchor_map.end()) {
-      for (auto q = dirfrags.lower_bound(dirfrag_t(it.first, 0));
-	   q != dirfrags.end() && q->ino == it.first;
-	   ++q)
-	frags.push_back(q->frag);
-    }
 
     if (first_commit) {
       auto q = loaded_anchor_map.find(it.first);
       if (q != loaded_anchor_map.end()) {
 	ceph_assert(p != anchor_map.end());
 	p->second.omap_idx = q->second.omap_idx;
-	bool same = p->second == q->second;
-	if (same) {
-	  auto r = loaded_dirfrags.lower_bound(dirfrag_t(it.first, 0));
-	  for (const auto& fg : frags) {
-	    if (r == loaded_dirfrags.end() || !(*r == dirfrag_t(it.first, fg))) {
-	      same = false;
-	      break;
-	    }
-	    ++r;
-	  }
-	  if (same && r != loaded_dirfrags.end() && r->ino == it.first)
-	    same = false;
-	}
+	bool same = (p->second == q->second);
 	loaded_anchor_map.erase(q);
 	if (same)
 	  continue;
@@ -496,7 +492,7 @@ void OpenFileTable::commit(MDSContext *c, uint64_t log_seq, int op_prio)
     if (p != anchor_map.end()) {
       bufferlist bl;
       encode(p->second, bl);
-      encode(frags, bl);
+      encode((__u32)0, bl); // frags set was encoded here
 
       ctl.write_size += bl.length() + len + 2 * sizeof(__u32);
       ctl.to_update[key].swap(bl);
@@ -533,7 +529,6 @@ void OpenFileTable::commit(MDSContext *c, uint64_t log_seq, int op_prio)
       }
     }
     loaded_anchor_map.clear();
-    loaded_dirfrags.clear();
   }
 
   {
@@ -709,14 +704,12 @@ void OpenFileTable::_load_finish(int op_r, int header_r, int values_r,
 					    std::make_tuple());
     RecoveredAnchor& anchor = it->second;
     decode(anchor, p);
+    frag_vec_t frags; // unused
+    decode(frags, p);
     ceph_assert(ino == anchor.ino);
     anchor.omap_idx = idx;
     anchor.auth = MDS_RANK_NONE;
 
-    frag_vec_t frags;
-    decode(frags, p);
-    for (const auto& fg : frags)
-      loaded_dirfrags.insert(loaded_dirfrags.end(), dirfrag_t(anchor.ino, fg));
 
     if (loaded_anchor_map.size() > count)
       ++omap_num_items[idx];
@@ -866,9 +859,6 @@ void OpenFileTable::_load_finish(int op_r, int header_r, int values_r,
 	      ceph_assert(count > 0);
 	      --count;
 	    }
-	    auto r = loaded_dirfrags.lower_bound(dirfrag_t(ino, 0));
-	    while (r != loaded_dirfrags.end() && r->ino == ino)
-	      loaded_dirfrags.erase(r++);
 	  }
 
 	  op_vec.resize(op_vec.size() + 1);
@@ -1023,37 +1013,36 @@ void OpenFileTable::_prefetch_dirfrags()
   ceph_assert(prefetch_state == DIRFRAGS);
 
   MDCache *mdcache = mds->mdcache;
-  list<CDir*> fetch_queue;
+  std::set<CDir*> fetch_queue;
 
-  CInode *last_in = nullptr;
-  for (auto df : loaded_dirfrags) {
-    CInode *diri;
-    if (last_in && last_in->ino() == df.ino) {
-      diri = last_in;
-    } else {
-      diri = mdcache->get_inode(df.ino);
-      if (!diri)
-	continue;
-      last_in = diri;
-    }
+  for (auto& it : loaded_anchor_map) {
+    if (it.second.frags.empty())
+      continue;
+    CInode *diri = mdcache->get_inode(it.first);
+    if (!diri)
+      continue;
     if (diri->state_test(CInode::STATE_REJOINUNDEF))
       continue;
 
-    CDir *dir = diri->get_dirfrag(df.frag);
-    if (dir) {
-      if (dir->is_auth() && !dir->is_complete())
-	fetch_queue.push_back(dir);
-    } else {
-      frag_vec_t leaves;
-      diri->dirfragtree.get_leaves_under(df.frag, leaves);
-      for (const auto& leaf : leaves) {
-	if (diri->is_auth()) {
-	  dir = diri->get_or_open_dirfrag(mdcache, leaf);
-	} else {
-	  dir = diri->get_dirfrag(leaf);
+    for (auto& fg: it.second.frags) {
+      CDir *dir = diri->get_dirfrag(fg);
+      if (dir) {
+	if (dir->is_auth() && !dir->is_complete())
+	  fetch_queue.insert(dir);
+      } else {
+	frag_vec_t leaves;
+	diri->dirfragtree.get_leaves_under(fg, leaves);
+	if (leaves.empty())
+	  leaves.push_back(diri->dirfragtree[fg.value()]);
+	for (auto& leaf : leaves) {
+	  if (diri->is_auth()) {
+	    dir = diri->get_or_open_dirfrag(mdcache, leaf);
+	  } else {
+	    dir = diri->get_dirfrag(leaf);
+	  }
+	  if (dir && dir->is_auth() && !dir->is_complete())
+	    fetch_queue.insert(dir);
 	}
-	if (dir && dir->is_auth() && !dir->is_complete())
-	  fetch_queue.push_back(dir);
       }
     }
   }

--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -83,8 +83,8 @@ protected:
   void _journal_finish(int r, uint64_t log_seq, MDSContext *fin,
 		       std::map<unsigned, std::vector<ObjectOperation> >& ops);
 
-  void get_ref(CInode *in);
-  void put_ref(CInode *in);
+  void get_ref(CInode *in, frag_t fg=-1U);
+  void put_ref(CInode *in, frag_t fg=-1U);
 
   object_t get_object_name(unsigned idx) const;
 
@@ -94,7 +94,6 @@ protected:
     journal_state = JOURNAL_NONE;
     loaded_journals.clear();
     loaded_anchor_map.clear();
-    loaded_dirfrags.clear();
   }
   void _load_finish(int op_r, int header_r, int values_r,
 		    unsigned idx, bool first, bool more,
@@ -114,7 +113,6 @@ protected:
   std::vector<unsigned> omap_num_items;
 
   map<inodeno_t, OpenedAnchor> anchor_map;
-  set<dirfrag_t> dirfrags;
 
   std::map<inodeno_t, int> dirty_items; // ino -> dirty state
 
@@ -130,7 +128,6 @@ protected:
 
   std::vector<std::map<std::string, bufferlist> > loaded_journals;
   map<inodeno_t, RecoveredAnchor> loaded_anchor_map;
-  set<dirfrag_t> loaded_dirfrags;
   MDSContext::vec waiting_for_load;
   bool load_done = false;
 

--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -49,9 +49,6 @@ public:
     waiting_for_load.push_back(c);
   }
 
-  bool get_ancestors(inodeno_t ino, vector<inode_backpointer_t>& ancestors,
-		     mds_rank_t& auth_hint);
-
   bool prefetch_inodes();
   bool is_prefetched() const { return prefetch_state == DONE; }
   void wait_for_prefetch(MDSContext *c) {
@@ -104,6 +101,10 @@ protected:
   void _open_ino_finish(inodeno_t ino, int r);
   void _prefetch_inodes();
   void _prefetch_dirfrags();
+
+  void _get_ancestors(const Anchor& parent,
+		      vector<inode_backpointer_t>& ancestors,
+		      mds_rank_t& auth_hint);
 
   MDSRank *mds;
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4810,12 +4810,9 @@ void Server::handle_client_setattr(MDRequestRef& mdr)
     pi.inode.mtime = mdr->get_op_stamp();
 
     // adjust client's max_size?
-    CInode::mempool_inode::client_range_map new_ranges;
-    bool max_increased = false;
-    mds->locker->calc_new_client_ranges(cur, pi.inode.size, true, &new_ranges, &max_increased);
-    if (pi.inode.client_ranges != new_ranges) {
-      dout(10) << " client_ranges " << pi.inode.client_ranges << " -> " << new_ranges << dendl;
-      pi.inode.client_ranges = new_ranges;
+    if (mds->locker->calc_new_client_ranges(cur, pi.inode.size)) {
+      dout(10) << " client_ranges "  << cur->get_previous_projected_inode()->client_ranges
+	       << " -> " << pi.inode.client_ranges << dendl;
       changed_ranges = true;
     }
   }

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4223,6 +4223,7 @@ void Server::handle_client_openc(MDRequestRef& mdr)
     in->inode.client_ranges[client].range.first = 0;
     in->inode.client_ranges[client].range.last = in->inode.get_layout_size_increment();
     in->inode.client_ranges[client].follows = follows;
+    in->mark_clientwriteable();
     cap->mark_clientwriteable();
   }
   
@@ -4873,6 +4874,7 @@ void Server::do_open_truncate(MDRequestRef& mdr, int cmode)
     pi.inode.client_ranges[client].range.last = pi.inode.get_layout_size_increment();
     pi.inode.client_ranges[client].follows = realm->get_newest_seq();
     changed_ranges = true;
+    in->mark_clientwriteable();
     cap->mark_clientwriteable();
   }
   
@@ -5843,6 +5845,7 @@ void Server::handle_client_mknod(MDRequestRef& mdr)
       newi->inode.client_ranges[client].range.first = 0;
       newi->inode.client_ranges[client].range.last = newi->inode.get_layout_size_increment();
       newi->inode.client_ranges[client].follows = follows;
+      newi->mark_clientwriteable();
       cap->mark_clientwriteable();
     }
   }

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -185,10 +185,11 @@ void StrayManager::_purge_stray_purged(
     auto &pi = in->project_inode();
     pi.inode.size = 0;
     pi.inode.max_size_ever = 0;
-    pi.inode.client_ranges.clear();
     pi.inode.truncate_size = 0;
     pi.inode.truncate_from = 0;
     pi.inode.version = in->pre_dirty();
+    pi.inode.client_ranges.clear();
+    in->clear_clientwriteable();
 
     le->metablob.add_dir_context(dn->dir);
     le->metablob.add_primary_dentry(dn, in, true);

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -570,6 +570,11 @@ struct inode_t {
 
   bool is_dirty_rstat() const { return !(rstat == accounted_rstat); }
 
+  uint64_t get_client_range(client_t client) const {
+    auto it = client_ranges.find(client);
+    return it != client_ranges.end() ? it->second.range.last : 0;
+  }
+
   uint64_t get_max_size() const {
     uint64_t max = 0;
       for (std::map<client_t,client_writeable_range_t>::const_iterator p = client_ranges.begin();


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47609
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
