### PR TITLE
octopus: mgr/dashboard: Show warning when replicated size is 1 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -146,6 +146,10 @@
                     *ngIf="form.showError('size', formDir)"
                     i18n>The size specified is out of range. A value from
                 {{ getMinSize() }} to {{ getMaxSize() }} is usable.</span>
+              <span class="text-warning-dark"
+                    *ngIf="form.getValue('size') === 1"
+                    i18n>A size of 1 will not create a replication of the
+                object. The 'Replicated size' includes the object itself.</span>
             </div>
           </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
@@ -310,6 +310,17 @@ describe('PoolFormComponent', () => {
       formHelper.expectValidChange('size', 2);
     });
 
+    it('validates if warning is displayed when size is 1', () => {
+      formHelper.setValue('poolType', 'replicated');
+      formHelper.expectValid('size');
+
+      formHelper.setValue('size', 1, true);
+      expect(fixtureHelper.getElementByCss('#size ~ .text-warning-dark')).toBeTruthy();
+
+      formHelper.setValue('size', 2, true);
+      expect(fixtureHelper.getElementByCss('#size ~ .text-warning-dark')).toBeFalsy();
+    });
+
     it('validates compression mode default value', () => {
       expect(form.getValue('mode')).toBe('none');
     });

--- a/src/pybind/mgr/dashboard/frontend/src/styles.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles.scss
@@ -9,10 +9,12 @@ $fa-font-path: '~fork-awesome/fonts';
 $font-family-icon: 'ForkAwesome';
 
 // Bootstrap
+$warning-dark: #fd7e14;
 $theme-colors: (
   'primary': $color-primary,
   'secondary': $color-accent,
-  'dark': $color-mild-gray
+  'dark': $color-mild-gray,
+  'warning-dark': $warning-dark
 );
 
 $font-family-sans-serif: 'Helvetica Neue', Helvetica, Arial, 'Noto Sans', sans-serif,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47770

---

backport of https://github.com/ceph/ceph/pull/37523
parent tracker: https://tracker.ceph.com/issues/42404

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh