### PR TITLE
nautilus: lvm/create.py: fix a typo in the help message

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/create.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/create.py
@@ -42,7 +42,7 @@ class Create(object):
         Create an OSD by assigning an ID and FSID, registering them with the
         cluster with an ID and FSID, formatting and mounting the volume, adding
         all the metadata to the logical volumes using LVM tags, and starting
-        the OSD daemon. This is a convinience command that combines the prepare
+        the OSD daemon. This is a convenience command that combines the prepare
         and activate steps.
 
         Encryption is supported via dmcrypt and the --dmcrypt flag.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48413

---

backport of https://github.com/ceph/ceph/pull/38034
parent tracker: https://tracker.ceph.com/issues/48273

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh