### PR TITLE
rgw_file: avoid long-ish delay on shutdown

### DIFF
--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -129,8 +129,8 @@ namespace rgw {
 	if (cur_gen != gen)
 	  goto restart; /* invalidated */
       }
+      cv.wait_for(uniq, std::chrono::seconds(delay_s));
       uniq.unlock();
-      std::this_thread::sleep_for(std::chrono::seconds(delay_s));
     }
   }
 

--- a/src/rgw/rgw_lib_frontend.h
+++ b/src/rgw/rgw_lib_frontend.h
@@ -14,6 +14,7 @@ namespace rgw {
   class RGWLibProcess : public RGWProcess {
     RGWAccessKey access_key;
     std::mutex mtx;
+    std::condition_variable cv;
     int gen;
     bool shutdown;
 
@@ -36,6 +37,7 @@ namespace rgw {
       for (const auto& fs: mounted_fs) {
 	fs.second->stop();
       }
+      cv.notify_all();
     }
 
     void register_fs(RGWLibFS* fs) {


### PR DESCRIPTION
Normal shutdown was likely to be delayed a substantial fraction
of rgw_nfs_namespace_expire_secs due to an ill-advised use of
this_thread::sleep_for.

Fixes: https://tracker.ceph.com/issues/47710

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
