### PR TITLE
mds: use proper gather for inode commit ops

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -1328,11 +1328,11 @@ struct C_IO_Inode_CommitBacktrace : public Context {
   C_IO_Inode_CommitBacktrace(CInode *i, version_t v, MDSContext *f) :
     in(i), version(v), fin(f) { }
   void finish(int r) override {
-    in->_commit_ops(r, version, fin, ops_vec, &bt);
+    in->_commit_ops(r, fin, ops_vec, &bt);
   }
 };
 
-void CInode::_commit_ops(int r, version_t version, MDSContext *fin,
+void CInode::_commit_ops(int r, Context *fin,
                          std::vector<CInodeCommitOperation> &ops_vec,
                          inode_backtrace_t *bt)
 {
@@ -1343,11 +1343,7 @@ void CInode::_commit_ops(int r, version_t version, MDSContext *fin,
     return;
   }
 
-  C_GatherBuilder gather(g_ceph_context,
-                         new C_OnFinisher(new C_IO_Inode_StoredBacktrace(this,
-                                                                         version,
-                                                                         fin),
-                         mdcache->mds->finisher));
+  C_GatherBuilder gather(g_ceph_context, fin);
 
   SnapContext snapc;
   object_t oid = get_object_name(ino(), frag_t(), "");

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -791,7 +791,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   void fetch(MDSContext *fin);
   void _fetched(ceph::buffer::list& bl, ceph::buffer::list& bl2, Context *fin);  
 
-  void _commit_ops(int r, version_t version, MDSContext *fin,
+  void _commit_ops(int r, Context *fin,
                    std::vector<CInodeCommitOperation> &ops_vec,
                    inode_backtrace_t *bt);
   void build_backtrace(int64_t pool, inode_backtrace_t& bt);

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -86,7 +86,7 @@ struct BatchCommitBacktrace : public Context {
     MDSGatherBuilder gather(g_ceph_context);
 
     for (auto &op : ops_vec) {
-      op.in->_commit_ops(r, op.version, gather.new_sub(), op.ops_vec, &op.bt);
+      op.in->_commit_ops(r, gather.new_sub(), op.ops_vec, &op.bt);
     }
     if (gather.has_subs()) {
       gather.set_finisher(new BatchStoredBacktrace(con, mds));


### PR DESCRIPTION
Improve CInode::_commit_ops.
MDS journal handles inodes concurrently by CInode::_commit_ops, fin is C_Gather, so no need to create new C_OnFinisher in gather, and fin can be Context rather than MDSContext to avoid unnecessary MDS lock.

Fixes: https://tracker.ceph.com/issues/47983
Signed-off-by: Erqi Chen <chenerqi@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
