### PR TITLE
fix potential crash in rgw_kafka

### DIFF
--- a/src/rgw/rgw_kafka.cc
+++ b/src/rgw/rgw_kafka.cc
@@ -64,7 +64,7 @@ struct connection_t {
   std::vector<rd_kafka_topic_t*> topics;
   bool marked_for_deletion = false;
   uint64_t delivery_tag = 1;
-  int status;
+  int status = STATUS_OK;
   mutable std::atomic<int> ref_count = 0;
   CephContext* const cct;
   CallbackList callbacks;
@@ -371,6 +371,7 @@ private:
       }
       conn->destroy(err);
       delete tag;
+      return;
     }
    
     if (tag) {


### PR DESCRIPTION
issues were detected by pvs-studio static analyzer

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
