### PR TITLE
DNM: Optional Yield Completions

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -101,7 +101,9 @@ set(common_srcs
   pretty_binary.cc
   utf8.c
   util.cc
-  version.cc)
+  version.cc
+  async/yield_context.cc
+  )
 
 if(WIN32)
   list(APPEND common_srcs
@@ -152,6 +154,8 @@ target_compile_definitions(common-common-objs PRIVATE
   "CEPH_LIBDIR=\"${CMAKE_INSTALL_FULL_LIBDIR}\""
   "CEPH_PKGLIBDIR=\"${CEPH_INSTALL_FULL_PKGLIBDIR}\""
   "CEPH_DATADIR=\"${CEPH_INSTALL_DATADIR}\"")
+target_include_directories(common-common-objs PRIVATE
+  $<TARGET_PROPERTY:spawn,INTERFACE_INCLUDE_DIRECTORIES>)
 
 set(common_mountcephfs_srcs
   armor.c

--- a/src/common/async/yield_context.cc
+++ b/src/common/async/yield_context.cc
@@ -1,0 +1,20 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020 Red Hat, Inc
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "common/async/yield_context.h"
+
+// Well, foo.
+
+std::mutex optional_yield::lock;
+std::function<void()> optional_yield::checker = nullptr;

--- a/src/common/async/yield_context.h
+++ b/src/common/async/yield_context.h
@@ -14,9 +14,16 @@
 
 #pragma once
 
+#include <mutex>
+#include <variant>
+
 #include <boost/range/begin.hpp>
 #include <boost/range/end.hpp>
 #include <boost/asio/io_context.hpp>
+#include <boost/asio/async_result.hpp>
+#include <boost/system/error_code.hpp>
+
+#include "common/async/blocked_completion.h"
 
 #include "acconfig.h"
 
@@ -27,27 +34,180 @@
 /// will, when passed a non-empty yield context, suspend this coroutine instead
 /// of the blocking the thread of execution
 class optional_yield {
-  boost::asio::io_context *c = nullptr;
-  spawn::yield_context *y = nullptr;
+  static std::mutex lock;
+  static std::function<void()> checker;
+
+  using cy = std::pair<boost::asio::io_context*, spawn::yield_context>;
+
+  std::variant<cy, ceph::async::use_blocked_t> v;
  public:
   /// construct with a valid io and yield_context
   explicit optional_yield(boost::asio::io_context& c,
-                          spawn::yield_context& y) noexcept
-    : c(&c), y(&y) {}
+                          const spawn::yield_context& y) noexcept
+    : v(cy(&c, y)) {}
 
   /// type tag to construct an empty object
-  struct empty_t {};
-  optional_yield(empty_t) noexcept {}
+  struct empty_t {
+    optional_yield operator[](boost::system::error_code& ec) const noexcept {
+      auto y = optional_yield(empty_t{});
+      std::get<ceph::async::use_blocked_t>(y.v) = ceph::async::use_blocked[ec];
+      return y;
+    }
+  };
+  optional_yield(empty_t) noexcept
+    : v(ceph::async::use_blocked) {}
+
+
+  optional_yield(const optional_yield&) = default;
+  optional_yield& operator =(const optional_yield& rhs) {
+    // Hideous way to get around types with references having no copy
+    // assignment operators.
+    v.~variant<cy, ceph::async::use_blocked_t>();
+    new (&v) std::variant<cy, ceph::async::use_blocked_t>(rhs.v);
+    return *this;
+  }
+  optional_yield(optional_yield&&) = default;
+  optional_yield& operator =(optional_yield&& rhs) {
+    v.~variant<cy, ceph::async::use_blocked_t>();
+    new (&v) std::variant<cy, ceph::async::use_blocked_t>(std::move(rhs.v));
+    return *this;
+  }
 
   /// implicit conversion to bool, returns true if non-empty
-  operator bool() const noexcept { return y; }
+  operator bool() const noexcept {
+    return std::holds_alternative<cy>(v);
+  }
+
+  /// Bind an error code to the completion
+  optional_yield operator[](boost::system::error_code& ec) const noexcept {
+    if (*this) {
+      auto y = std::get<cy>(v).second[ec];
+      return optional_yield(get_io_context(), y);
+    } else {
+      return empty_t{}[ec];
+    }
+  }
 
   /// return a reference to the associated io_context. only valid if non-empty
-  boost::asio::io_context& get_io_context() const noexcept { return *c; }
+  boost::asio::io_context& get_io_context() const noexcept {
+    return *std::get<cy>(v).first;
+  }
 
   /// return a reference to the yield_context. only valid if non-empty
-  spawn::yield_context& get_yield_context() const noexcept { return *y; }
+  spawn::yield_context& get_yield_context() noexcept {
+    return std::get<cy>(v).second;
+  };
+
+  /// Get blocking continuation, only valid if empty.
+  ceph::async::use_blocked_t& get_blocked() noexcept {
+    return std::get<ceph::async::use_blocked_t>(v);
+  }
+
+  // Set the checker for yield contexts
+  static void set_checker(std::function<void()> f) {
+    std::unique_lock l(lock);
+    checker = std::move(f);
+  }
+
+  /// Call the checker for yield contexts
+  static void check() {
+    std::unique_lock l(lock);
+    auto f = checker;
+    l.unlock();
+    if (f) f();
+  }
 };
 
 // type tag object to construct an empty optional_yield
 static constexpr optional_yield::empty_t null_yield{};
+
+namespace boost::asio {
+template<typename ReturnType, typename... Args>
+class async_result<optional_yield, ReturnType(Args...)>
+{
+  using yield_result = async_result<spawn::yield_context, void(Args...)>;
+  using blocked_result = async_result<ceph::async::use_blocked_t,
+				       ReturnType(Args...)>;
+
+  using retvar = std::variant<yield_result, blocked_result>;
+  retvar r;
+
+public:
+  class completion_handler_type {
+    friend async_result;
+    using yield_handler =
+      typename async_result<spawn::yield_context,
+			    void(Args...)>::completion_handler_type;
+    using blocked_handler =
+      typename async_result<ceph::async::use_blocked_t,
+			    void(Args...)>::completion_handler_type;
+
+    using v_type = std::variant<yield_handler, blocked_handler>;
+    v_type v;
+
+  public:
+    completion_handler_type(optional_yield y)
+      : v(y ?
+	  v_type(yield_handler(y.get_yield_context())) :
+	  v_type(blocked_handler(y.get_blocked()))) {}
+
+    template<typename... Args2>
+    void operator ()(Args2&&... args) noexcept {
+      if (std::holds_alternative<
+	    typename async_result<ceph::async::use_blocked_t,
+	                          void(Args...)>::completion_handler_type>(v)) {
+	optional_yield::check();
+      }
+      std::visit([&](auto& h) {
+	h(std::forward<Args2>(args)...);
+      }, v);
+    }
+
+    bool yielding() const noexcept {
+      return std::holds_alternative<yield_handler>(v);
+    }
+  };
+  using return_type = typename async_result<spawn::yield_context,
+					    void(Args...)>::return_type;
+private:
+  static retvar build(completion_handler_type& h) {
+    using yh = typename completion_handler_type::yield_handler;
+    using bh = typename completion_handler_type::blocked_handler;
+    if (std::holds_alternative<yh>(h.v)) {
+      return retvar(std::in_place_type<yield_result>, std::get<yh>(h.v));
+    } else {
+      return retvar(std::in_place_type<blocked_result>, std::get<bh>(h.v));
+    }
+  }
+
+public:
+
+  explicit async_result(completion_handler_type& h)
+    : r(build(h)) {}
+
+  return_type get() {
+    return std::visit([](auto&& v) { return v.get(); }, r);
+  }
+};
+
+template<typename ReturnType, typename... Args>
+class async_result<optional_yield::empty_t, ReturnType(Args...)>
+  : public async_result<optional_yield, ReturnType(Args...)>
+{
+public:
+  class completion_handler_type
+    : public async_result<optional_yield,
+			  ReturnType(Args...)>::completion_handler_type
+  {
+  public:
+    completion_handler_type(const optional_yield::empty_t&)
+      : async_result<optional_yield,
+		     ReturnType(Args...)>::completion_handler_type(null_yield)
+      {}
+  };
+
+
+  explicit async_result(completion_handler_type& h)
+    : async_result<optional_yield, ReturnType(Args...)>(h) {}
+};
+}

--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -590,6 +590,14 @@ int rgw_tools_init(CephContext *cct)
 {
   ext_mime_map = new std::map<std::string, std::string>;
   ext_mime_map_init(cct, cct->_conf->rgw_mime_types_file.c_str());
+
+  // Complain if we block in a thread that shouldn't block.
+  optional_yield::set_checker([cct]() {
+    if (is_asio_thread) {
+      ldout(cct, 20) << "WARNING: blocking librados call" << dendl;
+    }
+  });
+
   // ignore errors; missing mime.types is not fatal
   return 0;
 }

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -337,10 +337,15 @@ add_ceph_unittest(unittest_cdc)
 add_executable(unittest_ceph_timer test_ceph_timer.cc)
 add_ceph_unittest(unittest_ceph_timer)
 
-
 add_executable(unittest_blocked_completion test_blocked_completion.cc)
 add_ceph_unittest(unittest_blocked_completion)
 target_link_libraries(unittest_blocked_completion Boost::system GTest::GTest)
+
+add_executable(unittest_yield_context_completion
+  test_yield_context_completion.cc)
+add_ceph_unittest(unittest_yield_context_completion)
+target_link_libraries(unittest_yield_context_completion ceph-common
+  Boost::system spawn GTest::GTest)
 
 add_executable(unittest_allocate_unique test_allocate_unique.cc)
 add_ceph_unittest(unittest_allocate_unique)

--- a/src/test/common/test_yield_context_completion.cc
+++ b/src/test/common/test_yield_context_completion.cc
@@ -1,0 +1,448 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+
+#include <boost/asio.hpp>
+#include <boost/system/error_code.hpp>
+
+#include <gtest/gtest.h>
+
+#include "common/async/bind_handler.h"
+#include "common/async/forward_handler.h"
+#include "common/async/yield_context.h"
+
+using namespace std::literals;
+
+namespace ba = boost::asio;
+namespace bs = boost::system;
+namespace ca = ceph::async;
+namespace s = spawn;
+
+class context_thread {
+  ba::io_context c;
+  ba::executor_work_guard<ba::io_context::executor_type> guard;
+  std::thread th;
+
+public:
+  context_thread() noexcept
+    : guard(ba::make_work_guard(c)),
+      th([this]() noexcept { c.run();}) {}
+
+  ~context_thread() {
+    guard.reset();
+    th.join();
+  }
+
+  ba::io_context& io_context() noexcept {
+    return c;
+  }
+
+  ba::io_context::executor_type get_executor() noexcept {
+    return c.get_executor();
+  }
+};
+
+struct move_only {
+  move_only() = default;
+  move_only(move_only&&) = default;
+  move_only& operator=(move_only&&) = default;
+  move_only(const move_only&) = delete;
+  move_only& operator=(const move_only&) = delete;
+};
+
+struct defaultless {
+  int a;
+  defaultless(int a) : a(a) {}
+};
+
+template<typename Executor, typename CompletionToken, typename... Args>
+auto id(const Executor& executor, CompletionToken&& token,
+	Args&& ...args)
+{
+  ba::async_completion<CompletionToken, void(Args...)> init(token);
+  auto a = ba::get_associated_allocator(init.completion_handler);
+  executor.post(ca::forward_handler(
+		  ca::bind_handler(std::move(init.completion_handler),
+				   std::forward<Args>(args)...)),
+		a);
+  return init.result.get();
+}
+
+TEST(NullYieldCompletion, Void)
+{
+  context_thread t;
+
+  ba::post(t.get_executor(), null_yield);
+}
+
+TEST(NullYieldCompletion, Timer)
+{
+  context_thread t;
+  ba::steady_timer timer(t.io_context(), 50ms);
+  timer.async_wait(null_yield);
+}
+
+TEST(NullYieldCompletion, NoError)
+{
+  context_thread t;
+  ba::steady_timer timer(t.io_context(), 1s);
+  bs::error_code ec;
+
+  EXPECT_NO_THROW(id(t.get_executor(), null_yield, bs::error_code{}));
+  EXPECT_NO_THROW(id(t.get_executor(), null_yield[ec], bs::error_code{}));
+  EXPECT_FALSE(ec);
+
+  int i;
+
+  EXPECT_NO_THROW(i = id(t.get_executor(), null_yield,
+			 bs::error_code{}, 5));
+  ASSERT_EQ(5, i);
+  EXPECT_NO_THROW(i = id(t.get_executor(), null_yield[ec],
+			 bs::error_code{}, 7));
+  EXPECT_FALSE(ec);
+  ASSERT_EQ(7, i);
+
+  float j;
+
+  EXPECT_NO_THROW(std::tie(i, j) = id(t.get_executor(), null_yield, 9,
+				      3.5));
+  ASSERT_EQ(9, i);
+  ASSERT_EQ(3.5, j);
+  EXPECT_NO_THROW(std::tie(i, j) = id(t.get_executor(), null_yield[ec],
+				      11, 2.25));
+  EXPECT_FALSE(ec);
+  ASSERT_EQ(11, i);
+  ASSERT_EQ(2.25, j);
+}
+
+TEST(NullYieldCompletion, AnError)
+{
+  context_thread t;
+  ba::steady_timer timer(t.io_context(), 1s);
+  bs::error_code ec;
+
+  EXPECT_THROW(id(t.get_executor(), null_yield,
+		  bs::error_code{EDOM, bs::system_category()}),
+	       bs::system_error);
+  EXPECT_NO_THROW(id(t.get_executor(), null_yield[ec],
+		     bs::error_code{EDOM, bs::system_category()}));
+  EXPECT_EQ(bs::error_code(EDOM, bs::system_category()), ec);
+
+  EXPECT_THROW(id(t.get_executor(), null_yield,
+		  bs::error_code{EDOM, bs::system_category()}, 5),
+	       bs::system_error);
+  EXPECT_NO_THROW(id(t.get_executor(), null_yield[ec],
+		     bs::error_code{EDOM, bs::system_category()}, 5));
+  EXPECT_EQ(bs::error_code(EDOM, bs::system_category()), ec);
+
+  EXPECT_THROW(id(t.get_executor(), null_yield,
+		  bs::error_code{EDOM, bs::system_category()}, 5, 3),
+	       bs::system_error);
+  EXPECT_NO_THROW(id(t.get_executor(), null_yield[ec],
+		     bs::error_code{EDOM, bs::system_category()}, 5, 3));
+  EXPECT_EQ(bs::error_code(EDOM, bs::system_category()), ec);
+}
+
+TEST(NullYieldCompletion, MoveOnly)
+{
+  context_thread t;
+  ba::steady_timer timer(t.io_context(), 1s);
+  bs::error_code ec;
+
+
+  EXPECT_NO_THROW(id(t.get_executor(), null_yield,
+			 bs::error_code{}, move_only{}));
+  EXPECT_NO_THROW(id(t.get_executor(), null_yield[ec],
+		     bs::error_code{}, move_only{}));
+  EXPECT_FALSE(ec);
+
+  {
+    auto [i, j] = id(t.get_executor(), null_yield, move_only{}, 5);
+    EXPECT_EQ(j, 5);
+  }
+  {
+    auto [i, j] = id(t.get_executor(), null_yield[ec], move_only{}, 5);
+    EXPECT_EQ(j, 5);
+  }
+  EXPECT_FALSE(ec);
+
+
+  EXPECT_THROW(id(t.get_executor(), null_yield,
+		  bs::error_code{EDOM, bs::system_category()}, move_only{}),
+	       bs::system_error);
+  EXPECT_NO_THROW(id(t.get_executor(), null_yield[ec],
+		     bs::error_code{EDOM, bs::system_category()}, move_only{}));
+  EXPECT_EQ(bs::error_code(EDOM, bs::system_category()), ec);
+
+  EXPECT_THROW(id(t.get_executor(), null_yield,
+		  bs::error_code{EDOM, bs::system_category()}, move_only{}, 3),
+	       bs::system_error);
+  EXPECT_NO_THROW(id(t.get_executor(), null_yield[ec],
+		     bs::error_code{EDOM, bs::system_category()},
+		     move_only{}, 3));
+  EXPECT_EQ(bs::error_code(EDOM, bs::system_category()), ec);
+}
+
+TEST(NullYieldCompletion, DefaultLess)
+{
+  context_thread t;
+  ba::steady_timer timer(t.io_context(), 1s);
+  bs::error_code ec;
+
+
+  {
+    auto l = id(t.get_executor(), null_yield, bs::error_code{}, defaultless{5});
+    EXPECT_EQ(5, l.a);
+  }
+  {
+    auto l = id(t.get_executor(), null_yield[ec], bs::error_code{}, defaultless{7});
+    EXPECT_EQ(7, l.a);
+  }
+
+  {
+    auto [i, j] = id(t.get_executor(), null_yield, defaultless{3}, 5);
+    EXPECT_EQ(i.a, 3);
+    EXPECT_EQ(j, 5);
+  }
+  {
+    auto [i, j] = id(t.get_executor(), null_yield[ec], defaultless{3}, 5);
+    EXPECT_EQ(i.a, 3);
+    EXPECT_EQ(j, 5);
+  }
+  EXPECT_FALSE(ec);
+
+  EXPECT_THROW(id(t.get_executor(), null_yield,
+		  bs::error_code{EDOM, bs::system_category()}, move_only{}),
+	       bs::system_error);
+  EXPECT_NO_THROW(id(t.get_executor(), null_yield[ec],
+		     bs::error_code{EDOM, bs::system_category()}, move_only{}));
+  EXPECT_EQ(bs::error_code(EDOM, bs::system_category()), ec);
+
+  EXPECT_THROW(id(t.get_executor(), null_yield,
+		  bs::error_code{EDOM, bs::system_category()}, move_only{}, 3),
+	       bs::system_error);
+  EXPECT_NO_THROW(id(t.get_executor(), null_yield[ec],
+		     bs::error_code{EDOM, bs::system_category()},
+		     move_only{}, 3));
+  EXPECT_EQ(bs::error_code(EDOM, bs::system_category()), ec);
+}
+
+
+
+TEST(NonEmptyOptionalYieldCompletion, Void)
+{
+  ba::io_context c;
+  s::spawn(c, [&](s::yield_context _y) {
+    optional_yield y(c, _y);
+    ba::post(c, y);
+  });
+  c.run();
+}
+
+TEST(NonEmptyOptionalYieldCompletion, Timer)
+{
+  ba::io_context c;
+  s::spawn(c, [&](s::yield_context _y) {
+    optional_yield y(c, _y);
+    ba::steady_timer timer(c, 50ms);
+    timer.async_wait(y);
+  });
+  c.run();
+}
+
+TEST(NonEmptyOptionalYieldCompletion, NoError)
+{
+  ba::io_context c;
+  s::spawn(c, [&](s::yield_context _y) {
+    optional_yield y(c, _y);
+    ba::steady_timer timer(c, 1s);
+    bs::error_code ec;
+
+    EXPECT_NO_THROW(id(c.get_executor(), y, bs::error_code{}));
+    EXPECT_NO_THROW(id(c.get_executor(), y[ec], bs::error_code{}));
+    EXPECT_FALSE(ec);
+
+    int i;
+
+    EXPECT_NO_THROW(i = id(c.get_executor(), y,
+			   bs::error_code{}, 5));
+    ASSERT_EQ(5, i);
+    EXPECT_NO_THROW(i = id(c.get_executor(), y[ec],
+			   bs::error_code{}, 7));
+    EXPECT_FALSE(ec);
+    ASSERT_EQ(7, i);
+
+    float j;
+
+    EXPECT_NO_THROW(std::tie(i, j) = id(c.get_executor(), y, 9,
+					3.5));
+    ASSERT_EQ(9, i);
+    ASSERT_EQ(3.5, j);
+    EXPECT_NO_THROW(std::tie(i, j) = id(c.get_executor(), y[ec],
+					11, 2.25));
+    EXPECT_FALSE(ec);
+    ASSERT_EQ(11, i);
+    ASSERT_EQ(2.25, j);
+  });
+  c.run();
+}
+
+TEST(NonEmptyOptionalYieldCompletion, AnError)
+{
+  ba::io_context c;
+  s::spawn(c, [&](s::yield_context _y) {
+    optional_yield y(c, _y);
+    ba::steady_timer timer(c, 1s);
+    bs::error_code ec;
+
+    EXPECT_THROW(id(c.get_executor(), y,
+		    bs::error_code{EDOM, bs::system_category()}),
+		 bs::system_error);
+    EXPECT_NO_THROW(id(c.get_executor(), y[ec],
+		       bs::error_code{EDOM, bs::system_category()}));
+    EXPECT_EQ(bs::error_code(EDOM, bs::system_category()), ec);
+
+    EXPECT_THROW(id(c.get_executor(), y,
+		    bs::error_code{EDOM, bs::system_category()}, 5),
+		 bs::system_error);
+    EXPECT_NO_THROW(id(c.get_executor(), y[ec],
+		       bs::error_code{EDOM, bs::system_category()}, 5));
+    EXPECT_EQ(bs::error_code(EDOM, bs::system_category()), ec);
+
+    EXPECT_THROW(id(c.get_executor(), y,
+		    bs::error_code{EDOM, bs::system_category()}, 5, 3),
+		 bs::system_error);
+    EXPECT_NO_THROW(id(c.get_executor(), y[ec],
+		       bs::error_code{EDOM, bs::system_category()}, 5, 3));
+    EXPECT_EQ(bs::error_code(EDOM, bs::system_category()), ec);
+  });
+  c.run();
+}
+
+TEST(NonEmptyOptionalYieldCompletion, MoveOnly)
+{
+  ba::io_context c;
+  s::spawn(c, [&](s::yield_context _y) {
+    optional_yield y(c, _y);
+    ba::steady_timer timer(c, 1s);
+    bs::error_code ec;
+
+
+    EXPECT_NO_THROW(id(c.get_executor(), y,
+		       bs::error_code{}, move_only{}));
+    EXPECT_NO_THROW(id(c.get_executor(), y[ec],
+		       bs::error_code{}, move_only{}));
+    EXPECT_FALSE(ec);
+
+    {
+      auto [i, j] = id(c.get_executor(), y, move_only{}, 5);
+      EXPECT_EQ(j, 5);
+    }
+    {
+      auto [i, j] = id(c.get_executor(), y[ec], move_only{}, 5);
+      EXPECT_EQ(j, 5);
+    }
+    EXPECT_FALSE(ec);
+
+
+    EXPECT_THROW(id(c.get_executor(), y,
+		    bs::error_code{EDOM, bs::system_category()}, move_only{}),
+		 bs::system_error);
+    EXPECT_NO_THROW(id(c.get_executor(), y[ec],
+		       bs::error_code{EDOM, bs::system_category()}, move_only{}));
+    EXPECT_EQ(bs::error_code(EDOM, bs::system_category()), ec);
+
+    EXPECT_THROW(id(c.get_executor(), y,
+		    bs::error_code{EDOM, bs::system_category()}, move_only{}, 3),
+		 bs::system_error);
+    EXPECT_NO_THROW(id(c.get_executor(), y[ec],
+		       bs::error_code{EDOM, bs::system_category()},
+		       move_only{}, 3));
+    EXPECT_EQ(bs::error_code(EDOM, bs::system_category()), ec);
+  });
+  c.run();
+}
+
+TEST(NonEmptyOptionalYieldCompletion, DefaultLess)
+{
+  ba::io_context c;
+  s::spawn(c, [&](s::yield_context _y) {
+    optional_yield y(c, _y);
+    ba::steady_timer timer(c, 1s);
+    bs::error_code ec;
+
+    {
+      auto l = id(c.get_executor(), y, bs::error_code{}, defaultless{5});
+      EXPECT_EQ(5, l.a);
+    }
+    {
+      auto l = id(c.get_executor(), y[ec], bs::error_code{}, defaultless{7});
+      EXPECT_EQ(7, l.a);
+    }
+
+    {
+      auto [i, j] = id(c.get_executor(), y, defaultless{3}, 5);
+      EXPECT_EQ(i.a, 3);
+      EXPECT_EQ(j, 5);
+    }
+    {
+      auto [i, j] = id(c.get_executor(), y[ec], defaultless{3}, 5);
+      EXPECT_EQ(i.a, 3);
+      EXPECT_EQ(j, 5);
+    }
+    EXPECT_FALSE(ec);
+
+    EXPECT_THROW(id(c.get_executor(), y,
+		    bs::error_code{EDOM, bs::system_category()}, move_only{}),
+		 bs::system_error);
+    EXPECT_NO_THROW(id(c.get_executor(), y[ec],
+		       bs::error_code{EDOM, bs::system_category()}, move_only{}));
+    EXPECT_EQ(bs::error_code(EDOM, bs::system_category()), ec);
+
+    EXPECT_THROW(id(c.get_executor(), y,
+		    bs::error_code{EDOM, bs::system_category()}, move_only{}, 3),
+		 bs::system_error);
+    EXPECT_NO_THROW(id(c.get_executor(), y[ec],
+		       bs::error_code{EDOM, bs::system_category()},
+		       move_only{}, 3));
+    EXPECT_EQ(bs::error_code(EDOM, bs::system_category()), ec);
+  });
+}
+
+TEST(OptionalYield, Check) {
+  bool triggered = false;
+
+  optional_yield::set_checker(
+    [&triggered]() {
+      triggered = true;
+    });
+  {
+    context_thread t;
+    ASSERT_FALSE(triggered);
+    ba::post(t.get_executor(), null_yield);
+    EXPECT_TRUE(triggered);
+  }
+  triggered = false;
+  {
+    ba::io_context c;
+    s::spawn(c, [&](s::yield_context _y) {
+      optional_yield y(c, _y);
+      ASSERT_FALSE(triggered);
+      ba::post(c.get_executor(), y);
+      EXPECT_FALSE(triggered);
+    });
+    c.run();
+  }
+  optional_yield::set_checker(nullptr);
+}


### PR DESCRIPTION
Submitted for your review and commentary. A changeset, poised between patch and example. Uploaded and applied to a repository hosted on a cloud in the Twilight Zone.

Allow optional_yield to be used as a completion token.

null_yield blocks and can be made to print a warning if we're in an Asio thread. (init_rgw_tools sets this up.)

A non-empty optional_yield completes as a yield_context.

Syntax/semantics copy that of yield-context in terms of error handling.