### PR TITLE
rgw: use the forward declaration of CephContext defined in common_fwd.h

### DIFF
--- a/src/rgw/rgw_lua_utils.h
+++ b/src/rgw/rgw_lua_utils.h
@@ -6,7 +6,7 @@
 #include <ctime>
 #include <lua.hpp>
 
-class CephContext;
+#include "include/common_fwd.h"
 
 namespace rgw::lua {
 


### PR DESCRIPTION
Clang complains:
In file included from /home/jenkins/workspace/ceph-master-compile/src/rgw/rgw_lua_utils.cc:5:
/home/jenkins/workspace/ceph-master-compile/src/rgw/rgw_lua_utils.h:8:1: error: declaration conflicts with target of using declaration already in scope
class CephContext;
^
/home/jenkins/workspace/ceph-master-compile/src/include/common_fwd.h:10:9: note: target of using declaration
  class CephContext;
        ^
/home/jenkins/workspace/ceph-master-compile/src/include/common_fwd.h:22:24: note: using declaration
using TOPNSPC::common::CephContext;

Which is more that correct.

To declare CephContext forward, include common_fwd.h.
But this was already included in the hierarcy.

fixes: https://github.com/ceph/ceph/pull/35477


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>