### PR TITLE
octopus: mgr/dashboard: remove pyOpenSSL version pinning

### DIFF
--- a/src/pybind/mgr/dashboard/constraints.txt
+++ b/src/pybind/mgr/dashboard/constraints.txt
@@ -2,7 +2,6 @@ CherryPy==13.1.0
 enum34==1.1.6
 more-itertools==4.1.0
 PyJWT==1.6.4
-pyopenssl==17.5.0
 bcrypt==3.1.4
 python3-saml==1.4.1
 requests==2.20.0


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48511

---

backport of https://github.com/ceph/ceph/pull/38498
parent tracker: https://tracker.ceph.com/issues/48506

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh