### PR TITLE
nautilus: ceph-volume: add no-systemd argument to zap

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -290,7 +290,7 @@ class Zap(object):
 
     @decorators.needs_root
     def zap_osd(self):
-        if self.args.osd_id:
+        if self.args.osd_id and not self.args.no_systemd:
             osd_is_running = systemctl.osd_is_active(self.args.osd_id)
             if osd_is_running:
                 mlogger.error("OSD ID %s is running, stop it with:" % self.args.osd_id)
@@ -382,6 +382,13 @@ class Zap(object):
         parser.add_argument(
             '--osd-fsid',
             help='Specify an OSD FSID to detect associated devices for zapping',
+        )
+
+        parser.add_argument(
+            '--no-systemd',
+            dest='no_systemd',
+            action='store_true',
+            help='Skip systemd unit checks',
         )
 
         if len(self.argv) == 0:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47846

---

backport of https://github.com/ceph/ceph/pull/37221
parent tracker: https://tracker.ceph.com/issues/47541

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh