### PR TITLE
mgr/cephadm: add NFS protocols setting

### DIFF
--- a/doc/cephadm/nfs.rst
+++ b/doc/cephadm/nfs.rst
@@ -47,6 +47,8 @@ an optional namespace:
     spec:
       pool: mypool
       namespace: mynamespace
+      protocols:
+      - NFSv4
 
 where ``pool`` is a RADOS pool where NFS client recovery data is stored
 and ``namespace`` is a RADOS namespace where NFS client recovery
@@ -57,3 +59,8 @@ The specification can then be applied using:
 .. prompt:: bash #
 
    ceph orch apply -i nfs.yaml
+
+.. note::
+   While NFSv3 can be specified as a protocol, it is deprecated and not
+   recommended for use in a multi-head cluster. Please consider using
+   NFSv4 instead.

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -55,6 +55,7 @@ class NFSService(CephService):
                            pool=spec.pool,
                            namespace=spec.namespace if spec.namespace else '',
                            rgw_user=rgw_user,
+                           protocols=', '.join(spec.protocols),
                            url=spec.rados_config_location())
             return self.mgr.template.render('services/nfs/ganesha.conf.j2', context)
 

--- a/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
@@ -2,7 +2,7 @@
 NFS_CORE_PARAM {
         Enable_NLM = false;
         Enable_RQUOTA = false;
-        Protocols = 4;
+        Protocols = {{ protocols }};
 }
 
 MDCACHE {


### PR DESCRIPTION
allow for the NFS protocals to be defined via a ServiceSpec

```
$ cat nfs.yaml
service_type: nfs
service_id: foo
placement:
  count: 2
spec:
  namespace: foo
  pool: nfs-ganesha
  protocols: 
  - NFSv3
  - NFSv4

$ ceph orch apply -i nfs.yaml
```

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
