### PR TITLE
blk: log is_valid_io() parameters when unsuccessful.

### DIFF
--- a/src/blk/BlockDevice.cc
+++ b/src/blk/BlockDevice.cc
@@ -196,3 +196,20 @@ void BlockDevice::reap_ioc()
     --ioc_reap_count;
   }
 }
+
+bool BlockDevice::is_valid_io(uint64_t off, uint64_t len) const {
+  bool ret = (off % block_size == 0 &&
+    len % block_size == 0 &&
+    len > 0 &&
+    off < size &&
+    off + len <= size);
+
+  if (!ret) {
+    derr << __func__ << " " << std::hex
+         << off << "~" << len
+         << " block_size " << block_size
+         << " size " << size
+         << std::dec << dendl;
+  }
+  return ret;
+}

--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -272,13 +272,7 @@ public:
   virtual void close() = 0;
 
 protected:
-  bool is_valid_io(uint64_t off, uint64_t len) const {
-    return (off % block_size == 0 &&
-            len % block_size == 0 &&
-            len > 0 &&
-            off < size &&
-            off + len <= size);
-  }
+  bool is_valid_io(uint64_t off, uint64_t len) const;
 };
 
 #endif //CEPH_BLK_BLOCKDEVICE_H


### PR DESCRIPTION
Be verbose when asserting due to unsuccessful call to BlockDevice::is_valid_io() 
Hopefully this will give some insight on the following issue.

Relates-to: https://tracker.ceph.com/issues/48276
Signed-off-by: Igor Fedotov <ifedotov@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
