### PR TITLE
mgr/dashboard: Fixing dashboard logs e2e test

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/logs.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/logs.e2e-spec.ts
@@ -1,14 +1,11 @@
 import { PoolPageHelper } from '../pools/pools.po';
-import { ConfigurationPageHelper } from './configuration.po';
 import { LogsPageHelper } from './logs.po';
 
 describe('Logs page', () => {
   const logs = new LogsPageHelper();
   const pools = new PoolPageHelper();
-  const configuration = new ConfigurationPageHelper();
 
   const poolname = 'e2e_logs_test_pool';
-  const configname = 'log_graylog_port';
   const today = new Date();
   let hour = today.getHours();
   if (hour > 12) {
@@ -55,19 +52,6 @@ describe('Logs page', () => {
       pools.navigateTo();
       pools.delete(poolname);
       logs.checkAuditForPoolFunction(poolname, 'delete', hour, minute);
-    });
-  });
-
-  describe('audit logs respond to editing configuration setting test', () => {
-    it('should change config settings and check audit logs reacted', () => {
-      configuration.navigateTo();
-      configuration.edit(configname, ['global', '5']);
-
-      logs.navigateTo();
-      logs.checkAuditForConfigChange(configname, 'global', hour, minute);
-
-      configuration.navigateTo();
-      configuration.configClear(configname);
     });
   });
 });


### PR DESCRIPTION
Yesterday there were some changes went in which disables the logging of config set and config-key set to to be logged in mgr audit logs (https://github.com/ceph/ceph/commit/4b83dfb1f74e8a59c802ff3c0eb4595f7e763762). Dashboard has an e2e test which checks for this config set and broke the current e2e jenkins job. This commit removes that certain test to fix the jenkins job.

Related to: https://github.com/ceph/ceph/pull/38479

**Failure Report**
```
1) Logs page
       audit logs respond to editing configuration setting test
         should change config settings and check audit logs reacted:

      Timed out retrying
      + expected - actual

      -'from=\'mgr.4139 \' entity=\'mgr.x\' cmd=[{"prefix": "config rm", "format": "json", "who": "client", "name": "log_graylog_port"}]: dispatchfrom=\'mgr.4139 172.21.2.17:0/31644\' entity=\'mgr.x\' cmd=[{"prefix": "config rm", "format": "json", "who": "client", "name": "log_graylog_port"}]: dispatchfrom=\'mgr.4139 \' entity=\'mgr.x\' cmd=[{"prefix": "config rm", "format": "json", "who": "mds", "name": "log_graylog_port"}]: dispatchfrom=\'mgr.4139 172.21.2.17:0/31644\' entity=\'mgr.x\' cmd=[{"prefix": "config rm", "format": "json", "who": "mds", "name": "log_graylog_port"}]: dispatchfrom=\'mgr.4139 \' entity=\'mgr.x\' cmd=[{"prefix": "config rm", "format": "json", "who": "osd", "name": "log_graylog_port"}]: dispatchfrom=\'mgr.4139 172.21.2.17:0/31644\' entity=\'mgr.x\' cmd=[{"prefix": "config rm", "format": "json", "who": "osd", "name": "log_graylog_port"}]: dispatchfrom=\'mgr.4139 \' entity=\'mgr.x\' cmd=[{"prefix": "config rm", "format": "json", "who": "mgr", "name": "log_graylog_port"}]: dispatchfrom=\'mgr.4139 172.21.2.17:0/31644\' entity=\'mgr.x\' cmd=[{"prefix": "config rm", "format": "json", "who": "mgr", "name": "log_graylog_port"}]: dispatchfrom=\'mgr.4139 \' entity=\'mgr.x\' cmd=[{"prefix": "config rm", "format": "json", "who": "mon", "name": "log_graylog_port"}]: dispatchfrom=\'mgr.4139 172.21.2.17:0/31644\' entity=\'mgr.x\' cmd=[{"prefix": "config rm", "format": "json", "who": "mon", "name": "log_graylog_port"}]: dispatchfrom=\'mgr.4139 \' entity=\'mgr.x\' cmd=[{"prefix": "config rm", "format": "json", "who": "client", "name": "log_graylog_port"}]: dispatchfrom=\'mgr.4139 172.21.2.17:0/31644\' entity=\'mgr.x\' cmd=[{"prefix": "config rm", "format": "json", "who": "client", "name": "log_graylog_port"}]: dispatchfrom=\'mgr.4139 \' entity=\'mgr.x\' cmd=[{"prefix": "config rm", "format": "json", "who": "mds", "name": "log_graylog_port"}]: dispatch'
      +'global'
      
      at LogsPageHelper.checkAuditForConfigChange (https://braggi17:41869/__cypress/tests?p=cypress/integration/cluster/logs.e2e-spec.ts:309:14)
      at Context.eval (https://braggi17:41869/__cypress/tests?p=cypress/integration/cluster/logs.e2e-spec.ts:233:18)
    
```

Fixes: https://tracker.ceph.com/issues/48623
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
