### PR TITLE
rgw: fix crash when get/put/delete policy on an none exist role

### DIFF
--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -360,6 +360,14 @@ int RGWPutRolePolicy::get_params()
     ldout(s->cct, 20) << "failed to parse policy: " << e.what() << dendl;
     return -ERR_MALFORMED_DOC;
   }
+
+  _role = RGWRole(g_ceph_context, store, role_name, s->user->user_id.tenant);
+  int op_ret = _role.get();
+  if (op_ret < 0) {
+    s->err.message = "The role with name " +  role_name + " cannot be found.";
+    return op_ret;
+  }
+
   return 0;
 }
 
@@ -390,6 +398,13 @@ int RGWGetRolePolicy::get_params()
   if (role_name.empty() || policy_name.empty()) {
     ldout(s->cct, 20) << "ERROR: One of role name or policy name is empty"<< dendl;
     return -EINVAL;
+  }
+
+  _role = RGWRole(g_ceph_context, store, role_name, s->user->user_id.tenant);
+  int op_ret = _role.get();
+  if (op_ret < 0) {
+    s->err.message = "The role with name " +  role_name + " cannot be found.";
+    return op_ret;
   }
   return 0;
 }
@@ -462,6 +477,13 @@ int RGWDeleteRolePolicy::get_params()
   if (role_name.empty() || policy_name.empty()) {
     ldout(s->cct, 20) << "ERROR: One of role name or policy name is empty"<< dendl;
     return -EINVAL;
+  }
+
+  _role = RGWRole(g_ceph_context, store, role_name, s->user->user_id.tenant);
+  int op_ret = _role.get();
+  if (op_ret < 0) {
+    s->err.message = "The role with name " +  role_name + " cannot be found.";
+    return op_ret;
   }
   return 0;
 }


### PR DESCRIPTION
when get/put/delete policy on a none exist role, rgw will crash
```
import boto3, json
import botocore
botocore.session.Session().set_debug_logger()
access_key = 'admin'
secret_key = 'admin'
#
configuration = boto3.session.Config(connect_timeout=3000000, read_timeout=3000000, retries={'max_attempts': 0})
#
iam_client = boto3.client('iam',
aws_access_key_id=access_key,
aws_secret_access_key=secret_key,
endpoint_url='http://127.0.0.1:7401',
region_name='',
use_ssl = False,
config = configuration,
)

iam_client.get_role_policy(
    RoleName='UpdateApp22222222sdas',
    PolicyName='abc',
)

policy = {
        "Version": "2012-10-17",
        "Statement": [
            {
                "Sid": "VisualEditor0",
                "Effect": "Allow",
                "Action": "s3:PutObject",
                "Resource": "arn:aws:s3:::test8/*"
            }
        ]
    }
# iam_client.put_role_policy(
#     RoleName='UpdateApp2',
#     PolicyName='abc',
#     PolicyDocument=json.dumps(policy, separators=(',', ':')).strip()
# )

# iam_client.delete_role_policy(
#     RoleName='UpdateApp22222222sdas',
#     PolicyName='abc'
# )


```



fix https://tracker.ceph.com/issues/48472

Signed-off-by: yuliyang_yewu <yuliyang_yewu@cmss.chinamobile.com>