### PR TITLE
mgr/dashboard: replace cdCopy2ClipboardButton Directive with a component

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-discovery-modal/iscsi-target-discovery-modal.component.html
@@ -48,10 +48,8 @@
                         class="btn btn-light"
                         cdPasswordButton="password">
                 </button>
-                <button type="button"
-                        class="btn btn-light"
-                        cdCopy2ClipboardButton="password">
-                </button>
+                <cd-copy-2-clipboard-button source="password">
+                </cd-copy-2-clipboard-button>
               </span>
             </div>
             <span class="invalid-feedback"
@@ -107,10 +105,8 @@
                         class="btn btn-light"
                         cdPasswordButton="mutual_password">
                 </button>
-                <button type="button"
-                        class="btn btn-light"
-                        cdCopy2ClipboardButton="mutual_password">
-                </button>
+                <cd-copy-2-clipboard-button source="mutual_password">
+                </cd-copy-2-clipboard-button>
               </span>
             </div>
             <span class="invalid-feedback"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi-target-form/iscsi-target-form.component.html
@@ -248,10 +248,8 @@
                           class="btn btn-light"
                           cdPasswordButton="target_password">
                   </button>
-                  <button type="button"
-                          class="btn btn-light"
-                          cdCopy2ClipboardButton="target_password">
-                  </button>
+                  <cd-copy-2-clipboard-button source="target_password">
+                  </cd-copy-2-clipboard-button>
                 </span>
               </div>
 
@@ -311,10 +309,8 @@
                           class="btn btn-light"
                           cdPasswordButton="target_mutual_password">
                   </button>
-                  <button type="button"
-                          class="btn btn-light"
-                          cdCopy2ClipboardButton="target_mutual_password">
-                  </button>
+                  <cd-copy-2-clipboard-button source="target_mutual_password">
+                  </cd-copy-2-clipboard-button>
                 </span>
               </div>
 
@@ -418,10 +414,8 @@
                                   class="btn btn-light"
                                   [cdPasswordButton]="'password' + ii">
                           </button>
-                          <button type="button"
-                                  class="btn btn-light"
-                                  [cdCopy2ClipboardButton]="'password' + ii">
-                          </button>
+                          <cd-copy-2-clipboard-button [source]="'password' + ii">
+                          </cd-copy-2-clipboard-button>
                         </span>
                       </div>
                       <span class="invalid-feedback"
@@ -478,10 +472,8 @@
                                   class="btn btn-light"
                                   [cdPasswordButton]="'mutual_password' + ii">
                           </button>
-                          <button type="button"
-                                  class="btn btn-light"
-                                  [cdCopy2ClipboardButton]="'mutual_password' + ii">
-                          </button>
+                          <cd-copy-2-clipboard-button [source]="'mutual_password' + ii">
+                          </cd-copy-2-clipboard-button>
                         </span>
                       </div>
                       <span class="invalid-feedback"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-create-modal/bootstrap-create-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/bootstrap-create-modal/bootstrap-create-modal.component.html
@@ -71,14 +71,9 @@
                     readonly>
           </textarea>
         </div>
-        <button class="btn btn-primary mb-3 float-right"
-                aria-label="Copy to Clipboard"
-                i18n-aria-label
-                title="Copy to Clipboard"
-                i18n-title
-                cdCopy2ClipboardButton="token">
-          <ng-container i18n>Copy to Clipboard</ng-container>
-        </button>
+        <cd-copy-2-clipboard-button class="float-right"
+                                    source="token">
+        </cd-copy-2-clipboard-button>
       </div>
 
       <div class="modal-footer">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/logs/logs.component.html
@@ -19,10 +19,10 @@
                                 [textItem]="logText"
                                 fileName="cluster_log">
             </cd-download-button>
-            <button type="button"
-                    class="btn btn-light"
-                    [cdCopy2ClipboardButton]="logText"
-                    [byId]="false"></button>
+            <cd-copy-2-clipboard-button
+                    [source]="logText"
+                    [byId]="false">
+            </cd-copy-2-clipboard-button>
           </div>
           <div class="card-body">
             <p *ngFor="let line of clog">
@@ -50,10 +50,10 @@
                                 [textItem]="logText"
                                 fileName="audit_log">
             </cd-download-button>
-            <button type="button"
-                    class="btn btn-light"
-                    [cdCopy2ClipboardButton]="logText"
-                    [byId]="false"></button>
+            <cd-copy-2-clipboard-button
+                    [source]="logText"
+                    [byId]="false">
+            </cd-copy-2-clipboard-button>
           </div>
           <div class="card-body">
             <p *ngFor="let line of audit_log">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-form/service-form.component.html
@@ -319,10 +319,8 @@
                           class="btn btn-light"
                           cdPasswordButton="api_password">
                   </button>
-                  <button type="button"
-                          class="btn btn-light"
-                          cdCopy2ClipboardButton="api_password">
-                  </button>
+                  <cd-copy-2-clipboard-button source="api_password">
+                  </cd-copy-2-clipboard-button>
                 </span>
                 <span class="invalid-feedback"
                       *ngIf="serviceForm.showError('api_password', frm, 'required')"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/telemetry/telemetry.component.html
@@ -207,7 +207,7 @@
               <button type="button"
                       class="btn btn-light"
                       (click)="next()">
-                <ng-container i18n>{{ actionLabels.NEXT }}</ng-container>
+                <ng-container>{{ actionLabels.NEXT }}</ng-container>
               </button>
             </div>
           </div>
@@ -267,10 +267,8 @@
                   <cd-download-button [objectItem]="report"
                                       fileName="telemetry_report">
                   </cd-download-button>
-                  <button type="button"
-                          class="btn btn-light"
-                          cdCopy2ClipboardButton="report">
-                  </button>
+                  <cd-copy-2-clipboard-button source="report">
+                  </cd-copy-2-clipboard-button>
                 </div>
               </div>
             </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
@@ -155,10 +155,8 @@
                           class="btn btn-light"
                           cdPasswordButton="access_key">
                   </button>
-                  <button type="button"
-                          class="btn btn-light"
-                          cdCopy2ClipboardButton="access_key">
-                  </button>
+                  <cd-copy-2-clipboard-button source="access_key">
+                  </cd-copy-2-clipboard-button>
                 </span>
               </div>
               <span class="invalid-feedback"
@@ -184,10 +182,8 @@
                           class="btn btn-light"
                           cdPasswordButton="secret_key">
                   </button>
-                  <button type="button"
-                          class="btn btn-light"
-                          cdCopy2ClipboardButton="secret_key">
-                  </button>
+                  <cd-copy-2-clipboard-button source="secret_key">
+                  </cd-copy-2-clipboard-button>
                 </span>
               </div>
               <span class="invalid-feedback"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.html
@@ -73,10 +73,8 @@
                         class="btn btn-light"
                         cdPasswordButton="access_key">
                 </button>
-                <button type="button"
-                        class="btn btn-light"
-                        cdCopy2ClipboardButton="access_key">
-                </button>
+                <cd-copy-2-clipboard-button source="access_key">
+                </cd-copy-2-clipboard-button>
               </span>
             </div>
             <span class="invalid-feedback"
@@ -104,10 +102,8 @@
                         class="btn btn-light"
                         cdPasswordButton="secret_key">
                 </button>
-                <button type="button"
-                        class="btn btn-light"
-                        cdCopy2ClipboardButton="secret_key">
-                </button>
+                <cd-copy-2-clipboard-button source="secret_key">
+                </cd-copy-2-clipboard-button>
               </span>
             </div>
             <span class="invalid-feedback"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.html
@@ -105,10 +105,8 @@
                           class="btn btn-light"
                           cdPasswordButton="secret_key">
                   </button>
-                  <button type="button"
-                          class="btn btn-light"
-                          cdCopy2ClipboardButton="secret_key">
-                  </button>
+                  <cd-copy-2-clipboard-button source="secret_key">
+                  </cd-copy-2-clipboard-button>
                 </span>
               </div>
               <span class="invalid-feedback"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.html
@@ -39,10 +39,8 @@
                         class="btn btn-light"
                         cdPasswordButton="secret_key">
                 </button>
-                <button type="button"
-                        class="btn btn-light"
-                        cdCopy2ClipboardButton="secret_key">
-                </button>
+                <cd-copy-2-clipboard-button source="secret_key">
+                </cd-copy-2-clipboard-button>
               </span>
             </div>
           </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
@@ -22,6 +22,7 @@ import { AlertPanelComponent } from './alert-panel/alert-panel.component';
 import { BackButtonComponent } from './back-button/back-button.component';
 import { ConfigOptionComponent } from './config-option/config-option.component';
 import { ConfirmationModalComponent } from './confirmation-modal/confirmation-modal.component';
+import { Copy2ClipboardButtonComponent } from './copy2clipboard-button/copy2clipboard-button.component';
 import { CriticalConfirmationModalComponent } from './critical-confirmation-modal/critical-confirmation-modal.component';
 import { DateTimePickerComponent } from './date-time-picker/date-time-picker.component';
 import { DocComponent } from './doc/doc.component';
@@ -88,6 +89,7 @@ import { UsageBarComponent } from './usage-bar/usage-bar.component';
     OrchestratorDocPanelComponent,
     DateTimePickerComponent,
     DocComponent,
+    Copy2ClipboardButtonComponent,
     DownloadButtonComponent,
     FormButtonPanelComponent
   ],
@@ -113,6 +115,7 @@ import { UsageBarComponent } from './usage-bar/usage-bar.component';
     OrchestratorDocPanelComponent,
     DateTimePickerComponent,
     DocComponent,
+    Copy2ClipboardButtonComponent,
     DownloadButtonComponent,
     FormButtonPanelComponent
   ]

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/copy2clipboard-button/copy2clipboard-button.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/copy2clipboard-button/copy2clipboard-button.component.html
@@ -1,0 +1,7 @@
+<button (click)="onClick()"
+        type="button"
+        class="btn btn-light"
+        i18n-title
+        title="Copy to Clipboard">
+  <i [ngClass]="[icons.clipboard]"></i>
+</button>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/copy2clipboard-button/copy2clipboard-button.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/copy2clipboard-button/copy2clipboard-button.component.spec.ts
@@ -4,10 +4,10 @@ import * as BrowserDetect from 'detect-browser';
 import { ToastrService } from 'ngx-toastr';
 
 import { configureTestBed } from '~/testing/unit-test-helper';
-import { Copy2ClipboardButtonDirective } from './copy2clipboard-button.directive';
+import { Copy2ClipboardButtonComponent } from './copy2clipboard-button.component';
 
-describe('Copy2clipboardButtonDirective', () => {
-  let directive: Copy2ClipboardButtonDirective;
+describe('Copy2ClipboardButtonComponent', () => {
+  let component: Copy2ClipboardButtonComponent;
 
   configureTestBed({
     providers: [
@@ -22,8 +22,8 @@ describe('Copy2clipboardButtonDirective', () => {
   });
 
   it('should create an instance', () => {
-    directive = new Copy2ClipboardButtonDirective(null, null, null);
-    expect(directive).toBeTruthy();
+    component = new Copy2ClipboardButtonComponent(null);
+    expect(component).toBeTruthy();
   });
 
   describe('test onClick behaviours', () => {
@@ -33,8 +33,8 @@ describe('Copy2clipboardButtonDirective', () => {
 
     beforeEach(() => {
       toastrService = TestBed.inject(ToastrService);
-      directive = new Copy2ClipboardButtonDirective(null, null, toastrService);
-      spyOn<any>(directive, 'getText').and.returnValue('foo');
+      component = new Copy2ClipboardButtonComponent(toastrService);
+      spyOn<any>(component, 'getText').and.returnValue('foo');
       Object.assign(navigator, {
         permissions: { query: jest.fn() },
         clipboard: {
@@ -51,14 +51,14 @@ describe('Copy2clipboardButtonDirective', () => {
           resolve();
         })
       );
-      directive.onClick();
+      component.onClick();
       expect(queryFn).not.toHaveBeenCalled();
       expect(writeTextFn).toHaveBeenCalledWith('foo');
     });
 
     it('should call permissions API', () => {
       spyOn(BrowserDetect, 'detect').and.returnValue({ name: 'chrome' });
-      directive.onClick();
+      component.onClick();
       expect(queryFn).toHaveBeenCalled();
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/copy2clipboard-button/copy2clipboard-button.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/copy2clipboard-button/copy2clipboard-button.component.ts
@@ -1,33 +1,28 @@
-import { Directive, ElementRef, HostListener, Input, OnInit, Renderer2 } from '@angular/core';
+import { Component, HostListener, Input } from '@angular/core';
 
 import { detect } from 'detect-browser';
 import { ToastrService } from 'ngx-toastr';
 
-@Directive({
-  selector: '[cdCopy2ClipboardButton]'
+import { Icons } from '~/app/shared/enum/icons.enum';
+
+@Component({
+  selector: 'cd-copy-2-clipboard-button',
+  templateUrl: './copy2clipboard-button.component.html',
+  styleUrls: ['./copy2clipboard-button.component.scss']
 })
-export class Copy2ClipboardButtonDirective implements OnInit {
+export class Copy2ClipboardButtonComponent {
   @Input()
-  private cdCopy2ClipboardButton: string;
+  private source: string;
+
   @Input()
   byId = true;
 
-  constructor(
-    private elementRef: ElementRef,
-    private renderer: Renderer2,
-    private toastr: ToastrService
-  ) {}
+  icons = Icons;
 
-  ngOnInit() {
-    const iElement = this.renderer.createElement('i');
-    this.renderer.addClass(iElement, 'fa');
-    this.renderer.addClass(iElement, 'fa-clipboard');
-    this.renderer.setAttribute(iElement, 'title', $localize`Copy to clipboard`);
-    this.renderer.appendChild(this.elementRef.nativeElement, iElement);
-  }
+  constructor(private toastr: ToastrService) {}
 
   private getText(): string {
-    const element = document.getElementById(this.cdCopy2ClipboardButton) as HTMLInputElement;
+    const element = document.getElementById(this.source) as HTMLInputElement;
     return element.value;
   }
 
@@ -35,7 +30,7 @@ export class Copy2ClipboardButtonDirective implements OnInit {
   onClick() {
     try {
       const browser = detect();
-      const text = this.byId ? this.getText() : this.cdCopy2ClipboardButton;
+      const text = this.byId ? this.getText() : this.source;
       const toastrFn = () => {
         this.toastr.success('Copied text to the clipboard successfully.');
       };

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/directives.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/directives.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 
 import { AutofocusDirective } from './autofocus.directive';
-import { Copy2ClipboardButtonDirective } from './copy2clipboard-button.directive';
 import { DimlessBinaryPerSecondDirective } from './dimless-binary-per-second.directive';
 import { DimlessBinaryDirective } from './dimless-binary.directive';
 import { FormInputDisableDirective } from './form-input-disable.directive';
@@ -20,7 +19,6 @@ import { TrimDirective } from './trim.directive';
   imports: [],
   declarations: [
     AutofocusDirective,
-    Copy2ClipboardButtonDirective,
     DimlessBinaryDirective,
     DimlessBinaryPerSecondDirective,
     PasswordButtonDirective,
@@ -37,7 +35,6 @@ import { TrimDirective } from './trim.directive';
   ],
   exports: [
     AutofocusDirective,
-    Copy2ClipboardButtonDirective,
     DimlessBinaryDirective,
     DimlessBinaryPerSecondDirective,
     PasswordButtonDirective,


### PR DESCRIPTION
Replaces Directive-Based copy2ClipboardButton with a Component-based version.
Further replaces all instances of Directive use with Component version.
Similar toastr logic used.
Fixes: https://tracker.ceph.com/issues/44960

Signed-off-by: Courtney Caldwell <ccaldwel@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
