### PR TITLE
global: reexpand the config meta just after the fork() is done

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,5 +1,9 @@
 >=16.0.0
 --------
+* $pid expansion in config paths like `admin_socket` will now properly expand
+  to the daemon pid for commands like `ceph-mds` or `ceph-osd`. Previously only
+  `ceph-fuse`/`rbd-nbd` expanded `$pid` with the actual daemon pid.
+
 * The allowable options for some "radosgw-admin" commands have been changed.
 
   * "mdlog-list", "datalog-list", "sync-error-list" no longer accepts

--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -179,9 +179,8 @@ int main(int argc, const char **argv, const char *envp[]) {
   }
 
   {
-    g_ceph_context->_conf.finalize_reexpand_meta();
     common_init_finish(g_ceph_context);
-   
+
     init_async_signal_handler();
     register_async_signal_handler(SIGHUP, sighup_handler);
 

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -1124,17 +1124,19 @@ void md_config_t::early_expand_meta(
 bool md_config_t::finalize_reexpand_meta(ConfigValues& values,
 					 const ConfigTracker& tracker)
 {
-  for (auto& [name, value] : may_reexpand_meta) {
-    set_val(values, tracker, name, value);
+  std::vector<std::string> reexpands;
+  reexpands.swap(may_reexpand_meta);
+  for (auto& name : reexpands) {
+    // always refresh the options if they are in the may_reexpand_meta
+    // map, because the options may have already been expanded with old
+    // meta.
+    const auto &opt_iter = schema.find(name);
+    ceph_assert(opt_iter != schema.end());
+    const Option &opt = opt_iter->second;
+    _refresh(values, opt);
   }
-  
-  if (!may_reexpand_meta.empty()) {
-    // meta expands could have modified anything.  Copy it all out again.
-    update_legacy_vals(values);
-    return true;
-  } else {
-    return false;
-  }
+
+  return !may_reexpand_meta.empty();
 }
 
 Option::value_t md_config_t::_expand_meta(
@@ -1218,7 +1220,7 @@ Option::value_t md_config_t::_expand_meta(
       } else if (var == "pid") {
 	out += stringify(getpid());
         if (o) {
-          may_reexpand_meta[o->name] = *str;
+          may_reexpand_meta.push_back(o->name);
         }
       } else if (var == "cctid") {
 	out += stringify((unsigned long long)this);

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -100,7 +100,7 @@ public:
   std::map<std::string,std::string> ignored_mon_values;
 
   /// original raw values saved that may need to re-expand at certain time
-  mutable std::map<std::string, std::string> may_reexpand_meta;
+  mutable std::vector<std::string> may_reexpand_meta;
 
   /// encoded, cached copy of of values + ignored_mon_values
   ceph::bufferlist values_bl;

--- a/src/common/config_proxy.h
+++ b/src/common/config_proxy.h
@@ -199,7 +199,6 @@ public:
     rev_obs_map_t rev_obs;
     if (config.finalize_reexpand_meta(values, obs_mgr)) {
       _gather_changes(values.changed, &rev_obs, nullptr);
-      values.changed.clear();
     }
 
     call_observers(locker, rev_obs);
@@ -256,7 +255,6 @@ public:
     if (!values.cluster.empty()) {
       // meta expands could have modified anything.  Copy it all out again.
       _gather_changes(values.changed, &rev_obs, oss);
-      values.changed.clear();
     }
 
     call_observers(locker, rev_obs);
@@ -268,6 +266,7 @@ public:
       [this, rev_obs](md_config_obs_t *obs, const std::string &key) {
         map_observer_changes(obs, key, rev_obs);
       }, oss);
+      changes.clear();
   }
   int set_val(const std::string_view key, const std::string& s,
               std::stringstream* err_ss=nullptr) {
@@ -290,7 +289,6 @@ public:
 
     rev_obs_map_t rev_obs;
     _gather_changes(values.changed, &rev_obs, nullptr);
-    values.changed.clear();
 
     call_observers(locker, rev_obs);
     return ret;
@@ -301,7 +299,6 @@ public:
 
     rev_obs_map_t rev_obs;
     _gather_changes(values.changed, &rev_obs, oss);
-    values.changed.clear();
 
     call_observers(locker, rev_obs);
     return ret;

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -515,6 +515,9 @@ int reopen_as_null(CephContext *cct, int fd)
 
 void global_init_postfork_start(CephContext *cct)
 {
+  // reexpand the meta in child process
+  cct->_conf.finalize_reexpand_meta();
+
   // restart log thread
   cct->_log->start();
   cct->notify_post_fork();

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -1594,7 +1594,6 @@ static int do_map(int argc, const char *argv[], Config *cfg, bool reconnect)
     global_init_postfork_start(g_ceph_context);
   }
 
-  g_ceph_context->_conf.finalize_reexpand_meta();
   common_init_finish(g_ceph_context);
   global_init_chdir(g_ceph_context);
 


### PR DESCRIPTION
Fixes:https://tracker.ceph.com/issues/48240
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
