### PR TITLE
nautilus: os/bluestore: fix segfault on out-of-bound offset provided to  claim_…

### DIFF
--- a/src/os/bluestore/fastbmap_allocator_impl.cc
+++ b/src/os/bluestore/fastbmap_allocator_impl.cc
@@ -678,6 +678,9 @@ uint64_t AllocatorLevel01Loose::_claim_free_to_right_l0(int64_t l0_pos_start)
   int64_t pos = l0_pos_start;
   slot_t bits = (slot_t)1 << (pos % d0);
   size_t idx = pos / d0;
+  if (idx >= l0.size()) {
+    return pos;
+  }
   slot_t* val_s = l0.data() + idx;
 
   int64_t pos_e = p2roundup<int64_t>(pos + 1, d0);

--- a/src/test/objectstore/fastbmap_allocator_test.cc
+++ b/src/test/objectstore/fastbmap_allocator_test.cc
@@ -1016,6 +1016,11 @@ TEST(TestAllocatorLevel01, test_claim_free_l2)
   ASSERT_EQ(0x1000, claimed);
   ASSERT_EQ(0x2000, al2.debug_get_free());
 
+  // claiming on the right boundary
+  claimed = al2.claim_free_to_right(capacity);
+  ASSERT_EQ(0x0, claimed);
+  ASSERT_EQ(0x2000, al2.debug_get_free());
+
   // extend allocator space up to 64M
   auto max_available2 = 64 * 1024 * 1024;
   al2.mark_free(max_available, max_available2 - max_available);


### PR DESCRIPTION
…free_to_right() call

Hybrid allocator might provide such an offset when final extent is marked as free by HybridAllocator::_add_to_tree().
Hence provides start+size point out to the end of the controled space.

Fixes: https://tracker.ceph.com/issues/48093

Signed-off-by: Igor Fedotov <ifedotov@suse.com>
(cherry picked from commit 0792382f4c51ec612d596efb13bf63fea92f3a2d)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
