### PR TITLE
rgw: extending existing ssl support for vault KMS

### DIFF
--- a/doc/radosgw/vault.rst
+++ b/doc/radosgw/vault.rst
@@ -400,6 +400,19 @@ Or, when using the transit secret engine::
 In the example above, the Gateway would only fetch transit encryption keys under
 ``https://vault-server:8200/v1/transit``.
 
+You can use custom ssl certs to authenticate with vault with help of
+following options::
+
+  rgw crypt vault verify ssl = true
+  rgw crypt vault ssl cacert = /etc/ceph/vault.ca
+  rgw crypt vault ssl clientcert = /etc/ceph/vault.crt
+  rgw crypt vault ssl clientkey = /etc/ceph/vault.key
+
+where vault.ca is CA certificate and vault.key/vault.crt are private key and ssl
+ceritificate generated for RGW to access the vault server. It highly recommended to
+set this option true, setting false is very dangerous and need to avoid since this
+runs in very secured enviroments.
+
 Transit engine compatibility support
 ------------------------------------
 The transit engine has compatibility support for previous

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2385,6 +2385,14 @@ options:
   services:
   - rgw
   with_legacy: true
+# TLS certs options
+- name: rgw_crypt_vault_ssl_cacert
+  type: str
+  level: advanced
+  desc: Path for custom ca certificate for accessing vault server
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_crypt_kmip_addr
   type: str
   level: advanced

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2376,6 +2376,15 @@ options:
   - rgw_crypt_vault_auth
   - rgw_crypt_vault_addr
   with_legacy: true
+# Enable TLS authentication rgw and vault
+- name: rgw_crypt_vault_verify_ssl
+  type: bool
+  level: advanced
+  desc: Should RGW verify the vault server SSL certificate.
+  default: true
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_crypt_kmip_addr
   type: str
   level: advanced

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2393,6 +2393,20 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_crypt_vault_ssl_clientcert
+  type: str
+  level: advanced
+  desc: Path for custom client certificate for accessing vault server
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_crypt_vault_ssl_clientkey
+  type: str
+  level: advanced
+  desc: Path for private key required for client cert
+  services:
+  - rgw
+  with_legacy: true
 - name: rgw_crypt_kmip_addr
   type: str
   level: advanced

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -614,6 +614,9 @@ int RGWHTTPClient::init_request(rgw_http_req_data *_req_data)
     curl_easy_setopt(easy_handle, CURLOPT_SSL_VERIFYPEER, 0L);
     curl_easy_setopt(easy_handle, CURLOPT_SSL_VERIFYHOST, 0L);
     dout(20) << "ssl verification is set to off" << dendl;
+  } else if (!ca_path.empty()) {
+    curl_easy_setopt(easy_handle, CURLOPT_CAINFO, ca_path.c_str());
+    dout(20) << "using custom ca cert "<< ca_path.c_str() << " for ssl" << dendl;
   }
   curl_easy_setopt(easy_handle, CURLOPT_PRIVATE, (void *)req_data);
   curl_easy_setopt(easy_handle, CURLOPT_TIMEOUT, req_timeout);

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -1265,7 +1265,7 @@ void *RGWHTTPManager::reqs_thread_entry()
               << cct->_conf->rgw_curl_low_speed_limit << " Bytes per second during " << cct->_conf->rgw_curl_low_speed_time << " seconds." << dendl;
           default:
             dout(20) << "ERROR: msg->data.result=" << result << " req_data->id=" << id << " http_status=" << http_status << dendl;
-            dout(20) << "ERROR: curl error: " << curl_easy_strerror((CURLcode)result) << dendl;
+            dout(20) << "ERROR: curl error: " << curl_easy_strerror((CURLcode)result) << " req_data->error_buf=" << req_data->error_buf << dendl;
 	    break;
         }
       }

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -614,9 +614,21 @@ int RGWHTTPClient::init_request(rgw_http_req_data *_req_data)
     curl_easy_setopt(easy_handle, CURLOPT_SSL_VERIFYPEER, 0L);
     curl_easy_setopt(easy_handle, CURLOPT_SSL_VERIFYHOST, 0L);
     dout(20) << "ssl verification is set to off" << dendl;
-  } else if (!ca_path.empty()) {
-    curl_easy_setopt(easy_handle, CURLOPT_CAINFO, ca_path.c_str());
-    dout(20) << "using custom ca cert "<< ca_path.c_str() << " for ssl" << dendl;
+  } else {
+    if (!ca_path.empty()) {
+      curl_easy_setopt(easy_handle, CURLOPT_CAINFO, ca_path.c_str());
+      dout(20) << "using custom ca cert "<< ca_path.c_str() << " for ssl" << dendl;
+    }
+    if (!client_cert.empty()) {
+      if (!client_key.empty()) {
+	curl_easy_setopt(easy_handle, CURLOPT_SSLCERT, client_cert.c_str());
+	curl_easy_setopt(easy_handle, CURLOPT_SSLKEY, client_key.c_str());
+	dout(20) << "using custom client cert " << client_cert.c_str()
+	  << " and private key " << client_key.c_str() << dendl;
+      } else {
+	dout(5) << "private key is missing for client certificate" << dendl;
+      }
+    }
   }
   curl_easy_setopt(easy_handle, CURLOPT_PRIVATE, (void *)req_data);
   curl_easy_setopt(easy_handle, CURLOPT_TIMEOUT, req_timeout);

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -40,6 +40,8 @@ class RGWHTTPClient : public RGWIOProvider,
 
   bool verify_ssl; // Do not validate self signed certificates, default to false
 
+  string ca_path;
+
   std::atomic<unsigned> stopped { 0 };
 
 
@@ -171,6 +173,10 @@ public:
 
   void *get_io_user_info() override {
     return user_info;
+  }
+
+  void set_ca_path(const string& _ca_path) {
+    ca_path = _ca_path;
   }
 };
 

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -42,6 +42,10 @@ class RGWHTTPClient : public RGWIOProvider,
 
   string ca_path;
 
+  string client_cert;
+
+  string client_key;
+
   std::atomic<unsigned> stopped { 0 };
 
 
@@ -177,6 +181,14 @@ public:
 
   void set_ca_path(const string& _ca_path) {
     ca_path = _ca_path;
+  }
+
+  void set_client_cert(const string& _client_cert) {
+    client_cert = _client_cert;
+  }
+
+  void set_client_key(const string& _client_key) {
+    client_key = _client_key;
   }
 };
 

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -258,6 +258,13 @@ protected:
       secret_req.set_ca_path(cct->_conf->rgw_crypt_vault_ssl_cacert);
     }
 
+    if (!cct->_conf->rgw_crypt_vault_ssl_clientcert.empty()) {
+      secret_req.set_client_cert(cct->_conf->rgw_crypt_vault_ssl_clientcert);
+    }
+    if (!cct->_conf->rgw_crypt_vault_ssl_clientkey.empty()) {
+      secret_req.set_client_key(cct->_conf->rgw_crypt_vault_ssl_clientkey);
+    }
+
     res = secret_req.process(null_yield);
     if (res < 0) {
       ldout(cct, 0) << "ERROR: Request to Vault failed with error " << res << dendl;

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -254,6 +254,10 @@ protected:
 
     secret_req.set_verify_ssl(cct->_conf->rgw_crypt_vault_verify_ssl);
 
+    if (!cct->_conf->rgw_crypt_vault_ssl_cacert.empty()) {
+      secret_req.set_ca_path(cct->_conf->rgw_crypt_vault_ssl_cacert);
+    }
+
     res = secret_req.process(null_yield);
     if (res < 0) {
       ldout(cct, 0) << "ERROR: Request to Vault failed with error " << res << dendl;

--- a/src/rgw/rgw_kms.cc
+++ b/src/rgw/rgw_kms.cc
@@ -252,6 +252,8 @@ protected:
       secret_req.append_header("X-Vault-Namespace", vault_namespace);
     }
 
+    secret_req.set_verify_ssl(cct->_conf->rgw_crypt_vault_verify_ssl);
+
     res = secret_req.process(null_yield);
     if (res < 0) {
       ldout(cct, 0) << "ERROR: Request to Vault failed with error " << res << dendl;


### PR DESCRIPTION
Currently RGW can communicate with vault using SSL with certain limitations. Libcurl uses system certs and it is enabled by generic option `rgw_verify_ssl` which is to enable SSL with any http server and RGW
Introducing two options for RGW to extend existing support for SSL in Vault KMS
`rgw_crypt_vault_verify_ssl` -> exclusive option to enable SSL for vault 
`rgw_crypt_vault_ssl_cert = <file path for ca cert>`


Fixes: https://tracker.ceph.com/issues/47776
Signed-off-by: Jiffin Tony Thottan <jthottan@redhat.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]


"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
