### PR TITLE
mgr/dashboard: use http://docs.ceph.com/en/${release}/ for the domain…

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/doc.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/doc.service.spec.ts
@@ -22,7 +22,13 @@ describe('DocService', () => {
 
   it('should return full URL', () => {
     expect(service.urlGenerator('iscsi', 'foo')).toBe(
-      'http://docs.ceph.com/docs/foo/mgr/dashboard/#enabling-iscsi-management'
+      'https://docs.ceph.com/en/foo/mgr/dashboard/#enabling-iscsi-management'
+    );
+  });
+
+  it('should return latest version URL for master', () => {
+    expect(service.urlGenerator('orch', 'master')).toBe(
+      'https://docs.ceph.com/en/latest/mgr/orchestrator'
     );
   });
 
@@ -60,7 +66,7 @@ describe('DocService', () => {
 
       nextSummary('foo');
       expect(result).toEqual(
-        'http://docs.ceph.com/docs/foo/mgr/dashboard/#enabling-prometheus-alerting'
+        'https://docs.ceph.com/en/foo/mgr/dashboard/#enabling-prometheus-alerting'
       );
       expect(i).toBe(1);
       expect(subscriber.closed).toBe(true);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/doc.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/doc.service.ts
@@ -24,7 +24,8 @@ export class DocService {
   }
 
   urlGenerator(section: string, release = 'master'): string {
-    const domain = `http://docs.ceph.com/docs/${release}/`;
+    const docVersion = release === 'master' ? 'latest' : release;
+    const domain = `https://docs.ceph.com/en/${docVersion}/`;
     const domainCeph = `https://ceph.io/`;
 
     const sections = {


### PR DESCRIPTION
… of the docs

since RTD uses this URL for the built document, and it's impossible to
configure RTD to match and substitude the prefix of the redirected URLs.
the closest setting is the "Prefix Redir" policies, but it does not
allow us to redirect "doc/${version}" to "$lang/$version", what RTD allows
is to redirect "doc/${version}" to "$lang/$default_version", where the
$default_version is configured in RTD. see
https://docs.readthedocs.io/en/stable/user-defined-redirects.html#prefix-redirects

Fixes: https://tracker.ceph.com/issues/48012
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
