### PR TITLE
octopus: rgw: during GC defer, prevent new GC enqueue

### DIFF
--- a/src/cls/rgw_gc/cls_rgw_gc.cc
+++ b/src/cls/rgw_gc/cls_rgw_gc.cc
@@ -494,6 +494,11 @@ static int cls_rgw_gc_queue_update_entry(cls_method_context_t hctx, bufferlist *
     return -ENOSPC;
   }
 
+  // Due to Tracker 47866 we are no longer executing this code, as it
+  // appears to possibly create a GC entry for an object that has not
+  // been deleted. Instead we will log at level 0 to perhaps confirm
+  // that when and how often this bug would otherwise be hit.
+#if 0
   cls_queue_enqueue_op enqueue_op;
   bufferlist bl_data;
   encode(op.info, bl_data);
@@ -504,6 +509,16 @@ static int cls_rgw_gc_queue_update_entry(cls_method_context_t hctx, bufferlist *
   if (ret < 0) {
     return ret;
   }
+#else
+  std::string first_chain = "<empty-chain>";
+  if (! op.info.chain.objs.empty()) {
+    first_chain = op.info.chain.objs.cbegin()->key.name;
+  }
+  CLS_LOG(0,
+	  "INFO: refrained from enqueueing GC entry during GC defer"
+	  " tag=%s, first_chain=%s\n",
+	  op.info.tag.c_str(), first_chain.c_str());
+#endif
 
   if (has_urgent_data) {
     head.bl_urgent_data.clear();

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2127,16 +2127,8 @@ int RGWGetObj::handle_slo_manifest(bufferlist& bl)
 
 int RGWGetObj::get_data_cb(bufferlist& bl, off_t bl_ofs, off_t bl_len)
 {
-  /* garbage collection related handling */
-  utime_t start_time = ceph_clock_now();
-  if (start_time > gc_invalidate_time) {
-    int r = store->getRados()->defer_gc(s->obj_ctx, s->bucket_info, obj, s->yield);
-    if (r < 0) {
-      ldpp_dout(this, 0) << "WARNING: could not defer gc entry for obj" << dendl;
-    }
-    gc_invalidate_time = start_time;
-    gc_invalidate_time += (s->cct->_conf->rgw_gc_obj_min_wait / 2);
-  }
+  /* garbage collection related handling:
+   * defer_gc disabled for https://tracker.ceph.com/issues/47866 */
   return send_response_data(bl, bl_ofs, bl_len);
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48331

---

backport of https://github.com/ceph/ceph/pull/38228
parent tracker: https://tracker.ceph.com/issues/47866

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh