### PR TITLE
rgw: roles: refactor roles class to the new multisite svc definitions 

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -38,6 +38,7 @@ set(librgw_common_srcs
   services/svc_quota.cc
   services/svc_sync_modules.cc
   services/svc_rados.cc
+  services/svc_role.cc
   services/svc_role_rados.cc
   services/svc_sys_obj.cc
   services/svc_sys_obj_cache.cc

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -38,6 +38,7 @@ set(librgw_common_srcs
   services/svc_quota.cc
   services/svc_sync_modules.cc
   services/svc_rados.cc
+  services/svc_role_rados.cc
   services/svc_sys_obj.cc
   services/svc_sys_obj_cache.cc
   services/svc_sys_obj_core.cc

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -5743,7 +5743,7 @@ int main(int argc, const char **argv)
         cerr << "failed to parse policy: " << e.what() << std::endl;
         return -EINVAL;
       }
-      RGWRole role(g_ceph_context, store->getRados()->pctl, role_name, path, assume_role_doc, tenant);
+      RGWRole role(g_ceph_context, store->ctl()->role, role_name, path, assume_role_doc, tenant);
       ret = role.create(true);
       if (ret < 0) {
         return -ret;
@@ -5757,7 +5757,7 @@ int main(int argc, const char **argv)
         cerr << "ERROR: empty role name" << std::endl;
         return -EINVAL;
       }
-      RGWRole role(g_ceph_context, store->getRados()->pctl, role_name, tenant);
+      RGWRole role(g_ceph_context, store->ctl()->role, role_name, tenant);
       ret = role.delete_obj();
       if (ret < 0) {
         return -ret;
@@ -5771,7 +5771,7 @@ int main(int argc, const char **argv)
         cerr << "ERROR: empty role name" << std::endl;
         return -EINVAL;
       }
-      RGWRole role(g_ceph_context, store->getRados()->pctl, role_name, tenant);
+      RGWRole role(g_ceph_context, store->ctl()->role, role_name, tenant);
       ret = role.get();
       if (ret < 0) {
         return -ret;
@@ -5799,7 +5799,7 @@ int main(int argc, const char **argv)
         return -EINVAL;
       }
 
-      RGWRole role(g_ceph_context, store->getRados()->pctl, role_name, tenant);
+      RGWRole role(g_ceph_context, store->ctl()->role, role_name, tenant);
       ret = role.get();
       if (ret < 0) {
         return -ret;
@@ -5847,7 +5847,7 @@ int main(int argc, const char **argv)
         return -EINVAL;
       }
 
-      RGWRole role(g_ceph_context, store->getRados()->pctl, role_name, tenant);
+      RGWRole role(g_ceph_context, store->ctl()->role, role_name, tenant);
       ret = role.get();
       if (ret < 0) {
         return -ret;
@@ -5866,7 +5866,7 @@ int main(int argc, const char **argv)
         cerr << "ERROR: Role name is empty" << std::endl;
         return -EINVAL;
       }
-      RGWRole role(g_ceph_context, store->getRados()->pctl, role_name, tenant);
+      RGWRole role(g_ceph_context, store->ctl()->role, role_name, tenant);
       ret = role.get();
       if (ret < 0) {
         return -ret;
@@ -5886,7 +5886,7 @@ int main(int argc, const char **argv)
         cerr << "ERROR: policy name is empty" << std::endl;
         return -EINVAL;
       }
-      RGWRole role(g_ceph_context, store->getRados()->pctl, role_name, tenant);
+      RGWRole role(g_ceph_context, store->ctl()->role, role_name, tenant);
       int ret = role.get();
       if (ret < 0) {
         return -ret;
@@ -5910,7 +5910,7 @@ int main(int argc, const char **argv)
         cerr << "ERROR: policy name is empty" << std::endl;
         return -EINVAL;
       }
-      RGWRole role(g_ceph_context, store->getRados()->pctl, role_name, tenant);
+      RGWRole role(g_ceph_context, store->ctl()->role, role_name, tenant);
       ret = role.get();
       if (ret < 0) {
         return -ret;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1063,7 +1063,7 @@ static void show_role_info(RGWRole& role, Formatter* formatter)
   formatter->flush(cout);
 }
 
-static void show_roles_info(vector<RGWRole>& roles, Formatter* formatter)
+static void show_roles_info(vector<RGWRoleInfo>& roles, Formatter* formatter)
 {
   formatter->open_array_section("Roles");
   for (const auto& it : roles) {
@@ -5814,11 +5814,8 @@ int main(int argc, const char **argv)
     }
   case OPT::ROLE_LIST:
     {
-      vector<RGWRole> result;
-      ret = RGWRole::get_roles_by_path_prefix(store->getRados(), g_ceph_context, path_prefix, tenant, result);
-      if (ret < 0) {
-        return -ret;
-      }
+      vector<RGWRoleInfo> result;
+      ret = store->ctl()->role->list_roles_by_path_prefix(path_prefix, tenant, result, null_yield);
       show_roles_info(result, formatter.get());
       return 0;
     }

--- a/src/rgw/rgw_metadata.h
+++ b/src/rgw/rgw_metadata.h
@@ -37,6 +37,8 @@ protected:
   
 public:
   RGWMetadataObject() {}
+  RGWMetadataObject(const obj_version& v,
+		    real_time m) : objv(v), mtime(m) {}
   virtual ~RGWMetadataObject() {}
   obj_version& get_version();
   real_time& get_mtime() { return mtime; }

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -321,8 +321,11 @@ void RGWListRoles::execute()
   if (op_ret < 0) {
     return;
   }
-  vector<RGWRole> result;
-  op_ret = RGWRole::get_roles_by_path_prefix(store->getRados(), s->cct, path_prefix, s->user->get_tenant(), result);
+  vector<RGWRoleInfo> result;
+  op_ret = store->ctl()->role->list_roles_by_path_prefix(path_prefix,
+                                                         s->user->get_tenant(),
+                                                         result,
+                                                         s->yield);
 
   if (op_ret == 0) {
     s->formatter->open_array_section("ListRolesResponse");
@@ -333,7 +336,7 @@ void RGWListRoles::execute()
     s->formatter->open_object_section("Roles");
     for (const auto& it : result) {
       s->formatter->open_object_section("member");
-      it.get_info().dump(s->formatter);
+      it.dump(s->formatter);
       s->formatter->close_section();
     }
     s->formatter->close_section();

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -26,7 +26,7 @@ int RGWRestRole::verify_permission()
   }
 
   string role_name = s->info.args.get("RoleName");
-  RGWRole role(s->cct, store->getRados()->pctl, role_name, s->user->get_tenant());
+  RGWRole role(s->cct, store->ctl()->role, role_name, s->user->get_tenant());
   if (op_ret = role.get(); op_ret < 0) {
     if (op_ret == -ENOENT) {
       op_ret = -ERR_NO_ROLE_FOUND;
@@ -130,7 +130,7 @@ void RGWCreateRole::execute()
   if (op_ret < 0) {
     return;
   }
-  RGWRole role(s->cct, store->getRados()->pctl, role_name, role_path, trust_policy,
+  RGWRole role(s->cct, store->ctl()->role, role_name, role_path, trust_policy,
                 s->user->get_tenant(), max_session_duration);
   op_ret = role.create(true);
 
@@ -229,7 +229,7 @@ void RGWGetRole::execute()
   if (op_ret < 0) {
     return;
   }
-  RGWRole role(s->cct, store->getRados()->pctl, role_name, s->user->get_tenant());
+  RGWRole role(s->cct, store->ctl()->role, role_name, s->user->get_tenant());
   op_ret = role.get();
 
   if (op_ret == -ENOENT) {

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -142,7 +142,7 @@ void RGWCreateRole::execute()
     s->formatter->open_object_section("CreateRoleResponse");
     s->formatter->open_object_section("CreateRoleResult");
     s->formatter->open_object_section("Role");
-    role.dump(s->formatter);
+    role.get_info().dump(s->formatter);
     s->formatter->close_section();
     s->formatter->close_section();
     s->formatter->open_object_section("ResponseMetadata");
@@ -246,7 +246,7 @@ void RGWGetRole::execute()
     s->formatter->close_section();
     s->formatter->open_object_section("GetRoleResult");
     s->formatter->open_object_section("Role");
-    role.dump(s->formatter);
+    role.get_info().dump(s->formatter);
     s->formatter->close_section();
     s->formatter->close_section();
     s->formatter->close_section();
@@ -333,7 +333,7 @@ void RGWListRoles::execute()
     s->formatter->open_object_section("Roles");
     for (const auto& it : result) {
       s->formatter->open_object_section("member");
-      it.dump(s->formatter);
+      it.get_info().dump(s->formatter);
       s->formatter->close_section();
     }
     s->formatter->close_section();

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -5854,7 +5854,7 @@ rgw::auth::s3::STSEngine::authenticate(
   string role_id;
   rgw::auth::RoleApplier::Role r;
   if (! token.roleId.empty()) {
-    RGWRole role(s->cct, ctl, token.roleId);
+    RGWRole role(s->cct, ctl->role, token.roleId);
     if (role.get_by_id() < 0) {
       return result_t::deny(-EPERM);
     }

--- a/src/rgw/rgw_role.cc
+++ b/src/rgw/rgw_role.cc
@@ -213,8 +213,6 @@ int RGWRole::get_by_id()
 
 int RGWRole::update()
 {
-  //auto& pool = ctl->svc->zone->get_zone_params().roles_pool;
-
   int ret = store_info(false);
   if (ret < 0) {
     ldout(cct, 0) << "ERROR:  updating info "
@@ -420,7 +418,7 @@ int RGWRole::get_roles_by_path_prefix(RGWRados *store,
       //Get id from info oid prefix + id
       string id = it.substr(pos + role_oid_prefix.length());
 
-      RGWRole role(cct, store->pctl);
+      RGWRole role(cct, store->ctl.role);
       role.set_id(id);
       int ret = role.read_info();
       if (ret < 0) {

--- a/src/rgw/rgw_role.cc
+++ b/src/rgw/rgw_role.cc
@@ -672,12 +672,12 @@ public:
     map<std::string, bufferlist> *pattrs = rci.has_attrs ? &rci.attrs : nullptr;
 
     int ret = rhandler->svc.role->store_info(op->ctx(),
-                                           rci.info,
-                                           &objv_tracker,
-                                           mtime,
-                                           false,
-                                           pattrs,
-                                           y);
+					     rci.info,
+					     &objv_tracker,
+					     mtime,
+					     false,
+					     pattrs,
+					     y);
 
     return ret < 0 ? ret : STATUS_APPLIED;
   }

--- a/src/rgw/rgw_role.cc
+++ b/src/rgw/rgw_role.cc
@@ -62,7 +62,7 @@ auto generate_ctime() {
 int RGWRole::create(bool exclusive, optional_yield y)
 {
   if (! info.validate_input()) {
-    ldout(cct, 0) << "ERROR: invalid input " << dendl;
+    ldout(cct, 0) << "ERROR: invalid input: " << info.err_msg << dendl;
     return -EINVAL;
   }
 
@@ -178,7 +178,6 @@ int RGWRoleInfo::get_role_policy(const string& policy_name, string& perm_policy)
 {
   const auto it = perm_policy_map.find(policy_name);
   if (it == perm_policy_map.end()) {
-    //ldout(cct, 0) << "ERROR: Policy name: " << policy_name << " not found" << dendl;
     return -ENOENT;
   } else {
     perm_policy = it->second;
@@ -190,12 +189,11 @@ int RGWRoleInfo::delete_policy(const string& policy_name)
 {
   const auto& it = perm_policy_map.find(policy_name);
   if (it == perm_policy_map.end()) {
-    //ldout(cct, 0) << "ERROR: Policy name: " << policy_name << " not found" << dendl;
     return -ENOENT;
   } else {
     perm_policy_map.erase(it);
   }
-    return 0;
+  return 0;
 }
 
 void RGWRoleInfo::dump(Formatter *f) const
@@ -272,30 +270,30 @@ int RGWRole::read_name()
 bool RGWRoleInfo::validate_input()
 {
   if (name.length() > MAX_ROLE_NAME_LEN) {
-    //ldout(cct, 0) << "ERROR: Invalid name length " << dendl;
+    set_err_msg("Invalid name length");
     return false;
   }
 
   if (path.length() > MAX_PATH_NAME_LEN) {
-    //ldout(cct, 0) << "ERROR: Invalid path length " << dendl;
+    set_err_msg("Invalid path length");
     return false;
   }
 
   std::regex regex_name("[A-Za-z0-9:=,.@-]+");
   if (! std::regex_match(name, regex_name)) {
-    //ldout(cct, 0) << "ERROR: Invalid chars in name " << dendl;
+    set_err_msg("Invalid chars in name");
     return false;
   }
 
   std::regex regex_path("(/[!-~]+/)|(/)");
   if (! std::regex_match(path,regex_path)) {
-    //ldout(cct, 0) << "ERROR: Invalid chars in path " << dendl;
+    set_err_msg("Invalid chars in path");
     return false;
   }
 
   if (max_session_duration < SESSION_DURATION_MIN ||
           max_session_duration > SESSION_DURATION_MAX) {
-    //ldout(cct, 0) << "ERROR: Invalid session duration, should be between 3600 and 43200 seconds " << dendl;
+    set_err_msg("Invalid session duration, should be between 3600 and 43200 seconds");
     return false;
   }
   return true;

--- a/src/rgw/rgw_role.cc
+++ b/src/rgw/rgw_role.cc
@@ -21,6 +21,7 @@
 
 #include "services/svc_zone.h"
 #include "services/svc_sys_obj.h"
+#include "services/svc_role.h"
 
 #define dout_subsys ceph_subsys_rgw
 
@@ -515,4 +516,134 @@ const string& RGWRole::get_info_oid_prefix()
 const string& RGWRole::get_path_oid_prefix()
 {
   return role_path_oid_prefix;
+}
+
+int RGWRoleCtl::store_info(const RGWRoleInfo& role,
+			   optional_yield y,
+			   const PutParams& params)
+{
+  return be_handler->call([&](RGWSI_MetaBackend_Handler::Op *op) {
+    return svc.role->store_info(op->ctx(),
+				role,
+				params.objv_tracker,
+				params.mtime,
+				params.exclusive,
+				params.attrs,
+				y);
+  });
+}
+
+int RGWRoleCtl::store_name(const std::string& role_id,
+			   const std::string& name,
+			   const std::string& tenant,
+			   optional_yield y,
+			   const PutParams& params)
+{
+  return be_handler->call([&](RGWSI_MetaBackend_Handler::Op *op) {
+    return svc.role->store_name(op->ctx(),
+				role_id,
+				name,
+				tenant,
+				params.objv_tracker,
+				params.mtime,
+				params.exclusive,
+				y);
+  });
+}
+
+int RGWRoleCtl::store_path(const std::string& role_id,
+			   const std::string& path,
+			   const std::string& tenant,
+			   optional_yield y,
+			   const PutParams& params)
+{
+  return be_handler->call([&](RGWSI_MetaBackend_Handler::Op *op) {
+    return svc.role->store_path(op->ctx(),
+				role_id,
+				path,
+				tenant,
+				params.objv_tracker,
+				params.mtime,
+				params.exclusive,
+				y);
+  });
+}
+
+std::pair<int, RGWRoleInfo>
+RGWRoleCtl::read_info(const std::string& role_id,
+		      optional_yield y,
+		      const GetParams& params)
+{
+  RGWRoleInfo info;
+  int ret = be_handler->call([&](RGWSI_MetaBackend_Handler::Op *op) {
+    return svc.role->read_info(op->ctx(),
+			       role_id,
+			       &info,
+			       params.objv_tracker,
+			       params.mtime,
+			       params.attrs,
+			       y);
+  });
+  return make_pair(ret, info);
+}
+
+std::pair<int, std::string>
+RGWRoleCtl::read_name(const std::string& name,
+		      const std::string& tenant,
+		      optional_yield y,
+		      const GetParams& params)
+{
+  std::string role_id;
+  int ret = be_handler->call([&](RGWSI_MetaBackend_Handler::Op *op) {
+    return svc.role->read_name(op->ctx(),
+			       name,
+			       tenant,
+			       role_id,
+			       params.objv_tracker,
+			       params.mtime,
+			       y);
+  });
+  return make_pair(ret, role_id);
+}
+
+int RGWRoleCtl::delete_info(const std::string& role_id,
+			    optional_yield y,
+			    const RemoveParams& params)
+{
+  return be_handler->call([&](RGWSI_MetaBackend_Handler::Op *op) {
+    return svc.role->delete_info(op->ctx(),
+				 role_id,
+				 params.objv_tracker,
+				 y);
+  });
+}
+
+int RGWRoleCtl::delete_name(const std::string& name,
+			    const std::string& tenant,
+			    optional_yield y,
+			    const RemoveParams& params)
+{
+  return be_handler->call([&](RGWSI_MetaBackend_Handler::Op *op) {
+    return svc.role->delete_name(op->ctx(),
+				 name,
+				 tenant,
+				 params.objv_tracker,
+				 y);
+  });
+}
+
+int RGWRoleCtl::delete_path(const std::string& role_id,
+			    const std::string& path,
+			    const std::string& tenant,
+			    optional_yield y,
+			    const RemoveParams& params)
+{
+  return be_handler->call([&](RGWSI_MetaBackend_Handler::Op *op) {
+    return svc.role->delete_path(op->ctx(),
+				 role_id,
+				 path,
+				 tenant,
+				 params.objv_tracker,
+				 y);
+  });
 }

--- a/src/rgw/rgw_role.cc
+++ b/src/rgw/rgw_role.cc
@@ -30,186 +30,186 @@ const string RGWRole::role_oid_prefix = "roles.";
 const string RGWRole::role_path_oid_prefix = "role_paths.";
 const string RGWRole::role_arn_prefix = "arn:aws:iam::";
 
-int RGWRole::store_info(bool exclusive)
-{
-  using ceph::encode;
-  string oid = get_info_oid_prefix() + id;
+// int RGWRole::store_info(bool exclusive)
+// {
+//   using ceph::encode;
+//   string oid = get_info_oid_prefix() + id;
 
-  bufferlist bl;
-  encode(*this, bl);
+//   bufferlist bl;
+//   encode(*this, bl);
 
-  auto svc = ctl->svc;
+//   auto svc = ctl->svc;
 
-  auto obj_ctx = ctl->svc->sysobj->init_obj_ctx();
-  return rgw_put_system_obj(obj_ctx, svc->zone->get_zone_params().roles_pool, oid,
-                            bl, exclusive, NULL, real_time(), NULL);
-}
+//   auto obj_ctx = ctl->svc->sysobj->init_obj_ctx();
+//   return rgw_put_system_obj(obj_ctx, svc->zone->get_zone_params().roles_pool, oid,
+//                             bl, exclusive, NULL, real_time(), NULL);
+// }
 
-int RGWRole::store_name(bool exclusive)
-{
-  RGWNameToId nameToId;
-  nameToId.obj_id = id;
+// int RGWRole::store_name(bool exclusive)
+// {
+//   RGWNameToId nameToId;
+//   nameToId.obj_id = id;
 
-  string oid = tenant + get_names_oid_prefix() + name;
+//   string oid = tenant + get_names_oid_prefix() + name;
 
-  bufferlist bl;
-  using ceph::encode;
-  encode(nameToId, bl);
+//   bufferlist bl;
+//   using ceph::encode;
+//   encode(nameToId, bl);
 
-  auto svc = ctl->svc;
+//   auto svc = ctl->svc;
 
-  auto obj_ctx = svc->sysobj->init_obj_ctx();
-  return rgw_put_system_obj(obj_ctx, svc->zone->get_zone_params().roles_pool, oid,
-              bl, exclusive, NULL, real_time(), NULL);
-}
+//   auto obj_ctx = svc->sysobj->init_obj_ctx();
+//   return rgw_put_system_obj(obj_ctx, svc->zone->get_zone_params().roles_pool, oid,
+//               bl, exclusive, NULL, real_time(), NULL);
+// }
 
-int RGWRole::store_path(bool exclusive)
-{
-  string oid = tenant + get_path_oid_prefix() + path + get_info_oid_prefix() + id;
+// int RGWRole::store_path(bool exclusive)
+// {
+//   string oid = tenant + get_path_oid_prefix() + path + get_info_oid_prefix() + id;
 
-  auto svc = ctl->svc;
+//   auto svc = ctl->svc;
 
-  bufferlist bl;
-  auto obj_ctx = svc->sysobj->init_obj_ctx();
-  return rgw_put_system_obj(obj_ctx, svc->zone->get_zone_params().roles_pool, oid,
-              bl, exclusive, NULL, real_time(), NULL);
-}
+//   bufferlist bl;
+//   auto obj_ctx = svc->sysobj->init_obj_ctx();
+//   return rgw_put_system_obj(obj_ctx, svc->zone->get_zone_params().roles_pool, oid,
+//               bl, exclusive, NULL, real_time(), NULL);
+// }
 
-int RGWRole::create(bool exclusive)
-{
-  int ret;
+// int RGWRole::create(bool exclusive)
+// {
+//   int ret;
 
-  if (! validate_input()) {
-    return -EINVAL;
-  }
+//   if (! validate_input()) {
+//     return -EINVAL;
+//   }
 
-  /* check to see the name is not used */
-  ret = read_id(name, tenant, id);
-  if (exclusive && ret == 0) {
-    ldout(cct, 0) << "ERROR: name " << name << " already in use for role id "
-                    << id << dendl;
-    return -EEXIST;
-  } else if ( ret < 0 && ret != -ENOENT) {
-    ldout(cct, 0) << "failed reading role id  " << id << ": "
-                  << cpp_strerror(-ret) << dendl;
-    return ret;
-  }
+//   /* check to see the name is not used */
+//   ret = read_id(info.name, info.tenant, info.id);
+//   if (exclusive && ret == 0) {
+//     ldout(cct, 0) << "ERROR: name " << info.name << " already in use for role id "
+//                     << info.id << dendl;
+//     return -EEXIST;
+//   } else if ( ret < 0 && ret != -ENOENT) {
+//     ldout(cct, 0) << "failed reading role id  " << id << ": "
+//                   << cpp_strerror(-ret) << dendl;
+//     return ret;
+//   }
 
-  /* create unique id */
-  uuid_d new_uuid;
-  char uuid_str[37];
-  new_uuid.generate_random();
-  new_uuid.print(uuid_str);
-  id = uuid_str;
+//   /* create unique id */
+//   uuid_d new_uuid;
+//   char uuid_str[37];
+//   new_uuid.generate_random();
+//   new_uuid.print(uuid_str);
+//   info.id = uuid_str;
 
-  //arn
-  arn = role_arn_prefix + tenant + ":role" + path + name;
+//   //arn
+//   info.arn = role_arn_prefix + tenant + ":role" + path + name;
 
-  // Creation time
-  real_clock::time_point t = real_clock::now();
+//   // Creation time
+//   real_clock::time_point t = real_clock::now();
 
-  struct timeval tv;
-  real_clock::to_timeval(t, tv);
+//   struct timeval tv;
+//   real_clock::to_timeval(t, tv);
 
-  char buf[30];
-  struct tm result;
-  gmtime_r(&tv.tv_sec, &result);
-  strftime(buf,30,"%Y-%m-%dT%H:%M:%S", &result);
-  sprintf(buf + strlen(buf),".%dZ",(int)tv.tv_usec/1000);
-  creation_date.assign(buf, strlen(buf));
+//   char buf[30];
+//   struct tm result;
+//   gmtime_r(&tv.tv_sec, &result);
+//   strftime(buf,30,"%Y-%m-%dT%H:%M:%S", &result);
+//   sprintf(buf + strlen(buf),".%dZ",(int)tv.tv_usec/1000);
+//   creation_date.assign(buf, strlen(buf));
 
-  auto svc = ctl->svc;
+//   auto svc = ctl->svc;
 
-  auto& pool = svc->zone->get_zone_params().roles_pool;
-  ret = store_info(exclusive);
-  if (ret < 0) {
-    ldout(cct, 0) << "ERROR:  storing role info in pool: " << pool.name << ": "
-                  << id << ": " << cpp_strerror(-ret) << dendl;
-    return ret;
-  }
+//   auto& pool = svc->zone->get_zone_params().roles_pool;
+//   ret = store_info(exclusive);
+//   if (ret < 0) {
+//     ldout(cct, 0) << "ERROR:  storing role info in pool: " << pool.name << ": "
+//                   << id << ": " << cpp_strerror(-ret) << dendl;
+//     return ret;
+//   }
 
-  ret = store_name(exclusive);
-  if (ret < 0) {
-    ldout(cct, 0) << "ERROR: storing role name in pool: " << pool.name << ": "
-                  << name << ": " << cpp_strerror(-ret) << dendl;
+//   ret = store_name(exclusive);
+//   if (ret < 0) {
+//     ldout(cct, 0) << "ERROR: storing role name in pool: " << pool.name << ": "
+//                   << name << ": " << cpp_strerror(-ret) << dendl;
 
-    //Delete the role info that was stored in the previous call
-    string oid = get_info_oid_prefix() + id;
-    int info_ret = rgw_delete_system_obj(svc->sysobj, pool, oid, NULL);
-    if (info_ret < 0) {
-      ldout(cct, 0) << "ERROR: cleanup of role id from pool: " << pool.name << ": "
-                  << id << ": " << cpp_strerror(-info_ret) << dendl;
-    }
-    return ret;
-  }
+//     //Delete the role info that was stored in the previous call
+//     string oid = get_info_oid_prefix() + id;
+//     int info_ret = rgw_delete_system_obj(svc->sysobj, pool, oid, NULL);
+//     if (info_ret < 0) {
+//       ldout(cct, 0) << "ERROR: cleanup of role id from pool: " << pool.name << ": "
+//                   << id << ": " << cpp_strerror(-info_ret) << dendl;
+//     }
+//     return ret;
+//   }
 
-  ret = store_path(exclusive);
-  if (ret < 0) {
-    ldout(cct, 0) << "ERROR: storing role path in pool: " << pool.name << ": "
-                  << path << ": " << cpp_strerror(-ret) << dendl;
-    //Delete the role info that was stored in the previous call
-    string oid = get_info_oid_prefix() + id;
-    int info_ret = rgw_delete_system_obj(svc->sysobj, pool, oid, NULL);
-    if (info_ret < 0) {
-      ldout(cct, 0) << "ERROR: cleanup of role id from pool: " << pool.name << ": "
-                  << id << ": " << cpp_strerror(-info_ret) << dendl;
-    }
-    //Delete role name that was stored in previous call
-    oid = tenant + get_names_oid_prefix() + name;
-    int name_ret = rgw_delete_system_obj(svc->sysobj, pool, oid, NULL);
-    if (name_ret < 0) {
-      ldout(cct, 0) << "ERROR: cleanup of role name from pool: " << pool.name << ": "
-                  << name << ": " << cpp_strerror(-name_ret) << dendl;
-    }
-    return ret;
-  }
-  return 0;
-}
+//   ret = store_path(exclusive);
+//   if (ret < 0) {
+//     ldout(cct, 0) << "ERROR: storing role path in pool: " << pool.name << ": "
+//                   << path << ": " << cpp_strerror(-ret) << dendl;
+//     //Delete the role info that was stored in the previous call
+//     string oid = get_info_oid_prefix() + id;
+//     int info_ret = rgw_delete_system_obj(svc->sysobj, pool, oid, NULL);
+//     if (info_ret < 0) {
+//       ldout(cct, 0) << "ERROR: cleanup of role id from pool: " << pool.name << ": "
+//                   << id << ": " << cpp_strerror(-info_ret) << dendl;
+//     }
+//     //Delete role name that was stored in previous call
+//     oid = info.tenant + get_names_oid_prefix() + info.name;
+//     int name_ret = rgw_delete_system_obj(svc->sysobj, pool, oid, NULL);
+//     if (name_ret < 0) {
+//       ldout(cct, 0) << "ERROR: cleanup of role name from pool: " << pool.name << ": "
+//                   << name << ": " << cpp_strerror(-name_ret) << dendl;
+//     }
+//     return ret;
+//   }
+//   return 0;
+// }
 
-int RGWRole::delete_obj()
-{
-  auto svc = ctl->svc;
-  auto& pool = svc->zone->get_zone_params().roles_pool;
+// int RGWRole::delete_obj()
+// {
+//   auto svc = ctl->svc;
+//   auto& pool = svc->zone->get_zone_params().roles_pool;
 
-  int ret = read_name();
-  if (ret < 0) {
-    return ret;
-  }
+//   int ret = read_name();
+//   if (ret < 0) {
+//     return ret;
+//   }
 
-  ret = read_info();
-  if (ret < 0) {
-    return ret;
-  }
+//   ret = read_info();
+//   if (ret < 0) {
+//     return ret;
+//   }
 
-  if (! perm_policy_map.empty()) {
-    return -ERR_DELETE_CONFLICT;
-  }
+//   if (! perm_policy_map.empty()) {
+//     return -ERR_DELETE_CONFLICT;
+//   }
 
-  // Delete id
-  string oid = get_info_oid_prefix() + id;
-  ret = rgw_delete_system_obj(svc->sysobj, pool, oid, NULL);
-  if (ret < 0) {
-    ldout(cct, 0) << "ERROR: deleting role id from pool: " << pool.name << ": "
-                  << id << ": " << cpp_strerror(-ret) << dendl;
-  }
+//   // Delete id
+//   string oid = get_info_oid_prefix() + info.id;
+//   ret = rgw_delete_system_obj(svc->sysobj, pool, oid, NULL);
+//   if (ret < 0) {
+//     ldout(cct, 0) << "ERROR: deleting role id from pool: " << pool.name << ": "
+//                   << id << ": " << cpp_strerror(-ret) << dendl;
+//   }
 
-  // Delete name
-  oid = tenant + get_names_oid_prefix() + name;
-  ret = rgw_delete_system_obj(svc->sysobj, pool, oid, NULL);
-  if (ret < 0) {
-    ldout(cct, 0) << "ERROR: deleting role name from pool: " << pool.name << ": "
-                  << name << ": " << cpp_strerror(-ret) << dendl;
-  }
+//   // Delete name
+//   oid = tenant + get_names_oid_prefix() + name;
+//   ret = rgw_delete_system_obj(svc->sysobj, pool, oid, NULL);
+//   if (ret < 0) {
+//     ldout(cct, 0) << "ERROR: deleting role name from pool: " << pool.name << ": "
+//                   << name << ": " << cpp_strerror(-ret) << dendl;
+//   }
 
-  // Delete path
-  oid = tenant + get_path_oid_prefix() + path + get_info_oid_prefix() + id;
-  ret = rgw_delete_system_obj(svc->sysobj, pool, oid, NULL);
-  if (ret < 0) {
-    ldout(cct, 0) << "ERROR: deleting role path from pool: " << pool.name << ": "
-                  << path << ": " << cpp_strerror(-ret) << dendl;
-  }
-  return ret;
-}
+//   // Delete path
+//   oid = tenant + get_path_oid_prefix() + path + get_info_oid_prefix() + id;
+//   ret = rgw_delete_system_obj(svc->sysobj, pool, oid, NULL);
+//   if (ret < 0) {
+//     ldout(cct, 0) << "ERROR: deleting role path from pool: " << pool.name << ": "
+//                   << path << ": " << cpp_strerror(-ret) << dendl;
+//   }
+//   return ret;
+// }
 
 int RGWRole::get()
 {
@@ -243,19 +243,19 @@ int RGWRole::update()
   int ret = store_info(false);
   if (ret < 0) {
     ldout(cct, 0) << "ERROR:  storing info in pool: " << pool.name << ": "
-                  << id << ": " << cpp_strerror(-ret) << dendl;
+                  << info.id << ": " << cpp_strerror(-ret) << dendl;
     return ret;
   }
 
   return 0;
 }
 
-void RGWRole::set_perm_policy(const string& policy_name, const string& perm_policy)
+void RGWRoleInfo::set_perm_policy(const string& policy_name, const string& perm_policy)
 {
   perm_policy_map[policy_name] = perm_policy;
 }
 
-vector<string> RGWRole::get_role_policy_names()
+vector<string> RGWRoleInfo::get_role_policy_names()
 {
   vector<string> policy_names;
   for (const auto& it : perm_policy_map)
@@ -266,11 +266,11 @@ vector<string> RGWRole::get_role_policy_names()
   return policy_names;
 }
 
-int RGWRole::get_role_policy(const string& policy_name, string& perm_policy)
+int RGWRoleInfo::get_role_policy(const string& policy_name, string& perm_policy)
 {
   const auto it = perm_policy_map.find(policy_name);
   if (it == perm_policy_map.end()) {
-    ldout(cct, 0) << "ERROR: Policy name: " << policy_name << " not found" << dendl;
+    //ldout(cct, 0) << "ERROR: Policy name: " << policy_name << " not found" << dendl;
     return -ENOENT;
   } else {
     perm_policy = it->second;
@@ -278,19 +278,19 @@ int RGWRole::get_role_policy(const string& policy_name, string& perm_policy)
   return 0;
 }
 
-int RGWRole::delete_policy(const string& policy_name)
+int RGWRoleInfo::delete_policy(const string& policy_name)
 {
   const auto& it = perm_policy_map.find(policy_name);
   if (it == perm_policy_map.end()) {
-    ldout(cct, 0) << "ERROR: Policy name: " << policy_name << " not found" << dendl;
+    //ldout(cct, 0) << "ERROR: Policy name: " << policy_name << " not found" << dendl;
     return -ENOENT;
   } else {
     perm_policy_map.erase(it);
   }
-  return 0;
+    return 0;
 }
 
-void RGWRole::dump(Formatter *f) const
+void RGWRoleInfo::dump(Formatter *f) const
 {
   encode_json("RoleId", id , f);
   encode_json("RoleName", name , f);
@@ -301,7 +301,7 @@ void RGWRole::dump(Formatter *f) const
   encode_json("AssumeRolePolicyDocument", trust_policy, f);
 }
 
-void RGWRole::decode_json(JSONObj *obj)
+void RGWRoleInfo::decode_json(JSONObj *obj)
 {
   JSONDecoder::decode_json("id", id, obj);
   JSONDecoder::decode_json("name", name, obj);
@@ -339,107 +339,106 @@ int RGWRole::read_id(const string& role_name, const string& tenant, string& role
   return 0;
 }
 
-int RGWRole::read_info()
-{
-  auto svc = ctl->svc;
-  auto& pool = svc->zone->get_zone_params().roles_pool;
-  string oid = get_info_oid_prefix() + id;
-  bufferlist bl;
-  auto obj_ctx = svc->sysobj->init_obj_ctx();
+// int RGWRole::read_info()
+// {
+//   auto svc = ctl->svc;
+//   auto& pool = svc->zone->get_zone_params().roles_pool;
+//   string oid = get_info_oid_prefix() + info.id;
+//   bufferlist bl;
+//   auto obj_ctx = svc->sysobj->init_obj_ctx();
 
-  int ret = rgw_get_system_obj(obj_ctx, pool, oid, bl, NULL, NULL, null_yield);
-  if (ret < 0) {
-    ldout(cct, 0) << "ERROR: failed reading role info from pool: " << pool.name <<
-                  ": " << id << ": " << cpp_strerror(-ret) << dendl;
-    return ret;
-  }
+//   int ret = rgw_get_system_obj(obj_ctx, pool, oid, bl, NULL, NULL, null_yield);
+//   if (ret < 0) {
+//     ldout(cct, 0) << "ERROR: failed reading role info from pool: " << pool.name <<
+//                   ": " << info.id << ": " << cpp_strerror(-ret) << dendl;
+//     return ret;
+//   }
 
-  try {
-    using ceph::decode;
-    auto iter = bl.cbegin();
-    decode(*this, iter);
-  } catch (buffer::error& err) {
-    ldout(cct, 0) << "ERROR: failed to decode role info from pool: " << pool.name <<
-                  ": " << id << dendl;
-    return -EIO;
-  }
+//   try {
+//     using ceph::decode;
+//     auto iter = bl.cbegin();
+//     decode(info, iter);
+//   } catch (buffer::error& err) {
+//     ldout(cct, 0) << "ERROR: failed to decode role info from pool: " << pool.name <<
+//                   ": " << info.id << dendl;
+//     return -EIO;
+//   }
 
-  return 0;
-}
+//   return 0;
+// }
 
-int RGWRole::read_name()
-{
-  auto svc = ctl->svc;
-  auto& pool = svc->zone->get_zone_params().roles_pool;
-  string oid = tenant + get_names_oid_prefix() + name;
-  bufferlist bl;
-  auto obj_ctx = svc->sysobj->init_obj_ctx();
+// int RGWRole::read_name()
+// {
+//   auto svc = ctl->svc;
+//   auto& pool = svc->zone->get_zone_params().roles_pool;
+//   string oid = tenant + get_names_oid_prefix() + name;
+//   bufferlist bl;
+//   auto obj_ctx = svc->sysobj->init_obj_ctx();
 
-  int ret = rgw_get_system_obj(obj_ctx, pool, oid, bl, NULL, NULL, null_yield);
-  if (ret < 0) {
-    ldout(cct, 0) << "ERROR: failed reading role name from pool: " << pool.name << ": "
-                  << name << ": " << cpp_strerror(-ret) << dendl;
-    return ret;
-  }
+//   int ret = rgw_get_system_obj(obj_ctx, pool, oid, bl, NULL, NULL, null_yield);
+//   if (ret < 0) {
+//     ldout(cct, 0) << "ERROR: failed reading role name from pool: " << pool.name << ": "
+//                   << name << ": " << cpp_strerror(-ret) << dendl;
+//     return ret;
+//   }
 
-  RGWNameToId nameToId;
-  try {
-    using ceph::decode;
-    auto iter = bl.cbegin();
-    decode(nameToId, iter);
-  } catch (buffer::error& err) {
-    ldout(cct, 0) << "ERROR: failed to decode role name from pool: " << pool.name << ": "
-                  << name << dendl;
-    return -EIO;
-  }
-  id = nameToId.obj_id;
-  return 0;
-}
+//   RGWNameToId nameToId;
+//   try {
+//     using ceph::decode;
+//     auto iter = bl.cbegin();
+//     decode(nameToId, iter);
+//   } catch (buffer::error& err) {
+//     ldout(cct, 0) << "ERROR: failed to decode role name from pool: " << pool.name << ": "
+//                   << name << dendl;
+//     return -EIO;
+//   }
+//   id = nameToId.obj_id;
+//   return 0;
+// }
 
-bool RGWRole::validate_input()
+bool RGWRoleInfo::validate_input()
 {
   if (name.length() > MAX_ROLE_NAME_LEN) {
-    ldout(cct, 0) << "ERROR: Invalid name length " << dendl;
+    //ldout(cct, 0) << "ERROR: Invalid name length " << dendl;
     return false;
   }
 
   if (path.length() > MAX_PATH_NAME_LEN) {
-    ldout(cct, 0) << "ERROR: Invalid path length " << dendl;
+    //ldout(cct, 0) << "ERROR: Invalid path length " << dendl;
     return false;
   }
 
   std::regex regex_name("[A-Za-z0-9:=,.@-]+");
   if (! std::regex_match(name, regex_name)) {
-    ldout(cct, 0) << "ERROR: Invalid chars in name " << dendl;
+    //ldout(cct, 0) << "ERROR: Invalid chars in name " << dendl;
     return false;
   }
 
   std::regex regex_path("(/[!-~]+/)|(/)");
   if (! std::regex_match(path,regex_path)) {
-    ldout(cct, 0) << "ERROR: Invalid chars in path " << dendl;
+    //ldout(cct, 0) << "ERROR: Invalid chars in path " << dendl;
     return false;
   }
 
   if (max_session_duration < SESSION_DURATION_MIN ||
           max_session_duration > SESSION_DURATION_MAX) {
-    ldout(cct, 0) << "ERROR: Invalid session duration, should be between 3600 and 43200 seconds " << dendl;
+    //ldout(cct, 0) << "ERROR: Invalid session duration, should be between 3600 and 43200 seconds " << dendl;
     return false;
   }
   return true;
 }
 
-void RGWRole::extract_name_tenant(const std::string& str)
-{
-  size_t pos = str.find('$');
-  if (pos != std::string::npos) {
+void RGWRoleInfo::extract_name_tenant(std::string_view str) {
+  if (auto pos = str.find('$');
+      pos != std::string::npos) {
     tenant = str.substr(0, pos);
-    name = str.substr(pos + 1);
+    name = str.substr(pos+1);
   }
 }
 
 void RGWRole::update_trust_policy(string& trust_policy)
 {
-  this->trust_policy = trust_policy;
+  this->info.trust_policy = trust_policy;
 }
 
 int RGWRole::get_roles_by_path_prefix(RGWRados *store,

--- a/src/rgw/rgw_role.cc
+++ b/src/rgw/rgw_role.cc
@@ -596,6 +596,22 @@ void RGWRoleCompleteInfo::decode_json(JSONObj *obj)
   has_attrs = JSONDecoder::decode_json("attrs", attrs, obj);
 }
 
+
+RGWMetadataObject *RGWRoleMetadataHandler::get_meta_obj(JSONObj *jo,
+							const obj_version& objv,
+							const ceph::real_time& mtime)
+{
+  RGWRoleCompleteInfo rci;
+
+  try {
+    decode_json_obj(rci, jo);
+  } catch (JSONDecoder:: err& e) {
+    return nullptr;
+  }
+
+  return new RGWRoleMetadataObject(rci, objv, mtime);
+}
+
 int RGWRoleMetadataHandler::do_get(RGWSI_MetaBackend_Handler::Op *op,
                                    std::string& entry,
                                    RGWMetadataObject **obj,

--- a/src/rgw/rgw_role.cc
+++ b/src/rgw/rgw_role.cc
@@ -660,3 +660,17 @@ RGWRoleMetadataHandler::RGWRoleMetadataHandler(RGWSI_Role *role_svc)
   base_init(role_svc->ctx(), role_svc->get_be_handler());
   svc.role = role_svc;
 }
+
+void RGWRoleCompleteInfo::dump(ceph::Formatter *f) const
+{
+  info.dump(f);
+  if (has_attrs) {
+    encode_json("attrs", attrs, f);
+  }
+}
+
+void RGWRoleCompleteInfo::decode_json(JSONObj *obj)
+{
+  decode_json_obj(info, obj);
+  has_attrs = JSONDecoder::decode_json("attrs", attrs, obj);
+}

--- a/src/rgw/rgw_role.cc
+++ b/src/rgw/rgw_role.cc
@@ -674,3 +674,84 @@ void RGWRoleCompleteInfo::decode_json(JSONObj *obj)
   decode_json_obj(info, obj);
   has_attrs = JSONDecoder::decode_json("attrs", attrs, obj);
 }
+
+int RGWRoleMetadataHandler::do_get(RGWSI_MetaBackend_Handler::Op *op,
+                                   std::string& entry,
+                                   RGWMetadataObject **obj,
+                                   optional_yield y)
+{
+  RGWRoleCompleteInfo rci;
+  RGWObjVersionTracker objv_tracker;
+  real_time mtime;
+
+  int ret = svc.role->read_info(op->ctx(),
+                                entry,
+                                &rci.info,
+                                &objv_tracker,
+                                &mtime,
+                                &rci.attrs,
+                                y);
+
+  if (ret < 0) {
+    return ret;
+  }
+
+  RGWRoleMetadataObject *rdo = new RGWRoleMetadataObject(rci, objv_tracker.read_version,
+                                                         mtime);
+  *obj = rdo;
+
+  return 0;
+}
+
+int RGWRoleMetadataHandler::do_remove(RGWSI_MetaBackend_Handler::Op *op,
+                                      std::string& entry,
+                                      RGWObjVersionTracker& objv_tracker,
+                                      optional_yield y)
+{
+  return svc.role->delete_info(op->ctx(), entry, &objv_tracker, y);
+}
+
+class RGWMetadataHandlerPut_Role : public RGWMetadataHandlerPut_SObj
+{
+  RGWRoleMetadataHandler *rhandler;
+  RGWRoleMetadataObject *mdo;
+public:
+  RGWMetadataHandlerPut_Role(RGWRoleMetadataHandler *handler,
+                             RGWSI_MetaBackend_Handler::Op *op,
+                             std::string& entry,
+                             RGWMetadataObject *obj,
+                             RGWObjVersionTracker& objv_tracker,
+                             optional_yield y,
+                             RGWMDLogSyncType type) :
+    RGWMetadataHandlerPut_SObj(handler, op, entry, obj, objv_tracker, y, type),
+    rhandler(handler) {
+    mdo = static_cast<RGWRoleMetadataObject*>(obj);
+  }
+
+  int put_checked() override {
+    auto& rci = mdo->get_rci();
+    auto mtime = mdo->get_mtime();
+    map<std::string, bufferlist> *pattrs = rci.has_attrs ? &rci.attrs : nullptr;
+
+    int ret = rhandler->svc.role->store_info(op->ctx(),
+                                           rci.info,
+                                           &objv_tracker,
+                                           mtime,
+                                           false,
+                                           pattrs,
+                                           y);
+
+    return ret < 0 ? ret : STATUS_APPLIED;
+  }
+};
+
+int RGWRoleMetadataHandler::do_put(RGWSI_MetaBackend_Handler::Op *op,
+                                   std::string& entry,
+                                   RGWMetadataObject *obj,
+                                   RGWObjVersionTracker& objv_tracker,
+                                   optional_yield y,
+                                   RGWMDLogSyncType type)
+{
+  RGWMetadataHandlerPut_Role put_op(this, op , entry, obj, objv_tracker, y, type);
+  return do_put_operate(&put_op);
+}

--- a/src/rgw/rgw_role.cc
+++ b/src/rgw/rgw_role.cc
@@ -66,6 +66,7 @@ int RGWRole::create(bool exclusive)
   int ret;
 
   if (! info.validate_input()) {
+    ldout(cct, 0) << "ERROR: invalid input " << dendl;
     return -EINVAL;
   }
 

--- a/src/rgw/rgw_role.cc
+++ b/src/rgw/rgw_role.cc
@@ -39,49 +39,27 @@ int RGWRole::store_info(bool exclusive, optional_yield y)
 			      RGWRoleCtl::PutParams().
 			      set_exclusive(exclusive));
 }
-// {
-//   using ceph::encode;
-//   string oid = get_info_oid_prefix() + id;
 
-//   bufferlist bl;
-//   encode(*this, bl);
+int RGWRole::store_name(bool exclusive, optional_yield y)
+{
+  return role_ctl->store_name(info.id,
+			      info.name,
+			      info.tenant,
+			      y,
+			      RGWRoleCtl::PutParams().
+			      set_exclusive(exclusive)
+			      );
+}
 
-//   auto svc = ctl->svc;
-
-//   auto obj_ctx = ctl->svc->sysobj->init_obj_ctx();
-//   return rgw_put_system_obj(obj_ctx, svc->zone->get_zone_params().roles_pool, oid,
-//                             bl, exclusive, NULL, real_time(), NULL);
-// }
-
-// int RGWRole::store_name(bool exclusive)
-// {
-//   RGWNameToId nameToId;
-//   nameToId.obj_id = id;
-
-//   string oid = tenant + get_names_oid_prefix() + name;
-
-//   bufferlist bl;
-//   using ceph::encode;
-//   encode(nameToId, bl);
-
-//   auto svc = ctl->svc;
-
-//   auto obj_ctx = svc->sysobj->init_obj_ctx();
-//   return rgw_put_system_obj(obj_ctx, svc->zone->get_zone_params().roles_pool, oid,
-//               bl, exclusive, NULL, real_time(), NULL);
-// }
-
-// int RGWRole::store_path(bool exclusive)
-// {
-//   string oid = tenant + get_path_oid_prefix() + path + get_info_oid_prefix() + id;
-
-//   auto svc = ctl->svc;
-
-//   bufferlist bl;
-//   auto obj_ctx = svc->sysobj->init_obj_ctx();
-//   return rgw_put_system_obj(obj_ctx, svc->zone->get_zone_params().roles_pool, oid,
-//               bl, exclusive, NULL, real_time(), NULL);
-// }
+int RGWRole::store_path(bool exclusive, optional_yield y)
+{
+  return role_ctl->store_path(info.id,
+			      info.path,
+			      info.tenant,
+			      y,
+			      RGWRoleCtl::PutParams().
+			      set_exclusive(exclusive));
+}
 
 // int RGWRole::create(bool exclusive)
 // {

--- a/src/rgw/rgw_role.cc
+++ b/src/rgw/rgw_role.cc
@@ -282,13 +282,13 @@ void RGWRoleInfo::dump(Formatter *f) const
 
 void RGWRoleInfo::decode_json(JSONObj *obj)
 {
-  JSONDecoder::decode_json("id", id, obj);
-  JSONDecoder::decode_json("name", name, obj);
-  JSONDecoder::decode_json("path", path, obj);
-  JSONDecoder::decode_json("arn", arn, obj);
-  JSONDecoder::decode_json("create_date", creation_date, obj);
-  JSONDecoder::decode_json("max_session_duration", max_session_duration, obj);
-  JSONDecoder::decode_json("assume_role_policy_document", trust_policy, obj);
+  JSONDecoder::decode_json("RoleId", id, obj);
+  JSONDecoder::decode_json("RoleName", name, obj);
+  JSONDecoder::decode_json("Path", path, obj);
+  JSONDecoder::decode_json("Arn", arn, obj);
+  JSONDecoder::decode_json("CreateDate", creation_date, obj);
+  JSONDecoder::decode_json("MaxSessionDuration", max_session_duration, obj);
+  JSONDecoder::decode_json("AssumeRolePolicyDocument", trust_policy, obj);
 }
 
 int RGWRole::read_id(const string& role_name, const string& tenant, string& role_id)

--- a/src/rgw/rgw_role.cc
+++ b/src/rgw/rgw_role.cc
@@ -654,3 +654,9 @@ int RGWRoleCtl::delete_path(const std::string& role_id,
 				 y);
   });
 }
+
+RGWRoleMetadataHandler::RGWRoleMetadataHandler(RGWSI_Role *role_svc)
+{
+  base_init(role_svc->ctx(), role_svc->get_be_handler());
+  svc.role = role_svc;
+}

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -9,6 +9,7 @@
 #include "common/ceph_context.h"
 
 class RGWCtl;
+class RGWRados;
 
 class RGWRole
 {

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -123,9 +123,6 @@ class RGWRoleCtl;
 class RGWRole
 {
   using string = std::string;
-  static const string role_name_oid_prefix;
-  static const string role_oid_prefix;
-  static const string role_path_oid_prefix;
   static const string role_arn_prefix;
 
   CephContext *cct;
@@ -190,15 +187,6 @@ public:
   int delete_policy(const string& policy_name) {
     return info.delete_policy(policy_name);
   }
-
-  static const string& get_names_oid_prefix();
-  static const string& get_info_oid_prefix();
-  static const string& get_path_oid_prefix();
-  static int get_roles_by_path_prefix(RGWRados *store,
-                                      CephContext *cct,
-                                      const string& path_prefix,
-                                      const string& tenant,
-                                      vector<RGWRole>& roles);
 
   void dump(Formatter *f) const {
     info.dump(f);
@@ -397,6 +385,11 @@ public:
 		  const std::string& tenant,
 		  optional_yield y,
 		  const RemoveParams& params = {});
+
+  int list_roles_by_path_prefix(const std::string& path_prefix,
+                                const std::string& tenant,
+                                vector<RGWRoleInfo>& roles,
+                                optional_yield y);
 };
 
 #endif /* CEPH_RGW_ROLE_H */

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -117,7 +117,6 @@ class RGWRole
   static const string role_arn_prefix;
 
   CephContext *cct;
-  RGWCtl *ctl; // fixme
   RGWRoleCtl *role_ctl;
   RGWRoleInfo info;
 
@@ -134,17 +133,17 @@ public:
   // args for RGWRoleInfo
   template <typename ...Args>
   RGWRole(CephContext *cct,
-          RGWCtl *ctl,
+          RGWRoleCtl *role_ctl,
           Args&& ...args)
   : cct(cct),
-    ctl(ctl),
+    role_ctl(role_ctl),
     info(std::forward<Args>(args)...)
  {}
 
   RGWRole(CephContext *cct,
-          RGWCtl *ctl)
+          RGWRoleCtl *role_ctl)
   : cct(cct),
-    ctl(ctl) {}
+    role_ctl(role_ctl) {}
 
   RGWRole() {}
 

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -122,8 +122,8 @@ class RGWRole
   RGWRoleInfo info;
 
   int store_info(bool exclusive, optional_yield y = null_yield);
-  int store_name(bool exclusive) { return 0; }
-  int store_path(bool exclusive) { return 0; }
+  int store_name(bool exclusive, optional_yield y = null_yield);
+  int store_path(bool exclusive, optional_yield y = null_yield);
   int read_id(const string& role_name, const string& tenant, string& role_id);
   int read_name() { return 0; }
   int read_info() { return 0; };

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -226,28 +226,30 @@ public:
 
 class RGWRoleMetadataHandler: public RGWMetadataHandler_GenericMetaBE
 {
+
+public:
   struct Svc {
     RGWSI_Role *role{nullptr};
   } svc;
-
-public:
 
   RGWRoleMetadataHandler(RGWSI_Role *role_svc);
 
   int do_get(RGWSI_MetaBackend_Handler::Op *op,
 	     std::string& entry,
 	     RGWMetadataObject **obj,
-	     optional_yield y) final
-  {
-    return 0; // TODO
-  }
+	     optional_yield y) final;
 
   int do_remove(RGWSI_MetaBackend_Handler::Op *op,
 		std::string& entry,
 		RGWObjVersionTracker& objv_tracker,
-		optional_yield y) final {
-    return 0; // TODO
-  }
+		optional_yield y) final;
+
+  int do_put(RGWSI_MetaBackend_Handler::Op *op,
+	     std::string& entr,
+	     RGWMetadataObject *obj,
+	     RGWObjVersionTracker& objv_tracker,
+	     optional_yield y,
+	     RGWMDLogSyncType type) override;
 };
 
 class RGWSI_Role;

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -7,7 +7,7 @@
 #include <string>
 
 #include "common/ceph_context.h"
-
+#include "rgw_metadata.h"
 class RGWCtl;
 class RGWRados;
 
@@ -196,7 +196,35 @@ public:
     info.dump(f);
   }
 };
-class RGWRoleMetadataHandler;
+
+//class RGWMetadataObject;
+
+class RGWRoleMetadataHandler: public RGWMetadataHandler_GenericMetaBE
+{
+  struct Svc {
+    RGWSI_Role *role{nullptr};
+  } svc;
+
+public:
+
+  RGWRoleMetadataHandler(RGWSI_Role *role_svc);
+
+  int do_get(RGWSI_MetaBackend_Handler::Op *op,
+	     std::string& entry,
+	     RGWMetadataObject **obj,
+	     optional_yield y) final
+  {
+    return 0; // TODO
+  }
+
+  int do_remove(RGWSI_MetaBackend_Handler::Op *op,
+		std::string& entry,
+		RGWObjVersionTracker& objv_tracker,
+		optional_yield y) final {
+    return 0; // TODO
+  }
+};
+
 class RGWSI_Role;
 class RGWSI_MetaBackend_Handler;
 
@@ -208,7 +236,10 @@ class RGWRoleCtl {
   RGWSI_MetaBackend_Handler *be_handler{nullptr};
 public:
   RGWRoleCtl(RGWSI_Role *_role_svc,
-	     RGWRoleMetadataHandler *_rmhander);
+	     RGWRoleMetadataHandler *_rmhandler) {
+    svc.role = _role_svc;
+    rmhandler = _rmhandler;
+  }
 
   struct PutParams {
     ceph::real_time mtime;

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -46,9 +46,11 @@ struct RGWRoleInfo
 	      std::string path,
 	      std::string trust_policy,
 	      std::string tenant,
-	      std::string max_session_duration_str="") :
-    path(std::move(path)),
-    trust_policy(std::move(trust_policy)) {
+	      std::string max_session_duration_str="") :name(std::move(name)),
+							path(std::move(path)),
+							trust_policy(std::move(trust_policy)),
+							tenant(std::move(tenant))
+  {
     if (this->path.empty())
       this->path = "/";
     extract_name_tenant(name);
@@ -60,7 +62,10 @@ struct RGWRoleInfo
   }
 
   RGWRoleInfo(std::string _name,
-	      std::string _tenant) {
+	      std::string _tenant) : name(std::move(_name)),
+				     tenant(std::move(_tenant))
+
+  {
     extract_name_tenant(_name);
     if (tenant.empty()) {
       tenant = std::move(_tenant);

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -379,6 +379,10 @@ public:
 				   optional_yield y,
 				   const GetParams& params = {});
 
+  int delete_role(const RGWRoleInfo& role,
+		  optional_yield y,
+		  const RemoveParams& params = {});
+
   int delete_info(const std::string& role_id,
 		  optional_yield y,
 		  const RemoveParams& params = {});

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -233,6 +233,12 @@ public:
 
   RGWRoleMetadataHandler(RGWSI_Role *role_svc);
 
+  std::string get_type() final { return "roles";  }
+
+  RGWMetadataObject *get_meta_obj(JSONObj *jo,
+				  const obj_version& objv,
+				  const ceph::real_time& mtime);
+
   int do_get(RGWSI_MetaBackend_Handler::Op *op,
 	     std::string& entry,
 	     RGWMetadataObject **obj,

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -107,7 +107,7 @@ struct RGWRoleInfo
 };
 WRITE_CLASS_ENCODER(RGWRoleInfo)
 
-
+class RGWRoleCtl;
 class RGWRole
 {
   using string = std::string;
@@ -117,10 +117,11 @@ class RGWRole
   static const string role_arn_prefix;
 
   CephContext *cct;
-  RGWCtl *ctl;
+  RGWCtl *ctl; // fixme
+  RGWRoleCtl *role_ctl;
   RGWRoleInfo info;
 
-  int store_info(bool exclusive) { return 0; }
+  int store_info(bool exclusive, optional_yield y = null_yield);
   int store_name(bool exclusive) { return 0; }
   int store_path(bool exclusive) { return 0; }
   int read_id(const string& role_name, const string& tenant, string& role_id);

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -215,12 +215,102 @@ public:
     RGWObjVersionTracker *objv_tracker {nullptr};
     std::map<std::string, bufferlist> *attrs {nullptr};
 
-    PutParams() {};
+    PutParams() {}
+
+    PutParams& set_objv_tracker(RGWObjVersionTracker *_objv_tracker) {
+      objv_tracker = _objv_tracker;
+      return *this;
+    }
+
+    PutParams& set_mtime(const ceph::real_time& _mtime) {
+      mtime = _mtime;
+      return *this;
+    }
+
+    PutParams& set_exclusive(bool _exclusive) {
+      exclusive = _exclusive;
+      return *this;
+    }
+
+    PutParams& set_attrs(map<string, bufferlist> *_attrs) {
+      attrs = _attrs;
+      return *this;
+    }
+  };
+
+  struct GetParams {
+    ceph::real_time *mtime{nullptr};
+    std::map<std::string, bufferlist> *attrs{nullptr};
+    RGWObjVersionTracker *objv_tracker {nullptr};
+
+    GetParams() {}
+
+    GetParams& set_objv_tracker(RGWObjVersionTracker *_objv_tracker) {
+      objv_tracker = _objv_tracker;
+      return *this;
+    }
+
+    GetParams& set_mtime(ceph::real_time *_mtime) {
+      mtime = _mtime;
+      return *this;
+    }
+
+    GetParams& set_attrs(map<string, bufferlist> *_attrs) {
+      attrs = _attrs;
+      return *this;
+    }
+  };
+
+  struct RemoveParams {
+    RGWObjVersionTracker *objv_tracker{nullptr};
+
+    RemoveParams() {}
+
+    RemoveParams& set_objv_tracker(RGWObjVersionTracker *_objv_tracker) {
+      objv_tracker = _objv_tracker;
+      return *this;
+    }
   };
 
   int store_info(const RGWRoleInfo& role,
 		 optional_yield y,
 		 const PutParams& params = {});
+
+  int store_name(const std::string& role_id,
+		 const std::string& name,
+		 const std::string& tenant,
+		 optional_yield y,
+		 const PutParams& params = {});
+
+  int store_path(const std::string& role_id,
+		 const std::string& path,
+		 const std::string& tenant,
+		 optional_yield y,
+		 const PutParams& params = {});
+
+  std::pair<int, RGWRoleInfo> read_info(const std::string& role_id,
+					optional_yield y,
+					const GetParams& params = {});
+
+  std::pair<int, string> read_name(const std::string& name,
+				   const std::string& tenant,
+				   optional_yield y,
+				   const GetParams& params = {});
+
+  int delete_info(const std::string& role_id,
+		  optional_yield y,
+		  const RemoveParams& params = {});
+
+  int delete_name(const std::string& name,
+		  const std::string& tenant,
+		  optional_yield y,
+		  const RemoveParams& params = {});
+
+  int delete_path(const std::string& role_id,
+		  const std::string& path,
+		  const std::string& tenant,
+		  optional_yield y,
+		  const RemoveParams& params = {});
 };
 
 #endif /* CEPH_RGW_ROLE_H */

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -197,6 +197,31 @@ public:
   }
 };
 
+struct RGWRoleCompleteInfo {
+  RGWRoleInfo info;
+  map<std::string, bufferlist> attrs;
+  bool has_attrs;
+
+  void dump(Formatter *f) const;
+  void decode_json(JSONObj *obj);
+};
+
+class RGWRoleMetadataObject: public RGWMetadataObject {
+  RGWRoleCompleteInfo rci;
+public:
+  RGWRoleMetadataObject() = default;
+  RGWRoleMetadataObject(const RGWRoleCompleteInfo& _rci,
+			const obj_version& v,
+			real_time m) : RGWMetadataObject(v,m), rci(_rci) {}
+
+  void dump(Formatter *f) const override {
+    rci.dump(f);
+  }
+
+  RGWRoleCompleteInfo& get_rci() {
+    return rci;
+  }
+};
 //class RGWMetadataObject;
 
 class RGWRoleMetadataHandler: public RGWMetadataHandler_GenericMetaBE

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -257,6 +257,12 @@ public:
 class RGWSI_Role;
 class RGWSI_MetaBackend_Handler;
 
+/// Defines control classes that call the low level service layer that handles
+/// storage, svc classes implement the low level object operations. Ctl classes
+/// can span over multiple service classes, for eg. User Ctl classes need to
+/// update the user indices when buckets are added/removed RoleCtl classes may
+/// need to update the RGW Account class that a role has been added deleted
+/// under an account.
 class RGWRoleCtl {
   struct Svc {
     RGWSI_Role *role {nullptr};

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -126,8 +126,6 @@ class RGWRole
   RGWRoleInfo info;
 
   int store_info(bool exclusive, optional_yield y = null_yield);
-  int store_name(bool exclusive, optional_yield y = null_yield);
-  int store_path(bool exclusive, optional_yield y = null_yield);
   int read_id(const string& role_name, const string& tenant, string& role_id);
   int read_name();
   int read_info();
@@ -341,14 +339,18 @@ public:
     }
   };
 
-  int store_info(const RGWRoleInfo& role,
-		 optional_yield y,
-		 const PutParams& params = {});
 
   int create(RGWRoleInfo& role,
 	     optional_yield y,
 	     const PutParams& params = {});
 
+  int store_info(const RGWRoleInfo& role,
+		 optional_yield y,
+		 const PutParams& params = {});
+
+  // The methods for store name & store path are currently unused and only
+  // useful for a potential rename name/path functionality in the future as
+  // create role would automatically create these for most uses
   int store_name(const std::string& role_id,
 		 const std::string& name,
 		 const std::string& tenant,
@@ -370,7 +372,7 @@ public:
 				   optional_yield y,
 				   const GetParams& params = {});
 
-  int delete_info(const RGWRoleInfo& info,
+  int delete_info(const std::string& role_id,
 		  optional_yield y,
 		  const RemoveParams& params = {});
 

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -271,6 +271,7 @@ public:
 	     RGWRoleMetadataHandler *_rmhandler) {
     svc.role = _role_svc;
     rmhandler = _rmhandler;
+    be_handler = _rmhandler->get_be_handler();
   }
 
   struct PutParams {

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -30,6 +30,8 @@ struct RGWRoleInfo
   string tenant;
   uint64_t max_session_duration;
 
+  string err_msg;
+
   void extract_name_tenant(std::string_view str);
   void set_perm_policy(const std::string& policy_name,
 		       const std::string& perm_policy);
@@ -74,6 +76,11 @@ struct RGWRoleInfo
 
   RGWRoleInfo(std::string _id) :
     id(std::move(_id)) {}
+
+  void set_err_msg(string msg) {
+    err_msg.clear();
+    err_msg = std::move(msg);
+  }
 
   void encode(bufferlist& bl) const {
     ENCODE_START(3, 1, bl);

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -131,7 +131,6 @@ class RGWRole
   int read_id(const string& role_name, const string& tenant, string& role_id);
   int read_name();
   int read_info();
-  bool validate_input();
   void extract_name_tenant(const std::string& str);
   void get_role_policy(const string& policy_name, string& perm_policy);
 public:

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -164,7 +164,7 @@ public:
 
   void set_id(const string& id) { this->info.id = id; }
 
-  int create(bool exclusive);
+  int create(bool exclusive, optional_yield y = null_yield);
   int delete_obj();
   int get();
   int get_by_id();
@@ -345,6 +345,10 @@ public:
 		 optional_yield y,
 		 const PutParams& params = {});
 
+  int create(RGWRoleInfo& role,
+	     optional_yield y,
+	     const PutParams& params = {});
+
   int store_name(const std::string& role_id,
 		 const std::string& name,
 		 const std::string& tenant,
@@ -366,7 +370,7 @@ public:
 				   optional_yield y,
 				   const GetParams& params = {});
 
-  int delete_info(const std::string& role_id,
+  int delete_info(const RGWRoleInfo& info,
 		  optional_yield y,
 		  const RemoveParams& params = {});
 

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -195,4 +195,32 @@ public:
     info.dump(f);
   }
 };
+class RGWRoleMetadataHandler;
+class RGWSI_Role;
+class RGWSI_MetaBackend_Handler;
+
+class RGWRoleCtl {
+  struct Svc {
+    RGWSI_Role *role {nullptr};
+  } svc;
+  RGWRoleMetadataHandler *rmhandler;
+  RGWSI_MetaBackend_Handler *be_handler{nullptr};
+public:
+  RGWRoleCtl(RGWSI_Role *_role_svc,
+	     RGWRoleMetadataHandler *_rmhander);
+
+  struct PutParams {
+    ceph::real_time mtime;
+    bool exclusive {false};
+    RGWObjVersionTracker *objv_tracker {nullptr};
+    std::map<std::string, bufferlist> *attrs {nullptr};
+
+    PutParams() {};
+  };
+
+  int store_info(const RGWRoleInfo& role,
+		 optional_yield y,
+		 const PutParams& params = {});
+};
+
 #endif /* CEPH_RGW_ROLE_H */

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -125,8 +125,8 @@ class RGWRole
   int store_name(bool exclusive, optional_yield y = null_yield);
   int store_path(bool exclusive, optional_yield y = null_yield);
   int read_id(const string& role_name, const string& tenant, string& role_id);
-  int read_name() { return 0; }
-  int read_info() { return 0; };
+  int read_name();
+  int read_info();
   bool validate_input();
   void extract_name_tenant(const std::string& str);
   void get_role_policy(const string& policy_name, string& perm_policy);
@@ -161,8 +161,8 @@ public:
 
   void set_id(const string& id) { this->info.id = id; }
 
-  int create(bool exclusive) { return 0; }
-  int delete_obj() {return 0;}
+  int create(bool exclusive);
+  int delete_obj();
   int get();
   int get_by_id();
   int update();

--- a/src/rgw/rgw_service.cc
+++ b/src/rgw/rgw_service.cc
@@ -366,6 +366,7 @@ int RGWCtlDef::init(RGWServices& svc)
   }
 
   meta.otp.reset(RGWOTPMetaHandlerAllocator::alloc());
+  meta.role = std::make_unique<RGWRoleMetadataHandler>(svc.role);
 
   user.reset(new RGWUserCtl(svc.zone, svc.user, (RGWUserMetadataHandler *)meta.user.get()));
   bucket.reset(new RGWBucketCtl(svc.zone,
@@ -411,10 +412,12 @@ int RGWCtl::init(RGWServices *_svc)
   meta.bucket = _ctl.meta.bucket.get();
   meta.bucket_instance = _ctl.meta.bucket_instance.get();
   meta.otp = _ctl.meta.otp.get();
+  meta.role = _ctl.meta.role.get();
 
   user = _ctl.user.get();
   bucket = _ctl.bucket.get();
   otp = _ctl.otp.get();
+  role = _ctl.role.get();
 
   r = meta.user->attach(meta.mgr);
   if (r < 0) {
@@ -440,6 +443,11 @@ int RGWCtl::init(RGWServices *_svc)
     return r;
   }
 
+  r = meta.role->attach(meta.mgr);
+  if (r < 0) {
+    ldout(cct, 0) << "ERROR: failed to start init otp ctl (" << cpp_strerror(-r) << dendl;
+    return r;
+  }
   return 0;
 }
 

--- a/src/rgw/rgw_service.cc
+++ b/src/rgw/rgw_service.cc
@@ -26,6 +26,7 @@
 #include "services/svc_sys_obj_cache.h"
 #include "services/svc_sys_obj_core.h"
 #include "services/svc_user_rados.h"
+#include "services/svc_role_rados.h"
 
 #include "common/errno.h"
 
@@ -34,6 +35,7 @@
 #include "rgw_metadata.h"
 #include "rgw_otp.h"
 #include "rgw_user.h"
+#include "rgw_role.h"
 
 #define dout_subsys ceph_subsys_rgw
 
@@ -71,6 +73,7 @@ int RGWServices_Def::init(CephContext *cct,
   sysobj = std::make_unique<RGWSI_SysObj>(cct);
   sysobj_core = std::make_unique<RGWSI_SysObj_Core>(cct);
   user_rados = std::make_unique<RGWSI_User_RADOS>(cct);
+  role_rados = std::make_unique<RGWSI_Role_RADOS>(cct);
 
   if (have_cache) {
     sysobj_cache = std::make_unique<RGWSI_SysObj_Cache>(cct);
@@ -110,6 +113,7 @@ int RGWServices_Def::init(CephContext *cct,
   }
   user_rados->init(rados.get(), zone.get(), sysobj.get(), sysobj_cache.get(),
                    meta.get(), meta_be_sobj.get(), sync_modules.get());
+  role_rados->init(zone.get(), meta.get(), meta_be_sobj.get(), sysobj.get());
 
   can_shutdown = true;
 
@@ -241,6 +245,12 @@ int RGWServices_Def::init(CephContext *cct,
       ldout(cct, 0) << "ERROR: failed to start otp service (" << cpp_strerror(-r) << dendl;
       return r;
     }
+
+    r = role_rados->start();
+    if (r < 0) {
+      ldout(cct, 0) << "ERROR: failed to start role_rados service (" << cpp_strerror(-r) << dendl;
+      return r;
+    }
   }
 
   /* cache or core services will be started by sysobj */
@@ -310,6 +320,7 @@ int RGWServices::do_init(CephContext *_cct, bool have_cache, bool raw, bool run_
   cache = _svc.sysobj_cache.get();
   core = _svc.sysobj_core.get();
   user = _svc.user_rados.get();
+  role = _svc.role_rados.get();
 
   return 0;
 }

--- a/src/rgw/rgw_service.cc
+++ b/src/rgw/rgw_service.cc
@@ -373,6 +373,7 @@ int RGWCtlDef::init(RGWServices& svc)
                                 svc.bucket_sync,
                                 svc.bi));
   otp.reset(new RGWOTPCtl(svc.zone, svc.otp));
+  role = std::make_unique<RGWRoleCtl>(svc.role, static_cast<RGWRoleMetadataHandler*>(meta.role.get()));
 
   RGWBucketMetadataHandlerBase *bucket_meta_handler = static_cast<RGWBucketMetadataHandlerBase *>(meta.bucket.get());
   RGWBucketInstanceMetadataHandlerBase *bi_meta_handler = static_cast<RGWBucketInstanceMetadataHandlerBase *>(meta.bucket_instance.get());

--- a/src/rgw/rgw_service.h
+++ b/src/rgw/rgw_service.h
@@ -63,6 +63,8 @@ class RGWSI_MetaBackend_OTP;
 class RGWSI_Notify;
 class RGWSI_OTP;
 class RGWSI_RADOS;
+class RGWSI_Role;
+class RGWSI_Role_RADOS;
 class RGWSI_Zone;
 class RGWSI_ZoneUtils;
 class RGWSI_Quota;
@@ -102,6 +104,7 @@ struct RGWServices_Def
   std::unique_ptr<RGWSI_SysObj_Cache> sysobj_cache;
   std::unique_ptr<RGWSI_User_RADOS> user_rados;
   std::unique_ptr<RGWDataChangesLog> datalog_rados;
+  std::unique_ptr<RGWSI_Role_RADOS> role_rados;
 
   RGWServices_Def();
   ~RGWServices_Def();
@@ -144,6 +147,7 @@ struct RGWServices
   RGWSI_SysObj_Cache *cache{nullptr};
   RGWSI_SysObj_Core *core{nullptr};
   RGWSI_User *user{nullptr};
+  RGWSI_Role *role{nullptr};
 
   int do_init(CephContext *cct, bool have_cache, bool raw_storage, bool run_sync);
 
@@ -164,6 +168,7 @@ class RGWMetadataHandler;
 class RGWUserCtl;
 class RGWBucketCtl;
 class RGWOTPCtl;
+class RGWRoleCtl;
 
 struct RGWCtlDef {
   struct _meta {
@@ -172,6 +177,7 @@ struct RGWCtlDef {
     std::unique_ptr<RGWMetadataHandler> bucket_instance;
     std::unique_ptr<RGWMetadataHandler> user;
     std::unique_ptr<RGWMetadataHandler> otp;
+    std::unique_ptr<RGWMetadataHandler> role;
 
     _meta();
     ~_meta();
@@ -180,6 +186,7 @@ struct RGWCtlDef {
   std::unique_ptr<RGWUserCtl> user;
   std::unique_ptr<RGWBucketCtl> bucket;
   std::unique_ptr<RGWOTPCtl> otp;
+  std::unique_ptr<RGWRoleCtl> role;
 
   RGWCtlDef();
   ~RGWCtlDef();
@@ -200,11 +207,13 @@ struct RGWCtl {
     RGWMetadataHandler *bucket_instance{nullptr};
     RGWMetadataHandler *user{nullptr};
     RGWMetadataHandler *otp{nullptr};
+    RGWMetadataHandler *role{nullptr};
   } meta;
 
   RGWUserCtl *user{nullptr};
   RGWBucketCtl *bucket{nullptr};
   RGWOTPCtl *otp{nullptr};
+  RGWRoleCtl *role{nullptr};
 
   int init(RGWServices *_svc);
 };

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -279,7 +279,7 @@ std::tuple<int, RGWRole> STSService::getRoleInfo(const string& arn)
   if (auto r_arn = rgw::ARN::parse(arn); r_arn) {
     auto pos = r_arn->resource.find_last_of('/');
     string roleName = r_arn->resource.substr(pos + 1);
-    RGWRole role(cct, store->getRados()->pctl, roleName, r_arn->account);
+    RGWRole role(cct, store->ctl()->role, roleName, r_arn->account);
     if (int ret = role.get(); ret < 0) {
       if (ret == -ENOENT) {
         ldout(cct, 0) << "Role doesn't exist: " << roleName << dendl;

--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -181,6 +181,20 @@ int rgw_put_system_obj(RGWSysObjectCtx& obj_ctx, const rgw_pool& pool, const str
                             objv_tracker, set_mtime, null_yield, pattrs);
 }
 
+int rgw_stat_system_obj(RGWSysObjectCtx& obj_ctx, const rgw_pool& pool,
+			const string& key, RGWObjVersionTracker *objv_tracker,
+			real_time *pmtime, optional_yield y,
+			map<string, bufferlist> *pattrs)
+{
+  rgw_raw_obj obj(pool, key);
+  auto sysobj = obj_ctx.get_obj(obj);
+  return sysobj.rop()
+               .set_attrs(pattrs)
+               .set_last_mod(pmtime)
+               .stat(y);
+}
+
+
 int rgw_get_system_obj(RGWSysObjectCtx& obj_ctx, const rgw_pool& pool, const string& key, bufferlist& bl,
                        RGWObjVersionTracker *objv_tracker, real_time *pmtime, optional_yield y, map<string, bufferlist> *pattrs,
                        rgw_cache_entry_info *cache_info,

--- a/src/rgw/rgw_tools.h
+++ b/src/rgw/rgw_tools.h
@@ -79,6 +79,10 @@ int rgw_get_system_obj(RGWSysObjectCtx& obj_ctx, const rgw_pool& pool, const str
                        RGWObjVersionTracker *objv_tracker, real_time *pmtime, optional_yield y, map<string, bufferlist> *pattrs = NULL,
                        rgw_cache_entry_info *cache_info = NULL,
 		       boost::optional<obj_version> refresh_version = boost::none);
+int rgw_stat_system_obj(RGWSysObjectCtx& obj_Ctx, const rgw_pool& pool,
+                        const string& key, RGWObjVersionTracker *objv_tracker,
+                        real_time *pmtime, optional_yield y,
+                        map<string, bufferlist> *pattrs = nullptr);
 int rgw_delete_system_obj(RGWSI_SysObj *sysobj_svc, const rgw_pool& pool, const string& oid,
                           RGWObjVersionTracker *objv_tracker);
 

--- a/src/rgw/services/svc_role.cc
+++ b/src/rgw/services/svc_role.cc
@@ -1,0 +1,21 @@
+#include "svc_role.h"
+
+const string role_name_oid_prefix = "role_names.";
+const string role_oid_prefix = "roles.";
+const string role_path_oid_prefix = "role_paths.";
+const string role_arn_prefix = "arn:aws:iam::";
+
+std::string RGWSI_Role::get_role_meta_key(const std::string& role_id)
+{
+  return role_oid_prefix + role_id;
+}
+
+std::string RGWSI_Role::get_role_name_meta_key(const std::string& role_name, const std::string& tenant)
+{
+  return tenant + role_name_oid_prefix + role_name;
+}
+
+std::string RGWSI_Role::get_role_path_meta_key(const std::string& path, const std::string& role_id, const std::string& tenant)
+{
+  return tenant + role_path_oid_prefix + path + role_oid_prefix + role_id;
+}

--- a/src/rgw/services/svc_role.cc
+++ b/src/rgw/services/svc_role.cc
@@ -1,10 +1,5 @@
 #include "svc_role.h"
 
-const string role_name_oid_prefix = "role_names.";
-const string role_oid_prefix = "roles.";
-const string role_path_oid_prefix = "role_paths.";
-const string role_arn_prefix = "arn:aws:iam::";
-
 std::string RGWSI_Role::get_role_meta_key(const std::string& role_id)
 {
   return role_oid_prefix + role_id;

--- a/src/rgw/services/svc_role.h
+++ b/src/rgw/services/svc_role.h
@@ -40,16 +40,20 @@ class RGWSI_Role: public RGWServiceInstance
 			 optional_yield y) = 0;
 
   virtual int store_name(RGWSI_MetaBackend::Context *ctx,
+			 const std::string& role_id,
 			 const std::string& name,
+			 const std::string& tenant,
 			 RGWObjVersionTracker * const objv_tracker,
-			 real_time * const pmtime,
+			 const real_time& mtime,
 			 bool exclusive,
 			 optional_yield y) = 0;
 
   virtual int store_path(RGWSI_MetaBackend::Context *ctx,
+			 const std::string& role_id,
 			 const std::string& path,
+			 const std::string& tenant,
 			 RGWObjVersionTracker * const objv_tracker,
-			 real_time * const pmtime,
+			 const real_time &mtime,
 			 bool exclusive,
 			 optional_yield y) = 0;
 
@@ -62,7 +66,9 @@ class RGWSI_Role: public RGWServiceInstance
 			optional_yield y) = 0;
 
   virtual int read_name(RGWSI_MetaBackend::Context *ctx,
-			std::string& name,
+			const std::string& name,
+			const std::string& tenant,
+			std::string& role_id,
 			RGWObjVersionTracker * const objv_tracker,
 			real_time * const pmtime,
 			optional_yield y) = 0;

--- a/src/rgw/services/svc_role.h
+++ b/src/rgw/services/svc_role.h
@@ -83,4 +83,18 @@ class RGWSI_Role: public RGWServiceInstance
 			  const std::string& name,
 			  RGWObjVersionTracker * const objv_tracker,
 			  optional_yield y) = 0;
+
+  virtual int delete_name(RGWSI_MetaBackend::Context *ctx,
+			  const std::string& name,
+			  const std::string& tenant,
+			  RGWObjVersionTracker * const objv_tracker,
+			  optional_yield y) = 0;
+
+  virtual int delete_path(RGWSI_MetaBackend::Context *ctx,
+			  const std::string& role_id,
+			  const std::string& path,
+			  const std::string& tenant,
+			  RGWObjVersionTracker * const objv_tracker,
+			  optional_yield y) = 0;
+
 };

--- a/src/rgw/services/svc_role.h
+++ b/src/rgw/services/svc_role.h
@@ -1,0 +1,76 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include "rgw/rgw_service.h"
+#include "svc_meta_be.h"
+
+class RGWRole;
+
+class RGWSI_Role: public RGWServiceInstance
+{
+ public:
+  RGWSI_Role(CephContext *cct) : RGWServiceInstance(cct) {}
+  virtual ~RGWSI_Role() {}
+
+  virtual RGWSI_MetaBackend_Handler* get_be_handler() = 0;
+
+  virtual int store_info(RGWSI_MetaBackend::Context *ctx,
+			 const RGWRole& role,
+			 RGWObjVersionTracker * const objv_tracker,
+			 real_time * const pmtime,
+			 bool exclusive,
+			 map<std::string, bufferlist> * pattrs,
+			 optional_yield y) = 0;
+
+  virtual int store_name(RGWSI_MetaBackend::Context *ctx,
+			 const std::string& name,
+			 RGWObjVersionTracker * const objv_tracker,
+			 real_time * const pmtime,
+			 bool exclusive,
+			 optional_yield y) = 0;
+
+  virtual int store_path(RGWSI_MetaBackend::Context *ctx,
+			 const std::string& path,
+			 RGWObjVersionTracker * const objv_tracker,
+			 real_time * const pmtime,
+			 bool exclusive,
+			 optional_yield y) = 0;
+
+  virtual int read_info(RGWSI_MetaBackend::Context *ctx,
+			RGWRole *role,
+			RGWObjVersionTracker * const objv_tracker,
+			real_time * const pmtime,
+			map<std::string, bufferlist> * pattrs,
+			optional_yield y) = 0;
+
+  virtual int read_name(RGWSI_MetaBackend::Context *ctx,
+			std::string& name,
+			RGWObjVersionTracker * const objv_tracker,
+			real_time * const pmtime,
+			optional_yield y) = 0;
+
+  virtual int read_path(RGWSI_MetaBackend::Context *ctx,
+			std::string& path,
+			RGWObjVersionTracker * const objv_tracker,
+			real_time * const pmtime,
+			optional_yield y) = 0;
+
+  virtual int delete_info(RGWSI_MetaBackend::Context *ctx,
+			  const std::string& name,
+			  RGWObjVersionTracker * const objv_tracker,
+			  optional_yield y) = 0;
+};

--- a/src/rgw/services/svc_role.h
+++ b/src/rgw/services/svc_role.h
@@ -31,7 +31,7 @@ class RGWSI_Role: public RGWServiceInstance
   virtual int store_info(RGWSI_MetaBackend::Context *ctx,
 			 const RGWRole& role,
 			 RGWObjVersionTracker * const objv_tracker,
-			 real_time * const pmtime,
+			 const real_time& mtime,
 			 bool exclusive,
 			 map<std::string, bufferlist> * pattrs,
 			 optional_yield y) = 0;

--- a/src/rgw/services/svc_role.h
+++ b/src/rgw/services/svc_role.h
@@ -27,6 +27,9 @@ class RGWSI_Role: public RGWServiceInstance
   virtual ~RGWSI_Role() {}
 
   virtual RGWSI_MetaBackend_Handler* get_be_handler() = 0;
+  static std::string get_role_meta_key(const std::string& role_id);
+  static std::string get_role_name_meta_key(const std::string& role_name, const std::string& tenant);
+  static std::string get_role_path_meta_key(const std::string& path, const std::string& role_id, const std::string& tenant);
 
   virtual int store_info(RGWSI_MetaBackend::Context *ctx,
 			 const RGWRole& role,
@@ -51,6 +54,7 @@ class RGWSI_Role: public RGWServiceInstance
 			 optional_yield y) = 0;
 
   virtual int read_info(RGWSI_MetaBackend::Context *ctx,
+			const std::string& role_id,
 			RGWRole *role,
 			RGWObjVersionTracker * const objv_tracker,
 			real_time * const pmtime,

--- a/src/rgw/services/svc_role.h
+++ b/src/rgw/services/svc_role.h
@@ -67,7 +67,7 @@ class RGWSI_Role: public RGWServiceInstance
 
   virtual int read_info(RGWSI_MetaBackend::Context *ctx,
 			const std::string& role_id,
-			RGWRoleInfo *role,
+			RGWRoleInfo *role,  // out param
 			RGWObjVersionTracker * const objv_tracker,
 			real_time * const pmtime,
 			map<std::string, bufferlist> * pattrs,
@@ -93,7 +93,6 @@ class RGWSI_Role: public RGWServiceInstance
 			  RGWObjVersionTracker * const objv_tracker,
 			  optional_yield y) = 0;
 
-
   virtual int delete_info(RGWSI_MetaBackend::Context *ctx,
 			  const std::string& id,
 			  RGWObjVersionTracker * const objv_tracker,
@@ -113,10 +112,10 @@ class RGWSI_Role: public RGWServiceInstance
 			  optional_yield y) = 0;
 
   virtual int list_roles_by_path_prefix(RGWSI_MetaBackend::Context *ctx,
-                                const std::string& path,
-                                const std::string& tenant,
-                                vector<RGWRoleInfo>& roles,
-                                optional_yield y) = 0;
+                                        const std::string& path,
+                                        const std::string& tenant,
+                                        vector<RGWRoleInfo>& roles,  // out param
+                                        optional_yield y) = 0;
 
 };
 

--- a/src/rgw/services/svc_role.h
+++ b/src/rgw/services/svc_role.h
@@ -31,6 +31,14 @@ class RGWSI_Role: public RGWServiceInstance
   static std::string get_role_name_meta_key(const std::string& role_name, const std::string& tenant);
   static std::string get_role_path_meta_key(const std::string& path, const std::string& role_id, const std::string& tenant);
 
+  virtual int create(RGWSI_MetaBackend::Context *ctx,
+		     RGWRoleInfo& role,
+		     RGWObjVersionTracker * const objv_tracker,
+		     const real_time& pmtime,
+		     bool exclusive,
+		     map<std::string, bufferlist> * pattrs,
+		     optional_yield y) = 0;
+
   virtual int store_info(RGWSI_MetaBackend::Context *ctx,
 			 const RGWRoleInfo& role,
 			 RGWObjVersionTracker * const objv_tracker,
@@ -80,7 +88,7 @@ class RGWSI_Role: public RGWServiceInstance
 			optional_yield y) = 0;
 
   virtual int delete_info(RGWSI_MetaBackend::Context *ctx,
-			  const std::string& name,
+			  const RGWRoleInfo& info,
 			  RGWObjVersionTracker * const objv_tracker,
 			  optional_yield y) = 0;
 

--- a/src/rgw/services/svc_role.h
+++ b/src/rgw/services/svc_role.h
@@ -98,3 +98,8 @@ class RGWSI_Role: public RGWServiceInstance
 			  optional_yield y) = 0;
 
 };
+
+const string role_name_oid_prefix = "role_names.";
+const string role_oid_prefix = "roles.";
+const string role_path_oid_prefix = "role_paths.";
+const string role_arn_prefix = "arn:aws:iam::";

--- a/src/rgw/services/svc_role.h
+++ b/src/rgw/services/svc_role.h
@@ -120,7 +120,6 @@ class RGWSI_Role: public RGWServiceInstance
 
 };
 
-const string role_name_oid_prefix = "role_names.";
-const string role_oid_prefix = "roles.";
-const string role_path_oid_prefix = "role_paths.";
-const string role_arn_prefix = "arn:aws:iam::";
+static const string role_name_oid_prefix = "role_names.";
+static const string role_oid_prefix = "roles.";
+static const string role_path_oid_prefix = "role_paths.";

--- a/src/rgw/services/svc_role.h
+++ b/src/rgw/services/svc_role.h
@@ -87,8 +87,15 @@ class RGWSI_Role: public RGWServiceInstance
 			real_time * const pmtime,
 			optional_yield y) = 0;
 
-  virtual int delete_info(RGWSI_MetaBackend::Context *ctx,
+  // deletes a role from the system and the supporting objects
+  virtual int delete_role(RGWSI_MetaBackend::Context *ctx,
 			  const RGWRoleInfo& info,
+			  RGWObjVersionTracker * const objv_tracker,
+			  optional_yield y) = 0;
+
+
+  virtual int delete_info(RGWSI_MetaBackend::Context *ctx,
+			  const std::string& id,
 			  RGWObjVersionTracker * const objv_tracker,
 			  optional_yield y) = 0;
 

--- a/src/rgw/services/svc_role.h
+++ b/src/rgw/services/svc_role.h
@@ -18,7 +18,7 @@
 #include "rgw/rgw_service.h"
 #include "svc_meta_be.h"
 
-class RGWRole;
+class RGWRoleInfo;
 
 class RGWSI_Role: public RGWServiceInstance
 {
@@ -32,7 +32,7 @@ class RGWSI_Role: public RGWServiceInstance
   static std::string get_role_path_meta_key(const std::string& path, const std::string& role_id, const std::string& tenant);
 
   virtual int store_info(RGWSI_MetaBackend::Context *ctx,
-			 const RGWRole& role,
+			 const RGWRoleInfo& role,
 			 RGWObjVersionTracker * const objv_tracker,
 			 const real_time& mtime,
 			 bool exclusive,
@@ -59,7 +59,7 @@ class RGWSI_Role: public RGWServiceInstance
 
   virtual int read_info(RGWSI_MetaBackend::Context *ctx,
 			const std::string& role_id,
-			RGWRole *role,
+			RGWRoleInfo *role,
 			RGWObjVersionTracker * const objv_tracker,
 			real_time * const pmtime,
 			map<std::string, bufferlist> * pattrs,

--- a/src/rgw/services/svc_role.h
+++ b/src/rgw/services/svc_role.h
@@ -112,6 +112,12 @@ class RGWSI_Role: public RGWServiceInstance
 			  RGWObjVersionTracker * const objv_tracker,
 			  optional_yield y) = 0;
 
+  virtual int list_roles_by_path_prefix(RGWSI_MetaBackend::Context *ctx,
+                                const std::string& path,
+                                const std::string& tenant,
+                                vector<RGWRoleInfo>& roles,
+                                optional_yield y) = 0;
+
 };
 
 const string role_name_oid_prefix = "role_names.";

--- a/src/rgw/services/svc_role_rados.cc
+++ b/src/rgw/services/svc_role_rados.cc
@@ -1,0 +1,6 @@
+#include "svc_role_rados.h"
+
+RGWSI_MetaBackend_Handler* RGWSI_Role_RADOS::get_be_handler()
+{
+  return be_handler;
+}

--- a/src/rgw/services/svc_role_rados.cc
+++ b/src/rgw/services/svc_role_rados.cc
@@ -9,7 +9,6 @@
 
 class RGWSI_Role_Module : public RGWSI_MBSObj_Handler_Module {
   RGWSI_Role_RADOS::Svc& svc;
-  std::string prefix;
 public:
   RGWSI_Role_Module(RGWSI_Role_RADOS::Svc& _svc): RGWSI_MBSObj_Handler_Module("Role"),
                                                   svc(_svc) {}
@@ -28,8 +27,7 @@ public:
   }
 
   bool is_valid_oid(const std::string& oid) override {
-    return !boost::algorithm::starts_with(oid, role_name_oid_prefix) ||
-      !boost::algorithm::starts_with(oid, role_path_oid_prefix);
+    return boost::algorithm::starts_with(oid, role_oid_prefix);
   }
 
   std::string key_to_oid(const std::string& key) override {
@@ -41,7 +39,7 @@ public:
   }
 
   const std::string& get_oid_prefix() {
-    return prefix;
+    return role_oid_prefix;
   }
 };
 

--- a/src/rgw/services/svc_role_rados.cc
+++ b/src/rgw/services/svc_role_rados.cc
@@ -130,19 +130,51 @@ int RGWSI_Role_RADOS::read_name(RGWSI_MetaBackend::Context *ctx,
   return 0;
 }
 
+static int delete_oid(RGWSI_MetaBackend::Context *ctx,
+                      RGWSI_MetaBackend* meta_be,
+                      const std::string& oid,
+                      RGWObjVersionTracker * const objv_tracker,
+                      optional_yield y)
+{
+  RGWSI_MBSObj_RemoveParams params;
+  int r = meta_be->remove(ctx, oid, params, objv_tracker, y);
+  if (r < 0 && r != -ENOENT && r != -ECANCELED) {
+    ldout(meta_be->ctx(),0) << "ERROR: RGWSI_Role: could not remove oid = "
+                                << oid << " r = "<< r << dendl;
+    return r;
+  }
+  return 0;
+}
 
 int RGWSI_Role_RADOS::delete_info(RGWSI_MetaBackend::Context *ctx,
                                   const std::string& role_id,
                                   RGWObjVersionTracker * const objv_tracker,
                                   optional_yield y)
 {
-  RGWSI_MBSObj_RemoveParams params;
 
-  int r = svc.meta_be->remove(ctx, get_role_meta_key(role_id), params, objv_tracker, y);
-  if (r < 0 && r != -ENOENT && r != -ECANCELED) {
-    ldout(svc.meta_be->ctx(),0) << "ERROR: could not remove RGWRole, id = "
-                                << role_id << " r = "<< r << dendl;
-    return r;
-  }
-  return 0;
+  return delete_oid(ctx, svc.meta_be, get_role_meta_key(role_id),
+                    objv_tracker, y);
+}
+
+int RGWSI_Role_RADOS::delete_name(RGWSI_MetaBackend::Context *ctx,
+                                  const std::string& name,
+                                  const std::string& tenant,
+                                  RGWObjVersionTracker * const objv_tracker,
+                                  optional_yield y)
+{
+  return delete_oid(ctx, svc.meta_be, get_role_name_meta_key(name, tenant),
+                    objv_tracker, y);
+
+}
+
+int RGWSI_Role_RADOS::delete_path(RGWSI_MetaBackend::Context *ctx,
+                                  const std::string& role_id,
+                                  const std::string& path,
+                                  const std::string& tenant,
+                                  RGWObjVersionTracker * const objv_tracker,
+                                  optional_yield y)
+{
+  return delete_oid(ctx, svc.meta_be, get_role_path_meta_key(path, role_id, tenant),
+                    objv_tracker, y);
+
 }

--- a/src/rgw/services/svc_role_rados.cc
+++ b/src/rgw/services/svc_role_rados.cc
@@ -1,6 +1,78 @@
 #include "svc_role_rados.h"
+#include "svc_meta_be_sobj.h"
+#include "rgw_role.h"
+
+#define dout_subsys ceph_subsys_rgw
 
 RGWSI_MetaBackend_Handler* RGWSI_Role_RADOS::get_be_handler()
 {
   return be_handler;
+}
+
+void RGWSI_Role_RADOS::init(RGWSI_Zone *_zone_svc,
+                            RGWSI_Meta *_meta_svc,
+                            RGWSI_MetaBackend *_meta_be_svc,
+                            RGWSI_SysObj *_sysobj_svc)
+{
+  svc.zone = _zone_svc;
+  svc.meta = _meta_svc;
+  svc.meta_be = _meta_be_svc;
+  svc.sysobj = _sysobj_svc;
+}
+
+int RGWSI_Role_RADOS::store_info(RGWSI_MetaBackend::Context *ctx,
+                                 const RGWRole& role,
+                                 RGWObjVersionTracker * const objv_tracker,
+                                 const real_time& mtime,
+                                 bool exclusive,
+                                 map<std::string, bufferlist> * pattrs,
+                                 optional_yield y)
+{
+  bufferlist data_bl;
+  encode(role, data_bl);
+  RGWSI_MBSObj_PutParams params(data_bl, pattrs, mtime, exclusive);
+
+  return svc.meta_be->put(ctx, get_role_meta_key(role.get_id()), params, objv_tracker, y);
+}
+
+int RGWSI_Role_RADOS::read_info(RGWSI_MetaBackend::Context *ctx,
+                                const std::string& role_id,
+                                RGWRole *role,
+                                RGWObjVersionTracker * const objv_tracker,
+                                real_time * const pmtime,
+                                map<std::string, bufferlist> * pattrs,
+                                optional_yield y)
+{
+  bufferlist data_bl;
+  RGWSI_MBSObj_GetParams params(&data_bl, pattrs, pmtime);
+
+  int r = svc.meta_be->get_entry(ctx, get_role_meta_key(role_id), params, objv_tracker, y);
+  if (r < 0)
+    return r;
+
+  auto bl_iter = data_bl.cbegin();
+  try  {
+    decode(*role, bl_iter);
+  } catch (buffer::error& err) {
+    ldout(svc.meta_be->ctx(),0) << "ERROR: failed to decode RGWRole, caught buffer::err " << dendl;
+    return -EIO;
+  }
+
+  return 0;
+}
+
+int RGWSI_Role_RADOS::delete_info(RGWSI_MetaBackend::Context *ctx,
+                                  const std::string& role_id,
+                                  RGWObjVersionTracker * const objv_tracker,
+                                  optional_yield y)
+{
+  RGWSI_MBSObj_RemoveParams params;
+
+  int r = svc.meta_be->remove(ctx, get_role_meta_key(role_id), params, objv_tracker, y);
+  if (r < 0 && r != -ENOENT && r != -ECANCELED) {
+    ldout(svc.meta_be->ctx(),0) << "ERROR: could not remove RGWRole, id = "
+                                << role_id << " r = "<< r << dendl;
+    return r;
+  }
+  return 0;
 }

--- a/src/rgw/services/svc_role_rados.cc
+++ b/src/rgw/services/svc_role_rados.cc
@@ -9,9 +9,11 @@
 
 class RGWSI_Role_Module : public RGWSI_MBSObj_Handler_Module {
   RGWSI_Role_RADOS::Svc& svc;
+  const std::string prefix;
 public:
-  RGWSI_Role_Module(RGWSI_Role_RADOS::Svc& _svc): RGWSI_MBSObj_Handler_Module("Role"),
-                                                  svc(_svc) {}
+  RGWSI_Role_Module(RGWSI_Role_RADOS::Svc& _svc): RGWSI_MBSObj_Handler_Module("roles"),
+                                                  svc(_svc),
+                                                  prefix(role_oid_prefix) {}
 
   void get_pool_and_oid(const std::string& key,
                         rgw_pool *pool,
@@ -22,24 +24,25 @@ public:
     }
 
     if (oid) {
-      *oid = key;
+      *oid = key_to_oid(key);
     }
   }
 
   bool is_valid_oid(const std::string& oid) override {
-    return boost::algorithm::starts_with(oid, role_oid_prefix);
+    return boost::algorithm::starts_with(oid, prefix);
   }
 
   std::string key_to_oid(const std::string& key) override {
-    return key;
+    return prefix + key;
   }
 
+  // This is called after `is_valid_oid` and is assumed to be a valid oid
   std::string oid_to_key(const std::string& oid) override {
-    return oid;
+    return oid.substr(prefix.size());
   }
 
   const std::string& get_oid_prefix() {
-    return role_oid_prefix;
+    return prefix;
   }
 };
 
@@ -88,8 +91,8 @@ int RGWSI_Role_RADOS::store_info(RGWSI_MetaBackend::Context *ctx,
   bufferlist data_bl;
   encode(role, data_bl);
   RGWSI_MBSObj_PutParams params(data_bl, pattrs, mtime, exclusive);
-  ldout(svc.meta_be->ctx(),0) << "abhi: storing info" << dendl;
-  return svc.meta_be->put(ctx, get_role_meta_key(role.id),
+  //ldout(svc.meta_be->ctx(),0) << "abhi: storing info" << dendl;
+  return svc.meta_be->put(ctx, role.id,
                           params, objv_tracker, y);
 }
 
@@ -142,7 +145,7 @@ int RGWSI_Role_RADOS::read_info(RGWSI_MetaBackend::Context *ctx,
   bufferlist data_bl;
   RGWSI_MBSObj_GetParams params(&data_bl, pattrs, pmtime);
 
-  int r = svc.meta_be->get_entry(ctx, get_role_meta_key(role_id), params, objv_tracker, y);
+  int r = svc.meta_be->get_entry(ctx, role_id, params, objv_tracker, y);
   if (r < 0)
     return r;
 

--- a/src/rgw/services/svc_role_rados.cc
+++ b/src/rgw/services/svc_role_rados.cc
@@ -386,3 +386,37 @@ int RGWSI_Role_RADOS::delete_path(RGWSI_MetaBackend::Context *ctx,
                     objv_tracker, y);
 
 }
+
+int RGWSI_Role_RADOS::list_roles_by_path_prefix(RGWSI_MetaBackend::Context *ctx,
+                                                const std::string& path_prefix,
+                                                const std::string& tenant,
+                                                vector<RGWRoleInfo>& roles,
+                                                optional_yield y)
+{
+  std::string prefix;
+  // List all roles if path prefix is empty
+  if (! path_prefix.empty()) {
+    prefix = tenant + role_path_oid_prefix + path_prefix;
+  } else {
+    prefix = tenant + role_path_oid_prefix;
+  }
+
+  auto syspool = svc.sysobj->get_pool(svc.zone->get_zone_params().roles_pool);
+
+  syspool.list_prefixed_objs(prefix, [&](const std::string& oid) {
+    if (auto pos = oid.rfind(role_oid_prefix);
+        pos != std::string::npos) {
+      auto path = oid.substr(0, pos);
+      if (path_prefix.empty() || path.find(path_prefix) != std::string::npos) {
+        auto role_id = oid.substr(pos + role_oid_prefix.length());
+        RGWRoleInfo role;
+        RGWObjVersionTracker ot;
+        int r = read_info(ctx, role_id, &role, &ot, nullptr, nullptr, y);
+        if (r == 0) {
+          roles.emplace_back(role);
+        }
+      }
+    }
+  });
+  return 0; // meta_be function calls have to return an int
+}

--- a/src/rgw/services/svc_role_rados.cc
+++ b/src/rgw/services/svc_role_rados.cc
@@ -1,9 +1,49 @@
 #include "svc_role_rados.h"
 #include "svc_meta_be_sobj.h"
+#include "svc_meta.h"
 #include "rgw_role.h"
 #include "rgw_zone.h"
+#include "svc_zone.h"
 
 #define dout_subsys ceph_subsys_rgw
+
+class RGWSI_Role_Module : public RGWSI_MBSObj_Handler_Module {
+  RGWSI_Role_RADOS::Svc& svc;
+  std::string prefix;
+public:
+  RGWSI_Role_Module(RGWSI_Role_RADOS::Svc& _svc): RGWSI_MBSObj_Handler_Module("Role"),
+                                                  svc(_svc) {}
+
+  void get_pool_and_oid(const std::string& key,
+                        rgw_pool *pool,
+                        std::string *oid) override
+  {
+    if (pool) {
+      *pool = svc.zone->get_zone_params().roles_pool;
+    }
+
+    if (oid) {
+      *oid = key;
+    }
+  }
+
+  bool is_valid_oid(const std::string& oid) override {
+    return !boost::algorithm::starts_with(oid, role_name_oid_prefix) ||
+      !boost::algorithm::starts_with(oid, role_path_oid_prefix);
+  }
+
+  std::string key_to_oid(const std::string& key) override {
+    return key;
+  }
+
+  std::string oid_to_key(const std::string& oid) override {
+    return oid;
+  }
+
+  const std::string& get_oid_prefix() {
+    return prefix;
+  }
+};
 
 RGWSI_MetaBackend_Handler* RGWSI_Role_RADOS::get_be_handler()
 {
@@ -21,6 +61,24 @@ void RGWSI_Role_RADOS::init(RGWSI_Zone *_zone_svc,
   svc.sysobj = _sysobj_svc;
 }
 
+int RGWSI_Role_RADOS::do_start()
+{
+
+  int r = svc.meta->create_be_handler(RGWSI_MetaBackend::Type::MDBE_SOBJ,
+                                      &be_handler);
+  if (r < 0) {
+    ldout(ctx(), 0) << "ERROR: failed to create be_handler for Roles: r="
+                    << r <<dendl;
+    return r;
+  }
+
+  auto module = new RGWSI_Role_Module(svc);
+  RGWSI_MetaBackend_Handler_SObj* bh= static_cast<RGWSI_MetaBackend_Handler_SObj *>(be_handler);
+  be_module.reset(module);
+  bh->set_module(module);
+  return 0;
+}
+
 int RGWSI_Role_RADOS::store_info(RGWSI_MetaBackend::Context *ctx,
                                  const RGWRoleInfo& role,
                                  RGWObjVersionTracker * const objv_tracker,
@@ -32,7 +90,7 @@ int RGWSI_Role_RADOS::store_info(RGWSI_MetaBackend::Context *ctx,
   bufferlist data_bl;
   encode(role, data_bl);
   RGWSI_MBSObj_PutParams params(data_bl, pattrs, mtime, exclusive);
-
+  ldout(svc.meta_be->ctx(),0) << "abhi: storing info" << dendl;
   return svc.meta_be->put(ctx, get_role_meta_key(role.id),
                           params, objv_tracker, y);
 }

--- a/src/rgw/services/svc_role_rados.cc
+++ b/src/rgw/services/svc_role_rados.cc
@@ -105,33 +105,7 @@ public:
     mtime(_mtime), exclusive(_exclusive), pattrs(_pattrs), y(_y)
   {}
 
-  // Creation time
-  auto generate_ctime() {
-    real_clock::time_point t = real_clock::now();
-
-    struct timeval tv;
-    real_clock::to_timeval(t, tv);
-
-    char buf[30];
-    struct tm result;
-    gmtime_r(&tv.tv_sec, &result);
-    strftime(buf,30,"%Y-%m-%dT%H:%M:%S", &result);
-    sprintf(buf + strlen(buf),".%dZ",(int)tv.tv_usec/1000);
-    return std::string(std::begin(buf), std::end(buf));
-  }
-
-
-  void populate_info(RGWRoleInfo& info) {
-    uuid_d new_role_id;
-    new_role_id.generate_random();
-
-    info.id = new_role_id.to_string();
-    info.arn = role_arn_prefix + info.tenant + ":role" + info.path + info.name;
-    info.creation_date = generate_ctime();
-  }
-
   int prepare() {
-
     if (exclusive) {
       // TODO replace this with a stat call instead we don't really need to read
       // the values here
@@ -146,7 +120,7 @@ public:
       }
     }
 
-    populate_info(info);
+
     return 0;
   }
 

--- a/src/rgw/services/svc_role_rados.cc
+++ b/src/rgw/services/svc_role_rados.cc
@@ -130,12 +130,18 @@ public:
   }
 
   int complete() {
+    // This creates the ancillary objects for roles, role_names & path
+    // objv_tracker is set to null for sysobj calls as these aren't tracked via
+    // the mdlog. A failure in name/path creation means we delete all the
+    // created objects in the transaction
+
     int r = svc_role->store_name(ctx, info.id, info.name, info.tenant,
-                                 objv_tracker, mtime, exclusive, y);
+                                 nullptr, mtime, exclusive, y);
+
 
     if (r == 0) {
       r = svc_role->store_path(ctx, info.id, info.path, info.tenant,
-                               objv_tracker, mtime, exclusive, y);
+                               nullptr, mtime, exclusive, y);
     }
 
     if (r < 0) {
@@ -161,15 +167,21 @@ int RGWSI_Role_RADOS::create(RGWSI_MetaBackend::Context *ctx,
 
   int r = Op.prepare();
   if (r < 0) {
+    ldout(svc.meta_be->ctx(),0) << __func__ << "ERROR: prepare role failed" << dendl;
     return r;
   }
 
   r = Op.put();
   if (r < 0) {
+    ldout(svc.meta_be->ctx(),0) << __func__ << "ERROR: put role failed" << dendl;
     return r;
   }
 
-  return Op.complete();
+  r = Op.complete();
+  if (r < 0) {
+    ldout(svc.meta_be->ctx(),0) << __func__ << "ERROR: completing PutRole failed" << dendl;
+  }
+  return r;
 }
 
 int RGWSI_Role_RADOS::store_info(RGWSI_MetaBackend::Context *ctx,
@@ -204,7 +216,8 @@ int RGWSI_Role_RADOS::store_name(RGWSI_MetaBackend::Context *ctx,
   encode(nameToId, data_bl);
 
   RGWSI_MetaBackend_SObj::Context_SObj *sys_ctx = static_cast<RGWSI_MetaBackend_SObj::Context_SObj *>(ctx);
-  return rgw_put_system_obj(*sys_ctx->obj_ctx,
+  auto& obj_ctx = *sys_ctx->obj_ctx;
+  return rgw_put_system_obj(obj_ctx,
                             svc.zone->get_zone_params().roles_pool,
                             get_role_name_meta_key(name, tenant),
                             data_bl,
@@ -226,7 +239,8 @@ int RGWSI_Role_RADOS::store_path(RGWSI_MetaBackend::Context *ctx,
 {
   bufferlist bl;
   RGWSI_MetaBackend_SObj::Context_SObj *sys_ctx = static_cast<RGWSI_MetaBackend_SObj::Context_SObj *>(ctx);
-  return rgw_put_system_obj(*sys_ctx->obj_ctx,
+  auto& obj_ctx = *sys_ctx->obj_ctx;
+  return rgw_put_system_obj(obj_ctx,
                             svc.zone->get_zone_params().roles_pool,
                             get_role_path_meta_key(path, role_id, tenant),
                             bl,

--- a/src/rgw/services/svc_role_rados.cc
+++ b/src/rgw/services/svc_role_rados.cc
@@ -22,7 +22,7 @@ void RGWSI_Role_RADOS::init(RGWSI_Zone *_zone_svc,
 }
 
 int RGWSI_Role_RADOS::store_info(RGWSI_MetaBackend::Context *ctx,
-                                 const RGWRole& role,
+                                 const RGWRoleInfo& role,
                                  RGWObjVersionTracker * const objv_tracker,
                                  const real_time& mtime,
                                  bool exclusive,
@@ -33,7 +33,7 @@ int RGWSI_Role_RADOS::store_info(RGWSI_MetaBackend::Context *ctx,
   encode(role, data_bl);
   RGWSI_MBSObj_PutParams params(data_bl, pattrs, mtime, exclusive);
 
-  return svc.meta_be->put(ctx, get_role_meta_key(role.get_id()),
+  return svc.meta_be->put(ctx, get_role_meta_key(role.id),
                           params, objv_tracker, y);
 }
 
@@ -77,7 +77,7 @@ int RGWSI_Role_RADOS::store_path(RGWSI_MetaBackend::Context *ctx,
 
 int RGWSI_Role_RADOS::read_info(RGWSI_MetaBackend::Context *ctx,
                                 const std::string& role_id,
-                                RGWRole *role,
+                                RGWRoleInfo *role,
                                 RGWObjVersionTracker * const objv_tracker,
                                 real_time * const pmtime,
                                 map<std::string, bufferlist> * pattrs,
@@ -94,7 +94,7 @@ int RGWSI_Role_RADOS::read_info(RGWSI_MetaBackend::Context *ctx,
   try  {
     decode(*role, bl_iter);
   } catch (buffer::error& err) {
-    ldout(svc.meta_be->ctx(),0) << "ERROR: failed to decode RGWRole, caught buffer::err " << dendl;
+    ldout(svc.meta_be->ctx(),0) << "ERROR: failed to decode RGWRoleInfo, caught buffer::err " << dendl;
     return -EIO;
   }
 
@@ -122,7 +122,7 @@ int RGWSI_Role_RADOS::read_name(RGWSI_MetaBackend::Context *ctx,
   try  {
     decode(nameToId, bl_iter);
   } catch (buffer::error& err) {
-    ldout(svc.meta_be->ctx(),0) << "ERROR: failed to decode RGWRole name, caught buffer::err " << dendl;
+    ldout(svc.meta_be->ctx(),0) << "ERROR: failed to decode RGWRoleInfo name, caught buffer::err " << dendl;
     return -EIO;
   }
 

--- a/src/rgw/services/svc_role_rados.h
+++ b/src/rgw/services/svc_role_rados.h
@@ -21,15 +21,27 @@
 class RGWSI_Role_RADOS: public RGWSI_Role
 {
  public:
+  struct Svc {
+    RGWSI_Zone *zone{nullptr};
+    RGWSI_Meta *meta{nullptr};
+    RGWSI_MetaBackend *meta_be{nullptr};
+    RGWSI_SysObj *sysobj{nullptr};
+  } svc;
+
   RGWSI_Role_RADOS(CephContext *cct) : RGWSI_Role(cct) {}
   ~RGWSI_Role_RADOS() {}
+
+  void init(RGWSI_Zone *_zone_svc,
+	    RGWSI_Meta *_meta_svc,
+	    RGWSI_MetaBackend *_meta_be_svc,
+	    RGWSI_SysObj *_sysobj_svc);
 
   RGWSI_MetaBackend_Handler * get_be_handler() override;
 
   int store_info(RGWSI_MetaBackend::Context *ctx,
   		 const RGWRole& role,
   		 RGWObjVersionTracker * const objv_tracker,
-  		 real_time * const pmtime,
+  		 const real_time& pmtime,
   		 bool exclusive,
   		 map<std::string, bufferlist> * pattrs,
   		 optional_yield y) override;
@@ -49,6 +61,7 @@ class RGWSI_Role_RADOS: public RGWSI_Role
   		 optional_yield y) override;
 
   int read_info(RGWSI_MetaBackend::Context *ctx,
+		const std::string& role_id,
   		RGWRole *role,
   		RGWObjVersionTracker * const objv_tracker,
   		real_time * const pmtime,

--- a/src/rgw/services/svc_role_rados.h
+++ b/src/rgw/services/svc_role_rados.h
@@ -47,16 +47,20 @@ class RGWSI_Role_RADOS: public RGWSI_Role
   		 optional_yield y) override;
 
   int store_name(RGWSI_MetaBackend::Context *ctx,
+		 const std::string& role_id,
   		 const std::string& name,
+		 const std::string& tenant,
   		 RGWObjVersionTracker * const objv_tracker,
-  		 real_time * const pmtime,
+  		 const real_time& mtime,
   		 bool exclusive,
   		 optional_yield y) override;
 
   int store_path(RGWSI_MetaBackend::Context *ctx,
-  		 const std::string& path,
+		 const std::string& role_id,
+		 const std::string& path,
+		 const std::string& tenant,
   		 RGWObjVersionTracker * const objv_tracker,
-  		 real_time * const pmtime,
+  		 const real_time& mtime,
   		 bool exclusive,
   		 optional_yield y) override;
 
@@ -69,7 +73,9 @@ class RGWSI_Role_RADOS: public RGWSI_Role
   		optional_yield y) override;
 
   int read_name(RGWSI_MetaBackend::Context *ctx,
-  		std::string& name,
+		const std::string& name,
+		const std::string& tenant,
+		std::string& role_id,
   		RGWObjVersionTracker * const objv_tracker,
   		real_time * const pmtime,
   		optional_yield y) override;

--- a/src/rgw/services/svc_role_rados.h
+++ b/src/rgw/services/svc_role_rados.h
@@ -91,6 +91,19 @@ class RGWSI_Role_RADOS: public RGWSI_Role
 		  RGWObjVersionTracker * const objv_tracker,
 		  optional_yield y) override;
 
+  int delete_name(RGWSI_MetaBackend::Context *ctx,
+		  const std::string& name,
+		  const std::string& tenant,
+		  RGWObjVersionTracker * const objv_tracker,
+		  optional_yield y) override;
+
+  int delete_path(RGWSI_MetaBackend::Context *ctx,
+		 const std::string& role_id,
+		 const std::string& path,
+		 const std::string& tenant,
+  		 RGWObjVersionTracker * const objv_tracker,
+  		 optional_yield y) override;
+
 
 private:
   RGWSI_MetaBackend_Handler *be_handler;

--- a/src/rgw/services/svc_role_rados.h
+++ b/src/rgw/services/svc_role_rados.h
@@ -1,0 +1,79 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include "svc_role.h"
+#include "svc_meta_be.h"
+
+class RGWSI_Role_RADOS: public RGWSI_Role
+{
+ public:
+  RGWSI_Role_RADOS(CephContext *cct) : RGWSI_Role(cct) {}
+  ~RGWSI_Role_RADOS() {}
+
+  RGWSI_MetaBackend_Handler * get_be_handler() override;
+
+  int store_info(RGWSI_MetaBackend::Context *ctx,
+  		 const RGWRole& role,
+  		 RGWObjVersionTracker * const objv_tracker,
+  		 real_time * const pmtime,
+  		 bool exclusive,
+  		 map<std::string, bufferlist> * pattrs,
+  		 optional_yield y) override;
+
+  int store_name(RGWSI_MetaBackend::Context *ctx,
+  		 const std::string& name,
+  		 RGWObjVersionTracker * const objv_tracker,
+  		 real_time * const pmtime,
+  		 bool exclusive,
+  		 optional_yield y) override;
+
+  int store_path(RGWSI_MetaBackend::Context *ctx,
+  		 const std::string& path,
+  		 RGWObjVersionTracker * const objv_tracker,
+  		 real_time * const pmtime,
+  		 bool exclusive,
+  		 optional_yield y) override;
+
+  int read_info(RGWSI_MetaBackend::Context *ctx,
+  		RGWRole *role,
+  		RGWObjVersionTracker * const objv_tracker,
+  		real_time * const pmtime,
+  		map<std::string, bufferlist> * pattrs,
+  		optional_yield y) override;
+
+  int read_name(RGWSI_MetaBackend::Context *ctx,
+  		std::string& name,
+  		RGWObjVersionTracker * const objv_tracker,
+  		real_time * const pmtime,
+  		optional_yield y) override;
+
+  int read_path(RGWSI_MetaBackend::Context *ctx,
+  		std::string& path,
+  		RGWObjVersionTracker * const objv_tracker,
+  		real_time * const pmtime,
+  		optional_yield y) override;
+
+  int delete_info(RGWSI_MetaBackend::Context *ctx,
+		  const std::string& name,
+		  RGWObjVersionTracker * const objv_tracker,
+		  optional_yield y) override;
+
+
+private:
+  RGWSI_MetaBackend_Handler *be_handler;
+  std::unique_ptr<RGWSI_MetaBackend::Module> be_module;
+};

--- a/src/rgw/services/svc_role_rados.h
+++ b/src/rgw/services/svc_role_rados.h
@@ -118,6 +118,11 @@ class RGWSI_Role_RADOS: public RGWSI_Role
   		 RGWObjVersionTracker * const objv_tracker,
   		 optional_yield y) override;
 
+  int list_roles_by_path_prefix(RGWSI_MetaBackend::Context *ctx,
+                                const std::string& path,
+                                const std::string& tenant,
+                                vector<RGWRoleInfo>& roles,
+                                optional_yield y) override;
 
 private:
   RGWSI_MetaBackend_Handler *be_handler;

--- a/src/rgw/services/svc_role_rados.h
+++ b/src/rgw/services/svc_role_rados.h
@@ -39,7 +39,7 @@ class RGWSI_Role_RADOS: public RGWSI_Role
   RGWSI_MetaBackend_Handler * get_be_handler() override;
 
   int store_info(RGWSI_MetaBackend::Context *ctx,
-  		 const RGWRole& role,
+  		 const RGWRoleInfo& role,
   		 RGWObjVersionTracker * const objv_tracker,
   		 const real_time& pmtime,
   		 bool exclusive,
@@ -66,7 +66,7 @@ class RGWSI_Role_RADOS: public RGWSI_Role
 
   int read_info(RGWSI_MetaBackend::Context *ctx,
 		const std::string& role_id,
-  		RGWRole *role,
+  		RGWRoleInfo *role,
   		RGWObjVersionTracker * const objv_tracker,
   		real_time * const pmtime,
   		map<std::string, bufferlist> * pattrs,

--- a/src/rgw/services/svc_role_rados.h
+++ b/src/rgw/services/svc_role_rados.h
@@ -47,6 +47,14 @@ class RGWSI_Role_RADOS: public RGWSI_Role
   		 map<std::string, bufferlist> * pattrs,
   		 optional_yield y) override;
 
+  int create(RGWSI_MetaBackend::Context *ctx,
+	     RGWRoleInfo& role,
+	     RGWObjVersionTracker * const objv_tracker,
+	     const real_time& pmtime,
+	     bool exclusive,
+	     map<std::string, bufferlist> * pattrs,
+	     optional_yield y) override;
+
   int store_name(RGWSI_MetaBackend::Context *ctx,
 		 const std::string& role_id,
   		 const std::string& name,
@@ -88,9 +96,9 @@ class RGWSI_Role_RADOS: public RGWSI_Role
   		optional_yield y) override { return 0; } // TODO impl me
 
   int delete_info(RGWSI_MetaBackend::Context *ctx,
-		  const std::string& name,
-		  RGWObjVersionTracker * const objv_tracker,
-		  optional_yield y) override;
+		   const RGWRoleInfo& info,
+		   RGWObjVersionTracker * const objv_tracker,
+		   optional_yield y) override;
 
   int delete_name(RGWSI_MetaBackend::Context *ctx,
 		  const std::string& name,

--- a/src/rgw/services/svc_role_rados.h
+++ b/src/rgw/services/svc_role_rados.h
@@ -37,6 +37,7 @@ class RGWSI_Role_RADOS: public RGWSI_Role
 	    RGWSI_SysObj *_sysobj_svc);
 
   RGWSI_MetaBackend_Handler * get_be_handler() override;
+  int do_start() override;
 
   int store_info(RGWSI_MetaBackend::Context *ctx,
   		 const RGWRoleInfo& role,

--- a/src/rgw/services/svc_role_rados.h
+++ b/src/rgw/services/svc_role_rados.h
@@ -84,7 +84,7 @@ class RGWSI_Role_RADOS: public RGWSI_Role
   		std::string& path,
   		RGWObjVersionTracker * const objv_tracker,
   		real_time * const pmtime,
-  		optional_yield y) override;
+  		optional_yield y) override { return 0; } // TODO impl me
 
   int delete_info(RGWSI_MetaBackend::Context *ctx,
 		  const std::string& name,

--- a/src/rgw/services/svc_role_rados.h
+++ b/src/rgw/services/svc_role_rados.h
@@ -95,8 +95,13 @@ class RGWSI_Role_RADOS: public RGWSI_Role
   		real_time * const pmtime,
   		optional_yield y) override { return 0; } // TODO impl me
 
+  int delete_role(RGWSI_MetaBackend::Context *ctx,
+		  const RGWRoleInfo& info,
+		  RGWObjVersionTracker * const objv_tracker,
+		  optional_yield y) override;
+
   int delete_info(RGWSI_MetaBackend::Context *ctx,
-		   const RGWRoleInfo& info,
+		   const std::string& role_id,
 		   RGWObjVersionTracker * const objv_tracker,
 		   optional_yield y) override;
 


### PR DESCRIPTION
Introduce RGWRole and related services which actually perform the sysobj IO. The RGWRole Class itself is split into a RGWRoleInfo struct that holds the actual data & RGWRole class which provides the same interface as before, so the only change at the callsites was to use the RGWRoleCtl class instead of the rados ctl classes. Role creation will create the related metadata objects for role names & paths, however only role_info metadata object is actually in the metadata log, similar to how user MDLog works.

TODO:
- [ ] forward to meta-master in admin and other create apis
- [x] move list by path prefix out of RGWRole
- [x] Replace read by stat calls for existence check in create apis
- [x] tests 
- [ ] commit cleanup

Fixes: https://tracker.ceph.com/issues/45659

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
