### PR TITLE
orchestrator: validate osd yaml

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -667,9 +667,15 @@ Examples:
         if inbuf:
             if unmanaged is not None:
                 return HandleCommandResult(-errno.EINVAL, stderr=usage)
-            try:
-                drivegroups = yaml.safe_load_all(inbuf)
 
+            try:
+                drivegroups = [_dg for _dg in yaml.safe_load_all(inbuf)]
+            except yaml.scanner.ScannerError as e:
+                msg = f"Invalid YAML received : {str(e)}"
+                self.log.exception(e)
+                return HandleCommandResult(-errno.EINVAL, stderr=msg)
+
+            try:
                 dg_specs = []
                 for dg in drivegroups:
                     spec = DriveGroupSpec.from_json(dg)


### PR DESCRIPTION
Validate the yaml document ahead of usage, to catch
any basic errors in the yaml doc. If errors are found the
exception is shown in the mgr log, and the user gets a
more friendly error message, without the traceback.

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>

