### PR TITLE
octopus: mgr/dashboard: The performance 'Client Read/Write' widget shows incorrect write values

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
@@ -95,7 +95,11 @@ export class HealthComponent implements OnInit, OnDestroy {
       )} ${this.i18n(`/s`)}`
     );
     ratioData.push(this.healthData.client_perf.read_op_per_sec);
-    ratioLabels.push(this.healthData.client_perf.write_op_per_sec);
+    ratioLabels.push(
+      `${this.i18n(`Writes`)}: ${this.dimless.transform(
+        this.healthData.client_perf.write_op_per_sec
+      )} ${this.i18n(`/s`)}`
+    );
     ratioData.push(this.calcPercentage(this.healthData.client_perf.write_op_per_sec, total));
 
     chart.labels = ratioLabels;


### PR DESCRIPTION
This PR fixes the erroneous backport https://github.com/ceph/ceph/commit/b2360b1a6101b5cc61c236047ce7c757fd02c93d#diff-ca1dfda3e90bbf562ce21e91142772f28f4562d9051610e7902862d2f951dae3.

Before:
![screenshot](https://user-images.githubusercontent.com/1897962/99687336-d4d96a00-2a84-11eb-9f74-b6535b3e6272.png)

After:
![Bildschirmfoto vom 2020-11-19 16-29-13](https://user-images.githubusercontent.com/1897962/99687347-d86cf100-2a84-11eb-855f-bc48e2d76cdc.png)

Fixes: https://tracker.ceph.com/issues/48295

Signed-off-by: Volker Theile <vtheile@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
