### PR TITLE
mgr/crash: Serialize command handling

### DIFF
--- a/src/pybind/mgr/crash/module.py
+++ b/src/pybind/mgr/crash/module.py
@@ -6,7 +6,7 @@ import json
 from collections import defaultdict
 from prettytable import PrettyTable
 import re
-from threading import Event
+from threading import Event, Lock
 
 
 DATEFMT = '%Y-%m-%dT%H:%M:%S.%f'
@@ -36,6 +36,7 @@ class Module(MgrModule):
     def __init__(self, *args, **kwargs):
         super(Module, self).__init__(*args, **kwargs)
         self.crashes = None
+        self.crashes_lock = Lock()
         self.run = True
         self.event = Event()
 
@@ -46,8 +47,9 @@ class Module(MgrModule):
     def serve(self):
         self.config_notify()
         while self.run:
-            self._refresh_health_checks()
-            self._prune(self.retain_interval)
+            with self.crashes_lock:
+                self._refresh_health_checks()
+                self._prune(self.retain_interval)
             wait = min(MAX_WAIT, max(self.warn_recent_interval / 100, MIN_WAIT))
             self.event.wait(wait)
             self.event.clear()
@@ -95,16 +97,17 @@ class Module(MgrModule):
         self.set_health_checks(health_checks)
 
     def handle_command(self, inbuf, command):
-        if not self.crashes:
-            self._load_crashes()
-        for cmd in self.COMMANDS:
-            if cmd['cmd'].startswith(command['prefix']):
-                handler = cmd['handler']
-                break
-        if handler is None:
-            return errno.EINVAL, '', 'unknown command %s' % command['prefix']
+        with self.crashes_lock:
+            if not self.crashes:
+                self._load_crashes()
+            for cmd in self.COMMANDS:
+                if cmd['cmd'].startswith(command['prefix']):
+                    handler = cmd['handler']
+                    break
+            if handler is None:
+                return errno.EINVAL, '', 'unknown command %s' % command['prefix']
 
-        return handler(self, command, inbuf)
+            return handler(self, command, inbuf)
 
     def time_from_string(self, timestr):
         # drop the 'Z' timezone indication, it's always UTC


### PR DESCRIPTION
All the implemented commands read or write the self.crashes structure.
We need to serialize them to avoid the threads from stepping over each
other toes.

This also makes sure that the main thread (serve method) does not
interfere with the commands.

Signed-off-by: Boris Ranto <branto@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
