### PR TITLE
qa/suites/rados/cephadm/dashboard: fix creating OSD failure

### DIFF
--- a/qa/workunits/cephadm/create_iscsi_disks.sh
+++ b/qa/workunits/cephadm/create_iscsi_disks.sh
@@ -27,6 +27,8 @@ for i in $(seq 3); do
     $SUDO truncate --size ${DISK_FILE_SIZE} ${DISK_FILE}
 
     $SUDO targetcli /backstores/fileio create "lun${i}" ${DISK_FILE}
+    # Workaround for https://tracker.ceph.com/issues/47758
+    $SUDO targetcli "/backstores/fileio/lun${i}" set attribute optimal_sectors=0
     $SUDO targetcli /iscsi/${TARGET_NAME}/tpg1/luns create "/backstores/fileio/lun${i}"
 done
 


### PR DESCRIPTION
The iSCSI disks report a larger optimal I/O size, which causes
ceph-volume to miscalculate the extent count. Workaround this by
reporting 0.

Fixes: https://tracker.ceph.com/issues/47742
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
