### PR TITLE
mgr/orchestrator: set `lsm_data` to default of Dict type

### DIFF
--- a/src/python-common/ceph/deployment/inventory.py
+++ b/src/python-common/ceph/deployment/inventory.py
@@ -51,7 +51,7 @@ class Device(object):
                  rejected_reasons=None,  # type: Optional[List[str]]
                  lvs=None,  # type: Optional[List[str]]
                  device_id=None,  # type: Optional[str]
-                 lsm_data={},  # type: Dict[str, Dict[str, str]]
+                 lsm_data=None,  # type: Optional[Dict[str, Dict[str, str]]]
                  ):
         self.path = path
         self.sys_api = sys_api if sys_api is not None else {}  # type: Dict[str, Any]
@@ -59,7 +59,7 @@ class Device(object):
         self.rejected_reasons = rejected_reasons if rejected_reasons is not None else []
         self.lvs = lvs
         self.device_id = device_id
-        self.lsm_data = lsm_data
+        self.lsm_data = lsm_data if lsm_data is not None else {}  # type: Dict[str, Dict[str, str]]
 
     def to_json(self):
         # type: () -> dict


### PR DESCRIPTION
similar to handling of `sys_api`, convert a NoneType to a Dict

Fixes: https://tracker.ceph.com/issues/47841
Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
