### PR TITLE
octopus: qa/workunits/rbd: fix permission issue when removing mirror peer

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -261,7 +261,7 @@ peer_add()
             peer_uuid=$(rbd mirror pool info --cluster ${cluster} --pool ${pool} --format xml | \
                 xmlstarlet sel -t -v "//peers/peer[site_name='${remote_cluster}']/uuid")
 
-            rbd --cluster ${cluster} --pool ${pool} mirror pool peer remove ${peer_uuid}
+            CEPH_ARGS='' rbd --cluster ${cluster} --pool ${pool} mirror pool peer remove ${peer_uuid}
         else
             test $error_code -eq 0
             if [ -n "$uuid_var_name" ]; then


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48085

---

backport of https://github.com/ceph/ceph/pull/37884
parent tracker: https://tracker.ceph.com/issues/48032

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh