### PR TITLE
cephadm: add host-maintenance subcommand

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -6298,6 +6298,74 @@ def command_exporter():
     exporter.run()
         
 
+##################################
+
+def systemd_target_state(target_name: str, subsystem: str = 'ceph') -> bool:
+    # TODO: UNITTEST
+    return os.path.exists(
+        os.path.join(
+            UNIT_DIR,
+            f"{subsystem}.target.wants",
+            target_name
+        )
+    )
+
+
+@infer_fsid
+def command_maintenance():
+    if not args.fsid:
+        raise Error('must pass --fsid to specify cluster')
+
+    target = f"ceph-{args.fsid}.target"
+    
+    if args.maintenance_action.lower() == 'enter':
+        logger.info("Requested to place host into maintenance")
+        if systemd_target_state(target):
+            _out, _err, code = call(
+                ['systemctl', 'disable', target],
+                verbose_on_failure=False
+            )
+            if code:
+                logger.error(f"Failed to disable the {target} target")
+                return "failed - to disable the target"
+            else:
+                # stopping a target waits by default
+                _out, _err, code = call(
+                    ['systemctl', 'stop', target],
+                    verbose_on_failure=False
+                )
+                if code:
+                    logger.error(f"Failed to stop the {target} target")
+                    return "failed - to disable the target"
+                else:
+                    return f"success - systemd target {target} disabled"
+
+        else:
+            return "skipped - target already disabled"
+
+    else:
+        logger.info("Requested to exit maintenance state")
+        # exit maintenance request
+        if not systemd_target_state(target):
+            _out, _err, code = call(
+                ['systemctl', 'enable', target],
+                verbose_on_failure=False
+            )
+            if code:
+                logger.error(f"Failed to enable the {target} target")
+                return "failed - unable to enable the target"
+            else:
+                # starting a target waits by default
+                _out, _err, code = call(
+                    ['systemctl', 'start', target],
+                    verbose_on_failure=False
+                )
+                if code:
+                    logger.error(f"Failed to start the {target} target")
+                    return "failed - unable to start the target"
+                else:
+                    return f"success - systemd target {target} enabled and started"
+
 
 ##################################
 
@@ -6860,6 +6928,18 @@ def _get_parser():
         default=get_hostname().split('.')[0],
         help='daemon identifer for the exporter')
     parser_exporter.set_defaults(func=command_exporter)
+
+    parser_maintenance = subparsers.add_parser(
+        'host-maintenance', help='Manage the maintenance state of a host')
+    parser_maintenance.add_argument(
+        '--fsid',
+        help='cluster FSID')
+    parser_maintenance.add_argument(
+        "maintenance_action",
+        type=str, 
+        choices=['enter', 'exit'],
+        help="Maintenance action - enter maintenance, or exit maintenance")
+    parser_maintenance.set_defaults(func=command_maintenance)
 
     return parser
 

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -101,6 +101,10 @@ class Inventory:
     def all_specs(self) -> List[HostSpec]:
         return list(map(self.spec_from_dict, self._inventory.values()))
 
+    def get_host_with_state(self, state: str = "") -> List[str]:
+        """return a list of host names in a specific state"""
+        return [h for h in self._inventory if self._inventory[h].get("status", "").lower() == state]
+
     def save(self) -> None:
         self.mgr.set_store('inventory', json.dumps(self._inventory))
 
@@ -448,6 +452,13 @@ class HostCache():
                 if d.daemon_type == service_type:
                     result.append(d)
         return result
+
+    def get_daemon_types(self, hostname: str) -> List[str]:
+        """Provide a list of the types of daemons on the host"""
+        result = set()
+        for _d, dm in self.daemons[hostname].items():
+            result.add(dm.daemon_type)
+        return list(result)
 
     def get_daemon_names(self):
         # type: () -> List[str]

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -111,6 +111,10 @@ class CephadmServe:
         @forall_hosts
         def refresh(host: str) -> None:
 
+            # skip hosts that are in maintenance - they could be powered off
+            if self.mgr.inventory._inventory[host].get("status", "").lower() == "maintenance":
+                return
+
             if self.mgr.cache.host_needs_check(host):
                 r = self._check_host(host)
                 if r is not None:

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -829,6 +829,18 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
+    def enter_host_maintenance(self, hostname: str) -> Completion:
+        """
+        Place a host in maintenance, stopping daemons and disabling it's systemd target
+        """
+        raise NotImplementedError()
+
+    def exit_host_maintenance(self, hostname: str) -> Completion:
+        """
+        Return a host from maintenance, restarting the clusters systemd target
+        """
+        raise NotImplementedError()
+
     def get_inventory(self, host_filter: Optional['InventoryFilter'] = None, refresh: bool = False) -> Completion[List['InventoryHost']]:
         """
         Returns something that was created by `ceph-volume inventory`.

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -318,7 +318,8 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
             table.left_padding_width = 0
             table.right_padding_width = 2
             for host in sorted(completion.result, key=lambda h: h.hostname):
-                table.add_row((host.hostname, host.addr, ' '.join(host.labels), host.status.capitalize()))
+                table.add_row((host.hostname, host.addr, ' '.join(
+                    host.labels), host.status.capitalize()))
             output = table.get_string()
         return HandleCommandResult(stdout=output)
 
@@ -364,7 +365,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         raise_if_exception(completion)
 
         return HandleCommandResult(stdout=completion.result_str())
-    
+
     @_cli_write_command(
         'orch host maintenance exit',
         'name=hostname,type=CephString',
@@ -625,7 +626,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
 
             remove_column = 'CONTAINER ID'
             if table.get_string(fields=[remove_column], border=False,
-                    header=False).count('<unknown>') == len(daemons):
+                                header=False).count('<unknown>') == len(daemons):
                 try:
                     table.del_column(remove_column)
                 except AttributeError as e:

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -318,7 +318,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
             table.left_padding_width = 0
             table.right_padding_width = 2
             for host in sorted(completion.result, key=lambda h: h.hostname):
-                table.add_row((host.hostname, host.addr, ' '.join(host.labels), host.status))
+                table.add_row((host.hostname, host.addr, ' '.join(host.labels), host.status.capitalize()))
             output = table.get_string()
         return HandleCommandResult(stdout=output)
 
@@ -352,6 +352,28 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         completion = self.host_ok_to_stop(hostname)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
+        return HandleCommandResult(stdout=completion.result_str())
+
+    @_cli_write_command(
+        'orch host maintenance enter',
+        'name=hostname,type=CephString',
+        desc='Prepare a host for maintenance by shutting down and disabling all Ceph daemons (cephadm only)')
+    def _host_maintenance_enter(self, hostname: str):
+        completion = self.enter_host_maintenance(hostname)
+        self._orchestrator_wait([completion])
+        raise_if_exception(completion)
+
+        return HandleCommandResult(stdout=completion.result_str())
+    
+    @_cli_write_command(
+        'orch host maintenance exit',
+        'name=hostname,type=CephString',
+        desc='Return a host from maintenance, restarting all Ceph daemons (cephadm only)')
+    def _host_maintenance_exit(self, hostname: str):
+        completion = self.exit_host_maintenance(hostname)
+        self._orchestrator_wait([completion])
+        raise_if_exception(completion)
+
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_read_command(


### PR DESCRIPTION
Initial patch to provide an enter and exit subcommand
to cephadm. Note these are simply 'primitives' that will
be used by mgr/cephadm

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>

