### PR TITLE
test/lazy-omap-stats: Fix compilation on alpine linux

### DIFF
--- a/src/test/lazy-omap-stats/lazy_omap_stats_test.h
+++ b/src/test/lazy-omap-stats/lazy_omap_stats_test.h
@@ -22,8 +22,8 @@
 #include "include/rados/librados.hpp"
 
 struct index_t {
-  uint byte_index = 0;
-  uint key_index = 0;
+  unsigned byte_index = 0;
+  unsigned key_index = 0;
 };
 
 class LazyOmapStatsTest
@@ -33,13 +33,13 @@ class LazyOmapStatsTest
   std::map<std::string, librados::bufferlist> payload;
 
   struct lazy_omap_test_t {
-    uint payload_size = 0;
-    uint replica_count = 3;
-    uint keys = 2000;
-    uint how_many = 50;
+    unsigned payload_size = 0;
+    unsigned replica_count = 3;
+    unsigned keys = 2000;
+    unsigned how_many = 50;
     std::string pool_name = "lazy_omap_test_pool";
-    uint total_bytes = 0;
-    uint total_keys = 0;
+    unsigned total_bytes = 0;
+    unsigned total_keys = 0;
   } conf;
 
   LazyOmapStatsTest(LazyOmapStatsTest&) = delete;
@@ -49,13 +49,13 @@ class LazyOmapStatsTest
   void write_omap(const std::string& object_name);
   const std::string get_name() const;
   void create_payload();
-  void write_many(const uint how_many);
+  void write_many(const unsigned how_many);
   void scrub() const;
   const int find_matches(std::string& output, std::regex& reg) const;
   void check_one();
   const int find_index(std::string& haystack, std::regex& needle,
                        std::string label) const;
-  const uint tally_column(const uint omap_bytes_index,
+  const unsigned tally_column(const unsigned omap_bytes_index,
                           const std::string& table, bool header) const;
   void check_column(const int index, const std::string& table,
                     const std::string& type, bool header = true) const;


### PR DESCRIPTION
alpine lacks uint typedef but has unsigned

This changes uint to unsigned in this file

Fixes: https://tracker.ceph.com/issues/48432

Signed-off-by: Duncan Bellamy <a16bitsysop@icloud.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]
test/lazy-omap-stats: lazy_omap_stats_test.h uses uint which alpine linux lacks
[A longer multiline description]
This changes uint to unsigned in this file

Fixes: https://tracker.ceph.com/issues/48432

Signed-off-by: Duncan Bellamy <a16bitsysop@icloud.com>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
