### PR TITLE
mgr/cephadm: add RGW support for NFS ganesha

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -239,6 +239,7 @@ class NFSGanesha(object):
         self.userid = dict_get(config_json, 'userid')
         self.extra_args = dict_get(config_json, 'extra_args', [])
         self.files = dict_get(config_json, 'files', {})
+        self.rgw = dict_get(config_json, 'rgw', {})
 
         # validate the supplied args
         self.validate()
@@ -248,13 +249,17 @@ class NFSGanesha(object):
         # type: (str, Union[int, str]) -> NFSGanesha
         return cls(fsid, daemon_id, get_parm(args.config_json), args.image)
 
-    @staticmethod
-    def get_container_mounts(data_dir):
+    def get_container_mounts(self, data_dir):
         # type: (str) -> Dict[str, str]
         mounts = dict()
         mounts[os.path.join(data_dir, 'config')] = '/etc/ceph/ceph.conf:z'
         mounts[os.path.join(data_dir, 'keyring')] = '/etc/ceph/keyring:z'
         mounts[os.path.join(data_dir, 'etc/ganesha')] = '/etc/ganesha:z'
+        if self.rgw:
+            cluster = self.rgw.get('cluster', 'ceph')
+            rgw_user = self.rgw.get('user', 'admin')
+            mounts[os.path.join(data_dir, 'keyring.rgw')] = \
+                    '/var/lib/ceph/radosgw/%s-%s/keyring:z' % (cluster, rgw_user)
         return mounts
 
     @staticmethod
@@ -293,6 +298,13 @@ class NFSGanesha(object):
                 if fname not in self.files:
                     raise Error('required file missing from config-json: %s' % fname)
 
+        # check for an RGW config
+        if self.rgw:
+            if not self.rgw.get('keyring'):
+                raise Error('RGW keyring is missing')
+            if not self.rgw.get('user'):
+                raise Error('RGW user is missing')
+
     def get_daemon_name(self):
         # type: () -> str
         return '%s.%s' % (self.daemon_type, self.daemon_id)
@@ -329,6 +341,14 @@ class NFSGanesha(object):
                 os.fchown(f.fileno(), uid, gid)
                 os.fchmod(f.fileno(), 0o600)
                 f.write(config_content)
+
+        # write the RGW keyring
+        if self.rgw:
+            keyring_path = os.path.join(data_dir, 'keyring.rgw')
+            with open(keyring_path, 'w') as f:
+                os.fchmod(f.fileno(), 0o600)
+                os.fchown(f.fileno(), uid, gid)
+                f.write(self.rgw.get('keyring', ''))
 
     def get_rados_grace_container(self, action):
         # type: (str) -> CephContainer
@@ -1931,7 +1951,8 @@ def get_container_mounts(fsid, daemon_type, daemon_id,
     if daemon_type == NFSGanesha.daemon_type:
         assert daemon_id
         data_dir = get_data_dir(fsid, daemon_type, daemon_id)
-        mounts.update(NFSGanesha.get_container_mounts(data_dir))
+        nfs_ganesha = NFSGanesha.init(fsid, daemon_id)
+        mounts.update(nfs_ganesha.get_container_mounts(data_dir))
 
     if daemon_type == CephIscsi.daemon_type:
         assert daemon_id

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -149,7 +149,7 @@ class NFSService(CephService):
             'prefix': 'auth get-or-create',
             'entity': entity,
             'caps': ['mon', 'allow r',
-                     'osd', 'allow rwx'],
+                     'osd', 'allow rwx tag rgw *=*'],
         })
 
         return keyring

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -153,3 +153,17 @@ class NFSService(CephService):
         })
 
         return keyring
+
+    def remove_rgw_keyring(self, daemon: DaemonDescription) -> None:
+        daemon_id: str = daemon.daemon_id
+        entity: AuthEntity = self.get_auth_entity(f'{daemon_id}-rgw')
+
+        logger.info(f'Remove keyring: {entity}')
+        ret, out, err = self.mgr.check_mon_command({
+            'prefix': 'auth rm',
+            'entity': entity,
+        })
+
+    def post_remove(self, daemon: DaemonDescription) -> None:
+        super().post_remove(daemon)
+        self.remove_rgw_keyring(daemon)

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -7,7 +7,7 @@ import rados
 from orchestrator import OrchestratorError, DaemonDescription
 
 from cephadm import utils
-from cephadm.services.cephadmservice import CephadmDaemonSpec, CephService
+from cephadm.services.cephadmservice import AuthEntity, CephadmDaemonSpec, CephService
 
 if TYPE_CHECKING:
     from cephadm.module import CephadmOrchestrator
@@ -49,19 +49,24 @@ class NFSService(CephService):
 
         deps: List[str] = []
 
-        # create the keyring
-        user = f'{daemon_type}.{daemon_id}'
-        keyring = self.create_keyring(daemon_spec)
+        # create the RADOS recovery pool keyring
+        rados_user = f'{daemon_type}.{daemon_id}'
+        rados_keyring = self.create_keyring(daemon_spec)
 
         # create the rados config object
         self.create_rados_config_obj(spec)
 
+        # create the RGW keyring
+        rgw_user = f'{rados_user}-rgw'
+        rgw_keyring = self.create_rgw_keyring(daemon_spec)
+
         # generate the ganesha config
         def get_ganesha_conf() -> str:
-            context = dict(user=user,
+            context = dict(user=rados_user,
                            nodeid=daemon_spec.name(),
                            pool=spec.pool,
                            namespace=spec.namespace if spec.namespace else '',
+                           rgw_user=rgw_user,
                            url=spec.rados_config_location())
             return self.mgr.template.render('services/nfs/ganesha.conf.j2', context)
 
@@ -71,7 +76,7 @@ class NFSService(CephService):
             config['pool'] = spec.pool
             if spec.namespace:
                 config['namespace'] = spec.namespace
-            config['userid'] = user
+            config['userid'] = rados_user
             config['extra_args'] = ['-N', 'NIV_EVENT']
             config['files'] = {
                 'ganesha.conf': get_ganesha_conf(),
@@ -79,35 +84,19 @@ class NFSService(CephService):
             config.update(
                 self.get_config_and_keyring(
                     daemon_type, daemon_id,
-                    keyring=keyring,
+                    keyring=rados_keyring,
                     host=host
                 )
             )
+            config['rgw'] = {
+                'cluster': 'ceph',
+                'user': rgw_user,
+                'keyring': rgw_keyring,
+            }
             logger.debug('Generated cephadm config-json: %s' % config)
             return config
 
         return get_cephadm_config(), deps
-
-    def create_keyring(self, daemon_spec: CephadmDaemonSpec) -> str:
-        assert daemon_spec.spec
-        daemon_id = daemon_spec.daemon_id
-        spec = daemon_spec.spec
-
-        entity = self.get_auth_entity(daemon_id)
-        logger.info('Create keyring: %s' % entity)
-
-        osd_caps = 'allow rw pool=%s' % (spec.pool)
-        if spec.namespace:
-            osd_caps = '%s namespace=%s' % (osd_caps, spec.namespace)
-
-        ret, keyring, err = self.mgr.check_mon_command({
-            'prefix': 'auth get-or-create',
-            'entity': entity,
-            'caps': ['mon', 'allow r',
-                     'osd', osd_caps],
-        })
-
-        return keyring
 
     def create_rados_config_obj(self,
                                 spec: NFSServiceSpec,
@@ -130,3 +119,37 @@ class NFSService(CephService):
                 # Create an empty config object
                 logger.info('Creating rados config object: %s' % obj)
                 ioctx.write_full(obj, ''.encode('utf-8'))
+
+    def create_keyring(self, daemon_spec: CephadmDaemonSpec[NFSServiceSpec]) -> str:
+        assert daemon_spec.spec
+        daemon_id = daemon_spec.daemon_id
+        spec = daemon_spec.spec
+        entity: AuthEntity = self.get_auth_entity(daemon_id)
+
+        osd_caps = 'allow rw pool=%s' % (spec.pool)
+        if spec.namespace:
+            osd_caps = '%s namespace=%s' % (osd_caps, spec.namespace)
+
+        logger.info('Create keyring: %s' % entity)
+        ret, keyring, err = self.mgr.check_mon_command({
+            'prefix': 'auth get-or-create',
+            'entity': entity,
+            'caps': ['mon', 'allow r',
+                     'osd', osd_caps],
+        })
+
+        return keyring
+
+    def create_rgw_keyring(self, daemon_spec: CephadmDaemonSpec[NFSServiceSpec]) -> str:
+        daemon_id = daemon_spec.daemon_id
+        entity: AuthEntity = self.get_auth_entity(f'{daemon_id}-rgw')
+
+        logger.info('Create keyring: %s' % entity)
+        ret, keyring, err = self.mgr.check_mon_command({
+            'prefix': 'auth get-or-create',
+            'entity': entity,
+            'caps': ['mon', 'allow r',
+                     'osd', 'allow rwx'],
+        })
+
+        return keyring

--- a/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
@@ -31,4 +31,9 @@ RADOS_URLS {
         watch_url = "{{ url }}";
 }
 
+RGW {
+        cluster = "ceph";
+        name = "client.{{ rgw_user }}";
+}
+
 %url    {{ url }}


### PR DESCRIPTION
- create an RGW keyring for NFS daemon access
- generate RGW FSAL in ganesha.conf

Fixes: https://tracker.ceph.com/issues/43686
Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
