### PR TITLE
octopus: qa: accept timeout argument in run_shell

### DIFF
--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -201,7 +201,7 @@ class CephFSMount(object):
         return self.run_shell(["bash", "-c", Raw(f"'{payload}'")], **kwargs)
 
     def run_shell(self, args, wait=True, stdin=None, check_status=True,
-                  omit_sudo=True):
+                  omit_sudo=True, timeout=10800):
         if isinstance(args, str):
             args = args.split()
 
@@ -209,7 +209,8 @@ class CephFSMount(object):
         return self.client_remote.run(args=args, stdout=StringIO(),
                                       stderr=StringIO(), wait=wait,
                                       stdin=stdin, check_status=check_status,
-                                      omit_sudo=omit_sudo)
+                                      omit_sudo=omit_sudo,
+                                      timeout=timeout)
 
     def open_no_data(self, basename):
         """


### PR DESCRIPTION
This was fixed differently in master in a way that's not easy to
backport.

Fixes: https://tracker.ceph.com/issues/48524
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
