### PR TITLE
ceph-volume: don't exit before empty report can be printed

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -459,7 +459,7 @@ class Batch(object):
         num_osds = len(plan)
         if num_osds == 0:
             mlogger.info('All data devices are unavailable')
-            exit(0)
+            return plan
         requested_osds = args.osds_per_device * len(phys_devs) + len(lvm_devs)
 
         fast_type = 'block_db' if args.bluestore else 'journal'
@@ -469,7 +469,7 @@ class Batch(object):
                                                  fast_type)
         if fast_devices and not fast_allocations:
             mlogger.info('{} fast devices were passed, but none are available'.format(len(fast_devices)))
-            exit(0)
+            return []
         if fast_devices and not len(fast_allocations) == num_osds:
             mlogger.error('{} fast allocations != {} num_osds'.format(
                 len(fast_allocations), num_osds))
@@ -481,7 +481,7 @@ class Batch(object):
                                                       'block_wal')
         if very_fast_devices and not very_fast_allocations:
             mlogger.info('{} very fast devices were passed, but none are available'.format(len(very_fast_devices)))
-            exit(0)
+            return []
         if very_fast_devices and not len(very_fast_allocations) == num_osds:
             mlogger.error('{} very fast allocations != {} num_osds'.format(
                 len(very_fast_allocations), num_osds))

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
@@ -45,7 +45,7 @@ class TestBatch(object):
     def test_json_report_valid_empty(self, format_, factory, conf_ceph_stub, mock_device_generator):
         # ensure json reports are valid when empty
         conf_ceph_stub('[global]\nfsid=asdf-lkjh')
-        devs = [mock_device_generator() for _ in range(5)]
+        devs = []
         args = factory(data_slots=1,
                        osds_per_device=1,
                        osd_ids=[],
@@ -54,6 +54,58 @@ class TestBatch(object):
                        devices=devs,
                        db_devices=[],
                        wal_devices=[],
+                       bluestore=True,
+                       block_db_size="1G",
+                       dmcrypt=True,
+                      )
+        b = batch.Batch([])
+        plan = b.get_plan(args)
+        b.args = args
+        report = b._create_report(plan)
+        json.loads(report)
+
+    @pytest.mark.parametrize('format_', ['json', 'json-pretty'])
+    def test_json_report_valid_empty_unavailable_fast(self, format_, factory, conf_ceph_stub, mock_device_generator):
+        # ensure json reports are valid when empty
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        devs = [mock_device_generator() for _ in range(5)]
+        fast_devs = [mock_device_generator()]
+        fast_devs[0].available_lvm = False
+        args = factory(data_slots=1,
+                       osds_per_device=1,
+                       osd_ids=[],
+                       report=True,
+                       format=format_,
+                       devices=devs,
+                       db_devices=fast_devs,
+                       wal_devices=[],
+                       bluestore=True,
+                       block_db_size="1G",
+                       dmcrypt=True,
+                      )
+        b = batch.Batch([])
+        plan = b.get_plan(args)
+        b.args = args
+        report = b._create_report(plan)
+        json.loads(report)
+
+
+    @pytest.mark.parametrize('format_', ['json', 'json-pretty'])
+    def test_json_report_valid_empty_unavailable_very_fast(self, format_, factory, conf_ceph_stub, mock_device_generator):
+        # ensure json reports are valid when empty
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        devs = [mock_device_generator() for _ in range(5)]
+        fast_devs = [mock_device_generator()]
+        very_fast_devs = [mock_device_generator()]
+        very_fast_devs[0].available_lvm = False
+        args = factory(data_slots=1,
+                       osds_per_device=1,
+                       osd_ids=[],
+                       report=True,
+                       format=format_,
+                       devices=devs,
+                       db_devices=fast_devs,
+                       wal_devices=very_fast_devs,
                        bluestore=True,
                        block_db_size="1G",
                        dmcrypt=True,


### PR DESCRIPTION
`get_plan()` called exit in case of an empty plan. This prevented a report
being printed under these circumstances. Avoid exit in this case. Also
adds tests to ensure an empty report is printed.

Fixes: https://tracker.ceph.com/issues/47760

Signed-off-by: Jan Fajerski <jfajerski@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
