### PR TITLE
mgr/cephadm: correct connection failure message

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1135,7 +1135,10 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self._reset_con(host)
 
             user = self.ssh_user if self.mode == 'root' else 'cephadm'
-            msg = f'''Failed to connect to {host} ({addr}).
+            if str(e).startswith("Can't communicate"):
+                msg = str(e)
+            else:
+                msg = f'''Failed to connect to {host} ({addr}).
 Please make sure that the host is reachable and accepts connections using the cephadm SSH key
 
 To add the cephadm SSH key to the host:


### PR DESCRIPTION
When add host fails with py3 missing, wasn't used in
the output returned to the admin - instead they saw
the generic failure message which "points them in the
wrong direction". This patch shows the py3 missing
message

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>