### PR TITLE
mgr/dashboard: displaying time in human-readable format

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.html
@@ -40,7 +40,7 @@
              let-row="row"
              let-value="value">
   <span *ngIf="row.backstore === 'user:rbd'">
-    {{ value | relativeDate }}
+    {{ value | relativeDate | notAvailable }}
   </span>
   <span *ngIf="row.backstore !== 'user:rbd'"
         class="text-muted">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.spec.ts
@@ -9,7 +9,6 @@ import { IscsiService } from '../../../shared/api/iscsi.service';
 import { CephShortVersionPipe } from '../../../shared/pipes/ceph-short-version.pipe';
 import { DimlessPipe } from '../../../shared/pipes/dimless.pipe';
 import { IscsiBackstorePipe } from '../../../shared/pipes/iscsi-backstore.pipe';
-import { RelativeDatePipe } from '../../../shared/pipes/relative-date.pipe';
 import { FormatterService } from '../../../shared/services/formatter.service';
 import { SharedModule } from '../../../shared/shared.module';
 import { IscsiComponent } from './iscsi.component';
@@ -36,7 +35,6 @@ describe('IscsiComponent', () => {
       CephShortVersionPipe,
       DimlessPipe,
       FormatterService,
-      RelativeDatePipe,
       IscsiBackstorePipe,
       { provide: IscsiService, useValue: fakeService }
     ]

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.html
@@ -13,7 +13,7 @@
         <tr>
           <td i18n
               class="bold">monmap modified</td>
-          <td>{{ mon_status.monmap.modified }}</td>
+          <td>{{ mon_status.monmap.modified | relativeDate }}</td>
         </tr>
         <tr>
           <td i18n

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.spec.ts
@@ -6,6 +6,7 @@ import { of } from 'rxjs';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { MonitorService } from '../../../shared/api/monitor.service';
+import { SharedModule } from '../../../shared/shared.module';
 import { MonitorComponent } from './monitor.component';
 
 describe('MonitorComponent', () => {
@@ -14,7 +15,7 @@ describe('MonitorComponent', () => {
   let getMonitorSpy: jasmine.Spy;
 
   configureTestBed({
-    imports: [HttpClientTestingModule],
+    imports: [HttpClientTestingModule, SharedModule],
     declarations: [MonitorComponent],
     schemas: [NO_ERRORS_SCHEMA],
     providers: [MonitorService]

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.ts
@@ -22,6 +22,7 @@ import { CellTemplate } from '../../../../shared/enum/cell-template.enum';
 import { CdTableColumn } from '../../../../shared/models/cd-table-column';
 import { CdTableFetchDataContext } from '../../../../shared/models/cd-table-fetch-data-context';
 import { Daemon } from '../../../../shared/models/daemon.interface';
+import { RelativeDatePipe } from '../../../../shared/pipes/relative-date.pipe';
 
 @Component({
   selector: 'cd-service-daemon-list',
@@ -52,7 +53,8 @@ export class ServiceDaemonListComponent implements OnInit, OnChanges, AfterViewI
   constructor(
     private hostService: HostService,
     private cephServiceService: CephServiceService,
-    private orchService: OrchestratorService
+    private orchService: OrchestratorService,
+    private relativeDatePipe: RelativeDatePipe
   ) {}
 
   ngOnInit() {
@@ -117,6 +119,7 @@ export class ServiceDaemonListComponent implements OnInit, OnChanges, AfterViewI
       {
         name: $localize`Last Refreshed`,
         prop: 'last_refresh',
+        pipe: this.relativeDatePipe,
         flexGrow: 2
       }
     ];

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
@@ -19,6 +19,7 @@ import { OrchestratorFeature } from '../../../shared/models/orchestrator.enum';
 import { OrchestratorStatus } from '../../../shared/models/orchestrator.interface';
 import { Permissions } from '../../../shared/models/permissions';
 import { CephServiceSpec } from '../../../shared/models/service.interface';
+import { RelativeDatePipe } from '../../../shared/pipes/relative-date.pipe';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { ModalService } from '../../../shared/services/modal.service';
 import { TaskWrapperService } from '../../../shared/services/task-wrapper.service';
@@ -61,6 +62,7 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
     private modalService: ModalService,
     private orchService: OrchestratorService,
     private cephServiceService: CephServiceService,
+    private relativeDatePipe: RelativeDatePipe,
     private taskWrapperService: TaskWrapperService,
     private urlBuilder: URLBuilderService
   ) {
@@ -119,6 +121,7 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
       {
         name: $localize`Last Refreshed`,
         prop: 'status.last_refresh',
+        pipe: this.relativeDatePipe,
         flexGrow: 1
       }
     ];

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/notifications-sidebar/notifications-sidebar.component.html
@@ -83,7 +83,7 @@
                   <br>
                 </ng-container>
                 <small class="date"
-                       [title]="notification.timestamp | cdDate">{{ notification.timestamp | duration: true }}</small>
+                       [title]="notification.timestamp | cdDate">{{ notification.timestamp | relativeDate }}</small>
                 <i class="float-right custom-icon"
                    [ngClass]="[notification.applicationClass]"
                    [title]="notification.application"></i>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/duration.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/duration.pipe.spec.ts
@@ -1,5 +1,3 @@
-import moment from 'moment';
-
 import { DurationPipe } from './duration.pipe';
 
 describe('DurationPipe', () => {
@@ -15,10 +13,5 @@ describe('DurationPipe', () => {
     expect(pipe.transform(60)).toBe('1 minute');
     expect(pipe.transform(600)).toBe('10 minutes');
     expect(pipe.transform(6000)).toBe('1 hour 40 minutes');
-  });
-
-  it('transforms date into a human readable relative duration', () => {
-    const date = moment().subtract(130, 'seconds');
-    expect(pipe.transform(date, true)).toBe('2 minutes ago');
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/duration.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/duration.pipe.ts
@@ -1,20 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-import moment from 'moment';
-
 @Pipe({
   name: 'duration',
   pure: false
 })
 export class DurationPipe implements PipeTransform {
-  transform(date: any, isRelative = false): string {
-    if (isRelative) {
-      return moment(date).fromNow();
-    } else {
-      return this._forHumans(date);
-    }
-  }
-
   /**
    * Translates seconds into human readable format of seconds, minutes, hours, days, and years
    * source: https://stackoverflow.com/a/34270811
@@ -22,7 +12,7 @@ export class DurationPipe implements PipeTransform {
    * @param  {number} seconds The number of seconds to be processed
    * @return {string}         The phrase describing the the amount of time
    */
-  _forHumans(seconds: number): string {
+  transform(seconds: number): string {
     const levels = [
       [`${Math.floor(seconds / 31536000)}`, 'years'],
       [`${Math.floor((seconds % 31536000) / 86400)}`, 'days'],

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/not-available.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/not-available.pipe.spec.ts
@@ -11,12 +11,20 @@ describe('NotAvailablePipe', () => {
     expect(pipe).toBeTruthy();
   });
 
-  it('transforms not available', () => {
+  it('transforms not available (1)', () => {
     expect(pipe.transform('')).toBe('n/a');
   });
 
-  it('transforms number', () => {
+  it('transforms not available (2)', () => {
+    expect(pipe.transform('', 'Unknown')).toBe('Unknown');
+  });
+
+  it('transform not necessary (1)', () => {
     expect(pipe.transform(0)).toBe(0);
     expect(pipe.transform(1)).toBe(1);
+  });
+
+  it('transform not necessary (2)', () => {
+    expect(pipe.transform('foo')).toBe('foo');
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/not-available.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/not-available.pipe.ts
@@ -1,12 +1,14 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
+import _ from 'lodash';
+
 @Pipe({
   name: 'notAvailable'
 })
 export class NotAvailablePipe implements PipeTransform {
-  transform(value: any): any {
+  transform(value: any, text?: string): any {
     if (value === '') {
-      return $localize`n/a`;
+      return _.defaultTo(text, $localize`n/a`);
     }
     return value;
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/relative-date.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/relative-date.pipe.spec.ts
@@ -9,17 +9,36 @@ describe('RelativeDatePipe', () => {
     expect(pipe).toBeTruthy();
   });
 
-  it('transforms without value', () => {
-    expect(pipe.transform(undefined)).toBe('unknown');
+  it('transforms date into a human readable relative time (1)', () => {
+    const date: Date = moment().subtract(130, 'seconds').toDate();
+    expect(pipe.transform(date)).toBe('2 minutes ago');
   });
 
-  it('transforms "in 7 days"', () => {
-    const value = moment().add(7, 'days').unix();
-    expect(pipe.transform(value)).toBe('in 7 days');
+  it('transforms date into a human readable relative time (2)', () => {
+    const date: Date = moment().subtract(65, 'minutes').toDate();
+    expect(pipe.transform(date)).toBe('An hour ago');
   });
 
-  it('transforms "7 days ago"', () => {
-    const value = moment().subtract(7, 'days').unix();
-    expect(pipe.transform(value)).toBe('7 days ago');
+  it('transforms date into a human readable relative time (3)', () => {
+    const date: string = moment().subtract(130, 'minutes').toISOString();
+    expect(pipe.transform(date)).toBe('2 hours ago');
+  });
+
+  it('transforms date into a human readable relative time (4)', () => {
+    const date: string = moment().subtract(30, 'seconds').toISOString();
+    expect(pipe.transform(date, false)).toBe('a few seconds ago');
+  });
+
+  it('transforms date into a human readable relative time (5)', () => {
+    const date: number = moment().subtract(3, 'days').unix();
+    expect(pipe.transform(date)).toBe('3 days ago');
+  });
+
+  it('invalid input (1)', () => {
+    expect(pipe.transform('')).toBe('');
+  });
+
+  it('invalid input (2)', () => {
+    expect(pipe.transform('2011-10-10T10:20:90')).toBe('');
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/relative-date.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/relative-date.pipe.ts
@@ -1,15 +1,57 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
+import _ from 'lodash';
 import moment from 'moment';
 
+moment.updateLocale('en', {
+  relativeTime: {
+    future: $localize`in %s`,
+    past: $localize`%s ago`,
+    s: $localize`a few seconds`,
+    ss: $localize`%d seconds`,
+    m: $localize`a minute`,
+    mm: $localize`%d minutes`,
+    h: $localize`an hour`,
+    hh: $localize`%d hours`,
+    d: $localize`a day`,
+    dd: $localize`%d days`,
+    w: $localize`a week`,
+    ww: $localize`%d weeks`,
+    M: $localize`a month`,
+    MM: $localize`%d months`,
+    y: $localize`a year`,
+    yy: $localize`%d years`
+  }
+});
+
 @Pipe({
-  name: 'relativeDate'
+  name: 'relativeDate',
+  pure: false
 })
 export class RelativeDatePipe implements PipeTransform {
-  transform(value: any): any {
-    if (!value) {
-      return 'unknown';
+  /**
+   * Convert a time into a human readable form, e.g. '2 minutes ago'.
+   * @param {Date | string | number} value The date to convert, should be
+   *   an ISO8601 string, an Unix timestamp (seconds) or Date object.
+   * @param {boolean} upperFirst Set to `true` to start the sentence
+   *   upper case. Defaults to `true`.
+   * @return {string} The time in human readable form or an empty string
+   *   on failure (e.g. invalid input).
+   */
+  transform(value: Date | string | number, upperFirst = true): string {
+    let date: moment.Moment;
+    if (_.isNumber(value)) {
+      date = moment.unix(value);
+    } else {
+      date = moment(value);
     }
-    return moment(value * 1000).fromNow();
+    if (!date.isValid()) {
+      return '';
+    }
+    let relativeDate: string = date.fromNow();
+    if (upperFirst) {
+      relativeDate = _.upperFirst(relativeDate);
+    }
+    return relativeDate;
   }
 }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47884

# Monitors page
![Bildschirmfoto vom 2020-10-23 12-25-15](https://user-images.githubusercontent.com/1897962/96992923-e03f8100-152a-11eb-98da-e85e48cc9ae9.png)

# Services page
(The pipe is using the local timezone (in this case UTC+2h) of the browser for calculation, that's why the UI shows `2 hours ago`).
![Bildschirmfoto vom 2020-10-23 12-17-26](https://user-images.githubusercontent.com/1897962/96992146-c3567e00-1529-11eb-9ce6-c519e27c90ba.png)

# iSCSI page
(When no data is available, previously it was an untranslated `unknown`)
![Bildschirmfoto vom 2020-10-23 09-34-28](https://user-images.githubusercontent.com/1897962/96974722-e8db8b80-1519-11eb-87ce-f45b820170fc.png)

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
