### PR TITLE
ceph-volume: allow symlinks as devices

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -218,7 +218,7 @@ class TestDevice(object):
         assert not disk.available
 
     def test_reject_readonly_device(self, device_info):
-        data = {"/dev/cdrom": {"ro": 1}}
+        data = {"/dev/sr0": {"ro": 1}}
         lsblk = {"TYPE": "disk"}
         device_info(devices=data,lsblk=lsblk)
         disk = device.Device("/dev/cdrom")

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -150,7 +150,7 @@ class Device(object):
                                             os.readlink(self.abspath))
             # check if we are not a device mapper
             if "dm-" not in temp_path:
-                self.abspath = temp_path;
+                self.abspath = temp_path
         self.sys_api = sys_info.devices.get(self.abspath, {})
         if not self.sys_api:
             # if no device was found check if we are a partition

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -146,8 +146,11 @@ class Device(object):
             sys_info.devices = disk.get_devices()
         # check if we are a symlink
         if os.path.islink(self.abspath):
-            self.abspath = os.path.join(os.path.dirname(self.abspath),
-                                        os.readlink(self.abspath))
+            temp_path = os.path.join(os.path.dirname(self.abspath),
+                                            os.readlink(self.abspath))
+            # check if we are not a device mapper
+            if "dm-" not in temp_path:
+                self.abspath = temp_path;
         self.sys_api = sys_info.devices.get(self.abspath, {})
         if not self.sys_api:
             # if no device was found check if we are a partition

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -144,6 +144,10 @@ class Device(object):
     def _parse(self):
         if not sys_info.devices:
             sys_info.devices = disk.get_devices()
+        # check if we are a symlink
+        if os.path.islink(self.abspath):
+                realpath = os.path.join(os.path.dirname(self.abspath),
+                                        os.readlink(self.abspath))
         self.sys_api = sys_info.devices.get(self.abspath, {})
         if not self.sys_api:
             # if no device was found check if we are a partition
@@ -153,7 +157,6 @@ class Device(object):
                 if part:
                     self.sys_api = part
                     break
-
         # if the path is not absolute, we have 'vg/lv', let's use LV name
         # to get the LV.
         if self.path[0] == '/':

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -146,7 +146,7 @@ class Device(object):
             sys_info.devices = disk.get_devices()
         # check if we are a symlink
         if os.path.islink(self.abspath):
-                realpath = os.path.join(os.path.dirname(self.abspath),
+            self.abspath = os.path.join(os.path.dirname(self.abspath),
                                         os.readlink(self.abspath))
         self.sys_api = sys_info.devices.get(self.abspath, {})
         if not self.sys_api:


### PR DESCRIPTION
This MR creates ability to use symlinks as devices for ceph-volume.
An example of usage is custom udev rules to map disk slots in enclosures to block device labels like:

```
/dev/data1 -> /dev/sda
/dev/data2 -> /dev/sdb
```

Fixes: https://tracker.ceph.com/issues/49103

Signed-off-by: Jan Sobczak jsobczak@cloudferro.com
