### PR TITLE
pybind/mgr/snap-schedule: fix deactivate

### DIFF
--- a/src/pybind/mgr/snap_schedule/fs/schedule.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule.py
@@ -207,12 +207,18 @@ class Schedule(object):
     GET_SCHEDULES = PROTO_GET_SCHEDULES + ' s.path = ?'''
 
     @classmethod
-    def get_db_schedules(cls, path, db, fs, repeat=None, start=None):
+    def get_db_schedules(cls, path, db, fs,
+                         schedule=None,
+                         start=None,
+                         repeat=None):
         query = cls.GET_SCHEDULES
         data: Tuple[Any, ...] = (path,)
         if repeat:
             query += ' AND sm.repeat = ?'
             data += (repeat,)
+        if schedule:
+            query += ' AND sm.schedule = ?'
+            data += (schedule,)
         if start:
             query += ' AND sm.start = ?'
             data += (start,)

--- a/src/pybind/mgr/snap_schedule/fs/schedule_client.py
+++ b/src/pybind/mgr/snap_schedule/fs/schedule_client.py
@@ -175,8 +175,8 @@ class SnapSchedClient(CephfsClient):
             sched = Schedule.get_db_schedules(path,
                                               db,
                                               fs_name,
-                                              repeat,
-                                              start)[0]
+                                              repeat=repeat,
+                                              start=start)[0]
             time = datetime.now(timezone.utc)
             with open_filesystem(self, fs_name) as fs_handle:
                 snap_ts = time.strftime(SNAPSHOT_TS_FORMAT)
@@ -244,9 +244,9 @@ class SnapSchedClient(CephfsClient):
         self.store_schedule_db(sched.fs)
 
     @updates_schedule_db
-    def rm_snap_schedule(self, fs, path, repeat, start):
+    def rm_snap_schedule(self, fs, path, schedule, start):
         db = self.get_schedule_db(fs)
-        Schedule.rm_schedule(db, path, repeat, start)
+        Schedule.rm_schedule(db, path, schedule, start)
 
     @updates_schedule_db
     def add_retention_spec(self,
@@ -273,13 +273,17 @@ class SnapSchedClient(CephfsClient):
         Schedule.rm_retention(db, path, retention_spec)
 
     @updates_schedule_db
-    def activate_snap_schedule(self, fs, path, repeat, start):
+    def activate_snap_schedule(self, fs, path, schedule, start):
         db = self.get_schedule_db(fs)
-        schedules = Schedule.get_db_schedules(path, db, fs, repeat, start)
+        schedules = Schedule.get_db_schedules(path, db, fs,
+                                              schedule=schedule,
+                                              start=start)
         [s.set_active(db) for s in schedules]
 
     @updates_schedule_db
-    def deactivate_snap_schedule(self, fs, path, repeat, start):
+    def deactivate_snap_schedule(self, fs, path, schedule, start):
         db = self.get_schedule_db(fs)
-        schedules = Schedule.get_db_schedules(path, db, fs, repeat, start)
+        schedules = Schedule.get_db_schedules(path, db, fs,
+                                              schedule=schedule,
+                                              start=start)
         [s.set_inactive(db) for s in schedules]


### PR DESCRIPTION
This commit adds another argument to get_db_schedules in order to able
to filter not only by the repeat column (schedule period in seconds,
used for snapshotting) but also by the schedule column (the user facing
schedule period, string like 3h).

Fixes: https://tracker.ceph.com/issues/47515

Signed-off-by: Jan Fajerski <jfajerski@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
