### PR TITLE
doc/cephfs: updated top-level links

### DIFF
--- a/doc/cephfs/additional-details-overview.rst
+++ b/doc/cephfs/additional-details-overview.rst
@@ -1,3 +1,7 @@
+==================
+Additional Details
+==================
+
 This page links to information about experimental features and other matters that don't fit neatly into the other categories in the CephFS Guide.
 
 

--- a/doc/cephfs/additional-details-overview.rst
+++ b/doc/cephfs/additional-details-overview.rst
@@ -1,0 +1,9 @@
+This page links to information about experimental features and other matters that don't fit neatly into the other categories in the CephFS Guide.
+
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+    Experimental Features <experimental-features>
+

--- a/doc/cephfs/admin-overview.rst
+++ b/doc/cephfs/admin-overview.rst
@@ -1,0 +1,23 @@
+==============
+Administration
+==============
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+    Create a CephFS file system <createfs>
+    Administrative commands <administration>
+	Provision/Add/Remove MDS(s) <add-remove-mds>
+    MDS failover and standby configuration <standby>
+    MDS Cache Size Limits <cache-size-limits>
+    MDS Configuration Settings <mds-config-ref>
+    Manual: ceph-mds <../../man/8/ceph-mds>
+    Export over NFS <nfs>
+    Export over NFS with volume nfs interface <fs-nfs-exports>
+    Application best practices <app-best-practices>
+    FS volume and subvolumes <fs-volumes>
+    CephFS Quotas <quota>
+    Health messages <health-messages>
+    Upgrading old file systems <upgrading>
+

--- a/doc/cephfs/administration.rst
+++ b/doc/cephfs/administration.rst
@@ -3,6 +3,24 @@
 CephFS Administrative commands
 ==============================
 
+.. toctree:: 
+   :maxdepth: 1
+   :hidden:
+
+    Create a CephFS file system <createfs>
+	Provision/Add/Remove MDS(s) <add-remove-mds>
+    MDS failover and standby configuration <standby>
+    MDS Cache Size Limits <cache-size-limits>
+    MDS Configuration Settings <mds-config-ref>
+    Manual: ceph-mds <../../man/8/ceph-mds>
+    Export over NFS <nfs>
+    Export over NFS with volume nfs interface <fs-nfs-exports>
+    Application best practices <app-best-practices>
+    FS volume and subvolumes <fs-volumes>
+    CephFS Quotas <quota>
+    Health messages <health-messages>
+    Upgrading old file systems <upgrading>
+
 File Systems
 ------------
 
@@ -385,30 +403,3 @@ This removes a rank from the failed set.
 This command resets the file system state to defaults, except for the name and
 pools. Non-zero ranks are saved in the stopped set.
 
-.. toctree::
-   :hidden:
-   :maxdepth: 1
-
-    Create a CephFS file system <createfs>
-    Provision/Add/Remove MDS(s) <add-remove-mds>
-    MDS failover and standby configuration <standby>
-    MDS Cache Size Limits <cache-size-limits>
-    MDS Configuration Settings <mds-config-ref>
-    Manual: ceph-mds <../../man/8/ceph-mds>
-    Export over NFS <nfs>
-    Export over NFS with volume nfs interface <fs-nfs-exports>
-    Application best practices <app-best-practices>
-    FS volume and subvolumes <fs-volumes>
-    CephFS Quotas <quota>
-    Health messages <health-messages>
-    Upgrading old file systems <upgrading>
-    Ceph File System IO Path <cephfs-io-path>
-    Configuring Directory Fragmentation <dirfrags>
-    Dynamic Metadata Management <dynamic-metadata-management>
-    File Layouts <file-layouts>
-    LazyIO <lazyio>
-    CephFS Distributed Metada Cache <mdcache>
-    MDS Journaling <mds-journaling>
-    MDS States <mds-states>
-    Configuring Multiple Active MDS Daemons <multimds>
-    Differences from POSIX <posix>

--- a/doc/cephfs/administration.rst
+++ b/doc/cephfs/administration.rst
@@ -384,3 +384,31 @@ This removes a rank from the failed set.
 
 This command resets the file system state to defaults, except for the name and
 pools. Non-zero ranks are saved in the stopped set.
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+    Create a CephFS file system <createfs>
+    Provision/Add/Remove MDS(s) <add-remove-mds>
+    MDS failover and standby configuration <standby>
+    MDS Cache Size Limits <cache-size-limits>
+    MDS Configuration Settings <mds-config-ref>
+    Manual: ceph-mds <../../man/8/ceph-mds>
+    Export over NFS <nfs>
+    Export over NFS with volume nfs interface <fs-nfs-exports>
+    Application best practices <app-best-practices>
+    FS volume and subvolumes <fs-volumes>
+    CephFS Quotas <quota>
+    Health messages <health-messages>
+    Upgrading old file systems <upgrading>
+    Ceph File System IO Path <cephfs-io-path>
+    Configuring Directory Fragmentation <dirfrags>
+    Dynamic Metadata Management <dynamic-metadata-management>
+    File Layouts <file-layouts>
+    LazyIO <lazyio>
+    CephFS Distributed Metada Cache <mdcache>
+    MDS Journaling <mds-journaling>
+    MDS States <mds-states>
+    Configuring Multiple Active MDS Daemons <multimds>
+    Differences from POSIX <posix>

--- a/doc/cephfs/cephfs-concepts-overview.rst
+++ b/doc/cephfs/cephfs-concepts-overview.rst
@@ -1,0 +1,13 @@
+The pages here explain basic CephFS concepts.
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+    Client eviction <eviction>
+    Scrubbing the File System <scrub>
+    Handling full file systems <full>
+    Metadata repair <disaster-recovery-experts>
+    Troubleshooting <troubleshooting>
+    Disaster recovery <disaster-recovery>
+    cephfs-journal-tool <cephfs-journal-tool>

--- a/doc/cephfs/cephfs-concepts-overview.rst
+++ b/doc/cephfs/cephfs-concepts-overview.rst
@@ -1,13 +1,20 @@
-The pages here explain basic CephFS concepts.
+===============
+CephFS Concepts
+===============
 
 .. toctree::
-   :hidden:
    :maxdepth: 1
+   :hidden:
 
-    Client eviction <eviction>
-    Scrubbing the File System <scrub>
-    Handling full file systems <full>
-    Metadata repair <disaster-recovery-experts>
-    Troubleshooting <troubleshooting>
-    Disaster recovery <disaster-recovery>
-    cephfs-journal-tool <cephfs-journal-tool>
+    MDS States <mds-states>
+    POSIX compatibility <posix>
+    MDS Journaling <mds-journaling>
+    File layouts <file-layouts>
+    Distributed Metadata Cache <mdcache>
+    Dynamic Metadata Management in CephFS <dynamic-metadata-management>
+    CephFS IO Path <cephfs-io-path>
+    LazyIO <lazyio>
+    Directory fragmentation <dirfrags>
+    Multiple active MDS daemons <multimds>
+
+The pages here explain basic CephFS concepts.

--- a/doc/cephfs/dev-guides-overview.rst
+++ b/doc/cephfs/dev-guides-overview.rst
@@ -1,0 +1,11 @@
+The pages here are developer guides for CephFS.
+
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+    Journaler Configuration <journaler>
+    Client's Capabilities <capabilities>
+    Java and Python bindings <api/index>
+    Mantle <mantle>

--- a/doc/cephfs/dev-guides-overview.rst
+++ b/doc/cephfs/dev-guides-overview.rst
@@ -1,3 +1,7 @@
+================
+Developer Guides
+================
+
 The pages here are developer guides for CephFS.
 
 

--- a/doc/cephfs/getting-started.rst
+++ b/doc/cephfs/getting-started.rst
@@ -1,0 +1,26 @@
+===========================
+Getting Started with CephFS
+===========================
+
+For most deployments of Ceph, setting up a CephFS file system is as simple as:
+
+.. code:: bash
+
+    ceph fs volume create <fs name>
+
+The Ceph `Orchestrator`_  will automatically create and configure MDS for
+your file system if the back-end deployment technology supports it (see
+`Orchestrator deployment table`_). Otherwise, please `deploy MDS manually
+as needed`_.
+
+Finally, to mount CephFS on your client nodes, see `Mount CephFS:
+Prerequisites`_ page. Additionally, a command-line shell utility is available
+for interactive access or scripting via the `cephfs-shell`_.
+
+.. _cephfs-administration: administration
+.. _Orchestrator: ../mgr/orchestrator
+.. _deploy MDS manually as needed: add-remove-mds
+.. _Orchestrator deployment table: ../mgr/orchestrator/#current-implementation-status
+.. _Mount CephFS\: Prerequisites: mount-prerequisites
+.. _cephfs-shell: cephfs-shell
+

--- a/doc/cephfs/index.rst
+++ b/doc/cephfs/index.rst
@@ -53,155 +53,25 @@ Finally, to mount CephFS on your client nodes, see `Mount CephFS:
 Prerequisites`_ page. Additionally, a command-line shell utility is available
 for interactive access or scripting via the `cephfs-shell`_.
 
+.. _cephfs-administration: administration
 .. _Orchestrator: ../mgr/orchestrator
 .. _deploy MDS manually as needed: add-remove-mds
 .. _Orchestrator deployment table: ../mgr/orchestrator/#current-implementation-status
 .. _Mount CephFS\: Prerequisites: mount-prerequisites
 .. _cephfs-shell: cephfs-shell
 
-
-.. raw:: html
-
-   <!---
-
-Administration
-^^^^^^^^^^^^^^
-
-.. raw:: html
-
-   --->
-
 .. toctree:: 
-   :maxdepth: 1
+   :maxdepth: 2
    :hidden:
+    
+    Administration <administration>
 
-    Create a CephFS file system <createfs>
-    Administrative commands <administration>
-	Provision/Add/Remove MDS(s) <add-remove-mds>
-    MDS failover and standby configuration <standby>
-    MDS Cache Size Limits <cache-size-limits>
-    MDS Configuration Settings <mds-config-ref>
-    Manual: ceph-mds <../../man/8/ceph-mds>
-    Export over NFS <nfs>
-    Export over NFS with volume nfs interface <fs-nfs-exports>
-    Application best practices <app-best-practices>
-    FS volume and subvolumes <fs-volumes>
-    CephFS Quotas <quota>
-    Health messages <health-messages>
-    Upgrading old file systems <upgrading>
+    Mounting CephFS <mounting-cephfs-overview>
 
+    CephFS Concepts <cephfs-concepts-overview>
 
-.. raw:: html
+    Troubleshooting and Disaster Recovery <troubleshooting-overview>
 
-   <!---
+    Developer Guide <dev-guides-overview>
 
-Mounting CephFS
-^^^^^^^^^^^^^^^
-
-.. raw:: html
-
-   --->
-
-.. toctree:: 
-   :maxdepth: 1
-   :hidden:
-
-    Client Configuration Settings <client-config-ref>
-    Client Authentication <client-auth>
-    Mount CephFS: Prerequisites <mount-prerequisites>
-    Mount CephFS using Kernel Driver <mount-using-kernel-driver>
-    Mount CephFS using FUSE <mount-using-fuse>
-    Use the CephFS Shell <cephfs-shell>
-    Supported Features of Kernel Driver <kernel-features>
-    Manual: ceph-fuse <../../man/8/ceph-fuse>
-    Manual: mount.ceph <../../man/8/mount.ceph>
-    Manual: mount.fuse.ceph <../../man/8/mount.fuse.ceph>
-
-
-.. raw:: html
-
-   <!---
-
-CephFS Concepts
-^^^^^^^^^^^^^^^
-
-.. raw:: html
-
-   --->
-
-.. toctree:: 
-   :maxdepth: 1
-   :hidden:
-
-    MDS States <mds-states>
-    POSIX compatibility <posix>
-    MDS Journaling <mds-journaling>
-    File layouts <file-layouts>
-    Distributed Metadata Cache <mdcache>
-    Dynamic Metadata Management in CephFS <dynamic-metadata-management>
-    CephFS IO Path <cephfs-io-path>
-    LazyIO <lazyio>
-    Directory fragmentation <dirfrags>
-    Multiple active MDS daemons <multimds>
-
-
-.. raw:: html
-
-   <!---
-
-Troubleshooting and Disaster Recovery
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. raw:: html
-
-   --->
-
-.. toctree:: 
-   :hidden:
-
-    Client eviction <eviction>
-    Scrubbing the File System <scrub>
-    Handling full file systems <full>
-    Metadata repair <disaster-recovery-experts>
-    Troubleshooting <troubleshooting>
-    Disaster recovery <disaster-recovery>
-    cephfs-journal-tool <cephfs-journal-tool>
-
-
-.. raw:: html
-
-   <!---
-
-Developer Guides
-^^^^^^^^^^^^^^^^
-
-.. raw:: html
-
-   --->
-
-.. toctree:: 
-   :maxdepth: 1
-   :hidden:
-
-    Journaler Configuration <journaler>
-    Client's Capabilities <capabilities>
-    Java and Python bindings <api/index>
-    Mantle <mantle>
-
-
-.. raw:: html
-
-   <!---
-
-Additional Details
-^^^^^^^^^^^^^^^^^^
-
-.. raw:: html
-
-   --->
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-    Experimental Features <experimental-features>
+    Additional Details <additional-details-overview>

--- a/doc/cephfs/index.rst
+++ b/doc/cephfs/index.rst
@@ -9,8 +9,8 @@
    :hidden:
 
     Getting Started with CephFS <getting-started>
-    
-    Administration <administration>
+
+    Administration <admin-overview>
 
     Mounting CephFS <mounting-cephfs-overview>
     
@@ -52,4 +52,4 @@ Ceph and was once the primary use-case for RADOS.  Now it is joined by two
 other storage interfaces to form a modern unified storage system: RBD (Ceph
 Block Devices) and RGW (Ceph Object Storage Gateway).
 
-
+.. include:: ./getting-started.rst

--- a/doc/cephfs/index.rst
+++ b/doc/cephfs/index.rst
@@ -4,6 +4,24 @@
  Ceph File System
 =================
 
+.. toctree:: 
+   :maxdepth: 2
+   :hidden:
+
+    Getting Started with CephFS <getting-started>
+    
+    Administration <administration>
+
+    Mounting CephFS <mounting-cephfs-overview>
+    
+    CephFS Concepts <cephfs-concepts-overview>
+
+    Troubleshooting and Disaster Recovery <troubleshooting-overview>
+       
+    Developer Guide <dev-guides-overview>
+
+    Additional Details <additional-details-overview>
+
 The Ceph File System, or **CephFS**, is a POSIX-compliant file system built on
 top of Ceph's distributed object store, **RADOS**. CephFS endeavors to provide
 a state-of-the-art, multi-use, highly available, and performant file store for
@@ -35,43 +53,3 @@ other storage interfaces to form a modern unified storage system: RBD (Ceph
 Block Devices) and RGW (Ceph Object Storage Gateway).
 
 
-Getting Started with CephFS
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-For most deployments of Ceph, setting up a CephFS file system is as simple as:
-
-.. code:: bash
-
-    ceph fs volume create <fs name>
-
-The Ceph `Orchestrator`_  will automatically create and configure MDS for
-your file system if the back-end deployment technology supports it (see
-`Orchestrator deployment table`_). Otherwise, please `deploy MDS manually
-as needed`_.
-
-Finally, to mount CephFS on your client nodes, see `Mount CephFS:
-Prerequisites`_ page. Additionally, a command-line shell utility is available
-for interactive access or scripting via the `cephfs-shell`_.
-
-.. _cephfs-administration: administration
-.. _Orchestrator: ../mgr/orchestrator
-.. _deploy MDS manually as needed: add-remove-mds
-.. _Orchestrator deployment table: ../mgr/orchestrator/#current-implementation-status
-.. _Mount CephFS\: Prerequisites: mount-prerequisites
-.. _cephfs-shell: cephfs-shell
-
-.. toctree:: 
-   :maxdepth: 2
-   :hidden:
-    
-    Administration <administration>
-
-    Mounting CephFS <mounting-cephfs-overview>
-
-    CephFS Concepts <cephfs-concepts-overview>
-
-    Troubleshooting and Disaster Recovery <troubleshooting-overview>
-
-    Developer Guide <dev-guides-overview>
-
-    Additional Details <additional-details-overview>

--- a/doc/cephfs/mounting-cephfs-overview.rst
+++ b/doc/cephfs/mounting-cephfs-overview.rst
@@ -1,0 +1,21 @@
+========================
+Mounting CephFS Overview
+========================
+
+The pages in this section explain matters related to mounting CephFS.
+
+.. toctree:: 
+   :maxdepth: 1
+   :hidden:
+
+    Client Configuration Settings <client-config-ref>
+    Client Authentication <client-auth>
+    Mount CephFS: Prerequisites <mount-prerequisites>
+    Mount CephFS using Kernel Driver <mount-using-kernel-driver>
+    Mount CephFS using FUSE <mount-using-fuse>
+    Use the CephFS Shell <cephfs-shell>
+    Supported Features of Kernel Driver <kernel-features>
+    Manual: ceph-fuse <../../man/8/ceph-fuse>
+    Manual: mount.ceph <../../man/8/mount.ceph>
+    Manual: mount.fuse.ceph <../../man/8/mount.fuse.ceph>
+

--- a/doc/cephfs/troubleshooting-overview.rst
+++ b/doc/cephfs/troubleshooting-overview.rst
@@ -1,18 +1,20 @@
-The pages here explain matters related to troubleshooting and disaster recovery.
-
+=====================================
+Troubleshooting and Disaster Recovery
+=====================================
 
 .. toctree:: 
    :maxdepth: 1
    :hidden:
 
-    Client Configuration Settings <client-config-ref>
-    Client Authentication <client-auth>
-    Mount CephFS: Prerequisites <mount-prerequisites>
-    Mount CephFS using Kernel Driver <mount-using-kernel-driver>
-    Mount CephFS using FUSE <mount-using-fuse>
-    Use the CephFS Shell <cephfs-shell>
-    Supported Features of Kernel Driver <kernel-features>
-    Manual: ceph-fuse <../../man/8/ceph-fuse>
-    Manual: mount.ceph <../../man/8/mount.ceph>
-    Manual: mount.fuse.ceph <../../man/8/mount.fuse.ceph>
+    Client eviction <eviction>
+    Scrubbing the File System <scrub>
+    Handling full file systems <full>
+    Metadata repair <disaster-recovery-experts>
+    Troubleshooting <troubleshooting>
+    Disaster recovery <disaster-recovery>
+    cephfs-journal-tool <cephfs-journal-tool>
+
+
+
+The pages here explain matters related to troubleshooting and disaster recovery.
 

--- a/doc/cephfs/troubleshooting-overview.rst
+++ b/doc/cephfs/troubleshooting-overview.rst
@@ -1,0 +1,18 @@
+The pages here explain matters related to troubleshooting and disaster recovery.
+
+
+.. toctree:: 
+   :maxdepth: 1
+   :hidden:
+
+    Client Configuration Settings <client-config-ref>
+    Client Authentication <client-auth>
+    Mount CephFS: Prerequisites <mount-prerequisites>
+    Mount CephFS using Kernel Driver <mount-using-kernel-driver>
+    Mount CephFS using FUSE <mount-using-fuse>
+    Use the CephFS Shell <cephfs-shell>
+    Supported Features of Kernel Driver <kernel-features>
+    Manual: ceph-fuse <../../man/8/ceph-fuse>
+    Manual: mount.ceph <../../man/8/mount.ceph>
+    Manual: mount.fuse.ceph <../../man/8/mount.fuse.ceph>
+


### PR DESCRIPTION
Top-level links weren't working, so I collected
them into .rst pages that act like target nodes,
and now the structure of the book is a bit more
evident and foregrounded than it was. It's
quite possible that we might want to alter this
arrangement of the TOC so that it exposes less
stuff, but at the very least this fixes the
problem of links going nowhere.

Fixes: https://tracker.ceph.com/issues/45344
Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
