### PR TITLE
octopus: mgr/dashboard: Disable sso without python3-saml

### DIFF
--- a/src/pybind/mgr/dashboard/services/sso.py
+++ b/src/pybind/mgr/dashboard/services/sso.py
@@ -150,6 +150,11 @@ def handle_sso_command(cmd):
                              'dashboard sso setup saml2']:
         return -errno.ENOSYS, '', ''
 
+    if cmd['prefix'] == 'dashboard sso disable':
+        mgr.SSO_DB.protocol = ''
+        mgr.SSO_DB.save()
+        return 0, 'SSO is "disabled".', ''
+
     if not python_saml_imported:
         return -errno.EPERM, '', 'Required library not found: `python3-saml`'
 
@@ -162,11 +167,6 @@ def handle_sso_command(cmd):
         mgr.SSO_DB.protocol = 'saml2'
         mgr.SSO_DB.save()
         return 0, 'SSO is "enabled" with "SAML2" protocol.', ''
-
-    if cmd['prefix'] == 'dashboard sso disable':
-        mgr.SSO_DB.protocol = ''
-        mgr.SSO_DB.save()
-        return 0, 'SSO is "disabled".', ''
 
     if cmd['prefix'] == 'dashboard sso status':
         if mgr.SSO_DB.protocol == 'saml2':


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48343

---

backport of https://github.com/ceph/ceph/pull/38084
parent tracker: https://tracker.ceph.com/issues/48237

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh