### PR TITLE
mgr/dashboard: Prevent table items from getting selected while expanding

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/configuration.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/configuration.e2e-spec.ts
@@ -19,10 +19,6 @@ describe('Configuration page', () => {
       configuration.getExpandCollapseElement().click();
     });
 
-    it('should verify that selected footer increases when an entry is clicked', () => {
-      configuration.getTableCount('selected').should('eq', 1);
-    });
-
     it('should check that details table opens (w/o tab header)', () => {
       configuration.getStatusTables().should('be.visible');
       configuration.getTabs().should('not.exist');

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/osds.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/osds.e2e-spec.ts
@@ -37,10 +37,6 @@ describe('OSDs page', () => {
         osds.getExpandCollapseElement().click();
       });
 
-      it('should verify that selected footer increases', () => {
-        osds.getTableCount('selected').should('equal', 1);
-      });
-
       it('should show the correct text for the tab labels', () => {
         cy.get('#tabset-osd-details > li > a').then(($tabs) => {
           const tabHeadings = $tabs.map((_i, e) => e.textContent).get();

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/rgw/buckets.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/rgw/buckets.po.ts
@@ -68,7 +68,7 @@ export class BucketsPageHelper extends PageHelper {
     cy.get('@versioningValueCell').should('have.text', this.versioningStateEnabled);
 
     // Disable versioning:
-    this.navigateEdit(name, false);
+    this.navigateEdit(name);
 
     cy.get('label[for=versioning]').click();
     cy.get('input[id=versioning]').should('not.be.checked');

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -305,6 +305,6 @@
      class="expand-collapse-icon tc_expand-collapse"
      title="Expand/Collapse Row"
      i18n-title
-     (click)="toggleExpandRow(row, isExpanded)">
+     (click)="toggleExpandRow(row, isExpanded, $event)">
   </a>
 </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -686,7 +686,7 @@ describe('TableComponent', () => {
     });
 
     it('should open the table details and close other expanded rows', () => {
-      component.toggleExpandRow(component.expanded, false);
+      component.toggleExpandRow(component.expanded, false, new Event('click'));
       expect(component.expanded).toEqual({ a: 1, b: 10, c: true });
       expect(component.table.rowDetail.collapseAllRows).toHaveBeenCalled();
       expect(component.setExpandedRow.emit).toHaveBeenCalledWith(component.expanded);
@@ -694,10 +694,25 @@ describe('TableComponent', () => {
     });
 
     it('should close the current table details expansion', () => {
-      component.toggleExpandRow(component.expanded, true);
+      component.toggleExpandRow(component.expanded, true, new Event('click'));
       expect(component.expanded).toBeUndefined();
       expect(component.setExpandedRow.emit).toHaveBeenCalledWith(undefined);
       expect(component.table.rowDetail.toggleExpandRow).toHaveBeenCalled();
+    });
+
+    it('should not select the row when the row is expanded', () => {
+      expect(component.selection.selected).toEqual([]);
+      component.toggleExpandRow(component.data[1], false, new Event('click'));
+      expect(component.selection.selected).toEqual([]);
+    });
+
+    it('should not change selection when expanding different row', () => {
+      expect(component.selection.selected).toEqual([]);
+      expect(component.expanded).toEqual(component.data[1]);
+      component.selection.selected = [component.data[2]];
+      component.toggleExpandRow(component.data[3], false, new Event('click'));
+      expect(component.selection.selected).toEqual([component.data[2]]);
+      expect(component.expanded).toEqual(component.data[3]);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -830,7 +830,8 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
     };
   }
 
-  toggleExpandRow(row: any, isExpanded: boolean) {
+  toggleExpandRow(row: any, isExpanded: boolean, event: any) {
+    event.stopPropagation();
     if (!isExpanded) {
       // If current row isn't expanded, collapse others
       this.expanded = row;


### PR DESCRIPTION
While clicking on the expand button inside a table, the entire row is getting selected. This commit prevent that from happening.

![captured (1)](https://user-images.githubusercontent.com/71764184/94798299-13489600-03ff-11eb-9262-87ead80dbec7.gif)


Fixes: https://tracker.ceph.com/issues/47376
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
