### PR TITLE
os/bluestore: fix inappropriate ENOSPC from avl/hybrid allocator

### DIFF
--- a/src/os/bluestore/AvlAllocator.cc
+++ b/src/os/bluestore/AvlAllocator.cc
@@ -240,7 +240,15 @@ int AvlAllocator::_allocate(
       max_size < range_size_alloc_threshold ||
       free_pct < range_size_alloc_free_pct) {
     *cursor = 0;
-    start = _block_picker(range_size_tree, cursor, size, unit);
+    do {
+      start = _block_picker(range_size_tree, cursor, size, unit);
+      if (start != -1ULL || !force_range_size_alloc) {
+        break;
+      }
+      // try to collect smaller extents as we could fail to retrieve
+      // that large block due to misaligned extents
+      size = p2align(size >> 1, unit);
+    } while (size >= unit);
   } else {
     start = _block_picker(range_tree, cursor, size, unit);
   }

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -482,6 +482,24 @@ TEST_P(AllocTest, test_alloc_contiguous)
   alloc->shutdown();
 }
 
+TEST_P(AllocTest, test_alloc_47883)
+{
+  uint64_t block = 0x1000;
+  uint64_t size = 1599858540544ul;
+
+  init_alloc(size, block);
+
+  alloc->init_add_free(0x1b970000, 0x26000);
+  alloc->init_add_free(0x1747e9d5000, 0x493000);
+  alloc->init_add_free(0x1747ee6a000, 0x196000);
+
+  PExtentVector extents;
+  auto need = 0x3f980000;
+  auto got = alloc->allocate(need, 0x10000, 0, (int64_t)0, &extents);
+  EXPECT_GT(got, 0);
+  EXPECT_EQ(got, 0x630000);
+}
+
 INSTANTIATE_TEST_SUITE_P(
   Allocator,
   AllocTest,


### PR DESCRIPTION
Under high fragmentation circumstances (in best-fit mode) these allocators might fail to
return continuous(longer than a single alloc unit) extents. Occurs when
requested size is longer than the maximum available extents and these
extents are unaligned with alloc unit. The latter results in the actual lengths of these extens are shorter
than the requested length and they do not match to the lookup. Which
finally causes no allocation at all.

Fixes: https://tracker.ceph.com/issues/47883
Signed-off-by: Igor Fedotov <ifedotov@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
