### PR TITLE
mgr/prometheus: don't store exception as e

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -200,7 +200,7 @@ class MetricCollectionThread(threading.Thread):
 
                 try:
                     data = self.mod.collect()
-                except Exception as e:
+                except:
                     # Log any issues encountered during the data collection and continue
                     self.mod.log.exception("failed to collect metrics:")
                     self.event.wait(self.mod.scrape_interval)


### PR DESCRIPTION
Python's `logging` module's `exception()` method will log the full exception and stack trace for us, so we do not need to store the exception in the `e` variable here.