### PR TITLE
rbd: cleanup code and output formatting in status action

### DIFF
--- a/src/tools/rbd/action/Status.cc
+++ b/src/tools/rbd/action/Status.cc
@@ -174,12 +174,12 @@ static int do_show_status(librados::IoCtx& io_ctx, const std::string &image_name
       f->close_section(); // migration
     }
     if (cache_state.present) {
-        f->open_object_section("image_cache_state");
-        f->dump_bool("clean", cache_state.clean);
-        f->dump_int("size", cache_state.size);
-        f->dump_string("host", cache_state.host);
-        f->dump_string("path", cache_state.path);
-	f->close_section(); // image_cache_state
+      f->open_object_section("image_cache_state");
+      f->dump_bool("clean", cache_state.clean);
+      f->dump_int("size", cache_state.size);
+      f->dump_string("host", cache_state.host);
+      f->dump_string("path", cache_state.path);
+      f->close_section(); // image_cache_state
     }
   } else {
     if (watchers.size()) {
@@ -201,7 +201,7 @@ static int do_show_status(librados::IoCtx& io_ctx, const std::string &image_name
 
       std::cout << "Migration:" << std::endl;
       std::cout << "\tsource: " << source_pool_name << "/"
-              << migration_status.source_image_name;
+                << migration_status.source_image_name;
       if (!migration_status.source_image_id.empty()) {
         std::cout << " (" << migration_status.source_image_id <<  ")";
       }
@@ -217,11 +217,12 @@ static int do_show_status(librados::IoCtx& io_ctx, const std::string &image_name
     }
 
     if (cache_state.present) {
-        std::cout << "image cache state:" << std::endl;
+        std::cout << "Image cache state:" << std::endl;
         std::cout << "\tclean: " << (cache_state.clean ? "true" : "false")
-                  << "  size: " << byte_u_t(cache_state.size)
-                  << "  host: " << cache_state.host
-                  << "  path: "  << cache_state.path << std::endl;
+                  << std::endl
+                  << "\tsize: " << byte_u_t(cache_state.size) << std::endl
+                  << "\thost: " << cache_state.host << std::endl
+                  << "\tpath: " << cache_state.path << std::endl;
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
