### PR TITLE
ceph-volume batch: return valid empty json reports

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -325,12 +325,11 @@ class Batch(object):
             setattr(self, '{}usable'.format(dev_list), [])
 
     def report(self, plan):
-        if self.args.format == 'json':
-            print(json.dumps([osd.report_json() for osd in plan]))
-        elif self.args.format == 'json-pretty':
-            print(json.dumps([osd.report_json() for osd in plan], indent=4,
-                       sort_keys=True))
-        else:
+        report = self._create_report(plan)
+        print(report)
+
+    def _create_report(self, plan):
+        if self.args.format == 'pretty':
             report = ''
             report += templates.total_osds.format(total_osds=len(plan))
 
@@ -338,8 +337,16 @@ class Batch(object):
             for osd in plan:
                 report += templates.osd_header
                 report += osd.report()
-
-            print(report)
+            return report
+        else:
+            json_report = []
+            for osd in plan:
+                json_report.append(osd.report_json())
+            if self.args.format == 'json':
+                return json.dumps(json_report)
+            elif self.args.format == 'json-pretty':
+                return json.dumps(json_report, indent=4,
+                                  sort_keys=True)
 
     def _check_slot_args(self):
         '''


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47729

Signed-off-by: Jan Fajerski <jfajerski@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
