### PR TITLE
cephfs: fix future rctimes

### DIFF
--- a/qa/workunits/fs/misc/rstats.sh
+++ b/qa/workunits/fs/misc/rstats.sh
@@ -75,6 +75,11 @@ touch d1/d2/f3 # create new file
 wait_until_changed rctime
 check_rctime
 
+old_value=`getfattr --only-value -n ceph.dir.rctime .`
+setfattr -n "ceph.dir.rctime" -v `date -d 'now+1hour' +%s` .
+wait_until_changed rctime
+check_rctime
+
 cd ..
 rm -rf rstats_testdir
 echo OK

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12918,7 +12918,13 @@ const Client::VXattr Client::_dir_vxattrs[] = {
   XATTR_NAME_CEPH(dir, rsubdirs, VXATTR_RSTAT),
   XATTR_NAME_CEPH(dir, rsnaps, VXATTR_RSTAT),
   XATTR_NAME_CEPH(dir, rbytes, VXATTR_RSTAT),
-  XATTR_NAME_CEPH(dir, rctime, VXATTR_RSTAT),
+  {
+    name: "ceph.dir.rctime",
+    getxattr_cb: &Client::_vxattrcb_dir_rctime,
+    readonly: false,
+    exists_cb: NULL,
+    flags: VXATTR_RSTAT,
+  },
   {
     name: "ceph.quota",
     getxattr_cb: &Client::_vxattrcb_quota,

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -2183,12 +2183,7 @@ void MDCache::predirty_journal_parents(MutationRef mut, EMetaBlob *blob,
 	pf->fragstat.mtime = mut->get_op_stamp();
 	pf->fragstat.change_attr++;
 	dout(10) << "predirty_journal_parents bumping change_attr to " << pf->fragstat.change_attr << " on " << parent << dendl;
-	if (pf->fragstat.mtime > pf->rstat.rctime) {
-	  dout(10) << "predirty_journal_parents updating mtime on " << *parent << dendl;
-	  pf->rstat.rctime = pf->fragstat.mtime;
-	} else {
-	  dout(10) << "predirty_journal_parents updating mtime UNDERWATER on " << *parent << dendl;
-	}
+	pf->rstat.rctime = std::max(pf->rstat.rctime, ceph_clock_now());
       }
       if (linkunlink) {
 	dout(10) << "predirty_journal_parents updating size on " << *parent << dendl;
@@ -2306,7 +2301,7 @@ void MDCache::predirty_journal_parents(MutationRef mut, EMetaBlob *blob,
       pi.inode->dirstat.add_delta(pf->fragstat, pf->accounted_fragstat, &touched_mtime, &touched_chattr);
       pf->accounted_fragstat = pf->fragstat;
       if (touched_mtime)
-	pi.inode->mtime = pi.inode->ctime = pi.inode->dirstat.mtime;
+	pi.inode->mtime = pi.inode->dirstat.mtime;
       if (touched_chattr)
 	pi.inode->change_attr = pi.inode->dirstat.change_attr;
       dout(20) << "predirty_journal_parents     gives " << pi.inode->dirstat << " on " << *pin << dendl;

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -206,6 +206,7 @@ public:
 
   bool xlock_policylock(MDRequestRef& mdr, CInode *in,
 			bool want_layout=false, bool xlock_snaplock=false);
+  bool wrlock_nestlock(MDRequestRef& mdr, CInode *in);
   CInode* try_get_auth_inode(MDRequestRef& mdr, inodeno_t ino);
   void handle_client_setattr(MDRequestRef& mdr);
   void handle_client_setlayout(MDRequestRef& mdr);
@@ -418,7 +419,8 @@ private:
            xattr_name == "ceph.dir.subvolume" ||
            xattr_name == "ceph.dir.pin" ||
            xattr_name == "ceph.dir.pin.random" ||
-           xattr_name == "ceph.dir.pin.distributed";
+           xattr_name == "ceph.dir.pin.distributed" ||
+           xattr_name == "ceph.dir.rctime";
   }
 
   static bool is_allowed_ceph_xattr(std::string_view xattr_name) {


### PR DESCRIPTION
In our cephfs cluster we get users who import files with invalid ctimes.
This affects the rctime up to the root and the rctime doesn't get updated for every new write until the future date is met.
Applications which depend on rctime to detect file changes optimally (rsync) can't run now.
Make rctime modifiable so sysadmins can fix them after fixing the invalid file's ctime.
Also make mtime not change the rctime, because it is a user modifiable field and it can be set to the future.
rctime should only change based on the value of ctime instead.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
