### PR TITLE
osd: Check for nosrub/nodeep-scrub in between chunks, to avoid races

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2657,24 +2657,6 @@ void PG::abort_scrub()
  */
 void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 {
-  // Since repair is only by request and we need to scrub afterward
-  // treat the same as req_scrub.
-  if (!scrubber.req_scrub) {
-    if (state_test(PG_STATE_DEEP_SCRUB)) {
-      if (get_osdmap()->test_flag(CEPH_OSDMAP_NODEEP_SCRUB) ||
-	  pool.info.has_flag(pg_pool_t::FLAG_NODEEP_SCRUB)) {
-           dout(10) << "nodeep_scrub set, aborting" << dendl;
-	abort_scrub();
-        return;
-      }
-    } else if (state_test(PG_STATE_SCRUBBING)) {
-      if (get_osdmap()->test_flag(CEPH_OSDMAP_NOSCRUB) || pool.info.has_flag(pg_pool_t::FLAG_NOSCRUB)) {
-         dout(10) << "noscrub set, aborting" << dendl;
-	 abort_scrub();
-         return;
-      }
-    }
-  }
   // check for map changes
   if (scrubber.is_chunky_scrub_active()) {
     if (scrubber.epoch_start != info.history.same_interval_since) {
@@ -2920,6 +2902,24 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
           done = true;
 	  break;
 	}
+        // Since repair is only by request and we need to scrub afterward
+        // treat the same as req_scrub.
+        if (!scrubber.req_scrub) {
+          if (state_test(PG_STATE_DEEP_SCRUB)) {
+            if (get_osdmap()->test_flag(CEPH_OSDMAP_NODEEP_SCRUB) ||
+	        pool.info.has_flag(pg_pool_t::FLAG_NODEEP_SCRUB)) {
+              dout(10) << "nodeep_scrub set, aborting" << dendl;
+	      abort_scrub();
+              return;
+            }
+          } else if (state_test(PG_STATE_SCRUBBING)) {
+            if (get_osdmap()->test_flag(CEPH_OSDMAP_NOSCRUB) || pool.info.has_flag(pg_pool_t::FLAG_NOSCRUB)) {
+              dout(10) << "noscrub set, aborting" << dendl;
+	      abort_scrub();
+              return;
+            }
+          }
+        }
 	// end (possible) preemption window
 	scrub_can_preempt = false;
 	if (scrub_preempted) {


### PR DESCRIPTION


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
