### PR TITLE
ceph-volume: fix test_setup_device_device_name_is_none

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
@@ -117,7 +117,7 @@ class TestPrepare(object):
             assert expected in str(error.value)
 
     def test_setup_device_device_name_is_none(self):
-        result = lvm.prepare.Prepare.setup_device(self=None, device_type='data', device_name=None, tags={'ceph.type': 'data'}, size=0, slots=None)
+        result = lvm.prepare.Prepare([]).setup_device(device_type='data', device_name=None, tags={'ceph.type': 'data'}, size=0, slots=None)
         assert result == ('', '', {'ceph.type': 'data'})
 
     @patch('ceph_volume.api.lvm.Volume.set_tags')


### PR DESCRIPTION
Let's call this function by using the same syntax than other tests.
This will make it work with py2 in nautilus branch.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>