### PR TITLE
cephfs: Fix variable declartion in capture list in lambda

### DIFF
--- a/src/tools/cephfs_mirror/Mirror.cc
+++ b/src/tools/cephfs_mirror/Mirror.cc
@@ -526,7 +526,8 @@ void Mirror::run() {
   for (auto &[filesystem, mirror_action] : m_mirror_actions) {
     dout(10) << ": trying to shutdown filesystem=" << filesystem << dendl;
     // wait for in-progress action and shutdown
-    m_cond.wait(locker, [this, &mirror_action] {return !mirror_action.action_in_progress;});
+    m_cond.wait(locker, [&mirror_action=mirror_action] 
+                {return !mirror_action.action_in_progress;});
     if (mirror_action.fs_mirror &&
         !mirror_action.fs_mirror->is_stopping() &&
         !mirror_action.fs_mirror->is_failed()) {


### PR DESCRIPTION
/home/jenkins/workspace/ceph-master-compile/src/tools/cephfs_mirror/Mirror.cc:529:33: error: 'mirror_action' in capture list does not name a variable
    m_cond.wait(locker, [this, &mirror_action] {return !mirror_action.action_in_progress;});
                                ^
/home/jenkins/workspace/ceph-master-compile/src/tools/cephfs_mirror/Mirror.cc:529:57: error: reference to local binding 'mirror_action' declared in enclosing function 'cephfs::mirror::Mirror::run'
    m_cond.wait(locker, [this, &mirror_action] {return !mirror_action.action_in_progress;});
                                                        ^
/home/jenkins/workspace/ceph-master-compile/src/tools/cephfs_mirror/Mirror.cc:526:27: note: 'mirror_action' declared here
  for (auto &[filesystem, mirror_action] : m_mirror_actions) {
                          ^
/home/jenkins/workspace/ceph-master-compile/src/tools/cephfs_mirror/Mirror.cc:529:26: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
    m_cond.wait(locker, [this, &mirror_action] {return !mirror_action.action_in_progress;});
                         ^~~~
1 warning and 2 errors generated.

Tracker: https://tracker.ceph.com/issues/47973
Fixes: https://github.com/ceph/ceph/pull/37313


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>