### PR TITLE
mds: don't access mds->mdsmap without holding mds_lock

### DIFF
--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2164,37 +2164,41 @@ public:
 
 class C_IO_Dir_Commit_Ops : public Context {
 public:
-  C_IO_Dir_Commit_Ops(CDir *d, int pr, bufferlist &&bl,
-		      vector<dentry_key_t> &&r, vector<CDir::dentry_commit_item> &&s,
+  C_IO_Dir_Commit_Ops(CDir *d, int pr,
+		      vector<CDir::dentry_commit_item> &&s, bufferlist &&bl,
+		      vector<dentry_key_t> &&r,
 		      mempool::mds_co::compact_set<mempool::mds_co::string> &&stale) :
     dir(d), op_prio(pr) {
+    metapool = dir->mdcache->mds->mdsmap->get_metadata_pool();
     version = dir->get_version();
     is_new = dir->is_new();
+    to_set.swap(s);
     dfts.swap(bl);
     to_remove.swap(r);
-    to_set.swap(s);
     stale_items.swap(stale);
   }
 
   void finish(int r) override {
-    dir->_omap_commit_ops(r, op_prio, version, is_new, dfts, to_remove, to_set,
-                          stale_items);
+    dir->_omap_commit_ops(r, op_prio, metapool, version, is_new, to_set, dfts,
+			  to_remove, stale_items);
   }
 
 private:
   CDir *dir;
-  version_t version;
   int op_prio;
+  int64_t metapool;
+  version_t version;
   bool is_new;
+  vector<CDir::dentry_commit_item> to_set;
   bufferlist dfts;
   vector<dentry_key_t> to_remove;
-  vector<CDir::dentry_commit_item> to_set;
   mempool::mds_co::compact_set<mempool::mds_co::string> stale_items;
 };
 
 // This is not locked by mds_lock
-void CDir::_omap_commit_ops(int r, int op_prio, version_t version, bool _new, bufferlist &dfts,
-                            vector<dentry_key_t>& to_remove, vector<dentry_commit_item> &to_set,
+void CDir::_omap_commit_ops(int r, int op_prio, int64_t metapool, version_t version, bool _new,
+			    vector<dentry_commit_item> &to_set, bufferlist &dfts,
+                            vector<dentry_key_t>& to_remove,
 			    mempool::mds_co::compact_set<mempool::mds_co::string> &stales)
 {
   dout(10) << __func__ << dendl;
@@ -2210,7 +2214,7 @@ void CDir::_omap_commit_ops(int r, int op_prio, version_t version, bool _new, bu
 
   SnapContext snapc;
   object_t oid = get_ondisk_object();
-  object_locator_t oloc(mdcache->mds->mdsmap->get_metadata_pool());
+  object_locator_t oloc(metapool);
 
   map<string, bufferlist> _set;
   set<string> _rm;
@@ -2414,9 +2418,8 @@ void CDir::_omap_commit(int op_prio)
     }
   }
 
-  auto c = new C_IO_Dir_Commit_Ops(this, op_prio, std::move(dfts),
-                                   std::move(to_remove), std::move(to_set),
-                                   std::move(stale_items));
+  auto c = new C_IO_Dir_Commit_Ops(this, op_prio, std::move(to_set), std::move(dfts),
+                                   std::move(to_remove), std::move(stale_items));
   stale_items.clear();
   mdcache->mds->finisher->queue(c);
 }

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -711,8 +711,9 @@ protected:
 
   // -- commit --
   void _commit(version_t want, int op_prio);
-  void _omap_commit_ops(int r, int op_prio, version_t version, bool _new, bufferlist &bl,
-                        vector<dentry_key_t> &to_remove, vector<dentry_commit_item> &to_set,
+  void _omap_commit_ops(int r, int op_prio, int64_t metapool, version_t version, bool _new,
+			vector<dentry_commit_item> &to_set, bufferlist &dfts,
+			vector<dentry_key_t> &to_remove,
 			mempool::mds_co::compact_set<mempool::mds_co::string> &_stale);
   void _omap_commit(int op_prio);
   void _parse_dentry(CDentry *dn, dentry_commit_item &item,


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47786
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
