### PR TITLE
MDSLogContext: fix typo in MDSLogContextBase and add more comments

### DIFF
--- a/src/mds/MDSContext.cc
+++ b/src/mds/MDSContext.cc
@@ -119,8 +119,9 @@ void MDSLogContextBase::complete(int r) {
   MDLog *mdlog = get_mds()->mdlog;
   uint64_t safe_pos = write_pos;
   pre_finish(r);
-  // MDSContextBase::complete() free this
+  // MDSIOContext::complete() free this
   MDSIOContextBase::complete(r);
+  // safe_pos must be updated after MDSIOContext::complete() call
   mdlog->set_safe_pos(safe_pos);
 }
 

--- a/src/mds/MDSContext.h
+++ b/src/mds/MDSContext.h
@@ -118,7 +118,7 @@ private:
 /**
  * Completion for an log operation, takes big MDSRank lock
  * before executing finish function. Update log's safe pos
- * after finish functuon return.
+ * after finish function return.
  */
 class MDSLogContextBase : public MDSIOContextBase
 {


### PR DESCRIPTION
It seems that there is no class socalled MDSContextBase.
Signed-off-by: haoyixing <haoyixing@kuaishou.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
