### PR TITLE
mgr/rook: Fix container id and image id in 'orch ps' 

### DIFF
--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -397,6 +397,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             if service_name is not None and service_name != sd.service_name():
                 continue
             sd.container_image_name = p['container_image_name']
+            sd.container_image_id = p['container_image_id']
             sd.created = p['created']
             sd.last_configured = p['created']
             sd.last_deployed = p['created']

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -374,7 +374,6 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         for p in pods:
             sd = orchestrator.DaemonDescription()
             sd.hostname = p['hostname']
-            sd.container_id = p['name']
             sd.daemon_type = p['labels']['app'].replace('rook-ceph-', '')
             status = {
                 'Pending': -1,

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -197,7 +197,7 @@ class RookCluster(object):
         self.rook_pods = KubernetesResource(self.coreV1_api.list_namespaced_pod,
                                             namespace=self.rook_env.namespace,
                                             label_selector="rook_cluster={0}".format(
-                                                self.rook_env.cluster_name))
+                                                self.rook_env.namespace))
         self.nodes = KubernetesResource(self.coreV1_api.list_node)
 
     def rook_url(self, path):
@@ -284,7 +284,7 @@ class RookCluster(object):
                         rook_cluster=rook
         And MDS containers additionally have `rook_filesystem` label
 
-        Label filter is rook_cluster=<cluster name>
+        Label filter is rook_cluster=<cluster namespace>
                         rook_file_system=<self.fs_name>
         """
         def predicate(item):

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -319,6 +319,7 @@ class RookCluster(object):
         pods = [i for i in self.rook_pods.items if predicate(i)]
 
         pods_summary = []
+        prefix = 'sha256:'
 
         for p in pods:
             d = p.to_dict()
@@ -329,12 +330,16 @@ class RookCluster(object):
                 image_name = c['image']
                 break
 
+            image_id = d['status']['container_statuses'][0]['image_id']
+            image_id = image_id.split(prefix)[1] if prefix in image_id else image_id
+
             s = {
                 "name": d['metadata']['name'],
                 "hostname": d['spec']['node_name'],
                 "labels": d['metadata']['labels'],
                 'phase': d['status']['phase'],
                 'container_image_name': image_name,
+                'container_image_id': image_id,
                 'refreshed': refreshed,
                 # these may get set below...
                 'started': None,


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---
-->
Fixes: https://tracker.ceph.com/issues/47513
Signed-off-by: Varsha Rao <varao@redhat.com>

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
