### PR TITLE
librbd/cache: fix some lock issues

### DIFF
--- a/src/librbd/cache/pwl/ImageCacheState.cc
+++ b/src/librbd/cache/pwl/ImageCacheState.cc
@@ -67,7 +67,6 @@ ImageCacheState<I>::ImageCacheState(
 
 template <typename I>
 void ImageCacheState<I>::write_image_cache_state(Context *on_finish) {
-  std::shared_lock owner_lock{m_image_ctx->owner_lock};
   JSONFormattable f;
   ::encode_json(IMAGE_CACHE_STATE.c_str(), *this, &f);
   std::ostringstream oss;
@@ -82,7 +81,6 @@ void ImageCacheState<I>::write_image_cache_state(Context *on_finish) {
 
 template <typename I>
 void ImageCacheState<I>::clear_image_cache_state(Context *on_finish) {
-  std::shared_lock owner_lock{m_image_ctx->owner_lock};
   ldout(m_image_ctx->cct, 20) << __func__ << " Remove state: " << dendl;
   m_plugin_api.execute_image_metadata_remove(
     m_image_ctx, IMAGE_CACHE_STATE, on_finish);

--- a/src/librbd/cache/pwl/ShutdownRequest.cc
+++ b/src/librbd/cache/pwl/ShutdownRequest.cc
@@ -131,7 +131,6 @@ void ShutdownRequest<I>::send_remove_image_cache_state() {
   using klass = ShutdownRequest<I>;
   Context *ctx = create_context_callback<klass, &klass::handle_remove_image_cache_state>(
     this);
-  std::shared_lock owner_lock{m_image_ctx.owner_lock};
   m_plugin_api.execute_image_metadata_remove(&m_image_ctx, IMAGE_CACHE_STATE, ctx);
 }
 

--- a/src/librbd/plugin/Api.cc
+++ b/src/librbd/plugin/Api.cc
@@ -26,6 +26,7 @@ void Api<I>::execute_image_metadata_set(
     I *image_ctx, const std::string &key,
     const std::string &value, Context *on_finish) {
   ImageCtx* ictx = util::get_image_ctx(image_ctx);
+  std::unique_lock owner_lock{ictx->owner_lock};
   ictx->operations->execute_metadata_set(key, value, on_finish);
 }
 
@@ -33,6 +34,7 @@ template <typename I>
 void Api<I>::execute_image_metadata_remove(
     I *image_ctx, const std::string &key, Context *on_finish) {
   ImageCtx* ictx = util::get_image_ctx(image_ctx);
+  std::unique_lock owner_lock{ictx->owner_lock};
   ictx->operations->execute_metadata_remove(key, on_finish);
 }
 


### PR DESCRIPTION
Use unique_lock instead of shared_lock when updating metadata.

Signed-off-by: Li, Xiaoyan <xiaoyan.li@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
