### PR TITLE
nautilus: mgr/insights: Test environment requires 'six'

### DIFF
--- a/src/pybind/mgr/insights/tox.ini
+++ b/src/pybind/mgr/insights/tox.ini
@@ -8,6 +8,7 @@ minversion = 2.8.1
 deps =
     pytest
     mock
+    six>=1.14.0
 setenv=
     UNITTEST = true
     py27: PYTHONPATH = {env:CEPH_LIB}/cython_modules/lib.2


### PR DESCRIPTION
This is causing nautilus 'make check' builds to fail in Jenkins with "E   ModuleNotFoundError: No module named 'six'" when running 'build/insights/py3/bin/py.test tests/'

Example: https://jenkins.ceph.com/job/ceph-pull-requests/64761/consoleFull#1181206387c19247c4-fcb7-4c61-9a5d-7e2b9731c678

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
