### PR TITLE
librbd: minor fix to IO shut-down and increased IO logging

### DIFF
--- a/src/librbd/deep_copy/ObjectCopyRequest.cc
+++ b/src/librbd/deep_copy/ObjectCopyRequest.cc
@@ -340,6 +340,7 @@ void ObjectCopyRequest<I>::send_write_object() {
 
   librados::ObjectWriteOperation op;
   if (!m_dst_image_ctx->migration_info.empty()) {
+    ldout(m_cct, 20) << "assert_snapc_seq=" << dst_snap_seq << dendl;
     cls_client::assert_snapc_seq(&op, dst_snap_seq,
                                  cls::rbd::ASSERT_SNAPC_SEQ_GT_SNAPSET_SEQ);
   }

--- a/src/librbd/io/ImageDispatcher.cc
+++ b/src/librbd/io/ImageDispatcher.cc
@@ -217,11 +217,11 @@ void ImageDispatcher<I>::shut_down(Context* on_finish) {
       delete async_op;
       on_finish->complete(0);
     });
-  on_finish = new LambdaContext([this, async_op, on_finish](int r) {
-      async_op->start_op(*this->m_image_ctx);
-      async_op->flush(on_finish);
+  on_finish = new LambdaContext([this, on_finish](int r) {
+      Dispatcher<I, ImageDispatcherInterface>::shut_down(on_finish);
     });
-  Dispatcher<I, ImageDispatcherInterface>::shut_down(on_finish);
+  async_op->start_op(*this->m_image_ctx);
+  async_op->flush(on_finish);
 }
 
 template <typename I>

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.cc
@@ -11,6 +11,11 @@
 #include <errno.h>
 #include <include/compat.h>
 
+#define dout_subsys ceph_subsys_rados
+#undef dout_prefix
+#define dout_prefix *_dout << "TestMemIoCtxImpl: " << this << " " << __func__ \
+                           << ": " << oid << " "
+
 static void to_vector(const interval_set<uint64_t> &set,
                       std::vector<std::pair<uint64_t, uint64_t> > *vec) {
   vec->clear();
@@ -73,6 +78,9 @@ int TestMemIoCtxImpl::append(const std::string& oid, const bufferlist &bl,
     return -EBLOCKLISTED;
   }
 
+  auto cct = m_client->cct();
+  ldout(cct, 20) << "length=" << bl.length() << ", snapc=" << snapc << dendl;
+
   TestMemCluster::SharedFile file;
   {
     std::unique_lock l{m_pool->file_lock};
@@ -127,6 +135,9 @@ int TestMemIoCtxImpl::create(const std::string& oid, bool exclusive,
     return -EBLOCKLISTED;
   }
 
+  auto cct = m_client->cct();
+  ldout(cct, 20) << "snapc=" << snapc << dendl;
+
   std::unique_lock l{m_pool->file_lock};
   if (exclusive) {
     TestMemCluster::SharedFile file = get_file(oid, false, CEPH_NOSNAP, {});
@@ -140,6 +151,9 @@ int TestMemIoCtxImpl::create(const std::string& oid, bool exclusive,
 }
 
 int TestMemIoCtxImpl::list_snaps(const std::string& oid, snap_set_t *out_snaps) {
+  auto cct = m_client->cct();
+  ldout(cct, 20) << dendl;
+
   if (m_client->is_blocklisted()) {
     return -EBLOCKLISTED;
   }
@@ -206,6 +220,23 @@ int TestMemIoCtxImpl::list_snaps(const std::string& oid, snap_set_t *out_snaps) 
       out_snaps->clones.push_back(head_clone);
     }
   }
+
+  ldout(cct, 20) << "seq=" << out_snaps->seq << ", "
+                 << "clones=[";
+  bool first_clone = true;
+  for (auto& clone : out_snaps->clones) {
+    *_dout << "{"
+           << "cloneid=" << clone.cloneid << ", "
+           << "snaps=" << clone.snaps << ", "
+           << "overlap=" << clone.overlap << ", "
+           << "size=" << clone.size << "}";
+    if (!first_clone) {
+      *_dout << ", ";
+    } else {
+      first_clone = false;
+    }
+  }
+  *_dout << "]" << dendl;
   return 0;
 
 }
@@ -358,6 +389,9 @@ int TestMemIoCtxImpl::remove(const std::string& oid, const SnapContext &snapc) {
   } else if (m_client->is_blocklisted()) {
     return -EBLOCKLISTED;
   }
+
+  auto cct = m_client->cct();
+  ldout(cct, 20) << "snapc=" << snapc << dendl;
 
   std::unique_lock l{m_pool->file_lock};
   TestMemCluster::SharedFile file = get_file(oid, false, CEPH_NOSNAP, snapc);
@@ -556,6 +590,9 @@ int TestMemIoCtxImpl::truncate(const std::string& oid, uint64_t size,
     return -EBLOCKLISTED;
   }
 
+  auto cct = m_client->cct();
+  ldout(cct, 20) << "size=" << size << ", snapc=" << snapc << dendl;
+
   TestMemCluster::SharedFile file;
   {
     std::unique_lock l{m_pool->file_lock};
@@ -594,6 +631,10 @@ int TestMemIoCtxImpl::write(const std::string& oid, bufferlist& bl, size_t len,
     return -EBLOCKLISTED;
   }
 
+  auto cct = m_client->cct();
+  ldout(cct, 20) << "extent=" << off << "~" << len << ", snapc=" << snapc
+                 << dendl;
+
   TestMemCluster::SharedFile file;
   {
     std::unique_lock l{m_pool->file_lock};
@@ -620,6 +661,9 @@ int TestMemIoCtxImpl::write_full(const std::string& oid, bufferlist& bl,
   } else if (m_client->is_blocklisted()) {
     return -EBLOCKLISTED;
   }
+
+  auto cct = m_client->cct();
+  ldout(cct, 20) << "length=" << bl.length() << ", snapc=" << snapc << dendl;
 
   TestMemCluster::SharedFile file;
   {
@@ -741,6 +785,10 @@ int TestMemIoCtxImpl::zero(const std::string& oid, uint64_t off, uint64_t len,
   if (m_client->is_blocklisted()) {
     return -EBLOCKLISTED;
   }
+
+  auto cct = m_client->cct();
+  ldout(cct, 20) << "extent=" << off << "~" << len << ", snapc=" << snapc
+                 << dendl;
 
   bool truncate_redirect = false;
   TestMemCluster::SharedFile file;


### PR DESCRIPTION
Increased debug logging on the migration IO path for assisting with the "TestMigration.StressLive" failure. Also fixed a race condition that resulted in that test hanging but which doesn't need to be backported.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
