### PR TITLE
doc/dev: update auto pr validation section

### DIFF
--- a/doc/dev/developer_guide/basic-workflow.rst
+++ b/doc/dev/developer_guide/basic-workflow.rst
@@ -221,21 +221,25 @@ as simple as::
 Automated PR validation
 -----------------------
 
-When your PR is created or updated, the Ceph project's `Continuous Integration
+When you create or update your PR, the Ceph project's `Continuous Integration
 (CI) <https://en.wikipedia.org/wiki/Continuous_integration>`_ infrastructure
-will test it automatically. At the time of this writing (September 2020), the
-automated CI testing included five tests to check that the commits in the PR
-are properly signed (see :ref:`submitting-patches`), to check that the
-documentation builds, to check that the submodules are unmodified, to check
-that the API is in order, and a :ref:`make-check` test.  Additional tests may
-be performed depending on which files are modified by your PR.
+automatically tests it. At the time of this writing (September 2020), the
+automated CI testing included five tests: 
 
-The :ref:`make-check`, builds the PR and runs it through a battery of
+#. a test to check that the commits are properly signed (see :ref:`submitting-patches`): 
+#. a test to check that the documentation builds
+#. a test to check that the submodules are unmodified
+#. a test to check that the API is in order
+#. a :ref:`make check<make-check>` test  
+   
+Additional tests may be performed depending on which files your PR modifies.
+
+The :ref:`make check<make-check>` test builds the PR and runs it through a battery of
 tests. These tests run on servers operated by the Ceph Continuous
 Integration (CI) team. When the tests complete, the result will be shown
 on GitHub in the pull request itself.
 
-You can (and should) also test your modifications before you open a PR.
+You should test your modifications before you open a PR.
 Refer to the chapters on testing for details.
 
 Notes on PR make check test

--- a/doc/dev/developer_guide/tests-unit-tests.rst
+++ b/doc/dev/developer_guide/tests-unit-tests.rst
@@ -33,9 +33,11 @@ framework`_.
 While it is possible to run ``ctest`` directly, it can be tricky to correctly
 set up your environment. Fortunately, a script is provided to make it easier
 run the unit tests on your code. It can be run from the top-level directory of
-the Ceph source tree by invoking::
+the Ceph source tree by invoking:
 
-.. prompt:: bash $
+  .. prompt:: bash $
+
+     ./run-make-check.sh
 
 You will need a minimum of 8GB of RAM and 32GB of free drive space for this
 command to complete successfully on x86_64; other architectures may have


### PR DESCRIPTION
This commit updates the "Automated PR Validation"
section of the "Basic Workflow" page in the
Developer Guide. This is part of a project that
aims to clean all of the sentences currently extant
in the Dev Guide, prior to a slight reorganization
of that guide for the sake of clarity and simplicity.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
