### PR TITLE
rgw/notifications: fix tag based filtering to work on all ops

### DIFF
--- a/src/rgw/rgw_notify.h
+++ b/src/rgw/rgw_notify.h
@@ -56,9 +56,9 @@ struct reservation_t {
   rgw::sal::RGWRadosStore* const store;
   const req_state* const s;
   size_t size;
-  const rgw::sal::RGWObject* const object;
+  rgw::sal::RGWObject* const object;
 
-  reservation_t(rgw::sal::RGWRadosStore* _store, const req_state* _s, const rgw::sal::RGWObject* _object) : 
+  reservation_t(rgw::sal::RGWRadosStore* _store, const req_state* _s, rgw::sal::RGWObject* _object) : 
       store(_store), s(_s), object(_object) {}
 
   // dtor doing resource leak guarding
@@ -68,10 +68,11 @@ struct reservation_t {
 
 // create a reservation on the 2-phase-commit queue
 int publish_reserve(EventType event_type,
-        reservation_t& reservation);
+        reservation_t& reservation,
+        const RGWObjTags* req_tags);
 
 // commit the reservation to the queue
-int publish_commit(const rgw::sal::RGWObject* obj,
+int publish_commit(rgw::sal::RGWObject* obj,
         uint64_t size,
         const ceph::real_time& mtime, 
         const std::string& etag, 

--- a/src/rgw/rgw_pubsub.cc
+++ b/src/rgw/rgw_pubsub.cc
@@ -236,7 +236,7 @@ void rgw_pubsub_s3_notifications::dump_xml(Formatter *f) const {
   do_encode_xml("NotificationConfiguration", list, "TopicConfiguration", f);
 }
 
-void rgw_pubsub_s3_record::dump(Formatter *f) const {
+void rgw_pubsub_s3_event::dump(Formatter *f) const {
   encode_json("eventVersion", eventVersion, f);
   encode_json("eventSource", eventSource, f);
   encode_json("awsRegion", awsRegion, f);
@@ -935,5 +935,5 @@ void RGWPubSub::SubWithEvents<EventType>::dump(Formatter* f) const {
 // explicit instantiation for the only two possible types
 // no need to move implementation to header
 template class RGWPubSub::SubWithEvents<rgw_pubsub_event>;
-template class RGWPubSub::SubWithEvents<rgw_pubsub_s3_record>;
+template class RGWPubSub::SubWithEvents<rgw_pubsub_s3_event>;
 

--- a/src/rgw/rgw_pubsub.cc
+++ b/src/rgw/rgw_pubsub.cc
@@ -77,7 +77,7 @@ bool rgw_s3_key_filter::has_content() const {
 }
 
 bool rgw_s3_key_value_filter::decode_xml(XMLObj* obj) {
-  kvl.clear();
+  kv.clear();
   XMLObjIter iter = obj->find("FilterRule");
   XMLObj *o;
 
@@ -89,13 +89,13 @@ bool rgw_s3_key_value_filter::decode_xml(XMLObj* obj) {
   while ((o = iter.get_next())) {
     RGWXMLDecoder::decode_xml("Name", key, o, throw_if_missing);
     RGWXMLDecoder::decode_xml("Value", value, o, throw_if_missing);
-    kvl.emplace(key, value);
+    kv.emplace(key, value);
   }
   return true;
 }
 
 void rgw_s3_key_value_filter::dump_xml(Formatter *f) const {
-  for (const auto& key_value : kvl) {
+  for (const auto& key_value : kv) {
     f->open_object_section("FilterRule");
     ::encode_xml("Name", key_value.first, f);
     ::encode_xml("Value", key_value.second, f);
@@ -104,7 +104,7 @@ void rgw_s3_key_value_filter::dump_xml(Formatter *f) const {
 }
 
 bool rgw_s3_key_value_filter::has_content() const {
-    return !kvl.empty();
+    return !kv.empty();
 }
 
 bool rgw_s3_filter::decode_xml(XMLObj* obj) {
@@ -166,10 +166,10 @@ bool match(const rgw_s3_key_filter& filter, const std::string& key) {
   return true;
 }
 
-bool match(const rgw_s3_key_value_filter& filter, const KeyValueList& kvl) {
+bool match(const rgw_s3_key_value_filter& filter, const KeyValueMap& kv) {
   // all filter pairs must exist with the same value in the object's metadata/tags
   // object metadata/tags may include items not in the filter
-  return std::includes(kvl.begin(), kvl.end(), filter.kvl.begin(), filter.kvl.end());
+  return std::includes(kv.begin(), kv.end(), filter.kv.begin(), filter.kv.end());
 }
 
 bool match(const rgw::notify::EventTypeList& events, rgw::notify::EventType event) {

--- a/src/rgw/rgw_pubsub.h
+++ b/src/rgw/rgw_pubsub.h
@@ -41,10 +41,10 @@ struct rgw_s3_key_filter {
 };
 WRITE_CLASS_ENCODER(rgw_s3_key_filter)
 
-using KeyValueList = boost::container::flat_map<std::string, std::string>;
+using KeyValueMap = boost::container::flat_map<std::string, std::string>;
 
 struct rgw_s3_key_value_filter {
-  KeyValueList kvl;
+  KeyValueMap kv;
   
   bool has_content() const;
   
@@ -53,12 +53,12 @@ struct rgw_s3_key_value_filter {
   
   void encode(bufferlist& bl) const {
     ENCODE_START(1, 1, bl);
-    encode(kvl, bl);
+    encode(kv, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator& bl) {
     DECODE_START(1, bl);
-    decode(kvl, bl);
+    decode(kv, bl);
     DECODE_FINISH(bl);
   }
 };
@@ -149,7 +149,7 @@ struct rgw_pubsub_s3_notification {
 // return true if the key matches the prefix/suffix/regex rules of the key filter
 bool match(const rgw_s3_key_filter& filter, const std::string& key);
 // return true if the key matches the metadata/tags rules of the metadata/tags filter
-bool match(const rgw_s3_key_value_filter& filter, const KeyValueList& kvl);
+bool match(const rgw_s3_key_value_filter& filter, const KeyValueMap& kv);
 // return true if the event type matches (equal or contained in) one of the events in the list
 bool match(const rgw::notify::EventTypeList& events, rgw::notify::EventType event);
 
@@ -250,9 +250,9 @@ struct rgw_pubsub_s3_record {
   // this is an rgw extension holding the internal bucket id
   std::string bucket_id;
   // meta data
-  KeyValueList x_meta_map;
+  KeyValueMap x_meta_map;
   // tags
-  KeyValueList tags;
+  KeyValueMap tags;
   // opaque data received from the topic
   // could be used to identify the gateway
   std::string opaque_data;

--- a/src/rgw/rgw_pubsub.h
+++ b/src/rgw/rgw_pubsub.h
@@ -205,7 +205,7 @@ struct rgw_pubsub_s3_notifications {
 ]
 }*/
 
-struct rgw_pubsub_s3_record {
+struct rgw_pubsub_s3_event {
   constexpr static const char* const json_type_plural = "Records";
   std::string eventVersion = "2.2";
   // aws:s3
@@ -323,7 +323,7 @@ struct rgw_pubsub_s3_record {
 
   void dump(Formatter *f) const;
 };
-WRITE_CLASS_ENCODER(rgw_pubsub_s3_record)
+WRITE_CLASS_ENCODER(rgw_pubsub_s3_event)
 
 struct rgw_pubsub_event {
   constexpr static const char* const json_type_plural = "events";
@@ -357,7 +357,7 @@ struct rgw_pubsub_event {
 };
 WRITE_CLASS_ENCODER(rgw_pubsub_event)
 
-// settign a unique ID for an event/record based on object hash and timestamp
+// settign a unique ID for an event based on object hash and timestamp
 void set_event_id(std::string& id, const std::string& hash, const utime_t& ts);
 
 struct rgw_pubsub_sub_dest {
@@ -737,7 +737,7 @@ public:
     if (conf.s3_id.empty()) {
       return std::make_shared<SubWithEvents<rgw_pubsub_event>>(this, sub);
     }
-    return std::make_shared<SubWithEvents<rgw_pubsub_s3_record>>(this, sub);
+    return std::make_shared<SubWithEvents<rgw_pubsub_s3_event>>(this, sub);
   }
 
   void get_meta_obj(rgw_raw_obj *obj) const;

--- a/src/rgw/rgw_pubsub_push.cc
+++ b/src/rgw/rgw_pubsub_push.cc
@@ -131,14 +131,14 @@ public:
     return new PostCR(json_format_pubsub_event(event), env, endpoint, ack_level, verify_ssl);
   }
 
-  RGWCoroutine* send_to_completion_async(const rgw_pubsub_s3_record& record, RGWDataSyncEnv* env) override {
-    return new PostCR(json_format_pubsub_event(record), env, endpoint, ack_level, verify_ssl);
+  RGWCoroutine* send_to_completion_async(const rgw_pubsub_s3_event& event, RGWDataSyncEnv* env) override {
+    return new PostCR(json_format_pubsub_event(event), env, endpoint, ack_level, verify_ssl);
   }
 
-  int send_to_completion_async(CephContext* cct, const rgw_pubsub_s3_record& record, optional_yield y) override {
+  int send_to_completion_async(CephContext* cct, const rgw_pubsub_s3_event& event, optional_yield y) override {
     bufferlist read_bl;
     RGWPostHTTPData request(cct, "POST", endpoint, &read_bl, verify_ssl);
-    const auto post_data = json_format_pubsub_event(record);
+    const auto post_data = json_format_pubsub_event(event);
     request.set_post_data(post_data);
     request.set_send_length(post_data.length());
     if (perfcounter) perfcounter->inc(l_rgw_pubsub_push_pending);
@@ -312,12 +312,12 @@ public:
     }
   }
   
-  RGWCoroutine* send_to_completion_async(const rgw_pubsub_s3_record& record, RGWDataSyncEnv* env) override {
+  RGWCoroutine* send_to_completion_async(const rgw_pubsub_s3_event& event, RGWDataSyncEnv* env) override {
     ceph_assert(conn);
     if (ack_level == ack_level_t::None) {
-      return new NoAckPublishCR(cct, topic, conn, json_format_pubsub_event(record));
+      return new NoAckPublishCR(cct, topic, conn, json_format_pubsub_event(event));
     } else {
-      return new AckPublishCR(cct, topic, conn, json_format_pubsub_event(record));
+      return new AckPublishCR(cct, topic, conn, json_format_pubsub_event(event));
     }
   }
 
@@ -375,17 +375,17 @@ public:
     }
   };
 
-  int send_to_completion_async(CephContext* cct, const rgw_pubsub_s3_record& record, optional_yield y) override {
+  int send_to_completion_async(CephContext* cct, const rgw_pubsub_s3_event& event, optional_yield y) override {
     ceph_assert(conn);
     if (ack_level == ack_level_t::None) {
-      return amqp::publish(conn, topic, json_format_pubsub_event(record));
+      return amqp::publish(conn, topic, json_format_pubsub_event(event));
     } else {
       // TODO: currently broker and routable are the same - this will require different flags but the same mechanism
       // note: dynamic allocation of Waiter is needed when this is invoked from a beast coroutine
       auto w = std::unique_ptr<Waiter>(new Waiter);
       const auto rc = amqp::publish_with_confirm(conn, 
         topic,
-        json_format_pubsub_event(record),
+        json_format_pubsub_event(event),
         std::bind(&Waiter::finish, w.get(), std::placeholders::_1));
       if (rc < 0) {
         // failed to publish, does not wait for reply
@@ -582,12 +582,12 @@ public:
     }
   }
   
-  RGWCoroutine* send_to_completion_async(const rgw_pubsub_s3_record& record, RGWDataSyncEnv* env) override {
+  RGWCoroutine* send_to_completion_async(const rgw_pubsub_s3_event& event, RGWDataSyncEnv* env) override {
     ceph_assert(conn);
     if (ack_level == ack_level_t::None) {
-      return new NoAckPublishCR(cct, topic, conn, json_format_pubsub_event(record));
+      return new NoAckPublishCR(cct, topic, conn, json_format_pubsub_event(event));
     } else {
-      return new AckPublishCR(cct, topic, conn, json_format_pubsub_event(record));
+      return new AckPublishCR(cct, topic, conn, json_format_pubsub_event(event));
     }
   }
 
@@ -645,16 +645,16 @@ public:
     }
   };
 
-  int send_to_completion_async(CephContext* cct, const rgw_pubsub_s3_record& record, optional_yield y) override {
+  int send_to_completion_async(CephContext* cct, const rgw_pubsub_s3_event& event, optional_yield y) override {
     ceph_assert(conn);
     if (ack_level == ack_level_t::None) {
-      return kafka::publish(conn, topic, json_format_pubsub_event(record));
+      return kafka::publish(conn, topic, json_format_pubsub_event(event));
     } else {
       // note: dynamic allocation of Waiter is needed when this is invoked from a beast coroutine
       auto w = std::unique_ptr<Waiter>(new Waiter);
       const auto rc = kafka::publish_with_confirm(conn, 
         topic,
-        json_format_pubsub_event(record),
+        json_format_pubsub_event(event),
         std::bind(&Waiter::finish, w.get(), std::placeholders::_1));
       if (rc < 0) {
         // failed to publish, does not wait for reply

--- a/src/rgw/rgw_pubsub_push.h
+++ b/src/rgw/rgw_pubsub_push.h
@@ -14,7 +14,7 @@ class RGWDataSyncEnv;
 class RGWCoroutine;
 class RGWHTTPArgs;
 struct rgw_pubsub_event;
-struct rgw_pubsub_s3_record;
+struct rgw_pubsub_s3_event;
 
 // endpoint base class all endpoint  - types should derive from it
 class RGWPubSubEndpoint {
@@ -37,11 +37,11 @@ public:
 
   // this method is used in order to send notification (S3 compliant) and wait for completion 
   // in async manner via a coroutine when invoked in the data sync environment
-  virtual RGWCoroutine* send_to_completion_async(const rgw_pubsub_s3_record& record, RGWDataSyncEnv* env) = 0;
+  virtual RGWCoroutine* send_to_completion_async(const rgw_pubsub_s3_event& event, RGWDataSyncEnv* env) = 0;
 
   // this method is used in order to send notification (S3 compliant) and wait for completion 
   // in async manner via a coroutine when invoked in the frontend environment
-  virtual int send_to_completion_async(CephContext* cct, const rgw_pubsub_s3_record& record, optional_yield y) = 0;
+  virtual int send_to_completion_async(CephContext* cct, const rgw_pubsub_s3_event& event, optional_yield y) = 0;
 
   // present as string
   virtual std::string to_str() const { return ""; }

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -478,6 +478,7 @@ class RGWObject {
     virtual bool placement_rules_match(rgw_placement_rule& r1, rgw_placement_rule& r2) = 0;
 
     RGWAttrs& get_attrs(void) { return attrs; }
+    const RGWAttrs& get_attrs(void) const { return attrs; }
     ceph::real_time get_mtime(void) const { return mtime; }
     uint64_t get_obj_size(void) const { return obj_size; }
     RGWBucket* get_bucket(void) const { return bucket; }

--- a/src/rgw/rgw_sync_module_pubsub.cc
+++ b/src/rgw/rgw_sync_module_pubsub.cc
@@ -264,38 +264,38 @@ static void make_event_ref(CephContext *cct, const rgw_bucket& bucket,
   encode_json("info", oevent, &e->info);
 }
 
-static void make_s3_record_ref(CephContext *cct, const rgw_bucket& bucket,
+static void make_s3_event_ref(CephContext *cct, const rgw_bucket& bucket,
                        const rgw_user& owner,
                        const rgw_obj_key& key,
                        const ceph::real_time& mtime,
-                       const std::vector<std::pair<std::string, std::string> > *attrs,
+                       const std::vector<std::pair<std::string, std::string>>* attrs,
                        rgw::notify::EventType event_type,
-                       EventRef<rgw_pubsub_s3_record> *record) {
-  *record = std::make_shared<rgw_pubsub_s3_record>();
+                       EventRef<rgw_pubsub_s3_event>* event) {
+  *event = std::make_shared<rgw_pubsub_s3_event>();
 
-  EventRef<rgw_pubsub_s3_record>& r = *record;
-  r->eventTime = mtime;
-  r->eventName = rgw::notify::to_string(event_type);
+  EventRef<rgw_pubsub_s3_event>& e = *event;
+  e->eventTime = mtime;
+  e->eventName = rgw::notify::to_string(event_type);
   // userIdentity: not supported in sync module
   // x_amz_request_id: not supported in sync module
   // x_amz_id_2: not supported in sync module
   // configurationId is filled from subscription configuration
-  r->bucket_name = bucket.name;
-  r->bucket_ownerIdentity = owner.to_str();
-  r->bucket_arn = to_string(rgw::ARN(bucket));
-  r->bucket_id = bucket.bucket_id; // rgw extension
-  r->object_key = key.name;
+  e->bucket_name = bucket.name;
+  e->bucket_ownerIdentity = owner.to_str();
+  e->bucket_arn = to_string(rgw::ARN(bucket));
+  e->bucket_id = bucket.bucket_id; // rgw extension
+  e->object_key = key.name;
   // object_size not supported in sync module
   objstore_event oevent(bucket, key, mtime, attrs);
-  r->object_etag = oevent.get_hash();
-  r->object_versionId = key.instance;
+  e->object_etag = oevent.get_hash();
+  e->object_versionId = key.instance;
  
   // use timestamp as per key sequence id (hex encoded)
   const utime_t ts(real_clock::now());
   boost::algorithm::hex((const char*)&ts, (const char*)&ts + sizeof(utime_t), 
-          std::back_inserter(r->object_sequencer));
+          std::back_inserter(e->object_sequencer));
  
-  set_event_id(r->id, r->object_etag, ts);
+  set_event_id(e->id, e->object_etag, ts);
 }
 
 class PSManager;
@@ -1022,11 +1022,10 @@ class RGWPSHandleObjEventCR : public RGWCoroutine {
   const PSEnvRef env;
   const rgw_user owner;
   const EventRef<rgw_pubsub_event> event;
-  const EventRef<rgw_pubsub_s3_record> record;
+  const EventRef<rgw_pubsub_s3_event> s3_event;
   const TopicsRef topics;
   bool has_subscriptions;
   bool event_handled;
-  bool sub_conf_found;
   PSSubscriptionRef sub;
   std::vector<PSTopicConfigRef>::const_iterator titer;
   std::set<std::string>::const_iterator siter;
@@ -1036,13 +1035,13 @@ public:
                       const PSEnvRef _env,
                       const rgw_user& _owner,
                       const EventRef<rgw_pubsub_event>& _event,
-                      const EventRef<rgw_pubsub_s3_record>& _record,
+                      const EventRef<rgw_pubsub_s3_event>& _s3_event,
                       const TopicsRef& _topics) : RGWCoroutine(_sc->cct),
                                           sc(_sc),
                                           env(_env),
                                           owner(_owner),
                                           event(_event),
-                                          record(_record),
+                                          s3_event(s3_event),
                                           topics(_topics),
                                           has_subscriptions(false),
                                           event_handled(false) {}
@@ -1106,23 +1105,23 @@ public:
             } 
           } else {
             // subscription was made by S3 compatible API
-            ldout(sc->cct, 20) << "storing record for subscription=" << *siter << " owner=" << owner << " ret=" << retcode << dendl;
-            record->configurationId = sub->sub_conf->s3_id;
-            record->opaque_data = (*titer)->opaque_data;
-            yield call(PSSubscription::store_event_cr(sc, sub, record));
+            ldout(sc->cct, 20) << "storing s3 event for subscription=" << *siter << " owner=" << owner << " ret=" << retcode << dendl;
+            s3_event->configurationId = sub->sub_conf->s3_id;
+            s3_event->opaque_data = (*titer)->opaque_data;
+            yield call(PSSubscription::store_event_cr(sc, sub, s3_event));
             if (retcode < 0) {
               if (perfcounter) perfcounter->inc(l_rgw_pubsub_store_fail);
-              ldout(sc->cct, 1) << "ERROR: failed to store record for subscription=" << *siter << " ret=" << retcode << dendl;
+              ldout(sc->cct, 1) << "ERROR: failed to store s3 event for subscription=" << *siter << " ret=" << retcode << dendl;
             } else {
               if (perfcounter) perfcounter->inc(l_rgw_pubsub_store_ok);
               event_handled = true;
             }
             if (sub->sub_conf->push_endpoint) {
-                ldout(sc->cct, 20) << "push record for subscription=" << *siter << " owner=" << owner << " ret=" << retcode << dendl;
-              yield call(PSSubscription::push_event_cr(sc, sub, record));
+                ldout(sc->cct, 20) << "push s3 event for subscription=" << *siter << " owner=" << owner << " ret=" << retcode << dendl;
+              yield call(PSSubscription::push_event_cr(sc, sub, s3_event));
               if (retcode < 0) {
                 if (perfcounter) perfcounter->inc(l_rgw_pubsub_push_failed);
-                ldout(sc->cct, 1) << "ERROR: failed to push record for subscription=" << *siter << " ret=" << retcode << dendl;
+                ldout(sc->cct, 1) << "ERROR: failed to push s3 event for subscription=" << *siter << " ret=" << retcode << dendl;
               } else {
                 if (perfcounter) perfcounter->inc(l_rgw_pubsub_push_ok);
                 event_handled = true;
@@ -1152,7 +1151,7 @@ class RGWPSHandleRemoteObjCBCR : public RGWStatRemoteObjCBCR {
   PSEnvRef env;
   std::optional<uint64_t> versioned_epoch;
   EventRef<rgw_pubsub_event> event;
-  EventRef<rgw_pubsub_s3_record> record;
+  EventRef<rgw_pubsub_s3_event> s3_event;
   TopicsRef topics;
 public:
   RGWPSHandleRemoteObjCBCR(RGWDataSyncCtx *_sc,
@@ -1179,20 +1178,20 @@ public:
           }
           attrs.push_back(std::make_pair(k, attr.second));
         } 
-        // at this point we don't know whether we need the ceph event or S3 record
+        // at this point we don't know whether we need the ceph event or S3 event
         // this is why both are created here, once we have information about the 
         // subscription, we will store/push only the relevant ones
         make_event_ref(sc->cct,
                        sync_pipe.info.source_bs.bucket, key,
                        mtime, &attrs,
                        rgw::notify::ObjectCreated, &event);
-        make_s3_record_ref(sc->cct,
+        make_s3_event_ref(sc->cct,
                        sync_pipe.info.source_bs.bucket, sync_pipe.dest_bucket_info.owner, key,
                        mtime, &attrs,
-                       rgw::notify::ObjectCreated, &record);
+                       rgw::notify::ObjectCreated, &s3_event);
       }
 
-      yield call(new RGWPSHandleObjEventCR(sc, env, sync_pipe.source_bucket_info.owner, event, record, topics));
+      yield call(new RGWPSHandleObjEventCR(sc, env, sync_pipe.source_bucket_info.owner, event, s3_event, topics));
       if (retcode < 0) {
         return set_cr_error(retcode);
       }
@@ -1278,7 +1277,7 @@ class RGWPSGenericObjEventCBCR : public RGWCoroutine {
   ceph::real_time mtime;
   rgw::notify::EventType event_type;
   EventRef<rgw_pubsub_event> event;
-  EventRef<rgw_pubsub_s3_record> record;
+  EventRef<rgw_pubsub_s3_event> s3_event;
   TopicsRef topics;
 public:
   RGWPSGenericObjEventCBCR(RGWDataSyncCtx *_sc,
@@ -1304,18 +1303,18 @@ public:
         ldout(sc->cct, 20) << "no topics found for " << bucket << "/" << key << dendl;
         return set_cr_done();
       }
-      // at this point we don't know whether we need the ceph event or S3 record
+      // at this point we don't know whether we need the ceph event or S3 event
       // this is why both are created here, once we have information about the 
       // subscription, we will store/push only the relevant ones
       make_event_ref(sc->cct,
                      bucket, key,
                      mtime, nullptr,
                      event_type, &event);
-      make_s3_record_ref(sc->cct,
+      make_s3_event_ref(sc->cct,
                      bucket, owner, key,
                      mtime, nullptr,
-                     event_type, &record);
-      yield call(new RGWPSHandleObjEventCR(sc, env, owner, event, record, topics));
+                     event_type, &s3_event);
+      yield call(new RGWPSHandleObjEventCR(sc, env, owner, event, s3_event, topics));
       if (retcode < 0) {
         return set_cr_error(retcode);
       }

--- a/src/test/rgw/rgw_multi/tests_ps.py
+++ b/src/test/rgw/rgw_multi/tests_ps.py
@@ -3817,7 +3817,7 @@ def test_ps_s3_tags_on_master():
         return SkipTest("PubSub push tests don't run in teuthology")
     hostname = get_ip()
     proc = init_rabbitmq()
-    if proc is  None:
+    if proc is None:
         return SkipTest('end2end amqp tests require rabbitmq-server installed')
     master_zone, _ = init_env(require_ps=False)
     realm = get_realm()
@@ -3869,19 +3869,25 @@ def test_ps_s3_tags_on_master():
     time.sleep(5)
     expected_tags = [{'val': 'world', 'key': 'hello'}, {'val': 'boom', 'key': 'ka'}]
     # check amqp receiver
+    filtered_count = 0
     for event in receiver.get_and_reset_events():
         obj_tags =  event['Records'][0]['s3']['object']['tags']
         assert_equal(obj_tags[0], expected_tags[0])
-
+        filtered_count += 1
+    assert_equal(filtered_count, 2)
+    
     # delete the objects
     for key in bucket.list():
         key.delete()
     print('wait for 5sec for the messages...')
     time.sleep(5)
     # check amqp receiver
+    filtered_count = 0
     for event in receiver.get_and_reset_events():
         obj_tags =  event['Records'][0]['s3']['object']['tags']
         assert_equal(obj_tags[0], expected_tags[0])
+        filtered_count += 1
+    assert_equal(filtered_count, 2)
 
     # cleanup
     stop_amqp_receiver(receiver, task)


### PR DESCRIPTION
fixes: https://tracker.ceph.com/issues/48321

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
]
</details>
