### PR TITLE
Wip stretch updates

### DIFF
--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -370,7 +370,7 @@ void MonMap::print(ostream& out) const
       << " (" << min_mon_release << ")\n";
   out << "election_strategy: " << strategy << "\n";
   if (disallowed_leaders.size()) {
-    out << "disallowed_leaders" << disallowed_leaders << "\n";
+    out << "disallowed_leaders " << disallowed_leaders << "\n";
   }
   unsigned i = 0;
   for (auto p = ranks.begin(); p != ranks.end(); ++p) {

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -1029,8 +1029,6 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
     if (!mon.osdmon()->is_readable()) {
       mon.osdmon()->wait_for_readable(op, new Monitor::C_RetryMessage(&mon, op));
     }
-    CrushWrapper crush;
-    mon.osdmon()->_get_pending_crush(crush);
     vector<string> argvec;
     map<string, string> loc;
     cmd_getval(cmdmap, "args", argvec);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -14369,7 +14369,7 @@ void OSDMonitor::try_enable_stretch_mode(stringstream& ss, bool *okay,
   if (retval == -1) {
     ss << dividing_bucket << " is not a valid crush bucket type";
     *errcode = -ENOENT;
-    ceph_assert(!commit || dividing_id != -1);
+    ceph_assert(!commit || retval != -1);
     return;
   }
   vector<int> subtrees;
@@ -14386,7 +14386,7 @@ void OSDMonitor::try_enable_stretch_mode(stringstream& ss, bool *okay,
   if (new_crush_rule_result < 0) {
     ss << "unrecognized crush rule " << new_crush_rule;
     *errcode = new_crush_rule_result;
-    ceph_assert(!commit || new_crush_rule_result);
+    ceph_assert(!commit || (new_crush_rule_result > 0));
     return;
   }
   __u8 new_rule = static_cast<__u8>(new_crush_rule_result);
@@ -14406,7 +14406,7 @@ void OSDMonitor::try_enable_stretch_mode(stringstream& ss, bool *okay,
   if (bucket_count != 2) {
     ss << "currently we only support 2-site stretch clusters!";
     *errcode = -EINVAL;
-    ceph_assert(!commit);
+    ceph_assert(!commit || bucket_count == 2);
     return;
   }
   // TODO: check CRUSH rules for pools so that we are appropriately divided

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3033,7 +3033,6 @@ void OSDMap::encode(ceph::buffer::list& bl, uint64_t features) const
       target_v = 6;
     }
     if (stretch_mode_enabled) {
-      ceph_assert(target_v >= 9);
       target_v = std::max((uint8_t)10, target_v);
     }
     ENCODE_START(target_v, 1, bl); // extended, osd-only data

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -647,7 +647,6 @@ void OSDMap::Incremental::encode(ceph::buffer::list& bl, uint64_t features) cons
 
   {
     uint8_t target_v = 9; // if bumping this, be aware of stretch_mode target_v 10!
-    uint8_t new_compat_v = 0;
     if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
       target_v = 2;
     } else if (!HAVE_FEATURE(features, SERVER_NAUTILUS)) {
@@ -656,7 +655,6 @@ void OSDMap::Incremental::encode(ceph::buffer::list& bl, uint64_t features) cons
     if (change_stretch_mode) {
       ceph_assert(target_v >= 9);
       target_v = std::max((uint8_t)10, target_v);
-      new_compat_v = std::max((uint8_t)10, std::max(new_compat_v, struct_compat));
     }
     ENCODE_START(target_v, 1, bl); // extended, osd-only data
     if (target_v < 7) {
@@ -707,7 +705,7 @@ void OSDMap::Incremental::encode(ceph::buffer::list& bl, uint64_t features) cons
       encode(new_stretch_mode_bucket, bl);
       encode(stretch_mode_enabled, bl);
     }
-    ENCODE_FINISH_NEW_COMPAT(bl, new_compat_v); // osd-only data
+    ENCODE_FINISH(bl); // osd-only data
   }
 
   crc_offset = bl.length();
@@ -3027,7 +3025,6 @@ void OSDMap::encode(ceph::buffer::list& bl, uint64_t features) const
     // NOTE: any new encoding dependencies must be reflected by
     // SIGNIFICANT_FEATURES
     uint8_t target_v = 9; // when bumping this, be aware of stretch_mode target_v 10!
-    uint8_t new_compat_v = 0;
     if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
       target_v = 1;
     } else if (!HAVE_FEATURE(features, SERVER_MIMIC)) {
@@ -3038,7 +3035,6 @@ void OSDMap::encode(ceph::buffer::list& bl, uint64_t features) const
     if (stretch_mode_enabled) {
       ceph_assert(target_v >= 9);
       target_v = std::max((uint8_t)10, target_v);
-      new_compat_v = std::max((uint8_t)10, std::max(new_compat_v, struct_compat));
     }
     ENCODE_START(target_v, 1, bl); // extended, osd-only data
     if (target_v < 7) {
@@ -3095,7 +3091,7 @@ void OSDMap::encode(ceph::buffer::list& bl, uint64_t features) const
       encode(recovering_stretch_mode, bl);
       encode(stretch_mode_bucket, bl);
     }
-    ENCODE_FINISH_NEW_COMPAT(bl, new_compat_v); // osd-only data
+    ENCODE_FINISH(bl); // osd-only data
   }
 
   crc_offset = bl.length();


### PR DESCRIPTION
A few short patches around stretch mode to handle other issues.
The important one is the monmap change.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
