### PR TITLE
crimson/osd: add _with_lock method to obc

### DIFF
--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -111,18 +111,28 @@ private:
       make_blocking_future(std::forward<LockF>(lockf)));
   }
 
+  template <typename Lock, typename Func>
+  auto _with_lock(Lock&& lock, Func&& func) {
+    Ref obc = this;
+    return lock.lock().then([&lock, func = std::forward<Func>(func), obc]() mutable {
+      return seastar::futurize_invoke(func).finally([&lock, obc] {
+	lock.unlock();
+      });
+    });
+  }
+
 public:
   template<RWState::State Type, typename Func>
   auto with_lock(Func&& func) {
     switch (Type) {
     case RWState::RWWRITE:
-      return seastar::with_lock(lock.for_write(), std::forward<Func>(func));
+      return _with_lock(lock.for_write(), std::forward<Func>(func));
     case RWState::RWREAD:
-      return seastar::with_lock(lock.for_read(), std::forward<Func>(func));
+      return _with_lock(lock.for_read(), std::forward<Func>(func));
     case RWState::RWEXCL:
-      return seastar::with_lock(lock.for_excl(), std::forward<Func>(func));
+      return _with_lock(lock.for_excl(), std::forward<Func>(func));
     case RWState::RWNONE:
-      return seastar::futurize_invoke(func);
+      return seastar::futurize_invoke(std::forward<Func>(func));
     default:
       assert(0 == "noop");
     }
@@ -131,11 +141,11 @@ public:
   auto with_promoted_lock(Func&& func) {
     switch (Type) {
     case RWState::RWWRITE:
-      return seastar::with_lock(lock.excl_from_write(), std::forward<Func>(func));
+      return _with_lock(lock.excl_from_write(), std::forward<Func>(func));
     case RWState::RWREAD:
-      return seastar::with_lock(lock.excl_from_read(), std::forward<Func>(func));
+      return _with_lock(lock.excl_from_read(), std::forward<Func>(func));
     case RWState::RWEXCL:
-      return seastar::with_lock(lock.excl_from_excl(), std::forward<Func>(func));
+      return _with_lock(lock.excl_from_excl(), std::forward<Func>(func));
      default:
       assert(0 == "noop");
     }


### PR DESCRIPTION
this is modeling the seastar::with_lock() method with the exception
that obc is also captured in the finally block.

Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
