### PR TITLE
nautilus: osdc/ObjectCacher: overwrite might cause stray read request callbacks

### DIFF
--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -1719,6 +1719,7 @@ int ObjectCacher::writex(OSDWrite *wr, ObjectSet *oset, Context *onfreespace,
     trace.event("start");
   }
 
+  list<Context*> wait_for_reads;
   for (vector<ObjectExtent>::iterator ex_it = wr->extents.begin();
        ex_it != wr->extents.end();
        ++ex_it) {
@@ -1731,6 +1732,12 @@ int ObjectCacher::writex(OSDWrite *wr, ObjectSet *oset, Context *onfreespace,
     BufferHead *bh = o->map_write(*ex_it, wr->journal_tid);
     bool missing = bh->is_missing();
     bh->snapc = wr->snapc;
+
+    // readers that need to be woken up due to an overwrite
+    for (auto& [_, wait_for_read] : bh->waitfor_read) {
+      wait_for_reads.splice(wait_for_reads.end(), wait_for_read);
+    }
+    bh->waitfor_read.clear();
 
     bytes_written += ex_it->length;
     if (bh->is_tx()) {
@@ -1790,6 +1797,8 @@ int ObjectCacher::writex(OSDWrite *wr, ObjectSet *oset, Context *onfreespace,
 
   int r = _wait_for_write(wr, bytes_written, oset, &trace, onfreespace);
   delete wr;
+
+  finish_contexts(cct, wait_for_reads, 0);
 
   //verify_stats();
   trim();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47705

NOTE: backport of ad1016b014d4c33dee3be66376bf9f3394160501 is not needed in nautilus; omitted

---

backport of https://github.com/ceph/ceph/pull/37286
parent tracker: https://tracker.ceph.com/issues/46822

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh