### PR TITLE
msg/async: drop unused member variable

### DIFF
--- a/src/msg/async/PosixStack.cc
+++ b/src/msg/async/PosixStack.cc
@@ -332,7 +332,7 @@ int PosixWorker::connect(const entity_addr_t &addr, const SocketOptions &opts, C
   return 0;
 }
 
-PosixNetworkStack::PosixNetworkStack(CephContext *c, const std::string &t)
-    : NetworkStack(c, t)
+PosixNetworkStack::PosixNetworkStack(CephContext *c)
+    : NetworkStack(c)
 {
 }

--- a/src/msg/async/PosixStack.h
+++ b/src/msg/async/PosixStack.h
@@ -45,7 +45,7 @@ class PosixNetworkStack : public NetworkStack {
   }
 
  public:
-  explicit PosixNetworkStack(CephContext *c, const std::string &t);
+  explicit PosixNetworkStack(CephContext *c);
 
   void spawn_worker(unsigned i, std::function<void ()> &&func) override {
     threads.resize(i+1);

--- a/src/msg/async/Stack.cc
+++ b/src/msg/async/Stack.cc
@@ -69,14 +69,14 @@ std::shared_ptr<NetworkStack> NetworkStack::create(CephContext *c,
   std::shared_ptr<NetworkStack> stack = nullptr;
 
   if (t == "posix")
-    stack.reset(new PosixNetworkStack(c, t));
+    stack.reset(new PosixNetworkStack(c));
 #ifdef HAVE_RDMA
   else if (t == "rdma")
-    stack.reset(new RDMAStack(c, t));
+    stack.reset(new RDMAStack(c));
 #endif
 #ifdef HAVE_DPDK
   else if (t == "dpdk")
-    stack.reset(new DPDKStack(c, t));
+    stack.reset(new DPDKStack(c));
 #endif
 
   if (stack == nullptr) {
@@ -98,7 +98,8 @@ std::shared_ptr<NetworkStack> NetworkStack::create(CephContext *c,
   return stack;
 }
 
-NetworkStack::NetworkStack(CephContext *c, const std:: string &t): type(t), started(false), cct(c)
+NetworkStack::NetworkStack(CephContext *c)
+  : cct(c)
 {
   ceph_assert(cct->_conf->ms_async_op_threads > 0);
 

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -293,7 +293,6 @@ class Worker {
 };
 
 class NetworkStack {
-  std::string type;
   unsigned num_workers = 0;
   ceph::spinlock pool_spin;
   bool started = false;
@@ -306,7 +305,7 @@ class NetworkStack {
   CephContext *cct;
   std::vector<Worker*> workers;
 
-  explicit NetworkStack(CephContext *c, const std::string &t);
+  explicit NetworkStack(CephContext *c);
  public:
   NetworkStack(const NetworkStack &) = delete;
   NetworkStack& operator=(const NetworkStack &) = delete;

--- a/src/msg/async/dpdk/DPDKStack.h
+++ b/src/msg/async/dpdk/DPDKStack.h
@@ -254,7 +254,7 @@ class DPDKStack : public NetworkStack {
   }
 
  public:
-  explicit DPDKStack(CephContext *cct, const string &t): NetworkStack(cct, t) {
+  explicit DPDKStack(CephContext *cct): NetworkStack(cct) {
     funcs.resize(cct->_conf->ms_async_max_op_threads);
   }
   virtual bool support_local_listen_table() const override { return true; }

--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -778,8 +778,8 @@ void RDMAWorker::handle_pending_message()
   dispatcher->notify_pending_workers();
 }
 
-RDMAStack::RDMAStack(CephContext *cct, const std::string &t)
-  : NetworkStack(cct, t), ib(std::make_shared<Infiniband>(cct)),
+RDMAStack::RDMAStack(CephContext *cct)
+  : NetworkStack(cct), ib(std::make_shared<Infiniband>(cct)),
     rdma_dispatcher(std::make_shared<RDMADispatcher>(cct, ib))
 {
   ldout(cct, 20) << __func__ << " constructing RDMAStack..." << dendl;

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -331,7 +331,7 @@ class RDMAStack : public NetworkStack {
   }
 
  public:
-  explicit RDMAStack(CephContext *cct, const std::string &t);
+  explicit RDMAStack(CephContext *cct);
   virtual ~RDMAStack();
   virtual bool nonblock_connect_need_writable_event() const override { return false; }
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
