### PR TITLE
mgr/dashboard: fix exception in get_smart_data_by_daemon

### DIFF
--- a/src/pybind/mgr/dashboard/requirements-lint.txt
+++ b/src/pybind/mgr/dashboard/requirements-lint.txt
@@ -8,3 +8,4 @@ rstcheck==3.3.1; python_version >= '3'
 autopep8; python_version >= '3'
 pyfakefs; python_version >= '3'
 isort==5.5.3
+pytest

--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -303,7 +303,7 @@ class CephService(object):
                         CephService._get_smart_data_by_device(device))
         else:
             msg = '[SMART] could not retrieve device list from daemon with type %s and ' +\
-                'with ID %d'
+                'with ID %s'
             logger.debug(msg, daemon_type, daemon_id)
         return smart_data
 

--- a/src/pybind/mgr/dashboard/tests/test_ceph_service.py
+++ b/src/pybind/mgr/dashboard/tests/test_ceph_service.py
@@ -2,12 +2,12 @@
 # pylint: disable=dangerous-default-value,too-many-public-methods
 from __future__ import absolute_import
 
+import logging
 import unittest
+from contextlib import contextmanager
+from unittest import mock
 
-try:
-    import mock
-except ImportError:
-    import unittest.mock as mock
+import pytest
 
 from ..services.ceph_service import CephService
 
@@ -66,3 +66,44 @@ class CephServiceTest(unittest.TestCase):
 
     def test_get_pg_status_without_match(self):
         self.assertEqual(self.service.get_pool_pg_status('no-pool'), {})
+
+
+@contextmanager
+def mock_smart_data(data):
+    devices = [{'devid': devid} for devid in data]
+
+    def _get_smart_data(d):
+        return {d['devid']: data[d['devid']]}
+
+    with mock.patch.object(CephService, '_get_smart_data_by_device', side_effect=_get_smart_data), \
+            mock.patch.object(CephService, 'get_devices_by_host', return_value=devices), \
+            mock.patch.object(CephService, 'get_devices_by_daemon', return_value=devices):
+        yield
+
+
+@pytest.mark.parametrize(
+    "by,args,log",
+    [
+        ('host', ('osd0',), 'from host osd0'),
+        ('daemon', ('osd', '1'), 'with ID 1')
+    ]
+)
+def test_get_smart_data(caplog, by, args, log):
+    # pylint: disable=protected-access
+    expected_data = {
+        'aaa': {'device': {'name': '/dev/sda'}},
+        'bbb': {'device': {'name': '/dev/sdb'}},
+    }
+    with mock_smart_data(expected_data):
+        smart_data = getattr(CephService, 'get_smart_data_by_{}'.format(by))(*args)
+        getattr(CephService, 'get_devices_by_{}'.format(by)).assert_called_with(*args)
+        CephService._get_smart_data_by_device.assert_called()
+        assert smart_data == expected_data
+
+    with caplog.at_level(logging.DEBUG):
+        with mock_smart_data([]):
+            smart_data = getattr(CephService, 'get_smart_data_by_{}'.format(by))(*args)
+            getattr(CephService, 'get_devices_by_{}'.format(by)).assert_called_with(*args)
+            CephService._get_smart_data_by_device.assert_not_called()
+            assert smart_data == {}
+            assert log in caplog.text


### PR DESCRIPTION
- Fix string substitution exception.
- Add more test coverage.

Fixes: https://tracker.ceph.com/issues/48245
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
