### PR TITLE
octopus: rbd: make common options override krbd-specific options

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -762,7 +762,7 @@ Per client instance `rbd device map` options:
 
 Per mapping (block device) `rbd device map` options:
 
-* rw - Map the image read-write (default).
+* rw - Map the image read-write (default).  Overridden by --read-only.
 
 * ro - Map the image read-only.  Equivalent to --read-only.
 
@@ -772,6 +772,7 @@ Per mapping (block device) `rbd device map` options:
   discards (since 4.9).
 
 * exclusive - Disable automatic exclusive lock transitions (since 4.12).
+  Equivalent to --exclusive.
 
 * lock_timeout=x - A timeout on waiting for the acquisition of exclusive lock
   (since 4.17, default is 0 seconds, meaning no timeout).

--- a/qa/rbd/krbd_blkroset.t
+++ b/qa/rbd/krbd_blkroset.t
@@ -343,6 +343,15 @@ rw -> ro with open_count > 0
   $ sudo rbd unmap $DEV
 
 
+"-o rw --read-only" should result in read-only mapping
+======================================================
+
+  $ DEV=$(sudo rbd map -o rw --read-only img)
+  $ blockdev --getro $DEV
+  1
+  $ sudo rbd unmap $DEV
+
+
 Teardown
 ========
 

--- a/src/tools/rbd/action/Kernel.cc
+++ b/src/tools/rbd/action/Kernel.cc
@@ -487,13 +487,6 @@ int execute_map(const po::variables_map &vm,
     return r;
   }
 
-  if (vm["read-only"].as<bool>()) {
-    put_map_option("rw", "ro");
-  }
-  if (vm["exclusive"].as<bool>()) {
-    put_map_option("exclusive", "exclusive");
-  }
-
   // parse default options first so they can be overwritten by cli options
   r = parse_map_options(
       g_conf().get_val<std::string>("rbd_default_map_options"));
@@ -510,6 +503,16 @@ int execute_map(const po::variables_map &vm,
         return r;
       }
     }
+  }
+
+  // parse options common to all device types after parsing krbd-specific
+  // options so that common options win (in particular "-o rw --read-only"
+  // should result in read-only mapping)
+  if (vm["read-only"].as<bool>()) {
+    put_map_option("rw", "ro");
+  }
+  if (vm["exclusive"].as<bool>()) {
+    put_map_option("exclusive", "exclusive");
   }
 
   utils::init_context();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47641

---

backport of https://github.com/ceph/ceph/pull/37385
parent tracker: https://tracker.ceph.com/issues/47625