### PR TITLE
nautilus: rgw: Empty reqs_change_state queue before unregistered_reqs

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -921,6 +921,13 @@ void RGWHTTPManager::manage_pending_requests()
 
   RWLock::WLocker wl(reqs_lock);
 
+  if (!reqs_change_state.empty()) {
+    for (auto siter : reqs_change_state) {
+      _set_req_state(siter);
+    }
+    reqs_change_state.clear();
+  }
+
   if (!unregistered_reqs.empty()) {
     for (auto& r : unregistered_reqs) {
       _unlink_request(r);
@@ -943,13 +950,6 @@ void RGWHTTPManager::manage_pending_requests()
     } else {
       max_threaded_req = iter->first + 1;
     }
-  }
-
-  if (!reqs_change_state.empty()) {
-    for (auto siter : reqs_change_state) {
-      _set_req_state(siter);
-    }
-    reqs_change_state.clear();
   }
 
   for (auto piter : remove_reqs) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46930

---

backport of https://github.com/ceph/ceph/pull/35597
parent tracker: https://tracker.ceph.com/issues/46867

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh