### PR TITLE
qa/mgr: Remove _wait_for_expected_get_result

### DIFF
--- a/qa/tasks/ceph_test_case.py
+++ b/qa/tasks/ceph_test_case.py
@@ -163,8 +163,7 @@ class CephTestCase(unittest.TestCase):
 
         self.wait_until_true(is_clear, timeout)
 
-    def wait_until_equal(self, get_fn, expect_val, timeout, reject_fn=None):
-        period = 5
+    def wait_until_equal(self, get_fn, expect_val, timeout, reject_fn=None, period=5):
         elapsed = 0
         while True:
             val = get_fn()

--- a/qa/tasks/mgr/dashboard/test_cluster_configuration.py
+++ b/qa/tasks/mgr/dashboard/test_cluster_configuration.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-import time
-
 from .helper import DashboardTestCase
 
 
@@ -30,14 +28,18 @@ class ClusterConfigurationTest(DashboardTestCase):
         orig_value = self._get_config_by_name(config_name)
 
         self._ceph_cmd(['config', 'set', 'mon', config_name, 'true'])
-        result = self._wait_for_expected_get_result(self._get_config_by_name, config_name,
-                                                    [{'section': 'mon', 'value': 'true'}])
-        self.assertEqual(result, [{'section': 'mon', 'value': 'true'}])
+        self.wait_until_equal(
+                    lambda: self._get_config_by_name(config_name),
+                    [{'section': 'mon', 'value': 'true'}],
+                    timeout=30,
+                    period=1)
 
         self._ceph_cmd(['config', 'set', 'mon', config_name, 'false'])
-        result = self._wait_for_expected_get_result(self._get_config_by_name, config_name,
-                                                    [{'section': 'mon', 'value': 'false'}])
-        self.assertEqual(result, [{'section': 'mon', 'value': 'false'}])
+        self.wait_until_equal(
+                    lambda: self._get_config_by_name(config_name),
+                    [{'section': 'mon', 'value': 'false'}],
+                    timeout=30,
+                    period=1)
 
         # restore value
         if orig_value:
@@ -87,9 +89,11 @@ class ClusterConfigurationTest(DashboardTestCase):
             'value': expected_result
         })
         self.assertStatus(201)
-        result = self._wait_for_expected_get_result(self._get_config_by_name, config_name,
-                                                    expected_result)
-        self.assertEqual(result, expected_result)
+        self.wait_until_equal(
+                    lambda: self._get_config_by_name(config_name),
+                    expected_result,
+                    timeout=30,
+                    period=1)
 
         # reset original value
         self._clear_all_values_for_config_option(config_name)
@@ -106,13 +110,20 @@ class ClusterConfigurationTest(DashboardTestCase):
             'value': expected_result
         })
         self.assertStatus(201)
-        self._wait_for_expected_get_result(self._get_config_by_name, config_name, expected_result)
+        self.wait_until_equal(
+                    lambda: self._get_config_by_name(config_name),
+                    expected_result,
+                    timeout=30,
+                    period=1)
 
         # delete it and check if it's deleted
         self._delete('/api/cluster_conf/{}?section={}'.format(config_name, 'mon'))
         self.assertStatus(204)
-        result = self._wait_for_expected_get_result(self._get_config_by_name, config_name, None)
-        self.assertEqual(result, None)
+        self.wait_until_equal(
+                    lambda: self._get_config_by_name(config_name),
+                    None,
+                    timeout=30,
+                    period=1)
 
         # reset original value
         self._clear_all_values_for_config_option(config_name)
@@ -135,9 +146,11 @@ class ClusterConfigurationTest(DashboardTestCase):
                              config_name))
 
         # check if config option value is still the original one
-        result = self._wait_for_expected_get_result(self._get_config_by_name, config_name,
-                                                    orig_value)
-        self.assertEqual(result, orig_value)
+        self.wait_until_equal(
+                    lambda: self._get_config_by_name(config_name),
+                    orig_value,
+                    timeout=30,
+                    period=1)
 
     def test_create_two_values(self):
         config_name = 'debug_ms'
@@ -154,9 +167,11 @@ class ClusterConfigurationTest(DashboardTestCase):
             'value': expected_result
         })
         self.assertStatus(201)
-        result = self._wait_for_expected_get_result(self._get_config_by_name, config_name,
-                                                    expected_result)
-        self.assertEqual(result, expected_result)
+        self.wait_until_equal(
+                    lambda: self._get_config_by_name(config_name),
+                    expected_result,
+                    timeout=30,
+                    period=1)
 
         # reset original value
         self._clear_all_values_for_config_option(config_name)
@@ -177,9 +192,11 @@ class ClusterConfigurationTest(DashboardTestCase):
         self.assertStatus(201)
 
         expected_result = [{'section': 'mon', 'value': '0/3'}]
-        result = self._wait_for_expected_get_result(self._get_config_by_name, config_name,
-                                                    expected_result)
-        self.assertEqual(result, expected_result)
+        self.wait_until_equal(
+                    lambda: self._get_config_by_name(config_name),
+                    expected_result,
+                    timeout=30,
+                    period=1)
 
         # reset original value
         self._clear_all_values_for_config_option(config_name)
@@ -199,9 +216,11 @@ class ClusterConfigurationTest(DashboardTestCase):
             'value': [{'section': 'mon', 'value': True}]})
         self.assertStatus(201)
 
-        result = self._wait_for_expected_get_result(self._get_config_by_name, config_name,
-                                                    expected_result)
-        self.assertEqual(result, expected_result)
+        self.wait_until_equal(
+                    lambda: self._get_config_by_name(config_name),
+                    expected_result,
+                    timeout=30,
+                    period=1)
 
         # reset original value
         self._clear_all_values_for_config_option(config_name)
@@ -226,9 +245,11 @@ class ClusterConfigurationTest(DashboardTestCase):
         self.assertStatus(200)
 
         for config_name, value in expected_result.items():
-            result = self._wait_for_expected_get_result(self._get_config_by_name, config_name,
-                                                        [value])
-            self.assertEqual(result, [value])
+            self.wait_until_equal(
+                        lambda: self._get_config_by_name(config_name),
+                        [value],
+                        timeout=30,
+                        period=1)
 
             # reset original value
             self._clear_all_values_for_config_option(config_name)
@@ -254,9 +275,11 @@ class ClusterConfigurationTest(DashboardTestCase):
 
         # check if config option values are still the original ones
         for config_name, value in orig_values.items():
-            result = self._wait_for_expected_get_result(self._get_config_by_name, config_name,
-                                                        value)
-            self.assertEqual(result, value)
+            self.wait_until_equal(
+                        lambda: self._get_config_by_name(config_name),
+                        value,
+                        timeout=30,
+                        period=1)
 
     def test_bulk_set_cant_update_at_runtime_partial(self):
         config_options = {
@@ -278,9 +301,11 @@ class ClusterConfigurationTest(DashboardTestCase):
 
         # check if config option values are still the original ones
         for config_name, value in orig_values.items():
-            result = self._wait_for_expected_get_result(self._get_config_by_name, config_name,
-                                                        value)
-            self.assertEqual(result, value)
+            self.wait_until_equal(
+                        lambda: self._get_config_by_name(config_name),
+                        value,
+                        timeout=30,
+                        period=1)
 
     def test_check_existence(self):
         """
@@ -354,18 +379,6 @@ class ClusterConfigurationTest(DashboardTestCase):
                 self.assertIsInstance(entry, dict)
                 self.assertIn('section', entry)
                 self.assertIn('value', entry)
-
-    def _wait_for_expected_get_result(self, get_func, get_params, expected_result, max_attempts=30,
-                                      sleep_time=1):
-        attempts = 0
-        while attempts < max_attempts:
-            get_result = get_func(get_params)
-            if get_result == expected_result:
-                self.assertStatus(200)
-                return get_result
-
-            time.sleep(sleep_time)
-            attempts += 1
 
     def _get_config_by_name(self, conf_name):
         data = self._get('/api/cluster_conf/{}'.format(conf_name))


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47793

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
