### PR TITLE
[WIP] jaegertracing spans for OSD's I/O path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -70,3 +70,15 @@
 [submodule "s3select"]
 	path = src/s3select
 	url = https://github.com/ceph/s3select.git
+[submodule "src/jaegertracing/opentracing-cpp"]
+	path = src/jaegertracing/opentracing-cpp
+	url = https://github.com/opentracing/opentracing-cpp.git
+	branch = v1.6.0
+[submodule "src/jaegertracing/jaeger-client-cpp"]
+	path = src/jaegertracing/jaeger-client-cpp
+	url = https://github.com/ideepika/jaeger-client-cpp.git
+	branch = hunter-disabled
+[submodule "src/jaegertracing/thrift"]
+	path = src/jaegertracing/thrift
+	url = https://github.com/apache/thrift.git
+	branch = 0.13.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,6 +354,11 @@ if(WITH_BLKIN)
   include_directories(SYSTEM src/blkin/blkin-lib)
 endif(WITH_BLKIN)
 
+option(WITH_JAEGER "Enable jaegertracing and it's dependent libraries" ON)
+if(WITH_JAEGER)
+  set(HAVE_JAEGER TRUE)
+endif()
+
 option(WITH_BOOST_CONTEXT "Enable boost::asio stackful coroutines" ON)
 if(WITH_BOOST_CONTEXT)
   set(HAVE_BOOST_CONTEXT ON)

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -820,7 +820,7 @@ Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{relea
 Provides:	python-rgw = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	python-rgw < %{_epoch_prefix}%{version}-%{release}
 %description -n python%{python3_pkgversion}-rgw
-This package contains Python 3 libraries for interacting with Cephs RADOS
+This package contains Python 3 libraries for interacting with Ceph RADOS
 gateway.
 
 %package -n python%{python3_pkgversion}-rados
@@ -834,7 +834,7 @@ Requires:	librados2 = %{_epoch_prefix}%{version}-%{release}
 Provides:	python-rados = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	python-rados < %{_epoch_prefix}%{version}-%{release}
 %description -n python%{python3_pkgversion}-rados
-This package contains Python 3 libraries for interacting with Cephs RADOS
+This package contains Python 3 libraries for interacting with Ceph's RADOS
 object store.
 
 %if 0%{with libradosstriper}
@@ -909,7 +909,7 @@ Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{relea
 Provides:	python-rbd = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	python-rbd < %{_epoch_prefix}%{version}-%{release}
 %description -n python%{python3_pkgversion}-rbd
-This package contains Python 3 libraries for interacting with Cephs RADOS
+This package contains Python 3 libraries for interacting with Ceph's RADOS
 block device.
 
 %package -n libcephfs2
@@ -940,7 +940,7 @@ Provides:	libcephfs2-devel = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	libcephfs2-devel < %{_epoch_prefix}%{version}-%{release}
 %description -n libcephfs-devel
 This package contains libraries and headers needed to develop programs
-that use Cephs distributed file system.
+that use Ceph distributed file system.
 
 %if 0%{with jaeger}
 %package -n libjaeger
@@ -968,7 +968,7 @@ Requires:	python%{python3_pkgversion}-ceph-argparse = %{_epoch_prefix}%{version}
 Provides:	python-cephfs = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	python-cephfs < %{_epoch_prefix}%{version}-%{release}
 %description -n python%{python3_pkgversion}-cephfs
-This package contains Python 3 libraries for interacting with Cephs distributed
+This package contains Python 3 libraries for interacting with Ceph's distributed
 file system.
 
 %package -n python%{python3_pkgversion}-ceph-argparse
@@ -1125,6 +1125,7 @@ This package provides Ceph’s default alerts for Prometheus.
 # LTO can be enabled as soon as the following GCC bug is fixed:
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48200
 %define _lto_cflags %{nil}
+%define _unpackaged_files_terminate_build 0
 
 %if 0%{with seastar}
 . /opt/rh/gcc-toolset-9/enable

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -61,6 +61,7 @@
 %endif
 %endif
 %bcond_with seastar
+%bcond_without jaeger
 %if 0%{?fedora} || 0%{?suse_version} >= 1500
 # distros that ship cmd2 and/or colorama
 %bcond_without cephfs_shell
@@ -199,6 +200,18 @@ BuildRequires:	socat
 %endif
 %if 0%{with zbd}
 BuildRequires:  libzbd-devel
+%endif
+%if 0%{with jaeger}
+BuildRequires:  bison
+BuildRequires:	flex
+%if 0%{?fedora} || 0%{?rhel}
+BuildRequires:  json-devel
+%endif
+%if 0%{?suse_version}
+BuildRequires:  nlohmann_json-devel
+%endif
+BuildRequires:  libevent-devel
+BuildRequires:  yaml-cpp-devel
 %endif
 %if 0%{with seastar}
 BuildRequires:  c-ares-devel
@@ -414,6 +427,9 @@ Requires:	python%{python3_pkgversion}-cephfs = %{_epoch_prefix}%{version}-%{rele
 Requires:	python%{python3_pkgversion}-rgw = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{python3_pkgversion}-ceph-argparse = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{python3_pkgversion}-ceph-common = %{_epoch_prefix}%{version}-%{release}
+%if 0%{with jaeger}
+Requires:	libjaeger = %{_epoch_prefix}%{version}-%{release}
+%endif
 %if 0%{?fedora} || 0%{?rhel}
 Requires:	python%{python3_pkgversion}-prettytable
 %endif
@@ -452,6 +468,9 @@ Requires:	ceph-base = %{_epoch_prefix}%{version}-%{release}
 %if 0%{?weak_deps}
 Recommends:	nvme-cli
 Recommends:	smartmontools
+%endif
+%if 0%{with jaeger}
+Requires:	libjaeger = %{_epoch_prefix}%{version}-%{release}
 %endif
 %description mon
 ceph-mon is the cluster monitor daemon for the Ceph distributed file
@@ -922,6 +941,20 @@ Obsoletes:	libcephfs2-devel < %{_epoch_prefix}%{version}-%{release}
 %description -n libcephfs-devel
 This package contains libraries and headers needed to develop programs
 that use Cephs distributed file system.
+
+%if 0%{with jaeger}
+%package -n libjaeger
+Summary:	Ceph distributed file system tracing library
+%if 0%{?suse_version}
+Group:		System/Libraries
+%endif
+Provides: 	libjaegertracing.so.0()(64bit)
+Provides:	libopentracing.so.1()(64bit)
+Provides:	libthrift.so.0.13.0()(64bit)
+%description -n libjaeger
+This package contains libraries and headers needed to provide distributed
+tracing for Ceph.
+%endif
 
 %package -n python%{python3_pkgversion}-cephfs
 Summary:	Python 3 libraries for Ceph distributed file system
@@ -2142,6 +2175,16 @@ fi
 %dir %{_includedir}/cephfs/metrics
 %{_includedir}/cephfs/metrics/Types.h
 %{_libdir}/libcephfs.so
+
+%if %{with jaeger}
+%files -n libjaeger
+%{_libdir}/libopentracing.so.*
+%{_libdir}/libthrift.so.*
+%{_libdir}/libjaegertracing.so.*
+
+%post -n libjaeger -p /sbin/ldconfig
+%postun -n libjaeger -p /sbin/ldconfig
+%endif
 
 %files -n python%{python3_pkgversion}-cephfs
 %{python3_sitearch}/cephfs.cpython*.so

--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -171,6 +171,7 @@ function(do_build_boost version)
   include(ExternalProject)
   ExternalProject_Add(Boost
     ${source_dir}
+    INSTALL_DIR "external"
     CONFIGURE_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ${configure_command}
     BUILD_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ${build_command}
     BUILD_IN_SOURCE 1

--- a/cmake/modules/BuildJaeger.cmake
+++ b/cmake/modules/BuildJaeger.cmake
@@ -1,0 +1,72 @@
+#
+#Copyright (C) 2020 Red Hat Inc.
+#
+#This is free software; you can redistribute it and/or
+#modify it under the terms of the GNU Lesser General Public
+#License version 2.1, as published by the Free Software
+#Foundation.  See file COPYING.
+################################################################################
+#
+# This module builds Jaeger after it's dependencies are installed and discovered
+# opentracing: is built using cmake/modules/Buildopentracing.cmake
+# Thrift: build using cmake/modules/Buildthrift.cmake
+# yaml-cpp, nlhomann-json: are installed locally and then discovered using
+# Find<package>.cmake
+# Boost Libraries used for building thrift are build and provided by
+# cmake/modules/BuildBoost.cmake
+
+function(build_jaeger)
+  set(Jaeger_SOURCE_DIR "${CMAKE_SOURCE_DIR}/src/jaegertracing/jaeger-client-cpp")
+  set(Jaeger_INSTALL_DIR "${CMAKE_BINARY_DIR}/external")
+  set(Jaeger_BINARY_DIR "${Jaeger_INSTALL_DIR}/Jaeger")
+
+  file(MAKE_DIRECTORY "${Jaeger_INSTALL_DIR}")
+  set(Jaeger_CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+                        -DBUILD_SHARED_LIBS=ON
+                        -DHUNTER_ENABLED=OFF
+                        -DBUILD_TESTING=OFF
+                        -DJAEGERTRACING_BUILD_EXAMPLES=OFF
+                        -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}/external
+                        -DCMAKE_INSTALL_RPATH=${CMAKE_BINARY_DIR}/external
+			-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE
+                        -Dopentracing_DIR=${CMAKE_SOURCE_DIR}/src/jaegertracing/opentracing-cpp
+			-Dnlohmann_json_DIR=/usr/lib
+			-DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/external
+			-DCMAKE_FIND_ROOT_PATH="${CMAKE_BINARY_DIR}/external"
+                        -DCMAKE_INSTALL_LIBDIR=${CMAKE_BINARY_DIR}/external/lib)
+
+  set(dependencies opentracing thrift)
+  include(BuildOpenTracing)
+  build_opentracing()
+  include(Buildthrift)
+  build_thrift()
+  if(NOT yaml-cpp_FOUND)
+    include(Buildyaml-cpp)
+    build_yamlcpp()
+    add_library(yaml-cpp::yaml-cpp SHARED IMPORTED)
+    add_dependencies(yaml-cpp::yaml-cpp yaml-cpp)
+    set_library_properties_for_external_project(yaml-cpp::yaml-cpp yaml-cpp)
+    list(APPEND dependencies "yaml-cpp")
+  endif()
+
+  if(CMAKE_MAKE_PROGRAM MATCHES "make")
+    # try to inherit command line arguments passed by parent "make" job
+    set(make_cmd $(MAKE))
+  else()
+    set(make_cmd ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG> --target Jaeger)
+  endif()
+  set(install_cmd $(MAKE) install DESTDIR=)
+
+  include(ExternalProject)
+  ExternalProject_Add(Jaeger
+    SOURCE_DIR ${Jaeger_SOURCE_DIR}
+    UPDATE_COMMAND ""
+    INSTALL_DIR "external"
+    PREFIX ${Jaeger_INSTALL_DIR}
+    CMAKE_ARGS ${Jaeger_CMAKE_ARGS}
+    BINARY_DIR ${Jaeger_BINARY_DIR}
+    BUILD_COMMAND ${make_cmd}
+    INSTALL_COMMAND ${install_cmd}
+    DEPENDS "${dependencies}"
+    )
+endfunction()

--- a/cmake/modules/BuildOpenTracing.cmake
+++ b/cmake/modules/BuildOpenTracing.cmake
@@ -1,0 +1,46 @@
+###############################################################################
+#Ceph - scalable distributed file system
+#
+#Copyright (C) 2020 Red Hat Inc.
+#
+#This is free software; you can redistribute it and/or
+#modify it under the terms of the GNU Lesser General Public
+#License version 2.1, as published by the Free Software
+#Foundation.  See file COPYING.
+################################################################################
+
+function(build_opentracing)
+  set(opentracing_SOURCE_DIR "${CMAKE_SOURCE_DIR}/src/jaegertracing/opentracing-cpp")
+  set(opentracing_BINARY_DIR "${CMAKE_BINARY_DIR}/external/opentracing-cpp")
+
+  set(opentracing_CMAKE_ARGS  -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+                              -DBUILD_MOCKTRACER=OFF
+			      -DENABLE_LINTING=OFF
+			      -DBUILD_STATIC_LIBS=OFF
+			      -DBUILD_TESTING=OFF
+                              -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/external
+                              -DCMAKE_INSTALL_RPATH=${CMAKE_BINARY_DIR}/external
+			      -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE
+                              -DCMAKE_INSTALL_LIBDIR=${CMAKE_BINARY_DIR}/external/lib
+                              -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}/external)
+
+  if(CMAKE_MAKE_PROGRAM MATCHES "make")
+    # try to inherit command line arguments passed by parent "make" job
+    set(make_cmd $(MAKE) )
+  else()
+    set(make_cmd ${CMAKE_COMMAND} --build <BINARY_DIR> --target opentracing)
+  endif()
+  set(install_cmd $(MAKE) install DESTDIR=)
+
+  include(ExternalProject)
+  ExternalProject_Add(opentracing
+    SOURCE_DIR ${opentracing_SOURCE_DIR}
+    UPDATE_COMMAND ""
+    INSTALL_DIR "external"
+    PREFIX "external/opentracing-cpp"
+    CMAKE_ARGS ${opentracing_CMAKE_ARGS}
+    BUILD_IN_SOURCE 1
+    BUILD_COMMAND ${make_cmd}
+    INSTALL_COMMAND ${install_cmd}
+    )
+endfunction()

--- a/cmake/modules/Buildthrift.cmake
+++ b/cmake/modules/Buildthrift.cmake
@@ -1,0 +1,63 @@
+###############################################################################
+#Ceph - scalable distributed file system
+#
+#Copyright (C) 2020 Red Hat Inc.
+#
+#This is free software; you can redistribute it and/or
+#modify it under the terms of the GNU Lesser General Public
+#License version 2.1, as published by the Free Software
+#Foundation.  See file COPYING.
+################################################################################
+
+function(build_thrift)
+  set(thrift_SOURCE_DIR "${CMAKE_SOURCE_DIR}/src/jaegertracing/thrift")
+  set(thrift_BINARY_DIR "${CMAKE_BINARY_DIR}/external/thrift")
+
+  set(thrift_CMAKE_ARGS  -DCMAKE_BUILD_TYPE=Release
+			 -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+			 -DBUILD_JAVA=OFF
+			 -DBUILD_PYTHON=OFF
+			 -DBUILD_TESTING=OFF
+			 -DBUILD_TUTORIALS=OFF
+			 -DBUILD_C_GLIB=OFF
+			 -DBUILD_HASKELL=OFF
+			 -DWITH_LIBEVENT=OFF
+			 -DWITH_ZLIB=OFF
+			 -DCMAKE_FIND_ROOT_PATH=${CMAKE_BINARY_DIR}/external
+			 -DCMAKE_INSTALL_RPATH=${CMAKE_BINARY_DIR}/external/lib
+			 -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE
+			 -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/external
+			 -DCMAKE_INSTALL_LIBDIR=${CMAKE_BINARY_DIR}/external/lib)
+
+  if(WITH_SYSTEM_BOOST)
+    message(STATUS "thrift will be using system boost")
+    set(dependencies "")
+    list(APPEND thrift_CMAKE_ARGS -DBOOST_ROOT=/opt/ceph)
+    list(APPEND thrift_CMAKE_ARGS -DCMAKE_FIND_ROOT_PATH=/opt/ceph)
+  else()
+    message(STATUS "thrift will be using external build boost")
+    set(dependencies Boost)
+    list(APPEND thrift_CMAKE_ARGS  -DCMAKE_FIND_ROOT_PATH=${CMAKE_BINARY_DIR}/boost)
+    list(APPEND thrift_CMAKE_ARGS  -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}/external)
+  endif()
+
+  if(CMAKE_MAKE_PROGRAM MATCHES "make")
+    # try to inherit command line arguments passed by parent "make" job
+    set(make_cmd $(MAKE))
+  else()
+    set(make_cmd ${CMAKE_COMMAND} --build <BINARY_DIR> --target thrift)
+  endif()
+
+  set(install_cmd $(MAKE) install DESTDIR=)
+
+  include(ExternalProject)
+  ExternalProject_Add(thrift
+    SOURCE_DIR ${thrift_SOURCE_DIR}
+    PREFIX "${CMAKE_BINARY_DIR}/external/thrift"
+    CMAKE_ARGS ${thrift_CMAKE_ARGS}
+    BINARY_DIR ${thrift_BINARY_DIR}
+    BUILD_COMMAND ${make_cmd}
+    INSTALL_COMMAND ${install_cmd}
+    DEPENDS ${dependencies}
+    )
+endfunction()

--- a/cmake/modules/Buildyaml-cpp.cmake
+++ b/cmake/modules/Buildyaml-cpp.cmake
@@ -1,0 +1,47 @@
+###############################################################################
+#Ceph - scalable distributed file system
+#
+#Copyright (C) 2020 Red Hat Inc.
+#
+#This is free software; you can redistribute it and/or
+#modify it under the terms of the GNU Lesser General Public
+#License version 2.1, as published by the Free Software
+#Foundation.  See file COPYING.
+################################################################################
+
+function(build_yamlcpp)
+  set(yaml-cpp_DOWNLOAD_DIR "${CMAKE_SOURCE_DIR}/src/jaegertracing")
+  set(yaml-cpp_SOURCE_DIR "${CMAKE_SOURCE_DIR}/src/jaegertracing/yaml-cpp")
+  set(yaml-cpp_BINARY_DIR "${CMAKE_BINARY_DIR}/external/yaml-cpp")
+
+  set(yaml-cpp_CMAKE_ARGS -DBUILD_SHARED_LIBS=ON
+		          -DYAML_CPP_BUILD_TESTS=OFF
+			  -DYAML_CPP_BUILD_CONTRIB=OFF
+        		  -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/external
+        		  -DCMAKE_INSTALL_RPATH=${CMAKE_BINARY_DIR}/external/lib
+			  -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE
+			  -DCMAKE_INSTALL_LIBDIR=${CMAKE_BINARY_DIR}/external/lib
+			  -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}/external)
+
+  if(CMAKE_MAKE_PROGRAM MATCHES "make")
+    # try to inherit command line arguments passed by parent "make" job
+    set(make_cmd "$(MAKE)")
+  else()
+    set(make_cmd ${CMAKE_COMMAND} --build <BINARY_DIR> --target yaml-cpp)
+  endif()
+set(install_cmd $(MAKE) install DESTDIR=)
+
+  include(ExternalProject)
+  ExternalProject_Add(yaml-cpp
+    GIT_REPOSITORY "https://github.com/jbeder/yaml-cpp.git"
+    GIT_TAG "yaml-cpp-0.6.2"
+    UPDATE_COMMAND ""
+    INSTALL_DIR "${CMAKE_BINARY_DIR}/external"
+    DOWNLOAD_DIR ${yaml-cpp_DOWNLOAD_DIR}
+    SOURCE_DIR ${yaml-cpp_SOURCE_DIR}
+    PREFIX "${CMAKE_BINARY_DIR}/external/yaml-cpp"
+    CMAKE_ARGS ${yaml-cpp_CMAKE_ARGS}
+    BUILD_COMMAND ${make_cmd}
+    INSTALL_COMMAND ${install_cmd}
+    )
+endfunction()

--- a/cmake/modules/ExternalProjectHelper.cmake
+++ b/cmake/modules/ExternalProjectHelper.cmake
@@ -1,0 +1,17 @@
+function (set_library_properties_for_external_project _target _lib)
+  set(_libfullname "${CMAKE_SHARED_LIBRARY_PREFIX}${_lib}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+  set(_libpath "${CMAKE_BINARY_DIR}/external/lib/${_libfullname}")
+  set(_includepath "${CMAKE_BINARY_DIR}/external/include")
+  message(STATUS "Configuring ${_target} with ${_libpath}")
+
+  file(MAKE_DIRECTORY "${_includepath}")
+  set_target_properties(${_target} PROPERTIES
+    INTERFACE_LINK_LIBRARIES "${_libpath}"
+    IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+    IMPORTED_LOCATION "${_libpath}"
+    INTERFACE_INCLUDE_DIRECTORIES "${_includepath}")
+  #  set_property(TARGET ${_target} APPEND PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES "CXX")
+  # Manually create the directory, it will be created as part of the build,
+  # but this runs in the configuration phase, and CMake generates an error if
+  # we add an include directory that does not exist yet.
+endfunction ()

--- a/cmake/modules/Findyaml-cpp.cmake
+++ b/cmake/modules/Findyaml-cpp.cmake
@@ -1,0 +1,62 @@
+#
+# This file is open source software, licensed to you under the terms
+# of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+# distributed with this work for additional information regarding copyright
+# ownership.  You may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# Copyright (C) 2018 Scylladb, Ltd.
+#
+
+find_package (PkgConfig REQUIRED)
+
+pkg_search_module (yaml-cpp_PC yaml-cpp)
+
+find_library (yaml-cpp_LIBRARY
+  NAMES yaml-cpp
+  HINTS
+    ${yaml-cpp_PC_LIBDIR}
+    ${yaml-cpp_PC_LIBRARY_DIRS})
+
+find_path (yaml-cpp_INCLUDE_DIR
+  NAMES yaml-cpp/yaml.h
+  PATH_SUFFIXES yaml-cpp
+  HINTS
+    ${yaml-cpp_PC_INCLUDEDIR}
+    ${yaml-cpp_PC_INCLUDE_DIRS})
+
+mark_as_advanced (
+  yaml-cpp_LIBRARY
+  yaml-cpp_INCLUDE_DIR)
+
+include (FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args (yaml-cpp
+  REQUIRED_VARS
+    yaml-cpp_LIBRARY
+    yaml-cpp_INCLUDE_DIR
+  VERSION_VAR yaml-cpp_PC_VERSION)
+
+set (yaml-cpp_LIBRARIES ${yaml-cpp_LIBRARY})
+set (yaml-cpp_INCLUDE_DIRS ${yaml-cpp_INCLUDE_DIR})
+
+if (yaml-cpp_FOUND AND NOT (TARGET yaml-cpp::yaml-cpp))
+  add_library (yaml-cpp::yaml-cpp UNKNOWN IMPORTED)
+
+  set_target_properties (yaml-cpp::yaml-cpp
+    PROPERTIES
+      IMPORTED_LOCATION ${yaml-cpp_LIBRARY}
+      INTERFACE_INCLUDE_DIRECTORIES ${yaml-cpp_INCLUDE_DIRS})
+endif ()

--- a/cmake/modules/IncludeJaeger.cmake
+++ b/cmake/modules/IncludeJaeger.cmake
@@ -1,0 +1,32 @@
+###############################################################################
+#Ceph - scalable distributed file system
+#
+#Copyright (C) 2020 Red Hat Inc.
+#
+#This is free software; you can redistribute it and/or
+#modify it under the terms of the GNU Lesser General Public
+#License version 2.1, as published by the Free Software
+#Foundation.  See file COPYING.
+################################################################################
+
+include(BuildJaeger)
+include(BuildOpenTracing)
+
+include(ExternalProjectHelper)
+
+build_jaeger()
+
+add_library(opentracing::libopentracing SHARED IMPORTED)
+add_dependencies(opentracing::libopentracing opentracing)
+add_library(jaegertracing::libjaegertracing SHARED IMPORTED)
+add_dependencies(jaegertracing::libjaegertracing Jaeger)
+add_library(thrift::libthrift SHARED IMPORTED)
+add_dependencies(thrift::libthrift thrift)
+
+#(set_library_properties_for_external_project _target _lib)
+set_library_properties_for_external_project(opentracing::libopentracing
+  opentracing)
+set_library_properties_for_external_project(jaegertracing::libjaegertracing
+  jaegertracing)
+set_library_properties_for_external_project(thrift::libthrift
+  thrift)

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,9 @@ Vcs-Browser: https://github.com/ceph/ceph
 Maintainer: Ceph Maintainers <ceph-maintainers@lists.ceph.com>
 Uploaders: Ken Dreyer <kdreyer@redhat.com>,
            Alfredo Deza <adeza@redhat.com>,
-Build-Depends: cmake (>= 3.10.2),
+Build-Depends: automake,
+               bison,
+               cmake (>= 3.10.2),
                cpio,
                cryptsetup-bin | cryptsetup,
                cython,
@@ -17,6 +19,7 @@ Build-Depends: cmake (>= 3.10.2),
                dh-exec,
                dh-python,
                dh-systemd,
+               flex,
                git,
                gperf,
                g++ (>= 7),
@@ -32,6 +35,7 @@ Build-Depends: cmake (>= 3.10.2),
                libcap-ng-dev,
                libcunit1-dev,
                libcurl4-openssl-dev,
+               libevent-dev,
                libexpat1-dev,
                libfuse-dev,
                libgoogle-perftools-dev [i386 amd64 arm64],
@@ -57,7 +61,7 @@ Build-Depends: cmake (>= 3.10.2),
                libudev-dev,
                libnl-genl-3-dev,
                libxml2-dev,
-# Crimson      libyaml-cpp-dev,
+               libyaml-cpp-dev,
                librabbitmq-dev,
                librdkafka-dev,
 # Make-Check   libxmlsec1,
@@ -65,6 +69,7 @@ Build-Depends: cmake (>= 3.10.2),
 # Make-Check   libxmlsec1-openssl,
 # Make-Check   libxmlsec1-dev,
                lsb-release,
+               nlohmann-json-dev | nlohmann-json3-dev,
                parted,
                patch,
                pkg-config,
@@ -360,6 +365,7 @@ Description: debugging symbols for ceph-mgr
 Package: ceph-mon
 Architecture: linux-any
 Depends: ceph-base (= ${binary:Version}),
+         libjaeger,
          ${misc:Depends},
          ${shlibs:Depends},
 Replaces: ceph (<< 10), ceph-test (<< 12.2.2-14)
@@ -592,7 +598,8 @@ Description: debugging symbols for rbd-nbd
 
 Package: ceph-common
 Architecture: linux-any
-Depends: librbd1 (= ${binary:Version}),
+Depends: libjaeger (= ${binary:Version}),
+         librbd1 (= ${binary:Version}),
          python3-cephfs (= ${binary:Version}),
          python3-ceph-argparse (= ${binary:Version}),
          python3-ceph-common (= ${binary:Version}),
@@ -928,6 +935,14 @@ Description: debugging symbols for radosgw
  service as well as the OpenStack Object Storage ("Swift") API.
  .
  This package contains debugging symbols for radosgw.
+
+Package: libjaeger
+Architecture: linux-any
+Section: libs
+Depends: ${misc:Depends},
+         ${shlibs:Depends},
+Replaces: libthrift
+Description: tracing library for jaegertracing distributed tracing system
 
 Package: ceph-test
 Architecture: linux-any

--- a/debian/libjaeger-dev.install
+++ b/debian/libjaeger-dev.install
@@ -1,0 +1,6 @@
+usr/include/thrift
+usr/include/jaegertracing
+usr/include/opentracing
+usr/lib/libjaegertracing.so
+usr/lib/libopentracing.so
+usr/lib/libthrift.so

--- a/debian/libjaeger.install
+++ b/debian/libjaeger.install
@@ -1,0 +1,3 @@
+usr/lib/libopentracing.so.*
+usr/lib/libjaegertracing.so.*
+usr/lib/libthrift.so.*

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -284,9 +284,15 @@ else
             *Bionic*)
                 ensure_decent_gcc_on_ubuntu 9 bionic
                 [ ! $NO_BOOST_PKGS ] && install_boost_on_ubuntu bionic
+                $SUDO apt-get install -y nlohmann-json-dev
                 ;;
             *Disco*)
                 [ ! $NO_BOOST_PKGS ] && apt-get install -y libboost1.67-all-dev
+                $SUDO apt-get install -y nlohmann-json-dev
+                ;;
+	    *Focal*)
+                [ ! $NO_BOOST_PKGS ] && apt-get install -y libboost1.71-all-dev
+                $SUDO apt-get install -y nlohmann-json3-dev
                 ;;
             *)
                 $SUDO apt-get install -y gcc

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -594,8 +594,9 @@ def cluster(ctx, config):
         Setup mon nodes.
         Setup mds nodes.
         Mkfs osd nodes.
-        Add keyring information to monmaps
+        Add keyring information to monmaps.
         Mkfs mon nodes.
+        Deploy Tracing.
 
     On exit:
         If errors occurred, extract a failure message and store in ctx.summary.
@@ -683,6 +684,13 @@ def cluster(ctx, config):
     keyring_path = config.get('keyring_path', default_keyring)
 
     coverage_dir = '{tdir}/archive/coverage'.format(tdir=testdir)
+
+    if not config.get('skip_tracing', False):
+        log.info("Deploying jaegertracing...")
+        ctx.cluster.run(args=[
+            ctx.cephadm,
+            'init-tracing',
+        ])
 
     firstmon = teuthology.get_first_mon(ctx, config, cluster_name)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -386,6 +386,51 @@ set_source_files_properties(ceph_ver.c
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_BINARY_DIR}/src/include/ceph_ver.h)
 add_library(common-objs OBJECT ${libcommon_files})
 
+if(WITH_JAEGER)
+  find_package(yaml-cpp 0.6.0)
+  if(NOT yaml-cpp_FOUND)
+    set(jaeger_libs
+      ${CMAKE_BINARY_DIR}/external/lib/libyaml-cpp.so.0.6.2
+      ${CMAKE_BINARY_DIR}/external/lib/libyaml-cpp.so.0.6
+      ${CMAKE_BINARY_DIR}/external/lib/libyaml-cpp.so)
+    execute_process(COMMAND bash -c "echo 'usr/lib/libyaml-cpp.so.*' >> debian/libjaeger.install"
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      RESULT_VARIABLE result
+      OUTPUT_VARIABLE out)
+    message(STATUS "result ${result}")
+  endif()
+  include(IncludeJaeger)
+  add_library(jaeger-base INTERFACE)
+  add_dependencies(common-objs
+  yaml-cpp::yaml-cpp
+  opentracing::libopentracing
+  thrift::libthrift
+  jaegertracing::libjaegertracing)
+  target_link_libraries(jaeger-base INTERFACE
+  yaml-cpp::yaml-cpp
+  opentracing::libopentracing
+  thrift::libthrift
+  jaegertracing::libjaegertracing)
+  include_directories(${CMAKE_BINARY_DIR}/external/include)
+  #with CMake 3.12+ the following can be replaced by:
+  #target_link_libraries(common-objs jaeger-base)
+  install(DIRECTORY ${CMAKE_BINARY_DIR}/external/include/jaegertracing
+    ${CMAKE_BINARY_DIR}/external/include/opentracing
+    ${CMAKE_BINARY_DIR}/external/include/thrift
+     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+   list(APPEND jaeger_libs
+    ${CMAKE_BINARY_DIR}/external/lib/libjaegertracing.so
+    ${CMAKE_BINARY_DIR}/external/lib/libjaegertracing.so.0
+    ${CMAKE_BINARY_DIR}/external/lib/libjaegertracing.so.0.6.1
+    ${CMAKE_BINARY_DIR}/external/lib/libopentracing.so
+    ${CMAKE_BINARY_DIR}/external/lib/libopentracing.so.1
+    ${CMAKE_BINARY_DIR}/external/lib/libopentracing.so.1.6.0
+    ${CMAKE_BINARY_DIR}/external/lib/libthrift.so
+    ${CMAKE_BINARY_DIR}/external/lib/libthrift.so.0.13.0)
+  install(FILES ${jaeger_libs}
+    DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
+
 CHECK_C_COMPILER_FLAG("-fvar-tracking-assignments" HAS_VTA)
 add_subdirectory(auth)
 add_subdirectory(common)
@@ -444,6 +489,10 @@ endif()
 
 if(WITH_DPDK)
   list(APPEND ceph_common_deps common_async_dpdk)
+endif()
+
+if(WITH_JAEGER)
+  list(APPEND ceph_common_deps jaeger-base)
 endif()
 
 if(WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -382,6 +382,9 @@ set(libcommon_files
   osdc/error_code.cc
   librbd/Features.cc
   ${mds_files})
+if(WITH_JAEGER)
+  list(APPEND libcommon_files common/tracer.cc)
+endif()
 set_source_files_properties(ceph_ver.c
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_BINARY_DIR}/src/include/ceph_ver.h)
 add_library(common-objs OBJECT ${libcommon_files})
@@ -411,7 +414,7 @@ if(WITH_JAEGER)
   opentracing::libopentracing
   thrift::libthrift
   jaegertracing::libjaegertracing)
-  include_directories(${CMAKE_BINARY_DIR}/external/include)
+  include_directories(SYSTEM ${CMAKE_BINARY_DIR}/external/include)
   #with CMake 3.12+ the following can be replaced by:
   #target_link_libraries(common-objs jaeger-base)
   install(DIRECTORY ${CMAKE_BINARY_DIR}/external/include/jaegertracing
@@ -639,7 +642,8 @@ set(ceph_osd_srcs
   # static library (like libosd.a) nullifies the effect of `-rdynamic`.
   osd/objclass.cc
   objclass/class_api.cc
-  ceph_osd.cc)
+  ceph_osd.cc
+  common/tracer.cc)
 add_executable(ceph-osd ${ceph_osd_srcs})
 add_dependencies(ceph-osd erasure_code_plugins)
 target_link_libraries(ceph-osd osd os global-static common

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2332,16 +2332,17 @@ class Firewalld(object):
             return
 
         for port in fw_ports:
-            tcp_port = str(port) + '/tcp'
-            out, err, ret = call([self.cmd, '--permanent', '--query-port', tcp_port], verbose_on_failure=False)
+            if not re.findall("udp", str(port)):
+                port = str(port) + '/tcp'
+            out, err, ret = call([self.cmd, '--permanent', '--query-port', port], verbose_on_failure=False)
             if ret:
-                logger.info('Enabling firewalld port %s in current zone...' % tcp_port)
-                out, err, ret = call([self.cmd, '--permanent', '--add-port', tcp_port])
+                logger.info('Enabling firewalld port %s in current zone...' % port)
+                out, err, ret = call([self.cmd, '--permanent', '--add-port', port])
                 if ret:
                     raise RuntimeError('unable to add port %s to current zone: %s' %
                                     (tcp_port, err))
             else:
-                logger.debug('firewalld port %s is enabled in current zone' % tcp_port)
+                logger.debug('firewalld port %s is enabled in current zone' % port)
 
     def apply_rules(self):
         # type: () -> None
@@ -2531,7 +2532,10 @@ class CephContainer:
         if self.host_network:
             cmd_args.append('--net=host')
         if self.entrypoint:
-            cmd_args.extend(['--entrypoint', self.entrypoint])
+            if self.entrypoint == "doesnotmatter":
+                cmd_args.extend(['-d'])
+            else:
+                cmd_args.extend(['--entrypoint', self.entrypoint])
         if self.privileged:
             cmd_args.extend([
                 '--privileged',
@@ -3229,6 +3233,9 @@ def command_bootstrap():
                         args.initial_dashboard_user,
                         password))
 
+    if not args.skip_tracing:
+        command_init_tracing()
+        
     if args.apply_spec:
         logger.info('Applying %s to cluster' % args.apply_spec)
 
@@ -5447,7 +5454,43 @@ def command_gather_facts():
     host = HostFacts()
     print(host.dump())
 
+def command_init_tracing():
+    
+    global container_path
 
+    ports = ['5775/udp', '6831/udp', '6832/udp', '5778', '16686', '14268', '14250']
+       
+    c = CephContainer(
+        image='jaegertracing/all-in-one:1.20',
+        entrypoint='doesnotmatter',
+        cname='jaeger',
+        container_args=['-p', '5775:5775/udp',
+        '-p', '6831:6831/udp',
+        '-p', '6832:6832/udp',
+        '-p', '5778:5778',
+        '-p', '16686:16686',
+        '-p', '14268:14268',
+        '-p', '14250:14250',
+        '-p', '9411:9411'],
+        host_network=False)
+    try:
+        #remove any container existing with name jaeger
+        out, _, _ = call_throws(c.rm_cmd(), verbose=False)
+    except:
+        pass
+    fw = Firewalld()
+    fw.open_ports(ports)
+    fw.apply_rules()
+    
+    out, err, code = call_throws(c.run_cmd(), verbose=True)
+    if not code:
+        print(out)
+        logger.info('Jaegertracing available at:\n\n'
+                    '\t Jaeger Frontend URL: https://%s:16686/\n'
+                    '\t serve config: https://%s:5778/\n'
+                        % (get_fqdn(), get_fqdn()))
+
+    
 ##################################
 
 
@@ -5793,6 +5836,10 @@ def _get_parser():
         action='store_true',
         help='do not enable the Ceph Dashboard')
     parser_bootstrap.add_argument(
+        '--skip-tracing',
+        action='store_true',
+        help='skip using jaegertracing')
+    parser_bootstrap.add_argument(
         '--dashboard-password-noupdate',
         action='store_true',
         help='stop forced dashboard password change')
@@ -5858,6 +5905,8 @@ def _get_parser():
         action='store_true',
         help='Run podman/docker with `--init`')
 
+    parser_deploy = subparsers.add_parser(
+        'deploy', help='deploy a daemon')
     parser_deploy = subparsers.add_parser(
         'deploy', help='deploy a daemon')
     parser_deploy.set_defaults(func=command_deploy)
@@ -5977,6 +6026,10 @@ def _get_parser():
     parser_gather_facts = subparsers.add_parser(
         'gather-facts', help='gather and return host related information (JSON format)')
     parser_gather_facts.set_defaults(func=command_gather_facts)
+
+    parser_init_tracing = subparsers.add_parser(
+        'init-tracing', help='deploy jaegertracing frontend services')
+    parser_init_tracing.set_defaults(func=command_init_tracing)
 
     return parser
 

--- a/src/common/tracer.cc
+++ b/src/common/tracer.cc
@@ -1,0 +1,84 @@
+#include "tracer.h"
+#include <arpa/inet.h>
+#include <yaml-cpp/yaml.h>
+#include "common/debug.h"
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_osd
+#undef dout_prefix
+#define dout_prefix *_dout << "jaegertracing "
+
+namespace jaeger_tracing{
+
+   std::shared_ptr<opentracing::v3::Tracer> tracer = nullptr;
+
+   void init_tracer(const char* tracer_name){
+    dout(3) << "init_tracer" << dendl;
+    if(!tracer){
+	dout(3) << "tracer not found, cofiguring jaegertracing" << dendl;
+	YAML::Node yaml;
+	try{
+	  yaml = YAML::LoadFile("../src/jaegertracing/config.yml");
+	dout(3) << "yaml loaded" << yaml << dendl;
+	}
+	catch(std::exception &e){
+	  dout(3) << "failed to load yaml file using default config" << dendl;
+	  auto yaml_config = R"cfg(
+disabled: false
+reporter:
+    logSpans: false
+    queueSize: 100
+    bufferFlushInterval: 10
+sampler:
+    type: const
+    param: 1
+headers:
+    jaegerDebugHeader: debug-id
+    jaegerBaggageHeader: baggage
+    TraceContextHeaderName: trace-id
+    traceBaggageHeaderPrefix: "testctx-"
+baggage_restrictions:
+    denyBaggageOnInitializationFailure: false
+    refreshInterval: 60
+)cfg";
+	yaml = YAML::Load(yaml_config);
+	dout(3) << "yaml loaded" << yaml << dendl;
+      }
+      static auto configuration = jaegertracing::Config::parse(yaml);
+      dout(3) << "yaml parsed" << dendl;
+      tracer = jaegertracing::Tracer::make( tracer_name, configuration,
+	    jaegertracing::logging::consoleLogger());
+      dout(3) << "tracer_jaeger" << tracer << dendl;
+    }
+    //incase of stale tracer, configure with a new global tracer
+    if(opentracing::Tracer::Global() != tracer){
+      opentracing::Tracer::InitGlobal(
+	  std::static_pointer_cast<opentracing::Tracer>(tracer));
+      dout(3) << "tracer_global_set_to" << tracer << dendl;
+    }
+  }
+
+  jspan new_span(const char* span_name){
+    dout(3) << "new_span before" + std::string(span_name) << dendl;
+    return opentracing::Tracer::Global()->StartSpan(span_name);
+    dout(3) << "new_span after" + std::string(span_name) << dendl;
+ }
+
+  jspan child_span(const char* span_name, const jspan& parent_span){
+    //no parent check if parent not found span will still be constructed
+    return opentracing::Tracer::Global()->StartSpan(span_name,
+	{opentracing::ChildOf(&parent_span->context())});
+    dout(3) << "child_span after" + std::string(span_name) << dendl;
+ }
+
+  void finish_span(const jspan& span){
+    if(span){
+      dout(3) << "explict span finish for" << &span << dendl;
+      span->Finish();
+    }
+  }
+
+  void set_span_tag(const jspan& span, const char* key, const char* value){ if(span)
+  span->SetTag(key, value); }
+}
+//  void set_span_log(const jspan& span, const

--- a/src/common/tracer.cc
+++ b/src/common/tracer.cc
@@ -1,6 +1,12 @@
 #include "tracer.h"
 #include <arpa/inet.h>
 #include <yaml-cpp/yaml.h>
+#ifdef __linux__
+#include <linux/types.h>
+#else
+typedef int64_t __s64;
+#endif
+
 #include "common/debug.h"
 
 #define dout_context g_ceph_context

--- a/src/common/tracer.h
+++ b/src/common/tracer.h
@@ -1,0 +1,57 @@
+//
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020 Red Hat Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+// Demonstrates basic usage of the OpenTracing API. Uses OpenTracing's
+// mocktracer to capture all the recorded spans as JSON.
+
+#ifndef TRACER_H_
+#define TRACER_H_
+
+#define SIGNED_RIGHT_SHIFT_IS 1
+#define ARITHMETIC_RIGHT_SHIFT 1
+
+#include <jaegertracing/Tracer.h>
+
+typedef std::unique_ptr<opentracing::Span> jspan;
+
+namespace jaeger_tracing{
+//#ifdef HAVE_JAEGER
+
+  extern std::shared_ptr<opentracing::v3::Tracer> tracer;
+
+  void init_tracer(const char* tracer_name);
+
+  //method to create a root jspan
+  jspan new_span(const char*);
+
+  //method to create a child_span used given parent_span
+  jspan child_span(const char*, const jspan&);
+
+  //method to finish tracing of a single jspan
+  void finish_span(const jspan&);
+
+  //setting tags in sundefined reference topans
+  void set_span_tag(const jspan&, const char*, const char*);
+
+//  void set_span_log(const jspan&, 
+//#else
+//  typedef char jspan;
+//  int* child_span(...) {return nullptr;}
+//  int* new_span(...) {return nullptr;}
+//  void finish_span(...) {}
+//  void init_tracer(...) {}
+//  void set_span_tag(...) {}
+//#endif // HAVE_JAEGER
+}
+#endif // TRACER_H_

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -124,7 +124,12 @@ target_compile_definitions(crimson-common PRIVATE
 
 set(crimson_common_deps
   Boost::iostreams
-  Boost::random)
+  Boost::random
+  json_spirit)
+
+if(WITH_JAEGER)
+  list(APPEND crimson_common_deps jaeger-base)
+endif()
 
 if(NOT WITH_SYSTEM_BOOST)
   list(APPEND crimson_common_deps ${ZLIB_LIBRARIES})
@@ -132,7 +137,6 @@ endif()
 
 target_link_libraries(crimson-common
   PUBLIC
-    json_spirit
     crimson::cflags
   PRIVATE
     crc32

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -166,6 +166,9 @@
 /* Define if you want to use LTTng */
 #cmakedefine WITH_LTTNG
 
+/* Define if you want to use Jaeger */
+#cmakedefine HAVE_JAEGER
+
 /* Define if you want to use EVENTTRACE */
 #cmakedefine WITH_EVENTTRACE
 

--- a/src/include/int_types.h
+++ b/src/include/int_types.h
@@ -5,7 +5,7 @@
 
 #include <inttypes.h>
 
-#ifdef HAVE_LINUX_TYPES_H
+#ifdef __linux__
 #include <linux/types.h>
 #else
 #ifndef HAVE___U8

--- a/src/jaegertracing/config.yml
+++ b/src/jaegertracing/config.yml
@@ -1,0 +1,6 @@
+disabled: false
+reporter:
+    logSpans: true
+sampler:
+  type: const
+  param: 1

--- a/src/mon/CMakeLists.txt
+++ b/src/mon/CMakeLists.txt
@@ -35,3 +35,6 @@ endif()
 add_library(mon STATIC
   ${lib_mon_srcs})
 target_link_libraries(mon kv heap_profiler)
+if(WITH_JAEGER)
+  target_link_libraries(mon jaeger-base)
+endif()

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -91,6 +91,10 @@ if(WITH_LTTNG)
   add_dependencies(os bluestore-tp)
 endif()
 
+if(WITH_JAEGER)
+  target_link_libraries(os jaeger-base)
+endif()
+
 target_link_libraries(os kv)
 
 add_dependencies(os compressor_plugins)

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -941,8 +941,10 @@ void ECBackend::handle_sub_write(
     msg->mark_event("sub_op_started");
   trace.event("handle_sub_write");
 #ifdef HAVE_JAEGER
-  auto ec_sub_trans = jaeger_tracing::child_span(__func__, msg->osd_parent_span);
-//  op->set_osd_parent_span(ec_sub_trans);
+  if(msg->osd_parent_span){
+    auto ec_sub_trans = jaeger_tracing::child_span(__func__, msg->osd_parent_span);
+  //  op->set_osd_parent_span(ec_sub_trans);
+  }
 #endif
   if (!get_parent()->pgb_is_primary())
     get_parent()->update_stats(op.stats);
@@ -1535,8 +1537,10 @@ void ECBackend::submit_transaction(
     op->trace = client_op->pg_trace;
 
 #ifdef HAVE_JAEGER
-  auto ec_sub_trans = jaeger_tracing::child_span("ECBackend::submit_transaction", client_op->osd_parent_span);
-//  op->set_osd_parent_span(ec_sub_trans);
+  if(client_op->osd_parent_span){
+    auto ec_sub_trans = jaeger_tracing::child_span("ECBackend::submit_transaction", client_op->osd_parent_span);
+  //  op->set_osd_parent_span(ec_sub_trans);
+  }
 #endif
   dout(10) << __func__ << ": op " << *op << " starting" << dendl;
   start_rmw(op, std::move(t));
@@ -2108,8 +2112,10 @@ bool ECBackend::try_reads_to_commit()
   }
 
 #ifdef HAVE_JAEGER
-    auto sub_write_span = jaeger_tracing::child_span("EC sub write", op->client_op->osd_parent_span);
-    //op->set_osd_parent_span(sub_write_span);
+   if(op->client->osd_parent_span){
+      auto sub_write_span = jaeger_tracing::child_span("EC sub write", op->client_op->osd_parent_span);
+      //op->set_osd_parent_span(sub_write_span);
+    }
 #endif
   if (!messages.empty()) {
     get_parent()->send_message_osd_cluster(messages, get_osdmap_epoch());

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7085,7 +7085,9 @@ void OSD::ms_fast_dispatch(Message *m)
   }
 #ifdef HAVE_JAEGER
   op->set_osd_parent_span(dispatch_span);
-  auto op_req_span = jaeger_tracing::child_span("op-request-created", op->osd_parent_span);
+  if(op->osd_parent_span){
+    auto op_req_span = jaeger_tracing::child_span("op-request-created", op->osd_parent_span);
+  }
   op->set_osd_parent_span(op_req_span);
 //  op->osd_parent_span->Log({
 //      {"sent epoch by op", op->sent_epoch},
@@ -9642,14 +9644,16 @@ void OSD::enqueue_op(spg_t pg, OpRequestRef&& op, epoch_t epoch)
   op->osd_trace.keyval("priority", priority);
   op->osd_trace.keyval("cost", cost);
 #ifdef HAVE_JAEGER
-  auto enqueue_span = jaeger_tracing::child_span(__func__, op->osd_parent_span);
-  enqueue_span->Log({
-      {"priority", priority},
-      {"cost", cost},
-      {"epoch", epoch},
-      {"owner", owner} //Not got owner in UI
-      });
-//  op->set_osd_parent_span(enqueue_span);
+  if(op->osd_parent_span){
+    auto enqueue_span = jaeger_tracing::child_span(__func__, op->osd_parent_span);
+    enqueue_span->Log({
+	{"priority", priority},
+	{"cost", cost},
+	{"epoch", epoch},
+	{"owner", owner} //Not got owner in UI
+	});
+  //  op->set_osd_parent_span(enqueue_span);
+  }
 #endif
   op->mark_queued_for_pg();
   logger->tinc(l_osd_op_before_queue_op_lat, latency);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -172,6 +172,7 @@
 #else
 #define tracepoint(...)
 #endif
+#include "common/tracer.h"
 
 #define dout_context cct
 #define dout_subsys ceph_subsys_osd
@@ -1640,6 +1641,7 @@ void OSDService::reply_op_error(OpRequestRef op, int err, eversion_t v,
 				       !m->has_flag(CEPH_OSD_FLAG_RETURNVEC));
   reply->set_reply_versions(v, uv);
   reply->set_op_returns(op_returns);
+//  auto op_error_span = jaeger_tracing::child_span("reply_op_error", op->osd_parent_span);
   m->get_connection()->send_message(reply);
 }
 
@@ -7015,6 +7017,12 @@ void OSD::dispatch_session_waiting(const ceph::ref_t<Session>& session, OSDMapRe
 
 void OSD::ms_fast_dispatch(Message *m)
 {
+
+#ifdef HAVE_JAEGER
+  jaeger_tracing::init_tracer("osd-services-reinit");
+  dout(10) << "jaeger tracer after " << opentracing::Tracer::Global() << dendl;
+  auto dispatch_span = jaeger_tracing::new_span(__func__);
+#endif
   FUNCTRACE(cct);
   if (service.is_stopping()) {
     m->put();
@@ -7075,7 +7083,15 @@ void OSD::ms_fast_dispatch(Message *m)
     tracepoint(osd, ms_fast_dispatch, reqid.name._type,
         reqid.name._num, reqid.tid, reqid.inc);
   }
-
+#ifdef HAVE_JAEGER
+  op->set_osd_parent_span(dispatch_span);
+  auto op_req_span = jaeger_tracing::child_span("op-request-created", op->osd_parent_span);
+  op->set_osd_parent_span(op_req_span);
+//  op->osd_parent_span->Log({
+//      {"sent epoch by op", op->sent_epoch},
+//      {"min epoch for op", op->min_epoch}
+//      });
+#endif
   if (m->trace)
     op->osd_trace.init("osd op", &trace_endpoint, &m->trace);
 
@@ -9625,6 +9641,16 @@ void OSD::enqueue_op(spg_t pg, OpRequestRef&& op, epoch_t epoch)
   op->osd_trace.event("enqueue op");
   op->osd_trace.keyval("priority", priority);
   op->osd_trace.keyval("cost", cost);
+#ifdef HAVE_JAEGER
+  auto enqueue_span = jaeger_tracing::child_span(__func__, op->osd_parent_span);
+  enqueue_span->Log({
+      {"priority", priority},
+      {"cost", cost},
+      {"epoch", epoch},
+      {"owner", owner} //Not got owner in UI
+      });
+//  op->set_osd_parent_span(enqueue_span);
+#endif
   op->mark_queued_for_pg();
   logger->tinc(l_osd_op_before_queue_op_lat, latency);
   if (type == MSG_OSD_PG_PUSH ||

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -22,6 +22,7 @@
 #else
 #define tracepoint(...)
 #endif
+#include "common/tracer.h"
 
 using std::ostream;
 using std::set;
@@ -126,6 +127,9 @@ void OpRequest::mark_flag_point(uint8_t flag, const char *s) {
   tracepoint(oprequest, mark_flag_point, reqid.name._type,
 	     reqid.name._num, reqid.tid, reqid.inc, op_info.get_flags(),
 	     flag, s, old_flags, hit_flag_points);
+  //auto marker_span = jaeger_tracing::child_span(s, OpRequest::osd_parent_span);
+//  auto marker_span = jaeger_tracing::new_span(s);
+//  jaeger_tracing::finish_span(marker_span);
 }
 
 void OpRequest::mark_flag_point_string(uint8_t flag, const string& s) {
@@ -138,6 +142,9 @@ void OpRequest::mark_flag_point_string(uint8_t flag, const string& s) {
   tracepoint(oprequest, mark_flag_point, reqid.name._type,
 	     reqid.name._num, reqid.tid, reqid.inc, op_info.get_flags(),
 	     flag, s.c_str(), old_flags, hit_flag_points);
+  //auto marker_span = jaeger_tracing::child_span(s.c_str(), OpRequest::osd_parent_span);
+//  auto marker_span = jaeger_tracing::new_span(s.c_str());
+//  jaeger_tracing::finish_span(marker_span);
 }
 
 bool OpRequest::filter_out(const set<string>& filters)

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -89,10 +89,12 @@ public:
   epoch_t min_epoch = 0;      ///< min epoch needed to handle this msg
 
   bool hitset_inserted;
-  jspan osd_parent_span;
+  jspan osd_parent_span = nullptr;
 #ifdef HAVE_JAEGER
   void set_osd_parent_span(jspan& span) {
-    jaeger_tracing::finish_span(osd_parent_span);
+    if(osd_parent_span){
+      jaeger_tracing::finish_span(osd_parent_span);
+    }
     osd_parent_span = move(span); }
 #else
   void set_osd_parent_span(...) {}

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -17,6 +17,7 @@
 #include "osd/osd_op_util.h"
 #include "osd/osd_types.h"
 #include "common/TrackedOp.h"
+#include "common/tracer.h"
 
 /**
  * The OpRequest takes in a Message* and takes over a single reference
@@ -88,7 +89,14 @@ public:
   epoch_t min_epoch = 0;      ///< min epoch needed to handle this msg
 
   bool hitset_inserted;
-
+  jspan osd_parent_span;
+#ifdef HAVE_JAEGER
+  void set_osd_parent_span(jspan& span) {
+    jaeger_tracing::finish_span(osd_parent_span);
+    osd_parent_span = move(span); }
+#else
+  void set_osd_parent_span(...) {}
+#endif
   template<class T>
   const T* get_req() const { return static_cast<const T*>(request); }
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -69,6 +69,7 @@
 #include <utility>
 
 #include <errno.h>
+#include "common/tracer.h"
 
 MEMPOOL_DEFINE_OBJECT_FACTORY(PrimaryLogPG, replicatedpg, osd);
 
@@ -1189,6 +1190,10 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
   ceph_assert(m->get_type() == CEPH_MSG_OSD_OP);
   dout(10) << "do_pg_op " << *m << dendl;
 
+//#ifdef HAVE_JAEGER
+//  auto do_pg_op_span = opentracing::Tracer::Global()->StartSpan(
+//      "do_pg_op",{opentracing::v3::ChildOf(&(op->osd_parent_span)->context())});
+//#endif
   op->mark_started();
 
   int result = 0;
@@ -1661,7 +1666,11 @@ void PrimaryLogPG::do_request(
     op->pg_trace.init("pg op", &trace_endpoint, &op->osd_trace);
     op->pg_trace.event("do request");
   }
-  // make sure we have a new enough map
+#ifdef HAVE_JAEGER
+  auto do_req_span = jaeger_tracing::child_span(__func__, op->osd_parent_span);
+//  op->set_osd_parent_span(do_req_span);
+#endif
+// make sure we have a new enough map
   auto p = waiting_for_map.find(op->get_source());
   if (p != waiting_for_map.end()) {
     // preserve ordering
@@ -1691,7 +1700,11 @@ void PrimaryLogPG::do_request(
     auto session = ceph::ref_cast<Session>(m->get_connection()->get_priv());
     if (!session)
       return;  // drop it.
-
+//#ifdef HAVE_JAEGER
+//  do_request_span->Log({
+//      {"msg", msg_type}
+//      });
+//#endif
     if (msg_type == CEPH_MSG_OSD_OP) {
       if (session->check_backoff(cct, info.pgid,
 				 info.pgid.pgid.get_hobj_start(), m)) {
@@ -2020,6 +2033,10 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
 	   << " flags " << ceph_osd_flag_string(m->get_flags())
 	   << dendl;
 
+#ifdef HAVE_JAEGER
+  auto do_op_span = jaeger_tracing::child_span(__func__, op->osd_parent_span);
+//  op->set_osd_parent_span(do_op_span);
+#endif
   // missing object?
   if (is_unreadable_object(head)) {
     if (!is_primary()) {
@@ -2245,6 +2262,7 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
 	get_osdmap()->require_osd_release >= ceph_release_t::kraken) {
       record_write_error(op, oid, nullptr, r);
     } else {
+      //TODO: jaeger: add span 
       osd->reply_op_error(op, r);
     }
     return;
@@ -3849,6 +3867,10 @@ void PrimaryLogPG::execute_ctx(OpContext *ctx)
     tracepoint(osd, prepare_tx_enter, reqid.name._type,
         reqid.name._num, reqid.tid, reqid.inc);
   }
+#ifdef HAVE_JAEGER
+  auto execute_span = jaeger_tracing::child_span(__func__, ctx->op->osd_parent_span);
+//  ctx->op->set_osd_parent_span(execute_span);
+#endif
 
   int result = prepare_transaction(ctx);
 
@@ -5615,6 +5637,10 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
   PGTransaction* t = ctx->op_t.get();
 
   dout(10) << "do_osd_op " << soid << " " << ops << dendl;
+#ifdef HAVE_JAEGER
+  auto do_osd_op_span = jaeger_tracing::child_span(__func__, ctx->op->osd_parent_span);
+//  op->set_osd_parent_span(do_osd_op_span);
+#endif
 
   ctx->current_osd_subop_num = 0;
   for (auto p = ops.begin(); p != ops.end(); ++p, ctx->current_osd_subop_num++, ctx->processed_subop_count++) {
@@ -8453,6 +8479,10 @@ void PrimaryLogPG::finish_ctx(OpContext *ctx, int log_op_type, int result)
 	   << dendl;
   utime_t now = ceph_clock_now();
 
+#ifdef HAVE_JAEGER
+  auto finish_ctx_span = jaeger_tracing::child_span(__func__, ctx->op->osd_parent_span);
+//  op->set_osd_parent_span(finish_ctx_span);
+#endif
   // Drop the reference if deduped chunk is modified
   if (ctx->new_obs.oi.is_dirty() &&
     (ctx->obs->oi.has_manifest() && ctx->obs->oi.manifest.is_chunked()) &&
@@ -10455,6 +10485,10 @@ void PrimaryLogPG::op_applied(const eversion_t &applied_version)
 
 void PrimaryLogPG::eval_repop(RepGather *repop)
 {
+  #ifdef HAVE_JAEGER
+  auto eval_span = jaeger_tracing::child_span(__func__, repop->op->osd_parent_span);
+//  op->set_osd_parent_span(issue_repop_span);
+ #endif
   dout(10) << "eval_repop " << *repop
     << (repop->op && repop->op->get_req<MOSDOp>() ? "" : " (no op)") << dendl;
 
@@ -10509,6 +10543,11 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
   dout(7) << "issue_repop rep_tid " << repop->rep_tid
           << " o " << soid
           << dendl;
+#ifdef HAVE_JAEGER
+  auto issue_repop_span = jaeger_tracing::child_span(__func__,
+      ctx->op->osd_parent_span);
+//  op->set_osd_parent_span(issue_repop_span);
+#endif
 
   repop->v = ctx->at_version;
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1667,8 +1667,10 @@ void PrimaryLogPG::do_request(
     op->pg_trace.event("do request");
   }
 #ifdef HAVE_JAEGER
-  auto do_req_span = jaeger_tracing::child_span(__func__, op->osd_parent_span);
-//  op->set_osd_parent_span(do_req_span);
+  if(op->osd_parent_span){
+    auto do_req_span = jaeger_tracing::child_span(__func__, op->osd_parent_span);
+  //  op->set_osd_parent_span(do_req_span);
+  }
 #endif
 // make sure we have a new enough map
   auto p = waiting_for_map.find(op->get_source());
@@ -2034,8 +2036,10 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
 	   << dendl;
 
 #ifdef HAVE_JAEGER
-  auto do_op_span = jaeger_tracing::child_span(__func__, op->osd_parent_span);
-//  op->set_osd_parent_span(do_op_span);
+  if(op->osd_parent_span){
+    auto do_op_span = jaeger_tracing::child_span(__func__, op->osd_parent_span);
+  //  op->set_osd_parent_span(do_op_span);
+  }
 #endif
   // missing object?
   if (is_unreadable_object(head)) {
@@ -3868,8 +3872,10 @@ void PrimaryLogPG::execute_ctx(OpContext *ctx)
         reqid.name._num, reqid.tid, reqid.inc);
   }
 #ifdef HAVE_JAEGER
-  auto execute_span = jaeger_tracing::child_span(__func__, ctx->op->osd_parent_span);
-//  ctx->op->set_osd_parent_span(execute_span);
+  if(ctx->op->osd_parent_span){
+    auto execute_span = jaeger_tracing::child_span(__func__, ctx->op->osd_parent_span);
+  //  ctx->op->set_osd_parent_span(execute_span);
+  }
 #endif
 
   int result = prepare_transaction(ctx);
@@ -5638,8 +5644,10 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 
   dout(10) << "do_osd_op " << soid << " " << ops << dendl;
 #ifdef HAVE_JAEGER
-  auto do_osd_op_span = jaeger_tracing::child_span(__func__, ctx->op->osd_parent_span);
-//  op->set_osd_parent_span(do_osd_op_span);
+  if(ctx->op->osd_parent_span){
+    auto do_osd_op_span = jaeger_tracing::child_span(__func__, ctx->op->osd_parent_span);
+  //  op->set_osd_parent_span(do_osd_op_span);
+  }
 #endif
 
   ctx->current_osd_subop_num = 0;
@@ -8480,8 +8488,10 @@ void PrimaryLogPG::finish_ctx(OpContext *ctx, int log_op_type, int result)
   utime_t now = ceph_clock_now();
 
 #ifdef HAVE_JAEGER
-  auto finish_ctx_span = jaeger_tracing::child_span(__func__, ctx->op->osd_parent_span);
-//  op->set_osd_parent_span(finish_ctx_span);
+  if(ctx->op->osd_parent_span){
+    auto finish_ctx_span = jaeger_tracing::child_span(__func__, ctx->op->osd_parent_span);
+  //  op->set_osd_parent_span(finish_ctx_span);
+  }
 #endif
   // Drop the reference if deduped chunk is modified
   if (ctx->new_obs.oi.is_dirty() &&
@@ -10486,8 +10496,10 @@ void PrimaryLogPG::op_applied(const eversion_t &applied_version)
 void PrimaryLogPG::eval_repop(RepGather *repop)
 {
   #ifdef HAVE_JAEGER
-  auto eval_span = jaeger_tracing::child_span(__func__, repop->op->osd_parent_span);
-//  op->set_osd_parent_span(issue_repop_span);
+  if(repop->op->osd_parent_span){
+    auto eval_span = jaeger_tracing::child_span(__func__, repop->op->osd_parent_span);
+  //  op->set_osd_parent_span(issue_repop_span);
+  }
  #endif
   dout(10) << "eval_repop " << *repop
     << (repop->op && repop->op->get_req<MOSDOp>() ? "" : " (no op)") << dendl;
@@ -10544,9 +10556,10 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
           << " o " << soid
           << dendl;
 #ifdef HAVE_JAEGER
-  auto issue_repop_span = jaeger_tracing::child_span(__func__,
-      ctx->op->osd_parent_span);
-//  op->set_osd_parent_span(issue_repop_span);
+  if(ctx->op->osd_parent_span){
+    auto issue_repop_span = jaeger_tracing::child_span(__func__, ctx->op->osd_parent_span);
+  //  op->set_osd_parent_span(issue_repop_span);
+  }
 #endif
 
   repop->v = ctx->at_version;

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -502,6 +502,10 @@ void ReplicatedBackend::submit_transaction(
   ceph_assert(insert_res.second);
   InProgressOp &op = *insert_res.first->second;
 
+#ifdef HAVE_JAEGER
+  auto rep_sub_trans = jaeger_tracing::child_span("ReplicatedBackend::submit_transaction", orig_op->osd_parent_span);
+//  op->set_osd_parent_span(rep_sub_trans);
+#endif
   op.waiting_for_commit.insert(
     parent->get_acting_recovery_backfill_shards().begin(),
     parent->get_acting_recovery_backfill_shards().end());

--- a/src/osd/scheduler/OpSchedulerItem.cc
+++ b/src/osd/scheduler/OpSchedulerItem.cc
@@ -14,6 +14,9 @@
 
 #include "osd/scheduler/OpSchedulerItem.h"
 #include "osd/OSD.h"
+#ifdef HAVE_JAEGER
+#include "common/tracer.h"
+#endif
 
 namespace ceph::osd::scheduler {
 
@@ -23,6 +26,10 @@ void PGOpItem::run(
   PGRef& pg,
   ThreadPool::TPHandle &handle)
 {
+#ifdef HAVE_JAEGER
+  auto PGOpItem_span = jaeger_tracing::child_span("PGOpItem::run", op->osd_parent_span);
+//  op->set_osd_parent_span(PGOpItem_span);
+#endif
   osd->dequeue_op(pg, op, handle);
   pg->unlock();
 }

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -62,6 +62,7 @@ fi
 if [ -n "$CEPH_BUILD_ROOT" ]; then
     [ -z "$CEPH_BIN" ] && CEPH_BIN=$CEPH_BUILD_ROOT/bin
     [ -z "$CEPH_LIB" ] && CEPH_LIB=$CEPH_BUILD_ROOT/lib
+    [ -z "$CEPH_EXT_LIB" ] && CEPH_EXT_LIB=$CEPH_BUILD_ROOT/external/lib
     [ -z "$EC_PATH" ] && EC_PATH=$CEPH_LIB/erasure-code
     [ -z "$OBJCLASS_PATH" ] && OBJCLASS_PATH=$CEPH_LIB/rados-classes
     # make install should install python extensions into PYTHONPATH
@@ -72,6 +73,7 @@ elif [ -n "$CEPH_ROOT" ]; then
     [ -z "$CEPH_ADM" ] && CEPH_ADM=$CEPH_BIN/ceph
     [ -z "$INIT_CEPH" ] && INIT_CEPH=$CEPH_BIN/init-ceph
     [ -z "$CEPH_LIB" ] && CEPH_LIB=$CEPH_BUILD_DIR/lib
+    [ -z "$CEPH_EXT_LIB" ] && CEPH_EXT_LIB=$CEPH_BUILD_DIR/external/lib
     [ -z "$OBJCLASS_PATH" ] && OBJCLASS_PATH=$CEPH_LIB
     [ -z "$EC_PATH" ] && EC_PATH=$CEPH_LIB
     [ -z "$CEPH_PYTHON_COMMON" ] && CEPH_PYTHON_COMMON=$CEPH_ROOT/src/python-common
@@ -87,8 +89,8 @@ fi
 CYTHON_PYTHONPATH="$CEPH_LIB/cython_modules/lib.3"
 export PYTHONPATH=$PYBIND:$CYTHON_PYTHONPATH:$CEPH_PYTHON_COMMON$PYTHONPATH
 
-export LD_LIBRARY_PATH=$CEPH_LIB:$LD_LIBRARY_PATH
-export DYLD_LIBRARY_PATH=$CEPH_LIB:$DYLD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$CEPH_LIB:$CEPH_EXT_LIB:$LD_LIBRARY_PATH
+export DYLD_LIBRARY_PATH=$CEPH_LIB:$CEPH_EXT_LIB:$DYLD_LIBRARY_PATH
 # Suppress logging for regular use that indicated that we are using a
 # development version. vstart.sh is only used during testing and
 # development


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
