### PR TITLE
librbd/migration: add thick-provisioned snapshot support to the raw format

### DIFF
--- a/qa/suites/rbd/cli/workloads/rbd_cli_migration.yaml
+++ b/qa/suites/rbd/cli/workloads/rbd_cli_migration.yaml
@@ -1,0 +1,5 @@
+tasks:
+- workunit:
+    clients:
+      client.0:
+        - rbd/cli_migration.sh

--- a/qa/workunits/rbd/cli_migration.sh
+++ b/qa/workunits/rbd/cli_migration.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+set -ex
+
+. $(dirname $0)/../../standalone/ceph-helpers.sh
+
+TEMPDIR=
+IMAGE1=image1
+IMAGE2=image2
+IMAGE3=image3
+IMAGES="${IMAGE1} ${IMAGE2} ${IMAGE3}"
+
+cleanup() {
+    cleanup_tempdir
+    remove_images
+}
+
+setup_tempdir() {
+    TEMPDIR=`mktemp -d`
+}
+
+cleanup_tempdir() {
+    rm -rf ${TEMPDIR}
+}
+
+create_base_image() {
+    local image=$1
+
+    rbd create --size 1G ${image}
+    rbd bench --io-type write --io-pattern rand --io-size=4K --io-total 256M ${image}
+    rbd snap create ${image}@1
+    rbd bench --io-type write --io-pattern rand --io-size=4K --io-total 64M ${image}
+    rbd snap create ${image}@2
+    rbd bench --io-type write --io-pattern rand --io-size=4K --io-total 128M ${image}
+}
+
+export_raw_image() {
+    local image=$1
+
+    rm -rf "${TEMPDIR}/${image}"
+    rbd export ${image} "${TEMPDIR}/${image}"
+}
+
+export_base_image() {
+    local image=$1
+
+    export_raw_image "${image}"
+    export_raw_image "${image}@1"
+    export_raw_image "${image}@2"
+}
+
+remove_image() {
+    local image=$1
+
+    (rbd migration abort $image || true) >/dev/null 2>&1
+    (rbd snap purge $image || true) >/dev/null 2>&1
+    (rbd rm $image || true) >/dev/null 2>&1
+}
+
+remove_images() {
+    for image in ${IMAGES}
+    do
+        remove_image ${image}
+    done
+}
+
+compare_images() {
+    local src_image=$1
+    local dst_image=$2
+
+    export_raw_image ${dst_image}
+    cmp "${TEMPDIR}/${src_image}" "${TEMPDIR}/${dst_image}"
+}
+
+test_import_native_format() {
+    local base_image=$1
+    local dest_image=$2
+
+    local pool_id=$(ceph osd pool ls detail --format xml | xmlstarlet sel -t -v "//pools/pool[pool_name='rbd']/pool_id")
+    cat > ${TEMPDIR}/spec.json <<EOF
+{
+  "type": "native",
+  "pool_id": ${pool_id},
+  "pool_namespace": "",
+  "image_name": "${base_image}"
+}
+EOF
+    cat ${TEMPDIR}/spec.json
+
+    rbd migration prepare --import-only \
+	--source-spec-path ${TEMPDIR}/spec.json ${dest_image}
+
+    compare_images "${base_image}@1" "${dest_image}@1"
+    compare_images "${base_image}@2" "${dest_image}@2"
+    compare_images "${base_image}" "${dest_image}"
+
+    rbd snap create ${dest_image}@head
+    rbd bench --io-type write --io-pattern rand --io-size=32K --io-total=32M ${dest_image}
+    compare_images "${base_image}" "${dest_image}@head"
+
+    rbd migration abort ${dest_image}
+
+    rbd migration prepare --import-only \
+        --source-spec-path ${TEMPDIR}/spec.json ${dest_image}
+    rbd migration execute ${dest_image}
+
+    compare_images "${base_image}@1" "${dest_image}@1"
+    compare_images "${base_image}@2" "${dest_image}@2"
+    compare_images "${base_image}" "${dest_image}"
+
+    rbd migration abort ${dest_image}
+
+    rbd migration prepare --import-only \
+        --source-spec "{\"type\": \"native\", \"pool_id\": "${pool_id}", \"image_name\": \"${base_image}\"}" \
+        ${dest_image}
+    rbd migration abort ${dest_image}
+
+    rbd migration prepare --import-only \
+        --source-spec "{\"type\": \"native\", \"pool_name\": \"rbd\", \"image_name\": \"${base_image}\"}" \
+        ${dest_image}
+    rbd migration execute ${dest_image}
+    rbd migration commit ${dest_image}
+
+    compare_images "${base_image}@1" "${dest_image}@1"
+    compare_images "${base_image}@2" "${dest_image}@2"
+    compare_images "${base_image}" "${dest_image}"
+
+    remove_image "${dest_image}"
+}
+
+test_import_raw_format() {
+    local base_image=$1
+    local dest_image=$2
+
+    cat > ${TEMPDIR}/spec.json <<EOF
+{
+  "type": "raw",
+  "stream": {
+    "type": "file",
+    "file_path": "${TEMPDIR}/${base_image}"
+  }
+}
+EOF
+    cat ${TEMPDIR}/spec.json
+
+    cat ${TEMPDIR}/spec.json | rbd migration prepare --import-only \
+	--source-spec-path - ${dest_image}
+    compare_images ${base_image} ${dest_image}
+    rbd migration abort ${dest_image}
+
+    rbd migration prepare --import-only \
+	--source-spec-path ${TEMPDIR}/spec.json ${dest_image}
+    rbd migration execute ${dest_image}
+    rbd migration commit ${dest_image}
+
+    compare_images ${base_image} ${dest_image}
+
+    remove_image "${dest_image}"
+
+    cat > ${TEMPDIR}/spec.json <<EOF
+{
+  "type": "raw",
+  "stream": {
+    "type": "file",
+    "file_path": "${TEMPDIR}/${base_image}"
+  },
+  "snapshots": [{
+    "type": "raw",
+    "name": "snap1",
+    "stream": {
+      "type": "file",
+      "file_path": "${TEMPDIR}/${base_image}@1"
+     }
+  }, {
+    "type": "raw",
+    "name": "snap2",
+    "stream": {
+      "type": "file",
+      "file_path": "${TEMPDIR}/${base_image}@2"
+     }
+  }]
+}
+EOF
+    cat ${TEMPDIR}/spec.json
+
+    rbd migration prepare --import-only \
+        --source-spec-path ${TEMPDIR}/spec.json ${dest_image}
+
+    rbd snap create ${dest_image}@head
+    rbd bench --io-type write --io-pattern rand --io-size=32K --io-total=32M ${dest_image}
+
+    compare_images "${base_image}" "${dest_image}@head"
+    compare_images "${base_image}@1" "${dest_image}@snap1"
+    compare_images "${base_image}@2" "${dest_image}@snap2"
+    compare_images "${base_image}" "${dest_image}@head"
+
+    rbd migration execute ${dest_image}
+
+    compare_images "${base_image}@1" "${dest_image}@snap1"
+    compare_images "${base_image}@2" "${dest_image}@snap2"
+    compare_images "${base_image}" "${dest_image}@head"
+
+    rbd migration commit ${dest_image}
+
+    remove_image "${dest_image}"
+}
+
+# make sure rbd pool is EMPTY.. this is a test script!!
+rbd ls 2>&1 | wc -l | grep -v '^0$' && echo "nonempty rbd pool, aborting!  run this script on an empty test cluster only." && exit 1
+
+setup_tempdir
+trap 'cleanup $?' INT TERM EXIT
+
+create_base_image ${IMAGE1}
+export_base_image ${IMAGE1}
+
+test_import_native_format ${IMAGE1} ${IMAGE2}
+test_import_raw_format ${IMAGE1} ${IMAGE2}
+
+echo OK

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -137,6 +137,7 @@ set(librbd_internal_srcs
   migration/NativeFormat.cc
   migration/OpenSourceImageRequest.cc
   migration/RawFormat.cc
+  migration/RawSnapshot.cc
   migration/S3Stream.cc
   migration/SourceSpecBuilder.cc
   migration/Utils.cc

--- a/src/librbd/image/RefreshParentRequest.cc
+++ b/src/librbd/image/RefreshParentRequest.cc
@@ -119,8 +119,8 @@ void RefreshParentRequest<I>::send_open_parent() {
         RefreshParentRequest<I>,
         &RefreshParentRequest<I>::handle_open_parent, false>(this));
     auto req = migration::OpenSourceImageRequest<I>::create(
-      &m_child_image_ctx, m_parent_md.spec.snap_id, m_migration_info,
-      &m_parent_image_ctx, ctx);
+      m_child_image_ctx.md_ctx, &m_child_image_ctx, m_parent_md.spec.snap_id,
+      m_migration_info, &m_parent_image_ctx, ctx);
     req->send();
     return;
   }

--- a/src/librbd/migration/NativeFormat.cc
+++ b/src/librbd/migration/NativeFormat.cc
@@ -153,8 +153,7 @@ void NativeFormat<I>::open(Context* on_finish) {
   }
 
   // open the source RBD image
-  auto ctx = util::create_async_context_callback(*m_image_ctx, on_finish);
-  m_image_ctx->state->open(flags, ctx);
+  m_image_ctx->state->open(flags, on_finish);
 }
 
 template <typename I>

--- a/src/librbd/migration/NativeFormat.cc
+++ b/src/librbd/migration/NativeFormat.cc
@@ -10,6 +10,7 @@
 #include "librbd/asio/ContextWQ.h"
 #include "librbd/io/ImageDispatchSpec.h"
 #include "json_spirit/json_spirit.h"
+#include "boost/lexical_cast.hpp"
 #include <sstream>
 
 #define dout_subsys ceph_subsys_rbd
@@ -24,6 +25,7 @@ namespace {
 
 const std::string TYPE_KEY{"type"};
 const std::string POOL_ID_KEY{"pool_id"};
+const std::string POOL_NAME_KEY{"pool_name"};
 const std::string POOL_NAMESPACE_KEY{"pool_namespace"};
 const std::string IMAGE_NAME_KEY{"image_name"};
 const std::string IMAGE_ID_KEY{"image_id"};
@@ -57,21 +59,52 @@ void NativeFormat<I>::open(Context* on_finish) {
   auto cct = m_image_ctx->cct;
   ldout(cct, 10) << dendl;
 
+  auto& pool_name_val = m_json_object[POOL_NAME_KEY];
+  if (pool_name_val.type() == json_spirit::str_type) {
+    librados::Rados rados(m_image_ctx->md_ctx);
+    librados::IoCtx io_ctx;
+    int r = rados.ioctx_create(pool_name_val.get_str().c_str(), io_ctx);
+    if (r < 0 ) {
+      lderr(cct) << "invalid pool name" << dendl;
+      on_finish->complete(r);
+      return;
+    }
+
+    m_pool_id = io_ctx.get_id();
+  } else if (pool_name_val.type() != json_spirit::null_type) {
+    lderr(cct) << "invalid pool name" << dendl;
+    on_finish->complete(-EINVAL);
+    return;
+  }
+
   auto& pool_id_val = m_json_object[POOL_ID_KEY];
-  if (pool_id_val.type() != json_spirit::int_type) {
+  if (m_pool_id != -1 && pool_id_val.type() != json_spirit::null_type) {
+    lderr(cct) << "cannot specify both pool name and pool id" << dendl;
+    on_finish->complete(-EINVAL);
+    return;
+  } else if (pool_id_val.type() == json_spirit::int_type) {
+    m_pool_id = pool_id_val.get_int64();
+  } else if (pool_id_val.type() == json_spirit::str_type) {
+    try {
+      m_pool_id = boost::lexical_cast<int64_t>(pool_id_val.get_str());
+    } catch (boost::bad_lexical_cast &) {
+    }
+  }
+
+  if (m_pool_id == -1) {
     lderr(cct) << "missing or invalid pool id" << dendl;
     on_finish->complete(-EINVAL);
     return;
   }
-  m_pool_id = pool_id_val.get_int64();
 
   auto& pool_namespace_val = m_json_object[POOL_NAMESPACE_KEY];
-  if (pool_namespace_val.type() != json_spirit::str_type) {
-    lderr(cct) << "missing or invalid pool namespace" << dendl;
+  if (pool_namespace_val.type() == json_spirit::str_type) {
+    m_pool_namespace = pool_namespace_val.get_str();
+  } else if (pool_namespace_val.type() != json_spirit::null_type) {
+    lderr(cct) << "invalid pool namespace" << dendl;
     on_finish->complete(-EINVAL);
     return;
   }
-  m_pool_namespace = pool_namespace_val.get_str();
 
   auto& image_name_val = m_json_object[IMAGE_NAME_KEY];
   if (image_name_val.type() != json_spirit::str_type) {

--- a/src/librbd/migration/OpenSourceImageRequest.cc
+++ b/src/librbd/migration/OpenSourceImageRequest.cc
@@ -102,12 +102,113 @@ void OpenSourceImageRequest<I>::handle_open_source(int r) {
     return;
   }
 
+  get_image_size();
+}
+
+template <typename I>
+void OpenSourceImageRequest<I>::get_image_size() {
+  ldout(m_cct, 10) << dendl;
+
+  auto ctx = util::create_context_callback<
+    OpenSourceImageRequest<I>,
+    &OpenSourceImageRequest<I>::handle_get_image_size>(this);
+  m_format->get_image_size(CEPH_NOSNAP, &m_image_size, ctx);
+}
+
+template <typename I>
+void OpenSourceImageRequest<I>::handle_get_image_size(int r) {
+  ldout(m_cct, 10) << "r=" << r << ", "
+                   << "image_size=" << m_image_size << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to retrieve image size: " << cpp_strerror(r)
+                 << dendl;
+    close_image(r);
+    return;
+  }
+
+  auto src_image_ctx = *m_src_image_ctx;
+  src_image_ctx->image_lock.lock();
+  src_image_ctx->size = m_image_size;
+  src_image_ctx->image_lock.unlock();
+
+  get_snapshots();
+}
+
+template <typename I>
+void OpenSourceImageRequest<I>::get_snapshots() {
+  ldout(m_cct, 10) << dendl;
+
+  auto ctx = util::create_context_callback<
+    OpenSourceImageRequest<I>,
+    &OpenSourceImageRequest<I>::handle_get_snapshots>(this);
+  m_format->get_snapshots(&m_snap_infos, ctx);
+}
+
+template <typename I>
+void OpenSourceImageRequest<I>::handle_get_snapshots(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to retrieve snapshots: " << cpp_strerror(r)
+                 << dendl;
+    close_image(r);
+    return;
+  }
+
+  // copy snapshot metadata to image ctx
+  auto src_image_ctx = *m_src_image_ctx;
+  src_image_ctx->image_lock.lock();
+
+  src_image_ctx->snaps.clear();
+  src_image_ctx->snap_info.clear();
+  src_image_ctx->snap_ids.clear();
+
+  ::SnapContext snapc;
+  for (auto it = m_snap_infos.rbegin(); it != m_snap_infos.rend(); ++it) {
+    auto& [snap_id, snap_info] = *it;
+    snapc.snaps.push_back(snap_id);
+
+    src_image_ctx->add_snap(
+      snap_info.snap_namespace, snap_info.name, snap_id,
+      snap_info.size, snap_info.parent, snap_info.protection_status,
+      snap_info.flags, snap_info.timestamp);
+  }
+  if (!snapc.snaps.empty()) {
+    snapc.seq = snapc.snaps[0];
+  }
+  src_image_ctx->snapc = snapc;
+
+  // ensure data_ctx and data_io_context are pointing to correct snapshot
+  if (src_image_ctx->open_snap_id != CEPH_NOSNAP) {
+    int r = src_image_ctx->snap_set(src_image_ctx->open_snap_id);
+    ceph_assert(r == 0);
+    src_image_ctx->open_snap_id = CEPH_NOSNAP;
+  }
+
+  src_image_ctx->image_lock.unlock();
+
+  finish(0);
+}
+
+template <typename I>
+void OpenSourceImageRequest<I>::close_image(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  auto ctx = new LambdaContext([this, r](int) {
+    finish(r);
+  });
+  (*m_src_image_ctx)->state->close(ctx);
+}
+
+template <typename I>
+void OpenSourceImageRequest<I>::register_image_dispatch() {
+  ldout(m_cct, 10) << dendl;
+
   // intercept any IO requests to the source image
   auto io_image_dispatch = ImageDispatch<I>::create(
     *m_src_image_ctx, std::move(m_format));
   (*m_src_image_ctx)->io_image_dispatcher->register_dispatch(io_image_dispatch);
-
-  finish(0);
 }
 
 template <typename I>
@@ -116,6 +217,8 @@ void OpenSourceImageRequest<I>::finish(int r) {
 
   if (r < 0) {
     *m_src_image_ctx = nullptr;
+  } else {
+    register_image_dispatch();
   }
 
   m_on_finish->complete(r);

--- a/src/librbd/migration/OpenSourceImageRequest.h
+++ b/src/librbd/migration/OpenSourceImageRequest.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_LIBRBD_MIGRATION_OPEN_SOURCE_IMAGE_REQUEST_H
 #define CEPH_LIBRBD_MIGRATION_OPEN_SOURCE_IMAGE_REQUEST_H
 
+#include "include/rados/librados_fwd.hpp"
 #include "librbd/Types.h"
 #include <memory>
 
@@ -20,17 +21,19 @@ struct FormatInterface;
 template <typename ImageCtxT>
 class OpenSourceImageRequest {
 public:
-  static OpenSourceImageRequest* create(ImageCtxT* destination_image_ctx,
+  static OpenSourceImageRequest* create(librados::IoCtx& io_ctx,
+                                        ImageCtxT* destination_image_ctx,
                                         uint64_t src_snap_id,
                                         const MigrationInfo &migration_info,
                                         ImageCtxT** source_image_ctx,
                                         Context* on_finish) {
-    return new OpenSourceImageRequest(destination_image_ctx, src_snap_id,
-                                      migration_info, source_image_ctx,
-                                      on_finish);
+    return new OpenSourceImageRequest(io_ctx, destination_image_ctx,
+                                      src_snap_id, migration_info,
+                                      source_image_ctx, on_finish);
   }
 
-  OpenSourceImageRequest(ImageCtxT* destination_image_ctx,
+  OpenSourceImageRequest(librados::IoCtx& io_ctx,
+                         ImageCtxT* destination_image_ctx,
                          uint64_t src_snap_id,
                          const MigrationInfo &migration_info,
                          ImageCtxT** source_image_ctx,
@@ -53,6 +56,8 @@ private:
    * @endverbatim
    */
 
+  CephContext* m_cct;
+  librados::IoCtx& m_io_ctx;
   ImageCtxT* m_dst_image_ctx;
   uint64_t m_src_snap_id;
   MigrationInfo m_migration_info;

--- a/src/librbd/migration/OpenSourceImageRequest.h
+++ b/src/librbd/migration/OpenSourceImageRequest.h
@@ -6,6 +6,7 @@
 
 #include "include/rados/librados_fwd.hpp"
 #include "librbd/Types.h"
+#include <map>
 #include <memory>
 
 struct Context;
@@ -51,10 +52,18 @@ private:
    * OPEN_SOURCE
    *    |
    *    v
-   * <finish>
+   * GET_IMAGE_SIZE  * * * * * * *
+   *    |                        *
+   *    v                        v
+   * GET_SNAPSHOTS * * * * > CLOSE_IMAGE
+   *    |                        |
+   *    v                        |
+   * <finish> <------------------/
    *
    * @endverbatim
    */
+
+  typedef std::map<uint64_t, SnapInfo> SnapInfos;
 
   CephContext* m_cct;
   librados::IoCtx& m_io_ctx;
@@ -66,8 +75,21 @@ private:
 
   std::unique_ptr<FormatInterface> m_format;
 
+  uint64_t m_image_size = 0;
+  SnapInfos m_snap_infos;
+
   void open_source();
   void handle_open_source(int r);
+
+  void get_image_size();
+  void handle_get_image_size(int r);
+
+  void get_snapshots();
+  void handle_get_snapshots(int r);
+
+  void close_image(int r);
+
+  void register_image_dispatch();
 
   void finish(int r);
 

--- a/src/librbd/migration/RawFormat.cc
+++ b/src/librbd/migration/RawFormat.cc
@@ -167,7 +167,8 @@ bool RawFormat<I>::read(
     io::ReadResult&& read_result, int op_flags, int read_flags,
     const ZTracer::Trace &parent_trace) {
   auto cct = m_image_ctx->cct;
-  ldout(cct, 20) << "image_extents=" << image_extents << dendl;
+  ldout(cct, 20) << "snap_id=" << snap_id << ", "
+                 << "image_extents=" << image_extents << dendl;
 
   auto snapshot_it = m_snapshots.find(snap_id);
   if (snapshot_it == m_snapshots.end()) {

--- a/src/librbd/migration/RawFormat.cc
+++ b/src/librbd/migration/RawFormat.cc
@@ -114,12 +114,6 @@ void RawFormat<I>::handle_open(int r, Context* on_finish) {
     return;
   }
 
-  auto head_snapshot = m_snapshots[CEPH_NOSNAP];
-  ceph_assert(head_snapshot);
-
-  m_image_ctx->image_lock.lock();
-  m_image_ctx->size = head_snapshot->get_snap_info().size;
-  m_image_ctx->image_lock.unlock();
   on_finish->complete(0);
 }
 

--- a/src/librbd/migration/RawFormat.cc
+++ b/src/librbd/migration/RawFormat.cc
@@ -15,6 +15,13 @@
 namespace librbd {
 namespace migration {
 
+namespace {
+
+static const std::string SNAPSHOTS_KEY {"snapshots"};
+
+
+} // anonymous namespace
+
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
 #define dout_prefix *_dout << "librbd::migration::RawFormat: " << this \
@@ -37,14 +44,45 @@ void RawFormat<I>::open(Context* on_finish) {
     handle_open(r, on_finish); });
 
   // treat the base image as a HEAD-revision snapshot
+  Snapshots snapshots;
   int r = m_source_spec_builder->build_snapshot(m_json_object, CEPH_NOSNAP,
-                                                &m_snapshots[CEPH_NOSNAP]);
+                                                &snapshots[CEPH_NOSNAP]);
   if (r < 0) {
     lderr(cct) << "failed to build HEAD revision handler: " << cpp_strerror(r)
                << dendl;
     on_finish->complete(r);
     return;
   }
+
+  auto& snapshots_val = m_json_object[SNAPSHOTS_KEY];
+  if (snapshots_val.type() == json_spirit::array_type) {
+    auto& snapshots_arr = snapshots_val.get_array();
+    for (auto& snapshot_val : snapshots_arr) {
+      uint64_t index = snapshots.size();
+      if (snapshot_val.type() != json_spirit::obj_type) {
+        lderr(cct) << "invalid snapshot " << index << " JSON: "
+                   << cpp_strerror(r) << dendl;
+        on_finish->complete(-EINVAL);
+        return;
+      }
+
+      auto& snapshot_obj = snapshot_val.get_obj();
+      r = m_source_spec_builder->build_snapshot(snapshot_obj, index,
+                                                &snapshots[index]);
+      if (r < 0) {
+        lderr(cct) << "failed to build snapshot " << index << " handler: "
+                   << cpp_strerror(r) << dendl;
+        on_finish->complete(r);
+        return;
+      }
+    }
+  } else if (snapshots_val.type() != json_spirit::null_type) {
+    lderr(cct) << "invalid snapshots array" << dendl;
+    on_finish->complete(-EINVAL);
+    return;
+  }
+
+  m_snapshots = std::move(snapshots);
 
   auto gather_ctx = new C_Gather(cct, on_finish);
   SnapshotInterface* previous_snapshot = nullptr;
@@ -63,8 +101,16 @@ void RawFormat<I>::handle_open(int r, Context* on_finish) {
   if (r < 0) {
     lderr(cct) << "failed to open raw image: " << cpp_strerror(r)
                << dendl;
+
+    auto gather_ctx = new C_Gather(cct, on_finish);
+    for (auto& [_, snapshot] : m_snapshots) {
+      snapshot->close(gather_ctx->new_sub());
+    }
+
     m_image_ctx->state->close(new LambdaContext(
-      [r, on_finish=on_finish](int _) { on_finish->complete(r); }));
+      [r, on_finish=gather_ctx->new_sub()](int _) { on_finish->complete(r); }));
+
+    gather_ctx->activate();
     return;
   }
 
@@ -147,13 +193,100 @@ void RawFormat<I>::list_snaps(io::Extents&& image_extents,
                               io::SnapshotDelta* snapshot_delta,
                               const ZTracer::Trace &parent_trace,
                               Context* on_finish) {
-  // raw does support snapshots so list the full IO extent as a delta
-  auto& snapshot = (*snapshot_delta)[{CEPH_NOSNAP, CEPH_NOSNAP}];
-  for (auto& image_extent : image_extents) {
-    snapshot.insert(image_extent.first, image_extent.second,
-                    {io::SPARSE_EXTENT_STATE_DATA, image_extent.second});
+  auto cct = m_image_ctx->cct;
+  ldout(cct, 20) << "image_extents=" << image_extents << dendl;
+
+  on_finish = new LambdaContext([this, snap_ids=std::move(snap_ids),
+                                 snapshot_delta, on_finish](int r) mutable {
+    handle_list_snaps(r, std::move(snap_ids), snapshot_delta, on_finish);
+  });
+
+  auto gather_ctx = new C_Gather(cct, on_finish);
+
+  std::optional<uint64_t> previous_size = std::nullopt;
+  for (auto& [snap_id, snapshot] : m_snapshots) {
+    auto& sparse_extents = (*snapshot_delta)[{snap_id, snap_id}];
+
+    // zero out any space between the previous snapshot end and this
+    // snapshot's end
+    auto& snap_info = snapshot->get_snap_info();
+    if (previous_size && *previous_size > snap_info.size) {
+      ldout(cct, 20) << "snapshot resize " << *previous_size << " -> "
+                     << snap_info.size << dendl;
+      interval_set<uint64_t> zero_interval;
+      zero_interval.insert(snap_info.size, *previous_size - snap_info.size);
+
+      for (auto& image_extent : image_extents) {
+        interval_set<uint64_t> image_interval;
+        image_interval.insert(image_extent.first, image_extent.second);
+
+        image_interval.intersection_of(zero_interval);
+        for (auto [image_offset, image_length] : image_interval) {
+          ldout(cct, 20) << "zeroing extent " << image_offset << "~"
+                         << image_length << " at snapshot " << snap_id << dendl;
+          sparse_extents.insert(image_offset, image_length,
+                                {io::SPARSE_EXTENT_STATE_ZEROED, image_length});
+        }
+      }
+    }
+    previous_size = snap_info.size;
+
+    // build set of data/zeroed extents for the current snapshot
+    snapshot->list_snap(io::Extents{image_extents}, list_snaps_flags,
+                        &sparse_extents, parent_trace, gather_ctx->new_sub());
   }
-  on_finish->complete(0);
+
+  gather_ctx->activate();
+}
+
+template <typename I>
+void RawFormat<I>::handle_list_snaps(int r, io::SnapIds&& snap_ids,
+                                     io::SnapshotDelta* snapshot_delta,
+                                     Context* on_finish) {
+  auto cct = m_image_ctx->cct;
+  ldout(cct, 20) << "r=" << r << ", "
+                 << "snapshot_delta=" << snapshot_delta << dendl;
+
+  io::SnapshotDelta orig_snapshot_delta = std::move(*snapshot_delta);
+  snapshot_delta->clear();
+
+  auto snap_id_it = snap_ids.begin();
+  ceph_assert(snap_id_it != snap_ids.end());
+
+  // merge any snapshot intervals that were not requested
+  std::list<io::SparseExtents*> pending_sparse_extents;
+  for (auto& [snap_key, sparse_extents] : orig_snapshot_delta) {
+    // advance to next valid requested snap id
+    while (snap_id_it != snap_ids.end() && *snap_id_it < snap_key.first) {
+      ++snap_id_it;
+    }
+    if (snap_id_it == snap_ids.end()) {
+      break;
+    }
+
+    // loop through older write/read snapshot sparse extents to remove any
+    // overlaps with the current sparse extent
+    for (auto prev_sparse_extents : pending_sparse_extents) {
+      for (auto& sparse_extent : sparse_extents) {
+        prev_sparse_extents->erase(sparse_extent.get_off(),
+                                   sparse_extent.get_len());
+      }
+    }
+
+    auto write_read_snap_ids = std::make_pair(*snap_id_it, snap_key.second);
+    (*snapshot_delta)[write_read_snap_ids] = std::move(sparse_extents);
+
+    if (write_read_snap_ids.first > snap_key.first) {
+      // the current snapshot wasn't requested so it might need to get
+      // merged with a later snapshot
+      pending_sparse_extents.push_back(&(*snapshot_delta)[write_read_snap_ids]);
+    } else {
+      // we don't merge results passed a valid requested snapshot
+      pending_sparse_extents.clear();
+    }
+  }
+
+  on_finish->complete(r);
 }
 
 } // namespace migration

--- a/src/librbd/migration/RawFormat.h
+++ b/src/librbd/migration/RawFormat.h
@@ -60,7 +60,7 @@ private:
   json_spirit::mObject m_json_object;
   const SourceSpecBuilder<ImageCtxT>* m_source_spec_builder;
 
-  std::unique_ptr<StreamInterface> m_stream;
+  std::shared_ptr<StreamInterface> m_stream;
 
 };
 

--- a/src/librbd/migration/RawFormat.h
+++ b/src/librbd/migration/RawFormat.h
@@ -8,6 +8,7 @@
 #include "librbd/Types.h"
 #include "librbd/migration/FormatInterface.h"
 #include "json_spirit/json_spirit.h"
+#include <map>
 #include <memory>
 
 struct Context;
@@ -20,7 +21,7 @@ struct ImageCtx;
 namespace migration {
 
 template <typename> struct SourceSpecBuilder;
-struct StreamInterface;
+struct SnapshotInterface;
 
 template <typename ImageCtxT>
 class RawFormat : public FormatInterface {
@@ -54,14 +55,16 @@ public:
                   Context* on_finish) override;
 
 private:
-  struct OpenRequest;
+  typedef std::shared_ptr<SnapshotInterface> Snapshot;
+  typedef std::map<uint64_t, Snapshot> Snapshots;
 
   ImageCtxT* m_image_ctx;
   json_spirit::mObject m_json_object;
   const SourceSpecBuilder<ImageCtxT>* m_source_spec_builder;
 
-  std::shared_ptr<StreamInterface> m_stream;
+  Snapshots m_snapshots;
 
+  void handle_open(int r, Context* on_finish);
 };
 
 } // namespace migration

--- a/src/librbd/migration/RawFormat.h
+++ b/src/librbd/migration/RawFormat.h
@@ -65,6 +65,9 @@ private:
   Snapshots m_snapshots;
 
   void handle_open(int r, Context* on_finish);
+
+  void handle_list_snaps(int r, io::SnapIds&& snap_ids,
+                         io::SnapshotDelta* snapshot_delta, Context* on_finish);
 };
 
 } // namespace migration

--- a/src/librbd/migration/RawSnapshot.cc
+++ b/src/librbd/migration/RawSnapshot.cc
@@ -71,7 +71,8 @@ struct RawSnapshot<I>::OpenRequest {
 
   void handle_get_image_size(int r) {
     auto cct = raw_snapshot->m_image_ctx->cct;
-    ldout(cct, 10) << "r=" << r << dendl;
+    ldout(cct, 10) << "r=" << r << ", "
+                   << "image_size=" << raw_snapshot->m_snap_info.size << dendl;
 
     if (r < 0) {
       lderr(cct) << "failed to open stream: " << cpp_strerror(r) << dendl;
@@ -130,7 +131,6 @@ template <typename I>
 void RawSnapshot<I>::open(SnapshotInterface* previous_snapshot,
                           Context* on_finish) {
   auto cct = m_image_ctx->cct;
-  ldout(cct, 10) << dendl;
 
   // special-case for treating the HEAD revision as a snapshot
   if (m_index != CEPH_NOSNAP) {
@@ -148,6 +148,8 @@ void RawSnapshot<I>::open(SnapshotInterface* previous_snapshot,
       return;
     }
   }
+
+  ldout(cct, 10) << "name=" << m_snap_info.name << dendl;
 
   int r = m_source_spec_builder->build_stream(m_json_object, &m_stream);
   if (r < 0) {

--- a/src/librbd/migration/RawSnapshot.cc
+++ b/src/librbd/migration/RawSnapshot.cc
@@ -1,0 +1,218 @@
+// -*- mode:c++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/migration/RawSnapshot.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Utils.h"
+#include "librbd/io/AioCompletion.h"
+#include "librbd/io/ReadResult.h"
+#include "librbd/migration/SourceSpecBuilder.h"
+#include "librbd/migration/StreamInterface.h"
+
+namespace librbd {
+namespace migration {
+
+namespace {
+
+const std::string NAME_KEY{"name"};
+
+} // anonymous namespace
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::migration::RawSnapshot::OpenRequest " \
+                           << this << " " << __func__ << ": "
+
+template <typename I>
+struct RawSnapshot<I>::OpenRequest {
+  RawSnapshot* raw_snapshot;
+  Context* on_finish;
+
+  OpenRequest(RawSnapshot* raw_snapshot, Context* on_finish)
+    : raw_snapshot(raw_snapshot), on_finish(on_finish) {
+  }
+
+  void send() {
+    open_stream();
+  }
+
+  void open_stream() {
+    auto cct = raw_snapshot->m_image_ctx->cct;
+    ldout(cct, 10) << dendl;
+
+    auto ctx = util::create_context_callback<
+      OpenRequest, &OpenRequest::handle_open_stream>(this);
+    raw_snapshot->m_stream->open(ctx);
+  }
+
+  void handle_open_stream(int r) {
+    auto cct = raw_snapshot->m_image_ctx->cct;
+    ldout(cct, 10) << "r=" << r << dendl;
+
+    if (r < 0) {
+      lderr(cct) << "failed to open stream: " << cpp_strerror(r) << dendl;
+      finish(r);
+      return;
+    }
+
+    get_image_size();
+  }
+
+  void get_image_size() {
+    auto cct = raw_snapshot->m_image_ctx->cct;
+    ldout(cct, 10) << dendl;
+
+    auto ctx = util::create_context_callback<
+      OpenRequest, &OpenRequest::handle_get_image_size>(this);
+    raw_snapshot->m_stream->get_size(&raw_snapshot->m_snap_info.size, ctx);
+  }
+
+  void handle_get_image_size(int r) {
+    auto cct = raw_snapshot->m_image_ctx->cct;
+    ldout(cct, 10) << "r=" << r << dendl;
+
+    if (r < 0) {
+      lderr(cct) << "failed to open stream: " << cpp_strerror(r) << dendl;
+      close_stream(r);
+      return;
+    }
+
+    finish(0);
+  }
+
+  void close_stream(int r) {
+    auto cct = raw_snapshot->m_image_ctx->cct;
+    ldout(cct, 10) << dendl;
+
+    auto ctx = new LambdaContext([this, r](int) {
+      handle_close_stream(r);
+    });
+    raw_snapshot->m_stream->close(ctx);
+  }
+
+  void handle_close_stream(int r) {
+    auto cct = raw_snapshot->m_image_ctx->cct;
+    ldout(cct, 10) << "r=" << r << dendl;
+
+    raw_snapshot->m_stream.reset();
+
+    finish(r);
+  }
+
+  void finish(int r) {
+    auto cct = raw_snapshot->m_image_ctx->cct;
+    ldout(cct, 10) << "r=" << r << dendl;
+
+    on_finish->complete(r);
+    delete this;
+  }
+};
+
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::migration::RawSnapshot: " << this \
+                           << " " << __func__ << ": "
+
+template <typename I>
+RawSnapshot<I>::RawSnapshot(I* image_ctx,
+                            const json_spirit::mObject& json_object,
+                            const SourceSpecBuilder<I>* source_spec_builder,
+                            uint64_t index)
+  : m_image_ctx(image_ctx), m_json_object(json_object),
+    m_source_spec_builder(source_spec_builder), m_index(index),
+    m_snap_info({}, {}, 0, {}, 0, 0, {}) {
+  auto cct = m_image_ctx->cct;
+  ldout(cct, 10) << dendl;
+}
+
+template <typename I>
+void RawSnapshot<I>::open(SnapshotInterface* previous_snapshot,
+                          Context* on_finish) {
+  auto cct = m_image_ctx->cct;
+  ldout(cct, 10) << dendl;
+
+  // special-case for treating the HEAD revision as a snapshot
+  if (m_index != CEPH_NOSNAP) {
+    auto& name_val = m_json_object[NAME_KEY];
+    if (name_val.type() == json_spirit::str_type) {
+      m_snap_info.name = name_val.get_str();
+    } else if (name_val.type() == json_spirit::null_type) {
+      uuid_d uuid_gen;
+      uuid_gen.generate_random();
+
+      m_snap_info.name = uuid_gen.to_string();
+    } else {
+      lderr(cct) << "invalid snapshot name" << dendl;
+      on_finish->complete(-EINVAL);
+      return;
+    }
+  }
+
+  int r = m_source_spec_builder->build_stream(m_json_object, &m_stream);
+  if (r < 0) {
+    lderr(cct) << "failed to build migration stream handler" << cpp_strerror(r)
+               << dendl;
+    on_finish->complete(r);
+    return;
+  }
+
+  auto req = new OpenRequest(this, on_finish);
+  req->send();
+}
+
+template <typename I>
+void RawSnapshot<I>::close(Context* on_finish) {
+  auto cct = m_image_ctx->cct;
+  ldout(cct, 10) << dendl;
+
+  if (!m_stream) {
+    on_finish->complete(0);
+    return;
+  }
+
+  m_stream->close(on_finish);
+}
+
+template <typename I>
+void RawSnapshot<I>::read(io::AioCompletion* aio_comp,
+                          io::Extents&& image_extents,
+                          io::ReadResult&& read_result, int op_flags,
+                          int read_flags,
+                          const ZTracer::Trace &parent_trace) {
+  auto cct = m_image_ctx->cct;
+  ldout(cct, 20) << "image_extents=" << image_extents << dendl;
+
+  aio_comp->read_result = std::move(read_result);
+  aio_comp->read_result.set_image_extents(image_extents);
+
+  aio_comp->set_request_count(1);
+  auto ctx = new io::ReadResult::C_ImageReadRequest(aio_comp,
+                                                    0, image_extents);
+
+  // raw directly maps the image-extent IO down to a byte IO extent
+  m_stream->read(std::move(image_extents), &ctx->bl, ctx);
+}
+
+template <typename I>
+void RawSnapshot<I>::list_snap(io::Extents&& image_extents,
+                               int list_snaps_flags,
+                               io::SparseExtents* sparse_extents,
+                               const ZTracer::Trace &parent_trace,
+                               Context* on_finish) {
+  auto cct = m_image_ctx->cct;
+  ldout(cct, 20) << "image_extents=" << image_extents << dendl;
+
+  // raw does support sparse extents so list the full IO extent as a delta
+  for (auto& [image_offset, image_length] : image_extents) {
+    sparse_extents->insert(image_offset, image_length,
+                           {io::SPARSE_EXTENT_STATE_DATA, image_length});
+  }
+
+  on_finish->complete(0);
+}
+
+} // namespace migration
+} // namespace librbd
+
+template class librbd::migration::RawSnapshot<librbd::ImageCtx>;

--- a/src/librbd/migration/RawSnapshot.h
+++ b/src/librbd/migration/RawSnapshot.h
@@ -1,0 +1,75 @@
+// -*- mode:c++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_MIGRATION_RAW_SNAPSHOT_H
+#define CEPH_LIBRBD_MIGRATION_RAW_SNAPSHOT_H
+
+#include "include/buffer_fwd.h"
+#include "include/int_types.h"
+#include "common/zipkin_trace.h"
+#include "librbd/Types.h"
+#include "librbd/io/Types.h"
+#include "librbd/migration/SnapshotInterface.h"
+#include "json_spirit/json_spirit.h"
+#include <memory>
+
+namespace librbd {
+
+struct ImageCtx;
+
+namespace migration {
+
+template <typename> struct SourceSpecBuilder;
+struct StreamInterface;
+
+template <typename ImageCtxT>
+class RawSnapshot : public SnapshotInterface {
+public:
+  static RawSnapshot* create(
+      ImageCtx* image_ctx, const json_spirit::mObject& json_object,
+      const SourceSpecBuilder<ImageCtxT>* source_spec_builder, uint64_t index) {
+    return new RawSnapshot(image_ctx, json_object, source_spec_builder, index);
+  }
+
+  RawSnapshot(ImageCtxT* image_ctx, const json_spirit::mObject& json_object,
+              const SourceSpecBuilder<ImageCtxT>* source_spec_builder,
+              uint64_t index);
+  RawSnapshot(const RawSnapshot&) = delete;
+  RawSnapshot& operator=(const RawSnapshot&) = delete;
+
+  void open(SnapshotInterface* previous_snapshot, Context* on_finish) override;
+  void close(Context* on_finish) override;
+
+  const SnapInfo& get_snap_info() const override {
+    return m_snap_info;
+  }
+
+  void read(io::AioCompletion* aio_comp, io::Extents&& image_extents,
+            io::ReadResult&& read_result, int op_flags, int read_flags,
+            const ZTracer::Trace &parent_trace) override;
+
+  void list_snap(io::Extents&& image_extents, int list_snaps_flags,
+                 io::SparseExtents* sparse_extents,
+                 const ZTracer::Trace &parent_trace,
+                 Context* on_finish) override;
+
+private:
+  struct OpenRequest;
+
+  ImageCtxT* m_image_ctx;
+  json_spirit::mObject m_json_object;
+  const SourceSpecBuilder<ImageCtxT>* m_source_spec_builder;
+  uint64_t m_index = 0;
+
+  SnapInfo m_snap_info;
+
+  std::shared_ptr<StreamInterface> m_stream;
+
+};
+
+} // namespace migration
+} // namespace librbd
+
+extern template class librbd::migration::RawSnapshot<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_MIGRATION_RAW_SNAPSHOT_H

--- a/src/librbd/migration/SnapshotInterface.h
+++ b/src/librbd/migration/SnapshotInterface.h
@@ -1,0 +1,48 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_MIGRATION_SNAPSHOT_INTERFACE_H
+#define CEPH_LIBRBD_MIGRATION_SNAPSHOT_INTERFACE_H
+
+#include "include/buffer_fwd.h"
+#include "include/int_types.h"
+#include "common/zipkin_trace.h"
+#include "librbd/Types.h"
+#include "librbd/io/Types.h"
+#include <string>
+
+struct Context;
+
+namespace librbd {
+
+namespace io {
+struct AioCompletion;
+struct ReadResult;
+} // namespace io
+
+namespace migration {
+
+struct SnapshotInterface {
+  virtual ~SnapshotInterface() {
+  }
+
+  virtual void open(SnapshotInterface* previous_snapshot,
+                    Context* on_finish) = 0;
+  virtual void close(Context* on_finish) = 0;
+
+  virtual const SnapInfo& get_snap_info() const = 0;
+
+  virtual void read(io::AioCompletion* aio_comp, io::Extents&& image_extents,
+                    io::ReadResult&& read_result, int op_flags, int read_flags,
+                    const ZTracer::Trace &parent_trace) = 0;
+
+  virtual void list_snap(io::Extents&& image_extents, int list_snaps_flags,
+                         io::SparseExtents* sparse_extents,
+                         const ZTracer::Trace &parent_trace,
+                         Context* on_finish) = 0;
+};
+
+} // namespace migration
+} // namespace librbd
+
+#endif // CEPH_LIBRBD_MIGRATION_SNAPSHOT_INTERFACE_H

--- a/src/librbd/migration/SourceSpecBuilder.cc
+++ b/src/librbd/migration/SourceSpecBuilder.cc
@@ -76,7 +76,7 @@ int SourceSpecBuilder<I>::build_format(
 template <typename I>
 int SourceSpecBuilder<I>::build_stream(
     const json_spirit::mObject& source_spec_object,
-    std::unique_ptr<StreamInterface>* stream) const {
+    std::shared_ptr<StreamInterface>* stream) const {
   auto cct = m_image_ctx->cct;
   ldout(cct, 10) << dendl;
 

--- a/src/librbd/migration/SourceSpecBuilder.cc
+++ b/src/librbd/migration/SourceSpecBuilder.cc
@@ -9,6 +9,7 @@
 #include "librbd/migration/S3Stream.h"
 #include "librbd/migration/NativeFormat.h"
 #include "librbd/migration/RawFormat.h"
+#include "librbd/migration/RawSnapshot.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
@@ -65,6 +66,32 @@ int SourceSpecBuilder<I>::build_format(
                                           import_only));
   } else if (type == "raw") {
     format->reset(RawFormat<I>::create(m_image_ctx, source_spec_object, this));
+  } else {
+    lderr(cct) << "unknown or unsupported format type '" << type << "'"
+               << dendl;
+    return -ENOSYS;
+  }
+  return 0;
+}
+
+template <typename I>
+int SourceSpecBuilder<I>::build_snapshot(
+    const json_spirit::mObject& source_spec_object, uint64_t index,
+    std::shared_ptr<SnapshotInterface>* snapshot) const {
+  auto cct = m_image_ctx->cct;
+  ldout(cct, 10) << dendl;
+
+  auto type_value_it = source_spec_object.find(TYPE_KEY);
+  if (type_value_it == source_spec_object.end() ||
+      type_value_it->second.type() != json_spirit::str_type) {
+    lderr(cct) << "failed to locate snapshot type value" << dendl;
+    return -EINVAL;
+  }
+
+  auto& type = type_value_it->second.get_str();
+  if (type == "raw") {
+    snapshot->reset(RawSnapshot<I>::create(m_image_ctx, source_spec_object,
+                                           this, index));
   } else {
     lderr(cct) << "unknown or unsupported format type '" << type << "'"
                << dendl;

--- a/src/librbd/migration/SourceSpecBuilder.h
+++ b/src/librbd/migration/SourceSpecBuilder.h
@@ -34,7 +34,7 @@ public:
                    std::unique_ptr<FormatInterface>* format) const;
 
   int build_stream(const json_spirit::mObject& source_spec_object,
-                   std::unique_ptr<StreamInterface>* stream) const;
+                   std::shared_ptr<StreamInterface>* stream) const;
 
 private:
   ImageCtxT* m_image_ctx;

--- a/src/librbd/migration/SourceSpecBuilder.h
+++ b/src/librbd/migration/SourceSpecBuilder.h
@@ -19,6 +19,7 @@ struct ImageCtx;
 namespace migration {
 
 struct FormatInterface;
+struct SnapshotInterface;
 struct StreamInterface;
 
 template <typename ImageCtxT>
@@ -32,6 +33,10 @@ public:
 
   int build_format(const json_spirit::mObject& format_object, bool import_only,
                    std::unique_ptr<FormatInterface>* format) const;
+
+  int build_snapshot(const json_spirit::mObject& source_spec_object,
+                     uint64_t index,
+                     std::shared_ptr<SnapshotInterface>* snapshot) const;
 
   int build_stream(const json_spirit::mObject& source_spec_object,
                    std::shared_ptr<StreamInterface>* stream) const;

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -93,6 +93,7 @@ set(unittest_librbd_srcs
   migration/test_mock_HttpClient.cc
   migration/test_mock_HttpStream.cc
   migration/test_mock_RawFormat.cc
+  migration/test_mock_RawSnapshot.cc
   migration/test_mock_S3Stream.cc
   migration/test_mock_Utils.cc
   mirror/snapshot/test_mock_CreateNonPrimaryRequest.cc

--- a/src/test/librbd/migration/test_mock_RawFormat.cc
+++ b/src/test/librbd/migration/test_mock_RawFormat.cc
@@ -29,7 +29,7 @@ template<>
 struct SourceSpecBuilder<librbd::MockTestImageCtx> {
 
   MOCK_CONST_METHOD2(build_stream, int(const json_spirit::mObject&,
-                                       std::unique_ptr<StreamInterface>*));
+                                       std::shared_ptr<StreamInterface>*));
 
 };
 
@@ -69,7 +69,7 @@ public:
                            MockStreamInterface* mock_stream_interface, int r) {
     EXPECT_CALL(mock_source_spec_builder, build_stream(_, _))
       .WillOnce(WithArgs<1>(Invoke([mock_stream_interface, r]
-        (std::unique_ptr<StreamInterface>* ptr) {
+        (std::shared_ptr<StreamInterface>* ptr) {
           ptr->reset(mock_stream_interface);
           return r;
         })));

--- a/src/test/librbd/migration/test_mock_RawFormat.cc
+++ b/src/test/librbd/migration/test_mock_RawFormat.cc
@@ -146,8 +146,6 @@ TEST_F(TestMockMigrationRawFormat, OpenClose) {
                         mock_snapshot_interface, 0);
 
   expect_snapshot_open(*mock_snapshot_interface, 0);
-  SnapInfo snap_info{{}, {}, 123, {}, 0, 0, {}};
-  expect_snapshot_get_info(*mock_snapshot_interface, snap_info);
 
   expect_snapshot_close(*mock_snapshot_interface, 0);
 
@@ -230,8 +228,6 @@ TEST_F(TestMockMigrationRawFormat, GetSnapshots) {
                         mock_snapshot_interface, 0);
 
   expect_snapshot_open(*mock_snapshot_interface, 0);
-  SnapInfo snap_info{{}, {}, 123, {}, 0, 0, {}};
-  expect_snapshot_get_info(*mock_snapshot_interface, snap_info);
 
   expect_snapshot_close(*mock_snapshot_interface, 0);
 
@@ -264,9 +260,8 @@ TEST_F(TestMockMigrationRawFormat, GetImageSize) {
                         mock_snapshot_interface, 0);
 
   expect_snapshot_open(*mock_snapshot_interface, 0);
-  SnapInfo snap_info{{}, {}, 123, {}, 0, 0, {}};
-  expect_snapshot_get_info(*mock_snapshot_interface, snap_info);
 
+  SnapInfo snap_info{{}, {}, 123, {}, 0, 0, {}};
   expect_snapshot_get_info(*mock_snapshot_interface, snap_info);
 
   expect_snapshot_close(*mock_snapshot_interface, 0);
@@ -300,8 +295,6 @@ TEST_F(TestMockMigrationRawFormat, GetImageSizeSnapshotDNE) {
                         mock_snapshot_interface, 0);
 
   expect_snapshot_open(*mock_snapshot_interface, 0);
-  SnapInfo snap_info{{}, {}, 123, {}, 0, 0, {}};
-  expect_snapshot_get_info(*mock_snapshot_interface, snap_info);
 
   expect_snapshot_close(*mock_snapshot_interface, 0);
 
@@ -333,8 +326,6 @@ TEST_F(TestMockMigrationRawFormat, Read) {
                         mock_snapshot_interface, 0);
 
   expect_snapshot_open(*mock_snapshot_interface, 0);
-  SnapInfo snap_info{{}, {}, 123, {}, 0, 0, {}};
-  expect_snapshot_get_info(*mock_snapshot_interface, snap_info);
 
   bufferlist expect_bl;
   expect_bl.append(std::string(123, '1'));
@@ -375,9 +366,8 @@ TEST_F(TestMockMigrationRawFormat, ListSnaps) {
                         mock_snapshot_interface, 0);
 
   expect_snapshot_open(*mock_snapshot_interface, 0);
-  SnapInfo snap_info{{}, {}, 123, {}, 0, 0, {}};
-  expect_snapshot_get_info(*mock_snapshot_interface, snap_info);
 
+  SnapInfo snap_info{{}, {}, 123, {}, 0, 0, {}};
   expect_snapshot_get_info(*mock_snapshot_interface, snap_info);
   io::SparseExtents sparse_extents;
   sparse_extents.insert(0, 123, {io::SPARSE_EXTENT_STATE_DATA, 123});
@@ -420,9 +410,8 @@ TEST_F(TestMockMigrationRawFormat, ListSnapsError) {
 
 
   expect_snapshot_open(*mock_snapshot_interface, 0);
-  SnapInfo snap_info{{}, {}, 123, {}, 0, 0, {}};
-  expect_snapshot_get_info(*mock_snapshot_interface, snap_info);
 
+  SnapInfo snap_info{{}, {}, 123, {}, 0, 0, {}};
   expect_snapshot_get_info(*mock_snapshot_interface, snap_info);
   io::SparseExtents sparse_extents;
   sparse_extents.insert(0, 123, {io::SPARSE_EXTENT_STATE_DATA, 123});
@@ -473,8 +462,6 @@ TEST_F(TestMockMigrationRawFormat, ListSnapsMerge) {
   expect_snapshot_open(*mock_snapshot_interface_head, 0);
 
   SnapInfo snap_info_head{{}, {}, 256, {}, 0, 0, {}};
-  expect_snapshot_get_info(*mock_snapshot_interface_head, snap_info_head);
-
   SnapInfo snap_info_1{snap_info_head};
   snap_info_1.size = 123;
   expect_snapshot_get_info(*mock_snapshot_interface_1, snap_info_1);

--- a/src/test/librbd/migration/test_mock_RawSnapshot.cc
+++ b/src/test/librbd/migration/test_mock_RawSnapshot.cc
@@ -1,0 +1,255 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_mock_fixture.h"
+#include "test/librbd/test_support.h"
+#include "test/librbd/mock/migration/MockStreamInterface.h"
+#include "include/rbd_types.h"
+#include "common/ceph_mutex.h"
+#include "librbd/migration/FileStream.h"
+#include "librbd/migration/RawSnapshot.h"
+#include "librbd/migration/SourceSpecBuilder.h"
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "json_spirit/json_spirit.h"
+
+namespace librbd {
+namespace {
+
+struct MockTestImageCtx : public MockImageCtx {
+  MockTestImageCtx(ImageCtx &image_ctx) : MockImageCtx(image_ctx) {
+  }
+};
+
+} // anonymous namespace
+
+namespace migration {
+
+template<>
+struct SourceSpecBuilder<librbd::MockTestImageCtx> {
+
+  MOCK_CONST_METHOD2(build_stream, int(const json_spirit::mObject&,
+                                       std::shared_ptr<StreamInterface>*));
+
+};
+
+} // namespace migration
+} // namespace librbd
+
+#include "librbd/migration/RawSnapshot.cc"
+
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::Invoke;
+using ::testing::WithArgs;
+
+namespace librbd {
+namespace migration {
+
+using ::testing::Invoke;
+
+class TestMockMigrationRawSnapshot : public TestMockFixture {
+public:
+  typedef RawSnapshot<MockTestImageCtx> MockRawSnapshot;
+  typedef SourceSpecBuilder<MockTestImageCtx> MockSourceSpecBuilder;
+
+  librbd::ImageCtx *m_image_ctx;
+
+  void SetUp() override {
+    TestMockFixture::SetUp();
+
+    ASSERT_EQ(0, open_image(m_image_name, &m_image_ctx));
+
+    json_spirit::mObject stream_obj;
+    stream_obj["type"] = "file";
+    json_object["stream"] = stream_obj;
+  }
+
+  void expect_build_stream(MockSourceSpecBuilder& mock_source_spec_builder,
+                           MockStreamInterface* mock_stream_interface, int r) {
+    EXPECT_CALL(mock_source_spec_builder, build_stream(_, _))
+      .WillOnce(WithArgs<1>(Invoke([mock_stream_interface, r]
+        (std::shared_ptr<StreamInterface>* ptr) {
+          ptr->reset(mock_stream_interface);
+          return r;
+        })));
+  }
+
+  void expect_stream_open(MockStreamInterface& mock_stream_interface, int r) {
+    EXPECT_CALL(mock_stream_interface, open(_))
+      .WillOnce(Invoke([r](Context* ctx) { ctx->complete(r); }));
+  }
+
+  void expect_stream_close(MockStreamInterface& mock_stream_interface, int r) {
+    EXPECT_CALL(mock_stream_interface, close(_))
+      .WillOnce(Invoke([r](Context* ctx) { ctx->complete(r); }));
+  }
+
+  void expect_stream_get_size(MockStreamInterface& mock_stream_interface,
+                              uint64_t size, int r) {
+    EXPECT_CALL(mock_stream_interface, get_size(_, _))
+      .WillOnce(Invoke([size, r](uint64_t* out_size, Context* ctx) {
+          *out_size = size;
+          ctx->complete(r);
+        }));
+  }
+
+  void expect_stream_read(MockStreamInterface& mock_stream_interface,
+                          const io::Extents& byte_extents,
+                          const bufferlist& bl, int r) {
+    EXPECT_CALL(mock_stream_interface, read(byte_extents, _, _))
+      .WillOnce(WithArgs<1, 2>(Invoke([bl, r]
+        (bufferlist* out_bl, Context* ctx) {
+          *out_bl = bl;
+          ctx->complete(r);
+        })));
+  }
+
+  json_spirit::mObject json_object;
+};
+
+TEST_F(TestMockMigrationRawSnapshot, OpenClose) {
+  MockTestImageCtx mock_image_ctx(*m_image_ctx);
+
+  InSequence seq;
+  MockSourceSpecBuilder mock_source_spec_builder;
+
+  auto mock_stream_interface = new MockStreamInterface();
+  expect_build_stream(mock_source_spec_builder, mock_stream_interface, 0);
+
+  expect_stream_open(*mock_stream_interface, 0);
+  expect_stream_get_size(*mock_stream_interface, 123, 0);
+
+  expect_stream_close(*mock_stream_interface, 0);
+
+  json_object["name"] = "snap1";
+  MockRawSnapshot mock_raw_snapshot(&mock_image_ctx, json_object,
+                                    &mock_source_spec_builder, 1);
+
+  C_SaferCond ctx1;
+  mock_raw_snapshot.open(nullptr, &ctx1);
+  ASSERT_EQ(0, ctx1.wait());
+
+  auto snap_info = mock_raw_snapshot.get_snap_info();
+  ASSERT_EQ("snap1", snap_info.name);
+  ASSERT_EQ(123, snap_info.size);
+
+  C_SaferCond ctx2;
+  mock_raw_snapshot.close(&ctx2);
+  ASSERT_EQ(0, ctx2.wait());
+}
+
+TEST_F(TestMockMigrationRawSnapshot, OpenError) {
+  MockTestImageCtx mock_image_ctx(*m_image_ctx);
+
+  InSequence seq;
+  MockSourceSpecBuilder mock_source_spec_builder;
+
+  auto mock_stream_interface = new MockStreamInterface();
+  expect_build_stream(mock_source_spec_builder, mock_stream_interface, 0);
+
+  expect_stream_open(*mock_stream_interface, -ENOENT);
+
+  MockRawSnapshot mock_raw_snapshot(&mock_image_ctx, json_object,
+                                    &mock_source_spec_builder, 0);
+
+  C_SaferCond ctx;
+  mock_raw_snapshot.open(nullptr, &ctx);
+  ASSERT_EQ(-ENOENT, ctx.wait());
+}
+
+TEST_F(TestMockMigrationRawSnapshot, GetSizeError) {
+  MockTestImageCtx mock_image_ctx(*m_image_ctx);
+
+  InSequence seq;
+  MockSourceSpecBuilder mock_source_spec_builder;
+
+  auto mock_stream_interface = new MockStreamInterface();
+  expect_build_stream(mock_source_spec_builder, mock_stream_interface, 0);
+
+  expect_stream_open(*mock_stream_interface, 0);
+  expect_stream_get_size(*mock_stream_interface, 0, -EINVAL);
+
+  expect_stream_close(*mock_stream_interface, 0);
+
+  MockRawSnapshot mock_raw_snapshot(&mock_image_ctx, json_object,
+                                    &mock_source_spec_builder, 0);
+
+  C_SaferCond ctx;
+  mock_raw_snapshot.open(nullptr, &ctx);
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockMigrationRawSnapshot, Read) {
+  MockTestImageCtx mock_image_ctx(*m_image_ctx);
+
+  InSequence seq;
+  MockSourceSpecBuilder mock_source_spec_builder;
+
+  auto mock_stream_interface = new MockStreamInterface();
+  expect_build_stream(mock_source_spec_builder, mock_stream_interface, 0);
+
+  expect_stream_open(*mock_stream_interface, 0);
+  expect_stream_get_size(*mock_stream_interface, 0, 0);
+
+  bufferlist expect_bl;
+  expect_bl.append(std::string(123, '1'));
+  expect_stream_read(*mock_stream_interface, {{123, 123}}, expect_bl, 0);
+
+  expect_stream_close(*mock_stream_interface, 0);
+
+  MockRawSnapshot mock_raw_snapshot(&mock_image_ctx, json_object,
+                                    &mock_source_spec_builder, 0);
+
+  C_SaferCond ctx1;
+  mock_raw_snapshot.open(nullptr, &ctx1);
+  ASSERT_EQ(0, ctx1.wait());
+
+  C_SaferCond ctx2;
+  auto aio_comp = io::AioCompletion::create_and_start(
+    &ctx2, m_image_ctx, io::AIO_TYPE_READ);
+  bufferlist bl;
+  io::ReadResult read_result{&bl};
+  mock_raw_snapshot.read(aio_comp, {{123, 123}}, std::move(read_result), 0, 0,
+                         {});
+  ASSERT_EQ(123, ctx2.wait());
+  ASSERT_EQ(expect_bl, bl);
+
+  C_SaferCond ctx3;
+  mock_raw_snapshot.close(&ctx3);
+  ASSERT_EQ(0, ctx3.wait());
+}
+
+TEST_F(TestMockMigrationRawSnapshot, ListSnap) {
+  MockTestImageCtx mock_image_ctx(*m_image_ctx);
+
+  InSequence seq;
+  MockSourceSpecBuilder mock_source_spec_builder;
+
+  auto mock_stream_interface = new MockStreamInterface();
+  expect_build_stream(mock_source_spec_builder, mock_stream_interface, 0);
+
+  expect_stream_open(*mock_stream_interface, 0);
+  expect_stream_get_size(*mock_stream_interface, 0, 0);
+
+  expect_stream_close(*mock_stream_interface, 0);
+
+  MockRawSnapshot mock_raw_snapshot(&mock_image_ctx, json_object,
+                                    &mock_source_spec_builder, 0);
+
+  C_SaferCond ctx1;
+  mock_raw_snapshot.open(nullptr, &ctx1);
+  ASSERT_EQ(0, ctx1.wait());
+
+  C_SaferCond ctx2;
+  io::SparseExtents sparse_extents;
+  mock_raw_snapshot.list_snap({{0, 123}}, 0, &sparse_extents, {}, &ctx2);
+  ASSERT_EQ(0, ctx2.wait());
+
+  C_SaferCond ctx3;
+  mock_raw_snapshot.close(&ctx3);
+  ASSERT_EQ(0, ctx3.wait());
+}
+
+} // namespace migration
+} // namespace librbd

--- a/src/test/librbd/mock/migration/MockSnapshotInterface.h
+++ b/src/test/librbd/mock/migration/MockSnapshotInterface.h
@@ -1,0 +1,44 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_TEST_LIBRBD_MOCK_MIGRATION_MOCK_SNAPSHOT_INTERFACE_H
+#define CEPH_TEST_LIBRBD_MOCK_MIGRATION_MOCK_SNAPSHOT_INTERFACE_H
+
+#include "include/buffer.h"
+#include "gmock/gmock.h"
+#include "librbd/io/AioCompletion.h"
+#include "librbd/io/ReadResult.h"
+#include "librbd/io/Types.h"
+#include "librbd/migration/SnapshotInterface.h"
+
+namespace librbd {
+namespace migration {
+
+struct MockSnapshotInterface : public SnapshotInterface {
+  MOCK_METHOD2(open, void(SnapshotInterface*, Context*));
+  MOCK_METHOD1(close, void(Context*));
+
+  MOCK_CONST_METHOD0(get_snap_info, const SnapInfo&());
+
+  MOCK_METHOD3(read, void(io::AioCompletion*, const io::Extents&,
+                          io::ReadResult&));
+  void read(io::AioCompletion* aio_comp, io::Extents&& image_extents,
+            io::ReadResult&& read_result, int op_flags, int read_flags,
+            const ZTracer::Trace &parent_trace) override {
+    read(aio_comp, image_extents, read_result);
+  }
+
+  MOCK_METHOD3(list_snap, void(const io::Extents&, io::SparseExtents*,
+                               Context*));
+  void list_snap(io::Extents&& image_extents, int list_snaps_flags,
+                 io::SparseExtents* sparse_extents,
+                 const ZTracer::Trace &parent_trace,
+                 Context* on_finish) override {
+    list_snap(image_extents, sparse_extents, on_finish);
+  }
+};
+
+} // namespace migration
+} // namespace librbd
+
+#endif // CEPH_TEST_LIBRBD_MOCK_MIGRATION_MOCK_SNAPSHOT_INTERFACE_H


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
