### PR TITLE
nautilus: mgr/dashboard: fix broken backporting

### DIFF
--- a/src/pybind/mgr/dashboard/services/rbd.py
+++ b/src/pybind/mgr/dashboard/services/rbd.py
@@ -87,7 +87,7 @@ class RbdConfiguration(object):
                     result = []
             else:  # pool config
                 pg_status = list(CephService.get_pool_pg_status(self._pool_name).keys())
-                if len(pg_status) == 1 and 'unknown' in pg_status[0]:
+                if len(pg_status) == 1 and 'incomplete' in pg_status[0]:
                     # If config_list would be called with ioctx if it's a bad pool,
                     # the dashboard would stop working, waiting for the response
                     # that would not happen.

--- a/src/pybind/mgr/dashboard/tests/test_rbd_service.py
+++ b/src/pybind/mgr/dashboard/tests/test_rbd_service.py
@@ -27,7 +27,7 @@ class RbdServiceTest(unittest.TestCase):
         get.return_value = {
             'by_pool': {
                 '1': {'active+clean': 32},
-                '2': {'unknown': 32},
+                '2': {'creating+incomplete': 32},
             }
         }
         config_list.return_value = [1, 2, 3]


### PR DESCRIPTION
A [previous backport](https://github.com/ceph/ceph/pull/35367) from a
[master PR](https://github.com/ceph/ceph/pull/32829) changed the testing
condition for PG status from 'incomplete' to 'unknown'.

Fixes: https://tracker.ceph.com/issues/46815
Co-authored-by: Mykola Golub <mgolub@suse.com>
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
