### PR TITLE
mgr/cephadm: many-to-many Prometheus error

### DIFF
--- a/src/pybind/mgr/cephadm/templates/services/prometheus/prometheus.yml.j2
+++ b/src/pybind/mgr/cephadm/templates/services/prometheus/prometheus.yml.j2
@@ -14,13 +14,12 @@ alerting:
 {% endif %}
 scrape_configs:
   - job_name: 'ceph'
+    honor_labels: true
     static_configs:
     - targets:
 {% for mgr in mgr_scrape_list %}
       - '{{ mgr }}'
 {% endfor %}
-      labels:
-        instance: 'ceph_cluster'
 {% if nodes %}
   - job_name: 'node'
     static_configs:


### PR DESCRIPTION
Fix configuration created by cephadm to prevent any "many-to-many
matching not allowed: matching labels must be unique on one side"
issues. The mgr/prometheus exporter exports suitable instance labels
itself, which can be taken over when `honor_labels` in Prometheus is set
to `true`.

Fixes: https://tracker.ceph.com/issues/47997

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
