### PR TITLE
ceph-volume: drop is_locked_raw_device() function

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/test_inventory.py
+++ b/src/ceph-volume/ceph_volume/tests/test_inventory.py
@@ -11,7 +11,6 @@ def device_report_keys(device_info):
     device_info(devices={
         # example output of disk.get_devices()
         '/dev/sdb': {'human_readable_size': '1.82 TB',
-                     'locked': 0,
                      'model': 'PERC H700',
                      'nr_requests': '128',
                      'partitions': {},
@@ -39,7 +38,6 @@ def device_sys_api_keys(device_info):
     device_info(devices={
         # example output of disk.get_devices()
         '/dev/sdb': {'human_readable_size': '1.82 TB',
-                     'locked': 0,
                      'model': 'PERC H700',
                      'nr_requests': '128',
                      'partitions': {},
@@ -68,7 +66,6 @@ def device_data(device_info):
             # example output of disk.get_devices()
             '/dev/sdb': {
                 'human_readable_size': '1.82 TB',
-                'locked': 0,
                 'model': 'PERC H700',
                 'nr_requests': '128',
                 'partitions': {},
@@ -123,7 +120,6 @@ class TestInventory(object):
 
     expected_sys_api_keys = [
         'human_readable_size',
-        'locked',
         'model',
         'nr_requests',
         'partitions',

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -552,7 +552,6 @@ class Device(object):
         reasons = [
             ('removable', 1, 'removable'),
             ('ro', 1, 'read-only'),
-            ('locked', 1, 'locked'),
         ]
         rejected = [reason for (k, v, reason) in reasons if
                     self.sys_api.get(k, '') == v]

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -723,28 +723,6 @@ def is_mapper_device(device_name):
     return device_name.startswith(('/dev/mapper', '/dev/dm-'))
 
 
-def is_locked_raw_device(disk_path):
-    """
-    A device can be locked by a third party software like a database.
-    To detect that case, the device is opened in Read/Write and exclusive mode
-    """
-    open_flags = (os.O_RDWR | os.O_EXCL)
-    open_mode = 0
-    fd = None
-
-    try:
-        fd = os.open(disk_path, open_flags, open_mode)
-    except OSError:
-        return 1
-
-    try:
-        os.close(fd)
-    except OSError:
-        return 1
-
-    return 0
-
-
 def get_block_devs_lsblk(device=''):
     '''
     This returns a list of lists with 3 items per inner list.
@@ -830,7 +808,6 @@ def get_devices(_sys_block_path='/sys/block', device=''):
         metadata['size'] = float(size) * 512
         metadata['human_readable_size'] = human_readable_size(metadata['size'])
         metadata['path'] = diskname
-        metadata['locked'] = is_locked_raw_device(metadata['path'])
 
         device_facts[diskname] = metadata
     return device_facts


### PR DESCRIPTION
It triggers udev events that can cause race conditions.
ceph-volume never takes decision based on this function,
it is used only for reporting.
Until we can find another way to achieve this, let's drop
this function that is causing more issues than something else.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>