### PR TITLE
octopus: qa/cephfs: add session_timeout option support

### DIFF
--- a/qa/cephfs/clusters/3-mds.yaml
+++ b/qa/cephfs/clusters/3-mds.yaml
@@ -4,7 +4,8 @@ roles:
 - [client.0, client.1]
 overrides:
   ceph:
-    max_mds: 3
+    cephfs:
+      max_mds: 3
 openstack:
 - volumes: # attached to each instance
     count: 4

--- a/qa/cephfs/clusters/9-mds.yaml
+++ b/qa/cephfs/clusters/9-mds.yaml
@@ -4,7 +4,8 @@ roles:
 - [client.0, client.1]
 overrides:
   ceph:
-    max_mds: 9
+    cephfs:
+      max_mds: 9
 openstack:
 - volumes: # attached to each instance
     count: 4

--- a/qa/cephfs/overrides/session_timeout.yaml
+++ b/qa/cephfs/overrides/session_timeout.yaml
@@ -1,0 +1,4 @@
+overrides:
+  ceph:
+    cephfs:
+      session_timeout: 300

--- a/qa/suites/fs/basic_workload/overrides/session_timeout.yaml
+++ b/qa/suites/fs/basic_workload/overrides/session_timeout.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/overrides/session_timeout.yaml

--- a/qa/suites/fs/thrash/overrides/session_timeout.yaml
+++ b/qa/suites/fs/thrash/overrides/session_timeout.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/overrides/session_timeout.yaml

--- a/qa/suites/fs/upgrade/featureful_client/old_client/overrides/multimds/no.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/overrides/multimds/no.yaml
@@ -1,3 +1,4 @@
 overrides:
   ceph:
-    max_mds: 1
+    cephfs:
+      max_mds: 1

--- a/qa/suites/fs/upgrade/featureful_client/old_client/overrides/multimds/yes.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/overrides/multimds/yes.yaml
@@ -1,3 +1,4 @@
 overrides:
   ceph:
-    max_mds: 2
+    cephfs:
+      max_mds: 2

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/overrides/multimds/no.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/overrides/multimds/no.yaml
@@ -1,3 +1,4 @@
 overrides:
   ceph:
-    max_mds: 1
+    cephfs:
+      max_mds: 1

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/overrides/multimds/yes.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/overrides/multimds/yes.yaml
@@ -1,3 +1,4 @@
 overrides:
   ceph:
-    max_mds: 2
+    cephfs:
+      max_mds: 2

--- a/qa/suites/fs/verify/overrides/session_timeout.yaml
+++ b/qa/suites/fs/verify/overrides/session_timeout.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/overrides/session_timeout.yaml

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -402,13 +402,8 @@ def cephfs_setup(ctx, config):
     if mdss.remotes:
         log.info('Setting up CephFS filesystem...')
 
-        fs = Filesystem(ctx, name='cephfs', create=True,
-                        ec_profile=config.get('cephfs_ec_profile', None))
-
-        cephfs_conf = config['cephfs']
-        max_mds = config_conf.get('max_mds', 1)
-        if max_mds > 1:
-            fs.set_max_mds(max_mds)
+        Filesystem(ctx, fs_config=config.get('cephfs', None), name='cephfs',
+                   create=True, ec_profile=config.get('cephfs_ec_profile', None))
 
     yield
 

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1687,6 +1687,13 @@ def task(ctx, config):
             cephfs:
               max_mds: 2
 
+    To change the mdsmap's default session_timeout (60 seconds), use::
+
+        tasks:
+        - ceph:
+            cephfs:
+              session_timeout: 300
+
     Note, this will cause the task to check the /scratch_devs file on each node
     for available devices.  If no such file is found, /dev/sdb will be used.
 

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -405,7 +405,8 @@ def cephfs_setup(ctx, config):
         fs = Filesystem(ctx, name='cephfs', create=True,
                         ec_profile=config.get('cephfs_ec_profile', None))
 
-        max_mds = config.get('max_mds', 1)
+        cephfs_conf = config['cephfs']
+        max_mds = config_conf.get('max_mds', 1)
         if max_mds > 1:
             fs.set_max_mds(max_mds)
 
@@ -1683,6 +1684,13 @@ def task(ctx, config):
             fs: xfs
             mkfs_options: [-b,size=65536,-l,logdev=/dev/sdc1]
             mount_options: [nobarrier, inode64]
+
+    To change the cephfs's default max_mds (1), use::
+
+        tasks:
+        - ceph:
+            cephfs:
+              max_mds: 2
 
     Note, this will cause the task to check the /scratch_devs file on each node
     for available devices.  If no such file is found, /dev/sdb will be used.

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -548,6 +548,9 @@ class Filesystem(MDSCluster):
     def set_max_mds(self, max_mds):
         self.set_var("max_mds", "%d" % max_mds)
 
+    def set_session_timeout(self, timeout):
+        self.set_var("session_timeout", "%d" % timeout)
+
     def set_allow_standby_replay(self, yes):
         self.set_var("allow_standby_replay", yes)
 
@@ -614,6 +617,11 @@ class Filesystem(MDSCluster):
             max_mds = self.fs_config.get('max_mds', 1)
             if max_mds > 1:
                 self.set_max_mds(max_mds)
+
+            # If absent will use the default value (60 seconds)
+            session_timeout = self.fs_config.get('session_timeout', 60)
+            if session_timeout != 60:
+                self.set_session_timeout(session_timeout)
 
         self.getinfo(refresh = True)
 

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -429,7 +429,7 @@ class Filesystem(MDSCluster):
     This object is for driving a CephFS filesystem.  The MDS daemons driven by
     MDSCluster may be shared with other Filesystems.
     """
-    def __init__(self, ctx, fscid=None, name=None, create=False,
+    def __init__(self, ctx, fs_config=None, fscid=None, name=None, create=False,
                  ec_profile=None):
         super(Filesystem, self).__init__(ctx)
 
@@ -440,6 +440,7 @@ class Filesystem(MDSCluster):
         self.metadata_overlay = False
         self.data_pool_name = None
         self.data_pools = None
+        self.fs_config = fs_config
 
         client_list = list(misc.all_roles_of_type(self._ctx.cluster, 'client'))
         self.client_id = client_list[0]
@@ -608,6 +609,11 @@ class Filesystem(MDSCluster):
                 pass
             else:
                 raise
+
+        if self.fs_config is not None:
+            max_mds = self.fs_config.get('max_mds', 1)
+            if max_mds > 1:
+                self.set_max_mds(max_mds)
 
         self.getinfo(refresh = True)
 

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -1119,6 +1119,7 @@ class LocalFilesystem(Filesystem, LocalMDSCluster):
         self.metadata_overlay = False
         self.data_pool_name = None
         self.data_pools = None
+        self.fs_config = None
 
         # Hack: cheeky inspection of ceph.conf to see what MDSs exist
         self.mds_ids = set()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47991

---

backport of https://github.com/ceph/ceph/pull/37629
parent tracker: https://tracker.ceph.com/issues/47565

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh