### PR TITLE
mds: account for closing sessions in hit_session

### DIFF
--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -1025,7 +1025,8 @@ int Session::check_access(CInode *in, unsigned mask,
 // track total and per session load
 void SessionMap::hit_session(Session *session) {
   uint64_t sessions = get_session_count_in_state(Session::STATE_OPEN) +
-                      get_session_count_in_state(Session::STATE_STALE);
+                      get_session_count_in_state(Session::STATE_STALE) +
+                      get_session_count_in_state(Session::STATE_CLOSING);
   ceph_assert(sessions != 0);
 
   double total_load = total_load_avg.hit();


### PR DESCRIPTION
While stopping an mds we can reply to a request while all client
sessions are closing. We shouldn't assert in this case.

Fixes: https://tracker.ceph.com/issues/47833
Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>
