### PR TITLE
mgr/cephadm: handle JSONDecodeError

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -928,7 +928,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         try:
             j = json.loads(data)
         except ValueError:
-            self.log.exception('unable to laod extra_ceph_conf')
+            msg = 'Unable to load extra_ceph_conf: Cannot decode JSON'
+            self.log.exception('%s: \'%s\'', msg, data)
             return CephadmOrchestrator.ExtraCephConf('', None)
         return CephadmOrchestrator.ExtraCephConf(j['conf'], str_to_datetime(j['last_modified']))
 
@@ -2122,8 +2123,8 @@ To check that the host is reachable:
             self.log.debug(f'image {image_name} -> {r}')
             return r
         except (ValueError, KeyError) as _:
-            msg = 'Failed to pull %s on %s: %s' % (image_name, host, '\n'.join(out))
-            self.log.exception(msg)
+            msg = 'Failed to pull %s on %s: Cannot decode JSON' % (image_name, host)
+            self.log.exception('%s: \'%s\'' % (msg, '\n'.join(out)))
             raise OrchestratorError(msg)
 
     @trivial_completion

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -200,9 +200,13 @@ class CephadmServe:
             if code:
                 return 'host %s cephadm ls returned %d: %s' % (
                     host, code, err)
+            ls = json.loads(''.join(out))
+        except ValueError:
+            msg = 'host %s scrape failed: Cannot decode JSON' % host
+            self.log.exception('%s: \'%s\'' % (msg, ''.join(out)))
+            return msg
         except Exception as e:
             return 'host %s scrape failed: %s' % (host, e)
-        ls = json.loads(''.join(out))
         dm = {}
         for d in ls:
             if not d['style'].startswith('cephadm'):
@@ -255,9 +259,13 @@ class CephadmServe:
             if code:
                 return 'host %s ceph-volume inventory returned %d: %s' % (
                     host, code, err)
+            devices = json.loads(''.join(out))
+        except ValueError:
+            msg = 'host %s scrape failed: Cannot decode JSON' % host
+            self.log.exception('%s: \'%s\'' % (msg, ''.join(out)))
+            return msg
         except Exception as e:
             return 'host %s ceph-volume inventory failed: %s' % (host, e)
-        devices = json.loads(''.join(out))
         try:
             out, err, code = self.mgr._run_cephadm(
                 host, 'mon',
@@ -267,9 +275,13 @@ class CephadmServe:
             if code:
                 return 'host %s list-networks returned %d: %s' % (
                     host, code, err)
+            networks = json.loads(''.join(out))
+        except ValueError:
+            msg = 'host %s scrape failed: Cannot decode JSON' % host
+            self.log.exception('%s: \'%s\'' % (msg, ''.join(out)))
+            return msg
         except Exception as e:
             return 'host %s list-networks failed: %s' % (host, e)
-        networks = json.loads(''.join(out))
         self.log.debug('Refreshed host %s devices (%d) networks (%s)' % (
             host, len(devices), len(networks)))
         devices = inventory.Devices.from_json(devices)

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -78,7 +78,9 @@ def get_cluster_health(mgr: 'CephadmOrchestrator') -> str:
     })
     try:
         j = json.loads(out)
-    except Exception as e:
+    except ValueError:
+        msg = 'Failed to parse health status: Cannot decode JSON'
+        logger.exception('%s: \'%s\'' % (msg, out))
         raise OrchestratorError('failed to parse health status')
 
     return j['status']


### PR DESCRIPTION
avoid exceptions when attempting to parse invalid JSON output and improve the mgr log lines to make these type of failures more obvious

Fixes: https://tracker.ceph.com/issues/48118
Fixes: https://tracker.ceph.com/issues/48119
Fixes: https://tracker.ceph.com/issues/48120

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
