### PR TITLE
RGW: Fix Swift GET container metadata

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2798,8 +2798,13 @@ void RGWListBucket::execute()
     return;
   }
 
+  op_ret = store->get_bucket(s->user.get(), s->bucket->get_key(), &bucket);
+  if (op_ret) {
+    return;
+  }
+
   if (need_container_stats()) {
-    op_ret = s->bucket->update_container_stats();
+    op_ret = bucket->update_container_stats();
   }
 
   rgw::sal::RGWBucket::ListParams params;
@@ -2813,7 +2818,7 @@ void RGWListBucket::execute()
 
   rgw::sal::RGWBucket::ListResults results;
 
-  op_ret = s->bucket->list(params, max, results, s->yield);
+  op_ret = bucket->list(params, max, results, s->yield);
   if (op_ret >= 0) {
     next_marker = results.next_marker;
     is_truncated = results.is_truncated;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -842,6 +842,8 @@ protected:
 
   int shard_id;
 
+  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+
   int parse_max_keys();
 
 public:

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -350,7 +350,7 @@ void RGWListBucket_ObjStore_SWIFT::send_response()
   map<string, bool>::iterator pref_iter = common_prefixes.begin();
 
   dump_start(s);
-  dump_container_metadata(s, s->bucket.get(), bucket_quota,
+  dump_container_metadata(s, bucket.get(), bucket_quota,
                           s->bucket->get_info().website_conf);
 
   s->formatter->open_array_section_with_attrs("container",


### PR DESCRIPTION
Currently when you run a GET on a container the X-Container-* metadata
returned is zeroed out and doesn't actaully return the current stats for
the container. If you do a HEAD however it behaves as expected.

This is because on a HEAD the container object is actaully pulled from
the store. So this patch does the same thing for a GET.

I pushed this back into the RGWListBucket class, so should benefit S3
and Swift apis, however if poeple have a problem with this, we could
just do it in the Swift child class, RGWListBucket_ObjStore_SWIFT.

Fixes: https://tracker.ceph.com/issues/47861
Fixes: https://tracker.ceph.com/issues/47781
Signed-off-by: Matthew Oliver <moliver@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
