### PR TITLE
mgr/cephadm: get rbd-mirror daemon-id when checking for strays

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -467,6 +467,14 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                 missing_names = []
                 for s in daemons:
                     name = '%s.%s' % (s.get('type'), s.get('id'))
+                    if s.get('type') == 'rbd-mirror':
+                        defaults = defaultdict(lambda: None, {'id': None})
+                        metadata = self.get_metadata("rbd-mirror", s.get('id'), default=defaults)
+                        if metadata['id']:
+                            name = '%s.%s' % (s.get('type'), metadata['id'])
+                        else:
+                            self.log.debug(
+                                "Failed to find daemon id for rbd-mirror service %s" % (s.get('id')))
                     if host not in self.inventory:
                         missing_names.append(name)
                         host_num_daemons += 1


### PR DESCRIPTION
Currently, list_servers() gets the rbd-mirror service-id instead
of the daemon-id so the daemon is marked as stray. This PR uses
that service-id to find the daemon-id and uses that to check if
the daemon is stray.

Fixes: https://tracker.ceph.com/issues/47639

Signed-off-by: Adam King <adking@redhat.com>

NOTE: There is a chance that after removing the rbd-mirror service `_check_for_strays` can run again before the metadata has updated causing an rbd-mirror daemon that doesn't exist anymore to be marked as a stray daemon until the `_check_for_strays` is run again after the metadata updates itself. This PR doesn't cause that issue (it could already happen before) but it doesn't fix it either.
