### PR TITLE
common/config: do not expand the pid for socket admin

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -1218,7 +1218,12 @@ Option::value_t md_config_t::_expand_meta(
       } else if (var == "id") {
 	out += values.name.get_id();
       } else if (var == "pid") {
-	out += stringify(getpid());
+        char *_pid = getenv("PID");
+        if (_pid) {
+          out += _pid;
+        } else {
+          out += stringify(getpid());
+        }
         if (o) {
           may_reexpand_meta.push_back(o->name);
         }

--- a/src/test/cli/ceph-conf/show-config-value.t
+++ b/src/test/cli/ceph-conf/show-config-value.t
@@ -8,13 +8,32 @@
   $ ceph-conf -n osd.0 --show-config-value INVALID -c /dev/null
   failed to get config option 'INVALID': option not found
   [1]
-  $ echo '[global]' > $TESTDIR/ceph.conf
-  $ echo 'mon_host=$public_network' >> $TESTDIR/ceph.conf
-  $ echo 'public_network=$mon_host' >> $TESTDIR/ceph.conf
+
+  $ cat > $TESTDIR/ceph.conf <<EOF
+  > [global]
+  >     mon_host = \$public_network
+  >     public_network = \$mon_host
+  > EOF
   $ ceph-conf --show-config-value mon_host -c $TESTDIR/ceph.conf
   variable expansion loop at mon_host=$public_network
   expansion stack:
   public_network=$mon_host
   mon_host=$public_network
   $mon_host
+  $ rm $TESTDIR/ceph.conf
+
+Name option test to strip the PID
+=================================
+  $ cat > $TESTDIR/ceph.conf <<EOF
+  > [client]
+  >     admin socket = \$name.\$pid.asok
+  > [global]
+  >     admin socket = \$name.asok
+  > EOF
+  $ ceph-conf --name client.admin.133423 --show-config-value admin_socket -c $TESTDIR/ceph.conf
+  client.admin.133423.asok
+  $ ceph-conf --name mds.a --show-config-value admin_socket -c $TESTDIR/ceph.conf
+  mds.a.asok
+  $ ceph-conf --name osd.0 --show-config-value admin_socket -c $TESTDIR/ceph.conf
+  osd.0.asok
   $ rm $TESTDIR/ceph.conf

--- a/src/tools/ceph_conf.cc
+++ b/src/tools/ceph_conf.cc
@@ -163,6 +163,47 @@ static int dump_all(const string& format)
   }
 }
 
+bool is_name_pid(std::string name, std::string& id)
+{
+  if (id.empty()) {
+    return false;
+  }
+  static const char* daemon_types[] = {"mon", "osd", "mds", "mgr"};
+  if (std::find(std::begin(daemon_types), std::end(daemon_types), name) !=
+      std::end(daemon_types)) {
+    // only override name and pid for non-daemon names
+    return false;
+  }
+  try {
+    std::stoi(id);
+  } catch (const std::logic_error&) {
+    // only override pid for $id which looks like pid
+    return false;
+  }
+  return true;
+}
+
+std::pair<std::string, std::string>
+maybe_override_name_pid(vector<const char*> args)
+{
+  for (auto i = args.begin(); i != args.end(); ++i) {
+    string val;
+    if (ceph_argparse_witharg(args, i, &val, "--name", "-n", (char*)NULL)) {
+      size_t dot_pos = val.rfind('.');
+      if (dot_pos != val.npos) {
+	string name = val.substr(0, dot_pos);
+	string id = val.substr(dot_pos + 1);
+        if (is_name_pid(name, id)) {
+          // override name
+          return {name, id};
+        }
+      }
+      return {val, ""};
+    }
+  }
+  return {};
+}
+
 int main(int argc, const char **argv)
 {
   vector<const char*> args;
@@ -176,8 +217,19 @@ int main(int argc, const char **argv)
   std::string dump_format;
 
   argv_to_vec(argc, argv, args);
+
   auto orig_args = args;
   auto cct = [&args] {
+    // override the name and PID for non-daemon names
+    auto [name, pid] = maybe_override_name_pid(args);
+    if (!name.empty()) {
+      // push the name option back
+      args.push_back("--name");
+      args.push_back(name.c_str());
+    }
+    if (!pid.empty()) {
+      setenv("PID", pid.c_str(), 1);
+    }
     std::map<std::string,std::string> defaults = {{"log_to_file", "false"}};
     return global_init(&defaults, args, CEPH_ENTITY_TYPE_CLIENT,
 		       CODE_ENVIRONMENT_DAEMON,


### PR DESCRIPTION
For the 'admin_socket' in ceph.conf, if the $pid is specified, for
the daemon it will expanded to the actual daemon PID and then as
the admin socket. But if we use the 'ceph-conf' tool to parse the
admin_socket path again by using:

$ ceph-conf --name client.admin.133423 --show-config-value admin_socket

The --name has already included the daemon PID, but the 'ceph-conf'
will expand the '$pid' again, which is incorrect.

Fixes: https://tracker.ceph.com/issues/47977
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
