### PR TITLE
librbd: fix race on watcher unregister

### DIFF
--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -223,7 +223,8 @@ private:
 
   Context *prepare_quiesce_request(const watch_notify::AsyncRequestId &request,
                                    C_NotifyAck *ack_ctx);
-  Context *prepare_unquiesce_request(const watch_notify::AsyncRequestId &request);
+  void prepare_unquiesce_request(const watch_notify::AsyncRequestId &request);
+  void cancel_quiesce_requests();
 
   void notify_quiesce(const watch_notify::AsyncRequestId &async_request_id,
                       size_t attempts, ProgressContext &prog_ctx,


### PR DESCRIPTION
It was possible that "unregister_watch" would get stuck forever
in "m_async_op_tracker.wait_for_ops", waiting for unqueiesce
notifications to complete, which had been already canceled
when "unregister" called "TaskFinisher::cancel_all".

Signed-off-by: Mykola Golub <mgolub@suse.com>