### PR TITLE
examples/boto3/README: examples notification

### DIFF
--- a/examples/boto3/README.md
+++ b/examples/boto3/README.md
@@ -13,15 +13,85 @@ The standard [AWS CLI](https://docs.aws.amazon.com/cli/latest/) may also be used
 ```
 aws --endpoint-url http://localhost:8000 s3api list-objects --bucket=mybucket --allow-unordered
 ```
-- Bucket notifications with filtering extensions:
+
+- Use the following command to set SNS signature to s3v2:
 ```
-aws --region=default --endpoint-url http://localhost:8000 s3api put-bucket-notification-configuration --bucket mybucket --notification-configuration='{"TopicConfigurations": [{"Id": "notif1", "TopicArn": "arn:aws:sns:default::mytopic",  
-"Events": ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"],  
-"Filter": {"Metadata": {"FilterRules": [{"Name": "x-amz-meta-foo", "Value": "bar"}, {"Name": "x-amz-meta-hello", "Value": "world"}]}, "Key": {"FilterRules": [{"Name": "regex", "Value": "([a-z]+)"}]}}}]}'
- ```
+aws configure set default.sns.signature_version s3
+```
+
+- Topic creation with endpoint:
+```
+aws --endpoint-url http://localhost:8000 sns create-topic --name=mytopic --attributes='{"push-endpoint": "amqp://localhost:5672", "amqp-exchange": "ex1", "amqp-ack-level": "broker"}'
+```
+Expected output:
+```
+{
+    "TopicArn": "arn:aws:sns:default::mytopic"
+}
+```
+
+- Get topic attributes:
+```
+aws --endpoint-url http://localhost:8000 sns get-topic-attributes --topic-arn="arn:aws:sns:default::mytopic"
+```
+Expected output:
+```
+{
+  "Attributes": {
+    "User": "",
+    "Name": "mytopic",
+    "EndPoint": "{\"EndpointAddress\":\"amqp://localhost:5672\",\"EndpointArgs\":\"Attributes.entry.1.key=push-endpoint&Attributes.entry.1.value=amqp://localhost:5672&Attributes.entry.2.key=amqp-exchange&Attributes.entry.2.value=ex1&Attributes.entry.3.key=amqp-ack-level&Attributes.entry.3.value=broker&Version=2010-03-31&amqp-ack-level=broker&amqp-exchange=ex1&push-endpoint=amqp://localhost:5672\",\"EndpointTopic\":\"mytopic\",\"HasStoredSecret\":\"false\",\"Persistent\":\"false\"}",
+    "TopicArn": "arn:aws:sns:default::mytopic",
+    "OpaqueData": ""
+  }
+}
+```
+
+- Bucket notifications with filtering extensions (bucket must exist before calling this command):
+```
+aws --region=default --endpoint-url http://localhost:8000 s3api put-bucket-notification-configuration --bucket=mybucket --notification-configuration='{"TopicConfigurations": [{"Id": "notif1", "TopicArn": "arn:aws:sns:default::mytopic", "Events": ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"], "Filter": {"Metadata": {"FilterRules": [{"Name": "x-amz-meta-foo", "Value": "bar"}, {"Name": "x-amz-meta-hello", "Value": "world"}]}, "Key": {"FilterRules": [{"Name": "regex", "Value": "([a-z]+)"}]}}}]}'
+```
+
 - Get configuration of a specific notification of a bucket:
 ```
 aws --endpoint-url http://localhost:8000 s3api get-bucket-notification-configuration --bucket=mybucket --notification=notif1
+```
+Expected output:
+```
+{
+  "TopicConfigurations": [
+    {
+      "Id": "notif1",
+      "TopicArn": "arn:aws:sns:default::mytopic",
+      "Events": [
+        "s3:ObjectCreated:*",
+        "s3:ObjectRemoved:*"
+      ],
+      "Filter": {
+        "Key": {
+          "FilterRules": [
+            {
+              "Name": "regex",
+              "Value": "([a-z]+)"
+            }
+          ]
+        },
+        "Metadata": {
+          "FilterRules": [
+            {
+              "Name": "x-amz-meta-foo",
+              "Value": "bar"
+            },
+            {
+              "Name": "x-amz-meta-hello",
+              "Value": "world"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
 ```
 
 # Developers

--- a/examples/boto3/topic_attributes.py
+++ b/examples/boto3/topic_attributes.py
@@ -1,0 +1,46 @@
+import sys
+import urllib
+import hmac
+import hashlib
+import base64
+import xmltodict
+import http.client
+from urllib import parse as urlparse
+from time import gmtime, strftime
+
+if len(sys.argv) == 2:
+    # topic arn as first argument
+    topic_arn = sys.argv[1]
+else:
+    print ('Usage: ' + sys.argv[0] + ' <topic arn> [region name]')
+    sys.exit(1)
+
+# endpoint and keys from vstart
+endpoint = '127.0.0.1:8000'
+access_key='0555b35654ad1656d804'
+secret_key='h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q=='
+
+
+parameters = {'Action': 'GetTopic', 'TopicArn': topic_arn}
+body = urlparse.urlencode(parameters)
+string_date = strftime("%a, %d %b %Y %H:%M:%S +0000", gmtime())
+content_type = 'application/x-www-form-urlencoded; charset=utf-8'
+resource = '/'
+method = 'POST'
+string_to_sign = method + '\n\n' + content_type + '\n' + string_date + '\n' + resource 
+signature = base64.b64encode(hmac.new(secret_key.encode('utf-8'), string_to_sign.encode('utf-8'), hashlib.sha1).digest()).decode('ascii')
+headers = {'Authorization': 'AWS '+access_key+':'+signature,
+                   'Date': string_date,
+                   'Host': endpoint,
+                   'Content-Type': content_type}
+http_conn = http.client.HTTPConnection(endpoint)
+http_conn.request(method, resource, body, headers)
+response = http_conn.getresponse()
+data = response.read()
+status = response.status
+http_conn.close()
+dict_response = xmltodict.parse(data)
+
+# getting attributes of a specific topic is an extension to AWS sns
+
+print(dict_response, status)


### PR DESCRIPTION
added examples on how to fetch attributes of a specific topic

Fixes: https://tracker.ceph.com/issues/46243

Signed-off-by: dorindabassey <dorindabassey@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
