### PR TITLE
Add log generation number to datalog entries

### DIFF
--- a/src/rgw/rgw_basic_types.cc
+++ b/src/rgw/rgw_basic_types.cc
@@ -69,11 +69,15 @@ std::string rgw_bucket::get_key(char tenant_delim, char id_delim, size_t reserve
   return key;
 }
 
-std::string rgw_bucket_shard::get_key(char tenant_delim, char id_delim,
+std::string rgw_bucket_shard::get_key(char tenant_delim, char id_delim, char gen_delim,
                                       char shard_delim) const
 {
-  static constexpr size_t shard_len{12}; // ":4294967295\0"
-  auto key = bucket.get_key(tenant_delim, id_delim, shard_len);
+  static constexpr size_t gen_shard_len{12}; // ":4294967295\0"
+  auto key = bucket.get_key(tenant_delim, id_delim, gen_shard_len);
+  if (gen_id > 0 && gen_delim) {
+    key.append(1, gen_delim);
+    key.append(std::to_string(gen_id));
+  }
   if (shard_id >= 0 && shard_delim) {
     key.append(1, shard_delim);
     key.append(std::to_string(shard_id));

--- a/src/rgw/rgw_basic_types.h
+++ b/src/rgw/rgw_basic_types.h
@@ -425,11 +425,12 @@ inline std::ostream& operator<<(std::ostream& out, const rgw_bucket &b) {
 struct rgw_bucket_shard {
   rgw_bucket bucket;
   int shard_id;
+  uint64_t gen_id;
 
-  rgw_bucket_shard() : shard_id(-1) {}
-  rgw_bucket_shard(const rgw_bucket& _b, int _sid) : bucket(_b), shard_id(_sid) {}
+  rgw_bucket_shard() : shard_id(-1), gen_id(-1) {}
+  rgw_bucket_shard(const rgw_bucket& _b, int _sid, int _gen_id) : bucket(_b), shard_id(_sid), gen_id(_gen_id) {}
 
-  std::string get_key(char tenant_delim = '/', char id_delim = ':',
+  std::string get_key(char tenant_delim = '/', char id_delim = ':', char gen_delim = ':',
                       char shard_delim = ':') const;
 
   bool operator<(const rgw_bucket_shard& b) const {

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1032,6 +1032,7 @@ int RGWBucket::sync(RGWBucketAdminOpState& op_state, map<string, bufferlist> *at
 
   int shards_num = bucket_info.layout.current_index.layout.normal.num_shards? bucket_info.layout.current_index.layout.normal.num_shards : 1;
   int shard_id = bucket_info.layout.current_index.layout.normal.num_shards? 0 : -1;
+  uint64_t gen_id = bucket_info.layout.current_index.gen? bucket_info.layout.current_index.gen : 0;
 
   if (!sync) {
     r = store->svc()->bilog_rados->log_stop(bucket_info, -1);
@@ -1048,7 +1049,7 @@ int RGWBucket::sync(RGWBucketAdminOpState& op_state, map<string, bufferlist> *at
   }
 
   for (int i = 0; i < shards_num; ++i, ++shard_id) {
-    r = store->svc()->datalog_rados->add_entry(bucket_info, shard_id);
+    r = store->svc()->datalog_rados->add_entry(bucket_info, shard_id, gen_id);
     if (r < 0) {
       set_err_msg(err_msg, "ERROR: failed writing data log:" + cpp_strerror(-r));
       return r;

--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -691,7 +691,7 @@ std::string RGWDataChangesLog::get_oid(int i) const {
   return be->get_oid(i);
 }
 
-int RGWDataChangesLog::add_entry(const RGWBucketInfo& bucket_info, int shard_id) {
+int RGWDataChangesLog::add_entry(const RGWBucketInfo& bucket_info, int shard_id, uint64_t gen_id) {
   auto& bucket = bucket_info.bucket;
 
   if (!filter_bucket(bucket, null_yield)) {
@@ -702,7 +702,7 @@ int RGWDataChangesLog::add_entry(const RGWBucketInfo& bucket_info, int shard_id)
     observer->on_bucket_changed(bucket.get_key());
   }
 
-  rgw_bucket_shard bs(bucket, shard_id);
+  rgw_bucket_shard bs(bucket, shard_id, gen_id);
 
   int index = choose_oid(bs);
   mark_modified(index, bs);

--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -672,8 +672,8 @@ void RGWDataChangesLog::update_renewed(const rgw_bucket_shard& bs,
   status->cur_expiration = expiration;
 }
 
-int RGWDataChangesLog::get_log_shard_id(rgw_bucket& bucket, int shard_id) {
-  rgw_bucket_shard bs(bucket, shard_id);
+int RGWDataChangesLog::get_log_shard_id(rgw_bucket& bucket, int shard_id, uint64_t gen_id) {
+  rgw_bucket_shard bs(bucket, shard_id, gen_id);
   return choose_oid(bs);
 }
 

--- a/src/rgw/rgw_datalog.h
+++ b/src/rgw/rgw_datalog.h
@@ -220,7 +220,7 @@ public:
 	    RGWSI_Cls *cls_svc, librados::Rados* lr);
 
   int add_entry(const RGWBucketInfo& bucket_info, int shard_id, uint64_t gen_id);
-  int get_log_shard_id(rgw_bucket& bucket, int shard_id);
+  int get_log_shard_id(rgw_bucket& bucket, int shard_id, uint64_t gen_id);
   int list_entries(int shard, int max_entries,
 		   std::vector<rgw_data_change_log_entry>& entries,
 		   std::optional<std::string_view> marker,

--- a/src/rgw/rgw_datalog.h
+++ b/src/rgw/rgw_datalog.h
@@ -219,7 +219,7 @@ public:
   int start(const RGWZone* _zone, const RGWZoneParams& zoneparams,
 	    RGWSI_Cls *cls_svc, librados::Rados* lr);
 
-  int add_entry(const RGWBucketInfo& bucket_info, int shard_id);
+  int add_entry(const RGWBucketInfo& bucket_info, int shard_id, uint64_t gen_id);
   int get_log_shard_id(rgw_bucket& bucket, int shard_id);
   int list_entries(int shard, int max_entries,
 		   std::vector<rgw_data_change_log_entry>& entries,

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -855,7 +855,8 @@ int RGWIndexCompletionThread::process()
       /* ignoring error, can't do anything about it */
       continue;
     }
-    r = store->svc.datalog_rados->add_entry(bucket_info, bs.shard_id);
+    uint64_t gen_id = bucket_info.layout.current_index.gen? bucket_info.layout.current_index.gen : 0;
+    r = store->svc.datalog_rados->add_entry(bucket_info, bs.shard_id, gen_id);
     if (r < 0) {
       lderr(store->ctx()) << "ERROR: failed writing data log" << dendl;
     }
@@ -5038,7 +5039,8 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y)
       return r;
     }
 
-    r = store->svc.datalog_rados->add_entry(target->bucket_info, bs->shard_id);
+    uint64_t gen_id = target->bucket_info.layout.current_index.gen? target->bucket_info.layout.current_index.gen : 0;
+    r = store->svc.datalog_rados->add_entry(target->bucket_info, bs->shard_id, gen_id);
     if (r < 0) {
       lderr(store->ctx()) << "ERROR: failed writing data log" << dendl;
       return r;
@@ -6108,7 +6110,8 @@ int RGWRados::Bucket::UpdateIndex::complete(int64_t poolid, uint64_t epoch,
 
   ret = store->cls_obj_complete_add(*bs, obj, optag, poolid, epoch, ent, category, remove_objs, bilog_flags, zones_trace);
 
-  int r = store->svc.datalog_rados->add_entry(target->bucket_info, bs->shard_id);
+  uint64_t gen_id = target->bucket_info.layout.current_index.gen? target->bucket_info.layout.current_index.gen : 0;
+  int r = store->svc.datalog_rados->add_entry(target->bucket_info, bs->shard_id, gen_id);
   if (r < 0) {
     lderr(store->ctx()) << "ERROR: failed writing data log" << dendl;
   }
@@ -6134,7 +6137,8 @@ int RGWRados::Bucket::UpdateIndex::complete_del(int64_t poolid, uint64_t epoch,
 
   ret = store->cls_obj_complete_del(*bs, optag, poolid, epoch, obj, removed_mtime, remove_objs, bilog_flags, zones_trace);
 
-  int r = store->svc.datalog_rados->add_entry(target->bucket_info, bs->shard_id);
+  uint64_t gen_id = target->bucket_info.layout.current_index.gen? target->bucket_info.layout.current_index.gen : 0;
+  int r = store->svc.datalog_rados->add_entry(target->bucket_info, bs->shard_id, gen_id);
   if (r < 0) {
     lderr(store->ctx()) << "ERROR: failed writing data log" << dendl;
   }
@@ -6160,7 +6164,8 @@ int RGWRados::Bucket::UpdateIndex::cancel()
    * for following the specific bucket shard log. Otherwise they end up staying behind, and users
    * have no way to tell that they're all caught up
    */
-  int r = store->svc.datalog_rados->add_entry(target->bucket_info, bs->shard_id);
+  uint64_t gen_id = target->bucket_info.layout.current_index.gen? target->bucket_info.layout.current_index.gen : 0;
+  int r = store->svc.datalog_rados->add_entry(target->bucket_info, bs->shard_id, gen_id);
   if (r < 0) {
     lderr(store->ctx()) << "ERROR: failed writing data log" << dendl;
   }
@@ -6802,7 +6807,8 @@ int RGWRados::bucket_index_link_olh(const RGWBucketInfo& bucket_info, RGWObjStat
     return r;
   }
 
-  r = svc.datalog_rados->add_entry(bucket_info, bs.shard_id);
+  uint64_t gen_id = bucket_info.layout.current_index.gen ? bucket_info.layout.current_index.gen : 0;
+  r = svc.datalog_rados->add_entry(bucket_info, bs.shard_id, gen_id);
   if (r < 0) {
     ldout(cct, 0) << "ERROR: failed writing data log" << dendl;
   }

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -224,9 +224,9 @@ int RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_ba
         uint32_t sid = bucket_shard_index(obj_key, num_shards);
         char buf[bucket_oid_base.size() + 64];
         if (gen_id) {
-          bucket_obj_with_generation(buf, sizeof(buf), bucket_oid_base, gen_id, sid);
+          snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, sid);
         } else {
-          bucket_obj_without_generation(buf, sizeof(buf), bucket_oid_base, sid);
+          snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), sid);
         }
         (*bucket_obj) = buf;
         if (shard_id) {
@@ -431,7 +431,7 @@ int RGWSI_BucketIndex_RADOS::handle_overwrite(const RGWBucketInfo& info,
   if (old_sync_enabled != new_sync_enabled) {
     int shards_num = info.layout.current_index.layout.normal.num_shards? info.layout.current_index.layout.normal.num_shards : 1;
     int shard_id = info.layout.current_index.layout.normal.num_shards? 0 : -1;
-    uint64_t gen_id = bucket_info.layout.current_index.gen? bucket_info.layout.current_index.gen : 0;
+    uint64_t gen_id = info.layout.current_index.gen? info.layout.current_index.gen : 0;
 
     int ret;
     if (!new_sync_enabled) {

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -53,7 +53,7 @@ class RGWSI_BucketIndex_RADOS : public RGWSI_BucketIndex
                                string *bucket_obj);
   int get_bucket_index_object(const string& bucket_oid_base, const string& obj_key,
                               uint32_t num_shards, rgw::BucketHashType hash_type,
-                              string *bucket_obj, int *shard_id);
+                              uint64_t gen_id, string *bucket_obj, int *shard_id);
 
   int cls_bucket_head(const RGWBucketInfo& bucket_info,
                       int shard_id,

--- a/src/rgw/services/svc_datalog_rados.cc
+++ b/src/rgw/services/svc_datalog_rados.cc
@@ -41,9 +41,9 @@ void RGWSI_DataLog_RADOS::set_observer(rgw::BucketChangeObserver *observer)
   log->set_observer(observer);
 }
 
-int RGWSI_DataLog_RADOS::get_log_shard_id(rgw_bucket& bucket, int shard_id)
+int RGWSI_DataLog_RADOS::get_log_shard_id(rgw_bucket& bucket, int shard_id, uint64_t gen_id)
 {
-  return log->get_log_shard_id(bucket, shard_id);
+  return log->get_log_shard_id(bucket, shard_id, gen_id);
 }
 
 std::string RGWSI_DataLog_RADOS::get_oid(int shard_id) const

--- a/src/rgw/services/svc_datalog_rados.cc
+++ b/src/rgw/services/svc_datalog_rados.cc
@@ -56,9 +56,9 @@ int RGWSI_DataLog_RADOS::get_info(int shard_id, RGWDataChangesLogInfo *info)
   return log->get_info(shard_id, info);
 }
 
-int RGWSI_DataLog_RADOS::add_entry(const RGWBucketInfo& bucket_info, int shard_id)
+int RGWSI_DataLog_RADOS::add_entry(const RGWBucketInfo& bucket_info, int shard_id, uint64_t gen_id)
 {
-  return log->add_entry(bucket_info, shard_id);
+  return log->add_entry(bucket_info, shard_id, gen_id);
 }
 
 int RGWSI_DataLog_RADOS::list_entries(int shard, int max_entries,

--- a/src/rgw/services/svc_datalog_rados.h
+++ b/src/rgw/services/svc_datalog_rados.h
@@ -53,7 +53,7 @@ public:
 
   void set_observer(rgw::BucketChangeObserver *observer);
 
-  int get_log_shard_id(rgw_bucket& bucket, int shard_id);
+  int get_log_shard_id(rgw_bucket& bucket, int shard_id, uint64_t gen_id);
   std::string get_oid(int shard_id) const;
 
   int get_info(int shard_id, RGWDataChangesLogInfo *info);

--- a/src/rgw/services/svc_datalog_rados.h
+++ b/src/rgw/services/svc_datalog_rados.h
@@ -58,7 +58,7 @@ public:
 
   int get_info(int shard_id, RGWDataChangesLogInfo *info);
 
-  int add_entry(const RGWBucketInfo& bucket_info, int shard_id);
+  int add_entry(const RGWBucketInfo& bucket_info, int shard_id, uint64_t gen_id);
   int list_entries(int shard, int max_entries,
 		   std::vector<rgw_data_change_log_entry>& entries,
 		   std::optional<std::string_view> marker,


### PR DESCRIPTION
Use generation number to identify which sharding layout a datalog entry belongs to.

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
