### PR TITLE
cephadm: Fix error setting 'mgr/cephadm/container_init' config

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3181,7 +3181,7 @@ def command_bootstrap():
         cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_password', args.registry_password, '--force'])
 
     if args.container_init:
-        cli(['config', 'set', 'mgr', 'mgr/cephadm/container_init', args.container_init, '--force'])
+        cli(['config', 'set', 'mgr', 'mgr/cephadm/container_init', str(args.container_init), '--force'])
 
     if not args.skip_dashboard:
         # Configure SSL port (cephadm only allows to configure dashboard SSL port)


### PR DESCRIPTION
This PR will fix the following issue when running `cephadm bootrstrap --container-init ...`:

```
['/usr/bin/podman', 'run', '--rm', '--net=host', '--ipc=host', '-e', 'CONTAINER_IMAGE=registry.opensuse.org/filesystems/ceph/master/u
pstream/images/ceph/ceph', '-e', 'NODE_NAME=node1', '-v', '/var/log/ceph/86501be0-f825-11ea-ba9f-525400bedfac:/var/log/ceph:z', '-v',
 '/tmp/ceph-tmpp4xdmtqe:/etc/ceph/ceph.client.admin.keyring:z', '-v', '/tmp/ceph-tmph6bq7nup:/etc/ceph/ceph.conf:z', '--entrypoint', 
'/usr/bin/ceph', 'registry.opensuse.org/filesystems/ceph/master/upstream/images/ceph/ceph', 'config', 'set', 'mgr', 'mgr/cephadm/cont
ainer_init', True, '--force']
Traceback (most recent call last):
  File "/usr/sbin/cephadm", line 5859, in <module>
    r = args.func()
  File "/usr/sbin/cephadm", line 1248, in _default_image
    return func()
  File "/usr/sbin/cephadm", line 3032, in command_bootstrap
    cli(['config', 'set', 'mgr', 'mgr/cephadm/container_init', args.container_init, '--force'])
  File "/usr/sbin/cephadm", line 2831, in cli
    ).run(timeout=timeout)
  File "/usr/sbin/cephadm", line 2479, in run
    self.run_cmd(), desc=self.entrypoint, timeout=timeout)
  File "/usr/sbin/cephadm", line 907, in call_throws
    out, err, ret = call(command, **kwargs)
  File "/usr/sbin/cephadm", line 799, in call
    logger.debug("Running command: %s" % ' '.join(command))
TypeError: sequence item 22: expected str instance, bool found
```

Fixes: https://tracker.ceph.com/issues/47501

Signed-off-by: Ricardo Marques <rimarques@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
