### PR TITLE
octopus: rgw/gc: fixing the condition when marker for a queue is

### DIFF
--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -208,7 +208,7 @@ int RGWGC::list(int *index, string& marker, uint32_t max, bool expired_only, std
       }
       obj_version objv;
       cls_version_read(store->gc_pool_ctx, obj_names[*index], &objv);
-      if (ret == -ENOENT) {
+      if (ret == -ENOENT || entries.size() == 0) {
         if (objv.ver == 0) {
           continue;
         } else {
@@ -252,6 +252,11 @@ int RGWGC::list(int *index, string& marker, uint32_t max, bool expired_only, std
     marker = next_marker;
 
     if (*index == max_objs - 1) {
+      if (queue_entries.size() > 0 && *truncated) {
+        processing_queue = true;
+      } else {
+        processing_queue = false;
+      }
       /* we cut short here, truncated will hold the correct value */
       return 0;
     }
@@ -537,13 +542,13 @@ int RGWGC::process(int index, int max_secs, bool expired_only,
         if (non_expired_entries.size() == 0) {
           transitioned_objects_cache[index] = true;
           marker.clear();
-          ldpp_dout(this, 20) << "RGWGC::process cls_rgw_gc_list returned ENOENT for non expired entries, so setting cache entry to TRUE" << dendl;
+          ldpp_dout(this, 20) << "RGWGC::process cls_rgw_gc_list returned NO non expired entries, so setting cache entry to TRUE" << dendl;
         } else {
           ret = 0;
           goto done;
         }
       }
-      if ((objv.ver == 0) && (ret == -ENOENT)) {
+      if ((objv.ver == 0) && (ret == -ENOENT || entries.size() == 0)) {
         ret = 0;
         goto done;
       }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47955

---

backport of https://github.com/ceph/ceph/pull/37666
parent tracker: https://tracker.ceph.com/issues/47909

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh