### PR TITLE
octopus: ceph-volume: prepare: use *-slots arguments for implicit sizing

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -596,7 +596,7 @@ class VolumeGroup(object):
         '''
         Return how many extents fit the VG slot times
         '''
-        return int(int(self.vg_free_count) / slots)
+        return int(int(self.vg_extent_count) / slots)
 
 
 def create_vg(devices, name=None, name_prefix=None):

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -208,6 +208,7 @@ class Prepare(object):
             lv_name_prefix = "osd-{}".format(device_type)
             kwargs = {'device': device,
                       'tags': {'ceph.type': device_type},
+                      'slots': self.args.data_slots,
                      }
             logger.debug('data device size: {}'.format(self.args.data_size))
             if self.args.data_size != 0:

--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -186,6 +186,7 @@ class TestCreateLV(object):
         self.foo_volume = api.Volume(lv_name='foo', lv_path='/path', vg_name='foo_group', lv_tags='')
         self.foo_group = api.VolumeGroup(vg_name='foo_group',
                                          vg_extent_size=4194304,
+                                         vg_extent_count=100,
                                          vg_free_count=100)
 
     @patch('ceph_volume.api.lvm.process.run')

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -490,7 +490,6 @@ class Device(object):
             # only check generic if no vgs are present. Vgs might hold lvs and
             # that might cause 'locked' to trigger
             rejected.extend(self._check_generic_reject_reasons())
-
         return len(rejected) == 0, rejected
 
     def _check_raw_reject_reasons(self):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48304

---

backport of https://github.com/ceph/ceph/pull/33787
parent tracker: https://tracker.ceph.com/issues/44494

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh