### PR TITLE
cephadm: mounted directory in rbd-mirror for remote cluster info

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1887,6 +1887,12 @@ def get_container_mounts(fsid, daemon_type, daemon_id,
         if daemon_type == 'rbd-mirror' or daemon_type == 'crash':
             # these do not search for their keyrings in a data directory
             mounts[data_dir + '/keyring'] = '/etc/ceph/ceph.client.%s.%s.keyring' % (daemon_type, daemon_id)
+        if daemon_type == 'rbd-mirror':
+            remote_info_dir = os.path.join(args.data_dir, fsid, 'remote-cluster-info')
+            if not os.path.exists(remote_info_dir):
+                uid, gid = extract_uid_gid()
+                makedirs(remote_info_dir, uid, gid, 0o755)
+            mounts[remote_info_dir] = '/etc/ceph'
 
     if daemon_type in ['mon', 'osd']:
         mounts['/dev'] = '/dev'  # FIXME: narrow this down?


### PR DESCRIPTION
When you add a peer with rbd mirror it searches /etc/ceph for
the conf file and keyring for the remote directory. Since cephadm
deploys the service in a container the user would have to copy
those files into the container for it to work and those files would be
removed every time an rbd-mirror container is redeployed. This provides
a directory on the host machine that is mounted to the rbd-mirror
container the user can put those files in instead that will be persistant 
through redeploys

Signed-off-by: Adam King <adking@redhat.com>

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
