### PR TITLE
nautilus: bluestore: provide a different name for fallback allocator

### DIFF
--- a/src/os/bluestore/HybridAllocator.cc
+++ b/src/os/bluestore/HybridAllocator.cc
@@ -204,7 +204,7 @@ void HybridAllocator::_spillover_range(uint64_t start, uint64_t end)
     bmap_alloc = new BitmapAllocator(cct,
       get_capacity(),
       get_block_size(),
-      get_name());
+      get_name() + ".fallback");
   }
   bmap_alloc->init_add_free(start, size);
 }


### PR DESCRIPTION
Originally primary Hybrid allocator provided its own name when creating a
secondary fallback allocator. This resulted in duplicate admin socket
command registrations for both allocator. Registration return code was
ignored and henoe nobody was aware of the issue. Nautilus might suffer
from the issue though since it asserts on command deregistration failure.
And duplicate name causes such a failure for the secode
unregister_command() call.

Fixes: https://tracker.ceph.com/issues/47672

Signed-off-by: Igor Fedotov <ifedotov@suse.com>
(cherry picked from commit b0866b60461b06e6563cad47d0ad3ce9302114f5)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
