### PR TITLE
mgr/dashboard: fix cephadm e2e test failure on deleting OSDs

### DIFF
--- a/qa/workunits/cephadm/test_dashboard_e2e.sh
+++ b/qa/workunits/cephadm/test_dashboard_e2e.sh
@@ -47,7 +47,7 @@ EOF
 cypress_run () {
     local specs="$1"
     local timeout="$2"
-    local override_config="ignoreTestFiles=*.po.ts,testFiles=${specs}"
+    local override_config="ignoreTestFiles=*.po.ts,retries=0,testFiles=${specs}"
 
     if [ x"$timeout" != "x" ]; then
         override_config="${override_config},defaultCommandTimeout=${timeout}"

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/osds.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/osds.po.ts
@@ -9,7 +9,7 @@ export class OSDsPageHelper extends PageHelper {
   pages = pages;
 
   columnIndex = {
-    id: 4,
+    id: 3,
     status: 5
   };
 


### PR DESCRIPTION
- Adapt the OSD ID column change in this PR:
  https://github.com/ceph/ceph/pull/37506
- Turn off Cypress retries because it makes the failure log misleading.

Fixes: https://tracker.ceph.com/issues/48209
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
