### PR TITLE
octopus: mgr/dashboard: Fix CRUSH map viewer VirtualScroll

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.html
@@ -5,7 +5,7 @@
            i18n>CRUSH map viewer</div>
       <div class="card-body">
         <div class="row">
-          <div class="col-sm-6 col-lg-6">
+          <div class="col-sm-6 col-lg-6 tree-container">
             <i *ngIf="loadingIndicator"
                [ngClass]="[icons.large, icons.spinner, icons.spin]"></i>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.scss
@@ -1,7 +1,3 @@
-::ng-deep tree-root {
-  tree-viewport {
-    div:first-child {
-      height: unset !important;
-    }
-  }
+.tree-container {
+  height: calc(100vh - 200px);
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/crushmap/crushmap.component.ts
@@ -24,6 +24,7 @@ export class CrushmapComponent implements OnInit {
   nodes: any[] = [];
   treeOptions: ITreeOptions = {
     useVirtualScroll: true,
+    nodeHeight: 22,
     actionMapping: {
       mouse: {
         click: this.onNodeSelected.bind(this)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48605

---

backport of https://github.com/ceph/ceph/pull/38456
parent tracker: https://tracker.ceph.com/issues/45873

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh