### PR TITLE
octopus: mgr/volumes/nfs: Fix wrong error message for pseudo path

### DIFF
--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -556,7 +556,7 @@ class FSExport(object):
             pseudo_path = self.format_path(pseudo_path)
             if not isabs(pseudo_path) or pseudo_path == "/":
                 return -errno.EINVAL, "", f"pseudo path {pseudo_path} is invalid. "\
-                        "It should not be absolute path or just '/'."
+                        "It should be an absolute path and it cannot be just '/'."
 
             if cluster_id not in self.exports:
                 self.exports[cluster_id] = []


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47891

---

backport of https://github.com/ceph/ceph/pull/37583
parent tracker: https://tracker.ceph.com/issues/47783

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh