### PR TITLE
blk/kernel: expose IORING_SETUP_{IOPOLL,SQPOLL} as options

### DIFF
--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -70,7 +70,9 @@ KernelDevice::KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, ai
   unsigned int iodepth = cct->_conf->bdev_aio_max_queue_depth;
 
   if (use_ioring && ioring_queue_t::supported()) {
-    io_queue = std::make_unique<ioring_queue_t>(iodepth);
+    bool use_ioring_hipri = cct->_conf.get_val<bool>("bdev_ioring_hipri");
+    bool use_ioring_sqthread_poll = cct->_conf.get_val<bool>("bdev_ioring_sqthread_poll");
+    io_queue = std::make_unique<ioring_queue_t>(iodepth, use_ioring_hipri, use_ioring_sqthread_poll);
   } else {
     static bool once;
     if (use_ioring && !once) {

--- a/src/blk/kernel/io_uring.cc
+++ b/src/blk/kernel/io_uring.cc
@@ -8,11 +8,6 @@
 #include "liburing.h"
 #include <sys/epoll.h>
 
-/* Options */
-
-static bool hipri = false;      /* use IO polling */
-static bool sq_thread = false;  /* use kernel submission/poller thread */
-
 struct ioring_data {
   struct io_uring io_uring;
   pthread_mutex_t cq_mutex;
@@ -108,9 +103,11 @@ static void build_fixed_fds_map(struct ioring_data *d,
   }
 }
 
-ioring_queue_t::ioring_queue_t(unsigned iodepth_) :
+ioring_queue_t::ioring_queue_t(unsigned iodepth_, bool hipri_, bool sq_thread_) :
   d(make_unique<ioring_data>()),
-  iodepth(iodepth_)
+  iodepth(iodepth_),
+  hipri(hipri_),
+  sq_thread(sq_thread_)
 {
 }
 

--- a/src/blk/kernel/io_uring.h
+++ b/src/blk/kernel/io_uring.h
@@ -13,13 +13,15 @@ struct ioring_data;
 struct ioring_queue_t final : public io_queue_t {
   std::unique_ptr<ioring_data> d;
   unsigned iodepth = 0;
+  bool hipri = false;
+  bool sq_thread = false;
 
   typedef std::list<aio_t>::iterator aio_iter;
 
   // Returns true if arch is x86-64 and kernel supports io_uring
   static bool supported();
 
-  ioring_queue_t(unsigned iodepth_);
+  ioring_queue_t(unsigned iodepth_, bool hipri_, bool sq_thread_);
   ~ioring_queue_t() final;
 
   int init(std::vector<int> &fds) final;

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4791,6 +4791,14 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description("Enables Linux io_uring API instead of libaio"),
 
+    Option("bdev_ioring_hipri", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("Enables Linux io_uring API Use polled IO completions"),
+
+    Option("bdev_ioring_sqthread_poll", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("Enables Linux io_uring API Offload submission/completion to kernel thread"),
+
     // -----------------------------------------
     // kstore
 


### PR DESCRIPTION
Signed-off-by: JiangYu <lnsyyj@hotmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
