### PR TITLE
nautilus: rpm: move python-enum34 into rhel 7 conditional

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -478,11 +478,9 @@ Recommends:	python%{_python_buildid}-influxdb
 %endif
 %if 0%{?rhel} == 7
 Requires:       pyOpenSSL
+Requires:       python-enum34
 %else
 Requires:       python%{_python_buildid}-pyOpenSSL
-%endif
-%if 0%{?rhel} < 8 || 0%{?suse_version}
-Requires:       python-enum34
 %endif
 %description mgr
 ceph-mgr enables python modules that provide services (such as the REST


### PR DESCRIPTION
There is no "python-enum34" RPM in openSUSE 15.1 (as this release
uses Python 3 exclusively), so the dependency cannot be satisfied.

This nautilus-only change fixes a nautilus-only commit which broke
nautilus on openSUSE and SUSE Linux Enterprise.

Fixes: fdfae1c00c0059a03389bdcfafa6b0ee8d95ad55
Signed-off-by: Nathan Cutler <ncutler@suse.com>
