### PR TITLE
rgw: fixing compilation errors

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -242,7 +242,7 @@ void *RGWLC::LCWorker::entry() {
 void RGWLC::initialize(CephContext *_cct, rgw::sal::RGWRadosStore *_store) {
   cct = _cct;
   store = _store;
-  sal_lc = std::move(store->get_lifecycle());
+  sal_lc = store->get_lifecycle();
   max_objs = cct->_conf->rgw_lc_max_objs;
   if (max_objs > HASH_PRIME)
     max_objs = HASH_PRIME;
@@ -2097,7 +2097,7 @@ int fix_lc_shard_entry(rgw::sal::RGWRadosStore* store,
 
     ret = guard_lc_modify(
       store, sal_lc, bucket_info.bucket, cookie,
-      [&sal_lc, &lc_oid](rgw::sal::Lifecycle* slc,
+      [&lc_oid](rgw::sal::Lifecycle* slc,
 			      const string& oid,
 			      const rgw::sal::Lifecycle::LCEntry& entry) {
 	return slc->set_entry(lc_oid, entry);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3828,7 +3828,7 @@ void RGWPutObj::execute(optional_yield y)
     ldpp_dout(this, 20) << "dest_placement for part=" << upload_info.dest_placement << dendl;
     processor.emplace<MultipartObjectProcessor>(
         &*aio, store, s->bucket.get(), pdest_placement,
-        s->owner.get_id(), obj_ctx, std::move(s->object->clone()),
+        s->owner.get_id(), obj_ctx, s->object->clone(),
         multipart_upload_id, multipart_part_num, multipart_part_str,
         this, s->yield);
   } else if(append) {
@@ -3839,7 +3839,7 @@ void RGWPutObj::execute(optional_yield y)
     pdest_placement = &s->dest_placement;
     processor.emplace<AppendObjectProcessor>(
             &*aio, store, s->bucket.get(), pdest_placement, s->bucket_owner.get_id(),
-	    obj_ctx, std::move(s->object->clone()),
+	    obj_ctx, s->object->clone(),
             s->req_id, position, &cur_accounted_size, this, s->yield);
   } else {
     if (s->bucket->versioning_enabled()) {
@@ -3853,7 +3853,7 @@ void RGWPutObj::execute(optional_yield y)
     pdest_placement = &s->dest_placement;
     processor.emplace<AtomicObjectProcessor>(
         &*aio, store, s->bucket.get(), pdest_placement,
-        s->bucket_owner.get_id(), obj_ctx,  std::move(s->object->clone()),
+        s->bucket_owner.get_id(), obj_ctx, s->object->clone(),
 	olh_epoch, s->req_id, this, s->yield);
   }
 

--- a/src/rgw/rgw_putobj_processor.h
+++ b/src/rgw/rgw_putobj_processor.h
@@ -153,7 +153,7 @@ class ManifestObjectProcessor : public HeadObjectProcessor,
       store(store), bucket(bucket),
       owner(owner),
       obj_ctx(obj_ctx), head_obj(std::move(_head_obj)),
-      writer(aio, store, bucket, obj_ctx, std::move(head_obj->clone()), dpp, y),
+      writer(aio, store, bucket, obj_ctx, head_obj->clone(), dpp, y),
       chunk(&writer, 0), stripe(&chunk, this, 0), dpp(dpp) {
         if (ptail_placement_rule) {
           tail_placement_rule = *ptail_placement_rule;
@@ -238,7 +238,7 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
                            const DoutPrefixProvider *dpp, optional_yield y)
     : ManifestObjectProcessor(aio, store, bucket, ptail_placement_rule,
                               owner, obj_ctx, std::move(_head_obj), dpp, y),
-      target_obj(std::move(head_obj->clone())), upload_id(upload_id),
+      target_obj(head_obj->clone()), upload_id(upload_id),
       part_num(part_num), part_num_str(part_num_str),
       mp(head_obj->get_name(), upload_id)
   {}

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3798,7 +3798,7 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
   rgw::BlockingAioThrottle aio(cct->_conf->rgw_put_obj_min_window_size);
   using namespace rgw::putobj;
   AtomicObjectProcessor processor(&aio, this->store, dest_bucket, nullptr, user_id,
-                                  obj_ctx, std::move(dest_obj->clone()), olh_epoch,
+                                  obj_ctx, dest_obj->clone(), olh_epoch,
 				  tag, dpp, null_yield);
   RGWRESTConn *conn;
   auto& zone_conn_map = svc.zone->get_zone_conn_map();
@@ -4459,7 +4459,7 @@ int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
   // it causes crashes in the ragweed tests
   AtomicObjectProcessor processor(&aio, this->store, bucket, &dest_placement,
                                   bucket->get_info().owner, obj_ctx,
-                                  std::move(dest_obj->clone()), olh_epoch, tag,
+                                  dest_obj->clone(), olh_epoch, tag,
 				  dpp, null_yield);
   int ret = processor.prepare(y);
   if (ret < 0)


### PR DESCRIPTION
Removing pessimizing moves and unused captures.

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>

