### PR TITLE
octopus: mgr/dashboard: get rgw daemon zonegroup name from mgr

### DIFF
--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -12,11 +12,11 @@ from ..exceptions import DashboardException
 from ..settings import Settings, Options
 from ..rest_client import RestClient, RequestException
 from ..tools import build_url, dict_contains_path, json_str_to_object,\
-                    partial_dict, dict_get
+                    dict_get
 from .. import mgr
 
 try:
-    from typing import Dict, List, Optional  # pylint: disable=unused-import
+    from typing import Any, Dict, List, Optional  # pylint: disable=unused-import
 except ImportError:
     pass  # For typing only
 
@@ -31,9 +31,9 @@ class NoCredentialsException(RequestException):
             'the dashboard.')
 
 
-def _determine_rgw_addr():
+def _get_daemon_info() -> Dict[str, Any]:
     """
-    Get a RGW daemon to determine the configured host (IP address) and port.
+    Retrieve RGW daemon info from MGR.
     Note, the service id of the RGW daemons may differ depending on the setup.
     Example 1:
     {
@@ -85,6 +85,15 @@ def _determine_rgw_addr():
             break
     if daemon is None:
         raise LookupError('No RGW daemon found')
+
+    return daemon
+
+
+def _determine_rgw_addr():
+    """
+    Parse RGW daemon info to determine the configured host (IP address) and port.
+    """
+    daemon = _get_daemon_info()
 
     addr = _parse_addr(daemon['addr'])
     port, ssl = _parse_frontend_config(daemon['metadata']['frontend_config#0'])
@@ -242,16 +251,6 @@ class RgwClient(RestClient):
     def _get_daemon_zone_info(self):  # type: () -> dict
         return json_str_to_object(self.proxy('GET', 'config?type=zone', None, None))
 
-    def _get_daemon_zonegroup_map(self):  # type: () -> List[dict]
-        zonegroups = json_str_to_object(
-            self.proxy('GET', 'config?type=zonegroup-map', None, None)
-        )
-
-        return [partial_dict(
-            zonegroup['val'],
-            ['api_name', 'zones']
-        ) for zonegroup in zonegroups['zonegroups']]
-
     def _get_realms_info(self):  # type: () -> dict
         return json_str_to_object(self.proxy('GET', 'realm?list', None, None))
 
@@ -334,6 +333,8 @@ class RgwClient(RestClient):
 
         # If user ID is not set, then try to get it via the RGW Admin Ops API.
         self.userid = userid if userid else self._get_user_id(self.admin_path)  # type: str
+
+        self._zonegroup_name: str = _get_daemon_info()['metadata']['zonegroup_name']
 
         logger.info("Created new connection: user=%s, host=%s, port=%s, ssl=%d, sslverify=%d",
                     self.userid, host, port, ssl, ssl_verify)
@@ -473,16 +474,6 @@ class RgwClient(RestClient):
 
     def get_placement_targets(self):  # type: () -> dict
         zone = self._get_daemon_zone_info()
-        # A zone without realm id can only belong to default zonegroup.
-        zonegroup_name = 'default'
-        if zone['realm_id']:
-            zonegroup_map = self._get_daemon_zonegroup_map()
-            for zonegroup in zonegroup_map:
-                for realm_zone in zonegroup['zones']:
-                    if realm_zone['id'] == zone['id']:
-                        zonegroup_name = zonegroup['api_name']
-                        break
-
         placement_targets = []  # type: List[Dict]
         for placement_pool in zone['placement_pools']:
             placement_targets.append(
@@ -492,7 +483,7 @@ class RgwClient(RestClient):
                 }
             )
 
-        return {'zonegroup': zonegroup_name, 'placement_targets': placement_targets}
+        return {'zonegroup': self._zonegroup_name, 'placement_targets': placement_targets}
 
     def get_realms(self):  # type: () -> List
         realms_info = self._get_realms_info()

--- a/src/pybind/mgr/dashboard/tests/test_rgw_client.py
+++ b/src/pybind/mgr/dashboard/tests/test_rgw_client.py
@@ -12,6 +12,16 @@ from ..settings import Settings
 from . import KVStoreMockMixin
 
 
+def _dummy_daemon_info():
+    return {
+        'addr': '172.20.0.2:0/256594694',
+        'metadata': {
+            'zonegroup_name': 'zonegroup2-realm1'
+        }
+    }
+
+
+@patch('dashboard.services.rgw_client._get_daemon_info', _dummy_daemon_info)
 class RgwClientTest(unittest.TestCase, KVStoreMockMixin):
     def setUp(self):
         RgwClient._user_instances.clear()  # pylint: disable=protected-access
@@ -34,41 +44,7 @@ class RgwClientTest(unittest.TestCase, KVStoreMockMixin):
         self.assertFalse(instance.session.verify)
 
     @patch.object(RgwClient, '_get_daemon_zone_info')
-    def test_get_placement_targets_from_default_zone(self, zone_info):
-        zone_info.return_value = {
-            'placement_pools': [
-                {
-                    'key': 'default-placement',
-                    'val': {
-                        'index_pool': 'default.rgw.buckets.index',
-                        'storage_classes': {
-                            'STANDARD': {
-                                'data_pool': 'default.rgw.buckets.data'
-                            }
-                        },
-                        'data_extra_pool': 'default.rgw.buckets.non-ec',
-                        'index_type': 0
-                    }
-                }
-            ],
-            'realm_id': ''
-        }
-
-        instance = RgwClient.admin_instance()
-        expected_result = {
-            'zonegroup': 'default',
-            'placement_targets': [
-                {
-                    'name': 'default-placement',
-                    'data_pool': 'default.rgw.buckets.data'
-                }
-            ]
-        }
-        self.assertEqual(expected_result, instance.get_placement_targets())
-
-    @patch.object(RgwClient, '_get_daemon_zone_info')
-    @patch.object(RgwClient, '_get_daemon_zonegroup_map')
-    def test_get_placement_targets_from_realm_zone(self, zonegroup_map, zone_info):
+    def test_get_placement_targets_from_zone(self, zone_info):
         zone_info.return_value = {
             'id': 'a0df30ea-4b5b-4830-b143-2bedf684663d',
             'placement_pools': [
@@ -83,34 +59,8 @@ class RgwClientTest(unittest.TestCase, KVStoreMockMixin):
                         }
                     }
                 }
-            ],
-            'realm_id': 'b5a25d1b-e7ed-4fe5-b461-74f24b8e759b'
+            ]
         }
-
-        zonegroup_map.return_value = [
-            {
-                'api_name': 'zonegroup1-realm1',
-                'zones': [
-                    {
-                        'id': '2ef7d0ef-7616-4e9c-8553-b732ebf0592b'
-                    },
-                    {
-                        'id': 'b1d15925-6c8e-408e-8485-5a62cbccfe1f'
-                    }
-                ]
-            },
-            {
-                'api_name': 'zonegroup2-realm1',
-                'zones': [
-                    {
-                        'id': '645f0f59-8fcc-4e11-95d5-24f289ee8e25'
-                    },
-                    {
-                        'id': 'a0df30ea-4b5b-4830-b143-2bedf684663d'
-                    }
-                ]
-            }
-        ]
 
         instance = RgwClient.admin_instance()
         expected_result = {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47811

---

backport of https://github.com/ceph/ceph/pull/37449
parent tracker: https://tracker.ceph.com/issues/47676

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh