### PR TITLE
ceph.in: try harder if asok path does not exist

### DIFF
--- a/doc/man/8/ceph-conf.rst
+++ b/doc/man/8/ceph-conf.rst
@@ -84,6 +84,13 @@ Options
    For example, if we specify ``--name osd.0``, the following sections will be
    searched: [osd.0], [osd], [global]
 
+.. option:: --pid *pid*
+
+   override the ``$pid`` when expanding options. For example, if an option is
+   configured like ``/var/log/$name.$pid.log``, the ``$pid`` portion in its
+   value will be substituded using the PID of **ceph-conf** instead of the
+   PID of the process specfied using the ``--name`` option.
+
 .. option:: -r, --resolve-search
 
    search for the first file that exists and can be opened in the resulted

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -20,11 +20,11 @@ Foundation.  See file COPYING.
 """
 
 from time import sleep
-import codecs
 import grp
 import os
 import pwd
 import shutil
+import stat
 import sys
 import time
 import platform
@@ -495,7 +495,7 @@ def format_help(cmddict, partial=None):
     return fullusage
 
 
-def ceph_conf(parsed_args, field, name):
+def ceph_conf(parsed_args, field, name, pid=None):
     cmd = 'ceph-conf'
     bindir = os.path.dirname(__file__)
     if shutil.which(cmd):
@@ -507,6 +507,8 @@ def ceph_conf(parsed_args, field, name):
 
     if name:
         args.extend(['--name', name])
+    if pid:
+        args.extend(['--pid', pid])
 
     # add any args in GLOBAL_ARGS
     for key, val in GLOBAL_ARGS.items():
@@ -525,6 +527,7 @@ def ceph_conf(parsed_args, field, name):
     if p.returncode != 0:
         raise RuntimeError('unable to get conf option %s for %s: %s' % (field, name, errdata))
     return outdata.rstrip()
+
 
 PROMPT = 'ceph> '
 
@@ -731,7 +734,20 @@ def ping_monitor(cluster_handle, name, timeout):
 
 
 def get_admin_socket(parsed_args, name):
-    return ceph_conf(parsed_args, 'admin_socket', name)
+    path = ceph_conf(parsed_args, 'admin_socket', name)
+    try:
+        if stat.S_ISSOCK(os.stat(path).st_mode):
+            return path
+    except OSError:
+        pass
+    # try harder, probably the "name" option is in the form of
+    # "${name}.${pid}"?
+    parts = name.rsplit('.', 1)
+    if len(parts) > 1 and parts[-1].isnumeric():
+        name, pid = parts
+        return ceph_conf(parsed_args, 'admin_socket', name, pid)
+    else:
+        return path
 
 
 def maybe_daemon_command(parsed_args, childargs):

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -730,6 +730,10 @@ def ping_monitor(cluster_handle, name, timeout):
     return 0
 
 
+def get_admin_socket(parsed_args, name):
+    return ceph_conf(parsed_args, 'admin_socket', name)
+
+
 def maybe_daemon_command(parsed_args, childargs):
     """
     Check if --admin-socket, daemon, or daemonperf command
@@ -751,8 +755,7 @@ def maybe_daemon_command(parsed_args, childargs):
             else:
                 # try resolve daemon name
                 try:
-                    sockpath = ceph_conf(parsed_args, 'admin_socket',
-                                         childargs[1])
+                    sockpath = get_admin_socket(parsed_args, childargs[1])
                 except Exception as e:
                     print('Can\'t get admin socket path: ' + str(e), file=sys.stderr)
                     return True, errno.EINVAL

--- a/src/test/cli/ceph-conf/help.t
+++ b/src/test/cli/ceph-conf/help.t
@@ -28,6 +28,7 @@
     [--format plain|json|json-pretty]
                                     dump variables in plain text, json or pretty
                                     json
+    [--pid <pid>]                   Override the $pid when expanding options
   
   If there is no action given, the action will default to --lookup.
   

--- a/src/test/cli/ceph-conf/show-config-value.t
+++ b/src/test/cli/ceph-conf/show-config-value.t
@@ -30,7 +30,7 @@ Name option test to strip the PID
   > [global]
   >     admin socket = \$name.asok
   > EOF
-  $ ceph-conf --name client.admin.133423 --show-config-value admin_socket -c $TESTDIR/ceph.conf
+  $ ceph-conf --name client.admin --pid 133423 --show-config-value admin_socket -c $TESTDIR/ceph.conf
   client.admin.133423.asok
   $ ceph-conf --name mds.a --show-config-value admin_socket -c $TESTDIR/ceph.conf
   mds.a.asok


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
