### PR TITLE
doc/dev: add to quick_guide new dependencies guidelines

### DIFF
--- a/doc/dev/quick_guide.rst
+++ b/doc/dev/quick_guide.rst
@@ -25,6 +25,34 @@ Example:
    ./install-deps.sh
    ./do_cmake.sh -DWITH_MANPAGE=OFF -DWITH_BABELTRACE=OFF -DWITH_MGR_DASHBOARD_FRONTEND=OFF
 
+Introducing new dependencies
+----------------------------
+Adding external dependencies should be avoided whenever possible, in order to
+reduce maintenance overhead. In case the new dependency is absolutely essential
+and must be introduced, please verify that its package is available in the
+repositories of all the supported distributions. In addition, pay attention to
+its version, since sometimes versions do not match across distributions.
+
+For RHEL and CentOS you can check if a dependency is available with:
+
+.. prompt:: bash $
+
+   dnf search <package_name>
+
+Make sure you add Extra Packages for Enterprise Linux (EPEL) repository to your
+``/etc/yum.repos.d/``.
+Instructions for doing so are found on the Fedora Wiki:
+https://fedoraproject.org/wiki/EPEL
+
+For Debian:
+
+.. prompt:: bash $
+
+   apt search <package_name>
+
+Both unit and integration tests which make use of the new dependency should be
+added as a part of the pull request that introduces the dependency.
+
 Running a development deployment
 --------------------------------
 Ceph contains a script called ``vstart.sh`` (see also :doc:`/dev/dev_cluster_deployement`) which allows developers to quickly test their code using


### PR DESCRIPTION
This is in order to help developers better understand the consequences
of introducing new dependencies to the project.

Fixes: https://tracker.ceph.com/issues/48420
Signed-off-by: Yaarit Hatuka <yaarit@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
