### PR TITLE
crimson/onode-staged-tree: fix match_stage_t related compile issue

### DIFF
--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
@@ -14,14 +14,14 @@ namespace crimson::os::seastore::onode {
 #ifdef UNIT_TESTS_BUILT
 enum class InsertType { BEGIN, LAST, MID };
 struct split_expectation_t {
-  uint8_t split_stage;
-  uint8_t insert_stage;
+  match_stage_t split_stage;
+  match_stage_t insert_stage;
   bool is_insert_left;
   InsertType insert_type;
 };
 struct last_split_info_t {
   search_position_t split_pos;
-  uint8_t insert_stage;
+  match_stage_t insert_stage;
   bool is_insert_left;
   InsertType insert_type;
   bool match(const split_expectation_t& e) const {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
@@ -13,10 +13,10 @@
 
 namespace crimson::os::seastore::onode {
 
-using match_stage_t = uint8_t;
-constexpr match_stage_t STAGE_LEFT = 2u;   // shard/pool/crush
-constexpr match_stage_t STAGE_STRING = 1u; // nspace/oid
-constexpr match_stage_t STAGE_RIGHT = 0u;  // snap/gen
+using match_stage_t = int8_t;
+constexpr match_stage_t STAGE_LEFT = 2;   // shard/pool/crush
+constexpr match_stage_t STAGE_STRING = 1; // nspace/oid
+constexpr match_stage_t STAGE_RIGHT = 0;  // snap/gen
 constexpr auto STAGE_TOP = STAGE_LEFT;
 constexpr auto STAGE_BOTTOM = STAGE_RIGHT;
 constexpr bool is_valid_stage(match_stage_t stage) {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
@@ -133,13 +133,10 @@ class KVPool {
       : str_sizes{str_sizes}, onodes{onode_sizes} {
     ceph_assert(range2.first < range2.second);
     ceph_assert(range2.second - 1 <= (unsigned)std::numeric_limits<shard_t>::max());
-    ceph_assert(range2.second - 1 <= std::numeric_limits<pool_t>::max());
     ceph_assert(range2.second - 1 <= std::numeric_limits<crush_hash_t>::max());
     ceph_assert(range1.first < range1.second);
     ceph_assert(range1.second - 1 <= 9);
     ceph_assert(range0.first < range0.second);
-    ceph_assert(range0.second - 1 <= std::numeric_limits<snap_t>::max());
-    ceph_assert(range0.second - 1 <= std::numeric_limits<gen_t>::max());
     std::random_device rd;
     for (unsigned i = range2.first; i < range2.second; ++i) {
       for (unsigned j = range1.first; j < range1.second; ++j) {


### PR DESCRIPTION
Change the type to int8_t for potential negative value when
substantiating the templates.

Specifically, clang will substantiate `staged_result_t<NODE_TYPE, STAGE-1>` when `STAGE` is 0, and result in compile error.
```
../src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h:355:56: error: non-type template argument evaluates to -1, which cannot be narrowed to type 'crimson::os::seastore::onode::match_stage_t' (aka 'unsigned char') [-Wc++11-narrowing]
        size_t index, const staged_result_t<NODE_TYPE, STAGE-1>& nxt_stage_result) {
                                                       ^
../src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h:966:29: note: in instantiation of template class 'crimson::os::seastore::onode::staged_result_t<crimson::os::seastore::onode::node_type_t::INTERNAL, '\x00'>' requested here
          auto nxt_result = NXT_STAGE_T::template lower_bound<GET_KEY>(
                            ^
../src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h:133:21: note: expanded from macro 'NXT_STAGE_T'
#define NXT_STAGE_T staged<next_param_t>
                    ^
../src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h:966:51: note: in instantiation of function template specialization 'crimson::os::seastore::onode::staged<crimson::os::seastore::onode::staged_params_item_iterator<crimson::os::seastore::onode::node_type_t::INTERNAL> >::lower_bound<true>' requested here
          auto nxt_result = NXT_STAGE_T::template lower_bound<GET_KEY>(
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
