### PR TITLE
cmake: Alter GIT_REPOSITORY for liburing

### DIFF
--- a/cmake/modules/Builduring.cmake
+++ b/cmake/modules/Builduring.cmake
@@ -8,7 +8,7 @@ function(build_uring)
   else()
     set(source_dir_args
       SOURCE_DIR ${CMAKE_BINARY_DIR}/src/liburing
-      GIT_REPOSITORY https://git.kernel.dk/liburing
+      GIT_REPOSITORY https://github.com/axboe/liburing.git
       GIT_TAG "liburing-0.7"
       GIT_SHALLOW TRUE
       GIT_CONFIG advice.detachedHead=false)


### PR DESCRIPTION
https://git.kernel.dk/liburing appears, at least currently, to be
unavailable. This could be reverted once it comes back.


This is currently causing build failures.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
