### PR TITLE
nautilus: rgw: Expiration days can't be zero and  transition days can be zero

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -857,7 +857,7 @@ public:
 
     auto mtime = get_effective_mtime(oc);
     bool is_expired;
-    if (transition.days <= 0) {
+    if (transition.days < 0) {
       if (transition.date == boost::none) {
         ldout(oc.cct, 20) << __func__ << "(): key=" << o.key << ": no transition day/date set in rule, skipping" << dendl;
         return false;

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -86,7 +86,7 @@ public:
   bool valid() const {
     if (!days.empty() && !date.empty()) {
       return false;
-    } else if (!days.empty() && get_days() < 0) {
+    } else if (!days.empty() && get_days() <= 0) {
       return false;
     }
     //We've checked date in xml parsing
@@ -130,7 +130,7 @@ public:
   bool valid() const {
     if (!days.empty() && !date.empty()) {
       return false;
-    } else if (!days.empty() && get_days() <=0) {
+    } else if (!days.empty() && get_days() < 0) {
       return false;
     }
     //We've checked date in xml parsing


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47318

---

backport of https://github.com/ceph/ceph/pull/30878
parent tracker: https://tracker.ceph.com/issues/47167

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh