### PR TITLE
cmake: set GIT_SHALLOW and UPDATE_DISCONNECTED

### DIFF
--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -32,6 +32,7 @@ if(WITH_GTEST_PARALLEL)
       SOURCE_DIR "${gtest_parallel_source_dir}"
       GIT_REPOSITORY "https://github.com/google/gtest-parallel.git"
       GIT_TAG "master"
+      GIT_SHALLOW TRUE
       CONFIGURE_COMMAND ""
       BUILD_COMMAND ""
       INSTALL_COMMAND "")

--- a/cmake/modules/Buildpmem.cmake
+++ b/cmake/modules/Buildpmem.cmake
@@ -17,6 +17,7 @@ function(build_pmem)
   ExternalProject_Add(pmdk_ext
       GIT_REPOSITORY "https://github.com/ceph/pmdk.git"
       GIT_TAG "1.7"
+      GIT_SHALLOW TRUE
       SOURCE_DIR ${CMAKE_BINARY_DIR}/src/pmdk
       CONFIGURE_COMMAND ""
       # Explicitly built w/o NDCTL, otherwise if ndtcl is present on the

--- a/cmake/modules/Builduring.cmake
+++ b/cmake/modules/Builduring.cmake
@@ -4,8 +4,8 @@ function(build_uring)
 
   include(ExternalProject)
   ExternalProject_Add(liburing_ext
-    GIT_REPOSITORY http://git.kernel.dk/liburing
-    GIT_TAG "4e360f71131918c36774f51688e5c65dea8d43f2"
+    GIT_REPOSITORY https://git.kernel.dk/liburing
+    GIT_TAG "liburing-0.7"
     SOURCE_DIR ${CMAKE_BINARY_DIR}/src/liburing
     CONFIGURE_COMMAND <SOURCE_DIR>/configure
     BUILD_COMMAND env CC=${CMAKE_C_COMPILER} ${make_cmd} -C src -s

--- a/cmake/modules/Builduring.cmake
+++ b/cmake/modules/Builduring.cmake
@@ -6,6 +6,8 @@ function(build_uring)
   ExternalProject_Add(liburing_ext
     GIT_REPOSITORY https://git.kernel.dk/liburing
     GIT_TAG "liburing-0.7"
+    GIT_SHALLOW TRUE
+    UPDATE_DISCONNECTED TRUE
     SOURCE_DIR ${CMAKE_BINARY_DIR}/src/liburing
     CONFIGURE_COMMAND <SOURCE_DIR>/configure
     BUILD_COMMAND env CC=${CMAKE_C_COMPILER} ${make_cmd} -C src -s

--- a/src/blk/kernel/io_uring.cc
+++ b/src/blk/kernel/io_uring.cc
@@ -134,7 +134,7 @@ int ioring_queue_t::init(std::vector<int> &fds)
   if (ret < 0)
     return ret;
 
-  ret = io_uring_register(d->io_uring.ring_fd, IORING_REGISTER_FILES,
+  ret = io_uring_register_files(&d->io_uring,
 			  &fds[0], fds.size());
   if (ret < 0) {
     ret = -errno;
@@ -211,15 +211,12 @@ get_cqe:
 
 bool ioring_queue_t::supported()
 {
-  struct io_uring_params p;
-
-  memset(&p, 0, sizeof(p));
-  int fd = io_uring_setup(16, &p);
-  if (fd < 0)
+  struct io_uring ring;
+  int ret = io_uring_queue_init(16, &ring, 0);
+  if (ret) {
     return false;
-
-  close(fd);
-
+  }
+  io_uring_queue_exit(&ring);
   return true;
 }
 

--- a/src/compressor/brotli/CMakeLists.txt
+++ b/src/compressor/brotli/CMakeLists.txt
@@ -9,6 +9,7 @@ ExternalProject_Add(brotli_ext
   DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/src/
   GIT_REPOSITORY "https://github.com/google/brotli.git"
   GIT_TAG "v1.0.7"
+  GIT_SHALLOW TRUE
   SOURCE_DIR ${CMAKE_BINARY_DIR}/src/brotli
   CONFIGURE_COMMAND ./configure-cmake --disable-debug 
   INSTALL_COMMAND ""


### PR DESCRIPTION
* GIT_SHALLOW=TRUE, so we don't pull the full git history,
  as we don't care about it.
* UPDATE_DISCONNECTED=TRUE, to skip the UPDATE step, this change
  somehow works around
  https://gitlab.kitware.com/cmake/cmake/-/issues/19703. otherwise
  cmake keeps building liburing.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
