### PR TITLE
ceph-volume batch: reject partitions in argparser

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -175,28 +175,28 @@ class Batch(object):
             'devices',
             metavar='DEVICES',
             nargs='*',
-            type=arg_validators.ValidDevice(),
+            type=arg_validators.ValidBatchDevice(),
             default=[],
             help='Devices to provision OSDs',
         )
         parser.add_argument(
             '--db-devices',
             nargs='*',
-            type=arg_validators.ValidDevice(),
+            type=arg_validators.ValidBatchDevice(),
             default=[],
             help='Devices to provision OSDs db volumes',
         )
         parser.add_argument(
             '--wal-devices',
             nargs='*',
-            type=arg_validators.ValidDevice(),
+            type=arg_validators.ValidBatchDevice(),
             default=[],
             help='Devices to provision OSDs wal volumes',
         )
         parser.add_argument(
             '--journal-devices',
             nargs='*',
-            type=arg_validators.ValidDevice(),
+            type=arg_validators.ValidBatchDevice(),
             default=[],
             help='Devices to provision OSDs journal volumes',
         )

--- a/src/ceph-volume/ceph_volume/util/arg_validators.py
+++ b/src/ceph-volume/ceph_volume/util/arg_validators.py
@@ -12,11 +12,23 @@ class ValidDevice(object):
         self.as_string = as_string
         self.gpt_ok = gpt_ok
 
-    def __call__(self, string):
-        device = Device(string)
+    def __call__(self, dev_path):
+        device = self._is_valid_device(dev_path)
+        return self._format_device(device)
+
+    def _format_device(self, device):
+        if self.as_string:
+            if device.is_lv:
+                # all codepaths expect an lv path to be returned in this format
+                return "{}/{}".format(device.vg_name, device.lv_name)
+            return device.path
+        return device
+
+    def _is_valid_device(self, dev_path):
+        device = Device(dev_path)
         error = None
         if not device.exists:
-            error = "Unable to proceed with non-existing device: %s" % string
+            error = "Unable to proceed with non-existing device: %s" % dev_path
         # FIXME this is not a nice API, this validator was meant to catch any
         # non-existing devices upfront, not check for gpt headers. Now this
         # needs to optionally skip checking gpt headers which is beyond
@@ -24,17 +36,24 @@ class ValidDevice(object):
         # configure this with a list of checks that can be excluded/included on
         # __init__
         elif device.has_gpt_headers and not self.gpt_ok:
-            error = "GPT headers found, they must be removed on: %s" % string
+            error = "GPT headers found, they must be removed on: %s" % dev_path
 
         if error:
             raise argparse.ArgumentError(None, error)
 
-        if self.as_string:
-            if device.is_lv:
-                # all codepaths expect an lv path to be returned in this format
-                return "{}/{}".format(device.vg_name, device.lv_name)
-            return string
         return device
+
+
+class ValidBatchDevice(ValidDevice):
+
+    def __call__(self, dev_path):
+        dev = self._is_valid_device(dev_path)
+        if dev.is_partition:
+            raise argparse.ArgumentError(
+                None,
+                '{} is a partition, please pass '
+                'LVs or raw block devices'.format(dev_path))
+        return self._format_device(dev)
 
 
 class OSDPath(object):


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47966

Signed-off-by: Jan Fajerski <jfajerski@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
