### PR TITLE
nautilus: test/librados: fix endian bugs in checksum test cases

### DIFF
--- a/src/test/librados/c_read_operations.cc
+++ b/src/test/librados/c_read_operations.cc
@@ -381,7 +381,7 @@ TEST_F(CReadOpsTest, Checksum) {
 
   {
     rados_read_op_t op = rados_create_read_op();
-    uint64_t init_value = -1;
+    ceph_le64 init_value = init_le64(-1);
     rados_read_op_checksum(op, LIBRADOS_CHECKSUM_TYPE_XXHASH64,
 			   reinterpret_cast<char *>(&init_value),
 			   sizeof(init_value), 0, len, 0, NULL, 0, NULL);
@@ -390,8 +390,8 @@ TEST_F(CReadOpsTest, Checksum) {
   }
 
   {
-    uint32_t init_value = -1;
-    uint32_t crc[2];
+    ceph_le32 init_value = init_le32(-1);
+    ceph_le32 crc[2];
     rados_read_op_t op = rados_create_read_op();
     rados_read_op_checksum(op, LIBRADOS_CHECKSUM_TYPE_CRC32C,
 			   reinterpret_cast<char *>(&init_value),
@@ -407,7 +407,7 @@ TEST_F(CReadOpsTest, Checksum) {
   }
 
   {
-    uint32_t init_value = -1;
+    ceph_le32 init_value = init_le32(-1);
     int rval;
     rados_read_op_t op = rados_create_read_op();
     rados_read_op_checksum(op, LIBRADOS_CHECKSUM_TYPE_XXHASH32,
@@ -419,8 +419,8 @@ TEST_F(CReadOpsTest, Checksum) {
   }
 
   {
-    uint32_t init_value = -1;
-    uint32_t crc[3];
+    ceph_le32 init_value = init_le32(-1);
+    ceph_le32 crc[3];
     int rval;
     rados_read_op_t op = rados_create_read_op();
     rados_read_op_checksum(op, LIBRADOS_CHECKSUM_TYPE_CRC32C,

--- a/src/test/librados/io.cc
+++ b/src/test/librados/io.cc
@@ -111,8 +111,8 @@ TEST_F(LibRadosIo, Checksum) {
 
   uint32_t expected_crc = ceph_crc32c(-1, reinterpret_cast<const uint8_t*>(buf),
                                       sizeof(buf));
-  uint32_t init_value = -1;
-  uint32_t crc[2];
+  ceph_le32 init_value = init_le32(-1);
+  ceph_le32 crc[2];
   ASSERT_EQ(0, rados_checksum(ioctx, "foo", LIBRADOS_CHECKSUM_TYPE_CRC32C,
 			      reinterpret_cast<char*>(&init_value),
 			      sizeof(init_value), sizeof(buf), 0, 0,

--- a/src/test/librados/misc_cxx.cc
+++ b/src/test/librados/misc_cxx.cc
@@ -707,11 +707,11 @@ public:
 
 typedef ::testing::Types<
     LibRadosChecksumParams<LIBRADOS_CHECKSUM_TYPE_XXHASH32,
-			   Checksummer::xxhash32, uint32_t>,
+			   Checksummer::xxhash32, ceph_le32>,
     LibRadosChecksumParams<LIBRADOS_CHECKSUM_TYPE_XXHASH64,
-			   Checksummer::xxhash64, uint64_t>,
+			   Checksummer::xxhash64, ceph_le64>,
     LibRadosChecksumParams<LIBRADOS_CHECKSUM_TYPE_CRC32C,
-			   Checksummer::crc32c, uint32_t>
+			   Checksummer::crc32c, ceph_le32>
   > LibRadosChecksumTypes;
 
 TYPED_TEST_CASE(LibRadosChecksum, LibRadosChecksumTypes);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47803

---

backport of https://github.com/ceph/ceph/pull/37215
parent tracker: https://tracker.ceph.com/issues/47516

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh