### PR TITLE
octopus: rgw: keep syncstopped flag when copying bucket shard headers

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -623,6 +623,7 @@ static int check_index(cls_method_context_t hctx,
 
   calc_header->tag_timeout = existing_header->tag_timeout;
   calc_header->ver = existing_header->ver;
+  calc_header->syncstopped = existing_header->syncstopped;
 
   map<string, bufferlist> keys;
   string start_obj;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48127

---

backport of https://github.com/ceph/ceph/pull/37892
parent tracker: https://tracker.ceph.com/issues/48037

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh