### PR TITLE
Adding missing Ceph Foundation board members

### DIFF
--- a/doc/foundation.rst
+++ b/doc/foundation.rst
@@ -112,7 +112,9 @@ Members
 * Phil Straw (SoftIron)
 * Robin Johnson (DigitalOcean)
 * Sage Weil (Red Hat) - Ceph project leader
+* Winston Damarillio (Amihan)
 * Xie Xingguo (ZTE)
+* Zhang Shaowen (China Mobile)
 
 Joining
 =======


### PR DESCRIPTION
These companies have been members since the beginning.