### PR TITLE
crimson/net: misc fixes and cleanups to messenger

### DIFF
--- a/src/crimson/admin/admin_socket.cc
+++ b/src/crimson/admin/admin_socket.cc
@@ -123,7 +123,7 @@ seastar::future<> AdminSocket::finalize_response(
 }
 
 
-seastar::future<> AdminSocket::handle_command(crimson::net::Connection* conn,
+seastar::future<> AdminSocket::handle_command(crimson::net::ConnectionRef conn,
 					      boost::intrusive_ptr<MCommand> m)
 {
   return execute_command(m->cmd, std::move(m->get_data())).then(

--- a/src/crimson/admin/admin_socket.cc
+++ b/src/crimson/admin/admin_socket.cc
@@ -7,6 +7,7 @@
 #include <fmt/format.h>
 #include <seastar/net/api.hh>
 #include <seastar/net/inet_address.hh>
+#include <seastar/core/future-util.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/thread.hh>

--- a/src/crimson/admin/admin_socket.h
+++ b/src/crimson/admin/admin_socket.h
@@ -126,7 +126,7 @@ class AdminSocket : public seastar::enable_lw_shared_from_this<AdminSocket> {
    * \param conn connection over which the incoming command message is received
    * \param m message carrying the command vector and optional input buffer
    */
-  seastar::future<> handle_command(crimson::net::Connection* conn,
+  seastar::future<> handle_command(crimson::net::ConnectionRef conn,
 				   boost::intrusive_ptr<MCommand> m);
 
 private:

--- a/src/crimson/common/errorator.h
+++ b/src/crimson/common/errorator.h
@@ -1017,6 +1017,7 @@ namespace ct_error {
     ct_error_code<std::errc::resource_unavailable_try_again>;
   using file_too_large =
     ct_error_code<std::errc::file_too_large>;
+  using address_in_use = ct_error_code<std::errc::address_in_use>;
 
   struct pass_further_all {
     template <class ErrorT>

--- a/src/crimson/mgr/client.cc
+++ b/src/crimson/mgr/client.cc
@@ -48,7 +48,7 @@ seastar::future<> Client::stop()
 }
 
 std::tuple<bool, seastar::future<>>
-Client::ms_dispatch(crimson::net::Connection* conn, MessageRef m)
+Client::ms_dispatch(crimson::net::ConnectionRef conn, MessageRef m)
 {
   bool dispatched = true;
   gate.dispatch_in_background(__func__, *this, [this, conn, &m, &dispatched] {
@@ -117,7 +117,7 @@ seastar::future<> Client::reconnect()
   });
 }
 
-seastar::future<> Client::handle_mgr_map(crimson::net::Connection*,
+seastar::future<> Client::handle_mgr_map(crimson::net::ConnectionRef,
                                          Ref<MMgrMap> m)
 {
   mgrmap = m->get_map();
@@ -131,7 +131,7 @@ seastar::future<> Client::handle_mgr_map(crimson::net::Connection*,
   }
 }
 
-seastar::future<> Client::handle_mgr_conf(crimson::net::Connection* conn,
+seastar::future<> Client::handle_mgr_conf(crimson::net::ConnectionRef,
                                           Ref<MMgrConfigure> m)
 {
   logger().info("{} {}", __func__, *m);

--- a/src/crimson/mgr/client.cc
+++ b/src/crimson/mgr/client.cc
@@ -47,7 +47,7 @@ seastar::future<> Client::stop()
   return fut;
 }
 
-std::tuple<bool, seastar::future<>>
+std::optional<seastar::future<>>
 Client::ms_dispatch(crimson::net::ConnectionRef conn, MessageRef m)
 {
   bool dispatched = true;
@@ -62,7 +62,7 @@ Client::ms_dispatch(crimson::net::ConnectionRef conn, MessageRef m)
       return seastar::now();
     }
   });
-  return {dispatched, seastar::now()};
+  return (dispatched ? std::make_optional(seastar::now()) : std::nullopt);
 }
 
 void Client::ms_handle_connect(crimson::net::ConnectionRef c)

--- a/src/crimson/mgr/client.h
+++ b/src/crimson/mgr/client.h
@@ -38,12 +38,12 @@ public:
 
 private:
   std::tuple<bool, seastar::future<>> ms_dispatch(
-      crimson::net::Connection* conn, Ref<Message> m) override;
+      crimson::net::ConnectionRef conn, Ref<Message> m) override;
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) final;
   void ms_handle_connect(crimson::net::ConnectionRef conn) final;
-  seastar::future<> handle_mgr_map(crimson::net::Connection* conn,
+  seastar::future<> handle_mgr_map(crimson::net::ConnectionRef conn,
 				   Ref<MMgrMap> m);
-  seastar::future<> handle_mgr_conf(crimson::net::Connection* conn,
+  seastar::future<> handle_mgr_conf(crimson::net::ConnectionRef conn,
 				    Ref<MMgrConfigure> m);
   seastar::future<> reconnect();
 

--- a/src/crimson/mgr/client.h
+++ b/src/crimson/mgr/client.h
@@ -37,8 +37,8 @@ public:
   void report();
 
 private:
-  seastar::future<> ms_dispatch(crimson::net::Connection* conn,
-				Ref<Message> m) override;
+  std::tuple<bool, seastar::future<>> ms_dispatch(
+      crimson::net::Connection* conn, Ref<Message> m) override;
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) final;
   void ms_handle_connect(crimson::net::ConnectionRef conn) final;
   seastar::future<> handle_mgr_map(crimson::net::Connection* conn,

--- a/src/crimson/mgr/client.h
+++ b/src/crimson/mgr/client.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include <seastar/core/gate.hh>
 #include <seastar/core/timer.hh>
 
+#include "crimson/common/gated.h"
 #include "crimson/net/Dispatcher.h"
 #include "crimson/net/Fwd.h"
 #include "mon/MgrMap.h"

--- a/src/crimson/mgr/client.h
+++ b/src/crimson/mgr/client.h
@@ -37,7 +37,7 @@ public:
   void report();
 
 private:
-  std::tuple<bool, seastar::future<>> ms_dispatch(
+  std::optional<seastar::future<>> ms_dispatch(
       crimson::net::ConnectionRef conn, Ref<Message> m) override;
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) final;
   void ms_handle_connect(crimson::net::ConnectionRef conn) final;

--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -518,7 +518,7 @@ bool Client::is_hunting() const {
   return !active_con;
 }
 
-std::tuple<bool, seastar::future<>>
+std::optional<seastar::future<>>
 Client::ms_dispatch(crimson::net::ConnectionRef conn, MessageRef m)
 {
   bool dispatched = true;
@@ -550,7 +550,7 @@ Client::ms_dispatch(crimson::net::ConnectionRef conn, MessageRef m)
       return seastar::now();
     }
   });
-  return {dispatched, seastar::now()};
+  return (dispatched ? std::make_optional(seastar::now()) : std::nullopt);
 }
 
 void Client::ms_handle_reset(crimson::net::ConnectionRef conn, bool /* is_replace */)

--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -519,7 +519,7 @@ bool Client::is_hunting() const {
 }
 
 std::tuple<bool, seastar::future<>>
-Client::ms_dispatch(crimson::net::Connection* conn, MessageRef m)
+Client::ms_dispatch(crimson::net::ConnectionRef conn, MessageRef m)
 {
   bool dispatched = true;
   gate.dispatch_in_background(__func__, *this, [this, conn, &m, &dispatched] {
@@ -785,7 +785,7 @@ int Client::handle_auth_bad_method(crimson::net::ConnectionRef conn,
   }
 }
 
-seastar::future<> Client::handle_monmap(crimson::net::Connection* conn,
+seastar::future<> Client::handle_monmap(crimson::net::ConnectionRef conn,
                                         Ref<MMonMap> m)
 {
   monmap.decode(m->monmapbl);
@@ -815,8 +815,8 @@ seastar::future<> Client::handle_monmap(crimson::net::Connection* conn,
   }
 }
 
-seastar::future<> Client::handle_auth_reply(crimson::net::Connection* conn,
-                                               Ref<MAuthReply> m)
+seastar::future<> Client::handle_auth_reply(crimson::net::ConnectionRef conn,
+                                            Ref<MAuthReply> m)
 {
   logger().info(
     "handle_auth_reply mon {} => {} returns {}: {}",

--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -518,10 +518,11 @@ bool Client::is_hunting() const {
   return !active_con;
 }
 
-seastar::future<>
+std::tuple<bool, seastar::future<>>
 Client::ms_dispatch(crimson::net::Connection* conn, MessageRef m)
 {
-  return gate.dispatch(__func__, *this, [this, conn, &m] {
+  bool dispatched = true;
+  gate.dispatch_in_background(__func__, *this, [this, conn, &m, &dispatched] {
     // we only care about these message types
     switch (m->get_type()) {
     case CEPH_MSG_MON_MAP:
@@ -545,9 +546,11 @@ Client::ms_dispatch(crimson::net::Connection* conn, MessageRef m)
       return handle_config(
 	boost::static_pointer_cast<MConfig>(m));
     default:
+      dispatched = false;
       return seastar::now();
     }
   });
+  return {dispatched, seastar::now()};
 }
 
 void Client::ms_handle_reset(crimson::net::ConnectionRef conn, bool /* is_replace */)

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -140,8 +140,8 @@ private:
 private:
   void tick();
 
-  seastar::future<> ms_dispatch(crimson::net::Connection* conn,
-				MessageRef m) override;
+  std::tuple<bool, seastar::future<>> ms_dispatch(crimson::net::Connection* conn,
+                                                  MessageRef m) override;
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) override;
 
   seastar::future<> handle_monmap(crimson::net::Connection* conn,

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -140,13 +140,13 @@ private:
 private:
   void tick();
 
-  std::tuple<bool, seastar::future<>> ms_dispatch(crimson::net::Connection* conn,
+  std::tuple<bool, seastar::future<>> ms_dispatch(crimson::net::ConnectionRef conn,
                                                   MessageRef m) override;
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) override;
 
-  seastar::future<> handle_monmap(crimson::net::Connection* conn,
+  seastar::future<> handle_monmap(crimson::net::ConnectionRef conn,
 				  Ref<MMonMap> m);
-  seastar::future<> handle_auth_reply(crimson::net::Connection* conn,
+  seastar::future<> handle_auth_reply(crimson::net::ConnectionRef conn,
 				      Ref<MAuthReply> m);
   seastar::future<> handle_subscribe_ack(Ref<MMonSubscribeAck> m);
   seastar::future<> handle_get_version_reply(Ref<MMonGetVersionReply> m);

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -140,8 +140,8 @@ private:
 private:
   void tick();
 
-  std::tuple<bool, seastar::future<>> ms_dispatch(crimson::net::ConnectionRef conn,
-                                                  MessageRef m) override;
+  std::optional<seastar::future<>> ms_dispatch(crimson::net::ConnectionRef conn,
+                                               MessageRef m) override;
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) override;
 
   seastar::future<> handle_monmap(crimson::net::ConnectionRef conn,

--- a/src/crimson/net/Connection.h
+++ b/src/crimson/net/Connection.h
@@ -147,10 +147,6 @@ class Connection : public seastar::enable_shared_from_this<Connection> {
   auto get_last_keepalive() const { return last_keepalive; }
   auto get_last_keepalive_ack() const { return last_keepalive_ack; }
 
-  seastar::shared_ptr<Connection> get_shared() {
-    return shared_from_this();
-  }
-
   struct user_private_t {
     virtual ~user_private_t() = default;
   };

--- a/src/crimson/net/Dispatcher.h
+++ b/src/crimson/net/Dispatcher.h
@@ -25,11 +25,10 @@ class Dispatcher {
   virtual ~Dispatcher() {}
 
   // Dispatchers are put into a chain as described by chain-of-responsibility
-  // pattern. If any of the dispatchers claims this message, it returns true
-  // to prevent other dispatchers from processing it, and returns a future
-  // to throttle the connection if it's too busy. Else, it returns false and
-  // the second future is ignored.
-  virtual std::tuple<bool, seastar::future<>> ms_dispatch(ConnectionRef, MessageRef) = 0;
+  // pattern. If any of the dispatchers claims this message, it returns a valid
+  // future to prevent other dispatchers from processing it, and this is also
+  // used to throttle the connection if it's too busy.
+  virtual std::optional<seastar::future<>> ms_dispatch(ConnectionRef, MessageRef) = 0;
 
   virtual void ms_handle_accept(ConnectionRef conn) {}
 

--- a/src/crimson/net/Dispatcher.h
+++ b/src/crimson/net/Dispatcher.h
@@ -14,20 +14,13 @@
 
 #pragma once
 
-#include <seastar/core/future.hh>
-#include <seastar/core/sharded.hh>
-#include <boost/intrusive/slist.hpp>
-
-#include "crimson/common/gated.h"
 #include "Fwd.h"
 
 class AuthAuthorizer;
 
 namespace crimson::net {
 
-class Dispatcher : public boost::intrusive::slist_base_hook<
-			    boost::intrusive::link_mode<
-			      boost::intrusive::safe_link>> {
+class Dispatcher {
  public:
   virtual ~Dispatcher() {}
 

--- a/src/crimson/net/Dispatcher.h
+++ b/src/crimson/net/Dispatcher.h
@@ -29,7 +29,7 @@ class Dispatcher {
   // to prevent other dispatchers from processing it, and returns a future
   // to throttle the connection if it's too busy. Else, it returns false and
   // the second future is ignored.
-  virtual std::tuple<bool, seastar::future<>> ms_dispatch(Connection*, MessageRef) = 0;
+  virtual std::tuple<bool, seastar::future<>> ms_dispatch(ConnectionRef, MessageRef) = 0;
 
   virtual void ms_handle_accept(ConnectionRef conn) {}
 

--- a/src/crimson/net/Dispatcher.h
+++ b/src/crimson/net/Dispatcher.h
@@ -36,9 +36,7 @@ class Dispatcher : public boost::intrusive::slist_base_hook<
   // to prevent other dispatchers from processing it, and returns a future
   // to throttle the connection if it's too busy. Else, it returns false and
   // the second future is ignored.
-  virtual std::tuple<bool, seastar::future<>> ms_dispatch(Connection* conn, MessageRef m) {
-    return {false, seastar::now<>()};
-  }
+  virtual std::tuple<bool, seastar::future<>> ms_dispatch(Connection*, MessageRef) = 0;
 
   virtual void ms_handle_accept(ConnectionRef conn) {}
 

--- a/src/crimson/net/Fwd.h
+++ b/src/crimson/net/Fwd.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <boost/container/small_vector.hpp>
 #include <seastar/core/future.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -38,7 +39,10 @@ using stop_t = seastar::stop_iteration;
 class Connection;
 using ConnectionRef = seastar::shared_ptr<Connection>;
 
+class Dispatcher;
 class ChainedDispatchers;
+constexpr std::size_t NUM_DISPATCHERS = 4u;
+using dispatchers_t = boost::container::small_vector<Dispatcher*, NUM_DISPATCHERS>;
 
 class Messenger;
 using MessengerRef = seastar::shared_ptr<Messenger>;

--- a/src/crimson/net/Fwd.h
+++ b/src/crimson/net/Fwd.h
@@ -23,6 +23,8 @@
 #include "msg/MessageRef.h"
 #include "msg/msg_types.h"
 
+#include "crimson/common/errorator.h"
+
 using auth_proto_t = int;
 
 class AuthConnectionMeta;

--- a/src/crimson/net/Fwd.h
+++ b/src/crimson/net/Fwd.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <seastar/core/future.hh>
+#include <seastar/core/future-util.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sharded.hh>
 
@@ -34,7 +36,7 @@ using stop_t = seastar::stop_iteration;
 class Connection;
 using ConnectionRef = seastar::shared_ptr<Connection>;
 
-class Dispatcher;
+class ChainedDispatchers;
 
 class Messenger;
 using MessengerRef = seastar::shared_ptr<Messenger>;

--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -66,16 +66,15 @@ public:
     return seastar::now();
   }
 
+  using bind_ertr = crimson::errorator<
+    crimson::ct_error::address_in_use // The address (range) is already bound
+    >;
   /// bind to the given address
-  /// throws std::system_error with address_in_use if the addr is already bound
-  // TODO: use errorated future
-  virtual seastar::future<> bind(const entity_addrvec_t& addr) = 0;
+  virtual bind_ertr::future<> bind(const entity_addrvec_t& addr) = 0;
 
   /// try to bind to the first unused port of given address
-  /// throws std::system_error with address_in_use if the range is unavailable
-  // TODO: use errorated future
-  virtual seastar::future<> try_bind(const entity_addrvec_t& addr,
-                                     uint32_t min_port, uint32_t max_port) = 0;
+  virtual bind_ertr::future<> try_bind(const entity_addrvec_t& addr,
+                                       uint32_t min_port, uint32_t max_port) = 0;
 
   /// start the messenger
   virtual seastar::future<> start(const std::list<Dispatcher*>&) = 0;

--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -66,9 +66,13 @@ public:
   }
 
   /// bind to the given address
+  /// throws std::system_error with address_in_use if the addr is already bound
+  // TODO: use errorated future
   virtual seastar::future<> bind(const entity_addrvec_t& addr) = 0;
 
   /// try to bind to the first unused port of given address
+  /// throws std::system_error with address_in_use if the range is unavailable
+  // TODO: use errorated future
   virtual seastar::future<> try_bind(const entity_addrvec_t& addr,
                                      uint32_t min_port, uint32_t max_port) = 0;
 

--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -90,8 +90,6 @@ public:
   // wait for messenger shutdown
   virtual seastar::future<> wait() = 0;
 
-  virtual void add_dispatcher(Dispatcher&) = 0;
-
   virtual void remove_dispatcher(Dispatcher&) = 0;
 
   virtual bool dispatcher_chain_empty() const = 0;

--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <list>
-
 #include "Fwd.h"
 #include "crimson/common/throttle.h"
 #include "msg/Message.h"
@@ -33,8 +31,6 @@ namespace crimson::net {
 #ifdef UNIT_TESTS_BUILT
 class Interceptor;
 #endif
-
-class Dispatcher;
 
 using Throttle = crimson::common::Throttle;
 using SocketPolicy = ceph::net::Policy<Throttle>;
@@ -77,13 +73,7 @@ public:
                                        uint32_t min_port, uint32_t max_port) = 0;
 
   /// start the messenger
-  virtual seastar::future<> start(const std::list<Dispatcher*>&) = 0;
-
-  seastar::future<> start(Dispatcher& dispatcher) {
-    std::list<Dispatcher*> dispatchers;
-    dispatchers.push_back(&dispatcher);
-    return start(dispatchers);
-  }
+  virtual seastar::future<> start(const dispatchers_t&) = 0;
 
   /// either return an existing connection to the peer,
   /// or a new pending connection

--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -73,14 +73,9 @@ void Protocol::close(bool dispatch_reset,
   auto gate_closed = gate.close();
 
   if (dispatch_reset) {
-    try {
-        dispatcher->ms_handle_reset(
-            seastar::static_pointer_cast<SocketConnection>(conn.shared_from_this()),
-            is_replace);
-    } catch (...) {
-      logger().error("{} got unexpected exception in ms_handle_reset() {}",
-                     conn, std::current_exception());
-    }
+    dispatcher->ms_handle_reset(
+        seastar::static_pointer_cast<SocketConnection>(conn.shared_from_this()),
+        is_replace);
   }
 
   // asynchronous operations

--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -7,7 +7,7 @@
 
 #include "crimson/common/log.h"
 #include "crimson/net/Errors.h"
-#include "crimson/net/Dispatcher.h"
+#include "crimson/net/chained_dispatchers.h"
 #include "crimson/net/Socket.h"
 #include "crimson/net/SocketConnection.h"
 #include "msg/Message.h"
@@ -21,10 +21,10 @@ namespace {
 namespace crimson::net {
 
 Protocol::Protocol(proto_t type,
-                   ChainedDispatchersRef& dispatcher,
+                   ChainedDispatchers& dispatchers,
                    SocketConnection& conn)
   : proto_type(type),
-    dispatcher(dispatcher),
+    dispatchers(dispatchers),
     conn(conn),
     auth_meta{seastar::make_lw_shared<AuthConnectionMeta>()}
 {}
@@ -73,7 +73,7 @@ void Protocol::close(bool dispatch_reset,
   auto gate_closed = gate.close();
 
   if (dispatch_reset) {
-    dispatcher->ms_handle_reset(
+    dispatchers.ms_handle_reset(
         seastar::static_pointer_cast<SocketConnection>(conn.shared_from_this()),
         is_replace);
   }

--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -80,7 +80,7 @@ void Protocol::close(bool dispatch_reset,
 
   // asynchronous operations
   assert(!close_ready.valid());
-  close_ready = std::move(gate_closed).finally([this] {
+  close_ready = std::move(gate_closed).then([this] {
     if (socket) {
       return socket->close();
     } else {

--- a/src/crimson/net/Protocol.h
+++ b/src/crimson/net/Protocol.h
@@ -50,7 +50,7 @@ class Protocol {
   virtual void print(std::ostream&) const = 0;
  protected:
   Protocol(proto_t type,
-           ChainedDispatchersRef& dispatcher,
+           ChainedDispatchers& dispatchers,
            SocketConnection& conn);
 
   virtual void trigger_close() = 0;
@@ -71,7 +71,7 @@ class Protocol {
   SocketRef socket;
 
  protected:
-  ChainedDispatchersRef dispatcher;
+  ChainedDispatchers& dispatchers;
   SocketConnection &conn;
 
   AuthConnectionMetaRef auth_meta;

--- a/src/crimson/net/ProtocolV1.cc
+++ b/src/crimson/net/ProtocolV1.cc
@@ -871,12 +871,13 @@ seastar::future<> ProtocolV1::read_message()
 
       if (unlikely(!conn.update_rx_seq(msg->get_seq()))) {
         // skip this message
-        return;
+        return seastar::now();
       }
 
       logger().debug("{} <== #{} === {} ({})",
                      conn, msg_ref->get_seq(), *msg_ref, msg_ref->get_type());
-      std::ignore = dispatcher->ms_dispatch(&conn, std::move(msg_ref));
+      // throttle the reading process by the returned future
+      return dispatchers.ms_dispatch(&conn, std::move(msg_ref));
     });
 }
 

--- a/src/crimson/net/ProtocolV1.cc
+++ b/src/crimson/net/ProtocolV1.cc
@@ -15,7 +15,7 @@
 #include "crimson/auth/AuthClient.h"
 #include "crimson/auth/AuthServer.h"
 #include "crimson/common/log.h"
-#include "Dispatcher.h"
+#include "chained_dispatchers.h"
 #include "Errors.h"
 #include "Socket.h"
 #include "SocketConnection.h"
@@ -125,10 +125,10 @@ void discard_up_to(std::deque<MessageRef>* queue,
 
 namespace crimson::net {
 
-ProtocolV1::ProtocolV1(ChainedDispatchersRef& dispatcher,
+ProtocolV1::ProtocolV1(ChainedDispatchers& dispatchers,
                        SocketConnection& conn,
                        SocketMessenger& messenger)
-  : Protocol(proto_t::v1, dispatcher, conn), messenger{messenger} {}
+  : Protocol(proto_t::v1, dispatchers, conn), messenger{messenger} {}
 
 ProtocolV1::~ProtocolV1() {}
 
@@ -917,10 +917,10 @@ void ProtocolV1::execute_open(open_t type)
   set_write_state(write_state_t::open);
 
   if (type == open_t::connected) {
-    dispatcher->ms_handle_connect(
+    dispatchers.ms_handle_connect(
         seastar::static_pointer_cast<SocketConnection>(conn.shared_from_this()));
   } else { // type == open_t::accepted
-    dispatcher->ms_handle_accept(
+    dispatchers.ms_handle_accept(
         seastar::static_pointer_cast<SocketConnection>(conn.shared_from_this()));
   }
 

--- a/src/crimson/net/ProtocolV1.h
+++ b/src/crimson/net/ProtocolV1.h
@@ -12,7 +12,7 @@ namespace crimson::net {
 
 class ProtocolV1 final : public Protocol {
  public:
-  ProtocolV1(ChainedDispatchersRef& dispatcher,
+  ProtocolV1(ChainedDispatchers& dispatchers,
              SocketConnection& conn,
              SocketMessenger& messenger);
   ~ProtocolV1() override;

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -1914,7 +1914,7 @@ seastar::future<> ProtocolV2::read_message(utime_t throttle_stamp)
           local_conf()->ms_die_on_old_message) {
         ceph_assert(0 == "old msgs despite reconnect_seq feature");
       }
-      return;
+      return seastar::now();
     } else if (message->get_seq() > cur_seq + 1) {
       logger().error("{} missed message? skipped from seq {} to {}",
                      conn, cur_seq, message->get_seq());
@@ -1932,7 +1932,8 @@ seastar::future<> ProtocolV2::read_message(utime_t throttle_stamp)
 
     // TODO: change MessageRef with seastar::shared_ptr
     auto msg_ref = MessageRef{message, false};
-    std::ignore = dispatcher->ms_dispatch(&conn, std::move(msg_ref));
+    // throttle the reading process by the returned future
+    return dispatchers.ms_dispatch(&conn, std::move(msg_ref));
   });
 }
 

--- a/src/crimson/net/ProtocolV2.h
+++ b/src/crimson/net/ProtocolV2.h
@@ -13,7 +13,7 @@ namespace crimson::net {
 
 class ProtocolV2 final : public Protocol {
  public:
-  ProtocolV2(ChainedDispatchersRef& dispatcher,
+  ProtocolV2(ChainedDispatchers& dispatchers,
              SocketConnection& conn,
              SocketMessenger& messenger);
   ~ProtocolV2() override;

--- a/src/crimson/net/Socket.h
+++ b/src/crimson/net/Socket.h
@@ -9,10 +9,10 @@
 #include <seastar/net/packet.hh>
 
 #include "include/buffer.h"
-#include "msg/msg_types.h"
 
 #include "crimson/common/log.h"
 #include "Errors.h"
+#include "Fwd.h"
 
 #ifdef UNIT_TESTS_BUILT
 #include "Interceptor.h"
@@ -197,7 +197,10 @@ public:
   FixedCPUServerSocket(const FixedCPUServerSocket&) = delete;
   FixedCPUServerSocket& operator=(const FixedCPUServerSocket&) = delete;
 
-  seastar::future<> listen(entity_addr_t addr);
+  using listen_ertr = crimson::errorator<
+    crimson::ct_error::address_in_use // The address is already bound
+    >;
+  listen_ertr::future<> listen(entity_addr_t addr);
 
   // fn_accept should be a nothrow function of type
   // seastar::future<>(SocketRef, entity_addr_t)

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -26,14 +26,14 @@ using namespace crimson::net;
 using crimson::common::local_conf;
 
 SocketConnection::SocketConnection(SocketMessenger& messenger,
-                                   ChainedDispatchersRef& dispatcher,
+                                   ChainedDispatchers& dispatchers,
                                    bool is_msgr2)
   : messenger(messenger)
 {
   if (is_msgr2) {
-    protocol = std::make_unique<ProtocolV2>(dispatcher, *this, messenger);
+    protocol = std::make_unique<ProtocolV2>(dispatchers, *this, messenger);
   } else {
-    protocol = std::make_unique<ProtocolV1>(dispatcher, *this, messenger);
+    protocol = std::make_unique<ProtocolV1>(dispatchers, *this, messenger);
   }
 #ifdef UNIT_TESTS_BUILT
   if (messenger.interceptor) {

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -18,13 +18,11 @@
 
 #include "msg/Policy.h"
 #include "crimson/common/throttle.h"
-#include "crimson/net/chained_dispatchers.h"
 #include "crimson/net/Connection.h"
 #include "crimson/net/Socket.h"
 
 namespace crimson::net {
 
-class Dispatcher;
 class Protocol;
 class SocketMessenger;
 class SocketConnection;
@@ -55,7 +53,7 @@ class SocketConnection : public Connection {
 
  public:
   SocketConnection(SocketMessenger& messenger,
-                   ChainedDispatchersRef& dispatcher,
+                   ChainedDispatchers& dispatchers,
                    bool is_msgr2);
   ~SocketConnection() override;
 

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -122,7 +122,8 @@ SocketMessenger::try_bind(const entity_addrvec_t& addrs,
   });
 }
 
-seastar::future<> SocketMessenger::start(const std::list<Dispatcher*>& _dispatchers) {
+seastar::future<> SocketMessenger::start(
+    const dispatchers_t& _dispatchers) {
   assert(seastar::this_shard_id() == master_sid);
 
   dispatchers.assign(_dispatchers);

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -48,7 +48,7 @@ seastar::future<> SocketMessenger::set_myaddrs(const entity_addrvec_t& addrs)
   return Messenger::set_myaddrs(my_addrs);
 }
 
-seastar::future<> SocketMessenger::do_bind(const entity_addrvec_t& addrs)
+SocketMessenger::bind_ertr::future<> SocketMessenger::do_bind(const entity_addrvec_t& addrs)
 {
   assert(seastar::this_shard_id() == master_sid);
   ceph_assert(addrs.front().get_family() == AF_INET);
@@ -60,52 +60,64 @@ seastar::future<> SocketMessenger::do_bind(const entity_addrvec_t& addrs)
     } else {
       return seastar::now();
     }
-  }).then([this] {
+  }).then([this] () -> bind_ertr::future<> {
     const entity_addr_t listen_addr = get_myaddr();
     logger().debug("{} do_bind: try listen {}...", *this, listen_addr);
     if (!listener) {
       logger().warn("{} do_bind: listener doesn't exist", *this);
-      return seastar::now();
+      return bind_ertr::now();
     }
     return listener->listen(listen_addr);
   });
 }
 
-seastar::future<> SocketMessenger::bind(const entity_addrvec_t& addrs)
+SocketMessenger::bind_ertr::future<>
+SocketMessenger::bind(const entity_addrvec_t& addrs)
 {
-  return do_bind(addrs).then([this] {
+  return do_bind(addrs).safe_then([this] {
     logger().info("{} bind: done", *this);
   });
 }
 
-seastar::future<>
+SocketMessenger::bind_ertr::future<>
 SocketMessenger::try_bind(const entity_addrvec_t& addrs,
                           uint32_t min_port, uint32_t max_port)
 {
   auto addr = addrs.front();
   if (addr.get_port() != 0) {
-    return do_bind(addrs).then([this] {
+    return do_bind(addrs).safe_then([this] {
       logger().info("{} try_bind: done", *this);
     });
   }
   ceph_assert(min_port <= max_port);
   return seastar::do_with(uint32_t(min_port),
                           [this, max_port, addr] (auto& port) {
-    return seastar::repeat([this, max_port, addr, &port] {
+    return seastar::repeat_until_value([this, max_port, addr, &port] {
       auto to_bind = addr;
       to_bind.set_port(port);
-      return do_bind(entity_addrvec_t{to_bind}).then([this] {
+      return do_bind(entity_addrvec_t{to_bind}
+      ).safe_then([this] () -> seastar::future<std::optional<bool>> {
         logger().info("{} try_bind: done", *this);
-        return stop_t::yes;
-      }).handle_exception_type([this, max_port, &port] (const std::system_error& e) {
-        assert(e.code() == std::errc::address_in_use);
+        return seastar::make_ready_future<std::optional<bool>>(
+            std::make_optional<bool>(true));
+      }, bind_ertr::all_same_way([this, max_port, &port]
+                                 (const std::error_code& e) mutable
+                                 -> seastar::future<std::optional<bool>> {
+        assert(e == std::errc::address_in_use);
         logger().trace("{} try_bind: {} already used", *this, port);
         if (port == max_port) {
-          throw;
+          return seastar::make_ready_future<std::optional<bool>>(
+              std::make_optional<bool>(false));
         }
         ++port;
-        return stop_t::no;
-      });
+        return seastar::make_ready_future<std::optional<bool>>();
+      }));
+    }).then([] (bool success) -> bind_ertr::future<> {
+      if (success) {
+        return bind_ertr::now();
+      } else {
+        return crimson::ct_error::address_in_use::make();
+      }
     });
   });
 }

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -74,9 +74,6 @@ class SocketMessenger final : public Messenger {
                              uint32_t min_port, uint32_t max_port) override;
 
   seastar::future<> start(ChainedDispatchersRef dispatchers) override;
-  void add_dispatcher(Dispatcher& disp) {
-    dispatchers->push_back(disp);
-  }
 
   ConnectionRef connect(const entity_addr_t& peer_addr,
                         const entity_name_t& peer_name) override;

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <list>
 #include <map>
 #include <set>
 #include <vector>
@@ -66,7 +65,7 @@ class SocketMessenger final : public Messenger {
   bind_ertr::future<> try_bind(const entity_addrvec_t& addr,
                                uint32_t min_port, uint32_t max_port) override;
 
-  seastar::future<> start(const std::list<Dispatcher*>& dispatchers) override;
+  seastar::future<> start(const dispatchers_t& dispatchers) override;
 
   ConnectionRef connect(const entity_addr_t& peer_addr,
                         const entity_name_t& peer_name) override;

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -49,7 +49,7 @@ class SocketMessenger final : public Messenger {
   uint32_t global_seq = 0;
   bool started = false;
 
-  seastar::future<> do_bind(const entity_addrvec_t& addr);
+  bind_ertr::future<> do_bind(const entity_addrvec_t& addr);
 
  public:
   SocketMessenger(const entity_name_t& myname,
@@ -61,10 +61,10 @@ class SocketMessenger final : public Messenger {
 
   // Messenger interfaces are assumed to be called from its own shard, but its
   // behavior should be symmetric when called from any shard.
-  seastar::future<> bind(const entity_addrvec_t& addr) override;
+  bind_ertr::future<> bind(const entity_addrvec_t& addr) override;
 
-  seastar::future<> try_bind(const entity_addrvec_t& addr,
-                             uint32_t min_port, uint32_t max_port) override;
+  bind_ertr::future<> try_bind(const entity_addrvec_t& addr,
+                               uint32_t min_port, uint32_t max_port) override;
 
   seastar::future<> start(const std::list<Dispatcher*>& dispatchers) override;
 

--- a/src/crimson/net/chained_dispatchers.cc
+++ b/src/crimson/net/chained_dispatchers.cc
@@ -13,7 +13,7 @@ namespace {
 namespace crimson::net {
 
 seastar::future<>
-ChainedDispatchers::ms_dispatch(crimson::net::Connection* conn,
+ChainedDispatchers::ms_dispatch(crimson::net::ConnectionRef conn,
                                 MessageRef m) {
   try {
     for (auto& dispatcher : dispatchers) {

--- a/src/crimson/net/chained_dispatchers.cc
+++ b/src/crimson/net/chained_dispatchers.cc
@@ -1,39 +1,81 @@
+#include "crimson/common/log.h"
 #include "crimson/net/chained_dispatchers.h"
 #include "crimson/net/Connection.h"
 #include "msg/Message.h"
 
+namespace {
+  seastar::logger& logger() {
+    return crimson::get_logger(ceph_subsys_ms);
+  }
+}
+
 seastar::future<>
 ChainedDispatchers::ms_dispatch(crimson::net::Connection* conn,
                                 MessageRef m) {
-  return seastar::do_for_each(dispatchers, [conn, m](Dispatcher& dispatcher) {
-    return dispatcher.ms_dispatch(conn, m);
-  });
+  try {
+    return seastar::do_for_each(dispatchers, [conn, m](Dispatcher& dispatcher) {
+      return dispatcher.ms_dispatch(conn, m);
+    }).handle_exception([conn] (std::exception_ptr eptr) {
+      logger().error("{} got unexpected exception in ms_dispatch() throttling {}",
+                     *conn, eptr);
+      ceph_abort();
+    });
+  } catch (...) {
+    logger().error("{} got unexpected exception in ms_dispatch() {}",
+                   *conn, std::current_exception());
+    ceph_abort();
+    return seastar::now();
+  }
 }
 
 void
 ChainedDispatchers::ms_handle_accept(crimson::net::ConnectionRef conn) {
-  for (auto& dispatcher : dispatchers) {
-    dispatcher.ms_handle_accept(conn);
+  try {
+    for (auto& dispatcher : dispatchers) {
+      dispatcher.ms_handle_accept(conn);
+    }
+  } catch (...) {
+    logger().error("{} got unexpected exception in ms_handle_accept() {}",
+                   *conn, std::current_exception());
+    ceph_abort();
   }
 }
 
 void
 ChainedDispatchers::ms_handle_connect(crimson::net::ConnectionRef conn) {
-  for(auto& dispatcher : dispatchers) {
-    dispatcher.ms_handle_connect(conn);
+  try {
+    for(auto& dispatcher : dispatchers) {
+      dispatcher.ms_handle_connect(conn);
+    }
+  } catch (...) {
+    logger().error("{} got unexpected exception in ms_handle_connect() {}",
+                   *conn, std::current_exception());
+    ceph_abort();
   }
 }
 
 void
 ChainedDispatchers::ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) {
-  for (auto& dispatcher : dispatchers) {
-    dispatcher.ms_handle_reset(conn, is_replace);
+  try {
+    for (auto& dispatcher : dispatchers) {
+      dispatcher.ms_handle_reset(conn, is_replace);
+    }
+  } catch (...) {
+    logger().error("{} got unexpected exception in ms_handle_reset() {}",
+                   *conn, std::current_exception());
+    ceph_abort();
   }
 }
 
 void
 ChainedDispatchers::ms_handle_remote_reset(crimson::net::ConnectionRef conn) {
-  for (auto& dispatcher : dispatchers) {
-    dispatcher.ms_handle_remote_reset(conn);
+  try {
+    for (auto& dispatcher : dispatchers) {
+      dispatcher.ms_handle_remote_reset(conn);
+    }
+  } catch (...) {
+    logger().error("{} got unexpected exception in ms_handle_remote_reset() {}",
+                   *conn, std::current_exception());
+    ceph_abort();
   }
 }

--- a/src/crimson/net/chained_dispatchers.cc
+++ b/src/crimson/net/chained_dispatchers.cc
@@ -17,16 +17,15 @@ ChainedDispatchers::ms_dispatch(crimson::net::ConnectionRef conn,
                                 MessageRef m) {
   try {
     for (auto& dispatcher : dispatchers) {
-      auto [dispatched, throttle_future] = dispatcher->ms_dispatch(conn, m);
-      if (dispatched) {
-        return std::move(throttle_future
+      auto dispatched = dispatcher->ms_dispatch(conn, m);
+      if (dispatched.has_value()) {
+        return std::move(*dispatched
         ).handle_exception([conn] (std::exception_ptr eptr) {
           logger().error("{} got unexpected exception in ms_dispatch() throttling {}",
                          *conn, eptr);
           ceph_abort();
         });
       }
-      assert(throttle_future.available());
     }
   } catch (...) {
     logger().error("{} got unexpected exception in ms_dispatch() {}",

--- a/src/crimson/net/chained_dispatchers.h
+++ b/src/crimson/net/chained_dispatchers.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <list>
-
 #include "Fwd.h"
 #include "crimson/common/log.h"
 
@@ -14,7 +12,7 @@ class Dispatcher;
 
 class ChainedDispatchers {
 public:
-  void assign(const std::list<Dispatcher*> _dispatchers) {
+  void assign(const dispatchers_t& _dispatchers) {
     assert(empty());
     assert(!_dispatchers.empty());
     dispatchers = _dispatchers;
@@ -32,7 +30,7 @@ public:
   void ms_handle_remote_reset(crimson::net::ConnectionRef conn);
 
  private:
-  std::list<Dispatcher*> dispatchers;
+  dispatchers_t dispatchers;
 };
 
 }

--- a/src/crimson/net/chained_dispatchers.h
+++ b/src/crimson/net/chained_dispatchers.h
@@ -10,13 +10,6 @@
 
 using crimson::net::Dispatcher;
 
-// in existing Messenger, dispatchers are put into a chain as described by
-// chain-of-responsibility pattern. we could do the same to stop processing
-// the message once any of the dispatchers claims this message, and prevent
-// other dispatchers from reading it. but this change is more involved as
-// it requires changing the ms_ methods to return a bool. so as an intermediate 
-// solution, we are using an observer dispatcher to notify all the interested
-// or unintersted parties.
 class ChainedDispatchers {
   boost::intrusive::slist<
     Dispatcher,

--- a/src/crimson/net/chained_dispatchers.h
+++ b/src/crimson/net/chained_dispatchers.h
@@ -25,7 +25,7 @@ public:
   bool empty() const {
     return dispatchers.empty();
   }
-  seastar::future<> ms_dispatch(crimson::net::Connection* conn, MessageRef m);
+  seastar::future<> ms_dispatch(crimson::net::ConnectionRef, MessageRef);
   void ms_handle_accept(crimson::net::ConnectionRef conn);
   void ms_handle_connect(crimson::net::ConnectionRef conn);
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace);

--- a/src/crimson/net/chained_dispatchers.h
+++ b/src/crimson/net/chained_dispatchers.h
@@ -3,27 +3,24 @@
 
 #pragma once
 
-#include <boost/intrusive/slist.hpp>
+#include <list>
 
-#include "crimson/net/Dispatcher.h"
+#include "Fwd.h"
 #include "crimson/common/log.h"
 
-using crimson::net::Dispatcher;
+namespace crimson::net {
+
+class Dispatcher;
 
 class ChainedDispatchers {
-  boost::intrusive::slist<
-    Dispatcher,
-    boost::intrusive::linear<true>,
-    boost::intrusive::cache_last<true>> dispatchers;
 public:
-  void push_front(Dispatcher& dispatcher) {
-    dispatchers.push_front(dispatcher);
+  void assign(const std::list<Dispatcher*> _dispatchers) {
+    assert(empty());
+    assert(!_dispatchers.empty());
+    dispatchers = _dispatchers;
   }
-  void push_back(Dispatcher& dispatcher) {
-    dispatchers.push_back(dispatcher);
-  }
-  void erase(Dispatcher& dispatcher) {
-    dispatchers.erase(dispatchers.iterator_to(dispatcher));
+  void clear() {
+    dispatchers.clear();
   }
   bool empty() const {
     return dispatchers.empty();
@@ -33,6 +30,9 @@ public:
   void ms_handle_connect(crimson::net::ConnectionRef conn);
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace);
   void ms_handle_remote_reset(crimson::net::ConnectionRef conn);
+
+ private:
+  std::list<Dispatcher*> dispatchers;
 };
 
-using ChainedDispatchersRef = seastar::lw_shared_ptr<ChainedDispatchers>;
+}

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -75,7 +75,7 @@ Heartbeat::start_messenger(crimson::net::Messenger& msgr,
                        local_conf()->ms_bind_port_min,
                        local_conf()->ms_bind_port_max)
   .safe_then([this, &msgr]() mutable {
-    return msgr.start(*this);
+    return msgr.start({this});
   }, crimson::net::Messenger::bind_ertr::all_same_way(
       [] (const std::error_code& e) {
     logger().error("heartbeat messenger try_bind(): address range is unavailable.");

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -204,7 +204,7 @@ void Heartbeat::remove_peer(osd_id_t peer)
 }
 
 std::tuple<bool, seastar::future<>>
-Heartbeat::ms_dispatch(crimson::net::Connection* conn, MessageRef m)
+Heartbeat::ms_dispatch(crimson::net::ConnectionRef conn, MessageRef m)
 {
   bool dispatched = true;
   gate.dispatch_in_background(__func__, *this, [this, conn, &m, &dispatched] {
@@ -258,7 +258,7 @@ void Heartbeat::ms_handle_accept(crimson::net::ConnectionRef conn)
   }
 }
 
-seastar::future<> Heartbeat::handle_osd_ping(crimson::net::Connection* conn,
+seastar::future<> Heartbeat::handle_osd_ping(crimson::net::ConnectionRef conn,
                                              Ref<MOSDPing> m)
 {
   switch (m->op) {
@@ -273,7 +273,7 @@ seastar::future<> Heartbeat::handle_osd_ping(crimson::net::Connection* conn,
   }
 }
 
-seastar::future<> Heartbeat::handle_ping(crimson::net::Connection* conn,
+seastar::future<> Heartbeat::handle_ping(crimson::net::ConnectionRef conn,
                                          Ref<MOSDPing> m)
 {
   auto min_message = static_cast<uint32_t>(
@@ -291,7 +291,7 @@ seastar::future<> Heartbeat::handle_ping(crimson::net::Connection* conn,
   return conn->send(reply);
 }
 
-seastar::future<> Heartbeat::handle_reply(crimson::net::Connection* conn,
+seastar::future<> Heartbeat::handle_reply(crimson::net::ConnectionRef conn,
                                           Ref<MOSDPing> m)
 {
   const osd_id_t from = m->get_source().num();
@@ -373,9 +373,9 @@ Heartbeat::Connection::~Connection()
   }
 }
 
-bool Heartbeat::Connection::matches(crimson::net::Connection* _conn) const
+bool Heartbeat::Connection::matches(crimson::net::ConnectionRef _conn) const
 {
-  return (conn && conn.get() == _conn);
+  return (conn && conn == _conn);
 }
 
 void Heartbeat::Connection::accepted(crimson::net::ConnectionRef accepted_conn)
@@ -551,7 +551,7 @@ void Heartbeat::Peer::send_heartbeat(
 }
 
 seastar::future<> Heartbeat::Peer::handle_reply(
-    crimson::net::Connection* conn, Ref<MOSDPing> m)
+    crimson::net::ConnectionRef conn, Ref<MOSDPing> m)
 {
   if (!session.is_started()) {
     // we haven't sent any ping yet

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -203,7 +203,7 @@ void Heartbeat::remove_peer(osd_id_t peer)
   peers.erase(peer);
 }
 
-std::tuple<bool, seastar::future<>>
+std::optional<seastar::future<>>
 Heartbeat::ms_dispatch(crimson::net::ConnectionRef conn, MessageRef m)
 {
   bool dispatched = true;
@@ -216,7 +216,7 @@ Heartbeat::ms_dispatch(crimson::net::ConnectionRef conn, MessageRef m)
       return seastar::now();
     }
   });
-  return {dispatched, seastar::now()};
+  return (dispatched ? std::make_optional(seastar::now()) : std::nullopt);
 }
 
 void Heartbeat::ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace)

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -49,18 +49,18 @@ public:
 
   // Dispatcher methods
   std::tuple<bool, seastar::future<>> ms_dispatch(
-      crimson::net::Connection* conn, MessageRef m) override;
+      crimson::net::ConnectionRef conn, MessageRef m) override;
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) override;
   void ms_handle_connect(crimson::net::ConnectionRef conn) override;
   void ms_handle_accept(crimson::net::ConnectionRef conn) override;
 
   void print(std::ostream&) const;
 private:
-  seastar::future<> handle_osd_ping(crimson::net::Connection* conn,
+  seastar::future<> handle_osd_ping(crimson::net::ConnectionRef conn,
 				    Ref<MOSDPing> m);
-  seastar::future<> handle_ping(crimson::net::Connection* conn,
+  seastar::future<> handle_ping(crimson::net::ConnectionRef conn,
 				Ref<MOSDPing> m);
-  seastar::future<> handle_reply(crimson::net::Connection* conn,
+  seastar::future<> handle_reply(crimson::net::ConnectionRef conn,
 				 Ref<MOSDPing> m);
   seastar::future<> handle_you_died();
 
@@ -182,10 +182,7 @@ class Heartbeat::Connection {
 
   ~Connection();
 
-  bool matches(crimson::net::Connection* _conn) const;
-  bool matches(crimson::net::ConnectionRef conn) const {
-    return matches(conn.get());
-  }
+  bool matches(crimson::net::ConnectionRef _conn) const;
   void connected() {
     set_connected();
   }
@@ -410,7 +407,7 @@ class Heartbeat::Peer final : private Heartbeat::ConnectionListener {
   }
   void send_heartbeat(
       clock::time_point, ceph::signedspan, std::vector<seastar::future<>>&);
-  seastar::future<> handle_reply(crimson::net::Connection*, Ref<MOSDPing>);
+  seastar::future<> handle_reply(crimson::net::ConnectionRef, Ref<MOSDPing>);
   void handle_reset(crimson::net::ConnectionRef conn, bool is_replace) {
     for_each_conn([&] (auto& _conn) {
       if (_conn.matches(conn)) {

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -48,8 +48,8 @@ public:
   void set_require_authorizer(bool);
 
   // Dispatcher methods
-  seastar::future<> ms_dispatch(crimson::net::Connection* conn,
-				MessageRef m) override;
+  std::tuple<bool, seastar::future<>> ms_dispatch(
+      crimson::net::Connection* conn, MessageRef m) override;
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) override;
   void ms_handle_connect(crimson::net::ConnectionRef conn) override;
   void ms_handle_accept(crimson::net::ConnectionRef conn) override;

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <seastar/core/future.hh>
 #include "common/ceph_time.h"
+#include "crimson/common/gated.h"
 #include "crimson/net/Dispatcher.h"
 #include "crimson/net/Fwd.h"
 

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -48,7 +48,7 @@ public:
   void set_require_authorizer(bool);
 
   // Dispatcher methods
-  std::tuple<bool, seastar::future<>> ms_dispatch(
+  std::optional<seastar::future<>> ms_dispatch(
       crimson::net::ConnectionRef conn, MessageRef m) override;
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) override;
   void ms_handle_connect(crimson::net::ConnectionRef conn) override;

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -6,7 +6,6 @@
 #include <cstdint>
 #include <seastar/core/future.hh>
 #include "common/ceph_time.h"
-#include "crimson/net/chained_dispatchers.h"
 #include "crimson/net/Dispatcher.h"
 #include "crimson/net/Fwd.h"
 
@@ -71,8 +70,7 @@ private:
   void add_reporter_peers(int whoami);
 
   seastar::future<> start_messenger(crimson::net::Messenger& msgr,
-				    const entity_addrvec_t& addrs,
-				    ChainedDispatchersRef);
+				    const entity_addrvec_t& addrs);
 private:
   const osd_id_t whoami;
   const crimson::osd::ShardServices& service;

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -265,10 +265,7 @@ seastar::future<> OSD::start()
     cluster_msgr->set_policy(entity_name_t::TYPE_CLIENT,
                              SocketPolicy::stateless_server(0));
 
-    std::list<Dispatcher*> dispatchers;
-    dispatchers.push_front(mgrc.get());
-    dispatchers.push_front(monc.get());
-    dispatchers.push_front(this);
+    crimson::net::dispatchers_t dispatchers{this, monc.get(), mgrc.get()};
     return seastar::when_all_succeed(
       cluster_msgr->try_bind(pick_addresses(CEPH_PICK_ADDRESS_CLUSTER),
                              local_conf()->ms_bind_port_min,

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -273,15 +273,23 @@ seastar::future<> OSD::start()
       cluster_msgr->try_bind(pick_addresses(CEPH_PICK_ADDRESS_CLUSTER),
                              local_conf()->ms_bind_port_min,
                              local_conf()->ms_bind_port_max)
-        .then([this, dispatchers]() mutable {
+        .safe_then([this, dispatchers]() mutable {
 	  return cluster_msgr->start(dispatchers);
-	}),
+        }, crimson::net::Messenger::bind_ertr::all_same_way(
+            [] (const std::error_code& e) {
+          logger().error("cluster messenger try_bind(): address range is unavailable.");
+          ceph_abort();
+        })),
       public_msgr->try_bind(pick_addresses(CEPH_PICK_ADDRESS_PUBLIC),
                             local_conf()->ms_bind_port_min,
                             local_conf()->ms_bind_port_max)
-        .then([this, dispatchers]() mutable {
+        .safe_then([this, dispatchers]() mutable {
 	  return public_msgr->start(dispatchers);
-	}));
+        }, crimson::net::Messenger::bind_ertr::all_same_way(
+            [] (const std::error_code& e) {
+          logger().error("public messenger try_bind(): address range is unavailable.");
+          ceph_abort();
+        })));
   }).then_unpack([this] {
     return seastar::when_all_succeed(monc->start(),
                                      mgrc->start());

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -614,11 +614,11 @@ seastar::future<Ref<PG>> OSD::load_pg(spg_t pgid)
   });
 }
 
-std::tuple<bool, seastar::future<>>
+std::optional<seastar::future<>>
 OSD::ms_dispatch(crimson::net::ConnectionRef conn, MessageRef m)
 {
   if (state.is_stopping()) {
-    return {false, seastar::now()};
+    return {};
   }
   bool dispatched = true;
   gate.dispatch_in_background(__func__, *this, [this, conn, &m, &dispatched] {
@@ -678,7 +678,7 @@ OSD::ms_dispatch(crimson::net::ConnectionRef conn, MessageRef m)
       return seastar::now();
     }
   });
-  return {dispatched, seastar::now()};
+  return (dispatched ? std::make_optional(seastar::now()) : std::nullopt);
 }
 
 void OSD::ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace)

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -96,7 +96,7 @@ class OSD final : public crimson::net::Dispatcher,
   OSDSuperblock superblock;
 
   // Dispatcher methods
-  std::tuple<bool, seastar::future<>> ms_dispatch(crimson::net::Connection*, MessageRef) final;
+  std::tuple<bool, seastar::future<>> ms_dispatch(crimson::net::ConnectionRef, MessageRef) final;
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) final;
   void ms_handle_remote_reset(crimson::net::ConnectionRef conn) final;
 
@@ -136,7 +136,7 @@ public:
   void dump_pg_state_history(Formatter*) const;
   void print(std::ostream&) const;
 
-  seastar::future<> send_incremental_map(crimson::net::Connection* conn,
+  seastar::future<> send_incremental_map(crimson::net::ConnectionRef conn,
 					 epoch_t first);
 
   /// @return the seq id of the pg stats being sent
@@ -178,21 +178,21 @@ private:
   seastar::future<Ref<PG>> handle_pg_create_info(
     std::unique_ptr<PGCreateInfo> info);
 
-  seastar::future<> handle_osd_map(crimson::net::Connection* conn,
+  seastar::future<> handle_osd_map(crimson::net::ConnectionRef conn,
                                    Ref<MOSDMap> m);
-  seastar::future<> handle_osd_op(crimson::net::Connection* conn,
+  seastar::future<> handle_osd_op(crimson::net::ConnectionRef conn,
 				  Ref<MOSDOp> m);
-  seastar::future<> handle_rep_op(crimson::net::Connection* conn,
+  seastar::future<> handle_rep_op(crimson::net::ConnectionRef conn,
 				  Ref<MOSDRepOp> m);
-  seastar::future<> handle_rep_op_reply(crimson::net::Connection* conn,
+  seastar::future<> handle_rep_op_reply(crimson::net::ConnectionRef conn,
 					Ref<MOSDRepOpReply> m);
-  seastar::future<> handle_peering_op(crimson::net::Connection* conn,
+  seastar::future<> handle_peering_op(crimson::net::ConnectionRef conn,
 				      Ref<MOSDPeeringOp> m);
-  seastar::future<> handle_recovery_subreq(crimson::net::Connection* conn,
+  seastar::future<> handle_recovery_subreq(crimson::net::ConnectionRef conn,
 					   Ref<MOSDFastDispatchOp> m);
-  seastar::future<> handle_scrub(crimson::net::Connection* conn,
+  seastar::future<> handle_scrub(crimson::net::ConnectionRef conn,
 				 Ref<MOSDScrub2> m);
-  seastar::future<> handle_mark_me_down(crimson::net::Connection* conn,
+  seastar::future<> handle_mark_me_down(crimson::net::ConnectionRef conn,
 					Ref<MOSDMarkMeDown> m);
 
   seastar::future<> committed_osd_maps(version_t first,
@@ -201,7 +201,7 @@ private:
 
   void check_osdmap_features();
 
-  seastar::future<> handle_command(crimson::net::Connection* conn,
+  seastar::future<> handle_command(crimson::net::ConnectionRef conn,
 				   Ref<MCommand> m);
   seastar::future<> start_asok_admin();
 

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -97,7 +97,7 @@ class OSD final : public crimson::net::Dispatcher,
   OSDSuperblock superblock;
 
   // Dispatcher methods
-  seastar::future<> ms_dispatch(crimson::net::Connection* conn, MessageRef m) final;
+  std::tuple<bool, seastar::future<>> ms_dispatch(crimson::net::Connection*, MessageRef) final;
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) final;
   void ms_handle_remote_reset(crimson::net::ConnectionRef conn) final;
 

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -96,7 +96,7 @@ class OSD final : public crimson::net::Dispatcher,
   OSDSuperblock superblock;
 
   // Dispatcher methods
-  std::tuple<bool, seastar::future<>> ms_dispatch(crimson::net::ConnectionRef, MessageRef) final;
+  std::optional<seastar::future<>> ms_dispatch(crimson::net::ConnectionRef, MessageRef) final;
   void ms_handle_reset(crimson::net::ConnectionRef conn, bool is_replace) final;
   void ms_handle_remote_reset(crimson::net::ConnectionRef conn) final;
 

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -13,7 +13,6 @@
 #include "crimson/common/type_helpers.h"
 #include "crimson/common/auth_handler.h"
 #include "crimson/common/gated.h"
-#include "crimson/net/chained_dispatchers.h"
 #include "crimson/admin/admin_socket.h"
 #include "crimson/common/simple_lru.h"
 #include "crimson/common/shared_lru.h"

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -70,7 +70,7 @@ seastar::future<> ClientRequest::start()
       }).then([this, opref](Ref<PG> pgref) {
 	PG &pg = *pgref;
 	if (pg.can_discard_op(*m)) {
-	  return osd.send_incremental_map(conn.get(), m->get_map_epoch());
+	  return osd.send_incremental_map(conn, m->get_map_epoch());
 	}
 	return with_blocking_future(
 	  handle.enter(pp(pg).await_map)

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -946,7 +946,7 @@ seastar::future<> PG::handle_rep_op(Ref<MOSDRepOp> req)
     });
 }
 
-void PG::handle_rep_op_reply(crimson::net::Connection* conn,
+void PG::handle_rep_op_reply(crimson::net::ConnectionRef conn,
 			     const MOSDRepOpReply& m)
 {
   if (!can_discard_replica_op(m)) {

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -513,7 +513,7 @@ public:
     with_obc_func_t&& f);
 
   seastar::future<> handle_rep_op(Ref<MOSDRepOp> m);
-  void handle_rep_op_reply(crimson::net::Connection* conn,
+  void handle_rep_op_reply(crimson::net::ConnectionRef conn,
 			   const MOSDRepOpReply& m);
 
   void print(std::ostream& os) const;

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -38,6 +38,15 @@ static std::random_device rd;
 static std::default_random_engine rng{rd()};
 static bool verbose = false;
 
+static entity_addr_t get_server_addr() {
+  static int port = 9030;
+  ++port;
+  entity_addr_t saddr;
+  saddr.parse("127.0.0.1", nullptr);
+  saddr.set_port(port);
+  return saddr;
+}
+
 static seastar::future<> test_echo(unsigned rounds,
                                    double keepalive_ratio,
                                    bool v2)
@@ -217,10 +226,8 @@ static seastar::future<> test_echo(unsigned rounds,
   auto client1 = seastar::make_shared<test_state::Client>(rounds, keepalive_ratio);
   auto client2 = seastar::make_shared<test_state::Client>(rounds, keepalive_ratio);
   // start servers and clients
-  entity_addr_t addr1;
-  addr1.parse("127.0.0.1:9010", nullptr);
-  entity_addr_t addr2;
-  addr2.parse("127.0.0.1:9011", nullptr);
+  auto addr1 = get_server_addr();
+  auto addr2 = get_server_addr();
   if (v2) {
     addr1.set_type(entity_addr_t::TYPE_MSGR2);
     addr2.set_type(entity_addr_t::TYPE_MSGR2);
@@ -332,8 +339,7 @@ static seastar::future<> test_concurrent_dispatch(bool v2)
   logger().info("test_concurrent_dispatch(v2={}):", v2);
   auto server = seastar::make_shared<test_state::Server>();
   auto client = seastar::make_shared<test_state::Client>();
-  entity_addr_t addr;
-  addr.parse("127.0.0.1:9010", nullptr);
+  auto addr = get_server_addr();
   if (v2) {
     addr.set_type(entity_addr_t::TYPE_MSGR2);
   } else {
@@ -455,8 +461,7 @@ seastar::future<> test_preemptive_shutdown(bool v2) {
   logger().info("test_preemptive_shutdown(v2={}):", v2);
   auto server = seastar::make_shared<test_state::Server>();
   auto client = seastar::make_shared<test_state::Client>();
-  entity_addr_t addr;
-  addr.parse("127.0.0.1:9010", nullptr);
+  auto addr = get_server_addr();
   if (v2) {
     addr.set_type(entity_addr_t::TYPE_MSGR2);
   } else {

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -77,7 +77,7 @@ static seastar::future<> test_echo(unsigned rounds,
         msgr->set_auth_client(&dummy_auth);
         msgr->set_auth_server(&dummy_auth);
         return msgr->bind(entity_addrvec_t{addr}).safe_then([this] {
-          return msgr->start(*this);
+          return msgr->start({this});
         }, crimson::net::Messenger::bind_ertr::all_same_way(
             [addr] (const std::error_code& e) {
           logger().error("test_echo(): "
@@ -152,7 +152,7 @@ static seastar::future<> test_echo(unsigned rounds,
         msgr->set_default_policy(crimson::net::SocketPolicy::lossy_client(0));
         msgr->set_auth_client(&dummy_auth);
         msgr->set_auth_server(&dummy_auth);
-        return msgr->start(*this);
+        return msgr->start({this});
       }
 
       seastar::future<> shutdown() {
@@ -304,7 +304,7 @@ static seastar::future<> test_concurrent_dispatch(bool v2)
         msgr->set_auth_client(&dummy_auth);
         msgr->set_auth_server(&dummy_auth);
         return msgr->bind(entity_addrvec_t{addr}).safe_then([this] {
-          return msgr->start(*this);
+          return msgr->start({this});
         }, crimson::net::Messenger::bind_ertr::all_same_way(
             [addr] (const std::error_code& e) {
           logger().error("test_concurrent_dispatch(): "
@@ -331,7 +331,7 @@ static seastar::future<> test_concurrent_dispatch(bool v2)
         msgr->set_default_policy(crimson::net::SocketPolicy::lossy_client(0));
         msgr->set_auth_client(&dummy_auth);
         msgr->set_auth_server(&dummy_auth);
-        return msgr->start(*this);
+        return msgr->start({this});
       }
     };
   };
@@ -394,7 +394,7 @@ seastar::future<> test_preemptive_shutdown(bool v2) {
         msgr->set_auth_client(&dummy_auth);
         msgr->set_auth_server(&dummy_auth);
         return msgr->bind(entity_addrvec_t{addr}).safe_then([this] {
-          return msgr->start(*this);
+          return msgr->start({this});
         }, crimson::net::Messenger::bind_ertr::all_same_way(
             [addr] (const std::error_code& e) {
           logger().error("test_preemptive_shutdown(): "
@@ -432,7 +432,7 @@ seastar::future<> test_preemptive_shutdown(bool v2) {
         msgr->set_default_policy(crimson::net::SocketPolicy::lossy_client(0));
         msgr->set_auth_client(&dummy_auth);
         msgr->set_auth_server(&dummy_auth);
-        return msgr->start(*this);
+        return msgr->start({this});
       }
       void send_pings(const entity_addr_t& addr) {
         auto conn = msgr->connect(addr, entity_name_t::TYPE_OSD);
@@ -927,7 +927,7 @@ class FailoverSuite : public Dispatcher {
     test_msgr->set_auth_server(&dummy_auth);
     test_msgr->interceptor = &interceptor;
     return test_msgr->bind(entity_addrvec_t{addr}).safe_then([this] {
-      return test_msgr->start(*this);
+      return test_msgr->start({this});
     }, Messenger::bind_ertr::all_same_way([addr] (const std::error_code& e) {
       logger().error("FailoverSuite: "
                      "there is another instance running at {}", addr);
@@ -1276,7 +1276,7 @@ class FailoverTest : public Dispatcher {
     cmd_msgr->set_default_policy(SocketPolicy::lossy_client(0));
     cmd_msgr->set_auth_client(&dummy_auth);
     cmd_msgr->set_auth_server(&dummy_auth);
-    return cmd_msgr->start(*this).then([this, cmd_peer_addr] {
+    return cmd_msgr->start({this}).then([this, cmd_peer_addr] {
       logger().info("CmdCli connect to CmdSrv({}) ...", cmd_peer_addr);
       cmd_conn = cmd_msgr->connect(cmd_peer_addr, entity_name_t::TYPE_OSD);
       return pingpong();
@@ -1436,7 +1436,7 @@ class FailoverSuitePeer : public Dispatcher {
     peer_msgr->set_auth_client(&dummy_auth);
     peer_msgr->set_auth_server(&dummy_auth);
     return peer_msgr->bind(entity_addrvec_t{addr}).safe_then([this] {
-      return peer_msgr->start(*this);
+      return peer_msgr->start({this});
     }, Messenger::bind_ertr::all_same_way([addr] (const std::error_code& e) {
       logger().error("FailoverSuitePeer: "
                      "there is another instance running at {}", addr);
@@ -1620,7 +1620,7 @@ class FailoverTestPeer : public Dispatcher {
     cmd_msgr->set_auth_client(&dummy_auth);
     cmd_msgr->set_auth_server(&dummy_auth);
     return cmd_msgr->bind(entity_addrvec_t{cmd_peer_addr}).safe_then([this] {
-      return cmd_msgr->start(*this);
+      return cmd_msgr->start({this});
     }, Messenger::bind_ertr::all_same_way([cmd_peer_addr] (const std::error_code& e) {
       logger().error("FailoverTestPeer: "
                      "there is another instance running at {}", cmd_peer_addr);

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -308,6 +308,11 @@ static seastar::future<> test_concurrent_dispatch(bool v2)
       crimson::net::MessengerRef msgr;
       crimson::auth::DummyAuthClientServer dummy_auth;
 
+      std::tuple<bool, seastar::future<>> ms_dispatch(
+          crimson::net::Connection* c, MessageRef m) override {
+        return {true, seastar::now()};
+      }
+
       seastar::future<> init(const entity_name_t& name,
                              const std::string& lname,
                              const uint64_t nonce) {

--- a/src/tools/crimson/perf_crimson_msgr.cc
+++ b/src/tools/crimson/perf_crimson_msgr.cc
@@ -153,7 +153,7 @@ static seastar::future<> run(
       }
 
       std::tuple<bool, seastar::future<>> ms_dispatch(
-          crimson::net::Connection* c, MessageRef m) override {
+          crimson::net::ConnectionRef c, MessageRef m) override {
         ceph_assert(m->get_type() == CEPH_MSG_OSD_OP);
 
         // server replies with MOSDOp to generate server-side write workload
@@ -308,7 +308,7 @@ static seastar::future<> run(
         conn_stats.connected_time = mono_clock::now();
       }
       std::tuple<bool, seastar::future<>> ms_dispatch(
-          crimson::net::Connection* c, MessageRef m) override {
+          crimson::net::ConnectionRef, MessageRef m) override {
         // server replies with MOSDOp to generate server-side write workload
         ceph_assert(m->get_type() == CEPH_MSG_OSD_OP);
 

--- a/src/tools/crimson/perf_crimson_msgr.cc
+++ b/src/tools/crimson/perf_crimson_msgr.cc
@@ -182,7 +182,7 @@ static seastar::future<> run(
             msgr->set_crc_data();
           }
           return msgr->bind(entity_addrvec_t{addr}).safe_then([this] {
-            return msgr->start(*this);
+            return msgr->start({this});
           }, crimson::net::Messenger::bind_ertr::all_same_way(
               [addr] (const std::error_code& e) {
             logger().error("Server: "
@@ -348,7 +348,7 @@ static seastar::future<> run(
               client.msgr->set_crc_header();
               client.msgr->set_crc_data();
             }
-            return client.msgr->start(client);
+            return client.msgr->start({&client});
           }
           return seastar::now();
         });

--- a/src/tools/crimson/perf_crimson_msgr.cc
+++ b/src/tools/crimson/perf_crimson_msgr.cc
@@ -152,7 +152,7 @@ static seastar::future<> run(
         msg_data.append_zero(msg_len);
       }
 
-      std::tuple<bool, seastar::future<>> ms_dispatch(
+      std::optional<seastar::future<>> ms_dispatch(
           crimson::net::ConnectionRef c, MessageRef m) override {
         ceph_assert(m->get_type() == CEPH_MSG_OSD_OP);
 
@@ -167,7 +167,7 @@ static seastar::future<> run(
         rep->write(0, msg_len, data);
         rep->set_tid(m->get_tid());
         std::ignore = c->send(std::move(rep));
-        return {true, seastar::now()};
+        return {seastar::now()};
       }
 
       seastar::future<> init(bool v1_crc_enabled, const entity_addr_t& addr) {
@@ -307,7 +307,7 @@ static seastar::future<> run(
       void ms_handle_connect(crimson::net::ConnectionRef conn) override {
         conn_stats.connected_time = mono_clock::now();
       }
-      std::tuple<bool, seastar::future<>> ms_dispatch(
+      std::optional<seastar::future<>> ms_dispatch(
           crimson::net::ConnectionRef, MessageRef m) override {
         // server replies with MOSDOp to generate server-side write workload
         ceph_assert(m->get_type() == CEPH_MSG_OSD_OP);
@@ -327,7 +327,7 @@ static seastar::future<> run(
         ++(conn_stats.received_count);
         depth.signal(1);
 
-        return {true, seastar::now()};
+        return {seastar::now()};
       }
 
       // should start messenger at this shard?


### PR DESCRIPTION
* `ms_dispatch()` to return a `tuple<bool, future>` and using `ConnectionRef`;
* Audit `ms_dispatch()` implementations and unlink futures that are not related to throttling;
* Link `ms_dispatch()` futures for throttling for both v1 and v2 protocols;
* Improve `bind()/try_bind()` interfaces to return errorated futures;
* Simplify the implementation of `ChainedDispatchers`;
* Improve Messenger `start()` and `stop()` interfaces;
* Fix a regression issue of perf_crimson_msgr caused by `ChainedDispatchers`;
* Avoid using `finally` when an unexpected exception is thrown;
* Use different ports for messenger/socket tests;
* Related refactors in UT, Messenger and OSD;

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
