### PR TITLE
crimson/seastore: add Extentmap node type in cache.cc

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -131,6 +131,10 @@ CachedExtentRef Cache::alloc_new_extent_by_type(
     return alloc_new_extent<lba_manager::btree::LBALeafNode>(t, length);
   case extent_types_t::ONODE_BLOCK:
     return alloc_new_extent<OnodeBlock>(t, length);
+  case extent_types_t::EXTMAP_INNER:
+    return alloc_new_extent<extentmap_manager::ExtMapInnerNode>(t, length);
+  case extent_types_t::EXTMAP_LEAF:
+    return alloc_new_extent<extentmap_manager::ExtMapLeafNode>(t, length);
   case extent_types_t::TEST_BLOCK:
     return alloc_new_extent<TestBlock>(t, length);
   case extent_types_t::TEST_BLOCK_PHYSICAL:

--- a/src/crimson/os/seastore/extentmap_manager/btree/extentmap_btree_node.h
+++ b/src/crimson/os/seastore/extentmap_manager/btree/extentmap_btree_node.h
@@ -81,6 +81,7 @@ struct ExtMapNode : LogicalCachedExtent {
 
   virtual bool at_max_capacity() const = 0;
   virtual bool at_min_capacity() const = 0;
+  virtual unsigned get_node_size() const = 0;
   virtual ~ExtMapNode() = default;
 
   using alloc_ertr = TransactionManager::alloc_extent_ertr;

--- a/src/crimson/os/seastore/extentmap_manager/btree/extentmap_btree_node_impl.cc
+++ b/src/crimson/os/seastore/extentmap_manager/btree/extentmap_btree_node_impl.cc
@@ -86,6 +86,7 @@ ExtMapInnerNode::rm_lextent(ext_context_t ec, objaddr_t lo, lext_map_val_t val)
 ExtMapInnerNode::split_children_ret
 ExtMapInnerNode::make_split_children(ext_context_t ec)
 {
+  logger().debug("{}: {}", "ExtMapInnerNode", __func__);
   return extmap_alloc_2extents<ExtMapInnerNode>(ec, EXTMAP_BLOCK_SIZE)
     .safe_then([this] (auto &&ext_pair) {
       auto [left, right] = ext_pair;
@@ -98,6 +99,7 @@ ExtMapInnerNode::make_split_children(ext_context_t ec)
 ExtMapInnerNode::full_merge_ret
 ExtMapInnerNode::make_full_merge(ext_context_t ec, ExtMapNodeRef right)
 {
+  logger().debug("{}: {}", "ExtMapInnerNode", __func__);
   return extmap_alloc_extent<ExtMapInnerNode>(ec, EXTMAP_BLOCK_SIZE)
     .safe_then([this, right] (auto &&replacement) {
       replacement->merge_from(*this, *right->cast<ExtMapInnerNode>());
@@ -110,6 +112,7 @@ ExtMapInnerNode::make_full_merge(ext_context_t ec, ExtMapNodeRef right)
 ExtMapInnerNode::make_balanced_ret
 ExtMapInnerNode::make_balanced(ext_context_t ec, ExtMapNodeRef _right, bool prefer_left)
 {
+  logger().debug("{}: {}", "ExtMapInnerNode", __func__);
   ceph_assert(_right->get_type() == type);
   return extmap_alloc_2extents<ExtMapInnerNode>(ec, EXTMAP_BLOCK_SIZE)
     .safe_then([this,  _right, prefer_left] (auto &&replacement_pair){
@@ -127,6 +130,7 @@ ExtMapInnerNode::split_entry_ret
 ExtMapInnerNode::split_entry(ext_context_t ec, objaddr_t lo,
 	                     internal_iterator_t iter, ExtMapNodeRef entry)
 {
+  logger().debug("{}: {}", "ExtMapInnerNode", __func__);
   if (!is_pending()) {
     auto mut = ec.tm.get_mutable_extent(ec.t, this)->cast<ExtMapInnerNode>();
     auto mut_iter = mut->iter_idx(iter->get_offset());
@@ -296,6 +300,7 @@ ExtMapLeafNode::rm_lextent(ext_context_t ec, objaddr_t lo, lext_map_val_t val)
 ExtMapLeafNode::split_children_ret
 ExtMapLeafNode::make_split_children(ext_context_t ec)
 {
+  logger().debug("{}: {}", "ExtMapLeafNode", __func__);
   return extmap_alloc_2extents<ExtMapLeafNode>(ec, EXTMAP_BLOCK_SIZE)
     .safe_then([this] (auto &&ext_pair) {
       auto [left, right] = ext_pair;
@@ -308,6 +313,7 @@ ExtMapLeafNode::make_split_children(ext_context_t ec)
 ExtMapLeafNode::full_merge_ret
 ExtMapLeafNode::make_full_merge(ext_context_t ec, ExtMapNodeRef right)
 {
+  logger().debug("{}: {}", "ExtMapLeafNode", __func__);
   return extmap_alloc_extent<ExtMapLeafNode>(ec, EXTMAP_BLOCK_SIZE)
     .safe_then([this, right] (auto &&replacement) {
       replacement->merge_from(*this, *right->cast<ExtMapLeafNode>());
@@ -319,6 +325,7 @@ ExtMapLeafNode::make_full_merge(ext_context_t ec, ExtMapNodeRef right)
 ExtMapLeafNode::make_balanced_ret
 ExtMapLeafNode::make_balanced(ext_context_t ec, ExtMapNodeRef _right, bool prefer_left)
 {
+  logger().debug("{}: {}", "ExtMapLeafNode", __func__);
   ceph_assert(_right->get_type() == type);
   return extmap_alloc_2extents<ExtMapLeafNode>(ec, EXTMAP_BLOCK_SIZE)
     .safe_then([this, _right, prefer_left] (auto &&replacement_pair) {

--- a/src/crimson/os/seastore/extentmap_manager/btree/extentmap_btree_node_impl.cc
+++ b/src/crimson/os/seastore/extentmap_manager/btree/extentmap_btree_node_impl.cc
@@ -73,7 +73,7 @@ ExtMapInnerNode::rm_lextent(ext_context_t ec, objaddr_t lo, lext_map_val_t val)
   auto rm_pt = get_containing_child(lo);
   return extmap_load_extent(ec, rm_pt->get_val(),  get_meta().depth - 1).safe_then(
     [this, ec, rm_pt, lo, val=std::move(val)](auto extent) mutable {
-    if (extent->at_min_capacity()) {
+    if (extent->at_min_capacity() && get_node_size() > 1) {
       return merge_entry(ec, lo, rm_pt, extent);
     } else {
       return merge_entry_ertr::make_ready_future<ExtMapNodeRef>(std::move(extent));

--- a/src/crimson/os/seastore/extentmap_manager/btree/extentmap_btree_node_impl.h
+++ b/src/crimson/os/seastore/extentmap_manager/btree/extentmap_btree_node_impl.h
@@ -114,6 +114,10 @@ struct ExtMapInnerNode
     return get_size() == get_capacity() / 2;
   }
 
+  unsigned get_node_size() const {
+    return get_size();
+  }
+
   /* get the iterator containing [l, r]
    */
   std::pair<internal_iterator_t, internal_iterator_t> bound(
@@ -245,6 +249,10 @@ struct ExtMapLeafNode
 
   bool at_min_capacity() const final {
     return get_size() == get_capacity() / 2;
+  }
+
+  unsigned get_node_size() const {
+    return get_size();
   }
 
   /* get the iterator containing [l, r]

--- a/src/test/crimson/seastore/test_extmap_manager.cc
+++ b/src/test/crimson/seastore/test_extmap_manager.cc
@@ -107,6 +107,18 @@ struct extentmap_manager_test_t :
     check_mappings(extmap_root, *t);
   }
 
+  void replay() {
+    logger().debug("{}: begin", __func__);
+    tm->close().unsafe_get();
+    destroy();
+    static_cast<segment_manager::EphemeralSegmentManager*>(&*segment_manager)->remount();
+    init();
+    tm->mount().unsafe_get();
+    extmap_manager = extentmap_manager::create_extentmap_manager(*tm);
+    logger().debug("{}: end", __func__);
+  }
+
+
 };
 
 TEST_F(extentmap_manager_test_t, basic)
@@ -145,7 +157,7 @@ TEST_F(extentmap_manager_test_t, basic)
   });
 }
 
-TEST_F(extentmap_manager_test_t, force_split)
+TEST_F(extentmap_manager_test_t, force_leafnode_split)
 {
   run_async([this] {
     extmap_root_t extmap_root(0, L_ADDR_NULL);
@@ -174,7 +186,7 @@ TEST_F(extentmap_manager_test_t, force_split)
 
 }
 
-TEST_F(extentmap_manager_test_t, force_split_merge)
+TEST_F(extentmap_manager_test_t, force_leafnode_split_merge)
 {
   run_async([this] {
     extmap_root_t extmap_root(0, L_ADDR_NULL);
@@ -186,57 +198,6 @@ TEST_F(extentmap_manager_test_t, force_split_merge)
     uint32_t len = 4096;
     uint32_t lo = 0;
     for (unsigned i = 0; i < 80; i++) {
-      auto t = tm->create_transaction();
-      logger().debug("opened split_merge transaction");
-      for (unsigned j = 0; j < 5; ++j) {
-        [[maybe_unused]] auto addref = insert_extent(extmap_root, *t, lo, {lo, len});
-        lo += len;
-	if ((i % 10 == 0) && (j == 3)) {
-	  check_mappings(extmap_root, *t);
-	}
-      }
-      logger().debug("submitting transaction");
-      tm->submit_transaction(std::move(t)).unsafe_get();
-      if (i % 50 == 0) {
-	check_mappings(extmap_root);
-      }
-    }
-    auto t = tm->create_transaction();
-    int i = 0;
-    for (const auto& [lo, ext]: test_ext_mappings) {
-      if (i % 3 != 0) {
-	rm_extent(extmap_root, *t, lo, ext);
-      }
-
-      if (i % 10 == 0) {
-        logger().debug("submitting transaction i= {}", i);
-	tm->submit_transaction(std::move(t)).unsafe_get();
-	t = tm->create_transaction();
-      }
-      if (i % 100 == 0) {
-        logger().debug("check_mappings  i= {}", i);
-	check_mappings(extmap_root, *t);
-	check_mappings(extmap_root);
-      }
-      i++;
-    }
-    logger().debug("finally submitting transaction ");
-    tm->submit_transaction(std::move(t)).unsafe_get();
-  });
-}
-
-TEST_F(extentmap_manager_test_t, force_split_balanced)
-{
-  run_async([this] {
-    extmap_root_t extmap_root(0, L_ADDR_NULL);
-    {
-      auto t = tm->create_transaction();
-      extmap_root = extmap_manager->initialize_extmap(*t).unsafe_get0();
-      tm->submit_transaction(std::move(t)).unsafe_get();
-    }
-    uint32_t len = 4096;
-    uint32_t lo = 0;
-    for (unsigned i = 0; i < 50; i++) {
       auto t = tm->create_transaction();
       logger().debug("opened split_merge transaction");
       for (unsigned j = 0; j < 5; ++j) {
@@ -254,27 +215,73 @@ TEST_F(extentmap_manager_test_t, force_split_balanced)
     }
     auto t = tm->create_transaction();
     int i = 0;
-    for (const auto& [lo, ext]: test_ext_mappings) {
-      if (i < 100) {
+    for (auto iter = test_ext_mappings.begin(); iter != test_ext_mappings.end();) {
+      auto [lo, ext] = *iter;
+      ++iter;
+      if (i % 3 != 0) {
         rm_extent(extmap_root, *t, lo, ext);
       }
+      i++;
 
       if (i % 10 == 0) {
-	logger().debug("submitting transaction i= {}", i);
+        logger().debug("submitting transaction i= {}", i);
         tm->submit_transaction(std::move(t)).unsafe_get();
         t = tm->create_transaction();
       }
-      if (i % 50 == 0) {
+      if (i % 100 == 0) {
         logger().debug("check_mappings  i= {}", i);
         check_mappings(extmap_root, *t);
         check_mappings(extmap_root);
       }
-      i++;
-      if (i == 100)
-	break;
     }
     logger().debug("finally submitting transaction ");
     tm->submit_transaction(std::move(t)).unsafe_get();
+  });
+}
+
+TEST_F(extentmap_manager_test_t, force_leafnode_split_merge_replay)
+{
+  run_async([this] {
+    extmap_root_t extmap_root(0, L_ADDR_NULL);
+    {
+      auto t = tm->create_transaction();
+      extmap_root = extmap_manager->initialize_extmap(*t).unsafe_get0();
+      tm->submit_transaction(std::move(t)).unsafe_get();
+      replay();
+    }
+    uint32_t len = 4096;
+    uint32_t lo = 0;
+    for (unsigned i = 0; i < 50; i++) {
+      auto t = tm->create_transaction();
+      logger().debug("opened split_merge transaction");
+      for (unsigned j = 0; j < 5; ++j) {
+        [[maybe_unused]] auto addref = insert_extent(extmap_root, *t, lo, {lo, len});
+        lo += len;
+      }
+      logger().debug("submitting transaction");
+      tm->submit_transaction(std::move(t)).unsafe_get();
+    }
+    replay();
+    auto t = tm->create_transaction();
+    int i = 0;
+    for (auto iter = test_ext_mappings.begin(); iter != test_ext_mappings.end();) {
+      auto [lo, ext] = *iter;
+      ++iter;
+      rm_extent(extmap_root, *t, lo, ext);
+      i++;
+
+      if (i % 10 == 0) {
+        logger().debug("submitting transaction i= {}", i);
+        tm->submit_transaction(std::move(t)).unsafe_get();
+        t = tm->create_transaction();
+      }
+      if (i% 100 == 0){
+        check_mappings(extmap_root);
+      }
+    }
+    logger().debug("finally submitting transaction ");
+    tm->submit_transaction(std::move(t)).unsafe_get();
+    replay();
     check_mappings(extmap_root);
   });
 }


### PR DESCRIPTION
and check node size before make  merge.

Signed-off-by: chunmei-liu <chunmei.liu@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
