### PR TITLE
doc/rados: erasure-code-lrc corrections

### DIFF
--- a/doc/rados/operations/erasure-code-lrc.rst
+++ b/doc/rados/operations/erasure-code-lrc.rst
@@ -4,12 +4,12 @@ Locally repairable erasure code plugin
 
 With the *jerasure* plugin, when an erasure coded object is stored on
 multiple OSDs, recovering from the loss of one OSD requires reading
-from all the others. For instance if *jerasure* is configured with
-*k=8* and *m=4*, losing one OSD requires reading from the eight
-others to repair.
+from *k* others. For instance if *jerasure* is configured with
+*k=8* and *m=4*, recovering from the loss of one OSD requires reading
+from eight others.
 
-The *lrc* erasure code plugin creates local parity chunks to be able
-to recover using less OSDs. For instance if *lrc* is configured with
+The *lrc* erasure code plugin creates local parity chunks to enable
+recovery using fewer surviving OSDs. For instance if *lrc* is configured with
 *k=8*, *m=4* and *l=4*, it will create an additional parity chunk for
 every four OSDs. When a single OSD is lost, it can be recovered with
 only four OSDs instead of eight.
@@ -34,7 +34,7 @@ observed.::
 Reduce recovery bandwidth between racks
 ---------------------------------------
 
-In Firefly the reduced bandwidth will only be observed if the primary
+In Firefly the bandwidth reduction will only be observed if the primary
 OSD is in the same rack as the lost chunk.::
 
         $ ceph osd erasure-code-profile set LRCprofile \
@@ -106,7 +106,7 @@ Where:
 
 ``crush-locality={bucket-type}``
 
-:Description: The type of the crush bucket in which each set of chunks
+:Description: The type of the CRUSH bucket in which each set of chunks
               defined by **l** will be stored. For instance, if it is
               set to **rack**, each group of **l** chunks will be
               placed in a different rack. It is used to create a
@@ -158,8 +158,8 @@ Low level plugin configuration
 ==============================
 
 The sum of **k** and **m** must be a multiple of the **l** parameter.
-The low level configuration parameters do not impose such a
-restriction and it may be more convenient to use it for specific
+The low level configuration parameters however do not enforce this
+restriction and it may be advantageous to use them for specific
 purposes. It is for instance possible to define two groups, one with 4
 chunks and another with 3 chunks. It is also possible to recursively
 define locality sets, for instance datacenters and racks into


### PR DESCRIPTION
doc/rados: erasure-code-lrc corrections

- Clarified / corrected jerasure recovery characterization cf. https://library.eecs.utk.edu/storage/125phpw0xFqAut-cs-07-603.pdf
- Capitalization
- Word choice:  OSDs are discrete / cardinal, so "fewer" instead of  "less"
- Reworked a few phrases to be less stilted

Signed-off-by: Anthony D'Atri <anthony.datri@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
