### PR TITLE
mgr/dashboard: RBD: Disable actions when name is not valid

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
@@ -301,4 +301,38 @@ describe('RbdListComponent', () => {
       }
     });
   });
+
+  const getActionDisable = (name: string) =>
+    component.tableActions.find((o) => o.name === name).disable;
+
+  const testActions = (selection: any, expected: string | boolean) => {
+    expect(getActionDisable('Edit')(selection)).toBe(expected);
+    expect(getActionDisable('Delete')(selection)).toBe(expected);
+    expect(getActionDisable('Copy')(selection)).toBe(expected);
+    expect(getActionDisable('Flatten')(selection)).toBeTruthy();
+    expect(getActionDisable('Move to Trash')(selection)).toBe(expected);
+  };
+
+  it('should test TableActions with valid/invalid image name', () => {
+    component.selection.selected = [
+      {
+        name: 'foobar',
+        pool_name: 'rbd',
+        snapshots: []
+      }
+    ];
+    testActions(component.selection, false);
+
+    component.selection.selected = [
+      {
+        name: 'foo/bar',
+        pool_name: 'rbd',
+        snapshots: []
+      }
+    ];
+    testActions(
+      component.selection,
+      `This RBD image has an invalid name and can't be managed by ceph.`
+    );
+  });
 });


### PR DESCRIPTION
Its possible to create RBD Images with invalid names using external tools and
this can cause problems in the dashboard.

We now check for the validity of each image name and
disable all actions if the name is invalid.

Fixes: https://tracker.ceph.com/issues/47785

Signed-off-by: Tiago Melo <tmelo@suse.com>

![image](https://user-images.githubusercontent.com/399326/96869219-bc166e00-145e-11eb-8801-9a3ad1a92634.png)
I'm not able to capture the tooltip, but currently it says: `This RBD image has an invalid name and can't be managed by ceph.`
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
