### PR TITLE
rpm: cephadm package is noarch

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -386,6 +386,7 @@ Base is the package that includes all the files shared amongst ceph servers
 
 %package -n cephadm
 Summary:        Utility to bootstrap Ceph clusters
+BuildArch:      noarch
 Requires:       lvm2
 Requires:       python%{python3_pkgversion}
 %if 0%{?weak_deps}


### PR DESCRIPTION
The cephadm package contains an architecture-independent Python script, empty directories, and an empty `authorized_keys` file. There are no architecture-dependent files here, so we can use a single noarch RPM across all host architectures.