### PR TITLE
doc/rados/operations: Add description of new auth profiles

### DIFF
--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -45,7 +45,6 @@ For details on configuring the Ceph Storage Cluster to use authentication,
 see `Cephx Config Reference`_. For details on the architecture of Cephx, see
 `Architecture - High Availability Authentication`_.
 
-
 Background
 ==========
 
@@ -55,7 +54,6 @@ Ceph users must have access to pools in order to read and write data.
 Additionally, Ceph users must have execute permissions to use Ceph's
 administrative commands. The following concepts will help you understand Ceph
 user management.
-
 
 User
 ----
@@ -292,6 +290,29 @@ The following entries describe valid capability profiles:
               cap supports optional ``pool`` and ``namespace`` keyword
               arguments.
 
+``profile simple-rados-client`` (Monitor only)
+
+:Description: Gives a user read-only permissions for monitor, OSD, and PG data.
+              Intended for use by direct librados client applications.
+
+``profile fs-client`` (Monitor only)
+
+:Description: Gives a user read-only permissions for monitor, OSD, PG, and MDS
+              data.  Intended for CephFS clients.
+
+``profile role-definer`` (Monitor and Auth)
+
+:Description: Gives a user **all** permissions for the auth subsystem, read-only
+              access to monitors, and nothing else.  Useful for automation
+              tools.  Do not assign this unless you really, **really** know what
+              you're doing as the security ramifications are substantial and
+              pervasive.
+
+``profile crash`` (Monitor only)
+
+:Description: Gives a user read-only access to monitors, used in conjunction
+              with the manager ``crash`` module when collecting daemon crash
+              dumps for later analysis.
 
 Pool
 ----
@@ -339,7 +360,6 @@ capability. Limited globbing of namespaces is supported; if the last character
 of the specified namespace is ``*``, then access is granted to any namespace
 starting with the provided argument.
 
-
 Managing Users
 ==============
 
@@ -350,7 +370,6 @@ Cluster.
 When you create or delete users in the Ceph Storage Cluster, you may need to
 distribute keys to clients so that they can be added to keyrings. See `Keyring
 Management`_ for details.
-
 
 List Users
 ----------
@@ -414,8 +433,6 @@ save the output to a file. Developers may also execute the following::
 	ceph auth export {TYPE.ID}
 
 The ``auth export`` command is identical to ``auth get``.
-
-
 
 Add a User
 ----------
@@ -486,7 +503,6 @@ For example::
 
 See `Authorization (Capabilities)`_ for additional details on capabilities.
 
-
 Delete a User
 -------------
 
@@ -513,7 +529,6 @@ software with a user's key  (e.g., libvirt). ::
 
 	mount -t ceph serverhost:/ mountpoint -o name=client.user,secret=`ceph auth print-key client.user`
 
-
 Import a User(s)
 ----------------
 
@@ -527,10 +542,9 @@ For example::
 	sudo ceph auth import -i /etc/ceph/ceph.keyring
 
 
-.. note:: The ceph storage cluster will add new users, their keys and their
+.. note:: The Ceph storage cluster will add new users, their keys and their
    capabilities and will update existing users, their keys and their
    capabilities.
-
 
 Keyring Management
 ==================
@@ -560,7 +574,6 @@ Cluster.
 The `User Management`_ section details how to list, get, add, modify and delete
 users directly in the Ceph Storage Cluster. However, Ceph also provides the
 ``ceph-authtool`` utility to allow you to manage keyrings from a Ceph client.
-
 
 Create a Keyring
 ----------------
@@ -596,7 +609,6 @@ intend to use the keyring for a particular user or group of users, ensure
 that you execute ``chown`` or ``chmod`` to establish appropriate keyring
 ownership and access.
 
-
 Add a User to a Keyring
 -----------------------
 
@@ -617,7 +629,6 @@ to specify the destination keyring and the source keyring.
 For example::
 
 	sudo ceph-authtool /etc/ceph/ceph.keyring --import-keyring /etc/ceph/ceph.client.admin.keyring
-
 
 Create a User
 -------------
@@ -642,7 +653,6 @@ the new user to the Ceph Storage Cluster. ::
 
 	sudo ceph auth add client.ringo -i /etc/ceph/ceph.keyring
 
-
 Modify a User
 -------------
 
@@ -662,7 +672,6 @@ from a keyring.
 You may also `Modify User Capabilities`_ directly in the cluster, store the
 results to a keyring file; then, import the keyring into your main
 ``ceph.keyring`` file.
-
 
 Command Line Usage
 ==================
@@ -708,7 +717,6 @@ Ceph supports the following usage for user name and secret:
 
 
 .. _pools: ../pools
-
 
 Limitations
 ===========


### PR DESCRIPTION
doc/rados/operations: Add description of new auth profiles

Document the `fs-client`, `simple-rados-client`, `role-definer`, and `crash` profiles.  The `crash` profile isn't mentioned in the tracker issue but I noticed it in the code and thought to include it for completeness.

I believe this also addresses the related https://tracker.ceph.com/issues/23612 and https://tracker.ceph.com/issues/23611

Fixes: https://tracker.ceph.com/issues/23442
Signed-off-by: Anthony D'Atri anthony.datri@gmail.com


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
