### PR TITLE
doc/rados/configuration: Modernize OSD configuration guidance and improve wording

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -995,7 +995,7 @@ Setting the quota value to 0 will disable the quota.
 
 Other thresholds that can trigger the above two warning conditions are
 ``mon_osd_nearfull_ratio`` and ``mon_osd_full_ratio``.  Visit the
-`Storage Capacity`_ and `No Free Drive Space`_ documents for details
+:ref:`storage-capacity` and :ref:`no-free-drive-space` documents for details
 and resolution.
 
 OBJECT_MISPLACED
@@ -1054,7 +1054,10 @@ PG_NOT_SCRUBBED
 _______________
 
 One or more PGs has not been scrubbed recently.  PGs are normally scrubbed
-within every ``osd_scrub_max_interval``, and this warning triggers when
+within every configured interval specified by
+:ref:`osd_scrub_max_interval <osd_scrub_max_interval>` globally. This
+interval can be overriden on per-pool basis with
+:ref:`scrub_max_interval <scrub_max_interval>`. The warning triggers when
 ``mon_warn_pg_not_scrubbed_ratio`` percentage of interval has elapsed without a
 scrub since it was due.
 
@@ -1213,5 +1216,3 @@ This warning can silenced by setting the
 
   ceph config global mon mon_warn_on_osd_down_out_interval_zero false
 
-.. _Storage Capacity: ../configuration/mon-config-ref/#storage-capacity
-.. _No Free Drive Space: ../troubleshooting/troubleshooting-osd/#no-free-drive-space

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -981,8 +981,9 @@ Setting the quota value to 0 will disable the quota.
 POOL_NEAR_FULL
 ______________
 
-One or more pools is approaching is quota.  The threshold to trigger
-this warning condition is controlled by the
+One or more pools is approaching a configured fullness threshold.
+
+One threshold that can trigger this warning condition is the
 ``mon_pool_quota_warn_threshold`` configuration option.
 
 Pool quotas can be adjusted up or down (or removed) with::
@@ -991,6 +992,11 @@ Pool quotas can be adjusted up or down (or removed) with::
   ceph osd pool set-quota <pool> max_objects <objects>
 
 Setting the quota value to 0 will disable the quota.
+
+Other thresholds that can trigger the above two warning conditions are
+``mon_osd_nearfull_ratio`` and ``mon_osd_full_ratio``.  Visit the
+`Storage Capacity`_ and `No Free Drive Space`_ documents for details
+and resolution.
 
 OBJECT_MISPLACED
 ________________
@@ -1097,8 +1103,6 @@ also indicate some other performance issue with the OSDs.
 The exact size of the snapshot trim queue is reported by the
 ``snaptrimq_len`` field of ``ceph pg ls -f json-detail``.
 
-
-
 Miscellaneous
 -------------
 
@@ -1192,7 +1196,6 @@ Alternatively, the capabilities for the user can be updated with::
 
 For more information about auth capabilities, see :ref:`user-management`.
 
-
 OSD_NO_DOWN_OUT_INTERVAL
 ________________________
 
@@ -1209,3 +1212,6 @@ This warning can silenced by setting the
 ``mon_warn_on_osd_down_out_interval_zero`` to false::
 
   ceph config global mon mon_warn_on_osd_down_out_interval_zero false
+
+.. _Storage Capacity: ../configuration/mon-config-ref/#storage-capacity
+.. _No Free Drive Space: ../troubleshooting/troubleshooting-osd/#no-free-drive-space


### PR DESCRIPTION
doc/rados/configuration: Modernize OSD configuration guidance and improve wording

Primary motivation is to address outdated info from the pre-BlueStore days, with various while-I-was-in-the-file edits to improve flow, spelling, missing or extra words etc.

Signed-off-by: Anthony D'Atri anthony.datri@gmail.com

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
