### PR TITLE
include/interval_set: do not inherit from std::iterator

### DIFF
--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -113,9 +113,15 @@ class interval_set {
     friend class interval_set;
   };
 
-  class const_iterator : public std::iterator <std::forward_iterator_tag, T>
+  class const_iterator
   {
     public:
+        using difference_type = ssize_t;
+        using value_type = const typename Map::value_type;
+        using pointer = const typename Map::value_type*;
+        using reference = const typename Map::value_type&;
+        using iterator_category = std::forward_iterator_tag;
+
         explicit const_iterator(typename Map::const_iterator iter)
           : _iter(iter)
         { }
@@ -136,7 +142,7 @@ class interval_set {
         }
 
         // Dereference this iterator to get a pair.
-        const_reference operator*() const {
+        reference operator*() const {
           return *_iter;
         }
 


### PR DESCRIPTION
std::iterator is deprecated in C++17, so drop it.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
