### PR TITLE
nautilus: ceph-volume: implement the --log-level flag

### DIFF
--- a/src/ceph-volume/ceph_volume/log.py
+++ b/src/ceph-volume/ceph_volume/log.py
@@ -7,7 +7,7 @@ BASE_FORMAT = "[%(name)s][%(levelname)-6s] %(message)s"
 FILE_FORMAT = "[%(asctime)s]" + BASE_FORMAT
 
 
-def setup(name='ceph-volume.log', log_path=None):
+def setup(name='ceph-volume.log', log_path=None, log_level=None):
     log_path = log_path or conf.log_path
     # if a non-root user calls help or other no-sudo-required command the
     # logger will fail to write to /var/lib/ceph/ so this /tmp/ path is used as
@@ -16,8 +16,9 @@ def setup(name='ceph-volume.log', log_path=None):
     root_logger = logging.getLogger()
     # The default path is where all ceph log files are, and will get rotated by
     # Ceph's logrotate rules.
-
-    root_logger.setLevel(logging.DEBUG)
+    log_level = log_level or "DEBUG"
+    log_level = getattr(logging, log_level.upper())
+    root_logger.setLevel(log_level)
 
     try:
         fh = logging.FileHandler(log_path)
@@ -27,7 +28,7 @@ def setup(name='ceph-volume.log', log_path=None):
         conf.log_path = tmp_log_file
         fh = logging.FileHandler(tmp_log_file)
 
-    fh.setLevel(logging.DEBUG)
+    fh.setLevel(log_level)
     fh.setFormatter(logging.Formatter(FILE_FORMAT))
 
     root_logger.addHandler(fh)

--- a/src/ceph-volume/ceph_volume/main.py
+++ b/src/ceph-volume/ceph_volume/main.py
@@ -120,6 +120,7 @@ Ceph Conf: {ceph_path}
         parser.add_argument(
             '--log-level',
             default='debug',
+            choices=['debug', 'info', 'warning', 'error', 'critical'],
             help='Change the file log level (defaults to debug)',
         )
         parser.add_argument(
@@ -131,7 +132,7 @@ Ceph Conf: {ceph_path}
         conf.log_path = args.log_path
         if os.path.isdir(conf.log_path):
             conf.log_path = os.path.join(args.log_path, 'ceph-volume.log')
-        log.setup()
+        log.setup(log_level=args.log_level)
         log.setup_console()
         logger = logging.getLogger(__name__)
         logger.info("Running command: ceph-volume %s %s", " ".join(main_args), " ".join(subcommand_args))

--- a/src/ceph-volume/ceph_volume/tests/test_main.py
+++ b/src/ceph-volume/ceph_volume/tests/test_main.py
@@ -49,3 +49,21 @@ class TestVolume(object):
         log = caplog.records[-2]
         assert log.message == 'Running command: ceph-volume --cluster barnacle lvm --help'
         assert log.levelname == 'INFO'
+
+    def test_logs_set_level_error(self, caplog):
+        with pytest.raises(SystemExit) as error:
+            main.Volume(argv=['ceph-volume', '--log-level', 'error', '--cluster', 'barnacle', 'lvm', '--help'])
+        # make sure we aren't causing an actual error
+        assert error.value.code == 0
+        assert caplog.records
+        # only log levels of 'ERROR' or above should be captured
+        for log in caplog.records:
+            assert log.levelname in ['ERROR', 'CRITICAL']
+
+    def test_logs_incorrect_log_level(self, capsys):
+        with pytest.raises(SystemExit) as error:
+            main.Volume(argv=['ceph-volume', '--log-level', 'foo', '--cluster', 'barnacle', 'lvm', '--help'])
+        # make sure this is an error
+        assert error.value.code != 0
+        stdout, stderr = capsys.readouterr()
+        assert "invalid choice" in stderr


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48187

---

backport of https://github.com/ceph/ceph/pull/37896
parent tracker: https://tracker.ceph.com/issues/48045

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh