### PR TITLE
rgw/lua: allow setting metadata via lua

### DIFF
--- a/doc/radosgw/lua-scripting.rst
+++ b/doc/radosgw/lua-scripting.rst
@@ -202,7 +202,7 @@ Request Fields
 +----------------------------------------------------+----------+--------------------------------------------------------------+----------+-----------+----------+
 | ``Request.HTTP.Resources``                         | table    | string to string resource map                                | yes      | no        | no       |
 +----------------------------------------------------+----------+--------------------------------------------------------------+----------+-----------+----------+
-| ``Request.HTTP.Metadata``                          | table    | string to string metadata map                                | yes      | no        | no       |
+| ``Request.HTTP.Metadata``                          | table    | string to string metadata map                                | yes      | yes       | no       |
 +----------------------------------------------------+----------+--------------------------------------------------------------+----------+-----------+----------+
 | ``Request.HTTP.Host``                              | string   | host name                                                    | no       | no        | no       |
 +----------------------------------------------------+----------+--------------------------------------------------------------+----------+-----------+----------+
@@ -290,7 +290,6 @@ Lua Code Samples
 - Use of operations log only in case of errors:
 
 .. code-block:: lua
-
   
   if Request.Response.HTTPStatusCode ~= 200 then
     RGWDebugLog("request is bad, use ops log")
@@ -306,3 +305,22 @@ Lua Code Samples
     Request.Response.Message = "<Message> something bad happened :-( </Message>"
   end
 
+- Add metadata to objects that was not originally sent by the client:
+
+In the `preRequest` context we should add:
+
+.. code-block:: lua
+
+  if Request.RGWOp == 'put_obj' then
+    Request.HTTP.Metadata["x-amz-meta-mydata"] = "my value"
+  end
+
+In the `postRequest` context we look at the metadata:
+
+.. code-block:: lua
+
+  RGWDebugLog("number of metadata entries is: " .. #Request.HTTP.Metadata)
+  for k, v in pairs(Request.HTTP.Metadata) do
+    RGWDebugLog("key=" .. k .. ", " .. "value=" .. v)
+  end
+ 

--- a/src/rgw/rgw_acl.h
+++ b/src/rgw/rgw_acl.h
@@ -117,6 +117,7 @@ protected:
   ACLGranteeType type;
   rgw_user id;
   string email;
+  mutable rgw_user email_id;
   ACLPermission permission;
   string name;
   ACLGroupTypeEnum group;
@@ -139,6 +140,19 @@ public:
     default:
       _id = id;
       return true;
+    }
+  }
+
+  const rgw_user* get_id() const {
+    switch(type.get_type()) {
+    case ACL_TYPE_EMAIL_USER:
+      email_id.from_str(email);
+      return &email_id;
+    case ACL_TYPE_GROUP:
+    case ACL_TYPE_REFERER:
+      return nullptr;
+    default:
+      return &id;
     }
   }
 

--- a/src/rgw/rgw_lua_request.cc
+++ b/src/rgw/rgw_lua_request.cc
@@ -46,8 +46,7 @@ struct ResponseMetaTable : public EmptyMetaTable {
   static int IndexClosure(lua_State* L) {
     const auto err = reinterpret_cast<const rgw_err*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    ceph_assert(lua_isstring(L, -1));
-    const char* index = lua_tostring(L, -1);
+    const char* index = luaL_checkstring(L, 2);
 
     if (strcasecmp(index, "HTTPStatusCode") == 0) {
       lua_pushinteger(L, err->http_ret);
@@ -66,17 +65,16 @@ struct ResponseMetaTable : public EmptyMetaTable {
   static int NewIndexClosure(lua_State* L) {
     auto err = reinterpret_cast<rgw_err*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    ceph_assert(lua_isstring(L, -2));
-    const char* index = lua_tostring(L, -2);
+    const char* index = luaL_checkstring(L, 2);
 
     if (strcasecmp(index, "HTTPStatusCode") == 0) {
-      err->http_ret = lua_tointeger(L, -1);
+      err->http_ret = luaL_checkinteger(L, 3);
     } else if (strcasecmp(index, "RGWCode") == 0) {
-      err->ret = lua_tointeger(L, -1);
+      err->ret = luaL_checkinteger(L, 3);
     } else if (strcasecmp(index, "HTTPStatus") == 0) {
-      err->err_code.assign(lua_tostring(L, -1));
+      err->err_code.assign(luaL_checkstring(L, 3));
     } else if (strcasecmp(index, "Message") == 0) {
-      err->message.assign(lua_tostring(L, -1));
+      err->message.assign(luaL_checkstring(L, 3));
     } else {
       throw_unknown_field(index, TableName());
     }
@@ -91,8 +89,7 @@ struct QuotaMetaTable : public EmptyMetaTable {
   static int IndexClosure(lua_State* L) {
     const auto info = reinterpret_cast<RGWQuotaInfo*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    ceph_assert(lua_isstring(L, -1));
-    const char* index = lua_tostring(L, -1);
+    const char* index = luaL_checkstring(L, 2);
 
     if (strcasecmp(index, "MaxSize") == 0) {
       lua_pushinteger(L, info->max_size);
@@ -116,8 +113,7 @@ struct PlacementRuleMetaTable : public EmptyMetaTable {
   static int IndexClosure(lua_State* L) {
     const auto rule = reinterpret_cast<rgw_placement_rule*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    ceph_assert(lua_isstring(L, -1));
-    const char* index = lua_tostring(L, -1);
+    const char* index = luaL_checkstring(L, 2);
 
     if (strcasecmp(index, "Name") == 0) {
       pushstring(L, rule->name);
@@ -137,8 +133,7 @@ struct UserMetaTable : public EmptyMetaTable {
   static int IndexClosure(lua_State* L) {
     const auto user = reinterpret_cast<const rgw_user*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    ceph_assert(lua_isstring(L, -1));
-    const char* index = lua_tostring(L, -1);
+    const char* index = luaL_checkstring(L, 2);
 
     if (strcasecmp(index, "Tenant") == 0) {
       pushstring(L, user->tenant);
@@ -158,8 +153,7 @@ struct OwnerMetaTable : public EmptyMetaTable {
   static int IndexClosure(lua_State* L) {
     const auto owner = reinterpret_cast<ACLOwner*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    ceph_assert(lua_isstring(L, -1));
-    const char* index = lua_tostring(L, -1);
+    const char* index = luaL_checkstring(L, 2);
 
     if (strcasecmp(index, "DisplayName") == 0) {
       pushstring(L, owner->get_display_name());
@@ -181,8 +175,7 @@ struct BucketMetaTable : public EmptyMetaTable {
   static int IndexClosure(lua_State* L) {
     const auto bucket = reinterpret_cast<Type*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    ceph_assert(lua_isstring(L, -1));
-    const char* index = lua_tostring(L, -1);
+    const char* index = luaL_checkstring(L, 2);
 
     if (strcasecmp(index, "Tenant") == 0) {
       pushstring(L, bucket->get_tenant());
@@ -224,8 +217,7 @@ struct ObjectMetaTable : public EmptyMetaTable {
   static int IndexClosure(lua_State* L) {
     const auto obj = reinterpret_cast<const Type*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    ceph_assert(lua_isstring(L, -1));
-    const char* index = lua_tostring(L, -1);
+    const char* index = luaL_checkstring(L, 2);
 
     if (strcasecmp(index, "Name") == 0) {
       pushstring(L, obj->get_name());
@@ -250,10 +242,8 @@ template<typename MapType>
 int StringMapWriteableNewIndex(lua_State* L) {
   const auto map = reinterpret_cast<MapType*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-  ceph_assert(lua_isstring(L, -1));
-  ceph_assert(lua_isstring(L, -2));
-  const char* value = lua_tostring(L, -1);
-  const char* index = lua_tostring(L, -2);
+  const char* index = luaL_checkstring(L, 2);
+  const char* value = luaL_checkstring(L, 3);
   map->insert_or_assign(index, value);
   return NO_RETURNVAL;
 }
@@ -268,8 +258,7 @@ struct StringMapMetaTable : public EmptyMetaTable {
   static int IndexClosure(lua_State* L) {
     const auto map = reinterpret_cast<MapType*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    ceph_assert(lua_isstring(L, -1));
-    const char* index = lua_tostring(L, -1);
+    const char* index = luaL_checkstring(L, 2);
 
     const auto it = map->find(std::string(index));
     if (it == map->end()) {
@@ -302,8 +291,7 @@ struct StringMapMetaTable : public EmptyMetaTable {
     if (lua_isnil(L, -1)) {
       next_it = map->begin();
     } else {
-      ceph_assert(lua_isstring(L, -1));
-      const char* index = lua_tostring(L, -1);
+      const char* index = luaL_checkstring(L, 2);
       const auto it = map->find(std::string(index));
       ceph_assert(it != map->end());
       next_it = std::next(it);
@@ -339,15 +327,14 @@ struct GrantMetaTable : public EmptyMetaTable {
   static int IndexClosure(lua_State* L) {
     const auto grant = reinterpret_cast<ACLGrant*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    ceph_assert(lua_isstring(L, -1));
-    const char* index = lua_tostring(L, -1);
+    const char* index = luaL_checkstring(L, 2);
 
     if (strcasecmp(index, "Type") == 0) {
       lua_pushinteger(L, grant->get_type().get_type());
     } else if (strcasecmp(index, "User") == 0) {
-      rgw_user id;
-      if (grant->get_id(id)) {
-        create_metatable<UserMetaTable>(L, false, &id);
+      const auto id_ptr = grant->get_id();
+      if (id_ptr) {
+        create_metatable<UserMetaTable>(L, false, const_cast<rgw_user*>(id_ptr));
       } else {
         lua_pushnil(L);
       }
@@ -371,8 +358,7 @@ struct GrantsMetaTable : public EmptyMetaTable {
   static int IndexClosure(lua_State* L) {
     const auto map = reinterpret_cast<ACLGrantMap*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    ceph_assert(lua_isstring(L, -1));
-    const char* index = lua_tostring(L, -1);
+    const char* index = luaL_checkstring(L, 2);
 
     const auto it = map->find(std::string(index));
     if (it == map->end()) {
@@ -401,8 +387,7 @@ struct GrantsMetaTable : public EmptyMetaTable {
     if (lua_isnil(L, -1)) {
       next_it = map->begin();
     } else {
-      ceph_assert(lua_isstring(L, -1));
-      const char* index = lua_tostring(L, -1);
+      const char* index = luaL_checkstring(L, 2);
       const auto it = map->find(std::string(index));
       ceph_assert(it != map->end());
       next_it = std::next(it);
@@ -453,8 +438,7 @@ struct ACLMetaTable : public EmptyMetaTable {
   static int IndexClosure(lua_State* L) {
     const auto acl = reinterpret_cast<Type*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    ceph_assert(lua_isstring(L, -1));
-    const char* index = lua_tostring(L, -1);
+    const char* index = luaL_checkstring(L, 2);
 
     if (strcasecmp(index, "Owner") == 0) {
       create_metatable<OwnerMetaTable>(L, false, &(acl->get_owner()));
@@ -482,7 +466,7 @@ struct StatementsMetaTable : public EmptyMetaTable {
   static int IndexClosure(lua_State* L) {
     const auto statements = reinterpret_cast<Type*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    const auto index = lua_tointeger(L, -1);
+    const auto index = luaL_checkinteger(L, 2);
 
     if (index >= (int)statements->size() || index < 0) {
       lua_pushnil(L);
@@ -510,8 +494,7 @@ struct StatementsMetaTable : public EmptyMetaTable {
     if (lua_isnil(L, -1)) {
       next_it = 0;
     } else {
-      ceph_assert(lua_isinteger(L, -1));
-      const auto it = lua_tointeger(L, -1);
+      const auto it = luaL_checkinteger(L, -1);
       next_it = it+1;
     }
 
@@ -545,8 +528,7 @@ struct PolicyMetaTable : public EmptyMetaTable {
   static int IndexClosure(lua_State* L) {
     const auto policy = reinterpret_cast<rgw::IAM::Policy*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    ceph_assert(lua_isstring(L, -1));
-    const char* index = lua_tostring(L, -1);
+    const char* index = luaL_checkstring(L, 2);
 
     if (strcasecmp(index, "Text") == 0) {
       pushstring(L, policy->text);
@@ -575,7 +557,7 @@ struct PoliciesMetaTable : public EmptyMetaTable {
   static int IndexClosure(lua_State* L) {
     const auto policies = reinterpret_cast<Type*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    const auto index = lua_tointeger(L, -1);
+    const auto index = luaL_checkinteger(L, 2);
 
     if (index >= (int)policies->size() || index < 0) {
       lua_pushnil(L);
@@ -603,7 +585,7 @@ struct PoliciesMetaTable : public EmptyMetaTable {
       next_it = 0;
     } else {
       ceph_assert(lua_isinteger(L, -1));
-      const auto it = lua_tointeger(L, -1);
+      const auto it = luaL_checkinteger(L, -1);
       next_it = it+1;
     }
 
@@ -637,8 +619,7 @@ struct HTTPMetaTable : public EmptyMetaTable {
   static int IndexClosure(lua_State* L) {
     const auto info = reinterpret_cast<req_info*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    ceph_assert(lua_isstring(L, -1));
-    const char* index = lua_tostring(L, -1);
+    const char* index = luaL_checkstring(L, 2);
 
     if (strcasecmp(index, "Parameters") == 0) {
       create_metatable<StringMapMetaTable<>>(L, false, &(info->args.get_params()));
@@ -672,8 +653,7 @@ struct CopyFromMetaTable : public EmptyMetaTable {
   static int IndexClosure(lua_State* L) {
     const auto s = reinterpret_cast<req_state*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    ceph_assert(lua_isstring(L, -1));
-    const char* index = lua_tostring(L, -1);
+    const char* index = luaL_checkstring(L, 2);
 
     if (strcasecmp(index, "Tenant") == 0) {
       pushstring(L, s->src_tenant_name);
@@ -695,8 +675,7 @@ struct ZoneGroupMetaTable : public EmptyMetaTable {
   static int IndexClosure(lua_State* L) {
     const auto s = reinterpret_cast<req_state*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    ceph_assert(lua_isstring(L, -1));
-    const char* index = lua_tostring(L, -1);
+    const char* index = luaL_checkstring(L, 2);
 
     if (strcasecmp(index, "Name") == 0) {
       pushstring(L, s->zonegroup_name);
@@ -718,8 +697,7 @@ struct RequestMetaTable : public EmptyMetaTable {
     const auto s = reinterpret_cast<req_state*>(lua_touserdata(L, lua_upvalueindex(1)));
     const auto op_name = reinterpret_cast<const char*>(lua_touserdata(L, lua_upvalueindex(2)));
 
-    ceph_assert(lua_isstring(L, -1));
-    const char* index = lua_tostring(L, -1);
+    const char* index = luaL_checkstring(L, 2);
 
     if (strcasecmp(index, "RGWOp") == 0) {
       pushstring(L, op_name);

--- a/src/rgw/rgw_lua_utils.h
+++ b/src/rgw/rgw_lua_utils.h
@@ -43,6 +43,7 @@ constexpr auto THREE_UPVALS = 3;
 constexpr auto FOUR_UPVALS  = 4;
 constexpr auto FIVE_UPVALS  = 5;
 
+constexpr auto NO_RETURNVAL    = 0;
 constexpr auto ONE_RETURNVAL    = 1;
 constexpr auto TWO_RETURNVALS   = 2;
 constexpr auto THREE_RETURNVALS = 3;
@@ -143,21 +144,21 @@ struct EmptyMetaTable {
   // to change, overload this function in the derived
   static int NewIndexClosure(lua_State* L) {
     throw std::runtime_error("trying to write to readonly field");
-    return 1;
+    return NO_RETURNVAL;
   }
   
   // by default nothing is iterable
   // to change, overload this function in the derived
   static int PairsClosure(lua_State* L) {
     throw std::runtime_error("trying to iterate over non-iterable field");
-    return 1;
+    return ONE_RETURNVAL;
   }
   
   // by default nothing is iterable
   // to change, overload this function in the derived
   static int LenClosure(lua_State* L) {
     throw std::runtime_error("trying to get length of non-iterable field");
-    return 1;
+    return ONE_RETURNVAL;
   }
 
   static void throw_unknown_field(const std::string& index, const std::string& table) {


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

This would allows setting metadata in cases that the client cannot be modified to do that.

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
