### PR TITLE
rgw: remove std:move() call that are unneeded

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1583,7 +1583,7 @@ namespace rgw {
                       &state->dest_placement,
                       state->bucket_owner.get_id(),
                       *static_cast<RGWObjectCtx *>(state->obj_ctx),
-                      std::move(state->object->clone()), olh_epoch, state->req_id,
+                      state->object->clone(), olh_epoch, state->req_id,
 		      this, state->yield);
 
     op_ret = processor->prepare(state->yield);

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -242,7 +242,7 @@ void *RGWLC::LCWorker::entry() {
 void RGWLC::initialize(CephContext *_cct, rgw::sal::RGWRadosStore *_store) {
   cct = _cct;
   store = _store;
-  sal_lc = std::move(store->get_lifecycle());
+  sal_lc = store->get_lifecycle();
   max_objs = cct->_conf->rgw_lc_max_objs;
   if (max_objs > HASH_PRIME)
     max_objs = HASH_PRIME;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3828,7 +3828,7 @@ void RGWPutObj::execute(optional_yield y)
     ldpp_dout(this, 20) << "dest_placement for part=" << upload_info.dest_placement << dendl;
     processor.emplace<MultipartObjectProcessor>(
         &*aio, store, s->bucket.get(), pdest_placement,
-        s->owner.get_id(), obj_ctx, std::move(s->object->clone()),
+        s->owner.get_id(), obj_ctx, s->object->clone(),
         multipart_upload_id, multipart_part_num, multipart_part_str,
         this, s->yield);
   } else if(append) {
@@ -3839,7 +3839,7 @@ void RGWPutObj::execute(optional_yield y)
     pdest_placement = &s->dest_placement;
     processor.emplace<AppendObjectProcessor>(
             &*aio, store, s->bucket.get(), pdest_placement, s->bucket_owner.get_id(),
-	    obj_ctx, std::move(s->object->clone()),
+	    obj_ctx, s->object->clone(),
             s->req_id, position, &cur_accounted_size, this, s->yield);
   } else {
     if (s->bucket->versioning_enabled()) {
@@ -3853,7 +3853,7 @@ void RGWPutObj::execute(optional_yield y)
     pdest_placement = &s->dest_placement;
     processor.emplace<AtomicObjectProcessor>(
         &*aio, store, s->bucket.get(), pdest_placement,
-        s->bucket_owner.get_id(), obj_ctx,  std::move(s->object->clone()),
+        s->bucket_owner.get_id(), obj_ctx,  s->object->clone(),
 	olh_epoch, s->req_id, this, s->yield);
   }
 

--- a/src/rgw/rgw_putobj_processor.h
+++ b/src/rgw/rgw_putobj_processor.h
@@ -153,7 +153,7 @@ class ManifestObjectProcessor : public HeadObjectProcessor,
       store(store), bucket(bucket),
       owner(owner),
       obj_ctx(obj_ctx), head_obj(std::move(_head_obj)),
-      writer(aio, store, bucket, obj_ctx, std::move(head_obj->clone()), dpp, y),
+      writer(aio, store, bucket, obj_ctx, head_obj->clone(), dpp, y),
       chunk(&writer, 0), stripe(&chunk, this, 0), dpp(dpp) {
         if (ptail_placement_rule) {
           tail_placement_rule = *ptail_placement_rule;
@@ -238,7 +238,7 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
                            const DoutPrefixProvider *dpp, optional_yield y)
     : ManifestObjectProcessor(aio, store, bucket, ptail_placement_rule,
                               owner, obj_ctx, std::move(_head_obj), dpp, y),
-      target_obj(std::move(head_obj->clone())), upload_id(upload_id),
+      target_obj(head_obj->clone()), upload_id(upload_id),
       part_num(part_num), part_num_str(part_num_str),
       mp(head_obj->get_name(), upload_id)
   {}

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3798,7 +3798,7 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
   rgw::BlockingAioThrottle aio(cct->_conf->rgw_put_obj_min_window_size);
   using namespace rgw::putobj;
   AtomicObjectProcessor processor(&aio, this->store, dest_bucket, nullptr, user_id,
-                                  obj_ctx, std::move(dest_obj->clone()), olh_epoch,
+                                  obj_ctx, dest_obj->clone(), olh_epoch,
 				  tag, dpp, null_yield);
   RGWRESTConn *conn;
   auto& zone_conn_map = svc.zone->get_zone_conn_map();
@@ -4459,7 +4459,7 @@ int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
   // it causes crashes in the ragweed tests
   AtomicObjectProcessor processor(&aio, this->store, bucket, &dest_placement,
                                   bucket->get_info().owner, obj_ctx,
-                                  std::move(dest_obj->clone()), olh_epoch, tag,
+                                  dest_obj->clone(), olh_epoch, tag,
 				  dpp, null_yield);
   int ret = processor.prepare(y);
   if (ret < 0)

--- a/src/rgw/rgw_sal_rados.h
+++ b/src/rgw/rgw_sal_rados.h
@@ -253,7 +253,7 @@ class RGWRadosBucket : public RGWBucket {
 			   bool *is_truncated, RGWUsageIter& usage_iter,
 			   map<rgw_user_bucket, rgw_usage_log_entry>& usage) override;
     virtual std::unique_ptr<RGWBucket> clone() {
-      return std::move(std::unique_ptr<RGWBucket>(new RGWRadosBucket(*this)));
+      return std::make_unique<RGWRadosBucket>(*this);
     }
 
     friend class RGWRadosStore;


### PR DESCRIPTION
Clang warns and suggests in all these case allong this:
```
warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
      return std::move(std::unique_ptr<RGWBucket>(new RGWRadosBucket(*this)));
             ^
/home/jenkins/workspace/ceph-master-compile/src/rgw/rgw_sal_rados.h:256:14: note: remove std::move call here
      return std::move(std::unique_ptr<RGWBucket>(new RGWRadosBucket(*this)));
             ^~~~~~~~~~                                                     ~
1 warning generated.
```




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>