### PR TITLE
qa/suite/rados: Introduce "scheduler" directory within rados perf suite.

### DIFF
--- a/qa/suites/rados/perf/scheduler/dmclock_1Shard_16Threads.yaml
+++ b/qa/suites/rados/perf/scheduler/dmclock_1Shard_16Threads.yaml
@@ -1,0 +1,7 @@
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd op num shards: 1
+        osd op num threads per shard: 16
+        osd op queue: mclock_scheduler

--- a/qa/suites/rados/perf/scheduler/dmclock_default_shards.yaml
+++ b/qa/suites/rados/perf/scheduler/dmclock_default_shards.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd op queue: mclock_scheduler

--- a/qa/suites/rados/perf/scheduler/wpq_default_shards.yaml
+++ b/qa/suites/rados/perf/scheduler/wpq_default_shards.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd op queue: wpq


### PR DESCRIPTION
Introduce a "scheduler" directory under the rados:perf tree to allow perf
suite to specify tests with the default scheduler(WPQ) and also with
the dmClock scheduler. One specification also overrides the number of
shards(1) and the number of threads per shard(16) to test with apart from
the default settings. This allows testing and performance benchmarking
with the new proposal to use one shard and multiple threads per shard with
the dmClock scheduler.

Signed-off-by: Sridhar Seshasayee <sseshasa@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
