### PR TITLE
octopus: cephfs: mds: dir->mark_new() should together with dir->mark_dirty()

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -11995,6 +11995,7 @@ void MDCache::_fragment_logged(MDRequestRef& mdr)
   for (const auto& dir : info.resultfrags) {
     dout(10) << " storing result frag " << *dir << dendl;
 
+    dir->mark_dirty(dir->pre_dirty(), mdr->ls);
     dir->mark_new(mdr->ls);
 
     // freeze and store them too


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48370

---

backport of https://github.com/ceph/ceph/pull/38109
parent tracker: https://tracker.ceph.com/issues/48249

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh