### PR TITLE
cmake: fix unknown pkg_search_module

### DIFF
--- a/cmake/modules/Findlibcryptsetup.cmake
+++ b/cmake/modules/Findlibcryptsetup.cmake
@@ -6,6 +6,7 @@
 # LIBCRYPTSETUP_VERSION
 # LIBCRYPTSETUP_FOUND
 
+find_package(PkgConfig QUIET REQUIRED)
 pkg_search_module(PC_libcryptsetup libcryptsetup)
 
 find_path(LIBCRYPTSETUP_INCLUDE_DIR


### PR DESCRIPTION
Need to include PkgConfig, or else the following build command fails.
```
 ./do_cmake.sh -j2 -DWITH_CCACHE=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DWITH_MGR_DASHBOARD_FRONTEND=OFF -DWITH_SEASTAR=OFF -DWITH_RBD_RWL=ON  -DWITH_CEPHFS=OFF -DWITH_KRBD=OFF -DWITH_MANPAGE=OFF -DWITH_FUSE=OFF -DWITH_XFS=OFF -DWITH_FILESTORE=OFF -DWITH_LIBCEPHFS=OFF -DWITH_LTTNG=OFF -DWITH_BABELTRACE=OFF
```

Signed-off-by: Li, Xiaoyan <xiaoyan.li@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
