### PR TITLE
vstart_runner: accepts multiple commands as str too

### DIFF
--- a/doc/dev/developer_guide/running-tests-locally.rst
+++ b/doc/dev/developer_guide/running-tests-locally.rst
@@ -133,6 +133,17 @@ vstart_runner.py primarily does three things -
     and without admin socket and ``LocalCephCluster`` provides methods to set
     or clear ``ceph.conf``.
 
+.. note:: vstart_runner.py deletes "adjust-ulimits" and "ceph-coverage" from
+          the command arguments unconditionally since they are not applicable
+          when tests are run on a developer's machine.
+
+.. note:: "omit_sudo" is re-set to False unconditionally in cases of commands
+          "passwd" and "chown".
+
+.. note:: The presence of binary file named after the first argument is
+          checked in ``<ceph-repo-root>/build/bin/``. If present, the first
+          argument is replaced with the path to binary file.
+
 Running Workunits Using vstart_enviroment.sh
 --------------------------------------------
 

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -701,7 +701,6 @@ class CephFSMount(object):
         return p.stdout.getvalue().strip()
 
     def run_shell(self, args, timeout=300, **kwargs):
-        args = args.split() if isinstance(args, str) else args
         kwargs.pop('omit_sudo', False)
         sudo = kwargs.pop('sudo', False)
         cwd = kwargs.pop('cwd', self.mountpoint)
@@ -709,7 +708,10 @@ class CephFSMount(object):
         stderr = kwargs.pop('stderr', StringIO())
 
         if sudo:
-            args.insert(0, 'sudo')
+            if isinstance(args, list):
+                args.insert(0, 'sudo')
+            elif isinstance(args, str):
+                args = 'sudo ' + args
 
         return self.client_remote.run(args=args, cwd=cwd, timeout=timeout,
                                       stdout=stdout, stderr=stderr,

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -804,18 +804,7 @@ class LocalCephManager(CephManager):
         self.cephadm = False
         self.rook = False
         self.testdir = None
-        self.run_cluster_cmd_prefix = [CEPH_CMD]
-        # XXX: Ceph API test CI job crashes because "ceph -w" process launched
-        # by run_ceph_w() crashes when shell is set to True.
-        # See https://tracker.ceph.com/issues/49644.
-        #
-        # The 2 possible workaround this are either setting "shell" to "False"
-        # when command "ceph -w" is executed or to prepend "exec sudo" to
-        # command arguments. We are going with latter since former would make
-        # it necessary to pass "shell" parameter to run() method. This leads
-        # to incompatibility with the method teuthology.orchestra.run's run()
-        # since it doesn't accept "shell" as parameter.
-        self.run_ceph_w_prefix = ['exec', 'sudo', CEPH_CMD]
+        self.run_ceph_w_prefix = self.run_cluster_cmd_prefix = [CEPH_CMD]
 
     def find_remote(self, daemon_type, daemon_id):
         """

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -31,6 +31,15 @@ Alternative usage:
 Following are few important notes that might save some investigation around
 vstart_runner.py -
 
+* If using the FUSE client, ensure that the fuse package is installed and
+  enabled on the system and that "user_allow_other" is added to /etc/fuse.conf.
+
+* If using the kernel client, the user must have the ability to run commands
+  with passwordless sudo access.
+
+* A failure on the kernel client may crash the host, so it's recommended to
+  use this functionality within a virtual machine.
+
 * "adjust-ulimits", "ceph-coverage" and "sudo" in command arguments are
   overridden by vstart_runner.py. Former two usually have no applicability
   for test runs on developer's machines and see note point on "omit_sudo"

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -129,6 +129,13 @@ def respawn_in_path(lib_path, python_paths):
         sys.path.insert(0, p)
 
 
+def launch_subprocess(args, cwd=None, env=None, shell=True,
+                      executable='/bin/bash'):
+    return subprocess.Popen(args, cwd=cwd, env=env, shell=shell,
+                            executable=executable, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+
+
 # Let's use some sensible defaults
 if os.path.exists("./CMakeCache.txt") and os.path.exists("./bin"):
 
@@ -461,10 +468,7 @@ sudo() {
         args, usr_args = self._perform_checks_and_adjustments(args, omit_sudo,
                                                               shell)
 
-        subproc = subprocess.Popen(args, stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE,
-                                   stdin=subprocess.PIPE, cwd=cwd, env=env,
-                                   shell=shell, executable='/bin/bash')
+        subproc = launch_subprocess(args, cwd, env, shell)
 
         if stdin:
             # Hack: writing to stdin is not deadlock-safe, but it "always" works

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -425,6 +425,8 @@ ceph-coverage() {
         # We'll let sudo be a part of command even omit flag says otherwise in
         # cases of commands which can normally be ran only by root.
         last_arg = args[args.rfind(' ') + 1 : ]
+        # XXX: should sudo be omitted/allowed by default in cases similar to
+        # that of "exec sudo" as well?
         if 'sudo' in args:
             for x in ('passwd', 'chown'):
                 if x == first_arg or x == last_arg or f' {x} ' in args:

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -609,7 +609,8 @@ def safe_kill(pid):
     os.kill annoyingly raises exception if process already dead.  Ignore it.
     """
     try:
-        return os.kill(pid, signal.SIGKILL)
+        return remote.run(args=f'sudo kill -{signal.SIGKILL.value} {pid}',
+                          omit_sudo=False)
     except OSError as e:
         if e.errno == errno.ESRCH:
             # Raced with process termination
@@ -1354,7 +1355,8 @@ def exec_test():
         if 'ceph-fuse' in line or 'ceph-mds' in line:
             pid = int(line.split()[0])
             log.warning("Killing stray process {0}".format(line))
-            os.kill(pid, signal.SIGKILL)
+            remote.run(args=f'sudo kill -{signal.SIGKILL.value} {pid}',
+                       omit_sudo=False)
 
     # Fire up the Ceph cluster if the user requested it
     if opt_create_cluster or opt_create_cluster_only:


### PR DESCRIPTION
Teuthology's orchestra.remote.run() can execute multiple commands passed
to it in form of character string where commands are separated by
newlines. Let's add that ability to vstart_runner.LocalRemote.run() as
well.
    
Fixes: https://tracker.ceph.com/issues/47849

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>