### PR TITLE
crimson/os: do not capture unused variables

### DIFF
--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -157,8 +157,7 @@ Journal::roll_journal_segment()
 
   return (current_journal_segment ?
 	  current_journal_segment->close() :
-	  Segment::close_ertr::now()).safe_then(
-    [this, old_segment_id] {
+	  Segment::close_ertr::now()).safe_then([this] {
       return segment_provider->get_segment();
     }).safe_then([this](auto segment) {
       return segment_manager.open(segment);
@@ -508,7 +507,7 @@ Journal::scan_segment_ret Journal::scan_segment(
 		[=, &current](auto &header, auto &bl) {
 		  return scan_segment_ertr::now(
 		  ).safe_then(
-		    [=, &current, &header, &bl]()
+		    [=, &header, &bl]()
 		    -> scan_segment_ertr::future<> {
 		    if (!delta_handler) {
 		      return scan_segment_ertr::now();
@@ -579,7 +578,7 @@ Journal::scan_segment_ret Journal::scan_segment(
 		  }
 		});
 	    });
-	}).safe_then([this, &current] {
+	}).safe_then([&current] {
 	  return scan_segment_ertr::make_ready_future<paddr_t>(current);
 	});
     });

--- a/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
+++ b/src/crimson/os/seastore/lba_manager/btree/btree_lba_manager.cc
@@ -436,7 +436,7 @@ BtreeLBAManager::get_physical_extent_if_live(
       return root->lookup(
 	op_context_t{cache, pin_set, t},
 	lba_node->get_node_meta().begin,
-	lba_node->get_node_meta().depth).safe_then([=, &t](LBANodeRef c) {
+	lba_node->get_node_meta().depth).safe_then([=](LBANodeRef c) {
 	  if (c->get_paddr() == lba_node->get_paddr()) {
 	    return get_physical_extent_if_live_ret(
 	      get_physical_extent_if_live_ertr::ready_future_marker{},

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -272,7 +272,7 @@ TransactionManager::get_extent_if_live_ret TransactionManager::get_extent_if_liv
 	    addr,
 	    laddr,
 	    len).safe_then(
-	      [this, &t, pin=std::move(pin)](CachedExtentRef ret) mutable {
+	      [this, pin=std::move(pin)](CachedExtentRef ret) mutable {
 		auto lref = ret->cast<LogicalCachedExtent>();
 		if (!lref->has_pin()) {
 		  lref->set_pin(std::move(pin));


### PR DESCRIPTION
silences warnings reported by clang iike:

btree_lba_manager.cc:439:50: warning: lambda capture 't' is not used [-Wunused-lambda-capture]
        lba_node->get_node_meta().depth).safe_then([=, &t](LBANodeRef c) {
                                                     ~~~^
1 warning generated.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
