### PR TITLE
rbd/tools: fix rwl related names

### DIFF
--- a/src/tools/rbd/action/Status.cc
+++ b/src/tools/rbd/action/Status.cc
@@ -24,9 +24,9 @@ namespace {
 const std::string IMAGE_CACHE_STATE = ".librbd/image_cache_state";
 
 struct ImageCacheState {
-  bool present;
-  bool clean;
-  int size;
+  bool present = false;
+  bool clean = false;
+  int size = 0;
   std::string host;
   std::string path;
 };
@@ -43,14 +43,14 @@ bool image_cache_parse(const std::string& s, ImageCacheState &cache_state) {
     if (success && (success = f.exists("clean"))) {
       cache_state.present = (bool)f["clean"];
     }
-    if (success && (success = f.exists("rwl_size"))) {
-      cache_state.size = (int)f["rwl_size"];
+    if (success && (success = f.exists("pwl_size"))) {
+      cache_state.size = (int)f["pwl_size"];
     }
-    if (success && (success = f.exists("rwl_host"))) {
-      cache_state.host = (std::string)f["rwl_host"];
+    if (success && (success = f.exists("pwl_host"))) {
+      cache_state.host = (std::string)f["pwl_host"];
     }
-    if (success && (success = f.exists("rwl_path"))) {
-      cache_state.path = (std::string)f["rwl_path"];
+    if (success && (success = f.exists("pwl_path"))) {
+      cache_state.path = (std::string)f["pwl_path"];
     }
   }
   return success;


### PR DESCRIPTION
These attributes have been renamed.

Signed-off-by: Li, Xiaoyan <xiaoyan.li@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
