### PR TITLE
qa/tasks: add a 'parallel' option support for the cram task

### DIFF
--- a/qa/tasks/cram.py
+++ b/qa/tasks/cram.py
@@ -16,7 +16,8 @@ log = logging.getLogger(__name__)
 def task(ctx, config):
     """
     Run all cram tests from the specified paths on the specified
-    clients. Each client runs tests in parallel.
+    clients. Each client runs tests in parallel as default, and
+    you can also disable it by adding "parallel: False" option.
 
     Limitations:
     Tests must have a .t suffix. Tests with duplicate names will
@@ -33,6 +34,7 @@ def task(ctx, config):
               - qa/test2.t]
               client.1: [qa/test.t]
             branch: foo
+            parallel: False
 
     You can also run a list of cram tests on all clients::
 
@@ -55,6 +57,8 @@ def task(ctx, config):
 
     overrides = ctx.config.get('overrides', {})
     refspec = get_refspec_after_overrides(config, overrides)
+
+    _parallel = config.get('parallel', True)
 
     git_url = teuth_config.get_ceph_qa_suite_git_url()
     log.info('Pulling tests from %s ref %s', git_url, refspec)
@@ -84,9 +88,13 @@ def task(ctx, config):
                         ],
                     )
 
-        with parallel() as p:
+        if _parallel:
+            with parallel() as p:
+                for role in clients.keys():
+                    p.spawn(_run_tests, ctx, role)
+        else:
             for role in clients.keys():
-                p.spawn(_run_tests, ctx, role)
+                _run_tests(ctx, role)
     finally:
         for client, tests in clients.items():
             (remote,) = ctx.cluster.only(client).remotes.keys()


### PR DESCRIPTION
For the ceph-iscsi test case we need to run the test sequentially,
because the client tests will depend on the gateway ones.

Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
