### PR TITLE
java: Add CephRgwFileSystem base on librgw for hadoop

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -33,8 +33,10 @@
 %bcond_without selinux
 %if 0%{?rhel} >= 8
 %bcond_with cephfs_java
+%bcond_with cephrgw_java
 %else
 %bcond_without cephfs_java
+%bcond_without cephrgw_java
 %endif
 %bcond_without amqp_endpoint
 %bcond_without kafka_endpoint
@@ -46,6 +48,7 @@
 %if 0%{?suse_version}
 %bcond_with amqp_endpoint
 %bcond_with cephfs_java
+%bcond_with cephrgw_java
 %bcond_with kafka_endpoint
 %bcond_with libradosstriper
 %ifarch x86_64 aarch64 ppc64le
@@ -123,7 +126,7 @@ Requires:       ceph-mds = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
 Requires:       ceph-mon = %{_epoch_prefix}%{version}-%{release}
 Requires(post):	binutils
-%if 0%{with cephfs_java}
+%if 0%{with cephfs_java} || 0%{with cephrgw_java}
 BuildRequires:	java-devel
 BuildRequires:	sharutils
 %endif
@@ -1030,6 +1033,47 @@ This package contains the Java libraries for the Ceph File System.
 
 %endif
 
+%if 0%{with cephrgw_java}
+
+%package -n libcephrgw_jni1
+Summary:	Java Native Interface library for CephRGW Java bindings
+%if 0%{?suse_version}
+Group:		System/Libraries
+%endif
+Requires:	java
+Requires:	librgw2 = %{_epoch_prefix}%{version}-%{release}
+%description -n libcephrgw_jni1
+This package contains the Java Native Interface library for CephRGW Java
+bindings.
+
+%package -n libcephrgw_jni-devel
+Summary:	Development files for CephRGW Java Native Interface library
+%if 0%{?suse_version}
+Group:		Development/Libraries/Java
+%endif
+Requires:	java
+Requires:	libcephrgw_jni1 = %{_epoch_prefix}%{version}-%{release}
+Obsoletes:	ceph-devel < %{_epoch_prefix}%{version}-%{release}
+Provides:	libcephrgw_jni1-devel = %{_epoch_prefix}%{version}-%{release}
+Obsoletes:	libcephrgw_jni1-devel < %{_epoch_prefix}%{version}-%{release}
+%description -n libcephrgw_jni-devel
+This package contains the development files for CephRGW Java Native Interface
+library.
+
+%package -n cephrgw-java
+Summary:	Java libraries for the CephRGW File System
+%if 0%{?suse_version}
+Group:		System/Libraries
+%endif
+Requires:	java
+Requires:	libcephrgw_jni1 = %{_epoch_prefix}%{version}-%{release}
+Requires:       junit
+BuildRequires:  junit
+%description -n cephrgw-java
+This package contains the Java libraries for the CephRGW File System.
+
+%endif
+
 %package -n rados-objclass-devel
 Summary:        RADOS object class development kit
 %if 0%{?suse_version}
@@ -1094,7 +1138,7 @@ This package provides Ceph’s default alerts for Prometheus.
 . /opt/rh/gcc-toolset-9/enable
 %endif
 
-%if 0%{with cephfs_java}
+%if 0%{with cephfs_java} || 0%{with cephrgw_java}
 # Find jni.h
 for i in /usr/{lib64,lib}/jvm/java/include{,/linux}; do
     [ -d $i ] && java_inc="$java_inc -I$i"
@@ -1161,6 +1205,9 @@ ${CMAKE} .. \
 %endif
 %if 0%{with cephfs_java}
     -DWITH_CEPHFS_JAVA=ON \
+%endif
+%if 0%{with cephrgw_java}
+    -DWITH_CEPHRGW_JAVA=ON \
 %endif
 %if 0%{with selinux}
     -DWITH_SELINUX=ON \
@@ -2147,6 +2194,21 @@ fi
 %files -n cephfs-java
 %{_javadir}/libcephfs.jar
 %{_javadir}/libcephfs-test.jar
+%endif
+
+%if 0%{with cephrgw_java}
+%files -n libcephrgw_jni1
+%{_libdir}/libcephrgw_jni.so.*
+
+%post -n libcephrgw_jni1 -p /sbin/ldconfig
+
+%postun -n libcephrgw_jni1 -p /sbin/ldconfig
+
+%files -n libcephrgw_jni-devel
+%{_libdir}/libcephrgw_jni.so
+
+%files -n cephrgw-java
+%{_javadir}/libcephrgw.jar
 %endif
 
 %files -n rados-objclass-devel

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -250,7 +250,8 @@ if(WITH_OCF)
 endif()
 
 option(WITH_CEPHFS_JAVA "build libcephfs Java bindings" OFF)
-if(WITH_CEPHFS_JAVA)
+option(WITH_CEPHRGW_JAVA "build libcephrgw Java bindings" OFF)
+if(WITH_CEPHFS_JAVA OR WITH_CEPHRGW_JAVA)
   add_subdirectory(java)
 endif()
 

--- a/src/java/CMakeLists.txt
+++ b/src/java/CMakeLists.txt
@@ -2,60 +2,95 @@ find_package(Java COMPONENTS Development REQUIRED)
 find_package(JNI REQUIRED)
 include(UseJava)
 
-set(java_srcs
-  java/com/ceph/crush/Bucket.java
-  java/com/ceph/fs/CephAlreadyMountedException.java
-  java/com/ceph/fs/CephFileAlreadyExistsException.java
-  java/com/ceph/fs/CephFileExtent.java
-  java/com/ceph/fs/CephMount.java
-  java/com/ceph/fs/CephNativeLoader.java
-  java/com/ceph/fs/CephNotDirectoryException.java
-  java/com/ceph/fs/CephNotMountedException.java
-  java/com/ceph/fs/CephPoolException.java
-  java/com/ceph/fs/CephStat.java
-  java/com/ceph/fs/CephStatVFS.java)
+if(WITH_CEPHFS_JAVA)
+  set(java_srcs
+    java/com/ceph/crush/Bucket.java
+    java/com/ceph/fs/CephAlreadyMountedException.java
+    java/com/ceph/fs/CephFileAlreadyExistsException.java
+    java/com/ceph/fs/CephFileExtent.java
+    java/com/ceph/fs/CephMount.java
+    java/com/ceph/fs/CephNativeLoader.java
+    java/com/ceph/fs/CephNotDirectoryException.java
+    java/com/ceph/fs/CephNotMountedException.java
+    java/com/ceph/fs/CephPoolException.java
+    java/com/ceph/fs/CephStat.java
+    java/com/ceph/fs/CephStatVFS.java)
+  
+  # note: for the -source 1.7 builds, we add
+  #   -Xlint:-options
+  # to get rid of the warning
+  #   warning: [options] bootstrap class path not set in conjunction with -source 1.7
+  # as per
+  #   https://blogs.oracle.com/darcy/entry/bootclasspath_older_source
+  set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.8" "-target" "1.8" "-Xlint:-options")
+  set(jni_header_dir "${CMAKE_CURRENT_BINARY_DIR}/native")
+  if(CMAKE_VERSION VERSION_LESS 3.11)
+    set(CMAKE_JAVA_COMPILE_FLAGS ${CMAKE_JAVA_COMPILE_FLAGS} "-h" ${jni_header_dir})
+    add_jar(libcephfs ${java_srcs})
+    add_custom_target(
+      jni-header
+      DEPENDS libcephfs)
+    add_dependencies(jni-header libcephfs)
+  else()
+    add_jar(libcephfs ${java_srcs}
+      GENERATE_NATIVE_HEADERS jni-header
+      DESTINATION ${jni_header_dir})
+  endif()
+  get_property(libcephfs_jar TARGET libcephfs PROPERTY JAR_FILE)
+  install_jar(libcephfs share/java)
+  
+  find_jar(JUNIT_JAR
+    NAMES junit4 junit
+    PATHS "/usr/share/java")
+  if(JUNIT_JAR)
+    set(CMAKE_JAVA_INCLUDE_PATH ${JUNIT_JAR} ${libcephfs_jar})
+    set(java_test_srcs
+      test/com/ceph/fs/CephAllTests.java
+      test/com/ceph/fs/CephDoubleMountTest.java
+      test/com/ceph/fs/CephMountCreateTest.java
+      test/com/ceph/fs/CephMountTest.java
+      test/com/ceph/fs/CephUnmountedTest.java)
+    add_jar(libcephfs-test ${java_test_srcs})
+    add_dependencies(libcephfs-test libcephfs)
+    install_jar(libcephfs-test share/java)
+  endif(JUNIT_JAR)
+endif(WITH_CEPHFS_JAVA)
 
-# note: for the -source 1.7 builds, we add
-#   -Xlint:-options
-# to get rid of the warning
-#   warning: [options] bootstrap class path not set in conjunction with -source 1.7
-# as per
-#   https://blogs.oracle.com/darcy/entry/bootclasspath_older_source
-set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.8" "-target" "1.8" "-Xlint:-options")
-set(jni_header_dir "${CMAKE_CURRENT_BINARY_DIR}/native")
-if(CMAKE_VERSION VERSION_LESS 3.11)
-  set(CMAKE_JAVA_COMPILE_FLAGS ${CMAKE_JAVA_COMPILE_FLAGS} "-h" ${jni_header_dir})
-  add_jar(libcephfs ${java_srcs})
-  add_custom_target(
-    jni-header
-    DEPENDS libcephfs)
-  add_dependencies(jni-header libcephfs)
-else()
-  add_jar(libcephfs ${java_srcs}
-    GENERATE_NATIVE_HEADERS jni-header
-    DESTINATION ${jni_header_dir})
-endif()
-get_property(libcephfs_jar TARGET libcephfs PROPERTY JAR_FILE)
-install_jar(libcephfs share/java)
-
-find_jar(JUNIT_JAR
-  NAMES junit4 junit
-  PATHS "/usr/share/java")
-if(JUNIT_JAR)
-  set(CMAKE_JAVA_INCLUDE_PATH ${JUNIT_JAR} ${libcephfs_jar})
-  set(java_test_srcs
-    test/com/ceph/fs/CephAllTests.java
-    test/com/ceph/fs/CephDoubleMountTest.java
-    test/com/ceph/fs/CephMountCreateTest.java
-    test/com/ceph/fs/CephMountTest.java
-    test/com/ceph/fs/CephUnmountedTest.java)
-  add_jar(libcephfs-test ${java_test_srcs})
-  add_dependencies(libcephfs-test libcephfs)
-  install_jar(libcephfs-test share/java)
-endif(JUNIT_JAR)
+if(WITH_CEPHRGW_JAVA)
+  set(rgw_java_srcs
+    java/com/ceph/rgw/CephFileAlreadyExistsException.java
+    java/com/ceph/rgw/CephRgwAdapter.java
+    java/com/ceph/rgw/CephNativeLoader.java
+    java/com/ceph/rgw/CephStat.java
+    java/com/ceph/rgw/CephStatVFS.java)
+  
+  # note: for the -source 1.7 builds, we add
+  #   -Xlint:-options
+  # to get rid of the warning
+  #   warning: [options] bootstrap class path not set in conjunction with -source 1.7
+  # as per
+  #   https://blogs.oracle.com/darcy/entry/bootclasspath_older_source
+  set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.8" "-target" "1.8" "-Xlint:-options")
+  set(jni_header_dir "${CMAKE_CURRENT_BINARY_DIR}/native")
+  if(CMAKE_VERSION VERSION_LESS 3.11)
+    set(CMAKE_JAVA_COMPILE_FLAGS ${CMAKE_JAVA_COMPILE_FLAGS} "-h" ${jni_header_dir})
+    add_jar(libcephrgw ${rgw_java_srcs})
+    add_custom_target(
+      rgwjni-header
+      DEPENDS libcephrgw)
+    add_dependencies(rgwjni-header libcephrgw)
+  else()
+    add_jar(libcephrgw ${rgw_java_srcs}
+      GENERATE_NATIVE_HEADERS rgwjni-header
+      DESTINATION ${jni_header_dir})
+  endif()
+  get_property(libcephrgw_jar TARGET libcephrgw PROPERTY JAR_FILE)
+  install_jar(libcephrgw share/java)
+endif(WITH_CEPHRGW_JAVA)
 
 add_subdirectory(native)
 
 add_custom_target(java DEPENDS
   libcephfs.jar
   libcephfs_jni)
+

--- a/src/java/java/com/ceph/rgw/CephFileAlreadyExistsException.java
+++ b/src/java/java/com/ceph/rgw/CephFileAlreadyExistsException.java
@@ -1,0 +1,44 @@
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package com.ceph.rgw;
+
+import java.io.IOException;
+
+/**
+ * Ceph file/directory already exists.
+ */
+public class CephFileAlreadyExistsException extends IOException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Construct CephFileAlreadyExistsException.
+     */
+    public CephFileAlreadyExistsException() {
+        super();
+    }
+
+    /**
+     * Construct CephFileAlreadyExistsException with message.
+     */
+    public CephFileAlreadyExistsException(String s) {
+        super(s);
+    }
+}

--- a/src/java/java/com/ceph/rgw/CephNativeLoader.java
+++ b/src/java/java/com/ceph/rgw/CephNativeLoader.java
@@ -1,0 +1,94 @@
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package com.ceph.rgw;
+
+class CephNativeLoader {
+    private static final CephNativeLoader instance = new CephNativeLoader();
+    private static boolean initialized = false;
+
+    private static final String JNI_PATH_ENV_VAR = "CEPH_JNI_PATH";
+    private static final String LIBRARY_NAME = "cephrgw_jni";
+    private static final String LIBRARY_FILE = "libcephrgw_jni.so";
+
+    private CephNativeLoader() {
+    }
+
+    public static CephNativeLoader getInstance() {
+        return instance;
+    }
+
+    public synchronized void loadLibrary() {
+        if (initialized)
+            return;
+
+        boolean success = false;
+
+        /*
+         * Allow a Ceph specific environment variable to force
+         * the loading path.
+         */
+        String path = System.getenv(JNI_PATH_ENV_VAR);
+        try {
+            if (path != null) {
+                System.out.println("Loading libcephrgw-jni: " + path);
+                System.load(path);
+                success = true;
+            } else {
+                try {
+                    /*
+                     * Try default Java loading path(s)
+                     */
+                    System.out.println("Loading libcephrgw-jni from default path: " +
+                            System.getProperty("java.library.path"));
+                    System.loadLibrary(LIBRARY_NAME);
+                    success = true;
+                } catch (final UnsatisfiedLinkError ule1) {
+                    try {
+                        /*
+                         * Try RHEL/CentOS default path
+                         */
+                        path = "/usr/lib64/" + LIBRARY_FILE;
+                        System.out.println("Loading libcephrgw-jni: " + path);
+                        System.load(path);
+                        success = true;
+                    } catch (final UnsatisfiedLinkError ule2) {
+                        /*
+                         * Try Ubuntu default path
+                         */
+                        path = "/usr/lib/jni/" + LIBRARY_FILE;
+                        System.out.println("Loading libcephrgw-jni: " + path);
+                        System.load(path);
+                        success = true;
+                    }
+                }
+            }
+        } finally {
+            System.out.println("Loading libcephrgw-jni: " +
+                    (success ? "Success!" : "Failure!"));
+        }
+
+        /*
+         * Finish initialization
+         */
+        CephRgwAdapter.native_initialize();
+        initialized = true;
+    }
+
+}

--- a/src/java/java/com/ceph/rgw/CephRgwAdapter.java
+++ b/src/java/java/com/ceph/rgw/CephRgwAdapter.java
@@ -1,0 +1,353 @@
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package com.ceph.rgw;
+
+import java.io.IOException;
+import java.io.FileNotFoundException;
+import java.net.InetAddress;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.LinkedList;
+import java.lang.String;
+
+public class CephRgwAdapter {
+    private long rgwFS;
+    private long rootFH;
+    private long bucketFH;
+    /*
+     * Flags for open().
+     *
+     * Must be synchronized with JNI if changed.
+     */
+    public static final int O_RDONLY = 1;
+    public static final int O_RDWR = 2;
+    public static final int O_APPEND = 4;
+    public static final int O_CREAT = 8;
+    public static final int O_TRUNC = 16;
+    public static final int O_EXCL = 32;
+    public static final int O_WRONLY = 64;
+    public static final int O_DIRECTORY = 128;
+
+    /*
+     * Whence flags for seek().
+     *
+     * Must be synchronized with JNI if changed.
+     */
+    public static final int SEEK_SET = 1;
+    public static final int SEEK_CUR = 2;
+    public static final int SEEK_END = 3;
+
+    /*
+     * Attribute flags for setattr().
+     *
+     * Must be synchronized with JNI if changed.
+     */
+    public static final int SETATTR_MODE = 1;
+    public static final int SETATTR_UID = 2;
+    public static final int SETATTR_GID = 4;
+    public static final int SETATTR_MTIME = 8;
+    public static final int SETATTR_ATIME = 16;
+
+    /*
+     * Flags for setxattr();
+     *
+     * Must be synchronized with JNI if changed.
+     */
+    public static final int XATTR_CREATE = 1;
+    public static final int XATTR_REPLACE = 2;
+    public static final int XATTR_NONE = 3;
+
+    /*
+     * Flags for flock();
+     *
+     * Must be synchronized with JNI if changed.
+     */
+    public static final int LOCK_SH = 1;
+    public static final int LOCK_EX = 2;
+    public static final int LOCK_NB = 4;
+    public static final int LOCK_UN = 8;
+
+    /*
+     * This is run by the class loader and will report early any problems
+     * finding or linking in the shared JNI library.
+     */
+    static {
+        loadLibrary();
+    }
+
+    static synchronized void loadLibrary() {
+        CephNativeLoader.getInstance().loadLibrary();
+    }
+
+    /*
+     * Package-private: called from CephNativeLoader
+     */
+    static native void native_initialize();
+
+    /*
+     * RW lock used for fine grained synchronization to native
+     */
+    private final ReentrantReadWriteLock rwlock = new ReentrantReadWriteLock();
+    private final Lock rlock = rwlock.readLock();
+    private final Lock wlock = rwlock.writeLock();
+
+    /*
+     * Controls clean-up synchronization between the constructor and finalize().
+     * If native_ceph_create fails, then we want a call to finalize() to not
+     * attempt to clean-up native context, because there is none.
+     */
+    private boolean initialized = false;
+
+    /*
+     * Try to clean-up. First, unmount() will catch users who forget to do the
+     * unmount manually. Second, release() will destroy the entire context. It
+     * is safe to call release after a failure in unmount.
+     */
+    protected void finalize() throws Throwable {
+        if (initialized) {
+            try {
+                unmount();
+            } catch (Exception e) {
+            }
+            try {
+                native_ceph_release(rgwFS);
+            } catch (Exception e) {
+            }
+        }
+        super.finalize();
+    }
+
+    /**
+     * Create a new CephRgwAdapter with specific client id.
+     *
+     * @param id client id.
+     */
+    public CephRgwAdapter(String cephArgs) {
+        native_ceph_create(cephArgs);
+        initialized = true;
+    }
+
+    private static native int native_ceph_create(String cephArgs);
+
+    /**
+     * Create a new CephRgwAdapter with default client id.
+     */
+    public CephRgwAdapter() {
+        this(null);
+    }
+
+    private long getLookupFH(boolean isRoot) {
+        if (isRoot == false)
+            return bucketFH;
+        return rootFH;
+    }
+
+    /**
+     * Activate the mount with a given root path.
+     *
+     * @param root The path to use as the root (pass null for "/").
+     */
+    public void mount(String uid, String access, String secret, String root) {
+        wlock.lock();
+        try {
+            rgwFS = native_ceph_mount(this, uid, access, secret, root);
+        } finally {
+            wlock.unlock();
+        }
+    }
+
+    private static native long native_ceph_mount(CephRgwAdapter obj, String uid, String access, String secret, String root);
+
+    /**
+     * Deactivate the mount.
+     * <p>
+     * The mount can be reactivated using mount(). Configuration parameters
+     * previously set are not reset.
+     */
+    public void unmount() {
+        wlock.lock();
+        try {
+            native_ceph_unmount(rgwFS);
+        } finally {
+            wlock.unlock();
+        }
+    }
+
+    private static native int native_ceph_unmount(long rgwFS);
+
+    /*
+     * Private access to low-level ceph_release.
+     */
+    private static native int native_ceph_release(long rgwFS);
+
+    public void statfs(String path, boolean isRoot, CephStatVFS statvfs) throws FileNotFoundException {
+        rlock.lock();
+        try {
+            native_ceph_statfs(rgwFS, getLookupFH(isRoot), path, statvfs);
+        } finally {
+            rlock.unlock();
+        }
+    }
+
+    private static native int native_ceph_statfs(long rgwFS, long fh, String path, CephStatVFS statvfs);
+
+    abstract class ListDirHandler {
+        void listDirHandler(String name, int mode, int uid, int gid, long size, long blksize, long blocks, long mTime, long aTime) throws IOException {
+            CephStat stat = new CephStat(mode, uid, gid, size, blksize, blocks, mTime, aTime);
+            listDirCallback(name, stat);
+        }
+
+        abstract void listDirCallback(String name, CephStat stat) throws IOException;
+    }
+
+    public int listdir(String dir, boolean isRoot, LinkedList<String> nameList, LinkedList<CephStat> statList) throws FileNotFoundException {
+        rlock.lock();
+        try {
+            int ret = native_ceph_listdir(rgwFS, getLookupFH(isRoot), dir, new ListDirHandler() {
+                @Override
+                void listDirCallback(String name, CephStat stat) {
+                    nameList.add(name);
+                    statList.add(stat);
+                }
+            });
+            if (ret != 0) {
+                nameList.clear();
+                statList.clear();
+                return 0;
+            }
+            return nameList.size();
+        } finally {
+            rlock.unlock();
+        }
+    }
+
+    private static native int native_ceph_listdir(long rgwFS, long fh, String path, ListDirHandler handler);
+
+    public void unlink(String path, boolean isRoot) throws FileNotFoundException {
+        rlock.lock();
+        try {
+            native_ceph_unlink(rgwFS, getLookupFH(isRoot), path);
+        } finally {
+            rlock.unlock();
+        }
+    }
+
+    private static native int native_ceph_unlink(long rgwFS, long fh, String path);
+
+    public int rename(String src_path, boolean srcIsRoot, String src_name, String dst_path, boolean dstIsRoot, String dst_name) throws FileNotFoundException {
+        rlock.lock();
+        try {
+            return native_ceph_rename(rgwFS, getLookupFH(srcIsRoot), src_path, src_name, getLookupFH(dstIsRoot), dst_path, dst_name);
+        } finally {
+            rlock.unlock();
+        }
+    }
+
+    private static native int native_ceph_rename(long rgwFS, long src_fd, String src_path, String src_name, long dst_fd, String dst_path, String dst_name);
+
+    public boolean mkdirs(String path, boolean isRoot, String name, int mode) throws IOException {
+        rlock.lock();
+        try {
+            return native_ceph_mkdirs(rgwFS, getLookupFH(isRoot), path, name, mode);
+        } finally {
+            rlock.unlock();
+        }
+    }
+
+    private static native boolean native_ceph_mkdirs(long rgwFS, long fd, String path, String name, int mode);
+
+    public void lstat(String path, boolean isRoot, CephStat stat) throws FileNotFoundException {
+        rlock.lock();
+        try {
+            native_ceph_lstat(rgwFS, getLookupFH(isRoot), path, stat);
+        } finally {
+            rlock.unlock();
+        }
+    }
+
+    private static native int native_ceph_lstat(long rgwFS, long fh, String path, CephStat stat);
+
+    public void setattr(String path, boolean isRoot, CephStat stat, int mask) throws FileNotFoundException {
+        rlock.lock();
+        try {
+            native_ceph_setattr(rgwFS, getLookupFH(isRoot), path, stat, mask);
+        } finally {
+            rlock.unlock();
+        }
+    }
+
+    private static native int native_ceph_setattr(long rgwFS, long fh, String path, CephStat stat, int mask);
+
+    public long open(String path, boolean isRoot, int flags, int mode) throws FileNotFoundException {
+        rlock.lock();
+        try {
+            return native_ceph_open(rgwFS, getLookupFH(isRoot), path, flags, mode);
+        } finally {
+            rlock.unlock();
+        }
+    }
+
+    private static native long native_ceph_open(long rgwFS, long fh, String path, int flags, int mode);
+
+    public void close(long fd) {
+        rlock.lock();
+        try {
+            native_ceph_close(rgwFS, fd);
+        } finally {
+            rlock.unlock();
+        }
+    }
+
+    private static native int native_ceph_close(long rgwFS, long fd);
+
+    public long read(long fd, long offset, byte[] buf, long size) {
+        rlock.lock();
+        try {
+            return native_ceph_read(rgwFS, fd, offset, buf, size);
+        } finally {
+            rlock.unlock();
+        }
+    }
+
+    private static native long native_ceph_read(long rgwFS, long fd, long offset, byte[] buf, long size);
+
+    public long write(long fd, long offset, byte[] buf, long size) {
+        rlock.lock();
+        try {
+            return native_ceph_write(rgwFS, fd, offset, buf, size);
+        } finally {
+            rlock.unlock();
+        }
+    }
+
+    private static native long native_ceph_write(long rgwFS, long fd, long offset, byte[] buf, long size);
+
+    public void fsync(long fd, boolean dataonly) {
+        rlock.lock();
+        try {
+            native_ceph_fsync(rgwFS, fd, dataonly);
+        } finally {
+            rlock.unlock();
+        }
+    }
+
+    private static native int native_ceph_fsync(long rgwFS, long fd, boolean dataonly);
+
+}

--- a/src/java/java/com/ceph/rgw/CephStat.java
+++ b/src/java/java/com/ceph/rgw/CephStat.java
@@ -1,0 +1,74 @@
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package com.ceph.rgw;
+
+/**
+ * Holds struct stat fields.
+ */
+public class CephStat {
+    private static final int FLAG_IFLNK = 0120000;
+    private static final int FLAG_IFREG = 0100000;
+    private static final int FLAG_IFDIR = 0040000;
+
+    /* Set from native */
+    public int mode;
+    public int uid;
+    public int gid;
+    public long size;
+    public long blksize;
+    public long blocks;
+    public long a_time;
+    public long m_time;
+
+    public CephStat() {
+    }
+
+    public CephStat(int mode) {
+        this.mode = mode;
+    }
+
+    public CephStat(long m_time, long a_time) {
+        this.m_time = m_time;
+        this.a_time = a_time;
+    }
+
+    public CephStat(int mode, int uid, int gid, long size, long blksize, long blocks, long m_time, long a_time) {
+        this.mode = mode;
+        this.uid = uid;
+        this.gid = gid;
+        this.size = size;
+        this.blksize = blksize;
+        this.blocks = blocks;
+        this.a_time = a_time;
+        this.m_time = m_time;
+    }
+
+    public boolean isFile() {
+        return (mode & FLAG_IFREG) != 0;
+    }
+
+    public boolean isDir() {
+        return (mode & FLAG_IFDIR) != 0;
+    }
+
+    public boolean isSymlink() {
+        return (mode & FLAG_IFLNK) != 0;
+    }
+}

--- a/src/java/java/com/ceph/rgw/CephStatVFS.java
+++ b/src/java/java/com/ceph/rgw/CephStatVFS.java
@@ -1,0 +1,33 @@
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package com.ceph.rgw;
+
+/**
+ * Holds struct statvfs fields.
+ */
+public class CephStatVFS {
+    public long bsize;
+    public long frsize;
+    public long blocks;
+    public long bavail;
+    public long files;
+    public long fsid;
+    public long namemax;
+}

--- a/src/java/native/CMakeLists.txt
+++ b/src/java/native/CMakeLists.txt
@@ -1,14 +1,30 @@
-add_library(cephfs_jni SHARED
-  libcephfs_jni.cc
-  ScopedLocalRef.h
-  JniConstants.cpp
-  JniConstants.h)
-set_target_properties(cephfs_jni PROPERTIES
-  VERSION 1.0.0
-  SOVERSION 1)
-add_dependencies(cephfs_jni jni-header)
-include_directories(${JNI_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(cephfs_jni PRIVATE cephfs ceph-common
-  ${EXTRALIBS} ${JNI_LIBRARIES})
-install(TARGETS cephfs_jni
-  DESTINATION ${CMAKE_INSTALL_LIBDIR})
+if(WITH_CEPHFS_JAVA)
+  add_library(cephfs_jni SHARED
+    libcephfs_jni.cc
+    ScopedLocalRef.h
+    JniConstants.cpp
+    JniConstants.h)
+  set_target_properties(cephfs_jni PROPERTIES
+    VERSION 1.0.0
+    SOVERSION 1)
+  add_dependencies(cephfs_jni jni-header)
+  include_directories(${JNI_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR})
+  target_link_libraries(cephfs_jni PRIVATE cephfs ceph-common
+    ${EXTRALIBS} ${JNI_LIBRARIES})
+  install(TARGETS cephfs_jni
+    DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif(WITH_CEPHFS_JAVA)
+
+if(WITH_CEPHRGW_JAVA)
+  add_library(cephrgw_jni SHARED
+    libcephrgw_jni.cc)
+  set_target_properties(cephrgw_jni PROPERTIES
+    VERSION 1.0.0
+    SOVERSION 1)
+  add_dependencies(cephrgw_jni rgwjni-header)
+  include_directories(${JNI_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR})
+  target_link_libraries(cephrgw_jni PRIVATE rgw ceph-common
+    ${EXTRALIBS} ${JNI_LIBRARIES})
+  install(TARGETS cephrgw_jni
+    DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif(WITH_CEPHRGW_JAVA)

--- a/src/java/native/libcephrgw_jni.cc
+++ b/src/java/native/libcephrgw_jni.cc
@@ -1,0 +1,997 @@
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/un.h>
+#include <jni.h>
+
+#include "include/rados/rgw_file.h"
+#include "common/dout.h"
+
+#define dout_subsys ceph_subsys_javaclient
+
+#include "com_ceph_rgw_CephRgwAdapter.h"
+
+#define CEPH_RGW_ADAPTER_CLASS		"com/ceph/rgw/CephRgwAdapter"
+#define CEPH_LISTDIR_HANDLER_CLASS	"com/ceph/rgw/CephRgwAdapter$ListDirHandler"
+#define CEPH_STAT_CLASS			"com/ceph/rgw/CephStat"
+#define CEPH_STAT_VFS_CLASS		"com/ceph/rgw/CephStatVFS"
+#define CEPH_FILEEXISTS_CLASS		"com/ceph/rgw/CephFileAlreadyExistsException"
+
+
+/*
+ * Flags to open(). must be synchronized with CephRgwAdapter.java
+ *
+ * There are two versions of flags: the version in Java and the version in the
+ * target library (e.g. libc or libcephfs). We control the Java values and map
+ * to the target value with fixup_* functions below. This is much faster than
+ * keeping the values in Java and making a cross-JNI up-call to retrieve them,
+ * and makes it easy to keep any platform specific value changes in this file.
+ */
+#define JAVA_O_RDONLY		1
+#define JAVA_O_RDWR		2
+#define JAVA_O_APPEND		4
+#define JAVA_O_CREAT		8
+#define JAVA_O_TRUNC		16
+#define JAVA_O_EXCL		32
+#define JAVA_O_WRONLY		64
+#define JAVA_O_DIRECTORY	128
+
+
+/*
+ * Whence flags for seek(). sync with CephRgwAdapter.java if changed.
+ *
+ * Mapping of SEEK_* done in seek function.
+ */
+#define JAVA_SEEK_SET	1
+#define JAVA_SEEK_CUR	2
+#define JAVA_SEEK_END	3
+
+
+/*
+ * File attribute flags. sync with CephRgwAdapter.java if changed.
+ */
+#define JAVA_SETATTR_MODE	1
+#define JAVA_SETATTR_UID	2
+#define JAVA_SETATTR_GID	4
+#define JAVA_SETATTR_MTIME	8
+#define JAVA_SETATTR_ATIME	16
+
+
+/*
+ * Setxattr flags. sync with CephRgwAdapter.java if changed.
+ */
+#define JAVA_XATTR_CREATE	1
+#define JAVA_XATTR_REPLACE	2
+#define JAVA_XATTR_NONE		3
+
+
+/*
+ * flock flags. sync with CephRgwAdapter.java if changed.
+ */
+#define JAVA_LOCK_SH	1
+#define JAVA_LOCK_EX	2
+#define JAVA_LOCK_NB	4
+#define JAVA_LOCK_UN	8
+
+/* Map JAVA_O_* open flags to values in libc */
+static inline int fixup_open_flags( jint jflags )
+{
+	int ret = 0;
+
+#define FIXUP_OPEN_FLAG( name )	\
+	if ( jflags & JAVA_ ## name ) \
+		ret |= name;
+
+	FIXUP_OPEN_FLAG( O_RDONLY )
+	FIXUP_OPEN_FLAG( O_RDWR )
+	FIXUP_OPEN_FLAG( O_APPEND )
+	FIXUP_OPEN_FLAG( O_CREAT )
+	FIXUP_OPEN_FLAG( O_TRUNC )
+	FIXUP_OPEN_FLAG( O_EXCL )
+	FIXUP_OPEN_FLAG( O_WRONLY )
+	FIXUP_OPEN_FLAG( O_DIRECTORY )
+
+#undef FIXUP_OPEN_FLAG
+
+	return(ret);
+}
+
+
+/* Map JAVA_SETATTR_* to values in ceph lib */
+static inline int fixup_attr_mask( jint jmask )
+{
+	int mask = 0;
+
+#define FIXUP_ATTR_MASK( name )	\
+	if ( jmask & JAVA_ ## name ) \
+		mask |= CEPH_ ## name;
+
+	FIXUP_ATTR_MASK( SETATTR_MODE )
+	FIXUP_ATTR_MASK( SETATTR_UID )
+	FIXUP_ATTR_MASK( SETATTR_GID )
+	FIXUP_ATTR_MASK( SETATTR_MTIME )
+	FIXUP_ATTR_MASK( SETATTR_ATIME )
+
+#undef FIXUP_ATTR_MASK
+
+	return(mask);
+}
+
+
+/* Cached field IDs for com.ceph.fs.CephStat */
+static jfieldID cephstat_mode_fid;
+static jfieldID cephstat_uid_fid;
+static jfieldID cephstat_gid_fid;
+static jfieldID cephstat_size_fid;
+static jfieldID cephstat_blksize_fid;
+static jfieldID cephstat_blocks_fid;
+static jfieldID cephstat_a_time_fid;
+static jfieldID cephstat_m_time_fid;
+
+/* Cached field IDs for com.ceph.fs.CephStatVFS */
+static jfieldID cephstatvfs_bsize_fid;
+static jfieldID cephstatvfs_frsize_fid;
+static jfieldID cephstatvfs_blocks_fid;
+static jfieldID cephstatvfs_bavail_fid;
+static jfieldID cephstatvfs_files_fid;
+static jfieldID cephstatvfs_fsid_fid;
+static jfieldID cephstatvfs_namemax_fid;
+
+static jmethodID	listdir_handler_mid;
+static jfieldID		bucket_fh_fid;
+static jfieldID		root_fh_fid;
+
+static CephContext *cct = nullptr;
+
+
+/*
+ * Exception throwing helper. Adapted from Apache Hadoop header
+ * org_apache_hadoop.h by adding the do {} while (0) construct.
+ */
+#define THROW( env, exception_name, message ) \
+	do { \
+		jclass ecls = env->FindClass( exception_name );	\
+		if ( ecls ) { \
+			int ret = env->ThrowNew( ecls, message ); \
+			if ( ret < 0 ) { \
+				printf( "(CephFS) Fatal Error\n" ); \
+			} \
+			env->DeleteLocalRef( ecls ); \
+		} \
+	} while ( 0 )
+
+
+static void cephThrowNullArg( JNIEnv *env, const char *msg )
+{
+	THROW( env, "java/lang/NullPointerException", msg );
+}
+
+
+static void cephThrowInternal( JNIEnv *env, const char *msg )
+{
+	THROW( env, "java/lang/InternalError", msg );
+}
+
+
+static void cephThrowIndexBounds( JNIEnv *env, const char *msg )
+{
+	THROW( env, "java/lang/IndexOutOfBoundsException", msg );
+}
+
+
+static void cephThrowFNF( JNIEnv *env, const char *msg )
+{
+	THROW( env, "java/io/FileNotFoundException", msg );
+}
+
+
+static void cephThrowFileExists( JNIEnv *env, const char *msg )
+{
+	THROW( env, CEPH_FILEEXISTS_CLASS, msg );
+}
+
+
+static void handle_error( JNIEnv* env, int rc )
+{
+	switch ( rc )
+	{
+	case -ENOENT:
+		cephThrowFNF( env, "" );
+		return;
+	case -EEXIST:
+		cephThrowFileExists( env, "" );
+		return;
+	default:
+		break;
+	}
+
+	THROW( env, "java/io/IOException", strerror( -rc ) );
+}
+
+
+#define CHECK_ARG_NULL( v, m, r )     \
+	do {	    \
+		if ( !(v) ) {	    \
+			cephThrowNullArg( env, (m) ); \
+			return (r);		   \
+		}	\
+	} while ( 0 )
+
+#define CHECK_ARG_BOUNDS( c, m, r )  \
+	do {	    \
+		if ( (c) ) {	 \
+			cephThrowIndexBounds( env, (m) ); \
+			return (r);    \
+		}     \
+	} while ( 0 )
+
+static void setup_field_ids( JNIEnv *env, jclass clz )
+{
+	jclass	cephstat_cls;
+	jclass	cephstatvfs_cls;
+	jclass	listdir_handler_cls;
+
+
+/*
+ * Get a fieldID from a class with a specific type
+ *
+ * clz: jclass
+ * field: field in clz
+ * type: integer, long, etc..
+ *
+ * This macro assumes some naming convention that is used
+ * only in this file:
+ *
+ *   GETFID(cephstat, mode, I) gets translated into
+ *     cephstat_mode_fid = env->GetFieldID(cephstat_cls, "mode", "I");
+ */
+#define GETFID( clz, field, type )	 \
+	do {	       \
+		clz ## _ ## field ## _fid = env->GetFieldID( clz ## _cls, # field, # type ); \
+		if ( !clz ## _ ## field ## _fid )	\
+			return;		\
+	} while ( 0 )
+
+	/* Cache CephStat fields */
+
+	cephstat_cls = env->FindClass( CEPH_STAT_CLASS );
+	if ( !cephstat_cls )
+		return;
+
+	GETFID( cephstat, mode, I );
+	GETFID( cephstat, uid, I );
+	GETFID( cephstat, gid, I );
+	GETFID( cephstat, size, J );
+	GETFID( cephstat, blksize, J );
+	GETFID( cephstat, blocks, J );
+	GETFID( cephstat, a_time, J );
+	GETFID( cephstat, m_time, J );
+
+	/* Cache CephStatVFS fields */
+
+	cephstatvfs_cls = env->FindClass( CEPH_STAT_VFS_CLASS );
+	if ( !cephstatvfs_cls )
+		return;
+
+	GETFID( cephstatvfs, bsize, J );
+	GETFID( cephstatvfs, frsize, J );
+	GETFID( cephstatvfs, blocks, J );
+	GETFID( cephstatvfs, bavail, J );
+	GETFID( cephstatvfs, files, J );
+	GETFID( cephstatvfs, fsid, J );
+	GETFID( cephstatvfs, namemax, J );
+
+#undef GETFID
+
+	listdir_handler_cls = env->FindClass( CEPH_LISTDIR_HANDLER_CLASS );
+	if ( !listdir_handler_cls )
+		return;
+	listdir_handler_mid = env->GetMethodID( listdir_handler_cls, "listDirHandler", "(Ljava/lang/String;IIIJJJJJ)V" );
+	if ( !listdir_handler_mid )
+		return;
+
+	root_fh_fid	= env->GetFieldID( clz, "rootFH", "J" );
+	bucket_fh_fid	= env->GetFieldID( clz, "bucketFH", "J" );
+}
+
+
+JNIEXPORT void JNICALL native_initialize( JNIEnv *env, jclass clz )
+{
+	setup_field_ids( env, clz );
+}
+
+
+JNIEXPORT jint JNICALL native_ceph_create( JNIEnv *env, jclass clz, jstring j_arg )
+{
+	librgw_t	rgw_h	= nullptr;
+	char		*c_arg	= nullptr;
+	int		ret;
+
+	CHECK_ARG_NULL( j_arg, "@j_arg is null", -1 );
+
+	if ( j_arg )
+	{
+		c_arg = (char *) env->GetStringUTFChars( j_arg, nullptr );
+	}
+
+	ret = librgw_create( &rgw_h, 1, &c_arg );
+
+	if ( c_arg )
+		env->ReleaseStringUTFChars( j_arg, c_arg );
+
+	if ( ret )
+	{
+		THROW( env, "java/lang/RuntimeException", "failed to create rgw" );
+		return(ret);
+	}
+
+	cct = (CephContext *) rgw_h;
+
+	return(ret);
+}
+
+
+JNIEXPORT jlong JNICALL native_ceph_mount( JNIEnv *env, jclass clz, jobject j_adapter,
+    jstring j_uid, jstring j_access, jstring j_secret, jstring j_root )
+{
+	struct rgw_file_handle	*bucket_fh;
+	const char		* c_uid		= env->GetStringUTFChars( j_uid, nullptr );
+	const char		* c_access	= env->GetStringUTFChars( j_access, nullptr );
+	const char		* c_secret	= env->GetStringUTFChars( j_secret, nullptr );
+	const char		* c_root	= env->GetStringUTFChars( j_root, nullptr );
+	struct rgw_fs		*rgw_fs;
+	struct stat		st;
+	int			ret;
+
+	ldout( cct, 10 ) << "jni: ceph_mount: " << (c_root ? c_root : "<nullptr>") << dendl;
+	ret = rgw_mount2( (librgw_t) cct, c_uid, c_access, c_secret, "/", &rgw_fs, RGW_MOUNT_FLAG_NONE );
+	ldout( cct, 10 ) << "jni: ceph_mount: exit ret" << ret << dendl;
+	env->ReleaseStringUTFChars( j_uid, c_uid );
+	env->ReleaseStringUTFChars( j_access, c_access );
+	env->ReleaseStringUTFChars( j_secret, c_secret );
+
+	if ( ret )
+	{
+		handle_error( env, ret );
+		return(ret);
+	}
+	ret = rgw_lookup( rgw_fs, rgw_fs->root_fh, c_root, &bucket_fh, nullptr, 0, RGW_LOOKUP_FLAG_NONE );
+	if ( ret )
+	{
+		st.st_mode	= 0777;
+		ret		= rgw_mkdir( rgw_fs, rgw_fs->root_fh, c_root, &st, RGW_SETATTR_MODE, &bucket_fh, RGW_MKDIR_FLAG_NONE );
+	}
+	if ( ret )
+	{
+		handle_error( env, ret );
+		rgw_umount( rgw_fs, RGW_UMOUNT_FLAG_NONE );
+		return(ret);
+	}
+
+	env->SetLongField( j_adapter, root_fh_fid, (long) rgw_fs->root_fh );
+	env->SetLongField( j_adapter, bucket_fh_fid, (long) bucket_fh );
+
+	return( (jlong) rgw_fs);
+}
+
+
+JNIEXPORT jint JNICALL native_ceph_unmount( JNIEnv *env, jclass clz, jlong j_rgw_fs )
+{
+	struct rgw_fs	*rgw_fs = (struct rgw_fs *) j_rgw_fs;
+	int		ret;
+
+	ldout( cct, 10 ) << "jni: ceph_unmount enter" << dendl;
+
+	ret = rgw_umount( rgw_fs, RGW_UMOUNT_FLAG_NONE );
+
+	ldout( cct, 10 ) << "jni: ceph_unmount exit ret " << ret << dendl;
+
+	if ( ret )
+		handle_error( env, ret );
+
+	return(ret);
+}
+
+
+JNIEXPORT jint JNICALL native_ceph_release( JNIEnv *env, jclass clz, jlong j_rgw_fs )
+{
+	ldout( cct, 10 ) << "jni: ceph_release called" << dendl;
+
+	librgw_shutdown( (librgw_t) cct );
+
+	return(0);
+}
+
+
+JNIEXPORT jint JNICALL native_ceph_statfs( JNIEnv *env, jclass clz, jlong j_rgw_fs,
+    jlong j_fh, jstring j_path, jobject j_cephstatvfs )
+{
+	struct rgw_fs		*rgw_fs = (struct rgw_fs *) j_rgw_fs;
+	struct rgw_file_handle	*root_fh= (struct rgw_file_handle *) j_fh;
+	struct rgw_file_handle	*rgw_fh;
+	struct rgw_statvfs	vfs_st;
+	const char		*c_path;
+	int			ret;
+
+	CHECK_ARG_NULL( j_path, "@path is null", -1 );
+	CHECK_ARG_NULL( j_cephstatvfs, "@stat is null", -1 );
+
+	c_path = env->GetStringUTFChars( j_path, nullptr );
+	if ( !c_path )
+	{
+		cephThrowInternal( env, "Failed to pin memory" );
+		return(-1);
+	}
+
+	ldout( cct, 10 ) << "jni:statfs: path " << c_path << dendl;
+	ret = rgw_lookup( rgw_fs, root_fh, c_path, &rgw_fh, nullptr, 0, RGW_LOOKUP_FLAG_NONE );
+	if ( ret < 0 )
+	{
+		handle_error( env, ret );
+		return(ret);
+	}
+
+	ret = rgw_statfs( rgw_fs, rgw_fh, &vfs_st, RGW_STATFS_FLAG_NONE );
+
+	ldout( cct, 10 ) << "jni: statfs: exit ret " << ret << dendl;
+
+	env->ReleaseStringUTFChars( j_path, c_path );
+
+	if ( ret < 0 )
+	{
+		handle_error( env, ret );
+		return(ret);
+	}
+
+	env->SetLongField( j_cephstatvfs, cephstatvfs_bsize_fid, vfs_st.f_bsize );
+	env->SetLongField( j_cephstatvfs, cephstatvfs_frsize_fid, vfs_st.f_frsize );
+	env->SetLongField( j_cephstatvfs, cephstatvfs_blocks_fid, vfs_st.f_blocks );
+	env->SetLongField( j_cephstatvfs, cephstatvfs_bavail_fid, vfs_st.f_bavail );
+	env->SetLongField( j_cephstatvfs, cephstatvfs_files_fid, vfs_st.f_files );
+	env->SetLongField( j_cephstatvfs, cephstatvfs_fsid_fid, vfs_st.f_fsid[0] );
+	env->SetLongField( j_cephstatvfs, cephstatvfs_namemax_fid, vfs_st.f_namemax );
+
+	return(ret);
+}
+
+
+struct rgw_cb_data {
+	JNIEnv			*env;
+	struct rgw_fs		*rgw_fs;
+	struct rgw_file_handle	*rgw_fh;
+	jobject			handler;
+};
+
+static bool readdir_cb( const char *name, void *arg, uint64_t offset,
+			struct stat *st, uint32_t mask, uint32_t flags )
+{
+	struct rgw_cb_data	*rgw_cb_data	= (struct rgw_cb_data *) arg;
+	JNIEnv			* env		= rgw_cb_data->env;
+	struct rgw_fs		* rgw_fs	= rgw_cb_data->rgw_fs;
+	struct rgw_file_handle	*dir_fh		= rgw_cb_data->rgw_fh;
+	struct rgw_file_handle	*rgw_fh;
+	int			ret;
+
+	if ( strcmp( name, "." ) == 0 || strcmp( name, ".." ) == 0 )
+		return(true);
+
+	ret = rgw_lookup( rgw_fs, dir_fh, name, &rgw_fh, st, mask,
+			  RGW_LOOKUP_FLAG_RCB | (flags & RGW_LOOKUP_TYPE_FLAGS) );
+	if ( ret < 0 )
+		return(false);
+
+	ret = rgw_getattr( rgw_fs, rgw_fh, st, RGW_GETATTR_FLAG_NONE );
+	if ( ret < 0 )
+		return(false);
+
+	jstring j_name = env->NewStringUTF( name );
+	env->CallVoidMethod( rgw_cb_data->handler, listdir_handler_mid, j_name,
+			     st->st_mode, st->st_uid, st->st_gid, st->st_size, st->st_blksize,
+			     st->st_blocks, st->st_mtime * 1000, st->st_atime * 1000 );
+	env->DeleteLocalRef( j_name );
+	return(true);
+}
+
+
+JNIEXPORT jint JNICALL native_ceph_listdir( JNIEnv *env, jclass clz,
+    jlong j_rgw_fs, jlong j_fh, jstring j_path, jobject handler )
+{
+	struct rgw_fs		*rgw_fs = (struct rgw_fs *) j_rgw_fs;
+	struct rgw_file_handle	*rgw_fh;
+	struct rgw_cb_data	rgw_cb_data;
+	const char		*c_path;
+	uint64_t		offset	= 0;
+	bool			eof	= false;
+	int			ret;
+
+	CHECK_ARG_NULL( j_path, "@path is null", -EINVAL);
+	c_path = env->GetStringUTFChars( j_path, nullptr );
+	if ( !c_path )
+	{
+		cephThrowInternal( env, "failed to pin memory" );
+		return(-ENOMEM);
+	}
+
+	ret = rgw_lookup( rgw_fs, (struct rgw_file_handle *)j_fh, c_path, &rgw_fh, nullptr, 0, RGW_LOOKUP_FLAG_NONE );
+	env->ReleaseStringUTFChars( j_path, c_path );
+	if ( ret < 0 )
+	{
+		handle_error( env, ret );
+		return(ret);
+	}
+
+	rgw_cb_data.env		= env;
+	rgw_cb_data.handler	= handler;
+	rgw_cb_data.rgw_fs	= rgw_fs;
+	rgw_cb_data.rgw_fh	= rgw_fh;
+	while ( !eof )
+	{
+		ret = rgw_readdir( rgw_fs, rgw_fh, &offset, readdir_cb, &rgw_cb_data, &eof, RGW_READDIR_FLAG_NONE );
+		if ( ret < 0 )
+		{
+			handle_error( env, ret );
+			break;
+		}
+	}
+	return(ret);
+}
+
+
+JNIEXPORT jint JNICALL native_ceph_unlink( JNIEnv *env, jclass clz, jlong j_rgw_fs, jlong j_fh, jstring j_path )
+{
+	struct rgw_fs	*rgw_fs = (struct rgw_fs *) j_rgw_fs;
+	const char	*c_path;
+	int		ret;
+
+	CHECK_ARG_NULL( j_path, "@path is null", -1 );
+
+	c_path = env->GetStringUTFChars( j_path, nullptr );
+	if ( !c_path )
+	{
+		cephThrowInternal( env, "failed to pin memory" );
+		return(-1);
+	}
+
+	ldout( cct, 10 ) << "jni: unlink: path " << c_path << dendl;
+	ret = rgw_unlink( rgw_fs, (struct rgw_file_handle *)j_fh, c_path, RGW_UNLINK_FLAG_NONE );
+
+	ldout( cct, 10 ) << "jni: unlink: exit ret " << ret << dendl;
+
+	env->ReleaseStringUTFChars( j_path, c_path );
+
+	if ( ret < 0 )
+		handle_error( env, ret );
+
+	return(ret);
+}
+
+
+JNIEXPORT jint JNICALL native_ceph_rename( JNIEnv *env, jclass clz,
+    jlong j_rgw_fs, jlong j_src_fh, jstring j_src_path, jstring j_src_name,
+    jlong j_dst_fh, jstring j_dst_path, jstring j_dst_name )
+{
+	struct rgw_fs		*rgw_fs		= (struct rgw_fs *) j_rgw_fs;
+	struct rgw_file_handle	*srcdir_fh	= (struct rgw_file_handle *) j_src_fh;
+	struct rgw_file_handle	*dstdir_fh	= (struct rgw_file_handle *) j_dst_fh;
+	struct rgw_file_handle	*src_fh;
+	struct rgw_file_handle	*dst_fh;
+	const char		*c_src_path;
+	const char		*c_src_name;
+	const char		*c_dst_path;
+	const char		*c_dst_name;
+	int			ret;
+
+	CHECK_ARG_NULL( j_src_path, "@src_path is null", -1 );
+	CHECK_ARG_NULL( j_src_name, "@src_name is null", -1 );
+	CHECK_ARG_NULL( j_dst_path, "@dst_path is null", -1 );
+	CHECK_ARG_NULL( j_dst_name, "@dst_name is null", -1 );
+
+	c_src_path	= env->GetStringUTFChars( j_src_path, nullptr );
+	c_src_name	= env->GetStringUTFChars( j_src_name, nullptr );
+	c_dst_path	= env->GetStringUTFChars( j_dst_path, nullptr );
+	c_dst_name	= env->GetStringUTFChars( j_dst_name, nullptr );
+
+	ret = rgw_lookup( rgw_fs, srcdir_fh, c_src_path, &src_fh, nullptr, 0,
+			  RGW_LOOKUP_FLAG_NONE );
+	if ( ret < 0 )
+	{
+		goto out;
+	}
+
+	ret = rgw_lookup( rgw_fs, dstdir_fh, c_dst_path, &dst_fh, nullptr, 0,
+			  RGW_LOOKUP_FLAG_NONE );
+	if ( ret < 0 )
+	{
+		goto out;
+	}
+
+	ldout( cct, 10 )	<< "jni:rename: from " << c_src_path << c_src_name
+				<< " to " << c_dst_path << c_dst_name << dendl;
+	ret = rgw_rename( rgw_fs, src_fh, c_src_name, dst_fh, c_dst_name, RGW_RENAME_FLAG_NONE );
+	ldout( cct, 10 ) << "jni: rename: exit ret " << ret << dendl;
+
+out:
+	env->ReleaseStringUTFChars( j_src_path, c_src_path );
+	env->ReleaseStringUTFChars( j_src_name, c_src_name );
+	env->ReleaseStringUTFChars( j_dst_path, c_dst_path );
+	env->ReleaseStringUTFChars( j_dst_name, c_dst_name );
+
+	if ( ret < 0 )
+		handle_error( env, ret );
+
+	return(ret);
+}
+
+
+JNIEXPORT jboolean JNICALL native_ceph_mkdirs( JNIEnv *env, jclass clz,
+    jlong j_rgw_fs, jlong j_fh, jstring j_path, jstring j_name, jint j_mode )
+{
+	struct rgw_fs		*rgw_fs = (struct rgw_fs *) j_rgw_fs;
+	struct rgw_file_handle	*root_fh = (struct rgw_file_handle *) j_fh;
+	struct rgw_file_handle	*rgw_fh;
+	struct rgw_file_handle	*fh;
+	const char		*c_path;
+	const char		*c_name;
+	struct stat		st;
+	int			ret;
+
+	CHECK_ARG_NULL( j_path, "@path is null", -1 );
+
+	c_path	= env->GetStringUTFChars( j_path, nullptr );
+	c_name	= env->GetStringUTFChars( j_name, nullptr );
+	if ( !c_path )
+	{
+		cephThrowInternal( env, "failed to pin memory" );
+		return(false);
+	}
+
+	ret = rgw_lookup( rgw_fs, root_fh, c_path, &rgw_fh, nullptr, 0, RGW_LOOKUP_FLAG_CREATE | RGW_LOOKUP_FLAG_DIR );
+	if ( ret < 0 )
+	{
+		handle_error( env, ret );
+		return(false);
+	}
+
+	ldout( cct, 10 ) << "jni: mkdirs: path " << c_path << " mode " << (int) j_mode << dendl;
+	st.st_mode	= (int) j_mode;
+	ret		= rgw_mkdir( rgw_fs, rgw_fh, c_name, &st, RGW_SETATTR_MODE, &fh, RGW_MKDIR_FLAG_NONE );
+
+	ldout( cct, 10 ) << "jni: mkdirs: exit ret " << ret << dendl;
+
+	env->ReleaseStringUTFChars( j_path, c_path );
+	env->ReleaseStringUTFChars( j_name, c_name );
+
+	if ( ret )
+		handle_error( env, ret );
+
+	return(!!ret);
+}
+
+
+static void fill_cephstat( JNIEnv *env, jobject j_cephstat, struct stat *st )
+{
+	env->SetIntField( j_cephstat, cephstat_mode_fid, st->st_mode );
+	env->SetIntField( j_cephstat, cephstat_uid_fid, st->st_uid );
+	env->SetIntField( j_cephstat, cephstat_gid_fid, st->st_gid );
+	env->SetLongField( j_cephstat, cephstat_size_fid, st->st_size );
+	env->SetLongField( j_cephstat, cephstat_blksize_fid, st->st_blksize );
+	env->SetLongField( j_cephstat, cephstat_blocks_fid, st->st_blocks );
+
+	env->SetLongField( j_cephstat, cephstat_m_time_fid, st->st_mtime * 1000 );
+	env->SetLongField( j_cephstat, cephstat_a_time_fid, st->st_atime * 1000 );
+}
+
+
+JNIEXPORT jint JNICALL native_ceph_lstat( JNIEnv *env, jclass clz,
+    jlong j_rgw_fs, jlong j_fh, jstring j_path, jobject j_cephstat )
+{
+	struct rgw_fs		*rgw_fs		= (struct rgw_fs *) j_rgw_fs;
+	struct rgw_file_handle	*root_fh	= (struct rgw_file_handle *) j_fh;
+	struct rgw_file_handle	*rgw_fh;
+	struct stat		st;
+	const char		*c_path;
+	int			ret;
+
+	CHECK_ARG_NULL( j_path, "@path is null", -1 );
+	CHECK_ARG_NULL( j_cephstat, "@stat is null", -1 );
+
+	c_path = (char *) env->GetStringUTFChars( j_path, nullptr );
+
+	ldout( cct, 10 ) << "jni: lstat: path " << c_path << " len " << strlen( c_path ) << dendl;
+	ret = rgw_lookup( rgw_fs, root_fh, c_path, &rgw_fh, nullptr, 0, RGW_LOOKUP_FLAG_NONE );
+	env->ReleaseStringUTFChars( j_path, c_path );
+	if ( ret < 0 )
+	{
+		goto out;
+	}
+	ret = rgw_getattr( rgw_fs, rgw_fh, &st, RGW_GETATTR_FLAG_NONE );
+	if ( ret == 0 )
+		fill_cephstat( env, j_cephstat, &st );
+
+out:
+	if ( ret < 0 )
+	{
+		handle_error( env, ret );
+	}
+
+	ldout( cct, 10 ) << "jni: lstat exit ret " << ret << dendl;
+	return(ret);
+}
+
+
+JNIEXPORT jint JNICALL native_ceph_setattr( JNIEnv *env, jclass clz,
+    jlong j_rgw_fs, jlong j_fh, jstring j_path, jobject j_cephstat, jint j_mask )
+{
+	struct rgw_fs		*rgw_fs		= (struct rgw_fs *) j_rgw_fs;
+	struct rgw_file_handle	*root_fh	= (struct rgw_file_handle *) j_fh;
+	struct rgw_file_handle	*rgw_fh;
+	struct stat		st;
+	const char		*c_path;
+	long 			mtime_msec;
+	long 			atime_msec;
+	int			mask = fixup_attr_mask( j_mask );
+	int 			ret;
+
+	CHECK_ARG_NULL( j_path, "@path is null", -1 );
+	CHECK_ARG_NULL( j_cephstat, "@stat is null", -1 );
+
+	c_path = env->GetStringUTFChars( j_path, nullptr );
+	if ( !c_path )
+	{
+		cephThrowInternal( env, "Failed to pin memory" );
+		return(-1);
+	}
+	ldout( cct, 10 ) << "jni: statfs: path " << c_path << dendl;
+	ret = rgw_lookup( rgw_fs, root_fh, c_path, &rgw_fh, nullptr, 0,
+			  RGW_LOOKUP_FLAG_NONE );
+	if ( ret < 0 )
+	{
+		handle_error( env, ret );
+		return(ret);
+	}
+
+	memset( &st, 0, sizeof(st) );
+
+	st.st_mode	= env->GetIntField( j_cephstat, cephstat_mode_fid );
+	st.st_uid	= env->GetIntField( j_cephstat, cephstat_uid_fid );
+	st.st_gid	= env->GetIntField( j_cephstat, cephstat_gid_fid );
+	mtime_msec	= env->GetLongField( j_cephstat, cephstat_m_time_fid );
+	atime_msec	= env->GetLongField( j_cephstat, cephstat_a_time_fid );
+	st.st_mtime	= mtime_msec / 1000;
+	st.st_atime	= atime_msec / 1000;
+
+	ldout( cct, 10 ) << "jni: setattr: path " << c_path << " mask " << mask << dendl;
+
+	ret = rgw_setattr( rgw_fs, rgw_fh, &st, mask, RGW_SETATTR_FLAG_NONE );
+	ldout( cct, 10 ) << "jni: setattr: exit ret " << ret << dendl;
+
+	env->ReleaseStringUTFChars( j_path, c_path );
+	if ( ret < 0 )
+		handle_error( env, ret );
+
+	return(ret);
+}
+
+
+JNIEXPORT jlong JNICALL native_ceph_open( JNIEnv *env, jclass clz,
+    jlong j_rgw_fs, jlong j_fh, jstring j_path, jint j_flags, jint j_mode )
+{
+	struct rgw_fs		*rgw_fs		= (struct rgw_fs *) j_rgw_fs;
+	struct rgw_file_handle	*root_fh	= (struct rgw_file_handle *) j_fh;
+	struct rgw_file_handle	*rgw_fh;
+	const char		*c_path;
+	uint32_t		lookup_flags	= RGW_LOOKUP_FLAG_FILE;
+	int			flags		= fixup_open_flags( j_flags );
+	int			ret;
+
+	CHECK_ARG_NULL( j_path, "@path is null", -1 );
+
+	c_path = env->GetStringUTFChars( j_path, nullptr );
+	if ( !c_path )
+	{
+		cephThrowInternal( env, "Failed to pin memory" );
+		return(-1);
+	}
+	if ( j_flags & JAVA_O_CREAT )
+		lookup_flags |= RGW_LOOKUP_FLAG_CREATE;
+	ldout( cct, 10 )	<< "jni: open: path " << c_path << " flags " << flags
+				<< " lookup_flags " << lookup_flags << dendl;
+
+	ret = rgw_lookup( rgw_fs, root_fh, c_path, &rgw_fh, nullptr, 0, lookup_flags );
+	if ( ret < 0 )
+	{
+		handle_error( env, ret );
+		return(ret);
+	}
+
+	ret = rgw_open( rgw_fs, rgw_fh, flags, RGW_OPEN_FLAG_NONE );
+	ldout( cct, 10 ) << "jni: open: exit ret " << ret << dendl;
+
+	env->ReleaseStringUTFChars( j_path, c_path );
+	if ( ret < 0 )
+		handle_error( env, ret );
+
+	return( (jlong) rgw_fh);
+}
+
+
+JNIEXPORT jint JNICALL native_ceph_close( JNIEnv *env, jclass clz, jlong j_rgw_fs, jlong j_fd )
+{
+	struct rgw_fs		*rgw_fs = (struct rgw_fs *) j_rgw_fs;
+	int			ret;
+
+	ldout( cct, 10 ) << "jni: close: fd " << (long) j_fd << dendl;
+	ret = rgw_close( rgw_fs, (struct rgw_file_handle *)j_fd, RGW_CLOSE_FLAG_RELE );
+	ldout( cct, 10 ) << "jni: close: ret " << ret << dendl;
+
+	if ( ret )
+		handle_error( env, ret );
+
+	return(ret);
+}
+
+
+JNIEXPORT jlong JNICALL native_ceph_read( JNIEnv *env, jclass clz,
+    jlong j_rgw_fs, jlong j_fd, jlong j_offset, jbyteArray j_buf, jlong j_size )
+{
+	struct rgw_fs		*rgw_fs = (struct rgw_fs *) j_rgw_fs;
+	struct rgw_file_handle	*fh	= (struct rgw_file_handle *) j_fd;
+	jboolean		iscopy	= JNI_FALSE;
+	size_t			bytes_read;
+	jsize			buf_size;
+	jbyte			*c_buf;
+	long			ret;
+
+	CHECK_ARG_NULL( j_buf, "@buf is null", -1 );
+	CHECK_ARG_BOUNDS( j_size < 0, "@size is negative", -1 );
+
+	buf_size = env->GetArrayLength( j_buf );
+	CHECK_ARG_BOUNDS( j_size > buf_size, "@size > @buf.length", -1 );
+
+	c_buf = env->GetByteArrayElements( j_buf, &iscopy );
+	if ( !c_buf )
+	{
+		cephThrowInternal( env, "failed to pin memory" );
+		return(-1);
+	}
+
+	ldout( cct, 10 ) << "jni: read: fd " << (int) j_fd << " len " << (long) j_size <<
+	" offset " << (long) j_offset << dendl;
+
+	ret = rgw_read( rgw_fs, fh, (long) j_offset, (long) j_size, &bytes_read, c_buf, RGW_READ_FLAG_NONE );
+	ldout( cct, 10 ) << "jni: read: exit ret " << ret << "bytes_read " << bytes_read << dendl;
+	if ( ret < 0 )
+	{
+		handle_error( env, (int) ret );
+		bytes_read = 0;
+	}
+
+	env->ReleaseByteArrayElements( j_buf, c_buf, JNI_COMMIT );
+	if ( iscopy )
+	{
+		free( c_buf );
+	}
+
+	return( (jlong) bytes_read);
+}
+
+
+JNIEXPORT jlong JNICALL native_ceph_write( JNIEnv *env, jclass clz,
+    jlong j_rgw_fs, jlong j_fd, jlong j_offset, jbyteArray j_buf, jlong j_size )
+{
+	struct rgw_fs		*rgw_fs = (struct rgw_fs *) j_rgw_fs;
+	struct rgw_file_handle	*fh	= (struct rgw_file_handle *) j_fd;
+	size_t			bytes_written;
+	jsize			buf_size;
+	jbyte			*c_buf;
+	long			ret;
+
+	CHECK_ARG_NULL( j_buf, "@buf is null", -1 );
+	CHECK_ARG_BOUNDS( j_size < 0, "@size is negative", -1 );
+
+	buf_size = env->GetArrayLength( j_buf );
+	CHECK_ARG_BOUNDS( j_size > buf_size, "@size > @buf.length", -1 );
+
+	c_buf = env->GetByteArrayElements( j_buf, 0 );
+	if ( !c_buf )
+	{
+		cephThrowInternal( env, "failed to pin memory" );
+		return(-1);
+	}
+
+	ldout( cct, 10 ) << "jni: write: fd " << (int) j_fd << " len " << (long) j_size <<
+	" offset " << (long) j_offset << dendl;
+
+	ret = rgw_write( rgw_fs, fh, (long) j_offset, (long) j_size, &bytes_written, c_buf, RGW_WRITE_FLAG_NONE );
+
+	ldout( cct, 10 ) << "jni: write: exit ret " << ret << dendl;
+
+	if ( ret < 0 )
+		handle_error( env, (int) ret );
+
+	env->ReleaseByteArrayElements( j_buf, c_buf, JNI_ABORT );
+
+	return( (jlong) bytes_written);
+}
+
+
+JNIEXPORT jint JNICALL native_ceph_fsync( JNIEnv *env, jclass clz,
+    jlong j_rgw_fs, jlong j_fd, jboolean j_dataonly )
+{
+	struct rgw_fs		*rgw_fs = (struct rgw_fs *) j_rgw_fs;
+	int			ret;
+
+	ldout( cct, 10 ) << "jni:fsync: fd " << (int) j_fd <<
+	" dataonly " << (j_dataonly ? 1 : 0) << dendl;
+
+	ret = rgw_fsync( rgw_fs, (struct rgw_file_handle *)j_fd, RGW_WRITE_FLAG_NONE );
+
+	ldout( cct, 10 ) << "jni: fsync: exit ret " << ret << dendl;
+
+	if ( ret )
+		handle_error( env, ret );
+
+	return(ret);
+}
+
+
+static const JNINativeMethod gMethods[] = {
+	{ "native_initialize",	 "()V",													     (void *) native_initialize	  },
+	{ "native_ceph_create",	 "(Ljava/lang/String;)I",										     (void *) native_ceph_create  },
+	{ "native_ceph_mount",	 "(Lcom/ceph/rgw/CephRgwAdapter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)J", (void *) native_ceph_mount	  },
+	{ "native_ceph_unmount", "(J)I",												     (void *) native_ceph_unmount },
+	{ "native_ceph_release", "(J)I",												     (void *) native_ceph_release },
+	{ "native_ceph_statfs",	 "(JJLjava/lang/String;Lcom/ceph/rgw/CephStatVFS;)I",							     (void *) native_ceph_statfs  },
+	{ "native_ceph_listdir", "(JJLjava/lang/String;Lcom/ceph/rgw/CephRgwAdapter$ListDirHandler;)I",					     (void *) native_ceph_listdir },
+	{ "native_ceph_unlink",	 "(JJLjava/lang/String;)I",										     (void *) native_ceph_unlink  },
+	{ "native_ceph_rename",	 "(JJLjava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;)I",			     (void *) native_ceph_rename  },
+	{ "native_ceph_mkdirs",	 "(JJLjava/lang/String;Ljava/lang/String;I)Z",								     (void *) native_ceph_mkdirs  },
+	{ "native_ceph_lstat",	 "(JJLjava/lang/String;Lcom/ceph/rgw/CephStat;)I",							     (void *) native_ceph_lstat	  },
+	{ "native_ceph_setattr", "(JJLjava/lang/String;Lcom/ceph/rgw/CephStat;I)I",							     (void *) native_ceph_setattr },
+	{ "native_ceph_open",	 "(JJLjava/lang/String;II)J",										     (void *) native_ceph_open	  },
+	{ "native_ceph_close",	 "(JJ)I",												     (void *) native_ceph_close	  },
+	{ "native_ceph_read",	 "(JJJ[BJ)J",												     (void *) native_ceph_read	  },
+	{ "native_ceph_write",	 "(JJJ[BJ)J",												     (void *) native_ceph_write	  },
+	{ "native_ceph_fsync",	 "(JJZ)I",												     (void *) native_ceph_fsync	  },
+};
+
+JNIEXPORT jint JNICALL JNI_OnLoad( JavaVM* vm, void* reserved )
+{
+	JNIEnv	* env	= nullptr;
+
+	if ( vm->GetEnv( (void * *) &env, JNI_VERSION_1_4 ) != JNI_OK )
+	{
+		return(JNI_FALSE);
+	}
+	assert( env != nullptr );
+
+	jclass clazz = env->FindClass( CEPH_RGW_ADAPTER_CLASS );
+	if ( clazz == nullptr )
+		return(JNI_FALSE);
+	if ( env->RegisterNatives( clazz, gMethods, sizeof(gMethods) / sizeof(gMethods[0]) ) < 0 )
+		return(JNI_FALSE);
+
+	return(JNI_VERSION_1_4);
+}


### PR DESCRIPTION
In the existing Hadoop S3a access Ceph solution, read and write requests are first sent to the object gateway, and then the radosgw daemon forwards the requests to the rados cluster. This patch add CephRgwFileSystem, it enables read and write requests to be directly sent to the rados cluster through the librgw, avoiding radosgw forwarding, shortening the I/O path, and improving performance.
HDFS CephRgwFileSystem encapsulates the read and write requests of Hadoop applications, invokes CephRgwAdapter, converts the requests to local librgw.so calls using libcephrgw_jni, and accesses the rados cluster. CephRgwFileSystem is stored in cephfs-hadoop repo, CephRgwAdapter and libcephrgw_jni are stored in ceph repo. Before compiling CephRgwFileSystem, install the cephrgw-java package corresponding to the CephRgwAdapter class.
CephRgwFileSystem  provides services externally using the cephrgw://bucket. If the bucket does not exist, it will be created. This patch supports HDFS read, write, ls, mkdir, delete, rename, and chmod. The current defect is that the rename directory and appending are not supported.

Fixes: https://tracker.ceph.com/issues/48513
Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>
Signed-off-by: Fengge Chen <chenfengge1@huawei.com>
Signed-off-by: luo rixin <luorixin@huawei.com>