### PR TITLE
mgr/dashboard: Disable the button in the 'disabled forms' & fix btn border

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/form-input-disable.directive.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/form-input-disable.directive.ts
@@ -6,7 +6,7 @@ import { FormScopeDirective } from './form-scope.directive';
 
 @Directive({
   selector:
-    'input:not([cdNoFormInputDisable]), select:not([cdNoFormInputDisable]), [cdFormInputDisable]'
+    'input:not([cdNoFormInputDisable]), select:not([cdNoFormInputDisable]), button:not([cdNoFormInputDisable]), [cdFormInputDisable]'
 })
 export class FormInputDisableDirective implements AfterViewInit {
   permissions: Permissions;

--- a/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_buttons.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_buttons.scss
@@ -34,6 +34,11 @@
     background-color: vv.$gray-300;
     border-color: vv.$gray-600 !important;
   }
+
+  &:disabled {
+    background-color: vv.$gray-200;
+    border-color: vv.$gray-400 !important;
+  }
 }
 
 // We have some inputs that don't have a corresponding formControlName,
@@ -51,6 +56,11 @@
     &.focus {
       outline: 0;
     }
+  }
+
+  &.disabled {
+    border: 0;
+    box-shadow: none;
   }
 }
 


### PR DESCRIPTION
Currently only the input and select components are disabled in the forms for the disabled forms (when user is read only). Clicking that Remove Custom Configuration button when the user is read only, it is leading to an error page. 

Also the disabled buttons are getting a border and box shadow when its focused. Removing that as well in this PR. (Seperate commit)

**Before disabling button**
![buttondisable](https://user-images.githubusercontent.com/71764184/97839239-c6aaf000-1d07-11eb-9a80-96e26b450151.png)

**After disabling button**
![buttondisabled](https://user-images.githubusercontent.com/71764184/97839244-c7dc1d00-1d07-11eb-8379-595e28ac8dc6.png)

**Disabled button Border before when focused**
![disabledbtn](https://user-images.githubusercontent.com/71764184/97857452-c882ac80-1d23-11eb-8b60-ae8e90750ce5.png)

**Disabled button Border after when focused**
![afterbtndisabled](https://user-images.githubusercontent.com/71764184/97857465-ccaeca00-1d23-11eb-9b95-af1d23b2f3dc.png)


Fixes: https://tracker.ceph.com/issues/48069
Fixes: https://tracker.ceph.com/issues/48063
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
