### PR TITLE
cephadm: Include version in cephadm script

### DIFF
--- a/doc/man/8/cephadm.rst
+++ b/doc/man/8/cephadm.rst
@@ -16,6 +16,7 @@ Synopsis
 |               {version,pull,inspect-image,ls,list-networks,adopt,rm-daemon,rm-cluster,run,shell,enter,ceph-volume,unit,logs,bootstrap,deploy,check-host,prepare-host,add-repo,rm-repo,install}
 |               ...
 
+| **cephadm** **version** [-h] [--cephadm]
 
 | **cephadm** **pull**
 
@@ -493,6 +494,17 @@ Arguments:
 
 * [--fsid FSID]           cluster FSID
 * [--name NAME, -n NAME]  daemon name (type.id)
+
+
+version
+-------
+
+Provides information about the ceph container image used, the Ceph version included in the image,
+and the cephadm script version.
+
+Arguments:
+
+* [--cephadm]              only shows the cephadm script version
 
 
 Availability

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+VERSION="0.1"
 DEFAULT_IMAGE = 'docker.io/ceph/daemon-base:latest-master-devel'
 DEFAULT_IMAGE_IS_MASTER = True
 LATEST_STABLE_RELEASE = 'octopus'
@@ -2637,10 +2638,10 @@ class CephContainer:
 @infer_image
 def command_version():
     # type: () -> int
-    out = CephContainer(args.image, 'ceph', ['--version']).run()
+    out = "cephadm script version %s\n" % VERSION
+    out += CephContainer(args.image, 'ceph', ['--version']).run()
     print(out.strip())
     return 0
-
 ##################################
 
 
@@ -5503,8 +5504,13 @@ def _get_parser():
     subparsers = parser.add_subparsers(help='sub-command')
 
     parser_version = subparsers.add_parser(
-        'version', help='get ceph version from container')
+        'version', help='get cephadm script version and ceph version from container')
     parser_version.set_defaults(func=command_version)
+    parser_version.add_argument(
+        '--cephadm',
+        action='version',
+        version=VERSION,
+        help='Only shows the cephadm script version')
 
     parser_pull = subparsers.add_parser(
         'pull', help='pull latest image version')


### PR DESCRIPTION
Set a version number for cephadm script and include this information as output
in the version command.

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>

```
[root@cephLab2-node-00 bin]# ./cephadm version --help
usage: cephadm version [-h] [--cephadm]

optional arguments:
  -h, --help  show this help message and exit
  --cephadm   Only shows the cephadm script version

[root@cephLab2-node-00 bin]# ./cephadm version
Using recent ceph image docker.io/ceph/daemon-base:latest-master-devel
cephadm script version 1.0
ceph version 16.0.0-6174-g699c2740 (699c2740fee4aa8f4d431fc313d25ac6cb444202) pacific (dev)

[root@cephLab2-node-00 bin]# ./cephadm version --cephadm
1.0
```


## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

