### PR TITLE
qa/cephfs: add session_timeout option support

### DIFF
--- a/qa/cephfs/clusters/3-mds.yaml
+++ b/qa/cephfs/clusters/3-mds.yaml
@@ -4,7 +4,8 @@ roles:
 - [client.0, client.1]
 overrides:
   ceph:
-    max_mds: 3
+    cephfs:
+      max_mds: 3
 openstack:
 - volumes: # attached to each instance
     count: 4

--- a/qa/cephfs/clusters/9-mds.yaml
+++ b/qa/cephfs/clusters/9-mds.yaml
@@ -4,7 +4,8 @@ roles:
 - [client.0, client.1]
 overrides:
   ceph:
-    max_mds: 9
+    cephfs:
+      max_mds: 9
 openstack:
 - volumes: # attached to each instance
     count: 4

--- a/qa/cephfs/overrides/session_timeout.yaml
+++ b/qa/cephfs/overrides/session_timeout.yaml
@@ -1,0 +1,4 @@
+overrides:
+  ceph:
+    cephfs:
+      session_timeout: 300

--- a/qa/suites/fs/basic_workload/overrides/session_timeout.yaml
+++ b/qa/suites/fs/basic_workload/overrides/session_timeout.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/overrides/session_timeout.yaml

--- a/qa/suites/fs/thrash/overrides/session_timeout.yaml
+++ b/qa/suites/fs/thrash/overrides/session_timeout.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/overrides/session_timeout.yaml

--- a/qa/suites/fs/upgrade/featureful_client/old_client/overrides/multimds/no.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/overrides/multimds/no.yaml
@@ -1,3 +1,4 @@
 overrides:
   ceph:
-    max_mds: 1
+    cephfs:
+      max_mds: 1

--- a/qa/suites/fs/upgrade/featureful_client/old_client/overrides/multimds/yes.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/overrides/multimds/yes.yaml
@@ -1,3 +1,4 @@
 overrides:
   ceph:
-    max_mds: 2
+    cephfs:
+      max_mds: 2

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/overrides/multimds/no.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/overrides/multimds/no.yaml
@@ -1,3 +1,4 @@
 overrides:
   ceph:
-    max_mds: 1
+    cephfs:
+      max_mds: 1

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/overrides/multimds/yes.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/overrides/multimds/yes.yaml
@@ -1,3 +1,4 @@
 overrides:
   ceph:
-    max_mds: 2
+    cephfs:
+      max_mds: 2

--- a/qa/suites/fs/verify/overrides/session_timeout.yaml
+++ b/qa/suites/fs/verify/overrides/session_timeout.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/overrides/session_timeout.yaml

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -428,13 +428,8 @@ def cephfs_setup(ctx, config):
     if mdss.remotes:
         log.info('Setting up CephFS filesystem...')
 
-        fs = Filesystem(ctx, name='cephfs', create=True,
-                        ec_profile=config.get('cephfs_ec_profile', None))
-
-        cephfs_conf = config['cephfs']
-        max_mds = config_conf.get('max_mds', 1)
-        if max_mds > 1:
-            fs.set_max_mds(max_mds)
+        Filesystem(ctx, fs_config=config.get('cephfs', None), name='cephfs',
+                   create=True, ec_profile=config.get('cephfs_ec_profile', None))
 
     yield
 

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1723,6 +1723,13 @@ def task(ctx, config):
             cephfs:
               max_mds: 2
 
+    To change the mdsmap's default session_timeout (60 seconds), use::
+
+        tasks:
+        - ceph:
+            cephfs:
+              session_timeout: 300
+
     Note, this will cause the task to check the /scratch_devs file on each node
     for available devices.  If no such file is found, /dev/sdb will be used.
 

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -431,7 +431,8 @@ def cephfs_setup(ctx, config):
         fs = Filesystem(ctx, name='cephfs', create=True,
                         ec_profile=config.get('cephfs_ec_profile', None))
 
-        max_mds = config.get('max_mds', 1)
+        cephfs_conf = config['cephfs']
+        max_mds = config_conf.get('max_mds', 1)
         if max_mds > 1:
             fs.set_max_mds(max_mds)
 
@@ -1719,6 +1720,13 @@ def task(ctx, config):
             fs: xfs
             mkfs_options: [-b,size=65536,-l,logdev=/dev/sdc1]
             mount_options: [nobarrier, inode64]
+
+    To change the cephfs's default max_mds (1), use::
+
+        tasks:
+        - ceph:
+            cephfs:
+              max_mds: 2
 
     Note, this will cause the task to check the /scratch_devs file on each node
     for available devices.  If no such file is found, /dev/sdb will be used.

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -571,6 +571,9 @@ class Filesystem(MDSCluster):
     def set_max_mds(self, max_mds):
         self.set_var("max_mds", "%d" % max_mds)
 
+    def set_session_timeout(self, timeout):
+        self.set_var("session_timeout", "%d" % timeout)
+
     def set_allow_standby_replay(self, yes):
         self.set_var("allow_standby_replay", yes)
 
@@ -637,6 +640,11 @@ class Filesystem(MDSCluster):
             max_mds = self.fs_config.get('max_mds', 1)
             if max_mds > 1:
                 self.set_max_mds(max_mds)
+
+            # If absent will use the default value (60 seconds)
+            session_timeout = self.fs_config.get('session_timeout', 60)
+            if session_timeout != 60:
+                self.set_session_timeout(session_timeout)
 
         self.getinfo(refresh = True)
 

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -452,7 +452,7 @@ class Filesystem(MDSCluster):
     This object is for driving a CephFS filesystem.  The MDS daemons driven by
     MDSCluster may be shared with other Filesystems.
     """
-    def __init__(self, ctx, fscid=None, name=None, create=False,
+    def __init__(self, ctx, fs_config=None, fscid=None, name=None, create=False,
                  ec_profile=None):
         super(Filesystem, self).__init__(ctx)
 
@@ -463,6 +463,7 @@ class Filesystem(MDSCluster):
         self.metadata_overlay = False
         self.data_pool_name = None
         self.data_pools = None
+        self.fs_config = fs_config
 
         client_list = list(misc.all_roles_of_type(self._ctx.cluster, 'client'))
         self.client_id = client_list[0]
@@ -631,6 +632,11 @@ class Filesystem(MDSCluster):
                 pass
             else:
                 raise
+
+        if self.fs_config is not None:
+            max_mds = self.fs_config.get('max_mds', 1)
+            if max_mds > 1:
+                self.set_max_mds(max_mds)
 
         self.getinfo(refresh = True)
 

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -1166,6 +1166,7 @@ class LocalFilesystem(Filesystem, LocalMDSCluster):
         self.metadata_overlay = False
         self.data_pool_name = None
         self.data_pools = None
+        self.fs_config = None
 
         # Hack: cheeky inspection of ceph.conf to see what MDSs exist
         self.mds_ids = set()


### PR DESCRIPTION
When the mds revoking the Fwbl caps, the clients need to flush
the dirty data back to the OSDs, but the flush may make the OSDs
to be overloaded and slow, which may take more than 60 seconds to
finish. Then the MDS daemons will report the WRN messages.

For the teuthology test cases, let's just increase the timeout
value to make it work.

Fixes: https://tracker.ceph.com/issues/47565
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
