### PR TITLE
[DNM] qa: launch interactive shell before test state tearDown

### DIFF
--- a/qa/tasks/ceph_test_case.py
+++ b/qa/tasks/ceph_test_case.py
@@ -3,6 +3,7 @@ import time
 import logging
 
 from teuthology.orchestra.run import CommandFailedError
+from teuthology.task import interactive
 
 log = logging.getLogger(__name__)
 
@@ -31,6 +32,9 @@ class CephTestCase(unittest.TestCase):
     # their special needs.  If not met, tests will be skipped.
     REQUIRE_MEMSTORE = False
 
+    # For vstart_runner.py
+    INTERACTIVE = False
+
     def setUp(self):
         self._mon_configs_set = set()
 
@@ -46,6 +50,10 @@ class CephTestCase(unittest.TestCase):
                         "would take too long on full sized OSDs")
 
     def tearDown(self):
+        # Allow interactive shell before tearing down test state.
+        if self.INTERACTIVE and TEST_FAILED:
+            interactive.task(ctx=self.ctx, config=None)
+
         self.config_clear()
 
         self.ceph_cluster.mon_manager.raw_cluster_cmd("log",


### PR DESCRIPTION
This is so tests can properly tear down any state. This solves the
problem of setUp needing to clean up after the previous test because we
did not do a full tear down so interactive mode has something to look
at.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
