### PR TITLE
os/bluestore: fix memory accounting in TwoQBufferCacheShard

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1211,7 +1211,6 @@ struct TwoQBufferCacheShard : public BlueStore::BufferCacheShard {
   list_t hot;      ///< "Am" hot buffers
   list_t warm_in;  ///< "A1in" newly warm buffers
   list_t warm_out; ///< "A1out" empty buffers we've evicted
-  uint64_t buffer_bytes = 0;     ///< bytes
 
   enum {
     BUFFER_NEW = 0,


### PR DESCRIPTION
Variable buffer_bytes has been redefined in TwoQBufferCacheShard,
causing PriCache to see always 0 usage when 2q cache was selected,
as it looks at it through BufferCacheShard::_get_bytes().

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>