### PR TITLE
pybind/cephfs: fix missing terminating NULL char in readlink()'s C string

### DIFF
--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -2167,7 +2167,7 @@ cdef class LibCephFS(object):
                 ret = ceph_readlink(self.cluster, _path, buf, _size)
             if ret < 0:
                 raise make_ex(ret, "error in readlink")
-            return buf
+            return buf[:ret]
         finally:
             free(buf)
 


### PR DESCRIPTION
The error is in test_readlink() in src/test/pybind/test_cephfs.py:
```
...
test_cephfs.test_readlink ... FAIL

======================================================================
FAIL: test_cephfs.test_readlink
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/tmhoang/test_cephfs.py", line 99, in test_readlink
    assert_equal(d, b"/file-1")
AssertionError: b'/file-1\xe8' != b'/file-1'
...
```
Fixes: https://tracker.ceph.com/issues/48408

Signed-off-by: Tuan Hoang <tmhoang@linux.ibm.com>
