### PR TITLE
cmake, rgw: always enable Boost.context

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,11 +357,6 @@ if(WITH_BLKIN)
   include_directories(SYSTEM src/blkin/blkin-lib)
 endif(WITH_BLKIN)
 
-option(WITH_BOOST_CONTEXT "Enable boost::asio stackful coroutines" ON)
-if(WITH_BOOST_CONTEXT)
-  set(HAVE_BOOST_CONTEXT ON)
-endif()
-
 #option for RGW
 option(WITH_RADOSGW "Rados Gateway is enabled" ON)
 option(WITH_RADOSGW_FCGI_FRONTEND "Rados Gateway's FCGI frontend is enabled" OFF)
@@ -374,10 +369,6 @@ if(WITH_RADOSGW)
   find_package(EXPAT REQUIRED)
   if(WITH_RADOSGW_FCGI_FRONTEND)
     find_package(fcgi REQUIRED)
-  endif()
-  if(WITH_RADOSGW_BEAST_FRONTEND AND NOT WITH_BOOST_CONTEXT)
-    message(WARNING "disabling WITH_RADOSGW_BEAST_FRONTEND, which depends on WITH_BOOST_CONTEXT")
-    set(WITH_RADOSGW_BEAST_FRONTEND OFF)
   endif()
   find_package(OATH REQUIRED)
 
@@ -568,15 +559,12 @@ option(WITH_SYSTEM_BOOST "require and build with system Boost" OFF)
 # Boost::thread depends on Boost::atomic, so list it explicitly.
 set(BOOST_COMPONENTS
   atomic chrono thread system regex random program_options date_time
-  iostreams)
+  iostreams context coroutine)
 set(BOOST_HEADER_COMPONENTS container)
 
 if(WITH_MGR)
   list(APPEND BOOST_COMPONENTS
     python${MGR_PYTHON_VERSION_MAJOR}${MGR_PYTHON_VERSION_MINOR})
-endif()
-if(WITH_BOOST_CONTEXT)
-  list(APPEND BOOST_COMPONENTS context coroutine)
 endif()
 if(WITH_SEASTAR)
   list(APPEND BOOST_COMPONENTS filesystem timer)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -593,7 +593,7 @@ if(WITH_SYSTEM_BOOST)
   if(BOOST_ROOT AND CMAKE_LIBRARY_ARCHITECTURE)
     set(BOOST_LIBRARYDIR "${BOOST_ROOT}/lib/${CMAKE_LIBRARY_ARCHITECTURE}")
   endif()
-  find_package(Boost 1.67 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
+  find_package(Boost 1.72 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
   if(NOT ENABLE_SHARED)
     set_property(TARGET Boost::iostreams APPEND PROPERTY
       INTERFACE_LINK_LIBRARIES ZLIB::ZLIB)
@@ -603,7 +603,7 @@ else()
     "max jobs for Boost build") # override w/-DBOOST_J=<n>
   set(Boost_USE_STATIC_LIBS ON)
   include(BuildBoost)
-  build_boost(1.67
+  build_boost(1.72
     COMPONENTS ${BOOST_COMPONENTS} ${BOOST_HEADER_COMPONENTS})
 endif()
 include_directories(BEFORE SYSTEM ${Boost_INCLUDE_DIRS})

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1173,11 +1173,6 @@ ${CMAKE} .. \
 %if 0%{with ocf}
     -DWITH_OCF=ON \
 %endif
-%ifarch aarch64 armv7hl mips mipsel ppc ppc64 ppc64le %{ix86} x86_64 s390x
-    -DWITH_BOOST_CONTEXT=ON \
-%else
-    -DWITH_BOOST_CONTEXT=OFF \
-%endif
 %if 0%{with cephfs_shell}
     -DWITH_CEPHFS_SHELL=ON \
 %endif

--- a/debian/rules
+++ b/debian/rules
@@ -34,13 +34,6 @@ ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
   extraopts += -DBOOST_J=$(NUMJOBS)
 endif
 
-ifneq (,$(filter $(DEB_HOST_ARCH), arm armel armhf arm64 i386 amd64 mips mipsel powerpc ppc64))
-  # libboost_context only support the archs above
-  extraopts += -DWITH_BOOST_CONTEXT=ON
-else
-  extraopts += -DWITH_BOOST_CONTEXT=OFF
-endif
-
 %:
 	dh $@ --buildsystem=cmake --with javahelper,python3,systemd --parallel
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -778,11 +778,9 @@ if(WITH_RBD)
   add_subdirectory(rbd_replay)
 endif(WITH_RBD)
 
-if(WITH_BOOST_CONTEXT)
-  set(SPAWN_BUILD_TESTS OFF CACHE INTERNAL "disable building of spawn unit tests")
-  set(SPAWN_INSTALL OFF CACHE INTERNAL "disable installation of spawn headers")
-  add_subdirectory(spawn)
-endif()
+set(SPAWN_BUILD_TESTS OFF CACHE INTERNAL "disable building of spawn unit tests")
+set(SPAWN_INSTALL OFF CACHE INTERNAL "disable installation of spawn headers")
+add_subdirectory(spawn)
 
 # RadosGW
 if(WITH_KVS)

--- a/src/common/async/yield_context.h
+++ b/src/common/async/yield_context.h
@@ -20,18 +20,7 @@
 
 #include "acconfig.h"
 
-#ifndef HAVE_BOOST_CONTEXT
-
-// hide the dependency on boost::context
-namespace spawn {
-struct yield_context;
-}
-
-#else // HAVE_BOOST_CONTEXT
 #include <spawn/spawn.hpp>
-
-#endif // HAVE_BOOST_CONTEXT
-
 
 /// optional-like wrapper for a spawn::yield_context and its associated
 /// boost::asio::io_context. operations that take an optional_yield argument

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -327,9 +327,6 @@
 /* Defined if getentropy() is available */
 #cmakedefine HAVE_GETENTROPY
 
-/* Defined if boost::context is available */
-#cmakedefine HAVE_BOOST_CONTEXT
-
 /* Defined if libradosstriper is enabled: */
 #cmakedefine WITH_LIBRADOSSTRIPER
 

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -177,10 +177,8 @@ target_include_directories(rgw_common PRIVATE "${CMAKE_SOURCE_DIR}/src/lua/src")
 target_include_directories(rgw_common PRIVATE "${CMAKE_BINARY_DIR}/src/lua")
 
 
-if(WITH_BOOST_CONTEXT)
-  target_include_directories(rgw_common PRIVATE
-    $<TARGET_PROPERTY:spawn,INTERFACE_INCLUDE_DIRECTORIES>)
-endif()
+target_include_directories(rgw_common PRIVATE
+  $<TARGET_PROPERTY:spawn,INTERFACE_INCLUDE_DIRECTORIES>)
 
 if(WITH_LTTNG)
   # rgw/rgw_op.cc includes "tracing/rgw_op.h"
@@ -259,10 +257,7 @@ if(WITH_CURL_OPENSSL)
 endif()
 
 target_link_libraries(rgw_a PRIVATE liblua)
-
-if(WITH_BOOST_CONTEXT)
-  target_link_libraries(rgw_a PUBLIC spawn)
-endif()
+target_link_libraries(rgw_a PUBLIC spawn)
 
 set(rgw_libs rgw_a)
 if(WITH_RADOSGW_AMQP_ENDPOINT)

--- a/src/rgw/rgw_aio.cc
+++ b/src/rgw/rgw_aio.cc
@@ -61,7 +61,6 @@ Aio::OpFunc aio_abstract(Op&& op) {
     };
 }
 
-#ifdef HAVE_BOOST_CONTEXT
 struct Handler {
   Aio* throttle = nullptr;
   AioResult& r;
@@ -93,19 +92,16 @@ Aio::OpFunc aio_abstract(Op&& op, boost::asio::io_context& context,
                               bind_executor(ex, Handler{aio, r}));
     };
 }
-#endif // HAVE_BOOST_CONTEXT
 
 template <typename Op>
 Aio::OpFunc aio_abstract(Op&& op, optional_yield y) {
   static_assert(std::is_base_of_v<librados::ObjectOperation, std::decay_t<Op>>);
   static_assert(!std::is_lvalue_reference_v<Op>);
   static_assert(!std::is_const_v<Op>);
-#ifdef HAVE_BOOST_CONTEXT
   if (y) {
     return aio_abstract(std::forward<Op>(op), y.get_io_context(),
                         y.get_yield_context());
   }
-#endif
   return aio_abstract(std::forward<Op>(op));
 }
 

--- a/src/rgw/rgw_aio_throttle.cc
+++ b/src/rgw/rgw_aio_throttle.cc
@@ -109,8 +109,6 @@ AioResultList BlockingAioThrottle::drain()
   return std::move(completed);
 }
 
-#ifdef HAVE_BOOST_CONTEXT
-
 template <typename CompletionToken>
 auto YieldingAioThrottle::async_wait(CompletionToken&& token)
 {
@@ -201,6 +199,4 @@ AioResultList YieldingAioThrottle::drain()
   }
   return std::move(completed);
 }
-#endif // HAVE_BOOST_CONTEXT
-
 } // namespace rgw

--- a/src/rgw/rgw_aio_throttle.h
+++ b/src/rgw/rgw_aio_throttle.h
@@ -78,7 +78,6 @@ class BlockingAioThrottle final : public Aio, private Throttle {
   AioResultList drain() override final;
 };
 
-#ifdef HAVE_BOOST_CONTEXT
 // a throttle that yields the coroutine instead of blocking. all public
 // functions must be called within the coroutine strand
 class YieldingAioThrottle final : public Aio, private Throttle {
@@ -112,12 +111,10 @@ class YieldingAioThrottle final : public Aio, private Throttle {
 
   AioResultList drain() override final;
 };
-#endif // HAVE_BOOST_CONTEXT
 
 // return a smart pointer to Aio
 inline auto make_throttle(uint64_t window_size, optional_yield y)
 {
-#ifdef HAVE_BOOST_CONTEXT
   std::unique_ptr<Aio> aio;
   if (y) {
     aio = std::make_unique<YieldingAioThrottle>(window_size,
@@ -127,9 +124,6 @@ inline auto make_throttle(uint64_t window_size, optional_yield y)
     aio = std::make_unique<BlockingAioThrottle>(window_size);
   }
   return aio;
-#else
-  return std::make_optional<BlockingAioThrottle>(window_size);
-#endif
 }
 
 } // namespace rgw

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -74,7 +74,6 @@ struct rgw_http_req_data : public RefCountedObject {
     if (done) {
       return ret;
     }
-#ifdef HAVE_BOOST_CONTEXT
     if (y) {
       auto& context = y.get_io_context();
       auto& yield = y.get_yield_context();
@@ -86,7 +85,6 @@ struct rgw_http_req_data : public RefCountedObject {
     if (is_asio_thread) {
       dout(20) << "WARNING: blocking http request" << dendl;
     }
-#endif
     std::unique_lock l{lock};
     cond.wait(l, [this]{return done==true;});
     return ret;

--- a/src/rgw/rgw_pubsub_push.cc
+++ b/src/rgw/rgw_pubsub_push.cc
@@ -350,15 +350,13 @@ public:
       if (done) {
         return ret;
       }
-#ifdef HAVE_BOOST_CONTEXT
       if (y) {
-        auto& io_ctx = y.get_io_context();
+	auto& io_ctx = y.get_io_context();
         auto& yield_ctx = y.get_yield_context();
         boost::system::error_code ec;
         async_wait(io_ctx, yield_ctx[ec]);
         return -ec.value();
       }
-#endif
       std::unique_lock l(lock);
       cond.wait(l, [this]{return (done==true);});
       return ret;
@@ -622,7 +620,6 @@ public:
       if (done) {
         return ret;
       }
-#ifdef HAVE_BOOST_CONTEXT
       if (y) {
         auto& io_ctx = y.get_io_context();
         auto& yield_ctx = y.get_yield_context();
@@ -630,7 +627,6 @@ public:
         async_wait(io_ctx, yield_ctx[ec]);
         return -ec.value();
       }
-#endif
       std::unique_lock l(lock);
       cond.wait(l, [this]{return (done==true);});
       return ret;

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -938,7 +938,6 @@ int RGWReshardWait::wait(optional_yield y)
     return -ECANCELED;
   }
 
-#ifdef HAVE_BOOST_CONTEXT
   if (y) {
     auto& context = y.get_io_context();
     auto& yield = y.get_yield_context();
@@ -956,7 +955,6 @@ int RGWReshardWait::wait(optional_yield y)
     waiters.erase(waiters.iterator_to(waiter));
     return -ec.value();
   }
-#endif
 
   cond.wait_for(lock, duration);
 

--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -250,7 +250,6 @@ int rgw_rados_operate(librados::IoCtx& ioctx, const std::string& oid,
                       librados::ObjectReadOperation *op, bufferlist* pbl,
                       optional_yield y, int flags)
 {
-#ifdef HAVE_BOOST_CONTEXT
   // given a yield_context, call async_operate() to yield the coroutine instead
   // of blocking
   if (y) {
@@ -268,7 +267,6 @@ int rgw_rados_operate(librados::IoCtx& ioctx, const std::string& oid,
   if (is_asio_thread) {
     dout(20) << "WARNING: blocking librados call" << dendl;
   }
-#endif
   return ioctx.operate(oid, op, nullptr, flags);
 }
 
@@ -276,7 +274,6 @@ int rgw_rados_operate(librados::IoCtx& ioctx, const std::string& oid,
                       librados::ObjectWriteOperation *op, optional_yield y,
 		      int flags)
 {
-#ifdef HAVE_BOOST_CONTEXT
   if (y) {
     auto& context = y.get_io_context();
     auto& yield = y.get_yield_context();
@@ -287,7 +284,6 @@ int rgw_rados_operate(librados::IoCtx& ioctx, const std::string& oid,
   if (is_asio_thread) {
     dout(20) << "WARNING: blocking librados call" << dendl;
   }
-#endif
   return ioctx.operate(oid, op, flags);
 }
 
@@ -295,7 +291,6 @@ int rgw_rados_notify(librados::IoCtx& ioctx, const std::string& oid,
                      bufferlist& bl, uint64_t timeout_ms, bufferlist* pbl,
                      optional_yield y)
 {
-#ifdef HAVE_BOOST_CONTEXT
   if (y) {
     auto& context = y.get_io_context();
     auto& yield = y.get_yield_context();
@@ -310,7 +305,6 @@ int rgw_rados_notify(librados::IoCtx& ioctx, const std::string& oid,
   if (is_asio_thread) {
     dout(20) << "WARNING: blocking librados call" << dendl;
   }
-#endif
   return ioctx.notify2(oid, bl, timeout_ms, pbl);
 }
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -8,9 +8,7 @@ target_include_directories(unit-main PRIVATE
   $<TARGET_PROPERTY:GTest::GTest,INTERFACE_INCLUDE_DIRECTORIES>)
 
 add_subdirectory(cls_hello)
-if(WITH_BOOST_CONTEXT)
 add_subdirectory(cls_fifo)
-endif()
 add_subdirectory(cls_lock)
 add_subdirectory(cls_cas)
 add_subdirectory(cls_log)
@@ -294,10 +292,7 @@ target_link_libraries(ceph_test_librgw_file_nfsns
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
   )
-if(WITH_BOOST_CONTEXT)
   target_link_libraries(ceph_test_librgw_file_nfsns spawn)
-endif()
-
 
 # ceph_test_librgw_file_aw (nfs write transaction [atomic write] tests)
 add_executable(ceph_test_librgw_file_aw
@@ -323,9 +318,7 @@ target_link_libraries(ceph_test_librgw_file_marker
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
   )
-if(WITH_BOOST_CONTEXT)
   target_link_libraries(ceph_test_librgw_file_marker spawn)
-endif()
 
 # ceph_test_rgw_token
 add_executable(ceph_test_rgw_token

--- a/src/test/cls_fifo/CMakeLists.txt
+++ b/src/test/cls_fifo/CMakeLists.txt
@@ -1,4 +1,3 @@
-if(WITH_BOOST_CONTEXT)
 add_executable(ceph_test_cls_fifo
   test_cls_fifo.cc
   )
@@ -37,4 +36,3 @@ target_link_libraries(ceph_bench_cls_fifo
 install(TARGETS
   ceph_test_cls_fifo
   DESTINATION ${CMAKE_INSTALL_BINDIR})
-endif()

--- a/src/test/librados/CMakeLists.txt
+++ b/src/test/librados/CMakeLists.txt
@@ -60,10 +60,7 @@ target_link_libraries(ceph_test_rados_api_aio_pp
 
 add_executable(ceph_test_rados_api_asio asio.cc)
 target_link_libraries(ceph_test_rados_api_asio global
-  librados ${UNITTEST_LIBS})
-if(WITH_BOOST_CONTEXT)
-  target_link_libraries(ceph_test_rados_api_asio Boost::coroutine Boost::context)
-endif()
+  librados ${UNITTEST_LIBS} Boost::coroutine Boost::context)
 
 add_executable(ceph_test_rados_api_list
   list.cc
@@ -132,10 +129,8 @@ add_executable(ceph_test_rados_api_tier_pp
   tier_cxx.cc
   $<TARGET_OBJECTS:unit-main>)
 target_link_libraries(ceph_test_rados_api_tier_pp
-  librados global ${UNITTEST_LIBS} Boost::system radostest-cxx cls_cas_internal)
-if(WITH_BOOST_CONTEXT)
-  target_link_libraries(ceph_test_rados_api_tier_pp spawn)
-endif()
+  librados global ${UNITTEST_LIBS} Boost::system radostest-cxx cls_cas_internal
+  spawn)
 
 add_executable(ceph_test_rados_api_snapshots
   snapshots.cc)

--- a/src/test/librados/asio.cc
+++ b/src/test/librados/asio.cc
@@ -19,12 +19,10 @@
 #include "common/errno.h"
 #include "global/global_init.h"
 
-#ifdef HAVE_BOOST_CONTEXT
 #define BOOST_COROUTINES_NO_DEPRECATION_WARNING
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/asio/spawn.hpp>
-#endif
 #include <boost/asio/use_future.hpp>
 
 #define dout_subsys ceph_subsys_rados
@@ -109,7 +107,6 @@ TEST_F(AsioRados, AsyncReadFuture)
   EXPECT_THROW(f2.get(), boost::system::system_error);
 }
 
-#ifdef HAVE_BOOST_CONTEXT
 TEST_F(AsioRados, AsyncReadYield)
 {
   boost::asio::io_service service;
@@ -131,7 +128,6 @@ TEST_F(AsioRados, AsyncReadYield)
 
   service.run();
 }
-#endif
 
 TEST_F(AsioRados, AsyncWriteCallback)
 {
@@ -173,7 +169,6 @@ TEST_F(AsioRados, AsyncWriteFuture)
   EXPECT_THROW(f2.get(), boost::system::system_error);
 }
 
-#ifdef HAVE_BOOST_CONTEXT
 TEST_F(AsioRados, AsyncWriteYield)
 {
   boost::asio::io_service service;
@@ -200,7 +195,6 @@ TEST_F(AsioRados, AsyncWriteYield)
 
   service.run();
 }
-#endif
 
 TEST_F(AsioRados, AsyncReadOperationCallback)
 {
@@ -251,7 +245,6 @@ TEST_F(AsioRados, AsyncReadOperationFuture)
   EXPECT_THROW(f2.get(), boost::system::system_error);
 }
 
-#ifdef HAVE_BOOST_CONTEXT
 TEST_F(AsioRados, AsyncReadOperationYield)
 {
   boost::asio::io_service service;
@@ -279,7 +272,6 @@ TEST_F(AsioRados, AsyncReadOperationYield)
 
   service.run();
 }
-#endif
 
 TEST_F(AsioRados, AsyncWriteOperationCallback)
 {
@@ -334,7 +326,6 @@ TEST_F(AsioRados, AsyncWriteOperationFuture)
   EXPECT_THROW(f2.get(), boost::system::system_error);
 }
 
-#ifdef HAVE_BOOST_CONTEXT
 TEST_F(AsioRados, AsyncWriteOperationYield)
 {
   boost::asio::io_service service;
@@ -362,7 +353,6 @@ TEST_F(AsioRados, AsyncWriteOperationYield)
 
   service.run();
 }
-#endif
 
 int main(int argc, char **argv)
 {

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -164,10 +164,8 @@ add_executable(unittest_rgw_dmclock_scheduler test_rgw_dmclock_scheduler.cc $<TA
 add_ceph_unittest(unittest_rgw_dmclock_scheduler)
 
 target_link_libraries(unittest_rgw_dmclock_scheduler rgw_schedulers global ${UNITTEST_LIBS})
-if(WITH_BOOST_CONTEXT)
-  target_compile_definitions(unittest_rgw_dmclock_scheduler PRIVATE BOOST_COROUTINES_NO_DEPRECATION_WARNING)
-  target_link_libraries(unittest_rgw_dmclock_scheduler Boost::coroutine Boost::context)
-endif()
+target_compile_definitions(unittest_rgw_dmclock_scheduler PRIVATE BOOST_COROUTINES_NO_DEPRECATION_WARNING)
+target_link_libraries(unittest_rgw_dmclock_scheduler Boost::coroutine Boost::context)
 
 if(WITH_RADOSGW_AMQP_ENDPOINT)
   add_executable(unittest_rgw_amqp test_rgw_amqp.cc)

--- a/src/test/rgw/test_rgw_dmclock_scheduler.cc
+++ b/src/test/rgw/test_rgw_dmclock_scheduler.cc
@@ -18,9 +18,7 @@
 #include "rgw/rgw_dmclock_async_scheduler.h"
 
 #include <optional>
-#ifdef HAVE_BOOST_CONTEXT
 #include <boost/asio/spawn.hpp>
-#endif
 #include <gtest/gtest.h>
 #include "acconfig.h"
 #include "global/global_context.h"
@@ -78,7 +76,6 @@ TEST(Queue, SyncRequest)
   EXPECT_EQ(0u, counters(client_id::auth)->get(queue_counters::l_cancel));
 }
 
-#ifdef HAVE_BOOST_CONTEXT
 TEST(Queue, RateLimit)
 {
   boost::asio::io_context context;
@@ -427,7 +424,5 @@ TEST(Queue, SpawnAsyncRequest)
   context.poll();
   EXPECT_TRUE(context.stopped());
 }
-
-#endif
 
 } // namespace rgw::dmclock

--- a/src/test/rgw/test_rgw_reshard_wait.cc
+++ b/src/test/rgw/test_rgw_reshard_wait.cc
@@ -13,9 +13,7 @@
  */
 
 #include "rgw/rgw_reshard.h"
-#ifdef HAVE_BOOST_CONTEXT
 #include <spawn/spawn.hpp>
-#endif
 
 #include <gtest/gtest.h>
 
@@ -60,7 +58,6 @@ TEST(ReshardWait, stop_block)
   short_waiter.stop();
 }
 
-#ifdef HAVE_BOOST_CONTEXT
 TEST(ReshardWait, wait_yield)
 {
   constexpr ceph::timespan wait_duration = 50ms;
@@ -165,4 +162,3 @@ TEST(ReshardWait, stop_multiple)
   EXPECT_GT(long_duration, elapsed); // waited less than 10s
   short_waiter.stop();
 }
-#endif // HAVE_BOOST_CONTEXT

--- a/src/test/rgw/test_rgw_throttle.cc
+++ b/src/test/rgw/test_rgw_throttle.cc
@@ -18,9 +18,7 @@
 #include <thread>
 #include "include/scope_guard.h"
 
-#ifdef HAVE_BOOST_CONTEXT
 #include <spawn/spawn.hpp>
-#endif
 #include <gtest/gtest.h>
 
 struct RadosEnv : public ::testing::Environment {
@@ -166,7 +164,6 @@ TEST_F(Aio_Throttle, ThrottleOverMax)
   EXPECT_EQ(window, max_outstanding);
 }
 
-#ifdef HAVE_BOOST_CONTEXT
 TEST_F(Aio_Throttle, YieldCostOverWindow)
 {
   auto obj = make_obj(__PRETTY_FUNCTION__);
@@ -216,6 +213,5 @@ TEST_F(Aio_Throttle, YieldingThrottleOverMax)
   EXPECT_EQ(0u, outstanding);
   EXPECT_EQ(window, max_outstanding);
 }
-#endif // HAVE_BOOST_CONTEXT
 
 } // namespace rgw

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -16,16 +16,16 @@ else()
 endif()
 install(TARGETS rados DESTINATION bin)
 
-if(WITH_BOOST_CONTEXT AND NOT WIN32)
+if(NOT WIN32)
 set(neorados_srcs
   neorados.cc)
 add_executable(neorados ${neorados_srcs})
 target_include_directories(neorados PRIVATE
   $<TARGET_PROPERTY:spawn,INTERFACE_INCLUDE_DIRECTORIES>)
+endif()
 
 target_link_libraries(neorados libneorados spawn ${CMAKE_DL_LIBS})
 #install(TARGETS neorados DESTINATION bin)
-endif()
 
 if(WITH_TESTS)
 add_executable(ceph_scratchtool scratchtool.c)


### PR DESCRIPTION
As Boost.Context supports s390 as of 1.72, bump Boost dependency to that version and remove conditional compilation around coroutines.