### PR TITLE
qa/tasks/openssl_keys.py: add subjectAltName to certificates

### DIFF
--- a/qa/tasks/openssl_keys.py
+++ b/qa/tasks/openssl_keys.py
@@ -108,11 +108,21 @@ class OpenSSLKeys(Task):
 
         cert.remote.run(args=['mkdir', '-p', self.cadir])
 
-        cert.key = '{}/{}.key'.format(self.cadir, cert.name)
-        cert.certificate = '{}/{}.crt'.format(self.cadir, cert.name)
+        cert.key = f'{self.cadir}/{cert.name}.key'
+        cert.certificate = f'{self.cadir}/{cert.name}.crt'
+
+        san_ext = []
+        add_san_default = False
+        cn = config.get('cn', '')
+        if cn == '':
+            cn = cert.remote.hostname
+            add_san_default = True
+        if config.get('add-san', add_san_default):
+            ext = f'{self.cadir}/{cert.name}.ext'
+            san_ext = ['-extfile', ext]
 
         # provide the common name in -subj to avoid the openssl command prompts
-        subject = '/CN={}'.format(config.get('cn', cert.remote.hostname))
+        subject = f'/CN={cn}'
 
         # if a ca certificate is provided, use it to sign the new certificate
         ca = config.get('ca', None)
@@ -120,25 +130,33 @@ class OpenSSLKeys(Task):
             # the ca certificate must have been created by a prior ssl task
             ca_cert = self.ctx.ssl_certificates.get(ca, None)
             if not ca_cert:
-                raise ConfigError('ssl: ca {} not found for certificate {}'
-                        .format(ca, cert.name))
+                raise ConfigError(f'ssl: ca {ca} not found for certificate {cert.name}')
+
+            csr = f'{self.cadir}/{cert.name}.csr'
+            srl = f'{self.cadir}/{ca_cert.name}.srl'
+            remove_files = ['rm', csr, srl]
 
             # these commands are run on the ca certificate's client because
             # they need access to its private key and cert
 
             # generate a private key and signing request
-            csr = '{}/{}.csr'.format(self.cadir, cert.name)
             ca_cert.remote.run(args=['openssl', 'req', '-nodes',
                 '-newkey', cert.key_type, '-keyout', cert.key,
                 '-out', csr, '-subj', subject])
 
+            if san_ext:
+                remove_files.append(ext)
+                ca_cert.remote.write_file(path=ext,
+                    data='subjectAltName = DNS:{},IP:{}'.format(
+                        cn,
+                        config.get('ip', cert.remote.ip_address)))
+
             # create the signed certificate
             ca_cert.remote.run(args=['openssl', 'x509', '-req', '-in', csr,
                 '-CA', ca_cert.certificate, '-CAkey', ca_cert.key, '-CAcreateserial',
-                '-out', cert.certificate, '-days', '365', '-sha256'])
+                '-out', cert.certificate, '-days', '365', '-sha256'] + san_ext)
 
-            srl = '{}/{}.srl'.format(self.cadir, ca_cert.name)
-            ca_cert.remote.run(args=['rm', csr, srl]) # clean up the signing request and serial
+            ca_cert.remote.run(args=remove_files) # clean up the signing request and serial
 
             # verify the new certificate against its ca cert
             ca_cert.remote.run(args=['openssl', 'verify',


### PR DESCRIPTION
Get rid of this annoying teuthology log message which appears
many many times:

.../urllib3/connection.py:395: SubjectAltNameWarning: Certificate
for <some_host> has no `subjectAltName`, falling back to check for a
`commonName` for now. This feature is being removed by major browsers and
deprecated by RFC 2818. (See https://github.com/urllib3/urllib3/issues/497
for details.)

I'm also adding the ip address, which also allows https://IPaddress/
This is part of the standard and works with most clients, but some
versions of python ignore this.  C'est la vie.

I've included some cleverness in the logic to only add SAN when
adding a certificate for a host (and not some other principal).

Fixes: https://tracker.ceph.com/issues/48177
Signed-off-by: Marcus Watts <mwatts@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
