### PR TITLE
mgr/dashboard: validate username while creation

### DIFF
--- a/qa/tasks/mgr/dashboard/test_user.py
+++ b/qa/tasks/mgr/dashboard/test_user.py
@@ -169,6 +169,16 @@ class UserTest(DashboardTestCase):
         self.assertError(code='role_does_not_exist',
                          component='user')
 
+    def test_create_user_invalid_chars_in_name(self):
+        self._create_user(username='userö',
+                          password='mypassword10#',
+                          name='administrator',
+                          email='my@email.com',
+                          roles=['administrator'])
+        self.assertStatus(400)
+        self.assertError(code='ceph_type_not_valid',
+                         component='user')
+
     def test_delete_user_does_not_exist(self):
         self._delete('/api/user/user2')
         self.assertStatus(404)

--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -16,10 +16,12 @@ from urllib.parse import unquote
 
 # pylint: disable=wrong-import-position
 import cherrypy
+# pylint: disable=import-error
+from ceph_argparse import ArgumentFormat  # type: ignore
 
 from .. import DEFAULT_VERSION
 from ..api.doc import SchemaInput, SchemaType
-from ..exceptions import PermissionNotValid, ScopeNotValid
+from ..exceptions import DashboardException, PermissionNotValid, ScopeNotValid
 from ..plugins import PLUGIN_MANAGER
 from ..security import Permission, Scope
 from ..services.auth import AuthManager, JwtManager
@@ -1008,3 +1010,20 @@ def allow_empty_body(func):  # noqa: N802
     except (AttributeError, KeyError):
         func._cp_config = {'tools.json_in.force': False}
     return func
+
+
+def validate_ceph_type(validations, component=''):
+    def decorator(func):
+        @wraps(func)
+        def validate_args(*args, **kwargs):
+            input_values = kwargs
+            for key, ceph_type in validations:
+                try:
+                    ceph_type.valid(input_values[key])
+                except ArgumentFormat as e:
+                    raise DashboardException(msg=e,
+                                             code='ceph_type_not_valid',
+                                             component=component)
+            return func(*args, **kwargs)
+        return validate_args
+    return decorator

--- a/src/pybind/mgr/dashboard/controllers/user.py
+++ b/src/pybind/mgr/dashboard/controllers/user.py
@@ -5,6 +5,7 @@ import time
 from datetime import datetime
 
 import cherrypy
+from ceph_argparse import CephString  # pylint: disable=import-error
 
 from .. import mgr
 from ..exceptions import DashboardException, PasswordPolicyException, \
@@ -13,7 +14,7 @@ from ..security import Scope
 from ..services.access_control import SYSTEM_ROLES, PasswordPolicy
 from ..services.auth import JwtManager
 from . import ApiController, BaseController, ControllerDoc, Endpoint, \
-    EndpointDoc, RESTController, allow_empty_body
+    EndpointDoc, RESTController, allow_empty_body, validate_ceph_type
 
 USER_SCHEMA = ([{
     "username": (str, 'Username of the user'),
@@ -81,6 +82,7 @@ class User(RESTController):
             raise cherrypy.HTTPError(404)
         return User._user_to_dict(user)
 
+    @validate_ceph_type([('username', CephString())], 'user')
     def create(self, username=None, password=None, name=None, email=None,
                roles=None, enabled=True, pwdExpirationDate=None, pwdUpdateRequired=True):
         if not username:

--- a/src/pybind/mgr/dashboard/run-backend-api-tests.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-tests.sh
@@ -35,7 +35,7 @@ get_cmake_variable() {
 
 [ -z "$BUILD_DIR" ] && BUILD_DIR=build
 CURR_DIR=`pwd`
-LOCAL_BUILD_DIR="$CURR_DIR/../../../../$BUILD_DIR"
+LOCAL_BUILD_DIR=$(cd "$CURR_DIR/../../../../$BUILD_DIR"; pwd)
 
 setup_teuthology() {
     TEMP_DIR=`mktemp -d`

--- a/src/pybind/mgr/dashboard/run-backend-api-tests.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-tests.sh
@@ -119,8 +119,7 @@ run_teuthology_tests() {
     local python_common_dir=$source_dir/src/python-common
     # In CI environment we set python paths inside build (where you find the required frontend build: "dist" dir).
     if [[ -n "$JENKINS_HOME" ]]; then
-        export PYBIND=$LOCAL_BUILD_DIR/src/pybind
-        pybind_dir=$PYBIND
+        pybind_dir+=":$LOCAL_BUILD_DIR/src/pybind"
     fi
     export PYTHONPATH=$source_dir/qa:$LOCAL_BUILD_DIR/lib/cython_modules/lib.3/:$pybind_dir:$python_common_dir:${COVERAGE_PATH}
     export RGW=${RGW:-1}

--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -168,7 +168,7 @@ passenv =
     PYTHONPATH
 setenv =
     UNITTEST = true
-    PYTHONPATH=$PYTHONPATH:..
+    PYTHONPATH=$PYTHONPATH:..:../..
     OPENAPI_FILE=openapi.yaml
     check: OPENAPI_FILE_TMP={envtmpdir}/{env:OPENAPI_FILE}
 commands =


### PR DESCRIPTION
When creating a user the username is not checked if it's valid from the Ceph perspective (`CephString`). The commit adds a decorator to check if the input values in the API are valid from the Ceph perspective by calling the `valid()` method of the Ceph-defined datatypes (`ceph_argparse.py`).

Fixes: https://tracker.ceph.com/issues/46548
Signed-off-by: Tatjana Dehler <tdehler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
