### PR TITLE
nautilus: rgw: fix expiration header returned even if there is only one tag in the object the same as the rule

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1611,21 +1611,19 @@ std::string s3_expiration_header(
       const RGWObjTags& rule_tagset = filter.get_tags();
       for (auto& tag : rule_tagset.get_tags()) {
 	/* remember, S3 tags are {key,value} tuples */
-	auto ma1 = obj_tag_map.find(tag.first);
-	if (ma1 != obj_tag_map.end()) {
-	  if (tag.second == ma1->second) {
-	    ldpp_dout(dpp, 10) << "tag match obj_key=" << obj_key
-			       << " rule_id=" << id
-			       << " tag=" << tag
-			       << " (ma=" << *ma1 << ")"
-			       << dendl;
-	    tag_match = true;
-	    break;
-	  }
-	}
+        tag_match = true;
+        auto obj_tag = obj_tag_map.find(tag.first);
+        if (obj_tag == obj_tag_map.end() || obj_tag->second != tag.second) {
+	        ldpp_dout(dpp, 10) << "tag does not match obj_key=" << obj_key
+			         << " rule_id=" << id
+			         << " tag=" << tag
+			         << dendl;
+	        tag_match = false;
+	        break;
+	      }
       }
       if (! tag_match)
-	continue;
+	      continue;
     }
 
     // compute a uniform expiration date


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47959

---

backport of https://github.com/ceph/ceph/pull/36199
parent tracker: https://tracker.ceph.com/issues/46614

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh