### PR TITLE
rgw: add x-amz-version-id and x-amz-copy-source-version-id for copyobj

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3264,6 +3264,8 @@ void RGWCopyObj_ObjStore_S3::send_partial_response(off_t ofs)
     if (op_ret)
     set_req_state_err(s, op_ret);
     dump_errno(s);
+    dump_header_if_nonempty(s, "x-amz-version-id", dest_object->get_instance());
+    dump_header_if_nonempty(s, "x-amz-copy-source-version-id", src_object->get_instance());
 
     // Explicitly use chunked transfer encoding so that we can stream the result
     // to the user without having to wait for the full length of it.


### PR DESCRIPTION
fix https://tracker.ceph.com/issues/48319

https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html#API_CopyObject_ResponseSyntax


Signed-off-by: yuliyang_yewu <yuliyang_yewu@cmss.chinamobile.com>