### PR TITLE
octopus: mgr/dashboard: log in non-admin users successfully if the telemetry notification is shown

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/telemetry-notification/telemetry-notification.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/telemetry-notification/telemetry-notification.component.spec.ts
@@ -7,9 +7,9 @@ import { of } from 'rxjs';
 import { AlertModule } from 'ngx-bootstrap/alert';
 
 import { configureTestBed, i18nProviders } from '../../../../testing/unit-test-helper';
-import { UserFormModel } from '../../../core/auth/user-form/user-form.model';
 import { MgrModuleService } from '../../api/mgr-module.service';
 import { UserService } from '../../api/user.service';
+import { Permissions } from '../../models/permissions';
 import { PipesModule } from '../../pipes/pipes.module';
 import { AuthStorageService } from '../../services/auth-storage.service';
 import { NotificationService } from '../../services/notification.service';
@@ -21,35 +21,17 @@ describe('TelemetryActivationNotificationComponent', () => {
   let fixture: ComponentFixture<TelemetryNotificationComponent>;
 
   let authStorageService: AuthStorageService;
-  let userService: UserService;
   let mgrModuleService: MgrModuleService;
   let notificationService: NotificationService;
 
   let isNotificationHiddenSpy: jasmine.Spy;
-  let getUsernameSpy: jasmine.Spy;
-  let userServiceGetSpy: jasmine.Spy;
+  let getPermissionsSpy: jasmine.Spy;
   let getConfigSpy: jasmine.Spy;
 
-  const user: UserFormModel = {
-    username: 'username',
-    password: undefined,
-    name: 'User 1',
-    email: 'user1@email.com',
-    roles: ['read-only'],
-    enabled: true,
-    pwdExpirationDate: undefined,
-    pwdUpdateRequired: true
-  };
-  const admin: UserFormModel = {
-    username: 'admin',
-    password: undefined,
-    name: 'User 1',
-    email: 'user1@email.com',
-    roles: ['administrator'],
-    enabled: true,
-    pwdExpirationDate: undefined,
-    pwdUpdateRequired: true
-  };
+  const configOptPermissions: Permissions = new Permissions({
+    'config-opt': ['read', 'create', 'update', 'delete']
+  });
+  const noConfigOptPermissions: Permissions = new Permissions({});
   const telemetryEnabledConfig = {
     enabled: true
   };
@@ -67,13 +49,13 @@ describe('TelemetryActivationNotificationComponent', () => {
     fixture = TestBed.createComponent(TelemetryNotificationComponent);
     component = fixture.componentInstance;
     authStorageService = TestBed.get(AuthStorageService);
-    userService = TestBed.get(UserService);
     mgrModuleService = TestBed.get(MgrModuleService);
     notificationService = TestBed.get(NotificationService);
 
     isNotificationHiddenSpy = spyOn(component, 'isNotificationHidden').and.returnValue(false);
-    getUsernameSpy = spyOn(authStorageService, 'getUsername').and.returnValue('username');
-    userServiceGetSpy = spyOn(userService, 'get').and.returnValue(of(admin)); // Not the best name but it sounded better than `getSpy`
+    getPermissionsSpy = spyOn(authStorageService, 'getPermissions').and.returnValue(
+      configOptPermissions
+    );
     getConfigSpy = spyOn(mgrModuleService, 'getConfig').and.returnValue(
       of(telemetryDisabledConfig)
     );
@@ -90,14 +72,13 @@ describe('TelemetryActivationNotificationComponent', () => {
     expect(component.displayNotification).toBe(false);
   });
 
-  it('should not show notification for an user without administrator role', () => {
-    userServiceGetSpy.and.returnValue(of(user));
+  it('should not show notification for a user without configOpt permissions', () => {
+    getPermissionsSpy.and.returnValue(noConfigOptPermissions);
     fixture.detectChanges();
     expect(component.displayNotification).toBe(false);
   });
 
   it('should not show notification if the module is enabled already', () => {
-    getUsernameSpy.and.returnValue('admin');
     getConfigSpy.and.returnValue(of(telemetryEnabledConfig));
     fixture.detectChanges();
     expect(component.displayNotification).toBe(false);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/telemetry-notification/telemetry-notification.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/telemetry-notification/telemetry-notification.component.ts
@@ -1,10 +1,9 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 
 import { I18n } from '@ngx-translate/i18n-polyfill';
+import * as _ from 'lodash';
 
-import { UserFormModel } from '../../../core/auth/user-form/user-form.model';
 import { MgrModuleService } from '../../api/mgr-module.service';
-import { UserService } from '../../api/user.service';
 import { NotificationType } from '../../enum/notification-type.enum';
 import { AuthStorageService } from '../../services/auth-storage.service';
 import { NotificationService } from '../../services/notification.service';
@@ -21,7 +20,6 @@ export class TelemetryNotificationComponent implements OnInit, OnDestroy {
   constructor(
     private mgrModuleService: MgrModuleService,
     private authStorageService: AuthStorageService,
-    private userService: UserService,
     private notificationService: NotificationService,
     private telemetryNotificationService: TelemetryNotificationService,
     private i18n: I18n
@@ -33,16 +31,14 @@ export class TelemetryNotificationComponent implements OnInit, OnDestroy {
     });
 
     if (!this.isNotificationHidden()) {
-      const username = this.authStorageService.getUsername();
-      this.userService.get(username).subscribe((user: UserFormModel) => {
-        if (user.roles.includes('administrator')) {
-          this.mgrModuleService.getConfig('telemetry').subscribe((options) => {
-            if (!options['enabled']) {
-              this.telemetryNotificationService.setVisibility(true);
-            }
-          });
-        }
-      });
+      const configOptPermissions = this.authStorageService.getPermissions().configOpt;
+      if (_.every(Object.values(configOptPermissions))) {
+        this.mgrModuleService.getConfig('telemetry').subscribe((options) => {
+          if (!options['enabled']) {
+            this.telemetryNotificationService.setVisibility(true);
+          }
+        });
+      }
     }
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47606

---

backport of https://github.com/ceph/ceph/pull/37043
parent tracker: https://tracker.ceph.com/issues/47331

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh