### PR TITLE
script/ceph-release-notes: --html flag to output PRs in HTML

### DIFF
--- a/src/script/ceph-release-notes
+++ b/src/script/ceph-release-notes
@@ -137,7 +137,7 @@ def _title_message(commit, pr, strict):
     message = "    " + "\n    ".join(lines)
     return (title, message)
 
-def make_release_notes(gh, repo, ref, plaintext, verbose, strict, use_tags):
+def make_release_notes(gh, repo, ref, plaintext, html, verbose, strict, use_tags):
 
     issue2prs = {}
     pr2issues = {}
@@ -227,6 +227,11 @@ def make_release_notes(gh, repo, ref, plaintext, verbose, strict, use_tags):
         if pr in pr2issues:
             if plaintext:
                 issues = map(lambda issue: '#' + str(issue), pr2issues[pr])
+            elif html:
+                issues = map(lambda issue: (
+                    '<a href="http://tracker.ceph.com/issues/{issue}">issue#{issue}</a>'
+                    ).format(issue=issue), pr2issues[pr]
+                )
             else:
                 issues = map(lambda issue: (
                     '`issue#{issue} <http://tracker.ceph.com/issues/{issue}>`_'
@@ -240,6 +245,18 @@ def make_release_notes(gh, repo, ref, plaintext, verbose, strict, use_tags):
                     title=title.encode("utf-8"),
                     issues=issues,
                     author=author.encode("utf-8")
+                )
+            )
+        elif html:
+            print (
+                (
+                    "<li><p>{title} ({issues}<a href=\""
+                    "https://github.com/ceph/ceph/pull/{pr}\""
+                    ">pr#{pr}</a>, {author})</p></li>"
+                ).format(
+                    title=title.encode("utf-8"),
+                    issues=issues,
+                    author=author.encode("utf-8"), pr=pr
                 )
             )
         else:
@@ -279,6 +296,9 @@ if __name__ == "__main__":
     parser.add_argument("--text", "-t",
                         action='store_true', default=None,
                         help="output plain text only, no links")
+    parser.add_argument("--html",
+                        action='store_true', default=None,
+                        help="output html format for website blog")
     parser.add_argument("--verbose", "-v",
                         action='store_true', default=None,
                         help="verbose")
@@ -304,6 +324,7 @@ if __name__ == "__main__":
         Repo(args.repo),
         args.rev,
         args.text,
+        args.html,
         args.verbose,
         args.strict,
         args.use_tags


### PR DESCRIPTION
This will probably only be useful until the new website is done but it'll save me hours.

Example output:
```
.Considering PR#36840
.Considering PR#36812
.Considering PR#37080
. done collecting merges.
<li><p>octopus: Enable per-RBD image monitoring (<a href="https://github.com/ceph/ceph/pull/37697">pr#37697</a>, Patrick Seidensal)</p></li>
<li><p>octopus: [ceph-volume]: remove unneeded call to get_devices() (<a href="https://github.com/ceph/ceph/pull/37412">pr#37412</a>, Marc Gariepy)</p></li>
<li><p>octopus: bluestore: fix collection_list ordering (<a href="https://github.com/ceph/ceph/pull/37048">pr#37048</a>, Mykola Golub)</p></li>
<li><p>octopus: mds: send scrub status to ceph-mgr only when scrub is running (<a href="http://tracker.ceph.com/issues/45349">issue#45349</a>, <a href="https://github.com/ceph/ceph/pull/36047">pr#36047</a>, Kefu Chai, Venky Shankar)</p></li>
```

Signed-off-by: David Galloway <dgallowa@redhat.com>
