### PR TITLE
octopus: mgr/dashboard: Disable TLS 1.0 and 1.1

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -9,6 +9,8 @@ import errno
 import logging
 import os
 import socket
+import ssl
+import sys
 import tempfile
 import threading
 import time
@@ -97,8 +99,8 @@ class CherryPyConfig(object):
         """
         server_addr = self.get_localized_module_option(  # type: ignore
             'server_addr', get_default_addr())
-        ssl = self.get_localized_module_option('ssl', True)  # type: ignore
-        if not ssl:
+        use_ssl = self.get_localized_module_option('ssl', True)  # type: ignore
+        if not use_ssl:
             server_port = self.get_localized_module_option('server_port', 8080)  # type: ignore
         else:
             server_port = self.get_localized_module_option('ssl_server_port', 8443)  # type: ignore
@@ -108,7 +110,7 @@ class CherryPyConfig(object):
                 'no server_addr configured; '
                 'try "ceph config set mgr mgr/{}/{}/server_addr <ip>"'
                 .format(self.module_name, self.get_mgr_id()))  # type: ignore
-        self.log.info('server: ssl=%s host=%s port=%d', 'yes' if ssl else 'no',  # type: ignore
+        self.log.info('server: ssl=%s host=%s port=%d', 'yes' if use_ssl else 'no',  # type: ignore
                       server_addr, server_port)
 
         # Initialize custom handlers.
@@ -144,7 +146,7 @@ class CherryPyConfig(object):
             'tools.plugin_hooks_filter_request.on': True,
         }
 
-        if ssl:
+        if use_ssl:
             # SSL initialization
             cert = self.get_store("crt")  # type: ignore
             if cert is not None:
@@ -166,9 +168,18 @@ class CherryPyConfig(object):
 
             verify_tls_files(cert_fname, pkey_fname)
 
+            # Create custom SSL context to disable TLS 1.0 and 1.1.
+            context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+            context.load_cert_chain(cert_fname, pkey_fname)
+            if sys.version_info >= (3, 7):
+                context.minimum_version = ssl.TLSVersion.TLSv1_2
+            else:
+                context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+
             config['server.ssl_module'] = 'builtin'
             config['server.ssl_certificate'] = cert_fname
             config['server.ssl_private_key'] = pkey_fname
+            config['server.ssl_context'] = context
 
         self.update_cherrypy_config(config)
 
@@ -176,7 +187,7 @@ class CherryPyConfig(object):
             'url_prefix', default=''))
 
         uri = "{0}://{1}:{2}{3}/".format(
-            'https' if ssl else 'http',
+            'https' if use_ssl else 'http',
             socket.getfqdn(server_addr if server_addr != '::' else ''),
             server_port,
             self.url_prefix


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48396

---

backport of https://github.com/ceph/ceph/pull/38286
parent tracker: https://tracker.ceph.com/issues/48360

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh