### PR TITLE
cephadm: create default output dir during bootstrap

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2848,7 +2848,7 @@ def command_bootstrap():
             logger.info(f"Creating directory {dirname} for {fname}")
             try:
                 # use makedirs to create intermediate missing dirs
-                os.makedirs(dirname, 0o700)
+                os.makedirs(dirname, 0o755)
             except PermissionError:
                 raise Error(f"Unable to create {dirname} due to permissions failure. Retry with root, or sudo or preallocate the directory.")
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2844,7 +2844,14 @@ def command_bootstrap():
                               '--allow-overwrite to overwrite' % f)
         dirname = os.path.dirname(f)
         if dirname and not os.path.exists(dirname):
-            raise Error('%s directory %s does not exist' % (f, dirname))
+            fname = os.path.basename(f)
+            logger.info(f"Creating directory {dirname} for {fname}")
+            try:
+                # use makedirs to create intermediate missing dirs
+                os.makedirs(dirname, 0o700)
+            except PermissionError:
+                raise Error(f"Unable to create {dirname} due to permissions failure. Retry with root, or sudo or preallocate the directory.")
+
 
     if not args.skip_prepare_host:
         command_prepare_host()


### PR DESCRIPTION
If the output dir doesn't exist the old behaviour was to
abort bootstrap. Since we're running with UID=0, this
patch will create the missing dirs for the user to keep the
bootstrap process going

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>