### PR TITLE
common: Add get_process_name implementation for Windows

### DIFF
--- a/src/common/code_environment.cc
+++ b/src/common/code_environment.cc
@@ -79,6 +79,31 @@ int get_process_name(char *buf, int len)
   return 0;
 }
 
+#elif defined(_WIN32)
+
+int get_process_name(char *buf, int len)
+{
+  if (len <= 0) {
+    return -EINVAL;
+  }
+
+  int length = GetModuleFileNameA(nullptr, buf, len);
+  if (length <= 0)
+    return -ENOSYS;
+
+  char* start = strrchr(buf, '\\');
+  if (!start)
+    return -ENOSYS;
+  start++;
+  char* end = strstr(start, ".exe");
+  if (!end)
+    return -ENOSYS;
+
+  memmove(buf, start, end - start);
+  buf[end - start] = '\0';
+  return 0;
+}
+
 #else
 
 int get_process_name(char *buf, int len)


### PR DESCRIPTION
This patch adds get_process_name for Windows based on
GetModuleFileName.

Signed-off-by: Alin Gabriel Serdean <aserdean@cloudbasesolutions.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
