### PR TITLE
mds: ignore sequence values on REQUEST_CLOSE

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -730,21 +730,6 @@ void Server::handle_client_session(const cref_t<MClientSession> &m)
       ceph_assert(session->is_open() || 
 	     session->is_stale() || 
 	     session->is_opening());
-      if (m->get_seq() < session->get_push_seq()) {
-	dout(10) << "old push seq " << m->get_seq() << " < " << session->get_push_seq() 
-		 << ", dropping" << dendl;
-	return;
-      }
-      // We are getting a seq that is higher than expected.
-      // Handle the same as any other seqn error.
-      //
-      if (m->get_seq() != session->get_push_seq()) {
-	dout(0) << "old push seq " << m->get_seq() << " != " << session->get_push_seq()
-		<< ", BUGGY!" << dendl;
-	mds->clog->warn() << "incorrect push seq " << m->get_seq() << " != "
-			  << session->get_push_seq() << ", dropping" << " from client : " << session->get_human_name();
-	return;
-      }
       journal_close_session(session, Session::STATE_CLOSING, NULL);
     }
     break;


### PR DESCRIPTION
When unmounting, clients send a REQUEST_CLOSE and just wait for the
reply before eventually giving up after a timeout and proceeding. If the
request crossed paths with a message from the server that bumped the seq
number, then the MDS will drop the request on the floor.

The clients never retransmit this request so the client just hangs,
sometimes even resulting in a blocklisting event when caps aren't
returned.

A REQUEST_CLOSE is an indicator that the client is unmounting. It's not
going to decide to not do that because the sequence number changed. Make
the MDS ignore the sequence on a REQUEST_CLOSE.

Fixes: https://tracker.ceph.com/issues/47563
Signed-off-by: Jeff Layton <jlayton@redhat.com>
