### PR TITLE
nautilus: ceph-volume: fix filestore/dmcrypt activate

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -157,16 +157,15 @@ class Prepare(object):
             lv = None
 
         if lv:
-            uuid = lv.lv_uuid
+            lv_uuid = lv.lv_uuid
             path = lv.lv_path
-            tags['ceph.%s_uuid' % device_type] = uuid
+            tags['ceph.%s_uuid' % device_type] = lv_uuid
             tags['ceph.%s_device' % device_type] = path
             lv.set_tags(tags)
         elif disk.is_device(device_name):
             # We got a disk, create an lv
             lv_type = "osd-{}".format(device_type)
-            uuid = system.generate_uuid()
-            tags['ceph.{}_uuid'.format(device_type)] = uuid
+            name_uuid = system.generate_uuid()
             kwargs = {
                 'device': device_name,
                 'tags': tags,
@@ -178,18 +177,21 @@ class Prepare(object):
                 kwargs['size'] = size
             lv = api.create_lv(
                 lv_type,
-                uuid,
+                name_uuid,
                 **kwargs)
             path = lv.lv_path
             tags['ceph.{}_device'.format(device_type)] = path
+            tags['ceph.{}_uuid'.format(device_type)] = lv.lv_uuid
+            lv_uuid = lv.lv_uuid
             lv.set_tags(tags)
         else:
             # otherwise assume this is a regular disk partition
-            uuid = self.get_ptuuid(device_name)
+            name_uuid = self.get_ptuuid(device_name)
             path = device_name
-            tags['ceph.%s_uuid' % device_type] = uuid
+            tags['ceph.%s_uuid' % device_type] = name_uuid
             tags['ceph.%s_device' % device_type] = path
-        return path, uuid, tags
+            lv_uuid = name_uuid
+        return path, lv_uuid, tags
 
     def prepare_data_device(self, device_type, osd_uuid):
         """

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
@@ -1,5 +1,6 @@
 import pytest
 from ceph_volume.devices import lvm
+from ceph_volume.api import lvm as api
 from mock.mock import patch, Mock
 
 
@@ -114,6 +115,49 @@ class TestPrepare(object):
             prepare.safe_prepare()
             expected = 'skipping {}, it is already prepared'.format('/dev/sdfoo')
             assert expected in str(error.value)
+
+    def test_setup_device_device_name_is_none(self):
+        result = lvm.prepare.Prepare.setup_device(self=None, device_type='data', device_name=None, tags={'ceph.type': 'data'}, size=0, slots=None)
+        assert result == ('', '', {'ceph.type': 'data'})
+
+    @patch('ceph_volume.api.lvm.Volume.set_tags')
+    @patch('ceph_volume.devices.lvm.prepare.api.get_first_lv')
+    def test_setup_device_lv_passed(self, m_get_first_lv, m_set_tags):
+        fake_volume = api.Volume(lv_name='lv_foo', lv_path='/fake-path', vg_name='vg_foo', lv_tags='', lv_uuid='fake-uuid')
+        m_get_first_lv.return_value = fake_volume
+        result = lvm.prepare.Prepare([]).setup_device(device_type='data', device_name='vg_foo/lv_foo', tags={'ceph.type': 'data'}, size=0, slots=None)
+
+        assert result == ('/fake-path', 'fake-uuid', {'ceph.type': 'data',
+                                                    'ceph.vdo': '0',
+                                                    'ceph.data_uuid': 'fake-uuid',
+                                                    'ceph.data_device': '/fake-path'})
+
+    @patch('ceph_volume.devices.lvm.prepare.api.create_lv')
+    @patch('ceph_volume.api.lvm.Volume.set_tags')
+    @patch('ceph_volume.util.disk.is_device')
+    def test_setup_device_device_passed(self, m_is_device, m_set_tags, m_create_lv):
+        fake_volume = api.Volume(lv_name='lv_foo', lv_path='/fake-path', vg_name='vg_foo', lv_tags='', lv_uuid='fake-uuid')
+        m_is_device.return_value = True
+        m_create_lv.return_value = fake_volume
+        result = lvm.prepare.Prepare([]).setup_device(device_type='data', device_name='/dev/sdx', tags={'ceph.type': 'data'}, size=0, slots=None)
+
+        assert result == ('/fake-path', 'fake-uuid', {'ceph.type': 'data',
+                                                    'ceph.vdo': '0',
+                                                    'ceph.data_uuid': 'fake-uuid',
+                                                    'ceph.data_device': '/fake-path'})
+
+    @patch('ceph_volume.devices.lvm.prepare.Prepare.get_ptuuid')
+    @patch('ceph_volume.devices.lvm.prepare.api.get_first_lv')
+    def test_setup_device_partition_passed(self, m_get_first_lv, m_get_ptuuid):
+        m_get_first_lv.side_effect = ValueError()
+        m_get_ptuuid.return_value = 'fake-uuid'
+        result = lvm.prepare.Prepare([]).setup_device(device_type='data', device_name='/dev/sdx', tags={'ceph.type': 'data'}, size=0, slots=None)
+
+        assert result == ('/dev/sdx', 'fake-uuid', {'ceph.type': 'data',
+                                                    'ceph.vdo': '0',
+                                                    'ceph.data_uuid': 'fake-uuid',
+                                                    'ceph.data_device': '/dev/sdx'})
+
 
 class TestActivate(object):
 

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
@@ -117,7 +117,7 @@ class TestPrepare(object):
             assert expected in str(error.value)
 
     def test_setup_device_device_name_is_none(self):
-        result = lvm.prepare.Prepare.setup_device(self=None, device_type='data', device_name=None, tags={'ceph.type': 'data'}, size=0, slots=None)
+        result = lvm.prepare.Prepare([]).setup_device(device_type='data', device_name=None, tags={'ceph.type': 'data'}, size=0, slots=None)
         assert result == ('', '', {'ceph.type': 'data'})
 
     @patch('ceph_volume.api.lvm.Volume.set_tags')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48302

---

backport of https://github.com/ceph/ceph/pull/38147
parent tracker: https://tracker.ceph.com/issues/48271

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh