### PR TITLE
kv/RocksDBStore: Added ability to set compound options

### DIFF
--- a/src/test/objectstore/TestRocksdbOptionParse.cc
+++ b/src/test/objectstore/TestRocksdbOptionParse.cc
@@ -26,7 +26,8 @@ TEST(RocksDBOption, simple) {
 			  "max_bytes_for_level_base = 104857600;"
 			  "target_file_size_base = 10485760;"
 			  "num_levels = 3;"
-			  "compression = kNoCompression;";
+			  "compression = kNoCompression;"
+			  "compaction_options_universal = {min_merge_width=4;size_ratio=2;max_size_amplification_percent=500}";
   int r = db->ParseOptionsFromString(options_string, options);
   ASSERT_EQ(0, r);
   ASSERT_EQ(536870912u, options.write_buffer_size);
@@ -39,6 +40,9 @@ TEST(RocksDBOption, simple) {
   ASSERT_EQ(10485760u, options.target_file_size_base);
   ASSERT_EQ(3, options.num_levels);
   ASSERT_EQ(rocksdb::kNoCompression, options.compression);
+  ASSERT_EQ(2, options.compaction_options_universal.size_ratio);
+  ASSERT_EQ(4, options.compaction_options_universal.min_merge_width);
+  ASSERT_EQ(500, options.compaction_options_universal.max_size_amplification_percent);
 }
 TEST(RocksDBOption, interpret) {
   rocksdb::Options options;


### PR DESCRIPTION
Imported rocksdb StringToMap that is able to properly parse compound options.
Now we are properly respecting '{}' and no longer splitting '{}' if '=' is inside them.
