### PR TITLE
octopus: global: reexpand conf meta in child process

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,5 +1,8 @@
-15.2.6
+15.2.8
 ------
+* $pid expansion in config paths like `admin_socket` will now properly expand
+  to the daemon pid for commands like `ceph-mds` or `ceph-osd`. Previously only
+  `ceph-fuse`/`rbd-nbd` expanded `$pid` with the actual daemon pid.
 
 * ceph-volume: The ``lvm batch` subcommand received a major rewrite. This closed
   a number of bugs and improves usability in terms of size specification and

--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -167,9 +167,8 @@ int main(int argc, const char **argv, const char *envp[]) {
   }
 
   {
-    g_ceph_context->_conf.finalize_reexpand_meta();
     common_init_finish(g_ceph_context);
-   
+
     init_async_signal_handler();
     register_async_signal_handler(SIGHUP, sighup_handler);
 

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -1107,17 +1107,19 @@ void md_config_t::early_expand_meta(
 bool md_config_t::finalize_reexpand_meta(ConfigValues& values,
 					 const ConfigTracker& tracker)
 {
-  for (auto& [name, value] : may_reexpand_meta) {
-    set_val(values, tracker, name, value);
+  std::vector<std::string> reexpands;
+  reexpands.swap(may_reexpand_meta);
+  for (auto& name : reexpands) {
+    // always refresh the options if they are in the may_reexpand_meta
+    // map, because the options may have already been expanded with old
+    // meta.
+    const auto &opt_iter = schema.find(name);
+    ceph_assert(opt_iter != schema.end());
+    const Option &opt = opt_iter->second;
+    _refresh(values, opt);
   }
-  
-  if (!may_reexpand_meta.empty()) {
-    // meta expands could have modified anything.  Copy it all out again.
-    update_legacy_vals(values);
-    return true;
-  } else {
-    return false;
-  }
+
+  return !may_reexpand_meta.empty();
 }
 
 Option::value_t md_config_t::_expand_meta(
@@ -1201,7 +1203,7 @@ Option::value_t md_config_t::_expand_meta(
       } else if (var == "pid") {
 	out += stringify(getpid());
         if (o) {
-          may_reexpand_meta[o->name] = *str;
+          may_reexpand_meta.push_back(o->name);
         }
       } else if (var == "cctid") {
 	out += stringify((unsigned long long)this);

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -100,7 +100,7 @@ public:
   std::map<std::string,std::string> ignored_mon_values;
 
   /// original raw values saved that may need to re-expand at certain time
-  mutable std::map<std::string, std::string> may_reexpand_meta;
+  mutable std::vector<std::string> may_reexpand_meta;
 
   /// encoded, cached copy of of values + ignored_mon_values
   ceph::bufferlist values_bl;

--- a/src/common/config_proxy.h
+++ b/src/common/config_proxy.h
@@ -199,7 +199,6 @@ public:
     rev_obs_map_t rev_obs;
     if (config.finalize_reexpand_meta(values, obs_mgr)) {
       _gather_changes(values.changed, &rev_obs, nullptr);
-      values.changed.clear();
     }
 
     call_observers(locker, rev_obs);
@@ -256,7 +255,6 @@ public:
     if (!values.cluster.empty()) {
       // meta expands could have modified anything.  Copy it all out again.
       _gather_changes(values.changed, &rev_obs, oss);
-      values.changed.clear();
     }
 
     call_observers(locker, rev_obs);
@@ -268,6 +266,7 @@ public:
       [this, rev_obs](md_config_obs_t *obs, const std::string &key) {
         map_observer_changes(obs, key, rev_obs);
       }, oss);
+      changes.clear();
   }
   int set_val(const std::string_view key, const std::string& s,
               std::stringstream* err_ss=nullptr) {
@@ -290,7 +289,6 @@ public:
 
     rev_obs_map_t rev_obs;
     _gather_changes(values.changed, &rev_obs, nullptr);
-    values.changed.clear();
 
     call_observers(locker, rev_obs);
     return ret;
@@ -301,7 +299,6 @@ public:
 
     rev_obs_map_t rev_obs;
     _gather_changes(values.changed, &rev_obs, oss);
-    values.changed.clear();
 
     call_observers(locker, rev_obs);
     return ret;

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -494,6 +494,9 @@ int reopen_as_null(CephContext *cct, int fd)
 
 void global_init_postfork_start(CephContext *cct)
 {
+  // reexpand the meta in child process
+  cct->_conf.finalize_reexpand_meta();
+
   // restart log thread
   cct->_log->start();
   cct->notify_post_fork();

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -1157,7 +1157,6 @@ static int do_map(int argc, const char *argv[], Config *cfg)
     global_init_postfork_start(g_ceph_context);
   }
 
-  g_ceph_context->_conf.finalize_reexpand_meta();
   common_init_finish(g_ceph_context);
   global_init_chdir(g_ceph_context);
 

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -1157,6 +1157,7 @@ static int do_map(int argc, const char *argv[], Config *cfg)
     global_init_postfork_start(g_ceph_context);
   }
 
+  g_ceph_context->_conf.finalize_reexpand_meta();
   common_init_finish(g_ceph_context);
   global_init_chdir(g_ceph_context);
 


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/48084
* https://tracker.ceph.com/issues/48456

---

backport of

* https://github.com/ceph/ceph/pull/37898
* https://github.com/ceph/ceph/pull/38058

parent trackers:

* https://tracker.ceph.com/issues/48046
* https://tracker.ceph.com/issues/48240

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh