### PR TITLE
rgw: support add tags when multipart uploading

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3543,7 +3543,7 @@ int RGWPutObj::verify_permission(optional_yield y)
 
     rgw_add_to_iam_environment(s->env, "s3:x-amz-acl", s->canned_acl);
 
-    if (obj_tags != nullptr && obj_tags->count() > 0){
+    if (obj_tags && obj_tags->count() > 0){
       auto tags = obj_tags->get_tags();
       for (const auto& kv: tags){
         rgw_add_to_iam_environment(s->env, "s3:RequestObjectTag/"+kv.first, kv.second);
@@ -4044,7 +4044,7 @@ void RGWPutObj::execute(optional_yield y)
     return;
   }
   encode_delete_at_attr(delete_at, attrs);
-  encode_obj_tags_attr(obj_tags.get(), attrs);
+  encode_obj_tags_attr(obj_tags, attrs);
   rgw_cond_decode_objtags(s, attrs);
 
   /* Add a custom metadata to expose the information whether an object
@@ -5824,6 +5824,8 @@ void RGWInitMultipart::execute(optional_yield y)
 
   policy.encode(aclbl);
   attrs[RGW_ATTR_ACL] = aclbl;
+
+  encode_obj_tags_attr(obj_tags, attrs);
 
   populate_with_generic_attrs(s, attrs);
 

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1131,7 +1131,7 @@ protected:
   string etag;
   bool chunked_upload;
   RGWAccessControlPolicy policy;
-  std::unique_ptr <RGWObjTags> obj_tags;
+  std::optional<RGWObjTags> obj_tags;
   const char *dlo_manifest;
   RGWSLOInfo *slo_info;
   rgw::sal::RGWAttrs attrs;
@@ -1714,6 +1714,7 @@ protected:
   string upload_id;
   RGWAccessControlPolicy policy;
   ceph::real_time mtime;
+  std::optional<RGWObjTags> obj_tags;
 
 public:
   RGWInitMultipart() {}
@@ -2082,9 +2083,9 @@ inline void encode_delete_at_attr(boost::optional<ceph::real_time> delete_at,
   attrs[RGW_ATTR_DELETE_AT] = delatbl;
 } /* encode_delete_at_attr */
 
-inline void encode_obj_tags_attr(RGWObjTags* obj_tags, map<string, bufferlist>& attrs)
+inline void encode_obj_tags_attr(const std::optional<RGWObjTags>& obj_tags, map<string, bufferlist>& attrs)
 {
-  if (obj_tags == nullptr){
+  if (!obj_tags) {
     // we assume the user submitted a tag format which we couldn't parse since
     // this wouldn't be parsed later by get/put obj tags, lets delete if the
     // attr was populated

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2363,7 +2363,7 @@ int RGWPutObj_ObjStore_S3::get_params(optional_yield y)
   /* handle object tagging */
   auto tag_str = s->info.env->get("HTTP_X_AMZ_TAGGING");
   if (tag_str){
-    obj_tags = std::make_unique<RGWObjTags>();
+    obj_tags = RGWObjTags{};
     ret = obj_tags->set_from_string(tag_str);
     if (ret < 0){
       ldpp_dout(this,0) << "setting obj tags failed with " << ret << dendl;
@@ -3645,6 +3645,18 @@ int RGWInitMultipart_ObjStore_S3::get_params(optional_yield y)
     return op_ret;
 
   policy = s3policy;
+
+  /* handle object tagging */
+  if (auto tag_str = s->info.env->get("HTTP_X_AMZ_TAGGING"); tag_str) {
+    obj_tags = RGWObjTags{};
+    if (int ret = obj_tags->set_from_string(tag_str); ret < 0) {
+      ldpp_dout(this, 0) << "setting obj tags failed with " << ret << dendl;
+      if (ret == -ERR_INVALID_TAG){
+        op_ret = -EINVAL;
+      }
+      return ret;
+    }
+  }
 
   return 0;
 }


### PR DESCRIPTION
Signed-off-by: Liu Lan <liulan_yewu@cmss.chinamobile.com>

And s3-tests: https://github.com/ceph/s3-tests/pull/370

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
