### PR TITLE
octopus: mon/MDSMonitor do not ignore mds's down:dne request

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -393,6 +393,10 @@ bool MDSMonitor::preprocess_beacon(MonOpRequestRef op)
   dout(10) << __func__ << ": GID exists in map: " << gid << dendl;
   info = fsmap.get_info_gid(gid);
 
+  if (state == MDSMap::STATE_DNE) {
+    return false;
+  }
+
   // old seq?
   if (info.state_seq > seq) {
     dout(7) << "mds_beacon " << *m << " has old seq, ignoring" << dendl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47958

---

backport of https://github.com/ceph/ceph/pull/37702
parent tracker: https://tracker.ceph.com/issues/47881

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh