### PR TITLE
librbd/plugin: delete field m_image_ctx in ParentCache

### DIFF
--- a/src/librbd/plugin/ParentCache.cc
+++ b/src/librbd/plugin/ParentCache.cc
@@ -35,20 +35,19 @@ namespace plugin {
 template <typename I>
 void ParentCache<I>::init(I* image_ctx, Api<I>& api, HookPoints* hook_points,
                           Context* on_finish) {
-  m_image_ctx = image_ctx;
-  bool parent_cache_enabled = m_image_ctx->config.template get_val<bool>(
+  bool parent_cache_enabled = image_ctx->config.template get_val<bool>(
     "rbd_parent_cache_enabled");
-  if (m_image_ctx->child == nullptr || !parent_cache_enabled ||
-      !m_image_ctx->data_ctx.is_valid()) {
+  if (image_ctx->child == nullptr || !parent_cache_enabled ||
+      !image_ctx->data_ctx.is_valid()) {
     on_finish->complete(0);
     return;
   }
 
-  auto cct = m_image_ctx->cct;
+  auto cct = image_ctx->cct;
   ldout(cct, 5) << dendl;
 
   auto parent_cache = cache::ParentCacheObjectDispatch<I>::create(
-    m_image_ctx, api);
+    image_ctx, api);
   on_finish = new LambdaContext([this, on_finish, parent_cache](int r) {
       if (r < 0) {
         // the object dispatcher will handle cleanup if successfully initialized
@@ -62,7 +61,6 @@ void ParentCache<I>::init(I* image_ctx, Api<I>& api, HookPoints* hook_points,
 
 template <typename I>
 void ParentCache<I>::handle_init_parent_cache(int r, Context* on_finish) {
-  auto cct = m_image_ctx->cct;
   ldout(cct, 5) << "r=" << r << dendl;
 
   if (r < 0) {

--- a/src/librbd/plugin/ParentCache.h
+++ b/src/librbd/plugin/ParentCache.h
@@ -23,9 +23,8 @@ public:
             Context* on_finish) override;
 
 private:
-  ImageCtxT* m_image_ctx = nullptr;
-
   void handle_init_parent_cache(int r, Context* on_finish);
+  using ceph::Plugin::cct;
 
 };
 


### PR DESCRIPTION
librbd::plugin::ParentCache may be shared by more than one images.

Signed-off-by: Li, Xiaoyan <xiaoyan.li@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
