### PR TITLE
rgw: use yum rather than dnf for teuthology testing of rgw-orphan-list

### DIFF
--- a/qa/workunits/rgw/test_rgw_orphan_list.sh
+++ b/qa/workunits/rgw/test_rgw_orphan_list.sh
@@ -56,9 +56,8 @@ uninstall_awscli() {
     cd "$here"
 }
 
-sudo dnf install -y s3cmd
-
-sudo yum install python3-setuptools
+sudo yum -y install s3cmd
+sudo yum -y install python3-setuptools
 sudo yum -y install python3-pip
 sudo pip3 install --upgrade setuptools
 sudo pip3 install python-swiftclient


### PR DESCRIPTION
The teuthology testing for rgw-orphan-list needs to install
`s3cmd`. Switch from using dnf to yum to work on a wider variety of
platforms.

Fixes: https://tracker.ceph.com/issues/47408
Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>