### PR TITLE
nautilus: mon/MonMap: fix unconditional failure for init_with_hosts

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,25 +1,6 @@
->= 14.2.12
-----------
+14.2.13
+-------
 
-* ceph-volume: The ``lvm batch` subcommand received a major rewrite. This closed
-  a number of bugs and improves usability in terms of size specification and
-  calculation, as well as idempotency behaviour and disk replacement process.
-  Please refer to https://docs.ceph.com/en/latest/ceph-volume/lvm/batch/ for
-  more detailed information.
-
-* The ``ceph df`` command now lists the number of pgs in each pool.
-
-* Monitors now have a config option ``mon_osd_warn_num_repaired``, 10 by default.
-  If any OSD has repaired more than this many I/O errors in stored data a
-  ``OSD_TOO_MANY_REPAIRS`` health warning is generated.  In order to allow
-  clearing of the warning, a new command ``ceph tell osd.# clear_shards_repaired [count]``
-  has been added.  By default it will set the repair count to 0.  If you wanted
-  to be warned again if additional repairs are performed you can provide a value
-  to the command and specify the value of ``mon_osd_warn_num_repaired``.
-  This command will be replaced in future releases by the health mute/unmute feature.
-
-* It is now possible to specify the initial monitor to contact for Ceph tools
-  and daemons using the ``mon_host_override`` config option or
-  ``--mon-host-override <ip>`` command-line switch. This generally should only
-  be used for debugging and only affects initial communication with Ceph's
-  monitor cluster.
+* This release fixes a regression introduced in 14.2.12 which broke deployments
+  that referred to MON hosts using DNS names instead of IP addresses in the
+  ``mon_host`` parameter in ``/etc/ceph/ceph.conf``.

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -449,10 +449,9 @@ void MonMap::_add_ambiguous_addr(const string& name,
   }
 }
 
-int
-MonMap::init_with_addrs(const std::vector<entity_addrvec_t>& addrs,
-                        bool for_mkfs,
-                        std::string_view prefix)
+void MonMap::init_with_addrs(const std::vector<entity_addrvec_t>& addrs,
+                             bool for_mkfs,
+                             std::string_view prefix)
 {
   char id = 'a';
   for (auto& addr : addrs) {
@@ -466,7 +465,6 @@ MonMap::init_with_addrs(const std::vector<entity_addrvec_t>& addrs,
       add(name, addr, 0);
     }
   }
-  return 0;
 }
 
 int MonMap::init_with_ips(const std::string& ips,
@@ -481,7 +479,8 @@ int MonMap::init_with_ips(const std::string& ips,
   }
   if (addrs.empty())
     return -ENOENT;
-  return init_with_addrs(addrs, for_mkfs, prefix);
+  init_with_addrs(addrs, for_mkfs, prefix);
+  return 0;
 }
 
 int MonMap::init_with_hosts(const std::string& hostlist,
@@ -502,9 +501,7 @@ int MonMap::init_with_hosts(const std::string& hostlist,
     return -EINVAL;
   if (addrs.empty())
     return -ENOENT;
-  if (!init_with_addrs(addrs, for_mkfs, prefix)) {
-    return -EINVAL;
-  }
+  init_with_addrs(addrs, for_mkfs, prefix);
   calc_legacy_ranks();
   return 0;
 }
@@ -808,7 +805,8 @@ int MonMap::build_initial(CephContext *cct, bool for_mkfs, ostream& errout)
   // cct?
   auto addrs = cct->get_mon_addrs();
   if (addrs != nullptr && (addrs->size() > 0)) {
-    return init_with_addrs(*addrs, for_mkfs, "noname-");
+    init_with_addrs(*addrs, for_mkfs, "noname-");
+    return 0;
   }
 
   // file?

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -443,11 +443,10 @@ protected:
    *
    * @param addrs  list of entity_addrvec_t's
    * @param prefix prefix to prepend to generated mon names
-   * @return 0 for success, -errno on error
    */
-  int init_with_addrs(const std::vector<entity_addrvec_t>& addrs,
-        bool for_mkfs,
-        std::string_view prefix);
+  void init_with_addrs(const std::vector<entity_addrvec_t>& addrs,
+                       bool for_mkfs,
+                       std::string_view prefix);
   /**
    * build a monmap from a list of ips
    *

--- a/src/test/mon/CMakeLists.txt
+++ b/src/test/mon/CMakeLists.txt
@@ -25,6 +25,13 @@ add_executable(unittest_mon_moncap
 add_ceph_unittest(unittest_mon_moncap)
 target_link_libraries(unittest_mon_moncap mon global)
 
+# unittest_mon_map
+add_executable(unittest_mon_monmap
+  MonMap.cc
+  )
+add_ceph_unittest(unittest_mon_monmap)
+target_link_libraries(unittest_mon_monmap mon global)
+
 # unittest_mon_pgmap
 add_executable(unittest_mon_pgmap
   PGMap.cc

--- a/src/test/mon/MonMap.cc
+++ b/src/test/mon/MonMap.cc
@@ -218,3 +218,22 @@ TEST_F(MonMapTest, DISABLED_build_initial_config_from_dns_with_domain) {
   ASSERT_EQ(os.str(), "192.168.1.13:6789/0");
 }
 
+TEST(MonMapBuildInitial, build_initial_mon_host_from_dns) {
+  CephContext *cct = (new CephContext(CEPH_ENTITY_TYPE_MON))->get();
+  cct->_conf.set_val("mon_host", "ceph.io");
+  MonMap monmap;
+  int r = monmap.build_initial(cct, false, std::cerr);
+  ASSERT_EQ(r, 0);
+  ASSERT_GE(monmap.mon_info.size(), 1u);
+  for (const auto& [name, info] : monmap.mon_info) {
+    std::cerr << info << std::endl;
+  }
+}
+
+TEST(MonMapBuildInitial, build_initial_mon_host_from_dns_fail) {
+  CephContext *cct = (new CephContext(CEPH_ENTITY_TYPE_MON))->get();
+  cct->_conf.set_val("mon_host", "ceph.noname");
+  MonMap monmap;
+  int r = monmap.build_initial(cct, false, std::cerr);
+  ASSERT_EQ(r, -EINVAL);
+}

--- a/src/test/mon/MonMap.cc
+++ b/src/test/mon/MonMap.cc
@@ -45,7 +45,7 @@ class MonMapTest : public ::testing::Test {
     }
 };
 
-TEST_F(MonMapTest, build_initial_config_from_dns) {
+TEST_F(MonMapTest, DISABLED_build_initial_config_from_dns) {
 
   MockResolvHWrapper *resolvH = new MockResolvHWrapper();
   DNSResolver::get_instance(resolvH);
@@ -102,25 +102,25 @@ TEST_F(MonMapTest, build_initial_config_from_dns) {
   int r = monmap.build_initial(cct, false, std::cerr);
 
   ASSERT_EQ(r, 0);
-  ASSERT_EQ(monmap.mon_addr.size(), (unsigned int)3);
-  map<string,entity_addr_t>::iterator it = monmap.mon_addr.find("mon.a");
-  ASSERT_NE(it, monmap.mon_addr.end());
+  ASSERT_EQ(monmap.mon_info.size(), (unsigned int)3);
+  auto it = monmap.mon_info.find("mon.a");
+  ASSERT_NE(it, monmap.mon_info.end());
   std::ostringstream os;
-  os << it->second;
+  os << it->second.public_addrs;
   ASSERT_EQ(os.str(), "192.168.1.11:6789/0");
   os.str("");
-  it = monmap.mon_addr.find("mon.b");
-  ASSERT_NE(it, monmap.mon_addr.end());
-  os << it->second;
+  it = monmap.mon_info.find("mon.b");
+  ASSERT_NE(it, monmap.mon_info.end());
+  os << it->second.public_addrs;
   ASSERT_EQ(os.str(), "192.168.1.12:6789/0");
   os.str("");
-  it = monmap.mon_addr.find("mon.c");
-  ASSERT_NE(it, monmap.mon_addr.end());
-  os << it->second;
+  it = monmap.mon_info.find("mon.c");
+  ASSERT_NE(it, monmap.mon_info.end());
+  os << it->second.public_addrs;
   ASSERT_EQ(os.str(), "192.168.1.13:6789/0");
 }
 
-TEST_F(MonMapTest, build_initial_config_from_dns_fail) {
+TEST_F(MonMapTest, DISABLED_build_initial_config_from_dns_fail) {
   MockResolvHWrapper *resolvH = new MockResolvHWrapper();
   DNSResolver::get_instance(resolvH);
 
@@ -139,11 +139,11 @@ TEST_F(MonMapTest, build_initial_config_from_dns_fail) {
   int r = monmap.build_initial(cct, false, std::cerr);
 
   ASSERT_EQ(r, -ENOENT);
-  ASSERT_EQ(monmap.mon_addr.size(), (unsigned int)0);
+  ASSERT_EQ(monmap.mon_info.size(), (unsigned int)0);
 
 }
 
-TEST_F(MonMapTest, build_initial_config_from_dns_with_domain) {
+TEST_F(MonMapTest, DISABLED_build_initial_config_from_dns_with_domain) {
 
   MockResolvHWrapper *resolvH = new MockResolvHWrapper();
   DNSResolver::get_instance(resolvH);
@@ -200,21 +200,21 @@ TEST_F(MonMapTest, build_initial_config_from_dns_with_domain) {
   int r = monmap.build_initial(cct, false, std::cerr);
 
   ASSERT_EQ(r, 0);
-  ASSERT_EQ(monmap.mon_addr.size(), (unsigned int)3);
-  map<string,entity_addr_t>::iterator it = monmap.mon_addr.find("mon.a");
-  ASSERT_NE(it, monmap.mon_addr.end());
+  ASSERT_EQ(monmap.mon_info.size(), (unsigned int)3);
+  auto it = monmap.mon_info.find("mon.a");
+  ASSERT_NE(it, monmap.mon_info.end());
   std::ostringstream os;
-  os << it->second;
+  os << it->second.public_addrs;
   ASSERT_EQ(os.str(), "192.168.1.11:6789/0");
   os.str("");
-  it = monmap.mon_addr.find("mon.b");
-  ASSERT_NE(it, monmap.mon_addr.end());
-  os << it->second;
+  it = monmap.mon_info.find("mon.b");
+  ASSERT_NE(it, monmap.mon_info.end());
+  os << it->second.public_addrs;
   ASSERT_EQ(os.str(), "192.168.1.12:6789/0");
   os.str("");
-  it = monmap.mon_addr.find("mon.c");
-  ASSERT_NE(it, monmap.mon_addr.end());
-  os << it->second;
+  it = monmap.mon_info.find("mon.c");
+  ASSERT_NE(it, monmap.mon_info.end());
+  os << it->second.public_addrs;
   ASSERT_EQ(os.str(), "192.168.1.13:6789/0");
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47986

---

backport of https://github.com/ceph/ceph/pull/37758
parent tracker: https://tracker.ceph.com/issues/47951

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh