### PR TITLE
build-integration-branch: send token in the header

### DIFF
--- a/src/script/build-integration-branch
+++ b/src/script/build-integration-branch
@@ -62,16 +62,15 @@ with open(os.environ['HOME'] + '/.github_token', 'r') as myfile:
 # get prs
 baseurl = urljoin('https://api.github.com', (
                       'repos/{repo}/issues?labels={label}'
-                      '&access_token={token}'
                       '&sort=created'
                       '&direction=asc'
                     )
                  )
 url = baseurl.format(
     label=label,
-    repo=repo,
-    token=token)
-r = requests.get(url)
+    repo=repo)
+r = requests.get(url,
+                 headers={'Authorization': 'token %s' % token})
 assert(r.ok)
 j = json.loads(r.text or r.content)
 print("--- found %d issues tagged with %s" % (len(j), label))
@@ -81,7 +80,8 @@ prtext = []
 for issue in j:
     if 'pull_request' not in issue:
         continue
-    r = requests.get(issue['pull_request']['url'] + '?access_token=' + token)
+    r = requests.get(issue['pull_request']['url'],
+                     headers={'Authorization': 'token %s' % token})
     pr = json.loads(r.text or r.content)
     prs.append(pr)
     prtext.append(pr['html_url'] + ' - ' + pr['title'])

--- a/src/script/build-integration-branch
+++ b/src/script/build-integration-branch
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-Builds integration branches. Something similar to 
+Builds integration branches. Something similar to
   $ git checkout -b branch-name
   $ for b in $(get-branches-from-github) ; do
   >   git pull b
@@ -19,56 +19,50 @@ Options:
   --no-date   Don't add `{postfix}` to the branch name.
 """
 
-from __future__ import print_function
-
 import json
 import os
 import requests
-from subprocess import call, check_output
 import sys
 import time
-try:
-    from urllib.parse import urljoin
-except:
-    from urlparse import urljoin
+
+from subprocess import call, check_output
+from urllib.parse import urljoin
 
 TIME_FORMAT = '%Y-%m-%d-%H%M'
 postfix = "-" + time.strftime(TIME_FORMAT, time.localtime())
 
-current_branch = check_output('git rev-parse --abbrev-ref HEAD', shell=True).strip().decode()
+current_branch = check_output('git rev-parse --abbrev-ref HEAD',
+                              shell=True).strip().decode()
 if current_branch in 'mimic nautilus octopus pacific'.split():
-  postfix += '-' + current_branch
-  print(f"Adding current branch name '-{current_branch}' as a postfix")
+    postfix += '-' + current_branch
+    print(f"Adding current branch name '-{current_branch}' as a postfix")
 
 repo = "ceph/ceph"
 
 try:
-  from docopt import docopt
-  arguments = docopt(__doc__.format(postfix=postfix))
-  label = arguments['<label>']
-  branch = label
-  if not arguments['--no-date']:
-      branch += postfix
+    from docopt import docopt
+    arguments = docopt(__doc__.format(postfix=postfix))
+    label = arguments['<label>']
+    branch = label
+    if not arguments['--no-date']:
+        branch += postfix
 except ImportError:
-  # Fallback without docopt.
-  label = sys.argv[1]
-  assert len(sys.argv) == 2
-  branch = label + postfix
+    # Fallback without docopt.
+    label = sys.argv[1]
+    assert len(sys.argv) == 2
+    branch = label + postfix
 
 
-with open(os.environ['HOME'] + '/.github_token', 'r') as myfile:
+with open(os.path.expanduser('~/.github_token')) as myfile:
     token = myfile.readline().strip()
 
 # get prs
-baseurl = urljoin('https://api.github.com', (
-                      'repos/{repo}/issues?labels={label}'
-                      '&sort=created'
-                      '&direction=asc'
-                    )
-                 )
-url = baseurl.format(
-    label=label,
-    repo=repo)
+baseurl = urljoin('https://api.github.com',
+                  ('repos/{repo}/issues?labels={label}'
+                   '&sort=created'
+                   '&direction=asc'))
+url = baseurl.format(label=label,
+                     repo=repo)
 r = requests.get(url,
                  headers={'Authorization': 'token %s' % token})
 assert(r.ok)


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
