### PR TITLE
octopus: Do not add sensitive information in Ceph log files

### DIFF
--- a/src/messages/MMonCommand.h
+++ b/src/messages/MMonCommand.h
@@ -15,11 +15,13 @@
 #ifndef CEPH_MMONCOMMAND_H
 #define CEPH_MMONCOMMAND_H
 
-#include "common/cmdparse.h"
 #include "messages/PaxosServiceMessage.h"
 
 #include <vector>
 #include <string>
+
+using TOPNSPC::common::cmdmap_from_json;
+using TOPNSPC::common::cmd_getval;
 
 class MMonCommand : public PaxosServiceMessage {
 public:
@@ -45,17 +47,17 @@ public:
     cmdmap_t cmdmap;
     stringstream ss;
     string prefix;
-    ceph::common::cmdmap_from_json(cmd, &cmdmap, ss);
-    ceph::common::cmd_getval(cmdmap, "prefix", prefix);
+    cmdmap_from_json(cmd, &cmdmap, ss);
+    cmd_getval(cmdmap, "prefix", prefix);
     // Some config values contain sensitive data, so don't log them
     o << "mon_command(";
     if (prefix == "config set") {
       string name;
-      ceph::common::cmd_getval(cmdmap, "name", name);
+      cmd_getval(cmdmap, "name", name);
       o << "[{prefix=" << prefix << ", name=" << name << "}]";
     } else if (prefix == "config-key set") {
       string key;
-      ceph::common::cmd_getval(cmdmap, "key", key);
+      cmd_getval(cmdmap, "key", key);
       o << "[{prefix=" << prefix << ", key=" << key << "}]";
     } else {
       for (unsigned i=0; i<cmd.size(); i++) {

--- a/src/messages/MMonCommand.h
+++ b/src/messages/MMonCommand.h
@@ -15,6 +15,7 @@
 #ifndef CEPH_MMONCOMMAND_H
 #define CEPH_MMONCOMMAND_H
 
+#include "common/cmdparse.h"
 #include "messages/PaxosServiceMessage.h"
 
 #include <vector>
@@ -41,10 +42,26 @@ private:
 public:
   std::string_view get_type_name() const override { return "mon_command"; }
   void print(std::ostream& o) const override {
+    cmdmap_t cmdmap;
+    stringstream ss;
+    string prefix;
+    ceph::common::cmdmap_from_json(cmd, &cmdmap, ss);
+    ceph::common::cmd_getval(cmdmap, "prefix", prefix);
+    // Some config values contain sensitive data, so don't log them
     o << "mon_command(";
-    for (unsigned i=0; i<cmd.size(); i++) {
-      if (i) o << ' ';
-      o << cmd[i];
+    if (prefix == "config set") {
+      string name;
+      ceph::common::cmd_getval(cmdmap, "name", name);
+      o << "[{prefix=" << prefix << ", name=" << name << "}]";
+    } else if (prefix == "config-key set") {
+      string key;
+      ceph::common::cmd_getval(cmdmap, "key", key);
+      o << "[{prefix=" << prefix << ", key=" << key << "}]";
+    } else {
+      for (unsigned i=0; i<cmd.size(); i++) {
+        if (i) o << ' ';
+        o << cmd[i];
+      }
     }
     o << " v " << version << ")";
   }

--- a/src/messages/MMonCommandAck.h
+++ b/src/messages/MMonCommandAck.h
@@ -15,8 +15,10 @@
 #ifndef CEPH_MMONCOMMANDACK_H
 #define CEPH_MMONCOMMANDACK_H
 
-#include "common/cmdparse.h"
 #include "messages/PaxosServiceMessage.h"
+
+using TOPNSPC::common::cmdmap_from_json;
+using TOPNSPC::common::cmd_getval;
 
 class MMonCommandAck : public PaxosServiceMessage {
 public:
@@ -37,19 +39,19 @@ public:
     cmdmap_t cmdmap;
     stringstream ss;
     string prefix;
-    ceph::common::cmdmap_from_json(cmd, &cmdmap, ss);
-    ceph::common::cmd_getval(cmdmap, "prefix", prefix);
+    cmdmap_from_json(cmd, &cmdmap, ss);
+    cmd_getval(cmdmap, "prefix", prefix);
     // Some config values contain sensitive data, so don't log them
     o << "mon_command_ack(";
     if (prefix == "config set") {
       string name;
-      ceph::common::cmd_getval(cmdmap, "name", name);
+      cmd_getval(cmdmap, "name", name);
       o << "[{prefix=" << prefix
         << ", name=" << name << "}]"
         << "=" << r << " " << rs << " v" << version << ")";
     } else if (prefix == "config-key set") {
       string key;
-      ceph::common::cmd_getval(cmdmap, "key", key);
+      cmd_getval(cmdmap, "key", key);
       o << "[{prefix=" << prefix << ", key=" << key << "}]"
         << "=" << r << " " << rs << " v" << version << ")";
     } else {

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -612,7 +612,10 @@ PyObject *ActivePyModules::get_typed_config(
         derr << "Module '" << module_name << "' is not available" << dendl;
         Py_RETURN_NONE;
     }
-    dout(10) << __func__ << " " << final_key << " found: " << value << dendl;
+    // removing value to hide sensitive data going into mgr logs
+    // leaving this for debugging purposes
+    // dout(10) << __func__ << " " << final_key << " found: " << value << dendl;
+    dout(10) << __func__ << " " << final_key << " found" << dendl;
     return module->get_typed_option_value(key, value);
   }
   PyEval_RestoreThread(tstate);

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -131,7 +131,10 @@ int MgrStandby::init()
   // We must register our config callback before calling init(), so
   // that we see the initial configuration message
   monc.register_config_callback([this](const std::string &k, const std::string &v){
-      dout(10) << "config_callback: " << k << " : " << v << dendl;
+      // removing value to hide sensitive data going into mgr logs
+      // leaving this for debugging purposes
+      // dout(10) << "config_callback: " << k << " : " << v << dendl;
+      dout(10) << "config_callback: " << k << " : " << dendl;
       if (k.substr(0, 4) == "mgr/") {
 	const std::string global_key = PyModule::config_prefix + k.substr(4);
         py_module_registry.handle_config(global_key, v);

--- a/src/mgr/PyModuleRegistry.cc
+++ b/src/mgr/PyModuleRegistry.cc
@@ -424,7 +424,10 @@ void PyModuleRegistry::handle_config(const std::string &k, const std::string &v)
   std::lock_guard l(module_config.lock);
 
   if (!v.empty()) {
-    dout(10) << "Loaded module_config entry " << k << ":" << v << dendl;
+    // removing value to hide sensitive data going into mgr logs
+    // leaving this for debugging purposes
+    // dout(10) << "Loaded module_config entry " << k << ":" << v << dendl;
+    dout(10) << "Loaded module_config entry " << k << ":" << dendl;
     module_config.config[k] = v;
   } else {
     module_config.config.erase(k);

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -801,13 +801,6 @@ void ConfigMonitor::load_config()
     it->next();
   }
   dout(10) << __func__ << " got " << num << " keys" << dendl;
-  dout(20) << __func__ << " config map:\n";
-  JSONFormatter jf(true);
-  jf.open_object_section("config_map");
-  config_map.dump(&jf);
-  jf.close_section();
-  jf.flush(*_dout);
-  *_dout << dendl;
 
   // refresh our own config
   {

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -877,8 +877,9 @@ bool ConfigMonitor::refresh_config(MonSession *s)
     dout(20) << __func__ << " no change, " << out << dendl;
     return false;
   }
-
-  dout(20) << __func__ << " " << out << dendl;
+  // removing this to hide sensitive data going into logs
+  // leaving this for debugging purposes
+ //  dout(20) << __func__ << " " << out << dendl;
   s->last_config = std::move(out);
   s->any_config = true;
   return true;

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3336,18 +3336,20 @@ void Monitor::handle_command(MonOpRequestRef op)
   if (!_allowed_command(session, service, prefix, cmdmap,
                         param_str_map, mon_cmd)) {
     dout(1) << __func__ << " access denied" << dendl;
-    (cmd_is_rw ? audit_clog->info() : audit_clog->debug())
-      << "from='" << session->name << " " << session->addrs << "' "
-      << "entity='" << session->entity_name << "' "
-      << "cmd=" << m->cmd << ":  access denied";
+    if (prefix != "config set" && prefix != "config-key set")
+      (cmd_is_rw ? audit_clog->info() : audit_clog->debug())
+        << "from='" << session->name << " " << session->addrs << "' "
+        << "entity='" << session->entity_name << "' "
+        << "cmd=" << m->cmd << ":  access denied";
     reply_command(op, -EACCES, "access denied", 0);
     return;
   }
 
-  (cmd_is_rw ? audit_clog->info() : audit_clog->debug())
-      << "from='" << session->name << " " << session->addrs << "' "
-      << "entity='" << session->entity_name << "' "
-      << "cmd=" << m->cmd << ": dispatch";
+  if (prefix != "config set" && prefix != "config-key set")
+    (cmd_is_rw ? audit_clog->info() : audit_clog->debug())
+        << "from='" << session->name << " " << session->addrs << "' "
+        << "entity='" << session->entity_name << "' "
+        << "cmd=" << m->cmd << ": dispatch";
 
   // compat kludge for legacy clients trying to tell commands that are
   // new.  see bottom of MonCommands.h.  we need to handle both (1)

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -41,6 +41,7 @@
 #include "MonCommand.h"
 
 
+#include "common/cmdparse.h"
 #include "common/config_obs.h"
 #include "common/LogClient.h"
 #include "auth/AuthClient.h"
@@ -839,7 +840,13 @@ public:
             ss << "session dropped for command ";
           }
         }
-        ss << "cmd='" << m->cmd << "': finished";
+        cmdmap_t cmdmap;
+        stringstream ds;
+        string prefix;
+        ceph::common::cmdmap_from_json(m->cmd, &cmdmap, ds);
+        ceph::common::cmd_getval(cmdmap, "prefix", prefix);
+        if (prefix != "config set" && prefix != "config-key set")
+          ss << "cmd='" << m->cmd << "': finished";
 
         mon->audit_clog->info() << ss.str();
 	mon->reply_command(op, rc, rs, rdata, version);

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -41,7 +41,6 @@
 #include "MonCommand.h"
 
 
-#include "common/cmdparse.h"
 #include "common/config_obs.h"
 #include "common/LogClient.h"
 #include "auth/AuthClient.h"
@@ -57,6 +56,7 @@
 #include "mon/MonOpRequest.h"
 #include "common/WorkQueue.h"
 
+using namespace TOPNSPC::common;
 
 #define CEPH_MON_PROTOCOL     13 /* cluster internal */
 
@@ -843,8 +843,8 @@ public:
         cmdmap_t cmdmap;
         stringstream ds;
         string prefix;
-        ceph::common::cmdmap_from_json(m->cmd, &cmdmap, ds);
-        ceph::common::cmd_getval(cmdmap, "prefix", prefix);
+        cmdmap_from_json(m->cmd, &cmdmap, ds);
+        cmd_getval(cmdmap, "prefix", prefix);
         if (prefix != "config set" && prefix != "config-key set")
           ss << "cmd='" << m->cmd << "': finished";
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48615

---

backport of https://github.com/ceph/ceph/pull/38479

NOTE: the master PR has seven commits, but this backport only has six. This is because commit 9f80520670e72f9b34f362db74acade464766e5a ("mon, messages: use TOPNSPC::common for crimson compatibility") is not needed to fix the bug in octopus.

parent tracker: https://tracker.ceph.com/issues/37503

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh