### PR TITLE
librbd: extend group snap create API to support flags

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -1364,6 +1364,10 @@ CEPH_RBD_API int rbd_group_image_list_cleanup(rbd_group_image_info_t *images,
 CEPH_RBD_API int rbd_group_snap_create(rados_ioctx_t group_p,
                                        const char *group_name,
                                        const char *snap_name);
+CEPH_RBD_API int rbd_group_snap_create2(rados_ioctx_t group_p,
+                                        const char *group_name,
+                                        const char *snap_name,
+                                        uint32_t flags);
 CEPH_RBD_API int rbd_group_snap_remove(rados_ioctx_t group_p,
                                        const char *group_name,
                                        const char *snap_name);

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -406,6 +406,8 @@ public:
 
   int group_snap_create(IoCtx& io_ctx, const char *group_name,
 			const char *snap_name);
+  int group_snap_create2(IoCtx& io_ctx, const char *group_name,
+                         const char *snap_name, uint32_t flags);
   int group_snap_remove(IoCtx& io_ctx, const char *group_name,
 			const char *snap_name);
   int group_snap_rename(IoCtx& group_ioctx, const char *group_name,

--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -440,6 +440,10 @@ finish:
 template <typename I>
 void notify_unquiesce(std::vector<I*> &ictxs,
                       const std::vector<uint64_t> &requests) {
+  if (requests.empty()) {
+    return;
+  }
+
   ceph_assert(requests.size() == ictxs.size());
   int image_count = ictxs.size();
   std::vector<C_SaferCond> on_finishes(image_count);
@@ -878,8 +882,8 @@ int Group<I>::image_get_group(I *ictx, group_info_t *group_info)
 
 template <typename I>
 int Group<I>::snap_create(librados::IoCtx& group_ioctx,
-    const char *group_name, const char *snap_name)
-{
+                          const char *group_name, const char *snap_name,
+                          uint32_t flags) {
   CephContext *cct = (CephContext *)group_ioctx.cct();
 
   string group_id;
@@ -891,9 +895,17 @@ int Group<I>::snap_create(librados::IoCtx& group_ioctx,
   std::vector<C_SaferCond*> on_finishes;
   std::vector<uint64_t> quiesce_requests;
   NoOpProgressContext prog_ctx;
+  uint64_t internal_flags = 0;
 
-  int r = cls_client::dir_get_id(&group_ioctx, RBD_GROUP_DIRECTORY,
-				 group_name, &group_id);
+  int r = util::snap_create_flags_api_to_internal(cct, flags, &internal_flags);
+  if (r < 0) {
+    return r;
+  }
+  internal_flags &= ~(SNAP_CREATE_FLAG_SKIP_NOTIFY_QUIESCE |
+                      SNAP_CREATE_FLAG_IGNORE_NOTIFY_QUIESCE_ERROR);
+
+  r = cls_client::dir_get_id(&group_ioctx, RBD_GROUP_DIRECTORY, group_name,
+                             &group_id);
   if (r < 0) {
     lderr(cct) << "error reading group id object: "
 	       << cpp_strerror(r)
@@ -979,10 +991,12 @@ int Group<I>::snap_create(librados::IoCtx& group_ioctx,
     goto remove_record;
   }
 
-  ldout(cct, 20) << "Sending quiesce notification" << dendl;
-  ret_code = notify_quiesce(ictxs, prog_ctx, &quiesce_requests);
-  if (ret_code != 0) {
-    goto remove_record;
+  if ((flags & RBD_SNAP_CREATE_SKIP_QUIESCE) == 0) {
+    ldout(cct, 20) << "Sending quiesce notification" << dendl;
+    ret_code = notify_quiesce(ictxs, prog_ctx, &quiesce_requests);
+    if (ret_code != 0 && (flags & RBD_SNAP_CREATE_IGNORE_QUIESCE_ERROR) == 0) {
+      goto remove_record;
+    }
   }
 
   ldout(cct, 20) << "Requesting exclusive locks for images" << dendl;

--- a/src/librbd/api/Group.h
+++ b/src/librbd/api/Group.h
@@ -38,7 +38,8 @@ struct Group {
   static int image_get_group(ImageCtxT *ictx, group_info_t *group_info);
 
   static int snap_create(librados::IoCtx& group_ioctx,
-                         const char *group_name, const char *snap_name);
+                         const char *group_name, const char *snap_name,
+                         uint32_t flags);
   static int snap_remove(librados::IoCtx& group_ioctx,
                          const char *group_name, const char *snap_name);
   static int snap_rename(librados::IoCtx& group_ioctx, const char *group_name,

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1329,7 +1329,19 @@ namespace librbd {
                group_ioctx.get_pool_name().c_str(),
 	       group_ioctx.get_id(), group_name, snap_name);
     int r = librbd::api::Group<>::snap_create(group_ioctx, group_name,
-                                              snap_name);
+                                              snap_name, 0);
+    tracepoint(librbd, group_snap_create_exit, r);
+    return r;
+  }
+
+  int RBD::group_snap_create2(IoCtx& group_ioctx, const char *group_name,
+                              const char *snap_name, uint32_t flags) {
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(group_ioctx));
+    tracepoint(librbd, group_snap_create_enter,
+               group_ioctx.get_pool_name().c_str(),
+	       group_ioctx.get_id(), group_name, snap_name);
+    int r = librbd::api::Group<>::snap_create(group_ioctx, group_name,
+                                              snap_name, flags);
     tracepoint(librbd, group_snap_create_exit, r);
     return r;
   }
@@ -6942,8 +6954,28 @@ extern "C" int rbd_group_snap_create(rados_ioctx_t group_p,
              group_ioctx.get_pool_name().c_str(),
 	     group_ioctx.get_id(), group_name, snap_name);
 
-  int r = librbd::api::Group<>::snap_create(group_ioctx, group_name, snap_name);
+  int r = librbd::api::Group<>::snap_create(group_ioctx, group_name,
+                                            snap_name, 0);
+  tracepoint(librbd, group_snap_create_exit, r);
 
+  return r;
+}
+
+extern "C" int rbd_group_snap_create2(rados_ioctx_t group_p,
+                                      const char *group_name,
+                                      const char *snap_name,
+                                      uint32_t flags)
+{
+  librados::IoCtx group_ioctx;
+  librados::IoCtx::from_rados_ioctx_t(group_p, group_ioctx);
+
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(group_ioctx));
+  tracepoint(librbd, group_snap_create_enter,
+             group_ioctx.get_pool_name().c_str(),
+	     group_ioctx.get_id(), group_name, snap_name);
+
+  int r = librbd::api::Group<>::snap_create(group_ioctx, group_name, snap_name,
+                                            flags);
   tracepoint(librbd, group_snap_create_exit, r);
 
   return r;

--- a/src/pybind/rbd/c_rbd.pxd
+++ b/src/pybind/rbd/c_rbd.pxd
@@ -645,8 +645,8 @@ cdef extern from "rbd/librbd.h" nogil:
     void rbd_group_image_list_cleanup(rbd_group_image_info_t *images,
                                       size_t group_image_info_size, size_t len)
 
-    int rbd_group_snap_create(rados_ioctx_t group_p, const char *group_name,
-                              const char *snap_name)
+    int rbd_group_snap_create2(rados_ioctx_t group_p, const char *group_name,
+                               const char *snap_name, uint32_t flags)
 
     int rbd_group_snap_remove(rados_ioctx_t group_p, const char *group_name,
                               const char *snap_name)

--- a/src/pybind/rbd/mock_rbd.pxi
+++ b/src/pybind/rbd/mock_rbd.pxi
@@ -824,8 +824,8 @@ cdef nogil:
     void rbd_group_image_list_cleanup(rbd_group_image_info_t *images,
                                       size_t group_image_info_size, size_t len):
         pass
-    int rbd_group_snap_create(rados_ioctx_t group_p, const char *group_name,
-                              const char *snap_name):
+    int rbd_group_snap_create2(rados_ioctx_t group_p, const char *group_name,
+                               const char *snap_name, uint32_t flags):
         pass
     int rbd_group_snap_remove(rados_ioctx_t group_p, const char *group_name,
                               const char *snap_name):

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -2668,11 +2668,12 @@ cdef class Group(object):
         """
         return GroupImageIterator(self)
 
-    def create_snap(self, snap_name):
+    def create_snap(self, snap_name, flags=0):
         """
         Create a snapshot for the group.
 
         :param snap_name: the name of the snapshot to create
+        :param flags: create snapshot flags
         :type name: str
 
         :raises: :class:`ObjectNotFound`
@@ -2683,8 +2684,10 @@ cdef class Group(object):
         snap_name = cstr(snap_name, 'snap_name')
         cdef:
             char *_snap_name = snap_name
+            uint32_t _flags = flags
         with nogil:
-            ret = rbd_group_snap_create(self._ioctx, self._name, _snap_name)
+            ret = rbd_group_snap_create2(self._ioctx, self._name, _snap_name,
+                                         _flags)
         if ret != 0:
             raise make_ex(ret, 'error creating group snapshot', group_errno_to_exception)
 

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -929,20 +929,23 @@
   rbd help group snap create
   usage: rbd group snap create [--pool <pool>] [--namespace <namespace>] 
                                [--group <group>] [--snap <snap>] 
+                               [--skip-quiesce] [--ignore-quiesce-error] 
                                <group-snap-spec> 
   
   Make a snapshot of a group.
   
   Positional arguments
-    <group-snap-spec>    group specification
-                         (example:
-                         [<pool-name>/[<namespace>/]]<group-name>@<snap-name>)
+    <group-snap-spec>       group specification
+                            (example:
+                            [<pool-name>/[<namespace>/]]<group-name>@<snap-name>)
   
   Optional arguments
-    -p [ --pool ] arg    pool name
-    --namespace arg      namespace name
-    --group arg          group name
-    --snap arg           snapshot name
+    -p [ --pool ] arg       pool name
+    --namespace arg         namespace name
+    --group arg             group name
+    --snap arg              snapshot name
+    --skip-quiesce          do not run quiesce hooks
+    --ignore-quiesce-error  ignore quiesce hook error
   
   rbd help group snap list
   usage: rbd group snap list [--format <format>] [--pretty-format] 

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -2528,6 +2528,27 @@ class TestGroups(object):
         self.group.remove_snap(snap_name)
         eq([], list(self.group.list_snaps()))
 
+    def test_group_snap_flags(self):
+        global snap_name
+        eq([], list(self.group.list_snaps()))
+
+        self.group.create_snap(snap_name, 0)
+        eq([snap_name], [snap['name'] for snap in self.group.list_snaps()])
+        self.group.remove_snap(snap_name)
+
+        self.group.create_snap(snap_name, RBD_SNAP_CREATE_SKIP_QUIESCE)
+        eq([snap_name], [snap['name'] for snap in self.group.list_snaps()])
+        self.group.remove_snap(snap_name)
+
+        self.group.create_snap(snap_name, RBD_SNAP_CREATE_IGNORE_QUIESCE_ERROR)
+        eq([snap_name], [snap['name'] for snap in self.group.list_snaps()])
+        self.group.remove_snap(snap_name)
+
+        assert_raises(InvalidArgument, self.group.create_snap, snap_name,
+                      RBD_SNAP_CREATE_SKIP_QUIESCE |
+                      RBD_SNAP_CREATE_IGNORE_QUIESCE_ERROR)
+        eq([], list(self.group.list_snaps()))
+
     def test_group_snap_list_many(self):
         global snap_name
         eq([], list(self.group.list_snaps()))

--- a/src/tools/rbd/action/Group.cc
+++ b/src/tools/rbd/action/Group.cc
@@ -47,7 +47,7 @@ void add_group_option(po::options_description *opt,
 }
 
 void add_prefixed_pool_option(po::options_description *opt,
-                            const std::string &prefix) {
+                              const std::string &prefix) {
   std::string name = prefix + "-" + at::POOL_NAME;
   std::string description = prefix + " pool name";
 
@@ -505,6 +505,12 @@ int execute_group_snap_create(const po::variables_map &vm,
     return r;
   }
 
+  uint32_t flags;
+  r = utils::get_snap_create_flags(vm, &flags);
+  if (r < 0) {
+    return r;
+  }
+
   librados::IoCtx io_ctx;
   librados::Rados rados;
 
@@ -514,7 +520,8 @@ int execute_group_snap_create(const po::variables_map &vm,
   }
 
   librbd::RBD rbd;
-  r = rbd.group_snap_create(io_ctx, group_name.c_str(), snap_name.c_str());
+  r = rbd.group_snap_create2(io_ctx, group_name.c_str(), snap_name.c_str(),
+                             flags);
   if (r < 0) {
     return r;
   }
@@ -821,9 +828,10 @@ void get_list_images_arguments(po::options_description *positional,
 }
 
 void get_group_snap_create_arguments(po::options_description *positional,
-				  po::options_description *options) {
+                                     po::options_description *options) {
   add_group_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE,
                          true);
+  at::add_snap_create_options(options);
 }
 
 void get_group_snap_remove_arguments(po::options_description *positional,


### PR DESCRIPTION
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
