### PR TITLE
mgr/dashboard: do not use "l" for variable name

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/home.py
+++ b/src/pybind/mgr/dashboard/controllers/home.py
@@ -87,7 +87,7 @@ class HomeController(BaseController, LanguageMixin):
         result.sort(key=lambda l: l[0])
         result.sort(key=lambda l: l[1], reverse=True)
         logger.debug("language preference: %s", result)
-        return [l[0] for l in result]
+        return [r[0] for r in result]
 
     def _language_dir(self, langs):
         for lang in langs:

--- a/src/pybind/mgr/dashboard/controllers/logs.py
+++ b/src/pybind/mgr/dashboard/controllers/logs.py
@@ -49,8 +49,8 @@ class Logs(BaseController):
     def load_buffer(self, buf, channel_name):
         lines = CephService.send_command(
             'mon', 'log last', channel=channel_name, num=LOG_BUFFER_SIZE, level='debug')
-        for l in lines:
-            buf.appendleft(l)
+        for line in lines:
+            buf.appendleft(line)
 
     def initialize_buffers(self):
         if not self._log_initialized:

--- a/src/pybind/mgr/dashboard/services/ganesha.py
+++ b/src/pybind/mgr/dashboard/services/ganesha.py
@@ -33,7 +33,7 @@ class Ganesha(object):
             raise NFSException("Ganesha config location is not configured. "
                                "Please set the GANESHA_RADOS_POOL_NAMESPACE "
                                "setting.")
-        location_list = [l.strip() for l in location_list_str.split(",")]
+        location_list = [loc.strip() for loc in location_list_str.split(",")]
         for location in location_list:
             cluster = None
             pool = None


### PR DESCRIPTION
see also https://www.flake8rules.com/rules/E741.html

also silences flake8 warnings like:

2: {tty:'./controllers/home.py:90:26: E741 ambiguous variable name 'l'':'./controllers/home.py:90:26: E741 ambiguous variable name 'l''}
2: {tty:'./controllers/logs.py:52:13: E741 ambiguous variable name 'l'':'./controllers/logs.py:52:13: E741 ambiguous variable name 'l''}
2: {tty:'./services/ganesha.py:36:40: E741 ambiguous variable name 'l'':'./services/ganesha.py:36:40: E741 ambiguous variable name 'l''}
2: 3     E741 ambiguous variable name 'l'

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
