### PR TITLE
nautilus: mds: fix purge_queue's _calculate_ops is inaccurate

### DIFF
--- a/src/mds/PurgeQueue.cc
+++ b/src/mds/PurgeQueue.cc
@@ -363,13 +363,11 @@ uint32_t PurgeQueue::_calculate_ops(const PurgeItem &item) const
     ops_required = 1 + leaves.size();
   } else {
     // File, work out concurrent Filer::purge deletes
+    // Account for removing (or zeroing) backtrace
     const uint64_t num = (item.size > 0) ?
       Striper::get_num_objects(item.layout, item.size) : 1;
 
     ops_required = std::min(num, g_conf()->filer_max_purge_ops);
-
-    // Account for removing (or zeroing) backtrace
-    ops_required += 1;
 
     // Account for deletions for old pools
     if (item.action != PurgeItem::TRUNCATE_FILE) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47605

---

backport of https://github.com/ceph/ceph/pull/37037
parent tracker: https://tracker.ceph.com/issues/47353

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh