### PR TITLE
mon: set session_timeout when adding to session_map

### DIFF
--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -193,6 +193,9 @@ struct MonSessionMap {
   }
 
   void add_session(MonSession *s) {
+    s->session_timeout = ceph_clock_now();
+    s->session_timeout += g_conf()->mon_session_timeout;
+
     sessions.push_back(&s->item);
     s->get();
     if (s->name.is_osd() &&


### PR DESCRIPTION
With msgr2, the session is added in Monitor::ms_handle_accept()
which is queued by ProtocolV2 at the end of handling CLIENT_IDENT
frame, before responding with SERVER_IDENT frame.  session_timeout
is 0 and gets set only in Monitor::ms_dispatch(), so if the session
trimming code in Monitor::tick() gets to the session before the peer
receives our SERVER_IDENT, handles it, sends the first message and
we receive it, the session is wrongly closed.

This doesn't happen with msgr1, because there the session is added in
Monitor::ms_dispatch(), upon receive of the first message (MSG_AUTH).

Fixes: https://tracker.ceph.com/issues/47697
Signed-off-by: Ilya Dryomov <idryomov@gmail.com>