### PR TITLE
rgw : clean instance string parsed from bilog when deleting null-vers…

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -2459,6 +2459,7 @@ RGWCoroutine *RGWDefaultDataSyncModule::create_delete_marker(RGWDataSyncCtx *sc,
                                                              rgw_bucket_entry_owner& owner, bool versioned, uint64_t versioned_epoch, rgw_zone_set *zones_trace)
 {
   auto sync_env = sc->env;
+  key.instance.clear();
   return new RGWRemoveObjCR(sync_env->async_rados, sync_env->store, sc->source_zone,
                             sync_pipe.dest_bucket_info, key, versioned, versioned_epoch,
                             &owner.id, &owner.display_name, true, &mtime, zones_trace);
@@ -2536,6 +2537,7 @@ RGWCoroutine *RGWArchiveDataSyncModule::create_delete_marker(RGWDataSyncCtx *sc,
   ldout(sc->cct, 0) << "SYNC_ARCHIVE: create_delete_marker: b=" << sync_pipe.info.source_bs.bucket << " k=" << key << " mtime=" << mtime
 	                            << " versioned=" << versioned << " versioned_epoch=" << versioned_epoch << dendl;
   auto sync_env = sc->env;
+  key.instance.clear();
   return new RGWRemoveObjCR(sync_env->async_rados, sync_env->store, sc->source_zone,
                             sync_pipe.dest_bucket_info, key, versioned, versioned_epoch,
                             &owner.id, &owner.display_name, true, &mtime, zones_trace);


### PR DESCRIPTION
When deleting the null-versionId object in a versioned bucket of master zone, bilog could be recorded as a delete-marker like this 
{
"op_id": "00000000006.18143.11",
"op_tag": "000000005f7054efp6hn0sm708vfbhjs",
"op": "link_olh_del",
"object": "cl-test",
"instance": "t-4KWRqy5IEx2DeJ8N3eZI5WyYeuHMM",
"state": "complete",
"index_ver": 6,
"timestamp": "2020-09-27 09:01:35.222086215Z",
"ver": {
"pool": -1,
"epoch": 3
},
"bilog_flags": 1,
"versioned": true,
"owner": "wds",
"owner_display_name": "wds",
"zones_trace": [
"51f3e8d5-43f6-41e1-8635-6c143ba5f3da"
]
},
The instance t-4KWRqy5IEx2DeJ8N3eZI5WyYeuHMM is not a actual versionId. Instead, randomly generated for object OLH. When datasync take place in second zone, the instance is treated as versionId of object, Of course this object cann't be found. At last, operations with null versionId cannot be deleted synchronously in second zone. So i clean the instance string when datasync thread get CLS_RGW_OP_LINK_OLH_DM type bilog. 

Fixes: https://tracker.ceph.com/issues/47529
Signed-off-by: caolei <halei15848934852@163.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
