### PR TITLE
octopus: mgr/dashboard: Add short descriptions to the telemetry report preview

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
@@ -235,7 +235,10 @@
             <div class="form-group row">
               <label i18n
                      for="reportId"
-                     class="cd-col-form-label">Report ID</label>
+                     class="cd-col-form-label">Report ID
+              <cd-helper i18n-html
+                         html="A randomized UUID to identify a particular cluster over the course of several telemetry reports.">
+              </cd-helper></label>
               <div class="cd-col-form-input">
                 <input class="form-control"
                        type="text"
@@ -249,7 +252,10 @@
             <div class="form-group row">
               <label i18n
                      for="report"
-                     class="cd-col-form-label">Report preview</label>
+                     class="cd-col-form-label">Report preview
+                <cd-helper i18n-html
+                           html="The actual telemetry data that will be submitted.">
+                </cd-helper></label>
               <div class="cd-col-form-input">
                 <textarea class="form-control"
                           id="report"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47792

---

backport of https://github.com/ceph/ceph/pull/37584
parent tracker: https://tracker.ceph.com/issues/47610

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh