### PR TITLE
nautilus: doc/rados: Fix osd_scrub_during_recovery default value

### DIFF
--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -258,7 +258,7 @@ scrubbing operations.
               Already running scrubs will be continued. This might be useful to reduce
               load on busy clusters.
 :Type: Boolean
-:Default: ``true``
+:Default: ``false``
 
 
 ``osd scrub thread timeout``


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46587

---

backport of https://github.com/ceph/ceph/pull/36096
parent tracker: https://tracker.ceph.com/issues/46531

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh