### PR TITLE
octopus: os/bluestore: fix segfault on out-of-bound offset provided to  claim_free_to_right() call

### DIFF
--- a/src/os/bluestore/fastbmap_allocator_impl.cc
+++ b/src/os/bluestore/fastbmap_allocator_impl.cc
@@ -678,6 +678,9 @@ uint64_t AllocatorLevel01Loose::_claim_free_to_right_l0(int64_t l0_pos_start)
   int64_t pos = l0_pos_start;
   slot_t bits = (slot_t)1 << (pos % d0);
   size_t idx = pos / d0;
+  if (idx >= l0.size()) {
+    return pos;
+  }
   slot_t* val_s = l0.data() + idx;
 
   int64_t pos_e = p2roundup<int64_t>(pos + 1, d0);

--- a/src/test/objectstore/fastbmap_allocator_test.cc
+++ b/src/test/objectstore/fastbmap_allocator_test.cc
@@ -1016,6 +1016,11 @@ TEST(TestAllocatorLevel01, test_claim_free_l2)
   ASSERT_EQ(0x1000, claimed);
   ASSERT_EQ(0x2000, al2.debug_get_free());
 
+  // claiming on the right boundary
+  claimed = al2.claim_free_to_right(capacity);
+  ASSERT_EQ(0x0, claimed);
+  ASSERT_EQ(0x2000, al2.debug_get_free());
+
   // extend allocator space up to 64M
   auto max_available2 = 64 * 1024 * 1024;
   al2.mark_free(max_available, max_available2 - max_available);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48094

---

backport of https://github.com/ceph/ceph/pull/37547
parent tracker: https://tracker.ceph.com/issues/47751

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh