### PR TITLE
mgr/prometheus: Fix 'pool filling up' with >50% usage

### DIFF
--- a/monitoring/prometheus/alerts/ceph_default_alerts.yml
+++ b/monitoring/prometheus/alerts/ceph_default_alerts.yml
@@ -230,8 +230,8 @@ groups:
       - alert: pool filling up
         expr: |
           (
-            predict_linear(ceph_pool_stored[2d], 3600 * 24 * 5) >=
-            ceph_pool_max_avail
+            predict_linear(ceph_pool_stored[2d], 3600 * 24 * 5)
+            >= ceph_pool_stored + ceph_pool_max_avail
           ) * on(pool_id) group_left(name) ceph_pool_metadata
         labels:
           severity: warning


### PR DESCRIPTION
As `ceph_pool_stored` grows, `ceph_pool_max_avail` shrinks. When you reach 50% capacity, the alert in it's current state will always be firing. 

The alert proposed in this PR will fire when the capacity of `ceph_pool_max_avail` is projected to reach below 0 bytes remaining capacity. This alert will work regardless of the utilization of your pool.


Fixes: https://tracker.ceph.com/issues/48354
Signed-off-by: Daniël Vos <danielvos@outlook.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
