### PR TITLE
log: convert types to specific types, so fmt gets a known type.

### DIFF
--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -322,7 +322,7 @@ void Log::_log_message(std::string_view s, bool crash)
       std::cerr << "problem writing to " << m_log_file << ": " << cpp_strerror(r) << std::endl;
   }
   if ((crash ? m_syslog_crash : m_syslog_log) >= 0) {
-    syslog(LOG_USER|LOG_INFO, "%.*s", s.size(), s.data());
+    syslog(LOG_USER|LOG_INFO, "%.*s", static_cast<int>s.size(), s.data());
   }
 
   if ((crash ? m_stderr_crash : m_stderr_log) >= 0) {
@@ -372,7 +372,7 @@ void Log::dump_recent()
   {
     char pthread_name[16] = {0}; //limited by 16B include terminating null byte.
     ceph_pthread_getname(pthread_id, pthread_name, sizeof(pthread_name));
-    _log_message(fmt::format("  {} / {}", pthread_id, pthread_name), true);
+    _log_message(fmt::format("  {} / {}", static_cast<void*>pthread_id, pthread_name), true);
   }
 
   _log_message(fmt::format("  max_recent {:9}", m_max_recent), true);


### PR DESCRIPTION
```
In file included from /home/jenkins/workspace/ceph-master-compile/src/log/Log.cc:27:
In file included from /usr/local/include/fmt/format.h:44:
/usr/local/include/fmt/core.h:1043:20: error: invalid application of 'sizeof' to an incomplete type 'pthread'
    static_assert(!sizeof(T), "formatting of non-void pointers is disallowed");
                   ^~~~~~~~~
/usr/local/include/fmt/core.h:1259:32: note: in instantiation of function template specialization 'fmt::v7::detail::arg_mapper<fmt::v7::basic_format_context<std::__1::back_insert_iterator<fmt::v7::detail::buffer<char> >, char> >::map<pthread>' requested here
  return arg_mapper<Context>().map(val);
                               ^
/usr/local/include/fmt/core.h:1408:23: note: in instantiation of function template specialization 'fmt::v7::detail::make_arg<true, fmt::v7::basic_format_context<std::__1::back_insert_iterator<fmt::v7::detail::buffer<char> >, char>, fmt::v7::detail::type::int_type, pthread *, 0>' requested here
        data_{detail::make_arg<
                      ^
/usr/local/include/fmt/core.h:1764:10: note: in instantiation of member function 'fmt::v7::format_arg_store<fmt::v7::basic_format_context<std::__1::back_insert_iterator<fmt::v7::detail::buffer<char> >, char>, pthread *const, char *>::format_arg_store' requested here
  return {args...};
         ^
/usr/local/include/fmt/core.h:1835:31: note: in instantiation of function template specialization 'fmt::v7::detail::make_args_checked<pthread *const &, char *, char [10], char>' requested here
  const auto& vargs = detail::make_args_checked<Args...>(format_str, args...);
                              ^
/home/jenkins/workspace/ceph-master-compile/src/log/Log.cc:376:23: note: in instantiation of function template specialization 'fmt::v7::format<char [10], pthread *const &, char *, char>' requested here
    _log_message(fmt::format("  {} / {}", pthread_id, (char*)pthread_name), true);
                      ^
/usr/include/sys/_pthreadtypes.h:46:8: note: forward declaration of 'pthread'
struct pthread;
       ^
1 error generated.
```
fixes: https://github.com/ceph/ceph/pull/37998



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>