### PR TITLE
rgw: Check all shards for user manifest parts

### DIFF
--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -154,7 +154,7 @@ class RGWBucket {
       RGWAccessListFilter *filter{nullptr};
       bool list_versions{false};
       bool allow_unordered{false};
-      int shard_id{0};
+      int shard_id{-1};
     };
     struct ListResults {
       vector<rgw_bucket_dir_entry> objs;


### PR DESCRIPTION
When we go and read an user manifest LO (or a DLO in the swift api)
there is a bug where we supply a defaulted params object that defaults
shard_id to 0. This means that when issueing a GET to the LO it'll only
check shard 0 for parts.

This is causing errors in tempest tests, and is obviously wrong.

This patch changes the shard_id to -1, so all shards are checked for
parts and therefore complete LO's are returned.

Fixes: https://tracker.ceph.com/issues/47801
Fixes: https://tracker.ceph.com/issues/47800
Signed-off-by: Matthew Oliver <moliver@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
