### PR TITLE
mgr/cephadm: give feedback of "cephadm unit ..."

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3599,10 +3599,18 @@ def command_unit():
 
     unit_name = get_unit_name_by_daemon_name(args.fsid, args.name)
 
-    call_throws([
-        'systemctl',
-        args.command,
-        unit_name])
+    def _readable_return(tpl, cmd):
+        # queries for status need to be passed-through
+        if cmd == 'status':
+            return tpl[0]
+        # all other queries (start, stop, restart, enable, disable)
+        # do not return anything. judge based on the return-code.
+        return 'success'
+
+    out_tpl = call_throws(['systemctl',
+                           args.command,
+                           unit_name])
+    logger.info(_readable_return(out_tpl, args.command))
 
 ##################################
 


### PR DESCRIPTION
The output is not very human friendly thouhgh.
There's quite a bit of room for UX/UI improvements.

Signed-off-by: Joshua Schmid <jschmid@suse.de>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
