### PR TITLE
mgr/cephadm: make type annotations mandatory for some modules

### DIFF
--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -22,6 +22,9 @@ ignore_missing_imports = True
 
 disallow_untyped_defs = True
 
+[mypy-cephadm.upgrade.*]
+disallow_untyped_defs = True
+
 # Make cephadm and rook happy
 [mypy-OpenSSL]
 ignore_missing_imports = True

--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -25,6 +25,9 @@ disallow_untyped_defs = True
 [mypy-cephadm.upgrade.*]
 disallow_untyped_defs = True
 
+[mypy-cephadm.serve.*]
+disallow_untyped_defs = True
+
 # Make cephadm and rook happy
 [mypy-OpenSSL]
 ignore_missing_imports = True

--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -28,6 +28,9 @@ disallow_untyped_defs = True
 [mypy-cephadm.serve.*]
 disallow_untyped_defs = True
 
+[mypy-cephadm.inventory]
+disallow_untyped_defs = True
+
 # Make cephadm and rook happy
 [mypy-OpenSSL]
 ignore_missing_imports = True

--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -31,6 +31,9 @@ disallow_untyped_defs = True
 [mypy-cephadm.inventory]
 disallow_untyped_defs = True
 
+[mypy-cephadm.schedule]
+disallow_untyped_defs = True
+
 # Make cephadm and rook happy
 [mypy-OpenSSL]
 ignore_missing_imports = True

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -41,25 +41,25 @@ class Inventory:
     def __contains__(self, host: str) -> bool:
         return host in self._inventory
 
-    def assert_host(self, host):
+    def assert_host(self, host: str) -> None:
         if host not in self._inventory:
             raise OrchestratorError('host %s does not exist' % host)
 
-    def add_host(self, spec: HostSpec):
+    def add_host(self, spec: HostSpec) -> None:
         self._inventory[spec.hostname] = spec.to_json()
         self.save()
 
-    def rm_host(self, host: str):
+    def rm_host(self, host: str) -> None:
         self.assert_host(host)
         del self._inventory[host]
         self.save()
 
-    def set_addr(self, host, addr):
+    def set_addr(self, host: str, addr: str) -> None:
         self.assert_host(host)
         self._inventory[host]['addr'] = addr
         self.save()
 
-    def add_label(self, host, label):
+    def add_label(self, host: str, label: str) -> None:
         self.assert_host(host)
 
         if 'labels' not in self._inventory[host]:
@@ -68,7 +68,7 @@ class Inventory:
             self._inventory[host]['labels'].append(label)
         self.save()
 
-    def rm_label(self, host, label):
+    def rm_label(self, host: str, label: str) -> None:
         self.assert_host(host)
 
         if 'labels' not in self._inventory[host]:
@@ -77,7 +77,7 @@ class Inventory:
             self._inventory[host]['labels'].remove(label)
         self.save()
 
-    def get_addr(self, host) -> str:
+    def get_addr(self, host: str) -> str:
         self.assert_host(host)
         return self._inventory[host].get('addr', host)
 
@@ -89,7 +89,7 @@ class Inventory:
                 else:
                     yield h
 
-    def spec_from_dict(self, info) -> HostSpec:
+    def spec_from_dict(self, info: dict) -> HostSpec:
         hostname = info['hostname']
         return HostSpec(
             hostname,
@@ -101,7 +101,7 @@ class Inventory:
     def all_specs(self) -> List[HostSpec]:
         return list(map(self.spec_from_dict, self._inventory.values()))
 
-    def save(self):
+    def save(self) -> None:
         self.mgr.set_store('inventory', json.dumps(self._inventory))
 
 
@@ -291,7 +291,7 @@ class HostCache():
         self.networks[host] = nets
         self.last_device_update[host] = datetime.datetime.utcnow()
 
-    def update_daemon_config_deps(self, host, name, deps, stamp):
+    def update_daemon_config_deps(self, host: str, name: str, deps: List[str], stamp: datetime.datetime) -> None:
         self.daemon_config_deps[host][name] = {
             'deps': deps,
             'last_config': stamp,
@@ -330,7 +330,7 @@ class HostCache():
             del self.last_device_update[host]
         self.mgr.event.set()
 
-    def distribute_new_registry_login_info(self):
+    def distribute_new_registry_login_info(self) -> None:
         self.registry_login_queue = set(self.mgr.inventory.keys())
 
     def save_host(self, host: str) -> None:
@@ -420,7 +420,7 @@ class HostCache():
         raise orchestrator.OrchestratorError(f'Unable to find {daemon_name} daemon(s)')
 
     def get_daemons_with_volatile_status(self) -> Iterator[Tuple[str, Dict[str, orchestrator.DaemonDescription]]]:
-        def alter(host, dd_orig: orchestrator.DaemonDescription) -> orchestrator.DaemonDescription:
+        def alter(host: str, dd_orig: orchestrator.DaemonDescription) -> orchestrator.DaemonDescription:
             dd = copy(dd_orig)
             if host in self.mgr.offline_hosts:
                 dd.status = -1
@@ -457,7 +457,7 @@ class HostCache():
                 r.append(name)
         return r
 
-    def get_daemon_last_config_deps(self, host, name) -> Tuple[Optional[List[str]], Optional[datetime.datetime]]:
+    def get_daemon_last_config_deps(self, host: str, name: str) -> Tuple[Optional[List[str]], Optional[datetime.datetime]]:
         if host in self.daemon_config_deps:
             if name in self.daemon_config_deps[host]:
                 return self.daemon_config_deps[host][name].get('deps', []), \
@@ -513,7 +513,7 @@ class HostCache():
             return True
         return False
 
-    def host_needs_osdspec_preview_refresh(self, host):
+    def host_needs_osdspec_preview_refresh(self, host: str) -> bool:
         if host in self.mgr.offline_hosts:
             logger.debug(f'Host "{host}" marked as offline. Skipping osdspec preview refresh')
             return False
@@ -530,7 +530,7 @@ class HostCache():
             seconds=self.mgr.host_check_interval)
         return host not in self.last_host_check or self.last_host_check[host] < cutoff
 
-    def host_needs_new_etc_ceph_ceph_conf(self, host: str):
+    def host_needs_new_etc_ceph_ceph_conf(self, host: str) -> bool:
         if not self.mgr.manage_etc_ceph_ceph_conf:
             return False
         if self.mgr.paused:
@@ -548,7 +548,7 @@ class HostCache():
         # already up to date:
         return False
 
-    def update_last_etc_ceph_ceph_conf(self, host: str):
+    def update_last_etc_ceph_ceph_conf(self, host: str) -> None:
         if not self.mgr.last_monmap:
             return
         self.last_etc_ceph_ceph_conf[host] = datetime.datetime.utcnow()
@@ -566,12 +566,12 @@ class HostCache():
         assert host in self.daemons
         self.daemons[host][dd.name()] = dd
 
-    def rm_daemon(self, host, name):
+    def rm_daemon(self, host: str, name: str) -> None:
         if host in self.daemons:
             if name in self.daemons[host]:
                 del self.daemons[host][name]
 
-    def daemon_cache_filled(self):
+    def daemon_cache_filled(self) -> bool:
         """
         i.e. we have checked the daemons for each hosts at least once.
         excluding offline hosts.
@@ -582,7 +582,7 @@ class HostCache():
         return all((self.host_had_daemon_refresh(h) or h in self.mgr.offline_hosts)
                    for h in self.get_hosts())
 
-    def schedule_daemon_action(self, host: str, daemon_name: str, action: str):
+    def schedule_daemon_action(self, host: str, daemon_name: str, action: str) -> None:
         priorities = {
             'start': 1,
             'restart': 2,
@@ -600,14 +600,14 @@ class HostCache():
             self.scheduled_daemon_actions[host] = {}
         self.scheduled_daemon_actions[host][daemon_name] = action
 
-    def rm_scheduled_daemon_action(self, host: str, daemon_name: str):
+    def rm_scheduled_daemon_action(self, host: str, daemon_name: str) -> None:
         if host in self.scheduled_daemon_actions:
             if daemon_name in self.scheduled_daemon_actions[host]:
                 del self.scheduled_daemon_actions[host][daemon_name]
             if not self.scheduled_daemon_actions[host]:
                 del self.scheduled_daemon_actions[host]
 
-    def get_scheduled_daemon_action(self, host, daemon) -> Optional[str]:
+    def get_scheduled_daemon_action(self, host: str, daemon: str) -> Optional[str]:
         return self.scheduled_daemon_actions.get(host, {}).get(daemon)
 
 
@@ -631,12 +631,12 @@ class EventStore():
         # limit to five events for now.
         self.events[event.kind_subject()] = self.events[event.kind_subject()][-5:]
 
-    def for_service(self, spec: ServiceSpec, level, message) -> None:
+    def for_service(self, spec: ServiceSpec, level: str, message: str) -> None:
         e = OrchestratorEvent(datetime.datetime.utcnow(), 'service',
                               spec.service_name(), level, message)
         self.add(e)
 
-    def from_orch_error(self, e: OrchestratorError):
+    def from_orch_error(self, e: OrchestratorError) -> None:
         if e.event_subject is not None:
             self.add(OrchestratorEvent(
                 datetime.datetime.utcnow(),
@@ -646,11 +646,11 @@ class EventStore():
                 str(e)
             ))
 
-    def for_daemon(self, daemon_name, level, message):
+    def for_daemon(self, daemon_name: str, level: str, message: str) -> None:
         e = OrchestratorEvent(datetime.datetime.utcnow(), 'daemon', daemon_name, level, message)
         self.add(e)
 
-    def for_daemon_from_exception(self, daemon_name, e: Exception):
+    def for_daemon_from_exception(self, daemon_name: str, e: Exception) -> None:
         self.for_daemon(
             daemon_name,
             "ERROR",
@@ -675,8 +675,8 @@ class EventStore():
         for k_s in unknowns:
             del self.events[k_s]
 
-    def get_for_service(self, name) -> List[OrchestratorEvent]:
+    def get_for_service(self, name: str) -> List[OrchestratorEvent]:
         return self.events.get('service:' + name, [])
 
-    def get_for_daemon(self, name) -> List[OrchestratorEvent]:
+    def get_for_daemon(self, name: str) -> List[OrchestratorEvent]:
         return self.events.get('daemon:' + name, [])

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -36,7 +36,7 @@ class SimpleScheduler(BaseScheduler):
     2) Select from list up to :count
     """
 
-    def __init__(self, spec):
+    def __init__(self, spec: ServiceSpec):
         super(SimpleScheduler, self).__init__(spec)
 
     def place(self, host_pool, count=None):
@@ -74,7 +74,7 @@ class HostAssignment(object):
     def get_hostnames(self) -> List[str]:
         return [h.hostname for h in self.hosts]
 
-    def validate(self):
+    def validate(self) -> None:
         self.spec.validate()
 
         if self.spec.placement.count == 0:
@@ -186,7 +186,7 @@ class HostAssignment(object):
         # remove duplicates before returning
         return list(dict.fromkeys(active_hosts))
 
-    def prefer_hosts_with_active_daemons(self, hosts: List[HostPlacementSpec], count) -> List[HostPlacementSpec]:
+    def prefer_hosts_with_active_daemons(self, hosts: List[HostPlacementSpec], count: int) -> List[HostPlacementSpec]:
         # try to prefer host with active daemon if possible
         active_hosts = self.get_hosts_with_active_daemon(hosts)
         if len(active_hosts) != 0 and count > 0:

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -84,13 +84,13 @@ class CephadmServe:
             self._serve_sleep()
         self.log.debug("serve exit")
 
-    def _serve_sleep(self):
+    def _serve_sleep(self) -> None:
         sleep_interval = 600
         self.log.debug('Sleeping for %d seconds', sleep_interval)
         ret = self.mgr.event.wait(sleep_interval)
         self.mgr.event.clear()
 
-    def _update_paused_health(self):
+    def _update_paused_health(self) -> None:
         if self.mgr.paused:
             self.mgr.health_checks['CEPHADM_PAUSED'] = {
                 'severity': 'warning',
@@ -109,7 +109,7 @@ class CephadmServe:
         failures = []
 
         @forall_hosts
-        def refresh(host):
+        def refresh(host: str) -> None:
 
             if self.mgr.cache.host_needs_check(host):
                 r = self._check_host(host)
@@ -180,9 +180,9 @@ class CephadmServe:
         if health_changed:
             self.mgr.set_health_checks(self.mgr.health_checks)
 
-    def _check_host(self, host):
+    def _check_host(self, host: str) -> Optional[str]:
         if host not in self.mgr.inventory:
-            return
+            return None
         self.log.debug(' checking %s' % host)
         try:
             out, err, code = self.mgr._run_cephadm(
@@ -199,8 +199,9 @@ class CephadmServe:
         except Exception as e:
             self.log.debug(' host %s failed check' % host)
             return 'host %s failed check: %s' % (host, e)
+        return None
 
-    def _refresh_host_daemons(self, host) -> Optional[str]:
+    def _refresh_host_daemons(self, host: str) -> Optional[str]:
         try:
             out, err, code = self.mgr._run_cephadm(
                 host, 'mon', 'ls', [], no_fsid=True)
@@ -257,7 +258,7 @@ class CephadmServe:
         self.mgr.cache.save_host(host)
         return None
 
-    def _refresh_facts(self, host):
+    def _refresh_facts(self, host: str) -> Optional[str]:
         try:
             out, err, code = self.mgr._run_cephadm(
                 host, cephadmNoImage, 'gather-facts', [],
@@ -270,8 +271,9 @@ class CephadmServe:
             return 'host %s gather facts failed: %s' % (host, e)
         self.log.debug('Refreshed host %s facts' % (host))
         self.mgr.cache.update_host_facts(host, json.loads(''.join(out)))
+        return None
 
-    def _refresh_host_devices(self, host) -> Optional[str]:
+    def _refresh_host_devices(self, host: str) -> Optional[str]:
         try:
             out, err, code = self.mgr._run_cephadm(
                 host, 'osd',
@@ -311,13 +313,13 @@ class CephadmServe:
         self.mgr.cache.save_host(host)
         return None
 
-    def _refresh_host_osdspec_previews(self, host) -> bool:
+    def _refresh_host_osdspec_previews(self, host: str) -> Optional[str]:
         self.update_osdspec_previews(host)
         self.mgr.cache.save_host(host)
         self.log.debug(f'Refreshed OSDSpec previews for host <{host}>')
-        return True
+        return None
 
-    def update_osdspec_previews(self, search_host: str = ''):
+    def update_osdspec_previews(self, search_host: str = '') -> None:
         # Set global 'pending' flag for host
         self.mgr.cache.loading_osdspec_preview.add(search_host)
         previews = []
@@ -426,7 +428,7 @@ class CephadmServe:
 
         return r
 
-    def _config_fn(self, service_type) -> Optional[Callable[[ServiceSpec], None]]:
+    def _config_fn(self, service_type: str) -> Optional[Callable[[ServiceSpec], None]]:
         fn = {
             'mds': self.mgr.mds_service.config,
             'rgw': self.mgr.rgw_service.config,
@@ -648,7 +650,7 @@ class CephadmServe:
                 self.mgr.requires_post_actions.remove(daemon_type)
                 self.mgr._get_cephadm_service(daemon_type).daemon_check_post(daemon_descs)
 
-    def convert_tags_to_repo_digest(self):
+    def convert_tags_to_repo_digest(self) -> None:
         if not self.mgr.use_repo_digest:
             return
         settings = self.mgr.upgrade.get_distinct_container_image_settings()

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -49,7 +49,7 @@ class UpgradeState:
         }
 
     @classmethod
-    def from_json(cls, data) -> Optional['UpgradeState']:
+    def from_json(cls, data: dict) -> Optional['UpgradeState']:
         if data:
             return cls(**data)
         else:
@@ -93,7 +93,7 @@ class CephadmUpgrade:
                 r.message = 'Upgrade paused'
         return r
 
-    def upgrade_start(self, image, version) -> str:
+    def upgrade_start(self, image: str, version: str) -> str:
         if self.mgr.mode != 'root':
             raise OrchestratorError('upgrade is not supported in %s mode' % (
                 self.mgr.mode))
@@ -210,7 +210,7 @@ class CephadmUpgrade:
         self.mgr.health_checks[alert_id] = alert
         self.mgr.set_health_checks(self.mgr.health_checks)
 
-    def _update_upgrade_progress(self, progress) -> None:
+    def _update_upgrade_progress(self, progress: float) -> None:
         if not self.upgrade_state:
             assert False, 'No upgrade in progress'
 


### PR DESCRIPTION
This is fixing a broken return value for `_refresh_host_osdspec_previews`


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
