### PR TITLE
mgr/dashboard: refactor the order of buttons shown in forms

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/block/images.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/block/images.po.ts
@@ -22,7 +22,7 @@ export class ImagesPageHelper extends PageHelper {
     cy.get('#size').type(size);
 
     // Click the create button and wait for image to be made
-    cy.contains('button', 'Create RBD').click();
+    cy.get('[data-cy=submitBtn]').click();
     this.getFirstTableCell(name).should('exist');
   }
 
@@ -35,7 +35,7 @@ export class ImagesPageHelper extends PageHelper {
     cy.get('#name').clear().type(newName);
     cy.get('#size').clear().type(newSize); // click the size box and send new size
 
-    cy.contains('button', 'Edit RBD').click();
+    cy.get('[data-cy=submitBtn]').click();
 
     this.getExpandCollapseElement(newName).click();
     cy.get('.table.table-striped.table-bordered').contains('td', newSize);
@@ -53,7 +53,7 @@ export class ImagesPageHelper extends PageHelper {
     cy.get('.table-actions button.dropdown-toggle').first().click();
     cy.get('button.move-to-trash').click();
 
-    cy.contains('button', 'Move Image').should('be.visible').click();
+    cy.get('[data-cy=submitBtn]').should('be.visible').click();
 
     // Clicks trash tab
     cy.contains('.nav-link', 'Trash').click();
@@ -79,7 +79,7 @@ export class ImagesPageHelper extends PageHelper {
       cy.get('cd-modal #name').clear().type(newName);
     }
 
-    cy.contains('button', 'Restore Image').click();
+    cy.get('[data-cy=submitBtn]').click();
 
     // clicks images tab
     cy.contains('.nav-link', 'Images').click();
@@ -102,7 +102,7 @@ export class ImagesPageHelper extends PageHelper {
       this.selectOption('poolName', pool);
       cy.get('#poolName').should('have.class', 'ng-valid'); // check if pool is selected
     }
-    cy.get('#purgeFormButton').click();
+    cy.get('[data-cy=submitBtn]').click();
     // Wait for image to delete and check it is not present
 
     this.getFirstTableCell(name).should('not.exist');

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/configuration.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/configuration.po.ts
@@ -20,7 +20,7 @@ export class ConfigurationPageHelper extends PageHelper {
       cy.get(`#${i}`).clear();
     }
     // Clicks save button and checks that values are not present for the selected config
-    cy.contains('button', 'Save').click();
+    cy.get('[data-cy=submitBtn]').click();
 
     // Enter config setting name into filter box
     this.seachTable(name);
@@ -57,7 +57,7 @@ export class ConfigurationPageHelper extends PageHelper {
 
     // Clicks save button then waits until the desired config is visible, clicks it,
     // then checks that each desired value appears with the desired number
-    cy.contains('button', 'Save').click();
+    cy.get('[data-cy=submitBtn]').click();
 
     // Enter config setting name into filter box
     this.seachTable(name);

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/role-mgmt.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/role-mgmt.po.ts
@@ -16,7 +16,7 @@ export class RoleMgmtPageHelper extends PageHelper {
     cy.get('#description').type(description);
 
     // Click the create button and wait for role to be made
-    cy.contains('button', 'Create Role').click();
+    cy.get('[data-cy=submitBtn]').click();
     cy.get('.breadcrumb-item.active').should('not.have.text', 'Create');
 
     this.getFirstTableCell(name).should('exist');
@@ -31,7 +31,7 @@ export class RoleMgmtPageHelper extends PageHelper {
     cy.get('#description').clear().type(description);
 
     // Click the edit button and check new values are present in table
-    cy.contains('button', 'Edit Role').click();
+    cy.get('[data-cy=submitBtn]').click();
     cy.get('.breadcrumb-item.active').should('not.have.text', 'Edit');
 
     this.getFirstTableCell(name).should('exist');

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/user-mgmt.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/user-mgmt.po.ts
@@ -17,7 +17,7 @@ export class UserMgmtPageHelper extends PageHelper {
     cy.get('#email').type(email);
 
     // Click the create button and wait for user to be made
-    cy.contains('button', 'Create User').click();
+    cy.get('[data-cy=submitBtn]').click();
     this.getFirstTableCell(username).should('exist');
   }
 
@@ -31,7 +31,7 @@ export class UserMgmtPageHelper extends PageHelper {
     cy.get('#email').clear().type(email);
 
     // Click the edit button and check new values are present in table
-    const editButton = cy.contains('button', 'Edit User');
+    const editButton = cy.get('[data-cy=submitBtn]');
     editButton.click();
     this.getFirstTableCell(email).should('exist');
     this.getFirstTableCell(name).should('exist');

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html
@@ -130,7 +130,7 @@
                           [form]="discoveryForm"
                           *ngIf="hasPermission"
                           i18n>Submit</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Cancel"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html
@@ -126,14 +126,10 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button (submitAction)="submitAction()"
-                          [form]="discoveryForm"
-                          *ngIf="hasPermission"
-                          i18n>Submit</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"
-                        name="Cancel"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="submitAction()"
+                              [form]="discoveryForm"
+                              [showSubmit]="hasPermission"
+                              [submitText]="actionLabels.SUBMIT"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.ts
@@ -4,6 +4,7 @@ import { FormControl, Validators } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
 import { IscsiService } from '~/app/shared/api/iscsi.service';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
@@ -27,6 +28,7 @@ export class IscsiTargetDiscoveryModalComponent implements OnInit {
   constructor(
     private authStorageService: AuthStorageService,
     public activeModal: NgbActiveModal,
+    public actionLabels: ActionLabelsI18n,
     private iscsiService: IscsiService,
     private notificationService: NotificationService
   ) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
@@ -690,12 +690,10 @@
 
       </div>
       <div class="card-footer">
-        <div class="text-right">
-          <cd-submit-button (submitAction)="submit()"
-                            i18n="form action button|Example: Create Pool@@formActionButton"
-                            [form]="formDir">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-          <cd-back-button></cd-back-button>
-        </div>
+        <cd-form-button-panel (submitActionEvent)="submit()"
+                              [form]="targetForm"
+                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+                              wrappingClass="text-right"></cd-form-button-panel>
       </div>
     </div>
   </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html
@@ -86,7 +86,7 @@
         <cd-submit-button i18n
                           [form]="settingsForm"
                           (submitAction)="save()">Confirm</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Cancel"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.html
@@ -83,13 +83,9 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button i18n
-                          [form]="settingsForm"
-                          (submitAction)="save()">Confirm</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"
-                        name="Cancel"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="save()"
+                              [form]="settingsForm"
+                              [submitText]="actionLabels.UPDATE"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-image-settings-modal/iscsi-target-image-settings-modal.component.ts
@@ -5,6 +5,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import _ from 'lodash';
 
 import { IscsiService } from '~/app/shared/api/iscsi.service';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 
 @Component({
@@ -23,7 +24,11 @@ export class IscsiTargetImageSettingsModalComponent implements OnInit {
 
   settingsForm: CdFormGroup;
 
-  constructor(public activeModal: NgbActiveModal, public iscsiService: IscsiService) {}
+  constructor(
+    public activeModal: NgbActiveModal,
+    public iscsiService: IscsiService,
+    public actionLabels: ActionLabelsI18n
+  ) {}
 
   ngOnInit() {
     const fg: Record<string, FormControl> = {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.html
@@ -26,7 +26,7 @@
         <cd-submit-button i18n
                           [form]="settingsForm"
                           (submitAction)="save()">Confirm</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Cancel"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.html
@@ -23,13 +23,9 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button i18n
-                          [form]="settingsForm"
-                          (submitAction)="save()">Confirm</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"
-                        name="Cancel"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="save()"
+                              [form]="settingsForm"
+                              [submitText]="actionLabels.UPDATE"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-iqn-settings-modal/iscsi-target-iqn-settings-modal.component.ts
@@ -5,6 +5,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import _ from 'lodash';
 
 import { IscsiService } from '~/app/shared/api/iscsi.service';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 
 @Component({
@@ -19,7 +20,11 @@ export class IscsiTargetIqnSettingsModalComponent implements OnInit {
 
   settingsForm: CdFormGroup;
 
-  constructor(public activeModal: NgbActiveModal, public iscsiService: IscsiService) {}
+  constructor(
+    public activeModal: NgbActiveModal,
+    public iscsiService: IscsiService,
+    public actionLabels: ActionLabelsI18n
+  ) {}
 
   ngOnInit() {
     const fg: Record<string, FormControl> = {};

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-create-modal/bootstrap-create-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-create-modal/bootstrap-create-modal.component.html
@@ -82,7 +82,7 @@
       </div>
 
       <div class="modal-footer">
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Close"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-import-modal/bootstrap-import-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-import-modal/bootstrap-import-modal.component.html
@@ -90,7 +90,7 @@
         <cd-submit-button i18n
                           [form]="importBootstrapForm"
                           (submitAction)="import()">Import</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Close"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-import-modal/bootstrap-import-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-import-modal/bootstrap-import-modal.component.html
@@ -87,13 +87,9 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button i18n
-                          [form]="importBootstrapForm"
-                          (submitAction)="import()">Import</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"
-                        name="Close"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="import()"
+                              [form]="importBootstrapForm"
+                              [submitText]="actionLabels.SUBMIT"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-import-modal/bootstrap-import-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-import-modal/bootstrap-import-modal.component.ts
@@ -8,6 +8,7 @@ import { last } from 'rxjs/operators';
 
 import { Pool } from '~/app/ceph/pool/pool';
 import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { FinishedTask } from '~/app/shared/models/finished-task';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
@@ -33,6 +34,7 @@ export class BootstrapImportModalComponent implements OnInit, OnDestroy {
 
   constructor(
     public activeModal: NgbActiveModal,
+    public actionLabels: ActionLabelsI18n,
     private rbdMirroringService: RbdMirroringService,
     private taskWrapper: TaskWrapperService
   ) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/edit-site-name-modal/edit-site-name-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/edit-site-name-modal/edit-site-name-modal.component.html
@@ -30,13 +30,9 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button i18n
-                          [form]="editSiteNameForm"
-                          (submitAction)="update()">Update</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"
-                        name="Cancel"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="update()"
+                              [form]="editSiteNameForm"
+                              [submitText]="actionLabels.UPDATE"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/edit-site-name-modal/edit-site-name-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/edit-site-name-modal/edit-site-name-modal.component.html
@@ -33,7 +33,7 @@
         <cd-submit-button i18n
                           [form]="editSiteNameForm"
                           (submitAction)="update()">Update</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Cancel"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/edit-site-name-modal/edit-site-name-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/edit-site-name-modal/edit-site-name-modal.component.ts
@@ -4,6 +4,7 @@ import { FormControl } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
 import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { FinishedTask } from '~/app/shared/models/finished-task';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
@@ -20,6 +21,7 @@ export class EditSiteNameModalComponent implements OnInit {
 
   constructor(
     public activeModal: NgbActiveModal,
+    public actionLabels: ActionLabelsI18n,
     private rbdMirroringService: RbdMirroringService,
     private taskWrapper: TaskWrapperService
   ) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.html
@@ -34,13 +34,9 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button i18n
-                          [form]="editModeForm"
-                          (submitAction)="update()">Update</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"
-                        name="Cancel"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="update()"
+                              [form]="editModeForm"
+                              [submitText]="actionLabels.UPDATE"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.html
@@ -37,7 +37,7 @@
         <cd-submit-button i18n
                           [form]="editModeForm"
                           (submitAction)="update()">Update</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Cancel"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-mode-modal/pool-edit-mode-modal.component.ts
@@ -5,6 +5,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { Subscription } from 'rxjs';
 
 import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { FinishedTask } from '~/app/shared/models/finished-task';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
@@ -37,6 +38,7 @@ export class PoolEditModeModalComponent implements OnInit, OnDestroy {
 
   constructor(
     public activeModal: NgbActiveModal,
+    public actionLabels: ActionLabelsI18n,
     private rbdMirroringService: RbdMirroringService,
     private taskWrapper: TaskWrapperService
   ) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.html
@@ -91,13 +91,9 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button i18n
-                          [form]="editPeerForm"
-                          (submitAction)="update()">Submit</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"
-                        name="Cancel"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="update()"
+                              [form]="editPeerForm"
+                              [submitText]="actionLabels.SUBMIT"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.html
@@ -94,7 +94,7 @@
         <cd-submit-button i18n
                           [form]="editPeerForm"
                           (submitAction)="update()">Submit</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Cancel"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/pool-edit-peer-modal/pool-edit-peer-modal.component.ts
@@ -4,6 +4,7 @@ import { AbstractControl, FormControl, Validators } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
 import { RbdMirroringService } from '~/app/shared/api/rbd-mirroring.service';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { FinishedTask } from '~/app/shared/models/finished-task';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
@@ -29,6 +30,7 @@ export class PoolEditPeerModalComponent implements OnInit {
 
   constructor(
     public activeModal: NgbActiveModal,
+    public actionLabels: ActionLabelsI18n,
     private rbdMirroringService: RbdMirroringService,
     private taskWrapper: TaskWrapperService
   ) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
@@ -328,12 +328,10 @@
 
       </div>
       <div class="card-footer">
-        <div class="text-right">
-          <cd-submit-button (submitAction)="submit()"
-                            i18n="form action button|Example: Create Pool@@formActionButton"
-                            [form]="formDir">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-          <cd-back-button></cd-back-button>
-        </div>
+        <cd-form-button-panel (submitActionEvent)="submit()"
+                              [form]="formDir"
+                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+                              wrappingClass="text-right"></cd-form-button-panel>
       </div>
     </div>
   </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-namespace-form/rbd-namespace-form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-namespace-form/rbd-namespace-form-modal.component.html
@@ -73,7 +73,7 @@
         <cd-submit-button [form]="namespaceForm"
                           (submitAction)="submit()"
                           i18n>Create Namespace</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Close"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-namespace-form/rbd-namespace-form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-namespace-form/rbd-namespace-form-modal.component.html
@@ -70,13 +70,9 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button [form]="namespaceForm"
-                          (submitAction)="submit()"
-                          i18n>Create Namespace</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"
-                        name="Close"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="submit()"
+                              [form]="namespaceForm"
+                              [submitText]="actionLabels.CREATE"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-namespace-form/rbd-namespace-form-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-namespace-form/rbd-namespace-form-modal.component.ts
@@ -13,6 +13,7 @@ import { Subject } from 'rxjs';
 import { Pool } from '~/app/ceph/pool/pool';
 import { PoolService } from '~/app/shared/api/pool.service';
 import { RbdService } from '~/app/shared/api/rbd.service';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { FinishedTask } from '~/app/shared/models/finished-task';
@@ -39,6 +40,7 @@ export class RbdNamespaceFormModalComponent implements OnInit {
 
   constructor(
     public activeModal: NgbActiveModal,
+    public actionLabels: ActionLabelsI18n,
     private authStorageService: AuthStorageService,
     private notificationService: NotificationService,
     private poolService: PoolService,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form-modal.component.html
@@ -29,14 +29,9 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button [form]="snapshotForm"
-                          i18n="form action button|Example: Create rbdSnapshot@@formActionButton"
-                          (submitAction)="submit()">{{ action | titlecase }}
-          {{ resource | upperFirst }}</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"
-                        name="Close"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="submit()"
+                              [form]="snapshotForm"
+                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form-modal.component.html
@@ -33,7 +33,7 @@
                           i18n="form action button|Example: Create rbdSnapshot@@formActionButton"
                           (submitAction)="submit()">{{ action | titlecase }}
           {{ resource | upperFirst }}</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Close"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.html
@@ -44,13 +44,9 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button i18n
-                          [form]="moveForm"
-                          (submitAction)="moveImage()">Move Image</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"
-                        name="Cancel"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="moveImage()"
+                              [form]="moveForm"
+                              [submitText]="actionLabels.MOVE"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.html
@@ -47,7 +47,7 @@
         <cd-submit-button i18n
                           [form]="moveForm"
                           (submitAction)="moveImage()">Move Image</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Cancel"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-move-modal/rbd-trash-move-modal.component.ts
@@ -4,6 +4,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import moment from 'moment';
 
 import { RbdService } from '~/app/shared/api/rbd.service';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { CdValidators } from '~/app/shared/forms/cd-validators';
@@ -34,6 +35,7 @@ export class RbdTrashMoveModalComponent implements OnInit {
   constructor(
     private rbdService: RbdService,
     public activeModal: NgbActiveModal,
+    public actionLabels: ActionLabelsI18n,
     private fb: CdFormBuilder,
     private taskWrapper: TaskWrapperService
   ) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-purge-modal/rbd-trash-purge-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-purge-modal/rbd-trash-purge-modal.component.html
@@ -39,14 +39,9 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button id="purgeFormButton"
-                          [form]="purgeForm"
-                          (submitAction)="purge()"
-                          i18n>Purge Trash</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"
-                        name="Cancel"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="purge()"
+                              [form]="purgeForm"
+                              [submitText]="actionLabels.PURGE"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-purge-modal/rbd-trash-purge-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-purge-modal/rbd-trash-purge-modal.component.html
@@ -43,7 +43,7 @@
                           [form]="purgeForm"
                           (submitAction)="purge()"
                           i18n>Purge Trash</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Cancel"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-purge-modal/rbd-trash-purge-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-purge-modal/rbd-trash-purge-modal.component.ts
@@ -5,6 +5,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { Pool } from '~/app/ceph/pool/pool';
 import { PoolService } from '~/app/shared/api/pool.service';
 import { RbdService } from '~/app/shared/api/rbd.service';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { FinishedTask } from '~/app/shared/models/finished-task';
@@ -26,6 +27,7 @@ export class RbdTrashPurgeModalComponent implements OnInit {
     private authStorageService: AuthStorageService,
     private rbdService: RbdService,
     public activeModal: NgbActiveModal,
+    public actionLabels: ActionLabelsI18n,
     private fb: CdFormBuilder,
     private poolService: PoolService,
     private taskWrapper: TaskWrapperService

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-restore-modal/rbd-trash-restore-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-restore-modal/rbd-trash-restore-modal.component.html
@@ -34,13 +34,9 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button [form]="restoreForm"
-                          (submitAction)="restore()"
-                          i18n>Restore Image</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"
-                        name="Cancel"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="restore()"
+                              [form]="restoreForm"
+                              [submitText]="actionLabels.RESTORE"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-restore-modal/rbd-trash-restore-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-restore-modal/rbd-trash-restore-modal.component.html
@@ -37,7 +37,7 @@
         <cd-submit-button [form]="restoreForm"
                           (submitAction)="restore()"
                           i18n>Restore Image</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Cancel"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-restore-modal/rbd-trash-restore-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-restore-modal/rbd-trash-restore-modal.component.ts
@@ -3,6 +3,7 @@ import { Component, OnInit } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
 import { RbdService } from '~/app/shared/api/rbd.service';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { ExecutingTask } from '~/app/shared/models/executing-task';
@@ -28,6 +29,7 @@ export class RbdTrashRestoreModalComponent implements OnInit {
   constructor(
     private rbdService: RbdService,
     public activeModal: NgbActiveModal,
+    public actionLabels: ActionLabelsI18n,
     private fb: CdFormBuilder,
     private taskWrapper: TaskWrapperService
   ) {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
@@ -150,13 +150,10 @@
       </div>
       <!-- Footer -->
       <div class="card-footer">
-        <div class="text-right">
-          <cd-submit-button [form]="formDir"
-                            (submitAction)="submit()">
-            <span i18n>Save</span>
-          </cd-submit-button>
-          <cd-back-button></cd-back-button>
-        </div>
+        <cd-form-button-panel (submitActionEvent)="submit()"
+                              [form]="configForm"
+                              [submitText]="actionLabels.UPDATE"
+                              wrappingClass="text-right"></cd-form-button-panel>
       </div>
     </div>
   </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
@@ -7,6 +7,7 @@ import _ from 'lodash';
 import { ConfigurationService } from '~/app/shared/api/configuration.service';
 import { ConfigFormModel } from '~/app/shared/components/config-option/config-option.model';
 import { ConfigOptionTypes } from '~/app/shared/components/config-option/config-option.types';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { CdForm } from '~/app/shared/forms/cd-form';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
@@ -30,6 +31,7 @@ export class ConfigurationFormComponent extends CdForm implements OnInit {
   availSections = ['global', 'mon', 'mgr', 'osd', 'mds', 'client'];
 
   constructor(
+    public actionLabels: ActionLabelsI18n,
     private route: ActivatedRoute,
     private router: Router,
     private configService: ConfigurationService,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-form/host-form.component.html
@@ -34,12 +34,10 @@
       </div>
 
       <div class="card-footer">
-        <div class="text-right">
-          <cd-submit-button [form]="formDir"
-                            i18n="form action button|Example: Create Pool@@formActionButton"
-                            (submitAction)="submit()">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-          <cd-back-button></cd-back-button>
-        </div>
+        <cd-form-button-panel (submitActionEvent)="submit()"
+                              [form]="hostForm"
+                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+                              wrappingClass="text-right"></cd-form-button-panel>
       </div>
     </div>
   </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.html
@@ -100,16 +100,10 @@
         </div>
       </div>
       <div class="card-footer">
-        <div class="text-right">
-          <cd-submit-button (submitAction)="onSubmit()"
-                            [form]="mgrModuleForm">
-            <ng-container i18n>Update</ng-container>
-          </cd-submit-button>
-          <button type="button"
-                  class="btn btn-light"
-                  routerLink="/mgr-modules"
-                  i18n>Back</button>
-        </div>
+        <cd-form-button-panel (submitActionEvent)="onSubmit()"
+                              [form]="mgrModuleForm"
+                              [submitText]="actionLabels.UPDATE"
+                              wrappingClass="text-right"></cd-form-button-panel>
       </div>
     </div>
   </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/mgr-modules/mgr-module-form/mgr-module-form.component.ts
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import { forkJoin as observableForkJoin } from 'rxjs';
 
 import { MgrModuleService } from '~/app/shared/api/mgr-module.service';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { CdForm } from '~/app/shared/forms/cd-form';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
@@ -24,6 +25,7 @@ export class MgrModuleFormComponent extends CdForm implements OnInit {
   moduleOptions: any[] = [];
 
   constructor(
+    public actionLabels: ActionLabelsI18n,
     private route: ActivatedRoute,
     private router: Router,
     private formBuilder: CdFormBuilder,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-creation-preview-modal/osd-creation-preview-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-creation-preview-modal/osd-creation-preview-modal.component.html
@@ -11,9 +11,9 @@
         <pre>{{ driveGroups | json}}</pre>
       </div>
       <div class="modal-footer">
-        <cd-submit-button (submitAction)="onSubmit()"
-                          [form]="formGroup">{{ action | titlecase }}</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"></cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="onSubmit()"
+                              [form]="formGroup"
+                              [submitText]="action | titlecase"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-creation-preview-modal/osd-creation-preview-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-creation-preview-modal/osd-creation-preview-modal.component.html
@@ -13,7 +13,7 @@
       <div class="modal-footer">
         <cd-submit-button (submitAction)="onSubmit()"
                           [form]="formGroup">{{ action | titlecase }}</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"></cd-back-button>
+        <cd-back-button (backAction)="activeModal.close()"></cd-back-button>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-modal/osd-devices-selection-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-modal/osd-devices-selection-modal.component.html
@@ -31,10 +31,10 @@
         </div>
       </div>
       <div class="modal-footer">
-        <cd-submit-button (submitAction)="onSubmit()"
-                          [form]="formGroup"
-                          [disabled]="!canSubmit || filteredDevices.length === 0">{{ action | titlecase }}</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"></cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="onSubmit()"
+                              [form]="formGroup"
+                              [disabled]="!canSubmit || filteredDevices.length === 0"
+                              [submitText]="action | titlecase"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-modal/osd-devices-selection-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-modal/osd-devices-selection-modal.component.html
@@ -34,7 +34,7 @@
         <cd-submit-button (submitAction)="onSubmit()"
                           [form]="formGroup"
                           [disabled]="!canSubmit || filteredDevices.length === 0">{{ action | titlecase }}</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"></cd-back-button>
+        <cd-back-button (backAction)="activeModal.close()"></cd-back-button>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-modal/osd-devices-selection-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-devices-selection-modal/osd-devices-selection-modal.component.spec.ts
@@ -23,7 +23,7 @@ describe('OsdDevicesSelectionModalComponent', () => {
 
   const expectSubmitButton = (enabled: boolean) => {
     const nativeElement = fixture.debugElement.nativeElement;
-    const button = nativeElement.querySelector('.modal-footer button');
+    const button = nativeElement.querySelector('.modal-footer .tc_submitButton');
     expect(button.disabled).toBe(!enabled);
   };
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-indiv-modal/osd-flags-indiv-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-indiv-modal/osd-flags-indiv-modal.component.html
@@ -42,7 +42,7 @@
                           (submitAction)="submitAction()"
                           [form]="osdFlagsForm"
                           i18n>Submit</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Cancel"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-indiv-modal/osd-flags-indiv-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-indiv-modal/osd-flags-indiv-modal.component.html
@@ -38,14 +38,10 @@
                 class="btn btn-light"
                 (click)="resetSelection()"
                 i18n>Restore previous selection</button>
-        <cd-submit-button *ngIf="permissions.osd.update"
-                          (submitAction)="submitAction()"
-                          [form]="osdFlagsForm"
-                          i18n>Submit</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"
-                        name="Cancel"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="submitAction()"
+                              [form]="osdFlagsForm"
+                              [showSubmit]="permissions.osd.update"
+                              [submitText]="actionLabels.UPDATE"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-indiv-modal/osd-flags-indiv-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-indiv-modal/osd-flags-indiv-modal.component.ts
@@ -5,6 +5,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import _ from 'lodash';
 
 import { OsdService } from '~/app/shared/api/osd.service';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { Flag } from '~/app/shared/models/flag';
 import { Permissions } from '~/app/shared/models/permissions';
@@ -59,6 +60,7 @@ export class OsdFlagsIndivModalComponent implements OnInit {
 
   constructor(
     public activeModal: NgbActiveModal,
+    public actionLabels: ActionLabelsI18n,
     private authStorageService: AuthStorageService,
     private osdService: OsdService,
     private notificationService: NotificationService

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-modal/osd-flags-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-modal/osd-flags-modal.component.html
@@ -31,14 +31,10 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button *ngIf="permissions.osd.update"
-                          (submitAction)="submitAction()"
-                          [form]="osdFlagsForm"
-                          i18n>Submit</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"
-                        name="Cancel"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="submitAction()"
+                              [form]="osdFlagsForm"
+                              [showSubmit]="permissions.osd.update"
+                              [submitText]="actionLabels.UPDATE"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-modal/osd-flags-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-modal/osd-flags-modal.component.html
@@ -35,7 +35,7 @@
                           (submitAction)="submitAction()"
                           [form]="osdFlagsForm"
                           i18n>Submit</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Cancel"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-modal/osd-flags-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-modal/osd-flags-modal.component.ts
@@ -5,6 +5,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import _ from 'lodash';
 
 import { OsdService } from '~/app/shared/api/osd.service';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { Permissions } from '~/app/shared/models/permissions';
 import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
@@ -115,6 +116,7 @@ export class OsdFlagsModalComponent implements OnInit {
 
   constructor(
     public activeModal: NgbActiveModal,
+    public actionLabels: ActionLabelsI18n,
     private authStorageService: AuthStorageService,
     private osdService: OsdService,
     private notificationService: NotificationService

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.html
@@ -122,14 +122,11 @@
         </fieldset>
       </div>
       <div class="card-footer">
-        <div class="text-right">
-          <cd-submit-button #previewButton
-                            (submitAction)="submit()"
-                            i18n
-                            [form]="formDir"
-                            [disabled]="dataDeviceSelectionGroups.devices.length === 0">Preview</cd-submit-button>
-          <cd-back-button></cd-back-button>
-        </div>
+        <cd-form-button-panel (submitActionEvent)="submit()"
+                              [form]="form"
+                              [disabled]="dataDeviceSelectionGroups.devices.length === 0"
+                              [submitText]="actionLabels.PREVIEW"
+                              wrappingClass="text-right"></cd-form-button-panel>
       </div>
     </div>
   </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-form/osd-form.component.spec.ts
@@ -49,7 +49,7 @@ describe('OsdFormComponent', () => {
   ];
 
   const expectPreviewButton = (enabled: boolean) => {
-    const debugElement = fixtureHelper.getElementByCss('.card-footer button');
+    const debugElement = fixtureHelper.getElementByCss('.tc_submitButton');
     expect(debugElement.nativeElement.disabled).toBe(!enabled);
   };
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-pg-scrub-modal/osd-pg-scrub-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-pg-scrub-modal/osd-pg-scrub-modal.component.html
@@ -34,12 +34,11 @@
         </div>
       </div>
       <div class="modal-footer">
-        <cd-submit-button *ngIf="permissions.configOpt.update"
-                          (submitAction)="submitAction()"
-                          i18n="form action button|Example: Create Pool@@formActionButton"
-                          [form]="osdPgScrubForm">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()">
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="submitAction()"
+                              [form]="osdPgScrubForm"
+                              [showSubmit]="permissions.configOpt.update"
+                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)">
+        </cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-pg-scrub-modal/osd-pg-scrub-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-pg-scrub-modal/osd-pg-scrub-modal.component.html
@@ -38,7 +38,7 @@
                           (submitAction)="submitAction()"
                           i18n="form action button|Example: Create Pool@@formActionButton"
                           [form]="osdPgScrubForm">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-        <cd-back-button [back]="activeModal.close">
+        <cd-back-button (backAction)="activeModal.close()">
         </cd-back-button>
       </div>
     </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-recv-speed-modal/osd-recv-speed-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-recv-speed-modal/osd-recv-speed-modal.component.html
@@ -82,14 +82,10 @@
         </div>
       </div>
       <div class="modal-footer">
-        <cd-submit-button *ngIf="permissions.configOpt.update"
-                          (submitAction)="submitAction()"
-                          [form]="osdRecvSpeedForm"
-                          i18n>Submit</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"
-                        name="Cancel"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="submitAction()"
+                              [form]="osdRecvSpeedForm"
+                              [submitText]="actionLabels.UPDATE"
+                              [showSubmit]="permissions.configOpt.update"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-recv-speed-modal/osd-recv-speed-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-recv-speed-modal/osd-recv-speed-modal.component.html
@@ -86,7 +86,7 @@
                           (submitAction)="submitAction()"
                           [form]="osdRecvSpeedForm"
                           i18n>Submit</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Cancel"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-recv-speed-modal/osd-recv-speed-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-recv-speed-modal/osd-recv-speed-modal.component.ts
@@ -7,6 +7,7 @@ import _ from 'lodash';
 import { ConfigurationService } from '~/app/shared/api/configuration.service';
 import { OsdService } from '~/app/shared/api/osd.service';
 import { ConfigOptionTypes } from '~/app/shared/components/config-option/config-option.types';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import { Permissions } from '~/app/shared/models/permissions';
@@ -27,6 +28,7 @@ export class OsdRecvSpeedModalComponent implements OnInit {
 
   constructor(
     public activeModal: NgbActiveModal,
+    public actionLabels: ActionLabelsI18n,
     private authStorageService: AuthStorageService,
     private configService: ConfigurationService,
     private notificationService: NotificationService,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-reweight-modal/osd-reweight-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-reweight-modal/osd-reweight-modal.component.html
@@ -29,14 +29,9 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button (submitAction)="reweight()"
-                          [form]="reweightForm"
-                          [disabled]="reweightForm.invalid"
-                          i18n>Reweight</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"
-                        name="Cancel"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="reweight()"
+                              [form]="reweightForm"
+                              [submitText]="actionLabels.REWEIGHT"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-reweight-modal/osd-reweight-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-reweight-modal/osd-reweight-modal.component.html
@@ -33,7 +33,7 @@
                           [form]="reweightForm"
                           [disabled]="reweightForm.invalid"
                           i18n>Reweight</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Cancel"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-reweight-modal/osd-reweight-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-reweight-modal/osd-reweight-modal.component.spec.ts
@@ -1,4 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -26,6 +27,7 @@ describe('OsdReweightModalComponent', () => {
       SubmitButtonComponent,
       BackButtonComponent
     ],
+    schemas: [NO_ERRORS_SCHEMA],
     providers: [OsdService, NgbActiveModal, CdFormBuilder]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-reweight-modal/osd-reweight-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-reweight-modal/osd-reweight-modal.component.ts
@@ -4,6 +4,7 @@ import { Validators } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
 import { OsdService } from '~/app/shared/api/osd.service';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 
@@ -18,6 +19,7 @@ export class OsdReweightModalComponent implements OnInit {
   reweightForm: CdFormGroup;
 
   constructor(
+    public actionLabels: ActionLabelsI18n,
     public activeModal: NgbActiveModal,
     private osdService: OsdService,
     private fb: CdFormBuilder

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.html
@@ -13,13 +13,9 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button (submitAction)="scrub()"
-                          [form]="scrubForm"
-                          i18n>Submit</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"
-                        name="Cancel"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="scrub()"
+                              [form]="scrubForm"
+                              [submitText]="actionLabels.UPDATE"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.html
@@ -16,7 +16,7 @@
         <cd-submit-button (submitAction)="scrub()"
                           [form]="scrubForm"
                           i18n>Submit</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Cancel"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.ts
@@ -5,6 +5,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { forkJoin } from 'rxjs';
 
 import { OsdService } from '~/app/shared/api/osd.service';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { JoinPipe } from '~/app/shared/pipes/join.pipe';
 import { NotificationService } from '~/app/shared/services/notification.service';
@@ -21,6 +22,7 @@ export class OsdScrubModalComponent implements OnInit {
 
   constructor(
     public activeModal: NgbActiveModal,
+    public actionLabels: ActionLabelsI18n,
     private osdService: OsdService,
     private notificationService: NotificationService,
     private joinPipe: JoinPipe

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-form/silence-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-form/silence-form.component.html
@@ -205,12 +205,9 @@
 
       <div class="card-footer">
         <div class="text-right">
-          <cd-submit-button (submitAction)="submit()"
-                            [form]="formDir"
-                            i18n="@@formTitle">
-            {{ action | titlecase }} {{ resource | upperFirst }}
-          </cd-submit-button>
-          <cd-back-button></cd-back-button>
+          <cd-form-button-panel (submitActionEvent)="submit()"
+                                [form]="form"
+                                [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"></cd-form-button-panel>
         </div>
       </div>
     </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-matcher-modal/silence-matcher-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-matcher-modal/silence-matcher-modal.component.html
@@ -80,7 +80,7 @@
                           [form]="form">
           <span i18n>{editMode, select, true {Edit} other {Add}}</span>
         </cd-submit-button>
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Close"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-matcher-modal/silence-matcher-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-matcher-modal/silence-matcher-modal.component.html
@@ -76,14 +76,9 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button (submitAction)="onSubmit()"
-                          [form]="form">
-          <span i18n>{editMode, select, true {Edit} other {Add}}</span>
-        </cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"
-                        name="Close"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="onSubmit()"
+                              [form]="form"
+                              [submitText]="getMode()"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-matcher-modal/silence-matcher-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/prometheus/silence-matcher-modal/silence-matcher-modal.component.ts
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import { merge, Observable, Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, filter, map } from 'rxjs/operators';
 
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
 import { CdFormGroup } from '~/app/shared/forms/cd-form-group';
 import {
@@ -54,7 +55,8 @@ export class SilenceMatcherModalComponent {
   constructor(
     private formBuilder: CdFormBuilder,
     private silenceMatcher: PrometheusSilenceMatcherService,
-    public activeModal: NgbActiveModal
+    public activeModal: NgbActiveModal,
+    public actionLabels: ActionLabelsI18n
   ) {
     this.createForm();
     this.subscribeToChanges();
@@ -88,6 +90,10 @@ export class SilenceMatcherModalComponent {
     this.possibleValues = _.sortedUniq(
       this.rules.map((r) => _.get(r, this.silenceMatcher.getAttributePath(name))).filter((x) => x)
     );
+  }
+
+  getMode() {
+    return this.editMode ? this.actionLabels.EDIT : this.actionLabels.ADD;
   }
 
   preFillControls(matcher: AlertmanagerSilenceMatcher) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -403,11 +403,9 @@
 
       <div class="card-footer">
         <div class="text-right">
-          <cd-submit-button (submitAction)="onSubmit()"
-                            i18n="form action button|Example: Create Pool@@formActionButton"
-                            [form]="serviceForm">{{ action | titlecase }} {{ resource | upperFirst }}
-          </cd-submit-button>
-          <cd-back-button></cd-back-button>
+          <cd-form-button-panel (submitActionEvent)="onSubmit()"
+                                [form]="serviceForm"
+                                [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"></cd-form-button-panel>
         </div>
       </div>
     </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
@@ -207,7 +207,7 @@
               <button type="button"
                       class="btn btn-light"
                       (click)="next()">
-                <ng-container i18n>Next</ng-container>
+                <ng-container i18n>{{ actionLabels.NEXT }}</ng-container>
               </button>
             </div>
           </div>
@@ -293,14 +293,11 @@
           </div>
           <div class="card-footer">
             <div class="button-group text-right">
-              <cd-submit-button (submitAction)="onSubmit()"
-                                [form]="previewForm">
-                <ng-container i18n>Save</ng-container>
-              </cd-submit-button>
-              <button type="button"
-                      class="btn btn-light"
-                      (click)="back()"
-                      i18n>Back</button>
+              <cd-form-button-panel (submitActionEvent)="onSubmit()"
+                                    (backActionEvent)="back()"
+                                    [form]="previewForm"
+                                    [submitText]="actionLabels.UPDATE"
+                                    [cancelText]="actionLabels.BACK"></cd-form-button-panel>
             </div>
           </div>
         </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.ts
@@ -7,6 +7,7 @@ import { forkJoin as observableForkJoin } from 'rxjs';
 
 import { MgrModuleService } from '~/app/shared/api/mgr-module.service';
 import { TelemetryService } from '~/app/shared/api/telemetry.service';
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
 import { CdForm } from '~/app/shared/forms/cd-form';
 import { CdFormBuilder } from '~/app/shared/forms/cd-form-builder';
@@ -43,6 +44,7 @@ export class TelemetryComponent extends CdForm implements OnInit {
   step = 1;
 
   constructor(
+    public actionLabels: ActionLabelsI18n,
     private formBuilder: CdFormBuilder,
     private mgrModuleService: MgrModuleService,
     private notificationService: NotificationService,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
@@ -485,13 +485,10 @@
       </div>
 
       <div class="card-footer">
-        <div class="text-right">
-          <cd-submit-button
-            (submitAction)="submitAction()"
-            i18n="form action button|Example: Create Pool@@formActionButton"
-            [form]="formDir">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-          <cd-back-button></cd-back-button>
-        </div>
+        <cd-form-button-panel (submitActionEvent)="submitAction()"
+                              [form]="nfsForm"
+                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+                              wrappingClass="text-right"></cd-form-button-panel>
       </div>
     </div>
   </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.html
@@ -114,10 +114,9 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button (submitAction)="onSubmit()"
-                          i18n="form action button|Example: Create Pool@@formActionButton"
-                          [form]="frm">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"></cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="onSubmit()"
+                              [form]="form"
+                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/crush-rule-form-modal/crush-rule-form-modal.component.html
@@ -117,7 +117,7 @@
         <cd-submit-button (submitAction)="onSubmit()"
                           i18n="form action button|Example: Create Pool@@formActionButton"
                           [form]="frm">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"></cd-back-button>
+        <cd-back-button (backAction)="activeModal.close()"></cd-back-button>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.html
@@ -409,7 +409,7 @@
         <cd-submit-button (submitAction)="onSubmit()"
                           i18n="form action button|Example: Create Pool@@formActionButton"
                           [form]="frm">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"></cd-back-button>
+        <cd-back-button (backAction)="activeModal.close()"></cd-back-button>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/erasure-code-profile-form/erasure-code-profile-form-modal.component.html
@@ -406,10 +406,9 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button (submitAction)="onSubmit()"
-                          i18n="form action button|Example: Create Pool@@formActionButton"
-                          [form]="frm">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"></cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="onSubmit()"
+                              [form]="form"
+                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -597,13 +597,10 @@
         </div>
       </div>
       <div class="card-footer">
-        <div class="text-right">
-          <cd-submit-button [form]="formDir"
-                            i18n="form action button|Example: Create Pool@@formActionButton"
-                            (submitAction)="submit()">{{ action | titlecase }} {{ resource | upperFirst }}
-          </cd-submit-button>
-          <cd-back-button></cd-back-button>
-        </div>
+        <cd-form-button-panel (submitActionEvent)="submit()"
+                              [form]="form"
+                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+                              wrappingClass="text-right"></cd-form-button-panel>
       </div>
 
     </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
@@ -289,12 +289,10 @@
 
       </div>
       <div class="card-footer">
-        <div class="text-right">
-          <cd-submit-button (submitAction)="submit()"
-                            i18n="form action button|Example: Create Pool@@formActionButton"
-                            [form]="bucketForm">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-          <cd-back-button></cd-back-button>
-        </div>
+        <cd-form-button-panel (submitActionEvent)="submit()"
+                              [form]="bucketForm"
+                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+                              wrappingClass="text-right"></cd-form-button-panel>
       </div>
     </div>
   </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html
@@ -64,7 +64,7 @@
         <cd-submit-button (submitAction)="onSubmit()"
                           i18n="form action button|Example: Create Pool@@formActionButton"
                           [form]="formGroup">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"></cd-back-button>
+        <cd-back-button (backAction)="activeModal.close()"></cd-back-button>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.html
@@ -61,10 +61,9 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button (submitAction)="onSubmit()"
-                          i18n="form action button|Example: Create Pool@@formActionButton"
-                          [form]="formGroup">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"></cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="onSubmit()"
+                              [form]="formGroup"
+                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
@@ -619,12 +619,10 @@
       </div>
 
       <div class="card-footer">
-        <div class="text-right">
-          <cd-submit-button (submitAction)="onSubmit()"
-                            i18n="form action button|Example: Create Pool@@formActionButton"
-                            [form]="userForm">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-          <cd-back-button></cd-back-button>
-        </div>
+        <cd-form-button-panel (submitActionEvent)="onSubmit()"
+                              [form]="userForm"
+                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+                              wrappingClass="text-right"></cd-form-button-panel>
       </div>
     </div>
   </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html
@@ -119,11 +119,10 @@
       </div>
 
       <div class="modal-footer">
-        <cd-submit-button *ngIf="!viewing"
-                          (submitAction)="onSubmit()"
-                          i18n="form action button|Example: Create Pool@@formActionButton"
-                          [form]="formGroup">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"></cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="onSubmit()"
+                              [form]="formGroup"
+                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+                              [showSubmit]="!viewing"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html
@@ -123,7 +123,7 @@
                           (submitAction)="onSubmit()"
                           i18n="form action button|Example: Create Pool@@formActionButton"
                           [form]="formGroup">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-        <cd-back-button [back]="activeModal.close"></cd-back-button>
+        <cd-back-button (backAction)="activeModal.close()"></cd-back-button>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html
@@ -1,7 +1,6 @@
 <cd-modal [modalRef]="bsModalRef">
   <ng-container i18n="form title|Example: Create Pool@@formTitle"
                 class="modal-title">{{ action | titlecase }} {{ resource | upperFirst }}</ng-container>
-
   <ng-container class="modal-content">
     <form #frm="ngForm"
           [formGroup]="formGroup"
@@ -122,10 +121,9 @@
 
       </div>
       <div class="modal-footer">
-        <cd-submit-button (submitAction)="onSubmit()"
-                          i18n="form action button|Example: Create Pool@@formActionButton"
-                          [form]="formGroup">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-        <cd-back-button (backAction)="bsModalRef.close()"></cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="onSubmit()"
+                              [form]="formGroup"
+                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html
@@ -125,7 +125,7 @@
         <cd-submit-button (submitAction)="onSubmit()"
                           i18n="form action button|Example: Create Pool@@formActionButton"
                           [form]="formGroup">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-        <cd-back-button [back]="bsModalRef.close"></cd-back-button>
+        <cd-back-button (backAction)="bsModalRef.close()"></cd-back-button>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.html
@@ -51,7 +51,7 @@
     </div>
 
     <div class="modal-footer">
-      <cd-back-button [back]="activeModal.close"></cd-back-button>
+      <cd-back-button (backAction)="activeModal.close()"></cd-back-button>
     </div>
   </ng-container>
 </cd-modal>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login-password-form/login-password-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login-password-form/login-password-form.component.html
@@ -85,19 +85,11 @@
             *ngIf="userForm.showError('confirmnewpassword', frm, 'match')"
             i18n>Password confirmation doesn't match the new password.</span>
     </div>
+    <cd-form-button-panel (submitActionEvent)="onSubmit()"
+                          (backActionEvent)="onCancel()"
+                          [form]="userForm"
+                          [disabled]="userForm.invalid"
+                          [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+                          wrappingClass="text-right"></cd-form-button-panel>
   </form>
-  <div class="form-footer">
-    <cd-submit-button class="full-width"
-                      btnClass="btn-block"
-                      (submitAction)="onSubmit()"
-                      [form]="userForm"
-                      [disabled]="userForm.invalid"
-                      i18n="form action button|Example: Create Pool@@formActionButton">
-      {{ action | titlecase }} {{ resource | upperFirst }}
-    </cd-submit-button>
-    <button class="btn btn-light"
-            (click)="onCancel()">
-      <ng-container i18n>Cancel</ng-container>
-    </button>
-  </div>
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-form/role-form.component.html
@@ -68,12 +68,10 @@
 
       </div>
       <div class="card-footer">
-        <div class="text-right">
-          <cd-submit-button (submitAction)="submit()"
-                            i18n="form action button|Example: Create Pool@@formActionButton"
-                            [form]="formDir">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-          <cd-back-button></cd-back-button>
-        </div>
+        <cd-form-button-panel (submitActionEvent)="submit()"
+                              [form]="roleForm"
+                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+                              wrappingClass="text-right"></cd-form-button-panel>
       </div>
     </div>
   </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
@@ -240,12 +240,10 @@
 
       </div>
       <div class="card-footer">
-        <div class="text-right">
-          <cd-submit-button (submitAction)="submit()"
-                            i18n="form action button|Example: Create Pool@@formActionButton"
-                            [form]="formDir">{{ action | titlecase }} {{ resource | upperFirst }}</cd-submit-button>
-          <cd-back-button></cd-back-button>
-        </div>
+        <cd-form-button-panel (submitActionEvent)="submit()"
+                              [form]="userForm"
+                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+                              wrappingClass="text-right"></cd-form-button-panel>
       </div>
     </div>
   </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-password-form/user-password-form.component.html
@@ -111,12 +111,10 @@
       </div>
 
       <div class="card-footer">
-        <cd-submit-button (submitAction)="onSubmit()"
-                          [form]="userForm"
-                          class="float-right"
-                          i18n="form action button|Example: Create Pool@@formActionButton">
-          {{ action | titlecase }} {{ resource | upperFirst }}
-        </cd-submit-button>
+        <cd-form-button-panel (submitActionEvent)="onSubmit()"
+                              [form]="userForm"
+                              [submitText]="(action | titlecase) + ' ' + (resource | upperFirst)"
+                              wrappingClass="text-right"></cd-form-button-panel>
       </div>
     </div>
   </form>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/back-button/back-button.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/back-button/back-button.component.ts
@@ -1,5 +1,5 @@
 import { Location } from '@angular/common';
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
 
@@ -9,8 +9,16 @@ import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
   styleUrls: ['./back-button.component.scss']
 })
 export class BackButtonComponent {
+  @Output() backAction = new EventEmitter();
+  @Input() name: string = this.actionLabels.CANCEL;
+
   constructor(private location: Location, private actionLabels: ActionLabelsI18n) {}
 
-  @Input() name: string = this.actionLabels.CANCEL;
-  @Input() back: Function = () => this.location.back();
+  back() {
+    if (this.backAction.observers.length === 0) {
+      this.location.back();
+    } else {
+      this.backAction.emit();
+    }
+  }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
@@ -26,6 +26,7 @@ import { CriticalConfirmationModalComponent } from './critical-confirmation-moda
 import { DateTimePickerComponent } from './date-time-picker/date-time-picker.component';
 import { DocComponent } from './doc/doc.component';
 import { DownloadButtonComponent } from './download-button/download-button.component';
+import { FormButtonPanelComponent } from './form-button-panel/form-button-panel.component';
 import { FormModalComponent } from './form-modal/form-modal.component';
 import { GrafanaComponent } from './grafana/grafana.component';
 import { HelperComponent } from './helper/helper.component';
@@ -87,7 +88,8 @@ import { UsageBarComponent } from './usage-bar/usage-bar.component';
     OrchestratorDocPanelComponent,
     DateTimePickerComponent,
     DocComponent,
-    DownloadButtonComponent
+    DownloadButtonComponent,
+    FormButtonPanelComponent
   ],
   providers: [],
   exports: [
@@ -111,7 +113,8 @@ import { UsageBarComponent } from './usage-bar/usage-bar.component';
     OrchestratorDocPanelComponent,
     DateTimePickerComponent,
     DocComponent,
-    DownloadButtonComponent
+    DownloadButtonComponent,
+    FormButtonPanelComponent
   ]
 })
 export class ComponentsModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/confirmation-modal/confirmation-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/confirmation-modal/confirmation-modal.component.html
@@ -12,14 +12,10 @@
         </p>
       </div>
       <div class="modal-footer">
-        <cd-submit-button [form]="confirmationForm"
-                          (submitAction)="onSubmit(confirmationForm.value)">
-          {{ buttonText }}
-        </cd-submit-button>
-        <cd-back-button (backAction)="boundCancel()"
-                        name="Cancel"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="onSubmit(confirmationForm.value)"
+                              (backActionEvent)="boundCancel()"
+                              [form]="confirmationForm"
+                              [submitText]="buttonText"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/confirmation-modal/confirmation-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/confirmation-modal/confirmation-modal.component.html
@@ -16,7 +16,7 @@
                           (submitAction)="onSubmit(confirmationForm.value)">
           {{ buttonText }}
         </cd-submit-button>
-        <cd-back-button [back]="boundCancel"
+        <cd-back-button (backAction)="boundCancel()"
                         name="Cancel"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/confirmation-modal/confirmation-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/confirmation-modal/confirmation-modal.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, NgModule, NO_ERRORS_SCHEMA, TemplateRef, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
-import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { NgbActiveModal, NgbModalModule, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
@@ -9,6 +8,7 @@ import { NgbActiveModal, NgbModalModule, NgbModalRef } from '@ng-bootstrap/ng-bo
 import { ModalService } from '~/app/shared/services/modal.service';
 import { configureTestBed, FixtureHelper } from '~/testing/unit-test-helper';
 import { BackButtonComponent } from '../back-button/back-button.component';
+import { FormButtonPanelComponent } from '../form-button-panel/form-button-panel.component';
 import { ModalComponent } from '../modal/modal.component';
 import { SubmitButtonComponent } from '../submit-button/submit-button.component';
 import { ConfirmationModalComponent } from './confirmation-modal.component';
@@ -72,11 +72,12 @@ describe('ConfirmationModalComponent', () => {
       BackButtonComponent,
       MockComponent,
       ModalComponent,
-      SubmitButtonComponent
+      SubmitButtonComponent,
+      FormButtonPanelComponent
     ],
     schemas: [NO_ERRORS_SCHEMA],
     imports: [ReactiveFormsModule, MockModule, RouterTestingModule, NgbModalModule],
-    providers: [NgbActiveModal, SubmitButtonComponent]
+    providers: [NgbActiveModal, SubmitButtonComponent, FormButtonPanelComponent]
   });
 
   beforeEach(() => {
@@ -161,10 +162,7 @@ describe('ConfirmationModalComponent', () => {
 
     it('should use the correct submit action', () => {
       // In order to ignore the `ElementRef` usage of `SubmitButtonComponent`
-      spyOn(
-        fixture.debugElement.query(By.directive(SubmitButtonComponent)).componentInstance,
-        'focusButton'
-      );
+      spyOn(fh.getElementByCss('.tc_submitButton').componentInstance, 'focusButton');
       fh.clickElement('.tc_submitButton');
       expect(component.onSubmit).toHaveBeenCalledTimes(1);
       expect(component.activeModal.close).toHaveBeenCalledTimes(0);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.html
@@ -47,7 +47,7 @@
                           (submitAction)="callSubmitAction()">
           <ng-container *ngTemplateOutlet="deletionHeading"></ng-container>
         </cd-submit-button>
-        <cd-back-button [back]="activeModal.close"
+        <cd-back-button (backAction)="activeModal.close()"
                         name="Cancel"
                         i18n-name>
         </cd-back-button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/critical-confirmation-modal/critical-confirmation-modal.component.html
@@ -42,15 +42,9 @@
         </div>
       </div>
       <div class="modal-footer">
-        <cd-submit-button #submitButton
-                          [form]="deletionForm"
-                          (submitAction)="callSubmitAction()">
-          <ng-container *ngTemplateOutlet="deletionHeading"></ng-container>
-        </cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"
-                        name="Cancel"
-                        i18n-name>
-        </cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="callSubmitAction()"
+                              [form]="deletionForm"
+                              [submitText]="(actionDescription | titlecase) + ' ' + itemDescription"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-button-panel/form-button-panel.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-button-panel/form-button-panel.component.html
@@ -1,0 +1,10 @@
+<div [class]="wrappingClass">
+  <cd-back-button class="m-2"
+                  (backAction)="backAction()"
+                  [name]="cancelText"></cd-back-button>
+  <cd-submit-button *ngIf="showSubmit"
+                    (submitAction)="submitAction()"
+                    [disabled]="disabled"
+                    [form]="form"
+                    data-cy="submitBtn">{{ submitText }}</cd-submit-button>
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-button-panel/form-button-panel.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-button-panel/form-button-panel.component.spec.ts
@@ -1,0 +1,25 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { configureTestBed } from '~/testing/unit-test-helper';
+import { FormButtonPanelComponent } from './form-button-panel.component';
+
+describe('FormButtonPanelComponent', () => {
+  let component: FormButtonPanelComponent;
+  let fixture: ComponentFixture<FormButtonPanelComponent>;
+
+  configureTestBed({
+    declarations: [FormButtonPanelComponent],
+    schemas: [NO_ERRORS_SCHEMA]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FormButtonPanelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-button-panel/form-button-panel.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-button-panel/form-button-panel.component.ts
@@ -1,0 +1,55 @@
+import { Location } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FormGroup, NgForm } from '@angular/forms';
+
+import { ActionLabelsI18n } from '~/app/shared/constants/app.constants';
+import { ModalService } from '~/app/shared/services/modal.service';
+
+@Component({
+  selector: 'cd-form-button-panel',
+  templateUrl: './form-button-panel.component.html',
+  styleUrls: ['./form-button-panel.component.scss']
+})
+export class FormButtonPanelComponent {
+  @Output()
+  submitActionEvent = new EventEmitter();
+  @Output()
+  backActionEvent = new EventEmitter();
+
+  @Input()
+  form: FormGroup | NgForm;
+  @Input()
+  showSubmit = true;
+  @Input()
+  wrappingClass = '';
+  @Input()
+  btnClass = '';
+  @Input()
+  submitText: string = this.actionLabels.CREATE;
+  @Input()
+  cancelText: string = this.actionLabels.CANCEL;
+  @Input()
+  disabled = false;
+
+  constructor(
+    private location: Location,
+    private actionLabels: ActionLabelsI18n,
+    private modalService: ModalService
+  ) {}
+
+  submitAction() {
+    this.submitActionEvent.emit();
+  }
+
+  backAction() {
+    if (this.backActionEvent.observers.length === 0) {
+      if (this.modalService.hasOpenModals()) {
+        this.modalService.dismissAll();
+      } else {
+        this.location.back();
+      }
+    } else {
+      this.backActionEvent.emit();
+    }
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.html
@@ -60,11 +60,9 @@
         </ng-container>
       </div>
       <div class="modal-footer">
-        <cd-submit-button [form]="formGroup"
-                          (submitAction)="onSubmitForm(formGroup.value)">
-          {{ submitButtonText }}
-        </cd-submit-button>
-        <cd-back-button (backAction)="activeModal.close()"></cd-back-button>
+        <cd-form-button-panel (submitActionEvent)="onSubmitForm(formGroup.value)"
+                              [form]="formGroup"
+                              [submitText]="submitButtonText"></cd-form-button-panel>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/form-modal/form-modal.component.html
@@ -64,7 +64,7 @@
                           (submitAction)="onSubmitForm(formGroup.value)">
           {{ submitButtonText }}
         </cd-submit-button>
-        <cd-back-button [back]="activeModal.close"></cd-back-button>
+        <cd-back-button (backAction)="activeModal.close()"></cd-back-button>
       </div>
     </form>
   </ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/constants/app.constants.ts
@@ -83,6 +83,10 @@ export class ActionLabelsI18n {
   REMOVE: string;
   EDIT: string;
   CANCEL: string;
+  PREVIEW: string;
+  MOVE: string;
+  NEXT: string;
+  BACK: string;
   CHANGE: string;
   COPY: string;
   CLONE: string;
@@ -104,6 +108,7 @@ export class ActionLabelsI18n {
   ROLLBACK: string;
   SCRUB: string;
   SET: string;
+  SUBMIT: string;
   SHOW: string;
   TRASH: string;
   UNPROTECT: string;
@@ -121,6 +126,7 @@ export class ActionLabelsI18n {
     /* Add an existing item to a container */
     this.ADD = $localize`Add`;
     this.SET = $localize`Set`;
+    this.SUBMIT = $localize`Submit`;
 
     /* Remove an item from a container WITHOUT deleting it */
     this.REMOVE = $localize`Remove`;
@@ -130,6 +136,12 @@ export class ActionLabelsI18n {
     this.EDIT = $localize`Edit`;
     this.UPDATE = $localize`Update`;
     this.CANCEL = $localize`Cancel`;
+    this.PREVIEW = $localize`Preview`;
+    this.MOVE = $localize`Move`;
+
+    /* Wizard wording */
+    this.NEXT = $localize`Next`;
+    this.BACK = $localize`Back`;
 
     /* Non-standard actions */
     this.CLONE = $localize`Clone`;
@@ -174,6 +186,8 @@ export class SucceededActionLabelsI18n {
   REMOVED: string;
   EDITED: string;
   CANCELED: string;
+  PREVIEWED: string;
+  MOVED: string;
   COPIED: string;
   CLONED: string;
   DEEP_SCRUBBED: string;
@@ -213,6 +227,8 @@ export class SucceededActionLabelsI18n {
     /* Make changes to an existing item */
     this.EDITED = $localize`Edited`;
     this.CANCELED = $localize`Canceled`;
+    this.PREVIEWED = $localize`Previewed`;
+    this.MOVED = $localize`Moved`;
 
     /* Non-standard actions */
     this.CLONED = $localize`Cloned`;


### PR DESCRIPTION
The PR corrects the buttons shown on forms by providing a `FormButtonPanel` component.

**After** <- **Before**
![Screenshot_2020-11-18_16-15-14](https://user-images.githubusercontent.com/8761082/99549160-a6db2380-29b9-11eb-9afb-5ff3f1d6dd2a.png)
![Screenshot_2020-11-18_16-16-33](https://user-images.githubusercontent.com/8761082/99549170-aa6eaa80-29b9-11eb-8fc4-c1c9365f50bb.png)

Fixes: https://tracker.ceph.com/issues/48016
Signed-off-by: Tatjana Dehler <tdehler@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
