### PR TITLE
nautilus: bluestore: Support flock retry

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -936,6 +936,8 @@ OPTION(bdev_nvme_unbind_from_kernel, OPT_BOOL)
 OPTION(bdev_nvme_retry_count, OPT_INT) // -1 means by default which is 4
 OPTION(bdev_enable_discard, OPT_BOOL)
 OPTION(bdev_async_discard, OPT_BOOL)
+OPTION(bdev_flock_retry_interval, OPT_FLOAT)
+OPTION(bdev_flock_retry, OPT_INT)
 
 OPTION(objectstore_blackhole, OPT_BOOL)
 

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -936,8 +936,6 @@ OPTION(bdev_nvme_unbind_from_kernel, OPT_BOOL)
 OPTION(bdev_nvme_retry_count, OPT_INT) // -1 means by default which is 4
 OPTION(bdev_enable_discard, OPT_BOOL)
 OPTION(bdev_async_discard, OPT_BOOL)
-OPTION(bdev_flock_retry_interval, OPT_FLOAT)
-OPTION(bdev_flock_retry, OPT_INT)
 
 OPTION(objectstore_blackhole, OPT_BOOL)
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4337,7 +4337,7 @@ std::vector<Option> get_global_options() {
     .set_default(0.1)
     .set_description("interval to retry the flock"),
     
-    Option("bdev_flock_retry", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    Option("bdev_flock_retry", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(3)
     .set_description("times to retry the flock"),
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4339,7 +4339,11 @@ std::vector<Option> get_global_options() {
     
     Option("bdev_flock_retry", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(3)
-    .set_description("times to retry the flock"),
+    .set_description("times to retry the flock")
+    .set_long_description(
+        "The number of times to retry on getting the block device lock. "
+        "Programs such as systemd-udevd may compete with Ceph for this lock. "
+        "0 means 'unlimited'."),
 
     Option("bluefs_alloc_size", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
     .set_default(1_M)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4332,6 +4332,14 @@ std::vector<Option> get_global_options() {
     Option("bdev_async_discard", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
     .set_description(""),
+    
+    Option("bdev_flock_retry_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(0.1)
+    .set_description("interval to retry the flock"),
+    
+    Option("bdev_flock_retry", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(3)
+    .set_description("times to retry the flock"),
 
     Option("bluefs_alloc_size", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
     .set_default(1_M)

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -60,11 +60,11 @@ int KernelDevice::_lock()
 {
   dout(10) << __func__ << " " << fd_directs[WRITE_LIFE_NOT_SET] << dendl;
   double retry_interval = cct->_conf.get_val<double>("bdev_flock_retry_interval");
-
+  uint64_t max_retry = cct->_conf.get_val<uint64_t>("bdev_flock_retry");
   // When the block changes, systemd-udevd will open the block,
   // read some information and close it. Then a failure occurs here.
   // So we need to try again here.
-  for (int i = 0; i < cct->_conf->bdev_flock_retry + 1; i++) {
+  for (uint64_t i = 0; i < max_retry + 1; i++) {
     int r = ::flock(fd_directs[WRITE_LIFE_NOT_SET], LOCK_EX | LOCK_NB);
     if (r < 0 && errno == EAGAIN) {
       dout(1) << __func__ << " flock busy on " << path << dendl;

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -82,7 +82,7 @@ int KernelDevice::_lock()
     dout(1) << __func__ << " flock busy on " << path << dendl;
     if (const uint64_t max_retry =
 	cct->_conf.get_val<uint64_t>("bdev_flock_retry");
-        nr_tries++ == max_retry) {
+        max_retry > 0 && nr_tries++ == max_retry) {
       return -EAGAIN;
     }
     double retry_interval =

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -59,24 +59,36 @@ KernelDevice::KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, ai
 int KernelDevice::_lock()
 {
   dout(10) << __func__ << " " << fd_directs[WRITE_LIFE_NOT_SET] << dendl;
-  double retry_interval = cct->_conf.get_val<double>("bdev_flock_retry_interval");
-  uint64_t max_retry = cct->_conf.get_val<uint64_t>("bdev_flock_retry");
   // When the block changes, systemd-udevd will open the block,
   // read some information and close it. Then a failure occurs here.
   // So we need to try again here.
-  for (uint64_t i = 0; i < max_retry + 1; i++) {
-    int r = ::flock(fd_directs[WRITE_LIFE_NOT_SET], LOCK_EX | LOCK_NB);
-    if (r < 0 && errno == EAGAIN) {
-      dout(1) << __func__ << " flock busy on " << path << dendl;
-      std::this_thread::sleep_for(ceph::make_timespan(retry_interval));
-    } else if (r < 0) {
-      derr << __func__ << " flock failed on " << path << dendl;    
-      break;
-    } else {
+  int fd = fd_directs[WRITE_LIFE_NOT_SET];
+  uint64_t nr_tries = 0;
+  for (;;) {
+    struct flock fl = { F_WRLCK,
+                        SEEK_SET };
+    int r = ::fcntl(fd, F_OFD_SETLK, &fl);
+    if (r < 0) {
+      if (errno == EINVAL) {
+        r = ::flock(fd, LOCK_EX | LOCK_NB);
+      }
+    }
+    if (r == 0) {
       return 0;
     }
+    if (errno != EAGAIN) {
+      return -errno;
+    }
+    dout(1) << __func__ << " flock busy on " << path << dendl;
+    if (const uint64_t max_retry =
+	cct->_conf.get_val<uint64_t>("bdev_flock_retry");
+        nr_tries++ == max_retry) {
+      return -EAGAIN;
+    }
+    double retry_interval =
+      cct->_conf.get_val<double>("bdev_flock_retry_interval");
+    std::this_thread::sleep_for(ceph::make_timespan(retry_interval));
   }
-  return -errno;
 }
 
 int KernelDevice::open(const string& p)

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -59,12 +59,25 @@ KernelDevice::KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, ai
 int KernelDevice::_lock()
 {
   dout(10) << __func__ << " " << fd_directs[WRITE_LIFE_NOT_SET] << dendl;
-  int r = ::flock(fd_directs[WRITE_LIFE_NOT_SET], LOCK_EX | LOCK_NB);
-  if (r < 0) {
-    derr << __func__ << " flock failed on " << path << dendl;
-    return -errno;
+  utime_t sleeptime;
+  sleeptime.set_from_double(cct->_conf->bdev_flock_retry_interval);
+
+  // When the block changes, systemd-udevd will open the block,
+  // read some information and close it. Then a failure occurs here.
+  // So we need to try again here.
+  for (int i = 0; i < cct->_conf->bdev_flock_retry + 1; i++) {
+    int r = ::flock(fd_directs[WRITE_LIFE_NOT_SET], LOCK_EX | LOCK_NB);
+    if (r < 0 && errno == EAGAIN) {
+      dout(1) << __func__ << " flock busy on " << path << dendl;    
+      sleeptime.sleep();
+    } else if (r < 0) {
+      derr << __func__ << " flock failed on " << path << dendl;    
+      break;
+    } else {
+      return 0;
+    }
   }
-  return 0;
+  return -errno;
 }
 
 int KernelDevice::open(const string& p)

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -59,8 +59,7 @@ KernelDevice::KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, ai
 int KernelDevice::_lock()
 {
   dout(10) << __func__ << " " << fd_directs[WRITE_LIFE_NOT_SET] << dendl;
-  utime_t sleeptime;
-  sleeptime.set_from_double(cct->_conf->bdev_flock_retry_interval);
+  double retry_interval = cct->_conf.get_val<double>("bdev_flock_retry_interval");
 
   // When the block changes, systemd-udevd will open the block,
   // read some information and close it. Then a failure occurs here.
@@ -68,8 +67,8 @@ int KernelDevice::_lock()
   for (int i = 0; i < cct->_conf->bdev_flock_retry + 1; i++) {
     int r = ::flock(fd_directs[WRITE_LIFE_NOT_SET], LOCK_EX | LOCK_NB);
     if (r < 0 && errno == EAGAIN) {
-      dout(1) << __func__ << " flock busy on " << path << dendl;    
-      sleeptime.sleep();
+      dout(1) << __func__ << " flock busy on " << path << dendl;
+      std::this_thread::sleep_for(ceph::make_timespan(retry_interval));
     } else if (r < 0) {
       derr << __func__ << " flock failed on " << path << dendl;    
       break;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47707

---

backport of https://github.com/ceph/ceph/pull/34566
parent tracker: https://tracker.ceph.com/issues/46124

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh