### PR TITLE
osdc: restart read on truncate/discard

### DIFF
--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -566,6 +566,7 @@ void ObjectCacher::Object::truncate(loff_t s)
   ceph_assert(ceph_mutex_is_locked(oc->lock));
   ldout(oc->cct, 10) << "truncate " << *this << " to " << s << dendl;
 
+  std::list<Context*> waiting_for_read;
   while (!data.empty()) {
     BufferHead *bh = data.rbegin()->second;
     if (bh->end() <= s)
@@ -580,11 +581,18 @@ void ObjectCacher::Object::truncate(loff_t s)
 
     // remove bh entirely
     ceph_assert(bh->start() >= s);
-    ceph_assert(bh->waitfor_read.empty());
+    for ([[maybe_unused]] auto& [off, ctxs] : bh->waitfor_read) {
+      waiting_for_read.splice(waiting_for_read.end(), ctxs);
+    }
+    bh->waitfor_read.clear();
     replace_journal_tid(bh, 0);
     oc->bh_remove(this, bh);
     delete bh;
   }
+  if (!waiting_for_read.empty()) {
+    ldout(oc->cct, 10) <<  "restarting reads post-truncate" << dendl;
+  }
+  finish_contexts(oc->cct, waiting_for_read, 0);
 }
 
 void ObjectCacher::Object::discard(loff_t off, loff_t len,
@@ -603,6 +611,7 @@ void ObjectCacher::Object::discard(loff_t off, loff_t len,
     complete = false;
   }
 
+  std::list<Context*> waiting_for_read;
   auto p = data_lower_bound(off);
   while (p != data.end()) {
     BufferHead *bh = p->second;
@@ -640,12 +649,19 @@ void ObjectCacher::Object::discard(loff_t off, loff_t len,
       // we should mark all Rx bh to zero
       continue;
     } else {
-      ceph_assert(bh->waitfor_read.empty());
+      for ([[maybe_unused]] auto& [off, ctxs] : bh->waitfor_read) {
+        waiting_for_read.splice(waiting_for_read.end(), ctxs);
+      }
+      bh->waitfor_read.clear();
     }
 
     oc->bh_remove(this, bh);
     delete bh;
   }
+  if (!waiting_for_read.empty()) {
+    ldout(oc->cct, 10) <<  "restarting reads post-discard" << dendl;
+  }
+  finish_contexts(oc->cct, waiting_for_read, 0); /* restart reads */
 }
 
 


### PR DESCRIPTION
This can be reliably reproduced by reading a large file (~500MB) on a
ceph-fuse mount and then evicting the client.

Now we see in the logs:

	2020-10-21T01:46:29.679+0000 7f00beffd700 10 objectcacher.object(10000000000.00000030/head) truncate object[10000000000.00000030/head oset 0x7f00a0006b08 wr 0/0] to 0
	2020-10-21T01:46:29.679+0000 7f00beffd700 10 objectcacher.object(10000000000.00000030/head) restarting reads post-truncate
	...
	2020-10-21T01:46:29.762+0000 7f00bffff700 20 objectcacher.object(10000000000.00000030/head) map_read error bh[ 0x7f0070004e30 1048576~3145728 0x7f008404a720 (0) v 0 error=-108] waiters = {}
	2020-10-21T01:46:29.762+0000 7f00bffff700 10 objectcacher readx hit bh bh[ 0x7f0070004e30 1048576~3145728 0x7f008404a720 (0) v 0 error=-108] waiters = {}
	2020-10-21T01:46:29.762+0000 7f00bffff700 10 objectcacher readx has all buffers
	2020-10-21T01:46:29.762+0000 7f00bffff700 20 objectcacher readx done 0x7f007c00a9b0 -108
	...
	2020-10-21T01:46:29.763+0000 7f0077fff700  3 client.4497 ll_read 0x7f0080023720 202637312~131072 = -108

Fixes: https://tracker.ceph.com/issues/46434
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
