### PR TITLE
librbd: remove io::ReadResult::set_clip_length

### DIFF
--- a/src/librbd/cache/WriteLogImageDispatch.cc
+++ b/src/librbd/cache/WriteLogImageDispatch.cc
@@ -63,8 +63,7 @@ bool WriteLogImageDispatch<I>::read(
 
   aio_comp->set_request_count(1);
   aio_comp->read_result = std::move(read_result);
-  uint64_t length = io::util::extents_length(image_extents);
-  aio_comp->read_result.set_clip_length(length);
+  aio_comp->read_result.set_image_extents(image_extents);
 
   auto *req_comp = new io::ReadResult::C_ImageReadRequest(
     aio_comp, image_extents);
@@ -218,7 +217,7 @@ bool WriteLogImageDispatch<I>::list_snaps(
 template <typename I>
 bool WriteLogImageDispatch<I>::preprocess_length(
     io::AioCompletion* aio_comp, io::Extents &image_extents) const {
-  auto total_bytes = io::util::extents_length(image_extents);
+  auto total_bytes = io::util::get_extents_length(image_extents);
   if (total_bytes == 0) {
     aio_comp->set_request_count(0);
     return true;

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -403,7 +403,6 @@ void ImageReadRequest<I>::send_request() {
   }
 
   AioCompletion *aio_comp = this->m_aio_comp;
-  aio_comp->read_result.set_clip_length(buffer_ofs);
   aio_comp->read_result.set_image_extents(image_extents);
 
   // issue the requests

--- a/src/librbd/io/ReadResult.h
+++ b/src/librbd/io/ReadResult.h
@@ -63,7 +63,6 @@ public:
   ReadResult(ceph::bufferlist *bl);
   ReadResult(Extents* extent_map, ceph::bufferlist* bl);
 
-  void set_clip_length(size_t length);
   void set_image_extents(const Extents& image_extents);
 
   void assemble_result(CephContext *cct);
@@ -112,7 +111,6 @@ private:
                          Vector,
                          Bufferlist,
                          SparseBufferlist> Buffer;
-  struct SetClipLengthVisitor;
   struct SetImageExtentsVisitor;
   struct AssembleResultVisitor;
 

--- a/src/librbd/io/Utils.cc
+++ b/src/librbd/io/Utils.cc
@@ -151,14 +151,6 @@ int clip_request(I *image_ctx, Extents *image_extents) {
   return 0;
 }
 
-uint64_t extents_length(Extents &extents) {
-  uint64_t total_bytes = 0;
-  for (auto& image_extent : extents) {
-    total_bytes += image_extent.second;
-  }
-  return total_bytes;
-}
-
 void unsparsify(CephContext* cct, ceph::bufferlist* bl,
                 const Extents& extent_map, uint64_t bl_off,
                 uint64_t out_bl_len) {

--- a/src/librbd/io/Utils.h
+++ b/src/librbd/io/Utils.h
@@ -37,7 +37,13 @@ void read_parent(ImageCtxT *image_ctx, uint64_t object_no,
 template <typename ImageCtxT = librbd::ImageCtx>
 int clip_request(ImageCtxT *image_ctx, Extents *image_extents);
 
-uint64_t extents_length(Extents &extents);
+inline uint64_t get_extents_length(const Extents &extents) {
+  uint64_t total_bytes = 0;
+  for (auto [_, extent_length] : extents) {
+    total_bytes += extent_length;
+  }
+  return total_bytes;
+}
 
 void unsparsify(CephContext* cct, ceph::bufferlist* bl,
                 const Extents& extent_map, uint64_t bl_off,


### PR DESCRIPTION
Combined the functionality with the newer 'set_image_extents' call
to simplify the call-site logic for IO reads.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
