### PR TITLE
rgw: lc: fix multipart iteration problem

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -824,7 +824,6 @@ int RGWLC::handle_multipart_expiration(rgw::sal::RGWBucket* target,
 				       LCWorker* worker, time_t stop_at, bool once)
 {
   MultipartMetaFilter mp_filter;
-  vector<rgw_bucket_dir_entry> objs;
   int ret;
   rgw::sal::RGWBucket::ListParams params;
   rgw::sal::RGWBucket::ListResults results;
@@ -887,7 +886,7 @@ int RGWLC::handle_multipart_expiration(rgw::sal::RGWBucket* target,
     }
     params.prefix = prefix_iter->first;
     do {
-      objs.clear();
+      results.objs.clear();
       ret = target->list(params, 1000, results, null_yield);
       if (ret < 0) {
           if (ret == (-ENOENT))
@@ -896,7 +895,7 @@ int RGWLC::handle_multipart_expiration(rgw::sal::RGWBucket* target,
           return ret;
       }
 
-      for (auto obj_iter = objs.begin(); obj_iter != objs.end(); ++obj_iter) {
+      for (auto obj_iter = results.objs.begin(); obj_iter != results.objs.end(); ++obj_iter) {
 	std::tuple<lc_op, rgw_bucket_dir_entry> t1 =
 	  {prefix_iter->second, *obj_iter};
 	worker->workpool->enqueue(WorkItem{t1});

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -351,6 +351,7 @@ int RGWRadosBucket::list(ListParams& params, int max, ListResults& results, opti
   list_op.params.prefix = params.prefix;
   list_op.params.delim = params.delim;
   list_op.params.marker = params.marker;
+  list_op.params.ns = params.ns;
   list_op.params.end_marker = params.end_marker;
   list_op.params.list_versions = params.list_versions;
   list_op.params.allow_unordered = params.allow_unordered;


### PR DESCRIPTION
Incomplete multiparts are not listed properly when running LC.
The reason is that the container object for the result and the namespace of the list_op are not properly set.

Signed-off-by: Ilsoo Byun <ilsoobyun@linecorp.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
