### PR TITLE
rgw: allow rgw-orphan-list to note when rados objects are in namespace

### DIFF
--- a/src/rgw/rgw-orphan-list
+++ b/src/rgw/rgw-orphan-list
@@ -18,6 +18,9 @@ delta_out="${out_dir}/orphan-list-${timestamp}.out"
 
 error_out() {
     echo "An error was encountered while running '$1'. Aborting."
+    if [ $# -gt 2 ] ;then
+	echo "Error: $3"
+    fi
     if [ $# -gt 1 ] ;then
 	echo "Review file '$2' for details."
     fi
@@ -54,10 +57,21 @@ echo "Pool is \"$pool\"."
 echo "Note: output files produced will be tagged with the current timestamp -- ${timestamp}."
 
 echo "running 'rados ls' at $(date)"
-rados ls --pool="$pool" >"$rados_out" 2>"$rados_err"
+rados ls --pool="$pool" --format=json-pretty --all >"$rados_out" 2>"$rados_err"
 if [ "$?" -ne 0 ] ;then
     error_out "rados ls" "$rados_err"
 fi
+
+# check for namespaces and error out if any found
+grep '^[[:blank:]]*"namespace":' "$rados_out" | grep --silent '[^:]*: "[^"]'
+if [ "${PIPESTATUS[1]}" -eq 0 ] ;then
+    error_out "rados ls" "$rados_out" "Found one or more RADOS objects existing in a namespace."
+fi
+
+# move from json to list of oids
+grep '^[[:blank:]]*"name":' "$rados_out" | sed 's/[^:]*: "\(.*\)"$/\1/' >"$temp_file"
+mv -f "$temp_file" "$rados_out"
+
 sort -u "$rados_out" >"$temp_file"
 mv -f "$temp_file" "$rados_out"
 


### PR DESCRIPTION
Currently namespaces and locators are ignored when `rados ls` is run
to see RADOS's known objects. At this point we do not expect RGW data
objects to be in RADOS namespaces, so when that's detected, we'll
error out with a message. Additionally when objects have locators, we
will prevent their output from entering the .intermediate file.

Fixes: https://tracker.ceph.com/issues/47771
Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>