### PR TITLE
test/store_test: pass raw Formatter pointer as expected

### DIFF
--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -7894,7 +7894,7 @@ TEST_P(StoreTest, KVDBHistogramTest) {
   }
 
   std::unique_ptr<Formatter> f(Formatter::create("store_test", "json-pretty", "json-pretty"));
-  store->generate_db_histogram(f);
+  store->generate_db_histogram(f.get());
   f->flush(cout);
   cout << std::endl;
 }
@@ -7938,7 +7938,7 @@ TEST_P(StoreTest, KVDBStatsTest) {
   }
 
   std::unique_ptr<Formatter> f(Formatter::create("store_test", "json-pretty", "json-pretty"));
-  store->get_db_statistics(f);
+  store->get_db_statistics(f.get());
   f->flush(cout);
   cout << std::endl;
 }
@@ -8483,7 +8483,7 @@ TEST_P(StoreTest, BluestoreStatistics) {
     ASSERT_TRUE(bl_eq(bl, readback));
   }
   std::unique_ptr<Formatter> f(Formatter::create("store_test", "json-pretty", "json-pretty"));
-  EXPECT_NO_THROW(store->get_db_statistics(f));
+  EXPECT_NO_THROW(store->get_db_statistics(f.get()));
   f->flush(cout);
   cout << std::endl;
 }


### PR DESCRIPTION
this addresses the FTBFS regression introduced by
f153a7031e56534723c0fc891869902c58acb473

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
