### PR TITLE
rgw: add an outstanding_requests perf counter

### DIFF
--- a/src/rgw/rgw_dmclock_async_scheduler.cc
+++ b/src/rgw/rgw_dmclock_async_scheduler.cc
@@ -62,6 +62,9 @@ int AsyncScheduler::schedule_request_impl(const client_id& client,
 void AsyncScheduler::request_complete()
 {
   --outstanding_requests;
+  if(auto c = counters(client_id::count)){
+    c->inc(throttle_counters::l_outstanding, -1);
+  }
   schedule(crimson::dmclock::TimeZero);
 }
 
@@ -138,6 +141,9 @@ void AsyncScheduler::process(const Time& now)
       break;
     }
     ++outstanding_requests;
+    if(auto c = counters(client_id::count)){
+      c->inc(throttle_counters::l_outstanding);
+    }
 
     // complete the request
     auto& r = pull.get_retn();

--- a/src/rgw/rgw_dmclock_async_scheduler.h
+++ b/src/rgw/rgw_dmclock_async_scheduler.h
@@ -191,6 +191,11 @@ public:
 
   void request_complete() override {
     --outstanding_requests;
+    if (auto c = counters();
+        c != nullptr) {
+      c->inc(throttle_counters::l_outstanding, -1);
+    }
+
   }
 
 private:
@@ -200,6 +205,7 @@ private:
     if (outstanding_requests++ >= max_requests) {
       if (auto c = counters();
           c != nullptr) {
+        c->inc(throttle_counters::l_outstanding);
         c->inc(throttle_counters::l_throttle);
       }
       return -EAGAIN;

--- a/src/rgw/rgw_dmclock_scheduler_ctx.cc
+++ b/src/rgw/rgw_dmclock_scheduler_ctx.cc
@@ -168,6 +168,7 @@ PerfCountersRef build(CephContext *cct, const std::string& name)
 
   PerfCountersBuilder b(cct, name, l_first, l_last);
   b.add_u64(l_throttle, "throttle", "Requests throttled");
+  b.add_u64(l_outstanding, "outstanding", "Outstanding Requests");
 
   auto logger = PerfCountersRef{ b.create_perf_counters(), cct };
   cct->get_perfcounters_collection()->add(logger.get());

--- a/src/rgw/rgw_dmclock_scheduler_ctx.h
+++ b/src/rgw/rgw_dmclock_scheduler_ctx.h
@@ -36,6 +36,7 @@ namespace throttle_counters {
   enum {
         l_first = 437219,
         l_throttle,
+        l_outstanding,
         l_last
   };
 


### PR DESCRIPTION
Expose the outstanding_requests variable so we can more easily tune rgw_max_concurrent_requests.

Related-to: https://tracker.ceph.com/issues/48358
Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>