### PR TITLE
mgr/dashboard: Show warning when replicated size is 1 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -143,6 +143,10 @@
                     *ngIf="form.showError('size', formDir)"
                     i18n>The size specified is out of range. A value from
                 {{ getMinSize() }} to {{ getMaxSize() }} is usable.</span>
+              <span class="text-warning-dark"
+                    *ngIf="form.getValue('size') === 1"
+                    i18n>A size of 1 will not create a replication of the
+                object. The 'Replicated size' includes the object itself.</span>
             </div>
           </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
@@ -319,6 +319,17 @@ describe('PoolFormComponent', () => {
       formHelper.expectValidChange('size', 2);
     });
 
+    it('validates if warning is displayed when size is 1', () => {
+      formHelper.setValue('poolType', 'replicated');
+      formHelper.expectValid('size');
+
+      formHelper.setValue('size', 1, true);
+      expect(fixtureHelper.getElementByCss('#size ~ .text-warning-dark')).toBeTruthy();
+
+      formHelper.setValue('size', 2, true);
+      expect(fixtureHelper.getElementByCss('#size ~ .text-warning-dark')).toBeFalsy();
+    });
+
     it('validates compression mode default value', () => {
       expect(form.getValue('mode')).toBe('none');
     });

--- a/src/pybind/mgr/dashboard/frontend/src/styles/defaults/_bootstrap-defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/defaults/_bootstrap-defaults.scss
@@ -38,7 +38,8 @@ $fg-color-over-dark-bg: $white;
 $fg-hover-color-over-dark-bg: $gray-500;
 
 $theme-colors: (
-  'accent': #ef5c55
+  'accent': #ef5c55,
+  'warning-dark': $orange
 );
 
 // Body


### PR DESCRIPTION
Issues a warning when creating a replicated pool and the replicated size
is 1. It won't stop the user from creating the pool, but will give the
user a hint that no replication will be created.

This pr is also going to add a new color to the bootstrap theme. In my opinion the orange has a better contrast on a white background. We should discuss if it would make sense to use orange for warnings instead of yellow.

Fixes: https://tracker.ceph.com/issues/42404
Signed-off-by: Sebastian Krah <skrah@suse.com>

![replicated_size1](https://user-images.githubusercontent.com/7863239/94907321-44c56e00-04a0-11eb-870a-109bb6197d70.png)

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
