### PR TITLE
ceph-volume: Fix "list index out of range" error

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -636,6 +636,8 @@ def human_readable_size(size):
     suffixes = ['B', 'KB', 'MB', 'GB', 'TB']
     suffix_index = 0
     while size > 1024:
+        if suffix_index == len(suffixes) - 1:
+            break
         suffix_index += 1
         size = size / 1024.0
     return "{size:.2f} {suffix}".format(


### PR DESCRIPTION
Fixes: Got "list index out of range" error while there is PiB sized disk attached
Signed-off-by: greensea <gs@bbxy.net>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
