### PR TITLE
rgw: disable prefetch in rgw_file to fix 3x read amplification

### DIFF
--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -2041,6 +2041,8 @@ public:
     return 0;
   }
 
+  bool prefetch_data() override { return false; }
+
 }; /* RGWReadRequest */
 
 /*

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -888,7 +888,7 @@ int RGWGetObj::verify_permission(optional_yield y)
 {
   s->object->set_atomic(s->obj_ctx);
 
-  if (get_data) {
+  if (prefetch_data()) {
     s->object->set_prefetch_data(s->obj_ctx);
   }
 


### PR DESCRIPTION
rgw: This PR disables prefetch in rgw_file (used by NFS-Ganesha).

Each call to `rgw_read` (`rgw_file.cc`) invokes three calls to `RGWRados::get_obj_state` with `RGWObjState::prefetch_data = true`. It results in great read amplification. If `length` argument in `rgw_read` call is smaller than `rgw_max_chunk_size`, then the amplification is threefold.

Tracker issue: https://tracker.ceph.com/issues/48289

Signed-off-by: Kajetan Janiak <kjaniak@cloudferro.com>