### PR TITLE
qa: krbd_stable_pages_required.sh: move to stable_writes attribute

### DIFF
--- a/qa/suites/krbd/wac/sysfs/tasks/stable_pages_required.yaml
+++ b/qa/suites/krbd/wac/sysfs/tasks/stable_pages_required.yaml
@@ -1,5 +1,0 @@
-tasks:
-- workunit:
-    clients:
-      all:
-        - rbd/krbd_stable_pages_required.sh

--- a/qa/suites/krbd/wac/sysfs/tasks/stable_writes.yaml
+++ b/qa/suites/krbd/wac/sysfs/tasks/stable_writes.yaml
@@ -1,0 +1,5 @@
+tasks:
+- workunit:
+    clients:
+      all:
+        - rbd/krbd_stable_writes.sh

--- a/qa/workunits/rbd/krbd_stable_writes.sh
+++ b/qa/workunits/rbd/krbd_stable_writes.sh
@@ -8,7 +8,7 @@ function assert_dm() {
 
     local devno
     devno=$(sudo dmsetup info -c --noheadings -o Major,Minor $name)
-    grep -q $val /sys/dev/block/$devno/bdi/stable_pages_required
+    grep -q $val /sys/dev/block/$devno/queue/stable_writes
 }
 
 function dmsetup_reload() {
@@ -22,7 +22,7 @@ function dmsetup_reload() {
     sudo dmsetup resume $name
 }
 
-IMAGE_NAME="stable-pages-required-test"
+IMAGE_NAME="stable-writes-test"
 
 rbd create --size 1 $IMAGE_NAME
 DEV=$(sudo rbd map $IMAGE_NAME)
@@ -31,11 +31,11 @@ fallocate -l 1M loopfile
 LOOP_DEV=$(sudo losetup -f --show loopfile)
 
 [[ $(blockdev --getsize64 $DEV) -eq 1048576 ]]
-grep -q 1 /sys/block/${DEV#/dev/}/bdi/stable_pages_required
+grep -q 1 /sys/block/${DEV#/dev/}/queue/stable_writes
 
 rbd resize --size 2 $IMAGE_NAME
 [[ $(blockdev --getsize64 $DEV) -eq 2097152 ]]
-grep -q 1 /sys/block/${DEV#/dev/}/bdi/stable_pages_required
+grep -q 1 /sys/block/${DEV#/dev/}/queue/stable_writes
 
 cat <<EOF | sudo dmsetup create tbl
 0 1024 linear $LOOP_DEV 0


### PR DESCRIPTION
bdi/stable_pages_required attribute was deprecated in 5.10 and now
always returns 0.  The replacement is queue/stable_writes.  (It is
also writeable, so we can simplify these test cases somewhat in the
future.)

Fixes: https://tracker.ceph.com/issues/48232
Signed-off-by: Ilya Dryomov <idryomov@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
