### PR TITLE
mds: stuck in resolve or rejoin when restarting MDS and reducing max_mds

### DIFF
--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -489,7 +489,7 @@ class MDCache {
   void cancel_ambiguous_import(CDir *);
   void finish_ambiguous_import(dirfrag_t dirino);
   void resolve_start(MDSContext *resolve_done_);
-  void send_resolves();
+  void send_resolves(bool reset_gather);
   void maybe_send_pending_resolves() {
     if (resolves_pending)
       send_subtree_resolves();

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1956,6 +1956,7 @@ void MDSRank::reconnect_done()
 void MDSRank::rejoin_joint_start()
 {
   dout(1) << "rejoin_joint_start" << dendl;
+  calc_recovery_set();
   mdcache->rejoin_send_rejoins();
 }
 void MDSRank::rejoin_start()
@@ -2378,7 +2379,11 @@ void MDSRankDispatcher::handle_mds_map(
       mdsmap->get_mds_set(resolve, MDSMap::STATE_RESOLVE);
       dout(10) << " resolve set is " << resolve << dendl;
       calc_recovery_set();
-      mdcache->send_resolves();
+      if (state == MDSMap::STATE_RESOLVE) {
+        mdcache->send_resolves(true);
+      }else{
+        mdcache->send_resolves(false);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/47843
Signed-off-by: chencan <chen.can2@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
