### PR TITLE
mgr/dashboard: Adding more style to the notification sidebar

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.html
@@ -53,7 +53,8 @@
 
     <hr>
 
-    <div *ngFor="let notification of notifications; let i = index">
+    <div *ngFor="let notification of notifications; let i = index"
+         [ngClass]="notification.borderClass">
       <div class="card tc_notification border-0">
         <div class="row no-gutters">
           <div class="col-md-2 text-center">

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.scss
@@ -23,7 +23,9 @@
 }
 
 .card-body {
-  padding-left: 5px;
+  padding-left: 0;
+  padding-right: 5px;
+  padding-top: 3px;
 }
 
 ngx-simplebar {
@@ -37,6 +39,10 @@ ngx-simplebar {
   padding: 5px 12px;
 }
 
+.btn-block {
+  width: 98%;
+}
+
 .btn-link .fa-trash-o {
   color: vv.$black;
 }
@@ -48,8 +54,11 @@ table {
 .row {
   margin-left: 0;
   margin-right: 0;
+  padding-bottom: 1rem;
+  padding-top: 1rem;
 }
 
-.fa-times {
-  margin-right: 10px;
+hr {
+  margin-bottom: 2px;
+  margin-top: 2px;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-notification.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-notification.ts
@@ -28,9 +28,11 @@ export class CdNotification extends CdNotificationConfig {
   textClass: string;
   iconClass: string;
   duration: number;
+  borderClass: string;
 
   private textClasses = ['text-danger', 'text-info', 'text-success'];
   private iconClasses = [Icons.warning, Icons.info, Icons.check];
+  private borderClasses = ['border-danger', 'border-info', 'border-success'];
 
   constructor(private config: CdNotificationConfig = new CdNotificationConfig()) {
     super(config.type, config.title, config.message, config.options, config.application);
@@ -40,6 +42,7 @@ export class CdNotification extends CdNotificationConfig {
     this.timestamp = new Date().toJSON();
     this.iconClass = this.iconClasses[this.type];
     this.textClass = this.textClasses[this.type];
+    this.borderClass = this.borderClasses[this.type];
     this.isFinishedTask = config.isFinishedTask;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_basics.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_basics.scss
@@ -73,3 +73,15 @@ option {
 .text-pre {
   white-space: pre;
 }
+
+.border-danger {
+  border-left: 4px solid vv.$danger;
+}
+
+.border-info {
+  border-left: 4px solid vv.$info;
+}
+
+.border-success {
+  border-left: 4px solid vv.$success;
+}


### PR DESCRIPTION
This commit improves the notification sidebar styling by adding a border on the left side and the color of the border aligns with the type of the warning (succes, info or danger).

**After:**

![notifupstream](https://user-images.githubusercontent.com/71764184/96879153-4e3b6800-1499-11eb-8cd7-835b4602a94f.png)

**Before**:

![before](https://user-images.githubusercontent.com/71764184/96879192-598e9380-1499-11eb-8d01-431690a6d605.png)



Fixes: https://tracker.ceph.com/issues/47950
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
