### PR TITLE
journal: possible race condition between flush and append callback

### DIFF
--- a/src/journal/ObjectRecorder.cc
+++ b/src/journal/ObjectRecorder.cc
@@ -97,7 +97,7 @@ void ObjectRecorder::flush(Context *on_safe) {
     // if currently handling flush notifications, wait so that
     // we notify in the correct order (since lock is dropped on
     // callback)
-    while (m_in_flight_callbacks) {
+    while (m_in_flight_callbacks > 0) {
       m_in_flight_callbacks_cond.wait(locker);
     }
 
@@ -138,7 +138,7 @@ void ObjectRecorder::flush(const ceph::ref_t<FutureImpl>& future) {
   }
 
   if (!m_object_closed && !m_overflowed && send_appends(true, future)) {
-    m_in_flight_callbacks = true;
+    ++m_in_flight_callbacks;
     notify_handler_unlock(locker, true);
   }
 }
@@ -169,7 +169,7 @@ bool ObjectRecorder::close() {
   ceph_assert(!m_object_closed);
   m_object_closed = true;
 
-  if (!m_in_flight_tids.empty() || m_in_flight_callbacks) {
+  if (!m_in_flight_tids.empty() || m_in_flight_callbacks > 0) {
     m_object_closed_notify = true;
     return false;
   }
@@ -181,7 +181,7 @@ void ObjectRecorder::handle_append_flushed(uint64_t tid, int r) {
   ldout(m_cct, 20) << "tid=" << tid << ", r=" << r << dendl;
 
   std::unique_lock locker{*m_lock};
-  m_in_flight_callbacks = true;
+  ++m_in_flight_callbacks;
 
   auto tid_iter = m_in_flight_tids.find(tid);
   ceph_assert(tid_iter != m_in_flight_tids.end());
@@ -235,7 +235,9 @@ void ObjectRecorder::handle_append_flushed(uint64_t tid, int r) {
 
   ldout(m_cct, 20) << "pending tids=" << m_in_flight_tids << dendl;
 
-  // all remaining unsent appends should be redirected to new object
+  // notify of overflow if one just occurred or indicate that all in-flight
+  // appends have completed on a closed object (or wake up stalled flush
+  // requests that was waiting for this strand to complete).
   notify_handler_unlock(locker, notify_overflowed);
 }
 
@@ -379,14 +381,16 @@ bool ObjectRecorder::send_appends(bool force, ceph::ref_t<FutureImpl> flush_futu
 
 void ObjectRecorder::wake_up_flushes() {
   ceph_assert(ceph_mutex_is_locked(*m_lock));
-  m_in_flight_callbacks = false;
-  m_in_flight_callbacks_cond.notify_all();
+  --m_in_flight_callbacks;
+  if (m_in_flight_callbacks == 0) {
+    m_in_flight_callbacks_cond.notify_all();
+  }
 }
 
 void ObjectRecorder::notify_handler_unlock(
     std::unique_lock<ceph::mutex>& locker, bool notify_overflowed) {
   ceph_assert(ceph_mutex_is_locked(*m_lock));
-  ceph_assert(m_in_flight_callbacks);
+  ceph_assert(m_in_flight_callbacks > 0);
 
   if (!m_object_closed && notify_overflowed) {
     // TODO need to delay completion until after aio_notify completes

--- a/src/journal/ObjectRecorder.h
+++ b/src/journal/ObjectRecorder.h
@@ -143,7 +143,7 @@ private:
 
   bufferlist m_prefetch_bl;
 
-  bool m_in_flight_callbacks = false;
+  uint32_t m_in_flight_callbacks = 0;
   ceph::condition_variable m_in_flight_callbacks_cond;
   uint64_t m_in_flight_bytes = 0;
 


### PR DESCRIPTION
When notifying the journal recorder of an overflow or if the object
close request has completed due to no more in-flight IO, it was
possible for a race between a flush request and the processing of
an append completion to attempt to kick off duplicate notifications.
Since the overflowed and closed callbacks are properly protected from
duplicates, use a counter instead of a boolean to track possible
in-flight handler callbacks.

Fixes: https://tracker.ceph.com/issues/47880
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
