### PR TITLE
doc: clarify osd recovery op priority and fix a couple of typos

### DIFF
--- a/doc/dev/osd_internals/backfill_reservation.rst
+++ b/doc/dev/osd_internals/backfill_reservation.rst
@@ -39,7 +39,7 @@ which PGs are recovered.  Admins can override the default order by using
 ``force-recovery`` or ``force-backfill``. A ``force-recovery`` with op
 priority ``255`` will start before a ``force-backfill`` op at priority ``254``.
 
-If a recovery is needed because a PG is below ``min_size`` a base priority of
+If recovery is needed because a PG is below ``min_size`` a base priority of
 ``220`` is used. This is incremented by the number of OSDs short of the pool's
 ``min_size`` as well as a value relative to the pool's ``recovery_priority``.
 The resultant priority is capped at ``253`` so that it does not confound forced
@@ -47,11 +47,12 @@ ops as described above. Under ordinary circumstances a recovery op is
 prioritized at ``180`` plus a value relative to the pool's ``recovery_priority``.
 The resultant priority is capped at ``219``.
 
-If a backfill op is needed because the number of acting OSDs is less than
+If backfill is needed because the number of acting OSDs is less than
 the pool's ``min_size``, a priority of ``220`` is used.  The number of OSDs
-short of the pool's `` min_size`` is added as well as a value relative to
+short of the pool's ``min_size`` is added as well as a value relative to
 the pool's ``recovery_priority``.  The total priority is limited to ``253``.
-If a backfill op is needed because a PG is undersized,
+
+If backfill is needed because a PG is undersized,
 a priority of ``140`` is used.  The number of OSDs below the size of the pool is
 added as well as a value relative to the pool's ``recovery_priority``.  The
 resultant priority is capped at ``179``.  If a backfill op is

--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -433,7 +433,9 @@ Operations
 
 ``osd client op priority``
 
-:Description: The priority set for client operations.
+:Description: The priority set for client operations.  This value is relative
+              to that of ``osd recovery op priority`` below.  The default
+              strongly favors client ops over recovery.
 
 :Type: 32-bit Integer
 :Default: ``63``
@@ -442,7 +444,12 @@ Operations
 
 ``osd recovery op priority``
 
-:Description: The priority set for recovery operations, if not specified by the pool's ``recovery_op_priority``.
+:Description: The priority of recovery operations vs client operations, if not specified by the
+              pool's ``recovery_op_priority``.  The default value prioritizes client
+              ops (see above) over recovery ops.  You may adjust the tradeoff of client
+              impact against the time to restore cluster health by lowering this value
+              for increased prioritization of client ops, or by increasing it to favor
+              recovery.
 
 :Type: 32-bit Integer
 :Default: ``3``


### PR DESCRIPTION
doc: clarify osd recovery op priority and fix a couple of typos

There has been some confusion on the ceph-users list about the polarity of the `osd_client_op_priority` and `osd_recovery_op_priority` values, and this reference eg. contradicts everything I've ever been told and experienced.

https://www.suse.com/support/kb/doc/?id=000019693

So my goal here is to add a bit of text to clarify the relationship between these two values.   And to fix a couple of typos in a dev document that are probably my fault.

Signed-off-by: Anthony D'Atri <anthony.datri@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
