### PR TITLE
octopus: mgr/rbd_support: store global schedule without localized prefix

### DIFF
--- a/src/pybind/mgr/rbd_support/schedule.py
+++ b/src/pybind/mgr/rbd_support/schedule.py
@@ -345,6 +345,18 @@ class Schedules:
 
         schedule_cfg = self.handler.module.get_module_option(
             self.handler.MODULE_OPTION_NAME, '')
+
+        # Previous versions incorrectly stored the global config in
+        # the localized module option. Check the config is here and fix it.
+        if not schedule_cfg:
+            schedule_cfg = self.handler.module.get_localized_module_option(
+                self.handler.MODULE_OPTION_NAME, '')
+            if schedule_cfg:
+                self.handler.module.set_module_option(
+                    self.handler.MODULE_OPTION_NAME, schedule_cfg)
+        self.handler.module.set_localized_module_option(
+            self.handler.MODULE_OPTION_NAME, None)
+
         if schedule_cfg:
             try:
                 level_spec = LevelSpec.make_global()

--- a/src/pybind/mgr/rbd_support/schedule.py
+++ b/src/pybind/mgr/rbd_support/schedule.py
@@ -343,7 +343,7 @@ class Schedules:
 
     def load(self, namespace_validator=None, image_validator=None):
 
-        schedule_cfg = self.handler.module.get_localized_module_option(
+        schedule_cfg = self.handler.module.get_module_option(
             self.handler.MODULE_OPTION_NAME, '')
         if schedule_cfg:
             try:
@@ -420,8 +420,8 @@ class Schedules:
 
     def save(self, level_spec, schedule):
         if level_spec.is_global():
-            schedule_cfg = schedule and schedule.to_json() or ''
-            self.handler.module.set_localized_module_option(
+            schedule_cfg = schedule and schedule.to_json() or None
+            self.handler.module.set_module_option(
                 self.handler.MODULE_OPTION_NAME, schedule_cfg)
             return
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48086

---

backport of https://github.com/ceph/ceph/pull/37864
parent tracker: https://tracker.ceph.com/issues/48020

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh