### PR TITLE
common/BackTrace: print path without symbol

### DIFF
--- a/src/common/BackTrace.cc
+++ b/src/common/BackTrace.cc
@@ -46,7 +46,7 @@ std::string BackTrace::demangle(const char* name)
       end = j;
     }
   }
-  if (begin && end) {
+  if (begin && end && begin < end) {
     std::string mangled(begin, end);
     int status;
     // only demangle a C++ mangled name


### PR DESCRIPTION
before ea6abcf34c11c80dec507f7dee8babd26440196c, we have

2: (()+0x14140) [0x7f4462af6140]

after ea6abcf34c11c80dec507f7dee8babd26440196c, we have

2: ()

after this change, we have

2: /lib/x86_64-linux-gnu/libpthread.so.0(+0x14140) [0x7f7137e2f140]

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
