### PR TITLE
octopus: qa/suites/rados: do not test with el7

### DIFF
--- a/qa/suites/rados/cephadm/smoke/distro/centos_7.yaml
+++ b/qa/suites/rados/cephadm/smoke/distro/centos_7.yaml
@@ -1,1 +1,0 @@
-.qa/distros/all/centos_7.yaml

--- a/qa/suites/rados/cephadm/smoke/distro/rhel_7.yaml
+++ b/qa/suites/rados/cephadm/smoke/distro/rhel_7.yaml
@@ -1,1 +1,0 @@
-.qa/distros/all/rhel_7.yaml


### PR DESCRIPTION
Without special filtering, it's not possible to schedule a teuthology suite on an octopus-based brach, if any yaml in the suite refers to centos_7 or rhel_7. This is because Shaman does not build centos 7 packages for Octopus anymore.

Fixes: https://tracker.ceph.com/issues/47796
