### PR TITLE
octopus: doc/mgr/orchestrator: Add hints related to custom containers to the docs

### DIFF
--- a/doc/mgr/orchestrator.rst
+++ b/doc/mgr/orchestrator.rst
@@ -447,8 +447,9 @@ A corresponding :ref:`orchestrator-cli-service-spec` must look like:
       - CONFIG_DIR
     files:
       CONFIG_DIR/foo.conf:
-          - refresh=true
-          - username=xyz
+        - refresh=true
+        - username=xyz
+        - "port: 1234"
 
 where the properties of a service specification are:
 
@@ -483,9 +484,11 @@ where the properties of a service specification are:
 * ``files``
     A dictionary, where the key is the relative path of the file and the
     value the file content. The content must be double quoted when using
-    a string. Use '\n' for line breaks in that case. Otherwise define
+    a string. Use '\\n' for line breaks in that case. Otherwise define
     multi-line content as list of strings. The given files will be created
     below the directory `/var/lib/ceph/<cluster-fsid>/<daemon-name>`.
+    The absolute path of the directory where the file will be created must
+    exist. Use the `dirs` property to create them if necessary.
 
 .. _orchestrator-cli-service-spec:
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/48113

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
