### PR TITLE
octopus: cephfs: client: fix inode ll_ref reference count leak

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6423,9 +6423,7 @@ int Client::_lookup(Inode *dir, const string& dname, int mask, InodeRef *target,
       int r = make_request(req, perms, &tmptarget, NULL, rand() % mdsmap->get_num_in_mds());
 
       if (r == 0) {
-	Inode *tempino = tmptarget.get();
-	_ll_get(tempino);
-	*target = tempino;
+	*target = std::move(tmptarget);
 	ldout(cct, 8) << __func__ << " found target " << (*target)->ino << dendl;
       } else {
 	*target = dir;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47989

---

backport of https://github.com/ceph/ceph/pull/37735
parent tracker: https://tracker.ceph.com/issues/47918

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh