### PR TITLE
src/script/ceph-backport.sh: abort if jq not available

### DIFF
--- a/src/script/ceph-backport.sh
+++ b/src/script/ceph-backport.sh
@@ -22,7 +22,7 @@ set -e
 
 full_path="$0"
 
-SCRIPT_VERSION="15.1.1.389"
+SCRIPT_VERSION="16.0.0.6848"
 active_milestones=""
 backport_pr_labels=""
 backport_pr_number=""
@@ -1400,6 +1400,16 @@ else
     abort_due_to_setup_problem
 fi
 
+#
+# do we have jq available?
+#
+
+if type jq >/dev/null 2>&1 ; then
+    debug "jq is available. Good."
+else
+    error "This script uses jq, but it does not seem to be installed"
+    abort_due_to_setup_problem
+fi
 
 #
 # is jq available?


### PR DESCRIPTION
This commit improves the error message displayed by the
script when the user tries to run in in an environment where
jq is missing.

Signed-off-by: Nathan Cutler <ncutler@suse.com>
