### PR TITLE
mgr/dashboard: display placement column in service table

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
@@ -47,6 +47,7 @@ import { RulesListComponent } from './prometheus/rules-list/rules-list.component
 import { SilenceFormComponent } from './prometheus/silence-form/silence-form.component';
 import { SilenceListComponent } from './prometheus/silence-list/silence-list.component';
 import { SilenceMatcherModalComponent } from './prometheus/silence-matcher-modal/silence-matcher-modal.component';
+import { PlacementPipe } from './services/placement.pipe';
 import { ServiceDaemonListComponent } from './services/service-daemon-list/service-daemon-list.component';
 import { ServiceDetailsComponent } from './services/service-details/service-details.component';
 import { ServiceFormComponent } from './services/service-form/service-form.component';
@@ -108,7 +109,8 @@ import { TelemetryComponent } from './telemetry/telemetry.component';
     TelemetryComponent,
     PrometheusTabsComponent,
     ServiceFormComponent,
-    OsdFlagsIndivModalComponent
+    OsdFlagsIndivModalComponent,
+    PlacementPipe
   ]
 })
 export class ClusterModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/placement.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/placement.pipe.spec.ts
@@ -1,0 +1,78 @@
+import { PlacementPipe } from './placement.pipe';
+
+describe('PlacementPipe', () => {
+  const pipe = new PlacementPipe();
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('transforms to no spec', () => {
+    expect(pipe.transform(undefined)).toBe('no spec');
+  });
+
+  it('transforms to unmanaged', () => {
+    expect(pipe.transform({ unmanaged: true })).toBe('unmanaged');
+  });
+
+  it('transforms placement (1)', () => {
+    expect(
+      pipe.transform({
+        placement: {
+          hosts: ['mon0']
+        }
+      })
+    ).toBe('mon0');
+  });
+
+  it('transforms placement (2)', () => {
+    expect(
+      pipe.transform({
+        placement: {
+          hosts: ['mon0', 'mgr0']
+        }
+      })
+    ).toBe('mon0;mgr0');
+  });
+
+  it('transforms placement (3)', () => {
+    expect(
+      pipe.transform({
+        placement: {
+          count: 1
+        }
+      })
+    ).toBe('count:1');
+  });
+
+  it('transforms placement (4)', () => {
+    expect(
+      pipe.transform({
+        placement: {
+          label: 'foo'
+        }
+      })
+    ).toBe('label:foo');
+  });
+
+  it('transforms placement (5)', () => {
+    expect(
+      pipe.transform({
+        placement: {
+          host_pattern: '*'
+        }
+      })
+    ).toBe('*');
+  });
+
+  it('transforms placement (6)', () => {
+    expect(
+      pipe.transform({
+        placement: {
+          count: 2,
+          hosts: ['mon0', 'mgr0']
+        }
+      })
+    ).toBe('mon0;mgr0;count:2');
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/placement.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/placement.pipe.ts
@@ -1,0 +1,41 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+import _ from 'lodash';
+
+@Pipe({
+  name: 'placement'
+})
+export class PlacementPipe implements PipeTransform {
+  /**
+   * Convert the placement configuration into human readable form.
+   * The output is equal to the column 'PLACEMENT' in 'ceph orch ls'.
+   * @param serviceSpec The service specification to process.
+   * @return The placement configuration as human readable string.
+   */
+  transform(serviceSpec: object | undefined): string {
+    if (_.isUndefined(serviceSpec)) {
+      return $localize`no spec`;
+    }
+    if (_.get(serviceSpec, 'unmanaged', false)) {
+      return $localize`unmanaged`;
+    }
+    const kv: Array<any> = [];
+    const hosts: Array<string> = _.get(serviceSpec, 'placement.hosts');
+    const count: number = _.get(serviceSpec, 'placement.count');
+    const label: string = _.get(serviceSpec, 'placement.label');
+    const hostPattern: string = _.get(serviceSpec, 'placement.host_pattern');
+    if (_.isArray(hosts)) {
+      kv.push(...hosts);
+    }
+    if (_.isNumber(count)) {
+      kv.push($localize`count:${count}`);
+    }
+    if (_.isString(label)) {
+      kv.push($localize`label:${label}`);
+    }
+    if (_.isString(hostPattern)) {
+      kv.push(...hostPattern);
+    }
+    return kv.join(';');
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.spec.ts
@@ -82,7 +82,10 @@ describe('ServicesComponent', () => {
   it('should have columns that are sortable', () => {
     expect(
       component.columns
+        // Filter the 'Expand/Collapse Row' column.
         .filter((column) => !(column.cellClass === 'cd-datatable-expand-collapse'))
+        // Filter the 'Placement' column.
+        .filter((column) => !(column.prop === ''))
         .every((column) => Boolean(column.prop))
     ).toBeTruthy();
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
@@ -24,6 +24,7 @@ import { AuthStorageService } from '~/app/shared/services/auth-storage.service';
 import { ModalService } from '~/app/shared/services/modal.service';
 import { TaskWrapperService } from '~/app/shared/services/task-wrapper.service';
 import { URLBuilderService } from '~/app/shared/services/url-builder.service';
+import { PlacementPipe } from './placement.pipe';
 
 const BASE_URL = 'services';
 
@@ -107,6 +108,12 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
         customTemplateConfig: {
           length: 12
         }
+      },
+      {
+        name: $localize`Placement`,
+        prop: '',
+        pipe: new PlacementPipe(),
+        flexGrow: 1
       },
       {
         name: $localize`Running`,


### PR DESCRIPTION
![Bildschirmfoto vom 2020-11-23 10-48-31](https://user-images.githubusercontent.com/1897962/99948241-73154a80-2d79-11eb-8f4e-c4e23d77e716.png)

Fixes: https://tracker.ceph.com/issues/44404

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
