### PR TITLE
mds: only update the requesting metrics

### DIFF
--- a/src/mds/MDSPerfMetricTypes.h
+++ b/src/mds/MDSPerfMetricTypes.h
@@ -39,10 +39,13 @@ struct CapHitMetric {
 
 struct ReadLatencyMetric {
   utime_t lat;
+  bool updated = false;
 
   DENC(ReadLatencyMetric, v, p) {
-    DENC_START(1, 1, p);
+    DENC_START(2, 1, p);
     denc(v.lat, p);
+    if (struct_v >= 2)
+      denc(v.updated, p);
     DENC_FINISH(p);
   }
 
@@ -58,10 +61,13 @@ struct ReadLatencyMetric {
 
 struct WriteLatencyMetric {
   utime_t lat;
+  bool updated = false;
 
   DENC(WriteLatencyMetric, v, p) {
-    DENC_START(1, 1, p);
+    DENC_START(2, 1, p);
     denc(v.lat, p);
+    if (struct_v >= 2)
+      denc(v.updated, p);
     DENC_FINISH(p);
   }
 
@@ -77,10 +83,13 @@ struct WriteLatencyMetric {
 
 struct MetadataLatencyMetric {
   utime_t lat;
+  bool updated = false;
 
   DENC(MetadataLatencyMetric, v, p) {
-    DENC_START(1, 1, p);
+    DENC_START(2, 1, p);
     denc(v.lat, p);
+    if (struct_v >= 2)
+      denc(v.updated, p);
     DENC_FINISH(p);
   }
 

--- a/src/mds/MetricAggregator.cc
+++ b/src/mds/MetricAggregator.cc
@@ -111,16 +111,22 @@ void MetricAggregator::refresh_metrics_for_rank(const entity_inst_t &client,
       c->second = metrics.cap_hit_metric.misses;
       break;
     case MDSPerformanceCounterType::READ_LATENCY_METRIC:
-      c->first = metrics.read_latency_metric.lat.tv.tv_sec;
-      c->second = metrics.read_latency_metric.lat.tv.tv_nsec;
+      if (metrics.read_latency_metric.updated) {
+        c->first = metrics.read_latency_metric.lat.tv.tv_sec;
+        c->second = metrics.read_latency_metric.lat.tv.tv_nsec;
+      }
       break;
     case MDSPerformanceCounterType::WRITE_LATENCY_METRIC:
-      c->first = metrics.write_latency_metric.lat.tv.tv_sec;
-      c->second = metrics.write_latency_metric.lat.tv.tv_nsec;
+      if (metrics.write_latency_metric.updated) {
+        c->first = metrics.write_latency_metric.lat.tv.tv_sec;
+        c->second = metrics.write_latency_metric.lat.tv.tv_nsec;
+      }
       break;
     case MDSPerformanceCounterType::METADATA_LATENCY_METRIC:
-      c->first = metrics.metadata_latency_metric.lat.tv.tv_sec;
-      c->second = metrics.metadata_latency_metric.lat.tv.tv_nsec;
+      if (metrics.metadata_latency_metric.updated) {
+        c->first = metrics.metadata_latency_metric.lat.tv.tv_sec;
+        c->second = metrics.metadata_latency_metric.lat.tv.tv_nsec;
+      }
       break;
     default:
       ceph_abort_msg("unknown counter type");

--- a/src/mds/MetricsHandler.cc
+++ b/src/mds/MetricsHandler.cc
@@ -140,8 +140,9 @@ void MetricsHandler::reset_seq() {
 }
 
 void MetricsHandler::handle_payload(Session *session, const CapInfoPayload &payload) {
-  dout(20) << ": session=" << session << ", hits=" << payload.cap_hits << ", misses="
-           << payload.cap_misses << dendl;
+  dout(20) << ": type=" << static_cast<ClientMetricType>(CapInfoPayload::METRIC_TYPE)
+	   << ", session=" << session << ", hits=" << payload.cap_hits << ", misses="
+	   << payload.cap_misses << dendl;
 
   auto it = client_metrics_map.find(session->info.inst);
   if (it == client_metrics_map.end()) {
@@ -155,7 +156,8 @@ void MetricsHandler::handle_payload(Session *session, const CapInfoPayload &payl
 }
 
 void MetricsHandler::handle_payload(Session *session, const ReadLatencyPayload &payload) {
-  dout(20) << ": session=" << session << ", latency=" << payload.lat << dendl;
+  dout(20) << ": type=" << static_cast<ClientMetricType>(ReadLatencyPayload::METRIC_TYPE)
+	   << ", session=" << session << ", latency=" << payload.lat << dendl;
 
   auto it = client_metrics_map.find(session->info.inst);
   if (it == client_metrics_map.end()) {
@@ -169,7 +171,8 @@ void MetricsHandler::handle_payload(Session *session, const ReadLatencyPayload &
 }
 
 void MetricsHandler::handle_payload(Session *session, const WriteLatencyPayload &payload) {
-  dout(20) << ": session=" << session << ", latency=" << payload.lat << dendl;
+  dout(20) << ": type=" << static_cast<ClientMetricType>(WriteLatencyPayload::METRIC_TYPE)
+	   << ", session=" << session << ", latency=" << payload.lat << dendl;
 
   auto it = client_metrics_map.find(session->info.inst);
   if (it == client_metrics_map.end()) {
@@ -183,7 +186,8 @@ void MetricsHandler::handle_payload(Session *session, const WriteLatencyPayload 
 }
 
 void MetricsHandler::handle_payload(Session *session, const MetadataLatencyPayload &payload) {
-  dout(20) << ": session=" << session << ", latency=" << payload.lat << dendl;
+  dout(20) << ": type=" << static_cast<ClientMetricType>(MetadataLatencyPayload::METRIC_TYPE)
+	   << ", session=" << session << ", latenc]y=" << payload.lat << dendl;
 
   auto it = client_metrics_map.find(session->info.inst);
   if (it == client_metrics_map.end()) {
@@ -197,7 +201,7 @@ void MetricsHandler::handle_payload(Session *session, const MetadataLatencyPaylo
 }
 
 void MetricsHandler::handle_payload(Session *session, const UnknownPayload &payload) {
-  dout(5) << ": session=" << session << ", ignoring unknown payload" << dendl;
+  dout(5) << ": type=Unknown, session=" << session << ", ignoring unknown payload" << dendl;
 }
 
 void MetricsHandler::handle_client_metrics(const cref_t<MClientMetrics> &m) {

--- a/src/mds/MetricsHandler.cc
+++ b/src/mds/MetricsHandler.cc
@@ -165,6 +165,7 @@ void MetricsHandler::handle_payload(Session *session, const ReadLatencyPayload &
   auto &metrics = it->second.second;
   metrics.update_type = UPDATE_TYPE_REFRESH;
   metrics.read_latency_metric.lat = payload.lat;
+  metrics.read_latency_metric.updated = true;
 }
 
 void MetricsHandler::handle_payload(Session *session, const WriteLatencyPayload &payload) {
@@ -178,6 +179,7 @@ void MetricsHandler::handle_payload(Session *session, const WriteLatencyPayload 
   auto &metrics = it->second.second;
   metrics.update_type = UPDATE_TYPE_REFRESH;
   metrics.write_latency_metric.lat = payload.lat;
+  metrics.write_latency_metric.updated = true;
 }
 
 void MetricsHandler::handle_payload(Session *session, const MetadataLatencyPayload &payload) {
@@ -191,6 +193,7 @@ void MetricsHandler::handle_payload(Session *session, const MetadataLatencyPaylo
   auto &metrics = it->second.second;
   metrics.update_type = UPDATE_TYPE_REFRESH;
   metrics.metadata_latency_metric.lat = payload.lat;
+  metrics.metadata_latency_metric.updated = true;
 }
 
 void MetricsHandler::handle_payload(Session *session, const UnknownPayload &payload) {

--- a/src/messages/MClientMetrics.h
+++ b/src/messages/MClientMetrics.h
@@ -29,7 +29,10 @@ public:
   }
 
   void print(ostream &out) const override {
-    out << "client_metrics";
+    out << "client_metrics ";
+    for (auto &i : updates) {
+      i.print(&out);
+    }
   }
 
   void encode_payload(uint64_t features) override {


### PR DESCRIPTION
Currently for the MDSs without global metrics needed to be refreshed,
the global metric counters will be zero and then after update_rank0,
the previous counters in aggregator will be reset.

Fixes: https://tracker.ceph.com/issues/47844

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
