### PR TITLE
librbd: Fix variable declaration in capture list in lambda

### DIFF
--- a/src/librbd/migration/HttpStream.cc
+++ b/src/librbd/migration/HttpStream.cc
@@ -105,7 +105,7 @@ void HttpStream<I>::read(io::Extents&& byte_extents, bufferlist* data,
     req.set(boost::beast::http::field::range, range.str());
 
     m_http_client->issue(std::move(req),
-      [this, byte_offset, byte_length, ctx](int r, HttpResponse&& response) {
+      [this, byte_offset=byte_offset, byte_length=byte_length, ctx](int r, HttpResponse&& response) {
         handle_read(r, std::move(response), byte_offset, byte_length, &ctx->bl,
                     ctx);
      });


### PR DESCRIPTION
Fixes: https://github.com/ceph/ceph/pull/38000



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>