### PR TITLE
mgr/cephadm: make generate_config internal, prepare before redeploy

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3983,8 +3983,12 @@ def command_deploy(ctx):
 
     # Get and check ports explicitly required to be opened
     daemon_ports = [] # type: List[int]
-    if ctx.tcp_ports:
-        daemon_ports = list(map(int, ctx.tcp_ports.split()))
+
+    # only check port in use if not reconfig or redeploy since service
+    # we are redeploying/reconfiguring will already be using the port
+    if not ctx.reconfig and not redeploy:
+        if ctx.tcp_ports:
+            daemon_ports = list(map(int, ctx.tcp_ports.split()))
 
     if daemon_type in Ceph.daemons:
         config, keyring = get_config_and_keyring(ctx)

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1599,14 +1599,15 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
         self._daemon_action_set_image(action, image, daemon_type, daemon_id)
 
-        if action == 'redeploy':
-            if self.daemon_is_self(daemon_type, daemon_id):
-                self.mgr_service.fail_over()
-                return ''  # unreachable
-            # stop, recreate the container+unit, then restart
-            return CephadmServe(self)._create_daemon(daemon_spec)
-        elif action == 'reconfig':
-            return CephadmServe(self)._create_daemon(daemon_spec, reconfig=True)
+        if action == 'redeploy' and self.daemon_is_self(daemon_type, daemon_id):
+            self.mgr_service.fail_over()
+            return ''  # unreachable
+
+        if action == 'redeploy' or action == 'reconfig':
+            if daemon_type != 'osd':
+                daemon_spec = self.cephadm_services[daemon_type_to_service(
+                    daemon_type)].prepare_create(daemon_spec)
+            return CephadmServe(self)._create_daemon(daemon_spec, reconfig=(action == 'reconfig'))
 
         actions = {
             'start': ['reset-failed', 'start'],

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -776,9 +776,6 @@ class CephadmServe:
                     if haspec.keepalived_container_image:
                         image = haspec.keepalived_container_image
 
-                cephadm_config, deps = self.mgr.cephadm_services[daemon_type_to_service(daemon_spec.daemon_type)].generate_config(
-                    daemon_spec)
-
                 # TCP port to open in the host firewall
                 if len(ports) > 0:
                     daemon_spec.extra_args.extend([
@@ -814,7 +811,7 @@ class CephadmServe:
                     [
                         '--name', daemon_spec.name(),
                     ] + daemon_spec.extra_args,
-                    stdin=json.dumps(cephadm_config),
+                    stdin=json.dumps(daemon_spec.final_config),
                     image=image)
                 if not code and daemon_spec.host in self.mgr.cache.daemons:
                     # prime cached service state with what we (should have)
@@ -825,7 +822,7 @@ class CephadmServe:
                         self.mgr.requires_post_actions.add(daemon_spec.daemon_type)
                 self.mgr.cache.invalidate_host_daemons(daemon_spec.host)
                 self.mgr.cache.update_daemon_config_deps(
-                    daemon_spec.host, daemon_spec.name(), deps, start_time)
+                    daemon_spec.host, daemon_spec.name(), daemon_spec.deps, start_time)
                 self.mgr.cache.save_host(daemon_spec.host)
                 msg = "{} {} on host '{}'".format(
                     'Reconfigured' if reconfig else 'Deployed', daemon_spec.name(), daemon_spec.host)

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -67,6 +67,11 @@ class CephadmDaemonSpec(Generic[ServiceSpecs]):
         # TCP ports used by the daemon
         self.ports: List[int] = ports or []
 
+        # values to be populated during generate_config calls
+        # and then used in _run_cephadm
+        self.final_config: Dict[str, Any] = {}
+        self.deps: List[str] = []
+
     def name(self) -> str:
         return '%s.%s' % (self.daemon_type, self.daemon_id)
 
@@ -416,6 +421,8 @@ class MonService(CephService):
         daemon_spec.ceph_conf = extra_config
         daemon_spec.keyring = keyring
 
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+
         return daemon_spec
 
     def _check_safe_to_destroy(self, mon_id: str) -> None:
@@ -497,6 +504,8 @@ class MgrService(CephService):
 
         daemon_spec.keyring = keyring
 
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+
         return daemon_spec
 
     def get_active_daemon(self, daemon_descrs: List[DaemonDescription]) -> DaemonDescription:
@@ -576,6 +585,8 @@ class MdsService(CephService):
                      'mds', 'allow'],
         })
         daemon_spec.keyring = keyring
+
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
 
         return daemon_spec
 
@@ -665,6 +676,8 @@ class RgwService(CephService):
         keyring = self.get_keyring(rgw_id)
 
         daemon_spec.keyring = keyring
+
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
 
         return daemon_spec
 
@@ -823,6 +836,8 @@ class RbdMirrorService(CephService):
 
         daemon_spec.keyring = keyring
 
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+
         return daemon_spec
 
 
@@ -841,6 +856,8 @@ class CrashService(CephService):
         })
 
         daemon_spec.keyring = keyring
+
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
 
         return daemon_spec
 

--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -25,6 +25,13 @@ class IscsiService(CephService):
 
     def prepare_create(self, daemon_spec: CephadmDaemonSpec[IscsiServiceSpec]) -> CephadmDaemonSpec:
         assert self.TYPE == daemon_spec.daemon_type
+        # if spec is not attached to daemon_spec it is likely a redeploy or reconfig and
+        # spec should be in spec store
+        if not daemon_spec.spec:
+            service_name: str = "iscsi." + daemon_spec.daemon_id.split('.')[0]
+            if service_name in self.mgr.spec_store.specs:
+                daemon_spec.spec = cast(
+                    IscsiServiceSpec, self.mgr.spec_store.specs.get(service_name))
         assert daemon_spec.spec
 
         spec = daemon_spec.spec
@@ -70,6 +77,8 @@ class IscsiService(CephService):
 
         daemon_spec.keyring = keyring
         daemon_spec.extra_files = {'iscsi-gateway.cfg': igw_conf}
+
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
 
         return daemon_spec
 

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -126,6 +126,7 @@ class OSDService(CephService):
                     host=host,
                     daemon_type='osd',
                 )
+                daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
                 CephadmServe(self.mgr)._create_daemon(
                     daemon_spec,
                     osd_uuid_map=osd_uuid_map)

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -291,7 +291,8 @@ class TestCephadm(object):
 
                 _run_cephadm.assert_called_with('test', 'mon.test', 'deploy', [
                                                 '--name', 'mon.test', '--reconfig', '--config-json', '-'],
-                                                stdin='{"config": "\\n\\n[mon]\\nk=v\\n", "keyring": ""}',
+                                                stdin='{"config": "\\n\\n[mon]\\nk=v\\n[mon.test]\\npublic network = 127.0.0.0/8\\n", '
+                                                + '"keyring": "", "files": {"config": "[mon.test]\\npublic network = 127.0.0.0/8\\n"}}',
                                                 image='')
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -3,7 +3,7 @@ import pytest
 from unittest.mock import MagicMock, call
 
 from cephadm.services.cephadmservice import MonService, MgrService, MdsService, RgwService, \
-    RbdMirrorService, CrashService, CephadmExporter
+    RbdMirrorService, CrashService, CephadmExporter, CephadmDaemonSpec
 from cephadm.services.iscsi import IscsiService
 from cephadm.services.nfs import NFSService
 from cephadm.services.osd import OSDService
@@ -28,6 +28,9 @@ class FakeMgr:
             self.config = cmd_dict.get('value')
             return 0, 'value set', ''
         return -1, '', 'error'
+
+    def get_minimal_ceph_conf(self) -> str:
+        return ''
 
 
 class TestCephadmService:
@@ -89,7 +92,9 @@ class TestCephadmService:
         iscsi_spec.spec.daemon_type = "iscsi"
         iscsi_spec.spec.ssl_cert = ''
 
-        iscsi_service.prepare_create(iscsi_spec)
+        iscsi_daemon_spec = CephadmDaemonSpec(host='host', daemon_id='a', spec=iscsi_spec)
+
+        iscsi_service.prepare_create(iscsi_daemon_spec)
 
         expected_caps = ['mon',
                          'profile rbd, allow command "osd blocklist", allow command "config-key get" with "key" prefix "iscsi/"',


### PR DESCRIPTION
makes generate_config into an internal function for prepare_create and calls
prepare_create whenever a service is redeployed or reconfigured

Fixes: https://tracker.ceph.com/issues/48373

Signed-off-by: Adam King <adking@redhat.com>

Some concerns here: 

The way ports are handled in the binary on redeploys here
is to  just assume the ports were checked on initial deploy and
skip the check (in code comment explains a bit more).

No prep functions are called before redploy/reconfig for osds. The
osd service has a different preparatory code path than the other 
services and I'm not sure if any of it needs to happen on a 
redeploy/reconfig. I've left them out since it seems safer and 
redeploying the osd service seemed to run successfully during
local tests with these changes.

Redeploy/reconfig won't work for custom containers, but it doesn't 
seem like it was possible before this change either.

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
