### PR TITLE
cmake: rename crimson tests named like foo_bar to foo-bar

### DIFF
--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -22,13 +22,13 @@ target_link_libraries(unittest-seastar-messenger crimson)
 add_executable(test-seastar-messenger-peer test_messenger_peer.cc)
 target_link_libraries(test-seastar-messenger-peer ceph-common global ${ALLOC_LIBS})
 
-add_executable(unittest-seastar-echo
+add_executable(test-seastar-echo
   test_alien_echo.cc)
-target_link_libraries(unittest-seastar-echo crimson)
+target_link_libraries(test-seastar-echo crimson)
 
-add_executable(unittest-async-echo
+add_executable(test-async-echo
   test_async_echo.cc)
-target_link_libraries(unittest-async-echo ceph-common global)
+target_link_libraries(test-async-echo ceph-common global)
 
 add_executable(unittest-seastar-alienstore-thread-pool
   test_alienstore_thread_pool.cc)

--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -1,69 +1,69 @@
-add_executable(unittest_seastar_buffer
+add_executable(unittest-seastar-buffer
   test_buffer.cc)
-add_ceph_test(unittest_seastar_buffer
-  unittest_seastar_buffer --memory 256M --smp 1)
-target_link_libraries(unittest_seastar_buffer crimson)
+add_ceph_test(unittest-seastar-buffer
+  unittest-seastar-buffer --memory 256M --smp 1)
+target_link_libraries(unittest-seastar-buffer crimson)
 
-add_executable(unittest_seastar_denc
+add_executable(unittest-seastar-denc
   test_denc.cc)
-add_ceph_unittest(unittest_seastar_denc)
-target_link_libraries(unittest_seastar_denc crimson GTest::Main)
+add_ceph_unittest(unittest-seastar-denc)
+target_link_libraries(unittest-seastar-denc crimson GTest::Main)
 
-add_executable(unittest_seastar_socket test_socket.cc)
-add_ceph_test(unittest_seastar_socket
-  unittest_seastar_socket --memory 256M --smp 2)
-target_link_libraries(unittest_seastar_socket crimson)
+add_executable(unittest-seastar-socket test_socket.cc)
+add_ceph_test(unittest-seastar-socket
+  unittest-seastar-socket --memory 256M --smp 2)
+target_link_libraries(unittest-seastar-socket crimson)
 
-add_executable(unittest_seastar_messenger test_messenger.cc)
-add_ceph_test(unittest_seastar_messenger
-  unittest_seastar_messenger --memory 256M --smp 1)
-target_link_libraries(unittest_seastar_messenger crimson)
+add_executable(unittest-seastar-messenger test_messenger.cc)
+add_ceph_test(unittest-seastar-messenger
+  unittest-seastar-messenger --memory 256M --smp 1)
+target_link_libraries(unittest-seastar-messenger crimson)
 
-add_executable(test_seastar_messenger_peer test_messenger_peer.cc)
-target_link_libraries(test_seastar_messenger_peer ceph-common global ${ALLOC_LIBS})
+add_executable(test-seastar-messenger-peer test_messenger_peer.cc)
+target_link_libraries(test-seastar-messenger-peer ceph-common global ${ALLOC_LIBS})
 
-add_executable(unittest_seastar_echo
+add_executable(unittest-seastar-echo
   test_alien_echo.cc)
-target_link_libraries(unittest_seastar_echo crimson)
+target_link_libraries(unittest-seastar-echo crimson)
 
-add_executable(unittest_async_echo
+add_executable(unittest-async-echo
   test_async_echo.cc)
-target_link_libraries(unittest_async_echo ceph-common global)
+target_link_libraries(unittest-async-echo ceph-common global)
 
-add_executable(unittest_seastar_alienstore_thread_pool
+add_executable(unittest-seastar-alienstore-thread-pool
   test_alienstore_thread_pool.cc)
-add_ceph_test(unittest_seastar_alienstore_thread_pool
-  unittest_seastar_alienstore_thread_pool --memory 256M --smp 1)
-target_link_libraries(unittest_seastar_alienstore_thread_pool
+add_ceph_test(unittest-seastar-alienstore-thread-pool
+  unittest-seastar-alienstore-thread-pool --memory 256M --smp 1)
+target_link_libraries(unittest-seastar-alienstore-thread-pool
   crimson-os
   crimson-alienstore
   crimson)
 
-add_executable(unittest_seastar_config
+add_executable(unittest-seastar-config
   test_config.cc)
-add_ceph_test(unittest_seastar_config
-  unittest_seastar_config --memory 256M)
-target_link_libraries(unittest_seastar_config crimson)
+add_ceph_test(unittest-seastar-config
+  unittest-seastar-config --memory 256M)
+target_link_libraries(unittest-seastar-config crimson)
 
-add_executable(unittest_seastar_monc
+add_executable(unittest-seastar-monc
   test_monc.cc)
-target_link_libraries(unittest_seastar_monc crimson)
+target_link_libraries(unittest-seastar-monc crimson)
 
-add_executable(unittest_seastar_perfcounters
+add_executable(unittest-seastar-perfcounters
   test_perfcounters.cc)
-add_ceph_test(unittest_seastar_perfcounters
-  unittest_seastar_perfcounters --memory 256M --smp 1)
-target_link_libraries(unittest_seastar_perfcounters crimson)
+add_ceph_test(unittest-seastar-perfcounters
+  unittest-seastar-perfcounters --memory 256M --smp 1)
+target_link_libraries(unittest-seastar-perfcounters crimson)
 
-add_executable(unittest_seastar_lru
+add_executable(unittest-seastar-lru
   test_lru.cc)
-add_ceph_unittest(unittest_seastar_lru --memory 256M --smp 1)
-target_link_libraries(unittest_seastar_lru crimson GTest::Main)
+add_ceph_unittest(unittest-seastar-lru --memory 256M --smp 1)
+target_link_libraries(unittest-seastar-lru crimson GTest::Main)
 
-add_executable(unittest_fixed_kv_node_layout
+add_executable(unittest-fixed-kv-node-layout
   test_fixed_kv_node_layout.cc)
-add_ceph_unittest(unittest_fixed_kv_node_layout)
-target_link_libraries(unittest_seastar_lru crimson GTest::Main)
+add_ceph_unittest(unittest-fixed-kv-node-layout)
+target_link_libraries(unittest-seastar-lru crimson GTest::Main)
 
 add_subdirectory(seastore)
 

--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -63,7 +63,6 @@ target_link_libraries(unittest-seastar-lru crimson GTest::Main)
 add_executable(unittest-fixed-kv-node-layout
   test_fixed_kv_node_layout.cc)
 add_ceph_unittest(unittest-fixed-kv-node-layout)
-target_link_libraries(unittest-seastar-lru crimson GTest::Main)
 
 add_subdirectory(seastore)
 

--- a/src/test/crimson/seastore/CMakeLists.txt
+++ b/src/test/crimson/seastore/CMakeLists.txt
@@ -1,55 +1,55 @@
-add_executable(unittest_transaction_manager
+add_executable(unittest-transaction-manager
   test_block.cc
   test_transaction_manager.cc
   ../gtest_seastar.cc)
-add_ceph_unittest(unittest_transaction_manager)
+add_ceph_unittest(unittest-transaction-manager)
 target_link_libraries(
-  unittest_transaction_manager
+  unittest-transaction-manager
   ${CMAKE_DL_LIBS}
   crimson-seastore
   crimson-os
   crimson-common)
 
-add_executable(unittest_btree_lba_manager
+add_executable(unittest-btree-lba-manager
   test_btree_lba_manager.cc
   ../gtest_seastar.cc)
-add_ceph_unittest(unittest_btree_lba_manager)
+add_ceph_unittest(unittest-btree-lba-manager)
 target_link_libraries(
-  unittest_btree_lba_manager
+  unittest-btree-lba-manager
   ${CMAKE_DL_LIBS}
   crimson-seastore
   crimson-os
   crimson-common)
 
-add_executable(unittest_seastore_journal
+add_executable(unittest-seastore-journal
   test_seastore_journal.cc)
-add_ceph_test(unittest_seastore_journal
-  unittest_seastore_journal)
+add_ceph_test(unittest-seastore-journal
+  unittest-seastore-journal)
 target_link_libraries(
-  unittest_seastore_journal
+  unittest-seastore-journal
   crimson::gtest
   crimson-seastore
   crimson-os
   crimson-common)
 
-add_executable(unittest_seastore_cache
+add_executable(unittest-seastore-cache
   test_block.cc
   test_seastore_cache.cc)
-add_ceph_test(unittest_seastore_cache
-  unittest_seastore_cache)
+add_ceph_test(unittest-seastore-cache
+  unittest-seastore-cache)
 target_link_libraries(
-  unittest_seastore_cache
+  unittest-seastore-cache
   crimson::gtest
   crimson-seastore
   crimson-os
   crimson-common)
 
-add_executable(unittest_extmap_manager
+add_executable(unittest-extmap-manager
   test_extmap_manager.cc
   ../gtest_seastar.cc)
-add_ceph_unittest(unittest_extmap_manager)
+add_ceph_unittest(unittest-extmap-manager)
 target_link_libraries(
-  unittest_extmap_manager
+  unittest-extmap-manager
   ${CMAKE_DL_LIBS}
   crimson-seastore)
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
