### PR TITLE
mgr/cephadm: improve iscsi dashboard config

### DIFF
--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -197,7 +197,6 @@ class CephadmService(metaclass=ABCMeta):
         cmd_dicts = get_set_cmd_dicts(out.strip())
         for cmd_dict in list(cmd_dicts):
             try:
-                logger.info('Setting Dashboard config for %s: command: %s', service_name, cmd_dict)
                 _, out, _ = self.mgr.check_mon_command(cmd_dict)
             except MonCommandFailed as e:
                 logger.warning('Failed to set Dashboard config for %s: %s', service_name, e)

--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -76,27 +76,39 @@ class IscsiService(CephService):
         def get_set_cmd_dicts(out: str) -> List[dict]:
             gateways = json.loads(out)['gateways']
             cmd_dicts = []
+            spec = cast(IscsiServiceSpec,
+                        self.mgr.spec_store.specs.get(daemon_descrs[0].service_name(), None))
+            if spec.api_secure and spec.ssl_cert and spec.ssl_key:
+                cmd_dicts.append({
+                    'prefix': 'dashboard set-iscsi-api-ssl-verification',
+                    'value': "false"
+                })
+            else:
+                cmd_dicts.append({
+                    'prefix': 'dashboard set-iscsi-api-ssl-verification',
+                    'value': "true"
+                })
             for dd in daemon_descrs:
                 spec = cast(IscsiServiceSpec,
                             self.mgr.spec_store.specs.get(dd.service_name(), None))
                 if not spec:
                     logger.warning('No ServiceSpec found for %s', dd)
                     continue
-                if not all([spec.api_user, spec.api_password]):
-                    reason = 'api_user or api_password is not specified in ServiceSpec'
-                    logger.warning(
-                        'Unable to add iSCSI gateway to the Dashboard for %s: %s', dd, reason)
-                    continue
-                host = self._inventory_get_addr(dd.hostname)
-                service_url = 'http://{}:{}@{}:{}'.format(
-                    spec.api_user, spec.api_password, host, spec.api_port or '5000')
-                gw = gateways.get(host)
+                ip = utils.resolve_ip(dd.hostname)
+                protocol = "http"
+                if spec.api_secure and spec.ssl_cert and spec.ssl_key:
+                    protocol = "https"
+                service_url = '{}://{}:{}@{}:{}'.format(
+                    protocol, spec.api_user or 'admin', spec.api_password or 'admin', ip, spec.api_port or '5000')
+                gw = gateways.get(dd.hostname)
                 if not gw or gw['service_url'] != service_url:
-                    logger.info('Adding iSCSI gateway %s to Dashboard', service_url)
+                    safe_service_url = '{}://{}:{}@{}:{}'.format(
+                        protocol, '<api-user>', '<api-password>', ip, spec.api_port or '5000')
+                    logger.info('Adding iSCSI gateway %s to Dashboard', safe_service_url)
                     cmd_dicts.append({
                         'prefix': 'dashboard iscsi-gateway-add',
                         'service_url': service_url,
-                        'name': host
+                        'name': dd.hostname
                     })
             return cmd_dicts
 

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -2,6 +2,7 @@ import logging
 import re
 import json
 import datetime
+import socket
 from enum import Enum
 from functools import wraps
 from typing import Optional, Callable, TypeVar, List, NewType, TYPE_CHECKING
@@ -97,3 +98,10 @@ def str_to_datetime(input: str) -> datetime.datetime:
 
 def datetime_to_str(dt: datetime.datetime) -> str:
     return dt.strftime(DATEFMT)
+
+
+def resolve_ip(hostname: str) -> str:
+    try:
+        return socket.getaddrinfo(hostname, None, flags=socket.AI_CANONNAME, type=socket.SOCK_STREAM)[0][4][0]
+    except socket.gaierror as e:
+        raise OrchestratorError(f"Cannot resolve ip for host {hostname}: {e}")

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -734,12 +734,12 @@ class IscsiServiceSpec(ServiceSpec):
         if not self.pool:
             raise ServiceSpecValidationError(
                 'Cannot add ISCSI: No Pool specified')
-        if not self.api_user:
-            raise ServiceSpecValidationError(
-                'Cannot add ISCSI: No Api user specified')
-        if not self.api_password:
-            raise ServiceSpecValidationError(
-                'Cannot add ISCSI: No Api password specified')
+
+        # Do not need to check for api_user and api_password as they
+        # now default to 'admin' when setting up the gateway url. Older
+        # iSCSI specs from before this change should be fine as they will
+        # have been required to have an api_user and api_password set and
+        # will be unaffected by the new default value.
 
 
 yaml.add_representer(IscsiServiceSpec, ServiceSpec.yaml_representer)


### PR DESCRIPTION
updating iscsi config dashboard to match what was done with ceph ansible.
This includes:
  - set iscsi api ssl verification to false when api_secure is set
  - using https rather than http in gateway url when api_secure is set
  - default api_user and api_password to "admin"
  - convert hostname to ip address when creating gateway url

Signed-off-by: Adam King <adking@redhat.com>

ceph ansible iscsi dashboard config options can be seen here: https://github.com/ceph/ceph-ansible/blob/master/roles/ceph-dashboard/tasks/configure_dashboard.yml#L256

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
