### PR TITLE
cephadm: install podman from the Kubic project

### DIFF
--- a/qa/distros/all/ubuntu_18.04_podman.yaml
+++ b/qa/distros/all/ubuntu_18.04_podman.yaml
@@ -1,11 +1,12 @@
 os_type: ubuntu
 os_version: "18.04"
 
-# feel free to remove this test, if ppa:projectatomic is no longer maintained.
+# feel free to remove this test, if Kubic project is no longer maintained.
 tasks:
 - exec:
     all:
-    - sudo apt -y install software-properties-common
-    - sudo add-apt-repository -y ppa:projectatomic/ppa
+    - curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/Release.key | sudo apt-key add -
+    - echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+    - sudo apt update
     - sudo apt -y install podman
     - echo -e "[registries.search]\nregistries = ['docker.io']" | sudo tee /etc/containers/registries.conf

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4584,6 +4584,7 @@ class Apt(Packager):
                                   branch=branch, commit=commit)
         self.distro = self.DISTRO_NAMES[distro]
         self.distro_codename = distro_codename
+        self.distro_version = distro_version
 
     def repo_path(self):
         return '/etc/apt/sources.list.d/ceph.list'
@@ -4625,15 +4626,17 @@ class Apt(Packager):
             logger.info('Removing repo at %s...' % self.repo_path())
             os.unlink(self.repo_path())
 
+        if self.distro == 'ubuntu':
+            self.rm_kubic_repo()
+
     def install(self, ls):
         logger.info('Installing packages %s...' % ls)
         call_throws(['apt', 'install', '-y'] + ls)
 
     def install_podman(self):
         if self.distro == 'ubuntu':
-            logger.info('Setting up repo for pdoman...')
-            self.install(['software-properties-common'])
-            call_throws(['add-apt-repository', '-y', 'ppa:projectatomic/ppa'])
+            logger.info('Setting up repo for podman...')
+            self.add_kubic_repo()
             call_throws(['apt', 'update'])
 
         logger.info('Attempting podman install...')
@@ -4642,6 +4645,49 @@ class Apt(Packager):
         except Error as e:
             logger.info('Podman did not work.  Falling back to docker...')
             self.install(['docker.io'])
+
+    def kubic_repo_url(self):
+        return 'https://download.opensuse.org/repositories/devel:/kubic:/' \
+               'libcontainers:/stable/xUbuntu_%s/' % self.distro_version
+
+    def kubic_repo_path(self):
+        return '/etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list'
+
+    def kubric_repo_gpgkey_url(self):
+        return '%s/Release.key' % self.kubic_repo_url()
+
+    def kubric_repo_gpgkey_path(self):
+        return '/etc/apt/trusted.gpg.d/kubic.release.gpg'
+
+    def add_kubic_repo(self):
+        url = self.kubric_repo_gpgkey_url()
+        logger.info('Installing repo GPG key from %s...' % url)
+        try:
+            response = urlopen(url)
+        except HTTPError as err:
+            logger.error('failed to fetch GPG repo key from %s: %s' % (
+                url, err))
+            raise Error('failed to fetch GPG key')
+        key = response.read().decode('utf-8')
+        tmp_key = write_tmp(key, 0, 0)
+        keyring = self.kubric_repo_gpgkey_path()
+        call_throws(['apt-key', '--keyring', keyring, 'add', tmp_key.name])
+
+        logger.info('Installing repo file at %s...' % self.kubic_repo_path())
+        content = 'deb %s /\n' % self.kubic_repo_url()
+        with open(self.kubic_repo_path(), 'w') as f:
+            f.write(content)
+
+    def rm_kubic_repo(self):
+        keyring = self.kubric_repo_gpgkey_path()
+        if os.path.exists(keyring):
+            logger.info('Removing repo GPG key %s...' % keyring)
+            os.unlink(keyring)
+
+        p = self.kubic_repo_path()
+        if os.path.exists(p):
+            logger.info('Removing repo at %s...' % p)
+            os.unlink(p)
 
 
 class YumDnf(Packager):


### PR DESCRIPTION
ppa:projectatomic is no longer maintained, updates are now provided via the Kubic project
    
Fixes: https://tracker.ceph.com/issues/48072
Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
