### PR TITLE
test: cancelling both noscrub *and* nodeep-scrub

### DIFF
--- a/qa/standalone/scrub/osd-scrub-test.sh
+++ b/qa/standalone/scrub/osd-scrub-test.sh
@@ -351,6 +351,10 @@ function _scrub_abort() {
     fi
 
     ceph osd set $stopscrub
+    if [ "$type" = "deep_scrub" ];
+    then
+      ceph osd set noscrub
+    fi
 
     # Wait for scrubbing to end
     set -o pipefail
@@ -375,7 +379,13 @@ function _scrub_abort() {
     fi
 
     local last_scrub=$(get_last_scrub_stamp $pgid)
-    ceph osd unset noscrub
+    ceph config set osd "osd_scrub_sleep" "0.1"
+
+    ceph osd unset $stopscrub
+    if [ "$type" = "deep_scrub" ];
+    then
+      ceph osd unset noscrub
+    fi
     TIMEOUT=$(($objects / 2))
     wait_for_scrub $pgid "$last_scrub" || return 1
 


### PR DESCRIPTION
as part of osd-scrub-test.sh.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
