### PR TITLE
octopus: mgr/dashboard: fix the error when exporting CephFS path "/" in NFS exports

### DIFF
--- a/src/pybind/mgr/dashboard/services/ganesha.py
+++ b/src/pybind/mgr/dashboard/services/ganesha.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 
 import logging
+import os
 import re
 
 from orchestrator import OrchestratorError
@@ -491,6 +492,8 @@ class CephFSFSal(FSal):
 
     def create_path(self, path):
         cfs = CephFS(self.fs_name)
+        if path == os.sep:
+            return
         cfs.mk_dirs(path)
 
     @classmethod


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47832

---

backport of https://github.com/ceph/ceph/pull/37154
parent tracker: https://tracker.ceph.com/issues/47397

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh