### PR TITLE
client: do not unset the client_debug_inject_tick_delay

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6524,13 +6524,6 @@ void Client::start_tick_thread()
       auto t_interval = clock::duration(cct->_conf.get_val<sec>("client_tick_interval"));
       auto d_interval = clock::duration(cct->_conf.get_val<sec>("client_debug_inject_tick_delay"));
 
-      // Clear the debug inject tick delay
-      if (unlikely(d_interval.count() > 0)) {
-        ldout(cct, 20) << "clear debug inject tick delay: " << d_interval << dendl;
-        ceph_assert(0 == cct->_conf.set_val("client_debug_inject_tick_delay", "0"));
-        cct->_conf.apply_changes(nullptr);
-      }
-
       auto interval = std::max(t_interval, d_interval);
       if (likely(since >= interval)) {
         tick();


### PR DESCRIPTION
https://tracker.ceph.com/issues/48235
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
