### PR TITLE
doc/dev/generatedocs.rst: fix highlight syntax

### DIFF
--- a/doc/dev/generatedocs.rst
+++ b/doc/dev/generatedocs.rst
@@ -11,6 +11,8 @@ To build the Ceph documentation set, you must:
 3. Build the documents
 4. Demo the documents (Optional)
 
+.. highlight:: bash
+
 Clone the Ceph Repository
 -------------------------
 
@@ -61,12 +63,12 @@ But you can just rebuild the document on changes using::
 
   admin/build-doc livehtml
 
-This feature uses `sphinx-autobuild` under the hood. You can also pass options to it. For
+This feature uses ``sphinx-autobuild`` under the hood. You can also pass options to it. For
 instance, to open the browser after building the documentation::
 
   admin/build-doc livehtml -- --open-browser
 
-Please see `sphinx-autobuild <https://pypi.org/project/sphinx-autobuild/>` for more details.
+Please see `sphinx-autobuild <https://pypi.org/project/sphinx-autobuild/>`_ for more details.
 
 Demo the Documents
 -------------------


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
