### PR TITLE
rgw/lua: fixing incompatible declarations of CephContext

### DIFF
--- a/src/rgw/rgw_lua_utils.h
+++ b/src/rgw/rgw_lua_utils.h
@@ -6,7 +6,7 @@
 #include <ctime>
 #include <lua.hpp>
 
-class CephContext;
+#include "include/common_fwd.h"
 
 namespace rgw::lua {
 


### PR DESCRIPTION
Existing forward declaration breaks OSD compilation (clang)

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>

