### PR TITLE
mgr/dashboard: Display a warning message in Dashboard when debug mode is enabled

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1216,3 +1216,15 @@ This warning can silenced by setting the
 
   ceph config global mon mon_warn_on_osd_down_out_interval_zero false
 
+DASHBOARD_DEBUG
+_______________
+
+The Dashboard debug mode is enabled. This means, if there is an error
+while processing a REST API request, the HTTP error response contains
+a Python traceback. This behaviour should be disabled in production
+environments because such a traceback might contain and expose sensible
+information.
+
+The debug mode can be disabled with::
+
+  ceph dashboard debug disable

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -276,9 +276,9 @@ class Module(MgrModule, CherryPyConfig):
 
         self._stopping = threading.Event()
         self.shutdown_event = threading.Event()
-
         self.ACCESS_CTRL_DB = None
         self.SSO_DB = None
+        self.health_checks = {}
 
     @classmethod
     def can_run(cls):
@@ -423,6 +423,15 @@ class Module(MgrModule, CherryPyConfig):
                 self.__pool_stats[pool_id][stat_name].append((now, stat_val))
 
         return self.__pool_stats
+
+    def config_notify(self):
+        """
+        This method is called whenever one of our config options is changed.
+        """
+        PLUGIN_MANAGER.hook.config_notify()
+
+    def refresh_health_checks(self):
+        self.set_health_checks(self.health_checks)
 
 
 class StandbyModule(MgrStandbyModule, CherryPyConfig):

--- a/src/pybind/mgr/dashboard/plugins/debug.py
+++ b/src/pybind/mgr/dashboard/plugins/debug.py
@@ -21,7 +21,8 @@ class Actions(Enum):
 
 
 @PM.add_plugin  # pylint: disable=too-many-ancestors
-class Debug(SP, I.CanCherrypy, I.ConfiguresCherryPy):  # pylint: disable=too-many-ancestors
+class Debug(SP, I.CanCherrypy, I.ConfiguresCherryPy,  # pylint: disable=too-many-ancestors
+            I.Setupable, I.ConfigNotify):
     NAME = 'debug'
 
     OPTIONS = [
@@ -33,6 +34,26 @@ class Debug(SP, I.CanCherrypy, I.ConfiguresCherryPy):  # pylint: disable=too-man
         )
     ]
 
+    @no_type_check  # https://github.com/python/mypy/issues/7806
+    def _refresh_health_checks(self):
+        debug = self.get_option(self.NAME)
+        if debug:
+            self.mgr.health_checks.update({'DASHBOARD_DEBUG': {
+                'severity': 'warning',
+                'summary': 'Dashboard debug mode is enabled',
+                'detail': [
+                    'Please disable debug mode in production environments using '
+                    '"ceph dashboard {} {}"'.format(self.NAME, Actions.DISABLE.value)
+                ]
+            }})
+        else:
+            self.mgr.health_checks.pop('DASHBOARD_DEBUG', None)
+        self.mgr.refresh_health_checks()
+
+    @PM.add_hook
+    def setup(self):
+        self._refresh_health_checks()
+
     @no_type_check
     def handler(self, action):
         ret = 0
@@ -40,10 +61,11 @@ class Debug(SP, I.CanCherrypy, I.ConfiguresCherryPy):  # pylint: disable=too-man
         if action in [Actions.ENABLE.value, Actions.DISABLE.value]:
             self.set_option(self.NAME, action == Actions.ENABLE.value)
             self.mgr.update_cherrypy_config({})
+            self._refresh_health_checks()
         else:
             debug = self.get_option(self.NAME)
             msg = "Debug: '{}'".format('enabled' if debug else 'disabled')
-        return (ret, msg, None)
+        return ret, msg, None
 
     COMMANDS = [
         SP.Command(
@@ -70,3 +92,7 @@ class Debug(SP, I.CanCherrypy, I.ConfiguresCherryPy):  # pylint: disable=too-man
             'environment': 'test_suite' if self.get_option(self.NAME) else 'production',
             'error_page.default': self.custom_error_response,
         })
+
+    @PM.add_hook
+    def config_notify(self):
+        self._refresh_health_checks()

--- a/src/pybind/mgr/dashboard/plugins/interfaces.py
+++ b/src/pybind/mgr/dashboard/plugins/interfaces.py
@@ -69,3 +69,13 @@ class FilterRequest(object):
         @PM.add_abcspec
         def filter_request_before_handler(self, request):
             pass
+
+
+@PM.add_interface
+class ConfigNotify(Interface):
+    @PM.add_abcspec
+    def config_notify(self):
+        """
+        This method is called whenever a option of this mgr module has
+        been modified.
+        """


### PR DESCRIPTION
Set a health check warning if debug mode is enabled.

![health_check](https://user-images.githubusercontent.com/1897962/101353888-a0dbb280-3894-11eb-89aa-d5b1d72303fd.png)

Fixes: https://tracker.ceph.com/issues/48475

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
