### PR TITLE
install-deps.sh: fixing PowerTools repo name on CentOS 8

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -328,7 +328,7 @@ else
                 $SUDO rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-$MAJOR_VERSION
                 $SUDO rm -f /etc/yum.repos.d/dl.fedoraproject.org*
 		if test $ID = centos -a $MAJOR_VERSION = 8 ; then
-                    $SUDO dnf config-manager --set-enabled PowerTools
+                    $SUDO dnf config-manager --set-enabled powertools
 		    # before EPEL8 and PowerTools provide all dependencies, we use sepia for the dependencies
                     $SUDO dnf config-manager --add-repo http://apt-mirror.front.sepia.ceph.com/lab-extras/8/
                     $SUDO dnf config-manager --setopt=apt-mirror.front.sepia.ceph.com_lab-extras_8_.gpgcheck=0 --save


### PR DESCRIPTION
Seems that this is the correct case for this repo on CentOS 8:


>> sudo dnf config-manager --set-enabled PowerTools
Error: No matching repo to modify: PowerTools.

>> sudo dnf repolist
repo id                                                                                                                                repo name
...
extras                                                                                                                                 CentOS Stream 8 - Extras
powertools                                                                                                                             CentOS Stream 8 - PowerTools

>> sudo dnf config-manager --set-enabled powertools


Signed-off-by: Ronen Friedman <rfriedma@redhat.com>

