### PR TITLE
rgw: an empty tagset is allowed by S3

### DIFF
--- a/src/rgw/rgw_tag.cc
+++ b/src/rgw/rgw_tag.cc
@@ -35,6 +35,9 @@ int RGWObjTags::check_and_add_tag(const string&key, const string& val){
 }
 
 int RGWObjTags::set_from_string(const string& input){
+  if (input.empty()) {
+    return 0;
+  }
   int ret=0;
   vector <string> kvs;
   boost::split(kvs, input, boost::is_any_of("&"));

--- a/src/rgw/rgw_tag_s3.cc
+++ b/src/rgw/rgw_tag_s3.cc
@@ -30,7 +30,8 @@ void RGWObjTagEntry_S3::dump_xml(Formatter *f) const {
 void RGWObjTagSet_S3::decode_xml(XMLObj *obj) {
   vector<RGWObjTagEntry_S3> entries;
 
-  RGWXMLDecoder::decode_xml("Tag", entries, obj, true);
+  bool mandatory{false};
+  RGWXMLDecoder::decode_xml("Tag", entries, obj, mandatory);
 
   for (auto& entry : entries) {
     const std::string& key = entry.get_key();


### PR DESCRIPTION
Signed-off-by: Liu Lan <liulan_yewu@cmss.chinamobile.com>

https://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html

> A user might send an empty tag set in PutObjectTagging, which is allowed by this policy (an empty tag set in the request removes any existing tags on the object).

Test for this pr: https://github.com/ceph/s3-tests/pull/376

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
