### PR TITLE
cephadm: command_unit: call systemctl with verbose=True

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -943,8 +943,10 @@ def call(command,  # type: List[str]
                                logging ON for the terminal
     :param timeout: timeout in seconds
     """
-    if not desc:
+    if desc is None:
         desc = command[0]
+    if desc:
+        desc += ': '
     timeout = timeout or args.timeout
 
     logger.debug("Running command: %s" % ' '.join(command))
@@ -977,7 +979,7 @@ def call(command,  # type: List[str]
         if end_time and (time.time() >= end_time):
             stop = True
             if process.poll() is None:
-                logger.info(desc + ':timeout after %s seconds' % timeout)
+                logger.info(desc + 'timeout after %s seconds' % timeout)
                 process.kill()
         if reads and process.poll() is not None:
             # we want to stop, but first read off anything remaining
@@ -1008,9 +1010,9 @@ def call(command,  # type: List[str]
                     out_buffer = lines.pop()
                     for line in lines:
                         if verbose:
-                            logger.info(desc + ':stdout ' + line)
+                            logger.info(desc + 'stdout ' + line)
                         else:
-                            logger.debug(desc + ':stdout ' + line)
+                            logger.debug(desc + 'stdout ' + line)
                 elif fd == process.stderr.fileno():
                     err += message
                     message = err_buffer + message
@@ -1018,37 +1020,37 @@ def call(command,  # type: List[str]
                     err_buffer = lines.pop()
                     for line in lines:
                         if verbose:
-                            logger.info(desc + ':stderr ' + line)
+                            logger.info(desc + 'stderr ' + line)
                         else:
-                            logger.debug(desc + ':stderr ' + line)
+                            logger.debug(desc + 'stderr ' + line)
                 else:
                     assert False
             except (IOError, OSError):
                 pass
         if verbose:
-            logger.debug(desc + ':profile rt=%s, stop=%s, exit=%s, reads=%s'
+            logger.debug(desc + 'profile rt=%s, stop=%s, exit=%s, reads=%s'
                 % (time.time()-start_time, stop, process.poll(), reads))
 
     returncode = process.wait()
 
     if out_buffer != '':
         if verbose:
-            logger.info(desc + ':stdout ' + out_buffer)
+            logger.info(desc + 'stdout ' + out_buffer)
         else:
-            logger.debug(desc + ':stdout ' + out_buffer)
+            logger.debug(desc + 'stdout ' + out_buffer)
     if err_buffer != '':
         if verbose:
-            logger.info(desc + ':stderr ' + err_buffer)
+            logger.info(desc + 'stderr ' + err_buffer)
         else:
-            logger.debug(desc + ':stderr ' + err_buffer)
+            logger.debug(desc + 'stderr ' + err_buffer)
 
     if returncode != 0 and verbose_on_failure and not verbose:
         # dump stdout + stderr
         logger.info('Non-zero exit code %d from %s' % (returncode, ' '.join(command)))
         for line in out.splitlines():
-            logger.info(desc + ':stdout ' + line)
+            logger.info(desc + 'stdout ' + line)
         for line in err.splitlines():
-            logger.info(desc + ':stderr ' + line)
+            logger.info(desc + 'stderr ' + line)
 
     return out, err, returncode
 
@@ -3626,7 +3628,10 @@ def command_unit():
     call_throws([
         'systemctl',
         args.command,
-        unit_name])
+        unit_name],
+        verbose=True,
+        desc=''
+    )
 
 ##################################
 


### PR DESCRIPTION
Otherwise `cephadm unit ... status` won't print anything

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

Replaces: #37651


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
