### PR TITLE
rpm,deb: change sudoers file mode to 440

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1263,7 +1263,7 @@ ln -sf %{_sbindir}/mount.ceph %{buildroot}/sbin/mount.ceph
 install -m 0644 -D udev/50-rbd.rules %{buildroot}%{_udevrulesdir}/50-rbd.rules
 
 # sudoers.d
-install -m 0600 -D sudoers.d/ceph-osd-smartctl %{buildroot}%{_sysconfdir}/sudoers.d/ceph-osd-smartctl
+install -m 0440 -D sudoers.d/ceph-osd-smartctl %{buildroot}%{_sysconfdir}/sudoers.d/ceph-osd-smartctl
 
 %if 0%{?rhel} >= 8
 pathfix.py -pni "%{__python3} %{py3_shbang_opts}" %{buildroot}%{_bindir}/*

--- a/debian/rules
+++ b/debian/rules
@@ -54,7 +54,7 @@ override_dh_auto_install:
 	install -D -m 644 udev/50-rbd.rules $(DESTDIR)/lib/udev/rules.d/50-rbd.rules
 	install -D -m 644 src/etc-rbdmap $(DESTDIR)/etc/ceph/rbdmap
 	install -D -m 644 etc/sysctl/90-ceph-osd.conf $(DESTDIR)/etc/sysctl.d/30-ceph-osd.conf
-	install -D -m 600 sudoers.d/ceph-osd-smartctl $(DESTDIR)/etc/sudoers.d/ceph-osd-smartctl
+	install -D -m 440 sudoers.d/ceph-osd-smartctl $(DESTDIR)/etc/sudoers.d/ceph-osd-smartctl
 	install -D -m 755 src/tools/rbd_nbd/rbd-nbd_quiesce $(DESTDIR)/usr/libexec/rbd-nbd/rbd-nbd_quiesce
 
 	install -m 755 src/cephadm/cephadm $(DESTDIR)/usr/sbin/cephadm


### PR DESCRIPTION
rpm,deb: change sudoers file mode to 440

change sudoers file mode to 440 to match recommended defaults.

From the sudoers man page.
> the default file mode is 0440 (read‐able by owner and group, writable by none). 
> The default mode may be changed via the “sudoers_mode” option to the sudoers
>  Plugin line in the sudo.conf(5) file.

Fixes: https://tracker.ceph.com/issues/48169
Signed-off-by: David Turner <drakonstein@gmail.com>
