### PR TITLE
osdc: Add objecter fastfail

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2447,6 +2447,16 @@ std::vector<Option> get_global_options() {
     .set_default(10.0)
     .set_description("Seconds before in-flight op is considered 'laggy' and we query mon for the latest OSDMap"),
 
+    Option("objecter_fastfail_timeout", Option::TYPE_SECS, Option::LEVEL_DEV)
+    .set_default(0)
+    .set_description("Timeout session on inactive pg: Duration (in seconds) after which the op is cancelled if the pg is inactive")
+    .set_long_description("It will cancel the op associated with a session that should be sent to a "
+                          "pg that is inactive after the specified duration. "
+                          "fastfail means that after the timeout configured the pg will be marked as invalid and "
+                          "all requests sent to it will be cancelled immediately "
+                          "For using this option the application must be able to handle the timeouts otherwise it may lead to "
+                          "data corruption"),
+
     Option("objecter_inflight_op_bytes", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
     .set_default(100_M)
     .set_description("Max in-flight data in bytes (both directions)"),

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1645,6 +1645,10 @@ public:
   std::atomic<bool> initialized{false};
 
 private:
+  struct fastfail {
+    std::unordered_set<pg_t> pgs;
+    std::shared_mutex lock;
+  } ffpgs;
   std::atomic<uint64_t> last_tid{0};
   std::atomic<unsigned> inflight_ops{0};
   std::atomic<int> client_inc{-1};
@@ -1920,6 +1924,7 @@ public:
     std::variant<std::unique_ptr<OpComp>, fu2::unique_function<OpSig>,
 		 Context*> onfinish;
     uint64_t ontimeout = 0;
+    uint64_t onfastfail = 0;
 
     ceph_tid_t tid = 0;
     int attempts = 0;
@@ -2446,6 +2451,7 @@ public:
 
   ceph::timespan mon_timeout;
   ceph::timespan osd_timeout;
+  ceph::timespan objecter_fastfail_timeout;
 
   MOSDOp *_prepare_osd_op(Op *op);
   void _send_op(Op *op);

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1527,7 +1527,7 @@ do_rgw()
     # Start server
     RGWDEBUG=""
     if [ "$debug" -ne 0 ]; then
-        RGWDEBUG="--debug-rgw=20 --debug-ms=1"
+        RGWDEBUG="--debug-rgw=1 --debug-ms=0"
     fi
 
     local CEPH_RGW_PORT_NUM="${CEPH_RGW_PORT}"


### PR DESCRIPTION
There is no point in indefinitely waiting when pg of an object is inactive. It is appropriate to cancel the op in such scenarios. Also, this tunable should be configurable from the ceph.conf as to enable or disable this feature.

Signed-off-by: Or Friedmann <ofriedma@redhat.com>

Fixes: https://tracker.ceph.com/issues/56956

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
