### PR TITLE
mon: removing access to an uninitialized variable

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -14300,7 +14300,7 @@ void OSDMonitor::try_enable_stretch_mode(stringstream& ss, bool *okay,
   if (retval == -1) {
     ss << dividing_bucket << " is not a valid crush bucket type";
     *errcode = -ENOENT;
-    ceph_assert(!commit || dividing_id != -1);
+    ceph_assert(!commit);
     return;
   }
   vector<int> subtrees;


### PR DESCRIPTION
... and silencing a compiler warning.

Whenever crush.get_validated_type_id() returns (-1), dividing_id
is indeed not initialized.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
