### PR TITLE
common/perf_counters: don't let dec() go negative 

### DIFF
--- a/src/common/perf_counters.cc
+++ b/src/common/perf_counters.cc
@@ -190,7 +190,17 @@ void PerfCounters::dec(int idx, uint64_t amt)
   ceph_assert(!(data.type & PERFCOUNTER_LONGRUNAVG));
   if (!(data.type & PERFCOUNTER_U64))
     return;
-  data.u64 -= amt;
+  if (amt > data.u64) {  // would wrap
+    // We should be able to uncomment this assert once there are no warnings
+    // generated from the lderr line below.
+    // assert(data.u64 >= amt); // Assert in debug builds.
+    lderr(m_cct) << "WARNING: " << __func__ << " " << data.u64 << " - " << amt
+                 << " for counter " << idx << " would wrap. Setting to 0"
+                 << dendl;
+    data.u64 = 0;
+  } else {
+    data.u64 -= amt;
+  }
 }
 
 void PerfCounters::set(int idx, uint64_t amt)


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47932

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
