### PR TITLE
nautilus: osd/PeeringState: prevent peer's num_objects going negative

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3349,7 +3349,8 @@ void PG::_update_calc_stats()
       // Primary should not be in the peer_info, skip if it is.
       if (peer.first == pg_whoami) continue;
       int64_t missing = 0;
-      int64_t peer_num_objects = peer.second.stats.stats.sum.num_objects;
+      int64_t peer_num_objects = 
+        std::max((int64_t)0, peer.second.stats.stats.sum.num_objects);
       // Backfill targets always track num_objects accurately
       // all other peers track missing accurately.
       if (is_backfill_targets(peer.first)) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46710

---

backport of https://github.com/ceph/ceph/pull/36274
parent tracker: https://tracker.ceph.com/issues/46705

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh