### PR TITLE
mgr/dashboard: Improvements in cluster > OSDs

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
@@ -267,8 +267,8 @@ export class OsdListComponent extends ListWithDetails implements OnInit {
       }
     ];
     this.columns = [
-      { prop: 'host.name', name: $localize`Host` },
       { prop: 'id', name: $localize`ID`, flexGrow: 1, cellTransformation: CellTemplate.bold },
+      { prop: 'host.name', name: $localize`Host` },
       {
         prop: 'collectedStates',
         name: $localize`Status`,

--- a/src/pybind/mgr/dashboard/tests/test_cephfs.py
+++ b/src/pybind/mgr/dashboard/tests/test_cephfs.py
@@ -4,9 +4,8 @@ from collections import defaultdict
 try:
     from mock import Mock
 except ImportError:
-    from unittest.mock import Mock
+    from unittest.mock import patch, Mock
 
-from .. import mgr
 from ..controllers.cephfs import CephFS
 from . import ControllerTestCase  # pylint: disable=no-name-in-module
 
@@ -25,15 +24,9 @@ def get_metadata_mock(key, meta_key):
     }[key]
 
 
+@patch('dashboard.mgr.get_metadata', Mock(side_effect=get_metadata_mock))
 class CephFsTest(ControllerTestCase):
     cephFs = CephFS()
-
-    @classmethod
-    def setup_server(cls):
-        mgr.get_metadata = Mock(side_effect=get_metadata_mock)
-
-    def tearDown(self):
-        mgr.get_metadata.stop()
 
     def test_append_of_mds_metadata_if_key_is_not_found(self):
         mds_versions = defaultdict(list)


### PR DESCRIPTION
Made osd-id the first column of the table instead of Host.

Fixes:https://tracker.ceph.com/issues/47478
Signed-off-by:Aashish Sharma <aasharma@redhat.com>

<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`