### PR TITLE
librbd: support the ability to process parent data prior to copyup

### DIFF
--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -872,7 +872,7 @@ void sparse_copyup(O* op, const E& extent_map, ceph::buffer::list data) {
 }
 
 void sparse_copyup(neorados::WriteOp* op,
-                   const std::map<uint64_t, uint64_t> &extent_map,
+                   const std::vector<std::pair<uint64_t, uint64_t>>& extent_map,
                    ceph::buffer::list data) {
   sparse_copyup<neorados::WriteOp>(op, extent_map, data);
 }

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -643,7 +643,7 @@ int copyup(librados::IoCtx *ioctx, const std::string &oid,
            ceph::buffer::list data);
 
 void sparse_copyup(neorados::WriteOp* op,
-                   const std::map<uint64_t, uint64_t> &extent_map,
+                   const std::vector<std::pair<uint64_t, uint64_t>>& extent_map,
                    ceph::buffer::list data);
 void sparse_copyup(librados::ObjectWriteOperation *op,
                    const std::map<uint64_t, uint64_t> &extent_map,

--- a/src/common/interval_map.h
+++ b/src/common/interval_map.h
@@ -16,6 +16,7 @@
 #define INTERVAL_MAP_H
 
 #include "include/interval_set.h"
+#include <initializer_list>
 
 template <typename K, typename V, typename S>
 /**
@@ -101,6 +102,13 @@ class interval_map {
     }
   }
 public:
+  interval_map() = default;
+  interval_map(std::initializer_list<typename map::value_type> l) {
+    for (auto& v : l) {
+      insert(v.first, v.second.first, v.second.second);
+    }
+  }
+
   interval_map intersect(K off, K len) const {
     interval_map ret;
     auto limits = get_range(off, len);

--- a/src/librbd/api/DiffIterate.cc
+++ b/src/librbd/api/DiffIterate.cc
@@ -122,15 +122,14 @@ private:
     CephContext *cct = m_cct;
 
     // merge per-snapshot deltas into an aggregate
-    interval_map<uint64_t, io::SnapshotExtent, io::SnapshotExtentSplitMerge>
-      aggregate_snapshot_extents;
+    io::SparseExtents aggregate_snapshot_extents;
     for (auto& [key, snapshot_extents] : m_snapshot_delta) {
       for (auto& snapshot_extent : snapshot_extents) {
         auto state = snapshot_extent.get_val().state;
 
         // ignore DNE object (and parent)
         if (key == io::WriteReadSnapIds{0, 0} &&
-            state != io::SNAPSHOT_EXTENT_STATE_DATA) {
+            state != io::SPARSE_EXTENT_STATE_DATA) {
           continue;
         }
 
@@ -147,7 +146,7 @@ private:
                      << "state=" << snapshot_extent.get_val().state << dendl;
       diffs->emplace_back(
         snapshot_extent.get_off(), snapshot_extent.get_len(),
-        snapshot_extent.get_val().state == io::SNAPSHOT_EXTENT_STATE_DATA);
+        snapshot_extent.get_val().state == io::SPARSE_EXTENT_STATE_DATA);
     }
   }
 };

--- a/src/librbd/cache/ObjectCacherObjectDispatch.h
+++ b/src/librbd/cache/ObjectCacherObjectDispatch.h
@@ -101,6 +101,11 @@ public:
       uint64_t journal_tid, uint64_t new_journal_tid) {
   }
 
+  void prepare_copyup(
+      uint64_t object_no,
+      io::SnapshotSparseBufferlist* snapshot_sparse_bufferlist) override {
+  }
+
 private:
   struct C_InvalidateCache;
 

--- a/src/librbd/cache/ParentCacheObjectDispatch.h
+++ b/src/librbd/cache/ParentCacheObjectDispatch.h
@@ -118,6 +118,11 @@ public:
       uint64_t journal_tid, uint64_t new_journal_tid) {
   }
 
+  void prepare_copyup(
+      uint64_t object_no,
+      io::SnapshotSparseBufferlist* snapshot_sparse_bufferlist) override {
+  }
+
   ImageCtxT* get_image_ctx() {
     return m_image_ctx;
   }

--- a/src/librbd/cache/WriteAroundObjectDispatch.h
+++ b/src/librbd/cache/WriteAroundObjectDispatch.h
@@ -106,6 +106,11 @@ public:
       uint64_t journal_tid, uint64_t new_journal_tid) override {
   }
 
+  void prepare_copyup(
+      uint64_t object_no,
+      io::SnapshotSparseBufferlist* snapshot_sparse_bufferlist) override {
+  }
+
 private:
   struct QueuedIO {
     QueuedIO(uint64_t length, Context* on_finish, Context* on_dispatched)

--- a/src/librbd/crypto/CryptoObjectDispatch.h
+++ b/src/librbd/crypto/CryptoObjectDispatch.h
@@ -97,6 +97,11 @@ public:
           uint64_t journal_tid, uint64_t new_journal_tid) override {
   }
 
+  void prepare_copyup(
+      uint64_t object_no,
+      io::SnapshotSparseBufferlist* snapshot_sparse_bufferlist) override {
+  }
+
 private:
 
   ImageCtxT* m_image_ctx;

--- a/src/librbd/deep_copy/ObjectCopyRequest.cc
+++ b/src/librbd/deep_copy/ObjectCopyRequest.cc
@@ -444,7 +444,7 @@ void ObjectCopyRequest<I>::compute_read_ops() {
     for (auto& image_interval : image_intervals) {
       auto state = image_interval.get_val().state;
       switch (state) {
-      case io::SNAPSHOT_EXTENT_STATE_DNE:
+      case io::SPARSE_EXTENT_STATE_DNE:
         ceph_assert(write_read_snap_ids == io::INITIAL_WRITE_READ_SNAP_IDS);
         if (read_from_parent) {
           // special-case for DNE object-extents since when flattening we need
@@ -456,10 +456,10 @@ void ObjectCopyRequest<I>::compute_read_ops() {
             image_interval.get_off(), image_interval.get_len());
         }
         break;
-      case io::SNAPSHOT_EXTENT_STATE_ZEROED:
+      case io::SPARSE_EXTENT_STATE_ZEROED:
         only_dne_extents = false;
         break;
-      case io::SNAPSHOT_EXTENT_STATE_DATA:
+      case io::SPARSE_EXTENT_STATE_DATA:
         ldout(m_cct, 20) << "read op: "
                          << "snap_ids=" << write_read_snap_ids << " "
                          << image_interval.get_off() << "~"
@@ -582,7 +582,7 @@ void ObjectCopyRequest<I>::compute_zero_ops() {
     for (auto& image_interval : image_intervals) {
       auto state = image_interval.get_val().state;
       switch (state) {
-      case io::SNAPSHOT_EXTENT_STATE_ZEROED:
+      case io::SPARSE_EXTENT_STATE_ZEROED:
         if (write_read_snap_ids != io::WriteReadSnapIds{0, 0}) {
           ldout(m_cct, 20) << "zeroed extent: "
                            << "src_snap_seq=" << src_snap_seq << " "
@@ -600,8 +600,8 @@ void ObjectCopyRequest<I>::compute_zero_ops() {
             image_interval.get_off(), image_interval.get_len());
         }
         break;
-      case io::SNAPSHOT_EXTENT_STATE_DNE:
-      case io::SNAPSHOT_EXTENT_STATE_DATA:
+      case io::SPARSE_EXTENT_STATE_DNE:
+      case io::SPARSE_EXTENT_STATE_DATA:
         break;
       default:
         ceph_abort();

--- a/src/librbd/deep_copy/ObjectCopyRequest.cc
+++ b/src/librbd/deep_copy/ObjectCopyRequest.cc
@@ -124,7 +124,7 @@ void ObjectCopyRequest<I>::send_read() {
       return;
     }
 
-    send_write_object();
+    send_update_object_map();
     return;
   }
 
@@ -188,6 +188,83 @@ void ObjectCopyRequest<I>::handle_read(int r) {
   m_read_snaps.erase(m_read_snaps.begin());
 
   send_read();
+}
+
+template <typename I>
+void ObjectCopyRequest<I>::send_update_object_map() {
+  if (!m_dst_image_ctx->test_features(RBD_FEATURE_OBJECT_MAP) ||
+      m_dst_object_state.empty()) {
+    send_write_object();
+    return;
+  }
+
+  m_dst_image_ctx->owner_lock.lock_shared();
+  m_dst_image_ctx->image_lock.lock_shared();
+  if (m_dst_image_ctx->object_map == nullptr) {
+    // possible that exclusive lock was lost in background
+    lderr(m_cct) << "object map is not initialized" << dendl;
+
+    m_dst_image_ctx->image_lock.unlock_shared();
+    m_dst_image_ctx->owner_lock.unlock_shared();
+    finish(-EINVAL);
+    return;
+  }
+
+  auto &dst_object_state = *m_dst_object_state.begin();
+  auto it = m_snap_map.find(dst_object_state.first);
+  ceph_assert(it != m_snap_map.end());
+  auto dst_snap_id = it->second.front();
+  auto object_state = dst_object_state.second;
+  m_dst_object_state.erase(m_dst_object_state.begin());
+
+  ldout(m_cct, 20) << "dst_snap_id=" << dst_snap_id << ", object_state="
+                   << static_cast<uint32_t>(object_state) << dendl;
+
+  int r;
+  auto finish_op_ctx = start_lock_op(m_dst_image_ctx->owner_lock, &r);
+  if (finish_op_ctx == nullptr) {
+    lderr(m_cct) << "lost exclusive lock" << dendl;
+    m_dst_image_ctx->image_lock.unlock_shared();
+    m_dst_image_ctx->owner_lock.unlock_shared();
+    finish(r);
+    return;
+  }
+
+  auto ctx = new LambdaContext([this, finish_op_ctx](int r) {
+      handle_update_object_map(r);
+      finish_op_ctx->complete(0);
+    });
+
+  auto dst_image_ctx = m_dst_image_ctx;
+  bool sent = dst_image_ctx->object_map->template aio_update<
+    Context, &Context::complete>(dst_snap_id, m_dst_object_number, object_state,
+                                 {}, {}, false, ctx);
+
+  // NOTE: state machine might complete before we reach here
+  dst_image_ctx->image_lock.unlock_shared();
+  dst_image_ctx->owner_lock.unlock_shared();
+  if (!sent) {
+    ceph_assert(dst_snap_id == CEPH_NOSNAP);
+    ctx->complete(0);
+  }
+}
+
+template <typename I>
+void ObjectCopyRequest<I>::handle_update_object_map(int r) {
+  ldout(m_cct, 20) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to update object map: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  if (!m_dst_object_state.empty()) {
+    send_update_object_map();
+    return;
+  }
+
+  send_write_object();
 }
 
 template <typename I>
@@ -317,82 +394,6 @@ void ObjectCopyRequest<I>::handle_write_object(int r) {
     return;
   }
 
-  send_update_object_map();
-}
-
-template <typename I>
-void ObjectCopyRequest<I>::send_update_object_map() {
-  if (!m_dst_image_ctx->test_features(RBD_FEATURE_OBJECT_MAP) ||
-      m_dst_object_state.empty()) {
-    finish(0);
-    return;
-  }
-
-  m_dst_image_ctx->owner_lock.lock_shared();
-  m_dst_image_ctx->image_lock.lock_shared();
-  if (m_dst_image_ctx->object_map == nullptr) {
-    // possible that exclusive lock was lost in background
-    lderr(m_cct) << "object map is not initialized" << dendl;
-
-    m_dst_image_ctx->image_lock.unlock_shared();
-    m_dst_image_ctx->owner_lock.unlock_shared();
-    finish(-EINVAL);
-    return;
-  }
-
-  auto &dst_object_state = *m_dst_object_state.begin();
-  auto it = m_snap_map.find(dst_object_state.first);
-  ceph_assert(it != m_snap_map.end());
-  auto dst_snap_id = it->second.front();
-  auto object_state = dst_object_state.second;
-  m_dst_object_state.erase(m_dst_object_state.begin());
-
-  ldout(m_cct, 20) << "dst_snap_id=" << dst_snap_id << ", object_state="
-                   << static_cast<uint32_t>(object_state) << dendl;
-
-  int r;
-  auto finish_op_ctx = start_lock_op(m_dst_image_ctx->owner_lock, &r);
-  if (finish_op_ctx == nullptr) {
-    lderr(m_cct) << "lost exclusive lock" << dendl;
-    m_dst_image_ctx->image_lock.unlock_shared();
-    m_dst_image_ctx->owner_lock.unlock_shared();
-    finish(r);
-    return;
-  }
-
-  auto ctx = new LambdaContext([this, finish_op_ctx](int r) {
-      handle_update_object_map(r);
-      finish_op_ctx->complete(0);
-    });
-
-  auto dst_image_ctx = m_dst_image_ctx;
-  bool sent = dst_image_ctx->object_map->template aio_update<
-    Context, &Context::complete>(dst_snap_id, m_dst_object_number, object_state,
-                                 {}, {}, false, ctx);
-
-  // NOTE: state machine might complete before we reach here
-  dst_image_ctx->image_lock.unlock_shared();
-  dst_image_ctx->owner_lock.unlock_shared();
-  if (!sent) {
-    ceph_assert(dst_snap_id == CEPH_NOSNAP);
-    ctx->complete(0);
-  }
-}
-
-template <typename I>
-void ObjectCopyRequest<I>::handle_update_object_map(int r) {
-  ldout(m_cct, 20) << "r=" << r << dendl;
-
-  if (r < 0) {
-    lderr(m_cct) << "failed to update object map: " << cpp_strerror(r) << dendl;
-    finish(r);
-    return;
-  }
-
-  if (!m_dst_object_state.empty()) {
-    send_update_object_map();
-    return;
-  }
   finish(0);
 }
 

--- a/src/librbd/deep_copy/ObjectCopyRequest.h
+++ b/src/librbd/deep_copy/ObjectCopyRequest.h
@@ -95,11 +95,9 @@ private:
     WRITE_OP_TYPE_REMOVE_TRUNC,
   };
 
-  typedef std::map<uint64_t, uint64_t> ExtentMap;
-
   struct ReadOp {
     interval_set<uint64_t> image_interval;
-    ExtentMap image_extent_map;
+    io::Extents image_extent_map;
     bufferlist out_bl;
   };
 

--- a/src/librbd/deep_copy/ObjectCopyRequest.h
+++ b/src/librbd/deep_copy/ObjectCopyRequest.h
@@ -139,6 +139,7 @@ private:
   void send_update_object_map();
   void handle_update_object_map(int r);
 
+  void process_copyup();
   void send_write_object();
   void handle_write_object(int r);
 

--- a/src/librbd/deep_copy/ObjectCopyRequest.h
+++ b/src/librbd/deep_copy/ObjectCopyRequest.h
@@ -74,13 +74,13 @@ private:
    *    |     /-----------\
    *    |     |           | (repeat for each snapshot)
    *    v     v           |
-   * WRITE_OBJECT --------/
-   *    |
+   * UPDATE_OBJECT_MAP ---/ (skip if object
+   *    |                    map disabled)
    *    |     /-----------\
    *    |     |           | (repeat for each snapshot)
    *    v     v           |
-   * UPDATE_OBJECT_MAP ---/ (skip if object
-   *    |                    map disabled)
+   * WRITE_OBJECT --------/
+   *    |
    *    v
    * <finish>
    *
@@ -159,11 +159,11 @@ private:
   void send_read();
   void handle_read(int r);
 
-  void send_write_object();
-  void handle_write_object(int r);
-
   void send_update_object_map();
   void handle_update_object_map(int r);
+
+  void send_write_object();
+  void handle_write_object(int r);
 
   Context *start_lock_op(ceph::shared_mutex &owner_lock, int* r);
 

--- a/src/librbd/deep_copy/ObjectCopyRequest.h
+++ b/src/librbd/deep_copy/ObjectCopyRequest.h
@@ -98,25 +98,7 @@ private:
     bufferlist out_bl;
   };
 
-  struct WriteOp {
-    WriteOp(WriteOpType type, uint64_t object_offset, uint64_t object_length)
-      : type(type), object_offset(object_offset), object_length(object_length) {
-    }
-    WriteOp(WriteOpType type, uint64_t object_offset, uint64_t object_length,
-            bufferlist&& bl)
-      : type(type), object_offset(object_offset), object_length(object_length),
-        bl(std::move(bl)) {
-    }
-
-    WriteOpType type;
-    uint64_t object_offset;
-    uint64_t object_length;
-
-    bufferlist bl;
-  };
-
   typedef std::pair<librados::snap_t, librados::snap_t> WriteReadSnapIds;
-  typedef std::list<WriteOp> WriteOps;
 
   ImageCtxT *m_src_image_ctx;
   ImageCtxT *m_dst_image_ctx;
@@ -139,7 +121,7 @@ private:
 
   std::map<WriteReadSnapIds, ReadOp> m_read_ops;
   std::list<WriteReadSnapIds> m_read_snaps;
-  std::map<librados::snap_t, WriteOps> m_write_ops;
+  io::SnapshotSparseBufferlist m_snapshot_sparse_bufferlist;
 
   std::map<librados::snap_t, interval_set<uint64_t>> m_dst_data_interval;
   std::map<librados::snap_t, interval_set<uint64_t>> m_dst_zero_interval;

--- a/src/librbd/deep_copy/ObjectCopyRequest.h
+++ b/src/librbd/deep_copy/ObjectCopyRequest.h
@@ -89,10 +89,7 @@ private:
 
   enum WriteOpType {
     WRITE_OP_TYPE_WRITE,
-    WRITE_OP_TYPE_ZERO,
-    WRITE_OP_TYPE_TRUNC,
-    WRITE_OP_TYPE_REMOVE,
-    WRITE_OP_TYPE_REMOVE_TRUNC,
+    WRITE_OP_TYPE_ZERO
   };
 
   struct ReadOp {

--- a/src/librbd/io/CopyupRequest.cc
+++ b/src/librbd/io/CopyupRequest.cc
@@ -247,6 +247,7 @@ void CopyupRequest<I>::deep_copy() {
   ceph_assert(m_image_ctx->parent != nullptr);
 
   m_lock.lock();
+  m_deep_copied = true;
   m_flatten = is_copyup_required() ? true : m_image_ctx->migration_info.flatten;
   m_lock.unlock();
 
@@ -401,7 +402,7 @@ void CopyupRequest<I>::copyup() {
 
   ldout(cct, 20) << dendl;
 
-  bool copy_on_read = m_pending_requests.empty();
+  bool copy_on_read = m_pending_requests.empty() && !m_deep_copied;
   bool deep_copyup = !snapc.snaps.empty() && !m_copyup_is_zero;
   if (m_copyup_is_zero) {
     m_copyup_data.clear();

--- a/src/librbd/io/CopyupRequest.cc
+++ b/src/librbd/io/CopyupRequest.cc
@@ -222,15 +222,18 @@ void CopyupRequest<I>::handle_read_from_parent(int r) {
   }
 
   // convert the image-extent extent map to object-extents
-  ExtentMap image_extent_map;
+  Extents image_extent_map;
   image_extent_map.swap(m_copyup_extent_map);
+  m_copyup_extent_map.reserve(m_copyup_extent_map.size());
+
   for (auto [image_offset, image_length] : image_extent_map) {
     striper::LightweightObjectExtents object_extents;
     Striper::file_to_extents(
       cct, &m_image_ctx->layout, image_offset, image_length, 0, 0,
       &object_extents);
     for (auto& object_extent : object_extents) {
-      m_copyup_extent_map[object_extent.offset] = object_extent.length;
+      m_copyup_extent_map.emplace_back(
+        object_extent.offset, object_extent.length);
     }
   }
 

--- a/src/librbd/io/CopyupRequest.h
+++ b/src/librbd/io/CopyupRequest.h
@@ -90,7 +90,7 @@ private:
   bool m_copyup_is_zero = true;
   bool m_deep_copied = false;
 
-  std::map<uint64_t, uint64_t> m_copyup_extent_map;
+  Extents m_copyup_extent_map;
   ceph::bufferlist m_copyup_data;
 
   AsyncOperation m_async_op;

--- a/src/librbd/io/CopyupRequest.h
+++ b/src/librbd/io/CopyupRequest.h
@@ -6,6 +6,7 @@
 
 #include "include/int_types.h"
 #include "include/buffer.h"
+#include "include/interval_set.h"
 #include "common/ceph_mutex.h"
 #include "common/zipkin_trace.h"
 #include "librbd/io/AsyncOperation.h"
@@ -39,7 +40,8 @@ public:
                 const ZTracer::Trace &parent_trace);
   ~CopyupRequest();
 
-  void append_request(AbstractObjectWriteRequest<ImageCtxT> *req);
+  void append_request(AbstractObjectWriteRequest<ImageCtxT> *req,
+                      const Extents& object_extents);
 
   void send();
 
@@ -103,6 +105,8 @@ private:
 
   WriteRequests m_restart_requests;
   bool m_append_request_permitted = true;
+
+  interval_set<uint64_t> m_write_object_extents;
 
   void read_from_parent();
   void handle_read_from_parent(int r);

--- a/src/librbd/io/CopyupRequest.h
+++ b/src/librbd/io/CopyupRequest.h
@@ -131,6 +131,8 @@ private:
   bool is_deep_copy() const;
 
   void compute_deep_copy_snap_ids();
+  void convert_copyup_extent_map();
+  void prepare_copyup_data();
 };
 
 } // namespace io

--- a/src/librbd/io/CopyupRequest.h
+++ b/src/librbd/io/CopyupRequest.h
@@ -86,6 +86,7 @@ private:
   bool m_flatten = false;
   bool m_copyup_required = true;
   bool m_copyup_is_zero = true;
+  bool m_deep_copied = false;
 
   std::map<uint64_t, uint64_t> m_copyup_extent_map;
   ceph::bufferlist m_copyup_data;

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -99,11 +99,11 @@ struct C_AssembleSnapshotDeltas : public C_AioRequest {
         auto& intervals = (*image_snapshot_delta)[key];
         auto& assembled_intervals = (*assembled_image_snapshot_delta)[key];
         for (auto [image_offset, image_length] : image_extents) {
-          SnapshotExtent snapshot_extent{object_extent.get_val().state,
-                                         image_length};
-          intervals.insert(image_offset, image_length, snapshot_extent);
+          SparseExtent sparse_extent{object_extent.get_val().state,
+                                     image_length};
+          intervals.insert(image_offset, image_length, sparse_extent);
           assembled_intervals.insert(image_offset, image_length,
-                                     snapshot_extent);
+                                     sparse_extent);
         }
       }
     }

--- a/src/librbd/io/ObjectDispatch.h
+++ b/src/librbd/io/ObjectDispatch.h
@@ -96,6 +96,11 @@ public:
       uint64_t journal_tid, uint64_t new_journal_tid) override {
   }
 
+  void prepare_copyup(
+      uint64_t object_no,
+      SnapshotSparseBufferlist* snapshot_sparse_bufferlist) override {
+  }
+
 private:
   ImageCtxT* m_image_ctx;
 

--- a/src/librbd/io/ObjectDispatchInterface.h
+++ b/src/librbd/io/ObjectDispatchInterface.h
@@ -90,6 +90,10 @@ struct ObjectDispatchInterface {
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       uint64_t journal_tid, uint64_t new_journal_tid) = 0;
 
+  virtual void prepare_copyup(
+      uint64_t object_no,
+      SnapshotSparseBufferlist* snapshot_sparse_bufferlist) = 0;
+
 };
 
 } // namespace io

--- a/src/librbd/io/ObjectDispatcher.cc
+++ b/src/librbd/io/ObjectDispatcher.cc
@@ -234,6 +234,21 @@ void ObjectDispatcher<I>::extent_overwritten(
 }
 
 template <typename I>
+void ObjectDispatcher<I>::prepare_copyup(
+    uint64_t object_no,
+    SnapshotSparseBufferlist* snapshot_sparse_bufferlist) {
+  auto cct = this->m_image_ctx->cct;
+  ldout(cct, 20) << "object_no=" << object_no << dendl;
+
+  std::shared_lock locker{this->m_lock};
+  for (auto it : this->m_dispatches) {
+    auto& object_dispatch_meta = it.second;
+    auto object_dispatch = object_dispatch_meta.dispatch;
+    object_dispatch->prepare_copyup(object_no, snapshot_sparse_bufferlist);
+  }
+}
+
+template <typename I>
 bool ObjectDispatcher<I>::send_dispatch(
     ObjectDispatchInterface* object_dispatch,
     ObjectDispatchSpec* object_dispatch_spec) {

--- a/src/librbd/io/ObjectDispatcher.h
+++ b/src/librbd/io/ObjectDispatcher.h
@@ -34,6 +34,10 @@ public:
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       uint64_t journal_tid, uint64_t new_journal_tid) override;
 
+  void prepare_copyup(
+      uint64_t object_no,
+      SnapshotSparseBufferlist* snapshot_sparse_bufferlist) override;
+
 protected:
   bool send_dispatch(ObjectDispatchInterface* object_dispatch,
                      ObjectDispatchSpec* object_dispatch_spec) override;

--- a/src/librbd/io/ObjectDispatcherInterface.h
+++ b/src/librbd/io/ObjectDispatcherInterface.h
@@ -22,6 +22,11 @@ public:
   virtual void extent_overwritten(
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       uint64_t journal_tid, uint64_t new_journal_tid) = 0;
+
+  virtual void prepare_copyup(
+      uint64_t object_no,
+      SnapshotSparseBufferlist* snapshot_sparse_bufferlist) = 0;
+
 };
 
 } // namespace io

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -883,7 +883,7 @@ void ObjectListSnapsRequest<I>::handle_list_snaps(int r) {
           for (auto& interval : diff_interval) {
             snapshot_delta[{end_snap_id, clone_end_snap_id}].insert(
               interval.first, interval.second,
-              SnapshotExtent(SNAPSHOT_EXTENT_STATE_DATA, interval.second));
+              SparseExtent(SPARSE_EXTENT_STATE_DATA, interval.second));
             if (maybe_whiteout_detected) {
               initial_written_extents.union_insert(interval.first,
                                                    interval.second);
@@ -903,7 +903,7 @@ void ObjectListSnapsRequest<I>::handle_list_snaps(int r) {
           for (auto& interval : zero_interval) {
             snapshot_delta[{end_snap_id, end_snap_id}].insert(
               interval.first, interval.second,
-              SnapshotExtent(SNAPSHOT_EXTENT_STATE_ZEROED, interval.second));
+              SparseExtent(SPARSE_EXTENT_STATE_ZEROED, interval.second));
             if (maybe_whiteout_detected) {
               initial_written_extents.union_insert(interval.first,
                                                    interval.second);
@@ -1057,8 +1057,8 @@ void ObjectListSnapsRequest<I>::zero_initial_extent(
                      << dendl;
       (*m_snapshot_delta)[INITIAL_WRITE_READ_SNAP_IDS].insert(
         offset, length,
-        SnapshotExtent(
-          (dne ? SNAPSHOT_EXTENT_STATE_DNE : SNAPSHOT_EXTENT_STATE_ZEROED),
+        SparseExtent(
+          (dne ? SPARSE_EXTENT_STATE_DNE : SPARSE_EXTENT_STATE_ZEROED),
           length));
     }
   }

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -564,13 +564,13 @@ void AbstractObjectWriteRequest<I>::copyup() {
     this->m_parent_extents.clear();
 
     // make sure to wait on this CopyupRequest
-    new_req->append_request(this);
+    new_req->append_request(this, std::move(get_copyup_overwrite_extents()));
     image_ctx->copyup_list[this->m_object_no] = new_req;
 
     image_ctx->copyup_list_lock.unlock();
     new_req->send();
   } else {
-    it->second->append_request(this);
+    it->second->append_request(this, std::move(get_copyup_overwrite_extents()));
     image_ctx->copyup_list_lock.unlock();
   }
 }

--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -199,6 +199,10 @@ protected:
     return r;
   }
 
+  virtual Extents get_copyup_overwrite_extents() const {
+    return {{m_object_off, m_object_len}};
+  }
+
 private:
   /**
    * @verbatim
@@ -304,7 +308,6 @@ public:
         } else {
           m_discard_action = DISCARD_ACTION_TRUNCATE;
         }
-        this->m_object_len = 0;
       } else {
         m_discard_action = DISCARD_ACTION_REMOVE;
       }
@@ -425,6 +428,10 @@ protected:
   void add_write_ops(neorados::WriteOp *wr) override;
 
   int filter_write_result(int r) const override;
+
+  Extents get_copyup_overwrite_extents() const override {
+    return {};
+  }
 
 private:
   ceph::bufferlist m_cmp_bl;

--- a/src/librbd/io/ReadResult.h
+++ b/src/librbd/io/ReadResult.h
@@ -61,7 +61,7 @@ public:
   ReadResult(char *buf, size_t buf_len);
   ReadResult(const struct iovec *iov, int iov_count);
   ReadResult(ceph::bufferlist *bl);
-  ReadResult(std::map<uint64_t, uint64_t> *extent_map, ceph::bufferlist *bl);
+  ReadResult(Extents* extent_map, ceph::bufferlist* bl);
 
   void set_clip_length(size_t length);
   void set_image_extents(const Extents& image_extents);
@@ -97,13 +97,12 @@ private:
   };
 
   struct SparseBufferlist {
-    std::map<uint64_t, uint64_t> *extent_map;
+    Extents *extent_map;
     ceph::bufferlist *bl;
 
     Extents image_extents;
 
-    SparseBufferlist(std::map<uint64_t, uint64_t> *extent_map,
-                     ceph::bufferlist *bl)
+    SparseBufferlist(Extents* extent_map, ceph::bufferlist* bl)
       : extent_map(extent_map), bl(bl) {
     }
   };

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.h
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.h
@@ -112,6 +112,11 @@ public:
       uint64_t journal_tid, uint64_t new_journal_tid) override {
   }
 
+  void prepare_copyup(
+      uint64_t object_no,
+      SnapshotSparseBufferlist* snapshot_sparse_bufferlist) override {
+  }
+
 private:
   struct MergedRequests {
     ceph::bufferlist data;

--- a/src/librbd/io/Types.cc
+++ b/src/librbd/io/Types.cc
@@ -9,12 +9,15 @@ namespace io {
 
 const WriteReadSnapIds INITIAL_WRITE_READ_SNAP_IDS{0, 0};
 
-std::ostream& operator<<(std::ostream& os, SnapshotExtentState state) {
+std::ostream& operator<<(std::ostream& os, SparseExtentState state) {
   switch (state) {
-  case SNAPSHOT_EXTENT_STATE_ZEROED:
+  case SPARSE_EXTENT_STATE_DNE:
+    os << "dne";
+    break;
+  case SPARSE_EXTENT_STATE_ZEROED:
     os << "zeroed";
     break;
-  case SNAPSHOT_EXTENT_STATE_DATA:
+  case SPARSE_EXTENT_STATE_DATA:
     os << "data";
     break;
   default:
@@ -24,7 +27,7 @@ std::ostream& operator<<(std::ostream& os, SnapshotExtentState state) {
   return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const SnapshotExtent& se) {
+std::ostream& operator<<(std::ostream& os, const SparseExtent& se) {
   os << "["
      << "state=" << se.state << ", "
      << "length=" << se.length << "]";

--- a/src/librbd/io/Types.h
+++ b/src/librbd/io/Types.h
@@ -131,64 +131,63 @@ enum {
   LIST_SNAPS_FLAG_IGNORE_ZEROED_EXTENTS         = 1UL << 2,
 };
 
-enum SnapshotExtentState {
-  SNAPSHOT_EXTENT_STATE_DNE,    /* does not exist */
-  SNAPSHOT_EXTENT_STATE_ZEROED,
-  SNAPSHOT_EXTENT_STATE_DATA
+enum SparseExtentState {
+  SPARSE_EXTENT_STATE_DNE,    /* does not exist */
+  SPARSE_EXTENT_STATE_ZEROED,
+  SPARSE_EXTENT_STATE_DATA
 };
 
-std::ostream& operator<<(std::ostream& os, SnapshotExtentState state);
+std::ostream& operator<<(std::ostream& os, SparseExtentState state);
 
-struct SnapshotExtent {
-  SnapshotExtentState state;
+struct SparseExtent {
+  SparseExtentState state;
   size_t length;
 
-  SnapshotExtent(SnapshotExtentState state, size_t length)
+  SparseExtent(SparseExtentState state, size_t length)
     : state(state), length(length) {
   }
 
-  operator SnapshotExtentState() const {
+  operator SparseExtentState() const {
     return state;
   }
 
-  bool operator==(const SnapshotExtent& rhs) const {
+  bool operator==(const SparseExtent& rhs) const {
     return state == rhs.state && length == rhs.length;
   }
 };
 
-std::ostream& operator<<(std::ostream& os, const SnapshotExtent& state);
+std::ostream& operator<<(std::ostream& os, const SparseExtent& state);
 
-struct SnapshotExtentSplitMerge {
-  SnapshotExtent split(uint64_t offset, uint64_t length,
-                       SnapshotExtent &se) const {
-    return SnapshotExtent(se.state, se.length);
+struct SparseExtentSplitMerge {
+  SparseExtent split(uint64_t offset, uint64_t length, SparseExtent &se) const {
+    return SparseExtent(se.state, se.length);
   }
 
-  bool can_merge(const SnapshotExtent& left,
-                 const SnapshotExtent& right) const {
+  bool can_merge(const SparseExtent& left, const SparseExtent& right) const {
     return left.state == right.state;
   }
 
-  SnapshotExtent merge(SnapshotExtent&& left, SnapshotExtent&& right) const {
-    SnapshotExtent se(left);
+  SparseExtent merge(SparseExtent&& left, SparseExtent&& right) const {
+    SparseExtent se(left);
     se.length += right.length;
     return se;
   }
 
-  uint64_t length(const SnapshotExtent& se) const {
+  uint64_t length(const SparseExtent& se) const {
     return se.length;
   }
 };
+
+typedef interval_map<uint64_t,
+                     SparseExtent,
+                     SparseExtentSplitMerge> SparseExtents;
 
 typedef std::vector<uint64_t> SnapIds;
 
 typedef std::pair<librados::snap_t, librados::snap_t> WriteReadSnapIds;
 extern const WriteReadSnapIds INITIAL_WRITE_READ_SNAP_IDS;
 
-typedef std::map<WriteReadSnapIds,
-                 interval_map<uint64_t,
-                              SnapshotExtent,
-                              SnapshotExtentSplitMerge>> SnapshotDelta;
+typedef std::map<WriteReadSnapIds, SparseExtents> SnapshotDelta;
 
 using striper::LightweightBufferExtents;
 using striper::LightweightObjectExtent;

--- a/src/librbd/journal/ObjectDispatch.h
+++ b/src/librbd/journal/ObjectDispatch.h
@@ -101,6 +101,11 @@ public:
       uint64_t object_no, uint64_t object_off, uint64_t object_len,
       uint64_t journal_tid, uint64_t new_journal_tid) override;
 
+  void prepare_copyup(
+      uint64_t object_no,
+      io::SnapshotSparseBufferlist* snapshot_sparse_bufferlist) override {
+  }
+
 private:
   ImageCtxT* m_image_ctx;
   Journal<ImageCtxT>* m_journal;

--- a/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
@@ -298,6 +298,10 @@ public:
     }
   }
 
+  void expect_prepare_copyup(MockTestImageCtx& mock_image_ctx) {
+    EXPECT_CALL(*mock_image_ctx.io_object_dispatcher, prepare_copyup(_, _));
+  }
+
   int create_snap(librbd::ImageCtx *image_ctx, const char* snap_name,
                   librados::snap_t *snap_id) {
     NoOpProgressContext prog_ctx;
@@ -518,6 +522,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Write) {
   expect_start_op(mock_exclusive_lock);
   expect_update_object_map(mock_dst_image_ctx, mock_object_map,
                            m_dst_snap_ids[0], OBJECT_EXISTS, 0);
+  expect_prepare_copyup(mock_dst_image_ctx);
   expect_start_op(mock_exclusive_lock);
   expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, 0);
 
@@ -592,6 +597,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteError) {
   expect_update_object_map(mock_dst_image_ctx, mock_object_map,
                            m_dst_snap_ids[0], OBJECT_EXISTS, 0);
 
+  expect_prepare_copyup(mock_dst_image_ctx);
   expect_start_op(mock_exclusive_lock);
   expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, -EINVAL);
 
@@ -650,6 +656,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteSnaps) {
   expect_update_object_map(mock_dst_image_ctx, mock_object_map,
                            m_dst_snap_ids[2], is_fast_diff(mock_dst_image_ctx) ?
                            OBJECT_EXISTS_CLEAN : OBJECT_EXISTS, 0);
+  expect_prepare_copyup(mock_dst_image_ctx);
   expect_start_op(mock_exclusive_lock);
   expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, 0);
   expect_start_op(mock_exclusive_lock);
@@ -707,6 +714,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Trim) {
   expect_start_op(mock_exclusive_lock);
   expect_update_object_map(mock_dst_image_ctx, mock_object_map,
                            m_dst_snap_ids[1], OBJECT_EXISTS, 0);
+  expect_prepare_copyup(mock_dst_image_ctx);
   expect_start_op(mock_exclusive_lock);
   expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, 0);
   expect_start_op(mock_exclusive_lock);
@@ -763,6 +771,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Remove) {
                            m_dst_snap_ids[1], is_fast_diff(mock_dst_image_ctx) ?
                            OBJECT_EXISTS_CLEAN : OBJECT_EXISTS, 0);
 
+  expect_prepare_copyup(mock_dst_image_ctx);
   expect_start_op(mock_exclusive_lock);
   expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, 0);
   expect_start_op(mock_exclusive_lock);
@@ -883,6 +892,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteSnapsStart) {
   expect_update_object_map(mock_dst_image_ctx, mock_object_map,
                            CEPH_NOSNAP, OBJECT_EXISTS, 0);
 
+  expect_prepare_copyup(mock_dst_image_ctx);
   expect_start_op(mock_exclusive_lock);
   expect_write(mock_dst_io_ctx, two,
                {m_dst_snap_ids[0], {m_dst_snap_ids[0]}}, 0);

--- a/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
@@ -516,10 +516,10 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Write) {
   expect_list_snaps(mock_src_image_ctx, 0);
   expect_read(mock_src_image_ctx, m_src_snap_ids[0], 0, one.range_end(), 0);
   expect_start_op(mock_exclusive_lock);
-  expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, 0);
-  expect_start_op(mock_exclusive_lock);
   expect_update_object_map(mock_dst_image_ctx, mock_object_map,
                            m_dst_snap_ids[0], OBJECT_EXISTS, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, 0);
 
   request->send();
   ASSERT_EQ(0, ctx.wait());
@@ -587,6 +587,11 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteError) {
   InSequence seq;
   expect_list_snaps(mock_src_image_ctx, 0);
   expect_read(mock_src_image_ctx, m_src_snap_ids[0], 0, one.range_end(), 0);
+
+  expect_start_op(mock_exclusive_lock);
+  expect_update_object_map(mock_dst_image_ctx, mock_object_map,
+                           m_dst_snap_ids[0], OBJECT_EXISTS, 0);
+
   expect_start_op(mock_exclusive_lock);
   expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, -EINVAL);
 
@@ -636,11 +641,6 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteSnaps) {
   expect_read(mock_src_image_ctx, m_src_snap_ids[0], 0, one.range_end(), 0);
   expect_read(mock_src_image_ctx, m_src_snap_ids[2], two, 0);
   expect_start_op(mock_exclusive_lock);
-  expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, 0);
-  expect_start_op(mock_exclusive_lock);
-  expect_write(mock_dst_io_ctx, two,
-               {m_dst_snap_ids[0], {m_dst_snap_ids[0]}}, 0);
-  expect_start_op(mock_exclusive_lock);
   expect_update_object_map(mock_dst_image_ctx, mock_object_map,
                            m_dst_snap_ids[0], OBJECT_EXISTS, 0);
   expect_start_op(mock_exclusive_lock);
@@ -650,6 +650,11 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteSnaps) {
   expect_update_object_map(mock_dst_image_ctx, mock_object_map,
                            m_dst_snap_ids[2], is_fast_diff(mock_dst_image_ctx) ?
                            OBJECT_EXISTS_CLEAN : OBJECT_EXISTS, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_write(mock_dst_io_ctx, two,
+               {m_dst_snap_ids[0], {m_dst_snap_ids[0]}}, 0);
 
   request->send();
   ASSERT_EQ(0, ctx.wait());
@@ -697,15 +702,15 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Trim) {
   expect_list_snaps(mock_src_image_ctx, 0);
   expect_read(mock_src_image_ctx, m_src_snap_ids[0], 0, one.range_end(), 0);
   expect_start_op(mock_exclusive_lock);
-  expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, 0);
-  expect_start_op(mock_exclusive_lock);
-  expect_truncate(mock_dst_io_ctx, trim_offset, 0);
-  expect_start_op(mock_exclusive_lock);
   expect_update_object_map(mock_dst_image_ctx, mock_object_map,
                            m_dst_snap_ids[0], OBJECT_EXISTS, 0);
   expect_start_op(mock_exclusive_lock);
   expect_update_object_map(mock_dst_image_ctx, mock_object_map,
                            m_dst_snap_ids[1], OBJECT_EXISTS, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_truncate(mock_dst_io_ctx, trim_offset, 0);
 
   request->send();
   ASSERT_EQ(0, ctx.wait());
@@ -748,10 +753,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Remove) {
   InSequence seq;
   expect_list_snaps(mock_src_image_ctx, 0);
   expect_read(mock_src_image_ctx, m_src_snap_ids[1], 0, one.range_end(), 0);
-  expect_start_op(mock_exclusive_lock);
-  expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, 0);
-  expect_start_op(mock_exclusive_lock);
-  expect_remove(mock_dst_io_ctx, 0);
+
   expect_start_op(mock_exclusive_lock);
   uint8_t state = OBJECT_EXISTS;
   expect_update_object_map(mock_dst_image_ctx, mock_object_map,
@@ -760,6 +762,11 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Remove) {
   expect_update_object_map(mock_dst_image_ctx, mock_object_map,
                            m_dst_snap_ids[1], is_fast_diff(mock_dst_image_ctx) ?
                            OBJECT_EXISTS_CLEAN : OBJECT_EXISTS, 0);
+
+  expect_start_op(mock_exclusive_lock);
+  expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_remove(mock_dst_io_ctx, 0);
 
   request->send();
   ASSERT_EQ(0, ctx.wait());
@@ -791,14 +798,9 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, ObjectMapUpdateError) {
                                                   mock_dst_image_ctx, 0, 0,
                                                   &ctx);
 
-  librados::MockTestMemIoCtxImpl &mock_dst_io_ctx(get_mock_io_ctx(
-    request->get_dst_io_ctx()));
-
   InSequence seq;
   expect_list_snaps(mock_src_image_ctx, 0);
   expect_read(mock_src_image_ctx, m_src_snap_ids[0], 0, one.range_end(), 0);
-  expect_start_op(mock_exclusive_lock);
-  expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, 0);
   expect_start_op(mock_exclusive_lock);
   expect_update_object_map(mock_dst_image_ctx, mock_object_map,
                            m_dst_snap_ids[0], OBJECT_EXISTS, -EBLOCKLISTED);
@@ -874,20 +876,20 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteSnapsStart) {
   expect_read(mock_src_image_ctx, m_src_snap_ids[2], three, 0);
 
   expect_start_op(mock_exclusive_lock);
-  expect_write(mock_dst_io_ctx, two,
-               {m_dst_snap_ids[0], {m_dst_snap_ids[0]}}, 0);
-
-  expect_start_op(mock_exclusive_lock);
-  expect_write(mock_dst_io_ctx, three,
-               {m_dst_snap_ids[1], {m_dst_snap_ids[1], m_dst_snap_ids[0]}}, 0);
-
-  expect_start_op(mock_exclusive_lock);
   expect_update_object_map(mock_dst_image_ctx, mock_object_map,
                            m_dst_snap_ids[1], OBJECT_EXISTS, 0);
 
   expect_start_op(mock_exclusive_lock);
   expect_update_object_map(mock_dst_image_ctx, mock_object_map,
                            CEPH_NOSNAP, OBJECT_EXISTS, 0);
+
+  expect_start_op(mock_exclusive_lock);
+  expect_write(mock_dst_io_ctx, two,
+               {m_dst_snap_ids[0], {m_dst_snap_ids[0]}}, 0);
+
+  expect_start_op(mock_exclusive_lock);
+  expect_write(mock_dst_io_ctx, three,
+               {m_dst_snap_ids[1], {m_dst_snap_ids[1], m_dst_snap_ids[0]}}, 0);
 
   request->send();
   ASSERT_EQ(0, ctx.wait());

--- a/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
@@ -99,8 +99,10 @@ public:
                                MockImageDispatch &mock_image_dispatch,
                                bool init_shutdown, int r) {
     expect_test_features(mock_image_ctx, RBD_FEATURE_EXCLUSIVE_LOCK, true);
-    expect_test_features(mock_image_ctx, RBD_FEATURE_JOURNALING,
-                         ((mock_image_ctx.features & RBD_FEATURE_JOURNALING) != 0));
+    if (!mock_image_ctx.clone_copy_on_read) {
+      expect_test_features(mock_image_ctx, RBD_FEATURE_JOURNALING,
+                           ((mock_image_ctx.features & RBD_FEATURE_JOURNALING) != 0));
+    }
     if (mock_image_ctx.clone_copy_on_read ||
         (mock_image_ctx.features & RBD_FEATURE_JOURNALING) != 0) {
       expect_set_require_lock(mock_image_dispatch, init_shutdown,

--- a/src/test/librbd/io/test_mock_CopyupRequest.cc
+++ b/src/test/librbd/io/test_mock_CopyupRequest.cc
@@ -342,6 +342,25 @@ struct TestMockIoCopyupRequest : public TestMockFixture {
         }));
   }
 
+  void expect_prepare_copyup(MockTestImageCtx& mock_image_ctx) {
+    EXPECT_CALL(*mock_image_ctx.io_object_dispatcher, prepare_copyup(_, _));
+  }
+
+  void expect_prepare_copyup(MockTestImageCtx& mock_image_ctx,
+                             const SparseBufferlist& in_sparse_bl,
+                             const SparseBufferlist& out_sparse_bl) {
+    EXPECT_CALL(*mock_image_ctx.io_object_dispatcher,
+                prepare_copyup(_, _))
+      .WillOnce(WithArg<1>(Invoke(
+        [in_sparse_bl, out_sparse_bl]
+        (SnapshotSparseBufferlist* snap_sparse_bl) {
+          auto& sparse_bl = (*snap_sparse_bl)[0];
+          EXPECT_EQ(in_sparse_bl, sparse_bl);
+
+          sparse_bl = out_sparse_bl;
+        })));
+  }
+
   void flush_async_operations(librbd::ImageCtx* ictx) {
     api::Io<>::flush(*ictx);
   }
@@ -373,6 +392,7 @@ TEST_F(TestMockIoCopyupRequest, Standard) {
   std::string data(4096, '1');
   expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
                      data, 0);
+  expect_prepare_copyup(mock_image_ctx);
 
   MockAbstractObjectWriteRequest mock_write_request;
   expect_get_pre_write_object_map_state(mock_image_ctx, mock_write_request,
@@ -429,6 +449,7 @@ TEST_F(TestMockIoCopyupRequest, StandardWithSnaps) {
   std::string data(4096, '1');
   expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
                      data, 0);
+  expect_prepare_copyup(mock_image_ctx);
 
   MockAbstractObjectWriteRequest mock_write_request;
   expect_get_pre_write_object_map_state(mock_image_ctx, mock_write_request,
@@ -477,6 +498,7 @@ TEST_F(TestMockIoCopyupRequest, CopyOnRead) {
   std::string data(4096, '1');
   expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
                      data, 0);
+  expect_prepare_copyup(mock_image_ctx);
 
   expect_object_map_at(mock_image_ctx, 0, OBJECT_NONEXISTENT);
   expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
@@ -523,6 +545,7 @@ TEST_F(TestMockIoCopyupRequest, CopyOnReadWithSnaps) {
   std::string data(4096, '1');
   expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
                      data, 0);
+  expect_prepare_copyup(mock_image_ctx);
 
   expect_object_map_at(mock_image_ctx, 0, OBJECT_NONEXISTENT);
   expect_object_map_update(mock_image_ctx, 1, 0, OBJECT_EXISTS, true, 0);
@@ -783,6 +806,7 @@ TEST_F(TestMockIoCopyupRequest, ZeroedCopyup) {
   InSequence seq;
 
   MockAbstractObjectWriteRequest mock_write_request;
+  expect_prepare_copyup(mock_image_ctx);
   expect_is_empty_write_op(mock_write_request, false);
   expect_get_pre_write_object_map_state(mock_image_ctx, mock_write_request,
                                         OBJECT_EXISTS);
@@ -828,6 +852,7 @@ TEST_F(TestMockIoCopyupRequest, ZeroedCopyOnRead) {
   std::string data(4096, '\0');
   expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
                      data, 0);
+  expect_prepare_copyup(mock_image_ctx);
 
   expect_object_map_at(mock_image_ctx, 0, OBJECT_NONEXISTENT);
   expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
@@ -867,6 +892,8 @@ TEST_F(TestMockIoCopyupRequest, NoOpCopyup) {
   expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
                      "", -ENOENT);
 
+  expect_prepare_copyup(mock_image_ctx);
+
   MockAbstractObjectWriteRequest mock_write_request;
   expect_is_empty_write_op(mock_write_request, true);
 
@@ -903,6 +930,7 @@ TEST_F(TestMockIoCopyupRequest, RestartWrite) {
   std::string data(4096, '1');
   expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
                      data, 0);
+  expect_prepare_copyup(mock_image_ctx);
 
   MockAbstractObjectWriteRequest mock_write_request1;
   expect_get_pre_write_object_map_state(mock_image_ctx, mock_write_request1,
@@ -958,12 +986,10 @@ TEST_F(TestMockIoCopyupRequest, ReadFromParentError) {
   expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
                      "", -EPERM);
 
-  MockAbstractObjectWriteRequest mock_write_request;
-  expect_is_empty_write_op(mock_write_request, false);
-
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
+  MockAbstractObjectWriteRequest mock_write_request;
   req->append_request(&mock_write_request, {});
   req->send();
 
@@ -1031,6 +1057,7 @@ TEST_F(TestMockIoCopyupRequest, UpdateObjectMapError) {
   std::string data(4096, '1');
   expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
                      data, 0);
+  expect_prepare_copyup(mock_image_ctx);
 
   MockAbstractObjectWriteRequest mock_write_request;
   expect_get_pre_write_object_map_state(mock_image_ctx, mock_write_request,
@@ -1079,6 +1106,7 @@ TEST_F(TestMockIoCopyupRequest, CopyupError) {
   std::string data(4096, '1');
   expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
                      data, 0);
+  expect_prepare_copyup(mock_image_ctx);
 
   MockAbstractObjectWriteRequest mock_write_request;
   expect_get_pre_write_object_map_state(mock_image_ctx, mock_write_request,
@@ -1128,6 +1156,7 @@ TEST_F(TestMockIoCopyupRequest, SparseCopyupNotSupported) {
   std::string data(4096, '1');
   expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
                      data, 0);
+  expect_prepare_copyup(mock_image_ctx);
 
   MockAbstractObjectWriteRequest mock_write_request;
   expect_get_pre_write_object_map_state(mock_image_ctx, mock_write_request,
@@ -1143,6 +1172,129 @@ TEST_F(TestMockIoCopyupRequest, SparseCopyupNotSupported) {
   auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
   req->append_request(&mock_write_request, {});
+  req->send();
+
+  ASSERT_EQ(0, mock_write_request.ctx.wait());
+}
+
+TEST_F(TestMockIoCopyupRequest, ProcessCopyup) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_parent_image_ctx(*ictx->parent);
+  MockTestImageCtx mock_image_ctx(*ictx, &mock_parent_image_ctx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  MockJournal mock_journal;
+  MockObjectMap mock_object_map;
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
+                      mock_object_map);
+
+  expect_op_work_queue(mock_image_ctx);
+  expect_is_lock_owner(mock_image_ctx);
+
+  InSequence seq;
+
+  MockImageRequest mock_image_request;
+  std::string data(4096, '1');
+  expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
+                     data, 0);
+
+  bufferlist in_prepare_bl;
+  in_prepare_bl.append(std::string(3072, '1'));
+  bufferlist out_prepare_bl;
+  out_prepare_bl.substr_of(in_prepare_bl, 0, 1024);
+  expect_prepare_copyup(
+    mock_image_ctx,
+    {{1024U, {3072U, {SPARSE_EXTENT_STATE_DATA, 3072,
+                      std::move(in_prepare_bl)}}}},
+    {{2048U, {1024U, {SPARSE_EXTENT_STATE_DATA, 1024,
+                      std::move(out_prepare_bl)}}}});
+
+  MockAbstractObjectWriteRequest mock_write_request;
+  expect_get_pre_write_object_map_state(mock_image_ctx, mock_write_request,
+                                        OBJECT_EXISTS);
+  expect_object_map_at(mock_image_ctx, 0, OBJECT_NONEXISTENT);
+  expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
+                           0);
+
+  expect_add_copyup_ops(mock_write_request);
+  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0),
+                       {{2048, 1024}}, data.substr(0, 1024), 0);
+  expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
+
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
+                                   {{0, 4096}}, {});
+  mock_image_ctx.copyup_list[0] = req;
+  req->append_request(&mock_write_request, {{0, 1024}});
+  req->send();
+
+  ASSERT_EQ(0, mock_write_request.ctx.wait());
+}
+
+TEST_F(TestMockIoCopyupRequest, ProcessCopyupOverwrite) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+  ictx->image_lock.lock();
+  ictx->add_snap(cls::rbd::UserSnapshotNamespace(), "1", 1, ictx->size,
+                 ictx->parent_md, RBD_PROTECTION_STATUS_UNPROTECTED,
+                 0, {});
+  ictx->snapc = {1, {1}};
+  ictx->image_lock.unlock();
+
+  MockTestImageCtx mock_parent_image_ctx(*ictx->parent);
+  MockTestImageCtx mock_image_ctx(*ictx, &mock_parent_image_ctx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  MockJournal mock_journal;
+  MockObjectMap mock_object_map;
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
+                      mock_object_map);
+
+  expect_test_features(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+  expect_is_lock_owner(mock_image_ctx);
+
+  InSequence seq;
+
+  MockImageRequest mock_image_request;
+  std::string data(4096, '1');
+  expect_read_parent(mock_parent_image_ctx, mock_image_request, {{0, 4096}},
+                     data, 0);
+
+  bufferlist in_prepare_bl;
+  in_prepare_bl.append(data);
+  bufferlist out_prepare_bl;
+  out_prepare_bl.substr_of(in_prepare_bl, 0, 1024);
+  expect_prepare_copyup(
+    mock_image_ctx,
+    {{0, {4096, {SPARSE_EXTENT_STATE_DATA, 4096,
+                 std::move(in_prepare_bl)}}}},
+    {{0, {1024, {SPARSE_EXTENT_STATE_DATA, 1024, bufferlist{out_prepare_bl}}}},
+     {2048, {1024, {SPARSE_EXTENT_STATE_DATA, 1024,
+                    bufferlist{out_prepare_bl}}}}});
+
+  MockAbstractObjectWriteRequest mock_write_request;
+  expect_get_pre_write_object_map_state(mock_image_ctx, mock_write_request,
+                                        OBJECT_EXISTS);
+  expect_object_map_at(mock_image_ctx, 0, OBJECT_NONEXISTENT);
+  expect_object_map_update(mock_image_ctx, 1, 0, OBJECT_EXISTS, true, 0);
+  expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
+                           0);
+
+  expect_add_copyup_ops(mock_write_request);
+  expect_sparse_copyup(mock_image_ctx, 0, ictx->get_object_name(0),
+                       {{0, 1024}, {2048, 1024}}, data.substr(0, 2048), 0);
+  expect_write(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0), 0);
+
+  auto req = new MockCopyupRequest(&mock_image_ctx, 0,
+                                   {{0, 4096}}, {});
+  mock_image_ctx.copyup_list[0] = req;
+  req->append_request(&mock_write_request, {{0, 1024}});
   req->send();
 
   ASSERT_EQ(0, mock_write_request.ctx.wait());

--- a/src/test/librbd/io/test_mock_CopyupRequest.cc
+++ b/src/test/librbd/io/test_mock_CopyupRequest.cc
@@ -389,7 +389,7 @@ TEST_F(TestMockIoCopyupRequest, Standard) {
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
-  req->append_request(&mock_write_request);
+  req->append_request(&mock_write_request, {});
   req->send();
 
   ASSERT_EQ(0, mock_write_request.ctx.wait());
@@ -447,7 +447,7 @@ TEST_F(TestMockIoCopyupRequest, StandardWithSnaps) {
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
-  req->append_request(&mock_write_request);
+  req->append_request(&mock_write_request, {});
   req->send();
 
   ASSERT_EQ(0, mock_write_request.ctx.wait());
@@ -580,7 +580,7 @@ TEST_F(TestMockIoCopyupRequest, DeepCopy) {
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
-  req->append_request(&mock_write_request);
+  req->append_request(&mock_write_request, {});
   req->send();
 
   ASSERT_EQ(0, mock_write_request.ctx.wait());
@@ -685,7 +685,7 @@ TEST_F(TestMockIoCopyupRequest, DeepCopyWithPostSnaps) {
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
-  req->append_request(&mock_write_request);
+  req->append_request(&mock_write_request, {});
   req->send();
 
   ASSERT_EQ(0, mock_write_request.ctx.wait());
@@ -757,7 +757,7 @@ TEST_F(TestMockIoCopyupRequest, DeepCopyWithPreAndPostSnaps) {
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
-  req->append_request(&mock_write_request);
+  req->append_request(&mock_write_request, {});
   req->send();
 
   ASSERT_EQ(0, mock_write_request.ctx.wait());
@@ -798,7 +798,7 @@ TEST_F(TestMockIoCopyupRequest, ZeroedCopyup) {
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
-  req->append_request(&mock_write_request);
+  req->append_request(&mock_write_request, {});
   req->send();
 
   ASSERT_EQ(0, mock_write_request.ctx.wait());
@@ -873,7 +873,7 @@ TEST_F(TestMockIoCopyupRequest, NoOpCopyup) {
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
-  req->append_request(&mock_write_request);
+  req->append_request(&mock_write_request, {});
   req->send();
 
   ASSERT_EQ(0, mock_write_request.ctx.wait());
@@ -922,12 +922,12 @@ TEST_F(TestMockIoCopyupRequest, RestartWrite) {
     mock_image_ctx.rados_api, *mock_image_ctx.get_data_io_context());
   EXPECT_CALL(mock_io_ctx, write(ictx->get_object_name(0), _, 0, 0, _))
     .WillOnce(WithoutArgs(Invoke([req, &mock_write_request2]() {
-                            req->append_request(&mock_write_request2);
+                            req->append_request(&mock_write_request2, {});
                             return 0;
                           })));
 
   mock_image_ctx.copyup_list[0] = req;
-  req->append_request(&mock_write_request1);
+  req->append_request(&mock_write_request1, {});
   req->send();
 
   ASSERT_EQ(0, mock_write_request1.ctx.wait());
@@ -964,7 +964,7 @@ TEST_F(TestMockIoCopyupRequest, ReadFromParentError) {
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
-  req->append_request(&mock_write_request);
+  req->append_request(&mock_write_request, {});
   req->send();
 
   ASSERT_EQ(-EPERM, mock_write_request.ctx.wait());
@@ -1001,7 +1001,7 @@ TEST_F(TestMockIoCopyupRequest, DeepCopyError) {
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
-  req->append_request(&mock_write_request);
+  req->append_request(&mock_write_request, {});
   req->send();
 
   ASSERT_EQ(-EPERM, mock_write_request.ctx.wait());
@@ -1042,7 +1042,7 @@ TEST_F(TestMockIoCopyupRequest, UpdateObjectMapError) {
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
-  req->append_request(&mock_write_request);
+  req->append_request(&mock_write_request, {});
   req->send();
 
   ASSERT_EQ(-EINVAL, mock_write_request.ctx.wait());
@@ -1096,7 +1096,7 @@ TEST_F(TestMockIoCopyupRequest, CopyupError) {
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
-  req->append_request(&mock_write_request);
+  req->append_request(&mock_write_request, {});
   req->send();
 
   ASSERT_EQ(-EPERM, mock_write_request.ctx.wait());
@@ -1142,7 +1142,7 @@ TEST_F(TestMockIoCopyupRequest, SparseCopyupNotSupported) {
 
   auto req = new MockCopyupRequest(&mock_image_ctx, 0, {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;
-  req->append_request(&mock_write_request);
+  req->append_request(&mock_write_request, {});
   req->send();
 
   ASSERT_EQ(0, mock_write_request.ctx.wait());

--- a/src/test/librbd/io/test_mock_CopyupRequest.cc
+++ b/src/test/librbd/io/test_mock_CopyupRequest.cc
@@ -615,9 +615,6 @@ TEST_F(TestMockIoCopyupRequest, DeepCopyOnRead) {
   expect_object_map_update(mock_image_ctx, CEPH_NOSNAP, 0, OBJECT_EXISTS, true,
                            0);
 
-  expect_sparse_copyup(mock_image_ctx, CEPH_NOSNAP, ictx->get_object_name(0),
-                       {}, "", 0);
-
   auto req = new MockCopyupRequest(&mock_image_ctx, 0,
                                    {{0, 4096}}, {});
   mock_image_ctx.copyup_list[0] = req;

--- a/src/test/librbd/io/test_mock_ImageRequest.cc
+++ b/src/test/librbd/io/test_mock_ImageRequest.cc
@@ -502,15 +502,15 @@ TEST_F(TestMockIoImageRequest, ListSnaps) {
 
   SnapshotDelta object_snapshot_delta;
   object_snapshot_delta[{5,6}].insert(
-    0, 1024, {SNAPSHOT_EXTENT_STATE_DATA, 1024});
+    0, 1024, {SPARSE_EXTENT_STATE_DATA, 1024});
   object_snapshot_delta[{5,5}].insert(
-    4096, 4096, {SNAPSHOT_EXTENT_STATE_ZEROED, 4096});
+    4096, 4096, {SPARSE_EXTENT_STATE_ZEROED, 4096});
   expect_object_list_snaps_request(mock_image_ctx, 0, object_snapshot_delta, 0);
   object_snapshot_delta = {};
   object_snapshot_delta[{5,6}].insert(
-    1024, 3072, {SNAPSHOT_EXTENT_STATE_DATA, 3072});
+    1024, 3072, {SPARSE_EXTENT_STATE_DATA, 3072});
   object_snapshot_delta[{5,5}].insert(
-    2048, 2048, {SNAPSHOT_EXTENT_STATE_ZEROED, 2048});
+    2048, 2048, {SPARSE_EXTENT_STATE_ZEROED, 2048});
   expect_object_list_snaps_request(mock_image_ctx, 1, object_snapshot_delta, 0);
 
   SnapshotDelta snapshot_delta;
@@ -528,11 +528,11 @@ TEST_F(TestMockIoImageRequest, ListSnaps) {
 
   SnapshotDelta expected_snapshot_delta;
   expected_snapshot_delta[{5,6}].insert(
-    0, 1024, {SNAPSHOT_EXTENT_STATE_DATA, 1024});
+    0, 1024, {SPARSE_EXTENT_STATE_DATA, 1024});
   expected_snapshot_delta[{5,6}].insert(
-    5120, 3072, {SNAPSHOT_EXTENT_STATE_DATA, 3072});
+    5120, 3072, {SPARSE_EXTENT_STATE_DATA, 3072});
   expected_snapshot_delta[{5,5}].insert(
-    6144, 6144, {SNAPSHOT_EXTENT_STATE_ZEROED, 6144});
+    6144, 6144, {SPARSE_EXTENT_STATE_ZEROED, 6144});
   ASSERT_EQ(expected_snapshot_delta, snapshot_delta);
 }
 

--- a/src/test/librbd/io/test_mock_ObjectRequest.cc
+++ b/src/test/librbd/io/test_mock_ObjectRequest.cc
@@ -37,7 +37,8 @@ namespace io {
 template <>
 struct CopyupRequest<librbd::MockImageCtx> {
   MOCK_METHOD0(send, void());
-  MOCK_METHOD1(append_request, void(AbstractObjectWriteRequest<librbd::MockTestImageCtx>*));
+  MOCK_METHOD2(append_request, void(AbstractObjectWriteRequest<librbd::MockTestImageCtx>*,
+                                    const Extents&));
 };
 
 template <>
@@ -244,10 +245,11 @@ struct TestMockIoObjectRequest : public TestMockFixture {
 
   void expect_copyup(MockCopyupRequest& mock_copyup_request,
                      MockAbstractObjectWriteRequest** write_request, int r) {
-    EXPECT_CALL(mock_copyup_request, append_request(_))
-      .WillOnce(Invoke([write_request](MockAbstractObjectWriteRequest *req) {
-                  *write_request = req;
-                }));
+    EXPECT_CALL(mock_copyup_request, append_request(_, _))
+      .WillOnce(WithArg<0>(
+        Invoke([write_request](MockAbstractObjectWriteRequest *req) {
+            *write_request = req;
+          })));
     EXPECT_CALL(mock_copyup_request, send())
       .WillOnce(Invoke([write_request, r]() {
                   (*write_request)->handle_copyup(r);

--- a/src/test/librbd/io/test_mock_ObjectRequest.cc
+++ b/src/test/librbd/io/test_mock_ObjectRequest.cc
@@ -1745,19 +1745,19 @@ TEST_F(TestMockIoObjectRequest, ListSnaps) {
 
   SnapshotDelta expected_snapshot_delta;
   expected_snapshot_delta[{5,6}].insert(
-    440320, 1024, {SNAPSHOT_EXTENT_STATE_DATA, 1024});
+    440320, 1024, {SPARSE_EXTENT_STATE_DATA, 1024});
   expected_snapshot_delta[{5,6}].insert(
-    2122728, 1024, {SNAPSHOT_EXTENT_STATE_DATA, 1024});
+    2122728, 1024, {SPARSE_EXTENT_STATE_DATA, 1024});
   expected_snapshot_delta[{5,6}].insert(
-    2220032, 2048, {SNAPSHOT_EXTENT_STATE_DATA, 2048});
+    2220032, 2048, {SPARSE_EXTENT_STATE_DATA, 2048});
   expected_snapshot_delta[{7,CEPH_NOSNAP}].insert(
-    2122728, 1024, {SNAPSHOT_EXTENT_STATE_DATA, 1024});
+    2122728, 1024, {SPARSE_EXTENT_STATE_DATA, 1024});
   expected_snapshot_delta[{7,CEPH_NOSNAP}].insert(
-    2221056, 1024, {SNAPSHOT_EXTENT_STATE_DATA, 1024});
+    2221056, 1024, {SPARSE_EXTENT_STATE_DATA, 1024});
   expected_snapshot_delta[{7,CEPH_NOSNAP}].insert(
-    3072000, 4096, {SNAPSHOT_EXTENT_STATE_DATA, 4096});
+    3072000, 4096, {SPARSE_EXTENT_STATE_DATA, 4096});
   expected_snapshot_delta[{5,5}].insert(
-    3072000, 4096, {SNAPSHOT_EXTENT_STATE_ZEROED, 4096});
+    3072000, 4096, {SPARSE_EXTENT_STATE_ZEROED, 4096});
   ASSERT_EQ(expected_snapshot_delta, snapshot_delta);
 }
 
@@ -1780,7 +1780,7 @@ TEST_F(TestMockIoObjectRequest, ListSnapsDNE) {
 
   SnapshotDelta expected_snapshot_delta;
   expected_snapshot_delta[{0,0}].insert(
-    440320, 1024, {SNAPSHOT_EXTENT_STATE_DNE, 1024});
+    440320, 1024, {SPARSE_EXTENT_STATE_DNE, 1024});
   ASSERT_EQ(expected_snapshot_delta, snapshot_delta);
 }
 
@@ -1803,7 +1803,7 @@ TEST_F(TestMockIoObjectRequest, ListSnapsEmpty) {
 
   SnapshotDelta expected_snapshot_delta;
   expected_snapshot_delta[{0,0}].insert(
-    440320, 1024, {SNAPSHOT_EXTENT_STATE_ZEROED, 1024});
+    440320, 1024, {SPARSE_EXTENT_STATE_ZEROED, 1024});
   ASSERT_EQ(expected_snapshot_delta, snapshot_delta);
 }
 
@@ -1842,7 +1842,7 @@ TEST_F(TestMockIoObjectRequest, ListSnapsParent) {
   MockImageListSnapsRequest mock_image_list_snaps_request;
   SnapshotDelta image_snapshot_delta;
   image_snapshot_delta[{1,6}].insert(
-    0, 1024, {SNAPSHOT_EXTENT_STATE_DATA, 1024});
+    0, 1024, {SPARSE_EXTENT_STATE_DATA, 1024});
   expect_image_list_snaps(mock_image_list_snaps_request,
                           {{0, 4096}}, image_snapshot_delta, 0);
 
@@ -1857,7 +1857,7 @@ TEST_F(TestMockIoObjectRequest, ListSnapsParent) {
 
   SnapshotDelta expected_snapshot_delta;
   expected_snapshot_delta[{0,0}].insert(
-    0, 1024, {SNAPSHOT_EXTENT_STATE_DATA, 1024});
+    0, 1024, {SPARSE_EXTENT_STATE_DATA, 1024});
   ASSERT_EQ(expected_snapshot_delta, snapshot_delta);
 }
 
@@ -1899,7 +1899,7 @@ TEST_F(TestMockIoObjectRequest, ListSnapsWholeObject) {
   SnapshotDelta expected_snapshot_delta;
   expected_snapshot_delta[{CEPH_NOSNAP,CEPH_NOSNAP}].insert(
     0, mock_image_ctx.layout.object_size - 1,
-    {SNAPSHOT_EXTENT_STATE_DATA, mock_image_ctx.layout.object_size - 1});
+    {SPARSE_EXTENT_STATE_DATA, mock_image_ctx.layout.object_size - 1});
   ASSERT_EQ(expected_snapshot_delta, snapshot_delta);
 }
 

--- a/src/test/librbd/mock/io/MockObjectDispatch.h
+++ b/src/test/librbd/mock/io/MockObjectDispatch.h
@@ -128,6 +128,7 @@ public:
 
   MOCK_METHOD5(extent_overwritten, void(uint64_t, uint64_t, uint64_t, uint64_t,
                                         uint64_t));
+  MOCK_METHOD2(prepare_copyup, void(uint64_t, SnapshotSparseBufferlist*));
 };
 
 } // namespace io

--- a/src/test/librbd/mock/io/MockObjectDispatcher.h
+++ b/src/test/librbd/mock/io/MockObjectDispatcher.h
@@ -32,6 +32,8 @@ public:
   MOCK_METHOD5(extent_overwritten, void(uint64_t, uint64_t, uint64_t, uint64_t,
                                         uint64_t));
 
+  MOCK_METHOD2(prepare_copyup, void(uint64_t, SnapshotSparseBufferlist*));
+
   MOCK_METHOD1(send, void(ObjectDispatchSpec*));
 };
 

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -679,7 +679,7 @@ TEST_F(TestInternal, SnapshotCopyup)
       BOOST_SCOPE_EXIT(ictx3) {
         ictx3->state->close();
       } BOOST_SCOPE_EXIT_END;
-      std::map<uint64_t, uint64_t> expected_m;
+      std::vector<std::pair<uint64_t, uint64_t>> expected_m;
       bufferlist expected_bl;
       if (ictx3->enable_sparse_copyup && sparse_read_supported) {
         if (snap_name == NULL) {
@@ -701,7 +701,7 @@ TEST_F(TestInternal, SnapshotCopyup)
           expected_bl.append(std::string(256 * 1, '1'));
         }
       }
-      std::map<uint64_t, uint64_t> read_m;
+      std::vector<std::pair<uint64_t, uint64_t>> read_m;
       librbd::io::ReadResult sparse_read_result{&read_m, &read_bl};
       EXPECT_EQ(1024 + 256,
                 api::Io<>::read(*ictx3, 0, 1024 + 256,


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
