### PR TITLE
crimson/osd: add more privacy

### DIFF
--- a/src/crimson/osd/osd_operations/background_recovery.cc
+++ b/src/crimson/osd/osd_operations/background_recovery.cc
@@ -23,7 +23,9 @@ BackgroundRecovery::BackgroundRecovery(
   ShardServices &ss,
   epoch_t epoch_started,
   crimson::osd::scheduler::scheduler_class_t scheduler_class)
-  : pg(pg), ss(ss), epoch_started(epoch_started),
+  : pg(pg),
+    epoch_started(epoch_started),
+    ss(ss),
     scheduler_class(scheduler_class)
 {}
 


### PR DESCRIPTION
* reorder the member variable and member function definitions so the
  private members are listed at the end of class. as requested by
  the CodingStyle
* mark some member variables and member functions private, as long as
  they are not used by other classes or non-friend classes.
* document UrgentRecovery
* refactor BackgroundRecovery::get_scheduler_params() to dedup
  the comments

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
