### PR TITLE
rgw: Be less noisy when probing FIFO existence

### DIFF
--- a/src/rgw/cls_fifo_legacy.cc
+++ b/src/rgw/cls_fifo_legacy.cc
@@ -73,8 +73,8 @@ int get_meta(lr::IoCtx& ioctx, const std::string& oid,
 	     std::optional<fifo::objv> objv, fifo::info* info,
 	     std::uint32_t* part_header_size,
 	     std::uint32_t* part_entry_overhead,
-	     uint64_t tid,
-	     optional_yield y)
+	     uint64_t tid, optional_yield y,
+	     bool probe)
 {
   lr::ObjectReadOperation op;
   fifo::op::get_meta gm;
@@ -100,7 +100,7 @@ int get_meta(lr::IoCtx& ioctx, const std::string& oid,
 	<< " decode failed: " << err.what()
 	<< " tid=" << tid << dendl;
       r = from_error_code(err.code());
-    } else {
+    } else if (!(probe && (r == -ENOENT || r == -ENODATA))) {
     lderr(static_cast<CephContext*>(ioctx.cct()))
       << __PRETTY_FUNCTION__ << ":" << __LINE__
       << " fifo::op::GET_META failed r=" << r << " tid=" << tid
@@ -867,7 +867,8 @@ int FIFO::trim_part(int64_t part_num, uint64_t ofs,
 }
 
 int FIFO::open(lr::IoCtx ioctx, std::string oid, std::unique_ptr<FIFO>* fifo,
-	       optional_yield y, std::optional<fifo::objv> objv)
+	       optional_yield y, std::optional<fifo::objv> objv,
+	       bool probe)
 {
   auto cct = static_cast<CephContext*>(ioctx.cct());
   ldout(cct, 20)
@@ -876,10 +877,13 @@ int FIFO::open(lr::IoCtx ioctx, std::string oid, std::unique_ptr<FIFO>* fifo,
   fifo::info info;
   std::uint32_t size;
   std::uint32_t over;
-  int r = get_meta(ioctx, std::move(oid), objv, &info, &size, &over, 0, y);
+  int r = get_meta(ioctx, std::move(oid), objv, &info, &size, &over, 0, y,
+		   probe);
   if (r < 0) {
-    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-	       << " get_meta failed: r=" << r << dendl;
+    if (!(probe && (r == -ENOENT || r == -ENODATA))) {
+      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " get_meta failed: r=" << r << dendl;
+    }
     return r;
   }
   std::unique_ptr<FIFO> f(new FIFO(std::move(ioctx), oid));

--- a/src/rgw/cls_fifo_legacy.h
+++ b/src/rgw/cls_fifo_legacy.h
@@ -55,7 +55,8 @@ int get_meta(lr::IoCtx& ioctx, const std::string& oid,
 	     std::optional<fifo::objv> objv, fifo::info* info,
 	     std::uint32_t* part_header_size,
 	     std::uint32_t* part_entry_overhead,
-	     std::uint64_t tid, optional_yield y);
+	     std::uint64_t tid, optional_yield y,
+	     bool probe = false);
 void update_meta(lr::ObjectWriteOperation* op, const fifo::objv& objv,
 		 const fifo::update& update);
 void part_init(lr::ObjectWriteOperation* op, std::string_view tag,
@@ -183,7 +184,10 @@ public:
 		  std::unique_ptr<FIFO>* fifo, //< OUT: Pointer to FIFO object
 		  optional_yield y, //< Optional yield context
 		  /// Operation will fail if FIFO is not at this version
-		  std::optional<fifo::objv> objv = std::nullopt);
+		  std::optional<fifo::objv> objv = std::nullopt,
+		  /// Probing for existence, don't print errors if we
+		  /// can't find it.
+		  bool probe = false);
   /// Create a new or open an existing FIFO.
   static int create(lr::IoCtx ioctx, //< IO Context
 		    std::string oid, //< OID for metadata object

--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -314,7 +314,8 @@ public:
       std::vector<rgw::cls::fifo::list_entry> log_entries;
       bool more = false;
       auto r = rgw::cls::fifo::FIFO::open(ioctx, oid,
-					  &fifo, null_yield);
+					  &fifo, null_yield,
+					  std::nullopt, true);
       if (r == -ENOENT || r == -ENODATA) {
 	continue;
       } else if (r < 0) {


### PR DESCRIPTION
Since when starting up the datalog we check whether Omap and FIFO
backed versions already exist, don't fill the error log with
complaints if they happen not to.