### PR TITLE
rgw: Avoid spamming OSD requests on startup

### DIFF
--- a/src/cls/log/cls_log_client.cc
+++ b/src/cls/log/cls_log_client.cc
@@ -113,8 +113,8 @@ public:
   }
 };
 
-void cls_log_list(librados::ObjectReadOperation& op, utime_t& from, utime_t& to,
-                  const string& in_marker, int max_entries,
+void cls_log_list(librados::ObjectReadOperation& op, const utime_t& from,
+		  const utime_t& to, const string& in_marker, int max_entries,
 		  list<cls_log_entry>& entries,
                   string *out_marker, bool *truncated)
 {

--- a/src/cls/log/cls_log_client.h
+++ b/src/cls/log/cls_log_client.h
@@ -19,9 +19,9 @@ void cls_log_add(librados::ObjectWriteOperation& op, cls_log_entry& entry);
 void cls_log_add(librados::ObjectWriteOperation& op, const utime_t& timestamp,
                  const std::string& section, const std::string& name, ceph::buffer::list& bl);
 
-void cls_log_list(librados::ObjectReadOperation& op, utime_t& from, utime_t& to,
-                  const std::string& in_marker, int max_entries,
-		  std::list<cls_log_entry>& entries,
+void cls_log_list(librados::ObjectReadOperation& op, const utime_t& from,
+		  const utime_t& to, const std::string& in_marker,
+		  int max_entries, std::list<cls_log_entry>& entries,
                   std::string *out_marker, bool *truncated);
 
 void cls_log_trim(librados::ObjectWriteOperation& op, const utime_t& from_time, const utime_t& to_time,

--- a/src/cls/log/cls_log_types.h
+++ b/src/cls/log/cls_log_types.h
@@ -65,6 +65,9 @@ inline bool operator ==(const cls_log_header& lhs, const cls_log_header& rhs) {
   return (lhs.max_marker == rhs.max_marker &&
 	  lhs.max_time == rhs.max_time);
 }
+inline bool operator !=(const cls_log_header& lhs, const cls_log_header& rhs) {
+  return !(lhs == rhs);
+}
 WRITE_CLASS_ENCODER(cls_log_header)
 
 

--- a/src/common/dynarray.h
+++ b/src/common/dynarray.h
@@ -1,0 +1,335 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <algorithm>
+#include <initializer_list>
+#include <iostream>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "include/uses_allocator.h"
+
+/// The problem:
+///     - Non-movable types
+///     - Non-default-constructible types
+///     - Entries whose constructor parameters depend on the index
+
+/// The limitations:
+///     - No resize
+///     - No insert
+///     - No delete
+
+
+/// The solution, a class with all the methods of vector that are
+/// compatible with never moving an element (i.e. no reallocations)
+
+namespace ceph {
+template<typename T, typename Allocator = std::allocator<T>>
+class dynarray {
+  template<typename...>
+  struct is_tuple : public std::false_type {};
+  template<typename ...Args>
+  struct is_tuple<std::tuple<Args...>> : public std::true_type {};
+
+  using elstore = std::aligned_storage_t<sizeof(T), alignof(T)>;
+  std::size_t len;
+  Allocator alloc;
+  elstore* p = nullptr;
+
+  static_assert(std::is_trivially_constructible_v<elstore>);
+  static_assert(sizeof(elstore) == sizeof(T));
+  static_assert(alignof(elstore) == alignof(T));
+  static_assert(sizeof(elstore[5]) == sizeof(T[5]));
+
+  elstore* allocate() {
+    if (len == 0)
+      return nullptr;
+
+    typename Allocator::template rebind<elstore>::other a(alloc);
+    return a.allocate(len);
+  }
+
+  void deallocate() {
+    if (p) {
+      for (std::size_t i = 0; i < len; ++i) {
+	reinterpret_cast<T*>(p + i)->~T();
+      }
+      typename Allocator::template rebind<elstore>::other a(alloc);
+      a.deallocate(p, len);
+    }
+    len = 0;
+    p = 0;
+  }
+
+public:
+  using value_type = T;
+  using allocator_type = Allocator;
+  using size_type = std::size_t;
+  using difference_type = std::ptrdiff_t;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using pointer = typename std::allocator_traits<Allocator>::pointer;
+  using const_pointer =
+    typename std::allocator_traits<Allocator>::const_pointer;
+  using iterator = T*;
+  using const_iterator = const T*;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+  dynarray() noexcept(noexcept(Allocator()))
+    : len(0), alloc({}) {}
+
+  explicit dynarray(const Allocator& alloc) noexcept
+    : len(0), alloc({}) {}
+
+  dynarray(std::size_t len, const T& value,
+	   const Allocator& alloc = Allocator{})
+    : len(len), alloc(alloc), p(allocate()) {
+    for (std::size_t i = 0; i < len; ++i)
+      uninitialized_construct_using_allocator(reinterpret_cast<T*>(p + i),
+					      alloc, value);
+  }
+
+  template<typename F>
+  dynarray(std::size_t len, F&& f,
+	   std::enable_if_t<std::is_invocable_v<F, std::size_t>,
+	                    const Allocator&> alloc = Allocator{})
+    : len(len), alloc(alloc), p(allocate()) {
+    for (std::size_t i = 0; i < len; ++i) {
+      if constexpr (std::is_constructible_v<
+		    T, std::invoke_result_t<F, std::size_t>>) {
+	uninitialized_construct_using_allocator(reinterpret_cast<T*>(p + i),
+						alloc,
+						std::forward<F>(f)(i));
+      } else {
+	std::apply([e = reinterpret_cast<T*>(p + i), &alloc](auto&& ...args) {
+	  uninitialized_construct_using_allocator(
+	    e, alloc, std::forward<decltype(args)>(args)...);
+	}, std::forward<F>(f)(i));
+      }
+    }
+  }
+
+  template<typename I>
+  dynarray(I start,
+	   typename std::enable_if_t<
+	     std::is_constructible_v<T,
+	       typename std::iterator_traits<I>::reference>, I> end,
+	   Allocator alloc = Allocator{})
+    : len(std::distance(start, end)), alloc(alloc), p(allocate()) {
+    int n = 0;
+    for (auto i = start; i != end; ++i, ++n)
+      uninitialized_construct_using_allocator(reinterpret_cast<T*>(p + n),
+					      alloc, *i);
+  }
+
+  dynarray(const dynarray&) = delete;
+  dynarray& operator =(const dynarray&) = delete;
+
+  dynarray(dynarray&& rhs) {
+    len = rhs.len;
+    p = rhs.p;
+    alloc = rhs.alloc;
+    rhs.len = 0;
+    rhs.p = 0;
+  }
+  dynarray& operator =(dynarray&& rhs) {
+    deallocate();
+    len = rhs.len;
+    p = rhs.p;
+    static_assert(
+      std::allocator_traits<Allocator>::
+      propagate_on_container_move_assignment::value,
+      "Since our members may be immovable, we can't reallocate space and "
+      "move them.");
+    alloc = rhs.alloc;
+    rhs.len = 0;
+    rhs.p = 0;
+    return *this;
+  }
+
+  dynarray(std::initializer_list<T> l, Allocator alloc = Allocator{})
+    : len(l.size()), alloc(alloc), p(allocate()) {
+    int i = 0;
+    for (const auto& e : l) {
+      uninitialized_construct_using_allocator(reinterpret_cast<T*>(p + i), alloc, e);
+      ++i;
+    }
+  }
+
+  ~dynarray() {
+    deallocate();
+  }
+
+  allocator_type get_allocator() noexcept {
+    return alloc;
+  }
+
+  reference& at(std::size_t i) {
+    if (i >= len)
+      throw std::out_of_range("Index out of range.");
+
+    return *reinterpret_cast<T*>(p + i);
+  }
+
+  const_reference& at(std::size_t i) const {
+    if (i >= len)
+      throw std::out_of_range("Index out of range.");
+
+    return *reinterpret_cast<T*>(p + i);
+  }
+
+  reference& operator [](std::size_t i) noexcept {
+    return *reinterpret_cast<T*>(p + i);
+  }
+
+  const_reference& operator [](std::size_t i) const noexcept {
+    return *reinterpret_cast<T*>(p + i);
+  }
+
+  reference& front() noexcept {
+    return *reinterpret_cast<T*>(p);
+  }
+
+  const_reference& front(std::size_t i) const noexcept {
+    return *reinterpret_cast<T*>(p);
+  }
+
+  reference& back() noexcept {
+    return *reinterpret_cast<T*>(p + len - 1);
+  }
+
+  const_reference& back(std::size_t i) const noexcept {
+    return *reinterpret_cast<T*>(p + len - 1);
+  }
+
+  pointer data() noexcept {
+    return reinterpret_cast<T*>(p);
+  }
+
+  const_pointer data() const noexcept {
+    return reinterpret_cast<T*>(p);
+  }
+
+  iterator begin() noexcept {
+    return data();
+  }
+  const_iterator begin() const noexcept {
+    return data();
+  }
+  const_iterator cbegin() const noexcept {
+    return data();
+  }
+
+  reverse_iterator rbegin() noexcept {
+    return std::make_reverse_iterator(begin());
+  }
+  const_reverse_iterator rbegin() const noexcept {
+    return std::make_reverse_iterator(begin());
+  }
+  const_reverse_iterator crbegin() const noexcept {
+    return std::make_reverse_iterator(cbegin());
+  }
+
+  iterator end() noexcept {
+    return data() ? data() + len : nullptr;
+  }
+  const_iterator end() const noexcept {
+    return data() ? data() + len : nullptr;
+  }
+  const_iterator cend() const noexcept {
+    return data() ? data() + len : nullptr;
+  }
+
+  reverse_iterator rend() noexcept {
+    return std::make_reverse_iterator(end());
+  }
+  const_reverse_iterator rend() const noexcept {
+    return std::make_reverse_iterator(end());
+  }
+  const_reverse_iterator crend() const noexcept {
+    return std::make_reverse_iterator(cend());
+  }
+
+  bool empty() const noexcept {
+    return !p;
+  }
+
+  size_type size() const noexcept {
+    return len;
+  }
+
+  size_type max_size() const noexcept {
+    return std::numeric_limits<difference_type>::max();
+  }
+
+  void swap(dynarray& other) {
+    using std::swap;
+    swap(len, other.len);
+    swap(p, other.p);
+    swap(alloc, other.alloc);
+  }
+};
+
+template<typename T, typename Alloc>
+bool operator ==(const dynarray<T, Alloc>& l, const dynarray<T, Alloc>& r) {
+  if (l.size() != r.size()) return false;
+  return std::equal(l.begin(), l.end(), r.begin());
+}
+template<typename T, typename Alloc>
+bool operator !=(const dynarray<T, Alloc>& l, const dynarray<T, Alloc>& r) {
+  return !(l == r);
+}
+template<typename T, typename Alloc>
+bool operator <(const dynarray<T, Alloc>& l, const dynarray<T, Alloc>& r) {
+  return std::lexicographical_compare(l.begin(), l.end(), r.begin(), r.end());
+}
+template<typename T, typename Alloc>
+bool operator <=(const dynarray<T, Alloc>& l, const dynarray<T, Alloc>& r) {
+  return (l < r) || (l == r);
+}
+template<typename T, typename Alloc>
+bool operator >=(const dynarray<T, Alloc>& l, const dynarray<T, Alloc>& r) {
+  return !(l < r);
+}
+template<typename T, typename Alloc>
+bool operator >(const dynarray<T, Alloc>& l, const dynarray<T, Alloc>& r) {
+  return (l >= r) && (l != r);
+}
+
+
+template<typename T, typename Alloc>
+void swap(dynarray<T, Alloc>& a, dynarray<T, Alloc>& b) {
+  a.swap(b);
+}
+
+template<typename T, typename Alloc>
+std::ostream& operator <<(std::ostream& m, const dynarray<T, Alloc>& v) {
+  bool first = true;
+  m << "[";
+  for (const auto& p : v) {
+    if (!first) m << ",";
+    m << p;
+    first = false;
+  }
+  m << "]";
+  return m;
+}
+
+/// Deduction guides
+template<typename F, typename Alloc =
+	 std::allocator<std::invoke_result_t<F, std::size_t>>>
+dynarray(std::size_t, F&&, const Alloc& = Alloc{}) ->
+  dynarray<std::invoke_result_t<F, std::size_t>, Alloc>;
+template<typename I, typename Alloc =
+	 std::allocator<typename std::iterator_traits<I>::value_type>>
+dynarray(I, I, const Alloc& = Alloc{}) ->
+  dynarray<typename std::iterator_traits<I>::value_type, Alloc>;
+}

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -135,6 +135,7 @@ set(librgw_common_srcs
   rgw_tag.cc
   rgw_tag_s3.cc
   rgw_tools.cc
+  rgw_log_backing.cc
   rgw_user.cc
   rgw_website.cc
   rgw_xml.cc

--- a/src/rgw/cls_fifo_legacy.cc
+++ b/src/rgw/cls_fifo_legacy.cc
@@ -39,7 +39,7 @@
 #include "cls_fifo_legacy.h"
 
 namespace rgw::cls::fifo {
-static constexpr auto dout_subsys = ceph_subsys_rgw;
+static constexpr auto dout_subsys = ceph_subsys_objclass;
 namespace cb = ceph::buffer;
 namespace fifo = rados::cls::fifo;
 

--- a/src/rgw/cls_fifo_legacy.cc
+++ b/src/rgw/cls_fifo_legacy.cc
@@ -428,28 +428,9 @@ public:
     return c;
   }
   static void complete(Ptr&& p, int r) {
-    auto c = p->_super->pc;
+    auto c = p->_super;
     p->_super = nullptr;
-    c->lock.lock();
-    c->rval = r;
-    c->complete = true;
-    c->lock.unlock();
-
-    auto cb_complete = c->callback_complete;
-    auto cb_complete_arg = c->callback_complete_arg;
-    if (cb_complete)
-      cb_complete(c, cb_complete_arg);
-
-    auto cb_safe = c->callback_safe;
-    auto cb_safe_arg = c->callback_safe_arg;
-    if (cb_safe)
-      cb_safe(c, cb_safe_arg);
-
-    c->lock.lock();
-    c->callback_complete = nullptr;
-    c->callback_safe = nullptr;
-    c->cond.notify_all();
-    c->put_unlock();
+    rgw_complete_aio_completion(c, r);
   }
 
   static void cb(lr::completion_t, void* arg) {

--- a/src/rgw/cls_fifo_legacy.cc
+++ b/src/rgw/cls_fifo_legacy.cc
@@ -109,6 +109,7 @@ int get_meta(lr::IoCtx& ioctx, const std::string& oid,
   return r;
 };
 
+namespace {
 void update_meta(lr::ObjectWriteOperation* op, const fifo::objv& objv,
 		 const fifo::update& update)
 {
@@ -175,6 +176,27 @@ int push_part(lr::IoCtx& ioctx, const std::string& oid, std::string_view tag,
   return retval;
 }
 
+void push_part(lr::IoCtx& ioctx, const std::string& oid, std::string_view tag,
+	       std::deque<cb::list> data_bufs, std::uint64_t tid,
+	       lr::AioCompletion* c)
+{
+  lr::ObjectWriteOperation op;
+  fifo::op::push_part pp;
+
+  pp.tag = tag;
+  pp.data_bufs = data_bufs;
+  pp.total_len = 0;
+
+  for (const auto& bl : data_bufs)
+    pp.total_len += bl.length();
+
+  cb::list in;
+  encode(pp, in);
+  op.exec(fifo::op::CLASS, fifo::op::PUSH_PART, in);
+  auto r = ioctx.aio_operate(oid, c, &op, lr::OPERATION_RETURNVEC);
+  ceph_assert(r >= 0);
+}
+
 void trim_part(lr::ObjectWriteOperation* op,
 	       std::optional<std::string_view> tag,
 	       std::uint64_t ofs, bool exclusive)
@@ -232,6 +254,70 @@ int list_part(lr::IoCtx& ioctx, const std::string& oid,
   return r;
 }
 
+struct list_entry_completion : public lr::ObjectOperationCompletion {
+  CephContext* cct;
+  int* r_out;
+  std::vector<fifo::part_list_entry>* entries;
+  bool* more;
+  bool* full_part;
+  std::string* ptag;
+  std::uint64_t tid;
+
+  list_entry_completion(CephContext* cct, int* r_out, std::vector<fifo::part_list_entry>* entries,
+			bool* more, bool* full_part, std::string* ptag,
+			std::uint64_t tid)
+    : cct(cct), r_out(r_out), entries(entries), more(more),
+      full_part(full_part), ptag(ptag), tid(tid) {}
+  virtual ~list_entry_completion() = default;
+  void handle_completion(int r, bufferlist& bl) override {
+    if (r >= 0) try {
+	fifo::op::list_part_reply reply;
+	auto iter = bl.cbegin();
+	decode(reply, iter);
+	if (entries) *entries = std::move(reply.entries);
+	if (more) *more = reply.more;
+	if (full_part) *full_part = reply.full_part;
+	if (ptag) *ptag = reply.tag;
+      } catch (const cb::error& err) {
+	lderr(cct)
+	  << __PRETTY_FUNCTION__ << ":" << __LINE__
+	  << " decode failed: " << err.what()
+	  << " tid=" << tid << dendl;
+	r = from_error_code(err.code());
+      } else if (r < 0) {
+      lderr(cct)
+	<< __PRETTY_FUNCTION__ << ":" << __LINE__
+	<< " fifo::op::LIST_PART failed r=" << r << " tid=" << tid
+	<< dendl;
+    }
+    if (r_out) *r_out = r;
+  }
+};
+
+lr::ObjectReadOperation list_part(CephContext* cct,
+				  std::optional<std::string_view> tag,
+				  std::uint64_t ofs,
+				  std::uint64_t max_entries,
+				  int* r_out,
+				  std::vector<fifo::part_list_entry>* entries,
+				  bool* more, bool* full_part,
+				  std::string* ptag, std::uint64_t tid)
+{
+  lr::ObjectReadOperation op;
+  fifo::op::list_part lp;
+
+  lp.tag = tag;
+  lp.ofs = ofs;
+  lp.max_entries = max_entries;
+
+  cb::list in;
+  encode(lp, in);
+  op.exec(fifo::op::CLASS, fifo::op::LIST_PART, in,
+	  new list_entry_completion(cct, r_out, entries, more, full_part,
+				    ptag, tid));
+  return op;
+}
+
 int get_part_info(lr::IoCtx& ioctx, const std::string& oid,
 		  fifo::part_header* header,
 		  std::uint64_t tid, optional_yield y)
@@ -264,29 +350,131 @@ int get_part_info(lr::IoCtx& ioctx, const std::string& oid,
   return r;
 }
 
-static void complete(lr::AioCompletion* c_, int r)
+struct partinfo_completion : public lr::ObjectOperationCompletion {
+  CephContext* cct;
+  int* rp;
+  fifo::part_header* h;
+  std::uint64_t tid;
+  partinfo_completion(CephContext* cct, int* rp, fifo::part_header* h,
+		      std::uint64_t tid) :
+    cct(cct), rp(rp), h(h), tid(tid) {
+  }
+  virtual ~partinfo_completion() = default;
+  void handle_completion(int r, bufferlist& bl) override {
+    if (r >= 0) try {
+	fifo::op::get_part_info_reply reply;
+	auto iter = bl.cbegin();
+	decode(reply, iter);
+	if (h) *h = std::move(reply.header);
+      } catch (const cb::error& err) {
+	r = from_error_code(err.code());
+	lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " decode failed: " << err.what()
+		   << " tid=" << tid << dendl;
+      } else {
+      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " fifo::op::GET_PART_INFO failed r=" << r << " tid=" << tid
+		 << dendl;
+    }
+    if (rp) {
+      *rp = r;
+    }
+  }
+};
+
+template<typename T>
+struct Completion {
+private:
+  lr::AioCompletion* _cur = nullptr;
+  lr::AioCompletion* _super;
+public:
+
+  using Ptr = std::unique_ptr<T>;
+
+  lr::AioCompletion* cur() const {
+    return _cur;
+  }
+  lr::AioCompletion* super() const {
+    return _super;
+  }
+
+  Completion(lr::AioCompletion* super) : _super(super) {
+    super->pc->get();
+  }
+
+  ~Completion() {
+    if (_super) {
+      _super->pc->put();
+    }
+    if (_cur)
+      _cur->release();
+    _super = nullptr;
+    _cur = nullptr;
+  }
+
+  // The only times that aio_operate can return an error are:
+  // 1. The completion contains a null pointer. This should just
+  //    crash, and in our case it does.
+  // 2. An attempt is made to write to a snapshot. RGW doesn't use
+  //    snapshots, so we don't care.
+  //
+  // So we will just assert that initiating an Aio operation succeeds
+  // and not worry about recovering.
+  static lr::AioCompletion* call(Ptr&& p) {
+    p->_cur = lr::Rados::aio_create_completion(static_cast<void*>(p.get()),
+					       &cb);
+    auto c = p->_cur;
+    p.release();
+    return c;
+  }
+  static void complete(Ptr&& p, int r) {
+    auto c = p->_super->pc;
+    p->_super = nullptr;
+    c->lock.lock();
+    c->rval = r;
+    c->complete = true;
+    c->lock.unlock();
+
+    auto cb_complete = c->callback_complete;
+    auto cb_complete_arg = c->callback_complete_arg;
+    if (cb_complete)
+      cb_complete(c, cb_complete_arg);
+
+    auto cb_safe = c->callback_safe;
+    auto cb_safe_arg = c->callback_safe_arg;
+    if (cb_safe)
+      cb_safe(c, cb_safe_arg);
+
+    c->lock.lock();
+    c->callback_complete = nullptr;
+    c->callback_safe = nullptr;
+    c->cond.notify_all();
+    c->put_unlock();
+  }
+
+  static void cb(lr::completion_t, void* arg) {
+    auto t = static_cast<T*>(arg);
+    auto r = t->_cur->get_return_value();
+    t->_cur->release();
+    t->_cur = nullptr;
+    t->handle(Ptr(t), r);
+  }
+};
+
+lr::ObjectReadOperation get_part_info(CephContext* cct,
+				      fifo::part_header* header,
+				      std::uint64_t tid, int* r = 0)
 {
-  auto c = c_->pc;
-  c->lock.lock();
-  c->rval = r;
-  c->complete = true;
-  c->lock.unlock();
+  lr::ObjectReadOperation op;
+  fifo::op::get_part_info gpi;
 
-  auto cb_complete = c->callback_complete;
-  auto cb_complete_arg = c->callback_complete_arg;
-  if (cb_complete)
-    cb_complete(c, cb_complete_arg);
-
-  auto cb_safe = c->callback_safe;
-  auto cb_safe_arg = c->callback_safe_arg;
-  if (cb_safe)
-    cb_safe(c, cb_safe_arg);
-
-  c->lock.lock();
-  c->callback_complete = NULL;
-  c->callback_safe = NULL;
-  c->cond.notify_all();
-  c->put_unlock();
+  cb::list in;
+  cb::list bl;
+  encode(gpi, in);
+  op.exec(fifo::op::CLASS, fifo::op::GET_PART_INFO, in,
+	  new partinfo_completion(cct, r, header, tid));
+  return op;
+}
 }
 
 std::optional<marker> FIFO::to_marker(std::string_view s)
@@ -385,11 +573,8 @@ int FIFO::_update_meta(const fifo::update& update,
   return r;
 }
 
-struct Updater {
+struct Updater : public Completion<Updater> {
   FIFO* fifo;
-  lr::AioCompletion* super;
-  lr::AioCompletion* cur = lr::Rados::aio_create_completion(
-    static_cast<void*>(this), &FIFO::update_callback);
   fifo::update update;
   fifo::objv version;
   bool reread = false;
@@ -398,92 +583,74 @@ struct Updater {
   Updater(FIFO* fifo, lr::AioCompletion* super,
 	  const fifo::update& update, fifo::objv version,
 	  bool* pcanceled, std::uint64_t tid)
-    : fifo(fifo), super(super), update(update), version(version),
-      pcanceled(pcanceled), tid(tid) {
-    super->pc->get();
-  }
-  ~Updater() {
-    cur->release();
-  }
-};
+    : Completion(super), fifo(fifo), update(update), version(version),
+      pcanceled(pcanceled) {}
 
-void FIFO::update_callback(lr::completion_t, void* arg)
-{
-  std::unique_ptr<Updater> updater(static_cast<Updater*>(arg));
-  auto cct = updater->fifo->cct;
-  auto tid = updater->tid;
-  ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		 << " entering: tid=" << tid << dendl;
-  if (!updater->reread) {
-    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		   << " handling async update_meta: tid="
-		   << tid << dendl;
-    int r = updater->cur->get_return_value();
+  void handle(Ptr&& p, int r) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " entering: tid=" << tid << dendl;
+    if (reread)
+      handle_reread(std::move(p), r);
+    else
+      handle_update(std::move(p), r);
+  }
+
+  void handle_update(Ptr&& p, int r) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " handling async update_meta: tid="
+			 << tid << dendl;
     if (r < 0 && r != -ECANCELED) {
-      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+      lderr(fifo->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
 		 << " update failed: r=" << r << " tid=" << tid << dendl;
-      complete(updater->super, r);
+      complete(std::move(p), r);
       return;
     }
     bool canceled = (r == -ECANCELED);
     if (!canceled) {
-      int r = updater->fifo->apply_update(&updater->fifo->info,
-					  updater->version,
-					  updater->update, tid);
+      int r = fifo->apply_update(&fifo->info, version, update, tid);
       if (r < 0) {
-	ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		       << " update failed, marking canceled: r=" << r << " tid="
-		       << tid << dendl;
+	ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			     << " update failed, marking canceled: r=" << r
+			     << " tid=" << tid << dendl;
 	canceled = true;
       }
     }
     if (canceled) {
-      updater->cur->release();
-      updater->cur = lr::Rados::aio_create_completion(
-	arg, &FIFO::update_callback);
-      updater->reread = true;
-      auto r = updater->fifo->read_meta(tid, updater->cur);
-      if (r < 0) {
-	lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		   << " failed dispatching read_meta: r=" << r << " tid="
-		   << tid << dendl;
-	complete(updater->super, r);
-      } else {
-	updater.release();
-      }
+      reread = true;
+      fifo->read_meta(tid, call(std::move(p)));
       return;
     }
-    if (updater->pcanceled)
-      *updater->pcanceled = false;
-    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		   << " completing: tid=" << tid << dendl;
-    complete(updater->super, 0);
-    return;
+    if (pcanceled)
+      *pcanceled = false;
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " completing: tid=" << tid << dendl;
+    complete(std::move(p), 0);
   }
 
-  ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		 << " handling async read_meta: tid="
-		 << tid << dendl;
-  int r = updater->cur->get_return_value();
-  if (r < 0 && updater->pcanceled) {
-    *updater->pcanceled = false;
-  } else if (r >= 0 && updater->pcanceled) {
-    *updater->pcanceled = true;
+  void handle_reread(Ptr&& p, int r) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " handling async read_meta: tid="
+			 << tid << dendl;
+    if (r < 0 && pcanceled) {
+      *pcanceled = false;
+    } else if (r >= 0 && pcanceled) {
+      *pcanceled = true;
+    }
+    if (r < 0) {
+      lderr(fifo->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		       << " failed dispatching read_meta: r=" << r << " tid="
+		       << tid << dendl;
+    } else {
+      ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			   << " completing: tid=" << tid << dendl;
+    }
+    complete(std::move(p), r);
   }
-  if (r < 0) {
-    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-	       << " failed dispatching read_meta: r=" << r << " tid="
-	       << tid << dendl;
-  } else {
-    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		   << " completing: tid=" << tid << dendl;
-  }
-  complete(updater->super, r);
-}
+};
 
-int FIFO::_update_meta(const fifo::update& update,
-		       fifo::objv version, bool* pcanceled,
-		       std::uint64_t tid, lr::AioCompletion* c)
+void FIFO::_update_meta(const fifo::update& update,
+			fifo::objv version, bool* pcanceled,
+			std::uint64_t tid, lr::AioCompletion* c)
 {
   ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
 		 << " entering: tid=" << tid << dendl;
@@ -491,15 +658,8 @@ int FIFO::_update_meta(const fifo::update& update,
   update_meta(&op, info.version, update);
   auto updater = std::make_unique<Updater>(this, c, update, version, pcanceled,
 					   tid);
-  auto r = ioctx.aio_operate(oid, updater->cur, &op);
-  if (r < 0) {
-    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-	       << " failed dispatching update_meta: r=" << r << " tid="
-	       << tid << dendl;
-  } else {
-    updater.release();
-  }
-  return r;
+  auto r = ioctx.aio_operate(oid, Updater::call(std::move(updater)), &op);
+  assert(r >= 0);
 }
 
 int FIFO::create_part(int64_t part_num, std::string_view tag, std::uint64_t tid,
@@ -806,6 +966,209 @@ int FIFO::_prepare_new_head(std::uint64_t tid, optional_yield y)
   return 0;
 }
 
+struct NewPartPreparer : public Completion<NewPartPreparer> {
+  FIFO* f;
+  std::vector<fifo::journal_entry> jentries;
+  int i = 0;
+  std::int64_t new_head_part_num;
+  bool canceled = false;
+  uint64_t tid;
+
+  NewPartPreparer(FIFO* f, lr::AioCompletion* super,
+		  std::vector<fifo::journal_entry> jentries,
+		  std::int64_t new_head_part_num,
+		  std::uint64_t tid)
+    : Completion(super), f(f), jentries(std::move(jentries)),
+      new_head_part_num(new_head_part_num), tid(tid) {}
+
+  void handle(Ptr&& p, int r) {
+    ldout(f->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		      << " entering: tid=" << tid << dendl;
+    if (r < 0) {
+      lderr(f->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		    << " _update_meta failed:  r=" << r
+		    << " tid=" << tid << dendl;
+      complete(std::move(p), r);
+      return;
+    }
+
+    if (canceled) {
+      std::unique_lock l(f->m);
+      auto iter = f->info.journal.find(jentries.front().part_num);
+      auto max_push_part_num = f->info.max_push_part_num;
+      auto head_part_num = f->info.head_part_num;
+      auto version = f->info.version;
+      auto found = (iter != f->info.journal.end());
+      l.unlock();
+      if ((max_push_part_num >= jentries.front().part_num &&
+	   head_part_num >= new_head_part_num)) {
+	ldout(f->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			  << " raced, but journaled and processed: i=" << i
+			  << " tid=" << tid << dendl;
+	complete(std::move(p), 0);
+	return;
+      }
+      if (i >= MAX_RACE_RETRIES) {
+	complete(std::move(p), -ECANCELED);
+	return;
+      }
+      if (!found) {
+	++i;
+	f->_update_meta(fifo::update{}
+			.journal_entries_add(jentries),
+                        version, &canceled, tid, call(std::move(p)));
+	return;
+      } else {
+	ldout(f->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			  << " raced, journaled but not processed: i=" << i
+			  << " tid=" << tid << dendl;
+	canceled = false;
+      }
+      // Fall through. We still need to process the journal.
+    }
+    f->process_journal(tid, super());
+    return;
+  }
+};
+
+void FIFO::_prepare_new_part(bool is_head, std::uint64_t tid,
+			     lr::AioCompletion* c)
+{
+  std::unique_lock l(m);
+  std::vector jentries = { info.next_journal_entry(generate_tag()) };
+  if (info.journal.find(jentries.front().part_num) != info.journal.end()) {
+    l.unlock();
+    ldout(cct, 5) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		  << " new part journaled, but not processed: tid="
+		  << tid << dendl;
+    process_journal(tid, c);
+    return;
+  }
+  std::int64_t new_head_part_num = info.head_part_num;
+  auto version = info.version;
+
+  if (is_head) {
+    auto new_head_jentry = jentries.front();
+    new_head_jentry.op = fifo::journal_entry::Op::set_head;
+    new_head_part_num = jentries.front().part_num;
+    jentries.push_back(std::move(new_head_jentry));
+  }
+  l.unlock();
+
+  auto n = std::make_unique<NewPartPreparer>(this, c, jentries,
+					     new_head_part_num, tid);
+  auto np = n.get();
+  _update_meta(fifo::update{}.journal_entries_add(jentries), version,
+	       &np->canceled, tid, NewPartPreparer::call(std::move(n)));
+}
+
+struct NewHeadPreparer : public Completion<NewHeadPreparer> {
+  FIFO* f;
+  int i = 0;
+  bool newpart;
+  std::int64_t new_head_num;
+  bool canceled = false;
+  std::uint64_t tid;
+
+  NewHeadPreparer(FIFO* f, lr::AioCompletion* super,
+		  bool newpart, std::int64_t new_head_num, std::uint64_t tid)
+    : Completion(super), f(f), newpart(newpart), new_head_num(new_head_num),
+      tid(tid) {}
+
+  void handle(Ptr&& p, int r) {
+    if (newpart)
+      handle_newpart(std::move(p), r);
+    else
+      handle_update(std::move(p), r);
+  }
+
+  void handle_newpart(Ptr&& p, int r) {
+    if (r < 0) {
+      lderr(f->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		    << " _prepare_new_part failed: r=" << r
+		    << " tid=" << tid << dendl;
+      complete(std::move(p), r);
+      return;
+    }
+    std::unique_lock l(f->m);
+    if (f->info.max_push_part_num < new_head_num) {
+      l.unlock();
+      lderr(f->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		    << " _prepare_new_part failed: r=" << r
+		    << " tid=" << tid << dendl;
+      complete(std::move(p), -EIO);
+    } else {
+      l.unlock();
+      complete(std::move(p), 0);
+    }
+  }
+
+  void handle_update(Ptr&& p, int r) {
+    std::unique_lock l(f->m);
+    auto head_part_num = f->info.head_part_num;
+    auto version = f->info.version;
+    l.unlock();
+
+    if (r < 0) {
+      lderr(f->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		    << " _update_meta failed: r=" << r
+		    << " tid=" << tid << dendl;
+      complete(std::move(p), r);
+      return;
+    }
+    if (canceled) {
+      if (i >= MAX_RACE_RETRIES) {
+	lderr(f->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		      << " canceled too many times, giving up: tid=" << tid << dendl;
+	complete(std::move(p), -ECANCELED);
+	return;
+      }
+
+      // Raced, but there's still work to do!
+      if (head_part_num < new_head_num) {
+	canceled = false;
+	++i;
+	ldout(f->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			  << " updating head: i=" << i << " tid=" << tid << dendl;
+	f->_update_meta(fifo::update{}.head_part_num(new_head_num),
+			version, &this->canceled, tid, call(std::move(p)));
+	return;
+      }
+    }
+    ldout(f->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " succeeded : i=" << i << " tid=" << tid << dendl;
+    complete(std::move(p), 0);
+    return;
+  }
+};
+
+void FIFO::_prepare_new_head(std::uint64_t tid, lr::AioCompletion* c)
+{
+  ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " entering: tid=" << tid << dendl;
+  std::unique_lock l(m);
+  int64_t new_head_num = info.head_part_num + 1;
+  auto max_push_part_num = info.max_push_part_num;
+  auto version = info.version;
+  l.unlock();
+
+  if (max_push_part_num < new_head_num) {
+    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " need new part: tid=" << tid << dendl;
+    auto n = std::make_unique<NewHeadPreparer>(this, c, true, new_head_num,
+					       tid);
+    _prepare_new_part(true, tid, NewHeadPreparer::call(std::move(n)));
+  } else {
+    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " updating head: tid=" << tid << dendl;
+    auto n = std::make_unique<NewHeadPreparer>(this, c, false, new_head_num,
+					       tid);
+    auto np = n.get();
+    _update_meta(fifo::update{}.head_part_num(new_head_num), version,
+		 &np->canceled, tid, NewHeadPreparer::call(std::move(n)));
+  }
+}
+
 int FIFO::push_entries(const std::deque<cb::list>& data_bufs,
 		       std::uint64_t tid, optional_yield y)
 {
@@ -823,6 +1186,18 @@ int FIFO::push_entries(const std::deque<cb::list>& data_bufs,
 	       << " push_part failed: r=" << r << " tid=" << tid << dendl;
   }
   return r;
+}
+
+void FIFO::push_entries(const std::deque<cb::list>& data_bufs,
+			std::uint64_t tid, lr::AioCompletion* c)
+{
+  std::unique_lock l(m);
+  auto head_part_num = info.head_part_num;
+  auto tag = info.head_tag;
+  const auto part_oid = info.part_oid(head_part_num);
+  l.unlock();
+
+  push_part(ioctx, part_oid, tag, data_bufs, tid, c);
 }
 
 int FIFO::trim_part(int64_t part_num, uint64_t ofs,
@@ -845,10 +1220,10 @@ int FIFO::trim_part(int64_t part_num, uint64_t ofs,
   return 0;
 }
 
-int FIFO::trim_part(int64_t part_num, uint64_t ofs,
-		    std::optional<std::string_view> tag,
-		    bool exclusive, std::uint64_t tid,
-		    lr::AioCompletion* c)
+void FIFO::trim_part(int64_t part_num, uint64_t ofs,
+		     std::optional<std::string_view> tag,
+		     bool exclusive, std::uint64_t tid,
+		     lr::AioCompletion* c)
 {
   ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
 		 << " entering: tid=" << tid << dendl;
@@ -858,12 +1233,7 @@ int FIFO::trim_part(int64_t part_num, uint64_t ofs,
   l.unlock();
   rgw::cls::fifo::trim_part(&op, tag, ofs, exclusive);
   auto r = ioctx.aio_operate(part_oid, c, &op);
-  if (r < 0) {
-    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-	       << " failed scheduling trim_part: r=" << r
-	       << " tid=" << tid << dendl;
-  }
-  return r;
+  ceph_assert(r >= 0);
 }
 
 int FIFO::open(lr::IoCtx ioctx, std::string oid, std::unique_ptr<FIFO>* fifo,
@@ -960,54 +1330,42 @@ int FIFO::read_meta(optional_yield y) {
   return read_meta(tid, y);
 }
 
-struct Reader {
+struct Reader : public Completion<Reader> {
   FIFO* fifo;
   cb::list bl;
-  lr::AioCompletion* super;
   std::uint64_t tid;
-  lr::AioCompletion* cur = lr::Rados::aio_create_completion(
-    static_cast<void*>(this), &FIFO::read_callback);
   Reader(FIFO* fifo, lr::AioCompletion* super, std::uint64_t tid)
-    : fifo(fifo), super(super), tid(tid) {
-    super->pc->get();
-  }
-  ~Reader() {
-    cur->release();
+    : Completion(super), fifo(fifo), tid(tid) {}
+
+  void handle(Ptr&& p, int r) {
+    auto cct = fifo->cct;
+    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " entering: tid=" << tid << dendl;
+    if (r >= 0) try {
+	fifo::op::get_meta_reply reply;
+	auto iter = bl.cbegin();
+	decode(reply, iter);
+	std::unique_lock l(fifo->m);
+	if (reply.info.version.same_or_later(fifo->info.version)) {
+	  fifo->info = std::move(reply.info);
+	  fifo->part_header_size = reply.part_header_size;
+	  fifo->part_entry_overhead = reply.part_entry_overhead;
+	}
+      } catch (const cb::error& err) {
+	lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " failed to decode response err=" << err.what()
+		   << " tid=" << tid << dendl;
+	r = from_error_code(err.code());
+      } else {
+      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " read_meta failed r=" << r
+		 << " tid=" << tid << dendl;
+    }
+    complete(std::move(p), r);
   }
 };
 
-void FIFO::read_callback(lr::completion_t, void* arg)
-{
-  std::unique_ptr<Reader> reader(static_cast<Reader*>(arg));
-  auto cct = reader->fifo->cct;
-  auto tid = reader->tid;
-  ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		 << " entering: tid=" << tid << dendl;
-  auto r = reader->cur->get_return_value();
-  if (r >= 0) try {
-      fifo::op::get_meta_reply reply;
-      auto iter = reader->bl.cbegin();
-      decode(reply, iter);
-      std::unique_lock l(reader->fifo->m);
-      if (reply.info.version.same_or_later(reader->fifo->info.version)) {
-	reader->fifo->info = std::move(reply.info);
-	reader->fifo->part_header_size = reply.part_header_size;
-	reader->fifo->part_entry_overhead = reply.part_entry_overhead;
-      }
-    } catch (const cb::error& err) {
-      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		 << " failed to decode response err=" << err.what()
-		 << " tid=" << tid << dendl;
-      r = from_error_code(err.code());
-    } else {
-    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-	       << " read_meta failed r=" << r
-	       << " tid=" << tid << dendl;
-  }
-  complete(reader->super, r);
-}
-
-int FIFO::read_meta(std::uint64_t tid, lr::AioCompletion* c)
+void FIFO::read_meta(std::uint64_t tid, lr::AioCompletion* c)
 {
   ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
 		 << " entering: tid=" << tid << dendl;
@@ -1016,16 +1374,10 @@ int FIFO::read_meta(std::uint64_t tid, lr::AioCompletion* c)
   cb::list in;
   encode(gm, in);
   auto reader = std::make_unique<Reader>(this, c, tid);
-  auto r = ioctx.aio_exec(oid, reader->cur, fifo::op::CLASS,
-			  fifo::op::GET_META, in, &reader->bl);
-  if (r < 0) {
-    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-	       << " failed scheduling read_meta r=" << r
-	       << " tid=" << tid << dendl;
-  } else {
-    reader.release();
-  }
-  return r;
+  auto rp = reader.get();
+  auto r = ioctx.aio_exec(oid, Reader::call(std::move(reader)), fifo::op::CLASS,
+			  fifo::op::GET_META, in, &rp->bl);
+  assert(r >= 0);
 }
 
 const fifo::info& FIFO::meta() const {
@@ -1038,6 +1390,10 @@ std::pair<std::uint32_t, std::uint32_t> FIFO::get_part_layout_info() const {
 
 int FIFO::push(const cb::list& bl, optional_yield y) {
   return push(std::vector{ bl }, y);
+}
+
+void FIFO::push(const cb::list& bl, lr::AioCompletion* c) {
+  push(std::vector{ bl }, c);
 }
 
 int FIFO::push(const std::vector<cb::list>& data_bufs, optional_yield y)
@@ -1151,6 +1507,167 @@ int FIFO::push(const std::vector<cb::list>& data_bufs, optional_yield y)
     return -ECANCELED;
   }
   return 0;
+}
+
+struct Pusher : public Completion<Pusher> {
+  FIFO* f;
+  std::deque<cb::list> remaining;
+  std::deque<cb::list> batch;
+  int i = 0;
+  std::uint64_t tid;
+  bool new_heading = false;
+
+  void prep_then_push(Ptr&& p, const unsigned successes) {
+    std::unique_lock l(f->m);
+    auto max_part_size = f->info.params.max_part_size;
+    auto part_entry_overhead = f->part_entry_overhead;
+    l.unlock();
+
+    ldout(f->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		      << " preparing push: remaining=" << remaining.size()
+		      << " batch=" << batch.size() << " i=" << i
+		      << " tid=" << tid << dendl;
+
+    uint64_t batch_len = 0;
+    if (successes > 0) {
+      if (successes == batch.size()) {
+	batch.clear();
+      } else  {
+	batch.erase(batch.begin(), batch.begin() + successes);
+	for (const auto& b : batch) {
+	  batch_len +=  b.length() + part_entry_overhead;
+	}
+      }
+    }
+
+    if (batch.empty() && remaining.empty()) {
+      complete(std::move(p), 0);
+      return;
+    }
+
+    while (!remaining.empty() &&
+	   (remaining.front().length() + batch_len <= max_part_size)) {
+
+      /* We can send entries with data_len up to max_entry_size,
+	 however, we want to also account the overhead when
+	 dealing with multiple entries. Previous check doesn't
+	 account for overhead on purpose. */
+      batch_len += remaining.front().length() + part_entry_overhead;
+      batch.push_back(std::move(remaining.front()));
+      remaining.pop_front();
+    }
+    ldout(f->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		      << " prepared push: remaining=" << remaining.size()
+		      << " batch=" << batch.size() << " i=" << i
+		      << " batch_len=" << batch_len
+		      << " tid=" << tid << dendl;
+    push(std::move(p));
+  }
+
+  void push(Ptr&& p) {
+    f->push_entries(batch, tid, call(std::move(p)));
+  }
+
+  void new_head(Ptr&& p) {
+    new_heading = true;
+    f->_prepare_new_head(tid, call(std::move(p)));
+  }
+
+  void handle(Ptr&& p, int r) {
+    if (!new_heading) {
+      if (r == -ERANGE) {
+	ldout(f->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		       << " need new head tid=" << tid << dendl;
+	new_head(std::move(p));
+	return;
+      }
+      if (r < 0) {
+	lderr(f->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		      << " push_entries failed: r=" << r
+		      << " tid=" << tid << dendl;
+	complete(std::move(p), r);
+	return;
+      }
+      i = 0; // We've made forward progress, so reset the race counter!
+      prep_then_push(std::move(p), r);
+    } else {
+      if (r < 0) {
+	lderr(f->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		      << " prepare_new_head failed: r=" << r
+		      << " tid=" << tid << dendl;
+	complete(std::move(p), r);
+	return;
+      }
+      new_heading = false;
+      handle_new_head(std::move(p), r);
+    }
+  }
+
+  void handle_new_head(Ptr&& p, int r) {
+    if (r == -ECANCELED) {
+      if (p->i == MAX_RACE_RETRIES) {
+	lderr(f->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		      << " canceled too many times, giving up: tid=" << tid << dendl;
+	complete(std::move(p), -ECANCELED);
+	return;
+      }
+      ++p->i;
+    } else if (r) {
+      complete(std::move(p), r);
+      return;
+    }
+
+    if (p->batch.empty()) {
+      prep_then_push(std::move(p), 0);
+      return;
+    } else {
+      push(std::move(p));
+      return;
+    }
+  }
+
+  Pusher(FIFO* f, std::deque<cb::list>&& remaining,
+	 std::uint64_t tid, lr::AioCompletion* super)
+    : Completion(super), f(f), remaining(std::move(remaining)),
+      tid(tid) {}
+};
+
+void FIFO::push(const std::vector<cb::list>& data_bufs,
+		lr::AioCompletion* c)
+{
+  std::unique_lock l(m);
+  auto tid = ++next_tid;
+  auto max_entry_size = info.params.max_entry_size;
+  auto need_new_head = info.need_new_head();
+  l.unlock();
+  ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " entering: tid=" << tid << dendl;
+  auto p = std::make_unique<Pusher>(this, std::deque<cb::list>(data_bufs.begin(), data_bufs.end()),
+				    tid, c);
+  // Validate sizes
+  for (const auto& bl : data_bufs) {
+    if (bl.length() > max_entry_size) {
+      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " entry bigger than max_entry_size tid=" << tid << dendl;
+      Pusher::complete(std::move(p), -E2BIG);
+      return;
+    }
+  }
+
+  if (data_bufs.empty() ) {
+    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " empty push, returning success tid=" << tid << dendl;
+    Pusher::complete(std::move(p), 0);
+    return;
+  }
+
+  if (need_new_head) {
+    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " need new head tid=" << tid << dendl;
+    p->new_head(std::move(p));
+  } else {
+    p->prep_then_push(std::move(p), 0);
+  }
 }
 
 int FIFO::list(int max_entries,
@@ -1340,157 +1857,115 @@ int FIFO::trim(std::string_view markstr, bool exclusive, optional_yield y)
   return 0;
 }
 
-struct Trimmer {
+struct Trimmer : public Completion<Trimmer> {
   FIFO* fifo;
   std::int64_t part_num;
   std::uint64_t ofs;
   std::int64_t pn;
   bool exclusive;
-  lr::AioCompletion* super;
   std::uint64_t tid;
-  lr::AioCompletion* cur = lr::Rados::aio_create_completion(
-    static_cast<void*>(this), &FIFO::trim_callback);
   bool update = false;
   bool canceled = false;
   int retries = 0;
 
   Trimmer(FIFO* fifo, std::int64_t part_num, std::uint64_t ofs, std::int64_t pn,
 	  bool exclusive, lr::AioCompletion* super, std::uint64_t tid)
-    : fifo(fifo), part_num(part_num), ofs(ofs), pn(pn), exclusive(exclusive),
-      super(super), tid(tid) {
-    super->pc->get();
-  }
-  ~Trimmer() {
-    cur->release();
+    : Completion(super), fifo(fifo), part_num(part_num), ofs(ofs), pn(pn),
+      exclusive(exclusive), tid(tid) {}
+
+  void handle(Ptr&& p, int r) {
+    auto cct = fifo->cct;
+    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " entering: tid=" << tid << dendl;
+    if (r == -ENOENT) {
+      r = 0;
+    }
+
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << (update ? " update_meta " : " trim ") << "failed: r="
+		 << r << " tid=" << tid << dendl;
+      complete(std::move(p), r);
+      return;
+    }
+
+    if (!update) {
+      ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		     << " handling preceding trim callback: tid=" << tid << dendl;
+      retries = 0;
+      if (pn < part_num) {
+	ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		       << " pn=" << pn << " tid=" << tid << dendl;
+	std::unique_lock l(fifo->m);
+	const auto max_part_size = fifo->info.params.max_part_size;
+	l.unlock();
+	fifo->trim_part(pn++, max_part_size, std::nullopt,
+			false, tid, call(std::move(p)));
+	return;
+      }
+
+      std::unique_lock l(fifo->m);
+      const auto tail_part_num = fifo->info.tail_part_num;
+      l.unlock();
+      update = true;
+      canceled = tail_part_num < part_num;
+      fifo->trim_part(part_num, ofs, std::nullopt, exclusive, tid,
+		      call(std::move(p)));
+      return;
+    }
+
+    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " handling update-needed callback: tid=" << tid << dendl;
+    std::unique_lock l(fifo->m);
+    auto tail_part_num = fifo->info.tail_part_num;
+    auto objv = fifo->info.version;
+    l.unlock();
+    if ((tail_part_num < part_num) &&
+	canceled) {
+      if (retries > MAX_RACE_RETRIES) {
+	lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " canceled too many times, giving up: tid=" << tid << dendl;
+	complete(std::move(p), -EIO);
+	return;
+      }
+      ++retries;
+      fifo->_update_meta(fifo::update{}
+			 .tail_part_num(part_num), objv, &canceled,
+                         tid, call(std::move(p)));
+    } else {
+      complete(std::move(p), 0);
+    }
   }
 };
 
-void FIFO::trim_callback(lr::completion_t, void* arg)
-{
-  std::unique_ptr<Trimmer> trimmer(static_cast<Trimmer*>(arg));
-  auto cct = trimmer->fifo->cct;
-  auto tid = trimmer->tid;
-  ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		 << " entering: tid=" << tid << dendl;
-  int r = trimmer->cur->get_return_value();
-  if (r == -ENOENT) {
-    r = 0;
-  }
-
-  if (r < 0) {
-    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-	       << " trim failed: r=" << r << " tid=" << tid << dendl;
-    complete(trimmer->super, r);
-    return;
-  }
-
-  if (!trimmer->update) {
-    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		   << " handling preceding trim callback: tid=" << tid << dendl;
-    trimmer->retries = 0;
-    if (trimmer->pn < trimmer->part_num) {
-      std::unique_lock l(trimmer->fifo->m);
-      const auto max_part_size = trimmer->fifo->info.params.max_part_size;
-      l.unlock();
-      trimmer->cur->release();
-      trimmer->cur = lr::Rados::aio_create_completion(arg, &FIFO::trim_callback);
-      r = trimmer->fifo->trim_part(trimmer->pn++, max_part_size, std::nullopt,
-				   false, tid, trimmer->cur);
-      if (r < 0) {
-	lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		   << " trim failed: r=" << r << " tid=" << tid << dendl;
-	complete(trimmer->super, r);
-      } else {
-	trimmer.release();
-      }
-      return;
-    }
-
-    std::unique_lock l(trimmer->fifo->m);
-    const auto tail_part_num = trimmer->fifo->info.tail_part_num;
-    l.unlock();
-    trimmer->cur->release();
-    trimmer->cur = lr::Rados::aio_create_completion(arg, &FIFO::trim_callback);
-    trimmer->update = true;
-    trimmer->canceled = tail_part_num < trimmer->part_num;
-    r = trimmer->fifo->trim_part(trimmer->part_num, trimmer->ofs,
-				 std::nullopt, trimmer->exclusive, tid, trimmer->cur);
-    if (r < 0) {
-      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		 << " failed scheduling trim: r=" << r << " tid=" << tid << dendl;
-      complete(trimmer->super, r);
-    } else {
-      trimmer.release();
-    }
-    return;
-  }
-
-  ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		 << " handling update-needed callback: tid=" << tid << dendl;
-  std::unique_lock l(trimmer->fifo->m);
-  auto tail_part_num = trimmer->fifo->info.tail_part_num;
-  auto objv = trimmer->fifo->info.version;
-  l.unlock();
-  if ((tail_part_num < trimmer->part_num) &&
-      trimmer->canceled) {
-    if (trimmer->retries > MAX_RACE_RETRIES) {
-      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		 << " canceled too many times, giving up: tid=" << tid << dendl;
-      complete(trimmer->super, -EIO);
-      return;
-    }
-    trimmer->cur->release();
-    trimmer->cur = lr::Rados::aio_create_completion(arg,
-						    &FIFO::trim_callback);
-    ++trimmer->retries;
-    r = trimmer->fifo->_update_meta(fifo::update{}
-				    .tail_part_num(trimmer->part_num),
-			            objv, &trimmer->canceled,
-                                    tid, trimmer->cur);
-    if (r < 0) {
-      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-		 << " failed scheduling _update_meta: r="
-		 << r << " tid=" << tid << dendl;
-      complete(trimmer->super, r);
-    } else {
-      trimmer.release();
-    }
-  } else {
-    complete(trimmer->super, 0);
-  }
-}
-
-int FIFO::trim(std::string_view markstr, bool exclusive, lr::AioCompletion* c) {
+void FIFO::trim(std::string_view markstr, bool exclusive,
+		lr::AioCompletion* c) {
   auto marker = to_marker(markstr);
-  if (!marker) {
-    return -EINVAL;
-  }
+  auto realmark = marker.value_or(::rgw::cls::fifo::marker{});
   std::unique_lock l(m);
   const auto max_part_size = info.params.max_part_size;
   const auto pn = info.tail_part_num;
   const auto part_oid = info.part_oid(pn);
   auto tid = ++next_tid;
   l.unlock();
-  auto trimmer = std::make_unique<Trimmer>(this, marker->num, marker->ofs, pn, exclusive, c,
-					   tid);
+  ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " entering: tid=" << tid << dendl;
+  auto trimmer = std::make_unique<Trimmer>(this, realmark.num, realmark.ofs,
+					   pn, exclusive, c, tid);
+  if (!marker) {
+    Trimmer::complete(std::move(trimmer), -EINVAL);
+  }
   ++trimmer->pn;
   auto ofs = marker->ofs;
   if (pn < marker->num) {
+    ldout(cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		   << " pn=" << pn << " tid=" << tid << dendl;
     ofs = max_part_size;
   } else {
     trimmer->update = true;
   }
-  auto r = trim_part(pn, ofs, std::nullopt, exclusive,
-		     tid, trimmer->cur);
-  if (r < 0) {
-    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
-	       << " failed scheduling trim_part: r="
-	       << r << " tid=" << tid << dendl;
-    complete(trimmer->super, r);
-  } else {
-    trimmer.release();
-  }
-  return r;
+  trim_part(pn, ofs, std::nullopt, exclusive,
+	    tid, Trimmer::call(std::move(trimmer)));
 }
 
 int FIFO::get_part_info(int64_t part_num,
@@ -1508,5 +1983,522 @@ int FIFO::get_part_info(int64_t part_num,
 	       << r << " tid=" << tid << dendl;
   }
   return r;
+}
+
+void FIFO::get_part_info(int64_t part_num,
+			 fifo::part_header* header,
+			 lr::AioCompletion* c)
+{
+  std::unique_lock l(m);
+  const auto part_oid = info.part_oid(part_num);
+  auto tid = ++next_tid;
+  l.unlock();
+  auto op = rgw::cls::fifo::get_part_info(cct, header, tid);
+  auto r = ioctx.aio_operate(part_oid, c, &op, nullptr);
+  ceph_assert(r >= 0);
+}
+
+struct InfoGetter : Completion<InfoGetter> {
+  FIFO* fifo;
+  fifo::part_header header;
+  fu2::function<void(int r, fifo::part_header&&)> f;
+  std::uint64_t tid;
+  bool headerread = false;
+
+  InfoGetter(FIFO* fifo, fu2::function<void(int r, fifo::part_header&&)> f,
+	     std::uint64_t tid, lr::AioCompletion* super)
+    : Completion(super), fifo(fifo), f(std::move(f)), tid(tid) {}
+  void handle(Ptr&& p, int r) {
+    if (!headerread) {
+      if (r < 0) {
+	lderr(fifo->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " read_meta failed: r="
+			 << r << " tid=" << tid << dendl;
+	if (f)
+	  f(r, {});
+	complete(std::move(p), r);
+	return;
+      }
+
+      auto info = fifo->meta();
+      auto hpn = info.head_part_num;
+      if (hpn < 0) {
+	ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			     << " no head, returning empty partinfo r="
+			     << r << " tid=" << tid << dendl;
+	if (f)
+	  f(0, {});
+	complete(std::move(p), r);
+	return;
+      }
+      headerread = true;
+      auto op = rgw::cls::fifo::get_part_info(fifo->cct, &header, tid);
+      std::unique_lock l(fifo->m);
+      auto oid = fifo->info.part_oid(hpn);
+      l.unlock();
+      r = fifo->ioctx.aio_operate(oid, call(std::move(p)), &op,
+				  nullptr);
+      ceph_assert(r >= 0);
+      return;
+    }
+
+    if (r < 0) {
+      lderr(fifo->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		       << " get_part_info failed: r="
+		       << r << " tid=" << tid << dendl;
+    }
+
+    if (f)
+      f(r, std::move(header));
+    complete(std::move(p), r);
+    return;
+  }
+};
+
+void FIFO::get_head_info(fu2::unique_function<void(int r,
+						   fifo::part_header&&)> f,
+			 lr::AioCompletion* c)
+{
+  std::unique_lock l(m);
+  auto tid = ++next_tid;
+  l.unlock();
+  auto ig = std::make_unique<InfoGetter>(this, std::move(f), tid, c);
+  read_meta(tid, InfoGetter::call(std::move(ig)));
+}
+
+struct JournalProcessor : public Completion<JournalProcessor> {
+private:
+  FIFO* const fifo;
+
+  std::vector<fifo::journal_entry> processed;
+  std::multimap<std::int64_t, fifo::journal_entry> journal;
+  std::multimap<std::int64_t, fifo::journal_entry>::iterator iter;
+  std::int64_t new_tail;
+  std::int64_t new_head;
+  std::int64_t new_max;
+  int race_retries = 0;
+  bool first_pp = true;
+  bool canceled = false;
+  std::uint64_t tid;
+
+  enum {
+    entry_callback,
+    pp_callback,
+  } state;
+
+  void create_part(Ptr&& p, int64_t part_num,
+		   std::string_view tag) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " entering: tid=" << tid << dendl;
+    state = entry_callback;
+    lr::ObjectWriteOperation op;
+    op.create(false); /* We don't need exclusivity, part_init ensures
+			 we're creating from the  same journal entry. */
+    std::unique_lock l(fifo->m);
+    part_init(&op, tag, fifo->info.params);
+    auto oid = fifo->info.part_oid(part_num);
+    l.unlock();
+    auto r = fifo->ioctx.aio_operate(oid, call(std::move(p)), &op);
+    ceph_assert(r >= 0);
+    return;
+  }
+
+  void remove_part(Ptr&& p, int64_t part_num,
+		   std::string_view tag) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " entering: tid=" << tid << dendl;
+    state = entry_callback;
+    lr::ObjectWriteOperation op;
+    op.remove();
+    std::unique_lock l(fifo->m);
+    auto oid = fifo->info.part_oid(part_num);
+    l.unlock();
+    auto r = fifo->ioctx.aio_operate(oid, call(std::move(p)), &op);
+    ceph_assert(r >= 0);
+    return;
+  }
+
+  void finish_je(Ptr&& p, int r,
+		 const fifo::journal_entry& entry) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " entering: tid=" << tid << dendl;
+
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " finishing entry: entry=" << entry
+			 << " tid=" << tid << dendl;
+
+    if (entry.op == fifo::journal_entry::Op::remove && r == -ENOENT)
+      r = 0;
+
+    if (r < 0) {
+      lderr(fifo->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		       << " processing entry failed: entry=" << entry
+		       << " r=" << r << " tid=" << tid << dendl;
+      complete(std::move(p), r);
+      return;
+    } else {
+      switch (entry.op) {
+      case fifo::journal_entry::Op::unknown:
+      case fifo::journal_entry::Op::set_head:
+	// Can't happen. Filtered out in process.
+	complete(std::move(p), -EIO);
+	return;
+
+      case fifo::journal_entry::Op::create:
+	if (entry.part_num > new_max) {
+	  new_max = entry.part_num;
+	}
+	break;
+      case fifo::journal_entry::Op::remove:
+	if (entry.part_num >= new_tail) {
+	  new_tail = entry.part_num + 1;
+	}
+	break;
+      }
+      processed.push_back(entry);
+    }
+    ++iter;
+    process(std::move(p));
+  }
+
+  void postprocess(Ptr&& p) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " entering: tid=" << tid << dendl;
+    if (processed.empty()) {
+      ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			   << " nothing to update any more: race_retries="
+			   << race_retries << " tid=" << tid << dendl;
+      complete(std::move(p), 0);
+      return;
+    }
+    pp_run(std::move(p), 0, false);
+  }
+
+public:
+
+  JournalProcessor(FIFO* fifo, std::uint64_t tid, lr::AioCompletion* super)
+    : Completion(super), fifo(fifo), tid(tid) {
+    std::unique_lock l(fifo->m);
+    journal = fifo->info.journal;
+    iter = journal.begin();
+    new_tail = fifo->info.tail_part_num;
+    new_head = fifo->info.head_part_num;
+    new_max = fifo->info.max_push_part_num;
+  }
+
+  void pp_run(Ptr&& p, int r, bool canceled) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " entering: tid=" << tid << dendl;
+    std::optional<int64_t> tail_part_num;
+    std::optional<int64_t> head_part_num;
+    std::optional<int64_t> max_part_num;
+
+    if (r < 0) {
+      lderr(fifo->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		       << " failed, r=: " << r << " tid=" << tid << dendl;
+      complete(std::move(p), r);
+    }
+
+
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " postprocessing: race_retries="
+			 << race_retries << " tid=" << tid << dendl;
+
+    if (!first_pp && r == 0 && !canceled) {
+      ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			   << " nothing to update any more: race_retries="
+			   << race_retries << " tid=" << tid << dendl;
+      complete(std::move(p), 0);
+      return;
+    }
+
+    first_pp = false;
+
+    if (canceled) {
+      if (race_retries >= MAX_RACE_RETRIES) {
+	lderr(fifo->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " canceled too many times, giving up: tid="
+			 << tid << dendl;
+	complete(std::move(p), -ECANCELED);
+	return;
+      }
+      ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			   << " update canceled, retrying: race_retries="
+			   << race_retries << " tid=" << tid << dendl;
+
+      ++race_retries;
+
+      std::vector<fifo::journal_entry> new_processed;
+      std::unique_lock l(fifo->m);
+      for (auto& e : processed) {
+	auto jiter = fifo->info.journal.find(e.part_num);
+	/* journal entry was already processed */
+	if (jiter == fifo->info.journal.end() ||
+	    !(jiter->second == e)) {
+	  continue;
+	}
+	new_processed.push_back(e);
+      }
+      processed = std::move(new_processed);
+    }
+
+    std::unique_lock l(fifo->m);
+    auto objv = fifo->info.version;
+    if (new_tail > fifo->info.tail_part_num) {
+      tail_part_num = new_tail;
+    }
+
+    if (new_head > fifo->info.head_part_num) {
+      head_part_num = new_head;
+    }
+
+    if (new_max > fifo->info.max_push_part_num) {
+      max_part_num = new_max;
+    }
+    l.unlock();
+
+    if (processed.empty() &&
+	!tail_part_num &&
+	!max_part_num) {
+      /* nothing to update anymore */
+      ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			   << " nothing to update any more: race_retries="
+			   << race_retries << " tid=" << tid << dendl;
+      complete(std::move(p), 0);
+      return;
+    }
+    state = pp_callback;
+    fifo->_update_meta(fifo::update{}
+		       .tail_part_num(tail_part_num)
+		       .head_part_num(head_part_num)
+		       .max_push_part_num(max_part_num)
+		       .journal_entries_rm(processed),
+                       objv, &this->canceled, tid, call(std::move(p)));
+    return;
+  }
+
+  JournalProcessor(const JournalProcessor&) = delete;
+  JournalProcessor& operator =(const JournalProcessor&) = delete;
+  JournalProcessor(JournalProcessor&&) = delete;
+  JournalProcessor& operator =(JournalProcessor&&) = delete;
+
+  void process(Ptr&& p) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " entering: tid=" << tid << dendl;
+    while (iter != journal.end()) {
+      ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			   << " processing entry: entry=" << *iter
+			   << " tid=" << tid << dendl;
+      const auto entry = iter->second;
+      switch (entry.op) {
+      case fifo::journal_entry::Op::create:
+	create_part(std::move(p), entry.part_num, entry.part_tag);
+	return;
+      case fifo::journal_entry::Op::set_head:
+	if (entry.part_num > new_head) {
+	  new_head = entry.part_num;
+	}
+	processed.push_back(entry);
+	++iter;
+	continue;
+      case fifo::journal_entry::Op::remove:
+	remove_part(std::move(p), entry.part_num, entry.part_tag);
+	return;
+      default:
+	lderr(fifo->cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " unknown journaled op: entry=" << entry << " tid="
+			 << tid << dendl;
+	complete(std::move(p), -EIO);
+	return;
+      }
+    }
+    postprocess(std::move(p));
+    return;
+  }
+
+  void handle(Ptr&& p, int r) {
+    ldout(fifo->cct, 20) << __PRETTY_FUNCTION__ << ":" << __LINE__
+			 << " entering: tid=" << tid << dendl;
+    switch (state) {
+    case entry_callback:
+      finish_je(std::move(p), r, iter->second);
+      return;
+    case pp_callback:
+      auto c = canceled;
+      canceled = false;
+      pp_run(std::move(p), r, c);
+      return;
+    }
+
+    abort();
+  }
+
+};
+
+void FIFO::process_journal(std::uint64_t tid, lr::AioCompletion* c) {
+  auto p = std::make_unique<JournalProcessor>(this, tid, c);
+  p->process(std::move(p));
+}
+
+struct Lister : Completion<Lister> {
+  FIFO* f;
+  std::vector<list_entry> result;
+  bool more = false;
+  std::int64_t part_num;
+  std::uint64_t ofs;
+  int max_entries;
+  int r_out = 0;
+  std::vector<fifo::part_list_entry> entries;
+  bool part_more = false;
+  bool part_full = false;
+  std::vector<list_entry>* entries_out;
+  bool* more_out;
+  std::uint64_t tid;
+
+  bool read = false;
+
+  void complete(Ptr&& p, int r) {
+    if (r >= 0) {
+      if (more_out) *more_out = more;
+      if (entries_out) *entries_out = std::move(result);
+    }
+    Completion::complete(std::move(p), r);
+  }
+
+public:
+  Lister(FIFO* f, std::int64_t part_num, std::uint64_t ofs, int max_entries,
+	 std::vector<list_entry>* entries_out, bool* more_out,
+	 std::uint64_t tid, lr::AioCompletion* super)
+    : Completion(super), f(f), part_num(part_num), ofs(ofs), max_entries(max_entries),
+      entries_out(entries_out), more_out(more_out), tid(tid) {
+    result.reserve(max_entries);
+  }
+
+  Lister(const Lister&) = delete;
+  Lister& operator =(const Lister&) = delete;
+  Lister(Lister&&) = delete;
+  Lister& operator =(Lister&&) = delete;
+
+  void handle(Ptr&& p, int r) {
+    if (read)
+      handle_read(std::move(p), r);
+    else
+      handle_list(std::move(p), r);
+  }
+
+  void list(Ptr&& p) {
+    if (max_entries > 0) {
+      part_more = false;
+      part_full = false;
+      entries.clear();
+
+      std::unique_lock l(f->m);
+      auto part_oid = f->info.part_oid(part_num);
+      l.unlock();
+
+      read = false;
+      auto op = list_part(f->cct, {}, ofs, max_entries, &r_out,
+			  &entries, &part_more, &part_full,
+			  nullptr, tid);
+      f->ioctx.aio_operate(part_oid, call(std::move(p)), &op, nullptr);
+    } else {
+      complete(std::move(p), 0);
+    }
+  }
+
+  void handle_read(Ptr&& p, int r) {
+    read = false;
+    if (r >= 0) r = r_out;
+    r_out = 0;
+
+    if (r < 0) {
+      complete(std::move(p), r);
+      return;
+    }
+
+    if (part_num < f->info.tail_part_num) {
+      /* raced with trim? restart */
+      max_entries += result.size();
+      result.clear();
+      part_num = f->info.tail_part_num;
+      ofs = 0;
+      list(std::move(p));
+      return;
+    }
+    /* assuming part was not written yet, so end of data */
+    more = false;
+    complete(std::move(p), 0);
+    return;
+  }
+
+  void handle_list(Ptr&& p, int r) {
+    if (r >= 0) r = r_out;
+    r_out = 0;
+    std::unique_lock l(f->m);
+    auto part_oid = f->info.part_oid(part_num);
+    l.unlock();
+    if (r == -ENOENT) {
+      read = true;
+      f->read_meta(tid, call(std::move(p)));
+      return;
+    }
+    if (r < 0) {
+      complete(std::move(p), r);
+      return;
+    }
+
+    more = part_full || part_more;
+    for (auto& entry : entries) {
+      list_entry e;
+      e.data = std::move(entry.data);
+      e.marker = marker{part_num, entry.ofs}.to_string();
+      e.mtime = entry.mtime;
+      result.push_back(std::move(e));
+    }
+    max_entries -= entries.size();
+    entries.clear();
+    if (max_entries > 0 && part_more) {
+      list(std::move(p));
+      return;
+    }
+
+    if (!part_full) { /* head part is not full */
+      complete(std::move(p), 0);
+      return;
+    }
+    ++part_num;
+    ofs = 0;
+    list(std::move(p));
+  }
+};
+
+void FIFO::list(int max_entries,
+		std::optional<std::string_view> markstr,
+		std::vector<list_entry>* out,
+		bool* more,
+		lr::AioCompletion* c) {
+  std::unique_lock l(m);
+  auto tid = ++next_tid;
+  std::int64_t part_num = info.tail_part_num;
+  l.unlock();
+  std::uint64_t ofs = 0;
+  std::optional<::rgw::cls::fifo::marker> marker;
+
+  if (markstr) {
+    marker = to_marker(*markstr);
+    if (marker) {
+      part_num = marker->num;
+      ofs = marker->ofs;
+    }
+  }
+
+  auto ls = std::make_unique<Lister>(this, part_num, ofs, max_entries, out,
+				     more, tid, c);
+  if (markstr && !marker) {
+    auto l = ls.get();
+    l->complete(std::move(ls), -EINVAL);
+  } else {
+    ls->list(std::move(ls));
+  }
 }
 }

--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -11,6 +11,7 @@
 #include "common/async/librados_completion.h"
 
 #include "cls/fifo/cls_fifo_types.h"
+#include "cls/log/cls_log_client.h"
 
 #include "cls_fifo_legacy.h"
 #include "rgw_datalog.h"
@@ -21,6 +22,7 @@
 static constexpr auto dout_subsys = ceph_subsys_rgw;
 
 namespace bs = boost::system;
+namespace lr = librados;
 
 void rgw_data_change::dump(ceph::Formatter *f) const
 {
@@ -70,12 +72,10 @@ void rgw_data_change_log_entry::decode_json(JSONObj *obj) {
 
 class RGWDataChangesOmap final : public RGWDataChangesBE {
   using centries = std::list<cls_log_entry>;
-  RGWSI_Cls& cls;
   std::vector<std::string> oids;
 public:
-  RGWDataChangesOmap(CephContext* cct, RGWSI_Cls& cls)
-    : RGWDataChangesBE(cct), cls(cls) {
-    auto num_shards = cct->_conf->rgw_data_log_num_shards;
+  RGWDataChangesOmap(lr::IoCtx& ioctx, int num_shards)
+    : RGWDataChangesBE(ioctx) {
     oids.reserve(num_shards);
     for (auto i = 0; i < num_shards; ++i) {
       oids.push_back(get_oid(i));
@@ -90,12 +90,13 @@ public:
     }
 
     cls_log_entry e;
-    cls.timelog.prepare_entry(e, ut, {}, key, entry);
+    cls_log_add_prepare_entry(e, utime_t(ut), {}, key, entry);
     std::get<centries>(out).push_back(std::move(e));
   }
   int push(int index, entries&& items) override {
-    auto r = cls.timelog.add(oids[index], std::get<centries>(items),
-			     nullptr, true, null_yield);
+    lr::ObjectWriteOperation op;
+    cls_log_add(op, std::get<centries>(items), true);
+    auto r = rgw_rados_operate(ioctx, oids[index], &op, null_yield);
     if (r < 0) {
       lderr(cct) << __PRETTY_FUNCTION__
 		 << ": failed to push to " << oids[index] << cpp_strerror(-r)
@@ -106,7 +107,9 @@ public:
   int push(int index, ceph::real_time now,
 	   const std::string& key,
 	   ceph::buffer::list&& bl) override {
-    auto r = cls.timelog.add(oids[index], now, {}, key, bl, null_yield);
+    lr::ObjectWriteOperation op;
+    cls_log_add(op, utime_t(now), {}, key, bl);
+    auto r = rgw_rados_operate(ioctx, oids[index], &op, null_yield);
     if (r < 0) {
       lderr(cct) << __PRETTY_FUNCTION__
 		 << ": failed to push to " << oids[index]
@@ -119,10 +122,10 @@ public:
 	   std::optional<std::string_view> marker,
 	   std::string* out_marker, bool* truncated) override {
     std::list<cls_log_entry> log_entries;
-    auto r = cls.timelog.list(oids[index], {}, {},
-			      max_entries, log_entries,
-			      std::string(marker.value_or("")),
-			      out_marker, truncated, null_yield);
+    lr::ObjectReadOperation op;
+    cls_log_list(op, {}, {}, std::string(marker.value_or("")),
+		 max_entries, log_entries, out_marker, truncated);
+    auto r = rgw_rados_operate(ioctx, oids[index], &op, nullptr, null_yield);
     if (r < 0) {
       lderr(cct) << __PRETTY_FUNCTION__
 		 << ": failed to list " << oids[index]
@@ -149,7 +152,9 @@ public:
   }
   int get_info(int index, RGWDataChangesLogInfo *info) override {
     cls_log_header header;
-    auto r = cls.timelog.info(oids[index], &header, null_yield);
+    lr::ObjectReadOperation op;
+    cls_log_info(op, &header);
+    auto r = rgw_rados_operate(ioctx, oids[index], &op, nullptr, null_yield);
     if (r == -ENOENT) r = 0;
     if (r < 0) {
       lderr(cct) << __PRETTY_FUNCTION__
@@ -162,10 +167,9 @@ public:
     return r;
   }
   int trim(int index, std::string_view marker) override {
-    auto r = cls.timelog.trim(oids[index], {}, {},
-			      {}, std::string(marker), nullptr,
-			      null_yield);
-
+    lr::ObjectWriteOperation op;
+    cls_log_trim(op, {}, {}, {}, std::string(marker));
+    auto r = rgw_rados_operate(ioctx, oids[index], &op, null_yield);
     if (r == -ENOENT) r = 0;
     if (r < 0) {
       lderr(cct) << __PRETTY_FUNCTION__
@@ -175,10 +179,10 @@ public:
     return r;
   }
   int trim(int index, std::string_view marker,
-	   librados::AioCompletion* c) override {
-    auto r = cls.timelog.trim(oids[index], {}, {},
-			    {}, std::string(marker), c, null_yield);
-
+	   lr::AioCompletion* c) override {
+    lr::ObjectWriteOperation op;
+    cls_log_trim(op, {}, {}, {}, std::string(marker));
+    auto r = ioctx.aio_operate(oids[index], c, &op, 0);
     if (r == -ENOENT) r = 0;
     if (r < 0) {
       lderr(cct) << __PRETTY_FUNCTION__
@@ -196,20 +200,12 @@ class RGWDataChangesFIFO final : public RGWDataChangesBE {
   using centries = std::vector<ceph::buffer::list>;
   std::vector<std::unique_ptr<rgw::cls::fifo::FIFO>> fifos;
 public:
-  RGWDataChangesFIFO(CephContext* cct, librados::Rados* rados,
-		     const rgw_pool& log_pool)
-    : RGWDataChangesBE(cct) {
-    librados::IoCtx ioctx;
-    auto shards = cct->_conf->rgw_data_log_num_shards;
-    auto r = rgw_init_ioctx(rados, log_pool.name, ioctx,
-			    true, false);
-    if (r < 0) {
-      throw bs::system_error(ceph::to_error_code(r));
-    }
+  RGWDataChangesFIFO(lr::IoCtx& ioctx, int shards)
+    : RGWDataChangesBE(ioctx) {
     fifos.resize(shards);
     for (auto i = 0; i < shards; ++i) {
-      r = rgw::cls::fifo::FIFO::create(ioctx, get_oid(i),
-				       &fifos[i], null_yield);
+      auto  r = rgw::cls::fifo::FIFO::create(ioctx, get_oid(i),
+					     &fifos[i], null_yield);
       if (r < 0) {
 	throw bs::system_error(ceph::to_error_code(r));
       }
@@ -371,7 +367,7 @@ RGWDataChangesLog::RGWDataChangesLog(CephContext* cct)
 
 int RGWDataChangesLog::start(const RGWZone* _zone,
 			     const RGWZoneParams& zoneparams,
-			     RGWSI_Cls *cls, librados::Rados* lr)
+			     librados::Rados* lr)
 {
   zone = _zone;
   ceph_assert(zone);
@@ -403,10 +399,10 @@ int RGWDataChangesLog::start(const RGWZone* _zone,
   try {
     switch (found) {
     case log_type::omap:
-      be = std::make_unique<RGWDataChangesOmap>(cct, *cls);
+      be = std::make_unique<RGWDataChangesOmap>(ioctx, num_shards);
       break;
     case log_type::fifo:
-      be = std::make_unique<RGWDataChangesFIFO>(cct, lr, log_pool);
+      be = std::make_unique<RGWDataChangesFIFO>(ioctx, num_shards);
       break;
     case log_type::neither:
       lderr(cct) << __PRETTY_FUNCTION__

--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -354,12 +354,7 @@ public:
       pc->cond.notify_all();
       pc->put_unlock();
     } else {
-      r = fifos[index]->trim(marker, false, c);
-      if (r < 0) {
-	lderr(cct) << __PRETTY_FUNCTION__
-		   << ": unable to trim FIFO: " << get_oid(index)
-		   << ": " << cpp_strerror(-r) << dendl;
-      }
+      fifos[index]->trim(marker, false, c);
     }
     return r;
   }

--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -73,9 +73,14 @@ void rgw_data_change_log_entry::decode_json(JSONObj *obj) {
 class RGWDataChangesOmap final : public RGWDataChangesBE {
   using centries = std::list<cls_log_entry>;
   std::vector<std::string> oids;
+  std::string get_oid(int i) const {
+    return datalog.get_oid(i);
+  }
 public:
-  RGWDataChangesOmap(lr::IoCtx& ioctx, int num_shards)
-    : RGWDataChangesBE(ioctx) {
+  RGWDataChangesOmap(lr::IoCtx& ioctx,
+		     RGWDataChangesLog& datalog,
+		     int num_shards)
+    : RGWDataChangesBE(ioctx, datalog) {
     oids.reserve(num_shards);
     for (auto i = 0; i < num_shards; ++i) {
       oids.push_back(get_oid(i));
@@ -199,9 +204,14 @@ public:
 class RGWDataChangesFIFO final : public RGWDataChangesBE {
   using centries = std::vector<ceph::buffer::list>;
   std::vector<std::unique_ptr<rgw::cls::fifo::FIFO>> fifos;
+  std::string get_oid(int i) const {
+    return datalog.get_oid(i);
+  }
 public:
-  RGWDataChangesFIFO(lr::IoCtx& ioctx, int shards)
-    : RGWDataChangesBE(ioctx) {
+  RGWDataChangesFIFO(lr::IoCtx& ioctx,
+		     RGWDataChangesLog& datalog,
+		     int shards)
+    : RGWDataChangesBE(ioctx, datalog) {
     fifos.resize(shards);
     for (auto i = 0; i < shards; ++i) {
       auto  r = rgw::cls::fifo::FIFO::create(ioctx, get_oid(i),
@@ -363,6 +373,7 @@ public:
 RGWDataChangesLog::RGWDataChangesLog(CephContext* cct)
   : cct(cct),
     num_shards(cct->_conf->rgw_data_log_num_shards),
+    prefix(get_prefix()),
     changes(cct->_conf->rgw_data_log_changes_size) {}
 
 int RGWDataChangesLog::start(const RGWZone* _zone,
@@ -391,18 +402,16 @@ int RGWDataChangesLog::start(const RGWZone* _zone,
     return -r;
   }
   auto found = log_acquire_backing(ioctx, num_shards, *backing, log_type::fifo,
-				   [this](int i) {
-				     return RGWDataChangesBE::get_oid(cct, i);
-				   },
+				   [this](int i) { return get_oid(i); },
 				   null_yield);
 
   try {
     switch (found) {
     case log_type::omap:
-      be = std::make_unique<RGWDataChangesOmap>(ioctx, num_shards);
+      be = std::make_unique<RGWDataChangesOmap>(ioctx, *this, num_shards);
       break;
     case log_type::fifo:
-      be = std::make_unique<RGWDataChangesFIFO>(ioctx, num_shards);
+      be = std::make_unique<RGWDataChangesFIFO>(ioctx, *this, num_shards);
       break;
     case log_type::neither:
       lderr(cct) << __PRETTY_FUNCTION__
@@ -529,7 +538,7 @@ bool RGWDataChangesLog::filter_bucket(const rgw_bucket& bucket,
 }
 
 std::string RGWDataChangesLog::get_oid(int i) const {
-  return be->get_oid(i);
+  return fmt::format("{}.{}", prefix, i);
 }
 
 int RGWDataChangesLog::add_entry(const RGWBucketInfo& bucket_info, int shard_id) {

--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -323,27 +323,7 @@ public:
 	   librados::AioCompletion* c) override {
     int r = 0;
     if (marker == rgw::cls::fifo::marker(0, 0).to_string()) {
-      auto pc = c->pc;
-      pc->get();
-      pc->lock.lock();
-      pc->rval = 0;
-      pc->complete = true;
-      pc->lock.unlock();
-      auto cb_complete = pc->callback_complete;
-      auto cb_complete_arg = pc->callback_complete_arg;
-      if (cb_complete)
-	cb_complete(pc, cb_complete_arg);
-
-      auto cb_safe = pc->callback_safe;
-      auto cb_safe_arg = pc->callback_safe_arg;
-      if (cb_safe)
-	cb_safe(pc, cb_safe_arg);
-
-      pc->lock.lock();
-      pc->callback_complete = NULL;
-      pc->callback_safe = NULL;
-      pc->cond.notify_all();
-      pc->put_unlock();
+      rgw_complete_aio_completion(c, 0);
     } else {
       fifos[index].trim(marker, false, c, null_yield);
     }

--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -14,6 +14,7 @@
 
 #include "cls_fifo_legacy.h"
 #include "rgw_datalog.h"
+#include "rgw_log_backing.h"
 #include "rgw_tools.h"
 
 #define dout_context g_ceph_context
@@ -67,38 +68,6 @@ void rgw_data_change_log_entry::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("entry", entry, obj);
 }
 
-int RGWDataChangesBE::remove(CephContext* cct, librados::Rados* rados,
-			     const rgw_pool& log_pool)
-{
-  auto num_shards = cct->_conf->rgw_data_log_num_shards;
-  librados::IoCtx ioctx;
-  auto r = rgw_init_ioctx(rados, log_pool.name, ioctx,
-			  false, false);
-  if (r < 0) {
-    if (r == -ENOENT) {
-      return 0;
-    } else {
-      lderr(cct) << __PRETTY_FUNCTION__
-		 << ": rgw_init_ioctx failed: " << log_pool.name
-		 << ": " << cpp_strerror(-r) << dendl;
-      return r;
-    }
-  }
-  for (auto i = 0; i < num_shards; ++i) {
-    auto oid = get_oid(cct, i);
-    librados::ObjectWriteOperation op;
-    op.remove();
-    auto r = rgw_rados_operate(ioctx, oid, &op, null_yield);
-    if (r < 0 && r != -ENOENT) {
-      lderr(cct) << __PRETTY_FUNCTION__
-		 << ": remove failed: " << log_pool.name << "/" << oid
-		 << ": " << cpp_strerror(-r) << dendl;
-    }
-  }
-  return 0;
-}
-
-
 class RGWDataChangesOmap final : public RGWDataChangesBE {
   using centries = std::list<cls_log_entry>;
   RGWSI_Cls& cls;
@@ -113,44 +82,6 @@ public:
     }
   }
   ~RGWDataChangesOmap() override = default;
-  static int exists(CephContext* cct, RGWSI_Cls& cls, bool* exists,
-		    bool* has_entries) {
-    auto num_shards = cct->_conf->rgw_data_log_num_shards;
-    std::string out_marker;
-    bool truncated = false;
-    std::list<cls_log_entry> log_entries;
-    const cls_log_header empty_info;
-    *exists = false;
-    *has_entries = false;
-    for (auto i = 0; i < num_shards; ++i) {
-      cls_log_header info;
-      auto oid = get_oid(cct, i);
-      auto r = cls.timelog.info(oid, &info, null_yield);
-      if (r < 0 && r != -ENOENT) {
-	lderr(cct) << __PRETTY_FUNCTION__
-		   << ": failed to get info " << oid << ": " << cpp_strerror(-r)
-		   << dendl;
-	return r;
-      } else if ((r == -ENOENT) || (info == empty_info)) {
-	continue;
-      }
-      *exists = true;
-      r = cls.timelog.list(oid, {}, {}, 100, log_entries, "", &out_marker,
-			   &truncated, null_yield);
-      if (r < 0) {
-	lderr(cct) << __PRETTY_FUNCTION__
-		   << ": failed to list " << oid << ": " << cpp_strerror(-r)
-		   << dendl;
-	return r;
-      } else if (!log_entries.empty()) {
-	*has_entries = true;
-	break; // No reason to continue, once we have both existence
-	       // AND non-emptiness
-      }
-    }
-    return 0;
-  }
-
   void prepare(ceph::real_time ut, const std::string& key,
 	       ceph::buffer::list&& entry, entries& out) override {
     if (!std::holds_alternative<centries>(out)) {
@@ -290,54 +221,6 @@ public:
 			     }));
   }
   ~RGWDataChangesFIFO() override = default;
-  static int exists(CephContext* cct, librados::Rados* rados,
-		    const rgw_pool& log_pool, bool* exists, bool* has_entries) {
-    auto num_shards = cct->_conf->rgw_data_log_num_shards;
-    librados::IoCtx ioctx;
-    auto r = rgw_init_ioctx(rados, log_pool.name, ioctx,
-			    false, false);
-    if (r < 0) {
-      if (r == -ENOENT) {
-	return 0;
-      } else {
-	lderr(cct) << __PRETTY_FUNCTION__
-		   << ": rgw_init_ioctx failed: " << log_pool.name
-		   << ": " << cpp_strerror(-r) << dendl;
-	return r;
-      }
-    }
-    *exists = false;
-    *has_entries = false;
-    for (auto i = 0; i < num_shards; ++i) {
-      std::unique_ptr<rgw::cls::fifo::FIFO> fifo;
-      auto oid = get_oid(cct, i);
-      std::vector<rgw::cls::fifo::list_entry> log_entries;
-      bool more = false;
-      auto r = rgw::cls::fifo::FIFO::open(ioctx, oid,
-					  &fifo, null_yield,
-					  std::nullopt, true);
-      if (r == -ENOENT || r == -ENODATA) {
-	continue;
-      } else if (r < 0) {
-	lderr(cct) << __PRETTY_FUNCTION__
-		   << ": unable to open FIFO: " << log_pool << "/" << oid
-		   << ": " << cpp_strerror(-r) << dendl;
-	return r;
-      }
-      *exists = true;
-      r = fifo->list(1, nullopt, &log_entries, &more,
-		     null_yield);
-      if (r < 0) {
-	lderr(cct) << __PRETTY_FUNCTION__
-		   << ": unable to list entries: " << log_pool << "/" << oid
-		   << ": " << cpp_strerror(-r) << dendl;
-      } else if (!log_entries.empty()) {
-	*has_entries = true;
-	break;
-      }
-    }
-    return 0;
-  }
   void prepare(ceph::real_time, const std::string&,
 	       ceph::buffer::list&& entry, entries& out) override {
     if (!std::holds_alternative<centries>(out)) {
@@ -491,83 +374,45 @@ int RGWDataChangesLog::start(const RGWZone* _zone,
 			     RGWSI_Cls *cls, librados::Rados* lr)
 {
   zone = _zone;
-  assert(zone);
-  auto backing = cct->_conf.get_val<std::string>("rgw_data_log_backing");
+  ceph_assert(zone);
+  auto backing = to_log_type(
+    cct->_conf.get_val<std::string>("rgw_data_log_backing"));
   // Should be guaranteed by `set_enum_allowed`
-  ceph_assert(backing == "auto" || backing == "fifo" || backing == "omap");
+  if (!backing) {
+    lderr(cct) << __PRETTY_FUNCTION__
+	       << ": Invalid backing store provided: "
+	       << cct->_conf.get_val<std::string>("rgw_data_log_backing")
+	       << dendl;
+    return -EINVAL;
+  }
   auto log_pool = zoneparams.log_pool;
-  bool omapexists = false, omaphasentries = false;
-  auto r = RGWDataChangesOmap::exists(cct, *cls, &omapexists, &omaphasentries);
+  auto r = rgw_init_ioctx(lr, log_pool, ioctx, true,
+			  *backing == log_type::omap);
   if (r < 0) {
     lderr(cct) << __PRETTY_FUNCTION__
-	       << ": Error when checking for existing Omap datalog backend: "
-	       << cpp_strerror(-r) << dendl;
+	       << ": Failed to initialized ioctx, r=" << r
+	       << ", pool=" << log_pool << dendl;
+    return -r;
   }
-  bool fifoexists = false, fifohasentries = false;
-  r = RGWDataChangesFIFO::exists(cct, lr, log_pool, &fifoexists, &fifohasentries);
-  if (r < 0) {
-    lderr(cct) << __PRETTY_FUNCTION__
-	       << ": Error when checking for existing FIFO datalog backend: "
-	       << cpp_strerror(-r) << dendl;
-  }
-  bool has_entries = omaphasentries || fifohasentries;
-  bool remove = false;
-
-  if (omapexists && fifoexists) {
-    if (has_entries) {
-      lderr(cct) << __PRETTY_FUNCTION__
-		 << ": Both Omap and FIFO backends exist, cannot continue."
-		 << dendl;
-      return -EINVAL;
-    }
-    ldout(cct, 0)
-      << __PRETTY_FUNCTION__
-      << ": Both Omap and FIFO backends exist, but are empty. Will remove."
-      << dendl;
-    remove = true;
-  }
-  if (backing == "omap" && fifoexists) {
-    if (has_entries) {
-      lderr(cct) << __PRETTY_FUNCTION__
-		 << ": Omap requested, but FIFO backend exists, cannot continue."
-		 << dendl;
-      return -EINVAL;
-    }
-    ldout(cct, 0) << __PRETTY_FUNCTION__
-		  << ": Omap requested, FIFO exists, but is empty. Deleting."
-		  << dendl;
-    remove = true;
-  }
-  if (backing == "fifo" && omapexists) {
-    if (has_entries) {
-      lderr(cct) << __PRETTY_FUNCTION__
-		 << ": FIFO requested, but Omap backend exists, cannot continue."
-		 << dendl;
-      return -EINVAL;
-    }
-    ldout(cct, 0) << __PRETTY_FUNCTION__
-		  << ": FIFO requested, Omap exists, but is empty. Deleting."
-		  << dendl;
-    remove = true;
-  }
-
-  if (remove) {
-    r = RGWDataChangesBE::remove(cct, lr, log_pool);
-    if (r < 0) {
-      lderr(cct) << __PRETTY_FUNCTION__
-		 << ": remove failed, cannot continue."
-		 << dendl;
-      return r;
-    }
-    omapexists = false;
-    fifoexists = false;
-  }
+  auto found = log_acquire_backing(ioctx, num_shards, *backing, log_type::fifo,
+				   [this](int i) {
+				     return RGWDataChangesBE::get_oid(cct, i);
+				   },
+				   null_yield);
 
   try {
-    if (backing == "omap" || (backing == "auto" && omapexists)) {
+    switch (found) {
+    case log_type::omap:
       be = std::make_unique<RGWDataChangesOmap>(cct, *cls);
-    } else if (backing != "omap") {
+      break;
+    case log_type::fifo:
       be = std::make_unique<RGWDataChangesFIFO>(cct, lr, log_pool);
+      break;
+    case log_type::neither:
+      lderr(cct) << __PRETTY_FUNCTION__
+		 << ": Unable to determine backing store."
+		 << dendl;
+      return -EIO;
     }
   } catch (bs::system_error& e) {
     lderr(cct) << __PRETTY_FUNCTION__

--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "common/debug.h"
+#include "common/dynarray.h"
 #include "common/errno.h"
 #include "common/error_code.h"
 
@@ -203,7 +204,7 @@ public:
 
 class RGWDataChangesFIFO final : public RGWDataChangesBE {
   using centries = std::vector<ceph::buffer::list>;
-  std::vector<std::unique_ptr<rgw::cls::fifo::FIFO>> fifos;
+  dynarray<LazyFIFO> fifos;
   std::string get_oid(int i) const {
     return datalog.get_oid(i);
   }
@@ -211,21 +212,10 @@ public:
   RGWDataChangesFIFO(lr::IoCtx& ioctx,
 		     RGWDataChangesLog& datalog,
 		     int shards)
-    : RGWDataChangesBE(ioctx, datalog) {
-    fifos.resize(shards);
-    for (auto i = 0; i < shards; ++i) {
-      auto  r = rgw::cls::fifo::FIFO::create(ioctx, get_oid(i),
-					     &fifos[i], null_yield);
-      if (r < 0) {
-	throw bs::system_error(ceph::to_error_code(r));
-      }
-    }
-    ceph_assert(fifos.size() == unsigned(shards));
-    ceph_assert(std::none_of(fifos.cbegin(), fifos.cend(),
-			     [](const auto& p) {
-			       return p == nullptr;
-			     }));
-  }
+    : RGWDataChangesBE(ioctx, datalog),
+      fifos(shards, [&ioctx, this](std::size_t i) {
+	return std::pair<lr::IoCtx&, std::string>(ioctx, get_oid(i));
+      }) {}
   ~RGWDataChangesFIFO() override = default;
   void prepare(ceph::real_time, const std::string&,
 	       ceph::buffer::list&& entry, entries& out) override {
@@ -236,7 +226,7 @@ public:
     std::get<centries>(out).push_back(std::move(entry));
   }
   int push(int index, entries&& items) override {
-    auto r = fifos[index]->push(std::get<centries>(items), null_yield);
+    auto r = fifos[index].push(std::get<centries>(items), null_yield);
     if (r < 0) {
       lderr(cct) << __PRETTY_FUNCTION__
 		 << ": unable to push to FIFO: " << get_oid(index)
@@ -247,7 +237,7 @@ public:
   int push(int index, ceph::real_time,
 	   const std::string&,
 	   ceph::buffer::list&& bl) override {
-    auto r = fifos[index]->push(std::move(bl), null_yield);
+    auto r = fifos[index].push(std::move(bl), null_yield);
     if (r < 0) {
       lderr(cct) << __PRETTY_FUNCTION__
 		 << ": unable to push to FIFO: " << get_oid(index)
@@ -261,8 +251,8 @@ public:
 	   std::string* out_marker, bool* truncated) override {
     std::vector<rgw::cls::fifo::list_entry> log_entries;
     bool more = false;
-    auto r = fifos[index]->list(max_entries, marker, &log_entries, &more,
-				null_yield);
+    auto r = fifos[index].list(max_entries, marker, &log_entries, &more,
+			       null_yield);
     if (r < 0) {
       lderr(cct) << __PRETTY_FUNCTION__
 		 << ": unable to list FIFO: " << get_oid(index)
@@ -293,14 +283,15 @@ public:
   }
   int get_info(int index, RGWDataChangesLogInfo *info) override {
     auto& fifo = fifos[index];
-    auto r = fifo->read_meta(null_yield);
+    auto r = fifo.read_meta(null_yield);
     if (r < 0) {
       lderr(cct) << __PRETTY_FUNCTION__
 		 << ": unable to get FIFO metadata: " << get_oid(index)
 		 << ": " << cpp_strerror(-r) << dendl;
       return r;
     }
-    auto m = fifo->meta();
+    rados::cls::fifo::info m;
+    fifo.meta(m, null_yield);
     auto p = m.head_part_num;
     if (p < 0) {
       info->marker = rgw::cls::fifo::marker{}.to_string();
@@ -308,7 +299,7 @@ public:
       return 0;
     }
     rgw::cls::fifo::part_info h;
-    r = fifo->get_part_info(p, &h, null_yield);
+    r = fifo.get_part_info(p, &h, null_yield);
     if (r < 0) {
       lderr(cct) << __PRETTY_FUNCTION__
 		 << ": unable to get part info: " << get_oid(index) << "/" << p
@@ -320,7 +311,7 @@ public:
     return 0;
   }
   int trim(int index, std::string_view marker) override {
-    auto r = fifos[index]->trim(marker, false, null_yield);
+    auto r = fifos[index].trim(marker, false, null_yield);
     if (r < 0) {
       lderr(cct) << __PRETTY_FUNCTION__
 		 << ": unable to trim FIFO: " << get_oid(index)
@@ -354,7 +345,7 @@ public:
       pc->cond.notify_all();
       pc->put_unlock();
     } else {
-      fifos[index]->trim(marker, false, c);
+      fifos[index].trim(marker, false, c, null_yield);
     }
     return r;
   }

--- a/src/rgw/rgw_datalog.h
+++ b/src/rgw/rgw_datalog.h
@@ -20,6 +20,7 @@
 
 #include "include/buffer.h"
 #include "include/encoding.h"
+#include "include/function2.hpp"
 
 #include "include/rados/librados.hpp"
 
@@ -114,34 +115,24 @@ struct RGWDataChangesLogMarker {
   RGWDataChangesLogMarker() = default;
 };
 
+class RGWDataChangesLog;
+
 class RGWDataChangesBE {
 protected:
   librados::IoCtx& ioctx;
   CephContext* const cct;
+  RGWDataChangesLog& datalog;
 private:
-  std::string prefix;
-  static std::string_view get_prefix(CephContext* cct) {
-    std::string_view prefix = cct->_conf->rgw_data_log_obj_prefix;
-    if (prefix.empty()) {
-      prefix = "data_log"sv;
-    }
-    return prefix;
-  }
 public:
   using entries = std::variant<std::list<cls_log_entry>,
 			       std::vector<ceph::buffer::list>>;
 
-  RGWDataChangesBE(librados::IoCtx& ioctx)
+  RGWDataChangesBE(librados::IoCtx& ioctx,
+		   RGWDataChangesLog& datalog)
     : ioctx(ioctx), cct(static_cast<CephContext*>(ioctx.cct())),
-      prefix(get_prefix(cct)) {}
+      datalog(datalog) {}
   virtual ~RGWDataChangesBE() = default;
 
-  static std::string get_oid(CephContext* cct, int i) {
-    return fmt::format("{}.{}", get_prefix(cct), i);
-  }
-  std::string get_oid(int i) {
-    return fmt::format("{}.{}", prefix, i);
-  }
   virtual void prepare(ceph::real_time now,
 		       const std::string& key,
 		       ceph::buffer::list&& entry,
@@ -169,6 +160,11 @@ class RGWDataChangesLog {
   std::unique_ptr<RGWDataChangesBE> be;
 
   const int num_shards;
+  std::string get_prefix() {
+    auto prefix = cct->_conf->rgw_data_log_obj_prefix;
+    return prefix.empty() ? prefix : "data_log"s;
+  }
+  std::string prefix;
 
   ceph::mutex lock = ceph::make_mutex("RGWDataChangesLog::lock");
   ceph::shared_mutex modified_lock =

--- a/src/rgw/rgw_datalog.h
+++ b/src/rgw/rgw_datalog.h
@@ -142,10 +142,6 @@ public:
   std::string get_oid(int i) {
     return fmt::format("{}.{}", prefix, i);
   }
-  static int remove(CephContext* cct, librados::Rados* rados,
-		    const rgw_pool& log_pool);
-
-
   virtual void prepare(ceph::real_time now,
 		       const std::string& key,
 		       ceph::buffer::list&& entry,
@@ -167,6 +163,7 @@ public:
 
 class RGWDataChangesLog {
   CephContext *cct;
+  librados::IoCtx ioctx;
   rgw::BucketChangeObserver *observer = nullptr;
   const RGWZone* zone;
   std::unique_ptr<RGWDataChangesBE> be;

--- a/src/rgw/rgw_datalog.h
+++ b/src/rgw/rgw_datalog.h
@@ -37,8 +37,6 @@
 #include "rgw_zone.h"
 #include "rgw_trim_bilog.h"
 
-#include "services/svc_cls.h"
-
 namespace bc = boost::container;
 
 enum DataLogEntityType {
@@ -118,6 +116,7 @@ struct RGWDataChangesLogMarker {
 
 class RGWDataChangesBE {
 protected:
+  librados::IoCtx& ioctx;
   CephContext* const cct;
 private:
   std::string prefix;
@@ -132,8 +131,9 @@ public:
   using entries = std::variant<std::list<cls_log_entry>,
 			       std::vector<ceph::buffer::list>>;
 
-  RGWDataChangesBE(CephContext* const cct)
-    : cct(cct), prefix(get_prefix(cct)) {}
+  RGWDataChangesBE(librados::IoCtx& ioctx)
+    : ioctx(ioctx), cct(static_cast<CephContext*>(ioctx.cct())),
+      prefix(get_prefix(cct)) {}
   virtual ~RGWDataChangesBE() = default;
 
   static std::string get_oid(CephContext* cct, int i) {
@@ -214,7 +214,7 @@ public:
   ~RGWDataChangesLog();
 
   int start(const RGWZone* _zone, const RGWZoneParams& zoneparams,
-	    RGWSI_Cls *cls_svc, librados::Rados* lr);
+	    librados::Rados* lr);
 
   int add_entry(const RGWBucketInfo& bucket_info, int shard_id);
   int get_log_shard_id(rgw_bucket& bucket, int shard_id);

--- a/src/rgw/rgw_log_backing.cc
+++ b/src/rgw/rgw_log_backing.cc
@@ -1,0 +1,414 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#include "cls/log/cls_log_client.h"
+
+#include "rgw_log_backing.h"
+#include "rgw_tools.h"
+#include "cls_fifo_legacy.h"
+
+static constexpr auto dout_subsys = ceph_subsys_rgw;
+
+struct logmark {
+  log_type found;
+  log_type specified;
+
+  void encode(ceph::buffer::list& bl) const {
+    using ceph::encode;
+    encode(uint32_t(found), bl);
+    encode(uint32_t(specified), bl);
+  }
+  void decode(ceph::buffer::list::const_iterator& bl) {
+    using ceph::decode;
+    uint32_t f, s;
+    decode(f, bl);
+    decode(s, bl);
+    found = static_cast<log_type>(f);
+    specified = static_cast<log_type>(s);
+  }
+
+  bool validate() {
+    if (!(found == log_type::omap || found == log_type::fifo)) {
+      return false;
+    }
+    if (found == log_type::omap && !(specified == log_type::omap ||
+				     specified == log_type::neither)) {
+      return false;
+    }
+    if (found == log_type::fifo && !(specified == log_type::fifo ||
+				     specified == log_type::neither)) {
+      return false;
+    }
+    return true;
+  }
+};
+WRITE_CLASS_ENCODER(logmark)
+static inline std::ostream& operator <<(std::ostream& m, const logmark& l) {
+  return m << "{ found: " << l.found << ", specified: " << l.specified << " }";
+}
+
+inline const auto logmark_omap_key = "logmap_validator"s;
+
+log_type log_quick_check(librados::IoCtx& ioctx,
+			 log_type specified,
+			 const fu2::unique_function<
+			   std::string(int) const>& get_oid,
+			 optional_yield y)
+{
+  auto cct = static_cast<CephContext*>(ioctx.cct());
+  librados::ObjectReadOperation op;
+  std::map<std::string, ceph::bufferlist> values;
+  int r_out = 0;
+  op.omap_get_vals_by_keys({ logmark_omap_key }, &values, &r_out);
+
+  auto oid = get_oid(0);
+  auto r = rgw_rados_operate(ioctx, oid,
+			     &op, nullptr, y);
+  if (r < 0 || r_out < 0 || values.empty()) {
+    if (r != -ENOENT) {
+      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " failed to read omap r=" << r
+		 << " on oid=" << oid << dendl;
+    }
+    return log_type::neither;
+  }
+
+  if (auto gotkey = values.begin()->first; gotkey != logmark_omap_key) {
+    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+	       << " can't happen: asked for key " << logmark_omap_key
+	       << " got key " << gotkey << dendl;
+    return log_type::neither;
+  }
+
+  logmark m;
+  try {
+    decode(m, values.begin()->second);
+  } catch (const buffer::error& e) {
+    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+	       << " error decoding logmark: " << e.what() << dendl;
+    return log_type::neither;
+  }
+  if (!m.validate()) {
+    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+	       << " invalid logmark: " << m << dendl;
+    return log_type::neither;
+  }
+
+  if ((m.found == log_type::omap && specified == log_type::fifo) ||
+      (m.found == log_type::fifo && specified == log_type::omap)) {
+    ldout(cct, 5) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		  << " discordant logmark: found=" << m.found
+		  << ", specified=" << specified << dendl;
+    return log_type::neither;
+  }
+
+  return m.found;
+}
+
+enum class shard_check { dne, omap, fifo, corrupt };
+inline std::ostream& operator <<(std::ostream& m, const shard_check& t) {
+  switch (t) {
+  case shard_check::dne:
+    return m << "shard_check::dne";
+  case shard_check::omap:
+    return m << "shard_check::omap";
+  case shard_check::fifo:
+    return m << "shard_check::fifo";
+  case shard_check::corrupt:
+    return m << "shard_check::corrupt";
+  }
+
+  return m << "shard_check::UNKNOWN=" << static_cast<uint32_t>(t);
+}
+
+namespace {
+/// Return the shard type, and a bool to see whether it has entries.
+std::pair<shard_check, bool>
+probe_shard(librados::IoCtx& ioctx, const std::string& oid, optional_yield y)
+{
+  auto cct = static_cast<CephContext*>(ioctx.cct());
+  bool omap = false;
+  {
+    librados::ObjectReadOperation op;
+    cls_log_header header;
+    cls_log_info(op, &header);
+    auto r = rgw_rados_operate(ioctx, oid, &op, nullptr, y);
+    if (r == -ENOENT) {
+      return { shard_check::dne, {} };
+    }
+
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " error probing for omap: r=" << r
+		 << ", oid=" << oid << dendl;
+      return { shard_check::corrupt, {} };
+    }
+    if (header != cls_log_header{})
+      omap = true;
+  }
+  std::unique_ptr<rgw::cls::fifo::FIFO> fifo;
+  auto r = rgw::cls::fifo::FIFO::open(ioctx, oid,
+				      &fifo, y,
+				      std::nullopt, true);
+  if (r < 0 && !(r == -ENOENT || r == -ENODATA)) {
+    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+	       << " error probing for fifo: r=" << r
+	       << ", oid=" << oid << dendl;
+    return { shard_check::corrupt, {} };
+  }
+  if (fifo && omap) {
+    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+	       << " fifo and omap found: oid=" << oid << dendl;
+    return { shard_check::corrupt, {} };
+  }
+  if (fifo) {
+    bool more = false;
+    std::vector<rgw::cls::fifo::list_entry> entries;
+    r = fifo->list(1, nullopt, &entries, &more, y);
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << ": unable to list entries: r=" << r
+		 << ", oid=" << oid << dendl;
+      return { shard_check::corrupt, {} };
+    }
+    return { shard_check::fifo, !entries.empty() };
+  }
+  if (omap) {
+    std::list<cls_log_entry> entries;
+    std::string out_marker;
+    bool truncated = false;
+    librados::ObjectReadOperation op;
+    cls_log_list(op, {}, {}, {}, 1, entries,
+		 &out_marker, &truncated);
+    auto r = rgw_rados_operate(ioctx, oid, &op, nullptr, y);
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << ": failed to list: r=" << r << ", oid=" << oid << dendl;
+      return { shard_check::corrupt, {} };
+    }
+    return { shard_check::omap, !entries.empty() };
+  }
+
+  // An object exists, but has never had FIFO or cls_log entries written
+  // to it. Likely just the marker Omap.
+  return { shard_check::dne, {} };
+}
+
+std::tuple<log_check, bool, log_type>
+handle_dne(librados::IoCtx& ioctx,
+	   log_type specified,
+	   log_type bias,
+	   std::string oid,
+	   optional_yield y)
+{
+  auto cct = static_cast<CephContext*>(ioctx.cct());
+  auto actual = specified == log_type::neither ? bias : specified;
+  if (actual == log_type::fifo) {
+    std::unique_ptr<rgw::cls::fifo::FIFO> fifo;
+    auto r = rgw::cls::fifo::FIFO::create(ioctx, oid,
+					  &fifo, y,
+					  std::nullopt);
+    if (r < 0) {
+      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " error creating FIFO: r=" << r
+		 << ", oid=" << oid << dendl;
+      return { log_check::corruption, {}, {} };
+    }
+  }
+  logmark m{ actual, specified };
+  librados::ObjectWriteOperation op;
+  op.create(false);
+  ceph::bufferlist bl;
+  encode(m, bl);
+  op.omap_set({ { logmark_omap_key, bl } });
+  auto r = rgw_rados_operate(ioctx, oid, &op, y);
+  if (r < 0) {
+    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+	       << " error setting logmark: r=" << r << dendl;
+    return { log_check::corruption, {}, {} };
+  }
+  return { log_check::concord, false, actual };
+}
+}
+
+std::tuple<log_check, bool, log_type>
+log_setup_backing(librados::IoCtx& ioctx,
+		  log_type specified,
+		  log_type bias,
+		  int shards,
+		  const fu2::unique_function<std::string(int) const>& get_oid,
+		  optional_yield y)
+{
+  ceph_assert(bias != log_type::neither);
+  auto cct = static_cast<CephContext*>(ioctx.cct());
+  {
+    librados::ObjectWriteOperation op;
+    op.omap_rm_keys({ logmark_omap_key });
+    auto oid = get_oid(0);
+    auto r = rgw_rados_operate(ioctx, oid, &op, y);
+    if (r < 0 && r != -ENOENT) {
+      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " error removing logmark: r=" << r << dendl;
+      return { log_check::corruption, {}, {} };
+    }
+  }
+  bool zero_exists = false;
+  auto check = shard_check::dne;
+  bool has_entries = false;
+  for (int i = 0; i < shards; ++i) {
+    auto [c, e] = probe_shard(ioctx, get_oid(i), y);
+    if (i == 0) zero_exists = (c != shard_check::dne);
+    if (c == shard_check::corrupt) return { log_check::corruption, {}, {} };
+    if (c == shard_check::dne) continue;
+    if (check == shard_check::dne) {
+      check = c;
+      continue;
+    }
+
+    if (check != c) {
+      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << " clashing types: check=" << check
+		 << ", c=" << c << dendl;
+      return { log_check::corruption, {}, {} };
+    }
+    if (e)
+      has_entries = true;
+  }
+  if (check == shard_check::corrupt) {
+    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+	       << " should be unreachable!" << dendl;
+    return { log_check::corruption, {}, {} };
+  }
+
+  if (check == shard_check::dne)
+    return handle_dne(ioctx,
+		      specified,
+		      bias,
+		      get_oid(0),
+		      y);
+
+  auto found = check == shard_check::fifo ? log_type::fifo : log_type::omap;
+  if ((specified != log_type::neither ) && (found != specified)) {
+    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+	       << " discord: found=" << found
+	       << ", specified=" << specified << dendl;
+    return { log_check::discord, has_entries, found };
+  }
+
+  logmark m{ found, specified };
+  librados::ObjectWriteOperation op;
+  if (!zero_exists) {
+    op.create(false);
+  }
+  ceph::bufferlist bl;
+  encode(m, bl);
+  op.omap_set({ { logmark_omap_key, bl } });
+  auto r = rgw_rados_operate(ioctx, get_oid(0), &op, y);
+  if (r < 0) {
+    lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+	       << " error setting logmark: r=" << r << dendl;
+    return { log_check::corruption, {}, {} };
+  }
+  return { log_check::concord, has_entries, found };
+}
+
+int log_remove(librados::IoCtx& ioctx,
+	       int shards,
+	       const fu2::unique_function<std::string(int) const>& get_oid,
+	       optional_yield y)
+{
+  int finalr = 0;
+  auto cct = static_cast<CephContext*>(ioctx.cct());
+  for (int i = 0; i < shards; ++i) {
+    auto oid = get_oid(i);
+    rados::cls::fifo::info info;
+    uint32_t part_header_size = 0, part_entry_overhead = 0;
+
+    auto r = rgw::cls::fifo::get_meta(ioctx, oid, nullopt, &info,
+				      &part_header_size, &part_entry_overhead,
+				      0, y, true);
+    if (r == -ENOENT) continue;
+    if (r == 0 && info.head_part_num > -1) {
+      for (auto j = info.tail_part_num; j <= info.head_part_num; ++j) {
+	librados::ObjectWriteOperation op;
+	op.remove();
+	auto part_oid = info.part_oid(j);
+	auto subr = rgw_rados_operate(ioctx, part_oid, &op, null_yield);
+	if (subr < 0 && subr != -ENOENT) {
+	  if (finalr != 0) finalr = subr;
+	  lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		     << ": failed removing FIFO part: part_oid=" << part_oid
+		     << ", subr=" << subr << dendl;
+	}
+      }
+    }
+    if (r < 0 && r != -ENODATA) {
+      if (finalr != 0) finalr = r;
+      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << ": failed checking FIFO part: oid=" << oid
+		 << ", r=" << r << dendl;
+    }
+    librados::ObjectWriteOperation op;
+    op.remove();
+    r = rgw_rados_operate(ioctx, oid, &op, null_yield);
+    if (r < 0 && r != -ENOENT) {
+      if (finalr != 0) finalr = r;
+      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << ": failed removing shard: oid=" << oid
+		 << ", r=" << r << dendl;
+    }
+  }
+  return finalr;
+}
+
+log_type log_acquire_backing(librados::IoCtx& ioctx,
+			     int shards,
+			     log_type specified,
+			     log_type bias,
+			     const fu2::unique_function<
+			       std::string(int) const>& get_oid,
+			     optional_yield y)
+{
+  auto cct = static_cast<CephContext*>(ioctx.cct());
+  {
+    auto found = log_quick_check(ioctx, specified, get_oid, y);
+    if (found != log_type::neither) {
+      return found;
+    }
+  }
+  {
+    auto [check, has_entries, found] = log_setup_backing(ioctx, specified, bias, shards,
+						       get_oid, y);
+    if (check == log_check::concord) {
+      return found;
+    }
+    if (check == log_check::corruption) {
+      lderr(cct) << __PRETTY_FUNCTION__ << ":" << __LINE__
+		 << ": corrupt log found, unable to proceed" << dendl;
+      return log_type::neither;
+    }
+    ceph_assert(check == log_check::discord);
+    if (has_entries) {
+      lderr(cct) << __PRETTY_FUNCTION__  << ":" << __LINE__ << ": "
+		 << specified << " specified, but"
+		 << found << " found, and log is not empty. Cannot continue."
+		 << dendl;
+      return log_type::neither;
+    }
+    ldout(cct, 5) << __PRETTY_FUNCTION__ << ":" << __LINE__ << ": "
+		  << specified << " specified, but"
+		  << found << " found. Log is empty. Deleting and recreating."
+		  << dendl;
+    if (log_remove(ioctx, shards, get_oid, y) < 0)
+      return log_type::neither;
+  }
+  auto [check, has_entries, found] = log_setup_backing(ioctx, specified, bias, shards,
+						       get_oid, y);
+  if (check != log_check::concord) {
+    lderr(cct) << __PRETTY_FUNCTION__ << ": " << __LINE__
+	       << ": failed to re-initialize log."
+	       << dendl;
+    return log_type::neither;
+  }
+  return found;
+}

--- a/src/rgw/rgw_log_backing.h
+++ b/src/rgw/rgw_log_backing.h
@@ -16,6 +16,8 @@
 
 #include "common/async/yield_context.h"
 
+#include "cls_fifo_legacy.h"
+
 /// Type of log backing, stored in the mark used in the quick check,
 /// and passed to checking functions.
 enum class log_type {
@@ -142,4 +144,138 @@ log_type log_acquire_backing(librados::IoCtx& ioctx,
 			       std::string(int) const>& get_oid,
 			     optional_yield y);
 
-#endif 
+
+class LazyFIFO {
+  librados::IoCtx& ioctx;
+  std::string oid;
+  std::mutex m;
+  std::unique_ptr<rgw::cls::fifo::FIFO> fifo;
+
+  int lazy_init(optional_yield y) {
+    std::unique_lock l(m);
+    if (fifo) return 0;
+    auto r = rgw::cls::fifo::FIFO::create(ioctx, oid, &fifo, y);
+    if (r) {
+      fifo.reset();
+    }
+    return r;
+  }
+
+public:
+
+  LazyFIFO(librados::IoCtx& ioctx, std::string oid)
+    : ioctx(ioctx), oid(std::move(oid)) {}
+
+  int read_meta(optional_yield y) {
+    auto r = lazy_init(y);
+    if (r < 0) return r;
+    return fifo->read_meta(y);
+  }
+
+  int meta(rados::cls::fifo::info& info, optional_yield y) {
+    auto r = lazy_init(y);
+    if (r < 0) return r;
+    info = fifo->meta();
+    return 0;
+  }
+
+  int get_part_layout_info(std::uint32_t& part_header_size,
+			   std::uint32_t& part_entry_overhead,
+			   optional_yield y) {
+    auto r = lazy_init(y);
+    if (r < 0) return r;
+    std::tie(part_header_size, part_entry_overhead)
+      = fifo->get_part_layout_info();
+    return 0;
+  }
+
+  int push(const ceph::buffer::list& bl,
+	   optional_yield y) {
+    auto r = lazy_init(y);
+    if (r < 0) return r;
+    return fifo->push(bl, y);
+  }
+
+  int push(ceph::buffer::list& bl,
+	   librados::AioCompletion* c,
+	   optional_yield y) {
+    auto r = lazy_init(y);
+    if (r < 0) return r;
+    fifo->push(bl, c);
+    return 0;
+  }
+
+  int push(const std::vector<ceph::buffer::list>& data_bufs,
+	   optional_yield y) {
+    auto r = lazy_init(y);
+    if (r < 0) return r;
+    return fifo->push(data_bufs, y);
+  }
+
+  int push(const std::vector<ceph::buffer::list>& data_bufs,
+	    librados::AioCompletion* c,
+	    optional_yield y) {
+    auto r = lazy_init(y);
+    if (r < 0) return r;
+    fifo->push(data_bufs, c);
+    return 0;
+  }
+
+  int list(int max_entries, std::optional<std::string_view> markstr,
+	   std::vector<rgw::cls::fifo::list_entry>* out,
+	   bool* more, optional_yield y) {
+    auto r = lazy_init(y);
+    if (r < 0) return r;
+    return fifo->list(max_entries, markstr, out, more, y);
+  }
+
+  int list(int max_entries, std::optional<std::string_view> markstr,
+	   std::vector<rgw::cls::fifo::list_entry>* out, bool* more,
+	   librados::AioCompletion* c, optional_yield y) {
+    auto r = lazy_init(y);
+    if (r < 0) return r;
+    fifo->list(max_entries, markstr, out, more, c);
+    return 0;
+  }
+
+  int trim(std::string_view markstr, bool exclusive, optional_yield y) {
+    auto r = lazy_init(y);
+    if (r < 0) return r;
+    return fifo->trim(markstr, exclusive, y);
+  }
+
+  int trim(std::string_view markstr, bool exclusive, librados::AioCompletion* c,
+	   optional_yield y) {
+    auto r = lazy_init(y);
+    if (r < 0) return r;
+    fifo->trim(markstr, exclusive, c);
+    return 0;
+  }
+
+  int get_part_info(int64_t part_num, rados::cls::fifo::part_header* header,
+		    optional_yield y) {
+    auto r = lazy_init(y);
+    if (r < 0) return r;
+    return fifo->get_part_info(part_num, header, y);
+  }
+
+  int get_part_info(int64_t part_num, rados::cls::fifo::part_header* header,
+		    librados::AioCompletion* c, optional_yield y) {
+    auto r = lazy_init(y);
+    if (r < 0) return r;
+    fifo->get_part_info(part_num, header, c);
+    return 0;
+  }
+
+  int get_head_info(fu2::unique_function<
+		      void(int r, rados::cls::fifo::part_header&&)>&& f,
+		    librados::AioCompletion* c,
+		    optional_yield y) {
+    auto r = lazy_init(y);
+    if (r < 0) return r;
+    fifo->get_head_info(std::move(f), c);
+    return 0;
+  }
+};
+
+#endif

--- a/src/rgw/rgw_log_backing.h
+++ b/src/rgw/rgw_log_backing.h
@@ -1,0 +1,145 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#ifndef CEPH_RGW_LOGBACKING_H
+#define CEPH_RGW_LOGBACKING_H
+
+#include <optional>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+#include <strings.h>
+
+#include "include/rados/librados.hpp"
+#include "include/function2.hpp"
+
+#include "common/async/yield_context.h"
+
+/// Type of log backing, stored in the mark used in the quick check,
+/// and passed to checking functions.
+enum class log_type {
+  neither = 0, //< "auto" in the config, invalid/indeterminate when returned.
+  omap = 1,
+  fifo = 2
+};
+
+inline std::optional<log_type> to_log_type(std::string_view s) {
+  if (strncasecmp(s.data(), "auto", s.length()) == 0) {
+    return log_type::neither;
+  } else if (strncasecmp(s.data(), "omap", s.length()) == 0) {
+    return log_type::omap;
+  } else if (strncasecmp(s.data(), "fifo", s.length()) == 0) {
+    return log_type::fifo;
+  } else {
+    return std::nullopt;
+  }
+}
+inline std::ostream& operator <<(std::ostream& m, const log_type& t) {
+  switch (t) {
+  case log_type::neither:
+    return m << "log_type::neither";
+  case log_type::omap:
+    return m << "log_type::omap";
+  case log_type::fifo:
+    return m << "log_type::fifo";
+  }
+
+  return m << "log_type::UNKNOWN=" << static_cast<uint32_t>(t);
+}
+
+/// Quickly check the log's backing store. Will check an OMAP value on
+/// the zeroth shard.
+///
+/// Returns `omap` or `fifo` if the key is set, well-formed,
+/// and concordant with the specified log type.
+///
+/// Returns `neither` otherwise
+log_type log_quick_check(librados::IoCtx& ioctx,
+			 log_type specified, //< Log type from configuration
+			 /// A function taking a shard number and
+			 /// returning an oid.
+			 const fu2::unique_function<
+			   std::string(int) const>& get_oid,
+			 optional_yield y);
+
+// Status from the long check
+enum class log_check {
+  concord = 0, //< Backing store format is compatible with that specified
+  discord = 1, //< Log is well-formed, but of an incompatible format
+  corruption = 2 //< Log is ill-formed. Mix of shard types, objects
+		 //< exist but are valid as neither type, etc.
+};
+inline std::ostream& operator <<(std::ostream& m, const log_check& t) {
+  switch (t) {
+  case log_check::concord:
+    return m << "log_check::concord";
+  case log_check::discord:
+    return m << "log_check::discord";
+  case log_check::corruption:
+    return m << "log_check::corruption";
+  }
+
+  return m << "log_check::UNKNOWN=" << static_cast<uint32_t>(t);
+}
+
+/// To be called if log_type_quick_check returns false.
+///
+/// This function will:
+/// Scan all shards of the log. If they exist, it will determine their
+/// type and whether they have any entries.
+///
+/// If concordant, it will then write the mark into the omap of the
+/// zero'th shard.
+///
+/// If no shards exist, a zero'th shard is created (`specified` if it is
+/// `fifo` or `omap`, `bias` if it's `neither`) and marked.
+///
+/// If the backing is opposite that specified, `discord` is returned
+/// as the status. Both `concord` and `discord` will be accompanied by
+/// a bool, true if the log is non-empty.
+///
+/// If the status is `corruption`, then the value of the bool is undefined.
+///
+/// The third argument is the found log type, will always be `omap` or
+/// `fifo` unless the status is `corruption`.
+std::tuple<log_check, bool, log_type>
+log_setup_backing(librados::IoCtx& ioctx,
+		  log_type specified, //< Log type specified in configuration
+		  log_type bias, //< Log type to use if `neither` and none
+		                 //< exists. //< *Must not* be `neither`.
+		  int shards, //< Total number of shards
+		  /// A function taking a shard number and
+		  /// returning an oid.
+		  const fu2::unique_function<std::string(int) const>& get_oid,
+		  optional_yield y);
+
+/// Remove all log shards and associated parts of fifos.
+///
+/// Return < 0 if there were unforeseen errors looking up/removing things.
+int log_remove(librados::IoCtx& ioctx,
+	       int shards, //< Total number of shards
+	       /// A function taking a shard number and
+	       /// returning an oid.
+	       const fu2::unique_function<std::string(int) const>& get_oid,
+	       optional_yield y);
+
+/// Combine the above in a useful way. Try a quick check, if that
+/// fails go through the long setup. If that results in discord but
+/// the log is empty, remove and re-setup.
+///
+/// Returns the available log type, or `neither` on error.
+log_type log_acquire_backing(librados::IoCtx& ioctx,
+			     int shards, //< Total number of shards
+			     /// Log type specified in configuration
+			     log_type specified,
+			     /// Log type to use if `neither` and none
+			     /// exists. *Must not* be `neither`.
+			     log_type bias,
+			     /// A function taking a shard number and
+			     /// returning an oid.
+			     const fu2::unique_function<
+			       std::string(int) const>& get_oid,
+			     optional_yield y);
+
+#endif 

--- a/src/rgw/rgw_service.cc
+++ b/src/rgw/rgw_service.cc
@@ -141,7 +141,7 @@ int RGWServices_Def::init(CephContext *cct,
     }
 
     r = datalog_rados->start(&zone->get_zone(),
-			     zone->get_zone_params(), cls.get(),
+			     zone->get_zone_params(),
 			     rados->get_rados_handle());
     if (r < 0) {
       ldout(cct, 0) << "ERROR: failed to start datalog_rados service (" << cpp_strerror(-r) << dendl;

--- a/src/rgw/rgw_tools.h
+++ b/src/rgw/rgw_tools.h
@@ -253,4 +253,9 @@ public:
 
 using RGWDataAccessRef = std::shared_ptr<RGWDataAccess>;
 
+/// Complete an AioCompletion. To return error values or otherwise
+/// satisfy the caller. Useful for making complicated asynchronous
+/// calls and error handling.
+void rgw_complete_aio_completion(librados::AioCompletion* c, int r);
+
 #endif

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -351,3 +351,6 @@ target_link_libraries(unittest_blocked_completion Boost::system GTest::GTest)
 
 add_executable(unittest_allocate_unique test_allocate_unique.cc)
 add_ceph_unittest(unittest_allocate_unique)
+
+add_executable(unittest_dynarray test_dynarray.cc)
+add_ceph_unittest(unittest_dynarray)

--- a/src/test/common/test_dynarray.cc
+++ b/src/test/common/test_dynarray.cc
@@ -1,0 +1,177 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "common/dynarray.h"
+#include <string>
+#include <vector>
+#include <gtest/gtest.h>
+
+using ceph::dynarray;
+
+struct immovable
+{
+  int a, b;
+
+  immovable(int a, int b)
+    : a(a), b(b) {}
+
+  immovable(const immovable&) = delete;
+  immovable& operator =(const immovable&) = delete;
+
+  immovable(immovable&&) = delete;
+  immovable& operator =(immovable&&) = delete;
+};
+
+TEST(Dynarray, Value)
+{
+  dynarray a(3, 1);
+  for (auto i = 0; i < 3; ++i) {
+    ASSERT_EQ(1, a[i]);
+  }
+}
+
+TEST(Dynarray, Single)
+{
+  dynarray a(3, [](std::size_t i) { return int(i); } );
+  for (auto i = 0; i < 3; ++i) {
+    ASSERT_EQ(i, a[i]);
+  }
+}
+
+TEST(Dynarray, Tuple)
+{
+  dynarray<immovable> a(3, [](std::size_t i) {
+    return std::tuple(int(i), int(i * 2));
+  });
+  for (auto i = 0; i < 3; ++i) {
+    ASSERT_EQ(i, a[i].a);
+    ASSERT_EQ(i * 2, a[i].b);
+  }
+}
+
+TEST(Dynarray, Iterator)
+{
+  std::vector v({1, 1, 2, 3, 5, 8});
+  dynarray a(v.begin(), v.end());
+
+  auto i = v.begin();
+  for (const auto& e : a) {
+    ASSERT_EQ(*i, e);
+    ++i;
+  }
+}
+
+TEST(Dynarray, Access) {
+  dynarray a{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    ASSERT_EQ(i, a.at(i));
+  }
+  EXPECT_THROW(a.at(11), std::out_of_range);
+
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    ASSERT_EQ(i, a[i]);
+  }
+
+  ASSERT_EQ(0, a.front());
+  ASSERT_EQ(10, a.back());
+
+  auto d = a.data();
+  for (std::size_t i = 0; i < a.size(); ++i) {
+    ASSERT_EQ(i, d[i]);
+  }
+}
+
+TEST(Dynarray, Move)
+{
+  {
+    dynarray a(3, 1);
+    for (const auto& e : a) {
+      ASSERT_EQ(1, e);
+    }
+    dynarray b(std::move(a));
+    ASSERT_TRUE(a.empty());
+    for (const auto& e : b) {
+      ASSERT_EQ(1, e);
+    }
+  }
+
+  {
+    dynarray a(3, 1);
+    for (const auto& e : a) {
+      ASSERT_EQ(1, e);
+    }
+    dynarray<int> b;
+    ASSERT_TRUE(b.empty());
+
+    b = std::move(a);
+    ASSERT_TRUE(a.empty());
+
+    for (const auto& e : b) {
+      ASSERT_EQ(1, e);
+    }
+  }
+}
+
+TEST(Dynarray, Compare) {
+  ASSERT_EQ(dynarray({0, 1}), dynarray({0, 1}));
+  ASSERT_LE(dynarray({0, 1}), dynarray({0, 1}));
+  ASSERT_GE(dynarray({0, 1}), dynarray({0, 1}));
+
+  ASSERT_LE(dynarray({0, 0}), dynarray({0, 1}));
+  ASSERT_GE(dynarray({1, 1}), dynarray({0, 1}));
+
+  ASSERT_NE(dynarray({0}), dynarray({0, 1}));
+  ASSERT_NE(dynarray({1, 0}), dynarray({0, 1}));
+
+  ASSERT_LT(dynarray({0}), dynarray({0, 1}));
+  ASSERT_LT(dynarray({0, 0}), dynarray({0, 1}));
+  ASSERT_GT(dynarray({1, 1}), dynarray({0, 1}));
+  ASSERT_GT(dynarray({1, 1}), dynarray({1}));
+}
+
+TEST(Dynarray, Swap) {
+  dynarray a{'a'};
+  dynarray b{'b'};
+
+  ASSERT_EQ('a', a.front());
+  ASSERT_EQ('b', b.front());
+
+  swap(a, b);
+  ASSERT_EQ('b', a.front());
+  ASSERT_EQ('a', b.front());
+}
+
+TEST(Dynarray, Empty) {
+  {
+    dynarray<int> a;
+    ASSERT_TRUE(a.empty());
+    int i = 0;
+    for ([[maybe_unused]] const auto& e : a) ++i;
+    ASSERT_EQ(0, i);
+  }
+
+  {
+    dynarray a(0, 1);
+    ASSERT_TRUE(a.empty());
+    int i = 0;
+    for ([[maybe_unused]] const auto& e : a) ++i;
+    ASSERT_EQ(0, i);
+  }
+
+  {
+    dynarray<int> a({});
+    ASSERT_TRUE(a.empty());
+    int i = 0;
+    for ([[maybe_unused]] const auto& e : a) ++i;
+    ASSERT_EQ(0, i);
+  }
+
+  {
+    dynarray a(0, [](std::size_t i) { return i; });
+    ASSERT_TRUE(a.empty());
+    int i = 0;
+    for ([[maybe_unused]] const auto& e : a) ++i;
+    ASSERT_EQ(0, i);
+  }
+}

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -209,6 +209,11 @@ add_executable(unittest_cls_fifo_legacy test_cls_fifo_legacy.cc)
 target_link_libraries(unittest_cls_fifo_legacy radostest-cxx ${UNITTEST_LIBS}
   ${rgw_libs})
 
+# unittest_log_backing
+add_executable(unittest_log_backing test_log_backing.cc)
+target_link_libraries(unittest_log_backing radostest-cxx ${UNITTEST_LIBS}
+  ${rgw_libs})
+
 add_executable(unittest_rgw_lua test_rgw_lua.cc)
 add_ceph_unittest(unittest_rgw_lua)
 target_link_libraries(unittest_rgw_lua ${rgw_libs} ${LUA_LIBRARIES})

--- a/src/test/rgw/test_cls_fifo_legacy.cc
+++ b/src/test/rgw/test_cls_fifo_legacy.cc
@@ -69,6 +69,8 @@ protected:
 };
 
 using LegacyClsFIFO = LegacyFIFO;
+using AioLegacyFIFO = LegacyFIFO;
+
 
 TEST_F(LegacyClsFIFO, TestCreate)
 {
@@ -577,8 +579,7 @@ TEST_F(LegacyFIFO, TestAioTrim)
     marker = result.front().marker;
     std::unique_ptr<R::AioCompletion> c(rados.aio_create_completion(nullptr,
 								    nullptr));
-    r = f->trim(*marker, false, c.get());
-    ASSERT_EQ(0, r);
+    f->trim(*marker, false, c.get());
     c->wait_for_complete();
     r = c->get_return_value();
     ASSERT_EQ(0, r);
@@ -644,4 +645,483 @@ TEST_F(LegacyFIFO, TestTrimExclusive) {
   std::tie(val, marker) = decode_entry<std::uint32_t>(result.front());
   ASSERT_EQ(result.size(), 1);
   ASSERT_EQ(max_entries - 1, val);
+}
+
+TEST_F(AioLegacyFIFO, TestPushListTrim)
+{
+  std::unique_ptr<RCf::FIFO> f;
+  auto r = RCf::FIFO::create(ioctx, fifo_id, &f, null_yield);
+  ASSERT_EQ(0, r);
+  static constexpr auto max_entries = 10u;
+  for (uint32_t i = 0; i < max_entries; ++i) {
+    cb::list bl;
+    encode(i, bl);
+    auto c = R::Rados::aio_create_completion();
+    f->push(bl, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    ASSERT_EQ(0, r);
+  }
+
+  std::optional<std::string> marker;
+  /* get entries one by one */
+  std::vector<RCf::list_entry> result;
+  bool more = false;
+  for (auto i = 0u; i < max_entries; ++i) {
+    auto c = R::Rados::aio_create_completion();
+    f->list(1, marker, &result, &more, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    ASSERT_EQ(0, r);
+
+    bool expected_more = (i != (max_entries - 1));
+    ASSERT_EQ(expected_more, more);
+    ASSERT_EQ(1, result.size());
+
+    std::uint32_t val;
+    std::tie(val, marker) = decode_entry<std::uint32_t>(result.front());
+
+    ASSERT_EQ(i, val);
+    result.clear();
+  }
+
+  /* get all entries at once */
+  std::string markers[max_entries];
+  std::uint32_t min_entry = 0;
+  auto c = R::Rados::aio_create_completion();
+  f->list(max_entries * 10, std::nullopt, &result, &more, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+
+  ASSERT_FALSE(more);
+  ASSERT_EQ(max_entries, result.size());
+  for (auto i = 0u; i < max_entries; ++i) {
+    std::uint32_t val;
+    std::tie(val, markers[i]) = decode_entry<std::uint32_t>(result[i]);
+    ASSERT_EQ(i, val);
+  }
+
+  /* trim one entry */
+  c = R::Rados::aio_create_completion();
+  f->trim(markers[min_entry], false, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+  ++min_entry;
+
+  c = R::Rados::aio_create_completion();
+  f->list(max_entries * 10, std::nullopt, &result, &more, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+  ASSERT_FALSE(more);
+  ASSERT_EQ(max_entries - min_entry, result.size());
+
+  for (auto i = min_entry; i < max_entries; ++i) {
+    std::uint32_t val;
+    std::tie(val, markers[i - min_entry]) =
+      decode_entry<std::uint32_t>(result[i - min_entry]);
+    EXPECT_EQ(i, val);
+  }
+}
+
+
+TEST_F(AioLegacyFIFO, TestPushTooBig)
+{
+  static constexpr auto max_part_size = 2048ull;
+  static constexpr auto max_entry_size = 128ull;
+
+  std::unique_ptr<RCf::FIFO> f;
+  auto r = RCf::FIFO::create(ioctx, fifo_id, &f, null_yield, std::nullopt,
+			     std::nullopt, false, max_part_size, max_entry_size);
+  ASSERT_EQ(0, r);
+
+  char buf[max_entry_size + 1];
+  memset(buf, 0, sizeof(buf));
+
+  cb::list bl;
+  bl.append(buf, sizeof(buf));
+
+  auto c = R::Rados::aio_create_completion();
+  f->push(bl, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  ASSERT_EQ(-E2BIG, r);
+  c->release();
+
+  c = R::Rados::aio_create_completion();
+  f->push(std::vector<cb::list>{}, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  EXPECT_EQ(0, r);
+}
+
+
+TEST_F(AioLegacyFIFO, TestMultipleParts)
+{
+  static constexpr auto max_part_size = 2048ull;
+  static constexpr auto max_entry_size = 128ull;
+  std::unique_ptr<RCf::FIFO> f;
+  auto r = RCf::FIFO::create(ioctx, fifo_id, &f, null_yield, std::nullopt,
+			     std::nullopt, false, max_part_size,
+			     max_entry_size);
+  ASSERT_EQ(0, r);
+
+  {
+    auto c = R::Rados::aio_create_completion();
+    f->get_head_info([&](int r, RCf::part_info&& p) {
+      ASSERT_TRUE(p.tag.empty());
+      ASSERT_EQ(0, p.magic);
+      ASSERT_EQ(0, p.min_ofs);
+      ASSERT_EQ(0, p.last_ofs);
+      ASSERT_EQ(0, p.next_ofs);
+      ASSERT_EQ(0, p.min_index);
+      ASSERT_EQ(0, p.max_index);
+      ASSERT_EQ(ceph::real_time{}, p.max_time);
+    }, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+  }
+
+  char buf[max_entry_size];
+  memset(buf, 0, sizeof(buf));
+  const auto [part_header_size, part_entry_overhead] =
+    f->get_part_layout_info();
+  const auto entries_per_part = ((max_part_size - part_header_size) /
+				 (max_entry_size + part_entry_overhead));
+  const auto max_entries = entries_per_part * 4 + 1;
+  /* push enough entries */
+  for (auto i = 0u; i < max_entries; ++i) {
+    cb::list bl;
+    *(int *)buf = i;
+    bl.append(buf, sizeof(buf));
+    auto c = R::Rados::aio_create_completion();
+    f->push(bl, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    EXPECT_EQ(0, r);
+  }
+
+  auto info = f->meta();
+  ASSERT_EQ(info.id, fifo_id);
+  /* head should have advanced */
+  ASSERT_GT(info.head_part_num, 0);
+
+  /* list all at once */
+  std::vector<RCf::list_entry> result;
+  bool more = false;
+  auto c = R::Rados::aio_create_completion();
+  f->list(max_entries, std::nullopt, &result, &more, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  EXPECT_EQ(0, r);
+  EXPECT_EQ(false, more);
+  ASSERT_EQ(max_entries, result.size());
+
+  for (auto i = 0u; i < max_entries; ++i) {
+    auto& bl = result[i].data;
+    ASSERT_EQ(i, *(int *)bl.c_str());
+  }
+
+  std::optional<std::string> marker;
+  /* get entries one by one */
+
+  for (auto i = 0u; i < max_entries; ++i) {
+    c = R::Rados::aio_create_completion();
+    f->list(1, marker, &result, &more, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    EXPECT_EQ(0, r);
+    ASSERT_EQ(result.size(), 1);
+    const bool expected_more = (i != (max_entries - 1));
+    ASSERT_EQ(expected_more, more);
+
+    std::uint32_t val;
+    std::tie(val, marker) = decode_entry<std::uint32_t>(result.front());
+
+    auto& entry = result.front();
+    auto& bl = entry.data;
+    ASSERT_EQ(i, *(int *)bl.c_str());
+    marker = entry.marker;
+  }
+
+  /* trim one at a time */
+  marker.reset();
+  for (auto i = 0u; i < max_entries; ++i) {
+    /* read single entry */
+    c = R::Rados::aio_create_completion();
+    f->list(1, marker, &result, &more, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    EXPECT_EQ(0, r);
+    ASSERT_EQ(result.size(), 1);
+    const bool expected_more = (i != (max_entries - 1));
+    ASSERT_EQ(expected_more, more);
+
+    marker = result.front().marker;
+    c = R::Rados::aio_create_completion();
+    f->trim(*marker, false, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    EXPECT_EQ(0, r);
+    ASSERT_EQ(result.size(), 1);
+
+    /* check tail */
+    info = f->meta();
+    ASSERT_EQ(info.tail_part_num, i / entries_per_part);
+
+    /* try to read all again, see how many entries left */
+    c = R::Rados::aio_create_completion();
+    f->list(max_entries, marker, &result, &more, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    EXPECT_EQ(0, r);
+    ASSERT_EQ(max_entries - i - 1, result.size());
+    ASSERT_EQ(false, more);
+  }
+
+  /* tail now should point at head */
+  info = f->meta();
+  ASSERT_EQ(info.head_part_num, info.tail_part_num);
+
+  /* check old tails are removed */
+  for (auto i = 0; i < info.tail_part_num; ++i) {
+    c = R::Rados::aio_create_completion();
+    RCf::part_info partinfo;
+    f->get_part_info(i, &partinfo, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    ASSERT_EQ(-ENOENT, r);
+  }
+  /* check current tail exists */
+  std::uint64_t next_ofs;
+  {
+    c = R::Rados::aio_create_completion();
+    RCf::part_info partinfo;
+    f->get_part_info(info.tail_part_num, &partinfo, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    next_ofs = partinfo.next_ofs;
+  }
+  ASSERT_EQ(0, r);
+
+  c = R::Rados::aio_create_completion();
+  f->get_head_info([&](int r, RCf::part_info&& p) {
+    ASSERT_EQ(next_ofs, p.next_ofs);
+  }, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+}
+
+TEST_F(AioLegacyFIFO, TestTwoPushers)
+{
+  static constexpr auto max_part_size = 2048ull;
+  static constexpr auto max_entry_size = 128ull;
+
+  std::unique_ptr<RCf::FIFO> f;
+  auto r = RCf::FIFO::create(ioctx, fifo_id, &f, null_yield, std::nullopt,
+			     std::nullopt, false, max_part_size,
+			     max_entry_size);
+  ASSERT_EQ(0, r);
+  char buf[max_entry_size];
+  memset(buf, 0, sizeof(buf));
+
+  auto [part_header_size, part_entry_overhead] = f->get_part_layout_info();
+  const auto entries_per_part = ((max_part_size - part_header_size) /
+				 (max_entry_size + part_entry_overhead));
+  const auto max_entries = entries_per_part * 4 + 1;
+  std::unique_ptr<RCf::FIFO> f2;
+  r = RCf::FIFO::open(ioctx, fifo_id, &f2, null_yield);
+  std::vector fifos{&f, &f2};
+
+  for (auto i = 0u; i < max_entries; ++i) {
+    cb::list bl;
+    *(int *)buf = i;
+    bl.append(buf, sizeof(buf));
+    auto& f = *fifos[i % fifos.size()];
+    auto c = R::Rados::aio_create_completion();
+    f->push(bl, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    ASSERT_EQ(0, r);
+  }
+
+  /* list all by both */
+  std::vector<RCf::list_entry> result;
+  bool more = false;
+  auto c = R::Rados::aio_create_completion();
+  f2->list(max_entries, std::nullopt, &result, &more, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(false, more);
+  ASSERT_EQ(max_entries, result.size());
+
+  c = R::Rados::aio_create_completion();
+  f2->list(max_entries, std::nullopt, &result, &more, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(false, more);
+  ASSERT_EQ(max_entries, result.size());
+
+  for (auto i = 0u; i < max_entries; ++i) {
+    auto& bl = result[i].data;
+    ASSERT_EQ(i, *(int *)bl.c_str());
+  }
+}
+
+TEST_F(AioLegacyFIFO, TestTwoPushersTrim)
+{
+  static constexpr auto max_part_size = 2048ull;
+  static constexpr auto max_entry_size = 128ull;
+  std::unique_ptr<RCf::FIFO> f1;
+  auto r = RCf::FIFO::create(ioctx, fifo_id, &f1, null_yield, std::nullopt,
+			     std::nullopt, false, max_part_size,
+			     max_entry_size);
+  ASSERT_EQ(0, r);
+
+  char buf[max_entry_size];
+  memset(buf, 0, sizeof(buf));
+
+  auto [part_header_size, part_entry_overhead] = f1->get_part_layout_info();
+  const auto entries_per_part = ((max_part_size - part_header_size) /
+				 (max_entry_size + part_entry_overhead));
+  const auto max_entries = entries_per_part * 4 + 1;
+
+  std::unique_ptr<RCf::FIFO> f2;
+  r = RCf::FIFO::open(ioctx, fifo_id, &f2, null_yield);
+  ASSERT_EQ(0, r);
+
+  /* push one entry to f2 and the rest to f1 */
+  for (auto i = 0u; i < max_entries; ++i) {
+    cb::list bl;
+    *(int *)buf = i;
+    bl.append(buf, sizeof(buf));
+    auto& f = (i < 1 ? f2 : f1);
+    auto c = R::Rados::aio_create_completion();
+    f->push(bl, c);
+    c->wait_for_complete();
+    r = c->get_return_value();
+    c->release();
+    ASSERT_EQ(0, r);
+  }
+
+  /* trim half by fifo1 */
+  auto num = max_entries / 2;
+  std::string marker;
+  std::vector<RCf::list_entry> result;
+  bool more = false;
+  auto c = R::Rados::aio_create_completion();
+  f1->list(num, std::nullopt, &result, &more, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(true, more);
+  ASSERT_EQ(num, result.size());
+
+  for (auto i = 0u; i < num; ++i) {
+    auto& bl = result[i].data;
+    ASSERT_EQ(i, *(int *)bl.c_str());
+  }
+
+  auto& entry = result[num - 1];
+  marker = entry.marker;
+  c = R::Rados::aio_create_completion();
+  f1->trim(marker, false, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+  /* list what's left by fifo2 */
+
+  const auto left = max_entries - num;
+  c = R::Rados::aio_create_completion();
+  f2->list(left, marker, &result, &more, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(left, result.size());
+  ASSERT_EQ(false, more);
+
+  for (auto i = num; i < max_entries; ++i) {
+    auto& bl = result[i - num].data;
+    ASSERT_EQ(i, *(int *)bl.c_str());
+  }
+}
+
+TEST_F(AioLegacyFIFO, TestPushBatch)
+{
+  static constexpr auto max_part_size = 2048ull;
+  static constexpr auto max_entry_size = 128ull;
+
+  std::unique_ptr<RCf::FIFO> f;
+  auto r = RCf::FIFO::create(ioctx, fifo_id, &f, null_yield, std::nullopt,
+			     std::nullopt, false, max_part_size,
+			     max_entry_size);
+  ASSERT_EQ(0, r);
+
+  char buf[max_entry_size];
+  memset(buf, 0, sizeof(buf));
+  auto [part_header_size, part_entry_overhead] = f->get_part_layout_info();
+  auto entries_per_part = ((max_part_size - part_header_size) /
+			   (max_entry_size + part_entry_overhead));
+  auto max_entries = entries_per_part * 4 + 1; /* enough entries to span multiple parts */
+  std::vector<cb::list> bufs;
+  for (auto i = 0u; i < max_entries; ++i) {
+    cb::list bl;
+    *(int *)buf = i;
+    bl.append(buf, sizeof(buf));
+    bufs.push_back(bl);
+  }
+  ASSERT_EQ(max_entries, bufs.size());
+
+  auto c = R::Rados::aio_create_completion();
+  f->push(bufs, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+
+  /* list all */
+
+  std::vector<RCf::list_entry> result;
+  bool more = false;
+  c = R::Rados::aio_create_completion();
+  f->list(max_entries, std::nullopt, &result, &more, c);
+  c->wait_for_complete();
+  r = c->get_return_value();
+  c->release();
+  ASSERT_EQ(0, r);
+  ASSERT_EQ(false, more);
+  ASSERT_EQ(max_entries, result.size());
+  for (auto i = 0u; i < max_entries; ++i) {
+    auto& bl = result[i].data;
+    ASSERT_EQ(i, *(int *)bl.c_str());
+  }
+  auto& info = f->meta();
+  ASSERT_EQ(info.head_part_num, 4);
 }

--- a/src/test/rgw/test_log_backing.cc
+++ b/src/test/rgw/test_log_backing.cc
@@ -1,0 +1,665 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "rgw_log_backing.h"
+
+#include <cerrno>
+#include <iostream>
+#include <string_view>
+
+#undef FMT_HEADER_ONLY
+#define FMT_HEADER_ONLY 1
+#include <fmt/format.h>
+
+#include "include/types.h"
+#include "include/rados/librados.hpp"
+
+#include "test/librados/test_cxx.h"
+#include "global/global_context.h"
+
+#include "cls/log/cls_log_client.h"
+
+#include "rgw/rgw_tools.h"
+#include "rgw/cls_fifo_legacy.h"
+
+#include "gtest/gtest.h"
+
+namespace lr = librados;
+namespace cb = ceph::buffer;
+namespace fifo = rados::cls::fifo;
+namespace RCf = rgw::cls::fifo;
+
+class LogBacking : public testing::Test {
+protected:
+  static constexpr int SHARDS = 3;
+  const std::string pool_name = get_temp_pool_name();
+  lr::Rados rados;
+  lr::IoCtx ioctx;
+
+  void SetUp() override {
+    ASSERT_EQ("", create_one_pool_pp(pool_name, rados));
+    ASSERT_EQ(0, rados.ioctx_create(pool_name.c_str(), ioctx));
+  }
+  void TearDown() override {
+    destroy_one_pool_pp(pool_name, rados);
+  }
+
+  static std::string get_oid(int i) {
+    return fmt::format("shard.{}", i);
+  }
+
+  void make_omap() {
+    for (int i = 0; i < SHARDS; ++i) {
+      using ceph::encode;
+      lr::ObjectWriteOperation op;
+      cb::list bl;
+      encode(i, bl);
+      cls_log_add(op, ceph_clock_now(), {}, "meow", bl);
+      auto r = rgw_rados_operate(ioctx, get_oid(i), &op, null_yield);
+      ASSERT_GE(r, 0);
+    }
+  }
+
+  void add_omap(int i) {
+    using ceph::encode;
+    lr::ObjectWriteOperation op;
+    cb::list bl;
+    encode(i, bl);
+    cls_log_add(op, ceph_clock_now(), {}, "meow", bl);
+    auto r = rgw_rados_operate(ioctx, get_oid(i), &op, null_yield);
+    ASSERT_GE(r, 0);
+  }
+
+  void empty_omap() {
+    for (int i = 0; i < SHARDS; ++i) {
+      auto oid = get_oid(i);
+      std::string to_marker;
+      {
+	lr::ObjectReadOperation op;
+	std::list<cls_log_entry> entries;
+	bool truncated = false;
+	cls_log_list(op, {}, {}, {}, 1, entries, &to_marker, &truncated);
+	auto r = rgw_rados_operate(ioctx, oid, &op, nullptr, null_yield);
+	ASSERT_GE(r, 0);
+	ASSERT_FALSE(entries.empty());
+      }
+      {
+	lr::ObjectWriteOperation op;
+	cls_log_trim(op, {}, {}, {}, to_marker);
+	auto r = rgw_rados_operate(ioctx, oid, &op, null_yield);
+	ASSERT_GE(r, 0);
+      }
+      {
+	lr::ObjectReadOperation op;
+	std::list<cls_log_entry> entries;
+	bool truncated = false;
+	cls_log_list(op, {}, {}, {}, 1, entries, &to_marker, &truncated);
+	auto r = rgw_rados_operate(ioctx, oid, &op, nullptr, null_yield);
+	ASSERT_GE(r, 0);
+	ASSERT_TRUE(entries.empty());
+      }
+    }
+  }
+
+  void make_fifo()
+    {
+      for (int i = 0; i < SHARDS; ++i) {
+	std::unique_ptr<RCf::FIFO> fifo;
+	auto r = RCf::FIFO::create(ioctx, get_oid(i), &fifo, null_yield);
+	ASSERT_EQ(0, r);
+	ASSERT_TRUE(fifo);
+      }
+    }
+
+  void add_fifo(int i)
+    {
+      using ceph::encode;
+      std::unique_ptr<RCf::FIFO> fifo;
+      auto r = RCf::FIFO::open(ioctx, get_oid(i), &fifo, null_yield);
+      ASSERT_GE(0, r);
+      ASSERT_TRUE(fifo);
+      cb::list bl;
+      encode(i, bl);
+      r = fifo->push(bl, null_yield);
+      ASSERT_GE(0, r);
+    }
+
+  void assert_empty() {
+    std::vector<lr::ObjectItem> result;
+    lr::ObjectCursor next;
+    auto r = ioctx.object_list(ioctx.object_list_begin(), ioctx.object_list_end(),
+			       100, {}, &result, &next);
+    ASSERT_GE(r, 0);
+    ASSERT_TRUE(result.empty());
+  }
+};
+
+TEST_F(LogBacking, TestOmap)
+{
+  make_omap();
+  // No mark, so all three should be false
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx,log_type::omap, get_oid, null_yield));
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::fifo, get_oid, null_yield));
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::neither, get_oid, null_yield));
+
+  auto [stat, has_entries, found] = log_setup_backing(ioctx,
+						      log_type::omap,
+						      log_type::fifo,
+						      SHARDS,
+						      get_oid,
+						      null_yield);
+  ASSERT_EQ(log_check::concord, stat);
+  ASSERT_TRUE(has_entries);
+  ASSERT_EQ(log_type::omap, found);
+
+  ASSERT_EQ(log_type::omap,
+	    log_quick_check(ioctx, log_type::omap, get_oid, null_yield));
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::fifo, get_oid, null_yield));
+  ASSERT_EQ(log_type::omap,
+	    log_quick_check(ioctx, log_type::neither, get_oid, null_yield));
+
+  std::tie(stat, has_entries, found) = log_setup_backing(ioctx,
+							 log_type::fifo,
+							 log_type::fifo,
+							 SHARDS,
+							 get_oid,
+							 null_yield);
+  ASSERT_EQ(log_check::discord, stat);
+  ASSERT_TRUE(has_entries);
+  ASSERT_EQ(log_type::omap, found);
+
+  // Mark will have been deleted
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx,log_type::omap, get_oid, null_yield));
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::fifo, get_oid, null_yield));
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::neither, get_oid, null_yield));
+
+  std::tie(stat, has_entries, found) = log_setup_backing(ioctx,
+							 log_type::neither,
+							 log_type::fifo,
+							 SHARDS,
+							 get_oid,
+							 null_yield);
+
+  ASSERT_EQ(log_check::concord, stat);
+  ASSERT_TRUE(has_entries);
+  ASSERT_EQ(log_type::omap, found);
+
+  ASSERT_EQ(log_type::omap,
+	    log_quick_check(ioctx, log_type::omap, get_oid, null_yield));
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::fifo, get_oid, null_yield));
+  ASSERT_EQ(log_type::omap,
+	    log_quick_check(ioctx, log_type::neither, get_oid, null_yield));
+
+
+  // Empty out omap.
+
+  empty_omap();
+  std::tie(stat, has_entries, found) = log_setup_backing(ioctx,
+							 log_type::omap,
+							 log_type::fifo,
+							 SHARDS,
+							 get_oid,
+							 null_yield);
+
+  ASSERT_EQ(log_check::concord, stat);
+  ASSERT_FALSE(has_entries);
+  ASSERT_EQ(log_type::omap, found);
+
+  // Check that we still show there are entries when all but the
+  // middle are empty.
+  add_omap(1);
+  std::tie(stat, has_entries, found) = log_setup_backing(ioctx,
+							 log_type::omap,
+							 log_type::fifo,
+							 SHARDS,
+							 get_oid,
+						  null_yield);
+
+  ASSERT_EQ(log_check::concord, stat);
+  ASSERT_TRUE(has_entries);
+  ASSERT_EQ(log_type::omap, found);
+
+  std::tie(stat, has_entries, found) = log_setup_backing(ioctx,
+							 log_type::fifo,
+							 log_type::fifo,
+							 SHARDS,
+							 get_oid,
+							 null_yield);
+
+  ASSERT_EQ(log_check::discord, stat);
+  ASSERT_TRUE(has_entries);
+  ASSERT_EQ(log_type::omap, found);
+
+  auto r = log_remove(ioctx, SHARDS, get_oid, null_yield);
+  ASSERT_GE(r, 0);
+  assert_empty();
+}
+
+TEST_F(LogBacking, TestFifo)
+{
+  make_fifo();
+  // No mark, so all three should be false
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx,log_type::omap, get_oid, null_yield));
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::fifo, get_oid, null_yield));
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::neither, get_oid, null_yield));
+
+  auto [stat, has_entries, found] = log_setup_backing(ioctx,
+						      log_type::fifo,
+						      log_type::fifo,
+						      SHARDS,
+						      get_oid,
+						      null_yield);
+  ASSERT_EQ(log_check::concord, stat);
+  ASSERT_FALSE(has_entries);
+  ASSERT_EQ(log_type::fifo, found);
+
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::omap, get_oid, null_yield));
+  ASSERT_EQ(log_type::fifo,
+	    log_quick_check(ioctx, log_type::fifo, get_oid, null_yield));
+  ASSERT_EQ(log_type::fifo,
+	    log_quick_check(ioctx, log_type::neither, get_oid, null_yield));
+
+  std::tie(stat, has_entries, found) = log_setup_backing(ioctx,
+							 log_type::omap,
+							 log_type::fifo,
+							 SHARDS,
+							 get_oid,
+							 null_yield);
+  ASSERT_EQ(log_check::discord, stat);
+  ASSERT_FALSE(has_entries);
+  ASSERT_EQ(log_type::fifo, found);
+
+  // Mark will have been deleted
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx,log_type::omap, get_oid, null_yield));
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::fifo, get_oid, null_yield));
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::neither, get_oid, null_yield));
+
+  std::tie(stat, has_entries, found) = log_setup_backing(ioctx,
+							 log_type::neither,
+							 log_type::fifo,
+							 SHARDS,
+							 get_oid,
+							 null_yield);
+
+  ASSERT_EQ(log_check::concord, stat);
+  ASSERT_FALSE(has_entries);
+  ASSERT_EQ(log_type::fifo, found);
+
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::omap, get_oid, null_yield));
+  ASSERT_EQ(log_type::fifo,
+	    log_quick_check(ioctx, log_type::fifo, get_oid, null_yield));
+  ASSERT_EQ(log_type::fifo,
+	    log_quick_check(ioctx, log_type::neither, get_oid, null_yield));
+
+  // Add an entry
+
+  add_fifo(1);
+
+  std::tie(stat, has_entries, found) = log_setup_backing(ioctx,
+							 log_type::fifo,
+							 log_type::fifo,
+							 SHARDS,
+							 get_oid,
+							 null_yield);
+
+  ASSERT_EQ(log_check::concord, stat);
+  ASSERT_TRUE(has_entries);
+  ASSERT_EQ(log_type::fifo, found);
+
+  std::tie(stat, has_entries, found) = log_setup_backing(ioctx,
+							 log_type::omap,
+							 log_type::fifo,
+							 SHARDS,
+							 get_oid,
+							 null_yield);
+
+  ASSERT_EQ(log_check::discord, stat);
+  ASSERT_TRUE(has_entries);
+  ASSERT_EQ(log_type::fifo, found);
+
+  auto r = log_remove(ioctx, SHARDS, get_oid, null_yield);
+  ASSERT_GE(r, 0);
+  assert_empty();
+}
+
+TEST_F(LogBacking, TestBiasOmap)
+{
+  // Nothing exists
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx,log_type::omap, get_oid, null_yield));
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::fifo, get_oid, null_yield));
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::neither, get_oid, null_yield));
+
+  auto [stat, has_entries, found] = log_setup_backing(ioctx,
+						      log_type::neither,
+						      log_type::omap,
+						      SHARDS,
+						      get_oid,
+						      null_yield);
+  ASSERT_EQ(log_check::concord, stat);
+  ASSERT_FALSE(has_entries);
+  ASSERT_EQ(log_type::omap, found);
+
+  ASSERT_EQ(log_type::omap,
+	    log_quick_check(ioctx, log_type::omap, get_oid, null_yield));
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::fifo, get_oid, null_yield));
+  ASSERT_EQ(log_type::omap,
+	    log_quick_check(ioctx, log_type::neither, get_oid, null_yield));
+
+
+  std::tie(stat, has_entries, found) = log_setup_backing(ioctx,
+							 log_type::omap,
+							 log_type::omap,
+							 SHARDS,
+							 get_oid,
+							 null_yield);
+
+  ASSERT_EQ(log_check::concord, stat);
+  ASSERT_FALSE(has_entries);
+  ASSERT_EQ(log_type::omap, found);
+
+  ASSERT_EQ(log_type::omap,
+	    log_quick_check(ioctx, log_type::omap, get_oid, null_yield));
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::fifo, get_oid, null_yield));
+  ASSERT_EQ(log_type::omap,
+	    log_quick_check(ioctx, log_type::neither, get_oid, null_yield));
+
+  auto r = log_remove(ioctx, SHARDS, get_oid, null_yield);
+  ASSERT_GE(r, 0);
+  assert_empty();
+}
+
+TEST_F(LogBacking, TestBiasFifo)
+{
+  // Nothing exists
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx,log_type::omap, get_oid, null_yield));
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::fifo, get_oid, null_yield));
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::neither, get_oid, null_yield));
+
+  auto [stat, has_entries, found] = log_setup_backing(ioctx,
+						      log_type::neither,
+						      log_type::fifo,
+						      SHARDS,
+						      get_oid,
+						      null_yield);
+  ASSERT_EQ(log_check::concord, stat);
+  ASSERT_FALSE(has_entries);
+  ASSERT_EQ(log_type::fifo, found);
+
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::omap, get_oid, null_yield));
+  ASSERT_EQ(log_type::fifo,
+	    log_quick_check(ioctx, log_type::fifo, get_oid, null_yield));
+  ASSERT_EQ(log_type::fifo,
+	    log_quick_check(ioctx, log_type::neither, get_oid, null_yield));
+
+  std::tie(stat, has_entries, found) = log_setup_backing(ioctx,
+							 log_type::fifo,
+							 log_type::fifo,
+							 SHARDS,
+							 get_oid,
+							 null_yield);
+
+  ASSERT_EQ(log_check::concord, stat);
+  ASSERT_FALSE(has_entries);
+  ASSERT_EQ(log_type::fifo, found);
+
+  ASSERT_EQ(log_type::neither,
+	    log_quick_check(ioctx, log_type::omap, get_oid, null_yield));
+  ASSERT_EQ(log_type::fifo,
+	    log_quick_check(ioctx, log_type::fifo, get_oid, null_yield));
+  ASSERT_EQ(log_type::fifo,
+	    log_quick_check(ioctx, log_type::neither, get_oid, null_yield));
+
+
+  auto r = log_remove(ioctx, SHARDS, get_oid, null_yield);
+  ASSERT_GE(r, 0);
+  assert_empty();
+}
+
+TEST_F(LogBacking, TestMixed) {
+  {
+    std::unique_ptr<RCf::FIFO> fifo;
+    auto r = RCf::FIFO::create(ioctx, get_oid(0), &fifo, null_yield);
+    ASSERT_EQ(0, r);
+    ASSERT_TRUE(fifo);
+  }
+  {
+    std::unique_ptr<RCf::FIFO> fifo;
+    auto r = RCf::FIFO::create(ioctx, get_oid(2), &fifo, null_yield);
+    ASSERT_EQ(0, r);
+    ASSERT_TRUE(fifo);
+  }
+  add_omap(1);
+
+  auto [stat, has_entries, found] = log_setup_backing(ioctx,
+						      log_type::neither,
+						      log_type::fifo,
+						      SHARDS,
+						      get_oid,
+						      null_yield);
+
+  ASSERT_EQ(log_check::corruption, stat);
+
+  std::tie(stat, has_entries, found) = log_setup_backing(ioctx,
+							 log_type::omap,
+							 log_type::fifo,
+							 SHARDS,
+							 get_oid,
+							 null_yield);
+  ASSERT_EQ(log_check::corruption, stat);
+
+  std::tie(stat, has_entries, found) = log_setup_backing(ioctx,
+							 log_type::fifo,
+							 log_type::fifo,
+							 SHARDS,
+							 get_oid,
+							 null_yield);
+  ASSERT_EQ(log_check::corruption, stat);
+
+  auto r = log_remove(ioctx, SHARDS, get_oid, null_yield);
+  ASSERT_GE(r, 0);
+  assert_empty();
+}
+
+TEST_F(LogBacking, TestCorruptShard) {
+  {
+    std::unique_ptr<RCf::FIFO> fifo;
+    auto r = RCf::FIFO::create(ioctx, get_oid(0), &fifo, null_yield);
+    ASSERT_EQ(0, r);
+    ASSERT_TRUE(fifo);
+  }
+  add_omap(0);
+
+  auto [stat, has_entries, found] = log_setup_backing(ioctx,
+						      log_type::neither,
+						      log_type::fifo,
+						      1,
+						      get_oid,
+						      null_yield);
+
+  ASSERT_EQ(log_check::corruption, stat);
+
+  std::tie(stat, has_entries, found) = log_setup_backing(ioctx,
+							 log_type::omap,
+							 log_type::fifo,
+							 1,
+							 get_oid,
+							 null_yield);
+  ASSERT_EQ(log_check::corruption, stat);
+
+  std::tie(stat, has_entries, found) = log_setup_backing(ioctx,
+							 log_type::fifo,
+							 log_type::fifo,
+							 1,
+							 get_oid,
+							 null_yield);
+  ASSERT_EQ(log_check::corruption, stat);
+
+  auto r = log_remove(ioctx, SHARDS, get_oid, null_yield);
+  ASSERT_GE(r, 0);
+  assert_empty();
+}
+
+TEST_F(LogBacking, TestFifoFromNeither) {
+  auto found = log_acquire_backing(ioctx, SHARDS, log_type::neither,
+				   log_type::fifo, get_oid, null_yield);
+  ASSERT_EQ(log_type::fifo, found);
+  found = log_acquire_backing(ioctx, SHARDS, log_type::neither,
+			      log_type::fifo, get_oid, null_yield);
+  ASSERT_EQ(log_type::fifo, found);
+  found = log_acquire_backing(ioctx, SHARDS, log_type::fifo,
+			      log_type::fifo, get_oid, null_yield);
+  ASSERT_EQ(log_type::fifo, found);
+  auto r = log_remove(ioctx, SHARDS, get_oid, null_yield);
+  ASSERT_GE(r, 0);
+  assert_empty();
+}
+
+TEST_F(LogBacking, TestFifoFromFifo) {
+  auto found = log_acquire_backing(ioctx, SHARDS, log_type::fifo,
+				     log_type::fifo, get_oid, null_yield);
+  ASSERT_EQ(log_type::fifo, found);
+  found = log_acquire_backing(ioctx, SHARDS, log_type::neither,
+			      log_type::fifo, get_oid, null_yield);
+  ASSERT_EQ(log_type::fifo, found);
+  found = log_acquire_backing(ioctx, SHARDS, log_type::fifo,
+			      log_type::fifo, get_oid, null_yield);
+  ASSERT_EQ(log_type::fifo, found);
+  auto r = log_remove(ioctx, SHARDS, get_oid, null_yield);
+  ASSERT_GE(r, 0);
+  assert_empty();
+}
+
+TEST_F(LogBacking, TestOmapFromNeither) {
+  auto found = log_acquire_backing(ioctx, SHARDS, log_type::neither,
+				   log_type::omap, get_oid, null_yield);
+  ASSERT_EQ(log_type::omap, found);
+  found = log_acquire_backing(ioctx, SHARDS, log_type::neither,
+			      log_type::fifo, get_oid, null_yield);
+  ASSERT_EQ(log_type::omap, found);
+  found = log_acquire_backing(ioctx, SHARDS, log_type::omap,
+			      log_type::fifo, get_oid, null_yield);
+  ASSERT_EQ(log_type::omap, found);
+  auto r = log_remove(ioctx, SHARDS, get_oid, null_yield);
+  ASSERT_GE(r, 0);
+  assert_empty();
+}
+
+TEST_F(LogBacking, TestOmapFromOmap) {
+  auto found = log_acquire_backing(ioctx, SHARDS, log_type::omap,
+				   log_type::omap, get_oid, null_yield);
+  ASSERT_EQ(log_type::omap, found);
+  found = log_acquire_backing(ioctx, SHARDS, log_type::neither,
+			      log_type::fifo, get_oid, null_yield);
+  ASSERT_EQ(log_type::omap, found);
+  found = log_acquire_backing(ioctx, SHARDS, log_type::omap,
+			      log_type::fifo, get_oid, null_yield);
+  ASSERT_EQ(log_type::omap, found);
+  auto r = log_remove(ioctx, SHARDS, get_oid, null_yield);
+  ASSERT_GE(r, 0);
+  assert_empty();
+}
+
+TEST_F(LogBacking, TestEmptyFifoToOmap) {
+  make_fifo();
+  // Neither specified, should stay fifo.
+  auto found = log_acquire_backing(ioctx, SHARDS, log_type::neither,
+				   log_type::omap, get_oid, null_yield);
+  ASSERT_EQ(log_type::fifo, found);
+
+  // Specified, should become omap.
+  found = log_acquire_backing(ioctx, SHARDS, log_type::omap,
+			      log_type::fifo, get_oid, null_yield);
+  ASSERT_EQ(log_type::omap, found);
+
+
+  auto r = log_remove(ioctx, SHARDS, get_oid, null_yield);
+  ASSERT_GE(r, 0);
+  assert_empty();
+}
+
+TEST_F(LogBacking, TestEmptyOmapToFifo) {
+  make_omap();
+  empty_omap();
+  // Neither specified, should stay omap.
+  auto found = log_acquire_backing(ioctx, SHARDS, log_type::neither,
+				   log_type::fifo, get_oid, null_yield);
+  ASSERT_EQ(log_type::omap, found);
+
+  // Specified, should become fifo.
+  found = log_acquire_backing(ioctx, SHARDS, log_type::fifo,
+			      log_type::fifo, get_oid, null_yield);
+  ASSERT_EQ(log_type::fifo, found);
+
+
+  auto r = log_remove(ioctx, SHARDS, get_oid, null_yield);
+  ASSERT_GE(r, 0);
+  assert_empty();
+}
+
+TEST_F(LogBacking, TestNonEmptyFifoToOmap) {
+  make_fifo();
+  add_fifo(1);
+  // Neither specified, should stay fifo.
+  auto found = log_acquire_backing(ioctx, SHARDS, log_type::neither,
+				   log_type::omap, get_oid, null_yield);
+  ASSERT_EQ(log_type::fifo, found);
+
+  // Omap Specified, should fail.
+  found = log_acquire_backing(ioctx, SHARDS, log_type::omap,
+			      log_type::fifo, get_oid, null_yield);
+  ASSERT_EQ(log_type::neither, found);
+}
+
+TEST_F(LogBacking, TestNonEmptyOmapToFifo) {
+  make_omap();
+  // Neither specified, should stay omap.
+  auto found = log_acquire_backing(ioctx, SHARDS, log_type::neither,
+				   log_type::fifo, get_oid, null_yield);
+  ASSERT_EQ(log_type::omap, found);
+
+  // Fifo Specified, should fail.
+  found = log_acquire_backing(ioctx, SHARDS, log_type::fifo,
+			      log_type::fifo, get_oid, null_yield);
+  ASSERT_EQ(log_type::neither, found);
+
+
+  auto r = log_remove(ioctx, SHARDS, get_oid, null_yield);
+  ASSERT_GE(r, 0);
+  assert_empty();
+}


### PR DESCRIPTION
Currently we send multiple OSD requests on startup to initialize the datalog. This is too many. To reduce this we mark a log (the set of shards) as usable with an omap entry on shard zero and take this as true unless something conflicts with it.

Secondly, initialize FIFOs lazily, so if we aren't doing anything relevant to the data log, don't pay to set them up.