### PR TITLE
rgw: support obj encryption stack on compression

### DIFF
--- a/src/rgw/rgw_compression.cc
+++ b/src/rgw/rgw_compression.cc
@@ -74,7 +74,23 @@ int RGWPutObj_Compress::process(bufferlist&& in, uint64_t logical_offset)
     }
     // end of compression stuff
   }
-  return Pipe::process(std::move(out), logical_offset);
+  // refresh compressed ofs for other pipe processers if have
+  if (out.length()) {
+    in_len = in.length();
+    out_len = out.length();
+    if (in_len >= out_len) {
+      logical_offset = logical_offset >= (in_len - out_len) ? (logical_offset + out_len - in_len) : 0;
+    } else {
+      logical_offset = logical_offset + out_len - in_len;
+    }
+    compressed_ofs = logical_offset;
+  } else {
+    compressed_ofs = logical_offset + out_len - in_len;
+    in_len = 0;
+    out_len = 0;
+  }
+
+  return Pipe::process(std::move(out), compressed_ofs);
 }
 
 //----------------RGWGetObj_Decompress---------------------
@@ -97,7 +113,7 @@ RGWGetObj_Decompress::RGWGetObj_Decompress(CephContext* cct_,
 int RGWGetObj_Decompress::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len)
 {
   ldout(cct, 10) << "Compression for rgw is enabled, decompress part "
-      << "bl_ofs="<< bl_ofs << bl_len << dendl;
+      << "bl_ofs=" << bl_ofs << " bl_len=" << bl_len << dendl;
 
   if (!compressor.get()) {
     // if compressor isn't available - error, because cannot return decompressed data?

--- a/src/rgw/rgw_compression.h
+++ b/src/rgw/rgw_compression.h
@@ -47,6 +47,9 @@ class RGWPutObj_Compress : public rgw::putobj::Pipe
   CompressorRef compressor;
   boost::optional<int32_t> compressor_message;
   std::vector<compression_block> blocks;
+  uint64_t compressed_ofs{0};
+  off_t in_len{0};
+  off_t out_len{0};
 public:
   RGWPutObj_Compress(CephContext* cct_, CompressorRef compressor,
                      rgw::putobj::DataProcessor *next)


### PR DESCRIPTION
Resolve conflict and recommit the pr #36539.
Add implementation for obj encryption stack on compression. Compressing first and then encrypting.

Fixes: https://tracker.ceph.com/issues/19988

Signed-off-by: Dai Zhiwei daizhiwei3@huawei.com
Signed-off-by: luo rixin luorixin@huawei.com