### PR TITLE
crimson/gtest_seastar: do not keep a copy of argv

### DIFF
--- a/src/test/crimson/gtest_seastar.cc
+++ b/src/test/crimson/gtest_seastar.cc
@@ -50,13 +50,14 @@ void seastar_gtest_env_t::reactor(int argc, char** argv)
 
 int main(int argc, char **argv)
 {
+  ::testing::InitGoogleTest(&argc, argv);
+
   seastar_test_suite_t::seastar_env.init(argc, argv);
 
   seastar::global_logger_registry().set_all_loggers_level(
     seastar::log_level::debug
   );
 
-  ::testing::InitGoogleTest(&argc, argv);
   int ret = RUN_ALL_TESTS();
 
   seastar_test_suite_t::seastar_env.stop();

--- a/src/test/crimson/gtest_seastar.h
+++ b/src/test/crimson/gtest_seastar.h
@@ -20,8 +20,6 @@ struct seastar_gtest_env_t {
   seastar::file_desc begin_fd;
   std::unique_ptr<seastar::readable_eventfd> on_end;
 
-  int argc = 0;
-  char **argv = nullptr;
   std::thread thread;
 
   seastar_gtest_env_t();
@@ -29,7 +27,7 @@ struct seastar_gtest_env_t {
 
   void init(int argc, char **argv);
   void stop();
-  void reactor();
+  void reactor(int argc, char **argv);
 
   template <typename Func>
   void run(Func &&func) {


### PR DESCRIPTION
argv is always available in the whole life cycle of the application, so
there is no need to keep a copy of it.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
