### PR TITLE
octopus: qa: ignore evicted client warnings 

### DIFF
--- a/qa/suites/upgrade/nautilus-x-singleton/1-install/nautilus.yaml
+++ b/qa/suites/upgrade/nautilus-x-singleton/1-install/nautilus.yaml
@@ -4,6 +4,7 @@ overrides:
       - \(MON_DOWN\)
       - \(MGR_DOWN\)
       - slow request
+      - evicting unresponsive client
 meta:
 - desc: install ceph/nautilus latest
 tasks:

--- a/qa/suites/upgrade/nautilus-x/parallel/1-ceph-install/nautilus.yaml
+++ b/qa/suites/upgrade/nautilus-x/parallel/1-ceph-install/nautilus.yaml
@@ -26,6 +26,7 @@ tasks:
       - Monitor daemon marked osd
       - Behind on trimming
       - Manager daemon
+      - evicting unresponsive client
     conf:
       global:
         mon warn on pool no app: false

--- a/qa/suites/upgrade/nautilus-x/stress-split/1-ceph-install/nautilus.yaml
+++ b/qa/suites/upgrade/nautilus-x/stress-split/1-ceph-install/nautilus.yaml
@@ -14,6 +14,8 @@ tasks:
         bluestore_warn_on_legacy_statfs: false
         bluestore warn on no per pool omap: false
         mon pg warn min per osd: 0
+    log-whitelist:
+      - evicting unresponsive client
 - exec:
     osd.0:
       - ceph osd require-osd-release nautilus

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -384,6 +384,7 @@ void MgrStandby::handle_mgr_map(ref_t<MMgrMap> mmap)
   // this MgrMap is changing its set of enabled modules
   bool need_respawn = py_module_registry.handle_mgr_map(map);
   if (need_respawn) {
+    dout(1) << "respawning because set of enabled modules changed!" << dendl;
     respawn();
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48285

---

backport of https://github.com/ceph/ceph/pull/37528
parent tracker: https://tracker.ceph.com/issues/47689

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh