### PR TITLE
osd/scheduler: rely on copy ellision to move return val

### DIFF
--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -117,9 +117,9 @@ void mClockScheduler::enqueue_front(OpSchedulerItem&& item)
 WorkItem mClockScheduler::dequeue()
 {
   if (!immediate.empty()) {
-    auto ret = std::move(immediate.back());
+    WorkItem work_item{std::move(immediate.back())};
     immediate.pop_back();
-    return std::move(ret);
+    return work_item;
   } else {
     mclock_queue_t::PullReq result = scheduler.pull_request();
     if (result.is_future()) {
@@ -127,7 +127,7 @@ WorkItem mClockScheduler::dequeue()
     } else if (result.is_none()) {
       ceph_assert(
 	0 == "Impossible, must have checked empty() first");
-      return std::move(*(OpSchedulerItem*)nullptr);
+      return {};
     } else {
       ceph_assert(result.is_retn());
 


### PR DESCRIPTION
C++14 enforces copy ellision in this case.

also silences warning of

src/osd/scheduler/mClockScheduler.cc:122:21: warning: redundant move in return statement [-Wredundant-move]
  122 |     return std::move(ret);
      |            ~~~~~~~~~^~~~~

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
