### PR TITLE
cephadm: verify root privileges before log dir create

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -6013,6 +6013,11 @@ def _parse_args(av):
 
 if __name__ == "__main__":
 
+    # root?
+    if os.geteuid() != 0:
+        sys.stderr.write('ERROR: cephadm should be run as root\n')
+        sys.exit(1)
+
     # Logger configuration
     if not os.path.exists(LOG_DIR):
         os.makedirs(LOG_DIR)
@@ -6032,11 +6037,6 @@ if __name__ == "__main__":
         for handler in logger.handlers:
           if handler.name == "console":
                handler.setLevel(logging.DEBUG)
-
-    # root?
-    if os.geteuid() != 0:
-        sys.stderr.write('ERROR: cephadm should be run as root\n')
-        sys.exit(1)
 
     if 'func' not in args:
         sys.stderr.write('No command specified; pass -h or --help for usage\n')


### PR DESCRIPTION
root privileges need to be verified before creating the log dir

introduced by 81a7df0

Fixes: https://tracker.ceph.com/issues/48166
Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
