### PR TITLE
nautilus: mgr/dashboard: remove pyOpenSSL version pinning

### DIFF
--- a/src/pybind/mgr/dashboard/constraints.txt
+++ b/src/pybind/mgr/dashboard/constraints.txt
@@ -2,7 +2,6 @@ CherryPy==13.1.0
 enum34==1.1.6
 more-itertools==4.1.0
 PyJWT==1.6.4
-pyopenssl==17.5.0
 bcrypt==3.1.4
 python3-saml==1.4.1
 requests==2.20.0

--- a/src/pybind/mgr/dashboard/requirements.txt
+++ b/src/pybind/mgr/dashboard/requirements.txt
@@ -19,7 +19,7 @@ py==1.5.2
 pycodestyle==2.4.0
 pycparser==2.18
 PyJWT==1.6.4
-pyopenssl==17.5.0
+pyopenssl
 pytest==3.3.2
 pytest-cov==2.5.1
 pytest-faulthandler==1.0.1


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48512

---

backport of https://github.com/ceph/ceph/pull/38498
parent tracker: https://tracker.ceph.com/issues/48506

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh