### PR TITLE
common/admin socket: Make the admin socket use linux abstract socket namespace

### DIFF
--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -189,8 +189,14 @@ std::string AdminSocket::bind_and_listen(const std::string &sock_path, int *fd)
   // FIPS zeroization audit 20191115: this memset is fine.
   memset(&address, 0, sizeof(struct sockaddr_un));
   address.sun_family = AF_UNIX;
+#ifdef __linux__
+  address.sun_path[0] = '\0';
+  snprintf(address.sun_path+1, sizeof(address.sun_path),
+	   "%s", sock_path.c_str());
+#else
   snprintf(address.sun_path, sizeof(address.sun_path),
 	   "%s", sock_path.c_str());
+#endif
   if (::bind(sock_fd, (struct sockaddr*)&address,
 	   sizeof(struct sockaddr_un)) != 0) {
     int err = errno;


### PR DESCRIPTION
Make the admin socket on linux use the abstract
namespace. With this change when Ceph
closes admin sockets in the abstract namespace,
the file are always deleted.

The admin socket files are not always cleaned up/
deleted when daemons are killed in a certain order.

Signed-off-by: Ali Maredia <amaredia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
