### PR TITLE
msg/async: refine worker creation in NetworkStack

### DIFF
--- a/src/msg/async/PosixStack.h
+++ b/src/msg/async/PosixStack.h
@@ -40,6 +40,10 @@ class PosixWorker : public Worker {
 class PosixNetworkStack : public NetworkStack {
   std::vector<std::thread> threads;
 
+  virtual Worker* create_worker(CephContext *c, unsigned worker_id) override {
+    return new PosixWorker(c, worker_id);
+  }
+
  public:
   explicit PosixNetworkStack(CephContext *c, const std::string &t);
 

--- a/src/msg/async/Stack.cc
+++ b/src/msg/async/Stack.cc
@@ -66,47 +66,42 @@ std::function<void ()> NetworkStack::add_thread(unsigned worker_id)
 std::shared_ptr<NetworkStack> NetworkStack::create(CephContext *c,
 						   const std::string &t)
 {
+  std::shared_ptr<NetworkStack> stack = nullptr;
+
   if (t == "posix")
-    return std::make_shared<PosixNetworkStack>(c, t);
+    stack.reset(new PosixNetworkStack(c, t));
 #ifdef HAVE_RDMA
   else if (t == "rdma")
-    return std::make_shared<RDMAStack>(c, t);
+    stack.reset(new RDMAStack(c, t));
 #endif
 #ifdef HAVE_DPDK
   else if (t == "dpdk")
-    return std::make_shared<DPDKStack>(c, t);
+    stack.reset(new DPDKStack(c, t));
 #endif
 
-  lderr(c) << __func__ << " ms_async_transport_type " << t <<
+  if (stack == nullptr) {
+    lderr(c) << __func__ << " ms_async_transport_type " << t <<
     " is not supported! " << dendl;
-  ceph_abort();
-  return nullptr;
-}
+    ceph_abort();
+    return nullptr;
+  }
+  
+  const int InitEventNumber = 5000;
+  for (unsigned worker_id = 0; worker_id < stack->num_workers; ++worker_id) {
+    Worker *w = stack->create_worker(c, worker_id);
+    int ret = w->center.init(InitEventNumber, worker_id, t);
+    if (ret)
+      throw std::system_error(-ret, std::generic_category());
+    stack->workers.push_back(w);
+  }
 
-Worker* NetworkStack::create_worker(CephContext *c, const std::string &type, unsigned worker_id)
-{
-  if (type == "posix")
-    return new PosixWorker(c, worker_id);
-#ifdef HAVE_RDMA
-  else if (type == "rdma")
-    return new RDMAWorker(c, worker_id);
-#endif
-#ifdef HAVE_DPDK
-  else if (type == "dpdk")
-    return new DPDKWorker(c, worker_id);
-#endif
-
-  lderr(c) << __func__ << " ms_async_transport_type " << type <<
-    " is not supported! " << dendl;
-  ceph_abort();
-  return nullptr;
+  return stack;
 }
 
 NetworkStack::NetworkStack(CephContext *c, const std:: string &t): type(t), started(false), cct(c)
 {
   ceph_assert(cct->_conf->ms_async_op_threads > 0);
 
-  const int InitEventNumber = 5000;
   num_workers = cct->_conf->ms_async_op_threads;
   if (num_workers >= EventCenter::MAX_EVENTCENTER) {
     ldout(cct, 0) << __func__ << " max thread limit is "
@@ -114,14 +109,6 @@ NetworkStack::NetworkStack(CephContext *c, const std:: string &t): type(t), star
                   << "Higher thread values are unnecessary and currently unsupported."
                   << dendl;
     num_workers = EventCenter::MAX_EVENTCENTER;
-  }
-
-  for (unsigned worker_id = 0; worker_id < num_workers; ++worker_id) {
-    Worker *w = create_worker(cct, type, worker_id);
-    int ret = w->center.init(InitEventNumber, worker_id, type);
-    if (ret)
-      throw std::system_error(-ret, std::generic_category());
-    workers.push_back(w);
   }
 }
 

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -300,6 +300,8 @@ class NetworkStack {
 
   std::function<void ()> add_thread(unsigned i);
 
+  virtual Worker* create_worker(CephContext *c, unsigned i) = 0;
+
  protected:
   CephContext *cct;
   std::vector<Worker*> workers;
@@ -316,8 +318,6 @@ class NetworkStack {
   static std::shared_ptr<NetworkStack> create(
     CephContext *c, const std::string &type);
 
-  static Worker* create_worker(
-    CephContext *c, const std::string &t, unsigned i);
   // backend need to override this method if backend doesn't support shared
   // listen table.
   // For example, posix backend has in kernel global listen table. If one

--- a/src/msg/async/dpdk/DPDKStack.h
+++ b/src/msg/async/dpdk/DPDKStack.h
@@ -248,6 +248,11 @@ class DPDKWorker : public Worker {
 
 class DPDKStack : public NetworkStack {
   vector<std::function<void()> > funcs;
+
+  virtual Worker* create_worker(CephContext *c, unsigned worker_id) override {
+    return new DPDKWorker(c, worker_id);
+  }
+
  public:
   explicit DPDKStack(CephContext *cct, const string &t): NetworkStack(cct, t) {
     funcs.resize(cct->_conf->ms_async_max_op_threads);

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -326,6 +326,10 @@ class RDMAStack : public NetworkStack {
 
   std::atomic<bool> fork_finished = {false};
 
+  virtual Worker* create_worker(CephContext *c, unsigned worker_id) override {
+    return new RDMAWorker(c, worker_id);
+  }
+
  public:
   explicit RDMAStack(CephContext *cct, const std::string &t);
   virtual ~RDMAStack();


### PR DESCRIPTION
This commit updates NetworkStack::create_worker() to a virtual
function to reduce type check redundancy.

Since calling a pure virtual function in a constructor method is
strictly prohibited, NetworkStack::create_worker() is currently
not implemented as a virtual function.
It requires duplicated type check with NetworkStack::create(),
making the code a little bit tricky.

Considering NetworkStack instances can only be instantiated
through NetworkStack::create(), this commit moves worker creation
out of its constructor to NetworkStack::create(), makes it a pure
virtual, and lets inherited classes implement it to remove the
type check redundancy. By making it a non-static, we can also
reduce unnecessary class member function exposure.

Signed-off-by: Insu Jang <insu_jang@tmax.co.kr>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
