### PR TITLE
octopus: rgw: fix user stats iterative increment

### DIFF
--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -177,7 +177,7 @@ int RGWRadosBucket::read_bucket_stats(optional_yield y)
 
 int RGWRadosBucket::sync_user_stats()
 {
-      return store->ctl()->bucket->sync_user_stats(user.info.user_id, info, &ent);
+      return store->ctl()->bucket->sync_user_stats(user.info.user_id, info);
 }
 
 int RGWRadosBucket::update_container_stats(void)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47037

---

backport of https://github.com/ceph/ceph/pull/36542
parent tracker: https://tracker.ceph.com/issues/46400

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh