### PR TITLE
os/bluestore: Only pass that decremented nref to 0 deletes object

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3478,7 +3478,8 @@ void BlueStore::Onode::get() {
   }
 }
 void BlueStore::Onode::put() {
-  if (--nref == 2) {
+  int n = --nref;
+  if (n == 2) {
     c->get_onode_cache()->unpin(this, [&]() {
         bool was_pinned = pinned;
         pinned = pinned && nref > 2; // intentionally use > not >= as we have
@@ -3486,12 +3487,12 @@ void BlueStore::Onode::put() {
         bool r = was_pinned && !pinned;
         // additional decrement for newly unpinned instance
         if (r) {
-          --nref;
+          n = --nref;
         }
         return cached && r;
       });
   }
-  if (nref == 0) {
+  if (n == 0) {
     delete this;
   }
 }


### PR DESCRIPTION
This is prevention of situations that two different threads passing over Onode::put decrement counter and after that counter is zero.
Now only the pass that made atomic transition 1=>0 destroys the Onode.