### PR TITLE
octopus: mgr/dashboard: adjust refresh intervals of Services and Daemons

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.html
@@ -4,7 +4,7 @@
           [data]="daemons"
           [columns]="columns"
           columnMode="flex"
-          [autoReload]="60000"
+          [autoReload]="5000"
           (fetchData)="getDaemons($event)">
 </cd-table>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.html
@@ -6,7 +6,7 @@
             forceIdentifier="true"
             columnMode="flex"
             selectionType="single"
-            [autoReload]="60000"
+            [autoReload]="5000"
             (fetchData)="getServices($event)"
             [hasDetails]="true"
             (setExpandedRow)="setExpandedRow($event)">


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48539

---

backport of https://github.com/ceph/ceph/pull/38441
parent tracker: https://tracker.ceph.com/issues/48455

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh