### PR TITLE
systemd: improve osd activation

### DIFF
--- a/systemd/ceph-osd@.service.in
+++ b/systemd/ceph-osd@.service.in
@@ -5,6 +5,9 @@ After=network-online.target local-fs.target time-sync.target
 Before=remote-fs-pre.target ceph-osd.target
 Wants=network-online.target local-fs.target time-sync.target remote-fs-pre.target ceph-osd.target
 
+Requires=ceph-volume-systemd2@%i.service
+After=ceph-volume-systemd2@%i.service
+
 [Service]
 Environment=CLUSTER=ceph
 EnvironmentFile=-@SYSTEMD_ENV_FILE@

--- a/systemd/ceph-volume@.service
+++ b/systemd/ceph-volume@.service
@@ -5,10 +5,12 @@ Wants=local-fs.target
 
 [Service]
 Type=oneshot
-KillMode=none
-Environment=CEPH_VOLUME_TIMEOUT=10000
-ExecStart=/bin/sh -c 'timeout $CEPH_VOLUME_TIMEOUT /usr/sbin/ceph-volume-systemd %i'
-TimeoutSec=0
+
+EnvironmentFile=-/etc/default/ceph
+Environment=CLUSTER=ceph
+
+ExecStart=/usr/sbin/ceph-volume-systemd --cluster ${CLUSTER} --osd-id %i activate
+ExecStart=/usr/sbin/ceph-volume-systemd --cluster ${CLUSTER} --osd-id %i deactivate
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

Improve the system osd activation by having `ceph-osd@` trigger a service that sets up the osd state directory.

This fixes a few things, e.g. deactivating a `ceph-osd` service will now actually deactivate it and it won't be started by `ceph-volume-systemd@....`

This is a rough Draft, I'll take care of any formalities if there is any interest in this getting merged, but I currently don't have the time,

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
