### PR TITLE
mgr/dashboard: Removing the black border on the text/input field when its clicked

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_forms.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_forms.scss
@@ -18,7 +18,7 @@
 
   &:focus {
     border-color: rgba(vv.$primary, 0.8);
-    box-shadow: inset 0 1px 1px rgba(vv.$black, 0.75), 0 0 8px 2px rgba(vv.$primary, 0.5);
+    box-shadow: 0 0 3px 2px rgba(vv.$primary, 0.5);
     outline: 0;
   }
 }


### PR DESCRIPTION

After:
![after](https://user-images.githubusercontent.com/71764184/96986653-91e8ad00-153f-11eb-8ce7-90435634d224.png)

Before:
![beforetxt](https://user-images.githubusercontent.com/71764184/96986660-9319da00-153f-11eb-8870-d396d17d1718.png)



Resolves: https://tracker.ceph.com/issues/47967
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
