### PR TITLE
src,cmake: define BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT for Boost.Asio users and cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,8 @@ foreach(policy
     CMP0056
     CMP0065
     CMP0074
-    CMP0075)
+    CMP0075
+    CMP0093)
   if(POLICY ${policy})
     cmake_policy(SET ${policy} NEW)
   endif()

--- a/src/json_spirit/json_spirit_reader_template.h
+++ b/src/json_spirit/json_spirit_reader_template.h
@@ -20,27 +20,18 @@
 #include <boost/bind/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/version.hpp>
-
-#if BOOST_VERSION >= 103800
-    #include <boost/spirit/include/classic_core.hpp>
-    #include <boost/spirit/include/classic_confix.hpp>
-    #include <boost/spirit/include/classic_escape_char.hpp>
-    #include <boost/spirit/include/classic_multi_pass.hpp>
-    #include <boost/spirit/include/classic_position_iterator.hpp>
-    #define spirit_namespace boost::spirit::classic
-#else
-    #include <boost/spirit/core.hpp>
-    #include <boost/spirit/utility/confix.hpp>
-    #include <boost/spirit/utility/escape_char.hpp>
-    #include <boost/spirit/iterator/multi_pass.hpp>
-    #include <boost/spirit/iterator/position_iterator.hpp>
-    #define spirit_namespace boost::spirit
-#endif
+#include <boost/spirit/include/classic_core.hpp>
+#include <boost/spirit/include/classic_confix.hpp>
+#include <boost/spirit/include/classic_escape_char.hpp>
+#include <boost/spirit/include/classic_multi_pass.hpp>
+#include <boost/spirit/include/classic_position_iterator.hpp>
 
 #include "include/ceph_assert.h"
 
 namespace json_spirit
 {
+    namespace spirit_namespace = boost::spirit::classic;
+
     const spirit_namespace::int_parser < boost::int64_t >  int64_p  = spirit_namespace::int_parser < boost::int64_t  >();
     const spirit_namespace::uint_parser< boost::uint64_t > uint64_p = spirit_namespace::uint_parser< boost::uint64_t >();
 

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(Boost_VERSION VERSION_GREATER_EQUAL 1.74)
+  add_definitions(-DBOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT)
+endif()
+
 set(librbd_types_srcs
   journal/Types.cc
   mirroring_watcher/Types.cc

--- a/src/rgw/rgw_dmclock_async_scheduler.h
+++ b/src/rgw/rgw_dmclock_async_scheduler.h
@@ -82,12 +82,8 @@ class AsyncScheduler : public md_config_obs_t, public Scheduler {
   using Completion = async::Completion<Signature, async::AsBase<Request>>;
 
   using Clock = ceph::coarse_real_clock;
-#if BOOST_VERSION < 107000
-  using Timer = boost::asio::basic_waitable_timer<Clock>;
-#else
   using Timer = boost::asio::basic_waitable_timer<Clock,
         boost::asio::wait_traits<Clock>, executor_type>;
-#endif
   Timer timer; //< timer for the next scheduled request
 
   CephContext *const cct;

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -253,13 +253,9 @@ class RGWReshardWait {
   ceph::condition_variable cond;
 
   struct Waiter : boost::intrusive::list_base_hook<> {
-#if BOOST_VERSION < 107000
-    using Timer = boost::asio::basic_waitable_timer<Clock>;
-#else
     using Executor = boost::asio::io_context::executor_type;
     using Timer = boost::asio::basic_waitable_timer<Clock,
           boost::asio::wait_traits<Clock>, Executor>;
-#endif
     Timer timer;
     explicit Waiter(boost::asio::io_context& ioc) : timer(ioc) {}
   };

--- a/src/test/confutils.cc
+++ b/src/test/confutils.cc
@@ -231,17 +231,6 @@ const char illegal_conf4[] = "\
         keyring = osd_keyring          ; osd's keyring\n\
 ";
 
-#if BOOST_VERSION < 107200
-// Boost::spirit > 1.72 asserts on chars that are not < 0x7f
-// unicode config file
-const char unicode_config_1[] = "\
-[global]\n\
-        log file =           \x66\xd1\x86\xd1\x9d\xd3\xad\xd3\xae     \n\
-        pid file =           foo-bar\n\
-[osd0]\n\
-";
-#endif
-
 const char override_config_1[] = "\
 [global]\n\
         log file =           global_log\n\
@@ -365,15 +354,6 @@ TEST(ConfUtils, ReadFiles2) {
   ASSERT_EQ(val, "/quite/a/long/path/for/a/log/file");
   ASSERT_EQ(cf1.read("global", "pid file", val), 0);
   ASSERT_EQ(val, "spork");
-
-#if BOOST_VERSION < 107200
-  std::string unicode_config_1f(next_tempfile(unicode_config_1));
-  ConfFile cf2;
-  ASSERT_EQ(cf2.parse_file(unicode_config_1f.c_str(), &err), 0);
-  ASSERT_EQ(err.tellp(), 0U);
-  ASSERT_EQ(cf2.read("global", "log file", val), 0);
-  ASSERT_EQ(val, "\x66\xd1\x86\xd1\x9d\xd3\xad\xd3\xae");
-#endif
 }
 
 TEST(ConfUtils, IllegalFiles) {


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
