### PR TITLE
librbd: relax requirements on finisher canceled callback

### DIFF
--- a/src/librbd/TaskFinisher.h
+++ b/src/librbd/TaskFinisher.h
@@ -65,8 +65,7 @@ public:
       return false;
     }
     it->second.first->complete(-ECANCELED);
-    bool canceled = m_safe_timer->cancel_event(it->second.second);
-    ceph_assert(canceled);
+    m_safe_timer->cancel_event(it->second.second);
     m_task_contexts.erase(it);
     return true;
   }
@@ -75,8 +74,7 @@ public:
     std::lock_guard l{*m_lock};
     for (auto &[task, pair] : m_task_contexts) {
       pair.first->complete(-ECANCELED);
-      bool canceled = m_safe_timer->cancel_event(pair.second);
-      ceph_assert(canceled);
+      m_safe_timer->cancel_event(pair.second);
     }
     m_task_contexts.clear();
   }
@@ -102,7 +100,9 @@ public:
       return false;
     }
     bool canceled = m_safe_timer->cancel_event(it->second.second);
-    ceph_assert(canceled);
+    if (!canceled) {
+      return false;
+    }
     auto timer_ctx = new C_Task(this, task);
     it->second.second = timer_ctx;
     m_safe_timer->add_event_after(seconds, timer_ctx);
@@ -117,8 +117,8 @@ public:
     std::lock_guard l{*m_lock};
     typename TaskContexts::iterator it = m_task_contexts.find(task);
     if (it != m_task_contexts.end()) {
-      if (it->second.second != NULL) {
-        ceph_assert(m_safe_timer->cancel_event(it->second.second));
+      if (it->second.second != NULL &&
+          m_safe_timer->cancel_event(it->second.second)) {
         delete it->second.first;
       } else {
         // task already scheduled on the finisher

--- a/src/librbd/TaskFinisher.h
+++ b/src/librbd/TaskFinisher.h
@@ -119,10 +119,10 @@ public:
     if (it != m_task_contexts.end()) {
       if (it->second.second != NULL &&
           m_safe_timer->cancel_event(it->second.second)) {
-        delete it->second.first;
+        it->second.first->complete(-ECANCELED);
       } else {
         // task already scheduled on the finisher
-        delete ctx;
+        ctx->complete(-ECANCELED);
         return false;
       }
     }


### PR DESCRIPTION
The finisher timer is started with safe_callbacks = false, and
cancel_event may fail.

When canceling a task it is safe to just ignore the cancel_event
result and proceed, because the returned false value means the
callback is in TaskFinisher::complete already but before
acquiring the lock, so when it eventually acquires the lock it
will just find out the task is already deleted and return.

Signed-off-by: Mykola Golub <mgolub@suse.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
