### PR TITLE
rgw: fix delete tags failed for latest version object

### DIFF
--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -1561,12 +1561,18 @@ int RadosObject::modify_obj_attrs(RGWObjectCtx* rctx, const char* attr_name, buf
 
 int RadosObject::delete_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, const char* attr_name, optional_yield y)
 {
+  rgw_obj target = get_obj();
+  int r = get_obj_attrs(rctx, y, dpp, &target);
+  if (r < 0) {
+    return r;
+  }
+
   Attrs rmattr;
   bufferlist bl;
 
   set_atomic(rctx);
   rmattr[attr_name] = bl;
-  return set_obj_attrs(dpp, rctx, nullptr, &rmattr, y);
+  return set_obj_attrs(dpp, rctx, nullptr, &rmattr, y, &target);
 }
 
 int RadosObject::copy_obj_data(RGWObjectCtx& rctx, Bucket* dest_bucket,


### PR DESCRIPTION
Signed-off-by: Liu Lan <liulan_yewu@cmss.chinamobile.com>

failed to delete the latest version object's tags in versioning enabled bucket.

```
# tags are not removed without specifying version
client.delete_object_tagging(Bucket=bucket_name, Key=key)

# success
client.delete_object_tagging(Bucket=bucket_name, Key=key, VersionId=version)
```

Also add these to [s3-tests](https://github.com/ceph/s3-tests/pull/372).



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
