### PR TITLE
mgr/dashboard: Temporary User Lockout if 10 Invalid Login attempts

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -333,6 +333,34 @@ commands::
 
   $ ceph dashboard ac-user-create <username> <password> administrator
 
+Account Lock-out
+^^^^^^^^^^^^^^^^
+
+It disables a user account if a user repeatedly enters the wrong credentials
+for multiple times. It is enabled by default to prevent brute-force or dictionary
+attacks. The user can get or set the default number of lock-out attempts using
+these commands respectively::
+
+  $ ceph dashboard get-account-lockout-attempts
+  $ ceph dashboard set-account-lockout-attempts <value:int>
+
+.. warning::
+
+  This feature can be disabled by setting the default number of lock-out attempts to 0.
+  However, by disabling this feature, the account is more vulnerable to brute-force or
+  dictionary based attacks. This can be disabled by::
+
+    $ ceph dashboard set-account-lockout-attempts 0
+
+Enable a Locked User
+^^^^^^^^^^^^^^^^^^^^
+
+If a user account is disabled as a result of multiple invalid login attempts, then
+it needs to be manually enabled by the administrator. This can be done by the following
+command::
+
+  $ ceph dashboard ac-user-enable <username>
+
 Accessing the Dashboard
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/pybind/mgr/dashboard/controllers/auth.py
+++ b/src/pybind/mgr/dashboard/controllers/auth.py
@@ -6,8 +6,9 @@ import logging
 import cherrypy
 
 from .. import mgr
-from ..exceptions import DashboardException
+from ..exceptions import InvalidCredentialsError, UserDoesNotExist
 from ..services.auth import AuthManager, JwtManager
+from ..settings import Settings
 from . import ApiController, ControllerDoc, EndpointDoc, RESTController, allow_empty_body
 
 logger = logging.getLogger('controllers.auth')
@@ -28,33 +29,48 @@ class Auth(RESTController):
     """
     Provide authenticates and returns JWT token.
     """
-
     def create(self, username, password):
         user_data = AuthManager.authenticate(username, password)
         user_perms, pwd_expiration_date, pwd_update_required = None, None, None
-        if user_data:
-            user_perms = user_data.get('permissions')
-            pwd_expiration_date = user_data.get('pwdExpirationDate', None)
-            pwd_update_required = user_data.get('pwdUpdateRequired', False)
+        max_attempt = Settings.ACCOUNT_LOCKOUT_ATTEMPTS
+        if max_attempt == 0 or mgr.ACCESS_CTRL_DB.get_attempt(username) < max_attempt:
+            if user_data:
+                user_perms = user_data.get('permissions')
+                pwd_expiration_date = user_data.get('pwdExpirationDate', None)
+                pwd_update_required = user_data.get('pwdUpdateRequired', False)
 
-        if user_perms is not None:
-            logger.debug('Login successful')
-            token = JwtManager.gen_token(username)
-            token = token.decode('utf-8')
-            cherrypy.response.headers['Authorization'] = "Bearer: {}".format(token)
-            return {
-                'token': token,
-                'username': username,
-                'permissions': user_perms,
-                'pwdExpirationDate': pwd_expiration_date,
-                'sso': mgr.SSO_DB.protocol == 'saml2',
-                'pwdUpdateRequired': pwd_update_required
-            }
-
-        logger.debug('Login failed')
-        raise DashboardException(msg='Invalid credentials',
-                                 code='invalid_credentials',
-                                 component='auth')
+            if user_perms is not None:
+                logger.info('Login successful: %s', username)
+                mgr.ACCESS_CTRL_DB.reset_attempt(username)
+                mgr.ACCESS_CTRL_DB.save()
+                token = JwtManager.gen_token(username)
+                token = token.decode('utf-8')
+                cherrypy.response.headers['Authorization'] = "Bearer: {}".format(token)
+                return {
+                    'token': token,
+                    'username': username,
+                    'permissions': user_perms,
+                    'pwdExpirationDate': pwd_expiration_date,
+                    'sso': mgr.SSO_DB.protocol == 'saml2',
+                    'pwdUpdateRequired': pwd_update_required
+                }
+            mgr.ACCESS_CTRL_DB.increment_attempt(username)
+            mgr.ACCESS_CTRL_DB.save()
+        else:
+            try:
+                user = mgr.ACCESS_CTRL_DB.get_user(username)
+                user.enabled = False
+                mgr.ACCESS_CTRL_DB.save()
+                logging.warning('Maximum number of unsuccessful log-in attempts '
+                                '(%d) reached for '
+                                'username "%s" so the account was blocked. '
+                                'An administrator will need to re-enable the account',
+                                max_attempt, username)
+                raise InvalidCredentialsError
+            except UserDoesNotExist:
+                raise InvalidCredentialsError
+        logger.info('Login failed: %s', username)
+        raise InvalidCredentialsError
 
     @RESTController.Collection('POST')
     @allow_empty_body

--- a/src/pybind/mgr/dashboard/exceptions.py
+++ b/src/pybind/mgr/dashboard/exceptions.py
@@ -45,6 +45,13 @@ class DashboardException(Exception):
         return str(abs(self.errno)) if self.errno is not None else 'Error'
 
 
+class InvalidCredentialsError(DashboardException):
+    def __init__(self):
+        super().__init__(msg='Invalid credentials',
+                         code='invalid_credentials',
+                         component='auth')
+
+
 # access control module exceptions
 class RoleAlreadyExists(Exception):
     def __init__(self, name):

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -290,6 +290,7 @@ class User(object):
         self.password = password
         self.name = name
         self.email = email
+        self.invalid_auth_attempt = 0
         if roles is None:
             self.roles = set()
         else:
@@ -328,6 +329,7 @@ class User(object):
         self.set_password_hash(password_hash(password))
 
     def set_password_hash(self, hashed_password):
+        self.invalid_auth_attempt = 0
         self.password = hashed_password
         self.refresh_last_update()
         self.refresh_pwd_expiration_date()
@@ -431,6 +433,23 @@ class AccessControlDB(object):
             if name not in self.roles:
                 raise RoleDoesNotExist(name)
             return self.roles[name]
+
+    def increment_attempt(self, username):
+        with self.lock:
+            if username in self.users:
+                self.users[username].invalid_auth_attempt += 1
+
+    def reset_attempt(self, username):
+        with self.lock:
+            if username in self.users:
+                self.users[username].invalid_auth_attempt = 0
+
+    def get_attempt(self, username):
+        with self.lock:
+            try:
+                return self.users[username].invalid_auth_attempt
+            except KeyError:
+                return 0
 
     def delete_role(self, name):
         with self.lock:
@@ -738,6 +757,7 @@ def ac_user_enable(_, username):
     try:
         user = mgr.ACCESS_CTRL_DB.get_user(username)
         user.enabled = True
+        mgr.ACCESS_CTRL_DB.reset_attempt(username)
 
         mgr.ACCESS_CTRL_DB.save()
         return 0, json.dumps(user.to_dict()), ''

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -20,6 +20,9 @@ class Options(object):
     ENABLE_BROWSABLE_API = (True, bool)
     REST_REQUESTS_TIMEOUT = (45, int)
 
+    # AUTHENTICATION ATTEMPTS
+    ACCOUNT_LOCKOUT_ATTEMPTS = (10, int)
+
     # API auditing
     AUDIT_API_ENABLED = (False, bool)
     AUDIT_API_LOG_PAYLOAD = (True, bool)


### PR DESCRIPTION
Implemented a user lockout mechanism if the user enters 10 invalid attempts. The attempt count gets resetted to 0 once the user succesfully logins before getting disabled. Once the user gets disabled administrator has to manually enable the user and resets the user's attempt count.


Fixes: https://tracker.ceph.com/issues/40914
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
