### PR TITLE
test/mon: FreeBSD returns ENOENT on resolv error

### DIFF
--- a/src/test/mon/MonMap.cc
+++ b/src/test/mon/MonMap.cc
@@ -237,5 +237,9 @@ TEST(MonMapBuildInitial, build_initial_mon_host_from_dns_fail) {
   cct->_conf.set_val("mon_host", "ceph.noname");
   MonMap monmap;
   int r = monmap.build_initial(cct.get(), false, std::cerr);
+#if defined(__FreeBSD__)
+  ASSERT_EQ(r, -ENOENT);
+#else
   ASSERT_EQ(r, -EINVAL);
+#endif
 }


### PR DESCRIPTION
Tracker: https://tracker.ceph.com/issues/48183



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>