### PR TITLE
nautilus: client: do not use g_conf().get_val<>() in libcephfs

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4177,7 +4177,7 @@ void Client::remove_session_caps(MetaSession *s)
 
 int Client::_do_remount(bool retry_on_error)
 {
-  uint64_t max_retries = g_conf().get_val<uint64_t>("mds_max_retries_on_remount_failure");
+  uint64_t max_retries = cct->_conf.get_val<uint64_t>("mds_max_retries_on_remount_failure");
 
   errno = 0;
   int r = remount_cb(callback_handle);

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -135,7 +135,8 @@ static int getgroups(fuse_req_t req, gid_t **sgids)
 
 static void get_fuse_groups(UserPerm& perms, fuse_req_t req)
 {
-  if (g_conf().get_val<bool>("fuse_set_user_groups")) {
+  CephFuse::Handle *cfuse = (CephFuse::Handle *)fuse_req_userdata(req);
+  if (cfuse->client->cct->_conf.get_val<bool>("fuse_set_user_groups")) {
     gid_t *gids = NULL;
     int count = getgroups(req, &gids);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48457

---

backport of https://github.com/ceph/ceph/pull/38033
parent tracker: https://tracker.ceph.com/issues/48206

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh