### PR TITLE
octopus: mgr/dashboard: Fix for misleading "Orchestrator is not available" error

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.html
@@ -1,4 +1,4 @@
-<cd-orchestrator-doc-panel *ngIf="!hasOrchestrator"></cd-orchestrator-doc-panel>
+<cd-orchestrator-doc-panel *ngIf="showDocPanel"></cd-orchestrator-doc-panel>
 <ng-container *ngIf="hasOrchestrator">
   <legend i18n>Devices</legend>
   <div class="row">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.spec.ts
@@ -43,6 +43,10 @@ describe('InventoryComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should not display doc panel if orchestrator is available', () => {
+    expect(component.showDocPanel).toBeFalsy();
+  });
+
   describe('after ngOnInit', () => {
     it('should load devices', () => {
       fixture.detectChanges();

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/inventory/inventory.component.ts
@@ -16,6 +16,7 @@ export class InventoryComponent implements OnChanges, OnInit {
   icons = Icons;
 
   hasOrchestrator = false;
+  showDocPanel = false;
 
   devices: Array<InventoryDevice> = [];
 
@@ -24,6 +25,7 @@ export class InventoryComponent implements OnChanges, OnInit {
   ngOnInit() {
     this.orchService.status().subscribe((status) => {
       this.hasOrchestrator = status.available;
+      this.showDocPanel = !status.available;
       if (status.available) {
         this.getInventory();
       }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.html
@@ -1,4 +1,4 @@
-<cd-orchestrator-doc-panel *ngIf="!hasOrchestrator"></cd-orchestrator-doc-panel>
+<cd-orchestrator-doc-panel *ngIf="showDocPanel"></cd-orchestrator-doc-panel>
 <cd-table *ngIf="hasOrchestrator"
           #daemonsTable
           [data]="daemons"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.spec.ts
@@ -111,4 +111,8 @@ describe('ServiceDaemonListComponent', () => {
     component.getDaemons(new CdTableFetchDataContext(() => {}));
     expect(component.daemons.length).toBe(3);
   });
+
+  it('should not display doc panel if orchestrator is available', () => {
+    expect(component.showDocPanel).toBeFalsy();
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/service-daemon-list/service-daemon-list.component.ts
@@ -46,6 +46,7 @@ export class ServiceDaemonListComponent implements OnInit, OnChanges, AfterViewI
   columns: CdTableColumn[] = [];
 
   hasOrchestrator = false;
+  showDocPanel = false;
 
   private daemonsTable: TableComponent;
   private daemonsTableTplsSub: Subscription;
@@ -125,6 +126,7 @@ export class ServiceDaemonListComponent implements OnInit, OnChanges, AfterViewI
 
     this.orchService.status().subscribe((data: { available: boolean }) => {
       this.hasOrchestrator = data.available;
+      this.showDocPanel = !data.available;
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.html
@@ -1,4 +1,4 @@
-<cd-orchestrator-doc-panel *ngIf="!hasOrchestrator"></cd-orchestrator-doc-panel>
+<cd-orchestrator-doc-panel *ngIf="showDocPanel"></cd-orchestrator-doc-panel>
 <ng-container *ngIf="hasOrchestrator">
   <cd-table [data]="services"
             [columns]="columns"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.spec.ts
@@ -90,4 +90,8 @@ describe('ServicesComponent', () => {
     component.getServices(new CdTableFetchDataContext(() => {}));
     expect(component.services.length).toBe(2);
   });
+
+  it('should not display doc panel if orchestrator is available', () => {
+    expect(component.showDocPanel).toBeFalsy();
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
@@ -28,6 +28,7 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
   @Input() hiddenColumns: string[] = [];
 
   permissions: Permissions;
+  showDocPanel = false;
 
   checkingOrchestrator = true;
   hasOrchestrator = false;
@@ -93,6 +94,7 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
 
     this.orchService.status().subscribe((status) => {
       this.hasOrchestrator = status.available;
+      this.showDocPanel = !status.available;
     });
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48494

---

backport of https://github.com/ceph/ceph/pull/38432
parent tracker: https://tracker.ceph.com/issues/48448

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh