### PR TITLE
mgr/dashboard: Moving copyright variable into the app.constants

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/about/about.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/about/about.component.html
@@ -40,7 +40,7 @@
   </div>
   <div class="modal-footer">
     <div class="text-left">
-      {{ copyright }}
+      {{ projectConstants.copyright }}
       {{ projectConstants.license }}
     </div>
   </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/about/about.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/about/about.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { BehaviorSubject } from 'rxjs';
 
+import { environment } from '../../../../environments/environment';
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SummaryService } from '../../../shared/services/summary.service';
 import { SharedModule } from '../../../shared/shared.module';
@@ -51,5 +52,9 @@ describe('AboutComponent', () => {
 
   it('should get host', () => {
     expect(component.hostAddr).toBe('localhost:11000');
+  });
+
+  it('should display copyright', () => {
+    expect(component.projectConstants.copyright).toContain(environment.year);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/about/about.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/about/about.component.ts
@@ -4,7 +4,6 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { detect } from 'detect-browser';
 import { Subscription } from 'rxjs';
 
-import { environment } from '../../../../environments/environment';
 import { UserService } from '../../../shared/api/user.service';
 import { AppConstants } from '../../../shared/constants/app.constants';
 import { Permission } from '../../../shared/models/permissions';
@@ -37,7 +36,6 @@ export class AboutComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.copyright = 'Copyright(c) ' + environment.year + ' Ceph contributors.';
     this.projectConstants = AppConstants;
     this.hostAddr = window.location.hostname;
     this.modalVariables = this.setVariables();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
@@ -1,9 +1,12 @@
 import { Injectable } from '@angular/core';
 
+import { environment } from '../../../environments/environment';
+
 export class AppConstants {
   public static readonly organization = 'ceph';
   public static readonly projectName = 'Ceph Dashboard';
   public static readonly license = 'Free software (LGPL 2.1).';
+  public static readonly copyright = 'Copyright(c) ' + environment.year + ' Ceph contributors.';
 }
 
 export enum URLVerbs {


### PR DESCRIPTION
Move the variable `copyright` from about.component.ts to the app.constants.ts

https://tracker.ceph.com/issues/48135
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
