### PR TITLE
octopus: mon: validate crush-failure-domain

### DIFF
--- a/qa/standalone/mon/osd-erasure-code-profile.sh
+++ b/qa/standalone/mon/osd-erasure-code-profile.sh
@@ -222,6 +222,17 @@ function TEST_profile_k_sanity() {
         m=1 || return 1
 }
 
+function TEST_invalid_crush_failure_domain() {
+    local dir=$1
+
+    run_mon $dir a || return 1
+
+    local profile=ec_profile
+    local crush_failure_domain=invalid_failure_domain
+
+    ! ceph osd erasure-code-profile set $profile k=4 m=2 crush-failure-domain=$crush_failure_domain 2>&1 || return 1
+}
+
 main osd-erasure-code-profile "$@"
 
 # Local Variables:

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -10803,6 +10803,18 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     err = parse_erasure_code_profile(profile, &profile_map, &ss);
     if (err)
       goto reply;
+    if (auto found = profile_map.find("crush-failure-domain");
+	found != profile_map.end()) {
+      const auto& failure_domain = found->second;
+      int failure_domain_type = osdmap.crush->get_type_id(failure_domain);
+      if (failure_domain_type < 0) {
+	ss << "erasure-code-profile " << profile_map
+	  << " contains an invalid failure-domain " << std::quoted(failure_domain);
+	err = -EINVAL;
+	goto reply;
+      }
+    }
+
     if (profile_map.find("plugin") == profile_map.end()) {
       ss << "erasure-code-profile " << profile_map
 	 << " must contain a plugin entry" << std::endl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48378

---

backport of https://github.com/ceph/ceph/pull/37150
parent tracker: https://tracker.ceph.com/issues/47452

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh