### PR TITLE
rpm/deb/cmake: install mount.fuse.ceph man page

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1788,6 +1788,7 @@ fi
 %{_bindir}/ceph-fuse
 %{_mandir}/man8/ceph-fuse.8*
 %{_sbindir}/mount.fuse.ceph
+%{_mandir}/man8/mount.fuse.ceph.8*
 %{_unitdir}/ceph-fuse@.service
 %{_unitdir}/ceph-fuse.target
 

--- a/debian/ceph-fuse.install
+++ b/debian/ceph-fuse.install
@@ -2,3 +2,4 @@ lib/systemd/system/ceph-fuse*
 usr/bin/ceph-fuse
 usr/sbin/mount.fuse.ceph sbin
 usr/share/man/man8/ceph-fuse.8
+usr/share/man/man8/mount.fuse.ceph.8

--- a/doc/man/8/CMakeLists.txt
+++ b/doc/man/8/CMakeLists.txt
@@ -13,6 +13,7 @@ set(server_srcs
   crushtool.rst
   ceph-run.rst
   mount.ceph.rst
+  mount.fuse.ceph.rst
   ceph-create-keys.rst)
 if(WITH_TESTS)
 list(APPEND server_srcs


### PR DESCRIPTION
Install the mount.fuse.ceph man page and ship it in the ceph-fuse packaging along with the corresponding mount.fuse.ceph binary.