### PR TITLE
mgr/rbd_support: store global schedule without localized prefix

### DIFF
--- a/src/pybind/mgr/rbd_support/schedule.py
+++ b/src/pybind/mgr/rbd_support/schedule.py
@@ -345,6 +345,18 @@ class Schedules:
 
         schedule_cfg = self.handler.module.get_module_option(
             self.handler.MODULE_OPTION_NAME, '')
+
+        # Previous versions incorrectly stored the global config in
+        # the localized module option. Check the config is here and fix it.
+        if not schedule_cfg:
+            schedule_cfg = self.handler.module.get_localized_module_option(
+                self.handler.MODULE_OPTION_NAME, '')
+            if schedule_cfg:
+                self.handler.module.set_module_option(
+                    self.handler.MODULE_OPTION_NAME, schedule_cfg)
+        self.handler.module.set_localized_module_option(
+            self.handler.MODULE_OPTION_NAME, None)
+
         if schedule_cfg:
             try:
                 level_spec = LevelSpec.make_global()

--- a/src/pybind/mgr/rbd_support/schedule.py
+++ b/src/pybind/mgr/rbd_support/schedule.py
@@ -343,7 +343,7 @@ class Schedules:
 
     def load(self, namespace_validator=None, image_validator=None):
 
-        schedule_cfg = self.handler.module.get_localized_module_option(
+        schedule_cfg = self.handler.module.get_module_option(
             self.handler.MODULE_OPTION_NAME, '')
         if schedule_cfg:
             try:
@@ -420,8 +420,8 @@ class Schedules:
 
     def save(self, level_spec, schedule):
         if level_spec.is_global():
-            schedule_cfg = schedule and schedule.to_json() or ''
-            self.handler.module.set_localized_module_option(
+            schedule_cfg = schedule and schedule.to_json() or None
+            self.handler.module.set_module_option(
                 self.handler.MODULE_OPTION_NAME, schedule_cfg)
             return
 


### PR DESCRIPTION
so it is still used after mgr failover

Fixes: https://tracker.ceph.com/issues/48020
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
