### PR TITLE
mgr/volumes/nfs: remove 'ganesha-' prefix from cluster id

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -34,6 +34,11 @@
   must still set the "enable_multiple" flag on the fs. Please see the CephFS
   documentation for more information.
 
+* volume/nfs: Recently "ganesha-" prefix from cluster id and nfs-ganesha common
+  config object was removed, to ensure consistent namespace across different
+  orchestrator backends. Please delete any existing nfs-ganesha clusters prior
+  to upgrading and redeploy new clusters after upgrading to Pacific.
+
 * A new health check, DAEMON_OLD_VERSION, will warn if different versions of Ceph are running
   on daemons. It will generate a health error if multiple versions are detected.
   This condition must exist for over mon_warn_older_version_delay (set to 1 week by default) in order for the

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -36,7 +36,7 @@ class TestNFS(MgrTestCase):
         self.pseudo_path = "/cephfs"
         self.path = "/"
         self.fs_name = "nfs-cephfs"
-        self.expected_name = "nfs.ganesha-test"
+        self.expected_name = "nfs.test"
         self.sample_export = {
          "export_id": 1,
          "path": self.path,
@@ -119,7 +119,7 @@ class TestNFS(MgrTestCase):
         # Disable any running nfs ganesha daemon
         self._check_nfs_server_status()
         self._nfs_cmd('cluster', 'create', self.export_type, self.cluster_id)
-        # Check for expected status and daemon name (nfs.ganesha-<cluster_id>)
+        # Check for expected status and daemon name (nfs.<cluster_id>)
         self._check_nfs_cluster_status('running', 'NFS Ganesha cluster deployment failed')
 
     def _test_delete_cluster(self):
@@ -496,7 +496,7 @@ class TestNFS(MgrTestCase):
             'set', self.cluster_id, '-i', '-'], stdin=config)
         time.sleep(30)
         res = self._sys_cmd(['rados', '-p', pool, '-N', self.cluster_id, 'get',
-                             f'userconf-nfs.ganesha-{user_id}', '-'])
+                             f'userconf-nfs.{user_id}', '-'])
         self.assertEqual(config, res.decode('utf-8'))
         self._test_mnt(pseudo_path, port, ip)
         self._nfs_cmd('cluster', 'config', 'reset', self.cluster_id)

--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -19,17 +19,17 @@ POOL_NAME = 'nfs-ganesha'
 def available_clusters(mgr):
     '''
     This method returns list of available cluster ids.
-    It removes 'ganesha-' prefixes from cluster service id returned by cephadm.
+    Service name is service_type.service_id
     Example:
     completion.result value:
-    <ServiceDescription of <NFSServiceSpec for service_name=nfs.ganesha-vstart>>
-    return value: ['ganesha-vstart'] -> ['vstart']
+    <ServiceDescription of <NFSServiceSpec for service_name=nfs.vstart>>
+    return value: ['vstart']
     '''
     # TODO check cephadm cluster list with rados pool conf objects
     completion = mgr.describe_service(service_type='nfs')
     mgr._orchestrator_wait([completion])
     orchestrator.raise_if_exception(completion)
-    return [cluster.spec.service_id.replace('ganesha-', '', 1) for cluster in completion.result
+    return [cluster.spec.service_id for cluster in completion.result
             if cluster.spec.service_id]
 
 
@@ -513,7 +513,7 @@ class FSExport(object):
     def _save_export(self, export):
         self.exports[self.rados_namespace].append(export)
         NFSRados(self.mgr, self.rados_namespace).write_obj(export.to_export_block(),
-                 f'export-{export.export_id}', f'conf-nfs.ganesha-{export.cluster_id}')
+                 f'export-{export.export_id}', f'conf-nfs.{export.cluster_id}')
 
     def _delete_export(self, cluster_id, pseudo_path, export_obj=None):
         try:
@@ -525,7 +525,7 @@ class FSExport(object):
             if export:
                 if pseudo_path:
                     NFSRados(self.mgr, self.rados_namespace).remove_obj(
-                             f'export-{export.export_id}', f'conf-nfs.ganesha-{cluster_id}')
+                             f'export-{export.export_id}', f'conf-nfs.{cluster_id}')
                 self.exports[cluster_id].remove(export)
                 self._delete_user(export.fsal.user_id)
                 if not self.exports[cluster_id]:
@@ -646,7 +646,7 @@ class NFSCluster:
         self.mgr = mgr
 
     def _set_cluster_id(self, cluster_id):
-        self.cluster_id = f"ganesha-{cluster_id}"
+        self.cluster_id = cluster_id
 
     def _set_pool_namespace(self, cluster_id):
         self.pool_ns = cluster_id


### PR DESCRIPTION
Orchestrator defines service name as "<service_type>.<service_id>". The ganesha
common config object name in orchestrator is "conf-<service_name>". Volume's
nfs plugin deploys nfs-ganesha clusters with 'ganesha' prefixed to cluster id
and common config object. It can cause unecessary issues with rook and cephadm
nfs deployments. So let's remove the prefix.

Fixes: https://tracker.ceph.com/issues/48514
Signed-off-by: Varsha Rao <varao@redhat.com>

Note: Not supporting backward compatibility
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

-->
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
