### PR TITLE
rgw: RGWListMultipart show Owner ID and DisplayName

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -400,8 +400,9 @@ static int get_multipart_info(const DoutPrefixProvider *dpp, struct req_state *s
 }
 
 static int get_multipart_info(const DoutPrefixProvider *dpp, struct req_state *s,
-			      const string& meta_oid,
-                              multipart_upload_info *upload_info)
+                              const string& meta_oid,
+                              multipart_upload_info *upload_info,
+                              rgw::sal::Attrs* attrs = nullptr)
 {
   map<string, bufferlist>::iterator iter;
   bufferlist header;
@@ -410,7 +411,11 @@ static int get_multipart_info(const DoutPrefixProvider *dpp, struct req_state *s
   meta_obj = s->bucket->get_object(rgw_obj_key(meta_oid, string(), mp_ns));
   meta_obj->set_in_extra_data(true);
 
-  return get_multipart_info(dpp, s, meta_obj.get(), upload_info);
+  int ret = get_multipart_info(dpp, s, meta_obj.get(), upload_info);
+  if (ret >= 0 && attrs) {
+    *attrs = meta_obj->get_attrs();
+  }
+  return ret;
 }
 
 static int read_bucket_policy(const DoutPrefixProvider *dpp, 
@@ -6261,7 +6266,19 @@ void RGWListMultipart::execute(optional_yield y)
   mp.init(s->object->get_name(), upload_id);
   meta_oid = mp.get_meta();
 
-  op_ret = get_multipart_info(this, s, meta_oid, nullptr);
+  rgw::sal::Attrs attrs;
+  op_ret = get_multipart_info(this, s, meta_oid, nullptr, &attrs);
+  /* decode policy */
+  map<string, bufferlist>::iterator iter = attrs.find(RGW_ATTR_ACL);
+  if (iter != attrs.end()) {
+    auto bliter = iter->second.cbegin();
+    try {
+      policy.decode(bliter);
+    } catch (buffer::error& err) {
+      ldpp_dout(this, 0) << "ERROR: could not decode policy, caught buffer::error" << dendl;
+      op_ret = -EIO;
+    }
+  }
   if (op_ret < 0)
     return;
 


### PR DESCRIPTION
fix https://tracker.ceph.com/issues/48262

```
<ListPartsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
<Bucket>appendtest</Bucket>
<Key>obj1</Key>
<UploadId>2~aNbTkapHNJAQntTKFBCDJM7UluF5k1w</UploadId>
<StorageClass>STANDARD</StorageClass>
<PartNumberMarker>0</PartNumberMarker>
<NextPartNumberMarker>0</NextPartNumberMarker>
<MaxParts>1000</MaxParts>
<IsTruncated>false</IsTruncated>
<Owner>
<ID></ID>   <= empty here
<DisplayName></DisplayName> <= empty here
</Owner>
</ListPartsResult>
```

Signed-off-by: yuliyang_yewu <yuliyang_yewu@cmss.chinamobile.com>

