### PR TITLE
nautilus: pybind/mgr/balancer: use "==" and "!=" for comparing str

### DIFF
--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -458,7 +458,7 @@ class Module(MgrModule):
             return (0, '', '')
         elif command['prefix'] == 'balancer pool ls':
             pool_ids = self.get_module_option('pool_ids')
-            if pool_ids is '':
+            if pool_ids == '':
                 return (0, '', '')
             pool_ids = pool_ids.split(',')
             pool_ids = [int(p) for p in pool_ids]
@@ -484,7 +484,7 @@ class Module(MgrModule):
             to_add = [str(pool_id_by_name[p]) for p in raw_names if p in pool_id_by_name]
             existing = self.get_module_option('pool_ids')
             final = to_add
-            if existing is not '':
+            if existing != '':
                 existing = existing.split(',')
                 final = set(to_add) | set(existing)
             self.set_module_option('pool_ids', ','.join(final))
@@ -492,7 +492,7 @@ class Module(MgrModule):
         elif command['prefix'] == 'balancer pool rm':
             raw_names = command['pools']
             existing = self.get_module_option('pool_ids')
-            if existing is '': # for idempotence
+            if existing == '': # for idempotence
                 return (0, '', '')
             existing = existing.split(',')
             osdmap = self.get_osdmap()
@@ -640,7 +640,7 @@ class Module(MgrModule):
                 osdmap = self.get_osdmap()
                 allow = self.get_module_option('pool_ids')
                 final = []
-                if allow is not '':
+                if allow != '':
                     allow = allow.split(',')
                     valid = [str(p['pool']) for p in osdmap.dump().get('pools', [])]
                     final = set(allow) & set(valid)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46461

---

backport of https://github.com/ceph/ceph/pull/35943
parent tracker: https://tracker.ceph.com/issues/46406

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh