### PR TITLE
rgw: support obj encryption stack on compression

### DIFF
--- a/src/rgw/rgw_compression.cc
+++ b/src/rgw/rgw_compression.cc
@@ -74,7 +74,23 @@ int RGWPutObj_Compress::process(bufferlist&& in, uint64_t logical_offset)
     }
     // end of compression stuff
   }
-  return Pipe::process(std::move(out), logical_offset);
+  // refresh compressed ofs for other pipe processers if have
+  if (out.length()) {
+    in_len = in.length();
+    out_len = out.length();
+    if (in_len >= out_len) {
+      logical_offset = logical_offset >= (in_len - out_len) ? (logical_offset + out_len - in_len) : 0;
+    } else {
+      logical_offset = logical_offset + out_len - in_len;
+    }
+    compressed_ofs = logical_offset;
+  } else {
+    compressed_ofs = logical_offset + out_len - in_len;
+    in_len = 0;
+    out_len = 0;
+  }
+
+  return Pipe::process(std::move(out), compressed_ofs);
 }
 
 //----------------RGWGetObj_Decompress---------------------
@@ -97,7 +113,7 @@ RGWGetObj_Decompress::RGWGetObj_Decompress(CephContext* cct_,
 int RGWGetObj_Decompress::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len)
 {
   ldout(cct, 10) << "Compression for rgw is enabled, decompress part "
-      << "bl_ofs="<< bl_ofs << bl_len << dendl;
+      << "bl_ofs=" << bl_ofs << " bl_len=" << bl_len << dendl;
 
   if (!compressor.get()) {
     // if compressor isn't available - error, because cannot return decompressed data?

--- a/src/rgw/rgw_compression.h
+++ b/src/rgw/rgw_compression.h
@@ -47,6 +47,9 @@ class RGWPutObj_Compress : public rgw::putobj::Pipe
   CompressorRef compressor;
   boost::optional<int32_t> compressor_message;
   std::vector<compression_block> blocks;
+  uint64_t compressed_ofs{0};
+  off_t in_len{0};
+  off_t out_len{0};
 public:
   RGWPutObj_Compress(CephContext* cct_, CompressorRef compressor,
                      rgw::putobj::DataProcessor *next)


### PR DESCRIPTION
Resolve conflict and recommit the pr #36539 because of base repository lost.

add implementation for obj encryption stack on compression. Compressing first and then encrypting.

	modified:   src/rgw/rgw_compression.cc
	modified:   src/rgw/rgw_compression.h
	modified:   src/rgw/rgw_op.cc

Fixes: https://tracker.ceph.com/issues/19988

Signed-off-by: Dai Zhiwei <daizhiwei3@huawei.com>
Signed-off-by: luo rixin <luorixin@huawei.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
