### PR TITLE
rgw: fix LC filter should contain both prefix and zero or more tags

### DIFF
--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -180,10 +180,13 @@ class LCFilter
     return !(has_prefix() || has_tags());
   }
 
-  // Determine if we need AND tag when creating xml
+  // Determine if we need AND when creating xml
   bool has_multi_condition() const {
     if (obj_tags.count() > 1)
       return true;
+    if (has_tags() && has_prefix()) {
+      return true;
+    }
     return false;
   }
 

--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -110,12 +110,12 @@ void RGWLifecycleConfiguration_S3::decode_xml(XMLObj *obj)
 
 void LCFilter_S3::dump_xml(Formatter *f) const
 {
-  if (has_prefix()) {
-    encode_xml("Prefix", prefix, f);
-  }
   bool multi = has_multi_condition();
   if (multi) {
     f->open_array_section("And");
+  }
+  if (has_prefix()) {
+    encode_xml("Prefix", prefix, f);
   }
   if (has_tags()) {
     const auto& tagset_s3 = static_cast<const RGWObjTagSet_S3 &>(obj_tags);

--- a/src/rgw/rgw_xml.cc
+++ b/src/rgw/rgw_xml.cc
@@ -150,6 +150,16 @@ find_first(const std::string& name)
   return nullptr;
 }
 
+int XMLObj::count(const string& name)
+{
+  int count = 0;
+  auto iter = XMLObj::find(name);
+  while (iter.get_next()) {
+    ++count;
+  }
+  return count;
+}
+
 RGWXMLParser::
 RGWXMLParser() : buf(nullptr), buf_len(0), cur_obj(nullptr), success(true), init_called(false)
 {

--- a/src/rgw/rgw_xml.h
+++ b/src/rgw/rgw_xml.h
@@ -75,6 +75,8 @@ public:
   XMLObjIter find_first();
   // return the first sub-tags matching the name
   XMLObj *find_first(const std::string& name);
+  // return sub-tag count
+  int count(const string& name);
 
   friend ostream& operator<<(ostream &out, const XMLObj &obj);
   friend RGWXMLParser;


### PR DESCRIPTION
Signed-off-by: Liu Lan <liulan_yewu@cmss.chinamobile.com>

I set a bucket LC rules with prefix + tags using AWS Java SDK.

```java
        Rule rule1 = new Rule()
                .withId("Delete after 365")
                .withFilter(new LifecycleFilter(
                     new LifecycleAndOperator(
                         Arrays.asList(
                            new LifecyclePrefixPredicate("YearlyDocuments/"),
                            new LifecycleTagPredicate(new Tag("expire_after", "ten_years")),
                            new LifecycleTagPredicate(new Tag("expire_after1", "ten_years")),
                            new LifecycleTagPredicate(new Tag("expire_after2", "ten_years")),
                            new LifecycleTagPredicate(new Tag("expire_after3", "ten_years")),
                            new LifecycleTagPredicate(new Tag("expire_after4", "ten_years")),
                            new LifecycleTagPredicate(new Tag("expire_after5", "ten_years")),
                            new LifecycleTagPredicate(new Tag("expire_after6", "ten_years")),
                            new LifecycleTagPredicate(new Tag("expire_after7", "ten_years")),
                            new LifecycleTagPredicate(new Tag("expire_after8", "ten_years")),
                            new LifecycleTagPredicate(new Tag("expire_after9", "ten_years")),
                            new LifecycleTagPredicate(new Tag("expire_after10", "ten_years")),
                            new LifecycleTagPredicate(new Tag("company", "true"))
                         )
                     )
                ))
                .withExpirationInDays(365)
                .withStatus(BucketLifecycleConfiguration.ENABLED);
```

But when I get the LC rules, the response does not contain Prefix in Filter:

```
resp = {BucketLifecycleConfiguration@3958} 
 rules = {ArrayList@3970}  size = 1
  0 = {BucketLifecycleConfiguration$Rule@3972} 
   id = "Delete after 365"
   prefix = null
   status = "Enabled"
   filter = {LifecycleFilter@3975} 
    predicate = {LifecycleAndOperator@3976} 
     operands = {ArrayList@3977}  size = 12 <----------- only contain tags, no prefix
      0 = {LifecycleTagPredicate@3979} 
      1 = {LifecycleTagPredicate@3980} 
      2 = {LifecycleTagPredicate@3981} 
      3 = {LifecycleTagPredicate@3982} 
      4 = {LifecycleTagPredicate@3983} 
      5 = {LifecycleTagPredicate@3984} 
      6 = {LifecycleTagPredicate@3985} 
      7 = {LifecycleTagPredicate@3986} 
      8 = {LifecycleTagPredicate@3987} 
      9 = {LifecycleTagPredicate@3988} 
      10 = {LifecycleTagPredicate@3989} 
      11 = {LifecycleTagPredicate@3990} 
   expirationInDays = 365
```

Because `LCFilter_S3::dump_xml` only dumps tags in <And> element.

Also add [s3-tests](https://github.com/ceph/s3-tests/pull/374) for this PR.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
