### PR TITLE
rgw multisite: remove sharding from bucket full sync

### DIFF
--- a/qa/suites/rgw/multisite/tasks/test_multi.yaml
+++ b/qa/suites/rgw/multisite/tasks/test_multi.yaml
@@ -24,3 +24,4 @@ tasks:
 - rgw-multisite-tests:
     config:
       reconfigure_delay: 60
+    args: ['-a', '!bucket_sync_disable'] # filter out disable/enable tests

--- a/qa/tasks/rgw_multisite_tests.py
+++ b/qa/tasks/rgw_multisite_tests.py
@@ -4,6 +4,7 @@ rgw multisite testing
 import logging
 import nose.core
 import nose.config
+from nose.plugins.manager import DefaultPluginManager
 
 from teuthology.exceptions import ConfigError
 from teuthology.task import Task
@@ -63,6 +64,7 @@ class RGWMultisiteTests(Task):
 
         # run nose tests in the rgw_multi.tests module
         conf = nose.config.Config(stream=get_log_stream(), verbosity=2)
+        conf.plugins = DefaultPluginManager() # overrides default = NoPlugins()
         error_msg = ''
         result = nose.run(defaultTest=tests.__name__, argv=argv, config=conf)
         if not result:

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2258,39 +2258,41 @@ static int bucket_source_sync_status(rgw::sal::RGWRadosStore *store, const RGWZo
     return r;
   }
 
+  out << indented{width, "source bucket"} << source_bucket_info.bucket.get_key() << std::endl;
+
   pipe.source.bucket = source_bucket;
   pipe.dest.bucket = bucket_info.bucket;
+
+  rgw_bucket_sync_status full_status;
+  r = rgw_read_bucket_full_sync_status(dpp(), store, pipe, &full_status, null_yield);
+  if (r < 0) {
+    lderr(store->ctx()) << "failed to read bucket full sync status: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  if (full_status.state == BucketSyncState::Init) {
+    out << indented{width} << "init: bucket sync has not started\n";
+    return 0;
+  }
+  if (full_status.state == BucketSyncState::Stopped) {
+    out << indented{width} << "stopped: bucket sync is disabled\n";
+    return 0;
+  }
+  if (full_status.state == BucketSyncState::Full) {
+    out << indented{width} << "full sync: " << full_status.full.count << " objects completed\n";
+    return 0;
+  }
 
   std::vector<rgw_bucket_shard_sync_info> status;
   r = rgw_read_bucket_inc_sync_status(dpp(), store, pipe, bucket_info, &source_bucket_info, &status);
   if (r < 0) {
-    lderr(store->ctx()) << "failed to read bucket sync status: " << cpp_strerror(r) << dendl;
+    lderr(store->ctx()) << "failed to read bucket incremental sync status: " << cpp_strerror(r) << dendl;
     return r;
   }
 
-  out << indented{width, "source bucket"} << source_bucket_info.bucket.get_key() << std::endl;
-
-  int num_full = 0;
-  int num_inc = 0;
-  uint64_t full_complete = 0;
   const size_t total_shards = status.size();
 
-  using BucketSyncState = rgw_bucket_shard_sync_info::SyncState;
-  for (size_t shard_id = 0; shard_id < total_shards; shard_id++) {
-    auto& m = status[shard_id];
-    if (m.state == BucketSyncState::StateFullSync) {
-      num_full++;
-      full_complete += m.full_marker.count;
-    } else if (m.state == BucketSyncState::StateIncrementalSync) {
-      num_inc++;
-    }
-  }
-
-  out << indented{width} << "full sync: " << num_full << "/" << total_shards << " shards\n";
-  if (num_full > 0) {
-    out << indented{width} << "full sync: " << full_complete << " objects completed\n";
-  }
-  out << indented{width} << "incremental sync: " << num_inc << "/" << total_shards << " shards\n";
+  out << indented{width} << "incremental sync on " << total_shards << " shards\n";
 
   BucketIndexShardsManager remote_markers;
   r = rgw_read_remote_bilog_info(conn, source_bucket, remote_markers, null_yield);
@@ -2306,15 +2308,15 @@ static int bucket_source_sync_status(rgw::sal::RGWRadosStore *store, const RGWZo
     if (r.second.empty()) {
       continue; // empty bucket index shard
     }
-    auto pos = BucketIndexShardsManager::get_shard_marker(m.inc_marker.position);
-    if (m.state != BucketSyncState::StateIncrementalSync || pos != r.second) {
+    const auto pos = BucketIndexShardsManager::get_shard_marker(m.inc_marker.position);
+    if (pos < r.second) {
       shards_behind.insert(shard_id);
     }
   }
   if (!shards_behind.empty()) {
     out << indented{width} << "bucket is behind on " << shards_behind.size() << " shards\n";
     out << indented{width} << "behind shards: [" << shards_behind << "]\n" ;
-  } else if (!num_full) {
+  } else {
     out << indented{width} << "bucket is caught up with source\n";
   }
   return 0;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2262,7 +2262,7 @@ static int bucket_source_sync_status(rgw::sal::RGWRadosStore *store, const RGWZo
   pipe.dest.bucket = bucket_info.bucket;
 
   std::vector<rgw_bucket_shard_sync_info> status;
-  r = rgw_bucket_sync_status(dpp(), store, pipe, bucket_info, &source_bucket_info, &status);
+  r = rgw_read_bucket_inc_sync_status(dpp(), store, pipe, bucket_info, &source_bucket_info, &status);
   if (r < 0) {
     lderr(store->ctx()) << "failed to read bucket sync status: " << cpp_strerror(r) << dendl;
     return r;

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -169,7 +169,7 @@ int RGWAsyncPutSystemObjAttrs::_send_request()
   auto sysobj = obj_ctx.get_obj(obj);
   return sysobj.wop()
                .set_objv_tracker(&objv_tracker)
-               .set_exclusive(false)
+               .set_exclusive(exclusive)
                .set_attrs(attrs)
                .write_attrs(null_yield);
 }
@@ -177,9 +177,9 @@ int RGWAsyncPutSystemObjAttrs::_send_request()
 RGWAsyncPutSystemObjAttrs::RGWAsyncPutSystemObjAttrs(RGWCoroutine *caller, RGWAioCompletionNotifier *cn,
                      RGWSI_SysObj *_svc,
                      RGWObjVersionTracker *_objv_tracker, const rgw_raw_obj& _obj,
-                     map<string, bufferlist> _attrs)
+                     map<string, bufferlist> _attrs, bool exclusive)
   : RGWAsyncRadosRequest(caller, cn), svc(_svc),
-    obj(_obj), attrs(std::move(_attrs))
+    obj(_obj), attrs(std::move(_attrs)), exclusive(exclusive)
 {
   if (_objv_tracker) {
     objv_tracker = *_objv_tracker;

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -334,13 +334,14 @@ class RGWAsyncPutSystemObjAttrs : public RGWAsyncRadosRequest {
   RGWSI_SysObj *svc;
   rgw_raw_obj obj;
   map<string, bufferlist> attrs;
+  bool exclusive;
 
 protected:
   int _send_request() override;
 public:
   RGWAsyncPutSystemObjAttrs(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, RGWSI_SysObj *_svc,
                        RGWObjVersionTracker *_objv_tracker, const rgw_raw_obj& _obj,
-                       map<string, bufferlist> _attrs);
+                       map<string, bufferlist> _attrs, bool exclusive);
 
   RGWObjVersionTracker objv_tracker;
 };
@@ -544,16 +545,18 @@ class RGWSimpleRadosWriteAttrsCR : public RGWSimpleCoroutine {
 
   rgw_raw_obj obj;
   map<string, bufferlist> attrs;
+  bool exclusive;
   RGWAsyncPutSystemObjAttrs *req = nullptr;
 
 public:
   RGWSimpleRadosWriteAttrsCR(RGWAsyncRadosProcessor *_async_rados,
                              RGWSI_SysObj *_svc, const rgw_raw_obj& _obj,
                              map<string, bufferlist> _attrs,
-                             RGWObjVersionTracker *objv_tracker = nullptr)
+                             RGWObjVersionTracker *objv_tracker = nullptr,
+                             bool exclusive = false)
     : RGWSimpleCoroutine(_svc->ctx()), async_rados(_async_rados),
       svc(_svc), objv_tracker(objv_tracker), obj(_obj),
-      attrs(std::move(_attrs)) {
+      attrs(std::move(_attrs)), exclusive(exclusive) {
   }
   ~RGWSimpleRadosWriteAttrsCR() override {
     request_cleanup();
@@ -568,7 +571,8 @@ public:
 
   int send_request() override {
     req = new RGWAsyncPutSystemObjAttrs(this, stack->create_completion_notifier(),
-			           svc, objv_tracker, obj, std::move(attrs));
+			           svc, objv_tracker, obj, std::move(attrs),
+                                   exclusive);
     async_rados->queue(req);
     return 0;
   }

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -498,14 +498,16 @@ class RGWSimpleRadosWriteCR : public RGWSimpleCoroutine {
   bufferlist bl;
   rgw_raw_obj obj;
   RGWObjVersionTracker *objv_tracker;
+  bool exclusive;
   RGWAsyncPutSystemObj *req{nullptr};
 
 public:
   RGWSimpleRadosWriteCR(RGWAsyncRadosProcessor *_async_rados, RGWSI_SysObj *_svc,
-		      const rgw_raw_obj& _obj,
-		      const T& _data, RGWObjVersionTracker *objv_tracker = nullptr)
+		      const rgw_raw_obj& _obj, const T& _data,
+                      RGWObjVersionTracker *objv_tracker = nullptr,
+                      bool exclusive = false)
     : RGWSimpleCoroutine(_svc->ctx()), async_rados(_async_rados),
-      svc(_svc), obj(_obj), objv_tracker(objv_tracker) {
+      svc(_svc), obj(_obj), objv_tracker(objv_tracker), exclusive(exclusive) {
     encode(_data, bl);
   }
 
@@ -522,7 +524,7 @@ public:
 
   int send_request() override {
     req = new RGWAsyncPutSystemObj(this, stack->create_completion_notifier(),
-			           svc, objv_tracker, obj, false, std::move(bl));
+			           svc, objv_tracker, obj, exclusive, std::move(bl));
     async_rados->queue(req);
     return 0;
   }

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -433,6 +433,9 @@ int RGWSimpleRadosReadCR<T>::request_complete()
     if (ret < 0) {
       return ret;
     }
+    if (objv_tracker) { // copy the updated version
+      *objv_tracker = req->objv_tracker;
+    }
     try {
       auto iter = req->bl.cbegin();
       if (iter.end()) {

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -45,11 +45,11 @@
 #undef dout_prefix
 #define dout_prefix (*_dout << "data sync: ")
 
-static string datalog_sync_status_oid_prefix = "datalog.sync-status";
-static string datalog_sync_status_shard_prefix = "datalog.sync-status.shard";
-static string datalog_sync_full_sync_index_prefix = "data.full-sync.index";
-static string bucket_status_oid_prefix = "bucket.sync-status";
-static string object_status_oid_prefix = "bucket.sync-status";
+static const string datalog_sync_status_oid_prefix = "datalog.sync-status";
+static const string datalog_sync_status_shard_prefix = "datalog.sync-status.shard";
+static const string datalog_sync_full_sync_index_prefix = "data.full-sync.index";
+static const string bucket_status_oid_prefix = "bucket.sync-status";
+static const string object_status_oid_prefix = "bucket.sync-status";
 
 
 void rgw_datalog_info::decode_json(JSONObj *obj) {

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -2771,17 +2771,11 @@ public:
         } else {
           // whether or not to do full sync, incremental sync will follow anyway
           if (sync_env->sync_module->should_full_sync()) {
-            status.state = rgw_bucket_shard_sync_info::StateFullSync;
             status.inc_marker.position = info.max_marker;
-          } else {
-            // clear the marker position unless we're resuming from SYNCSTOP
-            if (!stopped) {
-              status.inc_marker.position = "";
-            }
-            status.state = rgw_bucket_shard_sync_info::StateIncrementalSync;
           }
           write_status = true;
           status.inc_marker.timestamp = ceph::real_clock::now();
+          status.state = rgw_bucket_shard_sync_info::StateIncrementalSync;
         }
 
         if (write_status) {

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1010,7 +1010,7 @@ public:
                             ceph::real_time* progress)
     : RGWCoroutine(_sc->cct), sc(_sc), sync_env(_sc->env),
       lease_cr(std::move(lease_cr)), sync_pair(_sync_pair), progress(progress),
-      status_oid(RGWBucketPipeSyncStatusManager::status_oid(sc->source_zone, sync_pair)),
+      status_oid(RGWBucketPipeSyncStatusManager::inc_status_oid(sc->source_zone, sync_pair)),
       tn(sync_env->sync_tracer->add_node(_tn_parent, "bucket",
                                          SSTR(bucket_shard_str{_sync_pair.dest_bs} << "<-" << bucket_shard_str{_sync_pair.source_bs} ))) {
   }
@@ -2733,7 +2733,7 @@ public:
                                         RGWObjVersionTracker& objv_tracker)
     : RGWCoroutine(_sc->cct), sc(_sc), sync_env(_sc->env),
       sync_pair(_sync_pair),
-      sync_status_oid(RGWBucketPipeSyncStatusManager::status_oid(sc->source_zone, _sync_pair)),
+      sync_status_oid(RGWBucketPipeSyncStatusManager::inc_status_oid(sc->source_zone, _sync_pair)),
       status(_status), objv_tracker(objv_tracker)
   {}
 
@@ -2907,7 +2907,7 @@ public:
                                    rgw_bucket_shard_sync_info *_status,
                                    RGWObjVersionTracker* objv_tracker)
     : RGWCoroutine(_sc->cct), sc(_sc), sync_env(_sc->env),
-      oid(RGWBucketPipeSyncStatusManager::status_oid(sc->source_zone, sync_pair)),
+      oid(RGWBucketPipeSyncStatusManager::inc_status_oid(sc->source_zone, sync_pair)),
       status(_status), objv_tracker(objv_tracker)
   {}
   int operate() override;
@@ -4895,8 +4895,8 @@ std::ostream& RGWBucketPipeSyncStatusManager::gen_prefix(std::ostream& out) cons
     << " bucket:" << dest_bucket << ' ';
 }
 
-string RGWBucketPipeSyncStatusManager::status_oid(const rgw_zone_id& source_zone,
-                                              const rgw_bucket_sync_pair_info& sync_pair)
+string RGWBucketPipeSyncStatusManager::inc_status_oid(const rgw_zone_id& source_zone,
+                                                      const rgw_bucket_sync_pair_info& sync_pair)
 {
   if (sync_pair.source_bs == sync_pair.dest_bs) {
     return bucket_status_oid_prefix + "." + source_zone.id + ":" + sync_pair.dest_bs.get_key();

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -988,37 +988,6 @@ std::ostream& operator<<(std::ostream& out, const bucket_shard_str& rhs) {
   return out;
 }
 
-class RGWSyncBucketShardCR : public RGWCoroutine {
-  RGWDataSyncCtx *sc;
-  RGWDataSyncEnv *sync_env;
-  boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr;
-  rgw_bucket_sync_pair_info sync_pair;
-  rgw_bucket_sync_pipe sync_pipe;
-  rgw_bucket_shard_sync_info sync_status;
-  RGWMetaSyncEnv meta_sync_env;
-  RGWObjVersionTracker objv_tracker;
-  ceph::real_time* progress;
-
-  const std::string status_oid;
-
-  RGWSyncTraceNodeRef tn;
-
-public:
-  RGWSyncBucketShardCR(RGWDataSyncCtx *_sc,
-                       boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
-                       const rgw_bucket_sync_pair_info& _sync_pair,
-                       const RGWSyncTraceNodeRef& _tn_parent,
-                       ceph::real_time* progress)
-    : RGWCoroutine(_sc->cct), sc(_sc), sync_env(_sc->env),
-      lease_cr(std::move(lease_cr)), sync_pair(_sync_pair), progress(progress),
-      status_oid(RGWBucketPipeSyncStatusManager::inc_status_oid(sc->source_zone, sync_pair)),
-      tn(sync_env->sync_tracer->add_node(_tn_parent, "bucket",
-                                         SSTR(bucket_shard_str{_sync_pair.dest_bs} << "<-" << bucket_shard_str{_sync_pair.source_bs} ))) {
-  }
-
-  int operate() override;
-};
-
 struct all_bucket_info {
   RGWBucketInfo bucket_info;
   map<string, bufferlist> attrs;
@@ -4282,6 +4251,12 @@ std::ostream& operator<<(std::ostream& out, std::optional<rgw_bucket_shard>& bs)
   return out;
 }
 
+static RGWCoroutine* sync_bucket_shard_cr(RGWDataSyncCtx* sc,
+                                          boost::intrusive_ptr<const RGWContinuousLeaseCR> lease,
+                                          const rgw_bucket_sync_pair_info& sync_pair,
+                                          const RGWSyncTraceNodeRef& tn,
+                                          ceph::real_time* progress);
+
 RGWRunBucketSourcesSyncCR::RGWRunBucketSourcesSyncCR(RGWDataSyncCtx *_sc,
                                                      boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
                                                      std::optional<rgw_bucket_shard> _target_bs,
@@ -4360,8 +4335,8 @@ int RGWRunBucketSourcesSyncCR::operate()
 
         ldpp_dout(sync_env->dpp, 20) << __func__ << "(): sync_pair=" << sync_pair << dendl;
 
-        yield spawn(new RGWSyncBucketShardCR(sc, lease_cr, sync_pair, tn,
-                                             &*cur_shard_progress), false);
+        yield spawn(sync_bucket_shard_cr(sc, lease_cr, sync_pair, tn,
+                                         &*cur_shard_progress), false);
         while (num_spawned() > BUCKET_SYNC_SPAWN_WINDOW) {
           set_status() << "num_spawned() > spawn_window";
           yield wait_for_child();
@@ -4674,6 +4649,46 @@ int RGWGetBucketPeersCR::operate()
   return 0;
 }
 
+class RGWSyncBucketShardCR : public RGWCoroutine {
+  RGWDataSyncCtx *sc;
+  RGWDataSyncEnv *sync_env;
+  boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr;
+  rgw_bucket_sync_pair_info sync_pair;
+  rgw_bucket_sync_pipe sync_pipe;
+  rgw_bucket_shard_sync_info sync_status;
+  RGWMetaSyncEnv meta_sync_env;
+  RGWObjVersionTracker objv_tracker;
+  ceph::real_time* progress;
+
+  const std::string status_oid;
+
+  RGWSyncTraceNodeRef tn;
+
+public:
+  RGWSyncBucketShardCR(RGWDataSyncCtx *_sc,
+                       boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
+                       const rgw_bucket_sync_pair_info& _sync_pair,
+                       const RGWSyncTraceNodeRef& _tn_parent,
+                       ceph::real_time* progress)
+    : RGWCoroutine(_sc->cct), sc(_sc), sync_env(_sc->env),
+      lease_cr(std::move(lease_cr)), sync_pair(_sync_pair), progress(progress),
+      status_oid(RGWBucketPipeSyncStatusManager::inc_status_oid(sc->source_zone, sync_pair)),
+      tn(sync_env->sync_tracer->add_node(_tn_parent, "bucket",
+                                         SSTR(bucket_shard_str{_sync_pair.dest_bs} << "<-" << bucket_shard_str{_sync_pair.source_bs} ))) {
+  }
+
+  int operate() override;
+};
+
+static RGWCoroutine* sync_bucket_shard_cr(RGWDataSyncCtx* sc,
+                                          boost::intrusive_ptr<const RGWContinuousLeaseCR> lease,
+                                          const rgw_bucket_sync_pair_info& sync_pair,
+                                          const RGWSyncTraceNodeRef& tn,
+                                          ceph::real_time* progress)
+{
+  return new RGWSyncBucketShardCR(sc, std::move(lease), sync_pair, tn, progress);
+}
+
 int RGWSyncBucketShardCR::operate()
 {
   reenter(this) {
@@ -4761,7 +4776,7 @@ RGWCoroutine *RGWRemoteBucketManager::run_sync_cr(int num)
     return nullptr;
   }
 
-  return new RGWSyncBucketShardCR(&sc, nullptr, sync_pairs[num], sync_env->sync_tracer->root_node, nullptr);
+  return sync_bucket_shard_cr(&sc, nullptr, sync_pairs[num], sync_env->sync_tracer->root_node, nullptr);
 }
 
 int RGWBucketPipeSyncStatusManager::init()

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1180,26 +1180,6 @@ struct rgw_sync_pipe_info_set {
   }
 };
 
-class RGWRunBucketsSyncBySourceCR : public RGWCoroutine {
-  RGWDataSyncCtx *sc;
-  RGWDataSyncEnv *sync_env;
-
-  rgw_bucket_shard source;
-
-  RGWSyncTraceNodeRef tn;
-
-public:
-  RGWRunBucketsSyncBySourceCR(RGWDataSyncCtx *_sc, const rgw_bucket_shard& _source, const RGWSyncTraceNodeRef& _tn_parent)
-    : RGWCoroutine(_sc->cct), sc(_sc), sync_env(_sc->env), source(_source),
-      tn(sync_env->sync_tracer->add_node(_tn_parent, "source",
-                                         SSTR(bucket_shard_str{_source} ))) {
-  }
-  ~RGWRunBucketsSyncBySourceCR() override {
-  }
-
-  int operate() override;
-};
-
 class RGWRunBucketSourcesSyncCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWDataSyncEnv *sync_env;
@@ -4687,15 +4667,6 @@ int RGWGetBucketPeersCR::operate()
       pipes->update_empty_bucket_info(buckets_info);
     }
 
-    return set_cr_done();
-  }
-
-  return 0;
-}
-
-int RGWRunBucketsSyncBySourceCR::operate()
-{
-  reenter(this) {
     return set_cr_done();
   }
 

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -81,6 +81,16 @@ class RGWReadDataSyncStatusMarkersCR : public RGWShardCollectCR {
 
   map<uint32_t, rgw_data_sync_marker>& markers;
 
+  int handle_result(int r) override {
+    if (r == -ENOENT) { // ENOENT is not a fatal error
+      return 0;
+    }
+    if (r < 0) {
+      ldout(cct, 4) << "failed to read data sync status: "
+          << cpp_strerror(r) << dendl;
+    }
+    return r;
+  }
  public:
   RGWReadDataSyncStatusMarkersCR(RGWDataSyncCtx *sc, int num_shards,
                                  map<uint32_t, rgw_data_sync_marker>& markers)
@@ -117,6 +127,16 @@ class RGWReadDataSyncRecoveringShardsCR : public RGWShardCollectCR {
   string marker;
   std::vector<RGWRadosGetOmapKeysCR::ResultPtr>& omapkeys;
 
+  int handle_result(int r) override {
+    if (r == -ENOENT) { // ENOENT is not a fatal error
+      return 0;
+    }
+    if (r < 0) {
+      ldout(cct, 4) << "failed to list recovering data sync: "
+          << cpp_strerror(r) << dendl;
+    }
+    return r;
+  }
  public:
   RGWReadDataSyncRecoveringShardsCR(RGWDataSyncCtx *sc, uint64_t _max_entries, int _num_shards,
                                     std::vector<RGWRadosGetOmapKeysCR::ResultPtr>& omapkeys)
@@ -352,6 +372,16 @@ class RGWReadRemoteDataLogInfoCR : public RGWShardCollectCR {
   int shard_id;
 #define READ_DATALOG_MAX_CONCURRENT 10
 
+  int handle_result(int r) override {
+    if (r == -ENOENT) { // ENOENT is not a fatal error
+      return 0;
+    }
+    if (r < 0) {
+      ldout(cct, 4) << "failed to fetch remote datalog info: "
+          << cpp_strerror(r) << dendl;
+    }
+    return r;
+  }
 public:
   RGWReadRemoteDataLogInfoCR(RGWDataSyncCtx *_sc,
                      int _num_shards,
@@ -442,6 +472,16 @@ class RGWListRemoteDataLogCR : public RGWShardCollectCR {
   map<int, string>::iterator iter;
 #define READ_DATALOG_MAX_CONCURRENT 10
 
+  int handle_result(int r) override {
+    if (r == -ENOENT) { // ENOENT is not a fatal error
+      return 0;
+    }
+    if (r < 0) {
+      ldout(cct, 4) << "failed to list remote datalog: "
+          << cpp_strerror(r) << dendl;
+    }
+    return r;
+  }
 public:
   RGWListRemoteDataLogCR(RGWDataSyncCtx *_sc,
                      map<int, string>& _shards,
@@ -4989,6 +5029,16 @@ class RGWCollectBucketSyncStatusCR : public RGWShardCollectCR {
   using Vector = std::vector<rgw_bucket_shard_sync_info>;
   Vector::iterator i, end;
 
+  int handle_result(int r) override {
+    if (r == -ENOENT) { // ENOENT is not a fatal error
+      return 0;
+    }
+    if (r < 0) {
+      ldout(cct, 4) << "failed to read bucket shard sync status: "
+          << cpp_strerror(r) << dendl;
+    }
+    return r;
+  }
  public:
   RGWCollectBucketSyncStatusCR(rgw::sal::RGWRadosStore *store, RGWDataSyncCtx *sc,
                                const RGWBucketInfo& source_bucket_info,

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -4999,12 +4999,12 @@ class RGWCollectBucketSyncStatusCR : public RGWShardCollectCR {
   }
 };
 
-int rgw_bucket_sync_status(const DoutPrefixProvider *dpp,
-                           rgw::sal::RGWRadosStore *store,
-                           const rgw_sync_bucket_pipe& pipe,
-                           const RGWBucketInfo& dest_bucket_info,
-                           const RGWBucketInfo *psource_bucket_info,
-                           std::vector<rgw_bucket_shard_sync_info> *status)
+int rgw_read_bucket_inc_sync_status(const DoutPrefixProvider *dpp,
+                                    rgw::sal::RGWRadosStore *store,
+                                    const rgw_sync_bucket_pipe& pipe,
+                                    const RGWBucketInfo& dest_bucket_info,
+                                    const RGWBucketInfo *psource_bucket_info,
+                                    std::vector<rgw_bucket_shard_sync_info> *status)
 {
   if (!pipe.source.zone ||
       !pipe.source.bucket ||

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -48,6 +48,7 @@
 static const string datalog_sync_status_oid_prefix = "datalog.sync-status";
 static const string datalog_sync_status_shard_prefix = "datalog.sync-status.shard";
 static const string datalog_sync_full_sync_index_prefix = "data.full-sync.index";
+static const string bucket_full_status_oid_prefix = "bucket.full-sync-status";
 static const string bucket_status_oid_prefix = "bucket.sync-status";
 static const string object_status_oid_prefix = "bucket.sync-status";
 
@@ -4893,6 +4894,19 @@ std::ostream& RGWBucketPipeSyncStatusManager::gen_prefix(std::ostream& out) cons
   auto zone = std::string_view{source_zone.value_or(rgw_zone_id("*")).id};
   return out << "bucket sync zone:" << zone.substr(0, 8)
     << " bucket:" << dest_bucket << ' ';
+}
+
+string RGWBucketPipeSyncStatusManager::full_status_oid(const rgw_zone_id& source_zone,
+                                                       const rgw_bucket& source_bucket,
+                                                       const rgw_bucket& dest_bucket)
+{
+  if (source_bucket == dest_bucket) {
+    return bucket_full_status_oid_prefix + "." + source_zone.id + ":"
+        + dest_bucket.get_key();
+  } else {
+    return bucket_full_status_oid_prefix + "." + source_zone.id + ":"
+        + dest_bucket.get_key() + ":" + source_bucket.get_key();
+  }
 }
 
 string RGWBucketPipeSyncStatusManager::inc_status_oid(const rgw_zone_id& source_zone,

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -2736,15 +2736,17 @@ class RGWInitBucketShardSyncStatusCoroutine : public RGWCoroutine {
   rgw_bucket_shard_sync_info& status;
   RGWObjVersionTracker& objv_tracker;
   rgw_bucket_index_marker_info info;
+  bool exclusive;
 public:
   RGWInitBucketShardSyncStatusCoroutine(RGWDataSyncCtx *_sc,
                                         const rgw_bucket_sync_pair_info& _sync_pair,
                                         rgw_bucket_shard_sync_info& _status,
-                                        RGWObjVersionTracker& objv_tracker)
+                                        RGWObjVersionTracker& objv_tracker,
+                                        bool exclusive)
     : RGWCoroutine(_sc->cct), sc(_sc), sync_env(_sc->env),
       sync_pair(_sync_pair),
       sync_status_oid(RGWBucketPipeSyncStatusManager::inc_status_oid(sc->source_zone, _sync_pair)),
-      status(_status), objv_tracker(objv_tracker)
+      status(_status), objv_tracker(objv_tracker), exclusive(exclusive)
   {}
 
   int operate() override {
@@ -2785,7 +2787,8 @@ public:
         if (write_status) {
           map<string, bufferlist> attrs;
           status.encode_all_attrs(attrs);
-          call(new RGWSimpleRadosWriteAttrsCR(sync_env->async_rados, sync_env->svc->sysobj, obj, attrs, &objv_tracker));
+          call(new RGWSimpleRadosWriteAttrsCR(sync_env->async_rados, sync_env->svc->sysobj,
+                                              obj, attrs, &objv_tracker, exclusive));
         } else {
           call(new RGWRadosRemoveCR(store, obj, &objv_tracker));
         }
@@ -2807,11 +2810,13 @@ RGWRemoteBucketManager::RGWRemoteBucketManager(const DoutPrefixProvider *_dpp,
                                                const rgw_zone_id& _source_zone,
                                                RGWRESTConn *_conn,
                                                const RGWBucketInfo& source_bucket_info,
-                                               const rgw_bucket& dest_bucket) : dpp(_dpp), sync_env(_sync_env)
+                                               const rgw_bucket& dest_bucket)
+  : dpp(_dpp), sync_env(_sync_env), conn(_conn), source_zone(_source_zone),
+    full_status_obj(sync_env->svc->zone->get_zone_params().log_pool,
+                    RGWBucketPipeSyncStatusManager::full_status_oid(source_zone,
+                                                                    source_bucket_info.bucket,
+                                                                    dest_bucket))
 {
-  conn = _conn;
-  source_zone = _source_zone;
-
   int num_shards = (source_bucket_info.layout.current_index.layout.normal.num_shards <= 0 ? 
                     1 : source_bucket_info.layout.current_index.layout.normal.num_shards);
 
@@ -2835,14 +2840,6 @@ RGWRemoteBucketManager::RGWRemoteBucketManager(const DoutPrefixProvider *_dpp,
   }
 
   sc.init(sync_env, conn, source_zone);
-}
-
-RGWCoroutine *RGWRemoteBucketManager::init_sync_status_cr(int num, RGWObjVersionTracker& objv_tracker)
-{
-  if ((size_t)num >= sync_pairs.size()) {
-    return nullptr;
-  }
-  return new RGWInitBucketShardSyncStatusCoroutine(&sc, sync_pairs[num], init_status, objv_tracker);
 }
 
 #define BUCKET_SYNC_ATTR_PREFIX RGW_ATTR_PREFIX "bucket-sync."
@@ -2941,6 +2938,234 @@ int RGWReadBucketPipeSyncStatusCoroutine::operate()
     return set_cr_done();
   }
   return 0;
+}
+
+// wrap ReadSyncStatus and set a flag if it's not in incremental
+class CheckBucketShardStatusIsIncremental : public RGWReadBucketPipeSyncStatusCoroutine {
+  bool* result;
+  rgw_bucket_shard_sync_info status;
+ public:
+  CheckBucketShardStatusIsIncremental(RGWDataSyncCtx* sc,
+                                      const rgw_bucket_sync_pair_info& sync_pair,
+                                      bool* result)
+    : RGWReadBucketPipeSyncStatusCoroutine(sc, sync_pair, &status, nullptr),
+      result(result)
+  {}
+
+  int operate() override {
+    int r = RGWReadBucketPipeSyncStatusCoroutine::operate();
+    if (state == RGWCoroutine_Done &&
+        status.state != rgw_bucket_shard_sync_info::StateIncrementalSync) {
+      *result = false;
+    }
+    return r;
+  }
+};
+
+class CheckAllBucketShardStatusIsIncremental : public RGWShardCollectCR {
+  // start with 1 shard, and only spawn more if we detect an existing shard.
+  // this makes the backward compatilibility check far less expensive in the
+  // general case where no shards exist
+  static constexpr int initial_concurrent_shards = 1;
+  static constexpr int max_concurrent_shards = 16;
+
+  RGWDataSyncCtx* sc;
+  rgw_bucket_sync_pair_info sync_pair;
+  const int num_shards;
+  bool* result;
+  int shard = 0;
+ public:
+  CheckAllBucketShardStatusIsIncremental(RGWDataSyncCtx* sc,
+                                         const rgw_bucket_sync_pair_info& sync_pair,
+                                         int num_shards, bool* result)
+    : RGWShardCollectCR(sc->cct, initial_concurrent_shards),
+      sc(sc), sync_pair(sync_pair), num_shards(num_shards), result(result)
+  {}
+
+  bool spawn_next() override {
+    // stop spawning if we saw any errors or non-incremental shards
+    if (shard >= num_shards || status < 0 || !*result) {
+      return false;
+    }
+    sync_pair.dest_bs.shard_id = shard++;
+    spawn(new CheckBucketShardStatusIsIncremental(sc, sync_pair, result), false);
+    return true;
+  }
+
+ private:
+  int handle_result(int r) override {
+    if (r < 0) {
+      ldout(cct, 4) << "failed to read bucket shard status: "
+          << cpp_strerror(r) << dendl;
+    } else if (shard == 0) {
+      // enable concurrency once the first shard succeeds
+      max_concurrent = max_concurrent_shards;
+    }
+    return r;
+  }
+};
+
+// wrap InitBucketShardSyncStatus with local storage for 'status' and 'objv'
+// and a loop to retry on racing writes
+class InitBucketShardStatusCR : public RGWCoroutine {
+  RGWDataSyncCtx* sc;
+  const rgw_bucket_sync_pair_info& pair;
+  rgw_bucket_shard_sync_info status;
+  RGWObjVersionTracker objv;
+  int tries = 10; // retry on racing writes
+  bool exclusive = true; // first try is exclusive
+  using ReadCR = RGWReadBucketPipeSyncStatusCoroutine;
+  using InitCR = RGWInitBucketShardSyncStatusCoroutine;
+ public:
+  InitBucketShardStatusCR(RGWDataSyncCtx* sc, const rgw_bucket_sync_pair_info& pair)
+    : RGWCoroutine(sc->cct), sc(sc), pair(pair)
+  {}
+  int operate() {
+    reenter(this) {
+      // try exclusive create with empty status
+      objv.generate_new_write_ver(cct);
+      yield call(new InitCR(sc, pair, status, objv, exclusive));
+      if (retcode >= 0) {
+        return set_cr_done();
+      } else if (retcode != -EEXIST) {
+        return set_cr_error(retcode);
+      }
+
+      exclusive = false;
+      // retry loop to reinitialize
+      while (--tries) {
+        objv.clear();
+        // read current status and objv
+        yield call(new ReadCR(sc, pair, &status, &objv));
+        if (retcode < 0) {
+          return set_cr_error(retcode);
+        }
+        yield call(new InitCR(sc, pair, status, objv, exclusive));
+        if (retcode >= 0) {
+          return set_cr_done();
+        } else if (retcode != -ECANCELED) {
+          return set_cr_error(retcode);
+        }
+      }
+      return set_cr_error(retcode);
+    }
+    return 0;
+  }
+};
+
+class InitBucketShardStatusCollectCR : public RGWShardCollectCR {
+  static constexpr int max_concurrent_shards = 16;
+  RGWDataSyncCtx* sc;
+  rgw_bucket_sync_pair_info sync_pair;
+  const int num_shards;
+  int shard = 0;
+
+  int handle_result(int r) override {
+    if (r < 0) {
+      ldout(cct, 4) << "failed to init bucket shard status: "
+          << cpp_strerror(r) << dendl;
+    }
+    return r;
+  }
+ public:
+  InitBucketShardStatusCollectCR(RGWDataSyncCtx* sc,
+                                 const rgw_bucket_sync_pair_info& sync_pair,
+                                 int num_shards)
+    : RGWShardCollectCR(sc->cct, max_concurrent_shards),
+      sc(sc), sync_pair(sync_pair), num_shards(num_shards)
+  {}
+
+  bool spawn_next() override {
+    if (shard >= num_shards || status < 0) { // stop spawning on any errors
+      return false;
+    }
+    sync_pair.dest_bs.shard_id = shard++;
+    spawn(new InitBucketShardStatusCR(sc, sync_pair), false);
+    return true;
+  }
+};
+
+class InitBucketFullSyncStatusCR : public RGWCoroutine {
+  RGWDataSyncCtx *sc;
+  RGWDataSyncEnv *sync_env;
+
+  const rgw_bucket_sync_pair_info& sync_pair;
+  const rgw_raw_obj& status_obj;
+  rgw_bucket_sync_status& status;
+  RGWObjVersionTracker& objv;
+  const int num_shards;
+  const bool check_compat;
+
+  bool all_incremental = true;
+public:
+  InitBucketFullSyncStatusCR(RGWDataSyncCtx* sc,
+                             const rgw_bucket_sync_pair_info& sync_pair,
+                             const rgw_raw_obj& status_obj,
+                             rgw_bucket_sync_status& status,
+                             RGWObjVersionTracker& objv,
+                             int num_shards, bool check_compat)
+    : RGWCoroutine(sc->cct), sc(sc), sync_env(sc->env),
+      sync_pair(sync_pair), status_obj(status_obj),
+      status(status), objv(objv), num_shards(num_shards),
+      check_compat(check_compat)
+  {}
+
+  int operate() override {
+    reenter(this) {
+      status.state = BucketSyncState::Init;
+
+      if (check_compat) {
+        // try to convert existing per-shard incremental status for backward compatibility
+        yield call(new CheckAllBucketShardStatusIsIncremental(sc, sync_pair, num_shards, &all_incremental));
+        if (retcode < 0) {
+          return set_cr_error(retcode);
+        }
+        if (all_incremental) {
+          // we can use existing status and resume incremental sync
+          status.state = BucketSyncState::Incremental;
+        }
+      }
+
+      if (status.state != BucketSyncState::Incremental) {
+        // initialize all shard sync status. this will populate the log marker
+        // positions where incremental sync will resume after full sync
+        yield call(new InitBucketShardStatusCollectCR(sc, sync_pair, num_shards));
+        if (retcode < 0) {
+          ldout(cct, 20) << "failed to init bucket shard status: "
+              << cpp_strerror(retcode) << dendl;
+          return set_cr_error(retcode);
+        }
+
+        if (sync_env->sync_module->should_full_sync()) {
+          status.state = BucketSyncState::Full;
+        } else {
+          status.state = BucketSyncState::Incremental;
+        }
+      }
+
+      ldout(cct, 20) << "writing bucket sync state=" << status.state << dendl;
+
+      // write bucket sync status
+      using CR = RGWSimpleRadosWriteCR<rgw_bucket_sync_status>;
+      yield call(new CR(sync_env->async_rados, sync_env->svc->sysobj,
+                        status_obj, status, &objv, false));
+      if (retcode < 0) {
+        ldout(cct, 20) << "failed to write bucket shard status: "
+            << cpp_strerror(retcode) << dendl;
+        return set_cr_error(retcode);
+      }
+      return set_cr_done();
+    }
+    return 0;
+  }
+};
+
+RGWCoroutine *RGWRemoteBucketManager::init_sync_status_cr(RGWObjVersionTracker& objv)
+{
+  constexpr bool check_compat = false;
+  const int num_shards = num_pipes();
+  return new InitBucketFullSyncStatusCR(&sc, sync_pairs[0], full_status_obj,
+                                        full_status, objv, num_shards, check_compat);
 }
 
 #define OMAP_READ_MAX_ENTRIES 10
@@ -4762,7 +4987,7 @@ int RGWSyncBucketShardCR::operate()
     do {
       if (sync_status.state == rgw_bucket_shard_sync_info::StateInit ||
           sync_status.state == rgw_bucket_shard_sync_info::StateStopped) {
-        yield call(new RGWInitBucketShardSyncStatusCoroutine(sc, sync_pair, sync_status, objv_tracker));
+        yield call(new RGWInitBucketShardSyncStatusCoroutine(sc, sync_pair, sync_status, objv_tracker, false));
         if (retcode == -ENOENT) {
           tn->log(0, "bucket sync disabled");
           drain_all();
@@ -4881,11 +5106,8 @@ int RGWBucketPipeSyncStatusManager::init_sync_status()
 
   for (auto& mgr : source_mgrs) {
     RGWCoroutinesStack *stack = new RGWCoroutinesStack(store->ctx(), &cr_mgr);
-
-    for (int i = 0; i < mgr->num_pipes(); ++i) {
-      objvs.emplace_back();
-      stack->call(mgr->init_sync_status_cr(i, objvs.back()));
-    }
+    objvs.emplace_back();
+    stack->call(mgr->init_sync_status_cr(objvs.back()));
 
     stacks.push_back(stack);
   }

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -5370,6 +5370,37 @@ class RGWCollectBucketSyncStatusCR : public RGWShardCollectCR {
   }
 };
 
+int rgw_read_bucket_full_sync_status(const DoutPrefixProvider *dpp,
+                                     rgw::sal::RGWRadosStore *store,
+                                     const rgw_sync_bucket_pipe& pipe,
+                                     rgw_bucket_sync_status *status,
+                                     optional_yield y)
+{
+  auto get_oid = RGWBucketPipeSyncStatusManager::full_status_oid;
+  const rgw_raw_obj obj{store->svc()->zone->get_zone_params().log_pool,
+                        get_oid(*pipe.source.zone, *pipe.source.bucket, *pipe.dest.bucket)};
+
+  auto svc = store->svc()->sysobj;
+  auto obj_ctx = svc->init_obj_ctx();
+  auto sysobj = svc->get_obj(obj_ctx, obj);
+  bufferlist bl;
+  int ret = sysobj.rop().read(&bl, y);
+  if (ret < 0)
+    return ret;
+
+  try {
+    auto iter = bl.cbegin();
+    using ceph::decode;
+    rgw_bucket_sync_status result;
+    decode(result, iter);
+    *status = result;
+    return 0;
+  } catch (const buffer::error& err) {
+    lderr(svc->ctx()) << "error decoding " << obj << ": " << err.what() << dendl;
+    return -EIO;
+  }
+}
+
 int rgw_read_bucket_inc_sync_status(const DoutPrefixProvider *dpp,
                                     rgw::sal::RGWRadosStore *store,
                                     const rgw_sync_bucket_pipe& pipe,

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -4919,13 +4919,12 @@ class RGWSyncBucketShardCR : public RGWCoroutine {
   RGWDataSyncEnv *sync_env;
   boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr;
   rgw_bucket_sync_pair_info sync_pair;
-  rgw_bucket_sync_pipe sync_pipe;
-  rgw_bucket_shard_sync_info sync_status;
-  RGWMetaSyncEnv meta_sync_env;
-  RGWObjVersionTracker objv_tracker;
+  rgw_bucket_sync_pipe& sync_pipe;
   ceph::real_time* progress;
 
   const std::string status_oid;
+  rgw_bucket_shard_sync_info sync_status;
+  RGWObjVersionTracker objv_tracker;
 
   RGWSyncTraceNodeRef tn;
 
@@ -4933,26 +4932,17 @@ public:
   RGWSyncBucketShardCR(RGWDataSyncCtx *_sc,
                        boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
                        const rgw_bucket_sync_pair_info& _sync_pair,
-                       const RGWSyncTraceNodeRef& _tn_parent,
+                       rgw_bucket_sync_pipe& sync_pipe,
+                       const RGWSyncTraceNodeRef& tn,
                        ceph::real_time* progress)
     : RGWCoroutine(_sc->cct), sc(_sc), sync_env(_sc->env),
-      lease_cr(std::move(lease_cr)), sync_pair(_sync_pair), progress(progress),
+      lease_cr(std::move(lease_cr)), sync_pair(_sync_pair), sync_pipe(sync_pipe), progress(progress),
       status_oid(RGWBucketPipeSyncStatusManager::inc_status_oid(sc->source_zone, sync_pair)),
-      tn(sync_env->sync_tracer->add_node(_tn_parent, "bucket",
-                                         SSTR(bucket_shard_str{_sync_pair.dest_bs} << "<-" << bucket_shard_str{_sync_pair.source_bs} ))) {
+      tn(tn) {
   }
 
   int operate() override;
 };
-
-static RGWCoroutine* sync_bucket_shard_cr(RGWDataSyncCtx* sc,
-                                          boost::intrusive_ptr<const RGWContinuousLeaseCR> lease,
-                                          const rgw_bucket_sync_pair_info& sync_pair,
-                                          const RGWSyncTraceNodeRef& tn,
-                                          ceph::real_time* progress)
-{
-  return new RGWSyncBucketShardCR(sc, std::move(lease), sync_pair, tn, progress);
-}
 
 int RGWSyncBucketShardCR::operate()
 {
@@ -4965,24 +4955,6 @@ int RGWSyncBucketShardCR::operate()
     }
 
     tn->log(20, SSTR("sync status for source bucket: " << sync_status.state));
-
-    yield call(new RGWSyncGetBucketInfoCR(sync_env, sync_pair.source_bs.bucket, &sync_pipe.source_bucket_info,
-                                          &sync_pipe.source_bucket_attrs, tn));
-    if (retcode < 0) {
-      tn->log(0, SSTR("ERROR: failed to retrieve bucket info for bucket=" << bucket_str{sync_pair.source_bs.bucket}));
-      drain_all();
-      return set_cr_error(retcode);
-    }
-
-    yield call(new RGWSyncGetBucketInfoCR(sync_env, sync_pair.dest_bs.bucket, &sync_pipe.dest_bucket_info, 
-                                          &sync_pipe.dest_bucket_attrs, tn));
-    if (retcode < 0) {
-      tn->log(0, SSTR("ERROR: failed to retrieve bucket info for bucket=" << bucket_str{sync_pair.source_bs.bucket}));
-      drain_all();
-      return set_cr_error(retcode);
-    }
-
-    sync_pipe.info = sync_pair;
 
     do {
       if (sync_status.state == rgw_bucket_shard_sync_info::StateInit ||
@@ -5029,6 +5001,110 @@ int RGWSyncBucketShardCR::operate()
     } while (sync_status.state != rgw_bucket_shard_sync_info::StateIncrementalSync);
 
     drain_all();
+    return set_cr_done();
+  }
+
+  return 0;
+}
+
+class RGWSyncBucketCR : public RGWCoroutine {
+  RGWDataSyncCtx *sc;
+  RGWDataSyncEnv *env;
+  boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr;
+  rgw_bucket_sync_pair_info sync_pair;
+  rgw_bucket_sync_pipe sync_pipe;
+  ceph::real_time* progress;
+
+  const rgw_raw_obj status_obj;
+  rgw_bucket_sync_status bucket_status;
+  RGWObjVersionTracker objv;
+
+  RGWSyncTraceNodeRef tn;
+
+public:
+  RGWSyncBucketCR(RGWDataSyncCtx *_sc,
+                  boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
+                  const rgw_bucket_sync_pair_info& _sync_pair,
+                  const RGWSyncTraceNodeRef& _tn_parent,
+                  ceph::real_time* progress)
+    : RGWCoroutine(_sc->cct), sc(_sc), env(_sc->env),
+      lease_cr(std::move(lease_cr)), sync_pair(_sync_pair), progress(progress),
+      status_obj(env->svc->zone->get_zone_params().log_pool,
+                 RGWBucketPipeSyncStatusManager::full_status_oid(sc->source_zone,
+                                                                 sync_pair.source_bs.bucket,
+                                                                 sync_pair.dest_bs.bucket)),
+      tn(env->sync_tracer->add_node(_tn_parent, "bucket",
+                                    SSTR(bucket_shard_str{_sync_pair.dest_bs} << "<-" << bucket_shard_str{_sync_pair.source_bs} ))) {
+  }
+
+  int operate() override;
+};
+
+static RGWCoroutine* sync_bucket_shard_cr(RGWDataSyncCtx* sc,
+                                          boost::intrusive_ptr<const RGWContinuousLeaseCR> lease,
+                                          const rgw_bucket_sync_pair_info& sync_pair,
+                                          const RGWSyncTraceNodeRef& tn,
+                                          ceph::real_time* progress)
+{
+  return new RGWSyncBucketCR(sc, std::move(lease), sync_pair, tn, progress);
+}
+
+int RGWSyncBucketCR::operate()
+{
+  reenter(this) {
+    // read source/destination bucket info
+    yield call(new RGWSyncGetBucketInfoCR(env, sync_pair.source_bs.bucket, &sync_pipe.source_bucket_info,
+                                          &sync_pipe.source_bucket_attrs, tn));
+    if (retcode < 0) {
+      tn->log(0, SSTR("ERROR: failed to retrieve bucket info for bucket=" << bucket_str{sync_pair.source_bs.bucket}));
+      return set_cr_error(retcode);
+    }
+
+    yield call(new RGWSyncGetBucketInfoCR(env, sync_pair.dest_bs.bucket, &sync_pipe.dest_bucket_info,
+                                          &sync_pipe.dest_bucket_attrs, tn));
+    if (retcode < 0) {
+      tn->log(0, SSTR("ERROR: failed to retrieve bucket info for bucket=" << bucket_str{sync_pair.source_bs.bucket}));
+      return set_cr_error(retcode);
+    }
+
+    sync_pipe.info = sync_pair;
+
+    // read bucket sync status
+    using CR = RGWSimpleRadosReadCR<rgw_bucket_sync_status>;
+    yield call(new CR(env->async_rados, env->svc->sysobj,
+                      status_obj, &bucket_status, true, &objv));
+    if (retcode < 0) {
+      return set_cr_error(retcode);
+    }
+
+    if (bucket_status.state == BucketSyncState::Init) {
+      // init sync status
+      yield {
+	// use exclusive create if it didn't exist. if we lose the race to
+	// create it, we'll fail with EEXIST and RGWSyncBucketCR() will come
+	// back later and read the new status
+	const bool exclusive = objv.version_for_check() == nullptr;
+        int num_shards = sync_pipe.dest_bucket_info.layout.current_index.layout.normal.num_shards;
+        call(new InitBucketFullSyncStatusCR(sc, sync_pair, status_obj,
+                                            bucket_status, objv, num_shards,
+                                            exclusive));
+      }
+      if (retcode < 0) {
+        return set_cr_error(retcode);
+      }
+    }
+
+    if (bucket_status.state == BucketSyncState::Full) {
+      // TODO: full sync
+    }
+
+    if (bucket_status.state == BucketSyncState::Incremental) {
+      yield call(new RGWSyncBucketShardCR(sc, lease_cr, sync_pair,
+                                          sync_pipe, tn, progress));
+      if (retcode < 0) {
+        return set_cr_error(retcode);
+      }
+    }
     return set_cr_done();
   }
 

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -4143,7 +4143,7 @@ int RGWBucketShardIncrementalSyncCR::operate()
         tn->log(0, "ERROR: lease is not taken, abort");
         return set_cr_error(-ECANCELED);
       }
-      tn->log(20, SSTR("listing bilog for incremental sync" << sync_info.inc_marker.position));
+      tn->log(20, SSTR("listing bilog for incremental sync; position=" << sync_info.inc_marker.position));
       set_status() << "listing bilog; position=" << sync_info.inc_marker.position;
       yield call(new RGWListBucketIndexLogCR(sc, bs, sync_info.inc_marker.position,
                                              &list_result));

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -3451,34 +3451,30 @@ struct bucket_list_result {
   }
 };
 
-class RGWListBucketShardCR: public RGWCoroutine {
+class RGWListRemoteBucketCR: public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWDataSyncEnv *sync_env;
   const rgw_bucket_shard& bs;
-  const string instance_key;
   rgw_obj_key marker_position;
 
   bucket_list_result *result;
 
 public:
-  RGWListBucketShardCR(RGWDataSyncCtx *_sc, const rgw_bucket_shard& bs,
-                       rgw_obj_key& _marker_position, bucket_list_result *_result)
+  RGWListRemoteBucketCR(RGWDataSyncCtx *_sc, const rgw_bucket_shard& bs,
+                        rgw_obj_key& _marker_position, bucket_list_result *_result)
     : RGWCoroutine(_sc->cct), sc(_sc), sync_env(_sc->env), bs(bs),
-      instance_key(bs.get_key()), marker_position(_marker_position),
-      result(_result) {}
+      marker_position(_marker_position), result(_result) {}
 
   int operate() override {
     reenter(this) {
       yield {
-        rgw_http_param_pair pairs[] = { { "rgwx-bucket-instance", instance_key.c_str() },
-					{ "versions" , NULL },
+        rgw_http_param_pair pairs[] = { { "versions" , NULL },
 					{ "format" , "json" },
 					{ "objs-container" , "true" },
 					{ "key-marker" , marker_position.name.c_str() },
 					{ "version-id-marker" , marker_position.instance.c_str() },
 	                                { NULL, NULL } };
-        // don't include tenant in the url, it's already part of instance_key
-        string p = string("/") + bs.bucket.name;
+        string p = string("/") + bs.bucket.get_key(':', 0);
         call(new RGWReadRESTResourceCR<bucket_list_result>(sync_env->cct, sc->conn, sync_env->http_manager, p, pairs, result));
       }
       if (retcode < 0) {
@@ -3534,37 +3530,34 @@ public:
 
 #define BUCKET_SYNC_UPDATE_MARKER_WINDOW 10
 
-class RGWBucketFullSyncShardMarkerTrack : public RGWSyncShardMarkerTrack<rgw_obj_key, rgw_obj_key> {
+class RGWBucketFullSyncMarkerTrack : public RGWSyncShardMarkerTrack<rgw_obj_key, rgw_obj_key> {
   RGWDataSyncCtx *sc;
   RGWDataSyncEnv *sync_env;
 
-  string marker_oid;
-  rgw_bucket_shard_full_sync_marker sync_marker;
+  const rgw_raw_obj& status_obj;
+  rgw_bucket_sync_status& sync_status;
   RGWSyncTraceNodeRef tn;
   RGWObjVersionTracker& objv_tracker;
 
 public:
-  RGWBucketFullSyncShardMarkerTrack(RGWDataSyncCtx *_sc,
-                                    const string& _marker_oid,
-                                    const rgw_bucket_shard_full_sync_marker& _marker,
-                                    RGWSyncTraceNodeRef tn,
-                                    RGWObjVersionTracker& objv_tracker)
+  RGWBucketFullSyncMarkerTrack(RGWDataSyncCtx *_sc,
+                               const rgw_raw_obj& status_obj,
+                               rgw_bucket_sync_status& sync_status,
+                               RGWSyncTraceNodeRef tn,
+                               RGWObjVersionTracker& objv_tracker)
     : RGWSyncShardMarkerTrack(BUCKET_SYNC_UPDATE_MARKER_WINDOW),
-      sc(_sc), sync_env(_sc->env), marker_oid(_marker_oid),
-      sync_marker(_marker), tn(std::move(tn)), objv_tracker(objv_tracker)
+      sc(_sc), sync_env(_sc->env), status_obj(status_obj),
+      sync_status(sync_status), tn(std::move(tn)), objv_tracker(objv_tracker)
   {}
 
   RGWCoroutine *store_marker(const rgw_obj_key& new_marker, uint64_t index_pos, const real_time& timestamp) override {
-    sync_marker.position = new_marker;
-    sync_marker.count = index_pos;
+    sync_status.full.position = new_marker;
+    sync_status.full.count = index_pos;
 
-    map<string, bufferlist> attrs;
-    sync_marker.encode_attr(attrs);
-
-    tn->log(20, SSTR("updating marker marker_oid=" << marker_oid << " marker=" << new_marker));
-    return new RGWSimpleRadosWriteAttrsCR(sync_env->async_rados, sync_env->svc->sysobj,
-                                          rgw_raw_obj(sync_env->svc->zone->get_zone_params().log_pool, marker_oid),
-                                          attrs, &objv_tracker);
+    tn->log(20, SSTR("updating marker oid=" << status_obj.oid << " marker=" << new_marker));
+    return new RGWSimpleRadosWriteCR<rgw_bucket_sync_status>(
+        sync_env->async_rados, sync_env->svc->sysobj,
+        status_obj, sync_status, &objv_tracker);
   }
 
   RGWOrderCallCR *allocate_order_control_cr() override {
@@ -3863,28 +3856,29 @@ done:
 
 #define BUCKET_SYNC_SPAWN_WINDOW 20
 
-class RGWBucketShardFullSyncCR : public RGWCoroutine {
+class RGWBucketFullSyncCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWDataSyncEnv *sync_env;
   rgw_bucket_sync_pipe& sync_pipe;
+  rgw_bucket_sync_status& sync_status;
   rgw_bucket_shard& bs;
   boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr;
   bucket_list_result list_result;
   list<bucket_list_entry>::iterator entries_iter;
-  rgw_bucket_shard_sync_info& sync_info;
   rgw_obj_key list_marker;
   bucket_list_entry *entry{nullptr};
 
   int total_entries{0};
 
-  int sync_status{0};
+  int sync_result{0};
 
-  const string& status_oid;
+  const rgw_raw_obj& status_obj;
+  RGWObjVersionTracker& objv;
 
   rgw_zone_set zones_trace;
 
   RGWSyncTraceNodeRef tn;
-  RGWBucketFullSyncShardMarkerTrack marker_tracker;
+  RGWBucketFullSyncMarkerTrack marker_tracker;
 
   struct _prefix_handler {
     RGWBucketSyncFlowManager::pipe_rules_ref rules;
@@ -3931,20 +3925,20 @@ class RGWBucketShardFullSyncCR : public RGWCoroutine {
   } prefix_handler;
 
 public:
-  RGWBucketShardFullSyncCR(RGWDataSyncCtx *_sc,
-                           rgw_bucket_sync_pipe& _sync_pipe,
-                           const std::string& status_oid,
-                           boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
-                           rgw_bucket_shard_sync_info& sync_info,
-                           RGWSyncTraceNodeRef tn_parent,
-                           RGWObjVersionTracker& objv_tracker)
+  RGWBucketFullSyncCR(RGWDataSyncCtx *_sc,
+                      rgw_bucket_sync_pipe& _sync_pipe,
+                      const rgw_raw_obj& status_obj,
+                      boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
+                      rgw_bucket_sync_status& sync_status,
+                      RGWSyncTraceNodeRef tn_parent,
+                      RGWObjVersionTracker& objv_tracker)
     : RGWCoroutine(_sc->cct), sc(_sc), sync_env(_sc->env),
-      sync_pipe(_sync_pipe), bs(_sync_pipe.info.source_bs),
-      lease_cr(std::move(lease_cr)), sync_info(sync_info),
-      status_oid(status_oid),
+      sync_pipe(_sync_pipe), sync_status(sync_status),
+      bs(_sync_pipe.info.source_bs),
+      lease_cr(std::move(lease_cr)), status_obj(status_obj), objv(objv_tracker),
       tn(sync_env->sync_tracer->add_node(tn_parent, "full_sync",
                                          SSTR(bucket_shard_str{bs}))),
-      marker_tracker(sc, status_oid, sync_info.full_marker, tn, objv_tracker)
+      marker_tracker(sc, status_obj, sync_status, tn, objv_tracker)
   {
     zones_trace.insert(sc->source_zone.id, sync_pipe.info.dest_bs.bucket.get_key());
     prefix_handler.set_rules(sync_pipe.get_rules());
@@ -3953,13 +3947,13 @@ public:
   int operate() override;
 };
 
-int RGWBucketShardFullSyncCR::operate()
+int RGWBucketFullSyncCR::operate()
 {
   int ret;
   reenter(this) {
-    list_marker = sync_info.full_marker.position;
+    list_marker = sync_status.full.position;
 
-    total_entries = sync_info.full_marker.count;
+    total_entries = sync_status.full.count;
     do {
       if (lease_cr && !lease_cr->is_locked()) {
         drain_all();
@@ -3974,8 +3968,7 @@ int RGWBucketShardFullSyncCR::operate()
         break;
       }
 
-      yield call(new RGWListBucketShardCR(sc, bs, list_marker,
-                                          &list_result));
+      yield call(new RGWListRemoteBucketCR(sc, bs, list_marker, &list_result));
       if (retcode < 0 && retcode != -ENOENT) {
         set_status("failed bucket listing, going down");
         drain_all();
@@ -4018,13 +4011,13 @@ int RGWBucketShardFullSyncCR::operate()
             again = collect(&ret, nullptr);
             if (ret < 0) {
               tn->log(10, "a sync operation returned error");
-              sync_status = ret;
+              sync_result = ret;
               /* we have reported this error */
             }
           }
         }
       }
-    } while (list_result.is_truncated && sync_status == 0);
+    } while (list_result.is_truncated && sync_result == 0);
     set_status("done iterating over all objects");
     /* wait for all operations to complete */
     while (num_spawned()) {
@@ -4034,7 +4027,7 @@ int RGWBucketShardFullSyncCR::operate()
         again = collect(&ret, nullptr);
         if (ret < 0) {
           tn->log(10, "a sync operation returned error");
-          sync_status = ret;
+          sync_result = ret;
           /* we have reported this error */
         }
       }
@@ -4043,26 +4036,29 @@ int RGWBucketShardFullSyncCR::operate()
     if (lease_cr && !lease_cr->is_locked()) {
       return set_cr_error(-ECANCELED);
     }
-    /* update sync state to incremental */
-    if (sync_status == 0) {
-      yield {
-        sync_info.state = rgw_bucket_shard_sync_info::StateIncrementalSync;
-        map<string, bufferlist> attrs;
-        sync_info.encode_state_attr(attrs);
-        call(new RGWSimpleRadosWriteAttrsCR(sync_env->async_rados, sync_env->svc->sysobj,
-                                            rgw_raw_obj(sync_env->svc->zone->get_zone_params().log_pool, status_oid),
-                                            attrs));
-      }
-    } else {
-      tn->log(10, SSTR("backing out with sync_status=" << sync_status));
+    yield call(marker_tracker.flush());
+    if (retcode < 0) {
+      tn->log(0, SSTR("ERROR: marker_tracker.flush() returned retcode=" << retcode));
+      return set_cr_error(retcode);
     }
-    if (retcode < 0 && sync_status == 0) { /* actually tried to set incremental state and failed */
+    /* update sync state to incremental */
+    if (sync_result == 0) {
+      sync_status.state = BucketSyncState::Incremental;
+      tn->log(5, SSTR("set bucket state=" << sync_status.state));
+      yield call(new RGWSimpleRadosWriteCR<rgw_bucket_sync_status>(
+              sync_env->async_rados, sync_env->svc->sysobj,
+              status_obj, sync_status, &objv));
+      tn->log(5, SSTR("bucket status objv=" << objv));
+    } else {
+      tn->log(10, SSTR("backing out with sync_status=" << sync_result));
+    }
+    if (retcode < 0 && sync_result == 0) { /* actually tried to set incremental state and failed */
       tn->log(0, SSTR("ERROR: failed to set sync state on bucket "
           << bucket_shard_str{bs} << " retcode=" << retcode));
       return set_cr_error(retcode);
     }
-    if (sync_status < 0) {
-      return set_cr_error(sync_status);
+    if (sync_result < 0) {
+      return set_cr_error(sync_result);
     }
     return set_cr_done();
   }
@@ -4914,6 +4910,7 @@ class RGWSyncBucketShardCR : public RGWCoroutine {
   boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr;
   rgw_bucket_sync_pair_info sync_pair;
   rgw_bucket_sync_pipe& sync_pipe;
+  BucketSyncState& bucket_state;
   ceph::real_time* progress;
 
   const std::string status_oid;
@@ -4927,10 +4924,12 @@ public:
                        boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
                        const rgw_bucket_sync_pair_info& _sync_pair,
                        rgw_bucket_sync_pipe& sync_pipe,
+                       BucketSyncState& bucket_state,
                        const RGWSyncTraceNodeRef& tn,
                        ceph::real_time* progress)
     : RGWCoroutine(_sc->cct), sc(_sc), sync_env(_sc->env),
-      lease_cr(std::move(lease_cr)), sync_pair(_sync_pair), sync_pipe(sync_pipe), progress(progress),
+      lease_cr(std::move(lease_cr)), sync_pair(_sync_pair),
+      sync_pipe(sync_pipe), bucket_state(bucket_state), progress(progress),
       status_oid(RGWBucketPipeSyncStatusManager::inc_status_oid(sc->source_zone, sync_pair)),
       tn(tn) {
   }
@@ -4944,57 +4943,24 @@ int RGWSyncBucketShardCR::operate()
     yield call(new RGWReadBucketPipeSyncStatusCoroutine(sc, sync_pair, &sync_status, &objv_tracker));
     if (retcode < 0 && retcode != -ENOENT) {
       tn->log(0, "ERROR: failed to read sync status for bucket");
-      drain_all();
       return set_cr_error(retcode);
     }
 
-    tn->log(20, SSTR("sync status for source bucket: " << sync_status.state));
+    tn->log(20, SSTR("sync status for source bucket shard: " << sync_status.state));
+    sync_status.state = rgw_bucket_shard_sync_info::StateIncrementalSync;
+    if (progress) {
+      *progress = sync_status.inc_marker.timestamp;
+    }
 
-    do {
-      if (sync_status.state == rgw_bucket_shard_sync_info::StateInit ||
-          sync_status.state == rgw_bucket_shard_sync_info::StateStopped) {
-        yield call(new RGWInitBucketShardSyncStatusCoroutine(sc, sync_pair, sync_status, objv_tracker, false));
-        if (retcode == -ENOENT) {
-          tn->log(0, "bucket sync disabled");
-          drain_all();
-          return set_cr_done();
-        }
-        if (retcode < 0) {
-          tn->log(0, SSTR("ERROR: init sync on bucket failed, retcode=" << retcode));
-          drain_all();
-          return set_cr_error(retcode);
-        }
-      }
-      if (progress) {
-        *progress = sync_status.inc_marker.timestamp;
-      }
-
-      if (sync_status.state == rgw_bucket_shard_sync_info::StateFullSync) {
-        yield call(new RGWBucketShardFullSyncCR(sc, sync_pipe,
-                                                status_oid, lease_cr,
-                                                sync_status, tn, objv_tracker));
-        if (retcode < 0) {
-          tn->log(5, SSTR("full sync on bucket failed, retcode=" << retcode));
-          drain_all();
-          return set_cr_error(retcode);
-        }
-      }
-
-      if (sync_status.state == rgw_bucket_shard_sync_info::StateIncrementalSync) {
-        yield call(new RGWBucketShardIncrementalSyncCR(sc, sync_pipe,
-                                                       status_oid, lease_cr,
-                                                       sync_status, tn,
-                                                       objv_tracker, progress));
-        if (retcode < 0) {
-          tn->log(5, SSTR("incremental sync on bucket failed, retcode=" << retcode));
-          drain_all();
-          return set_cr_error(retcode);
-        }
-      }
-      // loop back to previous states unless incremental sync returns normally
-    } while (sync_status.state != rgw_bucket_shard_sync_info::StateIncrementalSync);
-
-    drain_all();
+    yield call(new RGWBucketShardIncrementalSyncCR(sc, sync_pipe,
+                                                   status_oid, lease_cr,
+                                                   sync_status, tn,
+                                                   objv_tracker, progress));
+    if (retcode < 0) {
+      tn->log(5, SSTR("incremental sync on bucket failed, retcode=" << retcode));
+      return set_cr_error(retcode);
+    }
+    // TODO: handle transition to StateStopped
     return set_cr_done();
   }
 
@@ -5004,7 +4970,8 @@ int RGWSyncBucketShardCR::operate()
 class RGWSyncBucketCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWDataSyncEnv *env;
-  boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr;
+  boost::intrusive_ptr<const RGWContinuousLeaseCR> data_lease_cr;
+  boost::intrusive_ptr<RGWContinuousLeaseCR> bucket_lease_cr;
   rgw_bucket_sync_pair_info sync_pair;
   rgw_bucket_sync_pipe sync_pipe;
   ceph::real_time* progress;
@@ -5012,6 +4979,7 @@ class RGWSyncBucketCR : public RGWCoroutine {
   const rgw_raw_obj status_obj;
   rgw_bucket_sync_status bucket_status;
   RGWObjVersionTracker objv;
+  bool init_check_compat = false;
 
   RGWSyncTraceNodeRef tn;
 
@@ -5022,7 +4990,7 @@ public:
                   const RGWSyncTraceNodeRef& _tn_parent,
                   ceph::real_time* progress)
     : RGWCoroutine(_sc->cct), sc(_sc), env(_sc->env),
-      lease_cr(std::move(lease_cr)), sync_pair(_sync_pair), progress(progress),
+      data_lease_cr(std::move(lease_cr)), sync_pair(_sync_pair), progress(progress),
       status_obj(env->svc->zone->get_zone_params().log_pool,
                  RGWBucketPipeSyncStatusManager::full_status_oid(sc->source_zone,
                                                                  sync_pair.source_bs.bucket,
@@ -5071,34 +5039,67 @@ int RGWSyncBucketCR::operate()
       return set_cr_error(retcode);
     }
 
-    if (bucket_status.state == BucketSyncState::Init) {
-      // init sync status
-      yield {
-	// use exclusive create if it didn't exist. if we lose the race to
-	// create it, we'll fail with EEXIST and RGWSyncBucketCR() will come
-	// back later and read the new status
-	const bool exclusive = objv.version_for_check() == nullptr;
-        int num_shards = sync_pipe.dest_bucket_info.layout.current_index.layout.normal.num_shards;
-        call(new InitBucketFullSyncStatusCR(sc, sync_pair, status_obj,
-                                            bucket_status, objv, num_shards,
-                                            exclusive));
-      }
-      if (retcode < 0) {
-        return set_cr_error(retcode);
-      }
-    }
+    do {
+      tn->log(20, SSTR("sync status for source bucket: " << bucket_status.state));
 
-    if (bucket_status.state == BucketSyncState::Full) {
-      // TODO: full sync
-    }
-
-    if (bucket_status.state == BucketSyncState::Incremental) {
-      yield call(new RGWSyncBucketShardCR(sc, lease_cr, sync_pair,
-                                          sync_pipe, tn, progress));
-      if (retcode < 0) {
-        return set_cr_error(retcode);
+      if (bucket_status.state == BucketSyncState::Init ||
+          bucket_status.state == BucketSyncState::Stopped) {
+        // init sync status
+        yield {
+          init_check_compat = objv.read_version.ver <= 1; // newly-created
+          int num_shards = sync_pipe.dest_bucket_info.layout.current_index.layout.normal.num_shards;
+          call(new InitBucketFullSyncStatusCR(sc, sync_pair, status_obj,
+                                              bucket_status, objv, num_shards,
+                                              init_check_compat));
+        }
+        if (retcode < 0) {
+          return set_cr_error(retcode);
+        }
       }
-    }
+
+      if (bucket_status.state == BucketSyncState::Full) {
+        // take a bucket-wide lease for full sync to prevent the bucket shards
+        // from duplicating the work
+        yield {
+          const std::string lock_name = "full sync";
+          const uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
+          bucket_lease_cr.reset(new RGWContinuousLeaseCR(env->async_rados, env->store, status_obj,
+                                                         lock_name, lock_duration, this));
+          spawn(bucket_lease_cr.get(), false);
+        }
+        while (!bucket_lease_cr->is_locked()) {
+          if (bucket_lease_cr->is_done()) {
+            tn->log(5, "failed to take bucket lease");
+            set_status("lease lock failed, early abort");
+            drain_all();
+            return set_cr_error(bucket_lease_cr->get_ret_status());
+          }
+          tn->log(5, "waiting on bucket lease");
+          yield set_sleeping(true);
+        }
+
+        yield call(new RGWBucketFullSyncCR(sc, sync_pipe, status_obj,
+                                           bucket_lease_cr, bucket_status,
+                                           tn, objv));
+        bucket_lease_cr->go_down();
+        drain_all();
+        bucket_lease_cr.reset();
+        if (retcode < 0) {
+          return set_cr_error(retcode);
+        }
+      }
+
+      if (bucket_status.state == BucketSyncState::Incremental) {
+        yield call(new RGWSyncBucketShardCR(sc, data_lease_cr, sync_pair,
+                                            sync_pipe, bucket_status.state,
+                                            tn, progress));
+        if (retcode < 0) {
+          return set_cr_error(retcode);
+        }
+      }
+      // loop back to previous states unless incremental sync returns normally
+    } while (bucket_status.state != BucketSyncState::Incremental);
+
     return set_cr_done();
   }
 

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -2849,9 +2849,6 @@ void rgw_bucket_shard_sync_info::decode_from_attrs(CephContext *cct, map<string,
   if (!decode_attr(cct, attrs, BUCKET_SYNC_ATTR_PREFIX "state", &state)) {
     decode_attr(cct, attrs, "state", &state);
   }
-  if (!decode_attr(cct, attrs, BUCKET_SYNC_ATTR_PREFIX "full_marker", &full_marker)) {
-    decode_attr(cct, attrs, "full_marker", &full_marker);
-  }
   if (!decode_attr(cct, attrs, BUCKET_SYNC_ATTR_PREFIX "inc_marker", &inc_marker)) {
     decode_attr(cct, attrs, "inc_marker", &inc_marker);
   }
@@ -2860,7 +2857,6 @@ void rgw_bucket_shard_sync_info::decode_from_attrs(CephContext *cct, map<string,
 void rgw_bucket_shard_sync_info::encode_all_attrs(map<string, bufferlist>& attrs)
 {
   encode_state_attr(attrs);
-  full_marker.encode_attr(attrs);
   inc_marker.encode_attr(attrs);
 }
 

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1412,11 +1412,7 @@ class RGWDataSyncShardCR : public RGWCoroutine {
   static constexpr int max_error_entries = DATA_SYNC_MAX_ERR_ENTRIES;
 
   ceph::coarse_real_time error_retry_time;
-
-#define RETRY_BACKOFF_SECS_MIN 60
-#define RETRY_BACKOFF_SECS_DEFAULT 60
-#define RETRY_BACKOFF_SECS_MAX 600
-  uint32_t retry_backoff_secs = RETRY_BACKOFF_SECS_DEFAULT;
+  static constexpr uint32_t retry_backoff_secs = 60;
 
   RGWSyncTraceNodeRef tn;
 
@@ -1674,15 +1670,6 @@ public:
                                     entry_timestamp, true), false);
           }
           if (!omapvals->more) {
-            if (error_marker.empty() && error_entries.empty()) {
-              /* the retry repo is empty, we back off a bit before calling it again */
-              retry_backoff_secs *= 2;
-              if (retry_backoff_secs > RETRY_BACKOFF_SECS_MAX) {
-                retry_backoff_secs = RETRY_BACKOFF_SECS_MAX;
-              }
-            } else {
-              retry_backoff_secs = RETRY_BACKOFF_SECS_DEFAULT;
-            }
             error_retry_time = ceph::coarse_real_clock::now() + make_timespan(retry_backoff_secs);
             error_marker.clear();
           }

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -4976,6 +4976,8 @@ class RGWSyncBucketCR : public RGWCoroutine {
   rgw_bucket_sync_pipe sync_pipe;
   ceph::real_time* progress;
 
+  const std::string lock_name = "bucket sync";
+  const uint32_t lock_duration;
   const rgw_raw_obj status_obj;
   rgw_bucket_sync_status bucket_status;
   RGWObjVersionTracker objv;
@@ -4991,6 +4993,7 @@ public:
                   ceph::real_time* progress)
     : RGWCoroutine(_sc->cct), sc(_sc), env(_sc->env),
       data_lease_cr(std::move(lease_cr)), sync_pair(_sync_pair), progress(progress),
+      lock_duration(cct->_conf->rgw_sync_lease_period),
       status_obj(env->svc->zone->get_zone_params().log_pool,
                  RGWBucketPipeSyncStatusManager::full_status_oid(sc->source_zone,
                                                                  sync_pair.source_bs.bucket,
@@ -5032,9 +5035,21 @@ int RGWSyncBucketCR::operate()
     sync_pipe.info = sync_pair;
 
     // read bucket sync status
-    using CR = RGWSimpleRadosReadCR<rgw_bucket_sync_status>;
-    yield call(new CR(env->async_rados, env->svc->sysobj,
-                      status_obj, &bucket_status, true, &objv));
+    using ReadCR = RGWSimpleRadosReadCR<rgw_bucket_sync_status>;
+    yield call(new ReadCR(env->async_rados, env->svc->sysobj,
+                          status_obj, &bucket_status, false, &objv));
+    if (retcode == -ENOENT) {
+      // use exclusive create to set state=Init
+      objv.generate_new_write_ver(cct);
+      using WriteCR = RGWSimpleRadosWriteCR<rgw_bucket_sync_status>;
+      yield call(new WriteCR(env->async_rados, env->svc->sysobj,
+                             status_obj, bucket_status, &objv, true));
+      if (retcode == -EEXIST) {
+        // raced with another create, read its status
+        yield call(new ReadCR(env->async_rados, env->svc->sysobj,
+                              status_obj, &bucket_status, false, &objv));
+      }
+    }
     if (retcode < 0) {
       return set_cr_error(retcode);
     }
@@ -5042,31 +5057,13 @@ int RGWSyncBucketCR::operate()
     do {
       tn->log(20, SSTR("sync status for source bucket: " << bucket_status.state));
 
-      if (bucket_status.state == BucketSyncState::Init ||
-          bucket_status.state == BucketSyncState::Stopped) {
-        // init sync status
-        yield {
-          init_check_compat = objv.read_version.ver <= 1; // newly-created
-          int num_shards = sync_pipe.dest_bucket_info.layout.current_index.layout.normal.num_shards;
-          call(new InitBucketFullSyncStatusCR(sc, sync_pair, status_obj,
-                                              bucket_status, objv, num_shards,
-                                              init_check_compat));
-        }
-        if (retcode < 0) {
-          return set_cr_error(retcode);
-        }
-      }
-
-      if (bucket_status.state == BucketSyncState::Full) {
-        // take a bucket-wide lease for full sync to prevent the bucket shards
-        // from duplicating the work
-        yield {
-          const std::string lock_name = "full sync";
-          const uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
-          bucket_lease_cr.reset(new RGWContinuousLeaseCR(env->async_rados, env->store, status_obj,
-                                                         lock_name, lock_duration, this));
-          spawn(bucket_lease_cr.get(), false);
-        }
+      // if the state wasn't Incremental, take a bucket-wide lease to prevent
+      // different shards from duplicating the init and full sync
+      if (bucket_status.state != BucketSyncState::Incremental) {
+        assert(!bucket_lease_cr);
+        bucket_lease_cr.reset(new RGWContinuousLeaseCR(env->async_rados, env->store, status_obj,
+                                                       lock_name, lock_duration, this));
+        yield spawn(bucket_lease_cr.get(), false);
         while (!bucket_lease_cr->is_locked()) {
           if (bucket_lease_cr->is_done()) {
             tn->log(5, "failed to take bucket lease");
@@ -5077,19 +5074,56 @@ int RGWSyncBucketCR::operate()
           tn->log(5, "waiting on bucket lease");
           yield set_sleeping(true);
         }
+        // reread the status after acquiring the lock
+        yield call(new ReadCR(env->async_rados, env->svc->sysobj,
+                              status_obj, &bucket_status, false, &objv));
+        if (retcode < 0) {
+          bucket_lease_cr->go_down();
+          drain_all();
+          bucket_lease_cr.reset();
+          return set_cr_error(retcode);
+        }
+      }
 
+      if (bucket_status.state == BucketSyncState::Init ||
+          bucket_status.state == BucketSyncState::Stopped) {
+        assert(bucket_lease_cr);
+        // init sync status
+        yield {
+          init_check_compat = objv.read_version.ver <= 1; // newly-created
+          int num_shards = sync_pipe.dest_bucket_info.layout.current_index.layout.normal.num_shards;
+          call(new InitBucketFullSyncStatusCR(sc, sync_pair, status_obj,
+                                              bucket_status, objv, num_shards,
+                                              init_check_compat));
+        }
+        if (retcode < 0) {
+          bucket_lease_cr->go_down();
+          drain_all();
+          bucket_lease_cr.reset();
+          return set_cr_error(retcode);
+        }
+      }
+
+      if (bucket_status.state == BucketSyncState::Full) {
+        assert(bucket_lease_cr);
         yield call(new RGWBucketFullSyncCR(sc, sync_pipe, status_obj,
                                            bucket_lease_cr, bucket_status,
                                            tn, objv));
-        bucket_lease_cr->go_down();
-        drain_all();
-        bucket_lease_cr.reset();
         if (retcode < 0) {
+          bucket_lease_cr->go_down();
+          drain_all();
+          bucket_lease_cr.reset();
           return set_cr_error(retcode);
         }
       }
 
       if (bucket_status.state == BucketSyncState::Incremental) {
+        // lease not required for incremental sync
+        if (bucket_lease_cr) {
+          bucket_lease_cr->go_down();
+          drain_all();
+          bucket_lease_cr.reset();
+        }
         yield call(new RGWSyncBucketShardCR(sc, data_lease_cr, sync_pair,
                                             sync_pipe, bucket_status.state,
                                             tn, progress));

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -530,7 +530,6 @@ struct rgw_bucket_shard_sync_info {
   };
 
   uint16_t state;
-  rgw_bucket_shard_full_sync_marker full_marker;
   rgw_bucket_shard_inc_sync_marker inc_marker;
 
   void decode_from_attrs(CephContext *cct, map<string, bufferlist>& attrs);
@@ -538,17 +537,19 @@ struct rgw_bucket_shard_sync_info {
   void encode_state_attr(map<string, bufferlist>& attrs);
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     encode(state, bl);
-    encode(full_marker, bl);
     encode(inc_marker, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
-     DECODE_START(1, bl);
+     DECODE_START(2, bl);
      decode(state, bl);
-     decode(full_marker, bl);
+     if (struct_v <= 1) {
+       rgw_bucket_shard_full_sync_marker full_marker;
+       decode(full_marker, bl);
+     }
      decode(inc_marker, bl);
      DECODE_FINISH(bl);
   }

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -561,6 +561,71 @@ struct rgw_bucket_shard_sync_info {
 };
 WRITE_CLASS_ENCODER(rgw_bucket_shard_sync_info)
 
+struct rgw_bucket_full_sync_status {
+  rgw_obj_key position;
+  uint64_t count = 0;
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(position, bl);
+    encode(count, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(position, bl);
+    decode(count, bl);
+    DECODE_FINISH(bl);
+  }
+
+  void dump(Formatter *f) const;
+  void decode_json(JSONObj *obj);
+};
+WRITE_CLASS_ENCODER(rgw_bucket_full_sync_status)
+
+enum class BucketSyncState : uint8_t {
+  Init = 0,
+  Full,
+  Incremental,
+  Stopped,
+};
+inline std::ostream& operator<<(std::ostream& out, const BucketSyncState& s) {
+  switch (s) {
+  case BucketSyncState::Init: out << "init"; break;
+  case BucketSyncState::Full: out << "full"; break;
+  case BucketSyncState::Incremental: out << "incremental"; break;
+  case BucketSyncState::Stopped: out << "stopped"; break;
+  }
+  return out;
+}
+
+void encode_json(const char *name, BucketSyncState state, Formatter *f);
+void decode_json_obj(BucketSyncState& state, JSONObj *obj);
+
+struct rgw_bucket_sync_status {
+  BucketSyncState state = BucketSyncState::Init;
+  rgw_bucket_full_sync_status full;
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(state, bl);
+    encode(full, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(state, bl);
+    decode(full, bl);
+    DECODE_FINISH(bl);
+  }
+
+  void dump(Formatter *f) const;
+  void decode_json(JSONObj *obj);
+};
+WRITE_CLASS_ENCODER(rgw_bucket_sync_status)
+
 struct rgw_bucket_index_marker_info {
   string bucket_ver;
   string master_ver;

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -725,7 +725,9 @@ public:
   map<int, rgw_bucket_shard_sync_info>& get_sync_status() { return sync_status; }
   int init_sync_status();
 
-  static string status_oid(const rgw_zone_id& source_zone, const rgw_bucket_sync_pair_info& bs);
+  static string inc_status_oid(const rgw_zone_id& source_zone,
+                               const rgw_bucket_sync_pair_info& bs);
+  // specific source obj sync status, can be used by sync modules
   static string obj_status_oid(const rgw_bucket_sync_pipe& sync_pipe,
                                const rgw_zone_id& source_zone, const rgw::sal::RGWObject* obj); /* specific source obj sync status,
                                                                                        can be used by sync modules */

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -649,10 +649,12 @@ class RGWRemoteBucketManager {
   RGWRESTConn *conn{nullptr};
   rgw_zone_id source_zone;
 
+  rgw_raw_obj full_status_obj;
   vector<rgw_bucket_sync_pair_info> sync_pairs;
 
   RGWDataSyncCtx sc;
-  rgw_bucket_shard_sync_info init_status;
+  rgw_bucket_sync_status full_status;
+  rgw_bucket_shard_sync_info shard_status;
 
   RGWBucketSyncCR *sync_cr{nullptr};
 
@@ -663,12 +665,8 @@ public:
                      const RGWBucketInfo& source_bucket_info,
                      const rgw_bucket& dest_bucket);
 
-  void init(const rgw_zone_id& _source_zone, RGWRESTConn *_conn,
-            const rgw_bucket& source_bucket, int shard_id,
-            const rgw_bucket& dest_bucket);
-
   RGWCoroutine *read_sync_status_cr(int num, rgw_bucket_shard_sync_info *sync_status);
-  RGWCoroutine *init_sync_status_cr(int num, RGWObjVersionTracker& objv_tracker);
+  RGWCoroutine *init_sync_status_cr(RGWObjVersionTracker& objv_tracker);
   RGWCoroutine *run_sync_cr(int num);
 
   int num_pipes() {

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -725,6 +725,9 @@ public:
   map<int, rgw_bucket_shard_sync_info>& get_sync_status() { return sync_status; }
   int init_sync_status();
 
+  static string full_status_oid(const rgw_zone_id& source_zone,
+                                const rgw_bucket& source_bucket,
+                                const rgw_bucket& dest_bucket);
   static string inc_status_oid(const rgw_zone_id& source_zone,
                                const rgw_bucket_sync_pair_info& bs);
   // specific source obj sync status, can be used by sync modules

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -674,13 +674,13 @@ public:
   int run();
 };
 
-/// read the sync status of all bucket shards from the given source zone
-int rgw_bucket_sync_status(const DoutPrefixProvider *dpp,
-                           rgw::sal::RGWRadosStore *store,
-                           const rgw_sync_bucket_pipe& pipe,
-                           const RGWBucketInfo& dest_bucket_info,
-                           const RGWBucketInfo *psource_bucket_info,
-                           std::vector<rgw_bucket_shard_sync_info> *status);
+/// read the incremental sync status of all bucket shards from the given source zone
+int rgw_read_bucket_inc_sync_status(const DoutPrefixProvider *dpp,
+                                    rgw::sal::RGWRadosStore *store,
+                                    const rgw_sync_bucket_pipe& pipe,
+                                    const RGWBucketInfo& dest_bucket_info,
+                                    const RGWBucketInfo *psource_bucket_info,
+                                    std::vector<rgw_bucket_shard_sync_info> *status);
 
 class RGWDefaultSyncModule : public RGWSyncModule {
 public:

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -742,6 +742,13 @@ public:
   int run();
 };
 
+/// read the full sync status with respect to a source bucket
+int rgw_read_bucket_full_sync_status(const DoutPrefixProvider *dpp,
+                                     rgw::sal::RGWRadosStore *store,
+                                     const rgw_sync_bucket_pipe& pipe,
+                                     rgw_bucket_sync_status *status,
+                                     optional_yield y);
+
 /// read the incremental sync status of all bucket shards from the given source zone
 int rgw_read_bucket_inc_sync_status(const DoutPrefixProvider *dpp,
                                     rgw::sal::RGWRadosStore *store,

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -1792,7 +1792,6 @@ void rgw_bucket_shard_sync_info::decode_json(JSONObj *obj)
   } else {
     state = StateInit;
   }
-  JSONDecoder::decode_json("full_marker", full_marker, obj);
   JSONDecoder::decode_json("inc_marker", inc_marker, obj);
 }
 
@@ -1817,7 +1816,6 @@ void rgw_bucket_shard_sync_info::dump(Formatter *f) const
     break;
   }
   encode_json("status", s, f);
-  encode_json("full_marker", full_marker, f);
   encode_json("inc_marker", inc_marker, f);
 }
 

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -1821,6 +1821,66 @@ void rgw_bucket_shard_sync_info::dump(Formatter *f) const
   encode_json("inc_marker", inc_marker, f);
 }
 
+void rgw_bucket_full_sync_status::decode_json(JSONObj *obj)
+{
+  JSONDecoder::decode_json("position", position, obj);
+  JSONDecoder::decode_json("count", count, obj);
+}
+
+void rgw_bucket_full_sync_status::dump(Formatter *f) const
+{
+  encode_json("position", position, f);
+  encode_json("count", count, f);
+}
+
+void encode_json(const char *name, BucketSyncState state, Formatter *f)
+{
+  switch (state) {
+  case BucketSyncState::Init:
+    encode_json(name, "init", f);
+    break;
+  case BucketSyncState::Full:
+    encode_json(name, "full-sync", f);
+    break;
+  case BucketSyncState::Incremental:
+    encode_json(name, "incremental-sync", f);
+    break;
+  case BucketSyncState::Stopped:
+    encode_json(name, "stopped", f);
+    break;
+  default:
+    encode_json(name, "unknown", f);
+    break;
+  }
+}
+
+void decode_json_obj(BucketSyncState& state, JSONObj *obj)
+{
+  std::string s;
+  decode_json_obj(s, obj);
+  if (s == "full-sync") {
+    state = BucketSyncState::Full;
+  } else if (s == "incremental-sync") {
+    state = BucketSyncState::Incremental;
+  } else if (s == "stopped") {
+    state = BucketSyncState::Stopped;
+  } else {
+    state = BucketSyncState::Init;
+  }
+}
+
+void rgw_bucket_sync_status::decode_json(JSONObj *obj)
+{
+  JSONDecoder::decode_json("state", state, obj);
+  JSONDecoder::decode_json("full", full, obj);
+}
+
+void rgw_bucket_sync_status::dump(Formatter *f) const
+{
+  encode_json("state", state, f);
+  encode_json("full", full, f);
+}
+
 /* This utility function shouldn't conflict with the overload of std::to_string
  * provided by string_ref since Boost 1.54 as it's defined outside of the std
  * namespace. I hope we'll remove it soon - just after merging the Matt's PR

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -869,10 +869,10 @@ void RGWOp_BILog_Status::execute()
 
     ldout(s->cct, 20) << "RGWOp_BILog_Status::execute(): getting sync status for pipe=" << pipe << dendl;
 
-    op_ret = rgw_bucket_sync_status(this, store, pipe, info, nullptr, &status);
+    op_ret = rgw_read_bucket_inc_sync_status(this, store, pipe, info, nullptr, &status);
 
     if (op_ret < 0) {
-      lderr(s->cct) << "ERROR: rgw_bucket_sync_status() on pipe=" << pipe << " returned ret=" << op_ret << dendl;
+      lderr(s->cct) << "ERROR: rgw_read_bucket_sync_status() on pipe=" << pipe << " returned ret=" << op_ret << dendl;
     }
     return;
   }
@@ -922,9 +922,9 @@ void RGWOp_BILog_Status::execute()
       pipe.dest.bucket = pinfo->bucket;
     }
 
-    int r = rgw_bucket_sync_status(this, store, pipe, *pinfo, &info, &current_status);
+    int r = rgw_read_bucket_inc_sync_status(this, store, pipe, *pinfo, &info, &current_status);
     if (r < 0) {
-      lderr(s->cct) << "ERROR: rgw_bucket_sync_status() on pipe=" << pipe << " returned ret=" << r << dendl;
+      lderr(s->cct) << "ERROR: rgw_read_bucket_sync_status() on pipe=" << pipe << " returned ret=" << r << dendl;
       op_ret = r;
       return;
     }

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -158,13 +158,13 @@ int RGWShardCollectCR::operate() {
     while (spawn_next()) {
       current_running++;
 
-      while (current_running >= max_concurrent) {
+      if (current_running >= max_concurrent) {
         int child_ret;
         yield wait_for_child();
         if (collect_next(&child_ret)) {
           current_running--;
-          if (child_ret < 0 && child_ret != -ENOENT) {
-            ldout(cct, 10) << __func__ << ": failed to fetch log status, ret=" << child_ret << dendl;
+          child_ret = handle_result(child_ret);
+          if (child_ret < 0) {
             status = child_ret;
           }
         }
@@ -175,8 +175,8 @@ int RGWShardCollectCR::operate() {
       yield wait_for_child();
       if (collect_next(&child_ret)) {
         current_running--;
-        if (child_ret < 0 && child_ret != -ENOENT) {
-          ldout(cct, 10) << __func__ << ": failed to fetch log status, ret=" << child_ret << dendl;
+        child_ret = handle_result(child_ret);
+        if (child_ret < 0) {
           status = child_ret;
         }
       }
@@ -199,6 +199,15 @@ class RGWReadRemoteMDLogInfoCR : public RGWShardCollectCR {
   int shard_id;
 #define READ_MDLOG_MAX_CONCURRENT 10
 
+  int handle_result(int r) override {
+    if (r == -ENOENT) { // ENOENT is not a fatal error
+      return 0;
+    }
+    if (r < 0) {
+      ldout(cct, 4) << "failed to fetch mdlog status: " << cpp_strerror(r) << dendl;
+    }
+    return r;
+  }
 public:
   RGWReadRemoteMDLogInfoCR(RGWMetaSyncEnv *_sync_env,
                      const std::string& period, int _num_shards,
@@ -220,6 +229,15 @@ class RGWListRemoteMDLogCR : public RGWShardCollectCR {
   map<int, string>::iterator iter;
 #define READ_MDLOG_MAX_CONCURRENT 10
 
+  int handle_result(int r) override {
+    if (r == -ENOENT) { // ENOENT is not a fatal error
+      return 0;
+    }
+    if (r < 0) {
+      ldout(cct, 4) << "failed to list remote mdlog shard: " << cpp_strerror(r) << dendl;
+    }
+    return r;
+  }
 public:
   RGWListRemoteMDLogCR(RGWMetaSyncEnv *_sync_env,
                      const std::string& period, map<int, string>& _shards,
@@ -737,6 +755,16 @@ class RGWReadSyncStatusMarkersCR : public RGWShardCollectCR {
   int shard_id{0};
   map<uint32_t, rgw_meta_sync_marker>& markers;
 
+  int handle_result(int r) override {
+    if (r == -ENOENT) { // ENOENT is not a fatal error
+      return 0;
+    }
+    if (r < 0) {
+      ldout(cct, 4) << "failed to read metadata sync markers: "
+          << cpp_strerror(r) << dendl;
+    }
+    return r;
+  }
  public:
   RGWReadSyncStatusMarkersCR(RGWMetaSyncEnv *env, int num_shards,
                              map<uint32_t, rgw_meta_sync_marker>& markers)

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -511,16 +511,20 @@ public:
 };
 
 class RGWShardCollectCR : public RGWCoroutine {
-  int cur_shard = 0;
-  int current_running;
+  int current_running = 0;
+ protected:
   int max_concurrent;
-  int status;
+  int status = 0;
 
-public:
-  RGWShardCollectCR(CephContext *_cct, int _max_concurrent) : RGWCoroutine(_cct),
-                                                             current_running(0),
-                                                             max_concurrent(_max_concurrent),
-                                                             status(0) {}
+  // called with the result of each child. error codes can be ignored by
+  // returning 0. if handle_result() returns a negative value, it's
+  // treated as an error and stored in 'status'. the last such error is
+  // reported to the caller with set_cr_error()
+  virtual int handle_result(int r) = 0;
+ public:
+  RGWShardCollectCR(CephContext *_cct, int _max_concurrent)
+    : RGWCoroutine(_cct), max_concurrent(_max_concurrent)
+  {}
 
   virtual bool spawn_next() = 0;
   int operate() override;

--- a/src/rgw/rgw_sync_checkpoint.cc
+++ b/src/rgw/rgw_sync_checkpoint.cc
@@ -99,8 +99,8 @@ int bucket_source_sync_checkpoint(const DoutPrefixProvider* dpp,
 
   std::vector<rgw_bucket_shard_sync_info> status;
   status.resize(std::max<size_t>(1, num_shards));
-  int r = rgw_bucket_sync_status(dpp, store, pipe, bucket_info,
-                                 &source_bucket_info, &status);
+  int r = rgw_read_bucket_inc_sync_status(dpp, store, pipe, bucket_info,
+                                          &source_bucket_info, &status);
   if (r < 0) {
     return r;
   }
@@ -115,7 +115,8 @@ int bucket_source_sync_checkpoint(const DoutPrefixProvider* dpp,
         << "      local status: " << status << '\n'
         << "    remote markers: " << remote_markers << dendl;
     std::this_thread::sleep_until(delay_until);
-    r = rgw_bucket_sync_status(dpp, store, pipe, bucket_info, &source_bucket_info, &status);
+    r = rgw_read_bucket_inc_sync_status(dpp, store, pipe, bucket_info,
+                                        &source_bucket_info, &status);
     if (r < 0) {
       return r;
     }

--- a/src/rgw/rgw_trim_bilog.cc
+++ b/src/rgw/rgw_trim_bilog.cc
@@ -385,6 +385,16 @@ class BucketTrimShardCollectCR : public RGWShardCollectCR {
   const RGWBucketInfo& bucket_info;
   const std::vector<std::string>& markers; //< shard markers to trim
   size_t i{0}; //< index of current shard marker
+
+  int handle_result(int r) override {
+    if (r == -ENOENT) { // ENOENT is not a fatal error
+      return 0;
+    }
+    if (r < 0) {
+      ldout(cct, 4) << "failed to trim bilog shard: " << cpp_strerror(r) << dendl;
+    }
+    return r;
+  }
  public:
   BucketTrimShardCollectCR(rgw::sal::RGWRadosStore *store, const RGWBucketInfo& bucket_info,
                            const std::vector<std::string>& markers)
@@ -568,6 +578,16 @@ class BucketTrimInstanceCollectCR : public RGWShardCollectCR {
   BucketTrimObserver *const observer;
   std::vector<std::string>::const_iterator bucket;
   std::vector<std::string>::const_iterator end;
+
+  int handle_result(int r) override {
+    if (r == -ENOENT) { // ENOENT is not a fatal error
+      return 0;
+    }
+    if (r < 0) {
+      ldout(cct, 4) << "failed to trim bucket instance: " << cpp_strerror(r) << dendl;
+    }
+    return r;
+  }
  public:
   BucketTrimInstanceCollectCR(rgw::sal::RGWRadosStore *store, RGWHTTPManager *http,
                               BucketTrimObserver *observer,

--- a/src/rgw/rgw_trim_mdlog.cc
+++ b/src/rgw/rgw_trim_mdlog.cc
@@ -30,6 +30,15 @@ class PurgeLogShardsCR : public RGWShardCollectCR {
 
   static constexpr int max_concurrent = 16;
 
+  int handle_result(int r) override {
+    if (r == -ENOENT) { // ENOENT is not a fatal error
+      return 0;
+    }
+    if (r < 0) {
+      ldout(cct, 4) << "failed to remove mdlog shard: " << cpp_strerror(r) << dendl;
+    }
+    return r;
+  }
  public:
   PurgeLogShardsCR(rgw::sal::RGWRadosStore *store, const RGWMetadataLog* mdlog,
                    const rgw_pool& pool, int num_shards)
@@ -263,6 +272,15 @@ class MetaMasterTrimShardCollectCR : public RGWShardCollectCR {
   std::string oid;
   const rgw_meta_sync_status& sync_status;
 
+  int handle_result(int r) override {
+    if (r == -ENOENT) { // ENOENT is not a fatal error
+      return 0;
+    }
+    if (r < 0) {
+      ldout(cct, 4) << "failed to trim mdlog shard: " << cpp_strerror(r) << dendl;
+    }
+    return r;
+  }
  public:
   MetaMasterTrimShardCollectCR(MasterTrimEnv& env, RGWMetadataLog *mdlog,
                                const rgw_meta_sync_status& sync_status)
@@ -314,6 +332,17 @@ class MetaMasterStatusCollectCR : public RGWShardCollectCR {
   MasterTrimEnv& env;
   connection_map::iterator c;
   std::vector<rgw_meta_sync_status>::iterator s;
+
+  int handle_result(int r) override {
+    if (r == -ENOENT) { // ENOENT is not a fatal error
+      return 0;
+    }
+    if (r < 0) {
+      ldout(cct, 4) << "failed to fetch metadata sync status: "
+          << cpp_strerror(r) << dendl;
+    }
+    return r;
+  }
  public:
   explicit MetaMasterStatusCollectCR(MasterTrimEnv& env)
     : RGWShardCollectCR(env.store->ctx(), MAX_CONCURRENT_SHARDS),
@@ -520,6 +549,15 @@ class MetaPeerTrimShardCollectCR : public RGWShardCollectCR {
   RGWMetaSyncEnv meta_env; //< for RGWListRemoteMDLogShardCR
   int shard_id{0};
 
+  int handle_result(int r) override {
+    if (r == -ENOENT) { // ENOENT is not a fatal error
+      return 0;
+    }
+    if (r < 0) {
+      ldout(cct, 4) << "failed to trim mdlog shard: " << cpp_strerror(r) << dendl;
+    }
+    return r;
+  }
  public:
   MetaPeerTrimShardCollectCR(PeerTrimEnv& env, RGWMetadataLog *mdlog)
     : RGWShardCollectCR(env.store->ctx(), MAX_CONCURRENT_SHARDS),

--- a/src/rgw/services/svc_sys_obj.cc
+++ b/src/rgw/services/svc_sys_obj.cc
@@ -96,7 +96,7 @@ int RGWSI_SysObj::Obj::WOp::write_attrs(optional_yield y)
   RGWSI_SysObj_Core *svc = source.core_svc;
   rgw_raw_obj& obj = source.get_obj();
 
-  return svc->set_attrs(obj, attrs, nullptr, objv_tracker, y);
+  return svc->set_attrs(obj, attrs, nullptr, objv_tracker, exclusive, y);
 }
 
 int RGWSI_SysObj::Obj::WOp::write_attr(const char *name, bufferlist& bl,
@@ -108,7 +108,7 @@ int RGWSI_SysObj::Obj::WOp::write_attr(const char *name, bufferlist& bl,
   map<string, bufferlist> m;
   m[name] = bl;
 
-  return svc->set_attrs(obj, m, nullptr, objv_tracker, y);
+  return svc->set_attrs(obj, m, nullptr, objv_tracker, exclusive, y);
 }
 
 int RGWSI_SysObj::Pool::list_prefixed_objs(const string& prefix, std::function<void(const string&)> cb)

--- a/src/rgw/services/svc_sys_obj_cache.cc
+++ b/src/rgw/services/svc_sys_obj_cache.cc
@@ -241,7 +241,7 @@ int RGWSI_SysObj_Cache::set_attrs(const rgw_raw_obj& obj,
                                   map<string, bufferlist>& attrs,
                                   map<string, bufferlist> *rmattrs,
                                   RGWObjVersionTracker *objv_tracker,
-                                  optional_yield y)
+                                  bool exclusive, optional_yield y)
 {
   rgw_pool pool;
   string oid;
@@ -253,7 +253,7 @@ int RGWSI_SysObj_Cache::set_attrs(const rgw_raw_obj& obj,
   }
   info.status = 0;
   info.flags = CACHE_FLAG_MODIFY_XATTRS;
-  int ret = RGWSI_SysObj_Core::set_attrs(obj, attrs, rmattrs, objv_tracker, y);
+  int ret = RGWSI_SysObj_Core::set_attrs(obj, attrs, rmattrs, objv_tracker, exclusive, y);
   string name = normal_name(pool, oid);
   if (ret >= 0) {
     if (objv_tracker && objv_tracker->read_version.ver) {

--- a/src/rgw/services/svc_sys_obj_cache.h
+++ b/src/rgw/services/svc_sys_obj_cache.h
@@ -59,7 +59,7 @@ protected:
                 map<string, bufferlist>& attrs,
                 map<string, bufferlist> *rmattrs,
                 RGWObjVersionTracker *objv_tracker,
-                optional_yield y);
+                bool exclusive, optional_yield y) override;
 
   int remove(RGWSysObjectCtxBase& obj_ctx,
              RGWObjVersionTracker *objv_tracker,

--- a/src/rgw/services/svc_sys_obj_core.cc
+++ b/src/rgw/services/svc_sys_obj_core.cc
@@ -295,7 +295,7 @@ int RGWSI_SysObj_Core::set_attrs(const rgw_raw_obj& obj,
                                  map<string, bufferlist>& attrs,
                                  map<string, bufferlist> *rmattrs,
                                  RGWObjVersionTracker *objv_tracker,
-                                 optional_yield y)
+                                 bool exclusive, optional_yield y)
 {
   RGWSI_RADOS::Obj rados_obj;
   int r = get_rados_obj(zone_svc, obj, &rados_obj);
@@ -306,6 +306,9 @@ int RGWSI_SysObj_Core::set_attrs(const rgw_raw_obj& obj,
 
   librados::ObjectWriteOperation op;
 
+  if (exclusive) {
+    op.create(true); // exclusive create
+  }
   if (objv_tracker) {
     objv_tracker->prepare_op_for_write(&op);
   }

--- a/src/rgw/services/svc_sys_obj_core.h
+++ b/src/rgw/services/svc_sys_obj_core.h
@@ -76,7 +76,7 @@ protected:
                         map<string, bufferlist>& attrs,
                         map<string, bufferlist> *rmattrs,
                         RGWObjVersionTracker *objv_tracker,
-                        optional_yield y);
+                        bool exclusive, optional_yield y);
 
   virtual int omap_get_all(const rgw_raw_obj& obj, std::map<string, bufferlist> *m,
                            optional_yield y);

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -1204,6 +1204,7 @@ def test_multipart_object_sync():
     mp.upload_part_from_file(StringIO('d' * part_size), 4)
     mp.complete_upload()
 
+    zonegroup_meta_checkpoint(zonegroup)
     zonegroup_bucket_checkpoint(zonegroup_conns, bucket.name)
 
 def test_encrypted_object_sync():

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -1099,6 +1099,7 @@ def test_set_bucket_policy():
         bucket.set_policy(policy)
         assert(bucket.get_policy().decode('ascii') == policy)
 
+@attr('bucket_sync_disable')
 def test_bucket_sync_disable():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
@@ -1113,6 +1114,7 @@ def test_bucket_sync_disable():
 
     zonegroup_data_checkpoint(zonegroup_conns)
 
+@attr('bucket_sync_disable')
 def test_bucket_sync_enable_right_after_disable():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
@@ -1147,6 +1149,7 @@ def test_bucket_sync_enable_right_after_disable():
 
     zonegroup_data_checkpoint(zonegroup_conns)
 
+@attr('bucket_sync_disable')
 def test_bucket_sync_disable_enable():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)


### PR DESCRIPTION
currently, bucket full sync runs once for each bucket index shard, by listing all objects in that shard and fetching them. this coupling with the index shards is problematic for resharding, because any full syncs in progress would be unable to continue their listing after a reshard

by moving full sync from per-bucket-shard to per-bucket, we can use a normal ordered bucket listing, which is stable across reshards. to track this full sync status, we add a new per-bucket sync status object, along with some backward-compatibility logic to skip a full sync if all of its shard status objects exist and show incremental sync

when starting full sync, a cls lock is acquired on this full sync status object to prevent other data sync shards from duplicating the work. the shards that fail to get this lock will retry until the full sync finishes

in the future, this bucket sync status object will be used to coordinate the per-shard incremental sync across reshard events

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
