### PR TITLE
osd: allow remote read by calling cls method from within cls context

### DIFF
--- a/qa/suites/crimson-rados/basic/tasks/rados_api_tests.yaml
+++ b/qa/suites/crimson-rados/basic/tasks/rados_api_tests.yaml
@@ -16,6 +16,9 @@ overrides:
         debug ms: 1
       mon:
         mon warn on pool no app: false
+      osd:
+        osd class load list: "*"
+        osd class default list: "*"
 tasks:
 - workunit:
     clients:

--- a/qa/suites/powercycle/osd/tasks/rados_api_tests.yaml
+++ b/qa/suites/powercycle/osd/tasks/rados_api_tests.yaml
@@ -7,6 +7,9 @@ overrides:
     conf:
       mon:
         mon warn on pool no app: false
+      osd:
+        osd class load list: "*"
+        osd class default list: "*"
 tasks:
 - ceph-fuse:
 - workunit:

--- a/qa/suites/rados/basic/tasks/rados_api_tests.yaml
+++ b/qa/suites/rados/basic/tasks/rados_api_tests.yaml
@@ -16,6 +16,9 @@ overrides:
         debug ms: 1
       mon:
         mon warn on pool no app: false
+      osd:
+        osd class load list: "*"
+        osd class default list: "*"
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rados/monthrash/workloads/rados_api_tests.yaml
+++ b/qa/suites/rados/monthrash/workloads/rados_api_tests.yaml
@@ -19,6 +19,9 @@ overrides:
         debug ms: 1
       mon:
         mon warn on pool no app: false
+      osd:
+        osd class load list: "*"
+        osd class default list: "*"
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rados/thrash/workloads/rados_api_tests.yaml
+++ b/qa/suites/rados/thrash/workloads/rados_api_tests.yaml
@@ -13,6 +13,9 @@ overrides:
       mon:
         mon warn on pool no app: false
         debug mgrc: 20
+      osd:
+        osd class load list: "*"
+        osd class default list: "*"
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rados/verify/tasks/rados_api_tests.yaml
+++ b/qa/suites/rados/verify/tasks/rados_api_tests.yaml
@@ -20,6 +20,9 @@ overrides:
         debug monc: 20
       mon:
         mon warn on pool no app: false
+      osd:
+        osd class load list: "*"
+        osd class default list: "*"
 tasks:
 - workunit:
     timeout: 6h

--- a/qa/suites/smoke/basic/tasks/test/mon_thrash.yaml
+++ b/qa/suites/smoke/basic/tasks/test/mon_thrash.yaml
@@ -23,6 +23,9 @@ overrides:
         ms inject internal delays: 0.002
         ms inject socket failures: 2500
         mon client directed command retry: 5
+      osd:
+        osd class load list: "*"
+        osd class default list: "*"
 tasks:
 - ceph:
     fs: xfs

--- a/qa/suites/smoke/basic/tasks/test/rados_api_tests.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rados_api_tests.yaml
@@ -18,6 +18,9 @@ tasks:
     conf:
       mon:
         mon warn on pool no app: false
+      osd:
+        osd class load list: "*"
+        osd class default list: "*"
 - thrashosds:
     chance_pgnum_grow: 2
     chance_pgnum_shrink: 2

--- a/qa/workunits/rados/test.sh
+++ b/qa/workunits/rados/test.sh
@@ -29,6 +29,7 @@ for f in \
     api_service api_service_pp \
     api_c_write_operations \
     api_c_read_operations \
+    api_cls_remote_reads \
     list_parallel \
     open_pools_parallel \
     delete_pools_parallel

--- a/src/cls/CMakeLists.txt
+++ b/src/cls/CMakeLists.txt
@@ -340,3 +340,13 @@ set_target_properties(cls_fifo PROPERTIES
   INSTALL_RPATH ""
   CXX_VISIBILITY_PRESET hidden)
 install(TARGETS cls_fifo DESTINATION ${cls_dir})
+
+# cls_test_remote_reads
+set(cls_test_remote_reads_srcs test_remote_reads/cls_test_remote_reads.cc)
+add_library(cls_test_remote_reads SHARED ${cls_test_remote_reads_srcs})
+set_target_properties(cls_test_remote_reads PROPERTIES
+  VERSION "1.0.0"
+  SOVERSION "1"
+  INSTALL_RPATH ""
+  CXX_VISIBILITY_PRESET hidden)
+install(TARGETS cls_test_remote_reads DESTINATION ${cls_dir})

--- a/src/cls/test_remote_reads/cls_test_remote_reads.cc
+++ b/src/cls/test_remote_reads/cls_test_remote_reads.cc
@@ -1,0 +1,87 @@
+/*
+ * This is an example RADOS object class that shows how to use remote reads.
+ */
+
+#include "common/ceph_json.h"
+#include "objclass/objclass.h"
+
+CLS_VER(1,0)
+CLS_NAME(test_remote_reads)
+
+cls_handle_t h_class;
+cls_method_handle_t h_test_read;
+cls_method_handle_t h_test_gather;
+
+/**
+ * read data
+ */
+static int test_read(cls_method_context_t hctx, bufferlist *in, bufferlist *out) {
+  int r = cls_cxx_read(hctx, 0, 0, out);
+  if (r < 0) {
+    CLS_ERR("%s: error reading data", __PRETTY_FUNCTION__);
+    return r;
+  }
+  return 0;
+}
+
+/**
+ * gather data from other objects using remote reads
+ */
+static int test_gather(cls_method_context_t hctx, bufferlist *in, bufferlist *out) {
+  std::map<std::string, bufferlist> src_obj_buffs;
+  int r = cls_cxx_get_gathered_data(hctx, &src_obj_buffs);
+  if (src_obj_buffs.empty()) {
+    // start remote reads
+    JSONParser parser;
+    bool b = parser.parse(in->c_str(), in->length());
+    if (!b) {
+      CLS_ERR("%s: failed to parse json", __PRETTY_FUNCTION__);
+      return -EBADMSG;
+    }
+    auto *o_cls = parser.find_obj("cls");
+    ceph_assert(o_cls);
+    std::string cls = o_cls->get_data_val().str;
+
+    auto *o_method = parser.find_obj("method");
+    ceph_assert(o_method);
+    std::string method = o_method->get_data_val().str;
+
+    auto *o_pool = parser.find_obj("pool");
+    ceph_assert(o_pool);
+    std::string pool = o_pool->get_data_val().str;
+
+    auto *o_src_objects = parser.find_obj("src_objects");
+    ceph_assert(o_src_objects);
+    auto src_objects_v = o_src_objects->get_array_elements();
+    std::set<std::string> src_objects;
+    for (auto it = src_objects_v.begin(); it != src_objects_v.end(); it++) {
+      std::string oid_without_double_quotes = it->substr(1, it->size()-2);
+      src_objects.insert(oid_without_double_quotes);
+    }
+    r = cls_cxx_gather(hctx, src_objects, pool, cls.c_str(), method.c_str(), *in);
+  } else {
+    // write data gathered using remote reads
+    int offset = 0;
+    for (std::map<std::string, bufferlist>::iterator it = src_obj_buffs.begin(); it != src_obj_buffs.end(); it++) {
+      bufferlist bl= it->second;
+      r = cls_cxx_write(hctx, offset, bl.length(), &bl);
+      offset += bl.length();
+    }
+  }
+  return r;
+}
+
+CLS_INIT(test_remote_reads)
+{
+  CLS_LOG(0, "loading cls_test_remote_reads");
+
+  cls_register("test_remote_reads", &h_class);
+  
+  cls_register_cxx_method(h_class, "test_read",
+			  CLS_METHOD_RD,
+			  test_read, &h_test_read);
+
+  cls_register_cxx_method(h_class, "test_gather",
+			  CLS_METHOD_RD | CLS_METHOD_WR,
+			  test_gather, &h_test_gather);
+}

--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -489,7 +489,7 @@ int cls_cxx_gather(cls_method_context_t hctx, const std::set<std::string> &src_o
   return 0;
 }
 
-std::shared_ptr<std::map<std::string, bufferlist> > cls_cxx_get_gathered_data(cls_method_context_t hctx)
+int cls_cxx_get_gathered_data(cls_method_context_t hctx, std::map<std::string, bufferlist> *results)
 {
-  return std::shared_ptr<std::map<std::string, bufferlist> >(new std::map<std::string, bufferlist>);
+  return 0;
 }

--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -482,3 +482,14 @@ uint64_t cls_get_osd_min_alloc_size(cls_method_context_t hctx) {
   // FIXME
   return 4096;
 }
+
+int cls_cxx_gather(cls_method_context_t hctx, const std::set<std::string> &src_objs, const std::string& pool,
+		   const char *cls, const char *method, bufferlist& inbl)
+{
+  return 0;
+}
+
+std::shared_ptr<std::map<std::string, bufferlist> > cls_cxx_get_gathered_data(cls_method_context_t hctx)
+{
+  return std::shared_ptr<std::map<std::string, bufferlist> >(new std::map<std::string, bufferlist>);
+}

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -152,7 +152,7 @@ extern int cls_get_snapset_seq(cls_method_context_t hctx, uint64_t *snap_seq);
 extern int cls_cxx_gather(cls_method_context_t hctx, const std::set<std::string> &src_objs, const std::string& pool,
 			  const char *cls, const char *method, bufferlist& inbl);
 
-extern std::shared_ptr<std::map<std::string, bufferlist> > cls_cxx_get_gathered_data(cls_method_context_t hctx);
+extern int cls_cxx_get_gathered_data(cls_method_context_t hctx, std::map<std::string, bufferlist> *results);
 
 /* These are also defined in rados.h and librados.h. Keep them in sync! */
 #define CEPH_OSD_TMAP_HDR 'h'

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -149,10 +149,10 @@ extern void cls_cxx_subop_version(cls_method_context_t hctx, std::string *s);
 extern int cls_get_snapset_seq(cls_method_context_t hctx, uint64_t *snap_seq);
 
 /* gather */
-extern int cls_cxx_gather(cls_method_context_t hctx, std::map<std::string, bufferlist*> *src_objs, const std::string& pool,
+extern int cls_cxx_gather(cls_method_context_t hctx, const std::set<std::string> &src_objs, const std::string& pool,
 			  const char *cls, const char *method, bufferlist& inbl);
 
-extern std::map<std::string, bufferlist*> *cls_cxx_get_gathered_data(cls_method_context_t hctx);
+extern std::shared_ptr<std::map<std::string, bufferlist> > cls_cxx_get_gathered_data(cls_method_context_t hctx);
 
 /* These are also defined in rados.h and librados.h. Keep them in sync! */
 #define CEPH_OSD_TMAP_HDR 'h'

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -148,6 +148,12 @@ extern void cls_cxx_subop_version(cls_method_context_t hctx, std::string *s);
 
 extern int cls_get_snapset_seq(cls_method_context_t hctx, uint64_t *snap_seq);
 
+/* gather */
+extern int cls_cxx_gather(cls_method_context_t hctx, std::map<std::string, bufferlist*> *src_objs, const std::string& pool,
+			  const char *cls, const char *method, bufferlist& inbl);
+
+extern std::map<std::string, bufferlist*> *cls_cxx_get_gathered_data(cls_method_context_t hctx);
+
 /* These are also defined in rados.h and librados.h. Keep them in sync! */
 #define CEPH_OSD_TMAP_HDR 'h'
 #define CEPH_OSD_TMAP_SET 's'

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10109,7 +10109,9 @@ int PrimaryLogPG::start_cls_gather(OpContext *ctx, std::map<std::string, bufferl
 {
   OpRequestRef op = ctx->op;
   MOSDOp *m = static_cast<MOSDOp*>(op->get_nonconst_req());
-  object_locator_t oloc = m->get_object_locator();
+
+  auto pool_id = osd->objecter->with_osdmap(std::mem_fn(&OSDMap::lookup_pg_pool_name), pool);
+  object_locator_t oloc(pool_id);
 
   ObjectState& obs = ctx->new_obs;
   object_info_t& oi = obs.oi;
@@ -10125,7 +10127,6 @@ int PrimaryLogPG::start_cls_gather(OpContext *ctx, std::map<std::string, bufferl
     std::string oid = it->first;
     ObjectOperation obj_op;
     obj_op.call(cls, method, inbl);
-    int64_t ret = osd->objecter->with_osdmap(std::mem_fn(&OSDMap::lookup_pg_pool_name), pool);
     uint32_t flags = 0;
     ceph_tid_t tid = osd->objecter->read(
 					 object_t(oid), oloc, obj_op,

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10086,16 +10086,14 @@ struct C_gather : public Context {
   void finish(int r) override {
     if (r == -ECANCELED)
       return;
-    pg->lock();
+    std::scoped_lock locker{*pg};
     map<hobject_t,PrimaryLogPG::CLSGatherOp>::iterator p = pg->cls_gather_ops.find(oid);
     if (p == pg->cls_gather_ops.end()) {
       // op was cancelled
-      pg->unlock();
       return;
     }
     pg->cls_gather_set_result(p, r);
     pg->execute_ctx(ctx);
-    pg->unlock();
   }
 };
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10089,7 +10089,7 @@ struct C_gather : public Context {
     if (r == -ECANCELED)
       return;
     std::scoped_lock locker{*pg};
-    map<hobject_t,PrimaryLogPG::CLSGatherOp>::iterator p = pg->cls_gather_ops.find(oid);
+    auto p = pg->cls_gather_ops.find(oid);
     if (p == pg->cls_gather_ops.end()) {
       // op was cancelled
       return;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10099,7 +10099,7 @@ struct C_gather : public Context {
   }
 };
 
-int PrimaryLogPG::start_cls_gather(OpContext *ctx, std::shared_ptr<std::map<std::string, bufferlist> > src_obj_buffs, const std::string& pool,
+int PrimaryLogPG::start_cls_gather(OpContext *ctx, std::map<std::string, bufferlist> *src_obj_buffs, const std::string& pool,
 				   const char *cls, const char *method, bufferlist& inbl)
 {
   OpRequestRef op = ctx->op;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10108,10 +10108,7 @@ int PrimaryLogPG::cls_gather(OpContext *ctx, std::map<std::string, bufferlist*> 
   ObjectContextRef obc = get_object_context(soid, false);
   C_GatherBuilder gather(cct);
 
-  CLSGatherOpRef cgop(std::make_shared<CLSGatherOp>());
-  cgop->ctx = ctx;
-  cgop->obc = obc;
-  cgop->op = op;
+  CLSGatherOpRef cgop(std::make_shared<CLSGatherOp>(ctx, obc, op));
   for (std::map<std::string, bufferlist*>::iterator it = src_objs->begin(); it != src_objs->end(); it++) {
     std::string oid = it->first;
     it->second = new bufferlist;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10109,6 +10109,7 @@ int PrimaryLogPG::cls_gather(OpContext *ctx, std::map<std::string, bufferlist*> 
   C_GatherBuilder gather(cct);
 
   CLSGatherOpRef cgop(std::make_shared<CLSGatherOp>());
+  cgop->ctx = ctx;
   cgop->obc = obc;
   cgop->op = op;
   for (std::map<std::string, bufferlist*>::iterator it = src_objs->begin(); it != src_objs->end(); it++) {
@@ -10938,7 +10939,8 @@ void PrimaryLogPG::cancel_cls_gather(CLSGatherOpRef cgop, bool requeue,
     dout(0) << __func__ << " " << cgop->obc->obs.oi.soid << " tid " << *p << dendl;
   }
   cgop->objecter_tids.clear();
-  object_contexts.purge(cgop->obc->obs.oi.soid);
+  close_op_ctx(cgop->ctx);
+  cgop->ctx = NULL;
   if (requeue) {
     if (cgop->op)
       requeue_op(cgop->op);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10144,7 +10144,7 @@ int PrimaryLogPG::finish_cls_gather(OpContext *ctx)
   map<hobject_t,PrimaryLogPG::CLSGatherOp>::iterator p = cls_gather_ops.find(soid);
   ceph_assert(p != cls_gather_ops.end());
   int r = p->second.rval;
-  cls_gather_ops.erase(soid);
+  cls_gather_ops.erase(p);
   return r;
 }
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10086,8 +10086,13 @@ struct C_gather : public Context {
   void finish(int r) override {
     if (r == -ECANCELED)
       return;
-    // TODO: check errors
     pg->lock();
+    map<hobject_t,PrimaryLogPG::CLSGatherOpRef>::iterator p = pg->cls_gather_ops.find(oid);
+    if (p == pg->cls_gather_ops.end()) {
+      // op was cancelled
+      pg->unlock();
+      return;
+    }
     pg->cls_gather_ops.erase(oid);
     pg->execute_ctx(ctx);
     pg->unlock();

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10936,7 +10936,7 @@ void PrimaryLogPG::cancel_cls_gather(CLSGatherOpRef cgop, bool requeue,
 {
   for (std::vector<ceph_tid_t>::iterator p = cgop->objecter_tids.begin(); p != cgop->objecter_tids.end(); p++) {
     tids->push_back(*p);
-    dout(0) << __func__ << " " << cgop->obc->obs.oi.soid << " tid " << *p << dendl;
+    dout(10) << __func__ << " " << cgop->obc->obs.oi.soid << " tid " << *p << dendl;
   }
   cgop->objecter_tids.clear();
   close_op_ctx(cgop->ctx);

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -259,11 +259,11 @@ public:
   typedef std::shared_ptr<FlushOp> FlushOpRef;
 
   struct CLSGatherOp {
-    OpContext *ctx;
+    OpContext *ctx = nullptr;
     ObjectContextRef obc;
     OpRequestRef op;
     std::vector<ceph_tid_t> objecter_tids;
-    int rval;
+    int rval = 0;
 
     CLSGatherOp(OpContext *ctx_, ObjectContextRef obc_, OpRequestRef op_)
       : ctx(ctx_), obc(obc_), op(op_)  {}

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -258,6 +258,17 @@ public:
   };
   typedef std::shared_ptr<FlushOp> FlushOpRef;
 
+  struct CLSGatherOp {
+    ObjectContextRef obc;
+    OpRequestRef op;
+    std::vector<ceph_tid_t> objecter_tids;
+    int rval;
+
+    CLSGatherOp() {}
+    ~CLSGatherOp() {}
+  };
+  typedef std::shared_ptr<CLSGatherOp> CLSGatherOpRef;
+
   friend struct RefCountCallback;
   struct ManifestOp {
     RefCountCallback *cb;
@@ -1389,6 +1400,11 @@ protected:
   bool is_present_clone(hobject_t coid);
 
   friend struct C_Flush;
+
+  // -- cls_gather --
+  std::map<hobject_t, CLSGatherOpRef> cls_gather_ops;
+  void cancel_cls_gather(CLSGatherOpRef cgop, bool requeue, std::vector<ceph_tid_t> *tids);
+  void cancel_cls_gather_ops(bool requeue, std::vector<ceph_tid_t> *tids);
 
   // -- scrub --
   bool _range_available_for_scrub(

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1405,6 +1405,7 @@ protected:
 
   // -- cls_gather --
   std::map<hobject_t, CLSGatherOp> cls_gather_ops;
+  void cls_gather_set_result(hobject_t oid, int r);
   void cancel_cls_gather(CLSGatherOp cgop, bool requeue, std::vector<ceph_tid_t> *tids);
   void cancel_cls_gather_ops(bool requeue, std::vector<ceph_tid_t> *tids);
 
@@ -1551,8 +1552,10 @@ public:
   int do_tmapup_slow(OpContext *ctx, ceph::buffer::list::const_iterator& bp, OSDOp& osd_op, ceph::buffer::list& bl);
 
   void do_osd_op_effects(OpContext *ctx, const ConnectionRef& conn);
-  int cls_gather(OpContext *ctx, std::shared_ptr<std::map<std::string, bufferlist> > src_objs, const std::string& pool,
-		 const char *cls, const char *method, bufferlist& inbl);
+  int start_cls_gather(OpContext *ctx, std::shared_ptr<std::map<std::string, bufferlist> > src_objs, const std::string& pool,
+		       const char *cls, const char *method, bufferlist& inbl);
+  int finish_cls_gather(OpContext *ctx);
+
 private:
   int do_scrub_ls(const MOSDOp *op, OSDOp *osd_op);
   bool check_src_targ(const hobject_t& soid, const hobject_t& toid) const;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -266,7 +266,7 @@ public:
     int rval;
 
     CLSGatherOp(OpContext *ctx_, ObjectContextRef obc_, OpRequestRef op_)
-      : ctx(ctx_), obc(obc_), op(op_) {}
+      : ctx(ctx_), obc(obc_), op(op_)  {}
     CLSGatherOp() {}
     ~CLSGatherOp() {}
   };
@@ -1405,8 +1405,8 @@ protected:
 
   // -- cls_gather --
   std::map<hobject_t, CLSGatherOp> cls_gather_ops;
-  void cls_gather_set_result(hobject_t oid, int r);
-  void cancel_cls_gather(CLSGatherOp cgop, bool requeue, std::vector<ceph_tid_t> *tids);
+  void cls_gather_set_result(map<hobject_t,PrimaryLogPG::CLSGatherOp>::iterator p, int r);
+  void cancel_cls_gather(map<hobject_t,CLSGatherOp>::iterator iter, bool requeue, std::vector<ceph_tid_t> *tids);
   void cancel_cls_gather_ops(bool requeue, std::vector<ceph_tid_t> *tids);
 
   // -- scrub --

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -267,9 +267,9 @@ public:
 
     CLSGatherOp(OpContext *ctx_, ObjectContextRef obc_, OpRequestRef op_)
       : ctx(ctx_), obc(obc_), op(op_) {}
+    CLSGatherOp() {}
     ~CLSGatherOp() {}
   };
-  typedef std::shared_ptr<CLSGatherOp> CLSGatherOpRef;
 
   friend struct RefCountCallback;
   struct ManifestOp {
@@ -1404,8 +1404,8 @@ protected:
   friend struct C_Flush;
 
   // -- cls_gather --
-  std::map<hobject_t, CLSGatherOpRef> cls_gather_ops;
-  void cancel_cls_gather(CLSGatherOpRef cgop, bool requeue, std::vector<ceph_tid_t> *tids);
+  std::map<hobject_t, CLSGatherOp> cls_gather_ops;
+  void cancel_cls_gather(CLSGatherOp cgop, bool requeue, std::vector<ceph_tid_t> *tids);
   void cancel_cls_gather_ops(bool requeue, std::vector<ceph_tid_t> *tids);
 
   // -- scrub --

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1405,7 +1405,6 @@ protected:
 
   // -- cls_gather --
   std::map<hobject_t, CLSGatherOp> cls_gather_ops;
-  void cls_gather_set_result(map<hobject_t,PrimaryLogPG::CLSGatherOp>::iterator p, int r);
   void cancel_cls_gather(map<hobject_t,CLSGatherOp>::iterator iter, bool requeue, std::vector<ceph_tid_t> *tids);
   void cancel_cls_gather_ops(bool requeue, std::vector<ceph_tid_t> *tids);
 
@@ -1554,7 +1553,6 @@ public:
   void do_osd_op_effects(OpContext *ctx, const ConnectionRef& conn);
   int start_cls_gather(OpContext *ctx, std::map<std::string, bufferlist> *src_objs, const std::string& pool,
 		       const char *cls, const char *method, bufferlist& inbl);
-  int finish_cls_gather(OpContext *ctx);
 
 private:
   int do_scrub_ls(const MOSDOp *op, OSDOp *osd_op);

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -196,7 +196,8 @@ public:
   friend struct CopyFromFinisher;
   friend class PromoteCallback;
   friend struct PromoteFinisher;
-
+  friend class C_gather;
+  
   struct ProxyReadOp {
     OpRequestRef op;
     hobject_t soid;
@@ -1532,6 +1533,8 @@ public:
   int do_tmapup_slow(OpContext *ctx, ceph::buffer::list::const_iterator& bp, OSDOp& osd_op, ceph::buffer::list& bl);
 
   void do_osd_op_effects(OpContext *ctx, const ConnectionRef& conn);
+  int cls_gather(OpContext *ctx, std::map<std::string, bufferlist*> *src_objs, const std::string& pool,
+		 const char *cls, const char *method, bufferlist& inbl);
 private:
   int do_scrub_ls(const MOSDOp *op, OSDOp *osd_op);
   bool check_src_targ(const hobject_t& soid, const hobject_t& toid) const;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1551,7 +1551,7 @@ public:
   int do_tmapup_slow(OpContext *ctx, ceph::buffer::list::const_iterator& bp, OSDOp& osd_op, ceph::buffer::list& bl);
 
   void do_osd_op_effects(OpContext *ctx, const ConnectionRef& conn);
-  int cls_gather(OpContext *ctx, std::map<std::string, bufferlist*> *src_objs, const std::string& pool,
+  int cls_gather(OpContext *ctx, std::shared_ptr<std::map<std::string, bufferlist> > src_objs, const std::string& pool,
 		 const char *cls, const char *method, bufferlist& inbl);
 private:
   int do_scrub_ls(const MOSDOp *op, OSDOp *osd_op);

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -259,6 +259,7 @@ public:
   typedef std::shared_ptr<FlushOp> FlushOpRef;
 
   struct CLSGatherOp {
+    OpContext *ctx;
     ObjectContextRef obc;
     OpRequestRef op;
     std::vector<ceph_tid_t> objecter_tids;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1552,7 +1552,7 @@ public:
   int do_tmapup_slow(OpContext *ctx, ceph::buffer::list::const_iterator& bp, OSDOp& osd_op, ceph::buffer::list& bl);
 
   void do_osd_op_effects(OpContext *ctx, const ConnectionRef& conn);
-  int start_cls_gather(OpContext *ctx, std::shared_ptr<std::map<std::string, bufferlist> > src_objs, const std::string& pool,
+  int start_cls_gather(OpContext *ctx, std::map<std::string, bufferlist> *src_objs, const std::string& pool,
 		       const char *cls, const char *method, bufferlist& inbl);
   int finish_cls_gather(OpContext *ctx);
 

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -265,7 +265,8 @@ public:
     std::vector<ceph_tid_t> objecter_tids;
     int rval;
 
-    CLSGatherOp() {}
+    CLSGatherOp(OpContext *ctx_, ObjectContextRef obc_, OpRequestRef op_)
+      : ctx(ctx_), obc(obc_), op(op_) {}
     ~CLSGatherOp() {}
   };
   typedef std::shared_ptr<CLSGatherOp> CLSGatherOpRef;

--- a/src/osd/objclass.cc
+++ b/src/osd/objclass.cc
@@ -727,6 +727,7 @@ int cls_cxx_gather(cls_method_context_t hctx, const std::set<std::string> &src_o
 
 int cls_cxx_get_gathered_data(cls_method_context_t hctx, std::map<std::string, bufferlist> *results)
 {
+  assert(results);
   PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext**)hctx;
   PrimaryLogPG::OpFinisher* op_finisher = nullptr;
   int r = 0;

--- a/src/osd/objclass.cc
+++ b/src/osd/objclass.cc
@@ -736,7 +736,7 @@ int cls_cxx_get_gathered_data(cls_method_context_t hctx, std::map<std::string, b
       op_finisher = op_finisher_it->second.get();
     }
   }
-  if (op_finisher == NULL) {
+  if (op_finisher == nullptr) {
     results->clear();
   } else {
     GatherFinisher *gf = (GatherFinisher*)op_finisher;

--- a/src/osd/objclass.cc
+++ b/src/osd/objclass.cc
@@ -740,7 +740,7 @@ int cls_cxx_get_gathered_data(cls_method_context_t hctx, std::map<std::string, b
     results->clear();
   } else {
     GatherFinisher *gf = (GatherFinisher*)op_finisher;
-    *results = gf->src_obj_buffs;
+    *results = std::move(gf->src_obj_buffs);
     r = gf->osd_op->rval;
   }
   return r;

--- a/src/osd/objclass.cc
+++ b/src/osd/objclass.cc
@@ -700,3 +700,41 @@ uint64_t cls_get_pool_stripe_width(cls_method_context_t hctx)
 
   return ctx->pg->get_pool().stripe_width;
 }
+
+struct GatherFinisher : public PrimaryLogPG::OpFinisher {
+  std::shared_ptr<std::map<std::string, bufferlist> > src_obj_buffs;
+  GatherFinisher(std::shared_ptr<std::map<std::string, bufferlist> > sob) : src_obj_buffs(sob) {}
+  int execute() override {
+    return 0;
+  }
+};
+
+int cls_cxx_gather(cls_method_context_t hctx, const std::set<std::string> &src_objs, const std::string& pool,
+		   const char *cls, const char *method, bufferlist& inbl)
+{
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext**)hctx;
+  std::shared_ptr<std::map<std::string, bufferlist> > src_obj_buffs(new std::map<std::string, bufferlist>);
+  for (std::set<std::string>::const_iterator it = src_objs.begin(); it != src_objs.end(); ++it) {
+    (*src_obj_buffs)[*it] = bufferlist();
+  }
+  (*pctx)->op_finishers[(*pctx)->current_osd_subop_num].reset(new GatherFinisher(src_obj_buffs));
+  return (*pctx)->pg->cls_gather(*pctx, src_obj_buffs, pool, cls, method, inbl);
+}
+
+std::shared_ptr<std::map<std::string, bufferlist> > cls_cxx_get_gathered_data(cls_method_context_t hctx)
+{
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext**)hctx;
+  PrimaryLogPG::OpFinisher* op_finisher = nullptr;
+  {
+    auto op_finisher_it = (*pctx)->op_finishers.find((*pctx)->current_osd_subop_num);
+    if (op_finisher_it != (*pctx)->op_finishers.end()) {
+      op_finisher = op_finisher_it->second.get();
+    }
+  }
+  if (op_finisher == NULL) {
+    return std::shared_ptr<std::map<std::string, bufferlist> >(new std::map<std::string, bufferlist>);
+  } else {
+    GatherFinisher *gf = (GatherFinisher*)op_finisher;
+    return std::move(gf->src_obj_buffs);
+  }
+}

--- a/src/test/librados/CMakeLists.txt
+++ b/src/test/librados/CMakeLists.txt
@@ -141,6 +141,12 @@ add_executable(ceph_test_rados_api_snapshots_pp
 target_link_libraries(ceph_test_rados_api_snapshots_pp
   librados ${UNITTEST_LIBS} radostest-cxx)
 
+add_executable(ceph_test_rados_api_cls_remote_reads
+  cls_remote_reads.cc
+  $<TARGET_OBJECTS:unit-main>)
+target_link_libraries(ceph_test_rados_api_cls_remote_reads
+  librados global ${UNITTEST_LIBS} radostest-cxx)
+
 install(TARGETS
   ceph_test_rados_api_aio
   ceph_test_rados_api_aio_pp
@@ -166,6 +172,7 @@ install(TARGETS
   ceph_test_rados_api_tier_pp
   ceph_test_rados_api_watch_notify
   ceph_test_rados_api_watch_notify_pp
+  ceph_test_rados_api_cls_remote_reads
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # unittest_librados

--- a/src/test/librados/cls_remote_reads.cc
+++ b/src/test/librados/cls_remote_reads.cc
@@ -1,0 +1,52 @@
+#include <set>
+#include <string>
+
+#include "common/ceph_json.h"
+#include "gtest/gtest.h"
+#include "test/librados/test_cxx.h"
+
+using namespace librados;
+
+TEST(ClsTestRemoteReads, TestGather) {
+  Rados cluster;
+  std::string pool_name = get_temp_pool_name();
+  ASSERT_EQ("", create_one_pool_pp(pool_name, cluster));
+  IoCtx ioctx;
+  cluster.ioctx_create(pool_name.c_str(), ioctx);
+
+  bufferlist in, out;
+  int object_size = 4096;
+  char buf[object_size];
+  memset(buf, 1, sizeof(buf));
+
+  // create source objects from which data are gathered
+  in.append(buf, sizeof(buf));
+  ASSERT_EQ(0, ioctx.write_full("src_object.1", in));
+  in.append(buf, sizeof(buf));
+  ASSERT_EQ(0, ioctx.write_full("src_object.2", in));
+  in.append(buf, sizeof(buf));
+  ASSERT_EQ(0, ioctx.write_full("src_object.3", in));
+
+  // construct JSON request passed to "test_gather" method, and in turn, to "test_read" method
+  JSONFormatter *formatter = new JSONFormatter(true);
+  formatter->open_object_section("foo");
+  std::set<std::string> src_objects;
+  src_objects.insert("src_object.1");
+  src_objects.insert("src_object.2");
+  src_objects.insert("src_object.3");
+  encode_json("src_objects", src_objects, formatter);
+  encode_json("cls", "test_remote_reads", formatter);
+  encode_json("method", "test_read", formatter);
+  encode_json("pool", pool_name, formatter);
+  formatter->close_section();
+  in.clear();
+  formatter->flush(in);
+
+  // create target object by combining data gathered from source objects using "test_read" method
+  ASSERT_EQ(0, ioctx.exec("tgt_object", "test_remote_reads", "test_gather", in, out));
+
+  // read target object and check its size
+  ASSERT_EQ(3*object_size, ioctx.read("tgt_object", out, 0, 0));
+
+  ASSERT_EQ(0, destroy_one_pool_pp(pool_name, cluster));
+}


### PR DESCRIPTION
This commit implements cls_cxx_gather() function, which can be used by a cls method to gather data from multiple source objects in parallel.

Fixes: https://tracker.ceph.com/issues/48182
Signed-off-by: Ken Iizawa <iizawa.ken@fujitsu.com>