### PR TITLE
rgw: send headers of quota settings

### DIFF
--- a/examples/boto3/delete_notification.py
+++ b/examples/boto3/delete_notification.py
@@ -13,7 +13,7 @@ elif len(sys.argv) == 2:
     bucketname = sys.argv[1]
     notification_name = ""
 else:
-    print 'Usage: ' + sys.argv[0] + ' <bucket> [notification]'
+    print('Usage: ' + sys.argv[0] + ' <bucket> [notification]')
     sys.exit(1)
 
 # endpoint and keys from vstart
@@ -30,7 +30,7 @@ client = boto3.client('s3',
 # deleting all notification configurations on a bucket (without deleting the bucket itself) are extension to AWS S3 API
 
 if notification_name == "":
-    print client.delete_bucket_notification_configuration(Bucket=bucketname)
+    print(client.delete_bucket_notification_configuration(Bucket=bucketname))
 else:
-    print client.delete_bucket_notification_configuration(Bucket=bucketname,
-                                                          Notification=notification_name)
+    print(client.delete_bucket_notification_configuration(Bucket=bucketname,
+                                                          Notification=notification_name))

--- a/examples/boto3/get_notification.py
+++ b/examples/boto3/get_notification.py
@@ -4,7 +4,7 @@ import boto3
 import sys
 
 if len(sys.argv) != 3:
-    print 'Usage: ' + sys.argv[0] + ' <bucket> <notification>'
+    print('Usage: ' + sys.argv[0] + ' <bucket> <notification>')
     sys.exit(1)
 
 # bucket name as first argument
@@ -24,5 +24,5 @@ client = boto3.client('s3',
 
 # getting a specific notification configuration is an extension to AWS S3 API
 
-print client.get_bucket_notification_configuration(Bucket=bucketname,
-                                                   Notification=notification_name)
+print(client.get_bucket_notification_configuration(Bucket=bucketname,
+                                                   Notification=notification_name))

--- a/examples/boto3/list_unordered.py
+++ b/examples/boto3/list_unordered.py
@@ -4,7 +4,7 @@ import boto3
 import sys
 
 if len(sys.argv) != 2:
-    print 'Usage: ' + sys.argv[0] + ' <bucket>'
+    print('Usage: ' + sys.argv[0] + ' <bucket>')
     sys.exit(1)
 
 # bucket name as first argument
@@ -22,4 +22,4 @@ client = boto3.client('s3',
 
 # geting an unordered list of objets is an extension to AWS S3 API
 
-print client.list_objects(Bucket=bucketname, AllowUnordered=True)
+print(client.list_objects(Bucket=bucketname, AllowUnordered=True))

--- a/examples/boto3/notification_filters.py
+++ b/examples/boto3/notification_filters.py
@@ -4,7 +4,7 @@ import boto3
 import sys
 
 if len(sys.argv) != 4:
-    print 'Usage: ' + sys.argv[0] + ' <bucket> <topic ARN> <notification Id>'
+    print('Usage: ' + sys.argv[0] + ' <bucket> <topic ARN> <notification Id>')
     sys.exit(1)
 
 # bucket name as first argument
@@ -44,5 +44,5 @@ topic_conf_list = [{'Id': notification_id,
                          }
                     }}]
 
-print client.put_bucket_notification_configuration(Bucket=bucketname,
-                                                   NotificationConfiguration={'TopicConfigurations': topic_conf_list})
+print(client.put_bucket_notification_configuration(Bucket=bucketname,
+                                                   NotificationConfiguration={'TopicConfigurations': topic_conf_list}))

--- a/examples/boto3/service-2.sdk-extras.json
+++ b/examples/boto3/service-2.sdk-extras.json
@@ -191,12 +191,22 @@
         "UsageStatsSummary": {
             "type": "structure",
             "members": {
-                "TotalBytes":{"shape":"TotalBytes"},
+		        "QuotaMaxBytes":{"shape":"QuotaMaxBytes"},
+		        "QuotaMaxBuckets":{"shape": "QuotaMaxBuckets"},
+		        "QuotaMaxObjCount":{"shape":"QuotaMaxObjCount"},
+		        "QuotaMaxBytesPerBucket":{"shape":"QuotaMaxBytesPerBucket"},
+                "QuotaMaxObjCountPerBucket":{"shape":"QuotaMaxObjCountPerBucket"},
+		        "TotalBytes":{"shape":"TotalBytes"},
                 "TotalBytesRounded":{"shape":"TotalBytesRounded"},
                 "TotalEntries":{"shape":"TotalEntries"}
             }
         },
-        "TotalBytesRounded":{"type":"integer"},
+        "QuotaMaxBytes":{"type":"integer"},
+	    "QuotaMaxBuckets":{"type": "integer"},
+	    "QuotaMaxObjCount":{"type":"integer"},
+	    "QuotaMaxBytesPerBucket":{"type":"integer"},
+	    "QuotaMaxObjCountPerBucket":{"type":"integer"},
+	    "TotalBytesRounded":{"type":"integer"},
         "TotalBytes":{"type":"integer"},
         "TotalEntries":{"type":"integer"}
     },

--- a/examples/boto3/topic_with_endpoint.py
+++ b/examples/boto3/topic_with_endpoint.py
@@ -15,7 +15,7 @@ elif len(sys.argv) == 2:
     topic_name = sys.argv[1]
     region_name = ""
 else:
-    print 'Usage: ' + sys.argv[0] + ' <topic name> [region name]'
+    print('Usage: ' + sys.argv[0] + ' <topic name> [region name]')
     sys.exit(1)
 
 # endpoint and keys from vstart
@@ -38,4 +38,4 @@ client = boto3.client('sns',
 endpoint_args = 'push-endpoint=amqp://127.0.0.1:5672&amqp-exchange=ex1&amqp-ack-level=broker'
 attributes = {nvp[0] : nvp[1] for nvp in urlparse.parse_qsl(endpoint_args, keep_blank_values=True)}
 
-print client.create_topic(Name=topic_name, Attributes=attributes)
+print(client.create_topic(Name=topic_name, Attributes=attributes))

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2414,7 +2414,7 @@ void RGWGetUsage::execute()
 
   RGWUsageIter usage_iter;
   
-  while (is_truncated) {
+  while (s->bucket && is_truncated) {
     op_ret = s->bucket->read_usage(start_epoch, end_epoch, max_entries, &is_truncated,
 				   usage_iter, usage);
     if (op_ret == -ENOENT) {

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1410,6 +1410,14 @@ void RGWGetUsage_ObjStore_S3::send_response()
        formatter->open_object_section("Stats");
      }
 
+     // send info about quota config
+     auto user_info = s->user->get_info();
+     encode_json("QuotaMaxBytes", user_info.user_quota.max_size, formatter);
+     encode_json("QuotaMaxBuckets", user_info.max_buckets, formatter);
+     encode_json("QuotaMaxObjCount", user_info.user_quota.max_objects, formatter);
+     encode_json("QuotaMaxBytesPerBucket", user_info.bucket_quota.max_objects, formatter);
+     encode_json("QuotaMaxObjCountPerBucket", user_info.bucket_quota.max_size, formatter);
+     // send info about user's capacity utilization
      encode_json("TotalBytes", stats.size, formatter);
      encode_json("TotalBytesRounded", stats.size_rounded, formatter);
      encode_json("TotalEntries", stats.num_objects, formatter);
@@ -2140,6 +2148,15 @@ static void dump_bucket_metadata(struct req_state *s, rgw::sal::RGWBucket* bucke
 {
   dump_header(s, "X-RGW-Object-Count", static_cast<long long>(bucket->get_count()));
   dump_header(s, "X-RGW-Bytes-Used", static_cast<long long>(bucket->get_size()));
+  // only bucket's owner is allowed to get the quota settings of the account
+  if (bucket->is_owner(s->user.get())) {
+    auto user_info = s->user->get_info();
+    dump_header(s, "X-RGW-Quota-User-Size", static_cast<long long>(user_info.user_quota.max_size));
+    dump_header(s, "X-RGW-Quota-User-Objects", static_cast<long long>(user_info.user_quota.max_objects));
+    dump_header(s, "X-RGW-Quota-Max-Buckets", static_cast<long long>(user_info.max_buckets));
+    dump_header(s, "X-RGW-Quota-Bucket-Size", static_cast<long long>(user_info.bucket_quota.max_size));
+    dump_header(s, "X-RGW-Quota-Bucket-Objects", static_cast<long long>(user_info.bucket_quota.max_objects));
+  }
 }
 
 void RGWStatBucket_ObjStore_S3::send_response()

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -176,7 +176,7 @@ void RGWListBuckets_ObjStore_SWIFT::send_response_begin(bool has_buckets)
             global_stats,
             policies_stats,
             attrs,
-            user_quota,
+            s->user->get_info().user_quota,
             static_cast<RGWAccessControlPolicy_SWIFTAcct&>(*s->user_acl));
     dump_errno(s);
     dump_header(s, "Accept-Ranges", "bytes");
@@ -282,7 +282,7 @@ void RGWListBuckets_ObjStore_SWIFT::send_response_end()
             global_stats,
             policies_stats,
             attrs,
-            user_quota,
+            s->user->get_info().user_quota,
             static_cast<RGWAccessControlPolicy_SWIFTAcct&>(*s->user_acl));
     dump_errno(s);
     end_header(s, nullptr, nullptr, s->formatter->get_len(), true);
@@ -556,7 +556,7 @@ void RGWStatAccount_ObjStore_SWIFT::send_response()
             global_stats,
             policies_stats,
             attrs,
-            user_quota,
+            s->user->get_info().user_quota,
             static_cast<RGWAccessControlPolicy_SWIFTAcct&>(*s->user_acl));
   }
 


### PR DESCRIPTION
Make the quota settings visible to s3 and swift users
rgw send headers of quota settings

Fixes: https://tracker.ceph.com/issues/47752
s3-tests: https://github.com/ceph/s3-tests/pull/371
Signed-off-by: Or Friedmann <ofriedma@redhat.com>