### PR TITLE
octopus: rgw/gc: fix for incrementing the perf counter 'gc_retire_object'

### DIFF
--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -479,6 +479,10 @@ public:
 	    index << " ret=" << ret << dendl;
       return ret;
     }
+    if (perfcounter) {
+      /* log the count of tags retired for rate estimation */
+      perfcounter->inc(l_rgw_gc_retire, num_entries);
+    }
     return 0;
   }
 }; // class RGWGCIOManger


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47956

---

backport of https://github.com/ceph/ceph/pull/37409
parent tracker: https://tracker.ceph.com/issues/47908

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh