### PR TITLE
crimson/net: fix test_preemptive_shutdown() failure

### DIFF
--- a/src/crimson/net/Protocol.cc
+++ b/src/crimson/net/Protocol.cc
@@ -70,6 +70,7 @@ void Protocol::close(bool dispatch_reset,
     socket->shutdown();
   }
   set_write_state(write_state_t::drop);
+  assert(!gate.is_closed());
   auto gate_closed = gate.close();
 
   if (dispatch_reset) {
@@ -306,6 +307,7 @@ void Protocol::write_event()
    case write_state_t::open:
      [[fallthrough]];
    case write_state_t::delay:
+    assert(!gate.is_closed());
     gate.dispatch_in_background("do_write_dispatch_sweep", *this, [this] {
       return do_write_dispatch_sweep();
     });

--- a/src/crimson/net/ProtocolV1.cc
+++ b/src/crimson/net/ProtocolV1.cc
@@ -952,6 +952,9 @@ void ProtocolV1::trigger_close()
 {
   logger().trace("{} trigger closing, was {}",
                  conn, static_cast<int>(state));
+  messenger.closing_conn(
+      seastar::static_pointer_cast<SocketConnection>(
+        conn.shared_from_this()));
 
   if (state == state_t::accepting) {
     messenger.unaccept_conn(seastar::static_pointer_cast<SocketConnection>(
@@ -969,6 +972,13 @@ void ProtocolV1::trigger_close()
   }
 
   state = state_t::closing;
+}
+
+void ProtocolV1::on_closed()
+{
+  messenger.closed_conn(
+      seastar::static_pointer_cast<SocketConnection>(
+        conn.shared_from_this()));
 }
 
 seastar::future<> ProtocolV1::fault()

--- a/src/crimson/net/ProtocolV1.cc
+++ b/src/crimson/net/ProtocolV1.cc
@@ -316,6 +316,7 @@ void ProtocolV1::start_connect(const entity_addr_t& _peer_addr,
   set_write_state(write_state_t::delay);
 
   ceph_assert(!socket);
+  ceph_assert(!gate.is_closed());
   conn.peer_addr = _peer_addr;
   conn.target_addr = _peer_addr;
   conn.set_peer_name(_peer_name);

--- a/src/crimson/net/ProtocolV1.h
+++ b/src/crimson/net/ProtocolV1.h
@@ -18,6 +18,7 @@ class ProtocolV1 final : public Protocol {
   ~ProtocolV1() override;
   void print(std::ostream&) const final;
  private:
+  void on_closed() override;
   bool is_connected() const override;
 
   void start_connect(const entity_addr_t& peer_addr,

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -164,6 +164,7 @@ void ProtocolV2::start_connect(const entity_addr_t& _peer_addr,
 {
   ceph_assert(state == state_t::NONE);
   ceph_assert(!socket);
+  ceph_assert(!gate.is_closed());
   conn.peer_addr = _peer_addr;
   conn.target_addr = _peer_addr;
   conn.set_peer_name(_peer_name);

--- a/src/crimson/net/ProtocolV2.cc
+++ b/src/crimson/net/ProtocolV2.cc
@@ -2103,6 +2103,10 @@ void ProtocolV2::execute_server_wait()
 
 void ProtocolV2::trigger_close()
 {
+  messenger.closing_conn(
+      seastar::static_pointer_cast<SocketConnection>(
+        conn.shared_from_this()));
+
   if (state == state_t::ACCEPTING || state == state_t::SERVER_WAIT) {
     messenger.unaccept_conn(
       seastar::static_pointer_cast<SocketConnection>(
@@ -2117,9 +2121,6 @@ void ProtocolV2::trigger_close()
   }
 
   protocol_timer.cancel();
-  messenger.closing_conn(
-      seastar::static_pointer_cast<SocketConnection>(
-	conn.shared_from_this()));
   trigger_state(state_t::CLOSING, write_state_t::drop, false);
 }
 


### PR DESCRIPTION
This should fix the specific error logged in https://tracker.ceph.com/issues/48108#note-7.

The issue in `test_preemptive_shutdown()` only happens when the client connection is still at `state_t::connection` and the client msgr is preemptively shutdown after 100ms. That's why it won't happen everytime.

The reason is that when a connection is closed during connection, `execute_open()` will be wrongly called and set the protocol `write_state` to `write_state_t::open`, causing a `seastar::gate_closed_exception` when sending messages and trying to call `write_event()`.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
