### PR TITLE
rgw: service account based authentication for vault

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2577,6 +2577,7 @@ options:
   enum_values:
   - token
   - agent
+  - service account
   with_legacy: true
 - name: rgw_crypt_vault_token_file
   type: str
@@ -2732,6 +2733,20 @@ options:
   level: advanced
   desc: sse-s3; kmip key template
   default: $keyid
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_crypt_vault_service_account_role
+  type: str
+  level: advanced
+  desc: kubernetes service account for vault authentication
+  services:
+  - rgw
+  with_legacy: true
+- name: rgw_crypt_vault_service_account_token_file
+  type: str
+  level: advanced
+  desc: If authentication method is 'service account', provide a path to the corresponding token file.
   services:
   - rgw
   with_legacy: true

--- a/src/rgw/rgw_kms.h
+++ b/src/rgw/rgw_kms.h
@@ -17,6 +17,7 @@ static const std::string RGW_SSE_KMS_BACKEND_KMIP = "kmip";
 
 static const std::string RGW_SSE_KMS_VAULT_AUTH_TOKEN = "token";
 static const std::string RGW_SSE_KMS_VAULT_AUTH_AGENT = "agent";
+static const std::string RGW_SSE_KMS_VAULT_AUTH_K8S_SA = "service account";
 
 static const std::string RGW_SSE_KMS_VAULT_SE_TRANSIT = "transit";
 static const std::string RGW_SSE_KMS_VAULT_SE_KV = "kv";


### PR DESCRIPTION
Currently, vault server authenticates RGW via token which is saved in a file.
In Kubernetes or OCS world service account can be used as authenticating between those two.
For that following need to be done:
At vault side,
Need to create a role and attach the role with service account and policy.

At RGW side,
There will be jwt token present in /var/run/secrets/kubernetes.io/serviceaccount/token and
using role specified send request to vault server as follows:
```console
# KUBE_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
# VAULT_SA_LOGIN=http://vault.default:8200/v1/auth/kubernetes/login
# curl --request POST --data '{"jwt": "'"$KUBE_TOKEN"'", "role": "rook-ceph-rgw"}' $VAULT_SA_LOGIN | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1652  100   687  100   965  38166  53611 --:--:-- --:--:-- --:--:-- 91777
{
  "request_id": "d3b3a7ba-6f9f-ed1e-2f7f-a5e3a3c0e119",
  "lease_id": "",
  "renewable": false,
  "lease_duration": 0,
  "data": null,
  "wrap_info": null,
  "warnings": null,
  "auth": {
    "client_token": "s.J31TfjkCEYske7VXOzZ0hOjZ",
    "accessor": "UKBLKjFpjv9lctzohTDizyQf",
    "policies": [
      "default",
      "rgw-kv-policy"
    ],
    "token_policies": [
      "default",
      "rgw-kv-policy"
    ],
    "metadata": {
      "role": "rook-ceph-rgw",
      "service_account_name": "rook-ceph-rgw",
      "service_account_namespace": "rook-ceph",
      "service_account_secret_name": "rook-ceph-rgw-token-g2q44",
      "service_account_uid": "01393961-3ceb-4df3-a384-8b78aba7b8f6"
    },
    "lease_duration": 86400,
    "renewable": true,
    "entity_id": "3fc23dc9-f850-9f41-0ae2-fbb0322979de",
    "token_type": "service",
    "orphan": true
  }
}
Fetch the "auth.client_token" from it and follows existing code flows in rgw_kms.cc
```
Fixes: https://tracker.ceph.com/issues/47777
Signed-off-by: Jiffin Tony Thottan <jthottan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
