### PR TITLE
octopus: Enable per-RBD image monitoring 

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -468,6 +468,14 @@ More details can be found in the documentation of the :ref:`mgr-prometheus`.
     [security]
     allow_embedding = true
 
+Enabling RBD-Image monitoring
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Due to performance reasons, monitoring of RBD images is disabled by default. For
+more information please see :ref:`prometheus-rbd-io-statistics`. If disabled,
+the overview and details dashboards will stay empty in Grafana and the metrics
+will not be visible in Prometheus.
+
 After you have set up Grafana and Prometheus, you will need to configure the
 connection information that the Ceph Dashboard will use to access Grafana.
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.html
@@ -129,6 +129,13 @@
        heading="Configuration">
     <cd-rbd-configuration-table [data]="selection['configuration']"></cd-rbd-configuration-table>
   </tab>
+  <tab i18n-heading
+       heading="Performance">
+    <cd-grafana [grafanaPath]="rbdDashboardUrl"
+                uid="YhCYGcuZz"
+                grafanaStyle="one">
+    </cd-grafana>
+  </tab>
 </tabset>
 
 <ng-template
@@ -146,4 +153,3 @@
           tooltip="This is the global value. No value for this option has been set for this image.">Global</span>
   </ng-template>
 </ng-template>
-

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, TemplateRef, ViewChild } from '@angular/core';
+import { Component, Input, OnChanges, TemplateRef, ViewChild } from '@angular/core';
 
 import { RbdFormModel } from '../rbd-form/rbd-form.model';
 
@@ -7,7 +7,7 @@ import { RbdFormModel } from '../rbd-form/rbd-form.model';
   templateUrl: './rbd-details.component.html',
   styleUrls: ['./rbd-details.component.scss']
 })
-export class RbdDetailsComponent {
+export class RbdDetailsComponent implements OnChanges {
   @Input()
   selection: RbdFormModel;
   @Input()
@@ -16,4 +16,12 @@ export class RbdDetailsComponent {
   poolConfigurationSourceTpl: TemplateRef<any>;
 
   constructor() {}
+
+  rbdDashboardUrl: string;
+
+  ngOnChanges() {
+    if (this.selection) {
+      this.rbdDashboardUrl = `rbd-details?var-Pool=${this.selection['pool_name']}&var-Image=${this.selection['name']}`;
+    }
+  }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.spec.ts
@@ -89,7 +89,7 @@ describe('RbdTrashMoveModalComponent', () => {
       component.moveImage();
       const req = httpTesting.expectOne('api/block/image/foo%2Fbar/move_trash');
       req.flush(null);
-      expect(req.request.body.delay).toBeGreaterThan(86390);
+      expect(req.request.body.delay).toBeGreaterThan(76390);
     });
   });
 });


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47602

---

backport of https://github.com/ceph/ceph/pull/37136
parent tracker: https://tracker.ceph.com/issues/47433

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh