### PR TITLE
mgr: Fix for dashboard/prometheus failure due to laggy pg state

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1,4 +1,5 @@
 import cherrypy
+from collections import defaultdict
 from distutils.version import StrictVersion
 import json
 import errno
@@ -13,7 +14,7 @@ from mgr_util import get_default_addr, profile_method
 from rbd import RBD
 from collections import namedtuple
 try:
-    from typing import Optional, Dict, Any, Set
+    from typing import DefaultDict, Optional, Dict, Any, Set
 except ImportError:
     pass
 
@@ -634,8 +635,7 @@ class Module(MgrModule):
         pg_summary = self.get('pg_summary')
 
         for pool in pg_summary['by_pool']:
-            num_by_state = dict((state, 0) for state in PG_STATES)
-            num_by_state['total'] = 0
+            num_by_state = defaultdict(int)  # type: DefaultDict[str, int]
 
             for state_name, count in pg_summary['by_pool'][pool].items():
                 for state in state_name.split('+'):


### PR DESCRIPTION
PG_STATES in pybind/mgr/mgr_module.py are synced with osd/osd_types.cc now.
pybind/mgr/prometheus/module.py: safe increment for pg_%STATE% metrics

Fixes: https://tracker.ceph.com/issues/46142
Signed-off-by: Alexander Sushko <alexandrsushko@gmail.com>