### PR TITLE
rgw: cls_rgw_gc_queue_remove_entries() manages deferred entries

### DIFF
--- a/src/cls/queue/cls_queue_types.h
+++ b/src/cls/queue/cls_queue_types.h
@@ -84,6 +84,17 @@ struct cls_queue_marker
 };
 WRITE_CLASS_ENCODER(cls_queue_marker)
 
+inline constexpr bool operator==(const cls_queue_marker& lhs,
+                                 const cls_queue_marker& rhs)
+{
+  return lhs.offset == rhs.offset && lhs.gen == rhs.gen;
+}
+inline constexpr bool operator!=(const cls_queue_marker& lhs,
+                                 const cls_queue_marker& rhs)
+{
+  return lhs.offset != rhs.offset || lhs.gen != rhs.gen;
+}
+
 struct cls_queue_head
 {
   uint64_t max_head_size = QUEUE_HEAD_SIZE_1K;

--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -645,7 +645,7 @@ int RGWGC::process(int index, int max_secs, bool expired_only,
 	} // chains loop
       } // else -- chains not empty
     } // entries loop
-    if (transitioned_objects_cache[index] && entries.size() > 0) {
+    if (transitioned_objects_cache[index]) {
       ret = io_manager.drain_ios();
       if (ret < 0) {
         goto done;


### PR DESCRIPTION
this follows up on https://github.com/ceph/ceph/pull/38228, which avoids writing new gc queue entries in `cls_rgw_gc_queue_update_entry()` for `defer_gc()`, to restore two invariants of the gc model:
1) a gc entry stays in the queue until `RGWGC::process()` sees it in `list_entries()` and removes it with `remove_entries()`
2) an urgent_data entry written by `cls_rgw_gc_queue_update_entry()` is eventually removed

for 1), `remove_entries()` reschedules any removed gc entries that were hidden from `list_entries()` due to urgent_data, using the deferred timestamp. that timestamp is guaranteed to be smaller than gc entries enqueued after, so won't delay further processing
for 2), `RGWGC::process()` calls into `remove_entries()` regularly, regardless of whether it found entries to GC, and `remove_entries()` removes urgent_data entries when:
* a gc entry with a matching `tag` is removed which wasn't hidden from `list_entries()`, meaning it was successfully GC'd
* a gc entry is removed with a timestamp larger than the deferred timestamp, meaning that we would have already seen the entry if it was queued for gc
* the queue is empty, all urgent_data can be cleared

Fixes: https://tracker.ceph.com/issues/48328
Fixes: https://tracker.ceph.com/issues/48329

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
