### PR TITLE
doc: fix the meaning of default_min_size of pools

### DIFF
--- a/doc/rados/configuration/pool-pg-config-ref.rst
+++ b/doc/rados/configuration/pool-pg-config-ref.rst
@@ -181,8 +181,8 @@ Ceph configuration file.
 ``osd_pool_default_min_size``
 
 :Description: Sets the minimum number of written replicas for objects in the
-             pool in order to acknowledge a write operation to the client.  If
-             minimum is not met, Ceph will not acknowledge the write to the
+             pool in order to acknowledge an I/O operation to the client.  If
+             minimum is not met, Ceph will not acknowledge the I/O to the
              client, **which may result in data loss**. This setting ensures
              a minimum number of replicas when operating in ``degraded`` mode.
 

--- a/doc/rados/configuration/pool-pg.conf
+++ b/doc/rados/configuration/pool-pg.conf
@@ -3,12 +3,12 @@
 	# By default, Ceph makes 3 replicas of RADOS objects. If you want to maintain four
 	# copies of an object the default value--a primary copy and three replica
 	# copies--reset the default values as shown in 'osd_pool_default_size'.
-	# If you want to allow Ceph to write a lesser number of copies in a degraded
-	# state, set 'osd_pool_default_min_size' to a number less than the
-	# 'osd_pool_default_size' value.
+	# If you want to allow Ceph to accept an I/O operation to a degraded PG,
+	# set 'osd_pool_default_min_size' to a number less than the
+	# 'osd pool default size' value.
 
 	osd_pool_default_size = 3  # Write an object 3 times.
-	osd_pool_default_min_size = 2 # Allow writing two copies in a degraded state.
+	osd_pool_default_min size = 2 # Accept an I/O operation to a PG that has two copies of an object.
 
 	# Ensure you have a realistic number of placement groups. We recommend
 	# approximately 100 per OSD. E.g., total number of OSDs multiplied by 100


### PR DESCRIPTION
`osd pool default min size` affects not only write operations, but also read operations.

## Checklist
- [o] References tracker ticket
- [o] Updates documentation if necessary
- [o] Includes tests for new functionality or reproducer for bug