### PR TITLE
octopus: ceph-volume inventory: make libstoragemgmt data retrieval optional

### DIFF
--- a/src/ceph-volume/ceph_volume/inventory/main.py
+++ b/src/ceph-volume/ceph_volume/inventory/main.py
@@ -38,17 +38,25 @@ class Inventory(object):
                   'no effect when <path> is passed'),
             default=False,
         )
+        parser.add_argument(
+            '--with-lsm',
+            action='store_true',
+            help=('Attempt to retrieve additional health and metadata through '
+                  'libstoragemgmt'),
+            default=False,
+        )
         self.args = parser.parse_args(self.argv)
         if self.args.path:
-            self.format_report(Device(self.args.path))
+            self.format_report(Device(self.args.path, with_lsm=self.args.with_lsm))
         else:
-            self.format_report(Devices(filter_for_batch=self.args.filter_for_batch))
+            self.format_report(Devices(filter_for_batch=self.args.filter_for_batch,
+                                       with_lsm=self.args.with_lsm))
 
     def get_report(self):
         if self.args.path:
-            return Device(self.args.path).json_report()
+            return Device(self.args.path, with_lsm=self.args.with_lsm).json_report()
         else:
-            return Devices(filter_for_batch=self.args.filter_for_batch).json_report()
+            return Devices(filter_for_batch=self.args.filter_for_batch, with_lsm=self.args.with_lsm).json_report()
 
     def format_report(self, inventory):
         if self.args.format == 'json':

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -27,10 +27,10 @@ class Devices(object):
     A container for Device instances with reporting
     """
 
-    def __init__(self, filter_for_batch=False):
+    def __init__(self, filter_for_batch=False, with_lsm=False):
         if not sys_info.devices:
             sys_info.devices = disk.get_devices()
-        self.devices = [Device(k) for k in
+        self.devices = [Device(k, with_lsm) for k in
                             sys_info.devices.keys()]
         if filter_for_batch:
             self.devices = [d for d in self.devices if d.available_lvm_batch]
@@ -83,7 +83,7 @@ class Device(object):
     # unittests
     lvs = []
 
-    def __init__(self, path):
+    def __init__(self, path, with_lsm=False):
         self.path = path
         # LVs can have a vg/lv path, while disks will have /dev/sda
         self.abspath = path
@@ -98,7 +98,7 @@ class Device(object):
         self._exists = None
         self._is_lvm_member = None
         self._parse()
-        self.lsm_data = self.fetch_lsm()
+        self.lsm_data = self.fetch_lsm(with_lsm)
 
         self.available_lvm, self.rejected_reasons_lvm = self._check_lvm_reject_reasons()
         self.available_raw, self.rejected_reasons_raw = self._check_raw_reject_reasons()
@@ -108,7 +108,7 @@ class Device(object):
 
         self.device_id = self._get_device_id()
 
-    def fetch_lsm(self):
+    def fetch_lsm(self, with_lsm):
         '''
         Attempt to fetch libstoragemgmt (LSM) metadata, and return to the caller
         as a dict. An empty dict is passed back to the caller if the target path
@@ -116,11 +116,11 @@ class Device(object):
         json returned will provide LSM attributes, and any associated errors that
         lsm encountered when probing the device.
         '''
-        if not self.exists or not self.is_device:
+        if not with_lsm or not self.exists or not self.is_device:
             return {}
 
         lsm_disk = LSMDisk(self.path)
-        
+
         return  lsm_disk.json_report()
 
     def __lt__(self, other):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48366

---

backport of https://github.com/ceph/ceph/pull/38149
parent tracker: https://tracker.ceph.com/issues/48270

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh