### PR TITLE
do_cmake.sh: use python-3.9 with fedora version 33

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -17,8 +17,10 @@ if [ -r /etc/os-release ]; then
   case "$ID" in
       fedora)
           PYBUILD="3.7"
-          if [ "$VERSION_ID" -ge "32" ] ; then
+          if [ "$VERSION_ID" -eq "32" ] ; then
               PYBUILD="3.8"
+          elif [ "$VERSION_ID" -ge "33" ] ; then
+              PYBUILD="3.9"
           fi
           ;;
       rhel|centos)


### PR DESCRIPTION
Fedora-33 (rawhide) now has python-3.9.
Build breaks on Fedoa-33 with Traceback:
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:165 (message):
Could NOT find Python3: Found unsuitable version "3.9.0", but required is
exact version "3.8" (found /usr/bin/python3, found components: Interpreter
Development)
    
Fixes: https://tracker.ceph.com/issues/47971
Signed-off-by: Sunny Kumar <sunkumar@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
