### PR TITLE
nautilus: rgw: S3 Put Bucket Policy should return 204 on success

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -7500,6 +7500,10 @@ void RGWDefaultResponseOp::send_response() {
 
 void RGWPutBucketPolicy::send_response()
 {
+  if (!op_ret) {
+    /* A successful Put Bucket Policy should return a 204 on success */
+    op_ret = STATUS_NO_CONTENT;
+  }
   if (op_ret) {
     set_req_state_err(s, op_ret);
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48426

---

backport of https://github.com/ceph/ceph/pull/35059
parent tracker: https://tracker.ceph.com/issues/45467

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh