### PR TITLE
rpm: require smartmontools on SUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -464,7 +464,11 @@ Provides:	ceph-test:/usr/bin/ceph-monstore-tool
 Requires:	ceph-base = %{_epoch_prefix}%{version}-%{release}
 %if 0%{?weak_deps}
 Recommends:	nvme-cli
+%if 0%{?suse_version}
+Requires:       smartmontools
+%else
 Recommends:	smartmontools
+%endif
 %endif
 %if 0%{with jaeger}
 Requires:	libjaeger = %{_epoch_prefix}%{version}-%{release}
@@ -725,7 +729,11 @@ Requires:	libstoragemgmt
 Requires:	python%{python3_pkgversion}-ceph-common = %{_epoch_prefix}%{version}-%{release}
 %if 0%{?weak_deps}
 Recommends:	nvme-cli
+%if 0%{?suse_version}
+Requires:       smartmontools
+%else
 Recommends:	smartmontools
+%endif
 %endif
 %description osd
 ceph-osd is the object storage daemon for the Ceph distributed file


### PR DESCRIPTION
SUSE container images are built using a process that excludes dependencies that
are merely recommended.

Fixes: https://tracker.ceph.com/issues/48604
Signed-off-by: Nathan Cutler <ncutler@suse.com>