### PR TITLE
qa: switch to 'osdop_read' instead of 'op_r'

### DIFF
--- a/qa/tasks/cephfs/test_readahead.py
+++ b/qa/tasks/cephfs/test_readahead.py
@@ -17,14 +17,14 @@ class TestReadahead(CephFSTestCase):
         self.mount_a.umount_wait()
         self.mount_a.mount_wait()
 
-        initial_op_r = self.mount_a.admin_socket(['perf', 'dump', 'objecter'])['objecter']['op_r']
+        initial_op_read = self.mount_a.admin_socket(['perf', 'dump', 'objecter'])['objecter']['osdop_read']
         self.mount_a.run_shell(["dd", "if=foo", "of=/dev/null", "bs=128k", "count=32"])
-        op_r = self.mount_a.admin_socket(['perf', 'dump', 'objecter'])['objecter']['op_r']
-        assert op_r >= initial_op_r
-        op_r -= initial_op_r
-        log.info("read operations: {0}".format(op_r))
+        op_read = self.mount_a.admin_socket(['perf', 'dump', 'objecter'])['objecter']['osdop_read']
+        assert op_read >= initial_op_read
+        op_read -= initial_op_read
+        log.info("read operations: {0}".format(op_read))
 
         # with exponentially increasing readahead, we should see fewer than 10 operations
         # but this test simply checks if the client is doing a remote read for each local read
-        if op_r >= 32:
+        if op_read >= 32:
             raise RuntimeError("readahead not working")


### PR DESCRIPTION
The 'op_r' will just acount CEPH_OSD_FLAG_READ flag, which will
include some other none real data read opcodes, like the CEPH_OSD_OP_STAT.

Fixes: https://tracker.ceph.com/issues/48207
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
