### PR TITLE
rpm: three spec file cleanups

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1398,14 +1398,6 @@ fi
 %postun base
 /sbin/ldconfig
 %systemd_postun ceph.target
-if [ $1 -ge 1 ] ; then
-  # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
-  # "yes". In any case: if units are not running, do not touch them.
-  SYSCONF_CEPH=%{_sysconfdir}/sysconfig/ceph
-  if [ -f $SYSCONF_CEPH -a -r $SYSCONF_CEPH ] ; then
-    source $SYSCONF_CEPH
-  fi
-fi
 
 %pre -n cephadm
 getent group cephadm >/dev/null || groupadd -r cephadm

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1398,8 +1398,7 @@ fi
 %postun base
 /sbin/ldconfig
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph.target
+%service_del_postun_without_restart ceph.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph.target
@@ -1558,8 +1557,7 @@ fi
 
 %postun mds
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-mds@\*.service ceph-mds.target
+%service_del_postun_without_restart ceph-mds@\*.service ceph-mds.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-mds@\*.service ceph-mds.target
@@ -1608,8 +1606,7 @@ fi
 
 %postun mgr
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-mgr@\*.service ceph-mgr.target
+%service_del_postun_without_restart ceph-mgr@\*.service ceph-mgr.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-mgr@\*.service ceph-mgr.target
@@ -1750,8 +1747,7 @@ fi
 
 %postun mon
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-mon@\*.service ceph-mon.target
+%service_del_postun_without_restart ceph-mon@\*.service ceph-mon.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-mon@\*.service ceph-mon.target
@@ -1811,8 +1807,7 @@ fi
 
 %postun -n rbd-mirror
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-rbd-mirror@\*.service ceph-rbd-mirror.target
+%service_del_postun_without_restart ceph-rbd-mirror@\*.service ceph-rbd-mirror.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-rbd-mirror@\*.service ceph-rbd-mirror.target
@@ -1859,8 +1854,7 @@ fi
 %postun immutable-object-cache
 test -n "$FIRST_ARG" || FIRST_ARG=$1
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-immutable-object-cache@\*.service ceph-immutable-object-cache.target
+%service_del_postun_without_restart ceph-immutable-object-cache@\*.service ceph-immutable-object-cache.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-immutable-object-cache@\*.service ceph-immutable-object-cache.target
@@ -1921,8 +1915,7 @@ fi
 %postun radosgw
 /sbin/ldconfig
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-radosgw@\*.service ceph-radosgw.target
+%service_del_postun_without_restart ceph-radosgw@\*.service ceph-radosgw.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-radosgw@\*.service ceph-radosgw.target
@@ -1989,8 +1982,7 @@ fi
 
 %postun osd
 %if 0%{?suse_version}
-DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-osd@\*.service ceph-volume@\*.service ceph-osd.target
+%service_del_postun_without_restart ceph-osd@\*.service ceph-volume@\*.service ceph-osd.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-osd@\*.service ceph-volume@\*.service ceph-osd.target

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1397,12 +1397,7 @@ fi
 
 %postun base
 /sbin/ldconfig
-%if 0%{?suse_version}
-%service_del_postun_without_restart ceph.target
-%endif
-%if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph.target
-%endif
 if [ $1 -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
   # "yes". In any case: if units are not running, do not touch them.
@@ -1556,12 +1551,7 @@ fi
 %endif
 
 %postun mds
-%if 0%{?suse_version}
-%service_del_postun_without_restart ceph-mds@\*.service ceph-mds.target
-%endif
-%if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-mds@\*.service ceph-mds.target
-%endif
 if [ $1 -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
   # "yes". In any case: if units are not running, do not touch them.
@@ -1605,12 +1595,7 @@ fi
 %endif
 
 %postun mgr
-%if 0%{?suse_version}
-%service_del_postun_without_restart ceph-mgr@\*.service ceph-mgr.target
-%endif
-%if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-mgr@\*.service ceph-mgr.target
-%endif
 if [ $1 -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
   # "yes". In any case: if units are not running, do not touch them.
@@ -1746,12 +1731,7 @@ fi
 %endif
 
 %postun mon
-%if 0%{?suse_version}
-%service_del_postun_without_restart ceph-mon@\*.service ceph-mon.target
-%endif
-%if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-mon@\*.service ceph-mon.target
-%endif
 if [ $1 -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
   # "yes". In any case: if units are not running, do not touch them.
@@ -1806,12 +1786,7 @@ fi
 %endif
 
 %postun -n rbd-mirror
-%if 0%{?suse_version}
-%service_del_postun_without_restart ceph-rbd-mirror@\*.service ceph-rbd-mirror.target
-%endif
-%if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-rbd-mirror@\*.service ceph-rbd-mirror.target
-%endif
 if [ $1 -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
   # "yes". In any case: if units are not running, do not touch them.
@@ -1853,12 +1828,7 @@ fi
 
 %postun immutable-object-cache
 test -n "$FIRST_ARG" || FIRST_ARG=$1
-%if 0%{?suse_version}
-%service_del_postun_without_restart ceph-immutable-object-cache@\*.service ceph-immutable-object-cache.target
-%endif
-%if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-immutable-object-cache@\*.service ceph-immutable-object-cache.target
-%endif
 if [ $FIRST_ARG -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
   # "yes". In any case: if units are not running, do not touch them.
@@ -1914,12 +1884,7 @@ fi
 
 %postun radosgw
 /sbin/ldconfig
-%if 0%{?suse_version}
-%service_del_postun_without_restart ceph-radosgw@\*.service ceph-radosgw.target
-%endif
-%if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-radosgw@\*.service ceph-radosgw.target
-%endif
 if [ $1 -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
   # "yes". In any case: if units are not running, do not touch them.
@@ -1981,12 +1946,7 @@ fi
 %endif
 
 %postun osd
-%if 0%{?suse_version}
-%service_del_postun_without_restart ceph-osd@\*.service ceph-volume@\*.service ceph-osd.target
-%endif
-%if 0%{?fedora} || 0%{?rhel}
 %systemd_postun ceph-osd@\*.service ceph-volume@\*.service ceph-osd.target
-%endif
 if [ $1 -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
   # "yes". In any case: if units are not running, do not touch them.


### PR DESCRIPTION
7d99e786df9654d896c43339c684519de4a9afa2
rpm: cleanup: drop use of DISABLE_RESTART_ON_UPDATE

This SUSE-specific variable is deprecated and use of
%service_del_postun_without_restart macro should be preferred these
days.

Signed-off-by: Franck Bui <fbui@suse.com>

---

f69aa5abfb2279919026144aa51e3c72f593e935
rpm: cleanup: drop %service_del_postun_without_restart

SUSE needs %service_del_postun (with or without restart) *only* if there
is a possibility that the RPM containing the unit file will be upgraded
from a version that packaged SysVinit scripts instead of systemd unit
files. (Which is not the case here.)

Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

3b53003f011cfbe51d3471ab9b6cdb9a24ecd4f7
rpm: cleanup: drop useless conditional block in %postun base

The "meat" of this conditional was ripped out by
328807f80bb6b5d1aa40631e88d755a194d5d2c2, leaving only an empty shell
behind.

Signed-off-by: Nathan Cutler <ncutler@suse.com>