### PR TITLE
cephadm: fix podman failure to pull authenticated registry image from systemd unit

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2597,6 +2597,10 @@ class CephContainer:
             '--rm',
             '--ipc=host',
         ]
+
+        if 'podman' in container_path and os.path.exists('/etc/ceph/podman-auth.json'):
+            cmd_args.append('--authfile=/etc/ceph/podman-auth.json')
+
         envs: List[str] = [
             '-e', 'CONTAINER_IMAGE=%s' % self.image,
             '-e', 'NODE_NAME=%s' % get_hostname(),
@@ -2739,6 +2743,8 @@ def _pull_image(image):
     ]
 
     cmd = [container_path, 'pull', image]
+    if 'podman' in container_path and os.path.exists('/etc/ceph/podman-auth.json'):
+            cmd.append('--authfile=/etc/ceph/podman-auth.json')
     cmd_str = ' '.join(cmd)
 
     for sleep_secs in [1, 4, 25]:
@@ -3392,10 +3398,14 @@ def command_registry_login():
 def registry_login(url, username, password):
     logger.info("Logging into custom registry.")
     try:
-        out, _, _ = call_throws([container_path, 'login',
-                                   '-u', username,
-                                   '-p', password,
-                                   url])
+        cmd = [container_path, 'login',
+               '-u', username, '-p', password,
+               url]
+        if 'podman' in container_path:
+            cmd.append('--authfile=/etc/ceph/podman-auth.json')
+        out, _, _ = call_throws(cmd)
+        if 'podman' in container_path:
+            os.chmod('/etc/ceph/podman-auth.json', 0o600)
     except:
         raise Error("Failed to login to custom registry @ %s as %s with given password" % (args.registry_url, args.registry_username))
 
@@ -3870,7 +3880,7 @@ def list_daemons(detail=True, legacy_dir=None):
             elif is_fsid(i):
                 fsid = str(i)  # convince mypy that fsid is a str here
                 for j in os.listdir(os.path.join(data_dir, i)):
-                    if '.' in j:
+                    if '.' in j and os.path.isdir(os.path.join(data_dir, fsid, j)):
                         name = j
                         (daemon_type, daemon_id) = j.split('.', 1)
                         unit_name = get_unit_name(fsid,


### PR DESCRIPTION
when the pull is initiated from unit.run and it is pulling from a authenticated registry it fails
all other containers pull there image during the extract_uid_gid() function

example of a failure: https://pastebin.com/w803smSQ

I login to the registry successfully, run bootstrap, check the containers running, look at the mgr log until the error occurs, check the log for the nodeexporter service which says it cant pull the container because of auth problems, and finally I manually pull the image with no issues.

same issue occurs when using the cephadm registry-login command or flags during bootstrap


I tracked down that node exporter is the only service that does not call extract_uid_gid() here https://github.com/ceph/ceph/blob/master/src/cephadm/cephadm#L3337

I dont understand why the pull is successful in extract_uid_gid()  and why it failes in unit.run any info on that would be helpful.

Signed-off-by: Daniel-Pivonka <dpivonka@redhat.com>
