### PR TITLE
crimson/os/seastore/.../lba_btree_node_impl: hold reference to *this during lookup

### DIFF
--- a/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/lba_btree_node_impl.cc
@@ -46,7 +46,7 @@ LBAInternalNode::lookup_ret LBAInternalNode::lookup(
     iter->get_val(),
     get_paddr()).safe_then([c, addr, depth](auto child) {
       return child->lookup(c, addr, depth);
-    });
+    }).finally([ref=LBANodeRef(this)] {});
 }
 
 LBAInternalNode::lookup_range_ret LBAInternalNode::lookup_range(


### PR DESCRIPTION
4f2f4f4ab0dab3eb76252e735f3f457411fea4d0 modified TransactionManager::mount() to use a weak_transaction
while calling init_cached_extents.  This is fine, but lookup() needs
to hold a reference to *this until the child lookup completes in order
to ensure residence in the lba pinning set.

Signed-off-by: Samuel Just <sjust@redhat.com>