### PR TITLE
doc/rados/operations: POOL_NEAR_FULL on OSD_NEAR_FULL

### DIFF
--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -467,6 +467,8 @@ by setting it in the ``[mon]`` section of the configuration file.
 
 .. index:: Ceph Storage Cluster; capacity planning, Ceph Monitor; capacity planning
 
+.. _storage-capacity:
+
 Storage Capacity
 ----------------
 

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -981,8 +981,9 @@ Setting the quota value to 0 will disable the quota.
 POOL_NEAR_FULL
 ______________
 
-One or more pools is approaching is quota.  The threshold to trigger
-this warning condition is controlled by the
+One or more pools is approaching a configured fullness threshold.
+
+One threshold that can trigger this warning condition is the
 ``mon_pool_quota_warn_threshold`` configuration option.
 
 Pool quotas can be adjusted up or down (or removed) with::
@@ -991,6 +992,11 @@ Pool quotas can be adjusted up or down (or removed) with::
   ceph osd pool set-quota <pool> max_objects <objects>
 
 Setting the quota value to 0 will disable the quota.
+
+Other thresholds that can trigger the above two warning conditions are
+``mon_osd_nearfull_ratio`` and ``mon_osd_full_ratio``.  Visit the
+:ref:`storage-capacity` and :ref:`no-free-drive-space` documents for details
+and resolution.
 
 OBJECT_MISPLACED
 ________________
@@ -1097,8 +1103,6 @@ also indicate some other performance issue with the OSDs.
 The exact size of the snapshot trim queue is reported by the
 ``snaptrimq_len`` field of ``ceph pg ls -f json-detail``.
 
-
-
 Miscellaneous
 -------------
 
@@ -1192,7 +1196,6 @@ Alternatively, the capabilities for the user can be updated with::
 
 For more information about auth capabilities, see :ref:`user-management`.
 
-
 OSD_NO_DOWN_OUT_INTERVAL
 ________________________
 
@@ -1209,3 +1212,4 @@ This warning can silenced by setting the
 ``mon_warn_on_osd_down_out_interval_zero`` to false::
 
   ceph config global mon mon_warn_on_osd_down_out_interval_zero false
+

--- a/doc/rados/troubleshooting/troubleshooting-osd.rst
+++ b/doc/rados/troubleshooting/troubleshooting-osd.rst
@@ -241,6 +241,7 @@ unexpected error), search the archives and tracker as above, and
 report it to the `ceph-devel`_ email list if there's no clear fix or
 existing bug.
 
+.. _no-free-drive-space:
 
 No Free Drive Space
 -------------------


### PR DESCRIPTION
doc/rados/operations: POOL_NEAR_FULL on OSD_NEAR_FULL

I poked through the code to verify that a [near]full OSD triggers the same flag.
Add a quick mention of this and references to discussion in other documents.

Fixes: https://tracker.ceph.com/issues/40579
Signed-off-by: Anthony D'Atri anthony.datri@gmail.com


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
