### PR TITLE
octopus: mon: set session_timeout when adding to session_map

### DIFF
--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -184,6 +184,9 @@ struct MonSessionMap {
   }
 
   void add_session(MonSession *s) {
+    s->session_timeout = ceph_clock_now();
+    s->session_timeout += g_conf()->mon_session_timeout;
+
     sessions.push_back(&s->item);
     s->get();
     if (s->name.is_osd() &&


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47747

---

backport of https://github.com/ceph/ceph/pull/37494
parent tracker: https://tracker.ceph.com/issues/47697

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh