### PR TITLE
rgw: Add IOC hook for IOC Cache

### DIFF
--- a/qa/suites/rgw/verify/0-install.yaml
+++ b/qa/suites/rgw/verify/0-install.yaml
@@ -4,6 +4,9 @@ tasks:
       extra_system_packages:
         deb: ['s3cmd']
         rpm: ['s3cmd']
+      extra_packages:
+        deb: ['ceph-immutable-object-cache']
+        rpm: ['ceph-immutable-object-cache']
 - ceph:
 - openssl_keys:
 - rgw:

--- a/qa/suites/rgw/verify/datacache/rgw-ioc-datacache.yaml
+++ b/qa/suites/rgw/verify/datacache/rgw-ioc-datacache.yaml
@@ -1,0 +1,24 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rgw d3n l1 local datacache enabled: true
+        rgw d3n l1 local datacache backend: ioc
+        rgw enable ops log: true
+        immutable object cache path: /tmp/rgw_datacache/
+        immutable object cache_max size: 10737418240
+        debug immutable_obj_cache: 20/20
+  rgw:
+    datacache: true
+    datacache_path: /tmp/rgw_datacache
+tasks:
+- immutable_object_cache:
+    client.0:
+      immutable object cache path: /tmp/rgw_datacache/
+- workunit:
+    clients:
+      client.0:
+      - rgw/run-datacache.sh
+    env:
+      RGW_DATACACHE_PATH: /tmp/rgw_datacache
+      RGW_DATACACHE_BACKEND: ioc

--- a/qa/tasks/immutable_object_cache.py
+++ b/qa/tasks/immutable_object_cache.py
@@ -18,6 +18,9 @@ def immutable_object_cache(ctx, config):
     log.info("start immutable object cache daemon")
     for client, client_config in config.items():
         (remote,) = ctx.cluster.only(client).remotes.keys()
+        cluster_name, daemon_type, client_id = teuthology.split_role(client)
+        client_with_id = daemon_type + '.' + client_id
+        client_with_cluster = cluster_name + '.' + client_with_id
         # make sure that there is one immutable object cache daemon on the same node.
         remote.run(
             args=[
@@ -26,7 +29,9 @@ def immutable_object_cache(ctx, config):
             )
         remote.run(
             args=[
-                'ceph-immutable-object-cache', '-b',
+                'sudo', 'ceph-immutable-object-cache', '-b',
+                '--cluster', cluster_name,
+                '--log-file', '/var/log/ceph/immutable-object-cache.{client_with_cluster}.log'.format(client_with_cluster=client_with_cluster)
                 ]
             )
     try:

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3451,6 +3451,19 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgw_d3n_l1_local_datacache_backend
+  type: str
+  level: advanced
+  desc: implementation of D3N local datacache
+  long_desc: The configuration of d3n is in D3N l1 local datacache.
+    The configuration of ioc_cache is in immutable_object_cache
+  default: d3n
+  services:
+  - rgw
+  enum_values:
+  - d3n
+  - ioc
+  with_legacy: true
 - name: rgw_d3n_l1_datacache_persistent_path
   type: str
   level: advanced

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -171,6 +171,7 @@ set(librgw_common_srcs
   rgw_lua_utils.cc
   rgw_lua.cc
   rgw_lua_data_filter.cc
+  rgw_ioc_dispatch.cc
   rgw_bucket_encryption.cc
   rgw_tracer.cc
   rgw_lua_background.cc)
@@ -219,6 +220,7 @@ endif()
 target_link_libraries(rgw_common
   PRIVATE
     global
+    ceph_immutable_object_cache_lib
     cls_2pc_queue_client
     cls_cmpomap_client
     cls_lock_client

--- a/src/rgw/rgw_aio.h
+++ b/src/rgw/rgw_aio.h
@@ -99,6 +99,8 @@ class Aio {
                             optional_yield y);
   static OpFunc d3n_cache_op(const DoutPrefixProvider *dpp, optional_yield y,
                              off_t read_ofs, off_t read_len, std::string& location);
+  static OpFunc ioc_cache_op(const DoutPrefixProvider *dpp, librados::ObjectReadOperation&& op, optional_yield y,
+                             off_t read_ofs, off_t read_len, void* arg);
 };
 
 } // namespace rgw

--- a/src/rgw/rgw_d3n_cacherequest.h
+++ b/src/rgw/rgw_d3n_cacherequest.h
@@ -132,7 +132,7 @@ struct D3nL1CacheRequest {
   };
 
   void file_aio_read_abstract(const DoutPrefixProvider *dpp, boost::asio::io_context& context, yield_context yield,
-                              std::string& file_path, off_t read_ofs, off_t read_len,
+                              const std::string& file_path, off_t read_ofs, off_t read_len,
                               rgw::Aio* aio, rgw::AioResult& r) {
     using namespace boost::asio;
     async_completion<yield_context, void()> init(yield);
@@ -140,7 +140,7 @@ struct D3nL1CacheRequest {
 
     auto& ref = r.obj.get_ref();
     ldpp_dout(dpp, 20) << "D3nDataCache: " << __func__ << "(): oid=" << ref.obj.oid << dendl;
-    async_read(dpp, context, file_path+"/"+ref.obj.oid, read_ofs, read_len, bind_executor(ex, d3n_libaio_handler{aio, r}));
+    async_read(dpp, context, file_path, read_ofs, read_len, bind_executor(ex, d3n_libaio_handler{aio, r}));
   }
 
 };

--- a/src/rgw/rgw_ioc_dispatch.cc
+++ b/src/rgw/rgw_ioc_dispatch.cc
@@ -1,0 +1,149 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#include "rgw_ioc_dispatch.h"
+#include "rgw_common.h"
+#include "rgw_aio.h"
+#include "rgw_d3n_cacherequest.h"
+
+#include "common/async/completion.h"
+#include "common/async/yield_context.h"
+#include "common/ceph_mutex.h"
+
+#include <aio.h>
+#include <errno.h>
+#include "common/error_code.h"
+#include "common/errno.h"
+
+using namespace ceph::immutable_obj_cache;
+
+#define dout_subsys ceph_subsys_rgw
+#define dout_context g_ceph_context
+
+void IOChook::init(CephContext* _cct, Context* on_finish) {
+  m_cct = _cct;
+  ceph_assert(m_cct != nullptr);
+  std::unique_lock locker{m_lock};
+  if(m_cache_client == nullptr) {
+    auto controller_path = m_cct->_conf.template get_val<std::string>(
+      "immutable_object_cache_sock");
+    m_cache_client = new CacheClient(controller_path.c_str(), m_cct);
+  }
+  create_cache_session(on_finish, false);
+}
+
+void IOChook::create_cache_session(Context *on_finish, bool is_reconnect) {
+  ceph_assert(ceph_mutex_is_locked_by_me(m_lock));
+  if(m_connecting) {
+    return;
+  }
+
+  m_connecting = true;
+
+  Context* register_ctx = new LambdaContext([this, on_finish](int ret) {
+    if(ret < 0) {
+      ldout(m_cct, 1) << "rgw_hook: IOC hook fail to register client." << dendl;
+    }
+    handle_register_client(ret < 0 ? false : true);
+
+    ceph_assert(m_connecting);
+    m_connecting = false;
+
+    if(on_finish != nullptr) {
+      on_finish->complete(0);
+    }
+  });
+
+  Context* connect_ctx = new LambdaContext([this, register_ctx](int ret) {
+    if(ret < 0) {
+      ldout(m_cct, 1)  << "rgw_hook: IOC hook fail to connect to IOC daemon" << dendl;
+      register_ctx->complete(0);
+      return;
+    }
+
+    ldout(m_cct, 20) << "rgw_hook: IOC hook connected to IOC daemon." << dendl;
+
+    m_cache_client->register_client(register_ctx);
+  });
+
+  if(m_cache_client != nullptr && is_reconnect) {
+    delete m_cache_client;
+    auto controller_path = m_cct->_conf.template get_val<std::string>(
+                                        "immutable_object_cache_sock");
+    m_cache_client = new CacheClient(controller_path.c_str(), m_cct);
+  }
+
+  ceph_assert(m_cache_client != nullptr);
+
+  m_cache_client->run();
+  m_cache_client->connect(connect_ctx);
+}
+
+int IOChook::handle_register_client(bool reg) {
+  ldout(m_cct, 20) << "rgw_hook: registering client" << dendl;
+
+  if(!reg) {
+    ldout(m_cct, 1) << "rgw_hook: IOC hook register fails." << dendl;
+  }
+  return 0;
+}
+
+void IOChook::read(const DoutPrefixProvider *dpp, std::string oid, std::string pool_ns, int64_t pool_id,
+                   off_t read_ofs, off_t read_len, optional_yield y,
+                   rgw::Aio::OpFunc&& radosread, rgw::Aio* aio, rgw::AioResult& r
+                  ) {
+
+  /* if IOC daemon still don't startup, or IOC daemon crash,
+     or session occur any error, try to re-connect daemon. */
+  std::unique_lock locker{m_lock};
+  if(!m_cache_client->is_session_work()) {
+    // go to read from rados first
+    ldout(m_cct, 5) << "rgw_hook: session didn't work, go to rados" << oid << dendl;
+    std::move(radosread)(aio,r);
+    // then try to conect to IOC daemon.
+    ldout(m_cct, 5) << "rgw_hook: IOC hook try to re-connect to IOC daemon." << dendl;
+    create_cache_session(nullptr, true);
+    return;
+  }
+
+  CacheGenContextURef gen_ctx = make_gen_lambda_context<ObjectCacheRequest*,
+                                            std::function<void(ObjectCacheRequest*)>>
+            ([this, dpp, oid, read_ofs, read_len, y, radosread=std::move(radosread), aio, &r](ObjectCacheRequest* ack) mutable {
+    handle_read_cache(dpp, ack, oid, read_ofs, read_len, y, std::move(radosread), aio, r);
+  });
+
+  ceph_assert(m_cache_client != nullptr);
+  m_cache_client->lookup_object(pool_ns,
+                                pool_id,
+                                CEPH_NOSNAP,
+                                read_len,
+                                oid,
+                                std::move(gen_ctx));
+
+  return;
+}
+
+void IOChook::handle_read_cache(const DoutPrefixProvider *dpp, ObjectCacheRequest* ack, std::string oid,
+                                off_t read_ofs, off_t read_len, optional_yield y,
+                                rgw::Aio::OpFunc&& radosread, rgw::Aio* aio, rgw::AioResult& r
+                                ) {
+  if(ack->type != RBDSC_READ_REPLY) {
+    // go back to read rados
+    ldout(m_cct, 5) << "rgw_hook: object is not in IOC cache, go to rados " << oid << dendl;
+    std::move(radosread)(aio,r);
+    return;
+  }
+
+  ceph_assert(ack->type == RBDSC_READ_REPLY);
+  std::string file_path = ((ObjectCacheReadReplyData*)ack)->cache_path;
+  if(file_path.empty()) {
+    ldout(m_cct, 5) << "rgw_hook: file path is empty, go to rados" << oid << dendl;
+    std::move(radosread)(aio,r);
+    return;
+  }
+
+  auto c = std::make_unique<D3nL1CacheRequest>();
+  c->file_aio_read_abstract(dpp, y.get_io_context(), y.get_yield_context(), file_path, read_ofs, read_len, aio, r);
+
+  return;
+}

--- a/src/rgw/rgw_ioc_dispatch.h
+++ b/src/rgw/rgw_ioc_dispatch.h
@@ -1,0 +1,142 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#ifndef CEPH_RGW_IOC_DISPATCH_H
+#define CEPH_RGW_IOC_DISPATCH_H
+
+#include "tools/immutable_object_cache/CacheClient.h"
+#include "tools/immutable_object_cache/Types.h"
+#include "tools/immutable_object_cache/SocketCommon.h"
+
+#include "rgw_rados.h"
+#include "rgw_aio.h"
+
+class IOChook {
+
+public:
+  IOChook()
+    : m_lock(ceph::make_mutex("rgw::cache::IOChook:session", true, false)),
+    m_cache_client(nullptr),
+    m_connecting(false) {}
+
+  ~IOChook() {
+    if(m_cache_client != nullptr) {
+      delete m_cache_client;
+      m_cache_client = nullptr;
+    }
+  }
+
+  void init(CephContext* _cct, Context* on_finish = nullptr);
+
+  void create_cache_session(Context *on_finish, bool is_reconnect);
+
+  int handle_register_client(bool reg);
+
+  void read(const DoutPrefixProvider *dpp, std::string oid, std::string pool_ns, int64_t pool_id,
+            off_t read_ofs, off_t read_len, optional_yield y,
+            rgw::Aio::OpFunc&& radosread, rgw::Aio* aio, rgw::AioResult& r
+           );
+
+  void handle_read_cache(const DoutPrefixProvider *dpp, ceph::immutable_obj_cache::ObjectCacheRequest* ack,
+                         std::string oid, off_t read_ofs, off_t read_len, optional_yield y,
+                         rgw::Aio::OpFunc&& radosread, rgw::Aio* aio, rgw::AioResult& r
+                        );
+
+public:
+  ceph::immutable_obj_cache::CacheClient* get_cache_client() { return m_cache_client;}
+
+private:
+  CephContext *m_cct;
+
+  ceph::mutex m_lock;
+
+  ceph::immutable_obj_cache::CacheClient* m_cache_client = nullptr;
+  bool m_connecting = false;
+};
+
+
+template <class T>
+class IOCRGWDataCache : public T
+{
+  IOChook ioc_hook;
+public:
+  IOCRGWDataCache(): T() {}
+
+  int init_rados() override {
+    int ret;
+    ret = T::init_rados();
+    if (ret < 0)
+      return ret;
+    ioc_hook.init(T::cct);
+    lsubdout(g_ceph_context, rgw, 4) << "rgw hook init" << dendl;
+    return 0;
+  }
+
+  int get_obj_iterate_cb(const DoutPrefixProvider *dpp,
+                         const rgw_raw_obj& read_obj, off_t obj_ofs,
+                         off_t read_ofs, off_t len, bool is_head_obj,
+                         RGWObjState *astate, void *arg) override;
+};
+
+
+template<class T>
+int IOCRGWDataCache<T>::get_obj_iterate_cb(const DoutPrefixProvider *dpp,
+                                 const rgw_raw_obj& read_obj, off_t obj_ofs,
+                                 off_t read_ofs, off_t len, bool is_head_obj,
+                                 RGWObjState *astate, void *arg) {
+  librados::ObjectReadOperation op;
+  struct get_obj_data* d = static_cast<struct get_obj_data*>(arg);
+  std::string oid, key;
+
+  int r = 0;
+
+  if (is_head_obj) {
+    // only when reading from the head object do we need to do the atomic test
+    r = T::append_atomic_test(dpp, astate, op);
+    if (r < 0)
+      return r;
+
+    if (astate && obj_ofs < astate->data.length()) {
+      unsigned chunk_len = std::min((uint64_t)astate->data.length() - obj_ofs, (uint64_t)len);
+
+      r = d->client_cb->handle_data(astate->data, obj_ofs, chunk_len);
+      if (r < 0)
+        return r;
+
+      len -= chunk_len;
+      d->offset += chunk_len;
+      read_ofs += chunk_len;
+      obj_ofs += chunk_len;
+      if (!len)
+        return 0;
+    }
+  }
+
+  auto obj = d->rgwrados->svc.rados->obj(read_obj);
+  r = obj.open(dpp);
+  if (r < 0) {
+    ldpp_dout(dpp, 4) << "failed to open rados context for " << read_obj << dendl;
+    return r;
+  }
+
+  ldpp_dout(dpp, 20) << "rados->get_obj_iterate_cb oid=" << read_obj.oid
+                     << " obj-ofs=" << obj_ofs
+                     << " read_ofs=" << read_ofs
+                     << " len=" << len
+                     << dendl;
+
+  op.read(read_ofs, len, nullptr, nullptr);
+
+  const uint64_t cost = len;
+  const uint64_t id = obj_ofs; // use logical object offset for sorting replies
+
+  if (is_head_obj) {
+    auto completed = d->aio->get(obj, rgw::Aio::librados_op(std::move(op), d->yield), cost, id);
+    return d->flush(std::move(completed));
+  } else {
+    auto completed = d->aio->get(obj, rgw::Aio::ioc_cache_op(dpp, std::move(op), d->yield, read_ofs, len, &ioc_hook), cost, id);
+    return d->flush(std::move(completed));
+  }
+}
+
+#endif

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -408,7 +408,7 @@ class RGWRados
   int append_atomic_test(const DoutPrefixProvider *dpp, RGWBucketInfo& bucket_info, rgw::sal::Object* obj,
                          librados::ObjectOperation& op, RGWObjState **state,
 			 RGWObjManifest** pmanifest, optional_yield y);
-  
+
   int update_placement_map();
   int store_bucket_info(RGWBucketInfo& info, std::map<std::string, bufferlist> *pattrs, RGWObjVersionTracker *objv_tracker, bool exclusive);
 


### PR DESCRIPTION
Use immutable object cache as the local data cache of RGW.
And it can also act as D3N l1 local datacache.

Signed-off-by: Feng Hualong <hualong.feng@intel.com>


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
