### PR TITLE
mgr/dashboard: test_standby* (tasks.mgr.test_dashboard.TestDashboard) failed locally

### DIFF
--- a/qa/tasks/mgr/test_dashboard.py
+++ b/qa/tasks/mgr/test_dashboard.py
@@ -28,6 +28,16 @@ class TestDashboard(MgrTestCase):
                                                      "mgr/dashboard/standby_error_status_code",
                                                      "500")
 
+    def wait_until_webserver_available(self, url):
+        def _check_connection():
+            try:
+                requests.get(url, allow_redirects=False, verify=False)
+                return True
+            except requests.ConnectionError:
+                pass
+            return False
+        self.wait_until_true(_check_connection, timeout=30)
+
     def test_standby(self):
         original_active_id = self.mgr_cluster.get_active_id()
         original_uri = self._get_uri("dashboard")
@@ -48,6 +58,9 @@ class TestDashboard(MgrTestCase):
 
         self.assertNotEqual(original_uri, failed_over_uri)
 
+        # Wait until web server of the standby node is settled.
+        self.wait_until_webserver_available(original_uri)
+
         # The original active daemon should have come back up as a standby
         # and be doing redirects to the new active daemon.
         r = requests.get(original_uri, allow_redirects=False, verify=False)
@@ -55,7 +68,7 @@ class TestDashboard(MgrTestCase):
         self.assertEqual(r.headers['Location'], failed_over_uri)
 
         # Ensure that every URL redirects to the active daemon.
-        r = requests.get("{}/runtime.js".format(original_uri),
+        r = requests.get("{}/runtime.js".format(original_uri.strip('/')),
                          allow_redirects=False,
                          verify=False)
         self.assertEqual(r.status_code, 303)
@@ -84,6 +97,9 @@ class TestDashboard(MgrTestCase):
             failed_active_id, failed_over_uri))
 
         self.assertNotEqual(original_uri, failed_over_uri)
+
+        # Wait until web server of the standby node is settled.
+        self.wait_until_webserver_available(original_uri)
 
         # Redirection should be disabled now, instead a 500 must be returned.
         r = requests.get(original_uri, allow_redirects=False, verify=False)


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/48449

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
