### PR TITLE
github: fix autolabel paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,10 +1,11 @@
 dashboard:
-  - /src/pybind/mgr/dashboard/**
-  - /qa/suites/rados/dashboard/**
-  - /qa/tasks/mgr/test_dashboard.py
-  - /qa/tasks/mgr/dashboard/**
-  - /monitoring/**
-  - /doc/mgr/dashboard.rst
+  - src/pybind/mgr/dashboard/**
+  - qa/suites/rados/dashboard/**
+  - qa/tasks/mgr/test_dashboard.py
+  - qa/tasks/mgr/dashboard/**
+  - monitoring/**
+  - doc/mgr/dashboard.rst
+  - doc/dev/developer_guide/dash-devel.rst
 
 CI:
-  - /.github/**
+  - .github/**


### PR DESCRIPTION
Remove starting / from paths and add missing doc path from dashboard.

Fixes: https://github.com/ceph/ceph/pull/38049
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
