### PR TITLE
mds: try to replicate hot dir to restarted MDS

### DIFF
--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2695,6 +2695,17 @@ bool CDir::contains(CDir *x)
   }
 }
 
+bool CDir::can_rep() const
+{
+  if (!is_rep()) 
+    return true;
+
+  unsigned mds_num = mdcache->mds->get_mds_map()->get_num_mds(MDSMap::STATE_ACTIVE);
+  if ((mds_num - 1) > get_replicas().size()) 
+    return true;
+  
+  return false;
+}
 
 
 /** set_dir_auth

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -488,6 +488,7 @@ public:
     if (dir_rep == REP_NONE) return false;
     return true;
   }
+  bool can_rep() const;
  
   // -- fetch --
   object_t get_ondisk_object() { 

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -1226,7 +1226,7 @@ void MDBalancer::hit_dir(CDir *dir, int type, int who, double amount)
     }
 
     if (dir->is_auth() && !dir->is_ambiguous_auth()) {
-      if (!dir->is_rep() &&
+      if (dir->can_rep() &&
 	  dir_pop >= g_conf()->mds_bal_replicate_threshold) {
 	// replicate
 	double rdp = dir->pop_me.get(META_POP_IRD).get();

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -11019,6 +11019,11 @@ int MDCache::send_dir_updates(CDir *dir, bool bcast)
   filepath path;
   dir->inode->make_path(path);
 
+  std::set<int32_t> dir_rep_set;
+  for (const auto &r : dir->dir_rep_by) {
+    dir_rep_set.insert(r);
+  }
+
   mds_rank_t whoami = mds->get_nodeid();
   for (set<mds_rank_t>::iterator it = who.begin();
        it != who.end();
@@ -11027,11 +11032,7 @@ int MDCache::send_dir_updates(CDir *dir, bool bcast)
     //if (*it == except) continue;
     dout(7) << "sending dir_update on " << *dir << " to " << *it << dendl;
 
-    std::set<int32_t> s;
-    for (const auto &r : dir->dir_rep_by) {
-      s.insert(r);
-    }
-    mds->send_message_mds(make_message<MDirUpdate>(mds->get_nodeid(), dir->dirfrag(), dir->dir_rep, s, path, bcast), *it);
+    mds->send_message_mds(make_message<MDirUpdate>(mds->get_nodeid(), dir->dirfrag(), dir->dir_rep, dir_rep_set, path, bcast), *it);
   }
 
   return 0;

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -10997,7 +10997,17 @@ int MDCache::send_dir_updates(CDir *dir, bool bcast)
 
   set<mds_rank_t> who;
   if (bcast) {
-    mds->get_mds_map()->get_active_mds_set(who);
+    set<mds_rank_t> mds_set;
+    mds->get_mds_map()->get_active_mds_set(mds_set);
+
+    set<mds_rank_t> replica_set;
+    for (const auto &p : dir->get_replicas()) {
+      replica_set.insert(p.first);
+    }
+
+    std::set_difference(mds_set.begin(), mds_set.end(),
+                        replica_set.begin(), replica_set.end(),
+                        std::inserter(who, who.end()));
   } else {
     for (const auto &p : dir->get_replicas()) {
       who.insert(p.first);


### PR DESCRIPTION
Hot dir would be replicated to other active MDSes, but if replica MDS restarted, auth MDS won't replicate this dir again even if it is still hot. This is because dir's dir_rep is set and dir is still hot, dir's dir_rep won't be unset.

So try to compare the active MDSes with dir's replica set, and replicat it to the MDS whom hasn't contain this dir's replica.

Fixes: https://tracker.ceph.com/issues/47662
    
Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
