### PR TITLE
crimson: make OpsExecuter unaware about the giant PG class

### DIFF
--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -16,6 +16,7 @@
 #include <seastar/core/thread.hh>
 
 #include "crimson/osd/exceptions.h"
+#include "crimson/osd/pg.h"
 #include "crimson/osd/watch.h"
 #include "osd/ClassHandler.h"
 

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -87,7 +87,7 @@ private:
   const OpInfo& op_info;
   const pg_pool_t& pool_info;  // for the sake of the ObjClass API
   PGBackend& backend;
-  Ref<MOSDOp> msg;
+  const MOSDOp& msg;
   std::optional<osd_op_params_t> osd_op_params;
   bool user_modify = false;
   ceph::os::Transaction txn;
@@ -170,12 +170,12 @@ public:
               const OpInfo& op_info,
               const pg_pool_t& pool_info,
               PGBackend& backend,
-              Ref<MOSDOp> msg)
+              const MOSDOp& msg)
     : obc(std::move(obc)),
       op_info(op_info),
       pool_info(pool_info),
       backend(backend),
-      msg(std::move(msg)) {
+      msg(msg) {
   }
 
   osd_op_errorator::future<> execute_op(class OSDOp& osd_op);
@@ -184,7 +184,7 @@ public:
   osd_op_errorator::future<> flush_changes(Func&& func, MutFunc&& mut_func) &&;
 
   const auto& get_message() const {
-    return *msg;
+    return msg;
   }
 
   size_t get_processed_rw_ops_num() const {

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -25,12 +25,12 @@
 #include "crimson/osd/shard_services.h"
 #include "crimson/osd/osdmap_gate.h"
 
-#include "crimson/osd/pg.h"
 #include "crimson/osd/pg_backend.h"
 #include "crimson/osd/exceptions.h"
 
 #include "messages/MOSDOp.h"
 
+class PG;
 class PGLSFilter;
 class OSDOp;
 
@@ -85,7 +85,7 @@ private:
 
   ObjectContextRef obc;
   const OpInfo& op_info;
-  PG& pg;
+  const pg_pool_t& pool_info;  // for the sake of the ObjClass API
   PGBackend& backend;
   Ref<MOSDOp> msg;
   std::optional<osd_op_params_t> osd_op_params;
@@ -166,11 +166,15 @@ private:
   }
 
 public:
-  OpsExecuter(ObjectContextRef obc, const OpInfo& op_info, PG& pg, Ref<MOSDOp> msg)
+  OpsExecuter(ObjectContextRef obc,
+              const OpInfo& op_info,
+              const pg_pool_t& pool_info,
+              PGBackend& backend,
+              Ref<MOSDOp> msg)
     : obc(std::move(obc)),
       op_info(op_info),
-      pg(pg),
-      backend(pg.get_backend()),
+      pool_info(pool_info),
+      backend(backend),
       msg(std::move(msg)) {
   }
 
@@ -188,7 +192,7 @@ public:
   }
 
   uint32_t get_pool_stripe_width() const {
-    return pg.get_pool().info.get_stripe_width();
+    return pool_info.get_stripe_width();
   }
 };
 
@@ -233,29 +237,21 @@ OpsExecuter::osd_op_errorator::future<> OpsExecuter::flush_changes(
   Func&& func,
   MutFunc&& mut_func) &&
 {
-  assert(obc);
   const bool want_mutate = !txn.empty();
-  if (want_mutate) {
-    // osd_op_params are instantiated by every wr-like operation.
-    assert(osd_op_params);
-    osd_op_params->req = std::move(msg);
-    osd_op_params->at_version = pg.next_version();
-    osd_op_params->pg_trim_to = pg.get_pg_trim_to();
-    osd_op_params->min_last_complete_ondisk = pg.get_min_last_complete_ondisk();
-    osd_op_params->last_complete = pg.get_info().last_complete;
-    if (user_modify) {
-      osd_op_params->user_at_version = osd_op_params->at_version.version;
-    }
-  }
+  // osd_op_params are instantiated by every wr-like operation.
+  assert(osd_op_params || !want_mutate);
+  assert(obc);
   if (__builtin_expect(op_effects.empty(), true)) {
     return want_mutate ? std::forward<MutFunc>(mut_func)(std::move(txn),
                                                          std::move(obc),
-                                                         std::move(*osd_op_params))
+                                                         std::move(*osd_op_params),
+                                                         user_modify)
                        : std::forward<Func>(func)(std::move(obc));
   } else {
     return (want_mutate ? std::forward<MutFunc>(mut_func)(std::move(txn),
                                                           std::move(obc),
-                                                          std::move(*osd_op_params))
+                                                          std::move(*osd_op_params),
+                                                          user_modify)
                         : std::forward<Func>(func)(std::move(obc))
     ).safe_then([this] {
       // let's do the cleaning of `op_effects` in destructor

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -608,8 +608,10 @@ seastar::future<Ref<MOSDOpReply>> PG::do_osd_ops(
   using osd_op_errorator = OpsExecuter::osd_op_errorator;
   const auto oid = m->get_snapid() == CEPH_SNAPDIR ? m->get_hobj().get_head()
                                                    : m->get_hobj();
+  // OpsExecuter gets PG as non-const as it's responsible for modying
+  // e.g. `projected_last_update`.
   auto ox =
-    std::make_unique<OpsExecuter>(obc, op_info, *this/* as const& */, m);
+    std::make_unique<OpsExecuter>(obc, op_info, *this, m);
 
   return crimson::do_for_each(
     m->ops, [obc, m, ox = ox.get()](OSDOp& osd_op) {

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -625,7 +625,7 @@ seastar::future<Ref<MOSDOpReply>> PG::do_osd_ops(
   const auto oid = m->get_snapid() == CEPH_SNAPDIR ? m->get_hobj().get_head()
                                                    : m->get_hobj();
   auto ox = std::make_unique<OpsExecuter>(
-    obc, op_info, get_pool().info, get_backend(), m);
+    obc, op_info, get_pool().info, get_backend(), *m);
   return crimson::do_for_each(
     m->ops, [obc, m, ox = ox.get()](OSDOp& osd_op) {
     logger().debug(

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -531,6 +531,10 @@ private:
   void do_peering_event(
     const boost::statechart::event_base &evt,
     PeeringCtx &rctx);
+  osd_op_params_t&& fill_op_params_bump_pg_version(
+    osd_op_params_t&& osd_op_p,
+    Ref<MOSDOp> m,
+    const bool user_modify);
   seastar::future<Ref<MOSDOpReply>> do_osd_ops(
     Ref<MOSDOp> m,
     ObjectContextRef obc,


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
