### PR TITLE
mgr/dashboard: Change the text 'Login' to 'Log in'

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/login.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/ui/login.po.ts
@@ -9,7 +9,7 @@ export class LoginPageHelper extends PageHelper {
   doLogin() {
     cy.get('[name=username]').type('admin');
     cy.get('#password').type('admin');
-    cy.contains('input', 'Login').click();
+    cy.get('[type=submit]').click();
     cy.get('cd-dashboard').should('exist');
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.html
@@ -58,7 +58,7 @@
     <input type="submit"
            class="btn btn-accent px-5 py-2"
            [disabled]="loginForm.invalid"
-           value="Login"
+           value="Log in"
            i18n-value>
   </form>
 </div>


### PR DESCRIPTION

![Screenshot from 2020-11-17 00-08-51](https://user-images.githubusercontent.com/71764184/99293778-1a215000-2869-11eb-850e-1cb13b078003.png)

Fixes: https://tracker.ceph.com/issues/48253
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
