### PR TITLE
octopus: rgw: rgw_file: avoid long-ish delay on shutdown

### DIFF
--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -130,8 +130,8 @@ namespace rgw {
 	if (cur_gen != gen)
 	  goto restart; /* invalidated */
       }
+      cv.wait_for(uniq, std::chrono::seconds(delay_s));
       uniq.unlock();
-      std::this_thread::sleep_for(std::chrono::seconds(delay_s));
     }
   }
 

--- a/src/rgw/rgw_lib_frontend.h
+++ b/src/rgw/rgw_lib_frontend.h
@@ -14,6 +14,7 @@ namespace rgw {
   class RGWLibProcess : public RGWProcess {
     RGWAccessKey access_key;
     std::mutex mtx;
+    std::condition_variable cv;
     int gen;
     bool shutdown;
 
@@ -36,6 +37,7 @@ namespace rgw {
       for (const auto& fs: mounted_fs) {
 	fs.second->stop();
       }
+      cv.notify_all();
     }
 
     void register_fs(RGWLibFS* fs) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47736

---

backport of https://github.com/ceph/ceph/pull/37501
parent tracker: https://tracker.ceph.com/issues/47710

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh