### PR TITLE
octopus: mon/MonMap: fix unconditional failure for init_with_hosts

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,5 +1,5 @@
->=15.2.6
---------
+15.2.6
+------
 
 * ceph-volume: The ``lvm batch` subcommand received a major rewrite. This closed
   a number of bugs and improves usability in terms of size specification and
@@ -10,22 +10,6 @@
 * The ``ceph df`` command now lists the number of pgs in each pool.
 
 * The ``bluefs_preextend_wal_files`` option has been removed.
-
->=15.2.5
---------
-
-* CephFS: Automatic static subtree partitioning policies may now be configured
-  using the new distributed and random ephemeral pinning extended attributes on
-  directories. See the documentation for more information:
-  https://docs.ceph.com/docs/master/cephfs/multimds/
-
-* Monitors now have a config option ``mon_osd_warn_num_repaired``, 10 by default.
-  If any OSD has repaired more than this many I/O errors in stored data a
- ``OSD_TOO_MANY_REPAIRS`` health warning is generated.
-
-* Now when noscrub and/or nodeep-scrub flags are set globally or per pool,
-  scheduled scrubs of the type disabled will be aborted. All user initiated
-  scrubs are NOT interrupted.
 
 * It is now possible to specify the initial monitor to contact for Ceph tools
   and daemons using the ``mon_host_override`` config option or

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -460,10 +460,9 @@ void MonMap::_add_ambiguous_addr(const string& name,
   }
 }
 
-int
-MonMap::init_with_addrs(const std::vector<entity_addrvec_t>& addrs,
-                        bool for_mkfs,
-                        std::string_view prefix)
+void MonMap::init_with_addrs(const std::vector<entity_addrvec_t>& addrs,
+                             bool for_mkfs,
+                             std::string_view prefix)
 {
   char id = 'a';
   for (auto& addr : addrs) {
@@ -477,7 +476,6 @@ MonMap::init_with_addrs(const std::vector<entity_addrvec_t>& addrs,
       add(name, addr, 0);
     }
   }
-  return 0;
 }
 
 int MonMap::init_with_ips(const std::string& ips,
@@ -492,7 +490,8 @@ int MonMap::init_with_ips(const std::string& ips,
   }
   if (addrs.empty())
     return -ENOENT;
-  return init_with_addrs(addrs, for_mkfs, prefix);
+  init_with_addrs(addrs, for_mkfs, prefix);
+  return 0;
 }
 
 int MonMap::init_with_hosts(const std::string& hostlist,
@@ -513,9 +512,7 @@ int MonMap::init_with_hosts(const std::string& hostlist,
     return -EINVAL;
   if (addrs.empty())
     return -ENOENT;
-  if (!init_with_addrs(addrs, for_mkfs, prefix)) {
-    return -EINVAL;
-  }
+  init_with_addrs(addrs, for_mkfs, prefix);
   calc_legacy_ranks();
   return 0;
 }
@@ -838,7 +835,8 @@ int MonMap::build_initial(CephContext *cct, bool for_mkfs, ostream& errout)
   // cct?
   auto addrs = cct->get_mon_addrs();
   if (addrs != nullptr && (addrs->size() > 0)) {
-    return init_with_addrs(*addrs, for_mkfs, "noname-");
+    init_with_addrs(*addrs, for_mkfs, "noname-");
+    return 0;
   }
 
   // file?

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -463,11 +463,10 @@ protected:
    *
    * @param addrs  list of entity_addrvec_t's
    * @param prefix prefix to prepend to generated mon names
-   * @return 0 for success, -errno on error
    */
-  int init_with_addrs(const std::vector<entity_addrvec_t>& addrs,
-        bool for_mkfs,
-        std::string_view prefix);
+  void init_with_addrs(const std::vector<entity_addrvec_t>& addrs,
+                       bool for_mkfs,
+                       std::string_view prefix);
   /**
    * build a monmap from a list of ips
    *

--- a/src/test/mon/CMakeLists.txt
+++ b/src/test/mon/CMakeLists.txt
@@ -25,6 +25,13 @@ add_executable(unittest_mon_moncap
 add_ceph_unittest(unittest_mon_moncap)
 target_link_libraries(unittest_mon_moncap mon global)
 
+# unittest_mon_map
+add_executable(unittest_mon_monmap
+  MonMap.cc
+  )
+add_ceph_unittest(unittest_mon_monmap)
+target_link_libraries(unittest_mon_monmap mon global)
+
 # unittest_mon_pgmap
 add_executable(unittest_mon_pgmap
   PGMap.cc

--- a/src/test/mon/MonMap.cc
+++ b/src/test/mon/MonMap.cc
@@ -218,3 +218,22 @@ TEST_F(MonMapTest, DISABLED_build_initial_config_from_dns_with_domain) {
   ASSERT_EQ(os.str(), "192.168.1.13:6789/0");
 }
 
+TEST(MonMapBuildInitial, build_initial_mon_host_from_dns) {
+  CephContext *cct = (new CephContext(CEPH_ENTITY_TYPE_MON))->get();
+  cct->_conf.set_val("mon_host", "ceph.io");
+  MonMap monmap;
+  int r = monmap.build_initial(cct, false, std::cerr);
+  ASSERT_EQ(r, 0);
+  ASSERT_GE(monmap.mon_info.size(), 1u);
+  for (const auto& [name, info] : monmap.mon_info) {
+    std::cerr << info << std::endl;
+  }
+}
+
+TEST(MonMapBuildInitial, build_initial_mon_host_from_dns_fail) {
+  CephContext *cct = (new CephContext(CEPH_ENTITY_TYPE_MON))->get();
+  cct->_conf.set_val("mon_host", "ceph.noname");
+  MonMap monmap;
+  int r = monmap.build_initial(cct, false, std::cerr);
+  ASSERT_EQ(r, -EINVAL);
+}

--- a/src/test/mon/MonMap.cc
+++ b/src/test/mon/MonMap.cc
@@ -45,7 +45,7 @@ class MonMapTest : public ::testing::Test {
     }
 };
 
-TEST_F(MonMapTest, build_initial_config_from_dns) {
+TEST_F(MonMapTest, DISABLED_build_initial_config_from_dns) {
 
   MockResolvHWrapper *resolvH = new MockResolvHWrapper();
   DNSResolver::get_instance(resolvH);
@@ -102,25 +102,25 @@ TEST_F(MonMapTest, build_initial_config_from_dns) {
   int r = monmap.build_initial(cct, false, std::cerr);
 
   ASSERT_EQ(r, 0);
-  ASSERT_EQ(monmap.mon_addr.size(), (unsigned int)3);
-  map<string,entity_addr_t>::iterator it = monmap.mon_addr.find("mon.a");
-  ASSERT_NE(it, monmap.mon_addr.end());
+  ASSERT_EQ(monmap.mon_info.size(), (unsigned int)3);
+  auto it = monmap.mon_info.find("mon.a");
+  ASSERT_NE(it, monmap.mon_info.end());
   std::ostringstream os;
-  os << it->second;
+  os << it->second.public_addrs;
   ASSERT_EQ(os.str(), "192.168.1.11:6789/0");
   os.str("");
-  it = monmap.mon_addr.find("mon.b");
-  ASSERT_NE(it, monmap.mon_addr.end());
-  os << it->second;
+  it = monmap.mon_info.find("mon.b");
+  ASSERT_NE(it, monmap.mon_info.end());
+  os << it->second.public_addrs;
   ASSERT_EQ(os.str(), "192.168.1.12:6789/0");
   os.str("");
-  it = monmap.mon_addr.find("mon.c");
-  ASSERT_NE(it, monmap.mon_addr.end());
-  os << it->second;
+  it = monmap.mon_info.find("mon.c");
+  ASSERT_NE(it, monmap.mon_info.end());
+  os << it->second.public_addrs;
   ASSERT_EQ(os.str(), "192.168.1.13:6789/0");
 }
 
-TEST_F(MonMapTest, build_initial_config_from_dns_fail) {
+TEST_F(MonMapTest, DISABLED_build_initial_config_from_dns_fail) {
   MockResolvHWrapper *resolvH = new MockResolvHWrapper();
   DNSResolver::get_instance(resolvH);
 
@@ -139,11 +139,11 @@ TEST_F(MonMapTest, build_initial_config_from_dns_fail) {
   int r = monmap.build_initial(cct, false, std::cerr);
 
   ASSERT_EQ(r, -ENOENT);
-  ASSERT_EQ(monmap.mon_addr.size(), (unsigned int)0);
+  ASSERT_EQ(monmap.mon_info.size(), (unsigned int)0);
 
 }
 
-TEST_F(MonMapTest, build_initial_config_from_dns_with_domain) {
+TEST_F(MonMapTest, DISABLED_build_initial_config_from_dns_with_domain) {
 
   MockResolvHWrapper *resolvH = new MockResolvHWrapper();
   DNSResolver::get_instance(resolvH);
@@ -200,21 +200,21 @@ TEST_F(MonMapTest, build_initial_config_from_dns_with_domain) {
   int r = monmap.build_initial(cct, false, std::cerr);
 
   ASSERT_EQ(r, 0);
-  ASSERT_EQ(monmap.mon_addr.size(), (unsigned int)3);
-  map<string,entity_addr_t>::iterator it = monmap.mon_addr.find("mon.a");
-  ASSERT_NE(it, monmap.mon_addr.end());
+  ASSERT_EQ(monmap.mon_info.size(), (unsigned int)3);
+  auto it = monmap.mon_info.find("mon.a");
+  ASSERT_NE(it, monmap.mon_info.end());
   std::ostringstream os;
-  os << it->second;
+  os << it->second.public_addrs;
   ASSERT_EQ(os.str(), "192.168.1.11:6789/0");
   os.str("");
-  it = monmap.mon_addr.find("mon.b");
-  ASSERT_NE(it, monmap.mon_addr.end());
-  os << it->second;
+  it = monmap.mon_info.find("mon.b");
+  ASSERT_NE(it, monmap.mon_info.end());
+  os << it->second.public_addrs;
   ASSERT_EQ(os.str(), "192.168.1.12:6789/0");
   os.str("");
-  it = monmap.mon_addr.find("mon.c");
-  ASSERT_NE(it, monmap.mon_addr.end());
-  os << it->second;
+  it = monmap.mon_info.find("mon.c");
+  ASSERT_NE(it, monmap.mon_info.end());
+  os << it->second.public_addrs;
   ASSERT_EQ(os.str(), "192.168.1.13:6789/0");
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47987

---

backport of https://github.com/ceph/ceph/pull/37758
parent tracker: https://tracker.ceph.com/issues/47951

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh