### PR TITLE
librbd: fix regression in object map diff request

### DIFF
--- a/src/librbd/deep_copy/ImageCopyRequest.cc
+++ b/src/librbd/deep_copy/ImageCopyRequest.cc
@@ -90,6 +90,11 @@ void ImageCopyRequest<I>::map_src_objects(uint64_t dst_object,
 
 template <typename I>
 void ImageCopyRequest<I>::compute_diff() {
+  if (m_flatten) {
+    send_object_copies();
+    return;
+  }
+
   ldout(m_cct, 10) << dendl;
 
   auto ctx = create_context_callback<

--- a/src/librbd/deep_copy/ImageCopyRequest.cc
+++ b/src/librbd/deep_copy/ImageCopyRequest.cc
@@ -65,6 +65,30 @@ void ImageCopyRequest<I>::cancel() {
 }
 
 template <typename I>
+void ImageCopyRequest<I>::map_src_objects(uint64_t dst_object,
+                                          std::set<uint64_t> *src_objects) {
+  std::vector<std::pair<uint64_t, uint64_t>> image_extents;
+  Striper::extent_to_file(m_cct, &m_dst_image_ctx->layout, dst_object, 0,
+                          m_dst_image_ctx->layout.object_size, image_extents);
+
+  for (auto &e : image_extents) {
+    std::map<object_t, std::vector<ObjectExtent>> src_object_extents;
+    Striper::file_to_extents(m_cct, m_src_image_ctx->format_string,
+                             &m_src_image_ctx->layout, e.first, e.second, 0,
+                             src_object_extents);
+    for (auto &p : src_object_extents) {
+      for (auto &s : p.second) {
+        src_objects->insert(s.objectno);
+      }
+    }
+  }
+
+  ceph_assert(!src_objects->empty());
+
+  ldout(m_cct, 20) << dst_object << " -> " << *src_objects << dendl;
+}
+
+template <typename I>
 void ImageCopyRequest<I>::compute_diff() {
   ldout(m_cct, 10) << dendl;
 
@@ -147,10 +171,24 @@ int ImageCopyRequest<I>::send_next_object_copy() {
   }
 
   uint64_t ono = m_object_no++;
-  if (ono < m_object_diff_state.size() &&
-      m_object_diff_state[ono] == object_map::DIFF_STATE_NONE) {
-    ldout(m_cct, 20) << "skipping clean object " << ono << dendl;
-    return 1;
+
+  if (m_object_diff_state.size() > 0) {
+    std::set<uint64_t> src_objects;
+    map_src_objects(ono, &src_objects);
+
+    bool skip = true;
+    for (auto src_ono : src_objects) {
+      if (src_ono >= m_object_diff_state.size() ||
+          m_object_diff_state[src_ono] != object_map::DIFF_STATE_NONE) {
+        skip = false;
+        break;
+      }
+    }
+
+    if (skip) {
+      ldout(m_cct, 20) << "skipping clean object " << ono << dendl;
+      return 1;
+    }
   }
 
   ldout(m_cct, 20) << "object_num=" << ono << dendl;

--- a/src/librbd/deep_copy/ImageCopyRequest.h
+++ b/src/librbd/deep_copy/ImageCopyRequest.h
@@ -14,6 +14,7 @@
 #include <functional>
 #include <map>
 #include <queue>
+#include <set>
 #include <vector>
 #include <boost/optional.hpp>
 
@@ -101,6 +102,8 @@ private:
   int m_ret_val = 0;
 
   BitVector<2> m_object_diff_state;
+
+  void map_src_objects(uint64_t dst_object, std::set<uint64_t> *src_objects);
 
   void compute_diff();
   void handle_compute_diff(int r);

--- a/src/librbd/object_map/DiffRequest.cc
+++ b/src/librbd/object_map/DiffRequest.cc
@@ -62,7 +62,7 @@ void DiffRequest<I>::load_object_map(
     }
   }
 
-  if ((m_image_ctx->features & RBD_FEATURE_FAST_DIFF) != 0) {
+  if ((m_image_ctx->features & RBD_FEATURE_FAST_DIFF) == 0) {
     image_locker->unlock();
 
     ldout(cct, 10) << "fast-diff feature not enabled" << dendl;


### PR DESCRIPTION
(when testing for fast-diff feature enabled)

Fix: https://tracker.ceph.com/issues/48412
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
