### PR TITLE
ceph-volume: pass filter_for_batch as keyword argument

### DIFF
--- a/src/ceph-volume/ceph_volume/inventory/main.py
+++ b/src/ceph-volume/ceph_volume/inventory/main.py
@@ -42,13 +42,13 @@ class Inventory(object):
         if self.args.path:
             self.format_report(Device(self.args.path))
         else:
-            self.format_report(Devices(self.args.filter_for_batch))
+            self.format_report(Devices(filter_for_batch=self.args.filter_for_batch))
 
     def get_report(self):
         if self.args.path:
             return Device(self.args.path).json_report()
         else:
-            return Devices(self.args.filter_for_batch).json_report()
+            return Devices(filter_for_batch=self.args.filter_for_batch).json_report()
 
     def format_report(self, inventory):
         if self.args.format == 'json':

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -27,7 +27,7 @@ class Devices(object):
     A container for Device instances with reporting
     """
 
-    def __init__(self, devices=None, filter_for_batch=False):
+    def __init__(self, filter_for_batch=False):
         if not sys_info.devices:
             sys_info.devices = disk.get_devices()
         self.devices = [Device(k) for k in


### PR DESCRIPTION
This PR also removes an unused ctor argument in the Devices class.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>

---

Follow-on fix for: https://github.com/ceph/ceph/pull/34740