### PR TITLE
mgr/dashboard: Fix property name in orchestrator status response

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/orchestrator.py
+++ b/src/pybind/mgr/dashboard/controllers/orchestrator.py
@@ -16,7 +16,7 @@ from . import ApiController, ControllerDoc, Endpoint, EndpointDoc, \
 
 STATUS_SCHEMA = {
     "available": (bool, "Orchestrator status"),
-    "description": (str, "Description")
+    "message": (str, "Error message")
 }
 
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-devices/inventory-devices.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory-devices/inventory-devices.component.spec.ts
@@ -13,6 +13,7 @@ import { TableActionsComponent } from '../../../../shared/datatable/table-action
 import { CdTableAction } from '../../../../shared/models/cd-table-action';
 import { CdTableSelection } from '../../../../shared/models/cd-table-selection';
 import { OrchestratorFeature } from '../../../../shared/models/orchestrator.enum';
+import { OrchestratorStatus } from '../../../../shared/models/orchestrator.interface';
 import { Permissions } from '../../../../shared/models/permissions';
 import { AuthStorageService } from '../../../../shared/services/auth-storage.service';
 import { SharedModule } from '../../../../shared/shared.module';
@@ -30,7 +31,7 @@ describe('InventoryDevicesComponent', () => {
   };
 
   const mockOrchStatus = (available: boolean, features?: OrchestratorFeature[]) => {
-    const orchStatus = { available: available, description: '', features: {} };
+    const orchStatus: OrchestratorStatus = { available: available, message: '', features: {} };
     if (features) {
       features.forEach((feature: OrchestratorFeature) => {
         orchStatus.features[feature] = { available: true };

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/orchestrator.interface.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/orchestrator.interface.ts
@@ -1,6 +1,6 @@
 export interface OrchestratorStatus {
   available: boolean;
-  description: string;
+  message: string;
   features: {
     [feature: string]: {
       available: boolean;

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -5048,12 +5048,12 @@ paths:
                   available:
                     description: Orchestrator status
                     type: boolean
-                  description:
-                    description: Description
+                  message:
+                    description: Error message
                     type: string
                 required:
                 - available
-                - description
+                - message
                 type: object
           description: OK
         '400':

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -23,13 +23,13 @@ class OrchestratorAPI(OrchestratorClientMixin):
 
     def status(self):
         try:
-            status, desc = super(OrchestratorAPI, self).available()
-            logger.info("is orchestrator available: %s, %s", status, desc)
-            return dict(available=status, description=desc)
-        except (RuntimeError, OrchestratorError, ImportError):
+            status, message = super().available()
+            logger.info("is orchestrator available: %s, %s", status, message)
+            return dict(available=status, message=message)
+        except (RuntimeError, OrchestratorError, ImportError) as e:
             return dict(
                 available=False,
-                description='Orchestrator is unavailable for unknown reason')
+                message='Orchestrator is unavailable for unknown reason: {}'.format(str(e)))
 
     def orchestrator_wait(self, completions):
         return self._orchestrator_wait(completions)


### PR DESCRIPTION
The response of the `status` endpoint of the `orchestrator` controller contains the property `description` instead of `message` as this is done by other `status` endpoints.

Fixes: https://tracker.ceph.com/issues/47926

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
