### PR TITLE
mgr/dashboard: enable different URL for users of browser to Grafana

### DIFF
--- a/doc/cephadm/monitoring.rst
+++ b/doc/cephadm/monitoring.rst
@@ -77,8 +77,20 @@ monitoring by following the steps below.
 
      ceph orch apply grafana 1
 
-Cephadm handles the prometheus, grafana, and alertmanager
-configurations automatically.
+Cephadm takes care of the configuration of Prometheus, Grafana, and Alertmanager
+automatically.
+
+However, there is one exception to this rule. In a some setups, the Dashboard
+user's browser might not be able to access the Grafana URL configured in Ceph
+Dashboard. One such scenario is when the cluster and the accessing user are each
+in a different DNS zone.
+
+For this case, there is an extra configuration option for Ceph Dashboard, which
+can be used to configure the URL for accessing Grafana by the user's browser.
+This value will never be altered by cephadm. To set this configuration option,
+issue the following command::
+
+  $ ceph dashboard set-grafana-frontend-api-url <grafana-server-api>
 
 It may take a minute or two for services to be deployed.  Once
 completed, you should see something like this from ``ceph orch ls``

--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -571,7 +571,8 @@ Configuring Dashboard
 After you have set up Grafana and Prometheus, you will need to configure the
 connection information that the Ceph Dashboard will use to access Grafana.
 
-Tell the dashboard the URL for the deployed Grafana instance::
+You need to tell the dashboard on which URL the Grafana instance is
+running/deployed::
 
   $ ceph dashboard set-grafana-api-url <grafana-server-url>  # default: ''
 
@@ -602,6 +603,38 @@ You can also access Grafana directly to monitor your cluster.
   clear the Grafana API URL we configured above::
 
     $ ceph dashboard reset-grafana-api-url
+
+Alternative URL for Browsers
+""""""""""""""""""""""""""""
+
+The Ceph Dashboard backend requires the Grafana URL to be able to verify the
+existence of Grafana Dashboards before the frontend even loads them. Due to the
+nature of how Grafana is implemented in Ceph Dashboard, this means that two
+working connections are required in order to be able to see Grafana graphs in
+Ceph Dashboard:
+
+- The backend (Ceph Mgr module) needs to verify the existence of the requested
+  graph. If this request succeeds, it lets the frontend know that it can safely
+  access Grafana.
+- The frontend then requests the Grafana graphs directly from the user's
+  browser using an iframe. The Grafana instance is accessed directly without any
+  detour through Ceph Dashboard.
+
+Now, it might be the case that your environment makes it difficult for the
+user's browser to directly access the URL configured in Ceph Dashboard. To solve
+this issue, a separate URL can be configured which will solely be used to tell
+the frontend (the user's browser) which URL it should use to access Grafana.
+This setting won't ever be changed automatically, unlike the GRAFANA_API_URL
+which is set by :ref:`cephadm` (only if cephadm is used to deploy monitoring
+services).
+
+To change the URL that is returned to the frontend issue the following command::
+
+  $ ceph dashboard set-grafana-frontend-api-url <grafana-server-url>
+
+If no value is set for that option, it will simply fall back to the value of the
+GRAFANA_API_URL option. If set, it will instruct the browser to use this URL to
+access Grafana.
 
 .. _dashboard-sso-support:
 
@@ -1404,7 +1437,7 @@ or a week in the future to revert this temporary logging increase.  This looks
 something like this::
 
     $ ceph config log
-    ... 
+    ...
     --- 11 --- 2020-11-07 11:11:11.960659 --- mgr.x/dashboard/log_level = debug ---
     ...
     $ ceph config reset 11

--- a/src/pybind/mgr/dashboard/controllers/grafana.py
+++ b/src/pybind/mgr/dashboard/controllers/grafana.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+from .. import mgr
 from ..exceptions import DashboardException
 from ..grafana import GrafanaRestClient, push_local_dashboards
 from ..security import Scope
@@ -16,13 +17,18 @@ URL_SCHEMA = {
 @ApiController('/grafana', Scope.GRAFANA)
 @ControllerDoc("Grafana Management API", "Grafana")
 class Grafana(BaseController):
-
     @Endpoint()
     @ReadPermission
-    @EndpointDoc("List Grafana URL Instance",
-                 responses={200: URL_SCHEMA})
+    @EndpointDoc("List Grafana URL Instance", responses={200: URL_SCHEMA})
     def url(self):
-        response = {'instance': Settings.GRAFANA_API_URL}
+        grafana_url = mgr.get_module_option('GRAFANA_API_URL')
+        grafana_frontend_url = mgr.get_module_option('GRAFANA_FRONTEND_API_URL')
+        if grafana_frontend_url != '' and grafana_url == '':
+            url = ''
+        else:
+            url = (mgr.get_module_option('GRAFANA_FRONTEND_API_URL')
+                   or mgr.get_module_option('GRAFANA_API_URL')).rstrip('/')
+        response = {'instance': url}
         return response
 
     @Endpoint()
@@ -30,7 +36,7 @@ class Grafana(BaseController):
     def validation(self, params):
         grafana = GrafanaRestClient()
         method = 'GET'
-        url = Settings.GRAFANA_API_URL.rstrip('/') + \
+        url = str(Settings.GRAFANA_API_URL).rstrip('/') + \
             '/api/dashboards/uid/' + params
         response = grafana.url_validation(method, url)
         return response

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -36,6 +36,7 @@ class Options(object):
 
     # Grafana settings
     GRAFANA_API_URL = ('', str)
+    GRAFANA_FRONTEND_API_URL = ('', str)
     GRAFANA_API_USERNAME = ('admin', str)
     GRAFANA_API_PASSWORD = ('admin', str)
     GRAFANA_API_SSL_VERIFY = (True, bool)


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47386

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
