### PR TITLE
qa/tasks/cephfs/nfs: Check if host ip is in cluster info output

### DIFF
--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -428,12 +428,14 @@ class TestNFS(MgrTestCase):
         '''
         self._test_create_cluster()
         info_output = json.loads(self._nfs_cmd('cluster', 'info', self.cluster_id))
+        info_ip = info_output[self.cluster_id][0].pop("ip")
         host_details = {self.cluster_id: [{
             "hostname": self._sys_cmd(['hostname']).decode("utf-8").strip(),
-            "ip": list(set(self._sys_cmd(['hostname', '-I']).decode("utf-8").split())),
             "port": 2049
             }]}
+        host_ip = self._sys_cmd(['hostname', '-I']).decode("utf-8").split()
         self.assertDictEqual(info_output, host_details)
+        self.assertTrue(any([ip in info_ip for ip in host_ip]))
         self._test_delete_cluster()
 
     def test_cluster_set_reset_user_config(self):


### PR DESCRIPTION
Along with host IP, sometimes Docker container IP's shows up in 'hostname -I'
output. Since this output is variable. Just check if host IP is present in the
cluster info output.

Fixes: https://tracker.ceph.com/issues/48491
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---
-->
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
