### PR TITLE
mgr/dashboard: Fix for misleading "Orchestrator is not available" error

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.html
@@ -1,4 +1,4 @@
-<cd-orchestrator-doc-panel *ngIf="!orchStatus?.available"></cd-orchestrator-doc-panel>
+<cd-orchestrator-doc-panel *ngIf="showDocPanel"></cd-orchestrator-doc-panel>
 <ng-container *ngIf="orchStatus?.available">
   <legend i18n>Devices</legend>
   <div class="row">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.spec.ts
@@ -42,6 +42,10 @@ describe('InventoryComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should not display doc panel if orchestrator is available', () => {
+    expect(component.showDocPanel).toBeFalsy();
+  });
+
   describe('after ngOnInit', () => {
     it('should load devices', () => {
       fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.ts
@@ -23,6 +23,7 @@ export class InventoryComponent implements OnChanges, OnInit, OnDestroy {
   icons = Icons;
 
   orchStatus: OrchestratorStatus;
+  showDocPanel = false;
 
   devices: Array<InventoryDevice> = [];
 
@@ -31,6 +32,7 @@ export class InventoryComponent implements OnChanges, OnInit, OnDestroy {
   ngOnInit() {
     this.orchService.status().subscribe((status) => {
       this.orchStatus = status;
+      this.showDocPanel = !status.available;
       if (status.available) {
         // Create a timer to get cached inventory from the orchestrator.
         // Do not ask the orchestrator frequently to refresh its cache data because it's expensive.

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.html
@@ -1,4 +1,4 @@
-<cd-orchestrator-doc-panel *ngIf="!hasOrchestrator"></cd-orchestrator-doc-panel>
+<cd-orchestrator-doc-panel *ngIf="showDocPanel"></cd-orchestrator-doc-panel>
 <cd-table *ngIf="hasOrchestrator"
           #daemonsTable
           [data]="daemons"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.spec.ts
@@ -110,4 +110,8 @@ describe('ServiceDaemonListComponent', () => {
     component.getDaemons(new CdTableFetchDataContext(() => undefined));
     expect(component.daemons.length).toBe(3);
   });
+
+  it('should not display doc panel if orchestrator is available', () => {
+    expect(component.showDocPanel).toBeFalsy();
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.ts
@@ -46,6 +46,7 @@ export class ServiceDaemonListComponent implements OnInit, OnChanges, AfterViewI
   columns: CdTableColumn[] = [];
 
   hasOrchestrator = false;
+  showDocPanel = false;
 
   private daemonsTable: TableComponent;
   private daemonsTableTplsSub: Subscription;
@@ -126,6 +127,7 @@ export class ServiceDaemonListComponent implements OnInit, OnChanges, AfterViewI
 
     this.orchService.status().subscribe((data: { available: boolean }) => {
       this.hasOrchestrator = data.available;
+      this.showDocPanel = !data.available;
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.html
@@ -1,4 +1,4 @@
-<cd-orchestrator-doc-panel *ngIf="!orchStatus?.available"></cd-orchestrator-doc-panel>
+<cd-orchestrator-doc-panel *ngIf="showDocPanel"></cd-orchestrator-doc-panel>
 <ng-container *ngIf="orchStatus?.available">
   <cd-table [data]="services"
             [columns]="columns"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.spec.ts
@@ -94,4 +94,8 @@ describe('ServicesComponent', () => {
     component.getServices(new CdTableFetchDataContext(() => undefined));
     expect(component.services.length).toBe(2);
   });
+
+  it('should not display doc panel if orchestrator is available', () => {
+    expect(component.showDocPanel).toBeFalsy();
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
@@ -45,6 +45,7 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
 
   permissions: Permissions;
   tableActions: CdTableAction[];
+  showDocPanel = false;
 
   orchStatus: OrchestratorStatus;
   actionOrchFeatures = {
@@ -139,6 +140,7 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
 
     this.orchService.status().subscribe((status: OrchestratorStatus) => {
       this.orchStatus = status;
+      this.showDocPanel = !status.available;
     });
   }
 


### PR DESCRIPTION

When switching between options, in the Services and Inventory page sometimes it shows "Orchestrator not available" error which appears for 2-3 second and then disappears and shows the normal page. This commit fixes that.

**BEFORE**
![chrome-capture (6)](https://user-images.githubusercontent.com/71764184/101042033-ba35e380-35a2-11eb-8a33-ab70591b30ca.gif)

**AFTER**
![chrome-capture (7)](https://user-images.githubusercontent.com/71764184/101042049-c02bc480-35a2-11eb-9212-b751ee60401e.gif)

Fixes: https://tracker.ceph.com/issues/48448
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
