### PR TITLE
nautilus: vstart.sh: fix fs set max_mds bug

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1085,7 +1085,7 @@ do
     [ $fs -eq $CEPH_NUM_FS ] && break
     fs=$(($fs + 1))
     if [ "$CEPH_MAX_MDS" -gt 1 ]; then
-        ceph_adm fs set "cephfs_${name}" max_mds "$CEPH_MAX_MDS"
+        ceph_adm fs set "${name}" max_mds "$CEPH_MAX_MDS"
     fi
 done
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47953

---

backport of https://github.com/ceph/ceph/pull/37752
parent tracker: https://tracker.ceph.com/issues/47946

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh