### PR TITLE
nautilus: cephfs-journal-tool: fix incorrect read_offset when finding missing objects

### DIFF
--- a/src/tools/cephfs/JournalScanner.cc
+++ b/src/tools/cephfs/JournalScanner.cc
@@ -194,8 +194,15 @@ int JournalScanner::scan_events()
       }
 
       objects_missing.push_back(obj_offset);
-      gap = true;
-      gap_start = read_offset;
+      if (!gap) {
+        gap_start = read_offset;
+        gap = true;
+      }
+      if (read_buf.length() > 0) {
+        read_offset += read_buf.length();
+        read_buf.clear();
+      }
+      read_offset += object_size - offset_in_obj;
       continue;
     } else {
       dout(4) << "Read 0x" << std::hex << this_object.length() << std::dec
@@ -229,7 +236,8 @@ int JournalScanner::scan_events()
         }
       } while (read_buf.length() >= sizeof(JournalStream::sentinel));
       dout(4) << "read_buf size is " << read_buf.length() << dendl;
-    } else {
+    } 
+    {
       dout(10) << "Parsing data, 0x" << std::hex << read_buf.length() << std::dec << " bytes available" << dendl;
       while(true) {
         // TODO: detect and handle legacy format journals: can do many things


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/46960

---

backport of https://github.com/ceph/ceph/pull/35096
parent tracker: https://tracker.ceph.com/issues/45575

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh