### PR TITLE
.github: add mon and mgr labelers

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,6 +11,24 @@ documentation:
   - man/**
   - "**/*.+(rst|md)"
 
+mon:
+  - doc/man/8/ceph-mon.rst
+  - doc/man/8/monmaptool.rst
+  - doc/mon/**
+  - qa/workunits/mon/**
+  - src/mon/**
+  - src/test/mon/**
+
+mgr:
+  - doc/mgr/**
+  - src/mgr/**
+  - src/pybind/mgr/ceph_module.pyi
+  - src/pybind/mgr/mgr_module.py
+  - src/pybind/mgr/mgr_util.py
+  - src/pybind/mgr/requirements.txt
+  - src/pybind/mgr/tox.ini
+  - src/test/mgr/**
+
 pybind:
   - src/pybind/cephfs/**
   - src/pybind/mgr/**


### PR DESCRIPTION
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
