### PR TITLE
octopus: test/store_test: use 'threadsafe' style for death tests

### DIFF
--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -3017,6 +3017,9 @@ TEST_P(StoreTest, MultipoolListTest) {
 TEST_P(StoreTest, SimpleCloneTest) {
   int r;
   coll_t cid;
+
+  SetDeathTestStyle("threadsafe");
+
   auto ch = store->create_new_collection(cid);
   {
     ObjectStore::Transaction t;
@@ -3289,13 +3292,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     ASSERT_TRUE(bl_eq(rl, final));
   }
 
-  //Unfortunately we need a workaround for filestore since EXPECT_DEATH
-  // macro has potential issues when using /in multithread environments. 
-  //It works well for all stores but filestore for now. 
-  //A fix setting gtest_death_test_style = "threadsafe" doesn't help as well - 
-  //  test app clone asserts on store folder presence.
-  //
-  if (string(GetParam()) != "filestore") { 
+  {
     //verify if non-empty collection is properly handled after store reload
     ch.reset();
     r = store->umount();
@@ -3316,8 +3313,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  //See comment above for "filestore" check explanation.
-  if (string(GetParam()) != "filestore") {
+  {
     ObjectStore::Transaction t;
     //verify if non-empty collection is properly handled when there are some pending removes and live records in db
     cerr << "Invalid rm coll again" << std::endl;

--- a/src/test/objectstore/store_test_fixture.cc
+++ b/src/test/objectstore/store_test_fixture.cc
@@ -70,6 +70,10 @@ void StoreTestFixture::TearDown()
   // config settings. Hence setting it to 'unsafe' here as test case is closing.
   g_conf()._clear_safe_to_start_threads();
   PopSettings(0);
+  if (!orig_death_test_style.empty()) {
+    ::testing::FLAGS_gtest_death_test_style = orig_death_test_style;
+    orig_death_test_style.clear();
+  }
   if (store) {
     int r = store->umount();
     EXPECT_EQ(0, r);

--- a/src/test/objectstore/store_test_fixture.h
+++ b/src/test/objectstore/store_test_fixture.h
@@ -13,6 +13,8 @@ class StoreTestFixture : virtual public ::testing::Test {
   std::stack<std::pair<std::string, std::string>> saved_settings;
   ConfigProxy* conf = nullptr;
 
+  std::string orig_death_test_style;
+
 public:
   boost::scoped_ptr<ObjectStore> store;
   ObjectStore::CollectionHandle ch;
@@ -23,6 +25,13 @@ public:
 
   void SetUp() override;
   void TearDown() override;
+  void SetDeathTestStyle(const char* new_style) {
+    if (orig_death_test_style.empty()) {
+      orig_death_test_style = ::testing::FLAGS_gtest_death_test_style;
+    }
+    ::testing::FLAGS_gtest_death_test_style = new_style;
+  }
+
   void SetVal(ConfigProxy& conf, const char* key, const char* val);
   struct SettingsBookmark {
     StoreTestFixture& s;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47994

---

backport of https://github.com/ceph/ceph/pull/37738
parent tracker: https://tracker.ceph.com/issues/47328

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh