### PR TITLE
cephadm: allow uid/gid == 0 in copy_tree, copy_files, move_files

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1467,7 +1467,7 @@ def copy_tree(src, dst, uid=None, gid=None):
     """
     Copy a directory tree from src to dst
     """
-    if not uid or not gid:
+    if uid is None or gid is None:
         (uid, gid) = extract_uid_gid()
 
     for src_dir in src:
@@ -1492,7 +1492,7 @@ def copy_files(src, dst, uid=None, gid=None):
     """
     Copy a files from src to dst
     """
-    if not uid or not gid:
+    if uid is None or gid is None:
         (uid, gid) = extract_uid_gid()
 
     for src_file in src:
@@ -1512,7 +1512,7 @@ def move_files(src, dst, uid=None, gid=None):
     """
     Move files from src to dst
     """
-    if not uid or not gid:
+    if uid is None or gid is None:
         (uid, gid) = extract_uid_gid()
 
     for src_file in src:


### PR DESCRIPTION
If the uid or gid passed to copy_tree(), copy_files() or move_files() is 0 (the root user), the current check for `if not uid or not gid` does the wrong thing, i.e. it thinks the uid and/or gid aren't set, then calls out to extract_uid_gid(), which fails when run against prometheus/grafana/alertmanager containers.

Fixes: https://tracker.ceph.com/issues/47745
Signed-off-by: Tim Serong <tserong@suse.com>