### PR TITLE
Bugfixes for erasure-code, systemd, cli and build files

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -ex
 
-git submodule update --init --recursive
+if [ -d .git ]; then
+    git submodule update --init --recursive
+fi
 
 : ${BUILD_DIR:=build}
 : ${CEPH_GIT_DIR:=..}

--- a/src/test/test_arch.cc
+++ b/src/test/test_arch.cc
@@ -69,7 +69,7 @@ TEST(Arch, all)
   expected = strstr(flags, " sse4_1 ") ? 1 : 0;
   EXPECT_EQ(expected, ceph_arch_intel_sse41);
 
-  expected = (strstr(flags, " sse3 ") || strstr(flags, " ssse3 ")) ? 1 : 0;
+  expected = (strstr(flags, " sse3 ") || strstr(flags, " ssse3 ") || strstr(flags, " pni ")) ? 1 : 0;
   EXPECT_EQ(expected, ceph_arch_intel_sse3);
 
   expected = strstr(flags, " ssse3 ") ? 1 : 0;


### PR DESCRIPTION
Apologies for putting a whole bunch of commits in the same PR - I just pushed number of commits into my master and they appeared in this PR automatically. I made an effort to ensure that each commit is in line with guidelines.

Most important commit in this PR is for erasure-code fixing bad_alloc .

Rest of commits are simple and self explanatory with exception of "build: use actual GCC settings for SIMD" which tries to rectify SIMD code generation so actual GCC settings are used.

Please don't judge me harshly - it is my first PR here.

Signed-off-by: Vladimir Bashkirtsev <vladimir@bashkirtsev.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
