### PR TITLE
octopus: mgr/dashboard: Updating the inbuilt ssl providers error

### DIFF
--- a/src/pybind/mgr/dashboard/cherrypy_backports.py
+++ b/src/pybind/mgr/dashboard/cherrypy_backports.py
@@ -95,11 +95,16 @@ def accept_exceptions_from_builtin_ssl(v):
                         # Check if it's one of the known errors
                         # Errors that are caught by PyOpenSSL, but thrown by
                         # built-in ssl
-                        _block_errors = ('unknown protocol', 'unknown ca',
-                                         'unknown_ca', 'inappropriate fallback',
+                        _block_errors = ('unknown protocol', 'unknown ca', 'unknown_ca',
+                                         'unknown error',
+                                         'https proxy request', 'inappropriate fallback',
                                          'wrong version number',
                                          'no shared cipher', 'certificate unknown',
-                                         'ccs received early')
+                                         'ccs received early',
+                                         'certificate verify failed',  # client cert w/o trusted CA
+                                         'version too low',  # caused by SSL3 connections
+                                         'unsupported protocol',  # caused by TLS1 connections
+                                        )
                         for error_text in _block_errors:
                             if error_text in e.args[1].lower():
                                 # Accepted error, let's pass

--- a/src/pybind/mgr/dashboard/cherrypy_backports.py
+++ b/src/pybind/mgr/dashboard/cherrypy_backports.py
@@ -104,7 +104,7 @@ def accept_exceptions_from_builtin_ssl(v):
                                          'certificate verify failed',  # client cert w/o trusted CA
                                          'version too low',  # caused by SSL3 connections
                                          'unsupported protocol',  # caused by TLS1 connections
-                                        )
+                                         'sslv3 alert bad certificate')
                         for error_text in _block_errors:
                             if error_text in e.args[1].lower():
                                 # Accepted error, let's pass


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48515

---

backport of https://github.com/ceph/ceph/pull/38484
parent tracker: https://tracker.ceph.com/issues/48490

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh