### PR TITLE
nautilus: mon/MDSMonitor: divide mds identifier and mds real name with dot

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -220,7 +220,7 @@ void MDSMonitor::encode_pending(MonitorDBStore::TransactionRef t)
 	metric.sev,
 	mds_metric_summary(metric.type));
       ostringstream ss;
-      ss << "mds" << info.name << "(mds." << rank << "): " << metric.message;
+      ss << "mds." << info.name << "(mds." << rank << "): " << metric.message;
       bool first = true;
       for (auto &p : metric.metadata) {
 	if (first) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47939

---

backport of https://github.com/ceph/ceph/pull/37608
parent tracker: https://tracker.ceph.com/issues/47806

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh