### PR TITLE
mgr/dashboard: Disable sso without python3-saml

### DIFF
--- a/src/pybind/mgr/dashboard/services/sso.py
+++ b/src/pybind/mgr/dashboard/services/sso.py
@@ -144,6 +144,11 @@ def handle_sso_command(cmd):
                              'dashboard sso setup saml2']:
         return -errno.ENOSYS, '', ''
 
+    if cmd['prefix'] == 'dashboard sso disable':
+        mgr.SSO_DB.protocol = ''
+        mgr.SSO_DB.save()
+        return 0, 'SSO is "disabled".', ''
+
     if not python_saml_imported:
         return -errno.EPERM, '', 'Required library not found: `python3-saml`'
 
@@ -156,11 +161,6 @@ def handle_sso_command(cmd):
         mgr.SSO_DB.protocol = 'saml2'
         mgr.SSO_DB.save()
         return 0, 'SSO is "enabled" with "SAML2" protocol.', ''
-
-    if cmd['prefix'] == 'dashboard sso disable':
-        mgr.SSO_DB.protocol = ''
-        mgr.SSO_DB.save()
-        return 0, 'SSO is "disabled".', ''
 
     if cmd['prefix'] == 'dashboard sso status':
         if mgr.SSO_DB.protocol == 'saml2':


### PR DESCRIPTION
mgr/dashboard: Disable sso without python3-saml

I am currently in a situation where I've upgraded from an older version of Ceph to Octopus, and since the upgrade SSO doesn't work anymore with the containerised installation due to a missing library (python3-saml). Unfortunately it is currently not possible to disable SSO again since all commands relating to `ceph dashboard sso` will fail with the error `Error EPERM: Required library not found: python3-saml`

This pull requests changes that and allows the `ceph dashboard sso disable` command without the requirement of the library so that we SSO can always be disabled again.

Fixes: https://tracker.ceph.com/issues/48237

Signed-off-by: Kevin Meijer <admin@kevinmeijer.nl>
