### PR TITLE
rbd/cache: store full cache path to image metadata

### DIFF
--- a/src/librbd/cache/pwl/AbstractWriteLog.cc
+++ b/src/librbd/cache/pwl/AbstractWriteLog.cc
@@ -493,23 +493,21 @@ void AbstractWriteLog<I>::pwl_init(Context *on_finish, DeferredContexts &later) 
 
   std::string pool_name = m_image_ctx.md_ctx.get_pool_name();
   std::string log_pool_name = pwl_path + "/rbd-pwl." + pool_name + "." + m_image_ctx.id + ".pool";
-  std::string log_poolset_name = pwl_path + "/rbd-pwl." + pool_name + "." + m_image_ctx.id + ".poolset";
-  m_log_pool_config_size = max(m_cache_state->size, MIN_POOL_SIZE);
-
   m_log_pool_name = log_pool_name;
-  get_pool_name(log_poolset_name);
+
+  m_log_pool_config_size = max(m_cache_state->size, MIN_POOL_SIZE);
 
   if ((!m_cache_state->present) &&
       (access(m_log_pool_name.c_str(), F_OK) == 0)) {
-    ldout(cct, 5) << "There's an existing pool/poolset file " << m_log_pool_name
+    ldout(cct, 5) << "There's an existing pool file " << m_log_pool_name
                   << ", While there's no cache in the image metatata." << dendl;
     if (remove(m_log_pool_name.c_str()) != 0) {
-      lderr(cct) << "Failed to remove the pool/poolset file " << m_log_pool_name
+      lderr(cct) << "Failed to remove the pool file " << m_log_pool_name
                  << dendl;
       on_finish->complete(-errno);
       return;
     } else {
-      ldout(cct, 5) << "Removed the existing pool/poolset file." << dendl;
+      ldout(cct, 5) << "Removed the existing pool file." << dendl;
     }
   }
 

--- a/src/librbd/cache/pwl/AbstractWriteLog.h
+++ b/src/librbd/cache/pwl/AbstractWriteLog.h
@@ -243,7 +243,6 @@ protected:
   ImageCtxT &m_image_ctx;
 
   std::string m_log_pool_name;
-  bool m_log_is_poolset = false;
   uint64_t m_log_pool_config_size; /* Configured size of RWL */
   uint64_t m_log_pool_actual_size = 0; /* Actual size of RWL pool */
 
@@ -342,7 +341,6 @@ protected:
   virtual void initialize_pool(Context *on_finish, pwl::DeferredContexts &later) = 0;
   virtual void write_data_to_buffer(
       std::shared_ptr<pwl::WriteLogEntry> ws_entry, pwl::WriteLogPmemEntry *pmem_entry) {}
-  virtual void get_pool_name(const std::string log_poolset_name) {}
   virtual void alloc_op_log_entries(pwl::GenericLogOperations &ops) {}
   virtual bool retire_entries(const unsigned long int frees_per_tx) {return false;}
   virtual void schedule_flush_and_append(pwl::GenericLogOperationsVector &ops) {}

--- a/src/librbd/cache/pwl/ImageCacheState.cc
+++ b/src/librbd/cache/pwl/ImageCacheState.cc
@@ -6,10 +6,10 @@
 #include "librbd/cache/pwl/ImageCacheState.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/Operations.h"
-#include "common/environment.h"
-#include "common/hostname.h"
 #include "common/config_proxy.h"
 #include "common/ceph_json.h"
+#include "common/environment.h"
+#include "common/hostname.h"
 
 #undef dout_subsys
 #define dout_subsys ceph_subsys_rbd_pwl
@@ -38,9 +38,6 @@ ImageCacheState<I>::ImageCacheState(I *image_ctx) : m_image_ctx(image_ctx) {
                             << dendl;
 
   ConfigProxy &config = image_ctx->config;
-  host = ceph_get_short_hostname();
-  path = config.get_val<std::string>("rbd_rwl_path");
-  size = config.get_val<uint64_t>("rbd_rwl_size");
   log_periodic_stats = config.get_val<bool>("rbd_rwl_log_periodic_stats");
 }
 

--- a/src/librbd/cache/pwl/ImageCacheState.h
+++ b/src/librbd/cache/pwl/ImageCacheState.h
@@ -22,12 +22,12 @@ class ImageCacheState {
 private:
   ImageCtxT* m_image_ctx;
 public:
-  bool present = true;
+  bool present = false;
   bool empty = true;
   bool clean = true;
   std::string host;
   std::string path;
-  uint64_t size;
+  uint64_t size = 0;
   bool log_periodic_stats;
 
   ImageCacheState(ImageCtxT* image_ctx);

--- a/src/librbd/cache/pwl/ReplicatedWriteLog.h
+++ b/src/librbd/cache/pwl/ReplicatedWriteLog.h
@@ -82,7 +82,6 @@ protected:
       pwl::GenericLogOperationsVector &ops, bool do_early_flush) override;
   Context *construct_flush_entry_ctx(
         const std::shared_ptr<pwl::GenericLogEntry> log_entry) override;
-  void get_pool_name(const std::string log_poolset_name) override;
   void initialize_pool(Context *on_finish, pwl::DeferredContexts &later) override;
   void write_data_to_buffer(
       std::shared_ptr<pwl::WriteLogEntry> ws_entry,


### PR DESCRIPTION

This PR updates two points:
1. Remove unsupported poolset. 
2. Currently it just saves the folder. This PR is to save the full path of the cache file. 

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
