### PR TITLE
nautilus: common, osd: add sanity checks around osd_scrub_max_preemptions

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3600,6 +3600,7 @@ std::vector<Option> get_global_options() {
 
     Option("osd_scrub_max_preemptions", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(5)
+    .set_min_max(0, 30)
     .set_description("Set the maximum number of times we will preempt a deep scrub due to a client operation before blocking client IO to complete the scrub"),
 
     Option("osd_deep_scrub_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5445,6 +5445,7 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	   * left end of the range if we are a tier because they may legitimately
 	   * not exist (see _scrub).
 	   */
+	  ceph_assert(scrubber.preempt_divisor > 0);
 	  int min = std::max<int64_t>(3, cct->_conf->osd_scrub_chunk_min /
 				      scrubber.preempt_divisor);
 	  int max = std::max<int64_t>(min, cct->_conf->osd_scrub_chunk_max /


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46262

---

backport of https://github.com/ceph/ceph/pull/35580
parent tracker: https://tracker.ceph.com/issues/46024

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh