### PR TITLE
doc/dev/developer_guide: What Is Merged and When?" could be less colloquial

### DIFF
--- a/doc/dev/developer_guide/merging.rst
+++ b/doc/dev/developer_guide/merging.rst
@@ -1,11 +1,10 @@
 .. _merging:
 
-What is Merged Where and When?
-===============================
+Commit merging:  scope and cadence
+==================================
 
-Commits are merged into branches according to criteria that change
-during the lifecycle of a Ceph release. This chapter is the inventory
-of what can be merged in which branch at a given point in time.
+Commits are merged into branches according to criteria specific to each phase
+of the Ceph release lifecycle. This chapter codifies these criteria.
 
 Development releases (i.e. x.0.z)
 ---------------------------------
@@ -13,38 +12,37 @@ Development releases (i.e. x.0.z)
 What ?
 ^^^^^^
 
-* features
-* bug fixes
+* Features
+* Bug fixes
 
 Where ?
 ^^^^^^^
 
-Features are merged to the master branch. Bug fixes should be merged
-to the corresponding named branch (e.g. "jewel" for 10.0.z, "kraken"
-for 11.0.z, etc.). However, this is not mandatory - bug fixes can be
-merged to the master branch as well, since the master branch is
-periodically merged to the named branch during the development
-releases phase. In either case, if the bugfix is important it can also
-be flagged for backport to one or more previous stable releases.
+Features are merged to the *master* branch. Bug fixes should be merged to the
+corresponding named branch (e.g. *nautilus* for 14.0.z, *pacific* for 16.0.z,
+etc.). However, this is not mandatory - bug fixes and documentation
+enhancements can be merged to the *master* branch as well, since the *master*
+branch is itself occasionally merged to the named branch during the development
+releases phase. In either case, if a bug fix is important it can also be
+flagged for backport to one or more previous stable releases.
 
 When ?
 ^^^^^^
 
-After the stable release candidates of the previous release enters
-phase 2 (see below).  For example: the "jewel" named branch was
-created when the infernalis release candidates entered phase 2. From
-this point on, master was no longer associated with infernalis. As
-soon as the named branch of the next stable release is created, master
-starts getting periodically merged into it.
+After each stable release, candidate branches for previous releases enter
+phase 2 (see below).  For example: the *jewel* named branch was created when
+the *infernalis* release candidates entered phase 2. From this point on,
+*master* was no longer associated with *infernalis*. After he named branch of
+the next stable release is created, *master* will be occasionally merged into
+it.
 
 Branch merges
 ^^^^^^^^^^^^^
 
-* The branch of the stable release is merged periodically into master.
-* The master branch is merged periodically into the branch of the
-  stable release.
-* The master is merged into the branch of the stable release
-  immediately after each development x.0.z release.
+* The latest stable release branch is merged periodically into master.
+* The master branch is merged periodically into the branch of the stable release.
+* The master is merged into the stable release branch
+  immediately after each development (x.0.z) release.
 
 Stable release candidates (i.e. x.1.z) phase 1
 ----------------------------------------------
@@ -52,18 +50,18 @@ Stable release candidates (i.e. x.1.z) phase 1
 What ?
 ^^^^^^
 
-* bug fixes only
+* Bug fixes only
 
 Where ?
 ^^^^^^^
 
-The branch of the stable release (e.g. "jewel" for 10.0.z, "kraken"
-for 11.0.z, etc.) or master.  Bug fixes should be merged to the named
-branch corresponding to the stable release candidate (e.g. "jewel" for
-10.1.z) or to master. During this phase, all commits to master will be
+The stable release branch (e.g. *jewel* for 10.0.z, *luminous*
+for 12.0.z, etc.) or *master*.  Bug fixes should be merged to the named
+branch corresponding to the stable release candidate (e.g. *jewel* for
+10.1.z) or to *master*. During this phase, all commits to *master* will be
 merged to the named branch, and vice versa. In other words, it makes
 no difference whether a commit is merged to the named branch or to
-master - it will make it into the next release candidate either way.
+*master* - it will make it into the next release candidate either way.
 
 When ?
 ^^^^^^
@@ -74,10 +72,9 @@ x.1.0 tag is set in the release branch.
 Branch merges
 ^^^^^^^^^^^^^
 
-* The branch of the stable release is merged periodically into master.
-* The master branch is merged periodically into the branch of the
-  stable release.
-* The master is merged into the branch of the stable release
+* The stable release branch is merged periodically into *master*.
+* The *master* branch is merged periodically into the stable release branch.
+* The *master* branch is merged into the stable release branch
   immediately after each x.1.z release candidate.
 
 Stable release candidates (i.e. x.1.z) phase 2
@@ -86,27 +83,26 @@ Stable release candidates (i.e. x.1.z) phase 2
 What ?
 ^^^^^^
 
-* bug fixes only
+* Bug fixes only
 
 Where ?
 ^^^^^^^
 
-The branch of the stable release (e.g. "jewel" for 10.0.z, "kraken"
-for 11.0.z, etc.). During this phase, all commits to the named branch
-will be merged into master. Cherry-picking to the named branch during
-release candidate phase 2 is done manually since the official
-backporting process only begins when the release is pronounced
-"stable".
+The stable release branch (e.g. *mimic* for 13.0.z, *octopus* for 15.0.z
+,etc.). During this phase, all commits to the named branch will be merged into
+*master*. Cherry-picking to the named branch during release candidate phase 2
+is performed manually since the official backporting process begins only when
+the release is pronounced "stable".
 
 When ?
 ^^^^^^
 
-After Sage Weil decides it is time for phase 2 to happen.
+After Sage Weil announces that it is time for phase 2 to happen.
 
 Branch merges
 ^^^^^^^^^^^^^
 
-* The branch of the stable release is merged periodically into master.
+* The stable release branch is occasionally merged into master.
 
 Stable releases (i.e. x.2.z)
 ----------------------------
@@ -114,21 +110,20 @@ Stable releases (i.e. x.2.z)
 What ?
 ^^^^^^
 
-* bug fixes
-* features are sometime accepted
-* commits should be cherry-picked from master when possible
-
-* commits that are not cherry-picked from master must be about a bug unique to
+* Bug fixes
+* Features are sometime accepted
+* Commits should be cherry-picked from *master* when possible
+* Commits that are not cherry-picked from *master* must pertain to a bug unique to
   the stable release
-* see also `the backport HOWTO`_
+* See also the `backport HOWTO`_ document
 
-.. _`the backport HOWTO`:
+.. _`backport HOWTO`:
   http://tracker.ceph.com/projects/ceph-releases/wiki/HOWTO#HOWTO
 
 Where ?
 ^^^^^^^
 
-The branch of the stable release (hammer for 0.94.x, infernalis for 9.2.x,
+The stable release branch (*hammer* for 0.94.x, *infernalis* for 9.2.x,
 etc.)
 
 When ?


### PR DESCRIPTION
doc/dev/developer_guide: "What Is Merged and When?" could be less colloquial

... and misc cleanup and formatting.

Fixes: https://tracker.ceph.com/issues/46364
Signed-off-by: Anthony D'Atri <anthony.datri@gmail.com>

@zdover23 PTAL.  I've endeavored to not change any _meaning_ but welcome a second pair of eyes given that git branching can be subtle.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
