### PR TITLE
mon/OSDMonitor: drop osd_epoch of manually marked out osd

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -896,6 +896,12 @@ void OSDMonitor::update_from_paxos(bool *need_bootstrap)
         osd_epochs.erase(osd_state.first);
       }
     }
+    for (const auto [osd, weight] : inc.new_weight) {
+      if (weight == CEPH_OSD_OUT) {
+        // manually marked out, so drop it
+        osd_epochs.erase(osd);
+      }
+    }
   }
 
   if (t) {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -886,14 +886,14 @@ void OSDMonitor::update_from_paxos(bool *need_bootstrap)
       t = MonitorDBStore::TransactionRef();
       tx_size = 0;
     }
-    for (const auto &osd_state : inc.new_state) {
-      if (osd_state.second & CEPH_OSD_UP) {
+    for (const auto [osd, state] : inc.new_state) {
+      if (state & CEPH_OSD_UP) {
 	// could be marked up *or* down, but we're too lazy to check which
-	last_osd_report.erase(osd_state.first);
+	last_osd_report.erase(osd);
       }
-      if (osd_state.second & CEPH_OSD_OUT) {
+      if (state & CEPH_OSD_OUT) {
         // could be marked in *or* out, but we can safely drop it
-        osd_epochs.erase(osd_state.first);
+        osd_epochs.erase(osd);
       }
     }
     for (const auto [osd, weight] : inc.new_weight) {
@@ -1070,19 +1070,20 @@ void OSDMonitor::start_mapping()
 
 void OSDMonitor::update_msgr_features()
 {
-  set<int> types;
-  types.insert((int)entity_name_t::TYPE_OSD);
-  types.insert((int)entity_name_t::TYPE_CLIENT);
-  types.insert((int)entity_name_t::TYPE_MDS);
-  types.insert((int)entity_name_t::TYPE_MON);
-  for (set<int>::iterator q = types.begin(); q != types.end(); ++q) {
+  const int types[] = {
+    entity_name_t::TYPE_OSD,
+    entity_name_t::TYPE_CLIENT,
+    entity_name_t::TYPE_MDS,
+    entity_name_t::TYPE_MON
+  };
+  for (int type : types) {
     uint64_t mask;
-    uint64_t features = osdmap.get_features(*q, &mask);
-    if ((mon->messenger->get_policy(*q).features_required & mask) != features) {
+    uint64_t features = osdmap.get_features(type, &mask);
+    if ((mon->messenger->get_policy(type).features_required & mask) != features) {
       dout(0) << "crush map has features " << features << ", adjusting msgr requires" << dendl;
-      ceph::net::Policy p = mon->messenger->get_policy(*q);
+      ceph::net::Policy p = mon->messenger->get_policy(type);
       p.features_required = (p.features_required & ~mask) | features;
-      mon->messenger->set_policy(*q, p);
+      mon->messenger->set_policy(type, p);
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
