### PR TITLE
Revert "rpm: on SUSE, podman is required for cephadm to work" and "spec: Podman (temporarily) requires apparmor-abstractions on suse"

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -386,9 +386,6 @@ Base is the package that includes all the files shared amongst ceph servers
 %package -n cephadm
 Summary:        Utility to bootstrap Ceph clusters
 Requires:       lvm2
-%if 0%{?suse_version}
-Requires:       apparmor-abstractions
-%endif
 Requires:       python%{python3_pkgversion}
 %if 0%{?weak_deps}
 Recommends:     podman

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -388,13 +388,10 @@ Summary:        Utility to bootstrap Ceph clusters
 Requires:       lvm2
 %if 0%{?suse_version}
 Requires:       apparmor-abstractions
-Requires:       podman
 %endif
 Requires:       python%{python3_pkgversion}
-%if ! 0%{?suse_version}
 %if 0%{?weak_deps}
 Recommends:     podman
-%endif
 %endif
 %description -n cephadm
 Utility to bootstrap a Ceph cluster and manage Ceph daemons deployed 


### PR DESCRIPTION
This reverts commit 009ade0c3ea624ecf47c8a3f9d1673b342e967cc.

`Requires: podman` causes podman to get included in the container image, and it's not needed on SUSE after all.

Signed-off-by: Nathan Cutler <ncutler@suse.com>

---

Revert "spec: Podman (temporarily) requires apparmor-abstractions on suse"

This reverts commit 070e5c3e35ea476815ff9fa4f71aed147fe1ea79.

This commit was working around a bug that was present in old (pre-1.8.0)
versions of podman. Since we are no longer running cephadm with versions
that old, we can safely drop this workaround.

Fixes: https://tracker.ceph.com/issues/47862
Signed-off-by: Nathan Cutler <ncutler@suse.com>
