### PR TITLE
nautilus: rgw: rgw-admin: fixes BucketInfo for missing buckets

### DIFF
--- a/qa/tasks/radosgw_admin_rest.py
+++ b/qa/tasks/radosgw_admin_rest.py
@@ -464,6 +464,11 @@ def task(ctx, config):
     assert out['usage']['rgw.main']['num_objects'] == 1
     assert out['usage']['rgw.main']['size_kb'] > 0
 
+    # TESTCASE 'bucket-stats6', 'bucket', 'stats', 'non-existent bucket', 'fails, 'bucket not found error'
+    (ret, out) = rgwadmin_rest(admin_conn, ['bucket', 'info'], {'bucket' : 'doesnotexist'})
+    assert ret == 404
+    assert out['Code'] == 'NoSuchBucket'
+
     # reclaim it
     key.delete()
 

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1644,8 +1644,15 @@ int RGWBucketAdminOp::limit_check(RGWRados *store,
 int RGWBucketAdminOp::info(RGWRados *store, RGWBucketAdminOpState& op_state,
                   RGWFormatterFlusher& flusher)
 {
+  RGWBucket bucket;
   int ret = 0;
   const std::string& bucket_name = op_state.get_bucket_name();
+  if (!bucket_name.empty()) {
+    ret = bucket.init(store, op_state);
+    if (ret < 0)
+      return ret;
+  }
+
   Formatter *formatter = flusher.get_formatter();
   flusher.start(0);
 

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1649,7 +1649,9 @@ int RGWBucketAdminOp::info(RGWRados *store, RGWBucketAdminOpState& op_state,
   const std::string& bucket_name = op_state.get_bucket_name();
   if (!bucket_name.empty()) {
     ret = bucket.init(store, op_state);
-    if (ret < 0)
+    if (-ENOENT == ret)
+      return -ERR_NO_SUCH_BUCKET;
+    else if (ret < 0)
       return ret;
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48100

---

backport of

* https://github.com/ceph/ceph/pull/34866
* https://github.com/ceph/ceph/pull/37929

parent trackers:

* https://tracker.ceph.com/issues/45193
* https://tracker.ceph.com/issues/48073

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh