### PR TITLE
crimson/osd: ObjectContext is not a Blocker anymore.

### DIFF
--- a/src/crimson/osd/object_context.cc
+++ b/src/crimson/osd/object_context.cc
@@ -8,13 +8,6 @@
 
 namespace crimson::osd {
 
-void ObjectContext::dump_detail(Formatter *f) const
-{
-  f->open_object_section("ObjectContext");
-  obs.oi.dump(f);
-  f->close_section();
-}
-
 ObjectContextRegistry::ObjectContextRegistry(crimson::common::ConfigProxy &conf)
 {
   obc_lru.set_target_size(conf.get_val<uint64_t>("crimson_osd_obc_lru_size"));


### PR DESCRIPTION
This is a follow-up to the c2dc437f78cd8be393c4d2eb8d79ce9c351ec4de
which removes unused OBC mebers after the with_lock() transition.

I'm not sure there is a reason to keep the `Blocker` bits as all
`ObjectContext::dump_detail()` does is just dumping `object_state_t`
while entering the OBC stage is already denoted by `PGPipeline::get_obc`.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
