### PR TITLE
nautilus: tools/rados: Set locator key when exporting or importing a pool

### DIFF
--- a/src/tools/rados/PoolDump.cc
+++ b/src/tools/rados/PoolDump.cc
@@ -70,6 +70,7 @@ int PoolDump::dump(IoCtx *io_ctx)
     const uint32_t op_size = 4096 * 1024;
     uint64_t offset = 0;
     io_ctx->set_namespace(i->get_nspace());
+    io_ctx->locator_set_key(i->get_locator());
     while (true) {
       bufferlist outdata;
       r = io_ctx->read(oid, outdata, op_size, offset);

--- a/src/tools/rados/RadosImport.cc
+++ b/src/tools/rados/RadosImport.cc
@@ -194,6 +194,7 @@ int RadosImport::get_object_rados(librados::IoCtx &ioctx, bufferlist &bl, bool n
   }
 
   ioctx.set_namespace(ob.hoid.hobj.get_namespace());
+  ioctx.locator_set_key(ob.hoid.hobj.get_key());
 
   string msg("Write");
   skipping = false;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46935

---

backport of https://github.com/ceph/ceph/pull/36408
parent tracker: https://tracker.ceph.com/issues/46824

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh