### PR TITLE
rgw: bring cls_fifo-based offload for Bucket Index Log

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -8,6 +8,7 @@
     single marker giving the end of the trimmed range.
   * Similarly the date ranges and marker ranges have been removed on
     the RESTful DATALog and MDLog list and trim operations.
+  * The same as above happened also to "bilog-trim"
 
 * ceph-volume: The ``lvm batch` subcommand received a major rewrite. This closed
   a number of bugs and improves usability in terms of size specification and

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1205,8 +1205,13 @@ static int read_olh(cls_method_context_t hctx,cls_rgw_obj_key& obj_key, rgw_buck
   return 0;
 }
 
-static void update_olh_log(rgw_bucket_olh_entry& olh_data_entry, OLHLogOp op, const string& op_tag,
-                           const cls_rgw_obj_key& key, bool delete_marker, uint64_t epoch)
+static void update_olh_log(rgw_bucket_olh_entry& olh_data_entry,
+                           OLHLogOp op,
+                           const string& op_tag,
+                           const cls_rgw_obj_key& key,
+                           bool delete_marker,
+                           std::optional<rgw_bucket_olh_log_bi_log_entry>&& bi_log_replay_data,
+                           uint64_t epoch)
 {
   vector<rgw_bucket_olh_log_entry>& log = olh_data_entry.pending_log[olh_data_entry.epoch];
   rgw_bucket_olh_log_entry log_entry;
@@ -1215,6 +1220,7 @@ static void update_olh_log(rgw_bucket_olh_entry& olh_data_entry, OLHLogOp op, co
   log_entry.op_tag = op_tag;
   log_entry.key = key;
   log_entry.delete_marker = delete_marker;
+  log_entry.bi_log_replay_data = std::move(bi_log_replay_data);
   log.push_back(log_entry);
 }
 
@@ -1479,11 +1485,16 @@ public:
     return 0;
   }
 
-  void update_log(OLHLogOp op, const string& op_tag, const cls_rgw_obj_key& key, bool delete_marker, uint64_t epoch = 0) {
+  void update_log(OLHLogOp op,
+                  const string& op_tag,
+                  const cls_rgw_obj_key& key,
+                  bool delete_marker,
+                  std::optional<rgw_bucket_olh_log_bi_log_entry> bi_log_replay_data,
+                  uint64_t epoch = 0) {
     if (epoch == 0) {
       epoch = olh_data_entry.epoch;
     }
-    update_olh_log(olh_data_entry, op, op_tag, key, delete_marker, epoch);
+    update_olh_log(olh_data_entry, op, op_tag, key, delete_marker, std::move(bi_log_replay_data), epoch);
   }
 
   bool exists() { return olh_data_entry.exists; }
@@ -1691,7 +1702,10 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
       return ret;
     }
     if (removing) {
-      olh.update_log(CLS_RGW_OLH_OP_REMOVE_INSTANCE, op.op_tag, op.key, false, op.olh_epoch);
+      olh.update_log(CLS_RGW_OLH_OP_REMOVE_INSTANCE, op.op_tag, op.key, false, std::nullopt, op.olh_epoch);
+    } else {
+      // XXX, HUH: obj.write(op.olh_epoch, ...) modifies the BI but this
+      // operation is NOT recorded in the BILog. Is this a bug?
     }
     return 0;
   }
@@ -1738,9 +1752,16 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
   }
 
   /* update the olh log */
-  olh.update_log(CLS_RGW_OLH_OP_LINK_OLH, op.op_tag, op.key, op.has_delete_marker());
+  rgw_bucket_dir_entry& entry = obj.get_dir_entry();
+  olh.update_log(CLS_RGW_OLH_OP_LINK_OLH, op.op_tag, op.key, op.has_delete_marker(),
+                 rgw_bucket_olh_log_bi_log_entry {
+                   obj.mtime(),
+                   entry.meta.owner,
+                   entry.meta.owner_display_name,
+                   op.zones_trace
+                 });
   if (removing) {
-    olh.update_log(CLS_RGW_OLH_OP_REMOVE_INSTANCE, op.op_tag, op.key, false);
+    olh.update_log(CLS_RGW_OLH_OP_REMOVE_INSTANCE, op.op_tag, op.key, false, std::nullopt);
   }
 
   if (promote) {
@@ -1773,8 +1794,6 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
   if (header.syncstopped) {
     return 0;
   }
-
-  rgw_bucket_dir_entry& entry = obj.get_dir_entry();
 
   rgw_bucket_entry_ver ver;
   ver.epoch = (op.olh_epoch ? op.olh_epoch : olh.get_epoch());
@@ -1870,7 +1889,8 @@ static int rgw_bucket_unlink_instance(cls_method_context_t hctx, bufferlist *in,
       return 0;
     }
 
-    olh.update_log(CLS_RGW_OLH_OP_REMOVE_INSTANCE, op.op_tag, op.key, false, op.olh_epoch);
+    olh.update_log(CLS_RGW_OLH_OP_REMOVE_INSTANCE, op.op_tag, op.key, false, std::nullopt, op.olh_epoch);
+    // XXX: no bilog handling. See the comment for ..._LINK_OLH.
     return olh.write();
   }
 
@@ -1901,20 +1921,20 @@ static int rgw_bucket_unlink_instance(cls_method_context_t hctx, bufferlist *in,
               next_key.name.c_str(), next_key.instance.c_str(), (int)next.is_delete_marker());
 
       olh.update(next_key, next.is_delete_marker());
-      olh.update_log(CLS_RGW_OLH_OP_LINK_OLH, op.op_tag, next_key, next.is_delete_marker());
+      olh.update_log(CLS_RGW_OLH_OP_LINK_OLH, op.op_tag, next_key, next.is_delete_marker(), std::nullopt);
     } else {
       // next_key is empty, but we need to preserve its name in case this entry
       // gets resharded, because this key is used for hash placement
       next_key.name = dest_key.name;
       olh.update(next_key, false);
-      olh.update_log(CLS_RGW_OLH_OP_UNLINK_OLH, op.op_tag, next_key, false);
+      olh.update_log(CLS_RGW_OLH_OP_UNLINK_OLH, op.op_tag, next_key, false, std::nullopt);
       olh.set_exists(false);
       olh.set_pending_removal(true);
     }
   }
 
   if (!obj.is_delete_marker()) {
-    olh.update_log(CLS_RGW_OLH_OP_REMOVE_INSTANCE, op.op_tag, op.key, false);
+    olh.update_log(CLS_RGW_OLH_OP_REMOVE_INSTANCE, op.op_tag, op.key, false, std::nullopt);
   } else {
     /* this is a delete marker, it's our responsibility to remove its
      * instance entry */

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1899,7 +1899,7 @@ static int rgw_bucket_unlink_instance(cls_method_context_t hctx, bufferlist *in,
 
   real_time mtime = obj.mtime(); /* mtime has no real meaning in
                                   * instance removal context */
-  ret = log_index_operation(hctx, op.key, CLSRGWUnlinkInstance::get_bilog_op_type(), op.op_tag,
+  ret = log_index_operation(hctx, op.key, op.op, op.op_tag,
                             mtime, ver,
                             header.ver, header.max_marker,
                             op.bilog_flags | RGW_BILOG_FLAG_VERSIONED_OP, NULL, NULL, &op.zones_trace);

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1089,7 +1089,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
   case CLS_RGW_OP_DEL:
     entry.meta = op.meta;
     if (ondisk) {
-      if (!entry.pending_map.size()) {
+      if (entry.pending_map.empty()) {
 	int ret = cls_cxx_map_remove_key(hctx, idx);
 	if (ret < 0)
 	  return ret;

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -123,10 +123,14 @@ static void bi_log_index_key(cls_method_context_t hctx, string& key, string& id,
   key.append(id);
 }
 
-static int log_index_operation(cls_method_context_t hctx, cls_rgw_obj_key& obj_key, RGWModifyOp op,
-                               string& tag, real_time& timestamp,
+static int log_index_operation(cls_method_context_t hctx,
+                               const cls_rgw_obj_key& obj_key,
+                               RGWModifyOp op,
+                               const string& tag,
+                               real_time& timestamp,
                                rgw_bucket_entry_ver& ver, uint64_t index_ver,
-                               string& max_marker, uint16_t bilog_flags, string *owner, string *owner_display_name, rgw_zone_set *zones_trace)
+                               string& max_marker, uint16_t bilog_flags, string *owner, string *owner_display_name,
+                               const rgw_zone_set *zones_trace)
 {
   bufferlist bl;
 
@@ -148,7 +152,7 @@ static int log_index_operation(cls_method_context_t hctx, cls_rgw_obj_key& obj_k
     entry.owner_display_name = *owner_display_name;
   }
   if (zones_trace) {
-    entry.zones_trace = std::move(*zones_trace);
+    entry.zones_trace = *zones_trace;
   }
 
   string key;
@@ -795,8 +799,10 @@ int rgw_bucket_set_tag_timeout(cls_method_context_t hctx, bufferlist *in, buffer
   return write_bucket_header(hctx, &header);
 }
 
-static int read_key_entry(cls_method_context_t hctx, cls_rgw_obj_key& key,
-			  string *idx, rgw_bucket_dir_entry *entry,
+static int read_key_entry(cls_method_context_t hctx,
+                          const cls_rgw_obj_key& key,
+                          string *idx,
+                          rgw_bucket_dir_entry *entry,
                           bool special_delete_marker_name = false);
 
 int rgw_bucket_prepare_op(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
@@ -907,8 +913,10 @@ static int read_index_entry(cls_method_context_t hctx, string& name, T* entry)
   return 0;
 }
 
-static int read_key_entry(cls_method_context_t hctx, cls_rgw_obj_key& key,
-			  string *idx, rgw_bucket_dir_entry *entry,
+static int read_key_entry(cls_method_context_t hctx,
+                          const cls_rgw_obj_key& key,
+                          string *idx,
+                          rgw_bucket_dir_entry *entry,
                           bool special_delete_marker_name)
 {
   encode_obj_index_key(key, idx);
@@ -941,17 +949,28 @@ static int read_key_entry(cls_method_context_t hctx, cls_rgw_obj_key& key,
   return 0;
 }
 
-int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
+static std::pair<int, rgw_cls_obj_complete_op>
+decode_complete_op(const ceph::bufferlist* in)
 {
-  // decode request
   rgw_cls_obj_complete_op op;
-  auto iter = in->cbegin();
   try {
+    auto iter = in->cbegin();
     decode(op, iter);
   } catch (ceph::buffer::error& err) {
     CLS_LOG(1, "ERROR: rgw_bucket_complete_op(): failed to decode request\n");
-    return -EINVAL;
+    return { -EINVAL, {} };
   }
+  return {0, std::move(op) };
+}
+
+int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
+{
+  // decode request
+  const auto [ decode_ret, op ] = decode_complete_op(in);
+  if (decode_ret < 0) {
+    return decode_ret;
+  }
+
   CLS_LOG(1, "rgw_bucket_complete_op(): request: op=%d name=%s instance=%s ver=%lu:%llu tag=%s\n",
           op.op, op.key.name.c_str(), op.key.instance.c_str(),
           (unsigned long)op.ver.pool, (unsigned long long)op.ver.epoch,
@@ -1044,7 +1063,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
     break;
   case CLS_RGW_OP_ADD:
     {
-      rgw_bucket_dir_entry_meta& meta = op.meta;
+      const rgw_bucket_dir_entry_meta& meta = op.meta;
       rgw_bucket_category_stats& stats = header.stats[meta.category];
       entry.meta = meta;
       entry.key = op.key;
@@ -1071,8 +1090,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
   }
 
   CLS_LOG(20, "rgw_bucket_complete_op(): remove_objs.size()=%d\n", (int)op.remove_objs.size());
-  for (auto remove_iter = op.remove_objs.begin(); remove_iter != op.remove_objs.end(); ++remove_iter) {
-    cls_rgw_obj_key& remove_key = *remove_iter;
+  for (const auto& remove_key : op.remove_objs) {
     CLS_LOG(1, "rgw_bucket_complete_op(): removing entries, read_index_entry name=%s instance=%s\n",
             remove_key.name.c_str(), remove_key.instance.c_str());
     rgw_bucket_dir_entry remove_entry;

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -123,6 +123,54 @@ static void bi_log_index_key(cls_method_context_t hctx, string& key, string& id,
   key.append(id);
 }
 
+// prepare a BILog entry basing on two sources of information:
+//   1. the state cls_rgw_bi_log_related_op which is solely constructed
+//      from data passed by a client;
+//   2. parameters computed locally (in cls_rgw). They can be
+//      problematic as client may have no access to it. Therefore,
+//      the goal is to minimize the set / eradicate it entirelly.
+static int log_index_operation(cls_method_context_t hctx,
+                               const cls_rgw_bi_log_related_op& op,
+                               const real_time& timestamp,
+                               const rgw_bucket_entry_ver& ver,
+                               uint64_t index_ver,
+                               string& max_marker, /* in out */
+                               const string *owner,
+                               const string *owner_display_name)
+{
+  bufferlist bl;
+
+  rgw_bi_log_entry entry;
+
+  entry.object = op.key.name;
+  entry.instance = op.key.instance;
+  entry.timestamp = timestamp;
+  entry.op = op.op;
+  entry.ver = ver;
+  entry.state = CLS_RGW_STATE_COMPLETE;
+  entry.index_ver = index_ver;
+  entry.tag = op.op_tag;
+  entry.bilog_flags = op.bilog_flags;
+  entry.zones_trace = op.zones_trace;
+  if (owner) {
+    entry.owner = *owner;
+  }
+  if (owner_display_name) {
+    entry.owner_display_name = *owner_display_name;
+  }
+
+  string key;
+  bi_log_index_key(hctx, key, entry.id, index_ver);
+
+  encode(entry, bl);
+
+  if (entry.id > max_marker)
+    max_marker = entry.id;
+
+  return cls_cxx_map_set_val(hctx, key, &bl);
+}
+
+// TODO: drop me
 static int log_index_operation(cls_method_context_t hctx,
                                const cls_rgw_obj_key& obj_key,
                                RGWModifyOp op,
@@ -1083,8 +1131,14 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
   }
 
   if (op.log_op && !header.syncstopped) {
-    rc = log_index_operation(hctx, op.key, op.op, op.op_tag, entry.meta.mtime, entry.ver,
-                             header.ver, header.max_marker, op.bilog_flags, NULL, NULL, &op.zones_trace);
+    rc = log_index_operation(hctx,
+                             op,
+                             entry.meta.mtime,
+                             entry.ver,
+                             header.ver,
+                             header.max_marker,
+                             nullptr,
+                             nullptr);
     if (rc < 0)
       return rc;
   }

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1071,7 +1071,6 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
     cancel = true;
   }
 
-  bufferlist op_bl;
   if (cancel) {
     if (op.op_tag.size()) {
       bufferlist new_key_bl;

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1563,9 +1563,9 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
   BIOLHEntry olh(hctx, op.key);
 
   /* read instance entry */
-  int ret = obj.init(op.delete_marker);
+  int ret = obj.init(op.has_delete_marker());
   bool existed = (ret == 0);
-  if (ret == -ENOENT && op.delete_marker) {
+  if (ret == -ENOENT && op.has_delete_marker()) {
     ret = 0;
   }
   if (ret < 0) {
@@ -1596,18 +1596,18 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
    */
   if (op.key.instance.empty()) {
     BIVerObjEntry other_obj(hctx, op.key);
-    ret = other_obj.init(!op.delete_marker); /* try reading the other
+    ret = other_obj.init(!op.has_delete_marker()); /* try reading the other
 					      * null versioned
 					      * entry */
     existed = (ret >= 0 && !other_obj.is_delete_marker());
-    if (ret >= 0 && other_obj.is_delete_marker() != op.delete_marker) {
+    if (ret >= 0 && other_obj.is_delete_marker() != op.has_delete_marker()) {
       ret = other_obj.unlink_list_entry();
       if (ret < 0) {
         return ret;
       }
     }
 
-    removing = existed && op.delete_marker;
+    removing = existed && op.has_delete_marker();
     if (!removing) {
       ret = other_obj.unlink();
       if (ret < 0) {
@@ -1615,10 +1615,10 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
       }
     }
   } else {
-    removing = (existed && !obj.is_delete_marker() && op.delete_marker);
+    removing = (existed && !obj.is_delete_marker() && op.has_delete_marker());
   }
 
-  if (op.delete_marker) {
+  if (op.has_delete_marker()) {
     /* a deletion marker, need to initialize entry as such */
     obj.init_as_delete_marker(op.meta);
   }
@@ -1673,7 +1673,7 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
     }
     olh.set_pending_removal(false);
   } else {
-    bool instance_only = (op.key.instance.empty() && op.delete_marker);
+    bool instance_only = (op.key.instance.empty() && op.has_delete_marker());
     cls_rgw_obj_key key(op.key.name);
     ret = convert_plain_entry_to_versioned(hctx, key, promote, instance_only);
     if (ret < 0) {
@@ -1684,13 +1684,13 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
   }
 
   /* update the olh log */
-  olh.update_log(CLS_RGW_OLH_OP_LINK_OLH, op.op_tag, op.key, op.delete_marker);
+  olh.update_log(CLS_RGW_OLH_OP_LINK_OLH, op.op_tag, op.key, op.has_delete_marker());
   if (removing) {
     olh.update_log(CLS_RGW_OLH_OP_REMOVE_INSTANCE, op.op_tag, op.key, false);
   }
 
   if (promote) {
-    olh.update(op.key, op.delete_marker);
+    olh.update(op.key, op.has_delete_marker());
   }
   olh.set_exists(true);
 
@@ -1728,12 +1728,12 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
   string *powner = NULL;
   string *powner_display_name = NULL;
 
-  if (op.delete_marker) {
+  if (op.has_delete_marker()) {
     powner = &entry.meta.owner;
     powner_display_name = &entry.meta.owner_display_name;
   }
 
-  ret = log_index_operation(hctx, op.key, CLSRGWLinkOLHBase::get_bilog_op_type(op.delete_marker), op.op_tag,
+  ret = log_index_operation(hctx, op.key, op.op, op.op_tag,
                             entry.meta.mtime, ver,
                             header.ver, header.max_marker, op.bilog_flags | RGW_BILOG_FLAG_VERSIONED_OP,
                             powner, powner_display_name, &op.zones_trace);

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1752,19 +1752,29 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
   return write_bucket_header(hctx, &header); /* updates header version */
 }
 
+static std::pair<int, rgw_cls_unlink_instance_op>
+decode_unlink_instance_op(const ceph::bufferlist* in)
+{
+  rgw_cls_unlink_instance_op op;
+  try {
+    auto iter = in->cbegin();
+    decode(op, iter);
+  } catch (ceph::buffer::error& err) {
+    CLS_LOG(0, "ERROR: rgw_bucket_rm_obj_instance_op(): failed to decode request\n");
+    return { -EINVAL, {} };
+  }
+  return { 0, std::move(op) };
+}
+
 static int rgw_bucket_unlink_instance(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 {
   string olh_data_idx;
   string instance_idx;
 
   // decode request
-  rgw_cls_unlink_instance_op op;
-  auto iter = in->cbegin();
-  try {
-    decode(op, iter);
-  } catch (ceph::buffer::error& err) {
-    CLS_LOG(0, "ERROR: rgw_bucket_rm_obj_instance_op(): failed to decode request\n");
-    return -EINVAL;
+  const auto [ decode_ret, op ] = decode_unlink_instance_op(in);
+  if (decode_ret < 0) {
+    return decode_ret;
   }
 
   cls_rgw_obj_key dest_key = op.key;

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1518,15 +1518,6 @@ static int convert_plain_entry_to_versioned(cls_method_context_t hctx,
   return 0;
 }
 
-static RGWModifyOp link_olh_get_bilog_op_type(bool delete_marker)
-{
-  if (delete_marker) {
-    return CLSRGWLinkOLH<true>::get_bilog_op_type();
-  } else {
-    return CLSRGWLinkOLH<false>::get_bilog_op_type();
-  }
-}
-
 static std::pair<int, rgw_cls_link_olh_op>
 decode_link_olh_op(const ceph::bufferlist* in)
 {
@@ -1742,7 +1733,7 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
     powner_display_name = &entry.meta.owner_display_name;
   }
 
-  ret = log_index_operation(hctx, op.key, link_olh_get_bilog_op_type(op.delete_marker), op.op_tag,
+  ret = log_index_operation(hctx, op.key, CLSRGWLinkOLHBase::get_bilog_op_type(op.delete_marker), op.op_tag,
                             entry.meta.mtime, ver,
                             header.ver, header.max_marker, op.bilog_flags | RGW_BILOG_FLAG_VERSIONED_OP,
                             powner, powner_display_name, &op.zones_trace);

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -148,7 +148,6 @@ static int log_index_operation(cls_method_context_t hctx,
   entry.op = op.op;
   entry.ver = ver;
   entry.state = CLS_RGW_STATE_COMPLETE;
-  entry.index_ver = index_ver;
   entry.tag = op.op_tag;
   entry.bilog_flags = op.bilog_flags;
   entry.zones_trace = op.zones_trace;
@@ -190,7 +189,6 @@ static int log_index_operation(cls_method_context_t hctx,
   entry.op = op;
   entry.ver = ver;
   entry.state = CLS_RGW_STATE_COMPLETE;
-  entry.index_ver = index_ver;
   entry.tag = tag;
   entry.bilog_flags = bilog_flags;
   if (owner) {
@@ -1046,7 +1044,6 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
     return rc;
   }
 
-  entry.index_ver = header.ver;
   /* resetting entry flags, entry might have been previously a delete
    * marker */
   entry.flags = (entry.key.instance.empty() ?
@@ -2260,7 +2257,6 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
         stats.total_size_rounded += cls_rgw_get_rounded_size(cur_change.meta.accounted_size);
         stats.actual_size += cur_change.meta.size;
         header_changed = true;
-        cur_change.index_ver = header.ver;
         bufferlist cur_state_bl;
         encode(cur_change, cur_state_bl);
         ret = cls_cxx_map_set_val(hctx, cur_change_key, &cur_state_bl);

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1500,6 +1500,14 @@ static int convert_plain_entry_to_versioned(cls_method_context_t hctx,
   return 0;
 }
 
+static RGWModifyOp link_olh_get_bilog_op_type(bool delete_marker)
+{
+  if (delete_marker) {
+    return CLSRGWLinkOLH<true>::get_bilog_op_type();
+  } else {
+    return CLSRGWLinkOLH<false>::get_bilog_op_type();
+  }
+}
 /*
  * Link an object version to an olh, update the relevant index
  * entries. It will also handle the deletion marker case. We have a
@@ -1705,8 +1713,7 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
     powner_display_name = &entry.meta.owner_display_name;
   }
 
-  RGWModifyOp operation = (op.delete_marker ? CLS_RGW_OP_LINK_OLH_DM : CLS_RGW_OP_LINK_OLH);
-  ret = log_index_operation(hctx, op.key, operation, op.op_tag,
+  ret = log_index_operation(hctx, op.key, link_olh_get_bilog_op_type(op.delete_marker), op.op_tag,
                             entry.meta.mtime, ver,
                             header.ver, header.max_marker, op.bilog_flags | RGW_BILOG_FLAG_VERSIONED_OP,
                             powner, powner_display_name, &op.zones_trace);
@@ -1862,7 +1869,7 @@ static int rgw_bucket_unlink_instance(cls_method_context_t hctx, bufferlist *in,
 
   real_time mtime = obj.mtime(); /* mtime has no real meaning in
                                   * instance removal context */
-  ret = log_index_operation(hctx, op.key, CLS_RGW_OP_UNLINK_INSTANCE, op.op_tag,
+  ret = log_index_operation(hctx, op.key, CLSRGWUnlinkInstance::get_bilog_op_type(), op.op_tag,
                             mtime, ver,
                             header.ver, header.max_marker,
                             op.bilog_flags | RGW_BILOG_FLAG_VERSIONED_OP, NULL, NULL, &op.zones_trace);

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -971,10 +971,10 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
     return decode_ret;
   }
 
-  CLS_LOG(1, "rgw_bucket_complete_op(): request: op=%d name=%s instance=%s ver=%lu:%llu tag=%s\n",
+  CLS_LOG(1, "rgw_bucket_complete_op(): request: op=%d name=%s instance=%s ver=%lu:%llu op_tag=%s\n",
           op.op, op.key.name.c_str(), op.key.instance.c_str(),
           (unsigned long)op.ver.pool, (unsigned long long)op.ver.epoch,
-          op.tag.c_str());
+          op.op_tag.c_str());
 
   rgw_bucket_dir_header header;
   int rc = read_bucket_header(hctx, &header);
@@ -1005,10 +1005,10 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
 		 0 :
 		 rgw_bucket_dir_entry::FLAG_VER);
 
-  if (op.tag.size()) {
-    auto pinter = entry.pending_map.find(op.tag);
+  if (op.op_tag.size()) {
+    auto pinter = entry.pending_map.find(op.op_tag);
     if (pinter == entry.pending_map.end()) {
-      CLS_LOG(1, "ERROR: couldn't find tag for pending operation\n");
+      CLS_LOG(1, "ERROR: couldn't find op_tag for pending operation\n");
       return -EINVAL;
     }
     entry.pending_map.erase(pinter);
@@ -1017,7 +1017,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
   bool cancel = false;
   bufferlist update_bl;
 
-  if (op.tag.size() && op.op == CLS_RGW_OP_CANCEL) {
+  if (op.op_tag.size() && op.op == CLS_RGW_OP_CANCEL) {
     CLS_LOG(1, "rgw_bucket_complete_op(): cancel requested\n");
     cancel = true;
   } else if (op.ver.pool == entry.ver.pool &&
@@ -1028,7 +1028,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
 
   bufferlist op_bl;
   if (cancel) {
-    if (op.tag.size()) {
+    if (op.op_tag.size()) {
       bufferlist new_key_bl;
       encode(entry, new_key_bl);
       return cls_cxx_map_set_val(hctx, idx, &new_key_bl);
@@ -1068,7 +1068,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
       entry.meta = meta;
       entry.key = op.key;
       entry.exists = true;
-      entry.tag = op.tag;
+      entry.tag = op.op_tag;
       stats.num_entries++;
       stats.total_size += meta.accounted_size;
       stats.total_size_rounded += cls_rgw_get_rounded_size(meta.accounted_size);
@@ -1083,7 +1083,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
   }
 
   if (op.log_op && !header.syncstopped) {
-    rc = log_index_operation(hctx, op.key, op.op, op.tag, entry.meta.mtime, entry.ver,
+    rc = log_index_operation(hctx, op.key, op.op, op.op_tag, entry.meta.mtime, entry.ver,
                              header.ver, header.max_marker, op.bilog_flags, NULL, NULL, &op.zones_trace);
     if (rc < 0)
       return rc;
@@ -1110,7 +1110,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
 
     if (op.log_op && !header.syncstopped) {
       ++header.ver; // increment index version, or we'll overwrite keys previously written
-      rc = log_index_operation(hctx, remove_key, CLS_RGW_OP_DEL, op.tag, remove_entry.meta.mtime,
+      rc = log_index_operation(hctx, remove_key, CLS_RGW_OP_DEL, op.op_tag, remove_entry.meta.mtime,
                                remove_entry.ver, header.ver, header.max_marker, op.bilog_flags, NULL, NULL, &op.zones_trace);
       if (rc < 0)
         continue;

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -125,7 +125,7 @@ static void bi_log_index_key(cls_method_context_t hctx, string& key, string& id,
 
 static int log_index_operation(cls_method_context_t hctx, cls_rgw_obj_key& obj_key, RGWModifyOp op,
                                string& tag, real_time& timestamp,
-                               rgw_bucket_entry_ver& ver, RGWPendingState state, uint64_t index_ver,
+                               rgw_bucket_entry_ver& ver, uint64_t index_ver,
                                string& max_marker, uint16_t bilog_flags, string *owner, string *owner_display_name, rgw_zone_set *zones_trace)
 {
   bufferlist bl;
@@ -137,7 +137,7 @@ static int log_index_operation(cls_method_context_t hctx, cls_rgw_obj_key& obj_k
   entry.timestamp = timestamp;
   entry.op = op;
   entry.ver = ver;
-  entry.state = state;
+  entry.state = CLS_RGW_STATE_COMPLETE;
   entry.index_ver = index_ver;
   entry.tag = tag;
   entry.bilog_flags = bilog_flags;
@@ -1065,7 +1065,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
 
   if (op.log_op && !header.syncstopped) {
     rc = log_index_operation(hctx, op.key, op.op, op.tag, entry.meta.mtime, entry.ver,
-                             CLS_RGW_STATE_COMPLETE, header.ver, header.max_marker, op.bilog_flags, NULL, NULL, &op.zones_trace);
+                             header.ver, header.max_marker, op.bilog_flags, NULL, NULL, &op.zones_trace);
     if (rc < 0)
       return rc;
   }
@@ -1093,7 +1093,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
     if (op.log_op && !header.syncstopped) {
       ++header.ver; // increment index version, or we'll overwrite keys previously written
       rc = log_index_operation(hctx, remove_key, CLS_RGW_OP_DEL, op.tag, remove_entry.meta.mtime,
-                               remove_entry.ver, CLS_RGW_STATE_COMPLETE, header.ver, header.max_marker, op.bilog_flags, NULL, NULL, &op.zones_trace);
+                               remove_entry.ver, header.ver, header.max_marker, op.bilog_flags, NULL, NULL, &op.zones_trace);
       if (rc < 0)
         continue;
     }
@@ -1708,7 +1708,7 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
   RGWModifyOp operation = (op.delete_marker ? CLS_RGW_OP_LINK_OLH_DM : CLS_RGW_OP_LINK_OLH);
   ret = log_index_operation(hctx, op.key, operation, op.op_tag,
                             entry.meta.mtime, ver,
-                            CLS_RGW_STATE_COMPLETE, header.ver, header.max_marker, op.bilog_flags | RGW_BILOG_FLAG_VERSIONED_OP,
+                            header.ver, header.max_marker, op.bilog_flags | RGW_BILOG_FLAG_VERSIONED_OP,
                             powner, powner_display_name, &op.zones_trace);
   if (ret < 0)
     return ret;
@@ -1864,7 +1864,7 @@ static int rgw_bucket_unlink_instance(cls_method_context_t hctx, bufferlist *in,
                                   * instance removal context */
   ret = log_index_operation(hctx, op.key, CLS_RGW_OP_UNLINK_INSTANCE, op.op_tag,
                             mtime, ver,
-                            CLS_RGW_STATE_COMPLETE, header.ver, header.max_marker,
+                            header.ver, header.max_marker,
                             op.bilog_flags | RGW_BILOG_FLAG_VERSIONED_OP, NULL, NULL, &op.zones_trace);
   if (ret < 0)
     return ret;
@@ -2129,7 +2129,7 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
 	  return ret;
         if (log_op && cur_disk.exists && !header.syncstopped) {
           ret = log_index_operation(hctx, cur_disk.key, CLS_RGW_OP_DEL, cur_disk.tag, cur_disk.meta.mtime,
-                                    cur_disk.ver, CLS_RGW_STATE_COMPLETE, header.ver, header.max_marker, 0, NULL, NULL, NULL);
+                                    cur_disk.ver, header.ver, header.max_marker, 0, NULL, NULL, NULL);
           if (ret < 0) {
             CLS_LOG(0, "ERROR: %s(): failed to log operation ret=%d", __func__, ret);
             return ret;
@@ -2153,7 +2153,7 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
 	  return ret;
         if (log_op && !header.syncstopped) {
           ret = log_index_operation(hctx, cur_change.key, CLS_RGW_OP_ADD, cur_change.tag, cur_change.meta.mtime,
-                                    cur_change.ver, CLS_RGW_STATE_COMPLETE, header.ver, header.max_marker, 0, NULL, NULL, NULL);
+                                    cur_change.ver, header.ver, header.max_marker, 0, NULL, NULL, NULL);
           if (ret < 0) {
             CLS_LOG(0, "ERROR: %s(): failed to log operation ret=%d", __func__, ret);
             return ret;

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -852,7 +852,7 @@ int rgw_bucket_prepare_op(cls_method_context_t hctx, bufferlist *in, bufferlist 
 }
 
 static void unaccount_entry(rgw_bucket_dir_header& header,
-			    rgw_bucket_dir_entry& entry)
+			    const rgw_bucket_dir_entry& entry)
 {
   rgw_bucket_category_stats& stats = header.stats[entry.meta.category];
   stats.num_entries--;

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1152,7 +1152,7 @@ static int read_olh(cls_method_context_t hctx,cls_rgw_obj_key& obj_key, rgw_buck
 }
 
 static void update_olh_log(rgw_bucket_olh_entry& olh_data_entry, OLHLogOp op, const string& op_tag,
-                           cls_rgw_obj_key& key, bool delete_marker, uint64_t epoch)
+                           const cls_rgw_obj_key& key, bool delete_marker, uint64_t epoch)
 {
   vector<rgw_bucket_olh_log_entry>& log = olh_data_entry.pending_log[olh_data_entry.epoch];
   rgw_bucket_olh_log_entry log_entry;
@@ -1232,7 +1232,7 @@ public:
     return instance_entry;
   }
 
-  void init_as_delete_marker(rgw_bucket_dir_entry_meta& meta) {
+  void init_as_delete_marker(const rgw_bucket_dir_entry_meta& meta) {
     /* a deletion marker, need to initialize it, there's no instance entry for it yet */
     instance_entry.key = key;
     instance_entry.flags = rgw_bucket_dir_entry::FLAG_DELETE_MARKER;
@@ -1409,7 +1409,7 @@ public:
     return olh_data_entry;
   }
 
-  void update(cls_rgw_obj_key& key, bool delete_marker) {
+  void update(const cls_rgw_obj_key& key, bool delete_marker) {
     olh_data_entry.delete_marker = delete_marker;
     olh_data_entry.key = key;
   }
@@ -1425,7 +1425,7 @@ public:
     return 0;
   }
 
-  void update_log(OLHLogOp op, const string& op_tag, cls_rgw_obj_key& key, bool delete_marker, uint64_t epoch = 0) {
+  void update_log(OLHLogOp op, const string& op_tag, const cls_rgw_obj_key& key, bool delete_marker, uint64_t epoch = 0) {
     if (epoch == 0) {
       epoch = olh_data_entry.epoch;
     }
@@ -1526,6 +1526,21 @@ static RGWModifyOp link_olh_get_bilog_op_type(bool delete_marker)
     return CLSRGWLinkOLH<false>::get_bilog_op_type();
   }
 }
+
+static std::pair<int, rgw_cls_link_olh_op>
+decode_link_olh_op(const ceph::bufferlist* in)
+{
+  rgw_cls_link_olh_op op;
+  try {
+    auto iter = in->cbegin();
+    decode(op, iter);
+  } catch (ceph::buffer::error& err) {
+    CLS_LOG(0, "ERROR: rgw_bucket_link_olh_op(): failed to decode request\n");
+    return { -EINVAL, {} };
+  }
+  return { 0, std::move(op) };
+}
+
 /*
  * Link an object version to an olh, update the relevant index
  * entries. It will also handle the deletion marker case. We have a
@@ -1548,13 +1563,9 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
   string instance_idx;
 
   // decode request
-  rgw_cls_link_olh_op op;
-  auto iter = in->cbegin();
-  try {
-    decode(op, iter);
-  } catch (ceph::buffer::error& err) {
-    CLS_LOG(0, "ERROR: rgw_bucket_link_olh_op(): failed to decode request\n");
-    return -EINVAL;
+  const auto [ decode_ret, op ] = decode_link_olh_op(in);
+  if (decode_ret < 0) {
+    return decode_ret;
   }
 
   BIVerObjEntry obj(hctx, op.key);

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -186,15 +186,14 @@ void cls_rgw_bucket_prepare_op(ObjectWriteOperation& o, RGWModifyOp op, string& 
   o.exec(RGW_CLASS, RGW_BUCKET_PREPARE_OP, in);
 }
 
-template <enum RGWModifyOp OpType>
-void CLSRGWCompleteModifyOp<OpType>::complete_op(librados::ObjectWriteOperation& o,
-                                                 const rgw_bucket_entry_ver& ver,
-                                                 const rgw_bucket_dir_entry_meta& dir_meta,
-                                                 const std::list<cls_rgw_obj_key> *remove_objs) const
+void CLSRGWCompleteModifyOpBase::complete_op(librados::ObjectWriteOperation& o,
+                                             const rgw_bucket_entry_ver& ver,
+                                             const rgw_bucket_dir_entry_meta& dir_meta,
+                                             const std::list<cls_rgw_obj_key> *remove_objs) const
 {
   bufferlist in;
   rgw_cls_obj_complete_op call;
-  call.op = get_bilog_op_type();
+  call.op = this->op_type;
   call.tag = this->op_tag;
   call.key = this->key;
   call.ver = ver;
@@ -371,20 +370,19 @@ int cls_rgw_bi_list(librados::IoCtx& io_ctx, const string oid,
   return 0;
 }
 
-template <bool DeleteMarkerV>
-void CLSRGWLinkOLH<DeleteMarkerV>::link_olh(librados::ObjectWriteOperation& op,
-                                            ceph::bufferlist& olh_tag,
-                                            const rgw_bucket_dir_entry_meta *meta,
-                                            uint64_t olh_epoch,
-                                            ceph::real_time unmod_since,
-                                            bool high_precision_time) const
+void CLSRGWLinkOLHBase::link_olh(librados::ObjectWriteOperation& op,
+                                 ceph::bufferlist& olh_tag,
+                                 const rgw_bucket_dir_entry_meta *meta,
+                                 uint64_t olh_epoch,
+                                 ceph::real_time unmod_since,
+                                 bool high_precision_time) const
 {
   ceph::bufferlist in, out;
   rgw_cls_link_olh_op call;
   call.key = this->key;
   call.olh_tag = std::string(olh_tag.c_str(), olh_tag.length());
   call.op_tag = this->op_tag;
-  call.delete_marker = DeleteMarkerV;
+  call.delete_marker = this->op_type;
   if (meta) {
     call.meta = *meta;
   }

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -210,31 +210,6 @@ void CLSRGWCompleteModifyOp<OpType>::complete_op(librados::ObjectWriteOperation&
   o.exec(RGW_CLASS, RGW_BUCKET_COMPLETE_OP, in);
 }
 
-void cls_rgw_bucket_complete_op(ObjectWriteOperation& o, RGWModifyOp op, string& tag,
-                                rgw_bucket_entry_ver& ver,
-                                const cls_rgw_obj_key& key,
-                                rgw_bucket_dir_entry_meta& dir_meta,
-                                list<cls_rgw_obj_key> *remove_objs, bool log_op,
-                                uint16_t bilog_flags,
-                                rgw_zone_set *zones_trace)
-{
-  if (op == CLS_RGW_OP_ADD) {
-    CLSRGWCompleteModifyOp<CLS_RGW_OP_ADD>{
-      log_op, key, tag, zones_trace, bilog_flags
-    }.complete_op(o, ver, dir_meta, remove_objs);
-  } else if (op == CLS_RGW_OP_DEL) {
-    CLSRGWCompleteModifyOp<CLS_RGW_OP_DEL>{
-      log_op, key, tag, zones_trace, bilog_flags
-    }.complete_op(o, ver, dir_meta, remove_objs);
-  } else if (op == CLS_RGW_OP_CANCEL) {
-    CLSRGWCompleteModifyOp<CLS_RGW_OP_CANCEL>{
-      log_op, key, tag, zones_trace, bilog_flags
-    }.complete_op(o, ver, dir_meta, remove_objs);
-  } else {
-    ceph_abort_msg("this shall not happen");
-  }
-}
-
 void cls_rgw_bucket_list_op(librados::ObjectReadOperation& op,
                             const cls_rgw_obj_key& start_obj,
                             const std::string& filter_prefix,
@@ -423,18 +398,6 @@ void CLSRGWLinkOLH<DeleteMarkerV>::link_olh(librados::ObjectWriteOperation& op,
   op.exec(RGW_CLASS, RGW_BUCKET_LINK_OLH, in);
 }
 
-void cls_rgw_bucket_link_olh(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& key,
-                            bufferlist& olh_tag, bool delete_marker,
-                            const string& op_tag, rgw_bucket_dir_entry_meta *meta,
-                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, rgw_zone_set& zones_trace)
-{
-  if (delete_marker) {
-    CLSRGWLinkOLH<true>{log_op, key, op_tag, &zones_trace}.link_olh(op, olh_tag, meta, olh_epoch, unmod_since, high_precision_time);
-  } else {
-    CLSRGWLinkOLH<false>{log_op, key, op_tag, &zones_trace}.link_olh(op, olh_tag, meta, olh_epoch, unmod_since, high_precision_time);
-  }
-}
-
 void CLSRGWUnlinkInstance::unlink_instance(librados::ObjectWriteOperation& op,
                                            const std::string& olh_tag,
                                            uint64_t olh_epoch) const
@@ -450,13 +413,6 @@ void CLSRGWUnlinkInstance::unlink_instance(librados::ObjectWriteOperation& op,
   call.zones_trace = *this->zones_trace;
   encode(call, in);
   op.exec(RGW_CLASS, RGW_BUCKET_UNLINK_INSTANCE, in);
-}
-
-void cls_rgw_bucket_unlink_instance(librados::ObjectWriteOperation& op,
-                                   const cls_rgw_obj_key& key, const string& op_tag,
-                                   const string& olh_tag, uint64_t olh_epoch, bool log_op, rgw_zone_set& zones_trace)
-{
-  CLSRGWUnlinkInstance{log_op, key, op_tag, &zones_trace}.unlink_instance(op, olh_tag, olh_epoch);
 }
 
 void cls_rgw_get_olh_log(librados::ObjectReadOperation& op, const cls_rgw_obj_key& olh, uint64_t ver_marker, const string& olh_tag, rgw_cls_read_olh_log_ret& log_ret, int& op_ret)

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -194,7 +194,7 @@ void CLSRGWCompleteModifyOpBase::complete_op(librados::ObjectWriteOperation& o,
   bufferlist in;
   rgw_cls_obj_complete_op call;
   call.op = this->op_type;
-  call.tag = this->op_tag;
+  call.op_tag = this->op_tag;
   call.key = this->key;
   call.ver = ver;
   call.meta = dir_meta;

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -173,7 +173,7 @@ void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
 
 void cls_rgw_bucket_prepare_op(ObjectWriteOperation& o, RGWModifyOp op, string& tag,
                                const cls_rgw_obj_key& key, const string& locator,
-                               rgw_zone_set& zones_trace)
+                               const rgw_zone_set& zones_trace)
 {
   rgw_cls_obj_prepare_op call;
   call.op = op;

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -202,9 +202,7 @@ void CLSRGWCompleteModifyOpBase::complete_op(librados::ObjectWriteOperation& o,
   call.bilog_flags = this->bilog_flags;
   if (remove_objs)
     call.remove_objs = *remove_objs;
-  if (this->zones_trace) {
-    call.zones_trace = *this->zones_trace;
-  }
+  call.zones_trace = this->zones_trace;
   encode(call, in);
   o.exec(RGW_CLASS, RGW_BUCKET_COMPLETE_OP, in);
 }
@@ -390,8 +388,7 @@ void CLSRGWLinkOLHBase::link_olh(librados::ObjectWriteOperation& op,
   call.log_op = this->log_op;
   call.unmod_since = unmod_since;
   call.high_precision_time = high_precision_time;
-  ceph_assert(this->zones_trace);
-  call.zones_trace = *this->zones_trace;
+  call.zones_trace = this->zones_trace;
   encode(call, in);
   op.exec(RGW_CLASS, RGW_BUCKET_LINK_OLH, in);
 }
@@ -407,8 +404,7 @@ void CLSRGWUnlinkInstance::unlink_instance(librados::ObjectWriteOperation& op,
   call.olh_epoch = olh_epoch;
   call.olh_tag = olh_tag;
   call.log_op = this->log_op;
-  ceph_assert(this->zones_trace);
-  call.zones_trace = *this->zones_trace;
+  call.zones_trace = this->zones_trace;
   encode(call, in);
   op.exec(RGW_CLASS, RGW_BUCKET_UNLINK_INSTANCE, in);
 }

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -186,18 +186,6 @@ void cls_rgw_bucket_prepare_op(ObjectWriteOperation& o, RGWModifyOp op, string& 
   o.exec(RGW_CLASS, RGW_BUCKET_PREPARE_OP, in);
 }
 
-CLSRGWCompleteModifyOpBase
-CLSRGWCompleteModifyOpBase::from_call(const rgw_cls_obj_complete_op& call)
-{
-  return { call.log_op,
-           call.key,
-           call.tag,
-           &call.zones_trace,
-           call.bilog_flags,
-           call.op
-  };
-}
-
 void CLSRGWCompleteModifyOpBase::complete_op(librados::ObjectWriteOperation& o,
                                              const rgw_bucket_entry_ver& ver,
                                              const rgw_bucket_dir_entry_meta& dir_meta,
@@ -382,18 +370,6 @@ int cls_rgw_bi_list(librados::IoCtx& io_ctx, const string oid,
   return 0;
 }
 
-CLSRGWLinkOLHBase
-CLSRGWLinkOLHBase::from_call(const rgw_cls_link_olh_op& call)
-{
-  return { call.log_op,
-           call.key,
-           call.op_tag,
-           &call.zones_trace,
-           call.bilog_flags,
-           CLSRGWLinkOLHBase::get_bilog_op_type(call.delete_marker)
-  };
-}
-
 void CLSRGWLinkOLHBase::link_olh(librados::ObjectWriteOperation& op,
                                  ceph::bufferlist& olh_tag,
                                  const rgw_bucket_dir_entry_meta *meta,
@@ -418,17 +394,6 @@ void CLSRGWLinkOLHBase::link_olh(librados::ObjectWriteOperation& op,
   call.zones_trace = *this->zones_trace;
   encode(call, in);
   op.exec(RGW_CLASS, RGW_BUCKET_LINK_OLH, in);
-}
-
-CLSRGWUnlinkInstance
-CLSRGWUnlinkInstance::from_call(const rgw_cls_unlink_instance_op& call)
-{
-  return { call.log_op,
-           call.key,
-           call.op_tag,
-           &call.zones_trace,
-           call.bilog_flags
-  };
 }
 
 void CLSRGWUnlinkInstance::unlink_instance(librados::ObjectWriteOperation& op,

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -186,6 +186,18 @@ void cls_rgw_bucket_prepare_op(ObjectWriteOperation& o, RGWModifyOp op, string& 
   o.exec(RGW_CLASS, RGW_BUCKET_PREPARE_OP, in);
 }
 
+CLSRGWCompleteModifyOpBase
+CLSRGWCompleteModifyOpBase::from_call(const rgw_cls_obj_complete_op& call)
+{
+  return { call.log_op,
+           call.key,
+           call.tag,
+           &call.zones_trace,
+           call.bilog_flags,
+           call.op
+  };
+}
+
 void CLSRGWCompleteModifyOpBase::complete_op(librados::ObjectWriteOperation& o,
                                              const rgw_bucket_entry_ver& ver,
                                              const rgw_bucket_dir_entry_meta& dir_meta,
@@ -370,6 +382,18 @@ int cls_rgw_bi_list(librados::IoCtx& io_ctx, const string oid,
   return 0;
 }
 
+CLSRGWLinkOLHBase
+CLSRGWLinkOLHBase::from_call(const rgw_cls_link_olh_op& call)
+{
+  return { call.log_op,
+           call.key,
+           call.op_tag,
+           &call.zones_trace,
+           call.bilog_flags,
+           CLSRGWLinkOLHBase::get_bilog_op_type(call.delete_marker)
+  };
+}
+
 void CLSRGWLinkOLHBase::link_olh(librados::ObjectWriteOperation& op,
                                  ceph::bufferlist& olh_tag,
                                  const rgw_bucket_dir_entry_meta *meta,
@@ -394,6 +418,17 @@ void CLSRGWLinkOLHBase::link_olh(librados::ObjectWriteOperation& op,
   call.zones_trace = *this->zones_trace;
   encode(call, in);
   op.exec(RGW_CLASS, RGW_BUCKET_LINK_OLH, in);
+}
+
+CLSRGWUnlinkInstance
+CLSRGWUnlinkInstance::from_call(const rgw_cls_unlink_instance_op& call)
+{
+  return { call.log_op,
+           call.key,
+           call.op_tag,
+           &call.zones_trace,
+           call.bilog_flags
+  };
 }
 
 void CLSRGWUnlinkInstance::unlink_instance(librados::ObjectWriteOperation& op,

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -193,7 +193,7 @@ void CLSRGWCompleteModifyOpBase::complete_op(librados::ObjectWriteOperation& o,
 {
   bufferlist in;
   rgw_cls_obj_complete_op call;
-  call.op = this->op_type;
+  call.op = this->op;
   call.op_tag = this->op_tag;
   call.key = this->key;
   call.ver = ver;
@@ -382,7 +382,7 @@ void CLSRGWLinkOLHBase::link_olh(librados::ObjectWriteOperation& op,
   call.key = this->key;
   call.olh_tag = std::string(olh_tag.c_str(), olh_tag.length());
   call.op_tag = this->op_tag;
-  call.delete_marker = this->op_type;
+  call.delete_marker = this->op;
   if (meta) {
     call.meta = *meta;
   }

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -380,7 +380,7 @@ void CLSRGWLinkOLHBase::link_olh(librados::ObjectWriteOperation& op,
   call.key = this->key;
   call.olh_tag = std::string(olh_tag.c_str(), olh_tag.length());
   call.op_tag = this->op_tag;
-  call.delete_marker = this->op;
+  call.op = this->op;
   if (meta) {
     call.meta = *meta;
   }

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -362,13 +362,6 @@ void cls_rgw_bucket_prepare_op(librados::ObjectWriteOperation& o, RGWModifyOp op
                                const cls_rgw_obj_key& key, const std::string& locator,
                                rgw_zone_set& zones_trace);
 
-void cls_rgw_bucket_complete_op(librados::ObjectWriteOperation& o, RGWModifyOp op, std::string& tag,
-                                rgw_bucket_entry_ver& ver,
-                                const cls_rgw_obj_key& key,
-                                rgw_bucket_dir_entry_meta& dir_meta,
-				std::list<cls_rgw_obj_key> *remove_objs, bool log_op,
-                                uint16_t bilog_op, rgw_zone_set *zones_trace);
-
 void cls_rgw_remove_obj(librados::ObjectWriteOperation& o, std::list<std::string>& keep_attr_prefixes);
 void cls_rgw_obj_store_pg_ver(librados::ObjectWriteOperation& o, const std::string& attr);
 void cls_rgw_obj_check_attrs_prefix(librados::ObjectOperation& o, const std::string& prefix, bool fail_if_exist);
@@ -383,14 +376,6 @@ int cls_rgw_bi_list(librados::IoCtx& io_ctx, const std::string oid,
                    const std::string& name, const std::string& marker, uint32_t max,
                    std::list<rgw_cls_bi_entry> *entries, bool *is_truncated);
 
-
-void cls_rgw_bucket_link_olh(librados::ObjectWriteOperation& op,
-                            const cls_rgw_obj_key& key, ceph::buffer::list& olh_tag,
-                            bool delete_marker, const std::string& op_tag, rgw_bucket_dir_entry_meta *meta,
-                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, rgw_zone_set& zones_trace);
-void cls_rgw_bucket_unlink_instance(librados::ObjectWriteOperation& op,
-                                   const cls_rgw_obj_key& key, const std::string& op_tag,
-                                   const std::string& olh_tag, uint64_t olh_epoch, bool log_op, rgw_zone_set& zones_trace);
 void cls_rgw_get_olh_log(librados::ObjectReadOperation& op, const cls_rgw_obj_key& olh, uint64_t ver_marker, const std::string& olh_tag, rgw_cls_read_olh_log_ret& log_ret, int& op_ret);
 void cls_rgw_trim_olh_log(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& olh, uint64_t ver, const std::string& olh_tag);
 void cls_rgw_clear_olh(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& olh, const std::string& olh_tag);

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -360,7 +360,7 @@ void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
 
 void cls_rgw_bucket_prepare_op(librados::ObjectWriteOperation& o, RGWModifyOp op, std::string& tag,
                                const cls_rgw_obj_key& key, const std::string& locator,
-                               rgw_zone_set& zones_trace);
+                               const rgw_zone_set& zones_trace);
 
 void cls_rgw_remove_obj(librados::ObjectWriteOperation& o, std::list<std::string>& keep_attr_prefixes);
 void cls_rgw_obj_store_pg_ver(librados::ObjectWriteOperation& o, const std::string& attr);

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -395,23 +395,6 @@ void cls_rgw_get_olh_log(librados::ObjectReadOperation& op, const cls_rgw_obj_ke
 void cls_rgw_trim_olh_log(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& olh, uint64_t ver, const std::string& olh_tag);
 void cls_rgw_clear_olh(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& olh, const std::string& olh_tag);
 
-// these overloads which call io_ctx.operate() should not be called in the rgw.
-// rgw_rados_operate() should be called after the overloads w/o calls to io_ctx.operate()
-#ifndef CLS_CLIENT_HIDE_IOCTX
-int cls_rgw_bucket_link_olh(librados::IoCtx& io_ctx, const std::string& oid,
-                            const cls_rgw_obj_key& key, ceph::buffer::list& olh_tag,
-                            bool delete_marker, const std::string& op_tag, rgw_bucket_dir_entry_meta *meta,
-                            uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, rgw_zone_set& zones_trace);
-int cls_rgw_bucket_unlink_instance(librados::IoCtx& io_ctx, const std::string& oid,
-                                   const cls_rgw_obj_key& key, const std::string& op_tag,
-                                   const std::string& olh_tag, uint64_t olh_epoch, bool log_op, rgw_zone_set& zones_trace);
-int cls_rgw_get_olh_log(librados::IoCtx& io_ctx, std::string& oid, const cls_rgw_obj_key& olh, uint64_t ver_marker,
-                        const std::string& olh_tag, rgw_cls_read_olh_log_ret& log_ret);
-int cls_rgw_clear_olh(librados::IoCtx& io_ctx, std::string& oid, const cls_rgw_obj_key& olh, const std::string& olh_tag);
-int cls_rgw_usage_log_trim(librados::IoCtx& io_ctx, const std::string& oid, const std::string& user, const std::string& bucket,
-                           uint64_t start_epoch, uint64_t end_epoch);
-#endif
-
 
 /**
  * Std::list the bucket with the starting object and filter prefix.

--- a/src/cls/rgw/cls_rgw_ops.cc
+++ b/src/cls/rgw/cls_rgw_ops.cc
@@ -165,7 +165,7 @@ void rgw_cls_link_olh_op::generate_test_instances(list<rgw_cls_link_olh_op*>& o)
   rgw_cls_link_olh_op *op = new rgw_cls_link_olh_op;
   op->key.name = "name";
   op->olh_tag = "olh_tag";
-  op->delete_marker = true;
+  op->op = CLS_RGW_OP_LINK_OLH_DM;
   op->op_tag = "op_tag";
   op->olh_epoch = 123;
   list<rgw_bucket_dir_entry_meta *> l;
@@ -183,7 +183,7 @@ void rgw_cls_link_olh_op::dump(Formatter *f) const
 {
   encode_json("key", key, f);
   encode_json("olh_tag", olh_tag, f);
-  encode_json("delete_marker", delete_marker, f);
+  encode_json("delete_marker", has_delete_marker(), f);
   encode_json("op_tag", op_tag, f);
   encode_json("meta", meta, f);
   encode_json("olh_epoch", olh_epoch, f);

--- a/src/cls/rgw/cls_rgw_ops.cc
+++ b/src/cls/rgw/cls_rgw_ops.cc
@@ -130,7 +130,7 @@ void rgw_cls_obj_complete_op::generate_test_instances(list<rgw_cls_obj_complete_
   op->locator = "locator";
   op->ver.pool = 2;
   op->ver.epoch = 100;
-  op->tag = "tag";
+  op->op_tag = "tag";
 
   list<rgw_bucket_dir_entry_meta *> l;
   rgw_bucket_dir_entry_meta::generate_test_instances(l);
@@ -154,7 +154,7 @@ void rgw_cls_obj_complete_op::dump(Formatter *f) const
   f->open_object_section("meta");
   meta.dump(f);
   f->close_section();
-  f->dump_string("tag", tag);
+  f->dump_string("tag", op_tag);
   f->dump_bool("log_op", log_op);
   f->dump_int("bilog_flags", bilog_flags);
   encode_json("zones_trace", zones_trace, f);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1497,11 +1497,8 @@ struct CLSRGWBilogOp {
   const uint16_t bilog_flags;
 };
 
-template <enum RGWModifyOp OpType>
-struct CLSRGWCompleteModifyOp : CLSRGWBilogOp {
-  constexpr static enum RGWModifyOp get_bilog_op_type() {
-    return OpType;
-  }
+struct CLSRGWCompleteModifyOpBase : CLSRGWBilogOp {
+  const enum RGWModifyOp op_type;
 
   void complete_op(librados::ObjectWriteOperation& o,
                    const rgw_bucket_entry_ver& ver,
@@ -1509,8 +1506,27 @@ struct CLSRGWCompleteModifyOp : CLSRGWBilogOp {
                    const std::list<cls_rgw_obj_key> *remove_objs) const;
 };
 
+template <enum RGWModifyOp OpType>
+struct CLSRGWCompleteModifyOp : CLSRGWCompleteModifyOpBase {
+  template <class... Args>
+  CLSRGWCompleteModifyOp(Args&&... args)
+    : CLSRGWCompleteModifyOpBase{ std::forward<Args>(args)..., OpType } {
+  }
+};
+
+struct CLSRGWLinkOLHBase : CLSRGWBilogOp {
+  const enum RGWModifyOp op_type;
+
+  void link_olh(librados::ObjectWriteOperation& op,
+                ceph::bufferlist& olh_tag,
+                const rgw_bucket_dir_entry_meta *meta,
+                uint64_t olh_epoch,
+                ceph::real_time unmod_since,
+                bool high_precision_time) const;
+};
+
 template <bool DeleteMarkerV>
-struct CLSRGWLinkOLH : CLSRGWBilogOp {
+struct CLSRGWLinkOLH : CLSRGWLinkOLHBase {
   constexpr static enum RGWModifyOp get_bilog_op_type() {
     if constexpr (DeleteMarkerV) {
       return CLS_RGW_OP_LINK_OLH_DM;
@@ -1518,12 +1534,11 @@ struct CLSRGWLinkOLH : CLSRGWBilogOp {
       return CLS_RGW_OP_LINK_OLH;
     }
   }
-  void link_olh(librados::ObjectWriteOperation& op,
-                ceph::bufferlist& olh_tag,
-                const rgw_bucket_dir_entry_meta *meta,
-                uint64_t olh_epoch,
-                ceph::real_time unmod_since,
-                bool high_precision_time) const;
+
+  template <class... Args>
+  CLSRGWLinkOLH(Args&&... args)
+    : CLSRGWLinkOLHBase { std::forward<Args>(args)..., get_bilog_op_type() } {
+  }
 };
 
 struct CLSRGWUnlinkInstance : CLSRGWBilogOp {

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1500,6 +1500,9 @@ struct CLSRGWBilogOp {
 struct CLSRGWCompleteModifyOpBase : CLSRGWBilogOp {
   const enum RGWModifyOp op_type;
 
+  static CLSRGWCompleteModifyOpBase from_call(
+    const rgw_cls_obj_complete_op& call);
+
   void complete_op(librados::ObjectWriteOperation& o,
                    const rgw_bucket_entry_ver& ver,
                    const rgw_bucket_dir_entry_meta& dir_meta,
@@ -1517,6 +1520,13 @@ struct CLSRGWCompleteModifyOp : CLSRGWCompleteModifyOpBase {
 struct CLSRGWLinkOLHBase : CLSRGWBilogOp {
   const enum RGWModifyOp op_type;
 
+  static CLSRGWLinkOLHBase from_call(const rgw_cls_link_olh_op& call);
+
+  static RGWModifyOp get_bilog_op_type(const bool delete_marker) {
+     return delete_marker ? CLS_RGW_OP_LINK_OLH_DM
+                          : CLS_RGW_OP_LINK_OLH;
+  }
+
   void link_olh(librados::ObjectWriteOperation& op,
                 ceph::bufferlist& olh_tag,
                 const rgw_bucket_dir_entry_meta *meta,
@@ -1528,11 +1538,7 @@ struct CLSRGWLinkOLHBase : CLSRGWBilogOp {
 template <bool DeleteMarkerV>
 struct CLSRGWLinkOLH : CLSRGWLinkOLHBase {
   constexpr static enum RGWModifyOp get_bilog_op_type() {
-    if constexpr (DeleteMarkerV) {
-      return CLS_RGW_OP_LINK_OLH_DM;
-    } else {
-      return CLS_RGW_OP_LINK_OLH;
-    }
+    return CLSRGWLinkOLHBase::get_bilog_op_type(DeleteMarkerV);
   }
 
   template <class... Args>
@@ -1545,6 +1551,8 @@ struct CLSRGWUnlinkInstance : CLSRGWBilogOp {
   constexpr static enum RGWModifyOp get_bilog_op_type() {
     return CLS_RGW_OP_UNLINK_INSTANCE;
   }
+
+  static CLSRGWUnlinkInstance from_call(const rgw_cls_unlink_instance_op& call);
 
   void unlink_instance(librados::ObjectWriteOperation& op,
                        const std::string& olh_tag,

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -92,7 +92,7 @@ struct rgw_cls_obj_complete_op
   std::string locator;
   rgw_bucket_entry_ver ver;
   rgw_bucket_dir_entry_meta meta;
-  std::string tag;
+  std::string op_tag;
   bool log_op;
   uint16_t bilog_flags;
 
@@ -107,7 +107,7 @@ struct rgw_cls_obj_complete_op
     encode(c, bl);
     encode(ver.epoch, bl);
     encode(meta, bl);
-    encode(tag, bl);
+    encode(op_tag, bl);
     encode(locator, bl);
     encode(remove_objs, bl);
     encode(ver, bl);
@@ -127,7 +127,7 @@ struct rgw_cls_obj_complete_op
     }
     decode(ver.epoch, bl);
     decode(meta, bl);
-    decode(tag, bl);
+    decode(op_tag, bl);
     if (struct_v >= 2) {
       decode(locator, bl);
     }

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -5,6 +5,7 @@
 #define CEPH_CLS_RGW_OPS_H
 
 #include "cls/rgw/cls_rgw_types.h"
+#include "include/rados/librados_fwd.hpp"
 
 struct rgw_cls_tag_timeout_op
 {
@@ -1486,5 +1487,54 @@ struct cls_rgw_get_bucket_resharding_ret  {
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_get_bucket_resharding_ret)
+
+struct CLSRGWBilogOp {
+  const bool log_op;
+
+  const cls_rgw_obj_key& key;
+  const std::string& op_tag;
+  const rgw_zone_set* const zones_trace;
+  const uint16_t bilog_flags;
+};
+
+template <enum RGWModifyOp OpType>
+struct CLSRGWCompleteModifyOp : CLSRGWBilogOp {
+  constexpr static enum RGWModifyOp get_bilog_op_type() {
+    return OpType;
+  }
+
+  void complete_op(librados::ObjectWriteOperation& o,
+                   const rgw_bucket_entry_ver& ver,
+                   const rgw_bucket_dir_entry_meta& dir_meta,
+                   const std::list<cls_rgw_obj_key> *remove_objs) const;
+};
+
+template <bool DeleteMarkerV>
+struct CLSRGWLinkOLH : CLSRGWBilogOp {
+  constexpr static enum RGWModifyOp get_bilog_op_type() {
+    if constexpr (DeleteMarkerV) {
+      return CLS_RGW_OP_LINK_OLH_DM;
+    } else {
+      return CLS_RGW_OP_LINK_OLH;
+    }
+  }
+  void link_olh(librados::ObjectWriteOperation& op,
+                ceph::bufferlist& olh_tag,
+                const rgw_bucket_dir_entry_meta *meta,
+                uint64_t olh_epoch,
+                ceph::real_time unmod_since,
+                bool high_precision_time) const;
+};
+
+struct CLSRGWUnlinkInstance : CLSRGWBilogOp {
+  constexpr static enum RGWModifyOp get_bilog_op_type() {
+    return CLS_RGW_OP_UNLINK_INSTANCE;
+  }
+
+  void unlink_instance(librados::ObjectWriteOperation& op,
+                       const std::string& olh_tag,
+                       uint64_t olh_epoch) const;
+};
+
 
 #endif /* CEPH_CLS_RGW_OPS_H */

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1495,7 +1495,7 @@ struct cls_rgw_bi_log_related_op {
   const std::string op_tag;
   const rgw_zone_set* const zones_trace;
   const uint16_t bilog_flags;
-  const enum RGWModifyOp op_type;
+  const enum RGWModifyOp op;
 };
 
 struct CLSRGWCompleteModifyOpBase : cls_rgw_bi_log_related_op {

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -248,6 +248,10 @@ struct rgw_cls_unlink_instance_op : cls_rgw_bi_log_related_op {
   uint64_t olh_epoch = 0;
   std::string olh_tag;
 
+  rgw_cls_unlink_instance_op() {
+    op = CLS_RGW_OP_UNLINK_INSTANCE;
+  }
+
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(3, 1, bl);
     encode(key, bl);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -86,30 +86,27 @@ struct rgw_cls_obj_prepare_op
 WRITE_CLASS_ENCODER(rgw_cls_obj_prepare_op)
 
 struct cls_rgw_bi_log_related_op {
-  bool log_op;
+  bool log_op = false;
 
   cls_rgw_obj_key key;
   std::string op_tag;
   rgw_zone_set zones_trace;
-  uint16_t bilog_flags;
+  uint16_t bilog_flags = 0;
   enum RGWModifyOp op;
 };
 
-struct rgw_cls_obj_complete_op
+struct rgw_cls_obj_complete_op : cls_rgw_bi_log_related_op
 {
-  RGWModifyOp op;
-  cls_rgw_obj_key key;
   std::string locator;
   rgw_bucket_entry_ver ver;
   rgw_bucket_dir_entry_meta meta;
-  std::string op_tag;
-  bool log_op;
-  uint16_t bilog_flags;
 
   std::list<cls_rgw_obj_key> remove_objs;
   rgw_zone_set zones_trace;
 
-  rgw_cls_obj_complete_op() : op(CLS_RGW_OP_ADD), log_op(false), bilog_flags(0) {}
+  rgw_cls_obj_complete_op() {
+    op = CLS_RGW_OP_ADD;
+  }
 
   void encode(ceph::buffer::list &bl) const {
     ENCODE_START(9, 7, bl);
@@ -178,20 +175,13 @@ struct rgw_cls_obj_complete_op
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_complete_op)
 
-struct rgw_cls_link_olh_op {
-  cls_rgw_obj_key key;
+struct rgw_cls_link_olh_op : cls_rgw_bi_log_related_op {
   std::string olh_tag;
-  bool delete_marker;
-  std::string op_tag;
+  bool delete_marker = 0;
   rgw_bucket_dir_entry_meta meta;
-  uint64_t olh_epoch;
-  bool log_op;
-  uint16_t bilog_flags;
+  uint64_t olh_epoch = 0;
   ceph::real_time unmod_since; /* only create delete marker if newer then this */
-  bool high_precision_time;
-  rgw_zone_set zones_trace;
-
-  rgw_cls_link_olh_op() : delete_marker(false), olh_epoch(0), log_op(false), bilog_flags(0), high_precision_time(false) {}
+  bool high_precision_time = false;
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(5, 1, bl);
@@ -245,16 +235,9 @@ struct rgw_cls_link_olh_op {
 };
 WRITE_CLASS_ENCODER(rgw_cls_link_olh_op)
 
-struct rgw_cls_unlink_instance_op {
-  cls_rgw_obj_key key;
-  std::string op_tag;
-  uint64_t olh_epoch;
-  bool log_op;
-  uint16_t bilog_flags;
+struct rgw_cls_unlink_instance_op : cls_rgw_bi_log_related_op {
+  uint64_t olh_epoch = 0;
   std::string olh_tag;
-  rgw_zone_set zones_trace;
-
-  rgw_cls_unlink_instance_op() : olh_epoch(0), log_op(false), bilog_flags(0) {}
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(3, 1, bl);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1500,9 +1500,6 @@ struct CLSRGWBilogOp {
 struct CLSRGWCompleteModifyOpBase : CLSRGWBilogOp {
   const enum RGWModifyOp op_type;
 
-  static CLSRGWCompleteModifyOpBase from_call(
-    const rgw_cls_obj_complete_op& call);
-
   void complete_op(librados::ObjectWriteOperation& o,
                    const rgw_bucket_entry_ver& ver,
                    const rgw_bucket_dir_entry_meta& dir_meta,
@@ -1519,8 +1516,6 @@ struct CLSRGWCompleteModifyOp : CLSRGWCompleteModifyOpBase {
 
 struct CLSRGWLinkOLHBase : CLSRGWBilogOp {
   const enum RGWModifyOp op_type;
-
-  static CLSRGWLinkOLHBase from_call(const rgw_cls_link_olh_op& call);
 
   static RGWModifyOp get_bilog_op_type(const bool delete_marker) {
      return delete_marker ? CLS_RGW_OP_LINK_OLH_DM
@@ -1551,8 +1546,6 @@ struct CLSRGWUnlinkInstance : CLSRGWBilogOp {
   constexpr static enum RGWModifyOp get_bilog_op_type() {
     return CLS_RGW_OP_UNLINK_INSTANCE;
   }
-
-  static CLSRGWUnlinkInstance from_call(const rgw_cls_unlink_instance_op& call);
 
   void unlink_instance(librados::ObjectWriteOperation& op,
                        const std::string& olh_tag,

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1495,11 +1495,10 @@ struct CLSRGWBilogOp {
   const std::string& op_tag;
   const rgw_zone_set* const zones_trace;
   const uint16_t bilog_flags;
+  const enum RGWModifyOp op_type;
 };
 
 struct CLSRGWCompleteModifyOpBase : CLSRGWBilogOp {
-  const enum RGWModifyOp op_type;
-
   void complete_op(librados::ObjectWriteOperation& o,
                    const rgw_bucket_entry_ver& ver,
                    const rgw_bucket_dir_entry_meta& dir_meta,
@@ -1515,8 +1514,6 @@ struct CLSRGWCompleteModifyOp : CLSRGWCompleteModifyOpBase {
 };
 
 struct CLSRGWLinkOLHBase : CLSRGWBilogOp {
-  const enum RGWModifyOp op_type;
-
   static RGWModifyOp get_bilog_op_type(const bool delete_marker) {
      return delete_marker ? CLS_RGW_OP_LINK_OLH_DM
                           : CLS_RGW_OP_LINK_OLH;
@@ -1543,6 +1540,11 @@ struct CLSRGWLinkOLH : CLSRGWLinkOLHBase {
 };
 
 struct CLSRGWUnlinkInstance : CLSRGWBilogOp {
+  template <class... Args>
+  CLSRGWUnlinkInstance(Args&&... args)
+    : CLSRGWBilogOp { std::forward<Args>(args)..., get_bilog_op_type() } {
+  }
+
   constexpr static enum RGWModifyOp get_bilog_op_type() {
     return CLS_RGW_OP_UNLINK_INSTANCE;
   }

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -85,6 +85,16 @@ struct rgw_cls_obj_prepare_op
 };
 WRITE_CLASS_ENCODER(rgw_cls_obj_prepare_op)
 
+struct cls_rgw_bi_log_related_op {
+  bool log_op;
+
+  cls_rgw_obj_key key;
+  std::string op_tag;
+  rgw_zone_set zones_trace;
+  uint16_t bilog_flags;
+  enum RGWModifyOp op;
+};
+
 struct rgw_cls_obj_complete_op
 {
   RGWModifyOp op;
@@ -1487,16 +1497,6 @@ struct cls_rgw_get_bucket_resharding_ret  {
   void dump(ceph::Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(cls_rgw_get_bucket_resharding_ret)
-
-struct cls_rgw_bi_log_related_op {
-  const bool log_op;
-
-  const cls_rgw_obj_key key;
-  const std::string op_tag;
-  const rgw_zone_set* const zones_trace;
-  const uint16_t bilog_flags;
-  const enum RGWModifyOp op;
-};
 
 struct CLSRGWCompleteModifyOpBase : cls_rgw_bi_log_related_op {
   void complete_op(librados::ObjectWriteOperation& o,

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1488,17 +1488,17 @@ struct cls_rgw_get_bucket_resharding_ret  {
 };
 WRITE_CLASS_ENCODER(cls_rgw_get_bucket_resharding_ret)
 
-struct CLSRGWBilogOp {
+struct cls_rgw_bi_log_related_op {
   const bool log_op;
 
-  const cls_rgw_obj_key& key;
-  const std::string& op_tag;
+  const cls_rgw_obj_key key;
+  const std::string op_tag;
   const rgw_zone_set* const zones_trace;
   const uint16_t bilog_flags;
   const enum RGWModifyOp op_type;
 };
 
-struct CLSRGWCompleteModifyOpBase : CLSRGWBilogOp {
+struct CLSRGWCompleteModifyOpBase : cls_rgw_bi_log_related_op {
   void complete_op(librados::ObjectWriteOperation& o,
                    const rgw_bucket_entry_ver& ver,
                    const rgw_bucket_dir_entry_meta& dir_meta,
@@ -1513,7 +1513,7 @@ struct CLSRGWCompleteModifyOp : CLSRGWCompleteModifyOpBase {
   }
 };
 
-struct CLSRGWLinkOLHBase : CLSRGWBilogOp {
+struct CLSRGWLinkOLHBase : cls_rgw_bi_log_related_op {
   static RGWModifyOp get_bilog_op_type(const bool delete_marker) {
      return delete_marker ? CLS_RGW_OP_LINK_OLH_DM
                           : CLS_RGW_OP_LINK_OLH;
@@ -1539,10 +1539,10 @@ struct CLSRGWLinkOLH : CLSRGWLinkOLHBase {
   }
 };
 
-struct CLSRGWUnlinkInstance : CLSRGWBilogOp {
+struct CLSRGWUnlinkInstance : cls_rgw_bi_log_related_op {
   template <class... Args>
   CLSRGWUnlinkInstance(Args&&... args)
-    : CLSRGWBilogOp { std::forward<Args>(args)..., get_bilog_op_type() } {
+    : cls_rgw_bi_log_related_op { std::forward<Args>(args)..., get_bilog_op_type() } {
   }
 
   constexpr static enum RGWModifyOp get_bilog_op_type() {

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -177,17 +177,20 @@ WRITE_CLASS_ENCODER(rgw_cls_obj_complete_op)
 
 struct rgw_cls_link_olh_op : cls_rgw_bi_log_related_op {
   std::string olh_tag;
-  bool delete_marker = 0;
   rgw_bucket_dir_entry_meta meta;
   uint64_t olh_epoch = 0;
   ceph::real_time unmod_since; /* only create delete marker if newer then this */
   bool high_precision_time = false;
 
+  bool has_delete_marker() const {
+    return op == CLS_RGW_OP_LINK_OLH_DM;
+  }
+
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(5, 1, bl);
     encode(key, bl);
     encode(olh_tag, bl);
-    encode(delete_marker, bl);
+    encode(bool { has_delete_marker() }, bl);
     encode(op_tag, bl);
     encode(meta, bl);
     encode(olh_epoch, bl);
@@ -205,7 +208,13 @@ struct rgw_cls_link_olh_op : cls_rgw_bi_log_related_op {
     DECODE_START(5, bl);
     decode(key, bl);
     decode(olh_tag, bl);
-    decode(delete_marker, bl);
+    {
+      // legacy
+      bool delete_marker;
+      decode(delete_marker, bl);
+      op = delete_marker ? CLS_RGW_OP_LINK_OLH_DM
+                         : CLS_RGW_OP_LINK_OLH;
+    }
     decode(op_tag, bl);
     decode(meta, bl);
     decode(olh_epoch, bl);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1509,10 +1509,19 @@ struct CLSRGWCompleteModifyOp : CLSRGWCompleteModifyOpBase {
   }
 };
 
-struct CLSRGWLinkOLHBase : cls_rgw_bi_log_related_op {
+struct CLSRGWLinkOLHBase : private cls_rgw_bi_log_related_op {
+  template <class... Args>
+  CLSRGWLinkOLHBase(Args&&... args)
+    : cls_rgw_bi_log_related_op{ std::forward<Args>(args)... } {
+  }
+
   static RGWModifyOp get_bilog_op_type(const bool delete_marker) {
      return delete_marker ? CLS_RGW_OP_LINK_OLH_DM
                           : CLS_RGW_OP_LINK_OLH;
+  }
+
+  std::string& get_op_tag_ref() {
+    return op_tag;
   }
 
   void link_olh(librados::ObjectWriteOperation& op,
@@ -1525,6 +1534,8 @@ struct CLSRGWLinkOLHBase : cls_rgw_bi_log_related_op {
 
 template <bool DeleteMarkerV>
 struct CLSRGWLinkOLH : CLSRGWLinkOLHBase {
+  using CLSRGWLinkOLHBase::CLSRGWLinkOLHBase;
+
   constexpr static enum RGWModifyOp get_bilog_op_type() {
     return CLSRGWLinkOLHBase::get_bilog_op_type(DeleteMarkerV);
   }

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -490,7 +490,6 @@ void rgw_bi_log_entry::decode_json(JSONObj *obj)
   } else {
     state = CLS_RGW_STATE_UNKNOWN;
   }
-  JSONDecoder::decode_json("index_ver", index_ver, obj);
   utime_t ut;
   JSONDecoder::decode_json("timestamp", ut, obj);
   timestamp = ut.to_real_time();
@@ -555,7 +554,7 @@ void rgw_bi_log_entry::dump(Formatter *f) const
       break;
   }
 
-  f->dump_int("index_ver", index_ver);
+  f->dump_int("index_ver", uint64_t{0});
   utime_t ut(timestamp);
   ut.gmtime_nsec(f->dump_stream("timestamp"));
   f->open_object_section("ver");
@@ -575,7 +574,6 @@ void rgw_bi_log_entry::generate_test_instances(list<rgw_bi_log_entry*>& ls)
   ls.back()->id = "midf";
   ls.back()->object = "obj";
   ls.back()->timestamp = ceph::real_clock::from_ceph_timespec({init_le32(2), init_le32(3)});
-  ls.back()->index_ver = 4323;
   ls.back()->tag = "tagasdfds";
   ls.back()->op = CLS_RGW_OP_DEL;
   ls.back()->state = CLS_RGW_STATE_PENDING_MODIFY;

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -376,6 +376,22 @@ void rgw_bucket_olh_entry::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("pending_removal", pending_removal, obj);
 }
 
+void rgw_bucket_olh_log_bi_log_entry::dump(Formatter *f) const
+{
+  encode_json("timestamp", timestamp, f);
+  encode_json("owner", owner, f);
+  encode_json("owner_display_name", owner_display_name, f);
+  encode_json("zones_trace", zones_trace, f);
+}
+
+void rgw_bucket_olh_log_bi_log_entry::decode_json(JSONObj *obj)
+{
+  JSONDecoder::decode_json("timestamp", timestamp, obj);
+  JSONDecoder::decode_json("owner", owner, obj);
+  JSONDecoder::decode_json("owner_display_name", owner_display_name, obj);
+  JSONDecoder::decode_json("zones_trace", zones_trace, obj);
+}
+
 void rgw_bucket_olh_log_entry::generate_test_instances(list<rgw_bucket_olh_log_entry*>& o)
 {
   rgw_bucket_olh_log_entry *entry = new rgw_bucket_olh_log_entry;
@@ -410,6 +426,9 @@ void rgw_bucket_olh_log_entry::dump(Formatter *f) const
   encode_json("op_tag", op_tag, f);
   encode_json("key", key, f);
   encode_json("delete_marker", delete_marker, f);
+
+  // since v2
+  encode_json("bi_log_replay_data", bi_log_replay_data, f);
 }
 
 void rgw_bucket_olh_log_entry::decode_json(JSONObj *obj)
@@ -429,6 +448,9 @@ void rgw_bucket_olh_log_entry::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("op_tag", op_tag, obj);
   JSONDecoder::decode_json("key", key, obj);
   JSONDecoder::decode_json("delete_marker", delete_marker, obj);
+
+  // since v2
+  JSONDecoder::decode_json("bi_log_replay_data", bi_log_replay_data, obj);
 }
 void rgw_bi_log_entry::decode_json(JSONObj *obj)
 {

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -539,6 +539,38 @@ enum OLHLogOp {
   CLS_RGW_OLH_OP_REMOVE_INSTANCE = 3,
 };
 
+// because of the need to preserve atomicity in  `Write::_do_write_meta()`
+// between updating Bucket Index (the `UpdateIndex::complete()` method)
+// and `RGWRados::set_olh()`, we reissue requests to link OLH basing OLH
+// log. However, to make that possible, these entries have to contain
+// some extra bits which are represented by the following struct.
+struct rgw_bucket_olh_log_bi_log_entry {
+  ceph::real_time timestamp;
+  std::string owner; /* only being set if it's a delete marker */
+  std::string owner_display_name; /* only being set if it's a delete marker */
+  rgw_zone_set zones_trace;
+
+  void encode(ceph::buffer::list &bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(timestamp, bl);
+    encode(owner, bl);
+    encode(owner_display_name, bl);
+    encode(zones_trace, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(ceph::buffer::list::const_iterator &bl) {
+    DECODE_START(1, bl);
+    decode(timestamp, bl);
+    decode(owner, bl);
+    decode(owner_display_name, bl);
+    decode(zones_trace, bl);
+    DECODE_FINISH(bl);
+  }
+  void dump(ceph::Formatter *f) const;
+  void decode_json(JSONObj *obj);
+};
+WRITE_CLASS_ENCODER(rgw_bucket_olh_log_bi_log_entry)
+
 struct rgw_bucket_olh_log_entry {
   uint64_t epoch;
   OLHLogOp op;
@@ -546,20 +578,23 @@ struct rgw_bucket_olh_log_entry {
   cls_rgw_obj_key key;
   bool delete_marker;
 
+  std::optional<rgw_bucket_olh_log_bi_log_entry> bi_log_replay_data;
+
   rgw_bucket_olh_log_entry() : epoch(0), op(CLS_RGW_OLH_OP_UNKNOWN), delete_marker(false) {}
 
-
   void encode(ceph::buffer::list &bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     encode(epoch, bl);
     encode((__u8)op, bl);
     encode(op_tag, bl);
     encode(key, bl);
     encode(delete_marker, bl);
+    // since struct_v >= 2
+    encode(bi_log_replay_data, bl);
     ENCODE_FINISH(bl);
   }
   void decode(ceph::buffer::list::const_iterator &bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     decode(epoch, bl);
     uint8_t c;
     decode(c, bl);
@@ -567,6 +602,9 @@ struct rgw_bucket_olh_log_entry {
     decode(op_tag, bl);
     decode(key, bl);
     decode(delete_marker, bl);
+    if (struct_v > 1) {
+      decode(bi_log_replay_data, bl);
+    }
     DECODE_FINISH(bl);
   }
   static void generate_test_instances(std::list<rgw_bucket_olh_log_entry*>& o);

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -8618,13 +8618,25 @@ next:
       cerr << "ERROR: bucket not specified" << std::endl;
       return EINVAL;
     }
+    if (!start_marker.empty()) {
+      std::cerr << "start-marker not allowed." << std::endl;
+      return -EINVAL;
+    }
+    if (!end_marker.empty()) {
+      if (marker.empty()) {
+	marker = end_marker;
+      } else {
+	std::cerr << "end-marker and marker not both allowed." << std::endl;
+	return -EINVAL;
+      }
+    }
     RGWBucketInfo bucket_info;
     int ret = init_bucket(tenant, bucket_name, bucket_id, bucket_info, bucket);
     if (ret < 0) {
       cerr << "ERROR: could not init bucket: " << cpp_strerror(-ret) << std::endl;
       return -ret;
     }
-    ret = store->svc()->bilog_rados->log_trim(bucket_info, shard_id, start_marker, end_marker);
+    ret = store->svc()->bilog_rados->log_trim(bucket_info, shard_id, marker);
     if (ret < 0) {
       cerr << "ERROR: trim_bi_log_entries(): " << cpp_strerror(-ret) << std::endl;
       return -ret;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -8655,11 +8655,19 @@ next:
       return -ret;
     }
     map<int, string> markers;
-    ret = store->svc()->bilog_rados->get_log_status(bucket_info, shard_id,
-						    &markers, null_yield);
-    if (ret < 0) {
-      cerr << "ERROR: get_bi_log_status(): " << cpp_strerror(-ret) << std::endl;
-      return -ret;
+    {
+      std::map<int, rgw_bucket_dir_header> headers;
+      ret = store->svc()->bi->get_dir_headers(bucket_info, shard_id, &headers,
+                                              null_yield);
+      if (ret < 0) {
+        cerr << "ERROR: get_bi_log_status(): " << cpp_strerror(-ret) << std::endl;
+        return ret;
+      }
+      ret = store->svc()->bilog_rados->log_get_max_marker(bucket_info, headers, shard_id, &markers);
+      if (ret < 0) {
+        cerr << "ERROR: get_bi_log_status(): " << cpp_strerror(-ret) << std::endl;
+        return -ret;
+      }
     }
     formatter->open_object_section("entries");
     encode_json("markers", markers, formatter.get());

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -377,7 +377,7 @@ int rgw_remove_bucket_bypass_gc(rgw::sal::RGWRadosStore *store, rgw_bucket& buck
   if (ret < 0)
     return ret;
 
-  ret = store->getRados()->get_bucket_stats(info, RGW_NO_SHARD, &bucket_ver, &master_ver, stats, NULL);
+  ret = store->getRados()->get_bucket_stats(info, RGW_NO_SHARD, &bucket_ver, &master_ver, stats);
   if (ret < 0)
     return ret;
 
@@ -1320,9 +1320,12 @@ static int bucket_stats(rgw::sal::RGWRadosStore *store,
 
   string bucket_ver, master_ver;
   string max_marker;
-  int ret = store->getRados()->get_bucket_stats(bucket_info, RGW_NO_SHARD,
-						&bucket_ver, &master_ver, stats,
-						&max_marker);
+  int ret = store->getRados()->get_bucket_stats_and_bilog_meta(bucket_info,
+                                                               RGW_NO_SHARD,
+                                                               &bucket_ver,
+                                                               &master_ver,
+                                                               stats,
+                                                               &max_marker);
   if (ret < 0) {
     cerr << "error getting bucket stats bucket=" << bucket.name << " ret=" << ret << std::endl;
     return ret;
@@ -1434,7 +1437,7 @@ int RGWBucketAdminOp::limit_check(rgw::sal::RGWRadosStore *store,
 	string bucket_ver, master_ver;
 	std::map<RGWObjCategory, RGWStorageStats> stats;
 	ret = store->getRados()->get_bucket_stats(info, RGW_NO_SHARD, &bucket_ver,
-				      &master_ver, stats, nullptr);
+						  &master_ver, stats);
 
 	if (ret < 0)
 	  continue;

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -75,6 +75,8 @@ void decode(bucket_index_layout_generation& l, bufferlist::const_iterator& bl);
 enum class BucketLogType : uint8_t {
   // colocated with bucket index, so the log layout matches the index layout
   InIndex,
+  // located externally to bucket index, in a cls_fifo instance
+  FIFO
 };
 
 inline std::ostream& operator<<(std::ostream& out, const BucketLogType &log_type)
@@ -82,6 +84,8 @@ inline std::ostream& operator<<(std::ostream& out, const BucketLogType &log_type
   switch (log_type) {
     case BucketLogType::InIndex:
       return out << "InIndex";
+    case BucketLogType::FIFO:
+      return out << "FIFO";
     default:
       return out << "Unknown";
   }

--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -380,6 +380,7 @@ public:
 		 << ": " << cpp_strerror(-r) << dendl;
       return r;
     }
+    entries.reserve(std::size(entries) + std::size(log_entries));
     for (const auto& entry : log_entries) {
       rgw_data_change_log_entry log_entry;
       log_entry.log_id = entry.marker;

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -379,7 +379,7 @@ int RGWBucketStatsCache::fetch_stats_from_storage(const rgw_user& user, const rg
 
   map<RGWObjCategory, RGWStorageStats> bucket_stats;
   r = store->getRados()->get_bucket_stats(bucket_info, RGW_NO_SHARD, &bucket_ver,
-                                  &master_ver, bucket_stats, nullptr);
+                                          &master_ver, bucket_stats);
   if (r < 0) {
     ldout(store->ctx(), 0) << "could not get bucket stats for bucket="
                            << bucket.name << dendl;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -836,7 +836,7 @@ struct complete_op_data {
   rgw_bucket_dir_entry_meta dir_meta;
   list<cls_rgw_obj_key> remove_objs;
   bool log_op;
-  uint16_t bilog_op;
+  uint16_t bilog_flags;
   rgw_zone_set zones_trace;
 
   bool stopped{false};
@@ -906,7 +906,7 @@ int RGWIndexCompletionThread::process()
 			       librados::ObjectWriteOperation o;
 			       cls_rgw_guard_bucket_resharding(o, -ERR_BUSY_RESHARDING);
 			       cls_rgw_bucket_complete_op(o, c->op, c->tag, c->ver, c->key, c->dir_meta, &c->remove_objs,
-							  c->log_op, c->bilog_op, &c->zones_trace);
+							  c->log_op, c->bilog_flags, &c->zones_trace);
 			       return bs->bucket_obj.operate(&o, null_yield);
                              });
     if (r < 0) {
@@ -964,7 +964,7 @@ public:
                          const cls_rgw_obj_key& key,
                          rgw_bucket_dir_entry_meta& dir_meta,
                          list<cls_rgw_obj_key> *remove_objs, bool log_op,
-                         uint16_t bilog_op,
+                         uint16_t bilog_flags,
                          rgw_zone_set *zones_trace,
                          complete_op_data **result);
   bool handle_completion(completion_t cb, complete_op_data *arg);
@@ -1017,7 +1017,7 @@ void RGWIndexCompletionManager::create_completion(const rgw_obj& obj,
                                                   const cls_rgw_obj_key& key,
                                                   rgw_bucket_dir_entry_meta& dir_meta,
                                                   list<cls_rgw_obj_key> *remove_objs, bool log_op,
-                                                  uint16_t bilog_op,
+                                                  uint16_t bilog_flags,
                                                   rgw_zone_set *zones_trace,
                                                   complete_op_data **result)
 {
@@ -1034,7 +1034,7 @@ void RGWIndexCompletionManager::create_completion(const rgw_obj& obj,
   entry->key = key;
   entry->dir_meta = dir_meta;
   entry->log_op = log_op;
-  entry->bilog_op = bilog_op;
+  entry->bilog_flags = bilog_flags;
 
   if (remove_objs) {
     for (auto iter = remove_objs->begin(); iter != remove_objs->end(); ++iter) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6834,8 +6834,8 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
   return -ERR_BUSY_RESHARDING;
 }
 
+template <bool DeleteMarkerV>
 int RGWRados::bucket_index_link_olh(const RGWBucketInfo& bucket_info, RGWObjState& olh_state, const rgw_obj& obj_instance,
-                                    bool delete_marker,
                                     const string& op_tag,
                                     struct rgw_bucket_dir_entry_meta *meta,
                                     uint64_t olh_epoch,
@@ -6863,7 +6863,7 @@ int RGWRados::bucket_index_link_olh(const RGWBucketInfo& bucket_info, RGWObjStat
 		      librados::ObjectWriteOperation op;
 		      cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
 		      cls_rgw_bucket_link_olh(op, key, olh_state.olh_tag,
-                                              delete_marker, op_tag, meta, olh_epoch,
+                                              DeleteMarkerV, op_tag, meta, olh_epoch,
 					      unmod_since, high_precision_time,
 					      svc.zone->get_zone().log_data, zones_trace);
                       return rgw_rados_operate(ref.pool.ioctx(), ref.obj.oid, &op, null_yield);
@@ -7328,9 +7328,10 @@ int RGWRados::set_olh(RGWObjectCtx& obj_ctx, const RGWBucketInfo& bucket_info, c
       }
       return ret;
     }
-    ret = bucket_index_link_olh(bucket_info, *state, target_obj, DeleteMarkerV,
-                                op_tag, meta, olh_epoch, unmod_since, high_precision_time,
-                                zones_trace, log_data_change);
+    ret = bucket_index_link_olh<DeleteMarkerV>(bucket_info, *state, target_obj,
+                                               op_tag, meta, olh_epoch, unmod_since,
+                                               high_precision_time, zones_trace,
+                                               log_data_change);
     if (ret < 0) {
       ldout(cct, 20) << "bucket_index_link_olh() target_obj=" << target_obj << " delete_marker=" << (int)DeleteMarkerV << " returned " << ret << dendl;
       if (ret == -ECANCELED) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6818,6 +6818,7 @@ struct BILogUpdateBatchFIFO {
                        const RGWBucketInfo& bucket_info);
 
   void add_maybe_flush(const uint64_t olh_epoch,
+                       const ceph::real_time set_mtime,
                        const cls_rgw_bi_log_related_op& bi_log_client_info) {
     ldout(cct, 20) << __PRETTY_FUNCTION__
                    << ": the cls_rgw_bi_log_related_op-taking variant"
@@ -6826,7 +6827,7 @@ struct BILogUpdateBatchFIFO {
 
     entry.object = bi_log_client_info.key.name;
     entry.instance = bi_log_client_info.key.instance;
-    // TODO: entry.timestamp
+    entry.timestamp = set_mtime;
     entry.op = bi_log_client_info.op;
     // olh epoch
     {
@@ -6917,7 +6918,7 @@ static BILogUpdateBatchFIFO get_or_create_fifo_bilog_op(CephContext* const cct,
 struct BILogNopHandler {
   CephContext* const cct;
 
-  void add_maybe_flush(const uint64_t, const cls_rgw_bi_log_related_op&) {
+  void add_maybe_flush(const uint64_t, ceph::real_time, const cls_rgw_bi_log_related_op&) {
     ldout(cct, 20) << __PRETTY_FUNCTION__
                    << ": the cls_rgw_bi_log_related_op-taking variant"
                    << dendl;
@@ -8448,6 +8449,7 @@ int RGWRados::cls_obj_complete_op(const RGWBucketInfo& bucket_info,
       // Index or externally (e.g. in cls_fifo).
       bilog_handler.add_maybe_flush(
         rgw_bucket_entry_ver{}.epoch,
+        ent.meta.mtime,
         static_cast<const cls_rgw_bi_log_related_op&>(op_issuer));
 
       // handle the BI::complete part. It happens ONLY after ensuring

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3252,10 +3252,8 @@ int RGWRados::Object::Write::write_meta(uint64_t size, uint64_t accounted_size,
   RGWBucketInfo& bucket_info = target->get_bucket_info();
 
   RGWRados::Bucket bop(target->get_store(), bucket_info);
-  RGWRados::Bucket::UpdateIndex index_op(&bop, target->get_obj());
-  index_op.set_zones_trace(meta.zones_trace);
+  RGWRados::Bucket::UpdateIndex index_op(&bop, target->get_obj(), meta.zones_trace);
 
-  
   bool assume_noent = (meta.if_match == NULL && meta.if_nomatch == NULL);
   RGWObjState *state;
   int r = target->get_state(&state, false, y, assume_noent);
@@ -5125,10 +5123,7 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y)
   RGWBucketInfo& bucket_info = target->get_bucket_info();
 
   RGWRados::Bucket bop(store, bucket_info);
-  RGWRados::Bucket::UpdateIndex index_op(&bop, obj);
-  
-  index_op.set_zones_trace(params.zones_trace);
-
+  RGWRados::Bucket::UpdateIndex index_op(&bop, obj, params.zones_trace);
   r = index_op.prepare(CLS_RGW_OP_DEL, &state->write_tag, y);
   if (r < 0)
     return r;
@@ -6000,10 +5995,12 @@ int RGWRados::Object::Read::range_to_ofs(uint64_t obj_size, int64_t &ofs, int64_
 
 RGWRados::Bucket::UpdateIndex::UpdateIndex(
   RGWRados::Bucket *_target,
-  const rgw_obj& _obj)
+  const rgw_obj& _obj,
+  rgw_zone_set *zones_trace)
 : target(_target),
   obj(_obj),
-  bs(target->get_store())
+  bs(target->get_store()),
+  zones_trace(zones_trace)
 {
   blind = (target->get_bucket_info().layout.current_index.layout.type == rgw::BucketIndexType::Indexless);
 }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7442,6 +7442,18 @@ int RGWRados::update_olh(RGWObjectCtx& obj_ctx,
   return 0;
 }
 
+static rgw_zone_set get_zones_trace(const RGWZone& zone,
+                                    const rgw_bucket& bucket,
+                                    const rgw_zone_set* const maybe_zones_trace)
+{
+  rgw_zone_set zones_trace;
+  if (maybe_zones_trace) {
+    zones_trace = *maybe_zones_trace;
+  }
+  zones_trace.insert(zone.id, bucket.get_key());
+  return zones_trace;
+}
+
 template <bool DeleteMarkerV>
 int RGWRados::set_olh(RGWObjectCtx& obj_ctx, const RGWBucketInfo& bucket_info, const rgw_obj& target_obj, rgw_bucket_dir_entry_meta *meta,
                       uint64_t olh_epoch, real_time unmod_since, bool high_precision_time,
@@ -7451,15 +7463,8 @@ int RGWRados::set_olh(RGWObjectCtx& obj_ctx, const RGWBucketInfo& bucket_info, c
   olh_obj.key.instance.clear();
 
   RGWObjState *state = NULL;
-
-  int ret = 0;
-  int i;
-  
-  rgw_zone_set zones_trace;
-  if (_zones_trace) {
-    zones_trace = *_zones_trace;
-  }
-  zones_trace.insert(svc.zone->get_zone().id, bucket_info.bucket.get_key());
+  const auto zones_trace = \
+    get_zones_trace(svc.zone->get_zone(), bucket_info.bucket, _zones_trace);
 #define MAX_ECANCELED_RETRY 100
   return with_bilog<CLSRGWLinkOLH<DeleteMarkerV>>(
     [&] (auto op_issuer, auto bilog_handler) {
@@ -7537,14 +7542,9 @@ int RGWRados::unlink_obj_instance(RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_i
   rgw_obj olh_obj = target_obj;
   olh_obj.key.instance.clear();
 
-  RGWObjState *state = NULL;
-
-  rgw_zone_set zones_trace;
-  if (_zones_trace) {
-    zones_trace = *_zones_trace;
-  }
-  zones_trace.insert(svc.zone->get_zone().id, bucket_info.bucket.get_key());
-
+  RGWObjState *state = nullptr;
+  const auto zones_trace = \
+    get_zones_trace(svc.zone->get_zone(), bucket_info.bucket, _zones_trace);
   return with_bilog<CLSRGWUnlinkInstance>(
     [&] (auto op_issuer, auto bilog_handler) {
       int ret, i;
@@ -8411,12 +8411,8 @@ bool RGWRados::process_expire_objects()
 int RGWRados::cls_obj_prepare_op(BucketShard& bs, RGWModifyOp op, string& tag,
                                  rgw_obj& obj, optional_yield y, rgw_zone_set *_zones_trace)
 {
-  rgw_zone_set zones_trace;
-  if (_zones_trace) {
-    zones_trace = *_zones_trace;
-  }
-  zones_trace.insert(svc.zone->get_zone().id, bs.bucket.get_key());
-
+  const auto zones_trace = \
+    get_zones_trace(svc.zone->get_zone(), bs.bucket, _zones_trace);
   ObjectWriteOperation o;
   cls_rgw_obj_key key(obj.key.get_index_key_name(), obj.key.instance);
   cls_rgw_guard_bucket_resharding(o, -ERR_BUSY_RESHARDING);
@@ -8431,11 +8427,8 @@ int RGWRados::cls_obj_complete_op(const RGWBucketInfo& bucket_info,
                                   const rgw_bucket_dir_entry& ent, RGWObjCategory category,
 				  list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags, rgw_zone_set *_zones_trace)
 {
-  rgw_zone_set zones_trace;
-  if (_zones_trace) {
-    zones_trace = *_zones_trace;
-  }
-  zones_trace.insert(svc.zone->get_zone().id, bs.bucket.get_key());
+  const auto zones_trace = \
+    get_zones_trace(svc.zone->get_zone(), bs.bucket, _zones_trace);
   return with_bilog<CLSRGWBucketModifyOpT>(
     [&, this] (auto op_issuer, auto bilog_handler) {
       // handle the bilog. It may be stored altogether with Bucket

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3230,7 +3230,7 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
   state = NULL;
 
   if (versioned_op && meta.olh_epoch) {
-    r = store->set_olh(target->get_ctx(), target->get_bucket_info(), obj, false, NULL, *meta.olh_epoch, real_time(), false, y, meta.zones_trace);
+    r = store->set_olh<false>(target->get_ctx(), target->get_bucket_info(), obj, NULL, *meta.olh_epoch, real_time(), false, y, meta.zones_trace);
     if (r < 0) {
       return r;
     }
@@ -4138,8 +4138,8 @@ set_err_state:
     // for OP_LINK_OLH to call set_olh() with a real olh_epoch
     if (olh_epoch && *olh_epoch > 0) {
       constexpr bool log_data_change = true;
-      ret = set_olh(obj_ctx, dest_bucket->get_info(), dest_obj->get_obj(), false, nullptr,
-                    *olh_epoch, real_time(), false, null_yield, zones_trace, log_data_change);
+      ret = set_olh<false>(obj_ctx, dest_bucket->get_info(), dest_obj->get_obj(), nullptr,
+                           *olh_epoch, real_time(), false, null_yield, zones_trace, log_data_change);
     } else {
       // we already have the latest copy
       ret = 0;
@@ -5079,7 +5079,7 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y)
         meta.mtime = params.mtime;
       }
 
-      int r = store->set_olh(target->get_ctx(), target->get_bucket_info(), marker, true, &meta, params.olh_epoch, params.unmod_since, params.high_precision_time, y, params.zones_trace);
+      int r = store->set_olh<true>(target->get_ctx(), target->get_bucket_info(), marker, &meta, params.olh_epoch, params.unmod_since, params.high_precision_time, y, params.zones_trace);
       if (r < 0) {
         return r;
       }
@@ -7294,7 +7294,8 @@ int RGWRados::update_olh(RGWObjectCtx& obj_ctx, RGWObjState *state, const RGWBuc
   return 0;
 }
 
-int RGWRados::set_olh(RGWObjectCtx& obj_ctx, const RGWBucketInfo& bucket_info, const rgw_obj& target_obj, bool delete_marker, rgw_bucket_dir_entry_meta *meta,
+template <bool DeleteMarkerV>
+int RGWRados::set_olh(RGWObjectCtx& obj_ctx, const RGWBucketInfo& bucket_info, const rgw_obj& target_obj, rgw_bucket_dir_entry_meta *meta,
                       uint64_t olh_epoch, real_time unmod_since, bool high_precision_time,
                       optional_yield y, rgw_zone_set *zones_trace, bool log_data_change)
 {
@@ -7321,17 +7322,17 @@ int RGWRados::set_olh(RGWObjectCtx& obj_ctx, const RGWBucketInfo& bucket_info, c
 
     ret = olh_init_modification(bucket_info, *state, olh_obj, &op_tag);
     if (ret < 0) {
-      ldout(cct, 20) << "olh_init_modification() target_obj=" << target_obj << " delete_marker=" << (int)delete_marker << " returned " << ret << dendl;
+      ldout(cct, 20) << "olh_init_modification() target_obj=" << target_obj << " delete_marker=" << (int)DeleteMarkerV << " returned " << ret << dendl;
       if (ret == -ECANCELED) {
         continue;
       }
       return ret;
     }
-    ret = bucket_index_link_olh(bucket_info, *state, target_obj, delete_marker,
+    ret = bucket_index_link_olh(bucket_info, *state, target_obj, DeleteMarkerV,
                                 op_tag, meta, olh_epoch, unmod_since, high_precision_time,
                                 zones_trace, log_data_change);
     if (ret < 0) {
-      ldout(cct, 20) << "bucket_index_link_olh() target_obj=" << target_obj << " delete_marker=" << (int)delete_marker << " returned " << ret << dendl;
+      ldout(cct, 20) << "bucket_index_link_olh() target_obj=" << target_obj << " delete_marker=" << (int)DeleteMarkerV << " returned " << ret << dendl;
       if (ret == -ECANCELED) {
         // the bucket index rejected the link_olh() due to olh tag mismatch;
         // attempt to reconstruct olh head attributes based on the bucket index

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6911,7 +6911,7 @@ int RGWRados::bucket_index_link_olh(const RGWBucketInfo& bucket_info,
     cls_rgw_obj_key {
       obj_instance.key.get_index_key_name(), obj_instance.key.instance},
     op_tag,
-    &zones_trace,
+    zones_trace,
     0);
   if (r < 0) {
     ldout(cct, 20) << "rgw_rados_operate() after cls_rgw_bucket_link_olh() returned r=" << r << dendl;
@@ -6966,7 +6966,7 @@ int RGWRados::bucket_index_unlink_instance(const RGWBucketInfo& bucket_info, con
     cls_rgw_obj_key {
       obj_instance.key.get_index_key_name(), obj_instance.key.instance },
     op_tag,
-    &zones_trace,
+    zones_trace,
     0);
   if (r < 0) {
     ldout(cct, 20) << "rgw_rados_operate() after cls_rgw_bucket_link_instance() returned r=" << r << dendl;
@@ -8346,7 +8346,7 @@ int RGWRados::cls_obj_complete_op(const RGWBucketInfo& bucket_info,
     bucket_info,
     cls_rgw_obj_key { ent.key.name, ent.key.instance },
     tag,
-    &zones_trace,
+    zones_trace,
     bilog_flags);
 }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -9154,21 +9154,24 @@ int RGWRados::check_disk_state(librados::IoCtx io_ctx,
 
   list_state.pending_map.clear(); // we don't need this and it inflates size
   if (!list_state.is_delete_marker() && !astate->exists) {
-      /* object doesn't exist right now -- hopefully because it's
-       * marked as !exists and got deleted */
+    /* object doesn't exist right now -- hopefully because it's
+     * marked as !exists and got deleted */
+
+    // encode a suggested removal of that key
+    list_state.ver.epoch = io_ctx.get_last_version();
+    list_state.ver.pool = io_ctx.get_id();
     if (list_state.exists) {
-      /* FIXME: what should happen now? Work out if there are any
-       * non-bad ways this could happen (there probably are, but annoying
-       * to handle!) */
       // if we're here, then the operation is delete_obj that got interrupted
       // AFTER removal of the underlying obj but BEFORE completing the BI op.
       // as the obj is purged, cancelation is impossible -- all we can do is
       // resuming the operation.
+      // "Resuming" means also taking care of the BILog entry. The head object
+      // is already deleted as the `astate` testified.
+      cls_rgw_encode_suggestion(CEPH_RGW_REMOVE | suggest_flag, list_state,
+                                suggested_updates);
+    } else {
+      cls_rgw_encode_suggestion(CEPH_RGW_REMOVE, list_state, suggested_updates);
     }
-    // encode a suggested removal of that key
-    list_state.ver.epoch = io_ctx.get_last_version();
-    list_state.ver.pool = io_ctx.get_id();
-    cls_rgw_encode_suggestion(CEPH_RGW_REMOVE, list_state, suggested_updates);
     return -ENOENT;
   }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6810,12 +6810,18 @@ static uint16_t get_olh_op_bilog_flags()
 }
 
 struct BILogUpdateBatchFIFO {
+  CephContext* cct;
   std::unique_ptr<rgw::cls::fifo::FIFO> fifo;
 
-  BILogUpdateBatchFIFO(RGWRados& store, const RGWBucketInfo& bucket_info);
+  BILogUpdateBatchFIFO(CephContext* cct,
+                       RGWRados& store,
+                       const RGWBucketInfo& bucket_info);
 
   void add_maybe_flush(const uint64_t olh_epoch,
                        const cls_rgw_bi_log_related_op& bi_log_client_info) {
+    ldout(cct, 20) << __PRETTY_FUNCTION__
+                   << ": the cls_rgw_bi_log_related_op-taking variant"
+                   << dendl;
     rgw_bi_log_entry entry;
 
     entry.object = bi_log_client_info.key.name;
@@ -6854,6 +6860,7 @@ struct BILogUpdateBatchFIFO {
                        const std::string& op_tag,
                        const bool delete_marker,
                        const rgw_bucket_olh_log_bi_log_entry& bi_log_replay_data) {
+    ldout(cct, 20) << __PRETTY_FUNCTION__ << ": the OLH-specific variant" << dendl;
     rgw_bi_log_entry entry;
 
     entry.object = key.name;
@@ -6888,8 +6895,10 @@ struct BILogUpdateBatchFIFO {
   }
 };
 
-BILogUpdateBatchFIFO::BILogUpdateBatchFIFO(RGWRados& store,
+BILogUpdateBatchFIFO::BILogUpdateBatchFIFO(CephContext* const cct,
+                                           RGWRados& store,
                                            const RGWBucketInfo& bucket_info)
+  : cct(cct)
 {
   ceph_assert(store.svc.bi_rados);
   fifo = RGWSI_BILog_RADOS_FIFO::open_fifo(bucket_info, *store.svc.bi_rados);
@@ -6898,14 +6907,20 @@ BILogUpdateBatchFIFO::BILogUpdateBatchFIFO(RGWRados& store,
   }
 }
 
-static BILogUpdateBatchFIFO get_or_create_fifo_bilog_op(RGWRados& store,
+static BILogUpdateBatchFIFO get_or_create_fifo_bilog_op(CephContext* const cct,
+                                                        RGWRados& store,
                                                         const RGWBucketInfo& binfo)
 {
-  return { store, binfo };
+  return { cct, store, binfo };
 }
 
 struct BILogNopHandler {
+  CephContext* const cct;
+
   void add_maybe_flush(const uint64_t, const cls_rgw_bi_log_related_op&) {
+    ldout(cct, 20) << __PRETTY_FUNCTION__
+                   << ": the cls_rgw_bi_log_related_op-taking variant"
+                   << dendl;
     /* NOP */
   }
 
@@ -6914,6 +6929,7 @@ struct BILogNopHandler {
                        const std::string& op_tag,
                        const bool delete_marker,
                        const rgw_bucket_olh_log_bi_log_entry&) {
+    ldout(cct, 20) << __PRETTY_FUNCTION__ << ": the OLH-specific variant" << dendl;
     /* NOP */
   }
 };
@@ -6924,6 +6940,8 @@ int RGWRados::with_bilog(F&& func,
                          const RGWBucketInfo& bucket_info,
                          Args&&... args)
 {
+  ldout(cct, 20) << __func__ << ": zone.log_data=" << svc.zone->get_zone().log_data << dendl;
+
   constexpr bool is_inindex = true;
   // there are actually two variants of with_bilog():
   //   1. CLSRGWBucketModifyOpT-taking one in which the passed lambda gets
@@ -6931,27 +6949,27 @@ int RGWRados::with_bilog(F&& func,
   //   2. void-taking one -- the lambda is called with `bilog_handler` only.
   if constexpr (std::is_same_v<CLSRGWBucketModifyOpT, void>) {
      if (svc.zone->get_zone().log_data && !is_inindex) {
-       return std::forward<F>(func)(get_or_create_fifo_bilog_op(*this, bucket_info));
+       return std::forward<F>(func)(get_or_create_fifo_bilog_op(cct, *this, bucket_info));
      } else {
-       return std::forward<F>(func)(BILogNopHandler{});
+       return std::forward<F>(func)(BILogNopHandler{cct});
      }
   } else {
     if (is_inindex) {
       return std::move(func)(CLSRGWBucketModifyOpT{
                                svc.zone->get_zone().log_data, std::forward<Args>(args)...},
-                             BILogNopHandler{});
+                             BILogNopHandler{cct});
     } else if (svc.zone->get_zone().log_data) {
       // BILog is stored externally to the BI (bucket index)
       return std::move(func)(CLSRGWBucketModifyOpT{
                                false /* log_data -- never log in-index */,
                                std::forward<Args>(args)...},
-                             get_or_create_fifo_bilog_op(*this, bucket_info));
+                             get_or_create_fifo_bilog_op(cct, *this, bucket_info));
     } else {
       // no log at all
       return std::move(func)(CLSRGWBucketModifyOpT{
                                false,
                                std::forward<Args>(args)...},
-                             BILogNopHandler{});
+                             BILogNopHandler{cct});
     }
   }
 }
@@ -7697,9 +7715,10 @@ int RGWRados::remove_olh_pending_entries(const RGWBucketInfo& bucket_info, RGWOb
   return 0;
 }
 
-static auto get_bilog_handler(const RGWBucketInfo& bucket_info)
+static auto get_bilog_handler(CephContext* const cct,
+                              const RGWBucketInfo& bucket_info)
 {
-  return BILogNopHandler{};
+  return BILogNopHandler{cct};
 }
 
 int RGWRados::follow_olh(const RGWBucketInfo& bucket_info, RGWObjectCtx& obj_ctx, RGWObjState *state, const rgw_obj& olh_obj, rgw_obj *target)
@@ -7720,7 +7739,7 @@ int RGWRados::follow_olh(const RGWBucketInfo& bucket_info, RGWObjectCtx& obj_ctx
   if (!pending_entries.empty()) {
     ldout(cct, 20) << __func__ << "(): found pending entries, need to update_olh() on bucket=" << olh_obj.bucket << dendl;
 
-    int ret = update_olh(obj_ctx, state, bucket_info, olh_obj, get_bilog_handler(bucket_info));
+    int ret = update_olh(obj_ctx, state, bucket_info, olh_obj, get_bilog_handler(cct, bucket_info));
     if (ret < 0) {
       return ret;
     }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6803,21 +6803,88 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
   return -ERR_BUSY_RESHARDING;
 }
 
+static uint16_t get_olh_op_bilog_flags()
+{
+  return 0;
+}
+
 struct BILogUpdateBatchFIFO {
   static constexpr char BILOG_FIFO_SUFFIX[] = ".bilog_fifo";
   std::unique_ptr<rgw::cls::fifo::FIFO> fifo;
 
   BILogUpdateBatchFIFO(RGWRados& store, const RGWBucketInfo& bucket_info);
 
-  template <class CLSRGWBucketModifyOpT, class F, class... Args>
-  int add_maybe_flush(F&& on_flushed,
-                      CLSRGWBucketModifyOpT&& bi_updater,
-                      Args&&... args)
-  {
-    // FIXME: CLSRGWBucketModifyOpT::get_bilog_entry...
-    ceph::bufferlist bl{};
+  void add_maybe_flush(const uint64_t olh_epoch,
+                       const cls_rgw_bi_log_related_op& bi_log_client_info) {
+    rgw_bi_log_entry entry;
+
+    entry.object = bi_log_client_info.key.name;
+    entry.instance = bi_log_client_info.key.instance;
+    // TODO: entry.timestamp
+    entry.op = bi_log_client_info.op;
+    // olh epoch
+    {
+      rgw_bucket_entry_ver ver;
+      ver.epoch = olh_epoch;
+      entry.ver = std::move(ver);
+    }
+    entry.state = CLS_RGW_STATE_COMPLETE;
+    entry.tag = bi_log_client_info.op_tag;
+    entry.bilog_flags = bi_log_client_info.bilog_flags;
+    // owner is non-empty only for OLH_DM
+    entry.owner = decltype(entry.owner){};
+    // owner_display_name is non-empty only for OLH_DM
+    entry.owner_display_name = decltype(entry.owner_display_name){};
+    entry.zones_trace = bi_log_client_info.zones_trace;
+
+#if 0
+    // TODO: handle the entry.id
+    bi_log_index_key(hctx, key, entry.id, index_ver);
+    if (entry.id > max_marker)
+      max_marker = entry.id;
+#endif
+
+    ceph::bufferlist bl;
+    encode(entry, bl);
     fifo->push(std::move(bl), null_yield /* FIXME */);
-    return std::move(on_flushed)(std::move(bi_updater));
+  }
+
+  void add_maybe_flush(const uint64_t olh_epoch,
+                       const cls_rgw_obj_key& key,
+                       const std::string& op_tag,
+                       const bool delete_marker,
+                       const rgw_bucket_olh_log_bi_log_entry& bi_log_replay_data) {
+    rgw_bi_log_entry entry;
+
+    entry.object = key.name;
+    entry.instance = key.instance;
+    entry.timestamp = bi_log_replay_data.timestamp;
+    entry.op = CLSRGWLinkOLHBase::get_bilog_op_type(delete_marker);
+    // olh epoch
+    {
+      rgw_bucket_entry_ver ver;
+      ver.epoch = olh_epoch;
+      entry.ver = std::move(ver);
+    }
+    entry.state = CLS_RGW_STATE_COMPLETE;
+    entry.tag = op_tag;
+    entry.bilog_flags = get_olh_op_bilog_flags() | RGW_BILOG_FLAG_VERSIONED_OP;
+    if (delete_marker) {
+      entry.owner = bi_log_replay_data.owner;
+      entry.owner_display_name = bi_log_replay_data.owner_display_name;
+    }
+    entry.zones_trace = bi_log_replay_data.zones_trace;
+
+#if 0
+    // TODO: handle the entry.id
+    bi_log_index_key(hctx, key, entry.id, index_ver);
+    if (entry.id > max_marker)
+      max_marker = entry.id;
+#endif
+
+    ceph::bufferlist bl;
+    encode(entry, bl);
+    fifo->push(std::move(bl), null_yield /* FIXME */);
   }
 };
 
@@ -6839,40 +6906,63 @@ static BILogUpdateBatchFIFO get_or_create_fifo_bilog_op(RGWRados& store,
   return { store, binfo };
 }
 
+struct BILogNopHandler {
+  void add_maybe_flush(const uint64_t, const cls_rgw_bi_log_related_op&) {
+    /* NOP */
+  }
+
+  void add_maybe_flush(const uint64_t,
+                       const cls_rgw_obj_key& key,
+                       const std::string& op_tag,
+                       const bool delete_marker,
+                       const rgw_bucket_olh_log_bi_log_entry&) {
+    /* NOP */
+  }
+};
+
 
 template <class CLSRGWBucketModifyOpT, class F, class... Args>
-int RGWRados::with_bilog(F&& on_flushed,
+int RGWRados::with_bilog(F&& func,
                          const RGWBucketInfo& bucket_info,
                          Args&&... args)
 {
-  constexpr bool is_inindex = false;
-  if (is_inindex) {
-    return std::move(on_flushed)(
-      CLSRGWBucketModifyOpT{
-        svc.zone->get_zone().log_data, std::forward<Args>(args)...});
+  constexpr bool is_inindex = true;
+  if constexpr (std::is_same_v<CLSRGWBucketModifyOpT, void>) {
+     if (svc.zone->get_zone().log_data && !is_inindex) {
+       return std::forward<F>(func)(get_or_create_fifo_bilog_op(*this, bucket_info));
+     } else {
+       return std::forward<F>(func)(BILogNopHandler{});
+     }
   } else {
-    return get_or_create_fifo_bilog_op(
-      *this,
-      bucket_info
-    ).add_maybe_flush(
-      std::move(on_flushed),
-      CLSRGWBucketModifyOpT{
-        svc.zone->get_zone().log_data, args...},
-      args...
-    );
+    if (is_inindex) {
+      return std::move(func)(CLSRGWBucketModifyOpT{
+                               svc.zone->get_zone().log_data, std::forward<Args>(args)...},
+                             BILogNopHandler{});
+    } else if (svc.zone->get_zone().log_data) {
+      // BILog is stored externally to the BI (bucket index)
+      return std::move(func)(CLSRGWBucketModifyOpT{
+                               false /* log_data -- never log in-index */,
+                               std::forward<Args>(args)...},
+                             get_or_create_fifo_bilog_op(*this, bucket_info));
+    } else {
+      // no log at all
+      return std::move(func)(CLSRGWBucketModifyOpT{
+                               false,
+                               std::forward<Args>(args)...},
+                             BILogNopHandler{});
+    }
   }
 }
 
-template <bool DeleteMarkerV>
-int RGWRados::bucket_index_link_olh(const RGWBucketInfo& bucket_info,
+template <bool DeleteMarkerV, class OpIssuerT>
+int RGWRados::bucket_index_link_olh(OpIssuerT& op_issuer,
+                                    const RGWBucketInfo& bucket_info,
                                     RGWObjState& olh_state,
                                     const rgw_obj& obj_instance,
-                                    const string& op_tag,
                                     struct rgw_bucket_dir_entry_meta *meta,
                                     uint64_t olh_epoch,
                                     real_time unmod_since,
                                     bool high_precision_time,
-                                    rgw_zone_set *_zones_trace,
                                     bool log_data_change)
 {
   rgw_rados_ref ref;
@@ -6881,38 +6971,23 @@ int RGWRados::bucket_index_link_olh(const RGWBucketInfo& bucket_info,
     return r;
   }
 
-  rgw_zone_set zones_trace;
-  if (_zones_trace) {
-    zones_trace = *_zones_trace;
-  }
-  zones_trace.insert(svc.zone->get_zone().id, bucket_info.bucket.get_key());
-
   BucketShard bs(this);
-  r = with_bilog<CLSRGWLinkOLH<DeleteMarkerV>>(
-    [&, this](auto bi_updater) {
-      return guard_reshard(&bs, obj_instance, bucket_info,
-        [&](BucketShard *bs) -> int {
-          cls_rgw_obj_key key{
-            obj_instance.key.get_index_key_name(), obj_instance.key.instance
-          };
-          librados::ObjectWriteOperation op;
-          cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
-          bi_updater.link_olh(op,
-                              olh_state.olh_tag,
-                              meta,
-                              olh_epoch,
-                              unmod_since,
-                              high_precision_time);
-          auto& ref = bs->bucket_obj.get_ref();
-          return rgw_rados_operate(ref.pool.ioctx(), ref.obj.oid, &op, null_yield);
-       });
-    },
-    bucket_info,
-    cls_rgw_obj_key {
-      obj_instance.key.get_index_key_name(), obj_instance.key.instance},
-    op_tag,
-    zones_trace,
-    0);
+  r = guard_reshard(&bs, obj_instance, bucket_info,
+    [&](BucketShard *bs) -> int {
+      cls_rgw_obj_key key{
+        obj_instance.key.get_index_key_name(), obj_instance.key.instance
+      };
+      librados::ObjectWriteOperation op;
+      cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
+      op_issuer.link_olh(op,
+                         olh_state.olh_tag,
+                         meta,
+                         olh_epoch,
+                         unmod_since,
+                         high_precision_time);
+      auto& ref = bs->bucket_obj.get_ref();
+      return rgw_rados_operate(ref.pool.ioctx(), ref.obj.oid, &op, null_yield);
+   });
   if (r < 0) {
     ldout(cct, 20) << "rgw_rados_operate() after cls_rgw_bucket_link_olh() returned r=" << r << dendl;
     return r;
@@ -6934,8 +7009,13 @@ void RGWRados::bucket_index_guard_olh_op(RGWObjState& olh_state, ObjectOperation
   op.cmpxattr(RGW_ATTR_OLH_ID_TAG, CEPH_OSD_CMPXATTR_OP_EQ, olh_state.olh_tag);
 }
 
-int RGWRados::bucket_index_unlink_instance(const RGWBucketInfo& bucket_info, const rgw_obj& obj_instance,
-                                           const string& op_tag, const string& olh_tag, uint64_t olh_epoch, rgw_zone_set *_zones_trace)
+template <class OpIssuerT>
+int RGWRados::bucket_index_unlink_instance(OpIssuerT& op_issuer,
+                                           const RGWBucketInfo& bucket_info,
+                                           const rgw_obj& obj_instance,
+                                           const string& olh_tag,
+                                           uint64_t olh_epoch,
+                                           rgw_zone_set *_zones_trace)
 {
   rgw_rados_ref ref;
   int r = get_obj_head_ref(bucket_info, obj_instance, &ref);
@@ -6951,23 +7031,14 @@ int RGWRados::bucket_index_unlink_instance(const RGWBucketInfo& bucket_info, con
 
   BucketShard bs(this);
 
-  r = with_bilog<CLSRGWUnlinkInstance>(
-    [&, this] (auto bi_updater) {
-      return guard_reshard(&bs, obj_instance, bucket_info,
-        [&](BucketShard *bs) -> int {
-          librados::ObjectWriteOperation op;
-          cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
-          bi_updater.unlink_instance(op, olh_tag, olh_epoch);
-          auto& ref = bs->bucket_obj.get_ref();
-          return rgw_rados_operate(ref.pool.ioctx(), ref.obj.oid, &op, null_yield);
-        });
-    },
-    bucket_info,
-    cls_rgw_obj_key {
-      obj_instance.key.get_index_key_name(), obj_instance.key.instance },
-    op_tag,
-    zones_trace,
-    0);
+  r = guard_reshard(&bs, obj_instance, bucket_info,
+    [&](BucketShard *bs) -> int {
+      librados::ObjectWriteOperation op;
+      cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
+      op_issuer.unlink_instance(op, olh_tag, olh_epoch);
+      auto& ref = bs->bucket_obj.get_ref();
+      return rgw_rados_operate(ref.pool.ioctx(), ref.obj.oid, &op, null_yield);
+    });
   if (r < 0) {
     ldout(cct, 20) << "rgw_rados_operate() after cls_rgw_bucket_link_instance() returned r=" << r << dendl;
     return r;
@@ -7161,9 +7232,16 @@ static int decode_olh_info(CephContext* cct, const bufferlist& bl, RGWOLHInfo *o
   }
 }
 
-int RGWRados::apply_olh_log(RGWObjectCtx& obj_ctx, RGWObjState& state, const RGWBucketInfo& bucket_info, const rgw_obj& obj,
-                            bufferlist& olh_tag, map<uint64_t, vector<rgw_bucket_olh_log_entry> >& log,
-                            uint64_t *plast_ver, rgw_zone_set* zones_trace)
+template <class BILogHandlerT>
+int RGWRados::apply_olh_log(RGWObjectCtx& obj_ctx,
+                            RGWObjState& state,
+                            const RGWBucketInfo& bucket_info,
+                            const rgw_obj& obj,
+                            bufferlist& olh_tag,
+                            map<uint64_t, vector<rgw_bucket_olh_log_entry> >& log,
+                            BILogHandlerT&& bilog_handler,
+                            uint64_t *plast_ver,
+                            rgw_zone_set* zones_trace)
 {
   if (log.empty()) {
     return 0;
@@ -7173,8 +7251,6 @@ int RGWRados::apply_olh_log(RGWObjectCtx& obj_ctx, RGWObjState& state, const RGW
 
   uint64_t last_ver = log.rbegin()->first;
   *plast_ver = last_ver;
-
-  map<uint64_t, vector<rgw_bucket_olh_log_entry> >::iterator iter = log.begin();
 
   op.cmpxattr(RGW_ATTR_OLH_ID_TAG, CEPH_OSD_CMPXATTR_OP_EQ, olh_tag);
   op.cmpxattr(RGW_ATTR_OLH_VER, CEPH_OSD_CMPXATTR_OP_GTE, last_ver);
@@ -7212,12 +7288,9 @@ int RGWRados::apply_olh_log(RGWObjectCtx& obj_ctx, RGWObjState& state, const RGW
     delete_marker = info.removed;
   }
 
-  for (iter = log.begin(); iter != log.end(); ++iter) {
-    vector<rgw_bucket_olh_log_entry>::iterator viter = iter->second.begin();
-    for (; viter != iter->second.end(); ++viter) {
-      rgw_bucket_olh_log_entry& entry = *viter;
-
-      ldout(cct, 20) << "olh_log_entry: epoch=" << iter->first << " op=" << (int)entry.op
+  for (const auto& [ olh_epoch, entries ] : log) {
+    for (const auto& entry : entries) {
+      ldout(cct, 20) << "olh_log_entry: epoch=" << olh_epoch << " op=" << (int)entry.op
                      << " key=" << entry.key.name << "[" << entry.key.instance << "] "
                      << (entry.delete_marker ? "(delete)" : "") << dendl;
       switch (entry.op) {
@@ -7226,17 +7299,26 @@ int RGWRados::apply_olh_log(RGWObjectCtx& obj_ctx, RGWObjState& state, const RGW
         break;
       case CLS_RGW_OLH_OP_LINK_OLH:
         // only overwrite a link of the same epoch if its key sorts before
-        if (link_epoch < iter->first || key.instance.empty() ||
+        if (link_epoch < olh_epoch || key.instance.empty() ||
             key.instance > entry.key.instance) {
-          ldout(cct, 20) << "apply_olh_log applying key=" << entry.key << " epoch=" << iter->first << " delete_marker=" << entry.delete_marker
+          ldout(cct, 20) << "apply_olh_log applying key=" << entry.key << " epoch=" << olh_epoch << " delete_marker=" << entry.delete_marker
               << " over current=" << key << " epoch=" << link_epoch << " delete_marker=" << delete_marker << dendl;
           need_to_link = true;
           need_to_remove = false;
           key = entry.key;
           delete_marker = entry.delete_marker;
         } else {
-          ldout(cct, 20) << "apply_olh skipping key=" << entry.key<< " epoch=" << iter->first << " delete_marker=" << entry.delete_marker
+          ldout(cct, 20) << "apply_olh skipping key=" << entry.key<< " epoch=" << olh_epoch << " delete_marker=" << entry.delete_marker
               << " before current=" << key << " epoch=" << link_epoch << " delete_marker=" << delete_marker << dendl;
+        }
+        if (entry.bi_log_replay_data) {
+          // TODO: this would be good user of batching, though the path with
+          // multiple entries is rather cold
+          bilog_handler.add_maybe_flush(olh_epoch,
+                                        entry.key,
+                                        entry.op_tag,
+                                        entry.delete_marker,
+                                        *entry.bi_log_replay_data);
         }
         break;
       case CLS_RGW_OLH_OP_UNLINK_OLH:
@@ -7328,7 +7410,13 @@ int RGWRados::apply_olh_log(RGWObjectCtx& obj_ctx, RGWObjState& state, const RGW
 /*
  * read olh log and apply it
  */
-int RGWRados::update_olh(RGWObjectCtx& obj_ctx, RGWObjState *state, const RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_zone_set *zones_trace)
+template <class BILogHandlerT>
+int RGWRados::update_olh(RGWObjectCtx& obj_ctx,
+                         RGWObjState *state,
+                         const RGWBucketInfo& bucket_info,
+                         const rgw_obj& obj,
+                         BILogHandlerT&& bilog_handler,
+                         rgw_zone_set *zones_trace)
 {
   map<uint64_t, vector<rgw_bucket_olh_log_entry> > log;
   bool is_truncated;
@@ -7339,7 +7427,7 @@ int RGWRados::update_olh(RGWObjectCtx& obj_ctx, RGWObjState *state, const RGWBuc
     if (ret < 0) {
       return ret;
     }
-    ret = apply_olh_log(obj_ctx, *state, bucket_info, obj, state->olh_tag, log, &ver_marker, zones_trace);
+    ret = apply_olh_log(obj_ctx, *state, bucket_info, obj, state->olh_tag, log, std::move(bilog_handler), &ver_marker, zones_trace);
     if (ret < 0) {
       return ret;
     }
@@ -7351,10 +7439,8 @@ int RGWRados::update_olh(RGWObjectCtx& obj_ctx, RGWObjState *state, const RGWBuc
 template <bool DeleteMarkerV>
 int RGWRados::set_olh(RGWObjectCtx& obj_ctx, const RGWBucketInfo& bucket_info, const rgw_obj& target_obj, rgw_bucket_dir_entry_meta *meta,
                       uint64_t olh_epoch, real_time unmod_since, bool high_precision_time,
-                      optional_yield y, rgw_zone_set *zones_trace, bool log_data_change)
+                      optional_yield y, rgw_zone_set *_zones_trace, bool log_data_change)
 {
-  string op_tag;
-
   rgw_obj olh_obj = target_obj;
   olh_obj.key.instance.clear();
 
@@ -7363,64 +7449,82 @@ int RGWRados::set_olh(RGWObjectCtx& obj_ctx, const RGWBucketInfo& bucket_info, c
   int ret = 0;
   int i;
   
+  rgw_zone_set zones_trace;
+  if (_zones_trace) {
+    zones_trace = *_zones_trace;
+  }
+  zones_trace.insert(svc.zone->get_zone().id, bucket_info.bucket.get_key());
 #define MAX_ECANCELED_RETRY 100
-  for (i = 0; i < MAX_ECANCELED_RETRY; i++) {
-    if (ret == -ECANCELED) {
-      obj_ctx.invalidate(olh_obj);
-    }
-
-    ret = get_obj_state(&obj_ctx, bucket_info, olh_obj, &state, false, y); /* don't follow olh */
-    if (ret < 0) {
-      return ret;
-    }
-
-    ret = olh_init_modification(bucket_info, *state, olh_obj, &op_tag);
-    if (ret < 0) {
-      ldout(cct, 20) << "olh_init_modification() target_obj=" << target_obj << " delete_marker=" << (int)DeleteMarkerV << " returned " << ret << dendl;
-      if (ret == -ECANCELED) {
-        continue;
-      }
-      return ret;
-    }
-    ret = bucket_index_link_olh<DeleteMarkerV>(bucket_info, *state, target_obj,
-                                               op_tag, meta, olh_epoch, unmod_since,
-                                               high_precision_time, zones_trace,
-                                               log_data_change);
-    if (ret < 0) {
-      ldout(cct, 20) << "bucket_index_link_olh() target_obj=" << target_obj << " delete_marker=" << (int)DeleteMarkerV << " returned " << ret << dendl;
-      if (ret == -ECANCELED) {
-        // the bucket index rejected the link_olh() due to olh tag mismatch;
-        // attempt to reconstruct olh head attributes based on the bucket index
-        int r2 = repair_olh(state, bucket_info, olh_obj);
-        if (r2 < 0 && r2 != -ECANCELED) {
-          return r2;
+  return with_bilog<CLSRGWLinkOLH<DeleteMarkerV>>(
+    [&] (auto op_issuer, auto bilog_handler) {
+      int ret, i;
+      for (i = 0; i < MAX_ECANCELED_RETRY; i++) {
+        if (ret == -ECANCELED) {
+          obj_ctx.invalidate(olh_obj);
         }
-        continue;
+
+        ret = get_obj_state(&obj_ctx, bucket_info, olh_obj, &state, false, y); /* don't follow olh */
+        if (ret < 0) {
+          return ret;
+        }
+ 
+        ret = olh_init_modification(bucket_info, *state, olh_obj, &op_issuer.op_tag);
+        if (ret < 0) {
+          ldout(cct, 20) << "olh_init_modification() target_obj=" << target_obj << " delete_marker=" << (int)DeleteMarkerV << " returned " << ret << dendl;
+          if (ret == -ECANCELED) {
+            continue;
+          }
+          return ret;
+        }
+        ret = bucket_index_link_olh<DeleteMarkerV>(op_issuer,
+                                                   bucket_info,
+                                                   *state,
+                                                   target_obj,
+                                                   meta,
+                                                   olh_epoch,
+                                                   unmod_since,
+                                                   high_precision_time,
+                                                   log_data_change);
+        if (ret < 0) {
+          ldout(cct, 20) << "bucket_index_link_olh() target_obj=" << target_obj << " delete_marker=" << (int)DeleteMarkerV << " returned " << ret << dendl;
+          if (ret == -ECANCELED) {
+            // the bucket index rejected the link_olh() due to olh tag mismatch;
+            // attempt to reconstruct olh head attributes based on the bucket index
+            int r2 = repair_olh(state, bucket_info, olh_obj);
+            if (r2 < 0 && r2 != -ECANCELED) {
+              return r2;
+            }
+            continue;
+          }
+          return ret;
+        }
+        break;
+      }
+
+      if (i == MAX_ECANCELED_RETRY) {
+        ldout(cct, 0) << "ERROR: exceeded max ECANCELED retries, aborting (EIO)" << dendl;
+        return -EIO;
+      }
+
+      ret = update_olh(obj_ctx, state, bucket_info, olh_obj, std::move(bilog_handler));
+      if (ret == -ECANCELED) { /* already did what we needed, no need to retry, raced with another user */
+        ret = 0;
+      } else if (ret < 0) {
+        ldout(cct, 20) << "update_olh() target_obj=" << target_obj << " returned " << ret << dendl;
+        return ret;
       }
       return ret;
-    }
-    break;
-  }
-
-  if (i == MAX_ECANCELED_RETRY) {
-    ldout(cct, 0) << "ERROR: exceeded max ECANCELED retries, aborting (EIO)" << dendl;
-    return -EIO;
-  }
-
-  ret = update_olh(obj_ctx, state, bucket_info, olh_obj);
-  if (ret == -ECANCELED) { /* already did what we needed, no need to retry, raced with another user */
-    ret = 0;
-  }
-  if (ret < 0) {
-    ldout(cct, 20) << "update_olh() target_obj=" << target_obj << " returned " << ret << dendl;
-    return ret;
-  }
-
-  return 0;
+    },
+    bucket_info,
+    cls_rgw_obj_key {
+      target_obj.key.get_index_key_name(), target_obj.key.instance},
+    std::string{}, //op_tag,
+    zones_trace,
+    get_olh_op_bilog_flags());
 }
 
 int RGWRados::unlink_obj_instance(RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_info, const rgw_obj& target_obj,
-                                  uint64_t olh_epoch, optional_yield y, rgw_zone_set *zones_trace)
+                                  uint64_t olh_epoch, optional_yield y, rgw_zone_set *_zones_trace)
 {
   string op_tag;
 
@@ -7429,55 +7533,66 @@ int RGWRados::unlink_obj_instance(RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_i
 
   RGWObjState *state = NULL;
 
-  int ret = 0;
-  int i;
+  rgw_zone_set zones_trace;
+  if (_zones_trace) {
+    zones_trace = *_zones_trace;
+  }
+  zones_trace.insert(svc.zone->get_zone().id, bucket_info.bucket.get_key());
 
-  for (i = 0; i < MAX_ECANCELED_RETRY; i++) {
-    if (ret == -ECANCELED) {
-      obj_ctx.invalidate(olh_obj);
-    }
+  return with_bilog<CLSRGWUnlinkInstance>(
+    [&] (auto op_issuer, auto bilog_handler) {
+      int ret, i;
+      for (i = 0; i < MAX_ECANCELED_RETRY; i++) {
+        if (ret == -ECANCELED) {
+          obj_ctx.invalidate(olh_obj);
+        }
 
-    ret = get_obj_state(&obj_ctx, bucket_info, olh_obj, &state, false, y); /* don't follow olh */
-    if (ret < 0)
-      return ret;
+        ret = get_obj_state(&obj_ctx, bucket_info, olh_obj, &state, false, y); /* don't follow olh */
+        if (ret < 0)
+          return ret;
 
-    ret = olh_init_modification(bucket_info, *state, olh_obj, &op_tag);
-    if (ret < 0) {
-      ldout(cct, 20) << "olh_init_modification() target_obj=" << target_obj << " returned " << ret << dendl;
-      if (ret == -ECANCELED) {
-        continue;
+        ret = olh_init_modification(bucket_info, *state, olh_obj, &op_tag);
+        if (ret < 0) {
+          ldout(cct, 20) << "olh_init_modification() target_obj=" << target_obj << " returned " << ret << dendl;
+          if (ret == -ECANCELED) {
+            continue;
+          }
+          return ret;
+        }
+
+        string olh_tag(state->olh_tag.c_str(), state->olh_tag.length());
+
+        ret = bucket_index_unlink_instance(op_issuer, bucket_info, target_obj, olh_tag, olh_epoch, _zones_trace);
+        if (ret < 0) {
+          ldout(cct, 20) << "bucket_index_unlink_instance() target_obj=" << target_obj << " returned " << ret << dendl;
+          if (ret == -ECANCELED) {
+            continue;
+          }
+          return ret;
+        }
+        break;
+      }
+
+      if (i == MAX_ECANCELED_RETRY) {
+        ldout(cct, 0) << "ERROR: exceeded max ECANCELED retries, aborting (EIO)" << dendl;
+        return -EIO;
+      }
+
+      ret = update_olh(obj_ctx, state, bucket_info, olh_obj, std::move(bilog_handler), _zones_trace);
+      if (ret == -ECANCELED) { /* already did what we needed, no need to retry, raced with another user */
+        return 0;
+      }
+      if (ret < 0) {
+        ldout(cct, 20) << "update_olh() target_obj=" << target_obj << " returned " << ret << dendl;
       }
       return ret;
-    }
-
-    string olh_tag(state->olh_tag.c_str(), state->olh_tag.length());
-
-    ret = bucket_index_unlink_instance(bucket_info, target_obj, op_tag, olh_tag, olh_epoch, zones_trace);
-    if (ret < 0) {
-      ldout(cct, 20) << "bucket_index_unlink_instance() target_obj=" << target_obj << " returned " << ret << dendl;
-      if (ret == -ECANCELED) {
-        continue;
-      }
-      return ret;
-    }
-    break;
-  }
-
-  if (i == MAX_ECANCELED_RETRY) {
-    ldout(cct, 0) << "ERROR: exceeded max ECANCELED retries, aborting (EIO)" << dendl;
-    return -EIO;
-  }
-
-  ret = update_olh(obj_ctx, state, bucket_info, olh_obj, zones_trace);
-  if (ret == -ECANCELED) { /* already did what we needed, no need to retry, raced with another user */
-    return 0;
-  }
-  if (ret < 0) {
-    ldout(cct, 20) << "update_olh() target_obj=" << target_obj << " returned " << ret << dendl;
-    return ret;
-  }
-
-  return 0;
+    },
+    bucket_info,
+    cls_rgw_obj_key {
+      target_obj.key.get_index_key_name(), target_obj.key.instance},
+    std::string{}, //op_tag,
+    zones_trace,
+    get_olh_op_bilog_flags());
 }
 
 void RGWRados::gen_rand_obj_instance_name(rgw_obj_key *target_key)
@@ -7580,6 +7695,11 @@ int RGWRados::remove_olh_pending_entries(const RGWBucketInfo& bucket_info, RGWOb
   return 0;
 }
 
+static auto get_bilog_handler(const RGWBucketInfo& bucket_info)
+{
+  return BILogNopHandler{};
+}
+
 int RGWRados::follow_olh(const RGWBucketInfo& bucket_info, RGWObjectCtx& obj_ctx, RGWObjState *state, const rgw_obj& olh_obj, rgw_obj *target)
 {
   map<string, bufferlist> pending_entries;
@@ -7598,7 +7718,7 @@ int RGWRados::follow_olh(const RGWBucketInfo& bucket_info, RGWObjectCtx& obj_ctx
   if (!pending_entries.empty()) {
     ldout(cct, 20) << __func__ << "(): found pending entries, need to update_olh() on bucket=" << olh_obj.bucket << dendl;
 
-    int ret = update_olh(obj_ctx, state, bucket_info, olh_obj);
+    int ret = update_olh(obj_ctx, state, bucket_info, olh_obj, get_bilog_handler(bucket_info));
     if (ret < 0) {
       return ret;
     }
@@ -8311,7 +8431,16 @@ int RGWRados::cls_obj_complete_op(const RGWBucketInfo& bucket_info,
   }
   zones_trace.insert(svc.zone->get_zone().id, bs.bucket.get_key());
   return with_bilog<CLSRGWBucketModifyOpT>(
-    [&, this] (auto bi_updater) {
+    [&, this] (auto op_issuer, auto bilog_handler) {
+      // handle the bilog. It may be stored altogether with Bucket
+      // Index or externally (e.g. in cls_fifo).
+      bilog_handler.add_maybe_flush(
+        rgw_bucket_entry_ver{}.epoch,
+        static_cast<const cls_rgw_bi_log_related_op&>(op_issuer));
+
+      // handle the BI::complete part. It happens ONLY after ensuring
+      // the `add_maybe_flush`, which is supposed to talk to cls_fifo
+      // in the OMAP-offload arrangement, is done.
       rgw_bucket_dir_entry_meta dir_meta{ ent.meta };
       dir_meta.category = category;
       rgw_bucket_entry_ver ver;
@@ -8320,23 +8449,23 @@ int RGWRados::cls_obj_complete_op(const RGWBucketInfo& bucket_info,
 
       ObjectWriteOperation o;
       cls_rgw_guard_bucket_resharding(o, -ERR_BUSY_RESHARDING);
-      bi_updater.complete_op(o, ver, dir_meta, remove_objs);
+      op_issuer.complete_op(o, ver, dir_meta, remove_objs);
 
       // TODO: it would be really cool to knock the completion manager
       // out and have it replaced with boost::asio-style continuations
       // on top of a thread pool.
       auto* const arg = index_completion_manager->create_completion(
         obj,
-        [ bi_updater = std::move(bi_updater),
+        [ op_issuer = std::move(op_issuer),
           ver,
           dir_meta,
           remove_objs = maybe_copy_remove_objs(remove_objs),
           this
         ] (librados::ObjectWriteOperation& o) {
           ldout(store->ctx(), 20) << "handling completion for key="
-                                  << bi_updater.key << dendl;
+                                  << op_issuer.key << dendl;
           cls_rgw_guard_bucket_resharding(o, -ERR_BUSY_RESHARDING);
-          bi_updater.complete_op(o, ver, dir_meta, &remove_objs);
+          op_issuer.complete_op(o, ver, dir_meta, &remove_objs);
         });
       librados::AioCompletion *completion = arg->rados_completion;
       int ret = bs.bucket_obj.aio_operate(arg->rados_completion, &o);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6962,7 +6962,9 @@ int RGWRados::with_bilog(F&& func,
 {
   ldout(cct, 20) << __func__ << ": zone.log_data=" << svc.zone->get_zone().log_data << dendl;
 
-  constexpr bool is_inindex = true;
+  const bool is_inindex = \
+    bucket_info.layout.logs.empty() ||
+    bucket_info.layout.logs.back().layout.type == rgw::BucketLogType::InIndex;
   // there are actually two variants of with_bilog():
   //   1. CLSRGWBucketModifyOpT-taking one in which the passed lambda gets
   //      both `op_issuer` and `bilog_handler`:

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6802,16 +6802,47 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
   return -ERR_BUSY_RESHARDING;
 }
 
+struct BILogUpdateBatchFIFO {
+  BILogUpdateBatchFIFO();
+
+  template <class CLSRGWBucketModifyOpT, class F, class... Args>
+  int add_maybe_flush(F&& on_flushed,
+                      CLSRGWBucketModifyOpT&& bi_updater,
+                      Args&&... args)
+  {
+    // 2. add to batch
+    // 3. flush
+    return std::move(on_flushed)(std::move(bi_updater));
+  }
+};
+
+BILogUpdateBatchFIFO::BILogUpdateBatchFIFO() {
+    // 1. create fifo instance
+}
+
+static BILogUpdateBatchFIFO get_or_create_fifo_bilog_op(const RGWBucketInfo& binfo)
+{
+  return {};
+}
+
+
 template <class CLSRGWBucketModifyOpT, class F, class... Args>
 int RGWRados::with_bilog(F&& on_flushed, Args&&... args)
 {
-  constexpr bool is_inindex = true;
+  constexpr bool is_inindex = false;
   if (is_inindex) {
     return std::move(on_flushed)(
       CLSRGWBucketModifyOpT{
         svc.zone->get_zone().log_data, std::forward<Args>(args)...});
   } else {
-    // TODO: the cls_fifo backend
+    return get_or_create_fifo_bilog_op(
+      RGWBucketInfo{}
+    ).add_maybe_flush(
+      std::move(on_flushed),
+      CLSRGWBucketModifyOpT{
+        svc.zone->get_zone().log_data, std::forward<Args>(args)...},
+      std::forward<Args>(args)...
+    );
   }
 }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6810,8 +6810,6 @@ static uint16_t get_olh_op_bilog_flags()
 }
 
 struct BILogUpdateBatchFIFO {
-  static constexpr auto BILOG_FIFO_SUFFIX = \
-    RGWSI_BILog_RADOS_FIFO::BILOG_FIFO_SUFFIX;
   std::unique_ptr<rgw::cls::fifo::FIFO> fifo;
 
   BILogUpdateBatchFIFO(RGWRados& store, const RGWBucketInfo& bucket_info);
@@ -6891,15 +6889,13 @@ struct BILogUpdateBatchFIFO {
 };
 
 BILogUpdateBatchFIFO::BILogUpdateBatchFIFO(RGWRados& store,
-                                           const RGWBucketInfo& bucket_info) {
-  RGWSI_RADOS::Pool index_pool;
-  std::string bucket_oid;
-  int r = store.svc.bi_rados->open_bucket_index(bucket_info, &index_pool, &bucket_oid);
-
-  rgw::cls::fifo::FIFO::create(index_pool.ioctx(),
-                               bucket_oid + BILOG_FIFO_SUFFIX,
-                               &fifo,
-                               null_yield /* FIXME */);
+                                           const RGWBucketInfo& bucket_info)
+{
+  ceph_assert(store.svc.bi_rados);
+  fifo = RGWSI_BILog_RADOS_FIFO::open_fifo(bucket_info, *store.svc.bi_rados);
+  if (!fifo) {
+    // TODO: "oops" here
+  }
 }
 
 static BILogUpdateBatchFIFO get_or_create_fifo_bilog_op(RGWRados& store,

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7472,7 +7472,7 @@ int RGWRados::set_olh(RGWObjectCtx& obj_ctx, const RGWBucketInfo& bucket_info, c
           return ret;
         }
  
-        ret = olh_init_modification(bucket_info, *state, olh_obj, &op_issuer.op_tag);
+        ret = olh_init_modification(bucket_info, *state, olh_obj, &op_issuer.get_op_tag_ref());
         if (ret < 0) {
           ldout(cct, 20) << "olh_init_modification() target_obj=" << target_obj << " delete_marker=" << (int)DeleteMarkerV << " returned " << ret << dendl;
           if (ret == -ECANCELED) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7807,34 +7807,29 @@ int RGWRados::get_bucket_stats_and_bilog_meta(
   string *max_marker,
   bool *syncstopped)
 {
-  vector<rgw_bucket_dir_header> headers;
-  map<int, string> bucket_instance_ids;
-  int r = cls_bucket_head(bucket_info, shard_id, headers, &bucket_instance_ids);
+  std::map<int, rgw_bucket_dir_header> headers;
+  int r = get_dir_headers(bucket_info, shard_id, headers);
   if (r < 0) {
     return r;
   }
 
-  ceph_assert(headers.size() == bucket_instance_ids.size());
-
-  auto iter = headers.begin();
-  map<int, string>::iterator viter = bucket_instance_ids.begin();
   BucketIndexShardsManager ver_mgr;
   BucketIndexShardsManager master_ver_mgr;
   BucketIndexShardsManager marker_mgr;
   char buf[64];
-  for(; iter != headers.end(); ++iter, ++viter) {
-    accumulate_raw_stats(*iter, stats);
-    snprintf(buf, sizeof(buf), "%lu", (unsigned long)iter->ver);
-    ver_mgr.add(viter->first, string(buf));
-    snprintf(buf, sizeof(buf), "%lu", (unsigned long)iter->master_ver);
-    master_ver_mgr.add(viter->first, string(buf));
+  for (const auto& [header_shard_id, header ] : headers) {
+    accumulate_raw_stats(header, stats);
+    snprintf(buf, sizeof(buf), "%lu", (unsigned long)header.ver);
+    ver_mgr.add(header_shard_id, string(buf));
+    snprintf(buf, sizeof(buf), "%lu", (unsigned long)header.master_ver);
+    master_ver_mgr.add(header_shard_id, string(buf));
     if (shard_id >= 0) {
-      *max_marker = iter->max_marker;
+      *max_marker = header.max_marker;
     } else {
-      marker_mgr.add(viter->first, iter->max_marker);
+      marker_mgr.add(header_shard_id, header.max_marker);
     }
     if (syncstopped != NULL)
-      *syncstopped = iter->syncstopped;
+      *syncstopped = header.syncstopped;
   }
   ver_mgr.to_string(bucket_ver);
   master_ver_mgr.to_string(master_ver);
@@ -8017,24 +8012,23 @@ int RGWRados::update_containers_stats(map<string, RGWBucketEnt>& m)
     ent.size = 0;
     ent.size_rounded = 0;
 
-    vector<rgw_bucket_dir_header> headers;
-
     RGWBucketInfo bucket_info;
     int ret = get_bucket_instance_info(obj_ctx, bucket, bucket_info, NULL, NULL, null_yield);
     if (ret < 0) {
       return ret;
     }
 
-    int r = cls_bucket_head(bucket_info, RGW_NO_SHARD, headers);
-    if (r < 0)
+    std::map<int, rgw_bucket_dir_header> headers;
+    int r = get_dir_headers(bucket_info, RGW_NO_SHARD, headers);
+    if (r < 0) {
       return r;
+    }
 
-    auto hiter = headers.begin();
-    for (; hiter != headers.end(); ++hiter) {
+    for ([[maybe_unused]] const auto& [ header_shard_id, header ] : headers) {
       RGWObjCategory category = main_category;
-      auto iter = (hiter->stats).find(category);
-      if (iter != hiter->stats.end()) {
-        struct rgw_bucket_category_stats& stats = iter->second;
+      if (const auto iter = header.stats.find(category);
+          iter != std::end(header.stats)) {
+        const struct rgw_bucket_category_stats& stats = iter->second;
         ent.count += stats.num_entries;
         ent.size += stats.total_size;
         ent.size_rounded += stats.total_size_rounded;
@@ -9225,12 +9219,13 @@ int RGWRados::check_disk_state(librados::IoCtx io_ctx,
   return 0;
 }
 
-int RGWRados::cls_bucket_head(const RGWBucketInfo& bucket_info, int shard_id, vector<rgw_bucket_dir_header>& headers, map<int, string> *bucket_instance_ids)
+int RGWRados::get_dir_headers(const RGWBucketInfo& bucket_info,
+                              const int shard_id,
+                              std::map<int, rgw_bucket_dir_header>& headers /* out */)
 {
-  return svc.bi->cls_bucket_head(bucket_info,
+  return svc.bi->get_dir_headers(bucket_info,
                                  shard_id,
                                  &headers,
-                                 bucket_instance_ids,
                                  null_yield /* the impl. ignores that */);
 }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6834,13 +6834,30 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
   return -ERR_BUSY_RESHARDING;
 }
 
+template <class CLSRGWBucketModifyOpT, class F, class... Args>
+int RGWRados::with_bilog(F&& on_flushed, Args&&... args)
+{
+  constexpr bool is_inindex = true;
+  if (is_inindex) {
+    return std::move(on_flushed)(
+      CLSRGWBucketModifyOpT{
+        svc.zone->get_zone().log_data, std::forward<Args>(args)...});
+  } else {
+    // TODO: the cls_fifo backend
+  }
+}
+
 template <bool DeleteMarkerV>
-int RGWRados::bucket_index_link_olh(const RGWBucketInfo& bucket_info, RGWObjState& olh_state, const rgw_obj& obj_instance,
+int RGWRados::bucket_index_link_olh(const RGWBucketInfo& bucket_info,
+                                    RGWObjState& olh_state,
+                                    const rgw_obj& obj_instance,
                                     const string& op_tag,
                                     struct rgw_bucket_dir_entry_meta *meta,
                                     uint64_t olh_epoch,
-                                    real_time unmod_since, bool high_precision_time,
-                                    rgw_zone_set *_zones_trace, bool log_data_change)
+                                    real_time unmod_since,
+                                    bool high_precision_time,
+                                    rgw_zone_set *_zones_trace,
+                                    bool log_data_change)
 {
   rgw_rados_ref ref;
   int r = get_obj_head_ref(bucket_info, obj_instance, &ref);
@@ -6855,24 +6872,37 @@ int RGWRados::bucket_index_link_olh(const RGWBucketInfo& bucket_info, RGWObjStat
   zones_trace.insert(svc.zone->get_zone().id, bucket_info.bucket.get_key());
 
   BucketShard bs(this);
-
-  r = guard_reshard(&bs, obj_instance, bucket_info,
-		    [&](BucketShard *bs) -> int {
-		      cls_rgw_obj_key key(obj_instance.key.get_index_key_name(), obj_instance.key.instance);
-		      auto& ref = bs->bucket_obj.get_ref();
-		      librados::ObjectWriteOperation op;
-		      cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
-		      cls_rgw_bucket_link_olh(op, key, olh_state.olh_tag,
-                                              DeleteMarkerV, op_tag, meta, olh_epoch,
-					      unmod_since, high_precision_time,
-					      svc.zone->get_zone().log_data, zones_trace);
-                      return rgw_rados_operate(ref.pool.ioctx(), ref.obj.oid, &op, null_yield);
-                    });
+  r = with_bilog<CLSRGWLinkOLH<DeleteMarkerV>>(
+    [&, this](auto bi_updater) {
+      return guard_reshard(&bs, obj_instance, bucket_info,
+        [&](BucketShard *bs) -> int {
+          cls_rgw_obj_key key{
+            obj_instance.key.get_index_key_name(), obj_instance.key.instance
+          };
+          librados::ObjectWriteOperation op;
+          cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
+          bi_updater.link_olh(op,
+                              olh_state.olh_tag,
+                              meta,
+                              olh_epoch,
+                              unmod_since,
+                              high_precision_time);
+          auto& ref = bs->bucket_obj.get_ref();
+          return rgw_rados_operate(ref.pool.ioctx(), ref.obj.oid, &op, null_yield);
+       });
+    },
+    cls_rgw_obj_key {
+      obj_instance.key.get_index_key_name(), obj_instance.key.instance},
+    op_tag,
+    &zones_trace,
+    0);
   if (r < 0) {
     ldout(cct, 20) << "rgw_rados_operate() after cls_rgw_bucket_link_olh() returned r=" << r << dendl;
     return r;
   }
 
+  // it's fine to have this unreliable -- if there is RGW e.g. dies
+  // between BI changes and the add_entry() call below, then fine.
   r = svc.datalog_rados->add_entry(bucket_info, bs.shard_id);
   if (r < 0) {
     ldout(cct, 0) << "ERROR: failed writing data log" << dendl;
@@ -6904,16 +6934,22 @@ int RGWRados::bucket_index_unlink_instance(const RGWBucketInfo& bucket_info, con
 
   BucketShard bs(this);
 
-  cls_rgw_obj_key key(obj_instance.key.get_index_key_name(), obj_instance.key.instance);
-  r = guard_reshard(&bs, obj_instance, bucket_info,
-		    [&](BucketShard *bs) -> int {
-		      auto& ref = bs->bucket_obj.get_ref();
-		      librados::ObjectWriteOperation op;
-		      cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
-		      cls_rgw_bucket_unlink_instance(op, key, op_tag,
-						     olh_tag, olh_epoch, svc.zone->get_zone().log_data, zones_trace);
-                      return rgw_rados_operate(ref.pool.ioctx(), ref.obj.oid, &op, null_yield);
-                    });
+  r = with_bilog<CLSRGWUnlinkInstance>(
+    [&, this] (auto bi_updater) {
+      return guard_reshard(&bs, obj_instance, bucket_info,
+        [&](BucketShard *bs) -> int {
+          librados::ObjectWriteOperation op;
+          cls_rgw_guard_bucket_resharding(op, -ERR_BUSY_RESHARDING);
+          bi_updater.unlink_instance(op, olh_tag, olh_epoch);
+          auto& ref = bs->bucket_obj.get_ref();
+          return rgw_rados_operate(ref.pool.ioctx(), ref.obj.oid, &op, null_yield);
+        });
+    },
+    cls_rgw_obj_key {
+      obj_instance.key.get_index_key_name(), obj_instance.key.instance },
+    op_tag,
+    &zones_trace,
+    0);
   if (r < 0) {
     ldout(cct, 20) << "rgw_rados_operate() after cls_rgw_bucket_link_instance() returned r=" << r << dendl;
     return r;
@@ -8244,36 +8280,44 @@ int RGWRados::cls_obj_prepare_op(BucketShard& bs, RGWModifyOp op, string& tag,
   return bs.bucket_obj.operate(&o, y);
 }
 
-int RGWRados::cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, RGWModifyOp op, string& tag,
+template <class CLSRGWBucketModifyOpT>
+int RGWRados::cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, string& tag,
                                   int64_t pool, uint64_t epoch,
                                   const rgw_bucket_dir_entry& ent, RGWObjCategory category,
 				  list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags, rgw_zone_set *_zones_trace)
 {
-  ObjectWriteOperation o;
-  rgw_bucket_dir_entry_meta dir_meta;
-  dir_meta = ent.meta;
-  dir_meta.category = category;
+  return with_bilog<CLSRGWBucketModifyOpT>(
+    [&, this] (auto bi_updater) {
+      ObjectWriteOperation o;
+      rgw_bucket_dir_entry_meta dir_meta;
+      dir_meta = ent.meta;
+      dir_meta.category = category;
 
-  rgw_zone_set zones_trace;
-  if (_zones_trace) {
-    zones_trace = *_zones_trace;
-  }
-  zones_trace.insert(svc.zone->get_zone().id, bs.bucket.get_key());
+      rgw_zone_set zones_trace;
+      if (_zones_trace) {
+        zones_trace = *_zones_trace;
+      }
+      zones_trace.insert(svc.zone->get_zone().id, bs.bucket.get_key());
 
-  rgw_bucket_entry_ver ver;
-  ver.pool = pool;
-  ver.epoch = epoch;
-  cls_rgw_obj_key key(ent.key.name, ent.key.instance);
-  cls_rgw_guard_bucket_resharding(o, -ERR_BUSY_RESHARDING);
-  cls_rgw_bucket_complete_op(o, op, tag, ver, key, dir_meta, remove_objs,
-                             svc.zone->get_zone().log_data, bilog_flags, &zones_trace);
-  complete_op_data *arg;
-  index_completion_manager->create_completion(obj, op, tag, ver, key, dir_meta, remove_objs,
-                                              svc.zone->get_zone().log_data, bilog_flags, &zones_trace, &arg);
-  librados::AioCompletion *completion = arg->rados_completion;
-  int ret = bs.bucket_obj.aio_operate(arg->rados_completion, &o);
-  completion->release(); /* can't reference arg here, as it might have already been released */
-  return ret;
+      rgw_bucket_entry_ver ver;
+      ver.pool = pool;
+      ver.epoch = epoch;
+      cls_rgw_obj_key key(ent.key.name, ent.key.instance);
+      cls_rgw_guard_bucket_resharding(o, -ERR_BUSY_RESHARDING);
+      cls_rgw_bucket_complete_op(o, CLSRGWBucketModifyOpT::get_bilog_op_type(), tag, ver, key, dir_meta, remove_objs,
+                                 svc.zone->get_zone().log_data, bilog_flags, &zones_trace);
+      complete_op_data *arg;
+      index_completion_manager->create_completion(obj, CLSRGWBucketModifyOpT::get_bilog_op_type(), tag, ver, key, dir_meta, remove_objs,
+                                                  svc.zone->get_zone().log_data, bilog_flags, &zones_trace, &arg);
+      librados::AioCompletion *completion = arg->rados_completion;
+      int ret = bs.bucket_obj.aio_operate(arg->rados_completion, &o);
+      completion->release(); /* can't reference arg here, as it might have already been released */
+      return ret;
+    },
+    cls_rgw_obj_key { ent.key.name, ent.key.instance },
+    tag,
+    _zones_trace,
+    bilog_flags);
 }
 
 int RGWRados::cls_obj_complete_add(BucketShard& bs, const rgw_obj& obj, string& tag,
@@ -8281,7 +8325,7 @@ int RGWRados::cls_obj_complete_add(BucketShard& bs, const rgw_obj& obj, string& 
                                    const rgw_bucket_dir_entry& ent, RGWObjCategory category,
                                    list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags, rgw_zone_set *zones_trace)
 {
-  return cls_obj_complete_op(bs, obj, CLS_RGW_OP_ADD, tag, pool, epoch, ent, category, remove_objs, bilog_flags, zones_trace);
+  return cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_ADD>>(bs, obj, tag, pool, epoch, ent, category, remove_objs, bilog_flags, zones_trace);
 }
 
 int RGWRados::cls_obj_complete_del(BucketShard& bs, string& tag,
@@ -8295,7 +8339,7 @@ int RGWRados::cls_obj_complete_del(BucketShard& bs, string& tag,
   rgw_bucket_dir_entry ent;
   ent.meta.mtime = removed_mtime;
   obj.key.get_index_key(&ent.key);
-  return cls_obj_complete_op(bs, obj, CLS_RGW_OP_DEL, tag, pool, epoch,
+  return cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_DEL>>(bs, obj, tag, pool, epoch,
 			     ent, RGWObjCategory::None, remove_objs,
 			     bilog_flags, zones_trace);
 }
@@ -8309,7 +8353,7 @@ int RGWRados::cls_obj_complete_cancel(BucketShard& bs, string& tag, rgw_obj& obj
   // of BI completion share the same `rgw_cls_obj_complete_op` structure
   // for client-OSD transport. However, this is just a nasty but private
   // implementation detail and shouldn't be exposed to upper layers.
-  return cls_obj_complete_op(bs, obj, CLS_RGW_OP_CANCEL, tag,
+  return cls_obj_complete_op<CLSRGWCompleteModifyOp<CLS_RGW_OP_CANCEL>>(bs, obj, tag,
 			     -1 /* pool id */, 0, ent,
 			     RGWObjCategory::None, nullptr, 0 /* bilog_flags */,
 			     zones_trace);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2979,6 +2979,7 @@ int RGWRados::swift_versioning_restore(RGWObjectCtx& obj_ctx,
 int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_size,
                                            map<string, bufferlist>& attrs,
                                            bool assume_noent, bool modify_tail,
+                                           RGWObjState *state,
                                            void *_index_op, optional_yield y)
 {
   RGWRados::Bucket::UpdateIndex *index_op = static_cast<RGWRados::Bucket::UpdateIndex *>(_index_op);
@@ -3127,11 +3128,6 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
                           !obj.key.instance.empty();
 
   bool versioned_op = (target->versioning_enabled() || is_olh || versioned_target);
-
-  if (versioned_op) {
-    index_op->set_bilog_flags(RGW_BILOG_FLAG_VERSIONED_OP);
-  }
-
   auto& ioctx = ref.pool.ioctx();
 
   tracepoint(rgw_rados, operate_enter, req_id.c_str());
@@ -3159,7 +3155,9 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
   r = index_op->complete(poolid, epoch, size, accounted_size,
                         meta.set_mtime, etag, content_type,
                         storage_class, &acl_bl,
-                        meta.category, meta.remove_objs, meta.user_data, meta.appendable);
+                        meta.category, meta.remove_objs,
+                        versioned_op ? RGW_BILOG_FLAG_VERSIONED_OP : 0,
+                        meta.user_data, meta.appendable);
   tracepoint(rgw_rados, complete_exit, req_id.c_str());
   if (r < 0)
     goto done_cancel;
@@ -5130,7 +5128,6 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y)
   RGWRados::Bucket::UpdateIndex index_op(&bop, obj);
   
   index_op.set_zones_trace(params.zones_trace);
-  index_op.set_bilog_flags(params.bilog_flags);
 
   r = index_op.prepare(CLS_RGW_OP_DEL, &state->write_tag, y);
   if (r < 0)
@@ -5151,7 +5148,8 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y)
       tombstone_entry entry{*state};
       obj_tombstone_cache->add(obj, entry);
     }
-    r = index_op.complete_del(poolid, ioctx.get_last_version(), state->mtime, params.remove_objs);
+    r = index_op.complete_del(poolid, ioctx.get_last_version(), state->mtime,
+                              params.remove_objs, params.bilog_flags);
     
     int ret = target->complete_atomic_modification();
     if (ret < 0) {
@@ -5233,7 +5231,7 @@ int RGWRados::delete_obj_index(const rgw_obj& obj, ceph::real_time mtime)
   RGWRados::Bucket bop(this, bucket_info);
   RGWRados::Bucket::UpdateIndex index_op(&bop, obj);
 
-  return index_op.complete_del(-1 /* pool */, 0, mtime, NULL);
+  return index_op.complete_del(-1 /* pool */, 0, mtime, nullptr, 0 /* bilog_flags */);
 }
 
 static void generate_fake_tag(RGWRados *store, map<string, bufferlist>& attrset, RGWObjManifest& manifest, bufferlist& manifest_bl, bufferlist& tag_bl)
@@ -5849,7 +5847,7 @@ int RGWRados::set_attrs(void *ctx, const RGWBucketInfo& bucket_info, rgw_obj& sr
       int64_t poolid = ioctx.get_id();
       r = index_op.complete(poolid, epoch, state->size, state->accounted_size,
                             mtime, etag, content_type, storage_class, &acl_bl,
-                            RGWObjCategory::Main, NULL);
+                            RGWObjCategory::Main, nullptr, 0);
     } else {
       int ret = index_op.cancel();
       if (ret < 0) {
@@ -6085,8 +6083,8 @@ int RGWRados::Bucket::UpdateIndex::complete(int64_t poolid, uint64_t epoch,
                                             const string& content_type, const string& storage_class,
                                             bufferlist *acl_bl,
                                             RGWObjCategory category,
-                                            list<rgw_obj_index_key> *remove_objs, const string *user_data,
-                                            bool appendable)
+                                            list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags,
+                                            const string *user_data, bool appendable)
 {
   if (blind) {
     return 0;
@@ -6134,7 +6132,8 @@ int RGWRados::Bucket::UpdateIndex::complete(int64_t poolid, uint64_t epoch,
 
 int RGWRados::Bucket::UpdateIndex::complete_del(int64_t poolid, uint64_t epoch,
                                                 real_time& removed_mtime,
-                                                list<rgw_obj_index_key> *remove_objs)
+                                                list<rgw_obj_index_key> *remove_objs,
+                                                uint16_t bilog_flags)
 {
   if (blind) {
     return 0;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3013,8 +3013,8 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
   bool reset_obj = (meta.flags & PUT_OBJ_CREATE) != 0;
 
   const string *ptag = meta.ptag;
-  if (!ptag && !index_op->get_optag()->empty()) {
-    ptag = index_op->get_optag();
+  if (const auto* optag = index_op->get_optag(); !ptag && optag && !optag->empty()) {
+    ptag = optag;
   }
   r = target->prepare_atomic_modification(op, reset_obj, ptag, meta.if_match, meta.if_nomatch, false, modify_tail, y);
   if (r < 0)

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -9228,28 +9228,11 @@ int RGWRados::check_disk_state(librados::IoCtx io_ctx,
 
 int RGWRados::cls_bucket_head(const RGWBucketInfo& bucket_info, int shard_id, vector<rgw_bucket_dir_header>& headers, map<int, string> *bucket_instance_ids)
 {
-  RGWSI_RADOS::Pool index_pool;
-  map<int, string> oids;
-  map<int, struct rgw_cls_list_ret> list_results;
-  int r = svc.bi_rados->open_bucket_index(bucket_info, shard_id, &index_pool, &oids, bucket_instance_ids);
-  if (r < 0) {
-    ldout(cct, 20) << "cls_bucket_head: open_bucket_index() returned "
-                   << r << dendl;
-    return r;
-  }
-
-  r = CLSRGWIssueGetDirHeader(index_pool.ioctx(), oids, list_results, cct->_conf->rgw_bucket_index_max_aio)();
-  if (r < 0) {
-    ldout(cct, 20) << "cls_bucket_head: CLSRGWIssueGetDirHeader() returned "
-                   << r << dendl;
-    return r;
-  }
-
-  map<int, struct rgw_cls_list_ret>::iterator iter = list_results.begin();
-  for(; iter != list_results.end(); ++iter) {
-    headers.push_back(std::move(iter->second.dir.header));
-  }
-  return 0;
+  return svc.bi->cls_bucket_head(bucket_info,
+                                 shard_id,
+                                 &headers,
+                                 bucket_instance_ids,
+                                 null_yield /* the impl. ignores that */);
 }
 
 int RGWRados::cls_bucket_head_async(const RGWBucketInfo& bucket_info, int shard_id, RGWGetDirHeader_CB *ctx, int *num_aio)

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6927,6 +6927,10 @@ int RGWRados::with_bilog(F&& func,
                          Args&&... args)
 {
   constexpr bool is_inindex = true;
+  // there are actually two variants of with_bilog():
+  //   1. CLSRGWBucketModifyOpT-taking one in which the passed lambda gets
+  //      both `op_issuer` and `bilog_handler`:
+  //   2. void-taking one -- the lambda is called with `bilog_handler` only.
   if constexpr (std::is_same_v<CLSRGWBucketModifyOpT, void>) {
      if (svc.zone->get_zone().log_data && !is_inindex) {
        return std::forward<F>(func)(get_or_create_fifo_bilog_op(*this, bucket_info));

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -21,6 +21,7 @@
 #include "common/Formatter.h"
 #include "common/Throttle.h"
 
+#include "cls_fifo_legacy.h"
 #include "rgw_sal.h"
 #include "rgw_zone.h"
 #include "rgw_cache.h"
@@ -6803,26 +6804,39 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
 }
 
 struct BILogUpdateBatchFIFO {
-  BILogUpdateBatchFIFO();
+  static constexpr char BILOG_FIFO_SUFFIX[] = ".bilog_fifo";
+  std::unique_ptr<rgw::cls::fifo::FIFO> fifo;
+
+  BILogUpdateBatchFIFO(RGWRados& store, const RGWBucketInfo& bucket_info);
 
   template <class CLSRGWBucketModifyOpT, class F, class... Args>
   int add_maybe_flush(F&& on_flushed,
                       CLSRGWBucketModifyOpT&& bi_updater,
                       Args&&... args)
   {
-    // 2. add to batch
-    // 3. flush
+    // FIXME: CLSRGWBucketModifyOpT::get_bilog_entry...
+    ceph::bufferlist bl{};
+    fifo->push(std::move(bl), null_yield /* FIXME */);
     return std::move(on_flushed)(std::move(bi_updater));
   }
 };
 
-BILogUpdateBatchFIFO::BILogUpdateBatchFIFO() {
-    // 1. create fifo instance
+BILogUpdateBatchFIFO::BILogUpdateBatchFIFO(RGWRados& store,
+                                           const RGWBucketInfo& bucket_info) {
+  RGWSI_RADOS::Pool index_pool;
+  std::string bucket_oid;
+  int r = store.svc.bi_rados->open_bucket_index(bucket_info, &index_pool, &bucket_oid);
+
+  rgw::cls::fifo::FIFO::create(index_pool.ioctx(),
+                               bucket_oid + BILOG_FIFO_SUFFIX,
+                               &fifo,
+                               null_yield /* FIXME */);
 }
 
-static BILogUpdateBatchFIFO get_or_create_fifo_bilog_op(const RGWBucketInfo& binfo)
+static BILogUpdateBatchFIFO get_or_create_fifo_bilog_op(RGWRados& store,
+                                                        const RGWBucketInfo& binfo)
 {
-  return {};
+  return { store, binfo };
 }
 
 
@@ -6838,12 +6852,13 @@ int RGWRados::with_bilog(F&& on_flushed,
         svc.zone->get_zone().log_data, std::forward<Args>(args)...});
   } else {
     return get_or_create_fifo_bilog_op(
-      RGWBucketInfo{}
+      *this,
+      bucket_info
     ).add_maybe_flush(
       std::move(on_flushed),
       CLSRGWBucketModifyOpT{
-        svc.zone->get_zone().log_data, std::forward<Args>(args)...},
-      std::forward<Args>(args)...
+        svc.zone->get_zone().log_data, args...},
+      args...
     );
   }
 }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7798,8 +7798,14 @@ int RGWRados::raw_obj_stat(rgw_raw_obj& obj, uint64_t *psize, real_time *pmtime,
   return 0;
 }
 
-int RGWRados::get_bucket_stats(RGWBucketInfo& bucket_info, int shard_id, string *bucket_ver, string *master_ver,
-    map<RGWObjCategory, RGWStorageStats>& stats, string *max_marker, bool *syncstopped)
+int RGWRados::get_bucket_stats_and_bilog_meta(
+  RGWBucketInfo& bucket_info,
+  const int shard_id,
+  string *bucket_ver,
+  string *master_ver,
+  map<RGWObjCategory, RGWStorageStats>& stats,
+  string *max_marker,
+  bool *syncstopped)
 {
   vector<rgw_bucket_dir_header> headers;
   map<int, string> bucket_instance_ids;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7815,7 +7815,6 @@ int RGWRados::get_bucket_stats_and_bilog_meta(
 
   BucketIndexShardsManager ver_mgr;
   BucketIndexShardsManager master_ver_mgr;
-  BucketIndexShardsManager marker_mgr;
   char buf[64];
   for (const auto& [header_shard_id, header ] : headers) {
     accumulate_raw_stats(header, stats);
@@ -7823,20 +7822,19 @@ int RGWRados::get_bucket_stats_and_bilog_meta(
     ver_mgr.add(header_shard_id, string(buf));
     snprintf(buf, sizeof(buf), "%lu", (unsigned long)header.master_ver);
     master_ver_mgr.add(header_shard_id, string(buf));
-    if (shard_id >= 0) {
-      *max_marker = header.max_marker;
-    } else {
-      marker_mgr.add(header_shard_id, header.max_marker);
-    }
     if (syncstopped != NULL)
       *syncstopped = header.syncstopped;
   }
   ver_mgr.to_string(bucket_ver);
   master_ver_mgr.to_string(master_ver);
-  if (shard_id < 0) {
-    marker_mgr.to_string(max_marker);
+  if (max_marker) {
+    return svc.bilog_rados->log_get_max_marker(bucket_info,
+                                               headers,
+                                               shard_id,
+                                               max_marker);
+  } else {
+    return 0;
   }
-  return 0;
 }
 
 class RGWGetBucketStatsContext : public RGWGetDirHeader_CB {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -9160,6 +9160,10 @@ int RGWRados::check_disk_state(librados::IoCtx io_ctx,
       /* FIXME: what should happen now? Work out if there are any
        * non-bad ways this could happen (there probably are, but annoying
        * to handle!) */
+      // if we're here, then the operation is delete_obj that got interrupted
+      // AFTER removal of the underlying obj but BEFORE completing the BI op.
+      // as the obj is purged, cancelation is impossible -- all we can do is
+      // resuming the operation.
     }
     // encode a suggested removal of that key
     list_state.ver.epoch = io_ctx.get_last_version();

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6894,6 +6894,19 @@ struct BILogUpdateBatchFIFO {
     encode(entry, bl);
     fifo->push(std::move(bl), null_yield /* FIXME */);
   }
+
+  void add_maybe_flush(RGWModifyOp op,
+                       const rgw_bucket_dir_entry& list_state,
+                       rgw_zone_set zones_trace) {
+    rgw_bi_log_entry entry;
+    entry.object = list_state.key.name;
+    entry.instance = list_state.key.instance;
+    entry.timestamp = list_state.meta.mtime;
+    entry.op = op;
+    entry.state = CLS_RGW_STATE_COMPLETE;
+    entry.tag = list_state.tag;
+    entry.zones_trace = std::move(zones_trace);
+  }
 };
 
 BILogUpdateBatchFIFO::BILogUpdateBatchFIFO(CephContext* const cct,
@@ -6931,6 +6944,12 @@ struct BILogNopHandler {
                        const bool delete_marker,
                        const rgw_bucket_olh_log_bi_log_entry&) {
     ldout(cct, 20) << __PRETTY_FUNCTION__ << ": the OLH-specific variant" << dendl;
+    /* NOP */
+  }
+
+  void add_maybe_flush(RGWModifyOp op,
+                       const rgw_bucket_dir_entry& list_state,
+                       rgw_zone_set) {
     /* NOP */
   }
 };
@@ -8583,20 +8602,22 @@ uint32_t RGWRados::calc_ordered_bucket_list_per_shard(uint32_t num_entries,
 }
 
 
-int RGWRados::cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
-				      const int shard_id,
-				      const rgw_obj_index_key& start_after,
-				      const string& prefix,
-				      const string& delimiter,
-				      const uint32_t num_entries,
-				      const bool list_versions,
-				      const uint16_t expansion_factor,
-				      ent_map_t& m,
-				      bool* is_truncated,
-				      bool* cls_filtered,
-				      rgw_obj_index_key *last_entry,
-                                      optional_yield y,
-				      check_filter_t force_check_filter)
+template <class BILogHandlerT>
+int RGWRados::_do_cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
+					  const int shard_id,
+					  const rgw_obj_index_key& start_after,
+					  const string& prefix,
+					  const string& delimiter,
+					  const uint32_t num_entries,
+					  const bool list_versions,
+					  const uint16_t expansion_factor,
+					  ent_map_t& m,
+					  bool* is_truncated,
+					  bool* cls_filtered,
+					  rgw_obj_index_key *last_entry,
+					  optional_yield y,
+					  check_filter_t force_check_filter,
+					  BILogHandlerT&& bilog_handler)
 {
   /* expansion_factor allows the number of entries to read to grow
    * exponentially; this is used when earlier reads are producing too
@@ -8769,7 +8790,7 @@ int RGWRados::cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
       librados::IoCtx sub_ctx;
       sub_ctx.dup(ioctx);
       r = check_disk_state(sub_ctx, bucket_info, dirent, dirent,
-			   updates[tracker.oid_name], y);
+			   updates[tracker.oid_name], y, bilog_handler);
       if (r < 0 && r != -ENOENT) {
 	return r;
       }
@@ -8849,18 +8870,55 @@ int RGWRados::cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
   return 0;
 }
 
+int RGWRados::cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
+				      const int shard_id,
+				      const rgw_obj_index_key& start_after,
+				      const string& prefix,
+				      const string& delimiter,
+				      const uint32_t num_entries,
+				      const bool list_versions,
+				      const uint16_t expansion_factor,
+				      ent_map_t& m,
+				      bool* is_truncated,
+				      bool* cls_filtered,
+				      rgw_obj_index_key *last_entry,
+                                      optional_yield y,
+				      check_filter_t force_check_filter)
+{
+  return with_bilog<void>([&, this] (auto bilog_handler) {
+    return _do_cls_bucket_list_ordered(bucket_info,
+				       shard_id,
+                                       start_after,
+                                       prefix,
+                                       delimiter,
+                                       num_entries,
+                                       list_versions,
+                                       expansion_factor,
+                                       m,
+                                       is_truncated,
+                                       cls_filtered,
+                                       last_entry,
+                                       std::move(y),
+				       std::move(force_check_filter),
+                                       std::move(bilog_handler));
+  }, bucket_info);
+}
 
-int RGWRados::cls_bucket_list_unordered(RGWBucketInfo& bucket_info,
-					int shard_id,
-					const rgw_obj_index_key& start_after,
-					const string& prefix,
-					uint32_t num_entries,
-					bool list_versions,
-					std::vector<rgw_bucket_dir_entry>& ent_list,
-					bool *is_truncated,
-					rgw_obj_index_key *last_entry,
-                                        optional_yield y,
-					check_filter_t force_check_filter) {
+
+template <class BILogHandlerT>
+int RGWRados::_do_cls_bucket_list_unordered(RGWBucketInfo& bucket_info,
+					    int shard_id,
+					    const rgw_obj_index_key& start_after,
+					    const string& prefix,
+					    uint32_t num_entries,
+					    bool list_versions,
+					    std::vector<rgw_bucket_dir_entry>& ent_list,
+					    bool *is_truncated,
+					    rgw_obj_index_key *last_entry,
+                                            optional_yield y,
+					    check_filter_t force_check_filter,
+					    BILogHandlerT&& bilog_handler)
+{
   ldout(cct, 10) << "cls_bucket_list_unordered " << bucket_info.bucket <<
     " start_after " << start_after.name << "[" << start_after.instance <<
     "] num_entries " << num_entries << dendl;
@@ -8950,7 +9008,8 @@ int RGWRados::cls_bucket_list_unordered(RGWBucketInfo& bucket_info,
 	 * and if the tags are old we need to do cleanup as well. */
 	librados::IoCtx sub_ctx;
 	sub_ctx.dup(ioctx);
-	r = check_disk_state(sub_ctx, bucket_info, dirent, dirent, updates[oid], y);
+	r = check_disk_state(sub_ctx, bucket_info, dirent, dirent,
+			     updates[oid], y, bilog_handler);
 	if (r < 0 && r != -ENOENT) {
 	  return r;
 	}
@@ -9005,8 +9064,35 @@ check_updates:
   }
 
   return 0;
-} // RGWRados::cls_bucket_list_unordered
+} // RGWRados::_do_cls_bucket_list_unordered
 
+int RGWRados::cls_bucket_list_unordered(RGWBucketInfo& bucket_info,
+					int shard_id,
+					const rgw_obj_index_key& start_after,
+					const string& prefix,
+					uint32_t num_entries,
+					bool list_versions,
+					std::vector<rgw_bucket_dir_entry>& ent_list,
+					bool *is_truncated,
+					rgw_obj_index_key *last_entry,
+					optional_yield y,
+					check_filter_t force_check_filter)
+{
+  return with_bilog<void>([&, this] (auto bilog_handler) {
+    return _do_cls_bucket_list_unordered(bucket_info,
+					 shard_id,
+					 start_after,
+					 prefix,
+					 num_entries,
+					 list_versions,
+					 ent_list,
+					 is_truncated,
+					 last_entry,
+					 std::move(y),
+					 std::move(force_check_filter),
+					 std::move(bilog_handler));
+  }, bucket_info);
+}
 
 int RGWRados::cls_obj_usage_log_add(const string& oid,
 				    rgw_usage_log_info& info)
@@ -9123,12 +9209,14 @@ int RGWRados::remove_objs_from_index(RGWBucketInfo& bucket_info, list<rgw_obj_in
   return r;
 }
 
+template <class BILogHandlerT>
 int RGWRados::check_disk_state(librados::IoCtx io_ctx,
                                const RGWBucketInfo& bucket_info,
                                rgw_bucket_dir_entry& list_state,
                                rgw_bucket_dir_entry& object,
                                bufferlist& suggested_updates,
-                               optional_yield y)
+                               optional_yield y,
+                               BILogHandlerT& bilog_handler)
 {
   const rgw_bucket& bucket = bucket_info.bucket;
   uint8_t suggest_flag = (svc.zone->get_zone().log_data ? CEPH_RGW_DIR_SUGGEST_LOG_OP : 0);
@@ -9169,6 +9257,13 @@ int RGWRados::check_disk_state(librados::IoCtx io_ctx,
       // is already deleted as the `astate` testified.
       cls_rgw_encode_suggestion(CEPH_RGW_REMOVE | suggest_flag, list_state,
                                 suggested_updates);
+      if (suggest_flag) {
+        bilog_handler.add_maybe_flush(CLS_RGW_OP_ADD,
+                                      list_state,
+                                      get_zones_trace(svc.zone->get_zone(),
+                                                      bucket_info.bucket,
+                                                      nullptr));
+      }
     } else {
       cls_rgw_encode_suggestion(CEPH_RGW_REMOVE, list_state, suggested_updates);
     }
@@ -9237,6 +9332,13 @@ int RGWRados::check_disk_state(librados::IoCtx io_ctx,
   list_state.meta.owner_display_name = owner.get_display_name();
 
   list_state.exists = true;
+  if (suggest_flag) {
+    bilog_handler.add_maybe_flush(CLS_RGW_OP_ADD,
+                                  list_state,
+                                  get_zones_trace(svc.zone->get_zone(),
+                                                  bucket_info.bucket,
+                                                  nullptr));
+  }
   cls_rgw_encode_suggestion(CEPH_RGW_UPDATE | suggest_flag, list_state, suggested_updates);
   return 0;
 }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -76,6 +76,7 @@ using namespace librados;
 #include "rgw_realm_watcher.h"
 #include "rgw_reshard.h"
 
+#include "services/svc_bilog_rados.h"
 #include "services/svc_zone.h"
 #include "services/svc_zone_utils.h"
 #include "services/svc_quota.h"
@@ -6809,7 +6810,8 @@ static uint16_t get_olh_op_bilog_flags()
 }
 
 struct BILogUpdateBatchFIFO {
-  static constexpr char BILOG_FIFO_SUFFIX[] = ".bilog_fifo";
+  static constexpr auto BILOG_FIFO_SUFFIX = \
+    RGWSI_BILog_RADOS_FIFO::BILOG_FIFO_SUFFIX;
   std::unique_ptr<rgw::cls::fifo::FIFO> fifo;
 
   BILogUpdateBatchFIFO(RGWRados& store, const RGWBucketInfo& bucket_info);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -894,7 +894,6 @@ int RGWIndexCompletionThread::process()
     r = store->guard_reshard(&bs, c->obj, bucket_info,
 			     [&](RGWRados::BucketShard *bs) -> int {
 			       librados::ObjectWriteOperation o;
-			       cls_rgw_guard_bucket_resharding(o, -ERR_BUSY_RESHARDING);
                                c->bi_update(o);
 			       return bs->bucket_obj.operate(&o, null_yield);
                              });
@@ -947,13 +946,9 @@ public:
     return result;
   }
 
-  template <class CLSRGWBucketModifyOpT>
-  void create_completion(CLSRGWBucketModifyOpT&& bi_updater,
-                         const rgw_obj& obj,
-                         rgw_bucket_entry_ver& ver,
-                         rgw_bucket_dir_entry_meta& dir_meta,
-                         list<cls_rgw_obj_key> *remove_objs,
-                         complete_op_data **result);
+  complete_op_data* create_completion(
+    const rgw_obj& obj,
+    std::function<void(librados::ObjectWriteOperation& o)> bi_update);
   bool handle_completion(completion_t cb, complete_op_data *arg);
 
   int start() {
@@ -1011,13 +1006,9 @@ maybe_copy_remove_objs(std::list<cls_rgw_obj_key>* const remove_objs)
   }
 }
 
-template <class CLSRGWBucketModifyOpT>
-void RGWIndexCompletionManager::create_completion(CLSRGWBucketModifyOpT&& bi_updater,
-                                                  const rgw_obj& obj,
-                                                  rgw_bucket_entry_ver& ver,
-                                                  rgw_bucket_dir_entry_meta& dir_meta,
-                                                  list<cls_rgw_obj_key> *remove_objs,
-                                                  complete_op_data **result)
+complete_op_data* RGWIndexCompletionManager::create_completion(
+  const rgw_obj& obj,
+  std::function<void(librados::ObjectWriteOperation& o)> bi_update)
 {
   auto* const entry = new complete_op_data;
   const int shard_id = next_shard();
@@ -1025,25 +1016,12 @@ void RGWIndexCompletionManager::create_completion(CLSRGWBucketModifyOpT&& bi_upd
   entry->manager_shard_id = shard_id;
   entry->manager = this;
   entry->obj = obj;
-  entry->bi_update = \
-    [ bi_updater = std::move(bi_updater),
-      ver,
-      obj,
-      dir_meta,
-      remove_objs = maybe_copy_remove_objs(remove_objs),
-      this
-    ] (librados::ObjectWriteOperation& o) {
-      ldout(store->ctx(), 20) << "handling completion for key="
-                              << bi_updater.key << dendl;
-      std::move(bi_updater).complete_op(o, ver, dir_meta, &remove_objs);
-    };
-
-  *result = entry;
-
+  entry->bi_update = std::move(bi_update);
   entry->rados_completion = librados::Rados::aio_create_completion(entry, obj_complete_cb);
 
   std::lock_guard l{locks[shard_id]};
   completions[shard_id].insert(entry);
+  return entry;
 }
 
 bool RGWIndexCompletionManager::handle_completion(completion_t cb, complete_op_data *arg)
@@ -8283,24 +8261,32 @@ int RGWRados::cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, string& t
   zones_trace.insert(svc.zone->get_zone().id, bs.bucket.get_key());
   return with_bilog<CLSRGWBucketModifyOpT>(
     [&, this] (auto bi_updater) {
-      ObjectWriteOperation o;
-      rgw_bucket_dir_entry_meta dir_meta;
-      dir_meta = ent.meta;
+      rgw_bucket_dir_entry_meta dir_meta{ ent.meta };
       dir_meta.category = category;
-
       rgw_bucket_entry_ver ver;
       ver.pool = pool;
       ver.epoch = epoch;
-      cls_rgw_obj_key key(ent.key.name, ent.key.instance);
+
+      ObjectWriteOperation o;
       cls_rgw_guard_bucket_resharding(o, -ERR_BUSY_RESHARDING);
       bi_updater.complete_op(o, ver, dir_meta, remove_objs);
-      complete_op_data *arg;
-      index_completion_manager->create_completion(std::move(bi_updater),
-                                                  obj,
-                                                  ver,
-                                                  dir_meta,
-                                                  remove_objs,
-                                                  &arg);
+
+      // TODO: it would be really cool to knock the completion manager
+      // out and have it replaced with boost::asio-style continuations
+      // on top of a thread pool.
+      auto* const arg = index_completion_manager->create_completion(
+        obj,
+        [ bi_updater = std::move(bi_updater),
+          ver,
+          dir_meta,
+          remove_objs = maybe_copy_remove_objs(remove_objs),
+          this
+        ] (librados::ObjectWriteOperation& o) {
+          ldout(store->ctx(), 20) << "handling completion for key="
+                                  << bi_updater.key << dendl;
+          cls_rgw_guard_bucket_resharding(o, -ERR_BUSY_RESHARDING);
+          bi_updater.complete_op(o, ver, dir_meta, &remove_objs);
+        });
       librados::AioCompletion *completion = arg->rados_completion;
       int ret = bs.bucket_obj.aio_operate(arg->rados_completion, &o);
       completion->release(); /* can't reference arg here, as it might have already been released */

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -828,16 +828,8 @@ struct complete_op_data {
   AioCompletion *rados_completion{nullptr};
   int manager_shard_id{-1};
   RGWIndexCompletionManager *manager{nullptr};
+  std::function<void(librados::ObjectWriteOperation& o)> bi_update;
   rgw_obj obj;
-  RGWModifyOp op;
-  string tag;
-  rgw_bucket_entry_ver ver;
-  cls_rgw_obj_key key;
-  rgw_bucket_dir_entry_meta dir_meta;
-  list<cls_rgw_obj_key> remove_objs;
-  bool log_op;
-  uint16_t bilog_flags;
-  rgw_zone_set zones_trace;
 
   bool stopped{false};
 
@@ -889,8 +881,6 @@ int RGWIndexCompletionThread::process()
     if (going_down()) {
       continue;
     }
-    ldout(store->ctx(), 20) << __func__ << "(): handling completion for key=" << c->key << dendl;
-
     RGWRados::BucketShard bs(store);
     RGWBucketInfo bucket_info;
 
@@ -905,8 +895,7 @@ int RGWIndexCompletionThread::process()
 			     [&](RGWRados::BucketShard *bs) -> int {
 			       librados::ObjectWriteOperation o;
 			       cls_rgw_guard_bucket_resharding(o, -ERR_BUSY_RESHARDING);
-			       cls_rgw_bucket_complete_op(o, c->op, c->tag, c->ver, c->key, c->dir_meta, &c->remove_objs,
-							  c->log_op, c->bilog_flags, &c->zones_trace);
+                               c->bi_update(o);
 			       return bs->bucket_obj.operate(&o, null_yield);
                              });
     if (r < 0) {
@@ -958,14 +947,12 @@ public:
     return result;
   }
 
-  void create_completion(const rgw_obj& obj,
-                         RGWModifyOp op, string& tag,
+  template <class CLSRGWBucketModifyOpT>
+  void create_completion(CLSRGWBucketModifyOpT&& bi_updater,
+                         const rgw_obj& obj,
                          rgw_bucket_entry_ver& ver,
-                         const cls_rgw_obj_key& key,
                          rgw_bucket_dir_entry_meta& dir_meta,
-                         list<cls_rgw_obj_key> *remove_objs, bool log_op,
-                         uint16_t bilog_flags,
-                         rgw_zone_set *zones_trace,
+                         list<cls_rgw_obj_key> *remove_objs,
                          complete_op_data **result);
   bool handle_completion(completion_t cb, complete_op_data *arg);
 
@@ -1011,42 +998,45 @@ static void obj_complete_cb(completion_t cb, void *arg)
 }
 
 
-void RGWIndexCompletionManager::create_completion(const rgw_obj& obj,
-                                                  RGWModifyOp op, string& tag,
+static std::list<cls_rgw_obj_key>
+maybe_copy_remove_objs(std::list<cls_rgw_obj_key>* const remove_objs)
+{
+  if (remove_objs) {
+    std::list<cls_rgw_obj_key> copy;
+    std::copy(std::begin(*remove_objs), std::end(*remove_objs),
+              std::back_inserter(copy));
+    return copy;
+  } else {
+    return {};
+  }
+}
+
+template <class CLSRGWBucketModifyOpT>
+void RGWIndexCompletionManager::create_completion(CLSRGWBucketModifyOpT&& bi_updater,
+                                                  const rgw_obj& obj,
                                                   rgw_bucket_entry_ver& ver,
-                                                  const cls_rgw_obj_key& key,
                                                   rgw_bucket_dir_entry_meta& dir_meta,
-                                                  list<cls_rgw_obj_key> *remove_objs, bool log_op,
-                                                  uint16_t bilog_flags,
-                                                  rgw_zone_set *zones_trace,
+                                                  list<cls_rgw_obj_key> *remove_objs,
                                                   complete_op_data **result)
 {
-  complete_op_data *entry = new complete_op_data;
-
-  int shard_id = next_shard();
+  auto* const entry = new complete_op_data;
+  const int shard_id = next_shard();
 
   entry->manager_shard_id = shard_id;
   entry->manager = this;
   entry->obj = obj;
-  entry->op = op;
-  entry->tag = tag;
-  entry->ver = ver;
-  entry->key = key;
-  entry->dir_meta = dir_meta;
-  entry->log_op = log_op;
-  entry->bilog_flags = bilog_flags;
-
-  if (remove_objs) {
-    for (auto iter = remove_objs->begin(); iter != remove_objs->end(); ++iter) {
-      entry->remove_objs.push_back(*iter);
-    }
-  }
-
-  if (zones_trace) {
-    entry->zones_trace = *zones_trace;
-  } else {
-    entry->zones_trace.insert(store->svc.zone->get_zone().id, obj.bucket.get_key());
-  }
+  entry->bi_update = \
+    [ bi_updater = std::move(bi_updater),
+      ver,
+      obj,
+      dir_meta,
+      remove_objs = maybe_copy_remove_objs(remove_objs),
+      this
+    ] (librados::ObjectWriteOperation& o) {
+      ldout(store->ctx(), 20) << "handling completion for key="
+                              << bi_updater.key << dendl;
+      std::move(bi_updater).complete_op(o, ver, dir_meta, &remove_objs);
+    };
 
   *result = entry;
 
@@ -8286,6 +8276,11 @@ int RGWRados::cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, string& t
                                   const rgw_bucket_dir_entry& ent, RGWObjCategory category,
 				  list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags, rgw_zone_set *_zones_trace)
 {
+  rgw_zone_set zones_trace;
+  if (_zones_trace) {
+    zones_trace = *_zones_trace;
+  }
+  zones_trace.insert(svc.zone->get_zone().id, bs.bucket.get_key());
   return with_bilog<CLSRGWBucketModifyOpT>(
     [&, this] (auto bi_updater) {
       ObjectWriteOperation o;
@@ -8293,22 +8288,19 @@ int RGWRados::cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, string& t
       dir_meta = ent.meta;
       dir_meta.category = category;
 
-      rgw_zone_set zones_trace;
-      if (_zones_trace) {
-        zones_trace = *_zones_trace;
-      }
-      zones_trace.insert(svc.zone->get_zone().id, bs.bucket.get_key());
-
       rgw_bucket_entry_ver ver;
       ver.pool = pool;
       ver.epoch = epoch;
       cls_rgw_obj_key key(ent.key.name, ent.key.instance);
       cls_rgw_guard_bucket_resharding(o, -ERR_BUSY_RESHARDING);
-      cls_rgw_bucket_complete_op(o, CLSRGWBucketModifyOpT::get_bilog_op_type(), tag, ver, key, dir_meta, remove_objs,
-                                 svc.zone->get_zone().log_data, bilog_flags, &zones_trace);
+      bi_updater.complete_op(o, ver, dir_meta, remove_objs);
       complete_op_data *arg;
-      index_completion_manager->create_completion(obj, CLSRGWBucketModifyOpT::get_bilog_op_type(), tag, ver, key, dir_meta, remove_objs,
-                                                  svc.zone->get_zone().log_data, bilog_flags, &zones_trace, &arg);
+      index_completion_manager->create_completion(std::move(bi_updater),
+                                                  obj,
+                                                  ver,
+                                                  dir_meta,
+                                                  remove_objs,
+                                                  &arg);
       librados::AioCompletion *completion = arg->rados_completion;
       int ret = bs.bucket_obj.aio_operate(arg->rados_completion, &o);
       completion->release(); /* can't reference arg here, as it might have already been released */
@@ -8316,7 +8308,7 @@ int RGWRados::cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, string& t
     },
     cls_rgw_obj_key { ent.key.name, ent.key.instance },
     tag,
-    _zones_trace,
+    &zones_trace,
     bilog_flags);
 }
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1225,6 +1225,8 @@ public:
   void bucket_index_guard_olh_op(RGWObjState& olh_state, librados::ObjectOperation& op);
   int olh_init_modification(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& olh_obj, string *op_tag);
   int olh_init_modification_impl(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& olh_obj, string *op_tag);
+  template <class CLSRGWBucketModifyOpT, class F, class... Args>
+  int with_bilog(F&& on_flushed, Args&&... args);
   template <bool DeleteMarkerV>
   int bucket_index_link_olh(const RGWBucketInfo& bucket_info, RGWObjState& olh_state,
                             const rgw_obj& obj_instance,
@@ -1300,7 +1302,8 @@ public:
 			     map<string, bufferlist> *pattrs, bool create_entry_point);
 
   int cls_obj_prepare_op(BucketShard& bs, RGWModifyOp op, string& tag, rgw_obj& obj, optional_yield y, rgw_zone_set *zones_trace = nullptr);
-  int cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, RGWModifyOp op, string& tag, int64_t pool, uint64_t epoch,
+  template <class CLSRGWBucketModifyOpT>
+  int cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, string& tag, int64_t pool, uint64_t epoch,
                           const rgw_bucket_dir_entry& ent, RGWObjCategory category, list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr);
   int cls_obj_complete_add(BucketShard& bs, const rgw_obj& obj, string& tag, int64_t pool, uint64_t epoch, const rgw_bucket_dir_entry& ent,
                            RGWObjCategory category, list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -924,7 +924,6 @@ public:
       RGWRados::Bucket *target;
       string optag;
       rgw_obj obj;
-      uint16_t bilog_flags{0};
       BucketShard bs;
       bool bs_initialized{false};
       bool blind;
@@ -960,10 +959,6 @@ public:
 
       UpdateIndex(RGWRados::Bucket *_target, const rgw_obj& _obj);
 
-      void set_bilog_flags(uint16_t flags) {
-        bilog_flags = flags;
-      }
-      
       void set_zones_trace(rgw_zone_set *_zones_trace) {
         zones_trace = _zones_trace;
       }
@@ -974,10 +969,13 @@ public:
                    const string& etag, const string& content_type,
                    const string& storage_class,
                    bufferlist *acl_bl, RGWObjCategory category,
-		   list<rgw_obj_index_key> *remove_objs, const string *user_data = nullptr, bool appendable = false);
+		   list<rgw_obj_index_key> *remove_objs,
+                   uint16_t bilog_flags,
+                   const string *user_data = nullptr, bool appendable = false);
       int complete_del(int64_t poolid, uint64_t epoch,
                        ceph::real_time& removed_mtime, /* mtime of removed object */
-                       list<rgw_obj_index_key> *remove_objs);
+                       list<rgw_obj_index_key> *remove_objs,
+                       uint16_t bilog_flags);
       int cancel();
 
       const string *get_optag() { return &optag; }

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1227,23 +1227,44 @@ public:
   int olh_init_modification_impl(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& olh_obj, string *op_tag);
   template <class CLSRGWBucketModifyOpT, class F, class... Args>
   int with_bilog(F&& on_flushed, const RGWBucketInfo& bucket_info, Args&&... args);
-  template <bool DeleteMarkerV>
-  int bucket_index_link_olh(const RGWBucketInfo& bucket_info, RGWObjState& olh_state,
+  template <bool DeleteMarkerV, class OpIssuerT>
+  int bucket_index_link_olh(OpIssuerT& op_issuer,
+                            const RGWBucketInfo& bucket_info,
+                            RGWObjState& olh_state,
                             const rgw_obj& obj_instance,
-                            const string& op_tag, struct rgw_bucket_dir_entry_meta *meta,
+                            struct rgw_bucket_dir_entry_meta *meta,
                             uint64_t olh_epoch,
-                            ceph::real_time unmod_since, bool high_precision_time,
-                            rgw_zone_set *zones_trace = nullptr,
+                            ceph::real_time unmod_since,
+                            bool high_precision_time,
                             bool log_data_change = false);
-  int bucket_index_unlink_instance(const RGWBucketInfo& bucket_info, const rgw_obj& obj_instance, const string& op_tag, const string& olh_tag, uint64_t olh_epoch, rgw_zone_set *zones_trace = nullptr);
+  template <class OpIssuerT>
+  int bucket_index_unlink_instance(OpIssuerT& op_issuer,
+                                   const RGWBucketInfo& bucket_info,
+                                   const rgw_obj& obj_instance,
+                                   const string& olh_tag,
+                                   uint64_t olh_epoch,
+                                   rgw_zone_set *zones_trace = nullptr);
   int bucket_index_read_olh_log(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& obj_instance, uint64_t ver_marker,
                                 map<uint64_t, vector<rgw_bucket_olh_log_entry> > *log, bool *is_truncated);
   int bucket_index_trim_olh_log(const RGWBucketInfo& bucket_info, RGWObjState& obj_state, const rgw_obj& obj_instance, uint64_t ver);
   int bucket_index_clear_olh(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& obj_instance);
-  int apply_olh_log(RGWObjectCtx& ctx, RGWObjState& obj_state, const RGWBucketInfo& bucket_info, const rgw_obj& obj,
-                    bufferlist& obj_tag, map<uint64_t, vector<rgw_bucket_olh_log_entry> >& log,
-                    uint64_t *plast_ver, rgw_zone_set *zones_trace = nullptr);
-  int update_olh(RGWObjectCtx& obj_ctx, RGWObjState *state, const RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_zone_set *zones_trace = nullptr);
+  template <class BILogHandlerT>
+  int apply_olh_log(RGWObjectCtx& ctx,
+                    RGWObjState& obj_state,
+                    const RGWBucketInfo& bucket_info,
+                    const rgw_obj& obj,
+                    bufferlist& obj_tag,
+                    map<uint64_t, vector<rgw_bucket_olh_log_entry> >& log,
+                    BILogHandlerT&& bilog_handler,
+                    uint64_t *plast_ver,
+                    rgw_zone_set *zones_trace = nullptr);
+  template <class BILogHandlerT>
+  int update_olh(RGWObjectCtx& obj_ctx,
+                 RGWObjState *state,
+                 const RGWBucketInfo& bucket_info,
+                 const rgw_obj& obj,
+                 BILogHandlerT&& bilog_handler,
+                 rgw_zone_set *zones_trace = nullptr);
   template <bool DeleteMarkerV>
   int set_olh(RGWObjectCtx& obj_ctx, const RGWBucketInfo& bucket_info, const rgw_obj& target_obj, rgw_bucket_dir_entry_meta *meta,
               uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1225,8 +1225,9 @@ public:
   void bucket_index_guard_olh_op(RGWObjState& olh_state, librados::ObjectOperation& op);
   int olh_init_modification(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& olh_obj, string *op_tag);
   int olh_init_modification_impl(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& olh_obj, string *op_tag);
+  template <bool DeleteMarkerV>
   int bucket_index_link_olh(const RGWBucketInfo& bucket_info, RGWObjState& olh_state,
-                            const rgw_obj& obj_instance, bool delete_marker,
+                            const rgw_obj& obj_instance,
                             const string& op_tag, struct rgw_bucket_dir_entry_meta *meta,
                             uint64_t olh_epoch,
                             ceph::real_time unmod_since, bool high_precision_time,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -920,64 +920,7 @@ public:
       shard_id = id;
     }
 
-    class UpdateIndex {
-      RGWRados::Bucket *target;
-      string optag;
-      rgw_obj obj;
-      BucketShard bs;
-      bool bs_initialized{false};
-      bool blind;
-      rgw_zone_set *zones_trace{nullptr};
-
-      int init_bs() {
-        int r =
-	  bs.init(target->get_bucket(), obj, nullptr /* no RGWBucketInfo */);
-        if (r < 0) {
-          return r;
-        }
-        bs_initialized = true;
-        return 0;
-      }
-
-      void invalidate_bs() {
-        bs_initialized = false;
-      }
-
-      int get_bucket_shard(BucketShard **pbs) {
-        if (!bs_initialized) {
-          int r = init_bs();
-          if (r < 0) {
-            return r;
-          }
-        }
-        *pbs = &bs;
-        return 0;
-      }
-
-      int guard_reshard(BucketShard **pbs, std::function<int(BucketShard *)> call);
-    public:
-
-      UpdateIndex(RGWRados::Bucket *_target,
-                  const rgw_obj& _obj,
-                  rgw_zone_set *zones_trace = nullptr);
-
-      int prepare(RGWModifyOp, const string *write_tag, optional_yield y);
-      int complete(int64_t poolid, uint64_t epoch, uint64_t size,
-                   uint64_t accounted_size, ceph::real_time& ut,
-                   const string& etag, const string& content_type,
-                   const string& storage_class,
-                   bufferlist *acl_bl, RGWObjCategory category,
-		   list<rgw_obj_index_key> *remove_objs,
-                   uint16_t bilog_flags,
-                   const string *user_data = nullptr, bool appendable = false);
-      int complete_del(int64_t poolid, uint64_t epoch,
-                       ceph::real_time& removed_mtime, /* mtime of removed object */
-                       list<rgw_obj_index_key> *remove_objs,
-                       uint16_t bilog_flags);
-      int cancel();
-
-      const string *get_optag() { return &optag; }
-    }; // class UpdateIndex
+    class UpdateIndex;
 
     class List {
     protected:

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1226,7 +1226,7 @@ public:
   int olh_init_modification(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& olh_obj, string *op_tag);
   int olh_init_modification_impl(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& olh_obj, string *op_tag);
   template <class CLSRGWBucketModifyOpT, class F, class... Args>
-  int with_bilog(F&& on_flushed, Args&&... args);
+  int with_bilog(F&& on_flushed, const RGWBucketInfo& bucket_info, Args&&... args);
   template <bool DeleteMarkerV>
   int bucket_index_link_olh(const RGWBucketInfo& bucket_info, RGWObjState& olh_state,
                             const rgw_obj& obj_instance,
@@ -1303,13 +1303,13 @@ public:
 
   int cls_obj_prepare_op(BucketShard& bs, RGWModifyOp op, string& tag, rgw_obj& obj, optional_yield y, rgw_zone_set *zones_trace = nullptr);
   template <class CLSRGWBucketModifyOpT>
-  int cls_obj_complete_op(BucketShard& bs, const rgw_obj& obj, string& tag, int64_t pool, uint64_t epoch,
+  int cls_obj_complete_op(const RGWBucketInfo& bucket_info, BucketShard& bs, const rgw_obj& obj, string& tag, int64_t pool, uint64_t epoch,
                           const rgw_bucket_dir_entry& ent, RGWObjCategory category, list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr);
-  int cls_obj_complete_add(BucketShard& bs, const rgw_obj& obj, string& tag, int64_t pool, uint64_t epoch, const rgw_bucket_dir_entry& ent,
+  int cls_obj_complete_add(const RGWBucketInfo& bucket_info, BucketShard& bs, const rgw_obj& obj, string& tag, int64_t pool, uint64_t epoch, const rgw_bucket_dir_entry& ent,
                            RGWObjCategory category, list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr);
-  int cls_obj_complete_del(BucketShard& bs, string& tag, int64_t pool, uint64_t epoch, rgw_obj& obj,
+  int cls_obj_complete_del(const RGWBucketInfo& bucket_info, BucketShard& bs, string& tag, int64_t pool, uint64_t epoch, rgw_obj& obj,
                            ceph::real_time& removed_mtime, list<rgw_obj_index_key> *remove_objs, uint16_t bilog_flags, rgw_zone_set *zones_trace = nullptr);
-  int cls_obj_complete_cancel(BucketShard& bs, string& tag, rgw_obj& obj, rgw_zone_set *zones_trace = nullptr);
+  int cls_obj_complete_cancel(const RGWBucketInfo& bucket_info, BucketShard& bs, string& tag, rgw_obj& obj, rgw_zone_set *zones_trace = nullptr);
   int cls_obj_set_bucket_tag_timeout(RGWBucketInfo& bucket_info, uint64_t timeout);
 
   using ent_map_t =

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1241,7 +1241,8 @@ public:
                     bufferlist& obj_tag, map<uint64_t, vector<rgw_bucket_olh_log_entry> >& log,
                     uint64_t *plast_ver, rgw_zone_set *zones_trace = nullptr);
   int update_olh(RGWObjectCtx& obj_ctx, RGWObjState *state, const RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_zone_set *zones_trace = nullptr);
-  int set_olh(RGWObjectCtx& obj_ctx, const RGWBucketInfo& bucket_info, const rgw_obj& target_obj, bool delete_marker, rgw_bucket_dir_entry_meta *meta,
+  template <bool DeleteMarkerV>
+  int set_olh(RGWObjectCtx& obj_ctx, const RGWBucketInfo& bucket_info, const rgw_obj& target_obj, rgw_bucket_dir_entry_meta *meta,
               uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time,
               optional_yield y, rgw_zone_set *zones_trace = nullptr, bool log_data_change = false);
   int repair_olh(RGWObjState* state, const RGWBucketInfo& bucket_info,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1342,6 +1342,22 @@ public:
 
   using check_filter_t = bool (*)(const std::string&);
 
+  template <class BILogHandlerT>
+  int _do_cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
+				  const int shard_id,
+				  const rgw_obj_index_key& start_after,
+				  const string& prefix,
+				  const string& delimiter,
+				  const uint32_t num_entries,
+				  const bool list_versions,
+				  const uint16_t exp_factor, // 0 means ignore
+				  ent_map_t& m,
+				  bool* is_truncated,
+				  bool* cls_filtered,
+				  rgw_obj_index_key *last_entry,
+				  optional_yield y,
+				  check_filter_t force_check_filter,
+				  BILogHandlerT&& bilog_handler);
   int cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
 			      const int shard_id,
 			      const rgw_obj_index_key& start_after,
@@ -1356,6 +1372,19 @@ public:
 			      rgw_obj_index_key *last_entry,
                               optional_yield y,
 			      check_filter_t force_check_filter = nullptr);
+  template <class BILogHandlerT>
+  int _do_cls_bucket_list_unordered(RGWBucketInfo& bucket_info,
+				    int shard_id,
+				    const rgw_obj_index_key& start_after,
+				    const string& prefix,
+				    uint32_t num_entries,
+				    bool list_versions,
+				    vector<rgw_bucket_dir_entry>& ent_list,
+				    bool *is_truncated,
+				    rgw_obj_index_key *last_entry,
+				    optional_yield y,
+				    check_filter_t,
+				    BILogHandlerT&& bilog_handler);
   int cls_bucket_list_unordered(RGWBucketInfo& bucket_info,
 				int shard_id,
 				const rgw_obj_index_key& start_after,
@@ -1458,12 +1487,14 @@ public:
    * and -errno on other failures. (-ENOENT is not a failure, and it
    * will encode that info as a suggested update.)
    */
+  template <class BILogHandlerT>
   int check_disk_state(librados::IoCtx io_ctx,
                        const RGWBucketInfo& bucket_info,
                        rgw_bucket_dir_entry& list_state,
                        rgw_bucket_dir_entry& object,
                        bufferlist& suggested_updates,
-                       optional_yield y);
+                       optional_yield y,
+                       BILogHandlerT& bilog_handler);
 
   /**
    * Init pool iteration

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1367,7 +1367,7 @@ public:
 				rgw_obj_index_key *last_entry,
                                 optional_yield y,
 				check_filter_t = nullptr);
-  int cls_bucket_head(const RGWBucketInfo& bucket_info, int shard_id, vector<rgw_bucket_dir_header>& headers, map<int, string> *bucket_instance_ids = NULL);
+  int get_dir_headers(const RGWBucketInfo& bucket_info, int shard_id, std::map<int, rgw_bucket_dir_header>& headers);
   int cls_bucket_head_async(const RGWBucketInfo& bucket_info, int shard_id, RGWGetDirHeader_CB *ctx, int *num_aio);
 
   int bi_get_instance(const RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_bucket_dir_entry *dirent);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1295,8 +1295,12 @@ public:
     rctx->set_prefetch_data(obj);
   }
   int decode_policy(bufferlist& bl, ACLOwner *owner);
+  int get_bucket_stats_and_bilog_meta(RGWBucketInfo& bucket_info, int shard_id, string *bucket_ver, string *master_ver,
+      map<RGWObjCategory, RGWStorageStats>& stats, string *max_marker, bool* syncstopped = nullptr);
   int get_bucket_stats(RGWBucketInfo& bucket_info, int shard_id, string *bucket_ver, string *master_ver,
-      map<RGWObjCategory, RGWStorageStats>& stats, string *max_marker, bool* syncstopped = NULL);
+      map<RGWObjCategory, RGWStorageStats>& stats) {
+    return get_bucket_stats_and_bilog_meta(bucket_info, shard_id, bucket_ver, master_ver, stats, nullptr, nullptr);
+  }
   int get_bucket_stats_async(RGWBucketInfo& bucket_info, int shard_id, RGWGetBucketStats_CB *cb);
 
   int put_bucket_instance_info(RGWBucketInfo& info, bool exclusive, ceph::real_time mtime, map<string, bufferlist> *pattrs);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -957,11 +957,9 @@ public:
       int guard_reshard(BucketShard **pbs, std::function<int(BucketShard *)> call);
     public:
 
-      UpdateIndex(RGWRados::Bucket *_target, const rgw_obj& _obj);
-
-      void set_zones_trace(rgw_zone_set *_zones_trace) {
-        zones_trace = _zones_trace;
-      }
+      UpdateIndex(RGWRados::Bucket *_target,
+                  const rgw_obj& _obj,
+                  rgw_zone_set *zones_trace = nullptr);
 
       int prepare(RGWModifyOp, const string *write_tag, optional_yield y);
       int complete(int64_t poolid, uint64_t epoch, uint64_t size,

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -510,6 +510,8 @@ void RGWOp_BILog_Info::execute(optional_yield y) {
                                                                 &max_marker,
                                                                 &syncstopped);
   if (ret < 0 && ret != -ENOENT) {
+    ldpp_dout(s, 5) << "ERROR: get_bucket_stats_and_bilog_meta returned "
+                    << ret << dendl;
     op_ret = ret;
     return;
   }

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -467,14 +467,14 @@ void RGWOp_BILog_Info::execute(optional_yield y) {
     return;
   }
 
-  int shard_id;
-  string bn;
-  op_ret = rgw_bucket_parse_bucket_instance(bucket_instance, &bn, &bucket_instance, &shard_id);
-  if (op_ret < 0) {
-    return;
-  }
-
+  int shard_id = RGW_NO_SHARD;
   if (!bucket_instance.empty()) {
+    string bn;
+    op_ret = rgw_bucket_parse_bucket_instance(bucket_instance, &bn, &bucket_instance, &shard_id);
+    if (op_ret < 0) {
+      ldpp_dout(s, 5) << "ERROR: cannot parse bucket_instance" << dendl;
+      return;
+    }
     rgw_bucket b(rgw_bucket_key(tenant_name, bn, bucket_instance));
     op_ret = store->getRados()->get_bucket_instance_info(*s->sysobj_ctx, b, bucket_info, NULL, NULL, s->yield);
     if (op_ret < 0) {
@@ -587,13 +587,8 @@ void RGWOp_BILog_Delete::execute(optional_yield y) {
       return;
     }
   }
-<<<<<<< 9ea481137d25fc7fcd143d2287ffcbd80d675548
-  op_ret = store->svc()->bilog_rados->log_trim(bucket_info, shard_id, start_marker, end_marker);
+  op_ret = store->svc()->bilog_rados->log_trim(bucket_info, shard_id, marker);
   if (op_ret < 0) {
-=======
-  http_ret = store->svc()->bilog_rados->log_trim(bucket_info, shard_id, marker);
-  if (http_ret < 0) {
->>>>>>> rgw: drop start-marker from bilog trim.
     ldpp_dout(s, 5) << "ERROR: trim_bi_log_entries() " << dendl;
   }
   return;

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -488,8 +488,27 @@ void RGWOp_BILog_Info::execute(optional_yield y) {
       return;
     }
   }
+  /* `RGWRados::get_bucket_stats()` mixes different resposibilities:
+   * retrieval of bucket's statistics with max_marker and sync control.
+   * Unfortunately, this is just a reflection of our data structures.
+   * The same `rgw_bucket_dir_header` carries things from both domains:
+   * _Bucket Index_ and _Bucket Index Log_.
+   * In the future we should consider introduction of an interface:
+   *
+   *   class RGWBucketMetaInfo {
+   *     virtual get_stats();
+   *     virtual get_max_marker();
+   *     virtual is_sync_stopped();
+   *   };
+   */
   map<RGWObjCategory, RGWStorageStats> stats;
-  int ret =  store->getRados()->get_bucket_stats(bucket_info, shard_id, &bucket_ver, &master_ver, stats, &max_marker, &syncstopped);
+  int ret =  store->getRados()->get_bucket_stats_and_bilog_meta(bucket_info,
+                                                                shard_id,
+                                                                &bucket_ver,
+                                                                &master_ver,
+                                                                stats,
+                                                                &max_marker,
+                                                                &syncstopped);
   if (ret < 0 && ret != -ENOENT) {
     op_ret = ret;
     return;

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -515,18 +515,31 @@ void RGWOp_BILog_Info::send_response() {
 }
 
 void RGWOp_BILog_Delete::execute(optional_yield y) {
+  if (s->info.args.exists("start-marker")) {
+    dout(5) << "start-marker is no longer accepted" << dendl;
+    op_ret = -EINVAL;
+    return;
+  }
+
+  string marker;
+  if (s->info.args.exists("end-marker")) {
+    if (!s->info.args.exists("marker")) {
+      marker = s->info.args.get("end-marker");
+    } else {
+      dout(5) << "end-marker and marker cannot both be provided" << dendl;
+      op_ret = -EINVAL;
+      return;
+    }
+  }
+
   string tenant_name = s->info.args.get("tenant"),
          bucket_name = s->info.args.get("bucket"),
-         start_marker = s->info.args.get("start-marker"),
-         end_marker = s->info.args.get("end-marker"),
          bucket_instance = s->info.args.get("bucket-instance");
-
-  RGWBucketInfo bucket_info;
 
   op_ret = 0;
   if ((bucket_name.empty() && bucket_instance.empty()) ||
-      end_marker.empty()) {
-    ldpp_dout(s, 5) << "ERROR: one of bucket and bucket instance, and also end-marker is mandatory" << dendl;
+      marker.empty()) {
+    ldpp_dout(s, 5) << "ERROR: one of bucket and bucket instance, and also marker is mandatory" << dendl;
     op_ret = -EINVAL;
     return;
   }
@@ -538,6 +551,7 @@ void RGWOp_BILog_Delete::execute(optional_yield y) {
     return;
   }
 
+  RGWBucketInfo bucket_info;
   if (!bucket_instance.empty()) {
     rgw_bucket b(rgw_bucket_key(tenant_name, bn, bucket_instance));
     op_ret = store->getRados()->get_bucket_instance_info(*s->sysobj_ctx, b, bucket_info, NULL, NULL, s->yield);
@@ -552,8 +566,13 @@ void RGWOp_BILog_Delete::execute(optional_yield y) {
       return;
     }
   }
+<<<<<<< 9ea481137d25fc7fcd143d2287ffcbd80d675548
   op_ret = store->svc()->bilog_rados->log_trim(bucket_info, shard_id, start_marker, end_marker);
   if (op_ret < 0) {
+=======
+  http_ret = store->svc()->bilog_rados->log_trim(bucket_info, shard_id, marker);
+  if (http_ret < 0) {
+>>>>>>> rgw: drop start-marker from bilog trim.
     ldpp_dout(s, 5) << "ERROR: trim_bi_log_entries() " << dendl;
   }
   return;

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -204,7 +204,7 @@ int RGWRadosBucket::get_bucket_stats(RGWBucketInfo& bucket_info, int shard_id,
 				     std::map<RGWObjCategory, RGWStorageStats>& stats,
 				     std::string *max_marker, bool *syncstopped)
 {
-  return store->getRados()->get_bucket_stats(bucket_info, shard_id, bucket_ver, master_ver, stats, max_marker, syncstopped);
+  return store->getRados()->get_bucket_stats_and_bilog_meta(bucket_info, shard_id, bucket_ver, master_ver, stats, max_marker, syncstopped);
 }
 
 int RGWRadosBucket::read_bucket_stats(optional_yield y)

--- a/src/rgw/rgw_service.cc
+++ b/src/rgw/rgw_service.cc
@@ -59,7 +59,7 @@ int RGWServices_Def::init(CephContext *cct,
   //    BILog as well?
   //    Liekly we would need to introduce use `bilog_rados->init()`
   //    as `datalog_rados` does with its `start()`. 
-  bilog_rados = std::make_unique<RGWSI_BILog_RADOS_InIndex>(cct);
+  bilog_rados = std::make_unique<RGWSI_BILog_RADOS_BackendDispatcher>(cct);
   cls = std::make_unique<RGWSI_Cls>(cct);
   config_key_rados = std::make_unique<RGWSI_ConfigKey_RADOS>(cct);
   datalog_rados = std::make_unique<RGWDataChangesLog>(cct);

--- a/src/rgw/rgw_service.cc
+++ b/src/rgw/rgw_service.cc
@@ -53,6 +53,12 @@ int RGWServices_Def::init(CephContext *cct,
   bucket_sobj = std::make_unique<RGWSI_Bucket_SObj>(cct);
   bucket_sync_sobj = std::make_unique<RGWSI_Bucket_Sync_SObj>(cct);
   bi_rados = std::make_unique<RGWSI_BucketIndex_RADOS>(cct);
+  // Q: will we have the bucket layout available here?
+  // A: metadata log uses the `neorados` along the path to determine
+  //    which backend (fifo / log) should be used. Would it be enough
+  //    BILog as well?
+  //    Liekly we would need to introduce use `bilog_rados->init()`
+  //    as `datalog_rados` does with its `start()`. 
   bilog_rados = std::make_unique<RGWSI_BILog_RADOS>(cct);
   cls = std::make_unique<RGWSI_Cls>(cct);
   config_key_rados = std::make_unique<RGWSI_ConfigKey_RADOS>(cct);
@@ -80,6 +86,7 @@ int RGWServices_Def::init(CephContext *cct,
 
   finisher->init();
   bi_rados->init(zone.get(), rados.get(), bilog_rados.get(), datalog_rados.get());
+  // the two stage initialization
   bilog_rados->init(bi_rados.get());
   bucket_sobj->init(zone.get(), sysobj.get(), sysobj_cache.get(),
                     bi_rados.get(), meta.get(), meta_be_sobj.get(),

--- a/src/rgw/rgw_service.cc
+++ b/src/rgw/rgw_service.cc
@@ -59,7 +59,7 @@ int RGWServices_Def::init(CephContext *cct,
   //    BILog as well?
   //    Liekly we would need to introduce use `bilog_rados->init()`
   //    as `datalog_rados` does with its `start()`. 
-  bilog_rados = std::make_unique<RGWSI_BILog_RADOS>(cct);
+  bilog_rados = std::make_unique<RGWSI_BILog_RADOS_InIndex>(cct);
   cls = std::make_unique<RGWSI_Cls>(cct);
   config_key_rados = std::make_unique<RGWSI_ConfigKey_RADOS>(cct);
   datalog_rados = std::make_unique<RGWDataChangesLog>(cct);

--- a/src/rgw/services/svc_bi.h
+++ b/src/rgw/services/svc_bi.h
@@ -39,10 +39,9 @@ public:
   virtual int handle_overwrite(const RGWBucketInfo& info,
                                const RGWBucketInfo& orig_info) = 0;
 
-  virtual int cls_bucket_head(const RGWBucketInfo& bucket_info,
+  virtual int get_dir_headers(const RGWBucketInfo& bucket_info,
                               int shard_id,
-                              vector<rgw_bucket_dir_header> *headers,
-                              map<int, string> *bucket_instance_ids,
+                              std::map<int, rgw_bucket_dir_header> *headers,
                               optional_yield y) = 0;
 };
 

--- a/src/rgw/services/svc_bi.h
+++ b/src/rgw/services/svc_bi.h
@@ -38,5 +38,11 @@ public:
 
   virtual int handle_overwrite(const RGWBucketInfo& info,
                                const RGWBucketInfo& orig_info) = 0;
+
+  virtual int cls_bucket_head(const RGWBucketInfo& bucket_info,
+                              int shard_id,
+                              vector<rgw_bucket_dir_header> *headers,
+                              map<int, string> *bucket_instance_ids,
+                              optional_yield y) = 0;
 };
 

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -93,7 +93,6 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index(const RGWBucketInfo& bucket_info,
                                                RGWSI_RADOS::Pool *index_pool,
                                                string *bucket_oid)
 {
-  const rgw_bucket& bucket = bucket_info.bucket;
   int r = open_bucket_index_pool(bucket_info, index_pool);
   if (r < 0) {
     ldout(cct, 20) << __func__ << ": open_bucket_index_pool() returned "
@@ -101,6 +100,7 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index(const RGWBucketInfo& bucket_info,
     return r;
   }
 
+  const rgw_bucket& bucket = bucket_info.bucket;
   if (bucket.bucket_id.empty()) {
     ldout(cct, 0) << "ERROR: empty bucket id for bucket operation" << dendl;
     return -EIO;

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -34,7 +34,7 @@ class RGWSI_BILog_RADOS;
 
 class RGWSI_BucketIndex_RADOS : public RGWSI_BucketIndex
 {
-  friend class RGWSI_BILog_RADOS;
+  friend class RGWSI_BILog_RADOS_InIndex;
 
   int open_pool(const rgw_pool& pool,
                 RGWSI_RADOS::Pool *index_pool,

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -55,12 +55,6 @@ class RGWSI_BucketIndex_RADOS : public RGWSI_BucketIndex
                               uint32_t num_shards, rgw::BucketHashType hash_type,
                               string *bucket_obj, int *shard_id);
 
-  int cls_bucket_head(const RGWBucketInfo& bucket_info,
-                      int shard_id,
-                      vector<rgw_bucket_dir_header> *headers,
-                      map<int, string> *bucket_instance_ids,
-                      optional_yield y);
-
 public:
 
   struct Svc {
@@ -127,6 +121,12 @@ public:
                         RGWSI_RADOS::Pool *index_pool,
                         map<int, string> *bucket_objs,
                         map<int, string> *bucket_instance_ids);
+
+  int cls_bucket_head(const RGWBucketInfo& bucket_info,
+                      int shard_id,
+                      vector<rgw_bucket_dir_header> *headers,
+                      map<int, string> *bucket_instance_ids,
+                      optional_yield y) override;
 };
 
 

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -122,10 +122,9 @@ public:
                         map<int, string> *bucket_objs,
                         map<int, string> *bucket_instance_ids);
 
-  int cls_bucket_head(const RGWBucketInfo& bucket_info,
+  int get_dir_headers(const RGWBucketInfo& bucket_info,
                       int shard_id,
-                      vector<rgw_bucket_dir_header> *headers,
-                      map<int, string> *bucket_instance_ids,
+                      std::map<int, rgw_bucket_dir_header> *headers,
                       optional_yield y) override;
 };
 

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -18,7 +18,9 @@ void RGWSI_BILog_RADOS_InIndex::init(RGWSI_BucketIndex_RADOS *bi_rados_svc)
   svc.bi = bi_rados_svc;
 }
 
-int RGWSI_BILog_RADOS_InIndex::log_trim(const RGWBucketInfo& bucket_info, int shard_id, string& start_marker, string& end_marker)
+int RGWSI_BILog_RADOS_InIndex::log_trim(const RGWBucketInfo& bucket_info,
+                                        const int shard_id,
+                                        string& end_marker)
 {
   RGWSI_RADOS::Pool index_pool;
   map<int, string> bucket_objs;
@@ -31,7 +33,9 @@ int RGWSI_BILog_RADOS_InIndex::log_trim(const RGWBucketInfo& bucket_info, int sh
     return r;
   }
 
-  r = start_marker_mgr.from_string(start_marker, shard_id);
+  // empty string nowadays. In the past we supported `start_marker` but
+  // it has to die because of cls_fifo. See also ae5660fbb6.
+  r = start_marker_mgr.from_string(std::string{}, shard_id);
   if (r < 0) {
     return r;
   }

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -181,30 +181,19 @@ int RGWSI_BILog_RADOS_InIndex::log_list(const RGWBucketInfo& bucket_info, int sh
   return 0;
 }
 
-int RGWSI_BILog_RADOS_InIndex::get_log_status(const RGWBucketInfo& bucket_info,
-                                              int shard_id,
-                                              map<int, string> *markers,
-                                              optional_yield y)
+int RGWSI_BILog_RADOS_InIndex::log_get_max_marker(
+  const RGWBucketInfo&,
+  const std::map<int, rgw_bucket_dir_header>& headers,
+  const int shard_id,
+  std::map<int, std::string> *max_markers)
 {
-  vector<rgw_bucket_dir_header> headers;
-  map<int, string> bucket_instance_ids;
-  int r = svc.bi->cls_bucket_head(bucket_info, shard_id, &headers, &bucket_instance_ids, y);
-  if (r < 0)
-    return r;
-
-  ceph_assert(headers.size() == bucket_instance_ids.size());
-
-  auto iter = headers.begin();
-  map<int, string>::iterator viter = bucket_instance_ids.begin();
-
-  for(; iter != headers.end(); ++iter, ++viter) {
+  for (const auto& [ header_shard_id, header ] : headers) {
     if (shard_id >= 0) {
-      (*markers)[shard_id] = iter->max_marker;
+      (*max_markers)[shard_id] = header.max_marker;
     } else {
-      (*markers)[viter->first] = iter->max_marker;
+      (*max_markers)[header_shard_id] = header.max_marker;
     }
   }
-
   return 0;
 }
 
@@ -351,9 +340,11 @@ int RGWSI_BILog_RADOS_FIFO::log_list(const RGWBucketInfo& bucket_info,
   return 0;
 }
 
-int RGWSI_BILog_RADOS_FIFO::get_log_status(const RGWBucketInfo& bucket_info,
-                                           int shard_id,
-                                           map<int, string> *markers)
+int RGWSI_BILog_RADOS_FIFO::log_get_max_marker(
+  const RGWBucketInfo& bucket_info,
+  const std::map<int, rgw_bucket_dir_header>&,
+  const int shard_id,
+  std::map<int, std::string>* max_markers)
 {
   if (shard_id > 1) {
     // the initial implementation does support single shard only.
@@ -387,7 +378,7 @@ int RGWSI_BILog_RADOS_FIFO::get_log_status(const RGWBucketInfo& bucket_info,
                << dendl;
     return ret;
   }
-  (*markers)[0] = rgw::cls::fifo::marker{
+  (*max_markers)[0] = rgw::cls::fifo::marker{
     head_part_num,
     head_part_header.last_ofs
   }.to_string();

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -358,7 +358,38 @@ int RGWSI_BILog_RADOS_FIFO::get_log_status(const RGWBucketInfo& bucket_info,
   if (shard_id > 1) {
     // the initial implementation does support single shard only.
     return 0;
+  } else {
+    ceph_assert(shard_id == 0 || shard_id == -1);
   }
-  ceph_assert(shard_id == 0 || shard_id == -1);
+  auto fifo = _open_fifo(bucket_info);
+  if (!fifo) {
+    lderr(cct) << __PRETTY_FUNCTION__
+               << ": unable to open FIFO: " << ""//get_oid(index)
+               << dendl;
+    return -EIO;
+  }
+  if (int ret = fifo->read_meta(null_yield); ret < 0) {
+    lderr(cct) << __PRETTY_FUNCTION__
+               << ": unable to read_meta() on FIFO: "
+               << cpp_strerror(-ret)
+               << dendl;
+    return ret;
+  }
+  const auto head_part_num = fifo->meta().head_part_num;
+  rados::cls::fifo::part_header head_part_header;
+  if (int ret = fifo->get_part_info(head_part_num,
+                                    &head_part_header,
+                                    null_yield);
+      ret < 0) {
+    lderr(cct) << __PRETTY_FUNCTION__
+               << ": unable to read_part_header() on FIFO: "
+               << cpp_strerror(-ret)
+               << dendl;
+    return ret;
+  }
+  (*markers)[0] = rgw::cls::fifo::marker{
+    head_part_num,
+    head_part_header.last_ofs
+  }.to_string();
   return 0;
 }

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -3,6 +3,7 @@
 
 #include "svc_bilog_rados.h"
 #include "svc_bi_rados.h"
+#include "svc_rados.h"
 
 #include "common/errno.h"
 #include "cls/rgw/cls_rgw_client.h"
@@ -272,14 +273,14 @@ int RGWSI_BILog_RADOS_FIFO::log_stop(const RGWBucketInfo& bucket_info,
 }
 
 std::unique_ptr<rgw::cls::fifo::FIFO>
-RGWSI_BILog_RADOS_FIFO::_open_fifo(const RGWBucketInfo& bucket_info)
+RGWSI_BILog_RADOS_FIFO::open_fifo(const RGWBucketInfo& bucket_info,
+                                  RGWSI_BucketIndex_RADOS& bi_rados)
 {
   RGWSI_RADOS::Pool index_pool;
   std::string bucket_oid;
-  ceph_assert(svc.bi);
-  if (const int ret = svc.bi->open_bucket_index(bucket_info,
-                                                &index_pool,
-                                                &bucket_oid);
+  if (const int ret = bi_rados.open_bucket_index(bucket_info,
+                                                 &index_pool,
+                                                 &bucket_oid);
       ret < 0) {
     return nullptr;
   }
@@ -291,6 +292,13 @@ RGWSI_BILog_RADOS_FIFO::_open_fifo(const RGWBucketInfo& bucket_info)
                                &ret_fifo,
                                null_yield /* FIXME */);
   return ret_fifo;
+}
+
+std::unique_ptr<rgw::cls::fifo::FIFO>
+RGWSI_BILog_RADOS_FIFO::_open_fifo(const RGWBucketInfo& bucket_info)
+{
+  ceph_assert(svc.bi);
+  return open_fifo(bucket_info, *svc.bi);
 }
 
 int RGWSI_BILog_RADOS_FIFO::log_list(const RGWBucketInfo& bucket_info,

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -197,6 +197,24 @@ int RGWSI_BILog_RADOS_InIndex::log_get_max_marker(
   return 0;
 }
 
+int RGWSI_BILog_RADOS_InIndex::log_get_max_marker(
+  const RGWBucketInfo&,
+  const std::map<int, rgw_bucket_dir_header>& headers,
+  const int shard_id,
+  std::string *max_marker)
+{
+  if (shard_id < 0) {
+    BucketIndexShardsManager marker_mgr;
+    for (const auto& [ header_shard_id, header ] : headers) {
+      marker_mgr.add(header_shard_id, header.max_marker);
+    }
+    marker_mgr.to_string(max_marker);
+  } else if (!headers.empty()) {
+    *max_marker = std::end(headers)->second.max_marker;
+  }
+  return 0;
+}
+
 // CLS FIFO
 void RGWSI_BILog_RADOS_FIFO::init(RGWSI_BucketIndex_RADOS *bi_rados_svc)
 {
@@ -344,7 +362,7 @@ int RGWSI_BILog_RADOS_FIFO::log_get_max_marker(
   const RGWBucketInfo& bucket_info,
   const std::map<int, rgw_bucket_dir_header>&,
   const int shard_id,
-  std::map<int, std::string>* max_markers)
+  std::string* max_marker)
 {
   if (shard_id > 1) {
     // the initial implementation does support single shard only.
@@ -378,9 +396,19 @@ int RGWSI_BILog_RADOS_FIFO::log_get_max_marker(
                << dendl;
     return ret;
   }
-  (*max_markers)[0] = rgw::cls::fifo::marker{
+  *max_marker = rgw::cls::fifo::marker{
     head_part_num,
     head_part_header.last_ofs
   }.to_string();
   return 0;
+}
+
+int RGWSI_BILog_RADOS_FIFO::log_get_max_marker(
+  const RGWBucketInfo& bucket_info,
+  const std::map<int, rgw_bucket_dir_header>& headers,
+  const int shard_id,
+  std::map<int, std::string>* max_markers)
+{
+  auto& max_marker = (*max_markers)[0];
+  return log_get_max_marker(bucket_info, headers, shard_id, &max_marker);
 }

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
+#include "rgw_bucket_layout.h"
 #include "svc_bilog_rados.h"
 #include "svc_bi_rados.h"
 #include "svc_rados.h"
@@ -438,10 +439,12 @@ RGWSI_BILog_RADOS_BackendDispatcher::RGWSI_BILog_RADOS_BackendDispatcher(
 RGWSI_BILog_RADOS& RGWSI_BILog_RADOS_BackendDispatcher::get_backend(
   const RGWBucketInfo& bucket_info)
 {
-  // TODO: teach this method about bilog layout
-  if constexpr(true) {
+  if (bucket_info.layout.logs.empty() /* no layout means the old way */ || \
+      bucket_info.layout.logs.back().layout.type == rgw::BucketLogType::InIndex) {
     return backend_inindex;
-  } else {
+  } else if (bucket_info.layout.logs.back().layout.type == rgw::BucketLogType::FIFO) {
     return backend_fifo;
+  } else {
+    ceph_abort_msg("Unknown BILog layout. This shouldn't happen!");
   }
 }

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -13,12 +13,12 @@ RGWSI_BILog_RADOS::RGWSI_BILog_RADOS(CephContext *cct) : RGWServiceInstance(cct)
 {
 }
 
-void RGWSI_BILog_RADOS::init(RGWSI_BucketIndex_RADOS *bi_rados_svc)
+void RGWSI_BILog_RADOS_InIndex::init(RGWSI_BucketIndex_RADOS *bi_rados_svc)
 {
   svc.bi = bi_rados_svc;
 }
 
-int RGWSI_BILog_RADOS::log_trim(const RGWBucketInfo& bucket_info, int shard_id, string& start_marker, string& end_marker)
+int RGWSI_BILog_RADOS_InIndex::log_trim(const RGWBucketInfo& bucket_info, int shard_id, string& start_marker, string& end_marker)
 {
   RGWSI_RADOS::Pool index_pool;
   map<int, string> bucket_objs;
@@ -45,7 +45,7 @@ int RGWSI_BILog_RADOS::log_trim(const RGWBucketInfo& bucket_info, int shard_id, 
 			      cct->_conf->rgw_bucket_index_max_aio)();
 }
 
-int RGWSI_BILog_RADOS::log_start(const RGWBucketInfo& bucket_info, int shard_id)
+int RGWSI_BILog_RADOS_InIndex::log_start(const RGWBucketInfo& bucket_info, int shard_id)
 {
   RGWSI_RADOS::Pool index_pool;
   map<int, string> bucket_objs;
@@ -56,7 +56,7 @@ int RGWSI_BILog_RADOS::log_start(const RGWBucketInfo& bucket_info, int shard_id)
   return CLSRGWIssueResyncBucketBILog(index_pool.ioctx(), bucket_objs, cct->_conf->rgw_bucket_index_max_aio)();
 }
 
-int RGWSI_BILog_RADOS::log_stop(const RGWBucketInfo& bucket_info, int shard_id)
+int RGWSI_BILog_RADOS_InIndex::log_stop(const RGWBucketInfo& bucket_info, int shard_id)
 {
   RGWSI_RADOS::Pool index_pool;
   map<int, string> bucket_objs;
@@ -77,7 +77,7 @@ static void build_bucket_index_marker(const string& shard_id_str,
   }
 }
 
-int RGWSI_BILog_RADOS::log_list(const RGWBucketInfo& bucket_info, int shard_id, string& marker, uint32_t max,
+int RGWSI_BILog_RADOS_InIndex::log_list(const RGWBucketInfo& bucket_info, int shard_id, string& marker, uint32_t max,
                                 std::list<rgw_bi_log_entry>& result, bool *truncated)
 {
   ldout(cct, 20) << __func__ << ": " << bucket_info.bucket << " marker " << marker << " shard_id=" << shard_id << " max " << max << dendl;
@@ -175,10 +175,10 @@ int RGWSI_BILog_RADOS::log_list(const RGWBucketInfo& bucket_info, int shard_id, 
   return 0;
 }
 
-int RGWSI_BILog_RADOS::get_log_status(const RGWBucketInfo& bucket_info,
-                                      int shard_id,
-                                      map<int, string> *markers,
-				      optional_yield y)
+int RGWSI_BILog_RADOS_InIndex::get_log_status(const RGWBucketInfo& bucket_info,
+                                              int shard_id,
+                                              map<int, string> *markers,
+                                              optional_yield y)
 {
   vector<rgw_bucket_dir_header> headers;
   map<int, string> bucket_instance_ids;

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -4,7 +4,9 @@
 #include "svc_bilog_rados.h"
 #include "svc_bi_rados.h"
 
+#include "common/errno.h"
 #include "cls/rgw/cls_rgw_client.h"
+
 
 
 #define dout_subsys ceph_subsys_rgw
@@ -206,3 +208,157 @@ int RGWSI_BILog_RADOS_InIndex::get_log_status(const RGWBucketInfo& bucket_info,
   return 0;
 }
 
+// CLS FIFO
+void RGWSI_BILog_RADOS_FIFO::init(RGWSI_BucketIndex_RADOS *bi_rados_svc)
+{
+  svc.bi = bi_rados_svc;
+}
+
+int RGWSI_BILog_RADOS_FIFO::log_trim(const RGWBucketInfo& bucket_info,
+                                     int shard_id,
+                                     string& marker)
+{
+  if (shard_id > 0) {
+    // the initial implementation does support single shard only.
+    // this is supposed to change in the future. It's worth to
+    // point out the plan is to decouple the BILog's sharding
+    // policy from the BI's one.
+    return 0;
+  }
+  ceph_assert(shard_id == 0 || shard_id == -1);
+
+  auto fifo = _open_fifo(bucket_info);
+  if (!fifo) {
+    lderr(cct) << __PRETTY_FUNCTION__
+               << ": unable to open FIFO: " << ""//get_oid(index)
+               << dendl;
+    return -EIO;
+  }
+  if (int ret = fifo->trim(marker, false, null_yield); ret < 0) {
+    lderr(cct) << __PRETTY_FUNCTION__
+               << ": unable to trim FIFO: " << ""//get_oid(index)
+               << ": " << cpp_strerror(-ret) << dendl;
+  }
+  return 0;
+}
+
+int RGWSI_BILog_RADOS_FIFO::log_start(const RGWBucketInfo& bucket_info,
+                                      int shard_id)
+{
+  if (shard_id > 0) {
+    // the initial implementation does support single shard only.
+    return 0;
+  }
+  ceph_assert(shard_id == 0 || shard_id == -1);
+  return 0;
+}
+
+int RGWSI_BILog_RADOS_FIFO::log_stop(const RGWBucketInfo& bucket_info,
+                                     int shard_id)
+{
+  if (shard_id > 0) {
+    // the initial implementation does support single shard only.
+    return 0;
+  }
+  ceph_assert(shard_id == 0 || shard_id == -1);
+  return 0;
+}
+
+std::unique_ptr<rgw::cls::fifo::FIFO>
+RGWSI_BILog_RADOS_FIFO::_open_fifo(const RGWBucketInfo& bucket_info)
+{
+  RGWSI_RADOS::Pool index_pool;
+  std::string bucket_oid;
+  ceph_assert(svc.bi);
+  if (const int ret = svc.bi->open_bucket_index(bucket_info,
+                                                &index_pool,
+                                                &bucket_oid);
+      ret < 0) {
+    return nullptr;
+  }
+
+  static constexpr char BILOG_FIFO_SUFFIX[] = ".bilog_fifo";
+  std::unique_ptr<rgw::cls::fifo::FIFO> ret_fifo;
+  rgw::cls::fifo::FIFO::create(index_pool.ioctx(),
+                               bucket_oid + BILOG_FIFO_SUFFIX,
+                               &ret_fifo,
+                               null_yield /* FIXME */);
+  return ret_fifo;
+}
+
+int RGWSI_BILog_RADOS_FIFO::log_list(const RGWBucketInfo& bucket_info,
+                                     int shard_id,
+                                     string& _marker /* in/out? */,
+                                     const uint32_t max_entries,
+                                     std::list<rgw_bi_log_entry>& result,
+                                     bool *truncated)
+{
+  ldout(cct, 20) << __func__ << ": " << bucket_info.bucket
+                 << " _marker=" << _marker << " shard_id=" << shard_id
+                 << " max_entries=" << max_entries << dendl;
+  if (shard_id > 0) {
+    // the initial implementation does support single shard only.
+    return 0;
+  } else {
+    ceph_assert(shard_id == 0 || shard_id == -1);
+  }
+
+  auto fifo = _open_fifo(bucket_info);
+  if (!fifo) {
+    lderr(cct) << __PRETTY_FUNCTION__
+               << ": unable to open FIFO: " << ""//get_oid(index)
+               << dendl;
+    return -EIO;
+  }
+
+  std::optional<std::string_view> marker;
+  if (!_marker.empty()) {
+    marker.emplace(std::move(_marker));
+  }
+
+  std::vector<rgw::cls::fifo::list_entry> raw_entries;
+  bool more = false;
+  auto r = fifo->list(max_entries, marker, &raw_entries, &more,
+                              null_yield);
+  if (r < 0) {
+    lderr(cct) << __PRETTY_FUNCTION__
+               << ": unable to list FIFO: " << ""//get_oid(index)
+               << ": " << cpp_strerror(-r) << dendl;
+    return r;
+  }
+
+  for (const auto& raw_entry : raw_entries) {
+    result.emplace_back();
+    auto& bilog_entry = result.back();
+
+    auto liter = raw_entry.data.cbegin();
+    try {
+      decode(bilog_entry, liter);
+    } catch (const buffer::error& err) {
+      lderr(cct) << __PRETTY_FUNCTION__
+                 << ": failed to decode data changes log entry: "
+                 << err.what() << dendl;
+      return -EIO;
+    }
+  }
+
+  if (truncated) {
+    *truncated = more;
+  }
+  if (!raw_entries.empty()) {
+    _marker = raw_entries.back().marker;
+  }
+  return 0;
+}
+
+int RGWSI_BILog_RADOS_FIFO::get_log_status(const RGWBucketInfo& bucket_info,
+                                           int shard_id,
+                                           map<int, string> *markers)
+{
+  if (shard_id > 1) {
+    // the initial implementation does support single shard only.
+    return 0;
+  }
+  ceph_assert(shard_id == 0 || shard_id == -1);
+  return 0;
+}

--- a/src/rgw/services/svc_bilog_rados.cc
+++ b/src/rgw/services/svc_bilog_rados.cc
@@ -412,3 +412,28 @@ int RGWSI_BILog_RADOS_FIFO::log_get_max_marker(
   auto& max_marker = (*max_markers)[0];
   return log_get_max_marker(bucket_info, headers, shard_id, &max_marker);
 }
+
+void RGWSI_BILog_RADOS_BackendDispatcher::init(
+  RGWSI_BucketIndex_RADOS* const bi_rados_svc)
+{
+  backend_inindex.init(bi_rados_svc);
+  backend_fifo.init(bi_rados_svc);
+}
+
+RGWSI_BILog_RADOS_BackendDispatcher::RGWSI_BILog_RADOS_BackendDispatcher(
+  CephContext* cct)
+  : RGWSI_BILog_RADOS(cct),
+    backend_inindex(cct),
+    backend_fifo(cct) {
+}
+
+RGWSI_BILog_RADOS& RGWSI_BILog_RADOS_BackendDispatcher::get_backend(
+  const RGWBucketInfo& bucket_info)
+{
+  // TODO: teach this method about bilog layout
+  if constexpr(true) {
+    return backend_inindex;
+  } else {
+    return backend_fifo;
+  }
+}

--- a/src/rgw/services/svc_bilog_rados.h
+++ b/src/rgw/services/svc_bilog_rados.h
@@ -38,8 +38,7 @@ public:
 
   virtual int log_trim(const RGWBucketInfo& bucket_info,
                        int shard_id,
-                       std::string& start_marker,
-                       std::string& end_marker) = 0;
+                       std::string& marker) = 0;
   virtual int log_list(const RGWBucketInfo& bucket_info,
                        int shard_id,
                        std::string& marker,
@@ -68,8 +67,7 @@ public:
 
   int log_trim(const RGWBucketInfo& bucket_info,
                int shard_id,
-               std::string& start_marker,
-               std::string& end_marker) override;
+               std::string& marker) override;
   int log_list(const RGWBucketInfo& bucket_info,
                int shard_id,
                std::string& marker,

--- a/src/rgw/services/svc_bilog_rados.h
+++ b/src/rgw/services/svc_bilog_rados.h
@@ -51,6 +51,10 @@ public:
                                  const std::map<int, rgw_bucket_dir_header>& headers,
                                  int shard_id,
                                  std::map<int, std::string> *max_markers) = 0;
+  virtual int log_get_max_marker(const RGWBucketInfo& bucket_info,
+                                 const std::map<int, rgw_bucket_dir_header>& headers,
+                                 int shard_id,
+                                 std::string *max_marker) = 0;
 };
 
 class RGWSI_BILog_RADOS_InIndex : public RGWSI_BILog_RADOS
@@ -81,6 +85,10 @@ public:
                          const std::map<int, rgw_bucket_dir_header>& headers,
                          int shard_id,
                          std::map<int, std::string> *max_markers) override;
+  int log_get_max_marker(const RGWBucketInfo& bucket_info,
+                         const std::map<int, rgw_bucket_dir_header>& headers,
+                         int shard_id,
+                         std::string *max_marker) override;
 };
 
 // RGWSI_BILog_RADOS_FIFO -- the reader part of the cls_fifo-based backend
@@ -123,4 +131,8 @@ public:
                          const std::map<int, rgw_bucket_dir_header>& headers,
                          int shard_id,
                          std::map<int, string> *max_markers) override;
+  int log_get_max_marker(const RGWBucketInfo& bucket_info,
+                         const std::map<int, rgw_bucket_dir_header>& headers,
+                         int shard_id,
+                         std::string *max_marker) override;
 };

--- a/src/rgw/services/svc_bilog_rados.h
+++ b/src/rgw/services/svc_bilog_rados.h
@@ -106,6 +106,9 @@ class RGWSI_BILog_RADOS_FIFO : public RGWSI_BILog_RADOS
 
   std::unique_ptr<rgw::cls::fifo::FIFO> _open_fifo(
     const RGWBucketInfo& bucket_info);
+  static std::unique_ptr<rgw::cls::fifo::FIFO> open_fifo(
+    const RGWBucketInfo& bucket_info,
+    RGWSI_BucketIndex_RADOS& bi_rados);
 
   friend struct BILogUpdateBatchFIFO;
 

--- a/src/rgw/services/svc_bilog_rados.h
+++ b/src/rgw/services/svc_bilog_rados.h
@@ -27,31 +27,58 @@
 class RGWSI_BILog_RADOS : public RGWServiceInstance
 {
 public:
+  virtual ~RGWSI_BILog_RADOS() {}
+
+  RGWSI_BILog_RADOS(CephContext *cct);
+
+  virtual void init(RGWSI_BucketIndex_RADOS *bi_rados_svc) = 0;
+
+  virtual int log_start(const RGWBucketInfo& bucket_info, int shard_id) = 0;
+  virtual int log_stop(const RGWBucketInfo& bucket_info, int shard_id) = 0;
+
+  virtual int log_trim(const RGWBucketInfo& bucket_info,
+                       int shard_id,
+                       std::string& start_marker,
+                       std::string& end_marker) = 0;
+  virtual int log_list(const RGWBucketInfo& bucket_info,
+                       int shard_id,
+                       std::string& marker,
+                       uint32_t max,
+                       std::list<rgw_bi_log_entry>& result,
+                       bool *truncated) = 0;
+
+  virtual int get_log_status(const RGWBucketInfo& bucket_info,
+                             int shard_id,
+                             map<int, string> *markers) = 0;
+};
+
+class RGWSI_BILog_RADOS_InIndex : public RGWSI_BILog_RADOS
+{
+public:
   struct Svc {
     RGWSI_BucketIndex_RADOS *bi{nullptr};
   } svc;
 
-  RGWSI_BILog_RADOS(CephContext *cct);
+  using RGWSI_BILog_RADOS::RGWSI_BILog_RADOS;
 
-  void init(RGWSI_BucketIndex_RADOS *bi_rados_svc);
+  void init(RGWSI_BucketIndex_RADOS *bi_rados_svc) override;
 
-  int log_start(const RGWBucketInfo& bucket_info, int shard_id);
-  int log_stop(const RGWBucketInfo& bucket_info, int shard_id);
+  int log_start(const RGWBucketInfo& bucket_info, int shard_id) override;
+  int log_stop(const RGWBucketInfo& bucket_info, int shard_id) override;
 
   int log_trim(const RGWBucketInfo& bucket_info,
                int shard_id,
                std::string& start_marker,
-               std::string& end_marker);
+               std::string& end_marker) override;
   int log_list(const RGWBucketInfo& bucket_info,
                int shard_id,
                std::string& marker,
                uint32_t max,
                std::list<rgw_bi_log_entry>& result,
-               bool *truncated);
+               bool *truncated) override;
 
   int get_log_status(const RGWBucketInfo& bucket_info,
                      int shard_id,
-                     map<int, string> *markers,
-                     optional_yield y);
+                     std::map<int, std::string> *markers,
+                     optional_yield y) override;
 };
-

--- a/src/rgw/services/svc_bilog_rados.h
+++ b/src/rgw/services/svc_bilog_rados.h
@@ -47,9 +47,10 @@ public:
                        std::list<rgw_bi_log_entry>& result,
                        bool *truncated) = 0;
 
-  virtual int get_log_status(const RGWBucketInfo& bucket_info,
-                             int shard_id,
-                             map<int, string> *markers) = 0;
+  virtual int log_get_max_marker(const RGWBucketInfo& bucket_info,
+                                 const std::map<int, rgw_bucket_dir_header>& headers,
+                                 int shard_id,
+                                 std::map<int, std::string> *max_markers) = 0;
 };
 
 class RGWSI_BILog_RADOS_InIndex : public RGWSI_BILog_RADOS
@@ -76,10 +77,10 @@ public:
                std::list<rgw_bi_log_entry>& result,
                bool *truncated) override;
 
-  int get_log_status(const RGWBucketInfo& bucket_info,
-                     int shard_id,
-                     std::map<int, std::string> *markers,
-                     optional_yield y) override;
+  int log_get_max_marker(const RGWBucketInfo& bucket_info,
+                         const std::map<int, rgw_bucket_dir_header>& headers,
+                         int shard_id,
+                         std::map<int, std::string> *max_markers) override;
 };
 
 // RGWSI_BILog_RADOS_FIFO -- the reader part of the cls_fifo-based backend
@@ -118,7 +119,8 @@ public:
                std::list<rgw_bi_log_entry>& result,
                bool *truncated) override;
 
-  int get_log_status(const RGWBucketInfo& bucket_info,
-                     int shard_id,
-                     map<int, string> *markers) override;
+  int log_get_max_marker(const RGWBucketInfo& bucket_info,
+                         const std::map<int, rgw_bucket_dir_header>& headers,
+                         int shard_id,
+                         std::map<int, string> *max_markers) override;
 };

--- a/src/rgw/services/svc_bilog_rados.h
+++ b/src/rgw/services/svc_bilog_rados.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "cls_fifo_legacy.h"
 #include "rgw/rgw_service.h"
 
 #include "svc_rados.h"
@@ -79,4 +80,45 @@ public:
                      int shard_id,
                      std::map<int, std::string> *markers,
                      optional_yield y) override;
+};
+
+// RGWSI_BILog_RADOS_FIFO -- the reader part of the cls_fifo-based backend
+// for BIlog.
+//
+// Responsibilities:
+//   * reading and treaming entries,
+//   * discovery of `max_marker` (imporant for our incremental sync feature),
+//   * managing the logging state (on/off).
+class RGWSI_BILog_RADOS_FIFO : public RGWSI_BILog_RADOS
+{
+  struct Svc {
+    RGWSI_BucketIndex_RADOS *bi{nullptr};
+  } svc;
+
+  std::unique_ptr<rgw::cls::fifo::FIFO> _open_fifo(
+    const RGWBucketInfo& bucket_info);
+
+  friend struct BILogUpdateBatchFIFO;
+
+public:
+  using RGWSI_BILog_RADOS::RGWSI_BILog_RADOS;
+
+  void init(RGWSI_BucketIndex_RADOS *bi_rados_svc) override;
+
+  int log_start(const RGWBucketInfo& bucket_info, int shard_id) override;
+  int log_stop(const RGWBucketInfo& bucket_info, int shard_id) override;
+
+  int log_trim(const RGWBucketInfo& bucket_info,
+               int shard_id,
+               std::string& marker) override;
+  int log_list(const RGWBucketInfo& bucket_info,
+               int shard_id,
+               std::string& marker,
+               uint32_t max,
+               std::list<rgw_bi_log_entry>& result,
+               bool *truncated) override;
+
+  int get_log_status(const RGWBucketInfo& bucket_info,
+                     int shard_id,
+                     map<int, string> *markers) override;
 };

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -925,6 +925,27 @@ auto gen_usage_log_info(std::string payer, std::string bucket, int total_usage_e
   return info;
 }
 
+static int cls_rgw_usage_log_trim(IoCtx& io_ctx,
+                                  const string& oid,
+                                  const string& user,
+                                  const string& bucket,
+                                  uint64_t start_epoch,
+                                  uint64_t end_epoch)
+{
+  bool done = false;
+  do {
+    ObjectWriteOperation op;
+    cls_rgw_usage_log_trim(op, user, bucket, start_epoch, end_epoch);
+    if (int r = io_ctx.operate(oid, &op); r == -ENODATA) {
+      done = true;
+    } else if (r < 0) {
+      return r;
+    }
+  } while (!done);
+
+  return 0;
+}
+
 TEST_F(cls_rgw, usage_basic)
 {
   string oid="usage.1";


### PR DESCRIPTION
This is a continuation of #37786. It brings support for `RGWRados::check_disk_state` as well as bucket layout.

TODO
-------
- [ ] Use dedicated `optional_yield` to not block on interactions with `cls_fifo`.
- [ ] Batching of pushes to `cls_fifo`.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
