### PR TITLE
pybind/mgr/prometheus: fix float+str error when calculating next_refresh

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -193,7 +193,7 @@ class MetricCollectionThread(threading.Thread):
                 duration = time.time() - start_time
 
                 self.mod.log.debug('collecting cache in thread done')
-                
+
                 sleep_time = self.mod.scrape_interval - duration
                 if sleep_time < 0:
                     self.mod.log.warning(
@@ -811,8 +811,8 @@ class Module(MgrModule):
         pools_refreshed = False
         if pools:
             next_refresh = self.rbd_stats['pools_refresh_time'] + \
-                self.get_localized_module_option(
-                'rbd_stats_pools_refresh_interval', 300)
+                float(self.get_localized_module_option(
+                'rbd_stats_pools_refresh_interval', 300))
             if rbd_stats_pools != pools or time.time() >= next_refresh:
                 self.refresh_rbd_stats_pools(pools)
                 pools_refreshed = True


### PR DESCRIPTION
After "config set mgr mgr/prometheus/rbd_stats_pools some_pool" and set
"rbd_stats_pools_refresh_interval", curl /metrics
will get TypeError: unsupported operand type(s) for +: 'float' and 'str'.
Looks like that we should change type before add.

Signed-off-by: haoyixing <haoyixing@kuaishou.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
