### PR TITLE
nautilus: qa/suites/krbd: whitelist MON_DOWN health warning

### DIFF
--- a/qa/suites/krbd/thrash/thrashers/mon-thrasher.yaml
+++ b/qa/suites/krbd/thrash/thrashers/mon-thrasher.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-whitelist:
+      - \(MON_DOWN\)
 tasks:
 - mon_thrash:
     revive_delay: 20


### PR DESCRIPTION
see also

- 93de19adcf1233ce4c68f1253e0b9abef6d97a9d
- 608e002195638e80323780f1907db40c0b9768f0

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit f1072fcadc8b31737d1534e7ddad7bd2bef0a0b5)