### PR TITLE
octopus: mgr/dashboard: additional logging to SMART data retrieval

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -87,6 +87,7 @@ class Osd(RESTController):
     def _get_smart_data(osd_id):
         # type: (str) -> dict
         """Returns S.M.A.R.T data for the given OSD ID."""
+        logger.debug('[SMART] retrieving data from OSD with ID %s', osd_id)
         return CephService.get_smart_data_by_daemon('osd', osd_id)
 
     @RESTController.Resource('GET')

--- a/src/pybind/mgr/dashboard/requirements-lint.txt
+++ b/src/pybind/mgr/dashboard/requirements-lint.txt
@@ -9,3 +9,4 @@ flake8-colors==0.1.6; python_version >= '3'
 rstcheck==3.3.1; python_version >= '3'
 autopep8; python_version >= '3'
 pyfakefs; python_version >= '3'
+pytest<4

--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -12,7 +12,7 @@ from .. import mgr
 from ..exceptions import DashboardException
 
 try:
-    from typing import Dict, Any, Union  # pylint: disable=unused-import
+    from typing import Dict, Any, Optional, Union  # pylint: disable=unused-import
 except ImportError:
     pass  # For typing only
 
@@ -158,8 +158,9 @@ class CephService(object):
             return {}
         return mgr.get("pg_summary")['by_pool'][pool['pool'].__str__()]
 
-    @classmethod
-    def send_command(cls, srv_type, prefix, srv_spec='', **kwargs):
+    @staticmethod
+    def send_command(srv_type, prefix, srv_spec='', **kwargs):
+        # type: (str, str, Optional[str], Any) -> Any
         """
         :type prefix: str
         :param srv_type: mon |
@@ -247,14 +248,14 @@ class CephService(object):
 
     @staticmethod
     def get_devices_by_host(hostname):
-        # (str) -> dict
+        # type: (str) -> dict
         return CephService.send_command('mon',
                                         'device ls-by-host',
                                         host=hostname)
 
     @staticmethod
     def get_devices_by_daemon(daemon_type, daemon_id):
-        # (str, str) -> dict
+        # type: (str, str) -> dict
         return CephService.send_command('mon',
                                         'device ls-by-daemon',
                                         who='{}.{}'.format(

--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -303,7 +303,7 @@ class CephService(object):
                         CephService._get_smart_data_by_device(device))
         else:
             msg = '[SMART] could not retrieve device list from daemon with type %s and ' +\
-                'with ID %d'
+                'with ID %s'
             logger.debug(msg, daemon_type, daemon_id)
         return smart_data
 

--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -279,6 +279,8 @@ class CephService(object):
                 if device['devid'] not in smart_data:
                     smart_data.update(
                         CephService._get_smart_data_by_device(device))
+        else:
+            logger.debug('[SMART] could not retrieve device list from host %s', hostname)
         return smart_data
 
     @staticmethod
@@ -299,6 +301,10 @@ class CephService(object):
                 if device['devid'] not in smart_data:
                     smart_data.update(
                         CephService._get_smart_data_by_device(device))
+        else:
+            msg = '[SMART] could not retrieve device list from daemon with type %s and ' +\
+                'with ID %d'
+            logger.debug(msg, daemon_type, daemon_id)
         return smart_data
 
     @classmethod

--- a/src/pybind/mgr/dashboard/tests/test_ceph_service.py
+++ b/src/pybind/mgr/dashboard/tests/test_ceph_service.py
@@ -2,11 +2,12 @@
 # pylint: disable=dangerous-default-value,too-many-public-methods
 from __future__ import absolute_import
 
+import logging
 import unittest
-try:
-    import mock
-except ImportError:
-    import unittest.mock as mock
+from unittest import mock
+from contextlib import contextmanager
+
+import pytest
 
 from ..services.ceph_service import CephService
 
@@ -65,3 +66,44 @@ class CephServiceTest(unittest.TestCase):
 
     def test_get_pg_status_without_match(self):
         self.assertEqual(self.service.get_pool_pg_status('no-pool'), {})
+
+
+@contextmanager
+def mock_smart_data(data):
+    devices = [{'devid': devid} for devid in data]
+
+    def _get_smart_data(d):
+        return {d['devid']: data[d['devid']]}
+
+    with mock.patch.object(CephService, '_get_smart_data_by_device', side_effect=_get_smart_data), \
+            mock.patch.object(CephService, 'get_devices_by_host', return_value=devices), \
+            mock.patch.object(CephService, 'get_devices_by_daemon', return_value=devices):
+        yield
+
+
+@pytest.mark.parametrize(
+    "by,args,log",
+    [
+        ('host', ('osd0',), 'from host osd0'),
+        ('daemon', ('osd', '1'), 'with ID 1')
+    ]
+)
+def test_get_smart_data(caplog, by, args, log):
+    # pylint: disable=protected-access
+    expected_data = {
+        'aaa': {'device': {'name': '/dev/sda'}},
+        'bbb': {'device': {'name': '/dev/sdb'}},
+    }
+    with mock_smart_data(expected_data):
+        smart_data = getattr(CephService, 'get_smart_data_by_{}'.format(by))(*args)
+        getattr(CephService, 'get_devices_by_{}'.format(by)).assert_called_with(*args)
+        CephService._get_smart_data_by_device.assert_called()
+        assert smart_data == expected_data
+
+    with caplog.at_level(logging.DEBUG):
+        with mock_smart_data([]):
+            smart_data = getattr(CephService, 'get_smart_data_by_{}'.format(by))(*args)
+            getattr(CephService, 'get_devices_by_{}'.format(by)).assert_called_with(*args)
+            CephService._get_smart_data_by_device.assert_not_called()
+            assert smart_data == {}
+            assert log in caplog.text


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/48131
* https://tracker.ceph.com/issues/48500

---

backport of https://github.com/ceph/ceph/pull/37637
parent tracker: https://tracker.ceph.com/issues/47834

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh