### PR TITLE
doc: increase visibility of the peering state diagram

### DIFF
--- a/doc/scripts/gen_state_diagram.py
+++ b/doc/scripts/gen_state_diagram.py
@@ -73,6 +73,17 @@ class StateMachineRenderer(object):
         self.subgraphnum = 0
         self.clusterlabel = {}
 
+        self.color_idx = 0
+        self.color_palette = [
+            "#000000",  # black
+            "#1e90ff",  # dodgerblue
+            "#ff0000",  # red
+            "#0000ff",  # blue
+            "#ffa500",  # orange
+            "#40e0d0",  # turquoise
+            "#c71585",  # mediumvioletred
+        ]
+
     def __str__(self):
         return "-------------------\n\nstates: %s\n\n machines: %s\n\n edges: %s\n\n context %s\n\n state_contents %s\n\n--------------------" % (
             self.states,
@@ -81,6 +92,13 @@ class StateMachineRenderer(object):
             self.context,
             self.state_contents
             )
+
+    def __next_color(self):
+        color = self.color_palette[self.color_idx]
+        self.color_idx += 1
+        if self.color_idx == len(self.color_palette):
+            self.color_idx = 0
+        return color
 
     def read_input(self, input_lines):
         previous_line = None
@@ -174,7 +192,12 @@ class StateMachineRenderer(object):
             yield "subgraph cluster%s {" % (str(self.subgraphnum),)
             self.subgraphnum += 1
             yield """\tlabel = "%s";""" % (state,)
-            yield """\tcolor = "blue";"""
+            yield """\tcolor = "black";"""
+
+            if state in self.machines.values():
+                yield """\tstyle = "filled";"""
+                yield """\tfillcolor = "lightgrey";"""
+
             for j in self.state_contents[state]:
                 for i in self.emit_state(j):
                     yield "\t"+i
@@ -183,7 +206,7 @@ class StateMachineRenderer(object):
             found = False
             for (k, v) in self.machines.items():
                 if v == state:
-                    yield state+"[shape=Mdiamond];"
+                    yield state+"[shape=Mdiamond style=filled fillcolor=lightgrey];"
                     found = True
                     break
             if not found:
@@ -197,7 +220,10 @@ class StateMachineRenderer(object):
             retval += "]"
             return retval
         for (fro, to) in self.edges[event]:
-            appendix = ['label="%s"' % (event,)]
+            color = self.__next_color()
+            appendix = ['label="%s"' % (event,),
+                        'color="%s"' % (color,),
+                        'fontcolor="%s"' % (color,)]
             if fro in self.machines.keys():
                 appendix.append("ltail=%s" % (self.clusterlabel[fro],))
                 while fro in self.machines.keys():


### PR DESCRIPTION
This change improves the visibility of the peering state diagram generated by the gen_state_diagram.py script in two aspects:

- Set the background color to "lightgray" for the nodes representing the initial states. Current code sets the shape of the initial nodes without an inner initial state to be "Mdiamond". However, it does nothing to the node with an inner initial state (e.g., Peering), which makes it hard to identify it to be the initial state of its parent.
- Use a distinguishable color palette for the coloring of the arrows and the associated labels. An arrow and the associated label have the same color such that we can see the label in the diagram is for this arrow and not for the other arrow with an equal (or shorter) distance to the label.

Here is the comparison between the current generated diagram and the diagram after the patch:
![peering_graph generated](https://user-images.githubusercontent.com/468515/99487761-e9e6b980-291b-11eb-84ed-56cf6ca4f450.png)
![peering_graph generated](https://user-images.githubusercontent.com/468515/99487883-18fd2b00-291c-11eb-8f8e-0aedef02d8b2.png)


Signed-off-by: Jianshen Liu <jliu120@ucsc.edu>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
