### PR TITLE
qa: reuse methods in vstart_runner.LocalCephManager

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1594,14 +1594,7 @@ class CephManager:
         kwargs['check_status'] = False
         return self.run_cluster_cmd(**kwargs).exitstatus
 
-    # XXX: Setting "shell" to True for LocalCephManager.run_ceph_w(), doesn't
-    # work with vstart_runner.py; see https://tracker.ceph.com/issues/49644.
-    # shell=False as default parameter is just to maintain compatibility
-    # between interfaces of CephManager.run_ceph_w() and
-    # LocalCephManager.run_ceph_w(). This doesn't affect how "ceph -w" process
-    # is launched by this method since this parameters remains unused in
-    # this method.
-    def run_ceph_w(self, watch_channel=None, shell=False):
+    def run_ceph_w(self, watch_channel=None):
         """
         Execute "ceph -w" in the background with stdout connected to a BytesIO,
         and return the RemoteProcess.

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1515,8 +1515,7 @@ class CephManager:
         self.controller = controller
         self.next_pool_id = 0
         self.cluster = cluster
-        self.cephadm = cephadm
-        self.rook = rook
+
         if (logger):
             self.log = lambda x: logger.info(x)
         else:
@@ -1526,9 +1525,21 @@ class CephManager:
                 """
                 print(x)
             self.log = tmp
+
         if self.config is None:
             self.config = dict()
+
+        # NOTE: These variables are meant to be overriden by vstart_runner.py.
+        self.rook = rook
+        self.cephadm = cephadm
         self.testdir = teuthology.get_testdir(self.ctx)
+        self.run_cluster_cmd_prefix = [
+            'sudo', 'adjust-ulimits', 'ceph-coverage',
+            f'{self.testdir}/archive/coverage', 'timeout', '120', 'ceph',
+            '--cluster', self.cluster]
+        self.run_ceph_w_prefix = ['sudo', 'daemon-helper', 'kill', 'ceph',
+                                  '--cluster', self.cluster]
+
         pools = self.list_pools()
         self.pools = {}
         for pool in pools:
@@ -1558,6 +1569,8 @@ class CephManager:
         """
         if isinstance(kwargs['args'], str):
             kwargs['args'] = shlex.split(kwargs['args'])
+        elif isinstance(kwargs['args'], tuple):
+            kwargs['args'] = list(kwargs['args'])
 
         if self.cephadm:
             return shell(self.ctx, self.cluster, self.controller,
@@ -1570,10 +1583,7 @@ class CephManager:
                            stdout=StringIO(),
                            check_status=kwargs.get('check_status', True))
 
-        prefix = ['sudo', 'adjust-ulimits', 'ceph-coverage',
-                  f'{self.testdir}/archive/coverage', 'timeout', '120', 'ceph',
-                  '--cluster', self.cluster]
-        kwargs['args'] = prefix + list(kwargs['args'])
+        kwargs['args'] = self.run_cluster_cmd_prefix + kwargs['args']
         return self.controller.run(**kwargs)
 
     def raw_cluster_cmd(self, *args, **kwargs) -> str:
@@ -1603,13 +1613,7 @@ class CephManager:
                               'cluster', 'audit', ...
         :type watch_channel: str
         """
-        args = ["sudo",
-                "daemon-helper",
-                "kill",
-                "ceph",
-                '--cluster',
-                self.cluster,
-                "-w"]
+        args = self.run_ceph_w_prefix + ['-w']
         if watch_channel is not None:
             args.append("--watch-channel")
             args.append(watch_channel)

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1528,6 +1528,7 @@ class CephManager:
             self.log = tmp
         if self.config is None:
             self.config = dict()
+        self.testdir = teuthology.get_testdir(self.ctx)
         pools = self.list_pools()
         self.pools = {}
         for pool in pools:
@@ -1569,9 +1570,8 @@ class CephManager:
                            stdout=StringIO(),
                            check_status=kwargs.get('check_status', True))
 
-        testdir = teuthology.get_testdir(self.ctx)
         prefix = ['sudo', 'adjust-ulimits', 'ceph-coverage',
-                  f'{testdir}/archive/coverage', 'timeout', '120', 'ceph',
+                  f'{self.testdir}/archive/coverage', 'timeout', '120', 'ceph',
                   '--cluster', self.cluster]
         kwargs['args'] = prefix + list(kwargs['args'])
         return self.controller.run(**kwargs)
@@ -1717,11 +1717,10 @@ class CephManager:
         if remote is None:
             remote = self.controller
 
-        testdir = teuthology.get_testdir(self.ctx)
         pre = [
             'adjust-ulimits',
             'ceph-coverage',
-            '{tdir}/archive/coverage'.format(tdir=testdir),
+           f'{self.testdir}/archive/coverage',
             'rados',
             '--cluster',
             self.cluster,
@@ -1833,12 +1832,11 @@ class CephManager:
         if self.rook:
             assert False, 'not implemented'
 
-        testdir = teuthology.get_testdir(self.ctx)
         args = [
             'sudo',
             'adjust-ulimits',
             'ceph-coverage',
-            '{tdir}/archive/coverage'.format(tdir=testdir),
+           f'{self.testdir}/archive/coverage',
             'timeout',
             str(timeout),
             'ceph',

--- a/qa/tasks/ceph_test_case.py
+++ b/qa/tasks/ceph_test_case.py
@@ -110,10 +110,7 @@ class CephTestCase(unittest.TestCase):
                 return found
 
             def __enter__(self):
-                # XXX: For reason behind setting "shell" to False, see
-                # https://tracker.ceph.com/issues/49644.
-                self.watcher_process = ceph_manager.run_ceph_w(watch_channel,
-                                                               shell=False)
+                self.watcher_process = ceph_manager.run_ceph_w(watch_channel)
 
             def __exit__(self, exc_type, exc_val, exc_tb):
                 if not self.watcher_process.finished:


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>