### PR TITLE
script/run-cbt.sh: drop bashism

### DIFF
--- a/src/script/run-cbt.sh
+++ b/src/script/run-cbt.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 usage() {
-    local prog_name=$1
+    prog_name=$1
     shift
     cat <<EOF
 usage:
@@ -86,13 +86,13 @@ fi
 # store absolute path before changing cwd
 source_dir=$(readlink -f $source_dir)
 if ! $use_existing; then
-    cd $build_dir
+    cd $build_dir || exit
     # seastar uses 128*8 aio in reactor for io and 10003 aio for events pooling
     # for each core, if it fails to enough aio context, the seastar application
     # bails out. and take other process into consideration, let's make it
     # 32768 per core
-    max_io=$(expr 32768 \* $(nproc))
-    if test $(/sbin/sysctl --values fs.aio-max-nr) -lt $max_io; then
+    max_io=$(expr 32768 \* "$(nproc)")
+    if test "$(/sbin/sysctl --values fs.aio-max-nr)" -lt $max_io; then
         sudo /sbin/sysctl -q -w fs.aio-max-nr=$max_io
     fi
     if $classical; then
@@ -105,7 +105,7 @@ if ! $use_existing; then
            --crimson --nodaemon --redirect-output \
            --osd-args "--memory 4G"
     fi
-    cd -
+    cd - || exit
 fi
 
 for config_file in $config_files; do
@@ -123,7 +123,7 @@ for config_file in $config_files; do
 done
 
 if ! $use_existing; then
-    cd $build_dir
+    cd $build_dir || exit
     if $classical; then
       $source_dir/src/stop.sh
     else


### PR DESCRIPTION
* "local" is not supported by POSIX shell, so drop it
* assign "$*" to a non-array variable, see
  https://github.com/koalaman/shellcheck/wiki/SC2124
* fail early if "cd" fails, see
  https://github.com/koalaman/shellcheck/wiki/SC2164
* quote "$(...)" with quotes to avoid string split

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
