### PR TITLE
test/docker-test: Allow persistent containers

### DIFF
--- a/src/test/docker-test-helper.sh
+++ b/src/test/docker-test-helper.sh
@@ -27,6 +27,9 @@ function setup_container() {
     local dockercmd=$3
     local opts="$4"
 
+    # rm not valid here
+    opts=${opts//' --rm'};
+
     local image=$(get_image_name $os_type $os_version)
     local build=true
     if $dockercmd images $image | grep --quiet "^$image " ; then
@@ -123,7 +126,7 @@ function run_in_docker() {
     mkdir -p $HOME/.ccache
     ccache="--volume $HOME/.ccache:$HOME/.ccache"
     user="--user $USER"
-    local cmd="$dockercmd run $opts --rm --name $image --privileged $ccache"
+    local cmd="$dockercmd run $opts --name $image --privileged $ccache"
     cmd+=" --volume $downstream:$downstream"
     cmd+=" --volume $upstream:$upstream"
     if test "$dockercmd" = "podman" ; then
@@ -131,8 +134,10 @@ function run_in_docker() {
     fi
     local status=0
     if test "$script" = "SHELL" ; then
+	echo Running: $cmd --tty --interactive --workdir $downstream $user $image bash
         $cmd --tty --interactive --workdir $downstream $user $image bash
     else
+	echo Running: $cmd --workdir $downstream $user $image "$@"
         if ! $cmd --workdir $downstream $user $image "$@" ; then
             status=1
         fi
@@ -169,8 +174,9 @@ $0 [options] command args ...
 
    [--shell]              run an interactive shell in the container
    [--remove-all]         remove the container and the image for the specified types+versions
+   [--no-rm]               don't remove the container when finished
 
-   [--opts options]       run the contain with 'options'
+   [--opts options]       run the container with 'options'
 
 docker-test.sh must be run from a Ceph clone and it will run the
 command in a container, using a copy of the clone so that long running
@@ -256,7 +262,7 @@ function main_docker() {
     fi
 
     local temp
-    temp=$(getopt -o scht:v:o:a:r: --long remove-all,verbose,shell,help,os-type:,os-version:,opts:,all:,ref: -n $0 -- "$@") || return 1
+    temp=$(getopt -o scht:v:o:a:r: --long remove-all,verbose,shell,no-rm,help,os-type:,os-version:,opts:,all:,ref: -n $0 -- "$@") || return 1
 
     eval set -- "$temp"
 
@@ -267,6 +273,7 @@ function main_docker() {
     local shell=false
     local opts
     local ref=$(git rev-parse HEAD)
+    local no-rm=false
 
     while true ; do
 	case "$1" in
@@ -307,6 +314,10 @@ function main_docker() {
                 ref="$2"
                 shift 2
                 ;;
+	    --no-rm)
+		no-rm=true
+		shift
+		;;
 	    --)
                 shift
                 break
@@ -324,6 +335,10 @@ function main_docker() {
 
     declare -A os_type2versions
     eval os_type2versions="$all"
+
+    if ! $no-rm ; then
+        opts+=" --rm"
+    fi
 
     for os_type in ${!os_type2versions[@]} ; do
         for os_version in ${os_type2versions[$os_type]} ; do


### PR DESCRIPTION
It can be useful to allow the container to persist for debugging
purposes. Also show the command used to create the container.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
