### PR TITLE
mgr/dashboard: add description for CRUSH Ruleset

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -325,6 +325,10 @@
                             [ngClass]="{'active': data.crushInfo}"
                             id="crush-info-button"
                             type="button"
+                            ngbTooltip="Placement and
+                            replication strategies or distribution policies that allow to
+                            specify how CRUSH places data replicas."
+                            i18n-ngbTooltip
                             (click)="data.crushInfo = !data.crushInfo">
                       <i [ngClass]="[icons.questionCircle]"
                          aria-hidden="true"></i>


### PR DESCRIPTION
This PR adds a description for CRUSH Ruleset as a tooltip to the crush-rule info button.

Fixes: https://tracker.ceph.com/issues/48067

Signed-off-by: Avan Thakkar <athakkar@redhat.com>

![Screenshot from 2020-11-02 13-23-33](https://user-images.githubusercontent.com/23611106/97843635-a41cd500-1d0f-11eb-94b3-13179526cc52.png)

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
