### PR TITLE
octopus: mds: account for closing sessions in hit_session

### DIFF
--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -1017,7 +1017,8 @@ int Session::check_access(CInode *in, unsigned mask,
 // track total and per session load
 void SessionMap::hit_session(Session *session) {
   uint64_t sessions = get_session_count_in_state(Session::STATE_OPEN) +
-                      get_session_count_in_state(Session::STATE_STALE);
+                      get_session_count_in_state(Session::STATE_STALE) +
+                      get_session_count_in_state(Session::STATE_CLOSING);
   ceph_assert(sessions != 0);
 
   double total_load = total_load_avg.hit();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47936

---

backport of https://github.com/ceph/ceph/pull/37646
parent tracker: https://tracker.ceph.com/issues/47833

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh