### PR TITLE
octopus: rgw: use yum rather than dnf for teuthology testing of rgw-orphan-list

### DIFF
--- a/qa/workunits/rgw/test_rgw_orphan_list.sh
+++ b/qa/workunits/rgw/test_rgw_orphan_list.sh
@@ -56,9 +56,8 @@ uninstall_awscli() {
     cd "$here"
 }
 
-sudo dnf install -y s3cmd
-
-sudo yum install python3-setuptools
+sudo yum -y install s3cmd
+sudo yum -y install python3-setuptools
 sudo yum -y install python3-pip
 sudo pip3 install --upgrade setuptools
 sudo pip3 install python-swiftclient


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47896

---

backport of https://github.com/ceph/ceph/pull/37684
parent tracker: https://tracker.ceph.com/issues/47408

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh