### PR TITLE
crimson/os: do not configure seastar allocator for alien threads

### DIFF
--- a/src/common/Thread.cc
+++ b/src/common/Thread.cc
@@ -84,9 +84,6 @@ void *Thread::entry_wrapper()
     _set_affinity(cpuid);
 
   ceph_pthread_setname(pthread_self(), thread_name.c_str());
-#ifdef WITH_SEASTAR
-  crimson::os::AlienStore::configure_thread_memory();
-#endif
   return entry();
 }
 

--- a/src/crimson/os/alienstore/alien_store.cc
+++ b/src/crimson/os/alienstore/alien_store.cc
@@ -5,7 +5,6 @@
 #include "alien_store.h"
 
 #include <map>
-#include <optional>
 #include <string_view>
 #include <boost/algorithm/string/trim.hpp>
 #include <fmt/format.h>
@@ -13,9 +12,7 @@
 
 #include <seastar/core/alien.hh>
 #include <seastar/core/future-util.hh>
-#include <seastar/core/memory.hh>
 #include <seastar/core/reactor.hh>
-#include <seastar/core/resource.hh>
 
 #include "common/ceph_context.h"
 #include "global/global_context.h"
@@ -568,15 +565,6 @@ ceph::buffer::list AlienStore::AlienOmapIterator::value()
 int AlienStore::AlienOmapIterator::status() const
 {
   return iter->status();
-}
-
-void AlienStore::configure_thread_memory()
-{
-  std::vector<seastar::resource::memory> layout;
-  // 1 GiB for experimenting. Perhaps we'll introduce a config option later.
-  // TODO: consider above.
-  layout.emplace_back(seastar::resource::memory{1024 * 1024 * 1024, 0});
-  seastar::memory::configure(layout, false, std::nullopt);
 }
 
 }

--- a/src/crimson/os/alienstore/alien_store.h
+++ b/src/crimson/os/alienstore/alien_store.h
@@ -111,7 +111,6 @@ public:
     CollectionRef ch,
     const ghobject_t& oid) final;
 
-  static void configure_thread_memory();
 private:
   constexpr static unsigned MAX_KEYS_PER_OMAP_GET_CALL = 32;
   mutable std::unique_ptr<crimson::os::ThreadPool> tp;

--- a/src/crimson/os/alienstore/thread_pool.cc
+++ b/src/crimson/os/alienstore/thread_pool.cc
@@ -5,7 +5,6 @@
 
 #include "include/ceph_assert.h"
 #include "crimson/common/config_proxy.h"
-#include "crimson/os/alienstore/alien_store.h"
 
 using crimson::common::local_conf;
 
@@ -23,7 +22,6 @@ ThreadPool::ThreadPool(size_t n_threads,
       if (cpu_id >= 0) {
         pin(cpu_id);
       }
-      crimson::os::AlienStore::configure_thread_memory();
       loop(queue_max_wait);
     });
   }

--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -4,9 +4,8 @@
 #pragma once
 
 #include <string>
-#include <unordered_map>
 #include <map>
-#include <typeinfo>
+#include <optional>
 #include <vector>
 
 #include <seastar/core/future.hh>

--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -1,10 +1,6 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#ifdef WITH_SEASTAR
-#include "crimson/os/alienstore/alien_store.h"
-#endif
-
 #include "BlueRocksEnv.h"
 #include "BlueFS.h"
 #include "include/stringify.h"
@@ -590,12 +586,4 @@ rocksdb::Status BlueRocksEnv::GetTestDirectory(std::string* path)
   static int foo = 0;
   *path = "temp_" + stringify(++foo);
   return rocksdb::Status::OK();
-}
-
-void BlueRocksEnv::StartThread(void(*function)(void* arg), void* arg)
-{
-#ifdef WITH_SEASTAR
-  crimson::os::AlienStore::configure_thread_memory();
-#endif
-  base_t::StartThread(function, arg);
 }

--- a/src/os/bluestore/BlueRocksEnv.h
+++ b/src/os/bluestore/BlueRocksEnv.h
@@ -16,8 +16,6 @@
 class BlueFS;
 
 class BlueRocksEnv : public rocksdb::EnvWrapper {
-  using base_t = EnvWrapper;
-
   void split(const std::string &fn, std::string *dir, std::string *file) {
     size_t slash = fn.rfind('/');
     *file = fn.substr(slash + 1);
@@ -157,9 +155,6 @@ public:
   // Get full directory name for this db.
   rocksdb::Status GetAbsolutePath(const std::string& db_path,
       std::string* output_path) override;
-
-  // Start new thread taking care about Seastar's allocator init.
-  void StartThread(void(*function)(void* arg), void* arg) override;
 
   explicit BlueRocksEnv(BlueFS *f);
 private:

--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -36,7 +36,6 @@ add_ceph_test(unittest-seastar-alienstore-thread-pool
   unittest-seastar-alienstore-thread-pool --memory 256M --smp 1)
 target_link_libraries(unittest-seastar-alienstore-thread-pool
   crimson-os
-  crimson-alienstore
   crimson)
 
 add_executable(unittest-seastar-config


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
