### PR TITLE
mgr/cephadm: avoid concurrency issues in OSDQueue()

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2199,13 +2199,13 @@ To check that the host is reachable:
 
         for daemon in to_remove_daemons:
             try:
-                self.to_remove_osds.enqueue(OSD(osd_id=int(daemon.daemon_id),
-                                                replace=replace,
-                                                force=force,
-                                                hostname=daemon.hostname,
-                                                fullname=daemon.name(),
-                                                process_started_at=datetime.datetime.utcnow(),
-                                                remove_util=self.rm_util))
+                self.to_remove_osds.put(OSD(osd_id=int(daemon.daemon_id),
+                                            replace=replace,
+                                            force=force,
+                                            hostname=daemon.hostname,
+                                            fullname=daemon.name(),
+                                            process_started_at=datetime.datetime.utcnow(),
+                                            remove_util=self.rm_util))
             except NotFoundError:
                 return f"Unable to find OSDs: {osd_ids}"
 

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -499,16 +499,16 @@ class TestCephadm(object):
             out = wait(cephadm_module, c)
             assert out == ["Removed osd.0 from host 'test'"]
 
-            cephadm_module.to_remove_osds.enqueue(OSD(osd_id=0,
-                                                      replace=False,
-                                                      force=False,
-                                                      hostname='test',
-                                                      fullname='osd.0',
-                                                      process_started_at=datetime.datetime.utcnow(),
-                                                      remove_util=cephadm_module.rm_util
-                                                      ))
+            cephadm_module.to_remove_osds.put(OSD(osd_id=0,
+                                                  replace=False,
+                                                  force=False,
+                                                  hostname='test',
+                                                  fullname='osd.0',
+                                                  process_started_at=datetime.datetime.utcnow(),
+                                                  remove_util=cephadm_module.rm_util
+                                                  ))
             cephadm_module.rm_util.process_removal_queue()
-            assert cephadm_module.to_remove_osds == OSDQueue()
+            assert isinstance(cephadm_module.to_remove_osds, OSDQueue)
 
             c = cephadm_module.remove_osds_status()
             out = wait(cephadm_module, c)


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

Since the set can be changed in the mgr/cephadm module we may run into this.\\

Fixes: https://tracker.ceph.com/issues/47700


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
