### PR TITLE
ceph-volume: remove mention of dmcache from docs and help text

### DIFF
--- a/doc/ceph-volume/intro.rst
+++ b/doc/ceph-volume/intro.rst
@@ -74,16 +74,11 @@ involved at all.
 -------------------
 By making use of :term:`LVM tags`, the :ref:`ceph-volume-lvm` sub-command is
 able to store and later re-discover and query devices associated with OSDs so
-that they can later activated. This includes support for lvm-based technologies
-like dm-cache as well.
-
-For ``ceph-volume``, the use of dm-cache is transparent, there is no difference
-for the tool, and it treats dm-cache like a plain logical volume.
+that they can later be activated.
 
 LVM performance penalty
 -----------------------
 In short: we haven't been able to notice any significant performance penalties
 associated with the change to LVM. By being able to work closely with LVM, the
-ability to work with other device mapper technologies (for example ``dmcache``)
-was a given: there is no technical difficulty in working with anything that can
-sit below a Logical Volume.
+ability to work with other device mapper technologies was a given: there is no
+technical difficulty in working with anything that can sit below a Logical Volume.

--- a/src/ceph-volume/ceph_volume/devices/lvm/main.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/main.py
@@ -13,10 +13,10 @@ from . import batch
 
 class LVM(object):
 
-    help = 'Use LVM and LVM-based technologies like dmcache to deploy OSDs'
+    help = 'Use LVM and LVM-based technologies to deploy OSDs'
 
     _help = dedent("""
-    Use LVM and LVM-based technologies like dmcache to deploy OSDs
+    Use LVM and LVM-based technologies to deploy OSDs
 
     {sub_help}
     """)


### PR DESCRIPTION
With the introduction of bluestore dmcache is no longer needed and
is no longer supported with `ceph-volume lvm`.

Resolves: rhbz#1876827
Fixes: https://tracker.ceph.com/issues/48039

Signed-off-by: Andrew Schoen <aschoen@redhat.com>