### PR TITLE
octopus: osd: fix bluestore bitmap allocator calculate wrong last_pos with hint

### DIFF
--- a/src/os/bluestore/fastbmap_allocator_impl.h
+++ b/src/os/bluestore/fastbmap_allocator_impl.h
@@ -708,7 +708,7 @@ protected:
       return;
     }
     if (hint != 0) {
-      last_pos = (hint / d) < l2.size() ? p2align(hint, d) : 0;
+      last_pos = (hint / (d * l2_granularity)) < l2.size() ? p2align(hint / l2_granularity, d) : 0;
     }
     auto l2_pos = last_pos;
     auto last_pos0 = last_pos;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48281

---

backport of https://github.com/ceph/ceph/pull/38043
parent tracker: https://tracker.ceph.com/issues/48214

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh