### PR TITLE
mgr/dashboard: fix disable action for MGR modules

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.spec.ts
@@ -129,23 +129,27 @@ describe('MgrModuleListComponent', () => {
       expect(component.table.refreshBtn).toHaveBeenCalled();
     }));
 
-    it('should not disable module (1)', () => {
+    it.only('should not disable module without selecting one', () => {
+      expect(component.getTableActionDisabledDesc()).toBeTruthy();
+    });
+
+    it('should not disable dashboard module', () => {
       component.selection.selected = [
         {
           name: 'dashboard'
         }
       ];
-      expect(component.isTableActionDisabled('enabled')).toBeTruthy();
+      expect(component.getTableActionDisabledDesc()).toBeTruthy();
     });
 
-    it('should not disable module (2)', () => {
+    it('should not disable an always-on module', () => {
       component.selection.selected = [
         {
           name: 'bar',
           always_on: true
         }
       ];
-      expect(component.isTableActionDisabled('enabled')).toBeTruthy();
+      expect(component.getTableActionDisabledDesc()).toBe('This Manager module is always on.');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-list/mgr-module-list.component.ts
@@ -88,7 +88,7 @@ export class MgrModuleListComponent extends ListWithDetails {
         name: $localize`Disable`,
         permission: 'update',
         click: () => this.updateModuleState(),
-        disable: () => () => this.getTableActionDisabledDesc(),
+        disable: () => this.getTableActionDisabledDesc(),
         icon: Icons.stop
       }
     ];
@@ -139,7 +139,7 @@ export class MgrModuleListComponent extends ListWithDetails {
   }
 
   getTableActionDisabledDesc(): string | boolean {
-    if (this.selection.first().always_on) {
+    if (this.selection.first()?.always_on) {
       return $localize`This Manager module is always on.`;
     }
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47947
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>

Fix the problem that a module can't be disabled:

![Screenshot_20201022_144405](https://user-images.githubusercontent.com/1691518/96849948-d49b7e00-1488-11eb-9bfd-a8f32aac7956.png)



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
