### PR TITLE
doc/cephadm: Adds explicit prerequisites, additional examples

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -6,6 +6,12 @@ Cephadm creates a new Ceph cluster by "bootstrapping" on a single
 host, expanding the cluster to encompass any additional hosts, and
 then deploying the needed services.
 
+Each host should be prepared as follows for deployment:
+
+- Allow SSH for the root user
+- For the first "bootstrapping" host and any other hosts intended to be monitors, set up passwordless SSH to all other hosts
+- Ensure that each host has a unique hostname (unique IP addresses are not sufficient for the instructions below)
+
 .. highlight:: console
 
 Requirements
@@ -97,6 +103,7 @@ You need to know which *IP address* to use for the cluster's first
 monitor daemon.  This is normally just the IP for the first host.  If there
 are multiple networks and interfaces, be sure to choose one that will
 be accessible by any host accessing the Ceph cluster.
+
 
 To bootstrap the cluster, first create an ``/etc/ceph`` directory:
 
@@ -236,6 +243,16 @@ To add each new host to the cluster, perform two steps:
 
      ceph orch host add host2
      ceph orch host add host3
+
+
+   If you have not configured your hostnames as aliases for IP addresses, you can provide the IP address after the hostname.  For example:
+
+   .. prompt:: bash #
+
+     ceph orch host add host2 192.168.1.41
+     ceph orch host add host3 192.168.1.42
+     
+   Additional options including adding multiple hosts are documented in the Orchestrator CLI.
 
 
 .. _deploy_additional_monitors:


### PR DESCRIPTION
Makes implicit host prerequisites explicit and provides additional examples for adding hosts in-line with the instructions.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
