### PR TITLE
cephadm: Push ceph-iscsi config options into mon-store

### DIFF
--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -35,7 +35,7 @@ class IscsiService(CephService):
             'entity': self.get_auth_entity(igw_id),
             'caps': ['mon', 'profile rbd, '
                             'allow command "osd blocklist", '
-                            'allow command "config-key get" with "key" prefix "iscsi/"',
+                            f'allow command "config-key get" with "key" prefix "iscsi/"',
                      'osd', 'allow rwx'],
         })
 
@@ -59,6 +59,21 @@ class IscsiService(CephService):
                 'prefix': 'config-key set',
                 'key': f'iscsi/{utils.name_to_config_section("iscsi")}.{igw_id}/iscsi-gateway.key',
                 'val': key_data,
+            })
+
+        # set up the mon-store options, they are all global for iscsi (atm)
+        config_options_in_mon = [
+            # (key, val)
+            (f'{ spec.mon_config_prefix }/trusted_ip_list', spec.trusted_ip_list or ''),
+            (f'{ spec.mon_config_prefix }/api_port', spec.api_port or ''),
+            (f'{ spec.mon_config_prefix }/api_user', spec.api_user or ''),
+            (f'{ spec.mon_config_prefix }/api_password', spec.api_password or ''),
+            (f'{ spec.mon_config_prefix }/api_secure', spec.api_secure or 'False')]
+        for key, val in config_options_in_mon:
+            ret, out, err = self.mgr.check_mon_command({
+                'prefix': 'config-key set',
+                'key': key,
+                'val': val,
             })
 
         context = {

--- a/src/pybind/mgr/cephadm/templates/services/iscsi/iscsi-gateway.cfg.j2
+++ b/src/pybind/mgr/cephadm/templates/services/iscsi/iscsi-gateway.cfg.j2
@@ -2,12 +2,12 @@
 [config]
 cluster_client_name = {{ client_name }}
 pool = {{ spec.pool }}
-trusted_ip_list = {{ spec.trusted_ip_list|default("''", true) }}
+trusted_ip_list = config://{{ spec.mon_config_prefix }}/trusted_ip_list
 minimum_gateways = 1
-api_port = {{ spec.api_port|default("''", true) }}
-api_user = {{ spec.api_user|default("''", true) }}
-api_password = {{ spec.api_password|default("''", true) }}
-api_secure = {{ spec.api_secure|default('False', true) }}
+api_port = config://{{ spec.mon_config_prefix }}/api_port
+api_user = config://{{ spec.mon_config_prefix }}/api_user
+api_password = config://{{ spec.mon_config_prefix }}/api_password
+api_secure = config://{{ spec.mon_config_prefix }}/api_secure
 log_to_stderr = True
 log_to_stderr_prefix = debug
 log_to_file = False

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -707,6 +707,7 @@ class IscsiServiceSpec(ServiceSpec):
                  ssl_cert: Optional[str] = None,
                  ssl_key: Optional[str] = None,
                  placement: Optional[PlacementSpec] = None,
+                 mon_config_prefix: Optional[str] = None,
                  unmanaged: bool = False,
                  preview_only: bool = False
                  ):
@@ -724,6 +725,9 @@ class IscsiServiceSpec(ServiceSpec):
         self.api_secure = api_secure
         self.ssl_cert = ssl_cert
         self.ssl_key = ssl_key
+        self.mon_config_prefix = mon_config_prefix
+        if not self.mon_config_prefix:
+            self.mon_config_prefix = 'iscsi'
 
         if not self.api_secure and self.ssl_cert and self.ssl_key:
             self.api_secure = True
@@ -740,6 +744,14 @@ class IscsiServiceSpec(ServiceSpec):
         if not self.api_password:
             raise ServiceSpecValidationError(
                 'Cannot add ISCSI: No Api password specified')
+        if not self.mon_config_prefix.startswith('iscsi/') and \
+                self.mon_config_prefix != 'iscsi':
+            raise ServiceSpecValidationError(
+                'Cannot add ISCSI: mon_config_prefix must start with iscsi/'
+                ' or just be iscsi')
+        if self.mon_config_prefix.endswith('/'):
+            raise ServiceSpecValidationError(
+                'Connot add ISCSI: mon_config_prefix cannot end in "/"')
 
 
 yaml.add_representer(IscsiServiceSpec, ServiceSpec.yaml_representer)


### PR DESCRIPTION
Currently the ceph-iscsi config options get placed in the
iscsi-gateway.cfg but this is volume mounted into the container and
lives under `/var/lib/ceph/<fsid>/<iscsi service>/iscsi-gateway.cfg`. This is
fine for day 1 situations but horrible on day 2.

To make this easier a PR was pushed to ceph-iscsi[0] which taught it how
to look in the mon config-key store for values to config options. This
took the same approach as RGW. A config value starting with a
`config://` will be treated as key in the mon store. E.g:

  config://my/awesome/key

Will go look for the value of `my/awesome/key`.

Now that the ceph-iscsi PR has merged, it's time to put this into
cephadm/orch.
This patch adds a new option to the iscsi spec called `mon_key_prefix`
which defaults to `iscsi`. Which allows someone to deploy a ceph-iscsi
service with either globally shared options or can seperate as required.

Note that because we set config-key get cap for the iscsi user to only
access keys starting with `iscsi/` this is also a hard requirement. By
default it'll place config options under `iscsi/..` keys:

  iscsi/trusted_ip_list
  iscsi/api_port
  iscsi/api_user
  iscsi/api_password
  iscsi/api_secure

If you want to have say 2 different sets some these options you could
always deploy services with different `mon_key_prefix`'s say as
`iscsi/datacenterA` and `iscsi/datacenterB`. Then they look at different
locations:

  iscsi/datacenterA/trusted_ip_list
  iscsi/dataventerA/api_port
  ...
  iscsi/datacenterB/trusted_ip_list
  iscsi/dataventerB/api_port
  ...

Best part is, now if you want to change a value, you don't need to dig
around and find a config file or do a redeloy, just run a `ceph config-key set` and
then restart the service.

[0] https://github.com/ceph/ceph-iscsi/pull/217

Signed-off-by: Matthew Oliver <moliver@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
