### PR TITLE
msg: add min delay packets support for mons

### DIFF
--- a/src/common/options/mon.yaml.in
+++ b/src/common/options/mon.yaml.in
@@ -1321,3 +1321,11 @@ options:
   services:
   - mon
   with_legacy: true
+- name: mon_use_min_delay_socket
+  type: bool
+  level: advanced
+  default: false
+  desc: priority packets between mons
+  with_legacy: true
+  see_also:
+  - osd_heartbeat_use_min_delay_socket

--- a/src/msg/async/PosixStack.cc
+++ b/src/msg/async/PosixStack.cc
@@ -206,6 +206,9 @@ class PosixConnectedSocketImpl final : public ConnectedSocketImpl {
   void close() override {
     compat_closesocket(_fd);
   }
+  void set_priority(int sd, int prio, int domain) override {
+    handler.set_priority(sd, prio, domain);
+  }
   int fd() const override {
     return _fd;
   }

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -32,6 +32,7 @@ class ConnectedSocketImpl {
   virtual void shutdown() = 0;
   virtual void close() = 0;
   virtual int fd() const = 0;
+  virtual void set_priority(int sd, int prio, int domain) = 0;
 };
 
 class ConnectedSocket;
@@ -121,6 +122,10 @@ class ConnectedSocket {
   /// Get file descriptor
   int fd() const {
     return _csi->fd();
+  }
+
+  void set_priority(int sd, int prio, int domain) {
+    _csi->set_priority(sd, prio, domain);
   }
 
   explicit operator bool() const {

--- a/src/msg/async/dpdk/DPDKStack.h
+++ b/src/msg/async/dpdk/DPDKStack.h
@@ -47,6 +47,7 @@ class DPDKServerSocketImpl : public ServerSocketImpl {
   virtual int fd() const override {
     return _listener.fd();
   }
+  virtual void set_priority(int sd, int prio, int domain) override {}
 };
 
 // NativeConnectedSocketImpl

--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -573,6 +573,11 @@ void RDMAConnectedSocketImpl::close()
   active = false;
 }
 
+void RDMAConnectedSocketImpl::set_priority(int sd, int prio, int domain) {
+    ceph::NetHandler net(cct);
+    net.set_priority(sd, prio, domain);
+}
+
 void RDMAConnectedSocketImpl::fault()
 {
   ldout(cct, 1) << __func__ << " tcp fd " << tcp_fd << dendl;

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -218,6 +218,7 @@ class RDMAConnectedSocketImpl : public ConnectedSocketImpl {
   virtual void shutdown() override;
   virtual void close() override;
   virtual int fd() const override { return notify_fd; }
+  virtual void set_priority(int sd, int prio, int domain) override;
   void fault();
   const char* get_qp_state() { return Infiniband::qp_state_string(qp->get_state()); }
   uint32_t get_peer_qpn () const { return peer_qpn; }


### PR DESCRIPTION
make packets between mons support DSCP (TOS)，just like osd heartbeat

when suffering network bottleneck, like switch qos control for only 50Mbps,
mon cluster may stuck in electing for long time and elects again and again, which intrduces many troubles, like it's hard to find where the problem is. even more worse, it may lead to IO hang when one osd can't serve IO. so it's better to keep mon cluster stable always.

Signed-off-by: Song Shun <song.shun3@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
