### PR TITLE
crimson/seastore: add online gc to seastore

### DIFF
--- a/src/crimson/common/fixed_kv_node_layout.h
+++ b/src/crimson/common/fixed_kv_node_layout.h
@@ -325,6 +325,8 @@ public:
   FixedKVNodeLayout(char *buf) :
     buf(buf) {}
 
+  virtual ~FixedKVNodeLayout() = default;
+
   const_iterator begin() const {
     return const_iterator(
       this,
@@ -639,6 +641,17 @@ private:
   }
 
   /**
+   * node_resolve/unresolve_vals
+   *
+   * If the representation for values depends in some way on the
+   * node in which they are located, users may implement
+   * resolve/unresolve to enable copy_from_foreign to handle that
+   * transition.
+   */
+  virtual void node_resolve_vals(iterator from, iterator to) const {}
+  virtual void node_unresolve_vals(iterator from, iterator to) const {}
+
+  /**
    * copy_from_foreign
    *
    * Copies entries from [from_src, to_src) to tgt.
@@ -658,6 +671,8 @@ private:
     memcpy(
       tgt->get_key_ptr(), from_src->get_key_ptr(),
       to_src->get_key_ptr() - from_src->get_key_ptr());
+    from_src->node->node_resolve_vals(tgt, tgt + (to_src - from_src));
+    tgt->node->node_unresolve_vals(tgt, tgt + (to_src - from_src));
   }
 
   /**

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -278,10 +278,8 @@ void Cache::complete_commit(
     logger().debug("complete_commit: new root {}", *t.root);
   }
 
-  paddr_t cur = final_block_start;
   for (auto &i: t.fresh_block_list) {
-    i->set_paddr(cur);
-    cur.offset += i->get_length();
+    i->set_paddr(final_block_start.add_relative(i->get_paddr()));
     i->last_committed_crc = i->get_crc32c();
     i->on_initial_write();
 

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -164,6 +164,7 @@ CachedExtentRef Cache::duplicate_for_write(
 
   ret->version++;
   ret->state = CachedExtent::extent_state_t::MUTATION_PENDING;
+  logger().debug("Cache::duplicate_for_write: {} -> {}", *i, *ret);
   return ret;
 }
 

--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -248,7 +248,15 @@ std::optional<record_t> Cache::try_construct_record(Transaction &t)
     if (i->get_type() == extent_types_t::ROOT) {
       assert(0 == "ROOT never gets written as a fresh block");
     }
-    record.extents.push_back(extent_t{std::move(bl)});
+
+    assert(bl.length() == i->get_length());
+    record.extents.push_back(extent_t{
+	i->get_type(),
+	i->is_logical()
+	? i->cast<LogicalCachedExtent>()->get_laddr()
+	: L_ADDR_NULL,
+	std::move(bl)
+      });
   }
 
   return std::make_optional<record_t>(std::move(record));

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -167,6 +167,28 @@ public:
   }
 
   /**
+   * get_extent_if_cached
+   *
+   * Returns extent at offset if in cache
+   */
+  Transaction::get_extent_ret get_extent_if_cached(
+    Transaction &t,
+    paddr_t offset,
+    CachedExtentRef *out) {
+    auto result = t.get_extent(offset, out);
+    if (result != Transaction::get_extent_ret::ABSENT) {
+      return result;
+    } else if (auto iter = extents.find_offset(offset);
+	       iter != extents.end()) {
+      if (out)
+	*out = &*iter;
+      return Transaction::get_extent_ret::PRESENT;
+    } else {
+      return Transaction::get_extent_ret::ABSENT;
+    }
+  }
+
+  /**
    * get_extent
    *
    * returns ref to extent at offset~length of type T either from
@@ -195,6 +217,41 @@ public:
 	  return get_extent_ertr::make_ready_future<TCachedExtentRef<T>>(
 	    std::move(ref));
 	});
+    }
+  }
+
+  /**
+   * get_extent_by_type
+   *
+   * Based on type, instantiate the correct concrete type
+   * and read in the extent at location offset~length.
+   */
+  get_extent_ertr::future<CachedExtentRef> get_extent_by_type(
+    extent_types_t type,  ///< [in] type tag
+    paddr_t offset,       ///< [in] starting addr
+    laddr_t laddr,        ///< [in] logical address if logical
+    segment_off_t length  ///< [in] length
+  );
+
+  get_extent_ertr::future<CachedExtentRef> get_extent_by_type(
+    Transaction &t,
+    extent_types_t type,
+    paddr_t offset,
+    laddr_t laddr,
+    segment_off_t length) {
+    CachedExtentRef ret;
+    auto status = get_extent_if_cached(t, offset, &ret);
+    if (status == Transaction::get_extent_ret::RETIRED) {
+      return get_extent_ertr::make_ready_future<CachedExtentRef>();
+    } else if (status == Transaction::get_extent_ret::PRESENT) {
+      return get_extent_ertr::make_ready_future<CachedExtentRef>(ret);
+    } else {
+      return get_extent_by_type(type, offset, laddr, length
+      ).safe_then([=, &t](CachedExtentRef ret) {
+	t.add_to_read_set(ret);
+	return get_extent_ertr::make_ready_future<CachedExtentRef>(
+	  std::move(ret));
+      });
     }
   }
 
@@ -443,19 +500,6 @@ private:
 
   /// Replace prev with next
   void replace_extent(CachedExtentRef next, CachedExtentRef prev);
-
-  /**
-   * get_extent_by_type
-   *
-   * Based on type, instantiate the correct concrete type
-   * and read in the extent at location offset~length.
-   */
-  get_extent_ertr::future<CachedExtentRef> get_extent_by_type(
-    extent_types_t type,  ///< [in] type tag
-    paddr_t offset,       ///< [in] starting addr
-    laddr_t laddr,        ///< [in] logical address if logical
-    segment_off_t length  ///< [in] length
-  );
 };
 
 }

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -295,7 +295,8 @@ public:
   void complete_commit(
     Transaction &t,            ///< [in, out] current transaction
     paddr_t final_block_start, ///< [in] offset of initial block
-    journal_seq_t seq          ///< [in] journal commit seq
+    journal_seq_t seq,         ///< [in] journal commit seq
+    SegmentCleaner *cleaner=nullptr ///< [out] optional segment stat listener
   );
 
   /**

--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -225,6 +225,10 @@ Journal::find_replay_segments_fut Journal::find_replay_segments()
 		i);
 	      return find_replay_segments_ertr::now();
 	    }
+	    logger().debug(
+	      "find_replay_segments: segment {} header {}",
+	      i,
+	      header);
 	    segments.emplace_back(i, std::move(header));
 	    return find_replay_segments_ertr::now();
 	  }).handle_error(
@@ -271,6 +275,13 @@ Journal::find_replay_segments_fut Journal::find_replay_segments()
 	      [&replay_from](const auto &seg) -> bool {
 		return seg.first == replay_from.segment;
 	      });
+	    if (from->second.journal_segment_seq != journal_tail.segment_seq) {
+	      logger().error(
+		"find_replay_segments: journal_tail {} does not match {}",
+		journal_tail,
+		from->second);
+	      assert(0 == "invalid");
+	    }
 	  } else {
 	    replay_from = paddr_t{from->first, (segment_off_t)block_size};
 	  }

--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -98,9 +98,10 @@ Journal::write_record_ret Journal::write_record(
   auto target = written_to;
   written_to += p2roundup(to_write.length(), (unsigned)block_size);
   logger().debug(
-    "write_record, mdlength {}, dlength {}",
+    "write_record, mdlength {}, dlength {}, target {}",
     rsize.mdlength,
-    rsize.dlength);
+    rsize.dlength,
+    target);
   return current_journal_segment->write(target, to_write).handle_error(
     write_record_ertr::pass_further{},
     crimson::ct_error::assert_all{ "TODO" }).safe_then([this, target] {

--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -96,7 +96,8 @@ Journal::write_record_ret Journal::write_record(
   ceph::bufferlist to_write = encode_record(
     rsize, std::move(record));
   auto target = written_to;
-  written_to += p2roundup(to_write.length(), (unsigned)block_size);
+  assert((to_write.length() % block_size) == 0);
+  written_to += to_write.length();
   logger().debug(
     "write_record, mdlength {}, dlength {}, target {}",
     rsize.mdlength,

--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -1,6 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <iostream>
+
 #include <boost/iterator/counting_iterator.hpp>
 
 #include "crimson/os/seastore/journal.h"
@@ -15,6 +17,15 @@ namespace {
 }
 
 namespace crimson::os::seastore {
+
+std::ostream &operator<<(std::ostream &out, const segment_header_t &header)
+{
+  return out << "segment_header_t("
+	     << "segment_seq=" << header.journal_segment_seq
+	     << ", physical_segment_id=" << header.physical_segment_id
+	     << ", journal_tail=" << header.journal_tail
+	     << ")";
+}
 
 Journal::Journal(SegmentManager &segment_manager)
   : block_size(segment_manager.get_block_size()),

--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -47,7 +47,7 @@ Journal::initialize_segment(Segment &segment)
   // write out header
   ceph_assert(segment.get_write_ptr() == 0);
   bufferlist bl;
-  segment_seq_t seq = current_journal_segment_seq++;
+  segment_seq_t seq = next_journal_segment_seq++;
   auto header = segment_header_t{
     seq,
     segment.get_segment_id(),
@@ -250,7 +250,7 @@ Journal::find_replay_segments_fut Journal::find_replay_segments()
 		rt.second.journal_segment_seq;
 	    });
 
-	  current_journal_segment_seq =
+	  next_journal_segment_seq =
 	    segments.rbegin()->second.journal_segment_seq + 1;
 	  std::for_each(
 	    segments.begin(),

--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -398,11 +398,25 @@ Journal::replay_segment(
   logger().debug("replay_segment: starting at {}", seq);
   return seastar::do_with(
     delta_scan_handler_t(
-      [&handler, seq](auto addr, auto base, const auto &delta) {
-	return handler(
-	  journal_seq_t{seq.segment_seq, addr},
-	  base,
-	  delta);
+      [=, &handler](auto addr, auto base, const auto &delta) {
+	/* The journal may validly contain deltas for extents in since released
+	 * segments.  We can detect those cases by whether the segment in question
+	 * currently has a sequence number > the current journal segment seq.
+	 * We can safely skip these deltas because the extent must already have
+	 * been rewritten.
+	 *
+	 * Note, this comparison exploits the fact that SEGMENT_SEQ_NULL is
+	 * a large number.
+	 */
+	if (delta.paddr != P_ADDR_NULL &&
+	    segment_provider->get_seq(delta.paddr.segment) > seq.segment_seq) {
+	  return replay_ertr::now();
+	} else {
+	  return handler(
+	    journal_seq_t{seq.segment_seq, addr},
+	    base,
+	    delta);
+	}
       }),
     [this, seq](auto &dhandler) {
       return scan_segment(

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -71,11 +71,17 @@ public:
   using get_segment_ret = get_segment_ertr::future<segment_id_t>;
   virtual get_segment_ret get_segment() = 0;
 
-  /* TODO: we'll want to use this to propogate information about segment contents */
-  virtual void put_segment(segment_id_t segment) = 0;
+  virtual void close_segment(segment_id_t) {}
+
+  virtual void set_journal_segment(
+    segment_id_t segment,
+    segment_seq_t seq) {}
 
   virtual journal_seq_t get_journal_tail_target() const = 0;
   virtual void update_journal_tail_committed(journal_seq_t tail_committed) = 0;
+
+  virtual void init_mark_segment_closed(
+    segment_id_t segment, segment_seq_t seq) {}
 
   virtual ~JournalSegmentProvider() {}
 };

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -190,6 +190,28 @@ public:
 	       const delta_info_t&)>;
   replay_ret replay(delta_handler_t &&delta_handler);
 
+  /**
+   * scan_extents
+   *
+   * Scans records beginning at addr until the first record boundary after
+   * addr + bytes_to_read.
+   *
+   * Returns <next_addr, list<extent, extent_info>>
+   * next_addr will be P_ADDR_NULL if no further extents exist in segment.
+   * If addr.offset == 0, scan will adjust to first record in segment.
+   */
+  using scan_extents_ertr = SegmentManager::read_ertr;
+  using scan_extents_ret_bare = std::pair<
+    paddr_t,
+    std::list<std::pair<paddr_t, extent_info_t>>
+    >;
+  using scan_extents_ret = scan_extents_ertr::future<scan_extents_ret_bare>;
+  scan_extents_ret scan_extents(
+    paddr_t addr,
+    extent_len_t bytes_to_read
+  );
+
+
 private:
   const extent_len_t block_size;
   const extent_len_t max_record_length;
@@ -285,6 +307,8 @@ private:
    * addr+bytes_to_read invoking delta_handler and extent_info_handler
    * on deltas and extent_infos respectively.  deltas, extent_infos
    * will only be decoded if the corresponding handler is included.
+   *
+   * @return next address to read from, P_ADDR_NULL if segment complete
    */
   using scan_segment_ertr = SegmentManager::read_ertr;
   using scan_segment_ret = scan_segment_ertr::future<paddr_t>;

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -41,6 +41,7 @@ struct segment_header_t {
     DENC_FINISH(p);
   }
 };
+std::ostream &operator<<(std::ostream &out, const segment_header_t &header);
 
 struct record_header_t {
   // Fixed portion

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -102,6 +102,8 @@ public:
   virtual void init_mark_segment_closed(
     segment_id_t segment, segment_seq_t seq) {}
 
+  virtual segment_seq_t get_seq(segment_id_t id) { return 0; }
+
   virtual ~JournalSegmentProvider() {}
 };
 

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -61,6 +61,24 @@ struct record_header_t {
   }
 };
 
+struct extent_info_t {
+  extent_types_t type = extent_types_t::NONE;
+  laddr_t addr = L_ADDR_NULL;
+  extent_len_t len = 0;
+
+  extent_info_t() = default;
+  extent_info_t(const extent_t &et)
+    : type(et.type), addr(et.addr), len(et.bl.length()) {}
+
+  DENC(extent_info_t, v, p) {
+    DENC_START(1, 1, p);
+    denc(v.type, p);
+    denc(v.addr, p);
+    denc(v.len, p);
+    DENC_FINISH(p);
+  }
+};
+
 /**
  * Callback interface for managing available segments
  */
@@ -266,3 +284,4 @@ private:
 }
 WRITE_CLASS_DENC_BOUNDED(crimson::os::seastore::segment_header_t)
 WRITE_CLASS_DENC_BOUNDED(crimson::os::seastore::record_header_t)
+WRITE_CLASS_DENC_BOUNDED(crimson::os::seastore::extent_info_t)

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -150,9 +150,9 @@ public:
     return roll.safe_then(
       [this, rsize, record=std::move(record)]() mutable {
 	return write_record(rsize, std::move(record)
-	).safe_then([this](auto addr) {
+	).safe_then([this, rsize](auto addr) {
 	  return std::make_pair(
-	    addr.add_offset(block_size),
+	    addr.add_offset(rsize.mdlength),
 	    get_journal_seq(addr));
 	});
       });

--- a/src/crimson/os/seastore/journal.h
+++ b/src/crimson/os/seastore/journal.h
@@ -220,15 +220,13 @@ private:
   JournalSegmentProvider *segment_provider = nullptr;
   SegmentManager &segment_manager;
 
-  segment_seq_t current_journal_segment_seq = 0;
+  segment_seq_t next_journal_segment_seq = 0;
 
   SegmentRef current_journal_segment;
   segment_off_t written_to = 0;
 
-  segment_id_t next_journal_segment_seq = NULL_SEG_ID;
-
   journal_seq_t get_journal_seq(paddr_t addr) {
-    return journal_seq_t{current_journal_segment_seq, addr};
+    return journal_seq_t{next_journal_segment_seq-1, addr};
   }
 
   /// prepare segment for writes, writes out segment header

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -135,6 +135,29 @@ public:
     Transaction &t,
     CachedExtentRef e) = 0;
 
+  /**
+   * Calls f for each mapping in [begin, end)
+   */
+  using scan_mappings_ertr = SegmentManager::read_ertr;
+  using scan_mappings_ret = scan_mappings_ertr::future<>;
+  using scan_mappings_func_t = std::function<
+    void(laddr_t, paddr_t, extent_len_t)>;
+  virtual scan_mappings_ret scan_mappings(
+    Transaction &t,
+    laddr_t begin,
+    laddr_t end,
+    scan_mappings_func_t &&f) = 0;
+
+  /**
+   * Calls f for each mapped space usage in [begin, end)
+   */
+  using scan_mapped_space_ertr = SegmentManager::read_ertr;
+  using scan_mapped_space_ret = scan_mapped_space_ertr::future<>;
+  using scan_mapped_space_func_t = std::function<
+    void(paddr_t, extent_len_t)>;
+  virtual scan_mapped_space_ret scan_mapped_space(
+    Transaction &t,
+    scan_mapped_space_func_t &&f) = 0;
 
   /**
    * rewrite_extent
@@ -147,7 +170,6 @@ public:
   virtual rewrite_extent_ret rewrite_extent(
     Transaction &t,
     CachedExtentRef extent) = 0;
-
 
   virtual void add_pin(LBAPin &pin) = 0;
 

--- a/src/crimson/os/seastore/lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager.h
@@ -171,6 +171,26 @@ public:
     Transaction &t,
     CachedExtentRef extent) = 0;
 
+  /**
+   * get_physical_extent_if_live
+   *
+   * Returns extent at addr/laddr if still live (if laddr
+   * still points at addr).  Extent must be an internal, physical
+   * extent.
+   *
+   * Returns a null CachedExtentRef if extent is not live.
+   */
+  using get_physical_extent_if_live_ertr = crimson::errorator<
+    crimson::ct_error::input_output_error>;
+  using get_physical_extent_if_live_ret =
+    get_physical_extent_if_live_ertr::future<CachedExtentRef>;
+  virtual get_physical_extent_if_live_ret get_physical_extent_if_live(
+    Transaction &t,
+    extent_types_t type,
+    paddr_t addr,
+    laddr_t laddr,
+    segment_off_t len) = 0;
+
   virtual void add_pin(LBAPin &pin) = 0;
 
   virtual ~LBAManager() {}

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -293,6 +293,42 @@ BtreeLBAManager::init_cached_extent_ret BtreeLBAManager::init_cached_extent(
     });
 }
 
+BtreeLBAManager::scan_mappings_ret BtreeLBAManager::scan_mappings(
+  Transaction &t,
+  laddr_t begin,
+  laddr_t end,
+  scan_mappings_func_t &&f)
+{
+  return seastar::do_with(
+    std::move(f),
+    [=, &t](auto &f) {
+      return get_root(t).safe_then(
+	[=, &t, &f](LBANodeRef lbaroot) mutable {
+	  return lbaroot->scan_mappings(
+	    get_context(t),
+	    begin,
+	    end,
+	    f);
+	});
+    });
+}
+
+BtreeLBAManager::scan_mapped_space_ret BtreeLBAManager::scan_mapped_space(
+    Transaction &t,
+    scan_mapped_space_func_t &&f)
+{
+  return seastar::do_with(
+    std::move(f),
+    [=, &t](auto &f) {
+      return get_root(t).safe_then(
+	[=, &t, &f](LBANodeRef lbaroot) mutable {
+	  return lbaroot->scan_mapped_space(
+	    get_context(t),
+	    f);
+	});
+    });
+}
+
 BtreeLBAManager::rewrite_extent_ret BtreeLBAManager::rewrite_extent(
   Transaction &t,
   CachedExtentRef extent)

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -87,6 +87,16 @@ public:
     Transaction &t,
     CachedExtentRef e) final;
 
+  scan_mappings_ret scan_mappings(
+    Transaction &t,
+    laddr_t begin,
+    laddr_t end,
+    scan_mappings_func_t &&f) final;
+
+  scan_mapped_space_ret scan_mapped_space(
+    Transaction &t,
+    scan_mapped_space_func_t &&f) final;
+
   rewrite_extent_ret rewrite_extent(
     Transaction &t,
     CachedExtentRef extent);

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -102,7 +102,9 @@ public:
     CachedExtentRef extent);
 
   void add_pin(LBAPin &pin) final {
-    pin_set.add_pin(reinterpret_cast<BtreeLBAPin*>(&pin)->pin);
+    auto *bpin = reinterpret_cast<BtreeLBAPin*>(&pin);
+    pin_set.add_pin(bpin->pin);
+    bpin->parent = nullptr;
   }
 
 private:

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.h
@@ -101,6 +101,13 @@ public:
     Transaction &t,
     CachedExtentRef extent);
 
+  get_physical_extent_if_live_ret get_physical_extent_if_live(
+    Transaction &t,
+    extent_types_t type,
+    paddr_t addr,
+    laddr_t laddr,
+    segment_off_t len) final;
+
   void add_pin(LBAPin &pin) final {
     auto *bpin = reinterpret_cast<BtreeLBAPin*>(&pin);
     pin_set.add_pin(bpin->pin);

--- a/src/crimson/os/seastore/lba_manager/btree/btree_range_pin.h
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_range_pin.h
@@ -219,6 +219,15 @@ public:
 
 class BtreeLBAPin : public LBAPin {
   friend class BtreeLBAManager;
+
+  /**
+   * parent
+   *
+   * populated until link_extent is called to ensure cache residence
+   * until add_pin is called.
+   */
+  CachedExtentRef parent;
+
   paddr_t paddr;
   btree_range_pin_t pin;
 
@@ -226,9 +235,10 @@ public:
   BtreeLBAPin() = default;
 
   BtreeLBAPin(
+    CachedExtentRef parent,
     paddr_t paddr,
     lba_node_meta_t &&meta)
-    : paddr(paddr) {
+    : parent(parent), paddr(paddr) {
     pin.set_range(std::move(meta));
   }
 

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node.h
@@ -9,6 +9,7 @@
 
 #include "crimson/common/log.h"
 #include "crimson/os/seastore/lba_manager/btree/btree_range_pin.h"
+#include "crimson/os/seastore/lba_manager.h"
 
 namespace crimson::os::seastore::lba_manager::btree {
 
@@ -114,6 +115,27 @@ struct LBANode : CachedExtent {
     laddr_t min,
     laddr_t max,
     extent_len_t len) = 0;
+
+  /**
+   * scan_mappings
+   *
+   * Call f for all mappings in [begin, end)
+   */
+  using scan_mappings_ertr = LBAManager::scan_mappings_ertr;
+  using scan_mappings_ret = LBAManager::scan_mappings_ret;
+  using scan_mappings_func_t = LBAManager::scan_mappings_func_t;
+  virtual scan_mappings_ret scan_mappings(
+    op_context_t c,
+    laddr_t begin,
+    laddr_t end,
+    scan_mappings_func_t &f) = 0;
+
+  using scan_mapped_space_ertr = LBAManager::scan_mapped_space_ertr;
+  using scan_mapped_space_ret = LBAManager::scan_mapped_space_ret;
+  using scan_mapped_space_func_t = LBAManager::scan_mapped_space_func_t;
+  virtual scan_mapped_space_ret scan_mapped_space(
+    op_context_t c,
+    scan_mapped_space_func_t &f) = 0;
 
   /**
    * mutate_mapping

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.cc
@@ -435,6 +435,7 @@ LBALeafNode::lookup_range_ret LBALeafNode::lookup_range(
     auto begin = i->get_key();
     ret.emplace_back(
       std::make_unique<BtreeLBAPin>(
+	this,
 	val.paddr,
 	lba_node_meta_t{ begin, begin + val.len, 0}));
   }
@@ -473,6 +474,7 @@ LBALeafNode::insert_ret LBALeafNode::insert(
   return insert_ret(
     insert_ertr::ready_future_marker{},
     std::make_unique<BtreeLBAPin>(
+      this,
       val.paddr,
       lba_node_meta_t{ begin, begin + val.len, 0}));
 }

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.cc
@@ -76,7 +76,7 @@ LBAInternalNode::lookup_range_ret LBAInternalNode::lookup_range(
 				pin_list.begin(), pin_list.end());
 		});
 	  });
-    }).safe_then([result=std::move(result_up)] {
+    }).safe_then([result=std::move(result_up), ref=LBANodeRef(this)] {
       return lookup_range_ertr::make_ready_future<lba_pin_list_t>(
 	std::move(*result));
     });
@@ -250,7 +250,7 @@ LBAInternalNode::scan_mappings_ret LBAInternalNode::scan_mappings(
 	get_paddr()).safe_then([=, &f](auto child) {
 	  return child->scan_mappings(c, begin, end, f);
 	});
-    });
+    }).safe_then([ref=LBANodeRef(this)]{});
 }
 
 LBAInternalNode::scan_mapped_space_ret LBAInternalNode::scan_mapped_space(
@@ -269,7 +269,7 @@ LBAInternalNode::scan_mapped_space_ret LBAInternalNode::scan_mapped_space(
 	get_paddr()).safe_then([=, &f](auto child) {
 	  return child->scan_mapped_space(c, f);
 	});
-    });
+    }).safe_then([ref=LBANodeRef(this)]{});
 }
 
 

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.cc
@@ -436,7 +436,7 @@ LBALeafNode::lookup_range_ret LBALeafNode::lookup_range(
     ret.emplace_back(
       std::make_unique<BtreeLBAPin>(
 	this,
-	val.paddr,
+	val.paddr.maybe_relative_to(get_paddr()),
 	lba_node_meta_t{ begin, begin + val.len, 0}));
   }
   return lookup_range_ertr::make_ready_future<lba_pin_list_t>(
@@ -475,7 +475,7 @@ LBALeafNode::insert_ret LBALeafNode::insert(
     insert_ertr::ready_future_marker{},
     std::make_unique<BtreeLBAPin>(
       this,
-      val.paddr,
+      val.paddr.maybe_relative_to(get_paddr()),
       lba_node_meta_t{ begin, begin + val.len, 0}));
 }
 

--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.h
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.h
@@ -121,6 +121,16 @@ struct LBAInternalNode
     laddr_t max,
     extent_len_t len) final;
 
+  scan_mappings_ret scan_mappings(
+    op_context_t c,
+    laddr_t begin,
+    laddr_t end,
+    scan_mappings_func_t &f) final;
+
+  scan_mapped_space_ret scan_mapped_space(
+    op_context_t c,
+    scan_mapped_space_func_t &f) final;
+
   std::tuple<LBANodeRef, LBANodeRef, laddr_t>
   make_split_children(op_context_t c) final {
     auto left = c.cache.alloc_new_extent<LBAInternalNode>(
@@ -365,6 +375,16 @@ struct LBALeafNode
     laddr_t min,
     laddr_t max,
     extent_len_t len) final;
+
+  scan_mappings_ret scan_mappings(
+    op_context_t c,
+    laddr_t begin,
+    laddr_t end,
+    scan_mappings_func_t &f) final;
+
+  scan_mapped_space_ret scan_mapped_space(
+    op_context_t c,
+    scan_mapped_space_func_t &f) final;
 
   std::tuple<LBANodeRef, LBANodeRef, laddr_t>
   make_split_children(op_context_t c) final {

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -282,6 +282,8 @@ std::ostream &operator<<(std::ostream &out, extent_types_t t);
 
 /* description of a new physical extent */
 struct extent_t {
+  extent_types_t type;  ///< type of extent
+  laddr_t addr;         ///< laddr of extent (L_ADDR_NULL for non-logical)
   ceph::bufferlist bl;  ///< payload, bl.length() == length, aligned
 };
 

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -278,6 +278,17 @@ enum class extent_types_t : uint8_t {
   NONE = 0xFF
 };
 
+inline bool is_logical_type(extent_types_t type) {
+  switch (type) {
+  case extent_types_t::ROOT:
+  case extent_types_t::LADDR_INTERNAL:
+  case extent_types_t::LADDR_LEAF:
+    return false;
+  default:
+    return true;
+  }
+}
+
 std::ostream &operator<<(std::ostream &out, extent_types_t t);
 
 /* description of a new physical extent */

--- a/src/crimson/os/seastore/segment_cleaner.h
+++ b/src/crimson/os/seastore/segment_cleaner.h
@@ -15,12 +15,197 @@
 namespace crimson::os::seastore {
 class Transaction;
 
+struct segment_info_t {
+  Segment::segment_state_t state = Segment::segment_state_t::EMPTY;
+
+  // Will be non-null for any segments in the current journal
+  segment_seq_t journal_segment_seq = NULL_SEG_SEQ;
+
+  bool is_empty() const {
+    return state == Segment::segment_state_t::EMPTY;
+  }
+
+  bool is_closed() const {
+    return state == Segment::segment_state_t::CLOSED;
+  }
+
+  bool is_open() const {
+    return state == Segment::segment_state_t::OPEN;
+  }
+};
+
+class SpaceTrackerI {
+public:
+  virtual int64_t allocate(
+    segment_id_t segment,
+    segment_off_t offset,
+    extent_len_t len) = 0;
+
+  virtual int64_t release(
+    segment_id_t segment,
+    segment_off_t offset,
+    extent_len_t len) = 0;
+
+  virtual int64_t get_usage(
+    segment_id_t segment) const = 0;
+
+  virtual bool equals(const SpaceTrackerI &other) const = 0;
+
+  virtual std::unique_ptr<SpaceTrackerI> make_empty() const = 0;
+
+  virtual void dump_usage(segment_id_t) const = 0;
+
+  virtual void reset() = 0;
+
+  virtual ~SpaceTrackerI() = default;
+};
+using SpaceTrackerIRef = std::unique_ptr<SpaceTrackerI>;
+
+class SpaceTrackerSimple : public SpaceTrackerI {
+  // Tracks live space for each segment
+  std::vector<int64_t> live_bytes_by_segment;
+
+  int64_t update_usage(segment_id_t segment, int64_t delta) {
+    assert(segment < live_bytes_by_segment.size());
+    live_bytes_by_segment[segment] += delta;
+    assert(live_bytes_by_segment[segment] >= 0);
+    return live_bytes_by_segment[segment];
+  }
+public:
+  SpaceTrackerSimple(size_t num_segments)
+    : live_bytes_by_segment(num_segments, 0) {}
+
+  int64_t allocate(
+    segment_id_t segment,
+    segment_off_t offset,
+    extent_len_t len) final {
+    return update_usage(segment, len);
+  }
+
+  int64_t release(
+    segment_id_t segment,
+    segment_off_t offset,
+    extent_len_t len) final {
+    return update_usage(segment, -len);
+  }
+
+  int64_t get_usage(segment_id_t segment) const final {
+    assert(segment < live_bytes_by_segment.size());
+    return live_bytes_by_segment[segment];
+  }
+
+  void dump_usage(segment_id_t) const final {}
+
+  void reset() final {
+    for (auto &i: live_bytes_by_segment)
+      i = 0;
+  }
+
+  SpaceTrackerIRef make_empty() const final {
+    return SpaceTrackerIRef(
+      new SpaceTrackerSimple(live_bytes_by_segment.size()));
+  }
+
+  bool equals(const SpaceTrackerI &other) const;
+};
+
+class SpaceTrackerDetailed : public SpaceTrackerI {
+  class SegmentMap {
+    int64_t used = 0;
+    std::vector<bool> bitmap;
+
+  public:
+    SegmentMap(size_t blocks) : bitmap(blocks, false) {}
+
+    int64_t update_usage(int64_t delta) {
+      used += delta;
+      return used;
+    }
+
+    int64_t allocate(
+      segment_id_t segment,
+      segment_off_t offset,
+      extent_len_t len,
+      const extent_len_t block_size);
+
+    int64_t release(
+      segment_id_t segment,
+      segment_off_t offset,
+      extent_len_t len,
+      const extent_len_t block_size);
+
+    int64_t get_usage() const {
+      return used;
+    }
+
+    void dump_usage(extent_len_t block_size) const;
+
+    void reset() {
+      used = 0;
+      for (auto &&i: bitmap) {
+	i = false;
+      }
+    }
+  };
+  const size_t block_size;
+  const size_t segment_size;
+
+  // Tracks live space for each segment
+  std::vector<SegmentMap> segment_usage;
+
+public:
+  SpaceTrackerDetailed(size_t num_segments, size_t segment_size, size_t block_size)
+    : block_size(block_size),
+      segment_size(segment_size),
+      segment_usage(num_segments, segment_size / block_size) {}
+
+  int64_t allocate(
+    segment_id_t segment,
+    segment_off_t offset,
+    extent_len_t len) final {
+    assert(segment < segment_usage.size());
+    return segment_usage[segment].allocate(segment, offset, len, block_size);
+  }
+
+  int64_t release(
+    segment_id_t segment,
+    segment_off_t offset,
+    extent_len_t len) final {
+    assert(segment < segment_usage.size());
+    return segment_usage[segment].release(segment, offset, len, block_size);
+  }
+
+  int64_t get_usage(segment_id_t segment) const final {
+    assert(segment < segment_usage.size());
+    return segment_usage[segment].get_usage();
+  }
+
+  void dump_usage(segment_id_t seg) const final;
+
+  void reset() final {
+    for (auto &i: segment_usage)
+      i.reset();
+  }
+
+  SpaceTrackerIRef make_empty() const final {
+    return SpaceTrackerIRef(
+      new SpaceTrackerDetailed(
+	segment_usage.size(),
+	segment_size,
+	block_size));
+  }
+
+  bool equals(const SpaceTrackerI &other) const;
+};
+
+
 class SegmentCleaner : public JournalSegmentProvider {
 public:
   /// Config
   struct config_t {
     size_t num_segments = 0;
     size_t segment_size = 0;
+    size_t block_size = 0;
     size_t target_journal_segments = 0;
     size_t max_journal_segments = 0;
 
@@ -29,6 +214,7 @@ public:
       return config_t{
 	manager.get_num_segments(),
 	static_cast<size_t>(manager.get_segment_size()),
+	(size_t)manager.get_block_size(),
 	2,
 	4};
     }
@@ -67,8 +253,13 @@ public:
   };
 
 private:
-  segment_id_t next = 0;
   const config_t config;
+
+  SpaceTrackerIRef space_tracker;
+  std::vector<segment_info_t> segments;
+  size_t empty_segments;
+  int64_t used_bytes = 0;
+  bool init_complete = false;
 
   journal_seq_t journal_tail_target;
   journal_seq_t journal_tail_committed;
@@ -77,21 +268,29 @@ private:
   ExtentCallbackInterface *ecb = nullptr;
 
 public:
-  SegmentCleaner(config_t config)
-    : config(config) {}
+  SegmentCleaner(config_t config, bool detailed = false)
+    : config(config),
+      space_tracker(
+	detailed ?
+	(SpaceTrackerI*)new SpaceTrackerDetailed(
+	  config.num_segments,
+	  config.segment_size,
+	  config.block_size) :
+	(SpaceTrackerI*)new SpaceTrackerSimple(
+	  config.num_segments)),
+      segments(config.num_segments),
+      empty_segments(config.num_segments) {}
 
   get_segment_ret get_segment() final;
 
-  // hack for testing until we get real space handling
-  void set_next(segment_id_t _next) {
-    next = _next;
-  }
-  segment_id_t get_next() const {
-    return next;
-  }
+  void close_segment(segment_id_t segment) final;
 
-
-  void put_segment(segment_id_t segment) final;
+  void set_journal_segment(
+    segment_id_t segment, segment_seq_t seq) final {
+    assert(segment < segments.size());
+    segments[segment].journal_segment_seq = seq;
+    assert(segments[segment].is_open());
+  }
 
   journal_seq_t get_journal_tail_target() const final {
     return journal_tail_target;
@@ -110,8 +309,64 @@ public:
     journal_head = head;
   }
 
+  void init_mark_segment_closed(segment_id_t segment, segment_seq_t seq) final {
+    crimson::get_logger(ceph_subsys_filestore).debug(
+      "SegmentCleaner::init_mark_segment_closed: segment {}, seq {}",
+      segment,
+      seq);
+    mark_closed(segment);
+    segments[segment].journal_segment_seq = seq;
+  }
+
+  void mark_space_used(
+    paddr_t addr,
+    extent_len_t len,
+    bool init_scan = false) {
+    assert(addr.segment < segments.size());
+
+    if (!init_scan && !init_complete)
+      return;
+
+    if (!init_scan) {
+      assert(segments[addr.segment].state == Segment::segment_state_t::OPEN);
+    }
+
+    used_bytes += len;
+    auto ret = space_tracker->allocate(
+      addr.segment,
+      addr.offset,
+      len);
+    assert(ret > 0);
+  }
+
+  void mark_space_free(
+    paddr_t addr,
+    extent_len_t len) {
+    if (!init_complete)
+      return;
+
+    used_bytes -= len;
+    assert(addr.segment < segments.size());
+
+    auto ret = space_tracker->release(
+      addr.segment,
+      addr.offset,
+      len);
+    assert(ret >= 0);
+  }
+
+  SpaceTrackerIRef get_empty_space_tracker() const {
+    return space_tracker->make_empty();
+  }
+
+  void complete_init() { init_complete = true; }
+
   void set_extent_callback(ExtentCallbackInterface *cb) {
     ecb = cb;
+  }
+
+  bool debug_check_space(const SpaceTrackerI &tracker) {
+    return space_tracker->equals(tracker);
   }
 
   /**
@@ -147,6 +402,9 @@ public:
     Transaction &t);
 
 private:
+
+  // journal status helpers
+
   journal_seq_t get_dirty_tail() const {
     auto ret = journal_head;
     ret.segment_seq -= std::min(
@@ -161,6 +419,40 @@ private:
       static_cast<size_t>(ret.segment_seq),
       config.max_journal_segments);
     return ret;
+  }
+  void mark_closed(segment_id_t segment) {
+    assert(segments.size() > segment);
+    if (init_complete) {
+      assert(segments[segment].is_open());
+    } else {
+      assert(segments[segment].is_empty());
+      assert(empty_segments > 0);
+      --empty_segments;
+    }
+    crimson::get_logger(ceph_subsys_filestore).debug(
+      "mark_closed: empty_segments: {}",
+      empty_segments);
+    segments[segment].state = Segment::segment_state_t::CLOSED;
+  }
+
+  void mark_empty(segment_id_t segment) {
+    assert(segments.size() > segment);
+    assert(segments[segment].is_closed());
+    assert(segments.size() > empty_segments);
+    ++empty_segments;
+    if (space_tracker->get_usage(segment) != 0) {
+      space_tracker->dump_usage(segment);
+      assert(space_tracker->get_usage(segment) == 0);
+    }
+    segments[segment].state = Segment::segment_state_t::EMPTY;
+  }
+
+  void mark_open(segment_id_t segment) {
+    assert(segments.size() > segment);
+    assert(segments[segment].is_empty());
+    assert(empty_segments > 0);
+    --empty_segments;
+    segments[segment].state = Segment::segment_state_t::OPEN;
   }
 };
 

--- a/src/crimson/os/seastore/segment_cleaner.h
+++ b/src/crimson/os/seastore/segment_cleaner.h
@@ -250,6 +250,26 @@ public:
     virtual rewrite_extent_ret rewrite_extent(
       Transaction &t,
       CachedExtentRef extent) = 0;
+
+    /**
+     * get_extent_if_live
+     *
+     * Returns extent at specified location if still referenced by
+     * lba_manager and not removed by t.
+     *
+     * See TransactionManager::get_extent_if_live and
+     * LBAManager::get_physical_extent_if_live.
+     */
+    using get_extent_if_live_ertr = crimson::errorator<
+      crimson::ct_error::input_output_error>;
+    using get_extent_if_live_ret = get_extent_if_live_ertr::future<
+      CachedExtentRef>;
+    virtual get_extent_if_live_ret get_extent_if_live(
+      Transaction &t,
+      extent_types_t type,
+      paddr_t addr,
+      laddr_t laddr,
+      segment_off_t len) = 0;
   };
 
 private:

--- a/src/crimson/os/seastore/segment_manager.h
+++ b/src/crimson/os/seastore/segment_manager.h
@@ -21,6 +21,12 @@ class Segment : public boost::intrusive_ref_counter<
   boost::thread_unsafe_counter>{
 public:
 
+  enum class segment_state_t {
+    EMPTY,
+    OPEN,
+    CLOSED
+  };
+
   /**
    * get_segment_id
    */

--- a/src/crimson/os/seastore/segment_manager/ephemeral.cc
+++ b/src/crimson/os/seastore/segment_manager/ephemeral.cc
@@ -116,6 +116,14 @@ EphemeralSegmentManager::~EphemeralSegmentManager()
   }
 }
 
+void EphemeralSegmentManager::remount()
+{
+  for (auto &i : segment_state) {
+    if (i == Segment::segment_state_t::OPEN)
+      i = Segment::segment_state_t::CLOSED;
+  }
+}
+
 SegmentManager::open_ertr::future<SegmentRef> EphemeralSegmentManager::open(
   segment_id_t id)
 {

--- a/src/crimson/os/seastore/segment_manager/ephemeral.h
+++ b/src/crimson/os/seastore/segment_manager/ephemeral.h
@@ -33,6 +33,7 @@ public:
 
 class EphemeralSegmentManager final : public SegmentManager {
   friend class EphemeralSegment;
+  using segment_state_t = Segment::segment_state_t;
 
   const ephemeral_config_t config;
 
@@ -40,11 +41,6 @@ class EphemeralSegmentManager final : public SegmentManager {
     return (addr.segment * config.segment_size) + addr.offset;
   }
 
-  enum class segment_state_t {
-    EMPTY,
-    OPEN,
-    CLOSED
-  };
   std::vector<segment_state_t> segment_state;
 
   char *buffer = nullptr;

--- a/src/crimson/os/seastore/segment_manager/ephemeral.h
+++ b/src/crimson/os/seastore/segment_manager/ephemeral.h
@@ -72,6 +72,8 @@ public:
     return config.segment_size;
   }
 
+  void remount();
+
   // public so tests can bypass segment interface when simpler
   Segment::write_ertr::future<> segment_write(
     paddr_t addr,

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -44,6 +44,7 @@ public:
   }
 
   void add_to_retired_set(CachedExtentRef ref) {
+    ceph_assert(!is_weak());
     if (!ref->is_initial_pending()) {
       // && retired_set.count(ref->get_paddr()) == 0
       // If it's already in the set, insert here will be a noop,
@@ -58,11 +59,14 @@ public:
   }
 
   void add_to_read_set(CachedExtentRef ref) {
+    if (is_weak()) return;
+
     ceph_assert(read_set.count(ref) == 0);
     read_set.insert(ref);
   }
 
   void add_fresh_extent(CachedExtentRef ref) {
+    ceph_assert(!is_weak());
     fresh_block_list.push_back(ref);
     ref->set_paddr(make_record_relative_paddr(offset));
     offset += ref->get_length();
@@ -70,6 +74,7 @@ public:
   }
 
   void add_mutated_extent(CachedExtentRef ref) {
+    ceph_assert(!is_weak());
     mutated_block_list.push_back(ref);
     write_set.insert(*ref);
   }
@@ -86,8 +91,20 @@ public:
     return retired_set;
   }
 
+  bool is_weak() const {
+    return weak;
+  }
+
 private:
   friend class Cache;
+  friend Ref make_transaction();
+  friend Ref make_weak_transaction();
+
+  /**
+   * If set, *this may not be used to perform writes and will not provide
+   * consistentency allowing operations using to avoid maintaining a read_set.
+   */
+  const bool weak;
 
   RootBlockRef root;        ///< ref to root if read or written by transaction
 
@@ -100,11 +117,17 @@ private:
   std::list<CachedExtentRef> mutated_block_list; ///< list of mutated blocks
 
   pextent_set_t retired_set; ///< list of extents mutated by this transaction
+
+  Transaction(bool weak) : weak(weak) {}
 };
 using TransactionRef = Transaction::Ref;
 
 inline TransactionRef make_transaction() {
-  return std::make_unique<Transaction>();
+  return std::unique_ptr<Transaction>(new Transaction(false));
+}
+
+inline TransactionRef make_weak_transaction() {
+  return std::unique_ptr<Transaction>(new Transaction(true));
 }
 
 }

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -79,6 +79,15 @@ public:
     write_set.insert(*ref);
   }
 
+  void mark_segment_to_release(segment_id_t segment) {
+    assert(to_release == NULL_SEG_ID);
+    to_release = segment;
+  }
+
+  segment_id_t get_segment_to_release() const {
+    return to_release;
+  }
+
   const auto &get_fresh_block_list() {
     return fresh_block_list;
   }
@@ -117,6 +126,9 @@ private:
   std::list<CachedExtentRef> mutated_block_list; ///< list of mutated blocks
 
   pextent_set_t retired_set; ///< list of extents mutated by this transaction
+
+  ///< if != NULL_SEG_ID, release this segment after completion
+  segment_id_t to_release = NULL_SEG_ID;
 
   Transaction(bool weak) : weak(weak) {}
 };

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -17,21 +17,8 @@ namespace crimson::os::seastore {
  * Representation of in-progress mutation. Used exclusively through Cache methods.
  */
 class Transaction {
-  friend class Cache;
-
-  RootBlockRef root;        ///< ref to root if read or written by transaction
-
-  segment_off_t offset = 0; ///< relative offset of next block
-
-  pextent_set_t read_set;   ///< set of extents read by paddr
-  ExtentIndex write_set;    ///< set of extents written by paddr
-
-  std::list<CachedExtentRef> fresh_block_list;   ///< list of fresh blocks
-  std::list<CachedExtentRef> mutated_block_list; ///< list of mutated blocks
-
-  pextent_set_t retired_set; ///< list of extents mutated by this transaction
-
 public:
+  using Ref = std::unique_ptr<Transaction>;
   enum class get_extent_ret {
     PRESENT,
     ABSENT,
@@ -98,8 +85,23 @@ public:
   const auto &get_retired_set() {
     return retired_set;
   }
+
+private:
+  friend class Cache;
+
+  RootBlockRef root;        ///< ref to root if read or written by transaction
+
+  segment_off_t offset = 0; ///< relative offset of next block
+
+  pextent_set_t read_set;   ///< set of extents read by paddr
+  ExtentIndex write_set;    ///< set of extents written by paddr
+
+  std::list<CachedExtentRef> fresh_block_list;   ///< list of fresh blocks
+  std::list<CachedExtentRef> mutated_block_list; ///< list of mutated blocks
+
+  pextent_set_t retired_set; ///< list of extents mutated by this transaction
 };
-using TransactionRef = std::unique_ptr<Transaction>;
+using TransactionRef = Transaction::Ref;
 
 inline TransactionRef make_transaction() {
   return std::make_unique<Transaction>();

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -233,6 +233,73 @@ TransactionManager::rewrite_extent_ret TransactionManager::rewrite_extent(
   return lba_manager.rewrite_extent(t, extent);
 }
 
+TransactionManager::get_extent_if_live_ret TransactionManager::get_extent_if_live(
+  Transaction &t,
+  extent_types_t type,
+  paddr_t addr,
+  laddr_t laddr,
+  segment_off_t len)
+{
+  CachedExtentRef ret;
+  auto status = cache.get_extent_if_cached(t, addr, &ret);
+  if (status != Transaction::get_extent_ret::ABSENT) {
+    return get_extent_if_live_ret(
+      get_extent_if_live_ertr::ready_future_marker{},
+      ret);
+  }
+
+  if (is_logical_type(type)) {
+    return lba_manager.get_mapping(
+      t,
+      laddr,
+      len).safe_then([=, &t](lba_pin_list_t pins) {
+	ceph_assert(pins.size() <= 1);
+	if (pins.empty()) {
+	  return get_extent_if_live_ret(
+	    get_extent_if_live_ertr::ready_future_marker{},
+	    CachedExtentRef());
+	}
+
+	auto pin = std::move(pins.front());
+	pins.pop_front();
+	ceph_assert(pin->get_laddr() == laddr);
+	ceph_assert(pin->get_length() == (extent_len_t)len);
+	if (pin->get_paddr() == addr) {
+	  return cache.get_extent_by_type(
+	    t,
+	    type,
+	    addr,
+	    laddr,
+	    len).safe_then(
+	      [this, &t, pin=std::move(pin)](CachedExtentRef ret) mutable {
+		auto lref = ret->cast<LogicalCachedExtent>();
+		if (!lref->has_pin()) {
+		  lref->set_pin(std::move(pin));
+		  lba_manager.add_pin(lref->get_pin());
+		}
+		return get_extent_if_live_ret(
+		  get_extent_if_live_ertr::ready_future_marker{},
+		  ret);
+	      });
+	} else {
+	  return get_extent_if_live_ret(
+	    get_extent_if_live_ertr::ready_future_marker{},
+	    CachedExtentRef());
+	}
+      });
+  } else {
+    logger().debug(
+      "TransactionManager::get_extent_if_live: non-logical extent {}",
+      addr);
+    return lba_manager.get_physical_extent_if_live(
+      t,
+      type,
+      addr,
+      laddr,
+      len);
+  }
+}
+
 TransactionManager::~TransactionManager() {}
 
 }

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -67,6 +67,11 @@ public:
     return make_transaction();
   }
 
+  /// Creates weak transaction
+  TransactionRef create_weak_transaction() {
+    return make_weak_transaction();
+  }
+
   /**
    * Read extents corresponding to specified lba range
    */

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -227,6 +227,14 @@ public:
     Transaction &t,
     CachedExtentRef extent) final;
 
+  using SegmentCleaner::ExtentCallbackInterface::get_extent_if_live_ret;
+  get_extent_if_live_ret get_extent_if_live(
+    Transaction &t,
+    extent_types_t type,
+    paddr_t addr,
+    laddr_t laddr,
+    segment_off_t len) final;
+
   ~TransactionManager();
 
 private:

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -235,6 +235,21 @@ public:
     laddr_t laddr,
     segment_off_t len) final;
 
+  using scan_extents_ret =
+    SegmentCleaner::ExtentCallbackInterface::scan_extents_ret;
+  scan_extents_ret scan_extents(
+    paddr_t addr,
+    extent_len_t bytes_to_read) final {
+    return journal.scan_extents(addr, bytes_to_read);
+  }
+
+  using release_segment_ret =
+    SegmentCleaner::ExtentCallbackInterface::release_segment_ret;
+  release_segment_ret release_segment(
+    segment_id_t id) {
+    return segment_manager.release(id);
+  }
+
   ~TransactionManager();
 
 private:

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -148,7 +148,7 @@ struct btree_lba_manager_test :
 	bottom->first + bottom->second.len <= addr)
       ++bottom;
 
-    auto top = t.mappings.upper_bound(addr + len);
+    auto top = t.mappings.lower_bound(addr + len);
     return std::make_pair(
       bottom,
       top

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -261,6 +261,17 @@ struct btree_lba_manager_test :
       EXPECT_EQ(i.first, ret->get_laddr());
       EXPECT_EQ(i.second.len, ret->get_length());
     }
+    lba_manager->scan_mappings(
+      *t.t,
+      0,
+      L_ADDR_MAX,
+      [iter=t.mappings.begin(), &t](auto l, auto p, auto len) mutable {
+	EXPECT_NE(iter, t.mappings.end());
+	EXPECT_EQ(l, iter->first);
+	EXPECT_EQ(p, iter->second.addr);
+	EXPECT_EQ(len, iter->second.len);
+	++iter;
+      }).unsafe_get();
   }
 };
 

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -50,10 +50,6 @@ struct btree_lba_manager_test :
       next++);
   }
 
-  void put_segment(segment_id_t segment) final {
-    return;
-  }
-
   journal_seq_t get_journal_tail_target() const final { return journal_seq_t{}; }
   void update_journal_tail_committed(journal_seq_t committed) final {}
 

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -131,6 +131,14 @@ struct btree_lba_manager_test :
     return t;
   }
 
+  auto create_weak_transaction() {
+    auto t = test_transaction_t{
+      make_weak_transaction(),
+      test_lba_mappings
+    };
+    return t;
+  }
+
   void submit_test_transaction(test_transaction_t t) {
     submit_transaction(std::move(t.t)).get0();
     test_lba_mappings.swap(t.mappings);

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -85,10 +85,6 @@ struct journal_test_t : seastar_test_suite_t, JournalSegmentProvider {
       next++);
   }
 
-  void put_segment(segment_id_t segment) final {
-    return;
-  }
-
   journal_seq_t get_journal_tail_target() const final { return journal_seq_t{}; }
   void update_journal_tail_committed(journal_seq_t paddr) final {}
 

--- a/src/test/crimson/seastore/test_seastore_journal.cc
+++ b/src/test/crimson/seastore/test_seastore_journal.cc
@@ -168,7 +168,7 @@ struct journal_test_t : seastar_test_suite_t, JournalSegmentProvider {
     char contents = distribution(generator);
     bufferlist bl;
     bl.append(buffer::ptr(buffer::create(blocks * block_size, contents)));
-    return extent_t{bl};
+    return extent_t{extent_types_t::TEST_BLOCK, L_ADDR_NULL, bl};
   }
 
   delta_info_t generate_delta(size_t bytes) {

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -166,6 +166,10 @@ struct transaction_manager_test_t : public seastar_test_suite_t {
     return { tm->create_transaction(), test_mappings };
   }
 
+  test_transaction_t create_weak_transaction() {
+    return { tm->create_weak_transaction(), test_mappings };
+  }
+
   TestBlockRef alloc_extent(
     test_transaction_t &t,
     laddr_t hint,
@@ -203,7 +207,7 @@ struct transaction_manager_test_t : public seastar_test_suite_t {
   }
 
   void check_mappings() {
-    auto t = create_transaction();
+    auto t = create_weak_transaction();
     check_mappings(t);
   }
 
@@ -264,7 +268,7 @@ struct transaction_manager_test_t : public seastar_test_suite_t {
       auto ext = get_extent(t, i.first, i.second.desc.len);
       EXPECT_EQ(i.second, ext->get_desc());
     }
-    auto lt = create_lazy_transaction();
+    auto lt = create_weak_transaction();
     lba_manager->scan_mappings(
       *lt.t,
       0,

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -101,6 +101,12 @@ struct transaction_manager_test_t : public seastar_test_suite_t {
     return segment_manager->init().safe_then([this] {
       return tm->mkfs();
     }).safe_then([this] {
+      return tm->close();
+    }).safe_then([this] {
+      destroy();
+      static_cast<segment_manager::EphemeralSegmentManager*>(
+	&*segment_manager)->remount();
+      init();
       return tm->mount();
     }).handle_error(
       crimson::ct_error::all_same_way([] {

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -264,6 +264,16 @@ struct transaction_manager_test_t : public seastar_test_suite_t {
       auto ext = get_extent(t, i.first, i.second.desc.len);
       EXPECT_EQ(i.second, ext->get_desc());
     }
+    auto lt = create_lazy_transaction();
+    lba_manager->scan_mappings(
+      *lt.t,
+      0,
+      L_ADDR_MAX,
+      [iter=lt.mappings.begin(), &lt](auto l, auto p, auto len) mutable {
+	EXPECT_NE(iter, lt.mappings.end());
+	EXPECT_EQ(l, iter->first);
+	++iter;
+      }).unsafe_get0();
   }
 
   void submit_transaction(test_transaction_t t) {

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -8,6 +8,7 @@
 #include "crimson/os/seastore/segment_cleaner.h"
 #include "crimson/os/seastore/cache.h"
 #include "crimson/os/seastore/transaction_manager.h"
+#include "crimson/os/seastore/segment_manager/ephemeral.h"
 #include "crimson/os/seastore/segment_manager.h"
 
 #include "test/crimson/seastore/test_block.h"
@@ -199,10 +200,9 @@ struct transaction_manager_test_t : public seastar_test_suite_t {
 
   void replay() {
     tm->close().unsafe_get();
-    auto next = segment_cleaner->get_next();
     destroy();
+    static_cast<segment_manager::EphemeralSegmentManager*>(&*segment_manager)->remount();
     init();
-    segment_cleaner->set_next(next);
     tm->mount().unsafe_get();
   }
 

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -359,6 +359,37 @@ TEST_F(transaction_manager_test_t, create_remove_same_transaction)
   });
 }
 
+TEST_F(transaction_manager_test_t, split_merge_read_same_transaction)
+{
+  constexpr laddr_t SIZE = 4096;
+  run_async([this] {
+    {
+      auto t = create_transaction();
+      for (unsigned i = 0; i < 300; ++i) {
+	auto extent = alloc_extent(
+	  t,
+	  laddr_t(i * SIZE),
+	  SIZE);
+      }
+      check_mappings(t);
+      submit_transaction(std::move(t));
+      check();
+    }
+    {
+      auto t = create_transaction();
+      for (unsigned i = 0; i < 240; ++i) {
+	dec_ref(
+	  t,
+	  laddr_t(i * SIZE));
+      }
+      check_mappings(t);
+      submit_transaction(std::move(t));
+      check();
+    }
+  });
+}
+
+
 TEST_F(transaction_manager_test_t, inc_dec_ref)
 {
   constexpr laddr_t SIZE = 4096;

--- a/src/test/crimson/seastore/transaction_manager_test_state.h
+++ b/src/test/crimson/seastore/transaction_manager_test_state.h
@@ -1,0 +1,75 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <random>
+
+#include "crimson/os/seastore/segment_cleaner.h"
+#include "crimson/os/seastore/cache.h"
+#include "crimson/os/seastore/transaction_manager.h"
+#include "crimson/os/seastore/segment_manager/ephemeral.h"
+#include "crimson/os/seastore/segment_manager.h"
+
+using namespace crimson;
+using namespace crimson::os;
+using namespace crimson::os::seastore;
+
+class TMTestState {
+protected:
+  std::unique_ptr<segment_manager::EphemeralSegmentManager> segment_manager;
+  std::unique_ptr<SegmentCleaner> segment_cleaner;
+  std::unique_ptr<Journal> journal;
+  std::unique_ptr<Cache> cache;
+  LBAManagerRef lba_manager;
+  std::unique_ptr<TransactionManager> tm;
+
+  TMTestState()
+    : segment_manager(
+      (segment_manager::EphemeralSegmentManager*)create_ephemeral(
+	segment_manager::DEFAULT_TEST_EPHEMERAL).release()) {
+    init();
+  }
+
+  void init() {
+    segment_cleaner = std::make_unique<SegmentCleaner>(
+      SegmentCleaner::config_t::default_from_segment_manager(
+	*segment_manager),
+      true);
+    journal = std::make_unique<Journal>(*segment_manager);
+    cache = std::make_unique<Cache>(*segment_manager);
+    lba_manager = lba_manager::create_lba_manager(*segment_manager, *cache);
+    tm = std::make_unique<TransactionManager>(
+      *segment_manager, *segment_cleaner, *journal, *cache, *lba_manager);
+
+    journal->set_segment_provider(&*segment_cleaner);
+    segment_cleaner->set_extent_callback(&*tm);
+  }
+
+  void destroy() {
+    tm.reset();
+    lba_manager.reset();
+    cache.reset();
+    journal.reset();
+    segment_cleaner.reset();
+  }
+
+  seastar::future<> tm_setup() {
+    return segment_manager->init().safe_then([this] {
+      return tm->mkfs();
+    }).safe_then([this] {
+      return tm->close();
+    }).safe_then([this] {
+      destroy();
+      static_cast<segment_manager::EphemeralSegmentManager*>(
+	&*segment_manager)->remount();
+      init();
+      return tm->mount();
+    }).handle_error(crimson::ct_error::assert_all{});
+  }
+
+  seastar::future<> tm_teardown() {
+    return tm->close(
+    ).handle_error(crimson::ct_error::assert_all{});
+  }
+};


### PR DESCRIPTION
Follow up to https://github.com/ceph/ceph/pull/36779.

Adds initial inline gc support to seastore.