### PR TITLE
mgr/dashboard: The /rgw/status endpoint does not check for running service

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -49,6 +49,8 @@ class Rgw(BaseController):
     def status(self):
         status = {'available': False, 'message': None}
         try:
+            if not CephService.get_service_list('rgw'):
+                raise LookupError('No RGW service is running.')
             instance = RgwClient.admin_instance()
             # Check if the service is online.
             if not instance.is_service_online():  # pragma: no cover - no complexity there

--- a/src/pybind/mgr/dashboard/tests/test_rgw.py
+++ b/src/pybind/mgr/dashboard/tests/test_rgw.py
@@ -3,8 +3,22 @@ try:
 except ImportError:
     import unittest.mock as mock
 
-from ..controllers.rgw import RgwUser
+from .. import mgr
+from ..controllers.rgw import Rgw, RgwUser
 from . import ControllerTestCase  # pylint: disable=no-name-in-module
+
+
+class RgwControllerTestCase(ControllerTestCase):
+    @classmethod
+    def setup_server(cls):
+        Rgw._cp_config['tools.authenticate.on'] = False  # pylint: disable=protected-access
+        cls.setup_controllers([Rgw], '/test')
+
+    def test_status_no_service(self):
+        mgr.list_servers.return_value = []
+        self._get('/test/api/rgw/status')
+        self.assertStatus(200)
+        self.assertJsonBody({'available': False, 'message': 'No RGW service is running.'})
 
 
 class RgwUserControllerTestCase(ControllerTestCase):


### PR DESCRIPTION
The `/api/rgw/status` endpoint does not check if a RGW service is running, it always tries to access the RGW Admin OPS API. This might lead to incorrect error messages.

Before:
![Bildschirmfoto vom 2020-12-10 15-44-42](https://user-images.githubusercontent.com/1897962/101796615-63338f80-3b09-11eb-9304-48b49cde883c.png)

After:
![Bildschirmfoto vom 2020-12-10 17-00-40](https://user-images.githubusercontent.com/1897962/101796642-6af33400-3b09-11eb-8f93-3b93a98a458e.png)

Fixes: https://tracker.ceph.com/issues/48542

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
