### PR TITLE
octopus: qa/mgr: mgr_test_case: raise SkipTest instead of calling skipTest()

### DIFF
--- a/qa/tasks/mgr/mgr_test_case.py
+++ b/qa/tasks/mgr/mgr_test_case.py
@@ -1,6 +1,8 @@
 import json
 import logging
 
+from unittest import SkipTest
+
 from teuthology import misc
 from tasks.ceph_test_case import CephTestCase
 
@@ -99,7 +101,7 @@ class MgrTestCase(CephTestCase):
         assert cls.mgr_cluster is not None
 
         if len(cls.mgr_cluster.mgr_ids) < cls.MGRS_REQUIRED:
-            cls.skipTest(
+            raise SkipTest(
                 "Only have {0} manager daemons, {1} are required".format(
                     len(cls.mgr_cluster.mgr_ids), cls.MGRS_REQUIRED))
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48279

---

backport of https://github.com/ceph/ceph/pull/37992
parent tracker: https://tracker.ceph.com/issues/48152

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh