### PR TITLE
nautilus: build-integration-branch: take PRs in chronological order

### DIFF
--- a/src/script/build-integration-branch
+++ b/src/script/build-integration-branch
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/src/script/build-integration-branch
+++ b/src/script/build-integration-branch
@@ -20,8 +20,13 @@ with open(os.environ['HOME'] + '/.github_token', 'r') as myfile:
     token = myfile.readline().strip()
 
 # get prs
-baseurl = urljoin('https://api.github.com',
-                  'repos/{repo}/issues?labels={label}&access_token={token}')
+baseurl = urljoin('https://api.github.com', (
+                      'repos/{repo}/issues?labels={label}'
+                      '&access_token={token}'
+                      '&sort=created'
+                      '&direction=asc'
+                    )
+                 )
 url = baseurl.format(
     label=label,
     repo=repo,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47878

---

backport of https://github.com/ceph/ceph/pull/31132
parent tracker: https://tracker.ceph.com/issues/42474

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh