### PR TITLE
rgw/cls_fifo_legacy: fix logical error with return values

### DIFF
--- a/src/rgw/cls_fifo_legacy.h
+++ b/src/rgw/cls_fifo_legacy.h
@@ -127,7 +127,7 @@ class FIFO {
   std::optional<marker> to_marker(std::string_view s);
 
   FIFO(lr::IoCtx&& ioc,
-       std::string oid)
+       const std::string& oid)
     : ioctx(std::move(ioc)), oid(oid) {}
 
   std::string generate_tag() const;


### PR DESCRIPTION
also fix some other logical error with return values
issues were detected by pvs-studio static analyzer

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
