### PR TITLE
doc/governance.rst - updating CLT list

### DIFF
--- a/doc/governance.rst
+++ b/doc/governance.rst
@@ -53,15 +53,14 @@ the CLT itself.
 Current CLT members are:
 
  * Abhishek Lekshmanan <abhishek@suse.com>
- * Alfredo Deza <adeza@redhat.com>
  * Casey Bodley <cbodley@redhat.com>
+ * Ernesto Puerta <epuerta@redhat.com>
  * Gregory Farnum <gfarnum@redhat.com>
  * Haomai Wang <haomai@xsky.com>
  * Jason Dillaman <dillaman@redhat.com>
  * Josh Durgin <jdurgin@redhat.com>
  * João Eduardo Luis <joao@suse.de>
  * Ken Dreyer <kdreyer@redhat.com>
- * Lenz Grimmer <lgrimmer@suse.com>
  * Matt Benjamin <mbenjami@redhat.com>
  * Myoungwon Oh <omwmw@sk.com>
  * Neha Ojha <nojha@redhat.com>
@@ -70,7 +69,6 @@ Current CLT members are:
  * Sebastian Wagner <swagner@suse.com>
  * Xie Xingguo <xie.xingguo@zte.com.cn>
  * Yehuda Sadeh <yehuda@redhat.com>
- * Zack Cerza <zcerza@redhat.com>
 
 Component Leads
 ---------------


### PR DESCRIPTION
This PR removes the following people from the
CLT. They've left the CLT:
* Lenz Grimmer
* Alfredo Deza
* Zack Cerza

This commit also adds:
* Ernesto Puerta

Fixes: https://tracker.ceph.com/issues/48436
Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
