### PR TITLE
crimson/seastore: fixing Clang errors and warnings

### DIFF
--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -666,7 +666,7 @@ Journal::scan_valid_records_ret Journal::scan_valid_records(
       return [=, &handler, &cursor, &budget_used] {
 	if (!cursor.last_valid_header_found) {
 	  return read_validate_record_metadata(cursor.offset, nonce
-	  ).safe_then([=, &cursor, &handler](auto md) {
+	  ).safe_then([=, &cursor](auto md) {
 	    logger().debug(
 	      "Journal::scan_valid_records: read complete {}",
 	      cursor.offset);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
@@ -83,6 +83,8 @@ class SeastoreNodeExtentManager final: public NodeExtentManager {
                      e->get_length(), e->get_laddr());
       assert(e->get_laddr() == addr);
       assert(e->get_length() == len);
+      std::ignore = addr;
+      std::ignore = len;
       return NodeExtentRef(e);
     });
   }
@@ -95,6 +97,7 @@ class SeastoreNodeExtentManager final: public NodeExtentManager {
       logger().debug("OTree::Seastore: allocated {}B at {:#x}",
                      extent->get_length(), extent->get_laddr());
       assert(extent->get_length() == len);
+      std::ignore = len;
       return NodeExtentRef(extent);
     });
   }

--- a/src/crimson/os/seastore/segment_manager/block.cc
+++ b/src/crimson/os/seastore/segment_manager/block.cc
@@ -36,7 +36,7 @@ static write_ertr::future<> do_write(
 	"do_write: dma_write got error {}",
 	e);
       return crimson::ct_error::input_output_error::make();
-  }).then([&device, length=bptr.length()](auto result)
+  }).then([length=bptr.length()](auto result)
 	       -> write_ertr::future<> {
     if (result != length) {
       return crimson::ct_error::input_output_error::make();

--- a/src/crimson/tools/store-nbd.cc
+++ b/src/crimson/tools/store-nbd.cc
@@ -503,7 +503,7 @@ public:
       tm->create_transaction(),
       [this, offset, size](auto &t) {
 	return tm->read_extents<TestBlock>(*t, offset, size
-	).safe_then([=, &t](auto ext_list) mutable {
+	).safe_then([=](auto ext_list) mutable {
 	  size_t cur = offset;
 	  bufferlist bl;
 	  for (auto &i: ext_list) {


### PR DESCRIPTION
Errors: capturing structured-binding "special ref"

Warnings: unused captures

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>

