### PR TITLE
octopus: mon: have 'mon stat' output json as well

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1165,6 +1165,11 @@ function test_mon_mon()
   ceph mon feature set kraken --yes-i-really-mean-it
   expect_false ceph mon feature set abcd
   expect_false ceph mon feature set abcd --yes-i-really-mean-it
+
+  # test mon stat
+  # don't check output, just ensure it does not fail.
+  ceph mon stat
+  ceph mon stat -f json | jq '.'
 }
 
 function test_mon_priority_and_weight()

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -278,10 +278,29 @@ bool MonmapMonitor::preprocess_command(MonOpRequestRef op)
   boost::scoped_ptr<Formatter> f(Formatter::create(format));
 
   if (prefix == "mon stat") {
-    mon->monmap->print_summary(ss);
-    ss << ", election epoch " << mon->get_epoch() << ", leader "
-       << mon->get_leader() << " " << mon->get_leader_name()
-       << ", quorum " << mon->get_quorum() << " " << mon->get_quorum_names();
+    if (f) {
+      f->open_object_section("monmap");
+      mon->monmap->dump_summary(f.get());
+      f->dump_string("leader", mon->get_leader_name());
+      f->open_array_section("quorum");
+      for (auto rank: mon->get_quorum()) {
+        std::string name = mon->monmap->get_name(rank);
+        f->open_object_section("mon");
+        f->dump_int("rank", rank);
+        f->dump_string("name", name);
+        f->close_section();  // mon
+      }
+      f->close_section();  // quorum
+      f->close_section();  // monmap
+      f->flush(ss);
+    } else {
+      mon->monmap->print_summary(ss);
+      ss << ", election epoch " << mon->get_epoch() << ", leader "
+         << mon->get_leader() << " " << mon->get_leader_name()
+         << ", quorum " << mon->get_quorum()
+         << " " << mon->get_quorum_names();
+    }
+
     rdata.append(ss);
     ss.str("");
     r = 0;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47898

---

backport of https://github.com/ceph/ceph/pull/37635
parent tracker: https://tracker.ceph.com/issues/46816

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh