### PR TITLE
nautilus: monitoring: Use null yaxes min for OSD read latency

### DIFF
--- a/monitoring/grafana/dashboards/osd-device-details.json
+++ b/monitoring/grafana/dashboards/osd-device-details.json
@@ -126,7 +126,7 @@
           "label": "Read (-) / Write (+)",
           "logBase": 1,
           "max": null,
-          "min": "0",
+          "min": null,
           "show": true
         },
         {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47995

---

backport of https://github.com/ceph/ceph/pull/37006
parent tracker: https://tracker.ceph.com/issues/47323

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh