### PR TITLE
rgw: lower x-amz-storage-class head

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -98,7 +98,7 @@ static const struct rgw_http_attr base_rgw_to_http_attrs[] = {
   { RGW_ATTR_CONTENT_ENC,       "Content-Encoding" },
   { RGW_ATTR_USER_MANIFEST,     "X-Object-Manifest" },
   { RGW_ATTR_X_ROBOTS_TAG ,     "X-Robots-Tag" },
-  { RGW_ATTR_STORAGE_CLASS ,    "X-Amz-Storage-Class" },
+  { RGW_ATTR_STORAGE_CLASS ,    "x-amz-storage-class" },
   /* RGW_ATTR_AMZ_WEBSITE_REDIRECT_LOCATION header depends on access mode:
    * S3 endpoint: x-amz-website-redirect-location
    * S3Website endpoint: Location


### PR DESCRIPTION
When head object to s3, the head `x-amz-storage-class` is all lowercase. While to rgw, it looks like `X-Amz-Storage-Class`.

```
root@ubuntu:~# curl --head https://rgwyest.s3-ap-northeast-1.amazonaws.com/test.png
HTTP/1.1 200 OK
x-amz-id-2: OjXkpFzwXDWU2sGw20HPe8QvsDgiekEPQbNlYNugL1Vg3dTagwsP9yPoN8PsHWSx7NJZf7rXlKs=
x-amz-request-id: 635B9BD824EFBF72
Date: Thu, 10 Dec 2020 06:06:57 GMT
Last-Modified: Thu, 10 Dec 2020 03:22:18 GMT
ETag: "f8fb8159899b565c85dbc7ef879b53e3"
x-amz-storage-class: STANDARD_IA
Accept-Ranges: bytes
Content-Type: image/png
Content-Length: 1638765
Server: AmazonS3

root@ubuntu:~# curl --head 10.221.128.14:8080/wyq/test
HTTP/1.1 200 OK
Content-Length: 1353
Accept-Ranges: bytes
Last-Modified: Thu, 10 Dec 2020 05:35:06 GMT
x-rgw-object-type: Normal
ETag: "ba7ceb73c5acc95c913b8ca0e806c0fc"
x-amz-meta-s3cmd-attrs: atime:1607567992/ctime:1604300725/gid:0/gname:root/md5:ba7ceb73c5acc95c913b8ca0e806c0fc/mode:33188/mtime:1604300715/uid:0/uname:root
X-Amz-Storage-Class: STANDARD_IA
x-amz-request-id: tx000000000000000000003-005fd1bafb-dd05-cn-north-3a
Content-Type: text/plain
Date: Thu, 10 Dec 2020 06:06:51 GMT
Connection: Keep-Alive


```








Signed-off-by: wangyunqing <wangyunqing@inspur.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
