### PR TITLE
mds/CDir: make the data length as long as possible for each op

### DIFF
--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2249,21 +2249,23 @@ void CDir::_omap_commit_ops(int r, int op_prio, version_t version, bool _new, bu
   };
 
   for (auto &key : stales) {
-    write_size += key.length() + sizeof(__u32);
-    _rm.emplace(key);
-
-    if (write_size >= max_write_size)
+    unsigned size = key.length() + sizeof(__u32);
+    if (write_size + size > max_write_size)
       commit_one();
+
+    write_size += size;
+    _rm.emplace(key);
   }
 
   for (auto &k : to_remove) {
     string key;
     k.encode(key);
-    write_size += key.length() + sizeof(__u32);
-    _rm.emplace(std::move(key));
-
-    if (write_size >= max_write_size)
+    unsigned size = key.length() + sizeof(__u32);
+    if (write_size + size > max_write_size)
       commit_one();
+
+    write_size += size;
+    _rm.emplace(std::move(key));
   }
 
   uint64_t off = 0;
@@ -2312,10 +2314,12 @@ void CDir::_omap_commit_ops(int r, int op_prio, version_t version, bool _new, bu
     }
     off += item.dft_len;
 
-    write_size += key.length() + bl.length() + 2 * sizeof(__u32);
-    _set[std::move(key)].swap(bl);
-    if (write_size >= max_write_size)
+    unsigned size = key.length() + bl.length() + 2 * sizeof(__u32);
+    if (write_size + size > max_write_size)
       commit_one();
+
+    write_size += size;
+    _set[std::move(key)].swap(bl);
   }
 
   commit_one(true);

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2249,7 +2249,7 @@ void CDir::_omap_commit_ops(int r, int op_prio, version_t version, bool _new, bu
   };
 
   for (auto &key : stales) {
-    write_size += key.length();
+    write_size += key.length() + sizeof(__u32);
     _rm.emplace(key);
 
     if (write_size >= max_write_size)
@@ -2259,7 +2259,7 @@ void CDir::_omap_commit_ops(int r, int op_prio, version_t version, bool _new, bu
   for (auto &k : to_remove) {
     string key;
     k.encode(key);
-    write_size += key.length();
+    write_size += key.length() + sizeof(__u32);
     _rm.emplace(std::move(key));
 
     if (write_size >= max_write_size)
@@ -2312,7 +2312,7 @@ void CDir::_omap_commit_ops(int r, int op_prio, version_t version, bool _new, bu
     }
     off += item.dft_len;
 
-    write_size += key.length() + bl.length();
+    write_size += key.length() + bl.length() + 2 * sizeof(__u32);
     _set[std::move(key)].swap(bl);
     if (write_size >= max_write_size)
       commit_one();


### PR DESCRIPTION
The max_write_size is 10M as default, and every time when the len
of the op data exceed it with a very small size it will be split
into two ops, one of which will always be very small.

Signed-off-by: Xiubo Li <xiubli@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
