### PR TITLE
cephfs: directory quota optimization

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12054,6 +12054,32 @@ int Client::_setxattr(Inode *in, const char *name, const void *value,
 	return -EOPNOTSUPP;
       if (vxattr->name.compare(0, 10, "ceph.quota") == 0 && value)
 	check_realm = true;
+
+      if ((vxattr->name.compare(0, 20, "ceph.quota.max_bytes") == 0)  && value) {
+        uint64_t i_value = 0;
+        string tmp((const char*)value, size);
+        try {
+          i_value = boost::lexical_cast<uint64_t>(tmp);
+        } catch (boost::bad_lexical_cast& e) {
+          ldout(cct, 8) << "ceph.quota.max_bytes cast i_value error " << "i_value:" << i_value  << ", tmp = "<< tmp << dendl;
+          return -EINVAL;
+        }
+        if((i_value != 0) && (in->rstat.rbytes > i_value))
+      return -EDQUOT;
+      }
+
+      if ((vxattr->name.compare(0, 20, "ceph.quota.max_files") == 0)  && value){
+        uint64_t i_value = 0;
+        string tmp((const char*)value, size);
+        try {
+          i_value = boost::lexical_cast<uint64_t>(tmp);
+        } catch (boost::bad_lexical_cast& e) {
+          ldout(cct, 8) << "ceph.quota.files cast i_value error " << "i_value:" << i_value  << ", tmp = "<< tmp << dendl;
+          return -EINVAL;
+        }
+        if((i_value != 0) && (in->rstat.rsize() > i_value))
+      return -EDQUOT;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes:https://tracker.ceph.com/issues/47931

it is not allowed to adjust the quota below the used capacity; if you want to re-quota, the quota size should be greater than or equal to the used capacity of the current directory. The file quota also has the same problem.

Signed-off-by: chenxi <chen.xi3@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
