### PR TITLE
mgr/dashboard: deletion of host doesn't reflect the dashboard

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -233,7 +233,11 @@ export class HostsComponent extends ListWithDetails implements OnInit {
           });
           return host;
         });
-        this.hosts = resp;
+        this.hosts = resp.filter((respKey: any) => {
+          if (respKey['sources']['ceph'] && respKey['sources']['orchestrator']) {
+            return respKey;
+          }
+        });
         this.isLoadingHosts = false;
       },
       () => {


### PR DESCRIPTION
This PR fixes the updation of the frontend host list upon the deletion of hosts

Fixes: https://tracker.ceph.com/issues/48290

Signed-off-by: Avan Thakkar <athakkar@redhat.com>

Deleted ceph-node-01/02

Before:
![Screenshot from 2020-11-19 12-57-20](https://user-images.githubusercontent.com/23611106/99673563-f1809c80-2a9a-11eb-97d2-63105e0ade2a.png)

After:
![Screenshot from 2020-11-19 18-05-28](https://user-images.githubusercontent.com/23611106/99673611-00ffe580-2a9b-11eb-8d23-de20b5c62aec.png)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
