### PR TITLE
doc, os/bluestore: Zoned storage related cleanup.

### DIFF
--- a/doc/dev/zoned-storage.rst
+++ b/doc/dev/zoned-storage.rst
@@ -34,21 +34,21 @@ Currently we can perform basic RADOS benchmarks on an OSD running on an HM-SMR
 drives, restart the OSD, and read the written data, and write new data, as can
 be seen below.
 
-Please contact Abutalib Aghayev <agayev@cs.cmu.edu> for questions.
+Please contact Abutalib Aghayev <agayev@psu.edu> for questions.
 
 ::
    
-  $ zbc_info /dev/sdc
+  $ sudo zbd report -i -n /dev/sdc
   Device /dev/sdc:
       Vendor ID: ATA HGST HSH721414AL T240
-      Zoned block device interface, Host-managed zone model
-      27344764928 512-bytes sectors
-      3418095616 logical blocks of 4096 B
-      3418095616 physical blocks of 4096 B
-      14000.520 GB capacity
-      Read commands are unrestricted
-      672 KiB max R/W size
-      Maximum number of open sequential write required zones: 128
+      Zone model: host-managed
+      Capacity: 14000.520 GB (27344764928 512-bytes sectors)
+      Logical blocks: 3418095616 blocks of 4096 B
+      Physical blocks: 3418095616 blocks of 4096 B
+      Zones: 52156 zones of 256.0 MB
+      Maximum number of open zones: no limit
+      Maximum number of active zones: no limit
+  52156 / 52156 zones
   $ MON=1 OSD=1 MDS=0 sudo ../src/vstart.sh --new --localhost --bluestore --bluestore-devs /dev/sdc --bluestore-zoned
   <snipped verbose output>
   $ sudo ./bin/ceph osd pool create bench 32 32

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1153,7 +1153,7 @@ public:
     // are laid out contiguously on disk, which is not the case in general.
     // Also, it should always be called after calling extent_map.fault_range(),
     // so that the extent map is loaded.
-    int64_t get_ondisk_starting_offset() const {
+    int64_t zoned_get_ondisk_starting_offset() const {
       return extent_map.extent_map.begin()->blob->
 	  get_blob().calc_offset(0, nullptr);
     }
@@ -1672,12 +1672,12 @@ public:
 
     void zoned_note_new_object(OnodeRef &o) {
       auto [_, ok] = zoned_onode_to_offset_map.emplace(
-	  std::pair<OnodeRef, std::vector<int64_t>>(o, {o->get_ondisk_starting_offset()}));
+	  std::pair<OnodeRef, std::vector<int64_t>>(o, {o->zoned_get_ondisk_starting_offset()}));
       ceph_assert(ok);
     }
 
     void zoned_note_updated_object(OnodeRef &o, int64_t prev_offset) {
-      int64_t new_offset = o->get_ondisk_starting_offset();
+      int64_t new_offset = o->zoned_get_ondisk_starting_offset();
       auto [it, ok] = zoned_onode_to_offset_map.emplace(
 	  std::pair<OnodeRef, std::vector<int64_t>>(o, {-prev_offset, new_offset}));
       if (!ok) {
@@ -2393,6 +2393,8 @@ private:
   // Functions related to zoned storage.
   uint64_t _zoned_piggyback_device_parameters_onto(uint64_t min_alloc_size);
   int _zoned_check_config_settings();
+  void _zoned_update_cleaning_metadata(TransContext *txc);
+  std::string _zoned_get_prefix(uint64_t offset);
 
 public:
   utime_t get_deferred_last_submitted() {
@@ -3432,10 +3434,6 @@ private:
 
   void _fsck_check_objects(FSCKDepth depth,
     FSCK_ObjectCtx& ctx);
-
-  // Zoned storage related stuff
-  void zoned_update_cleaning_metadata(TransContext *txc);
-  std::string zoned_get_prefix(uint64_t offset);
 };
 
 inline std::ostream& operator<<(std::ostream& out, const BlueStore::volatile_statfs& s) {


### PR DESCRIPTION
 Update zoned-storage.rst, prefix all zone-related functions with zoned, and move them to one place.

Signed-off-by: Abutalib Aghayev agayev@psu.edu

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
