### PR TITLE
nautilus: ceph-volume: remove mention of dmcache from docs and help text

### DIFF
--- a/doc/ceph-volume/intro.rst
+++ b/doc/ceph-volume/intro.rst
@@ -74,16 +74,11 @@ involved at all.
 -------------------
 By making use of :term:`LVM tags`, the :ref:`ceph-volume-lvm` sub-command is
 able to store and later re-discover and query devices associated with OSDs so
-that they can later activated. This includes support for lvm-based technologies
-like dm-cache as well.
-
-For ``ceph-volume``, the use of dm-cache is transparent, there is no difference
-for the tool, and it treats dm-cache like a plain logical volume.
+that they can later be activated.
 
 LVM performance penalty
 -----------------------
 In short: we haven't been able to notice any significant performance penalties
 associated with the change to LVM. By being able to work closely with LVM, the
-ability to work with other device mapper technologies (for example ``dmcache``)
-was a given: there is no technical difficulty in working with anything that can
-sit below a Logical Volume.
+ability to work with other device mapper technologies was a given: there is no
+technical difficulty in working with anything that can sit below a Logical Volume.

--- a/src/ceph-volume/ceph_volume/devices/lvm/main.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/main.py
@@ -13,10 +13,10 @@ from . import batch
 
 class LVM(object):
 
-    help = 'Use LVM and LVM-based technologies like dmcache to deploy OSDs'
+    help = 'Use LVM and LVM-based technologies to deploy OSDs'
 
     _help = dedent("""
-    Use LVM and LVM-based technologies like dmcache to deploy OSDs
+    Use LVM and LVM-based technologies to deploy OSDs
 
     {sub_help}
     """)

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
@@ -8,7 +8,7 @@ class TestLVM(object):
     def test_main_spits_help_with_no_arguments(self, capsys):
         lvm.main.LVM([]).main()
         stdout, stderr = capsys.readouterr()
-        assert 'Use LVM and LVM-based technologies like dmcache to deploy' in stdout
+        assert 'Use LVM and LVM-based technologies to deploy' in stdout
 
     def test_main_shows_activate_subcommands(self, capsys):
         lvm.main.LVM([]).main()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48189

---

backport of https://github.com/ceph/ceph/pull/37741
parent tracker: https://tracker.ceph.com/issues/48039

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh