### PR TITLE
[DNM] pybind/mgr/dashboard: track issue with test_pool_create

### DIFF
--- a/src/pybind/mgr/dashboard/services/rbd.py
+++ b/src/pybind/mgr/dashboard/services/rbd.py
@@ -84,7 +84,7 @@ class RbdConfiguration(object):
                     with rbd.Image(ioctx, self._image_name) as image:
                         result = image.config_list()
                 except rbd.ImageNotFound:
-                    result = []
+                    result = [{'name': 'debug', 'source': 1, 'value': 'image not found'}]
             else:  # pool config
                 pg_status = list(CephService.get_pool_pg_status(self._pool_name).keys())
                 if len(pg_status) == 1 and 'unknown' in pg_status[0]:
@@ -99,9 +99,9 @@ class RbdConfiguration(object):
                     # https://tracker.ceph.com/issues/44224
                     #
                     # @TODO: If #44224 is addressed remove this workaround
-                    return []
+                    return [{'name': 'debug', 'source': 1, 'value': 'pg_status is unknown'}]
                 result = self._rbd.config_list(ioctx)
-            return list(result)
+            return list(result) + [{'name': 'debug', 'source': 1, 'value': 'returned by rbd.config_list'}]
 
         if self._pool_name:
             ioctx = mgr.rados.open_ioctx(self._pool_name)


### PR DESCRIPTION
Created just for testing test failure

Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
