### PR TITLE
cephadm: assign keyring and ceph.conf to cephadm user

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3052,10 +3052,14 @@ def command_bootstrap():
         os.fchmod(f.fileno(), 0o600)
         f.write('[client.admin]\n'
                 '\tkey = ' + admin_key + '\n')
+        if args.ssh_user:
+            shutil.chown(f.name(), user=args.ssh_user, group=args.ssh_user)
     logger.info('Wrote keyring to %s' % args.output_keyring)
 
     with open(args.output_config, 'w') as f:
         f.write(config)
+        if args.ssh_user:
+            shutil.chown(f.name(), user=args.ssh_user, group=args.ssh_user)
     logger.info('Wrote config to %s' % args.output_config)
 
     # wait for the service to become available


### PR DESCRIPTION
If the cephadm user is being used (if you'll pardon that manner of
speaking), it should own the keyring and ceph.conf files that we are
creating.

Signed-off-by: Nathan Cutler <ncutler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
