### PR TITLE
Test mon scrub and exercise mon scrub error injectors 

### DIFF
--- a/qa/config/rados.yaml
+++ b/qa/config/rados.yaml
@@ -6,3 +6,5 @@ overrides:
         osd op queue cut off: debug_random
         osd debug verify missing on start: true
         osd debug verify cached snaps: true
+      mon:
+        mon scrub interval: 300

--- a/qa/suites/rados/monthrash/ceph.yaml
+++ b/qa/suites/rados/monthrash/ceph.yaml
@@ -8,8 +8,12 @@ overrides:
         mon osdmap full prune min: 15
         mon osdmap full prune interval: 2
         mon osdmap full prune txsize: 2
+        mon scrub inject crc mismatch: 0.01
+        mon scrub inject missing keys: 0.05
 # thrashing monitors may make mgr have trouble w/ its keepalive
     log-ignorelist:
+      - ScrubResult
+      - scrub mismatch
       - overall HEALTH_
       - \(MGR_DOWN\)
 # slow mons -> slow peering -> PG_AVAILABILITY


### PR DESCRIPTION
During analysis of a downstream issue we discovered mon scrubs almost never get tested.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
