### PR TITLE
test/librbd: rename tests to match proper namespaces

### DIFF
--- a/src/test/librbd/crypto/openssl/test_DataCryptor.cc
+++ b/src/test/librbd/crypto/openssl/test_DataCryptor.cc
@@ -14,7 +14,7 @@ const unsigned char TEST_IV[16] = {2};
 const unsigned char TEST_IV_2[16] = {3};
 const unsigned char TEST_DATA[4096] = {4};
 
-struct TestDataCryptor : public TestFixture {
+struct TestCryptoOpensslDataCryptor : public TestFixture {
     DataCryptor *cryptor;
 
     void SetUp() override {
@@ -30,28 +30,28 @@ struct TestDataCryptor : public TestFixture {
     }
 };
 
-TEST_F(TestDataCryptor, InvalidCipherName) {
+TEST_F(TestCryptoOpensslDataCryptor, InvalidCipherName) {
   EXPECT_EQ(-EINVAL, cryptor->init(nullptr, TEST_KEY, sizeof(TEST_KEY)));
   EXPECT_EQ(-EINVAL, cryptor->init("", TEST_KEY, sizeof(TEST_KEY)));
   EXPECT_EQ(-EINVAL, cryptor->init("Invalid", TEST_KEY, sizeof(TEST_KEY)));
 }
 
-TEST_F(TestDataCryptor, InvalidKey) {
+TEST_F(TestCryptoOpensslDataCryptor, InvalidKey) {
   EXPECT_EQ(-EINVAL, cryptor->init(TEST_CIPHER_NAME, nullptr, 0));
   EXPECT_EQ(-EINVAL, cryptor->init(TEST_CIPHER_NAME, nullptr,
                                    sizeof(TEST_KEY)));
   EXPECT_EQ(-EINVAL, cryptor->init(TEST_CIPHER_NAME, TEST_KEY, 1));
 }
 
-TEST_F(TestDataCryptor, GetContextInvalidMode) {
+TEST_F(TestCryptoOpensslDataCryptor, GetContextInvalidMode) {
   EXPECT_EQ(nullptr, cryptor->get_context(static_cast<CipherMode>(-1)));
 }
 
-TEST_F(TestDataCryptor, ReturnNullContext) {
+TEST_F(TestCryptoOpensslDataCryptor, ReturnNullContext) {
   cryptor->return_context(nullptr, static_cast<CipherMode>(-1));
 }
 
-TEST_F(TestDataCryptor, ReturnContextInvalidMode) {
+TEST_F(TestCryptoOpensslDataCryptor, ReturnContextInvalidMode) {
   auto ctx = cryptor->get_context(CipherMode::CIPHER_MODE_ENC);
   ASSERT_NE(ctx, nullptr);
   cryptor->return_context(ctx, CipherMode::CIPHER_MODE_DEC);
@@ -60,7 +60,7 @@ TEST_F(TestDataCryptor, ReturnContextInvalidMode) {
   cryptor->return_context(ctx, static_cast<CipherMode>(-1));
 }
 
-TEST_F(TestDataCryptor, EncryptDecrypt) {
+TEST_F(TestCryptoOpensslDataCryptor, EncryptDecrypt) {
   auto ctx = cryptor->get_context(CipherMode::CIPHER_MODE_ENC);
   ASSERT_NE(ctx, nullptr);
   cryptor->init_context(ctx, TEST_IV, sizeof(TEST_IV));
@@ -78,7 +78,7 @@ TEST_F(TestDataCryptor, EncryptDecrypt) {
   cryptor->return_context(ctx, CipherMode::CIPHER_MODE_DEC);
 }
 
-TEST_F(TestDataCryptor, ReuseContext) {
+TEST_F(TestCryptoOpensslDataCryptor, ReuseContext) {
   auto ctx = cryptor->get_context(CipherMode::CIPHER_MODE_ENC);
   ASSERT_NE(ctx, nullptr);
 
@@ -105,7 +105,7 @@ TEST_F(TestDataCryptor, ReuseContext) {
   cryptor->return_context(ctx2, CipherMode::CIPHER_MODE_ENC);
 }
 
-TEST_F(TestDataCryptor, InvalidIVLength) {
+TEST_F(TestCryptoOpensslDataCryptor, InvalidIVLength) {
   auto ctx = cryptor->get_context(CipherMode::CIPHER_MODE_ENC);
   ASSERT_NE(ctx, nullptr);
 

--- a/src/test/librbd/crypto/test_mock_BlockCrypto.cc
+++ b/src/test/librbd/crypto/test_mock_BlockCrypto.cc
@@ -21,7 +21,7 @@ MATCHER_P(CompareArrayToString, s, "") {
   return (memcmp(arg, s.c_str(), s.length()) == 0);
 }
 
-struct TestMockBlockCrypto : public TestFixture {
+struct TestMockCryptoBlockCrypto : public TestFixture {
     MockDataCryptor cryptor;
     ceph::ref_t<BlockCrypto<MockCryptoContext>> bc;
     int cryptor_block_size = 2;
@@ -73,7 +73,7 @@ struct TestMockBlockCrypto : public TestFixture {
     }
 };
 
-TEST_F(TestMockBlockCrypto, Encrypt) {
+TEST_F(TestMockCryptoBlockCrypto, Encrypt) {
   uint32_t image_offset = 0x1234 * block_size;
 
   ceph::bufferlist data1;
@@ -104,19 +104,19 @@ TEST_F(TestMockBlockCrypto, Encrypt) {
   ASSERT_TRUE(data.is_aligned(block_size));
 }
 
-TEST_F(TestMockBlockCrypto, UnalignedImageOffset) {
+TEST_F(TestMockCryptoBlockCrypto, UnalignedImageOffset) {
   ceph::bufferlist data;
   data.append("1234");
   ASSERT_EQ(-EINVAL, bc->encrypt(&data, 2));
 }
 
-TEST_F(TestMockBlockCrypto, UnalignedDataLength) {
+TEST_F(TestMockCryptoBlockCrypto, UnalignedDataLength) {
   ceph::bufferlist data;
   data.append("123");
   ASSERT_EQ(-EINVAL, bc->encrypt(&data, 0));
 }
 
-TEST_F(TestMockBlockCrypto, GetContextError) {
+TEST_F(TestMockCryptoBlockCrypto, GetContextError) {
   ceph::bufferlist data;
   data.append("1234");
   EXPECT_CALL(cryptor, get_context(CipherMode::CIPHER_MODE_ENC)).WillOnce(
@@ -124,7 +124,7 @@ TEST_F(TestMockBlockCrypto, GetContextError) {
   ASSERT_EQ(-EIO, bc->encrypt(&data, 0));
 }
 
-TEST_F(TestMockBlockCrypto, InitContextError) {
+TEST_F(TestMockCryptoBlockCrypto, InitContextError) {
   ceph::bufferlist data;
   data.append("1234");
   expect_get_context(CipherMode::CIPHER_MODE_ENC);
@@ -132,7 +132,7 @@ TEST_F(TestMockBlockCrypto, InitContextError) {
   ASSERT_EQ(-123, bc->encrypt(&data, 0));
 }
 
-TEST_F(TestMockBlockCrypto, UpdateContextError) {
+TEST_F(TestMockCryptoBlockCrypto, UpdateContextError) {
   ceph::bufferlist data;
   data.append("1234");
   expect_get_context(CipherMode::CIPHER_MODE_ENC);

--- a/src/test/librbd/crypto/test_mock_CryptoContextPool.cc
+++ b/src/test/librbd/crypto/test_mock_CryptoContextPool.cc
@@ -14,7 +14,7 @@ using ::testing::Return;
 namespace librbd {
 namespace crypto {
 
-struct TestMockCryptoContextPool : public ::testing::Test {
+struct TestMockCryptoCryptoContextPool : public ::testing::Test {
     MockDataCryptor cryptor;
 
     void expect_get_context(CipherMode mode) {
@@ -28,7 +28,7 @@ struct TestMockCryptoContextPool : public ::testing::Test {
     }
 };
 
-TEST_F(TestMockCryptoContextPool, Test) {
+TEST_F(TestMockCryptoCryptoContextPool, Test) {
   CryptoContextPool<MockCryptoContext> pool(&cryptor, 1);
 
   expect_get_context(CipherMode::CIPHER_MODE_ENC);


### PR DESCRIPTION
Some of the new crypto tests use a generic test name that
doesn't include the full namespace of the class under test.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
