### PR TITLE
cephadm: only support --name and --fsid for logs command

### DIFF
--- a/doc/man/8/cephadm.rst
+++ b/doc/man/8/cephadm.rst
@@ -49,7 +49,7 @@ Synopsis
 
 | **cephadm** **unit**  [-h] [--fsid FSID] --name NAME command
 
-| **cephadm** **logs** [-h] [--fsid FSID] --name NAME [command [command ...]]
+| **cephadm** **logs** [-h] [--fsid FSID] --name NAME
 
 | **cephadm** **bootstrap** [-h] [--config CONFIG] [--mon-id MON_ID]
 |                           [--mon-addrv MON_ADDRV] [--mon-ip MON_IP]

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3617,8 +3617,6 @@ def command_logs():
 
     cmd = [find_program('journalctl')]
     cmd.extend(['-u', unit_name])
-    if args.command:
-        cmd.extend(args.command)
 
     # call this directly, without our wrapper, so that we get an unmolested
     # stdout with logger prefixing.
@@ -5702,9 +5700,6 @@ def _get_parser():
         '--name', '-n',
         required=True,
         help='daemon name (type.id)')
-    parser_logs.add_argument(
-        'command', nargs='*',
-        help='additional journalctl args')
 
     parser_bootstrap = subparsers.add_parser(
         'bootstrap', help='bootstrap a cluster (mon + mgr daemons)')


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47169

Signed-off-by: Adam King <adking@redhat.com>

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
