### PR TITLE
nautilus: mon: have 'mon stat' output json as well

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -4,9 +4,6 @@
 * MGR: progress module can now be turned on/off, using the commands:
   ``ceph progress on`` and ``ceph progress off``.
 
-14.2.13
--------
-
-* This release fixes a regression introduced in 14.2.12 which broke deployments
-  that referred to MON hosts using DNS names instead of IP addresses in the
-  ``mon_host`` parameter in ``/etc/ceph/ceph.conf``.
+* The structured output of ``ceph status`` or ``ceph -s`` is now more
+  concise, particularly the ``mgrmap`` and ``monmap`` sections, and the
+  structure of the ``osdmap`` section has been cleaned up.

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1180,6 +1180,11 @@ function test_mon_mon()
   ceph mon feature set kraken --yes-i-really-mean-it
   expect_false ceph mon feature set abcd
   expect_false ceph mon feature set abcd --yes-i-really-mean-it
+
+  # test mon stat
+  # don't check output, just ensure it does not fail.
+  ceph mon stat
+  ceph mon stat -f json | jq '.'
 }
 
 function gen_secrets_file()

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -360,6 +360,14 @@ void MonMap::dump(Formatter *f) const
   f->close_section();
 }
 
+void MonMap::dump_summary(Formatter *f) const
+{
+  f->dump_unsigned("epoch", epoch);
+  f->dump_string("min_mon_release_name", std::to_string(min_mon_release));
+  f->dump_unsigned("num_mons", ranks.size());
+}
+
+
 // an ambiguous mon addr may be legacy or may be msgr2--we aren' sure.
 // when that happens we need to try them both (unless we can
 // reasonably infer from the port number which it is).

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -433,6 +433,7 @@ public:
   void print(ostream& out) const;
   void print_summary(ostream& out) const;
   void dump(ceph::Formatter *f) const;
+  void dump_summary(ceph::Formatter *f) const;
 
   static void generate_test_instances(list<MonMap*>& o);
 protected:

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2955,7 +2955,7 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
 	  mono_clock::now() - quorum_since).count());
     }
     f->open_object_section("monmap");
-    monmap->dump(f);
+    monmap->dump_summary(f);
     f->close_section();
     f->open_object_section("osdmap");
     osdmon()->osdmap.print_summary(f, cout, string(12, ' '));

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -277,10 +277,29 @@ bool MonmapMonitor::preprocess_command(MonOpRequestRef op)
   boost::scoped_ptr<Formatter> f(Formatter::create(format));
 
   if (prefix == "mon stat") {
-    mon->monmap->print_summary(ss);
-    ss << ", election epoch " << mon->get_epoch() << ", leader "
-       << mon->get_leader() << " " << mon->get_leader_name()
-       << ", quorum " << mon->get_quorum() << " " << mon->get_quorum_names();
+    if (f) {
+      f->open_object_section("monmap");
+      mon->monmap->dump_summary(f.get());
+      f->dump_string("leader", mon->get_leader_name());
+      f->open_array_section("quorum");
+      for (auto rank: mon->get_quorum()) {
+        std::string name = mon->monmap->get_name(rank);
+        f->open_object_section("mon");
+        f->dump_int("rank", rank);
+        f->dump_string("name", name);
+        f->close_section();  // mon
+      }
+      f->close_section();  // quorum
+      f->close_section();  // monmap
+      f->flush(ss);
+    } else {
+      mon->monmap->print_summary(ss);
+      ss << ", election epoch " << mon->get_epoch() << ", leader "
+         << mon->get_leader() << " " << mon->get_leader_name()
+         << ", quorum " << mon->get_quorum()
+         << " " << mon->get_quorum_names();
+    }
+
     rdata.append(ss);
     ss.str("");
     r = 0;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47899

---

backport of https://github.com/ceph/ceph/pull/37635
parent tracker: https://tracker.ceph.com/issues/46816

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh