### PR TITLE
octopus: mgr/balancer: fix available pgs sent to calc_pg_upmaps

### DIFF
--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -1006,10 +1006,8 @@ class Module(MgrModule):
         random.shuffle(adjusted_pools)
         pool_dump = osdmap_dump.get('pools', [])
         for pool in adjusted_pools:
-            num_pg = 0
             for p in pool_dump:
                 if p['pool_name'] == pool:
-                    num_pg = p['pg_num']
                     pool_id = p['pool']
                     break
 
@@ -1024,7 +1022,7 @@ class Module(MgrModule):
                     if s['state_name'] == 'active+clean':
                         num_pg_active_clean += s['count']
                         break
-            available = left - (num_pg - num_pg_active_clean)
+            available = min(left, num_pg_active_clean)
             did = plan.osdmap.calc_pg_upmaps(inc, max_deviation, available, [pool])
             total_did += did
             left -= did


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48399

---

backport of https://github.com/ceph/ceph/pull/38206
parent tracker: https://tracker.ceph.com/issues/48309

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh