### PR TITLE
octopus: rgw: fix invalid payload issue when serving s3website error page

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -5137,7 +5137,7 @@ int RGWHandler_REST_S3Website::error_handler(int err_no,
        On failure, we need the double-error handler
      */
     new_err_no = RGWHandler_REST_S3Website::serve_errordoc(http_error_code, s->bucket_info.website_conf.error_doc);
-    if (new_err_no && new_err_no != -1) {
+    if (new_err_no != -1) {
       err_no = new_err_no;
     }
   } else {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48345

---

backport of https://github.com/ceph/ceph/pull/37914
parent tracker: https://tracker.ceph.com/issues/48064

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh