### PR TITLE
cmake: do not always require extra link flags for std::filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -626,7 +626,7 @@ set(WITH_MGR_ROOK_CLIENT WITH_MGR_DASHBOARD_FRONTEND)
 include_directories(SYSTEM ${PROJECT_BINARY_DIR}/include)
 
 find_package(Threads REQUIRED)
-find_package(StdFilesystem)
+find_package(StdFilesystem REQUIRED)
 
 option(WITH_SELINUX "build SELinux policy" OFF)
 if(WITH_SELINUX)

--- a/cmake/modules/FindStdFilesystem.cmake
+++ b/cmake/modules/FindStdFilesystem.cmake
@@ -1,43 +1,57 @@
 set(_std_filesystem_test_src
   ${CMAKE_CURRENT_LIST_DIR}/FindStdFilesystem_test.cc)
 
-macro(try_std_filesystem_library _library _result)
+macro(try_std_filesystem_library _library _result _already_included)
   set(_std_filesystem_try_compile_arg
     CXX_STANDARD 17)
+  if(NOT _library STREQUAL "")
+    list(APPEND _std_filesystem_try_compile_arg
+      LINK_LIBRARIES ${_library})
+  endif()
   try_compile(_std_filesystem_compiles
     ${CMAKE_CURRENT_BINARY_DIR}
     SOURCES ${_std_filesystem_test_src}
-    LINK_LIBRARIES ${_library}
     ${_std_filesystem_try_compile_arg})
   unset(_std_filesystem_try_compile_arg)
   if(_std_filesystem_compiles)
-    set(${_result} ${_library})
+    if(NOT _library STREQUAL "")
+      set(${_result} ${_library})
+    else()
+      set(${_already_included} "included by standard library")
+    endif()
   endif()
   unset(_std_filesystem_compiles)
 endmacro()
 
-
-if(NOT StdFilesystem_LIBRARY)
-  try_std_filesystem_library("stdc++fs" StdFilesystem_LIBRARY)
-endif()
-if(NOT StdFilesystem_LIBRARY)
-  try_std_filesystem_library("c++experimental" StdFilesystem_LIBRARY)
-endif()
-if(NOT StdFilesystem_LIBRARY)
-  try_std_filesystem_library("c++fs" StdFilesystem_LIBRARY)
-endif()
+set(_std_filesystem_required_var "StdFilesystem_LIBRARY")
+set(_std_filesystem_already_included FALSE)
+foreach(library
+    ""
+    "stdc++fs"
+    "c++experimental"
+    "c++fs")
+  try_std_filesystem_library("${library}" StdFilesystem_LIBRARY _std_filesystem_already_included)
+  if(_std_filesystem_already_included)
+    set(_std_filesystem_required_var "_std_filesystem_already_included")
+    break()
+  elseif(StdFilesystem_LIBRARY)
+    break()
+  endif()
+endforeach()
 
 unset(_std_filesystem_test_src)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(StdFilesystem
   FOUND_VAR StdFilesystem_FOUND
-  REQUIRED_VARS StdFilesystem_LIBRARY)
+  REQUIRED_VARS ${_std_filesystem_required_var})
 
 mark_as_advanced(StdFilesystem_LIBRARY)
 
 if(StdFilesystem_FOUND AND NOT (TARGET StdFilesystem::filesystem))
   add_library(StdFilesystem::filesystem INTERFACE IMPORTED)
-  set_target_properties(StdFilesystem::filesystem PROPERTIES
+  if(StdFilesystem_LIBRARY)
+    set_target_properties(StdFilesystem::filesystem PROPERTIES
       INTERFACE_LINK_LIBRARIES ${StdFilesystem_LIBRARY})
+  endif()
 endif()

--- a/src/test/admin_socket_output.cc
+++ b/src/test/admin_socket_output.cc
@@ -14,7 +14,6 @@
 
 #include <iostream>
 #include <regex>                 // For regex, regex_search
-#include <experimental/filesystem> // For extension
 
 #include "common/admin_socket_client.h"     // For AdminSocketClient
 #include "common/ceph_json.h"               // For JSONParser, JSONObjIter

--- a/src/test/admin_socket_output.h
+++ b/src/test/admin_socket_output.h
@@ -19,9 +19,13 @@
 #include <map>
 #include <set>
 #include <vector>
-#include <experimental/filesystem>       // For path
-
+#if __has_include(<filesystem>)	 // For extension
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
+#endif
 
 using socket_results = std::map<std::string, std::string>;
 using test_functions =

--- a/src/test/common/test_util.cc
+++ b/src/test/common/test_util.cc
@@ -16,12 +16,18 @@
 #include "include/util.h"
 #include "gtest/gtest.h"
 
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
 #include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
 
 #if defined(__linux__)
 TEST(util, collect_sys_info)
 {
-  if (!std::experimental::filesystem::exists("/etc/os-release")) {
+  if (!fs::exists("/etc/os-release")) {
     GTEST_SKIP() << "skipping as '/etc/os-release' does not exist";
   }
 

--- a/src/test/immutable_object_cache/test_object_store.cc
+++ b/src/test/immutable_object_cache/test_object_store.cc
@@ -4,7 +4,13 @@
 #include <iostream>
 #include <unistd.h>
 
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
 #include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
 
 #include "gtest/gtest.h"
 #include "include/Context.h"
@@ -18,7 +24,6 @@
 
 #include "tools/immutable_object_cache/ObjectCacheStore.h"
 
-namespace efs = std::experimental::filesystem;
 using namespace ceph::immutable_obj_cache;
 
 std::string test_cache_path("/tmp/test_ceph_immutable_shared_cache");
@@ -85,7 +90,7 @@ TEST_F(TestObjectStore, test_1) {
 
   std::string cache_path(test_cache_path);
 
-  efs::remove_all(test_cache_path);
+  fs::remove_all(test_cache_path);
 
   init_object_cache_store(m_temp_pool_name, m_temp_volume_name, 1000, true);
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
