### PR TITLE
WIP: mgr/dashboard: build with NodeJS 12.18.2

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -74,7 +74,7 @@ build_dashboard_frontend() {
 
   $CURR_DIR/src/tools/setup-virtualenv.sh $TEMP_DIR
   $TEMP_DIR/bin/pip install nodeenv
-  $TEMP_DIR/bin/nodeenv -p --node=12.16.2
+  $TEMP_DIR/bin/nodeenv -p --node=12.18.2
   cd src/pybind/mgr/dashboard/frontend
 
   . $TEMP_DIR/bin/activate

--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -34,7 +34,7 @@ else()
     OUTPUT "${mgr-dashboard-nodeenv-dir}/bin/npm"
     COMMAND ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python=${MGR_PYTHON_EXECUTABLE} ${mgr-dashboard-nodeenv-dir}
     COMMAND ${mgr-dashboard-nodeenv-dir}/bin/pip install nodeenv
-    COMMAND ${mgr-dashboard-nodeenv-dir}/bin/nodeenv -p --node=12.16.2
+    COMMAND ${mgr-dashboard-nodeenv-dir}/bin/nodeenv -p --node=12.18.2
     COMMAND mkdir ${mgr-dashboard-nodeenv-dir}/.npm
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "dashboard nodeenv is being installed"


### PR DESCRIPTION
Update the version of NodeJS that we use to build the dashboard.

RHEL 8 and CentOS 8 ship NodeJS 12.18.2, so I've picked this version to make it easier to build outside of nodeenv.

I've not tested this at all. I'm just wondering if we can easily use RHEL's system packages instead of relying on nodeenv.

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>