### PR TITLE
octopus: cephfs: release client dentry_lease before send caps release to mds

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1912,6 +1912,7 @@ void Client::encode_dentry_release(Dentry *dn, MetaRequest *req,
     rel.item.dname_len = dn->name.length();
     rel.item.dname_seq = dn->lease_seq;
     rel.dname = dn->name;
+    dn->lease_mds = -1;
   }
   ldout(cct, 25) << __func__ << " exit(dn:"
 	   << dn << ")" << dendl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48129

---

backport of https://github.com/ceph/ceph/pull/37664
parent tracker: https://tracker.ceph.com/issues/47854

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh