### PR TITLE
nautilus: rbd: librbd: ignore -ENOENT error when disabling object-map

### DIFF
--- a/src/librbd/operation/DisableFeaturesRequest.cc
+++ b/src/librbd/operation/DisableFeaturesRequest.cc
@@ -481,7 +481,7 @@ Context *DisableFeaturesRequest<I>::handle_remove_object_map(int *result) {
   CephContext *cct = image_ctx.cct;
   ldout(cct, 20) << this << " " << __func__ << ": r=" << *result << dendl;
 
-  if (*result < 0) {
+  if (*result < 0 && *result != -ENOENT) {
     lderr(cct) << "failed to remove object map: " << cpp_strerror(*result) << dendl;
     return handle_finish(*result);
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47890

---

backport of https://github.com/ceph/ceph/pull/37643
parent tracker: https://tracker.ceph.com/issues/47840

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh