### PR TITLE
mds: defer storing the OpenFileTable journal without the mds_lock

### DIFF
--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -76,10 +76,26 @@ protected:
   static const int DIRTY_UNDEF	= -2;
 
   unsigned num_pending_commit = 0;
+  void _encode_header(bufferlist &bl, version_t& _omap_version,
+                      unsigned _omap_num_objs, int j_state);
   void _encode_header(bufferlist& bl, int j_state);
   void _commit_finish(int r, uint64_t log_seq, MDSContext *fin);
-  void _journal_finish(int r, uint64_t log_seq, MDSContext *fin,
-		       std::map<unsigned, std::vector<ObjectOperation> >& ops);
+
+  struct omap_update_ctrl_meta {
+    std::map<string, bufferlist> to_update;
+    std::set<string> to_remove;
+  };
+  struct omap_update_ctl {
+    unsigned write_size = 0;
+    bool clear = false;
+    int meta_idx = -1;
+
+    std::vector<struct omap_update_ctrl_meta> metas;
+  };
+  void _journal_commit(int r, uint64_t log_seq, MDSContext *c, int op_prio,
+                       version_t& _omap_version, unsigned _old_num_objs,
+                       unsigned _omap_num_objs,
+                       std::vector<struct omap_update_ctl>& omap_updates);
 
   void get_ref(CInode *in, frag_t fg=-1U);
   void put_ref(CInode *in, frag_t fg=-1U);


### PR DESCRIPTION
When flushing the OpenFileTable journal to osd disk may take a bit
longer, if we hold the mds_lock or other locks, it may cause other
threads to idle wait.

Fixes: https://tracker.ceph.com/issues/48394
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
