### PR TITLE
mgr/dashboard: Add short descriptions to the telemetry report preview

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
@@ -229,7 +229,11 @@
             <div class="form-group row">
               <label i18n
                      for="reportId"
-                     class="cd-col-form-label">Report ID</label>
+                     class="cd-col-form-label">Report ID
+              <cd-helper i18n-html
+                         html="A randomized UUID to identify a particular cluster over the course of several telemetry reports.">
+              </cd-helper>
+              </label>
               <div class="cd-col-form-input">
                 <input class="form-control"
                        type="text"
@@ -243,7 +247,11 @@
             <div class="form-group row">
               <label i18n
                      for="report"
-                     class="cd-col-form-label">Report preview</label>
+                     class="cd-col-form-label">Report preview
+                <cd-helper i18n-html
+                           html="The actual telemetry data that will be submitted.">
+                </cd-helper>
+              </label>
               <div class="cd-col-form-input">
                 <textarea class="form-control"
                           id="report"


### PR DESCRIPTION
A small info icon with a popover on the telemetry report preview form step2 for
Report ID and Report Preview.

```
Report ID: "A randomized UUID to identify a particular cluster over the course of several telemetry reports."
Report preview: "The actual telemetry data that will be submitted."
```

![helper](https://user-images.githubusercontent.com/71764184/95367735-bbc09380-08f2-11eb-98e5-fc6f5a93583b.png)

Fixes: https://tracker.ceph.com/issues/47610
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
