### PR TITLE
github/labeler: add "crimson" to labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,25 @@
+pybind:
+  - src/pybind/cephfs/*
+  - src/pybind/mgr/*
+  - src/pybind/rados/*
+  - src/pybind/rbd/*
+  - src/pybind/rgw/*
+  - src/pybind/*
+
+common:
+  - src/common
+  - src/global
+  - src/log
+
+core:
+  - src/blk/**
+  - src/crush/*
+  - src/librados/**
+  - src/mgr/**
+  - src/mon/**
+  - src/os/**
+  - src/osd/**
+
 crimson:
   - doc/dev/crimson/**
   - src/crimson/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,9 @@
+crimson:
+  - doc/dev/crimson/**
+  - src/crimson/**
+  - src/test/crimson/**
+  - qa/suites/crimson-rados/**
+
 dashboard:
   - src/pybind/mgr/dashboard/**
   - qa/suites/rados/dashboard/**


### PR DESCRIPTION
so crimson related changes can be labeled by the labler action.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
