### PR TITLE
octopus: rpm,deb: drop /etc/sudoers.d/cephadm

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1302,7 +1302,6 @@ install -m 0644 -D udev/50-rbd.rules %{buildroot}%{_udevrulesdir}/50-rbd.rules
 
 # sudoers.d
 install -m 0600 -D sudoers.d/ceph-osd-smartctl %{buildroot}%{_sysconfdir}/sudoers.d/ceph-osd-smartctl
-install -m 0600 -D sudoers.d/cephadm %{buildroot}%{_sysconfdir}/sudoers.d/cephadm
 
 %if 0%{?rhel} >= 8
 pathfix.py -pni "%{__python3} %{py3_shbang_opts}" %{buildroot}%{_bindir}/*
@@ -1459,7 +1458,6 @@ exit 0
 %files -n cephadm
 %{_sbindir}/cephadm
 %{_mandir}/man8/cephadm.8*
-%{_sysconfdir}/sudoers.d/cephadm
 %attr(0700,cephadm,cephadm) %dir %{_sharedstatedir}/cephadm
 %attr(0700,cephadm,cephadm) %dir %{_sharedstatedir}/cephadm/.ssh
 %attr(0600,cephadm,cephadm) %{_sharedstatedir}/cephadm/.ssh/authorized_keys

--- a/debian/cephadm.install
+++ b/debian/cephadm.install
@@ -1,3 +1,2 @@
 usr/sbin/cephadm
 usr/share/man/man8/cephadm.8
-etc/sudoers.d/cephadm

--- a/debian/rules
+++ b/debian/rules
@@ -62,7 +62,6 @@ override_dh_auto_install:
 	install -D -m 644 src/etc-rbdmap $(DESTDIR)/etc/ceph/rbdmap
 	install -D -m 644 etc/sysctl/90-ceph-osd.conf $(DESTDIR)/etc/sysctl.d/30-ceph-osd.conf
 	install -D -m 600 sudoers.d/ceph-osd-smartctl $(DESTDIR)/etc/sudoers.d/ceph-osd-smartctl
-	install -D -m 600 sudoers.d/cephadm $(DESTDIR)/etc/sudoers.d/cephadm
 
 	install -m 755 src/cephadm/cephadm $(DESTDIR)/usr/sbin/cephadm
 

--- a/sudoers.d/cephadm
+++ b/sudoers.d/cephadm
@@ -1,7 +1,0 @@
-# allow cephadm user to sudo cephadm
-cephadm ALL=NOPASSWD: /usr/bin/cephadm --image * ls
-cephadm ALL=NOPASSWD: /usr/bin/cephadm --image * unit *
-cephadm ALL=NOPASSWD: /usr/bin/cephadm --image * shell *
-cephadm ALL=NOPASSWD: /usr/bin/cephadm --image * deploy *
-cephadm ALL=NOPASSWD: /usr/bin/cephadm --image * ceph-volume *
-cephadm ALL=NOPASSWD: /usr/bin/cephadm --image * rm-daemon *


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47644

---

backport of https://github.com/ceph/ceph/pull/36972
parent tracker: https://tracker.ceph.com/issues/47112

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh