### PR TITLE
cephadm: `podman images` prints <none> despint dangling=false

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1410,12 +1410,16 @@ def get_last_local_ceph_image():
          '--filter', 'label=ceph=True',
          '--filter', 'dangling=false',
          '--format', '{{.Repository}} {{.Tag}}'])
+    return _filter_last_local_images(out)
+
+def _filter_last_local_images(out) -> Optional[str]:
     for line in out.splitlines():
         if len(line.split()) == 2:
             repository, tag = line.split()
-            r = '{}:{}'.format(repository, tag)
-            logger.info('Using recent ceph image %s' % r)
-            return r
+            if '<none>' not in [repository, tag]:
+                r = '{}:{}'.format(repository, tag)
+                logger.info('Using recent ceph image %s' % r)
+                return r
     return None
 
 

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -278,6 +278,10 @@ default via fe80::2480:28ec:5097:3fe2 dev wlp2s0 proto ra metric 20600 pref medi
         result = cd.dict_get_join({'a': 1}, 'a')
         assert result == 1
 
+    def test_filter_last_local_images(self):
+        assert cd._filter_last_local_images("""<none> <none>
+registry.suse.com/ses/7/ceph/ceph latest""") == 'registry.suse.com/ses/7/ceph/ceph:latest'
+
 
 class TestCustomContainer(unittest.TestCase):
     cc: cd.CustomContainer


### PR DESCRIPTION
We really need `get_last_local_ceph_image` to never return anything
containing `<none>`

Fixes: https://tracker.ceph.com/issues/48277

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

See also: #37186
Conflicts with #38032 @mgfritch 


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
