### PR TITLE
messages: use final specifier for destructor

### DIFF
--- a/src/messages/MAuth.h
+++ b/src/messages/MAuth.h
@@ -33,7 +33,7 @@ public:
 
   MAuth() : PaxosServiceMessage{CEPH_MSG_AUTH, 0}, protocol(0), monmap_epoch(0) { }
 private:
-  ~MAuth() override {}
+  ~MAuth() final {}
 
 public:
   std::string_view get_type_name() const override { return "auth"; }

--- a/src/messages/MAuthReply.h
+++ b/src/messages/MAuthReply.h
@@ -35,7 +35,7 @@ public:
       result_bl = *bl;
   }
 private:
-  ~MAuthReply() override {}
+  ~MAuthReply() final {}
 
 public:
   std::string_view get_type_name() const override { return "auth_reply"; }

--- a/src/messages/MCacheExpire.h
+++ b/src/messages/MCacheExpire.h
@@ -68,7 +68,7 @@ protected:
   MCacheExpire(int f) :
     MMDSOp{MSG_MDS_CACHEEXPIRE},
     from(f) { }
-  ~MCacheExpire() override {}
+  ~MCacheExpire() final {}
 
 public:
   std::string_view get_type_name() const override { return "cache_expire";}

--- a/src/messages/MClientCapRelease.h
+++ b/src/messages/MClientCapRelease.h
@@ -61,7 +61,7 @@ private:
   {
     memset(&head, 0, sizeof(head));
   }
-  ~MClientCapRelease() override {}
+  ~MClientCapRelease() final {}
 };
 
 #endif

--- a/src/messages/MClientCaps.h
+++ b/src/messages/MClientCaps.h
@@ -167,7 +167,7 @@ protected:
     head.migrate_seq = mseq;
     memset(&peer, 0, sizeof(peer));
   }
-  ~MClientCaps() override {}
+  ~MClientCaps() final {}
 
 private:
   file_layout_t layout;

--- a/src/messages/MClientLease.h
+++ b/src/messages/MClientLease.h
@@ -59,7 +59,7 @@ protected:
     h.last = sl;
     h.duration_ms = 0;
   }
-  ~MClientLease() override {}
+  ~MClientLease() final {}
 
 public:
   std::string_view get_type_name() const override { return "client_lease"; }

--- a/src/messages/MClientMetrics.h
+++ b/src/messages/MClientMetrics.h
@@ -21,7 +21,7 @@ protected:
   MClientMetrics(std::vector<ClientMetricMessage> updates)
     : SafeMessage(CEPH_MSG_CLIENT_METRICS, HEAD_VERSION, COMPAT_VERSION), updates(updates) {
   }
-  ~MClientMetrics() { }
+  ~MClientMetrics() final {}
 
 public:
   std::string_view get_type_name() const override {

--- a/src/messages/MClientQuota.h
+++ b/src/messages/MClientQuota.h
@@ -14,7 +14,7 @@ protected:
     SafeMessage{CEPH_MSG_CLIENT_QUOTA},
     ino(0)
   {}
-  ~MClientQuota() override {}
+  ~MClientQuota() final {}
 
 public:
   std::string_view get_type_name() const override { return "client_quota"; }

--- a/src/messages/MClientReclaim.h
+++ b/src/messages/MClientReclaim.h
@@ -54,7 +54,7 @@ protected:
     SafeMessage{CEPH_MSG_CLIENT_RECLAIM, HEAD_VERSION, COMPAT_VERSION},
     uuid(_uuid), flags(_flags) {}
 private:
-  ~MClientReclaim() override {}
+  ~MClientReclaim() final {}
 
   std::string uuid;
   uint32_t flags = 0;

--- a/src/messages/MClientReclaimReply.h
+++ b/src/messages/MClientReclaimReply.h
@@ -59,7 +59,7 @@ protected:
     result(r), epoch(e) {}
 
 private:
-  ~MClientReclaimReply() override {}
+  ~MClientReclaimReply() final {}
 
   int32_t result;
   epoch_t epoch;

--- a/src/messages/MClientReconnect.h
+++ b/src/messages/MClientReconnect.h
@@ -33,7 +33,7 @@ public:
 private:
   MClientReconnect() :
     SafeMessage{CEPH_MSG_CLIENT_RECONNECT, HEAD_VERSION, COMPAT_VERSION} {}
-  ~MClientReconnect() override {}
+  ~MClientReconnect() final {}
 
   size_t cap_size = 0;
   size_t realm_size = 0;

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -320,7 +320,7 @@ protected:
     head.result = result;
     head.safe = 1;
   }
-  ~MClientReply() override {}
+  ~MClientReply() final {}
 
 public:
   std::string_view get_type_name() const override { return "creply"; }

--- a/src/messages/MClientRequest.h
+++ b/src/messages/MClientRequest.h
@@ -95,7 +95,7 @@ protected:
     memset(&head, 0, sizeof(head));
     head.op = op;
   }
-  ~MClientRequest() override {}
+  ~MClientRequest() final {}
 
 public:
   void set_mdsmap_epoch(epoch_t e) { head.mdsmap_epoch = e; }

--- a/src/messages/MClientRequestForward.h
+++ b/src/messages/MClientRequestForward.h
@@ -34,7 +34,7 @@ protected:
     ceph_assert(client_must_resend);
     header.tid = t;
   }
-  ~MClientRequestForward() override {}
+  ~MClientRequestForward() final {}
 
 public:
   int get_dest_mds() const { return dest_mds; }

--- a/src/messages/MClientSession.h
+++ b/src/messages/MClientSession.h
@@ -51,7 +51,7 @@ protected:
     head.seq = 0;
     st.encode_timeval(&head.stamp);
   }
-  ~MClientSession() override {}
+  ~MClientSession() final {}
 
 public:
   std::string_view get_type_name() const override { return "client_session"; }

--- a/src/messages/MClientSnap.h
+++ b/src/messages/MClientSnap.h
@@ -32,7 +32,7 @@ protected:
     memset(&head, 0, sizeof(head));
     head.op = o;
   }
-  ~MClientSnap() override {}
+  ~MClientSnap() final {}
 
 public:  
   std::string_view get_type_name() const override { return "client_snap"; }

--- a/src/messages/MCommand.h
+++ b/src/messages/MCommand.h
@@ -31,7 +31,7 @@ public:
       fsid(f) { }
 
 private:
-  ~MCommand() override {}
+  ~MCommand() final {}
 
 public:
   std::string_view get_type_name() const override { return "command"; }

--- a/src/messages/MCommandReply.h
+++ b/src/messages/MCommandReply.h
@@ -35,7 +35,7 @@ public:
     : Message{MSG_COMMAND_REPLY},
       r(_r), rs(s) { }
 private:
-  ~MCommandReply() override {}
+  ~MCommandReply() final {}
 
 public:
   std::string_view get_type_name() const override { return "command_reply"; }

--- a/src/messages/MDentryLink.h
+++ b/src/messages/MDentryLink.h
@@ -47,7 +47,7 @@ protected:
     dirfrag(df),
     dn(n),
     is_primary(p) {}
-  ~MDentryLink() override {}
+  ~MDentryLink() final {}
 
 public:
   std::string_view get_type_name() const override { return "dentry_link";}

--- a/src/messages/MDentryUnlink.h
+++ b/src/messages/MDentryUnlink.h
@@ -42,7 +42,7 @@ protected:
     MMDSOp(MSG_MDS_DENTRYUNLINK, HEAD_VERSION, COMPAT_VERSION),
     dirfrag(df),
     dn(n) {}
-  ~MDentryUnlink() override {}
+  ~MDentryUnlink() final {}
 
 public:
   std::string_view get_type_name() const override { return "dentry_unlink";}

--- a/src/messages/MDirUpdate.h
+++ b/src/messages/MDirUpdate.h
@@ -57,7 +57,7 @@ public:
   }
 
 protected:
-  ~MDirUpdate() {}
+  ~MDirUpdate() final {}
   MDirUpdate() : MMDSOp(MSG_MDS_DIRUPDATE, HEAD_VERSION, COMPAT_VERSION) {}
   MDirUpdate(mds_rank_t f,
 	     dirfrag_t dirfrag,

--- a/src/messages/MDiscover.h
+++ b/src/messages/MDiscover.h
@@ -64,7 +64,7 @@ protected:
     want(want_path_),
     want_base_dir(want_base_dir_),
     path_locked(path_locked_) { }
-  ~MDiscover() override {}
+  ~MDiscover() final {}
 
 public:
   std::string_view get_type_name() const override { return "Dis"; }

--- a/src/messages/MDiscoverReply.h
+++ b/src/messages/MDiscoverReply.h
@@ -141,7 +141,7 @@ protected:
   {
     header.tid = 0;
   }
-  ~MDiscoverReply() override {}
+  ~MDiscoverReply() final {}
 
 public:
   std::string_view get_type_name() const override { return "discover_reply"; }

--- a/src/messages/MExportCaps.h
+++ b/src/messages/MExportCaps.h
@@ -32,7 +32,7 @@ public:
 protected:
   MExportCaps() :
     MMDSOp{MSG_MDS_EXPORTCAPS, HEAD_VERSION, COMPAT_VERSION} {}
-  ~MExportCaps() override {}
+  ~MExportCaps() final {}
 
 public:
   std::string_view get_type_name() const override { return "export_caps"; }

--- a/src/messages/MExportCapsAck.h
+++ b/src/messages/MExportCapsAck.h
@@ -31,7 +31,7 @@ protected:
     MMDSOp{MSG_MDS_EXPORTCAPSACK, HEAD_VERSION, COMPAT_VERSION} {}
   MExportCapsAck(inodeno_t i) :
     MMDSOp{MSG_MDS_EXPORTCAPSACK, HEAD_VERSION, COMPAT_VERSION}, ino(i) {}
-  ~MExportCapsAck() override {}
+  ~MExportCapsAck() final {}
 
 public:
   std::string_view get_type_name() const override { return "export_caps_ack"; }

--- a/src/messages/MExportDir.h
+++ b/src/messages/MExportDir.h
@@ -31,7 +31,7 @@ protected:
     MMDSOp{MSG_MDS_EXPORTDIR}, dirfrag(df) {
     set_tid(tid);
   }
-  ~MExportDir() override {}
+  ~MExportDir() final {}
 
 public:
   std::string_view get_type_name() const override { return "Ex"; }

--- a/src/messages/MExportDirAck.h
+++ b/src/messages/MExportDirAck.h
@@ -31,7 +31,7 @@ protected:
     MMDSOp{MSG_MDS_EXPORTDIRACK}, dirfrag(df) {
     set_tid(tid);
   }
-  ~MExportDirAck() override {}
+  ~MExportDirAck() final {}
 
 public:
   std::string_view get_type_name() const override { return "ExAck"; }

--- a/src/messages/MExportDirCancel.h
+++ b/src/messages/MExportDirCancel.h
@@ -33,7 +33,7 @@ protected:
     MMDSOp{MSG_MDS_EXPORTDIRCANCEL, HEAD_VERSION, COMPAT_VERSION}, dirfrag(df) {
     set_tid(tid);
   }
-  ~MExportDirCancel() override {}
+  ~MExportDirCancel() final {}
 
 public:
   std::string_view get_type_name() const override { return "ExCancel"; }

--- a/src/messages/MExportDirDiscover.h
+++ b/src/messages/MExportDirDiscover.h
@@ -43,7 +43,7 @@ protected:
     from(f), dirfrag(df), path(p), started(false) {
     set_tid(tid);
   }
-  ~MExportDirDiscover() override {}
+  ~MExportDirDiscover() final {}
 
 public:
   std::string_view get_type_name() const override { return "ExDis"; }

--- a/src/messages/MExportDirDiscoverAck.h
+++ b/src/messages/MExportDirDiscoverAck.h
@@ -38,7 +38,7 @@ protected:
     dirfrag(df), success(s) {
     set_tid(tid);
   }
-  ~MExportDirDiscoverAck() override {}
+  ~MExportDirDiscoverAck() final {}
 
 public:
   std::string_view get_type_name() const override { return "ExDisA"; }

--- a/src/messages/MExportDirFinish.h
+++ b/src/messages/MExportDirFinish.h
@@ -36,7 +36,7 @@ protected:
     MMDSOp{MSG_MDS_EXPORTDIRFINISH, HEAD_VERSION, COMPAT_VERSION}, dirfrag(df), last(l) {
     set_tid(tid);
   }
-  ~MExportDirFinish() override {}
+  ~MExportDirFinish() final {}
 
 public:
   std::string_view get_type_name() const override { return "ExFin"; }

--- a/src/messages/MExportDirNotify.h
+++ b/src/messages/MExportDirNotify.h
@@ -44,7 +44,7 @@ protected:
     base(i), ack(a), old_auth(oa), new_auth(na) {
     set_tid(tid);
   }
-  ~MExportDirNotify() override {}
+  ~MExportDirNotify() final {}
 
 public:
   std::string_view get_type_name() const override { return "ExNot"; }

--- a/src/messages/MExportDirNotifyAck.h
+++ b/src/messages/MExportDirNotifyAck.h
@@ -36,7 +36,7 @@ protected:
     MMDSOp{MSG_MDS_EXPORTDIRNOTIFYACK, HEAD_VERSION, COMPAT_VERSION}, dirfrag(df), new_auth(na) {
     set_tid(tid);
   }
-  ~MExportDirNotifyAck() override {}
+  ~MExportDirNotifyAck() final {}
 
 public:
   std::string_view get_type_name() const override { return "ExNotA"; }

--- a/src/messages/MExportDirPrep.h
+++ b/src/messages/MExportDirPrep.h
@@ -49,7 +49,7 @@ protected:
   {
     set_tid(tid);
   }
-  ~MExportDirPrep() override {}
+  ~MExportDirPrep() final {}
 
 public:
   std::string_view get_type_name() const override { return "ExP"; }

--- a/src/messages/MExportDirPrepAck.h
+++ b/src/messages/MExportDirPrepAck.h
@@ -36,7 +36,7 @@ protected:
     MMDSOp{MSG_MDS_EXPORTDIRPREPACK, HEAD_VERSION, COMPAT_VERSION}, dirfrag(df), success(s) {
     set_tid(tid);
   }
-  ~MExportDirPrepAck() override {}
+  ~MExportDirPrepAck() final {}
 
 public:  
   bool is_success() const { return success; }

--- a/src/messages/MFSMap.h
+++ b/src/messages/MFSMap.h
@@ -37,7 +37,7 @@ public:
 private:
   FSMap fsmap;
 
-  ~MFSMap() override {}
+  ~MFSMap() final {}
 
 public:
   std::string_view get_type_name() const override { return "fsmap"; }

--- a/src/messages/MFSMapUser.h
+++ b/src/messages/MFSMapUser.h
@@ -36,7 +36,7 @@ public:
 private:
   FSMapUser fsmap;
 
-  ~MFSMapUser() override {}
+  ~MFSMapUser() final {}
 
 public:
   std::string_view get_type_name() const override { return "fsmap.user"; }

--- a/src/messages/MForward.h
+++ b/src/messages/MForward.h
@@ -55,7 +55,7 @@ public:
     msg = (PaxosServiceMessage*)m->get();
   }
 private:
-  ~MForward() override {
+  ~MForward() final {
     if (msg) {
       // message was unclaimed
       msg->put();

--- a/src/messages/MGatherCaps.h
+++ b/src/messages/MGatherCaps.h
@@ -14,7 +14,7 @@ public:
 protected:
   MGatherCaps() :
     MMDSOp{MSG_MDS_GATHERCAPS, HEAD_VERSION, COMPAT_VERSION} {}
-  ~MGatherCaps() override {}
+  ~MGatherCaps() final {}
 
 public:
   std::string_view get_type_name() const override { return "gather_caps"; }

--- a/src/messages/MGetPoolStats.h
+++ b/src/messages/MGetPoolStats.h
@@ -31,7 +31,7 @@ public:
   }
 
 private:
-  ~MGetPoolStats() override {}
+  ~MGetPoolStats() final {}
 
 public:
   std::string_view get_type_name() const override { return "getpoolstats"; }

--- a/src/messages/MGetPoolStatsReply.h
+++ b/src/messages/MGetPoolStatsReply.h
@@ -35,7 +35,7 @@ public:
   }
 
 private:
-  ~MGetPoolStatsReply() override {}
+  ~MGetPoolStatsReply() final {}
 
 public:
   std::string_view get_type_name() const override { return "getpoolstats"; }

--- a/src/messages/MHeartbeat.h
+++ b/src/messages/MHeartbeat.h
@@ -40,7 +40,7 @@ protected:
       load(load),
       beat(beat)
   {}
-  ~MHeartbeat() override {}
+  ~MHeartbeat() final {}
 
 public:
   std::string_view get_type_name() const override { return "HB"; }

--- a/src/messages/MInodeFileCaps.h
+++ b/src/messages/MInodeFileCaps.h
@@ -36,7 +36,7 @@ protected:
     this->ino = ino;
     this->caps = caps;
   }
-  ~MInodeFileCaps() override {}
+  ~MInodeFileCaps() final {}
 
 public:
   std::string_view get_type_name() const override { return "inode_file_caps";}

--- a/src/messages/MLock.h
+++ b/src/messages/MLock.h
@@ -63,7 +63,7 @@ protected:
     lock->get_parent()->set_object_info(object_info);
     lockdata = std::move(bl);
   }
-  ~MLock() override {}
+  ~MLock() final {}
   
 public:
   std::string_view get_type_name() const override { return "ILock"; }

--- a/src/messages/MLog.h
+++ b/src/messages/MLog.h
@@ -30,7 +30,7 @@ public:
     : PaxosServiceMessage{MSG_LOG, 0}, fsid(f), entries{std::move(e)} { }
   MLog(const uuid_d& f) : PaxosServiceMessage(MSG_LOG, 0), fsid(f) { }
 private:
-  ~MLog() override {}
+  ~MLog() final {}
 
 public:
   std::string_view get_type_name() const override { return "log"; }

--- a/src/messages/MLogAck.h
+++ b/src/messages/MLogAck.h
@@ -32,7 +32,7 @@ public:
   MLogAck() : Message{MSG_LOGACK} {}
   MLogAck(uuid_d& f, version_t l) : Message{MSG_LOGACK}, fsid(f), last(l) {}
 private:
-  ~MLogAck() override {}
+  ~MLogAck() final {}
 
 public:
   std::string_view get_type_name() const override { return "log_ack"; }

--- a/src/messages/MMDSBeacon.h
+++ b/src/messages/MMDSBeacon.h
@@ -218,7 +218,7 @@ protected:
     mds_features(feat) {
     set_priority(CEPH_MSG_PRIO_HIGH);
   }
-  ~MMDSBeacon() override {}
+  ~MMDSBeacon() final {}
 
 public:
   const uuid_d& get_fsid() const { return fsid; }

--- a/src/messages/MMDSCacheRejoin.h
+++ b/src/messages/MMDSCacheRejoin.h
@@ -346,7 +346,7 @@ private:
 
   MMDSCacheRejoin(int o) : MMDSCacheRejoin() { op = o; }
   MMDSCacheRejoin() : MMDSOp{MSG_MDS_CACHEREJOIN, HEAD_VERSION, COMPAT_VERSION} {}
-  ~MMDSCacheRejoin() override {}
+  ~MMDSCacheRejoin() final {}
 };
 
 WRITE_CLASS_ENCODER(MMDSCacheRejoin::inode_strong)

--- a/src/messages/MMDSFindIno.h
+++ b/src/messages/MMDSFindIno.h
@@ -28,7 +28,7 @@ public:
 protected:
   MMDSFindIno() : MMDSOp{MSG_MDS_FINDINO, HEAD_VERSION, COMPAT_VERSION} {}
   MMDSFindIno(ceph_tid_t t, inodeno_t i) : MMDSOp{MSG_MDS_FINDINO, HEAD_VERSION, COMPAT_VERSION}, tid(t), ino(i) {}
-  ~MMDSFindIno() override {}
+  ~MMDSFindIno() final {}
 
 public:
   std::string_view get_type_name() const override { return "findino"; }

--- a/src/messages/MMDSFindInoReply.h
+++ b/src/messages/MMDSFindInoReply.h
@@ -28,7 +28,7 @@ public:
 protected:
   MMDSFindInoReply() : MMDSOp{MSG_MDS_FINDINOREPLY, HEAD_VERSION, COMPAT_VERSION} {}
   MMDSFindInoReply(ceph_tid_t t) : MMDSOp{MSG_MDS_FINDINOREPLY, HEAD_VERSION, COMPAT_VERSION}, tid(t) {}
-  ~MMDSFindInoReply() override {}
+  ~MMDSFindInoReply() final {}
 
 public:
   std::string_view get_type_name() const override { return "findinoreply"; }

--- a/src/messages/MMDSFragmentNotify.h
+++ b/src/messages/MMDSFragmentNotify.h
@@ -44,7 +44,7 @@ protected:
     base_dirfrag(df), bits(b) {
     set_tid(tid);
   }
-  ~MMDSFragmentNotify() override {}
+  ~MMDSFragmentNotify() final {}
 
 public: 
   std::string_view get_type_name() const override { return "fragment_notify"; }

--- a/src/messages/MMDSFragmentNotifyAck.h
+++ b/src/messages/MMDSFragmentNotifyAck.h
@@ -35,7 +35,7 @@ protected:
     base_dirfrag(df), bits(b) {
     set_tid(tid);
   }
-  ~MMDSFragmentNotifyAck() override {}
+  ~MMDSFragmentNotifyAck() final {}
 
 public:
   std::string_view get_type_name() const override { return "fragment_notify_ack"; }

--- a/src/messages/MMDSLoadTargets.h
+++ b/src/messages/MMDSLoadTargets.h
@@ -33,7 +33,7 @@ protected:
   MMDSLoadTargets(mds_gid_t g, std::set<mds_rank_t>& mds_targets) :
     PaxosServiceMessage(MSG_MDS_OFFLOAD_TARGETS, 0),
     global_id(g), targets(mds_targets) {}
-  ~MMDSLoadTargets() override {}
+  ~MMDSLoadTargets() final {}
 
 public:
   std::string_view get_type_name() const override { return "mds_load_targets"; }

--- a/src/messages/MMDSMap.h
+++ b/src/messages/MMDSMap.h
@@ -45,7 +45,7 @@ protected:
     mm.encode(encoded, -1);  // we will reencode with fewer features as necessary
   }
 
-  ~MMDSMap() override {}
+  ~MMDSMap() final {}
 
 public:
   std::string_view get_type_name() const override { return "mdsmap"; }

--- a/src/messages/MMDSMetrics.h
+++ b/src/messages/MMDSMetrics.h
@@ -22,7 +22,7 @@ protected:
     : MMDSOp(MSG_MDS_METRICS, HEAD_VERSION, COMPAT_VERSION),
       metrics_message(metrics_message) {
   }
-  ~MMDSMetrics() { }
+  ~MMDSMetrics() final {}
 
 public:
   std::string_view get_type_name() const override {

--- a/src/messages/MMDSOpenIno.h
+++ b/src/messages/MMDSOpenIno.h
@@ -32,7 +32,7 @@ protected:
     if (pa)
       ancestors = *pa;
   }
-  ~MMDSOpenIno() override {}
+  ~MMDSOpenIno() final {}
 
 public:
   std::string_view get_type_name() const override { return "openino"; }

--- a/src/messages/MMDSPeerRequest.h
+++ b/src/messages/MMDSPeerRequest.h
@@ -170,7 +170,7 @@ protected:
     MMDSOp{MSG_MDS_PEER_REQUEST, HEAD_VERSION, COMPAT_VERSION},
     reqid(ri), attempt(att), op(o), flags(0), lock_type(0),
     inode_export_v(0), srcdn_auth(MDS_RANK_NONE) { }
-  ~MMDSPeerRequest() override {}
+  ~MMDSPeerRequest() final {}
 
 public:
   void encode_payload(uint64_t features) override {

--- a/src/messages/MMDSPing.h
+++ b/src/messages/MMDSPing.h
@@ -20,7 +20,7 @@ protected:
   MMDSPing(version_t seq)
     : MMDSOp(MSG_MDS_PING, HEAD_VERSION, COMPAT_VERSION), seq(seq) {
   }
-  ~MMDSPing() { }
+  ~MMDSPing() final {}
 
 public:
   std::string_view get_type_name() const override {

--- a/src/messages/MMDSResolve.h
+++ b/src/messages/MMDSResolve.h
@@ -96,7 +96,7 @@ public:
 protected:
   MMDSResolve() : MMDSOp{MSG_MDS_RESOLVE, HEAD_VERSION, COMPAT_VERSION}
  {}
-  ~MMDSResolve() override {}
+  ~MMDSResolve() final {}
 
 public:
   std::string_view get_type_name() const override { return "mds_resolve"; }

--- a/src/messages/MMDSResolveAck.h
+++ b/src/messages/MMDSResolveAck.h
@@ -28,7 +28,7 @@ public:
 
 protected:
   MMDSResolveAck() : MMDSOp{MSG_MDS_RESOLVEACK, HEAD_VERSION, COMPAT_VERSION} {}
-  ~MMDSResolveAck() override {}
+  ~MMDSResolveAck() final {}
 
 public:
   std::string_view get_type_name() const override { return "resolve_ack"; }

--- a/src/messages/MMDSSnapUpdate.h
+++ b/src/messages/MMDSSnapUpdate.h
@@ -34,7 +34,7 @@ protected:
     MMDSOp{MSG_MDS_SNAPUPDATE}, ino(i), snap_op(op) {
       set_tid(tid);
     }
-  ~MMDSSnapUpdate() override {}
+  ~MMDSSnapUpdate() final {}
 
 public:
   std::string_view get_type_name() const override { return "snap_update"; }

--- a/src/messages/MMDSTableRequest.h
+++ b/src/messages/MMDSTableRequest.h
@@ -33,7 +33,7 @@ protected:
     table(tab), op(o), reqid(r) {
     set_tid(v);
   }
-  ~MMDSTableRequest() override {}
+  ~MMDSTableRequest() final {}
 
 public:
   std::string_view get_type_name() const override { return "mds_table_request"; }

--- a/src/messages/MMgrBeacon.h
+++ b/src/messages/MMgrBeacon.h
@@ -108,7 +108,7 @@ public:
   }
 
 private:
-  ~MMgrBeacon() override {}
+  ~MMgrBeacon() final {}
 
 public:
 

--- a/src/messages/MMgrCommand.h
+++ b/src/messages/MMgrCommand.h
@@ -19,7 +19,7 @@ public:
       fsid(f) { }
 
 private:
-  ~MMgrCommand() override {}
+  ~MMgrCommand() final {}
 
 public:
   std::string_view get_type_name() const override { return "mgr_command"; }

--- a/src/messages/MMgrCommandReply.h
+++ b/src/messages/MMgrCommandReply.h
@@ -23,7 +23,7 @@ public:
     : Message{MSG_MGR_COMMAND_REPLY},
       r(_r), rs(s) { }
 private:
-  ~MMgrCommandReply() override {}
+  ~MMgrCommandReply() final {}
 
 public:
   std::string_view get_type_name() const override { return "mgr_command_reply"; }

--- a/src/messages/MMgrDigest.h
+++ b/src/messages/MMgrDigest.h
@@ -47,7 +47,7 @@ public:
 private:
   MMgrDigest() :
     Message{MSG_MGR_DIGEST} {}
-  ~MMgrDigest() override {}
+  ~MMgrDigest() final {}
 
   using RefCountedObject::put;
   using RefCountedObject::get;

--- a/src/messages/MMgrMap.h
+++ b/src/messages/MMgrMap.h
@@ -32,7 +32,7 @@ private:
   MMgrMap(const MgrMap &map_) :
     Message{MSG_MGR_MAP}, map(map_)
   {}
-  ~MMgrMap() override {}
+  ~MMgrMap() final {}
 
 public:
   std::string_view get_type_name() const override { return "mgrmap"; }

--- a/src/messages/MMonCommand.h
+++ b/src/messages/MMonCommand.h
@@ -36,7 +36,7 @@ public:
   { }
 
 private:
-  ~MMonCommand() override {}
+  ~MMonCommand() final {}
 
 public:
   std::string_view get_type_name() const override { return "mon_command"; }

--- a/src/messages/MMonCommandAck.h
+++ b/src/messages/MMonCommandAck.h
@@ -28,7 +28,7 @@ public:
     PaxosServiceMessage{MSG_MON_COMMAND_ACK, v},
     cmd(c), r(_r), rs(s) { }
 private:
-  ~MMonCommandAck() override {}
+  ~MMonCommandAck() final {}
 
 public:
   std::string_view get_type_name() const override { return "mon_command"; }

--- a/src/messages/MMonElection.h
+++ b/src/messages/MMonElection.h
@@ -72,7 +72,7 @@ public:
     m->encode(monmap_bl, CEPH_FEATURES_ALL);
   }
 private:
-  ~MMonElection() override {}
+  ~MMonElection() final {}
 
 public:
   std::string_view get_type_name() const override { return "election"; }

--- a/src/messages/MMonGetMap.h
+++ b/src/messages/MMonGetMap.h
@@ -23,7 +23,7 @@ class MMonGetMap : public Message {
 public:
   MMonGetMap() : Message{CEPH_MSG_MON_GET_MAP} { }
 private:
-  ~MMonGetMap() override {}
+  ~MMonGetMap() final {}
 
 public:
   std::string_view get_type_name() const override { return "mon_getmap"; }

--- a/src/messages/MMonGetOSDMap.h
+++ b/src/messages/MMonGetOSDMap.h
@@ -36,7 +36,7 @@ public:
       inc_first(0),
       inc_last(0) { }
 private:
-  ~MMonGetOSDMap() override {}
+  ~MMonGetOSDMap() final {}
 
 public:
   void request_full(epoch_t first, epoch_t last) {

--- a/src/messages/MMonGetPurgedSnaps.h
+++ b/src/messages/MMonGetPurgedSnaps.h
@@ -15,7 +15,7 @@ public:
       start(s),
       last(l) {}
 private:
-  ~MMonGetPurgedSnaps() override {}
+  ~MMonGetPurgedSnaps() final {}
 
 public:
   std::string_view get_type_name() const override {

--- a/src/messages/MMonGetPurgedSnapsReply.h
+++ b/src/messages/MMonGetPurgedSnapsReply.h
@@ -17,7 +17,7 @@ public:
       start(s),
       last(l) {}
 private:
-  ~MMonGetPurgedSnapsReply() override {}
+  ~MMonGetPurgedSnapsReply() final {}
 
 public:
   std::string_view get_type_name() const override {

--- a/src/messages/MMonGetVersion.h
+++ b/src/messages/MMonGetVersion.h
@@ -54,7 +54,7 @@ public:
   std::string what;
 
 private:
-  ~MMonGetVersion() override {}
+  ~MMonGetVersion() final {}
 };
 
 #endif

--- a/src/messages/MMonGetVersionReply.h
+++ b/src/messages/MMonGetVersionReply.h
@@ -60,7 +60,7 @@ public:
   version_t oldest_version = 0;
 
 private:
-  ~MMonGetVersionReply() override {}
+  ~MMonGetVersionReply() final {}
 };
 
 #endif

--- a/src/messages/MMonGlobalID.h
+++ b/src/messages/MMonGlobalID.h
@@ -23,7 +23,7 @@ public:
   MMonGlobalID() : PaxosServiceMessage{MSG_MON_GLOBAL_ID, 0}
   {}
 private:
-  ~MMonGlobalID() override {}
+  ~MMonGlobalID() final {}
 
 public:
   std::string_view get_type_name() const override { return "global_id"; }

--- a/src/messages/MMonHealth.h
+++ b/src/messages/MMonHealth.h
@@ -31,7 +31,7 @@ public:
   MMonHealth() : MMonQuorumService{MSG_MON_HEALTH, HEAD_VERSION} { }
 
 private:
-  ~MMonHealth() override { }
+  ~MMonHealth() final { }
 
 public:
   std::string_view get_type_name() const override { return "mon_health"; }

--- a/src/messages/MMonHealthChecks.h
+++ b/src/messages/MMonHealthChecks.h
@@ -23,7 +23,7 @@ public:
   {}
 
 private:
-  ~MMonHealthChecks() override { }
+  ~MMonHealthChecks() final { }
 
 public:
   std::string_view get_type_name() const override { return "mon_health_checks"; }

--- a/src/messages/MMonJoin.h
+++ b/src/messages/MMonJoin.h
@@ -33,7 +33,7 @@ public:
   { }
   
 private:
-  ~MMonJoin() override {}
+  ~MMonJoin() final {}
 
 public:
   std::string_view get_type_name() const override { return "mon_join"; }

--- a/src/messages/MMonMap.h
+++ b/src/messages/MMonMap.h
@@ -30,7 +30,7 @@ public:
     monmapbl = std::move(bl);
   }
 private:
-  ~MMonMap() override {}
+  ~MMonMap() final {}
 
 public:
   std::string_view get_type_name() const override { return "mon_map"; }

--- a/src/messages/MMonMgrReport.h
+++ b/src/messages/MMonMgrReport.h
@@ -36,7 +36,7 @@ public:
     : PaxosServiceMessage{MSG_MON_MGR_REPORT, 0, HEAD_VERSION, COMPAT_VERSION}
   {}
 private:
-  ~MMonMgrReport() override {}
+  ~MMonMgrReport() final {}
 
 public:
   std::string_view get_type_name() const override { return "monmgrreport"; }

--- a/src/messages/MMonPaxos.h
+++ b/src/messages/MMonPaxos.h
@@ -76,7 +76,7 @@ private:
   }
 
 private:
-  ~MMonPaxos() override {}
+  ~MMonPaxos() final {}
 
 public:
   std::string_view get_type_name() const override { return "paxos"; }

--- a/src/messages/MMonPing.h
+++ b/src/messages/MMonPing.h
@@ -53,7 +53,7 @@ private:
     : Message{MSG_MON_PING, HEAD_VERSION, COMPAT_VERSION}
   {}
 private:
-  ~MMonPing() override {}
+  ~MMonPing() final {}
 
 public:
   void decode_payload() override {

--- a/src/messages/MMonProbe.h
+++ b/src/messages/MMonProbe.h
@@ -71,7 +71,7 @@ public:
       required_features(0),
       mon_release{mr} {}
 private:
-  ~MMonProbe() override {}
+  ~MMonProbe() final {}
 
 public:
   std::string_view get_type_name() const override { return "mon_probe"; }

--- a/src/messages/MMonQuorumService.h
+++ b/src/messages/MMonQuorumService.h
@@ -25,7 +25,7 @@ protected:
   MMonQuorumService(int type, int head)
     : Message{type, head, 1}
   {}
-  ~MMonQuorumService() override { }
+  ~MMonQuorumService() override {}
 
 public:
   void set_epoch(epoch_t e) {

--- a/src/messages/MMonSubscribe.h
+++ b/src/messages/MMonSubscribe.h
@@ -39,7 +39,7 @@ public:
 
   MMonSubscribe() : Message{CEPH_MSG_MON_SUBSCRIBE, HEAD_VERSION, COMPAT_VERSION} { }
 private:
-  ~MMonSubscribe() override {}
+  ~MMonSubscribe() final {}
 
 public:
   void sub_want(const char *w, version_t start, unsigned flags) {

--- a/src/messages/MMonSubscribeAck.h
+++ b/src/messages/MMonSubscribeAck.h
@@ -28,7 +28,7 @@ public:
   MMonSubscribeAck(uuid_d& f, int i) : Message{CEPH_MSG_MON_SUBSCRIBE_ACK},
 				       interval(i), fsid(f) { }
 private:
-  ~MMonSubscribeAck() override {}
+  ~MMonSubscribeAck() final {}
 
 public:
   std::string_view get_type_name() const override { return "mon_subscribe_ack"; }

--- a/src/messages/MOSDAlive.h
+++ b/src/messages/MOSDAlive.h
@@ -26,7 +26,7 @@ public:
   MOSDAlive(epoch_t h, epoch_t w) : PaxosServiceMessage{MSG_OSD_ALIVE, h}, want(w) {}
   MOSDAlive() : MOSDAlive{0, 0} {}
 private:
-  ~MOSDAlive() override {}
+  ~MOSDAlive() final {}
 
 public:
   void encode_payload(uint64_t features) override {

--- a/src/messages/MOSDBoot.h
+++ b/src/messages/MOSDBoot.h
@@ -53,7 +53,7 @@ private:
   { }
   
 private:
-  ~MOSDBoot() override { }
+  ~MOSDBoot() final { }
 
 public:
   std::string_view get_type_name() const override { return "osd_boot"; }

--- a/src/messages/MOSDFailure.h
+++ b/src/messages/MOSDFailure.h
@@ -57,7 +57,7 @@ private:
       flags(extra_flags),
       epoch(e), failed_for(duration) { }
 private:
-  ~MOSDFailure() override {}
+  ~MOSDFailure() final {}
 
 public:
   int get_target_osd() { return target_osd; }

--- a/src/messages/MOSDForceRecovery.h
+++ b/src/messages/MOSDForceRecovery.h
@@ -48,7 +48,7 @@ public:
     Message{MSG_OSD_FORCE_RECOVERY, HEAD_VERSION, COMPAT_VERSION},
     fsid(f), forced_pgs(pgs), options(opts) {}
 private:
-  ~MOSDForceRecovery() {}
+  ~MOSDForceRecovery() final {}
 
 public:
   std::string_view get_type_name() const { return "force_recovery"; }

--- a/src/messages/MOSDFull.h
+++ b/src/messages/MOSDFull.h
@@ -17,7 +17,7 @@ public:
   uint32_t state = 0;
 
 private:
-  ~MOSDFull() {}
+  ~MOSDFull() final {}
 
 public:
   MOSDFull(epoch_t e, unsigned s)

--- a/src/messages/MOSDMap.h
+++ b/src/messages/MOSDMap.h
@@ -64,7 +64,7 @@ public:
       fsid(f), encode_features(features),
       oldest_map(0), newest_map(0) { }
 private:
-  ~MOSDMap() override {}
+  ~MOSDMap() final {}
 public:
   // marshalling
   void decode_payload() override {

--- a/src/messages/MOSDMarkMeDead.h
+++ b/src/messages/MOSDMarkMeDead.h
@@ -25,7 +25,7 @@ private:
       fsid(fs), target_osd(osd),
       epoch(e) {}
  private:
-  ~MOSDMarkMeDead() override {}
+  ~MOSDMarkMeDead() final {}
 
 public:
   epoch_t get_epoch() const { return epoch; }

--- a/src/messages/MOSDMarkMeDown.h
+++ b/src/messages/MOSDMarkMeDown.h
@@ -39,7 +39,7 @@ private:
       fsid(fs), target_osd(osd), target_addrs(av),
       epoch(e), request_ack(request_ack) {}
  private:
-  ~MOSDMarkMeDown() override {}
+  ~MOSDMarkMeDown() final {}
 
 public: 
   epoch_t get_epoch() const { return epoch; }

--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -193,7 +193,7 @@ public:
     reqid.inc = inc;
   }
 private:
-  ~MOSDOp() override {}
+  ~MOSDOp() final {}
 
 public:
   void set_mtime(utime_t mt) { mtime = mt; }

--- a/src/messages/MOSDOpReply.h
+++ b/src/messages/MOSDOpReply.h
@@ -165,7 +165,7 @@ public:
     }
   }
 private:
-  ~MOSDOpReply() override {}
+  ~MOSDOpReply() final {}
 
 public:
   void encode_payload(uint64_t features) override {

--- a/src/messages/MOSDPGBackfill.h
+++ b/src/messages/MOSDPGBackfill.h
@@ -97,7 +97,7 @@ public:
       map_epoch(e), query_epoch(e),
       pgid(p) {}
 private:
-  ~MOSDPGBackfill() override {}
+  ~MOSDPGBackfill() final {}
 
 public:
   std::string_view get_type_name() const override { return "pg_backfill"; }

--- a/src/messages/MOSDPGBackfillRemove.h
+++ b/src/messages/MOSDPGBackfillRemove.h
@@ -49,7 +49,7 @@ public:
       map_epoch(map_epoch) {}
 
 private:
-  ~MOSDPGBackfillRemove() {}
+  ~MOSDPGBackfillRemove() final {}
 
 public:
   std::string_view get_type_name() const override { return "backfill_remove"; }

--- a/src/messages/MOSDPGCreate.h
+++ b/src/messages/MOSDPGCreate.h
@@ -40,7 +40,7 @@ public:
       epoch(e)
   {}
 private:
-  ~MOSDPGCreate() override {}
+  ~MOSDPGCreate() final {}
 
 public:
   std::string_view get_type_name() const override { return "pg_create"; }

--- a/src/messages/MOSDPGCreate2.h
+++ b/src/messages/MOSDPGCreate2.h
@@ -25,7 +25,7 @@ public:
     : Message{MSG_OSD_PG_CREATE2, HEAD_VERSION, COMPAT_VERSION},
       epoch(e) { }
 private:
-  ~MOSDPGCreate2() override {}
+  ~MOSDPGCreate2() final {}
 
 public:
   std::string_view get_type_name() const override {

--- a/src/messages/MOSDPGInfo.h
+++ b/src/messages/MOSDPGInfo.h
@@ -46,7 +46,7 @@ public:
     set_priority(CEPH_MSG_PRIO_HIGH);
   }
 private:
-  ~MOSDPGInfo() override {}
+  ~MOSDPGInfo() final {}
 
 public:
   std::string_view get_type_name() const override { return "pg_info"; }

--- a/src/messages/MOSDPGInfo2.h
+++ b/src/messages/MOSDPGInfo2.h
@@ -63,7 +63,7 @@ public:
   }
 
 private:
-  ~MOSDPGInfo2() override {}
+  ~MOSDPGInfo2() final {}
 
 public:
   std::string_view get_type_name() const override {

--- a/src/messages/MOSDPGLease.h
+++ b/src/messages/MOSDPGLease.h
@@ -41,7 +41,7 @@ public:
     spgid(p),
     lease(lease) { }
 private:
-  ~MOSDPGLease() override {}
+  ~MOSDPGLease() final {}
 
 public:
   std::string_view get_type_name() const override { return "pg_lease"; }

--- a/src/messages/MOSDPGLeaseAck.h
+++ b/src/messages/MOSDPGLeaseAck.h
@@ -41,7 +41,7 @@ public:
     spgid(p),
     lease_ack(lease_ack) { }
 private:
-  ~MOSDPGLeaseAck() override {}
+  ~MOSDPGLeaseAck() final {}
 
 public:
   std::string_view get_type_name() const override { return "pg_lease_ack"; }

--- a/src/messages/MOSDPGLog.h
+++ b/src/messages/MOSDPGLog.h
@@ -81,7 +81,7 @@ public:
   }
 
 private:
-  ~MOSDPGLog() override {}
+  ~MOSDPGLog() final {}
 
 public:
   std::string_view get_type_name() const override { return "PGlog"; }

--- a/src/messages/MOSDPGNotify.h
+++ b/src/messages/MOSDPGNotify.h
@@ -52,7 +52,7 @@ private:
     set_priority(CEPH_MSG_PRIO_HIGH);
   }
 private:
-  ~MOSDPGNotify() override {}
+  ~MOSDPGNotify() final {}
 
 public:  
   std::string_view get_type_name() const override { return "PGnot"; }

--- a/src/messages/MOSDPGNotify2.h
+++ b/src/messages/MOSDPGNotify2.h
@@ -57,7 +57,7 @@ public:
   }
 
 private:
-  ~MOSDPGNotify2() override {}
+  ~MOSDPGNotify2() final {}
 
 public:
   std::string_view get_type_name() const override {

--- a/src/messages/MOSDPGQuery.h
+++ b/src/messages/MOSDPGQuery.h
@@ -49,7 +49,7 @@ private:
     set_priority(CEPH_MSG_PRIO_HIGH);
   }
 private:
-  ~MOSDPGQuery() override {}
+  ~MOSDPGQuery() final {}
 
 public:  
   std::string_view get_type_name() const override { return "pg_query"; }

--- a/src/messages/MOSDPGQuery2.h
+++ b/src/messages/MOSDPGQuery2.h
@@ -51,7 +51,7 @@ public:
   }
 
 private:
-  ~MOSDPGQuery2() override {}
+  ~MOSDPGQuery2() final {}
 
 public:
   std::string_view get_type_name() const override {

--- a/src/messages/MOSDPGRecoveryDelete.h
+++ b/src/messages/MOSDPGRecoveryDelete.h
@@ -58,7 +58,7 @@ public:
   {}
 
 private:
-  ~MOSDPGRecoveryDelete() {}
+  ~MOSDPGRecoveryDelete() final {}
 
 public:
   std::string_view get_type_name() const { return "recovery_delete"; }

--- a/src/messages/MOSDPGRemove.h
+++ b/src/messages/MOSDPGRemove.h
@@ -40,7 +40,7 @@ private:
     pg_list.swap(l);
   }
 private:
-  ~MOSDPGRemove() override {}
+  ~MOSDPGRemove() final {}
 
 public:
   std::string_view get_type_name() const override { return "PGrm"; }

--- a/src/messages/MOSDPGScan.h
+++ b/src/messages/MOSDPGScan.h
@@ -100,7 +100,7 @@ public:
       begin(be), end(en) {
   }
 private:
-  ~MOSDPGScan() override {}
+  ~MOSDPGScan() final {}
 
 public:
   std::string_view get_type_name() const override { return "pg_scan"; }

--- a/src/messages/MOSDPGTemp.h
+++ b/src/messages/MOSDPGTemp.h
@@ -33,7 +33,7 @@ public:
     : MOSDPGTemp(0)
   {}
 private:
-  ~MOSDPGTemp() override {}
+  ~MOSDPGTemp() final {}
 
 public:
   void encode_payload(uint64_t features) override {

--- a/src/messages/MOSDPGTrim.h
+++ b/src/messages/MOSDPGTrim.h
@@ -51,7 +51,7 @@ public:
     MOSDPeeringOp{MSG_OSD_PG_TRIM, HEAD_VERSION, COMPAT_VERSION},
     epoch(mv), pgid(p), trim_to(tt) { }
 private:
-  ~MOSDPGTrim() override {}
+  ~MOSDPGTrim() final {}
 
 public:
   std::string_view get_type_name() const override { return "pg_trim"; }

--- a/src/messages/MOSDPGUpdateLogMissing.h
+++ b/src/messages/MOSDPGUpdateLogMissing.h
@@ -73,7 +73,7 @@ public:
   {}
 
 private:
-  ~MOSDPGUpdateLogMissing() override {}
+  ~MOSDPGUpdateLogMissing() final {}
 
 public:
   std::string_view get_type_name() const override { return "PGUpdateLogMissing"; }

--- a/src/messages/MOSDPGUpdateLogMissingReply.h
+++ b/src/messages/MOSDPGUpdateLogMissingReply.h
@@ -71,7 +71,7 @@ public:
     {}
 
 private:
-  ~MOSDPGUpdateLogMissingReply() override {}
+  ~MOSDPGUpdateLogMissingReply() final {}
 
 public:
   std::string_view get_type_name() const override { return "PGUpdateLogMissingReply"; }

--- a/src/messages/MOSDPing.h
+++ b/src/messages/MOSDPing.h
@@ -89,7 +89,7 @@ private:
     : Message{MSG_OSD_PING, HEAD_VERSION, COMPAT_VERSION}
   {}
 private:
-  ~MOSDPing() override {}
+  ~MOSDPing() final {}
 
 public:
   void decode_payload() override {

--- a/src/messages/MOSDRepOp.h
+++ b/src/messages/MOSDRepOp.h
@@ -172,7 +172,7 @@ public:
     min_last_complete_ondisk = rollback_to;
   }
 private:
-  ~MOSDRepOp() override {}
+  ~MOSDRepOp() final {}
 
 public:
   std::string_view get_type_name() const override { return "osd_repop"; }

--- a/src/messages/MOSDRepOpReply.h
+++ b/src/messages/MOSDRepOpReply.h
@@ -136,7 +136,7 @@ public:
       ack_type(0), result(0),
       final_decode_needed(true) {}
 private:
-  ~MOSDRepOpReply() override {}
+  ~MOSDRepOpReply() final {}
 
 public:
   std::string_view get_type_name() const override { return "osd_repop_reply"; }

--- a/src/messages/MOSDRepScrub.h
+++ b/src/messages/MOSDRepScrub.h
@@ -72,7 +72,7 @@ public:
 
 
 private:
-  ~MOSDRepScrub() override {}
+  ~MOSDRepScrub() final {}
 
 public:
   std::string_view get_type_name() const override { return "replica scrub"; }

--- a/src/messages/MOSDRepScrubMap.h
+++ b/src/messages/MOSDRepScrubMap.h
@@ -49,7 +49,7 @@ public:
       from(from) {}
 
 private:
-  ~MOSDRepScrubMap() {}
+  ~MOSDRepScrubMap() final {}
 
 public:
   std::string_view get_type_name() const override { return "rep_scrubmap"; }

--- a/src/messages/MOSDScrub.h
+++ b/src/messages/MOSDScrub.h
@@ -40,7 +40,7 @@ public:
     Message{MSG_OSD_SCRUB, HEAD_VERSION, COMPAT_VERSION},
     fsid(f), scrub_pgs(pgs), repair(r), deep(d) {}
 private:
-  ~MOSDScrub() override {}
+  ~MOSDScrub() final {}
 
 public:
   std::string_view get_type_name() const override { return "scrub"; }

--- a/src/messages/MOSDScrub2.h
+++ b/src/messages/MOSDScrub2.h
@@ -25,7 +25,7 @@ public:
     Message{MSG_OSD_SCRUB2, HEAD_VERSION, COMPAT_VERSION},
     fsid(f), epoch(e), scrub_pgs(pgs), repair(r), deep(d) {}
 private:
-  ~MOSDScrub2() override {}
+  ~MOSDScrub2() final {}
 
 public:
   std::string_view get_type_name() const override { return "scrub2"; }

--- a/src/messages/MPGStats.h
+++ b/src/messages/MPGStats.h
@@ -37,7 +37,7 @@ public:
   {}
 
 private:
-  ~MPGStats() override {}
+  ~MPGStats() final {}
 
 public:
   std::string_view get_type_name() const override { return "pg_stats"; }

--- a/src/messages/MPGStatsAck.h
+++ b/src/messages/MPGStatsAck.h
@@ -24,7 +24,7 @@ public:
   MPGStatsAck() : Message{MSG_PGSTATSACK} {}
 
 private:
-  ~MPGStatsAck() override {}
+  ~MPGStatsAck() final {}
 
 public:
   std::string_view get_type_name() const override { return "pg_stats_ack"; }

--- a/src/messages/MPing.h
+++ b/src/messages/MPing.h
@@ -22,7 +22,7 @@ class MPing : public Message {
 public:
   MPing() : Message{CEPH_MSG_PING} {}
 private:
-  ~MPing() override {}
+  ~MPing() final {}
 
 public:
   void decode_payload() override { }

--- a/src/messages/MPoolOp.h
+++ b/src/messages/MPoolOp.h
@@ -41,7 +41,7 @@ public:
   }
 
 private:
-  ~MPoolOp() override {}
+  ~MPoolOp() final {}
 
 public:
   std::string_view get_type_name() const override { return "poolop"; }

--- a/src/messages/MRemoveSnaps.h
+++ b/src/messages/MRemoveSnaps.h
@@ -28,7 +28,7 @@ protected:
     PaxosServiceMessage{MSG_REMOVE_SNAPS, 0} {
     snaps.swap(s);
   }
-  ~MRemoveSnaps() override {}
+  ~MRemoveSnaps() final {}
 
 public:
   std::string_view get_type_name() const override { return "remove_snaps"; }

--- a/src/messages/MRoute.h
+++ b/src/messages/MRoute.h
@@ -39,7 +39,7 @@ public:
       msg(m),
       send_osdmap_first(0) {}
 private:
-  ~MRoute() override {
+  ~MRoute() final {
     if (msg)
       msg->put();
   }

--- a/src/messages/MServiceMap.h
+++ b/src/messages/MServiceMap.h
@@ -16,7 +16,7 @@ public:
       service_map(sm) {
   }
 private:
-  ~MServiceMap() override {}
+  ~MServiceMap() final {}
 
 public:
   std::string_view get_type_name() const override { return "service_map"; }

--- a/src/messages/MStatfs.h
+++ b/src/messages/MStatfs.h
@@ -37,7 +37,7 @@ public:
   }
 
 private:
-  ~MStatfs() override {}
+  ~MStatfs() final {}
 
 public:
   std::string_view get_type_name() const override { return "statfs"; }

--- a/src/messages/MTimeCheck.h
+++ b/src/messages/MTimeCheck.h
@@ -40,7 +40,7 @@ public:
   {}
 
 private:
-  ~MTimeCheck() override {}
+  ~MTimeCheck() final {}
 
 public:
   std::string_view get_type_name() const override { return "time_check"; }

--- a/src/messages/MTimeCheck2.h
+++ b/src/messages/MTimeCheck2.h
@@ -40,7 +40,7 @@ public:
   { }
 
 private:
-  ~MTimeCheck2() override { }
+  ~MTimeCheck2() final { }
 
 public:
   std::string_view get_type_name() const override { return "time_check2"; }

--- a/src/messages/MWatchNotify.h
+++ b/src/messages/MWatchNotify.h
@@ -45,7 +45,7 @@ private:
       return_code(0),
       notifier_gid(n) { }
 private:
-  ~MWatchNotify() override {}
+  ~MWatchNotify() final {}
 
 public:
   void decode_payload() override {

--- a/src/messages/PaxosServiceMessage.h
+++ b/src/messages/PaxosServiceMessage.h
@@ -25,7 +25,7 @@ public:
       version(v), deprecated_session_mon(-1), deprecated_session_mon_tid(0),
       rx_election_epoch(0)  { }
  protected:
-  virtual ~PaxosServiceMessage() override {}
+  ~PaxosServiceMessage() override {}
 
  public:
   void paxos_encode() {


### PR DESCRIPTION
Some messages were missing "override".

The presence of override makes "virtual" redundant but it improves
readability and is, IMHO, a defensive coding measure since the
inheritance could change far in the future.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
