### PR TITLE
test/crimson: do not link against crimson-{os,common}

### DIFF
--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -5,9 +5,10 @@ function(add_ceph_test test_name test_path)
   add_test(NAME ${test_name} COMMAND ${test_path} ${ARGN})
   if(TARGET ${test_name})
     add_dependencies(tests ${test_name})
+    set_property(TARGET ${test_name}
+      PROPERTY EXCLUDE_FROM_ALL TRUE)
   endif()
-  set_property(TEST
-    ${test_name}
+  set_property(TEST ${test_name}
     PROPERTY ENVIRONMENT 
     CEPH_ROOT=${CMAKE_SOURCE_DIR}
     CEPH_BIN=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
@@ -18,8 +19,7 @@ function(add_ceph_test test_name test_path)
     PYTHONPATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cython_modules/lib.3:${CMAKE_SOURCE_DIR}/src/pybind
     CEPH_BUILD_VIRTUALENV=${CEPH_BUILD_VIRTUALENV})
   # none of the tests should take more than 1 hour to complete
-  set_property(TEST
-    ${test_name}
+  set_property(TEST ${test_name}
     PROPERTY TIMEOUT ${CEPH_TEST_TIMEOUT})
 endfunction()
 

--- a/qa/standalone/misc/ver-health.sh
+++ b/qa/standalone/misc/ver-health.sh
@@ -85,7 +85,7 @@ function TEST_check_version_health_1() {
     ceph health detail | grep DAEMON_OLD_VERSION && return 1
 
     kill_daemons $dir KILL osd.1
-    EXTRA_OPTS=" --debug_version_for_testing=01.00.00-gversion-test" activate_osd $dir 1
+    ceph_debug_version_for_testing=01.00.00-gversion-test activate_osd $dir 1
 
     wait_for_health_string "HEALTH_WARN .*There is a daemon running an older version of ceph" || return 1
 
@@ -96,9 +96,9 @@ function TEST_check_version_health_1() {
     ceph health detail | grep -q "osd.1 is running an older version of ceph: 01.00.00-gversion-test" || return 1
 
     kill_daemons $dir KILL osd.2
-    EXTRA_OPTS=" --debug_version_for_testing=01.00.00-gversion-test" activate_osd $dir 2
+    ceph_debug_version_for_testing=01.00.00-gversion-test activate_osd $dir 2
     kill_daemons $dir KILL osd.0
-    EXTRA_OPTS=" --debug_version_for_testing=02.00.00-gversion-test" activate_osd $dir 0
+    ceph_debug_version_for_testing=02.00.00-gversion-test activate_osd $dir 0
 
     wait_for_health_string "HEALTH_ERR .*There are daemons running multiple old versions of ceph" || return 1
 
@@ -135,12 +135,12 @@ function TEST_check_version_health_2() {
     ceph health detail | grep DAEMON_OLD_VERSION && return 1
 
     kill_daemons $dir KILL mon.b
-    EXTRA_OPTS=" --debug_version_for_testing=01.00.00-gversion-test" run_mon $dir b --mon_warn_older_version_delay=0.0
+    ceph_debug_version_for_testing=01.00.00-gversion-test run_mon $dir b --mon_warn_older_version_delay=0.0
     # XXX: Manager doesn't seem to use the test specific config for version
     #kill_daemons $dir KILL mgr.x
-    #EXTRA_OPTS=" --debug_version_for_testing=02.00.00-gversion-test" run_mgr $dir x
+    #ceph_debug_version_for_testing=02.00.00-gversion-test run_mgr $dir x
     kill_daemons $dir KILL mds.m
-    EXTRA_OPTS=" --debug_version_for_testing=01.00.00-gversion-test" run_mds $dir m
+    ceph_debug_version_for_testing=01.00.00-gversion-test run_mds $dir m
 
     wait_for_health_string "HEALTH_WARN .*There are daemons running an older version of ceph" || return 1
 
@@ -151,9 +151,9 @@ function TEST_check_version_health_2() {
     ceph health detail | grep -q "mon.b mds.m are running an older version of ceph: 01.00.00-gversion-test" || return 1
 
     kill_daemons $dir KILL osd.2
-    EXTRA_OPTS=" --debug_version_for_testing=01.00.00-gversion-test" activate_osd $dir 2
+    ceph_debug_version_for_testing=01.00.00-gversion-test activate_osd $dir 2
     kill_daemons $dir KILL osd.0
-    EXTRA_OPTS=" --debug_version_for_testing=02.00.00-gversion-test" activate_osd $dir 0
+    ceph_debug_version_for_testing=02.00.00-gversion-test activate_osd $dir 0
 
     wait_for_health_string "HEALTH_ERR .*There are daemons running multiple old versions of ceph" || return 1
 
@@ -187,7 +187,7 @@ function TEST_check_version_health_3() {
     ceph health detail | grep DAEMON_OLD_VERSION && return 1
 
     kill_daemons $dir KILL osd.1
-    EXTRA_OPTS=" --debug_version_for_testing=01.00.00-gversion-test" activate_osd $dir 1
+    ceph_debug_version_for_testing=01.00.00-gversion-test activate_osd $dir 1
 
     # Wait 50% of 20 second delay config
     sleep 10
@@ -204,9 +204,9 @@ function TEST_check_version_health_3() {
     ceph health detail | grep -q "osd.1 is running an older version of ceph: 01.00.00-gversion-test" || return 1
 
     kill_daemons $dir KILL osd.2
-    EXTRA_OPTS=" --debug_version_for_testing=01.00.00-gversion-test" activate_osd $dir 2
+    ceph_debug_version_for_testing=01.00.00-gversion-test activate_osd $dir 2
     kill_daemons $dir KILL osd.0
-    EXTRA_OPTS=" --debug_version_for_testing=02.00.00-gversion-test" activate_osd $dir 0
+    ceph_debug_version_for_testing=02.00.00-gversion-test activate_osd $dir 0
 
     wait_for_health_string "HEALTH_ERR .*There are daemons running multiple old versions of ceph" || return 1
 

--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -631,9 +631,7 @@ public:
     } else {
       f->open_object_section("version");
       if (command == "version") {
-#ifndef WITH_ALIEN
-	f->dump_string("version", ceph_version_to_str(nullptr));
-#endif
+	f->dump_string("version", ceph_version_to_str());
 	f->dump_string("release", ceph_release_to_str());
 	f->dump_string("release_type", ceph_release_type());
       } else if (command == "git_version") {

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -8821,10 +8821,6 @@ std::vector<Option> get_mds_client_options() {
     .set_description("Size of thread pool for ASIO completions")
     .add_tag("client"),
 
-    Option("debug_version_for_testing", Option::TYPE_STR, Option::LEVEL_DEV)
-    .set_default("")
-    .set_description("Override ceph_version_short for testing"),
-
     Option("client_shutdown_timeout", Option::TYPE_SECS, Option::LEVEL_ADVANCED)
     .set_flag(Option::FLAG_RUNTIME)
     .set_default(30)

--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -229,7 +229,7 @@ void collect_sys_info(map<string, string> *m, CephContext *cct)
 {
   // version
   (*m)["ceph_version"] = pretty_version_to_str();
-  (*m)["ceph_version_short"] = ceph_version_to_str(cct);
+  (*m)["ceph_version_short"] = ceph_version_to_str();
   (*m)["ceph_release"] = ceph_release_to_str();
 
   #ifndef _WIN32

--- a/src/common/version.cc
+++ b/src/common/version.cc
@@ -14,7 +14,7 @@
 
 #include "common/version.h"
 
-#include <string.h>
+#include <stdlib.h>
 #include <sstream>
 
 #include "ceph_ver.h"
@@ -23,15 +23,14 @@
 #define _STR(x) #x
 #define STRINGIFY(x) _STR(x)
 
-// Keep ver.c_str() available
-static std::string ver;
-
-const char *ceph_version_to_str(CephContext *cct)
+const char *ceph_version_to_str()
 {
-  if (cct) ver = cct->_conf.get_val<std::string>("debug_version_for_testing");
-  if (ver.size() > 0)
-    return ver.c_str();
-  return CEPH_GIT_NICE_VER;
+  char* debug_version_for_testing = getenv("ceph_debug_version_for_testing");
+  if (debug_version_for_testing) {
+    return debug_version_for_testing;
+  } else {
+    return CEPH_GIT_NICE_VER;
+  }
 }
 
 const char *ceph_release_to_str(void)

--- a/src/common/version.h
+++ b/src/common/version.h
@@ -16,10 +16,9 @@
 #define CEPH_COMMON_VERSION_H
 
 #include <string>
-#include "common/ceph_context.h"
 
 // Return a string describing the Ceph version
-const char *ceph_version_to_str(CephContext *cct);
+const char *ceph_version_to_str();
 
 // Return a string with the Ceph release
 const char *ceph_release_to_str(void);

--- a/src/crimson/admin/admin_socket.cc
+++ b/src/crimson/admin/admin_socket.cc
@@ -298,7 +298,7 @@ class VersionHook final : public AdminSocketHook {
   {
     unique_ptr<Formatter> f{Formatter::create(format, "json-pretty", "json-pretty")};
     f->open_object_section("version");
-    f->dump_string("version", ceph_version_to_str(nullptr));
+    f->dump_string("version", ceph_version_to_str());
     f->dump_string("release", ceph_release_to_str());
     f->dump_string("release_type", ceph_release_type());
     f->close_section();

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -1,9 +1,6 @@
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/rocksdb/include")
-set(crimson_alien_srcs
-    alien_store.cc
-    thread_pool.cc)
 
-list(APPEND crimson_alien_srcs
+add_library(crimson-alien-common STATIC
   ${PROJECT_SOURCE_DIR}/src/common/admin_socket.cc
   ${PROJECT_SOURCE_DIR}/src/common/blkdev.cc
   ${PROJECT_SOURCE_DIR}/src/common/ceph_context.cc
@@ -26,6 +23,12 @@ list(APPEND crimson_alien_srcs
   ${PROJECT_SOURCE_DIR}/src/common/util.cc
   ${PROJECT_SOURCE_DIR}/src/crush/CrushLocation.cc
   ${PROJECT_SOURCE_DIR}/src/global/global_context.cc
+  $<TARGET_OBJECTS:compressor_objs>
+  $<TARGET_OBJECTS:common_prioritycache_obj>)
+
+add_library(crimson-alienstore STATIC
+  alien_store.cc
+  thread_pool.cc
   ${PROJECT_SOURCE_DIR}/src/os/ObjectStore.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/Allocator.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/AvlAllocator.cc
@@ -40,10 +43,6 @@ list(APPEND crimson_alien_srcs
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/HybridAllocator.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/StupidAllocator.cc
   ${PROJECT_SOURCE_DIR}/src/os/bluestore/BitmapAllocator.cc)
-
-add_library(crimson-alienstore STATIC ${crimson_alien_srcs}
-  $<TARGET_OBJECTS:compressor_objs>
-  $<TARGET_OBJECTS:common_prioritycache_obj>)
 if(WITH_LTTNG)
   add_dependencies(crimson-alienstore bluestore-tp)
 endif()
@@ -54,6 +53,7 @@ target_link_libraries(crimson-alienstore
   fmt::fmt
   kv
   heap_profiler
+  crimson-alien-common
   ${BLKID_LIBRARIES}
   ${UDEV_LIBRARIES}
   crimson

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -56,6 +56,5 @@ target_link_libraries(crimson-alienstore
   heap_profiler
   ${BLKID_LIBRARIES}
   ${UDEV_LIBRARIES}
-  crimson-os
   crimson
   blk)

--- a/src/crimson/os/seastore/CMakeLists.txt
+++ b/src/crimson/os/seastore/CMakeLists.txt
@@ -34,6 +34,4 @@ add_library(crimson-seastore STATIC
   ../../../test/crimson/seastore/test_block.cc
 	)
 target_link_libraries(crimson-seastore
-  crimson
-  crimson-os)
-
+  crimson)

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -139,7 +139,7 @@ seastar::future<> RecoveryBackend::handle_backfill(
 seastar::future<> RecoveryBackend::handle_backfill_remove(
   MOSDPGBackfillRemove& m)
 {
-  logger().debug("{} m.ls=", __func__, m.ls);
+  logger().debug("{} m.ls={}", __func__, m.ls);
   assert(m.get_type() == MSG_OSD_PG_BACKFILL_REMOVE);
 
   ObjectStore::Transaction t;

--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -204,7 +204,7 @@ static void handle_fatal_signal(int signum)
 	now.gmtime(jf.dump_stream("timestamp"));
 	jf.dump_string("process_name", g_process_name);
 	jf.dump_string("entity_name", g_ceph_context->_conf->name.to_str());
-	jf.dump_string("ceph_version", ceph_version_to_str(g_ceph_context));
+	jf.dump_string("ceph_version", ceph_version_to_str());
 
 	struct utsname u;
 	r = uname(&u);

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -362,7 +362,7 @@ extern "C" void ceph_userperm_destroy(UserPerm *perm)
 extern "C" const char *ceph_version(int *pmajor, int *pminor, int *ppatch)
 {
   int major, minor, patch;
-  const char *v = ceph_version_to_str(nullptr);
+  const char *v = ceph_version_to_str();
 
   int n = sscanf(v, "%d.%d.%d", &major, &minor, &patch);
   if (pmajor)

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3642,7 +3642,7 @@ void Monitor::handle_command(MonOpRequestRef op)
       f.reset(Formatter::create("json-pretty"));
     f->open_object_section("report");
     f->dump_stream("cluster_fingerprint") << fingerprint;
-    f->dump_string("version", ceph_version_to_str(cct));
+    f->dump_string("version", ceph_version_to_str());
     f->dump_string("commit", git_version_to_str());
     f->dump_stream("timestamp") << ceph_clock_now();
 

--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -44,7 +44,7 @@ add_executable(unittest-seastar-alienstore-thread-pool
 add_ceph_test(unittest-seastar-alienstore-thread-pool
   unittest-seastar-alienstore-thread-pool --memory 256M --smp 1)
 target_link_libraries(unittest-seastar-alienstore-thread-pool
-  crimson-os
+  crimson-alienstore
   crimson)
 
 add_executable(unittest-seastar-config

--- a/src/test/crimson/seastore/CMakeLists.txt
+++ b/src/test/crimson/seastore/CMakeLists.txt
@@ -6,9 +6,7 @@ add_ceph_unittest(unittest-transaction-manager)
 target_link_libraries(
   unittest-transaction-manager
   ${CMAKE_DL_LIBS}
-  crimson-seastore
-  crimson-os
-  crimson-common)
+  crimson-seastore)
 
 add_executable(unittest-btree-lba-manager
   test_btree_lba_manager.cc
@@ -17,9 +15,7 @@ add_ceph_unittest(unittest-btree-lba-manager)
 target_link_libraries(
   unittest-btree-lba-manager
   ${CMAKE_DL_LIBS}
-  crimson-seastore
-  crimson-os
-  crimson-common)
+  crimson-seastore)
 
 add_executable(unittest-seastore-journal
   test_seastore_journal.cc)
@@ -28,9 +24,7 @@ add_ceph_test(unittest-seastore-journal
 target_link_libraries(
   unittest-seastore-journal
   crimson::gtest
-  crimson-seastore
-  crimson-os
-  crimson-common)
+  crimson-seastore)
 
 add_executable(unittest-seastore-cache
   test_block.cc
@@ -40,9 +34,7 @@ add_ceph_test(unittest-seastore-cache
 target_link_libraries(
   unittest-seastore-cache
   crimson::gtest
-  crimson-seastore
-  crimson-os
-  crimson-common)
+  crimson-seastore)
 
 add_executable(unittest-extmap-manager
   test_extmap_manager.cc

--- a/src/test/crimson/seastore/onode_tree/CMakeLists.txt
+++ b/src/test/crimson/seastore/onode_tree/CMakeLists.txt
@@ -3,9 +3,7 @@ add_executable(test-seastore-onode-tree-node
 add_ceph_unittest(test-seastore-onode-tree-node)
 target_link_libraries(test-seastore-onode-tree-node
   crimson-seastore
-  GTest::Main
-  crimson-os
-  crimson-common)
+  GTest::Main)
 
 add_executable(unittest-staged-fltree
   test_staged_fltree.cc

--- a/src/tools/immutable_object_cache/CacheClient.cc
+++ b/src/tools/immutable_object_cache/CacheClient.cc
@@ -380,7 +380,7 @@ namespace immutable_obj_cache {
   int CacheClient::register_client(Context* on_finish) {
     ObjectCacheRequest* reg_req = new ObjectCacheRegData(RBDSC_REGISTER,
                                                          m_sequence_id++,
-                                                         ceph_version_to_str(m_cct));
+                                                         ceph_version_to_str());
     reg_req->encode();
 
     bufferlist bl;


### PR DESCRIPTION
this change partially reverts 652dbacc7424efbd3c3175de8ba79ed29edd55c8
quite a few test does not use crimson-os at all, so no need to link
against this library.

even worse is that crimson-os contains crimson-seastore *and*
crimson-alienstore. this introduces cyclic references.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
