### PR TITLE
blk/kernel/io_uring: Use syscall for io_uring register/setup

### DIFF
--- a/src/blk/kernel/io_uring.cc
+++ b/src/blk/kernel/io_uring.cc
@@ -134,8 +134,8 @@ int ioring_queue_t::init(std::vector<int> &fds)
   if (ret < 0)
     return ret;
 
-  ret = io_uring_register(d->io_uring.ring_fd, IORING_REGISTER_FILES,
-			  &fds[0], fds.size());
+  ret = syscall(SYS_io_uring_register, d->io_uring.ring_fd, IORING_REGISTER_FILES,
+                &fds[0], fds.size());
   if (ret < 0) {
     ret = -errno;
     goto close_ring_fd;
@@ -214,7 +214,7 @@ bool ioring_queue_t::supported()
   struct io_uring_params p;
 
   memset(&p, 0, sizeof(p));
-  int fd = io_uring_setup(16, &p);
+  int fd = syscall(SYS_io_uring_setup, 16, &p);
   if (fd < 0)
     return false;
 


### PR DESCRIPTION
Without this PR I was unable to compile io_uring support into master on centos 8.2 with kernel 5.9.  I suspect that libc doesn't have support yet or something, so for now let's just execute these syscalls directly until support has caught up.

Signed-off-by: Mark Nelson <mnelson@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
