### PR TITLE
mds: ensure dirfrags are fetched once

### DIFF
--- a/src/mds/OpenFileTable.cc
+++ b/src/mds/OpenFileTable.cc
@@ -1053,7 +1053,7 @@ void OpenFileTable::_prefetch_dirfrags()
   ceph_assert(prefetch_state == DIRFRAGS);
 
   MDCache *mdcache = mds->mdcache;
-  std::vector<CDir*> fetch_queue;
+  std::set<CDir*> fetch_queue;
 
   for (auto& [ino, anchor] : loaded_anchor_map) {
     if (anchor.frags.empty())
@@ -1068,7 +1068,7 @@ void OpenFileTable::_prefetch_dirfrags()
       CDir *dir = diri->get_dirfrag(fg);
       if (dir) {
 	if (dir->is_auth() && !dir->is_complete())
-	  fetch_queue.push_back(dir);
+	  fetch_queue.insert(dir);
       } else {
 	frag_vec_t leaves;
 	diri->dirfragtree.get_leaves_under(fg, leaves);
@@ -1081,7 +1081,7 @@ void OpenFileTable::_prefetch_dirfrags()
 	    dir = diri->get_dirfrag(leaf);
 	  }
 	  if (dir && dir->is_auth() && !dir->is_complete())
-	    fetch_queue.push_back(dir);
+	    fetch_queue.insert(dir);
 	}
       }
     }

--- a/src/mds/OpenFileTable.cc
+++ b/src/mds/OpenFileTable.cc
@@ -1055,16 +1055,16 @@ void OpenFileTable::_prefetch_dirfrags()
   MDCache *mdcache = mds->mdcache;
   std::vector<CDir*> fetch_queue;
 
-  for (auto& it : loaded_anchor_map) {
-    if (it.second.frags.empty())
+  for (auto& [ino, anchor] : loaded_anchor_map) {
+    if (anchor.frags.empty())
       continue;
-    CInode *diri = mdcache->get_inode(it.first);
+    CInode *diri = mdcache->get_inode(ino);
     if (!diri)
       continue;
     if (diri->state_test(CInode::STATE_REJOINUNDEF))
       continue;
 
-    for (auto& fg: it.second.frags) {
+    for (auto& fg: anchor.frags) {
       CDir *dir = diri->get_dirfrag(fg);
       if (dir) {
 	if (dir->is_auth() && !dir->is_complete())


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
