### PR TITLE
Revert "rbd: add missing FileStream::get_size"

### DIFF
--- a/src/librbd/migration/FileStream.cc
+++ b/src/librbd/migration/FileStream.cc
@@ -223,11 +223,6 @@ void FileStream<I>::read(io::Extents&& byte_extents, bufferlist* data,
   on_finish->complete(-EIO);
 }
 
-template <typename I>
-void FileStream<I>::get_size(uint64_t* size, Context* on_finish) {
-  on_finish->complete(-EIO);
-}
-
 #endif // BOOST_ASIO_HAS_POSIX_STREAM_DESCRIPTOR
 
 } // namespace migration


### PR DESCRIPTION
Revert "rbd: add missing FileStream::get_size"

This function was missing initially and was added by two separate
commits [1][2]. We have to remove one of the two definitions.

This reverts commit c17c53f460254c29e961227e19484c527fd08fc7.

[1] c17c53f460254c29e961227e19484c527fd08fc7
[2] 074dd33c4f0112839a7c51ab97c805ee288d84c1

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>