### PR TITLE
rbd: minor rbd-wnbd improvements

### DIFF
--- a/src/tools/rbd_wnbd/rbd_wnbd.cc
+++ b/src/tools/rbd_wnbd/rbd_wnbd.cc
@@ -590,7 +590,7 @@ Service options:
   --hard-disconnect           Skip attempting a soft disconnect
   --soft-disconnect-timeout   Cummulative soft disconnect timeout in seconds,
                               used when disconnecting existing mappings. A hard
-                              disconnect will be issuedwhen hitting the timeout.
+                              disconnect will be issued when hitting the timeout
   --service-thread-count      The number of workers used when mapping or
                               unmapping images. Default: 8
 
@@ -1138,6 +1138,8 @@ static int parse_args(std::vector<const char*>& args,
       cmd = Service;
     } else if (strcmp(*args.begin(), "stats") == 0) {
       cmd = Stats;
+    } else if (strcmp(*args.begin(), "help") == 0) {
+      return HELP_INFO;
     } else {
       *err_msg << "rbd-wnbd: unknown command: " <<  *args.begin();
       return -EINVAL;

--- a/src/tools/rbd_wnbd/rbd_wnbd.cc
+++ b/src/tools/rbd_wnbd/rbd_wnbd.cc
@@ -396,7 +396,10 @@ int load_mapping_config_from_registry(string devpath, Config* cfg)
   auto reg_key = RegistryKey(
     g_ceph_context, HKEY_LOCAL_MACHINE, strKey.c_str(), false);
   if (!reg_key.hKey) {
-    return -EINVAL;
+    if (reg_key.missingKey)
+      return -ENOENT;
+    else
+      return -EINVAL;
   }
 
   reg_key.get("devpath", cfg->devpath);


### PR DESCRIPTION
rbd: minor rbd-wnbd improvements

This PR updates the ``rbd-wnbd show`` command exit code, returning -ENOENT when the specified mapping does not exist. At the moment, the caller has no way of telling if the mapping is missing or if there was an unexpected error.

At the same time, we're including a ``rbd-wnbd help`` command.
