### PR TITLE
nautilus: mgr/dashboard: Datatable catches select events from other datatables

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -87,7 +87,7 @@
                  [cssClasses]="paginationClasses"
                  [selectionType]="selectionType"
                  [selected]="selection.selected"
-                 (select)="onSelect()"
+                 (select)="onSelect($event)"
                  [sorts]="userConfig.sorts"
                  (sort)="changeSorting($event)"
                  [columns]="tableColumns"

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -454,9 +454,13 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
     this.onSelect();
   }
 
-  onSelect() {
-    this.selection.update();
-    this.updateSelection.emit(_.clone(this.selection));
+  onSelect($event: any) {
+    // Ensure we do not process DOM 'select' events.
+    // https://github.com/swimlane/ngx-datatable/issues/899
+    if (_.has($event, 'selected')) {
+      this.selection.selected = $event['selected'];
+      this.updateSelection.emit(_.clone(this.selection));
+    }
   }
 
   toggleColumn($event: any) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -451,7 +451,7 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
       return;
     }
     this.selection.selected = newSelected;
-    this.onSelect();
+    this.onSelect(this.selection);
   }
 
   onSelect($event: any) {
@@ -459,8 +459,8 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
     // https://github.com/swimlane/ngx-datatable/issues/899
     if (_.has($event, 'selected')) {
       this.selection.selected = $event['selected'];
-      this.updateSelection.emit(_.clone(this.selection));
     }
+    this.updateSelection.emit(_.clone(this.selection));
   }
 
   toggleColumn($event: any) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47198

---

backport of https://github.com/ceph/ceph/pull/36590
parent tracker: https://tracker.ceph.com/issues/46903

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh