### PR TITLE
crimson/osd: recover_missing() doesn't return std::optional anymore.

### DIFF
--- a/src/crimson/osd/osd_operations/background_recovery.cc
+++ b/src/crimson/osd/osd_operations/background_recovery.cc
@@ -64,9 +64,9 @@ seastar::future<> BackgroundRecovery::start()
 seastar::future<bool> UrgentRecovery::do_recovery()
 {
   if (!pg->has_reset_since(epoch_started)) {
-    auto futopt = pg->get_recovery_handler()->recover_missing(soid, need);
-    assert(futopt);
-    return with_blocking_future(std::move(*futopt)).then([] {
+    return with_blocking_future(
+      pg->get_recovery_handler()->recover_missing(soid, need)
+    ).then([] {
       return seastar::make_ready_future<bool>(false);
     });
   }

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -151,13 +151,8 @@ size_t PGRecovery::start_primary_recovery_ops(
       if (pg->get_recovery_backend()->is_recovering(head)) {
 	++skipped;
       } else {
-	auto futopt = recover_missing(soid, item.need);
-	if (futopt) {
-	  out->push_back(std::move(*futopt));
-	  ++started;
-	} else {
-	  ++skipped;
-	}
+	out->push_back(recover_missing(soid, item.need));
+	++started;
       }
     }
 
@@ -257,7 +252,7 @@ size_t PGRecovery::start_replica_recovery_ops(
   return started;
 }
 
-std::optional<crimson::osd::blocking_future<>> PGRecovery::recover_missing(
+crimson::osd::blocking_future<> PGRecovery::recover_missing(
   const hobject_t &soid, eversion_t need)
 {
   if (pg->get_peering_state().get_missing_loc().is_deleted(soid)) {

--- a/src/crimson/osd/pg_recovery.h
+++ b/src/crimson/osd/pg_recovery.h
@@ -40,7 +40,7 @@ private:
   std::vector<pg_shard_t> get_replica_recovery_order() const {
     return pg->get_replica_recovery_order();
   }
-  std::optional<crimson::osd::blocking_future<>> recover_missing(
+  crimson::osd::blocking_future<> recover_missing(
     const hobject_t &soid, eversion_t need);
   size_t prep_object_replica_deletes(
     const hobject_t& soid,


### PR DESCRIPTION
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
