### PR TITLE
mgr/dashboard: Use pipe instead of calling function within template

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/smart-list/smart-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/smart-list/smart-list.component.html
@@ -8,11 +8,11 @@
     dashboard.</cd-alert-panel>
 
   <ng-container *ngIf="!error && !incompatible">
-    <cd-alert-panel *ngIf="isEmpty(data)"
+    <cd-alert-panel *ngIf="data | isEmpty"
                     type="info"
                     i18n>No SMART data available.</cd-alert-panel>
 
-    <ng-container *ngIf="!isEmpty(data)">
+    <ng-container *ngIf="!(data | isEmpty)">
       <ul ngbNav
           #nav="ngbNav"
           class="nav-tabs">
@@ -26,7 +26,7 @@
             </ng-container>
 
             <ng-template #noError>
-              <cd-alert-panel *ngIf="isEmpty(device.value.info?.smart_status); else hasSmartStatus"
+              <cd-alert-panel *ngIf="device.value.info?.smart_status | isEmpty; else hasSmartStatus"
                               id="alert-self-test-unknown"
                               size="slim"
                               type="warning"
@@ -54,7 +54,7 @@
               </ng-template>
             </ng-template>
 
-            <ng-container *ngIf="!isEmpty(device.value.info) || !isEmpty(device.value.smart)">
+            <ng-container *ngIf="!(device.value.info | isEmpty) || !(device.value.smart | isEmpty)">
               <ul ngbNav
                   #innerNav="ngbNav"
                   class="nav-tabs">
@@ -62,10 +62,10 @@
                   <a ngbNavLink
                      i18n>Device Information</a>
                   <ng-template ngbNavContent>
-                    <cd-table-key-value *ngIf="!isEmpty(device.value.info)"
+                    <cd-table-key-value *ngIf="!(device.value.info | isEmpty)"
                                         [renderObjects]="true"
                                         [data]="device.value.info"></cd-table-key-value>
-                    <cd-alert-panel *ngIf="isEmpty(device.value.info)"
+                    <cd-alert-panel *ngIf="device.value.info | isEmpty"
                                     id="alert-device-info-unavailable"
                                     type="info"
                                     i18n>No device information available for this device.</cd-alert-panel>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/smart-list/smart-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/shared/smart-list/smart-list.component.ts
@@ -145,10 +145,6 @@ smartmontools is required to successfully retrieve data.`;
     }
   }
 
-  isEmpty(value: any) {
-    return _.isEmpty(value);
-  }
-
   ngOnInit() {
     this.smartDataColumns = [
       { prop: 'id', name: $localize`ID` },

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/is-empty.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/is-empty.pipe.spec.ts
@@ -1,0 +1,49 @@
+import { IsEmptyPipe } from './is-empty.pipe';
+
+describe('IsEmptyPipe', () => {
+  const pipe = new IsEmptyPipe();
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should transform to true (1)', () => {
+    expect(pipe.transform(NaN)).toBeTruthy();
+  });
+
+  it('should transform to true (2)', () => {
+    expect(pipe.transform(undefined)).toBeTruthy();
+  });
+
+  it('should transform to true (3)', () => {
+    expect(pipe.transform(null)).toBeTruthy();
+  });
+
+  it('should transform to true (4)', () => {
+    expect(pipe.transform('')).toBeTruthy();
+  });
+
+  it('should transform to true (5)', () => {
+    expect(pipe.transform({})).toBeTruthy();
+  });
+
+  it('should transform to true (6)', () => {
+    expect(pipe.transform([])).toBeTruthy();
+  });
+
+  it('should transform to true (7)', () => {
+    expect(pipe.transform(6)).toBeTruthy();
+  });
+
+  it('should transform to false (1)', () => {
+    expect(pipe.transform('a')).toBeFalsy();
+  });
+
+  it('should transform to false (2)', () => {
+    expect(pipe.transform([1])).toBeFalsy();
+  });
+
+  it('should transform to false (3)', () => {
+    expect(pipe.transform({ foo: 'bar' })).toBeFalsy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/is-empty.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/is-empty.pipe.ts
@@ -1,0 +1,21 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+import _ from 'lodash';
+
+@Pipe({
+  name: 'isEmpty'
+})
+export class IsEmptyPipe implements PipeTransform {
+  /**
+   * Checks if the given value is an empty object, collection, map, or set.
+   * Objects are considered empty if they have no own enumerable string
+   * keyed properties. Array-like values such as arguments objects, arrays,
+   * buffers or strings are considered empty if they have a length of 0.
+   * Similarly, maps and sets are considered empty if they have a size of 0.
+   * @param value The value to check.
+   * @return Returns `true` if value is empty, else `false`.
+   */
+  transform(value: any): boolean {
+    return _.isEmpty(value);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/pipes.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/pipes.module.ts
@@ -16,6 +16,7 @@ import { EncodeUriPipe } from './encode-uri.pipe';
 import { FilterPipe } from './filter.pipe';
 import { HealthColorPipe } from './health-color.pipe';
 import { IopsPipe } from './iops.pipe';
+import { IsEmptyPipe } from './is-empty.pipe';
 import { IscsiBackstorePipe } from './iscsi-backstore.pipe';
 import { JoinPipe } from './join.pipe';
 import { LogPriorityPipe } from './log-priority.pipe';
@@ -58,7 +59,8 @@ import { UpperFirstPipe } from './upper-first.pipe';
     RbdConfigurationSourcePipe,
     DurationPipe,
     MapPipe,
-    TruncatePipe
+    TruncatePipe,
+    IsEmptyPipe
   ],
   exports: [
     ArrayPipe,
@@ -87,7 +89,8 @@ import { UpperFirstPipe } from './upper-first.pipe';
     RbdConfigurationSourcePipe,
     DurationPipe,
     MapPipe,
-    TruncatePipe
+    TruncatePipe,
+    IsEmptyPipe
   ],
   providers: [
     ArrayPipe,
@@ -112,7 +115,8 @@ import { UpperFirstPipe } from './upper-first.pipe';
     NotAvailablePipe,
     UpperFirstPipe,
     MapPipe,
-    TruncatePipe
+    TruncatePipe,
+    IsEmptyPipe
   ]
 })
 export class PipesModule {}


### PR DESCRIPTION
Refactor code. Use pipes instead of calling a function from within the template.

Fixes: https://tracker.ceph.com/issues/48051

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
