### PR TITLE
cephadm: Get rid of injected_argv

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -17,26 +17,6 @@ DEFAULT_RETRY = 10
 SHELL_DEFAULT_CONF = '/etc/ceph/ceph.conf'
 SHELL_DEFAULT_KEYRING = '/etc/ceph/ceph.client.admin.keyring'
 
-"""
-You can invoke cephadm in two ways:
-
-1. The normal way, at the command line.
-
-2. By piping the script to the python3 binary.  In this latter case, you should
-   prepend one or more lines to the beginning of the script.
-
-   For arguments,
-
-       injected_argv = [...]
-
-   e.g.,
-
-       injected_argv = ['ls']
-
-   For reading stdin from the '--config-json -' argument,
-
-       injected_stdin = '...'
-"""
 import argparse
 import datetime
 import fcntl
@@ -1796,11 +1776,8 @@ def get_parm(option):
         if cached_stdin is not None:
             j = cached_stdin
         else:
-            try:
-                j = injected_stdin  # type: ignore
-            except NameError:
-                j = sys.stdin.read()
-                cached_stdin = j
+            j = sys.stdin.read()
+            cached_stdin = j
     else:
         # inline json string
         if option[0] == '{' and option[-1] == '}':
@@ -5998,11 +5975,8 @@ if __name__ == "__main__":
     dictConfig(logging_config)
     logger = logging.getLogger()
 
-    # allow argv to be injected
-    try:
-        av = injected_argv  # type: ignore
-    except NameError:
-        av = sys.argv[1:]
+    # Process command line
+    av = sys.argv[1:]
     logger.debug("%s\ncephadm %s" % ("-" * 80, av))
     args = _parse_args(av)
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1092,7 +1092,7 @@ To check that the host is reachable:
                      command: str,
                      args: List[str],
                      addr: Optional[str] = "",
-                     stdin: Optional[str] = "",
+                     stdin: str = "",
                      no_fsid: Optional[bool] = False,
                      error_ok: Optional[bool] = False,
                      image: Optional[str] = "",
@@ -1103,7 +1103,6 @@ To check that the host is reachable:
 
         :env_vars: in format -> [KEY=VALUE, ..]
         """
-        assert isinstance(stdin, str)
 
         with self._remote_connection(host, addr) as tpl:
             conn, connr = tpl
@@ -1133,8 +1132,10 @@ To check that the host is reachable:
             if self.mode == 'root':
                 try:
                     python = connr.choose_python()
-                    cephadm_dest = '/var/lib/ceph/%s/cephadm/%s' % (
-                        self._cluster_fsid, self.get_mgr_id())
+
+                    mgrd = self.cache.get_daemon("mgr.%s" % self.get_mgr_id())
+                    cephadm_dest = '/var/lib/ceph/%s/cephadm/%s/%s/cephadm' % (
+                        self._cluster_fsid, self.get_mgr_id(), mgrd.container_image_id)
                     self._copy_cephadm(conn, cephadm_dest)
 
                     self.log.info("Tying to execute : %s" %

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -755,11 +755,13 @@ class TestCephadm(object):
             assert_rm_daemon(cephadm_module, spec.service_name(), 'host1')  # verifies ok-to-stop
             assert_rm_daemon(cephadm_module, spec.service_name(), 'host2')
 
+    @mock.patch("cephadm.inventory.HostCache.get_daemon")
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
     @mock.patch("remoto.process.check")
-    def test_offline(self, _check, _get_connection, cephadm_module):
+    def test_offline(self, _check, _get_connection, _get_daemon, cephadm_module):
         _check.return_value = '{}', '', 0
         _get_connection.return_value = mock.Mock(), mock.Mock()
+
         with with_host(cephadm_module, 'test'):
             _get_connection.side_effect = HostNotFound
             code, out, err = cephadm_module.check_host('test')
@@ -820,9 +822,10 @@ class TestCephadm(object):
             conn_3, r = cephadm_module._get_connection("test")
             assert not(conn is conn_3)
 
+    @mock.patch("cephadm.inventory.HostCache.get_daemon")
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
     @mock.patch("remoto.process.check")
-    def test_etc_ceph(self, _check, _get_connection, cephadm_module):
+    def test_etc_ceph(self, _check, _get_connection, _get_daemon, cephadm_module):
         _get_connection.return_value = mock.Mock(), mock.Mock()
         _check.return_value = '{}', '', 0
 

--- a/src/script/gen_static_command_descriptions.py
+++ b/src/script/gen_static_command_descriptions.py
@@ -63,6 +63,9 @@ def list_mgr_module(m_name):
     sys.modules['werkzeug'] = mock.Mock()
     sys.modules['werkzeug.serving'] = mock.Mock()
 
+    # make cephadm happy:
+    sys.modules['remoto'] = mock.Mock(__version__="1.1.4")
+
     mgr_mod = __import__(m_name, globals(), locals(), [], 0)
 
     def subclass(x):


### PR DESCRIPTION
Removed the injected_argv parameter and the injection of code in the cephadm
script we send to hosts.
Now the script is copied and after that we execute the cephadm command.
I would like to copy it only one time (when adding new hosts) but this will be
 part of a future PR, together with other prs to:
 - Introduce cephadm version
 - Get rid of packaged/root mode
 - Use pex or eggs

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>

Note:
To test this is a bit tricky .. because the cephadm binary is by default obtained from "/usr/sbin" folder in the mgr container.
The new cephadm binary included in this pr is the one to test, so in order to do it properly:
```
1. Use the new script to bootstarp the cluster

2. Copy the new script to a location accessible from manager container:
for example:
/usr/share/ceph/mgr/cephadm/cephadm

3. Open a ceph shell:
 Change "cephadm_path": point to the new "cephadm tool" script
# ceph config get mgr cephadm_path
/usr/sbin/cephadm

# ceph config set mgr cephadm_path /usr/share/ceph/mgr/cephadm/cephadm

# Force read the new "cephadm" script from the orchestrator module
ceph mgr module disable cephadm
ceph mgr module enable cephadm

4. Add new hosts and OSDs..
```.
 
