### PR TITLE
neorados: use lambda instead of std::mem_fn()

### DIFF
--- a/src/neorados/RADOS.cc
+++ b/src/neorados/RADOS.cc
@@ -899,8 +899,9 @@ void RADOS::lookup_pool(std::string_view name,
        objecter = impl->objecter]
       (bs::error_code ec) mutable {
 	int64_t ret =
-	  objecter->with_osdmap(std::mem_fn(&OSDMap::lookup_pg_pool_name),
-				name);
+	  objecter->with_osdmap([&](const OSDMap &osdmap) {
+	    return osdmap.lookup_pg_pool_name(name);
+	  });
 	if (ret < 0)
 	  ca::dispatch(std::move(c), osdc_errc::pool_dne,
 		       std::int64_t(0));


### PR DESCRIPTION
this addresses the FTBFS with GCC-10.2.0. FWIW, i cannot create a minimal
reproducer.

the error message was:
```
/usr/bin/g++-10 -DBOOST_ASIO_DISABLE_THREAD_KEYWORD_EXTENSION -DHAVE_CONFIG_H -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_REENTRANT -D_THREAD_SAFE -D__CEPH__ -D__STDC_FORMAT_MACROS -D__linux__
-Isrc/include -I../src -isystem /opt/ceph/include -isystem include -isystem\
 ../src/xxHash -isystem ../src/rapidjson/include -fno-omit-frame-pointer -g -fPIC -Wall -fno-strict-aliasing -fsigned-char -Wtype-limits -Wignored-qualifiers -Wpointer-arith -Werror=format-security
-Winit-self -Wno-unknown-pragmas -Wnon-virtual-dtor -Wno-ignored-qualifie\
rs -ftemplate-depth-1024 -Wpessimizing-move -Wredundant-move -Wstrict-null-sentinel -Woverloaded-virtual -fno-new-ttp-matching -DCEPH_DEBUG_MUTEX -fstack-protector-strong -D_GLIBCXX_ASSERTIONS
-fdiagnostics-color=auto -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-\
realloc -fno-builtin-free -std=c++17 -MD -MT src/neorados/CMakeFiles/neorados_api_obj.dir/RADOS.cc.o -MF src/neorados/CMakeFiles/neorados_api_obj.dir/RADOS.cc.o.d -o
src/neorados/CMakeFiles/neorados_api_obj.dir/RADOS.cc.o -c ../src/neorados/RADOS.cc
In file included from /usr/include/c++/10/bits/move.h:57,
                 from /usr/include/c++/10/bits/stl_pair.h:59,
                 from /usr/include/c++/10/utility:70,
                 from /usr/include/c++/10/optional:36,
                 from ../src/neorados/RADOS.cc:17:
/usr/include/c++/10/type_traits: In substitution of ‘template<class _Fp, class _Tp1, class ... _Args> static std::__result_of_success<decltype
((declval<_Tp1>)().*(declval<_Fp>)()((declval<_Args>)()...)), std::__invoke_memfun_ref> std::__result_of_memfun_ref_impl::_S_tes\
t(int) [with _Fp = long int (OSDMap::*)(std::basic_string_view<char>) const; _Tp1 = OSDMap&; _Args = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&}]’:
/usr/include/c++/10/type_traits:2377:56:   required from ‘struct std::__result_of_memfun_ref<long int (OSDMap::*)(std::basic_string_view<char>) const, OSDMap&, std::__cxx11::basic_string<char,
std::char_traits<char>, std::allocator<char> >&>’
/usr/include/c++/10/type_traits:2463:21:   required from ‘struct std::__result_of_memfun<long int (OSDMap::*)(std::basic_string_view<char>) const, OSDMap&, std::__cxx11::basic_string<char,
std::char_traits<char>, std::allocator<char> >&>’
/usr/include/c++/10/type_traits:2496:12:   required from ‘struct std::__result_of_impl<false, true, long int (OSDMap::* const&)(std::basic_string_view<char>) const, OSDMap&,
std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&>’
/usr/include/c++/10/type_traits:2522:12:   required from ‘struct std::__invoke_result<long int (OSDMap::* const&)(std::basic_string_view<char>) const, OSDMap&, std::__cxx11::basic_string<char,
std::char_traits<char>, std::allocator<char> >&>’
/usr/include/c++/10/bits/invoke.h:89:5:   required by substitution of ‘template<class _Callable, class ... _Args> constexpr typename std::__invoke_result<_Functor, _ArgTypes>::type
std::__invoke(_Callable&&, _Args&& ...) [with _Callable = long int (OSDMap::* const&)(std:\
:basic_string_view<char>) const; _Args = {OSDMap&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&}]’
/usr/include/c++/10/functional:121:27:   required by substitution of ‘template<class ... _Args> decltype (std::__invoke(((const std::_Mem_fn_base<long int (OSDMap::*)(std::basic_string_view<char>)
const, true>*)this)->std::_Mem_fn_base<long int (OSDMap::*)(std::basic_str\
ing_view<char>) const, true>::_M_pmf, (forward<_Args>)(std::_Mem_fn_base<_MemFunPtr, __is_mem_fn>::operator()::__args)...)) std::_Mem_fn_base<long int (OSDMap::*)(std::basic_string_view<char>) const,
true>::operator()<_Args ...>(_Args&& ...) const [with _Args = {OSDMap&,\
 std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&}]’
../src/osdc/Objecter.h:2600:38:   required from ‘decltype(auto) Objecter::with_osdmap(Callback&&, Args&& ...) [with Callback = std::_Mem_fn<long int (OSDMap::*)(std::basic_string_view<char>) const>;
Args = {std::__cxx11::basic_string<char, std::char_traits<char>, std::al\
locator<char> >&}]’
../src/neorados/RADOS.cc:903:9:   required from here
/usr/include/c++/10/type_traits:2366:50: internal compiler error: in build_over_call, at cp/call.c:8976
 2366 |       (std::declval<_Tp1>().*std::declval<_Fp>())(std::declval<_Args>()...)
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
0x5de01a build_over_call
    ../../src/gcc/cp/call.c:8976
0xaa30fe build_new_method_call_1
    ../../src/gcc/cp/call.c:10385
0xaa429e build_new_method_call(tree_node*, tree_node*, vec<tree_node*, va_gc, vl_embed>**, tree_node*, int, tree_node**, int)
    ../../src/gcc/cp/call.c:10460
0xaa429e build_special_member_call(tree_node*, tree_node*, vec<tree_node*, va_gc, vl_embed>**, tree_node*, int, int)
    ../../src/gcc/cp/call.c:9861
0xa94458 build_temp
    ../../src/gcc/cp/call.c:7128
0xa94458 convert_like_real_1
    ../../src/gcc/cp/call.c:7705
0xa95b3d perform_implicit_conversion_flags(tree_node*, tree_node*, int, int)
    ../../src/gcc/cp/call.c:11921
0xca79f5 convert_arguments
    ../../src/gcc/cp/typeck.c:4197
0xca79f5 cp_build_function_call_vec(tree_node*, vec<tree_node*, va_gc, vl_embed>**, int, tree_node*)
    ../../src/gcc/cp/typeck.c:4031
0xb4c4d0 build_offset_ref_call_from_tree(tree_node*, vec<tree_node*, va_gc, vl_embed>**, int)
    ../../src/gcc/cp/decl2.c:5276
0xc28b46 tsubst_copy_and_build(tree_node*, tree_node*, int, tree_node*, bool, bool)
    ../../src/gcc/cp/pt.c:20073
0xc2b204 tsubst(tree_node*, tree_node*, int, tree_node*)
    ../../src/gcc/cp/pt.c:15946
0xc2db88 tsubst_template_args(tree_node*, tree_node*, int, tree_node*)
    ../../src/gcc/cp/pt.c:13193
0xc3331b tsubst_aggr_type
    ../../src/gcc/cp/pt.c:13396
0xc35911 tsubst_function_type
    ../../src/gcc/cp/pt.c:14942
0xc2ae00 tsubst(tree_node*, tree_node*, int, tree_node*)
    ../../src/gcc/cp/pt.c:15753
0xc3988c tsubst_function_decl
    ../../src/gcc/cp/pt.c:13787
0xc2316f tsubst_decl
    ../../src/gcc/cp/pt.c:14230
0xc33a29 instantiate_template_1
    ../../src/gcc/cp/pt.c:20871
0xc4321b instantiate_template(tree_node*, tree_node*, int)
    ../../src/gcc/cp/pt.c:20928
Please submit a full bug report,
```
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
