### PR TITLE
librbd: fix Clang warnings

### DIFF
--- a/src/librbd/migration/HttpClient.cc
+++ b/src/librbd/migration/HttpClient.cc
@@ -460,7 +460,7 @@ private:
     if (work->header_only()) {
       m_parser.emplace(std::move(*m_header_parser));
     }
-    response = std::move(m_parser->release());
+    response = m_parser->release();
 
     // basic response code handling in a common location
     int r = 0;

--- a/src/librbd/migration/HttpClient.h
+++ b/src/librbd/migration/HttpClient.h
@@ -156,7 +156,6 @@ private:
         boost::beast::ssl_stream<boost::beast::tcp_stream>& stream) = 0;
   };
 
-  struct HttpSessionInterface;
   template <typename D> struct HttpSession;
   struct PlainHttpSession;
   struct SslHttpSession;


### PR DESCRIPTION
- Double declaration
- Unneeded std::move()
```
/home/jenkins/workspace/ceph-master-compile/src/testk_HttpClient.cc:34:
/home/jenkins/workspace/ceph-master-compile/src/librbd/migration/HttpClienng a temporary object prevents copy elision [-Wpessimizing-move]
    response = std::move(m_parser->release());
               ^
/home/jenkins/workspace/ceph-master-compile/src/librbd/migration/HttpClienstd::move call here
    response = std::move(m_parser->release());
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>