### PR TITLE
ceph-volume: cache disk.get_devices with lru_cache

### DIFF
--- a/src/ceph-volume/ceph_volume/__init__.py
+++ b/src/ceph-volume/ceph_volume/__init__.py
@@ -1,10 +1,6 @@
 from collections import namedtuple
 
 
-sys_info = namedtuple('sys_info', ['devices'])
-sys_info.devices = dict()
-
-
 class UnloadedConfig(object):
     """
     This class is used as the default value for conf.ceph so that if

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -282,7 +282,6 @@ def device_info(monkeypatch, patch_bluestore_label):
         blkid = blkid if blkid else {}
         udevadm = udevadm if udevadm else {}
         lv = Factory(**lv) if lv else None
-        monkeypatch.setattr("ceph_volume.sys_info.devices", {})
         monkeypatch.setattr("ceph_volume.util.device.disk.get_devices", lambda: devices)
         if not devices:
             monkeypatch.setattr("ceph_volume.util.device.lvm.get_first_lv", lambda filters: lv)

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -2,7 +2,7 @@
 
 import os
 from functools import total_ordering
-from ceph_volume import sys_info, process
+from ceph_volume import process
 from ceph_volume.api import lvm
 from ceph_volume.util import disk, system
 from ceph_volume.util.lsmdisk import LSMDisk
@@ -28,10 +28,8 @@ class Devices(object):
     """
 
     def __init__(self, devices=None, filter_for_batch=False):
-        if not sys_info.devices:
-            sys_info.devices = disk.get_devices()
         self.devices = [Device(k) for k in
-                            sys_info.devices.keys()]
+                            disk.get_devices().keys()]
         if filter_for_batch:
             self.devices = [d for d in self.devices if d.available_lvm_batch]
 
@@ -142,13 +140,11 @@ class Device(object):
         return hash(self.path)
 
     def _parse(self):
-        if not sys_info.devices:
-            sys_info.devices = disk.get_devices()
-        self.sys_api = sys_info.devices.get(self.abspath, {})
+        self.sys_api = disk.get_devices().get(self.abspath, {})
         if not self.sys_api:
             # if no device was found check if we are a partition
             partname = self.abspath.split('/')[-1]
-            for device, info in sys_info.devices.items():
+            for device, info in disk.get_devices().items():
                 part = info['partitions'].get(partname, {})
                 if part:
                     self.sys_api = part

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -6,6 +6,10 @@ from ceph_volume import process
 from ceph_volume.api import lvm
 from ceph_volume.util.system import get_file_contents
 
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
 
 logger = logging.getLogger(__name__)
 
@@ -735,6 +739,7 @@ def get_block_devs_lsblk():
     return [re.split(r'\s+', line) for line in stdout]
 
 
+@lru_cache(maxsize=8)
 def get_devices(_sys_block_path='/sys/block'):
     """
     Captures all available block devices as reported by lsblk.

--- a/src/ceph-volume/setup.py
+++ b/src/ceph-volume/setup.py
@@ -16,7 +16,7 @@ setup(
     zip_safe = False,
     install_requires=[
         'ceph',
-        'backports.functools_lru_cache'
+        'backports.functools_lru_cache; python_version < "3.2.0"'
     ],
     dependency_links=[''.join(['file://', os.path.join(os.getcwd(), '../',
                                                        'python-common#egg=ceph-1.0.0')])],

--- a/src/ceph-volume/setup.py
+++ b/src/ceph-volume/setup.py
@@ -14,7 +14,10 @@ setup(
     keywords='ceph volume disk devices lvm',
     url="https://github.com/ceph/ceph",
     zip_safe = False,
-    install_requires='ceph',
+    install_requires=[
+        'ceph',
+        'backports.functools_lru_cache'
+    ],
     dependency_links=[''.join(['file://', os.path.join(os.getcwd(), '../',
                                                        'python-common#egg=ceph-1.0.0')])],
     tests_require=[


### PR DESCRIPTION
Use ``lru_cache`` to cache the return value of ``util.disk.get_devices``. The ``backports.functools-lru-cache`` library is used to provide py2 support for nautilus and luminous backporting.

More discussion can be found in this PR: https://github.com/ceph/ceph/pull/37319