### PR TITLE
[DNM TEST FAILURES] nautilus: qa: ignore logrotate state rename error

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -154,13 +154,12 @@ def ceph_log(ctx, config):
             while not self.stop_event.is_set():
                 self.stop_event.wait(timeout=30)
                 try:
-                    run.wait(
-                        ctx.cluster.run(
-                            args=['sudo', 'logrotate', '/etc/logrotate.d/ceph-test.conf'
-                                  ],
-                            wait=False,
-                        )
+                    p = ctx.cluster.run(
+                        args=['sudo', 'logrotate', '/etc/logrotate.d/ceph-test.conf'],
+                        wait=False,
+                        stderr=StringIO()
                     )
+                    run.wait(p)
                 except exceptions.ConnectionLostError as e:
                     # Some tests may power off nodes during test, in which
                     # case we will see connection errors that we should ignore.
@@ -174,6 +173,12 @@ def ceph_log(ctx, config):
                     log.debug("Missed logrotate, EOFError")
                 except SSHException:
                     log.debug("Missed logrotate, SSHException")
+                except run.CommandFailedError as e:
+                    err = p.stderr.getvalue()
+                    if 'error: error renaming temp state file' in err:
+                        log.info('ignoring transient state error: %s', e)
+                    else:
+                        raise
                 except socket.error as e:
                     if e.errno in (errno.EHOSTUNREACH, errno.ECONNRESET):
                         log.debug("Missed logrotate, host unreachable")

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -154,12 +154,12 @@ def ceph_log(ctx, config):
             while not self.stop_event.is_set():
                 self.stop_event.wait(timeout=30)
                 try:
-                    p = ctx.cluster.run(
-                        args=['sudo', 'logrotate', '/etc/logrotate.d/ceph-test.conf'],
-                        wait=False,
-                        stderr=StringIO()
+                    procs = ctx.cluster.run(
+                          args=['sudo', 'logrotate', '/etc/logrotate.d/ceph-test.conf'],
+                          wait=False,
+                          stderr=StringIO()
                     )
-                    run.wait(p)
+                    run.wait(procs)
                 except exceptions.ConnectionLostError as e:
                     # Some tests may power off nodes during test, in which
                     # case we will see connection errors that we should ignore.
@@ -174,11 +174,13 @@ def ceph_log(ctx, config):
                 except SSHException:
                     log.debug("Missed logrotate, SSHException")
                 except run.CommandFailedError as e:
-                    err = p.stderr.getvalue()
-                    if 'error: error renaming temp state file' in err:
-                        log.info('ignoring transient state error: %s', e)
-                    else:
-                        raise
+                    for p in procs:
+                        if p.finished and p.exitstatus != 0:
+                            err = p.stderr.getvalue()
+                            if 'error: error renaming temp state file' in err:
+                                log.info('ignoring transient state error: %s', e)
+                            else:
+                                raise
                 except socket.error as e:
                     if e.errno in (errno.EHOSTUNREACH, errno.ECONNRESET):
                         log.debug("Missed logrotate, host unreachable")


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/47660
* https://tracker.ceph.com/issues/47820

---

backport of:

* https://github.com/ceph/ceph/pull/37266
* https://github.com/ceph/ceph/pull/37441

parent trackers:

* https://tracker.ceph.com/issues/42433
* https://tracker.ceph.com/issues/47677

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh