### PR TITLE
include: explicitly define all types needed for libc++ iterator

### DIFF
--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -43,9 +43,15 @@ class interval_set {
 
   class const_iterator;
 
-  class iterator : public std::iterator <std::forward_iterator_tag, T>
+  class iterator
   {
     public:
+        using difference_type = ssize_t;
+        using value_type = typename Map::value_type;
+        using pointer = typename Map::value_type*;
+        using reference = typename Map::value_type&;
+        using iterator_category = std::forward_iterator_tag;
+
         explicit iterator(typename Map::iterator iter)
           : _iter(iter)
         { }


### PR DESCRIPTION
There is a serious difference between iterator in
    libstdc++ (gcc) versus libc++ (clang)

This generates a rather big and vague set of warnings and notes.
The crux is the warnings about `requirement '!__is_forward_iterator....`
Extra information can also be found on:
    https://www.fluentcpp.com/2018/05/08/std-iterator-deprecated/

```
/home/jenkins/workspace/ceph-master-compile/src/librbd/deep_copy/ObjectCopyRequest.cc:142:15: error: no matching constructor for initialization of 'io::Extents' (aka 'vector<pair<unsigned long, unsigned long> >')
  io::Extents image_extents{read_op.image_interval.begin(),
              ^            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/jenkins/workspace/ceph-master-compile/src/librbd/deep_copy/ObjectCopyRequest.cc:769:35: note: in instantiation of member function 'librbd::deep_copy::ObjectCopyRequest<librbd::ImageCtx>::send_read' requested here
template class librbd::deep_copy::ObjectCopyRequest<librbd::ImageCtx>;
                                  ^
/usr/include/c++/v1/vector:516:14: note: candidate constructor not viable: no known conversion from 'interval_set<unsigned long, std::map>::iterator' to 'std::__1::vector<std::__1::pair<unsigned long, unsigned long>, std::__1::allocator<std::__1::pair<unsigned long, unsigned long> > >::size_type' (aka 'unsigned long') for 1st argument
    explicit vector(size_type __n, const allocator_type& __a);
             ^
/usr/include/c++/v1/vector:518:5: note: candidate constructor not viable: no known conversion from 'interval_set<unsigned long, std::map>::iterator' to 'std::__1::vector<std::__1::pair<unsigned long, unsigned long>, std::__1::allocator<std::__1::pair<unsigned long, unsigned long> > >::size_type' (aka 'unsigned long') for 1st argument
    vector(size_type __n, const value_type& __x);
    ^
/usr/include/c++/v1/vector:559:5: note: candidate constructor not viable: no known conversion from 'interval_set<unsigned long, std::map>::iterator' to 'const std::__1::vector<std::__1::pair<unsigned long, unsigned long>, std::__1::allocator<std::__1::pair<unsigned long, unsigned long> > >' for 1st argument
    vector(const vector& __x, const allocator_type& __a);
    ^
/usr/include/c++/v1/vector:568:5: note: candidate constructor not viable: no known conversion from 'interval_set<unsigned long, std::map>::iterator' to 'initializer_list<std::__1::vector<std::__1::pair<unsigned long, unsigned long>, std::__1::allocator<std::__1::pair<unsigned long, unsigned long> > >::value_type>' (aka 'initializer_list<std::__1::pair<unsigned long, unsigned long> >') for 1st argument
    vector(initializer_list<value_type> __il, const allocator_type& __a);
    ^
/usr/include/c++/v1/vector:579:5: note: candidate constructor not viable: no known conversion from 'interval_set<unsigned long, std::map>::iterator' to 'std::__1::vector<std::__1::pair<unsigned long, unsigned long>, std::__1::allocator<std::__1::pair<unsigned long, unsigned long> > >' for 1st argument
    vector(vector&& __x, const allocator_type& __a);
    ^
/usr/include/c++/v1/vector:521:9: note: candidate template ignored: requirement '!__is_forward_iterator<interval_set<unsigned long, std::map>::iterator>::value' was not satisfied [with _InputIterator = interval_set<unsigned long, std::map>::iterator]
        vector(_InputIterator __first,
        ^
/usr/include/c++/v1/vector:536:9: note: candidate template ignored: requirement 'is_constructible<std::__1::pair<unsigned long, unsigned long>, unsigned long &>::value' was not satisfied [with _ForwardIterator = interval_set<unsigned long, std::map>::iterator]
        vector(_ForwardIterator __first,
        ^
/usr/include/c++/v1/vector:502:40: note: candidate constructor not viable: requires single argument '__a', but 2 arguments were provided
    _LIBCPP_INLINE_VISIBILITY explicit vector(const allocator_type& __a)
                                       ^
/usr/include/c++/v1/vector:514:14: note: candidate constructor not viable: requires single argument '__n', but 2 arguments were provided
    explicit vector(size_type __n);
             ^
/usr/include/c++/v1/vector:558:5: note: candidate constructor not viable: requires single argument '__x', but 2 arguments were provided
    vector(const vector& __x);
    ^
/usr/include/c++/v1/vector:565:5: note: candidate constructor not viable: requires single argument '__il', but 2 arguments were provided
    vector(initializer_list<value_type> __il);
    ^
/usr/include/c++/v1/vector:571:5: note: candidate constructor not viable: requires single argument '__x', but 2 arguments were provided
    vector(vector&& __x)
    ^
/usr/include/c++/v1/vector:519:5: note: candidate constructor not viable: requires 3 arguments, but 2 were provided
    vector(size_type __n, const value_type& __x, const allocator_type& __a);
    ^
/usr/include/c++/v1/vector:496:5: note: candidate constructor not viable: requires 0 arguments, but 2 were provided
    vector() _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value)
    ^
/usr/include/c++/v1/vector:529:9: note: candidate constructor template not viable: requires at least 3 arguments, but 2 were provided
        vector(_InputIterator __first, _InputIterator __last, const allocator_type& __a,
        ^
/usr/include/c++/v1/vector:543:9: note: candidate constructor template not viable: requires at least 3 arguments, but 2 were provided
        vector(_ForwardIterator __first, _ForwardIterator __last, const allocator_type& __a,
        ^
1 error generated.
```




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>