### PR TITLE
vstart_runner: print result line unless opt_rotate_log is set

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -1373,7 +1373,8 @@ class LogStream(object):
             self._write()
 
     def _write(self):
-        self._del_result_lines()
+        if opt_rotate_logs:
+            self._del_result_lines()
         if self.buffer == '':
             return
 


### PR DESCRIPTION
Unless the option to rotate logs is set, don't delete the final result
line printed by unittest.

Without this patch following is how end of vstart_runner.py's output looks -
```
020-12-03 15:55:57,589.589 INFO:__main__:Stopped test: test_cd_with_args (tasks.cephfs.test_cephfs_shell.TestCD)
Test that when cd is issued with an argument, CWD is changed in 16.692507s
2020-12-03 15:55:57,590.590 INFO:__main__:test_cd_with_args (tasks.cephfs.test_cephfs_shell.TestCD)
2020-12-03 15:55:57,590.590 INFO:__main__:Test that when cd is issued with an argument, CWD is changed ... ok
2020-12-03 15:55:57,591.591 INFO:__main__:> ip netns list
2020-12-03 15:55:57,594.594 INFO:__main__:> sudo ip link delete ceph-brx
Cannot find device "ceph-brx"
```

This patch restores it to the following -
```
2020-12-03 16:07:46,570.570 INFO:__main__:test_ls_H_prints_human_readable_file_size (tasks.cephfs.test_cephfs_shell.TestLS)
2020-12-03 16:07:46,570.570 INFO:__main__:Test "ls -lH" prints human readable file size. ... ok
2020-12-03 16:07:46,570.570 INFO:__main__:
2020-12-03 16:07:46,570.570 INFO:__main__:----------------------------------------------------------------------
2020-12-03 16:07:46,570.570 INFO:__main__:Ran 1 test in 18.444s
2020-12-03 16:07:46,570.570 INFO:__main__:
2020-12-03 16:07:46,570.570 INFO:__main__:
2020-12-03 16:07:46,571.571 INFO:__main__:> ip netns list
2020-12-03 16:07:46,574.574 INFO:__main__:> sudo ip link delete ceph-brx
Cannot find device "ceph-brx"
2020-12-03 16:07:46,609.609 INFO:__main__:OK
2020-12-03 16:07:46,610.610 INFO:__main__:
```
Fixes: https://tracker.ceph.com/issues/48447

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>