### PR TITLE
neorados: removing an unused captured variable

### DIFF
--- a/src/test/neorados/common_tests.h
+++ b/src/test/neorados/common_tests.h
@@ -32,7 +32,7 @@ auto create_pool(neorados::RADOS& r, std::string_view pname,
 		(boost::system::error_code ec) mutable {
 		  r.lookup_pool(
 		    pname,
-		    [&r, h = std::move(h)]
+		    [h = std::move(h)]
 		    (boost::system::error_code ec, std::int64_t pool) mutable {
 		      std::move(h)(ec, pool);
 		    });


### PR DESCRIPTION
neorados: removing an unused captured variable.
Silencing a compiler warning.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>

