### PR TITLE
rgw/amqp/kafka: prevent concurrent shutdowns from happening

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -57,7 +57,6 @@ extern "C" {
 #include "rgw_http_client_curl.h"
 #include "rgw_zone.h"
 #include "rgw_pubsub.h"
-#include "rgw_sync_module_pubsub.h"
 #include "rgw_bucket_sync.h"
 #include "rgw_sync_checkpoint.h"
 #include "rgw_lua.h"

--- a/src/rgw/rgw_sync_module_pubsub.cc
+++ b/src/rgw/rgw_sync_module_pubsub.cc
@@ -17,12 +17,6 @@
 #include "rgw_pubsub_push.h"
 #include "rgw_notify_event_type.h"
 #include "rgw_perf_counters.h"
-#ifdef WITH_RADOSGW_AMQP_ENDPOINT
-#include "rgw_amqp.h"
-#endif
-#ifdef WITH_RADOSGW_KAFKA_ENDPOINT
-#include "rgw_kafka.h"
-#endif
 
 #include <boost/algorithm/hex.hpp>
 #include <boost/asio/yield.hpp>
@@ -1383,25 +1377,6 @@ RGWPSSyncModuleInstance::RGWPSSyncModuleInstance(CephContext *cct, const JSONFor
   } else {
     effective_conf.decode_json(&p);
   }
-#ifdef WITH_RADOSGW_AMQP_ENDPOINT
-  if (!rgw::amqp::init(cct)) {
-    ldout(cct, 1) << "ERROR: failed to initialize AMQP manager in pubsub sync module" << dendl;
-  }
-#endif
-#ifdef WITH_RADOSGW_KAFKA_ENDPOINT
-  if (!rgw::kafka::init(cct)) {
-    ldout(cct, 1) << "ERROR: failed to initialize Kafka manager in pubsub sync module" << dendl;
-  }
-#endif
-}
-
-RGWPSSyncModuleInstance::~RGWPSSyncModuleInstance() {
-#ifdef WITH_RADOSGW_AMQP_ENDPOINT
-  rgw::amqp::shutdown();
-#endif
-#ifdef WITH_RADOSGW_KAFKA_ENDPOINT
-  rgw::kafka::shutdown();
-#endif
 }
 
 RGWDataSyncModule *RGWPSSyncModuleInstance::get_data_handler()

--- a/src/rgw/rgw_sync_module_pubsub.h
+++ b/src/rgw/rgw_sync_module_pubsub.h
@@ -26,7 +26,7 @@ class RGWPSSyncModuleInstance : public RGWSyncModuleInstance {
   JSONFormattable effective_conf;
 public:
   RGWPSSyncModuleInstance(CephContext *cct, const JSONFormattable& config);
-  ~RGWPSSyncModuleInstance();
+  ~RGWPSSyncModuleInstance() = default;
   RGWDataSyncModule *get_data_handler() override;
   RGWRESTMgr *get_rest_filter(int dialect, RGWRESTMgr *orig) override;
   bool supports_user_writes() override {


### PR DESCRIPTION
this may be causing radosgw-admin and possibly radosgw to hang during
shutdown

fixes: https://tracker.ceph.com/issues/48293

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
