### PR TITLE
octopus: osdc/ObjectCacher: overwrite might cause stray read request callbacks

### DIFF
--- a/src/librbd/image/OpenRequest.cc
+++ b/src/librbd/image/OpenRequest.cc
@@ -534,7 +534,8 @@ Context* OpenRequest<I>::send_parent_cache(int *result) {
   bool parent_cache_enabled = m_image_ctx->config.template get_val<bool>(
     "rbd_parent_cache_enabled");
 
-  if (m_image_ctx->child == nullptr || !parent_cache_enabled) {
+  if (m_image_ctx->child == nullptr || !parent_cache_enabled ||
+      !m_image_ctx->data_ctx.is_valid()) {
     return send_init_cache(result);
   }
 
@@ -563,8 +564,8 @@ Context* OpenRequest<I>::handle_parent_cache(int* result) {
 
 template <typename I>
 Context *OpenRequest<I>::send_init_cache(int *result) {
-  // cache is disabled or parent image context
-  if (!m_image_ctx->cache || m_image_ctx->child != nullptr) {
+  if (!m_image_ctx->cache || m_image_ctx->child != nullptr ||
+      !m_image_ctx->data_ctx.is_valid()) {
     return send_register_watch(result);
   }
 

--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -1719,6 +1719,7 @@ int ObjectCacher::writex(OSDWrite *wr, ObjectSet *oset, Context *onfreespace,
     trace.event("start");
   }
 
+  list<Context*> wait_for_reads;
   for (vector<ObjectExtent>::iterator ex_it = wr->extents.begin();
        ex_it != wr->extents.end();
        ++ex_it) {
@@ -1731,6 +1732,12 @@ int ObjectCacher::writex(OSDWrite *wr, ObjectSet *oset, Context *onfreespace,
     BufferHead *bh = o->map_write(*ex_it, wr->journal_tid);
     bool missing = bh->is_missing();
     bh->snapc = wr->snapc;
+
+    // readers that need to be woken up due to an overwrite
+    for (auto& [_, wait_for_read] : bh->waitfor_read) {
+      wait_for_reads.splice(wait_for_reads.end(), wait_for_read);
+    }
+    bh->waitfor_read.clear();
 
     bytes_written += ex_it->length;
     if (bh->is_tx()) {
@@ -1790,6 +1797,8 @@ int ObjectCacher::writex(OSDWrite *wr, ObjectSet *oset, Context *onfreespace,
 
   int r = _wait_for_write(wr, bytes_written, oset, &trace, onfreespace);
   delete wr;
+
+  finish_contexts(cct, wait_for_reads, 0);
 
   //verify_stats();
   trim();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47706

---

backport of https://github.com/ceph/ceph/pull/37286
parent tracker: https://tracker.ceph.com/issues/46822

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh