### PR TITLE
ceph-volume: allow listing devices by OSD ID

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -1164,3 +1164,15 @@ def get_device_lvs(device, name_prefix=''):
     lvs = _output_parser(stdout, LV_FIELDS)
     return [Volume(**lv) for lv in lvs if lv['lv_name'] and
             lv['lv_name'].startswith(name_prefix)]
+
+
+def get_lvs_from_path(devpath):
+    lvs = []
+    if os.path.isabs(devpath):
+        # we have a block device
+        lvs = get_device_lvs(devpath)
+        if not lvs:
+            # maybe this was a LV path /dev/vg_name/lv_name or /dev/mapper/
+            lvs = get_lvs(filters={'path': devpath})
+
+    return lvs

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -1128,6 +1128,14 @@ def get_single_lv(fields=LV_FIELDS, filters=None, tags=None):
     return lvs[0]
 
 
+def get_lvs_from_osd_id(osd_id):
+    return get_lvs(tags={'ceph.osd_id': osd_id})
+
+
+def get_single_lv_from_osd_id(osd_id):
+    return get_single_lv(tags={'ceph.osd_id': osd_id})
+
+
 def get_lv_by_name(name):
     stdout, stderr, returncode = process.call(
         ['lvs', '--noheadings', '-o', LV_FIELDS, '-S',

--- a/src/ceph-volume/ceph_volume/devices/lvm/listing.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/listing.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 import argparse
 import json
 import logging
-import os.path
 from textwrap import dedent
 from ceph_volume import decorators
 from ceph_volume.api import lvm as api
@@ -140,22 +139,6 @@ class List(object):
         """
         return self.create_report(api.get_lvs())
 
-    def get_lvs_from_path(self, device):
-        lvs = []
-        if os.path.isabs(device):
-            # we have a block device
-            lvs = api.get_device_lvs(device)
-            if not lvs:
-                # maybe this was a LV path /dev/vg_name/lv_name or /dev/mapper/
-                lvs = api.get_lvs(filters={'path': device})
-        else:
-            # vg_name/lv_name was passed
-            vg_name, lv_name = device.split('/')
-            lvs = api.get_lvs(filters={'lv_name': lv_name,
-                                       'vg_name': vg_name})
-
-        return lvs
-
     def single_report(self, arg):
         """
         Generate a report for a single device. This can be either a logical
@@ -167,7 +150,7 @@ class List(object):
         if isinstance(arg, int) or arg.isdigit():
             lv = api.get_lvs_from_osd_id(arg)
         elif arg[0] == '/':
-            lv = self.get_lvs_from_path(arg)
+            lv = api.get_lvs_from_path(arg)
         else:
             lv = [api.get_single_lv(filters={'lv_name': arg.split('/')[1]})]
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>