### PR TITLE
mon/MonMap: fix unconditional failure for init_with_hosts

### DIFF
--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -501,10 +501,9 @@ void MonMap::_add_ambiguous_addr(const string& name,
   }
 }
 
-int
-MonMap::init_with_addrs(const std::vector<entity_addrvec_t>& addrs,
-                        bool for_mkfs,
-                        std::string_view prefix)
+void MonMap::init_with_addrs(const std::vector<entity_addrvec_t>& addrs,
+                             bool for_mkfs,
+                             std::string_view prefix)
 {
   char id = 'a';
   for (auto& addr : addrs) {
@@ -518,7 +517,6 @@ MonMap::init_with_addrs(const std::vector<entity_addrvec_t>& addrs,
       add(name, addr, 0);
     }
   }
-  return 0;
 }
 
 int MonMap::init_with_ips(const std::string& ips,
@@ -533,7 +531,8 @@ int MonMap::init_with_ips(const std::string& ips,
   }
   if (addrs.empty())
     return -ENOENT;
-  return init_with_addrs(addrs, for_mkfs, prefix);
+  init_with_addrs(addrs, for_mkfs, prefix);
+  return 0;
 }
 
 int MonMap::init_with_hosts(const std::string& hostlist,
@@ -554,9 +553,7 @@ int MonMap::init_with_hosts(const std::string& hostlist,
     return -EINVAL;
   if (addrs.empty())
     return -ENOENT;
-  if (!init_with_addrs(addrs, for_mkfs, prefix)) {
-    return -EINVAL;
-  }
+  init_with_addrs(addrs, for_mkfs, prefix);
   calc_legacy_ranks();
   return 0;
 }
@@ -901,7 +898,8 @@ int MonMap::build_initial(CephContext *cct, bool for_mkfs, ostream& errout)
   // cct?
   auto addrs = cct->get_mon_addrs();
   if (addrs != nullptr && (addrs->size() > 0)) {
-    return init_with_addrs(*addrs, for_mkfs, "noname-");
+    init_with_addrs(*addrs, for_mkfs, "noname-");
+    return 0;
   }
 
   // file?

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -493,11 +493,10 @@ protected:
    *
    * @param addrs  list of entity_addrvec_t's
    * @param prefix prefix to prepend to generated mon names
-   * @return 0 for success, -errno on error
    */
-  int init_with_addrs(const std::vector<entity_addrvec_t>& addrs,
-        bool for_mkfs,
-        std::string_view prefix);
+  void init_with_addrs(const std::vector<entity_addrvec_t>& addrs,
+                       bool for_mkfs,
+                       std::string_view prefix);
   /**
    * build a monmap from a list of ips
    *

--- a/src/test/mon/CMakeLists.txt
+++ b/src/test/mon/CMakeLists.txt
@@ -25,6 +25,13 @@ add_executable(unittest_mon_moncap
 add_ceph_unittest(unittest_mon_moncap)
 target_link_libraries(unittest_mon_moncap mon global)
 
+# unittest_mon_map
+add_executable(unittest_mon_monmap
+  MonMap.cc
+  )
+add_ceph_unittest(unittest_mon_monmap)
+target_link_libraries(unittest_mon_monmap mon global)
+
 # unittest_mon_pgmap
 add_executable(unittest_mon_pgmap
   PGMap.cc

--- a/src/test/mon/MonMap.cc
+++ b/src/test/mon/MonMap.cc
@@ -220,3 +220,22 @@ TEST_F(MonMapTest, DISABLED_build_initial_config_from_dns_with_domain) {
   ASSERT_EQ(os.str(), "192.168.1.13:6789/0");
 }
 
+TEST(MonMapBuildInitial, build_initial_mon_host_from_dns) {
+  boost::intrusive_ptr<CephContext> cct = new CephContext(CEPH_ENTITY_TYPE_MON);
+  cct->_conf.set_val("mon_host", "ceph.io");
+  MonMap monmap;
+  int r = monmap.build_initial(cct.get(), false, std::cerr);
+  ASSERT_EQ(r, 0);
+  ASSERT_GE(monmap.mon_info.size(), 1u);
+  for (const auto& [name, info] : monmap.mon_info) {
+    std::cerr << info << std::endl;
+  }
+}
+
+TEST(MonMapBuildInitial, build_initial_mon_host_from_dns_fail) {
+  boost::intrusive_ptr<CephContext> cct = new CephContext(CEPH_ENTITY_TYPE_MON);
+  cct->_conf.set_val("mon_host", "ceph.noname");
+  MonMap monmap;
+  int r = monmap.build_initial(cct.get(), false, std::cerr);
+  ASSERT_EQ(r, -EINVAL);
+}

--- a/src/test/mon/MonMap.cc
+++ b/src/test/mon/MonMap.cc
@@ -20,6 +20,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include <boost/smart_ptr/intrusive_ptr.hpp>
+
 #include <sstream>
 
 #define TEST_DEBUG 20
@@ -45,7 +47,7 @@ class MonMapTest : public ::testing::Test {
     }
 };
 
-TEST_F(MonMapTest, build_initial_config_from_dns) {
+TEST_F(MonMapTest, DISABLED_build_initial_config_from_dns) {
 
   MockResolvHWrapper *resolvH = new MockResolvHWrapper();
   DNSResolver::get_instance(resolvH);
@@ -96,31 +98,31 @@ TEST_F(MonMapTest, build_initial_config_from_dns) {
 
 
 
-  CephContext *cct = (new CephContext(CEPH_ENTITY_TYPE_MON))->get();
+  boost::intrusive_ptr<CephContext> cct = new CephContext(CEPH_ENTITY_TYPE_MON);
   cct->_conf.set_val("mon_dns_srv_name", "cephmon");
   MonMap monmap;
-  int r = monmap.build_initial(cct, false, std::cerr);
+  int r = monmap.build_initial(cct.get(), false, std::cerr);
 
   ASSERT_EQ(r, 0);
-  ASSERT_EQ(monmap.mon_addr.size(), (unsigned int)3);
-  map<string,entity_addr_t>::iterator it = monmap.mon_addr.find("mon.a");
-  ASSERT_NE(it, monmap.mon_addr.end());
+  ASSERT_EQ(monmap.mon_info.size(), (unsigned int)3);
+  auto it = monmap.mon_info.find("mon.a");
+  ASSERT_NE(it, monmap.mon_info.end());
   std::ostringstream os;
-  os << it->second;
+  os << it->second.public_addrs;
   ASSERT_EQ(os.str(), "192.168.1.11:6789/0");
   os.str("");
-  it = monmap.mon_addr.find("mon.b");
-  ASSERT_NE(it, monmap.mon_addr.end());
-  os << it->second;
+  it = monmap.mon_info.find("mon.b");
+  ASSERT_NE(it, monmap.mon_info.end());
+  os << it->second.public_addrs;
   ASSERT_EQ(os.str(), "192.168.1.12:6789/0");
   os.str("");
-  it = monmap.mon_addr.find("mon.c");
-  ASSERT_NE(it, monmap.mon_addr.end());
-  os << it->second;
+  it = monmap.mon_info.find("mon.c");
+  ASSERT_NE(it, monmap.mon_info.end());
+  os << it->second.public_addrs;
   ASSERT_EQ(os.str(), "192.168.1.13:6789/0");
 }
 
-TEST_F(MonMapTest, build_initial_config_from_dns_fail) {
+TEST_F(MonMapTest, DISABLED_build_initial_config_from_dns_fail) {
   MockResolvHWrapper *resolvH = new MockResolvHWrapper();
   DNSResolver::get_instance(resolvH);
 
@@ -133,17 +135,17 @@ TEST_F(MonMapTest, build_initial_config_from_dns_fail) {
       .WillOnce(Return(0));
 #endif
 
-  CephContext *cct = (new CephContext(CEPH_ENTITY_TYPE_MON))->get();
+  boost::intrusive_ptr<CephContext> cct = new CephContext(CEPH_ENTITY_TYPE_MON);
   // using default value of mon_dns_srv_name option
   MonMap monmap;
-  int r = monmap.build_initial(cct, false, std::cerr);
+  int r = monmap.build_initial(cct.get(), false, std::cerr);
 
   ASSERT_EQ(r, -ENOENT);
-  ASSERT_EQ(monmap.mon_addr.size(), (unsigned int)0);
+  ASSERT_EQ(monmap.mon_info.size(), (unsigned int)0);
 
 }
 
-TEST_F(MonMapTest, build_initial_config_from_dns_with_domain) {
+TEST_F(MonMapTest, DISABLED_build_initial_config_from_dns_with_domain) {
 
   MockResolvHWrapper *resolvH = new MockResolvHWrapper();
   DNSResolver::get_instance(resolvH);
@@ -194,27 +196,27 @@ TEST_F(MonMapTest, build_initial_config_from_dns_with_domain) {
 
 
 
-  CephContext *cct = (new CephContext(CEPH_ENTITY_TYPE_MON))->get();
+  boost::intrusive_ptr<CephContext> cct = new CephContext(CEPH_ENTITY_TYPE_MON);
   cct->_conf.set_val("mon_dns_srv_name", "cephmon_ceph.com");
   MonMap monmap;
-  int r = monmap.build_initial(cct, false, std::cerr);
+  int r = monmap.build_initial(cct.get(), false, std::cerr);
 
   ASSERT_EQ(r, 0);
-  ASSERT_EQ(monmap.mon_addr.size(), (unsigned int)3);
-  map<string,entity_addr_t>::iterator it = monmap.mon_addr.find("mon.a");
-  ASSERT_NE(it, monmap.mon_addr.end());
+  ASSERT_EQ(monmap.mon_info.size(), (unsigned int)3);
+  auto it = monmap.mon_info.find("mon.a");
+  ASSERT_NE(it, monmap.mon_info.end());
   std::ostringstream os;
-  os << it->second;
+  os << it->second.public_addrs;
   ASSERT_EQ(os.str(), "192.168.1.11:6789/0");
   os.str("");
-  it = monmap.mon_addr.find("mon.b");
-  ASSERT_NE(it, monmap.mon_addr.end());
-  os << it->second;
+  it = monmap.mon_info.find("mon.b");
+  ASSERT_NE(it, monmap.mon_info.end());
+  os << it->second.public_addrs;
   ASSERT_EQ(os.str(), "192.168.1.12:6789/0");
   os.str("");
-  it = monmap.mon_addr.find("mon.c");
-  ASSERT_NE(it, monmap.mon_addr.end());
-  os << it->second;
+  it = monmap.mon_info.find("mon.c");
+  ASSERT_NE(it, monmap.mon_info.end());
+  os << it->second.public_addrs;
   ASSERT_EQ(os.str(), "192.168.1.13:6789/0");
 }
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47951
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
