### PR TITLE
ceph-volume: make create/prepare idempotent

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/create.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/create.py
@@ -22,8 +22,12 @@ class Create(object):
     def create(self, args):
         if not args.osd_fsid:
             args.osd_fsid = system.generate_uuid()
+
         prepare_step = Prepare([])
-        prepare_step.safe_prepare(args)
+        prepared = prepare_step.safe_prepare(args)
+        if not prepared:
+            return
+
         osd_id = prepare_step.osd_id
         try:
             # we try this for activate only when 'creating' an OSD, because a rollback should not

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -288,8 +288,12 @@ class Prepare(object):
                 msg = ('{} is already prepared but not as '
                       'requested'.format(self.args.data))
                 terminal.error(msg)
-            logger.info(msg)
-            return False
+        else:   # we have some used and some unused devs
+            msg = 'some block devs are already used by Ceph'
+            terminal.error(msg)
+
+        logger.info(msg)
+        return False
 
     def safe_prepare(self, args=None):
         """


### PR DESCRIPTION
When prepare or create subcommand is passed a device that is already a
ceph device, print the message that the device is skipped and return
zero.

Fixes: https://tracker.ceph.com/issues/47584



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>