### PR TITLE
octopus: mgr/dashboard: cluster > manager modules

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/mgr-modules.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/mgr-modules.e2e-spec.ts
@@ -10,7 +10,7 @@ describe('Manager modules page', () => {
 
   describe('breadcrumb test', () => {
     it('should open and show breadcrumb', () => {
-      mgrmodules.expectBreadcrumbText('Manager modules');
+      mgrmodules.expectBreadcrumbText('Manager Modules');
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -189,7 +189,7 @@ const routes: Routes = [
       // Mgr modules
       {
         path: 'mgr-modules',
-        data: { breadcrumbs: 'Cluster/Manager modules' },
+        data: { breadcrumbs: 'Cluster/Manager Modules' },
         children: [
           {
             path: '',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.ts
@@ -58,7 +58,6 @@ export class MgrModuleListComponent extends ListWithDetails {
       {
         name: this.i18n('Always-On'),
         prop: 'always_on',
-        isHidden: true,
         flexGrow: 1,
         cellClass: 'text-center',
         cellTransformation: CellTemplate.checkIcon

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -145,7 +145,7 @@
             class="tc_submenuitem tc_submenuitem_modules"
             *ngIf="permissions.configOpt.read">
           <a i18n
-             routerLink="/mgr-modules">Manager modules</a>
+             routerLink="/mgr-modules">Manager Modules</a>
         </li>
         <li routerLinkActive="active"
             class="tc_submenuitem tc_submenuitem_log"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47675

---

backport of https://github.com/ceph/ceph/pull/37387
parent tracker: https://tracker.ceph.com/issues/47484

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh