### PR TITLE
crimson/onode-staged-tree: fix explicit template instantiation for clang

### DIFF
--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.cc
@@ -9,9 +9,6 @@ namespace crimson::os::seastore::onode {
 
 #define ITER_T item_iterator_t<NODE_TYPE>
 #define ITER_INST(NT) item_iterator_t<NT>
-#define ITER_TEMPLATE(NT) template class ITER_INST(NT)
-ITER_TEMPLATE(node_type_t::LEAF);
-ITER_TEMPLATE(node_type_t::INTERNAL);
 
 template <node_type_t NODE_TYPE>
 template <KeyT KT>
@@ -81,11 +78,11 @@ node_offset_t ITER_T::trim_at(
   return trim_size;
 }
 
+#define ITER_TEMPLATE(NT) template class ITER_INST(NT)
+ITER_TEMPLATE(node_type_t::LEAF);
+ITER_TEMPLATE(node_type_t::INTERNAL);
+
 #define APPEND_T ITER_T::Appender<KT>
-template class ITER_INST(node_type_t::LEAF)::Appender<KeyT::VIEW>;
-template class ITER_INST(node_type_t::INTERNAL)::Appender<KeyT::VIEW>;
-template class ITER_INST(node_type_t::LEAF)::Appender<KeyT::HOBJ>;
-template class ITER_INST(node_type_t::INTERNAL)::Appender<KeyT::HOBJ>;
 
 template <node_type_t NODE_TYPE>
 template <KeyT KT>
@@ -158,5 +155,11 @@ void APPEND_T::wrap_nxt(char* _p_append) {
       p_offset_while_open, node_offset_t(p_offset_while_open - _p_append));
   p_append = _p_append;
 }
+
+#define APPEND_TEMPLATE(NT, KT) template class ITER_INST(NT)::Appender<KT>
+APPEND_TEMPLATE(node_type_t::LEAF, KeyT::VIEW);
+APPEND_TEMPLATE(node_type_t::INTERNAL, KeyT::VIEW);
+APPEND_TEMPLATE(node_type_t::LEAF, KeyT::HOBJ);
+APPEND_TEMPLATE(node_type_t::INTERNAL, KeyT::HOBJ);
 
 }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.cc
@@ -10,15 +10,6 @@ namespace crimson::os::seastore::onode {
 
 #define NODE_T node_extent_t<FieldType, NODE_TYPE>
 #define NODE_INST(FT, NT) node_extent_t<FT, NT>
-#define NODE_TEMPLATE(FT, NT) template class NODE_INST(FT, NT)
-NODE_TEMPLATE(node_fields_0_t, node_type_t::INTERNAL);
-NODE_TEMPLATE(node_fields_1_t, node_type_t::INTERNAL);
-NODE_TEMPLATE(node_fields_2_t, node_type_t::INTERNAL);
-NODE_TEMPLATE(internal_fields_3_t, node_type_t::INTERNAL);
-NODE_TEMPLATE(node_fields_0_t, node_type_t::LEAF);
-NODE_TEMPLATE(node_fields_1_t, node_type_t::LEAF);
-NODE_TEMPLATE(node_fields_2_t, node_type_t::LEAF);
-NODE_TEMPLATE(leaf_fields_3_t, node_type_t::LEAF);
 
 template <typename FieldType, node_type_t NODE_TYPE>
 const char* NODE_T::p_left_bound() const {
@@ -176,24 +167,17 @@ node_offset_t NODE_T::trim_at(
   return 0;
 }
 
+#define NODE_TEMPLATE(FT, NT) template class NODE_INST(FT, NT)
+NODE_TEMPLATE(node_fields_0_t, node_type_t::INTERNAL);
+NODE_TEMPLATE(node_fields_1_t, node_type_t::INTERNAL);
+NODE_TEMPLATE(node_fields_2_t, node_type_t::INTERNAL);
+NODE_TEMPLATE(internal_fields_3_t, node_type_t::INTERNAL);
+NODE_TEMPLATE(node_fields_0_t, node_type_t::LEAF);
+NODE_TEMPLATE(node_fields_1_t, node_type_t::LEAF);
+NODE_TEMPLATE(node_fields_2_t, node_type_t::LEAF);
+NODE_TEMPLATE(leaf_fields_3_t, node_type_t::LEAF);
+
 #define APPEND_T node_extent_t<FieldType, NODE_TYPE>::Appender<KT>
-#define APPEND_TEMPLATE(FT, NT, KT) template class node_extent_t<FT, NT>::Appender<KT>
-APPEND_TEMPLATE(node_fields_0_t, node_type_t::INTERNAL, KeyT::VIEW);
-APPEND_TEMPLATE(node_fields_1_t, node_type_t::INTERNAL, KeyT::VIEW);
-APPEND_TEMPLATE(node_fields_2_t, node_type_t::INTERNAL, KeyT::VIEW);
-APPEND_TEMPLATE(internal_fields_3_t, node_type_t::INTERNAL, KeyT::VIEW);
-APPEND_TEMPLATE(node_fields_0_t, node_type_t::LEAF, KeyT::VIEW);
-APPEND_TEMPLATE(node_fields_1_t, node_type_t::LEAF, KeyT::VIEW);
-APPEND_TEMPLATE(node_fields_2_t, node_type_t::LEAF, KeyT::VIEW);
-APPEND_TEMPLATE(leaf_fields_3_t, node_type_t::LEAF, KeyT::VIEW);
-APPEND_TEMPLATE(node_fields_0_t, node_type_t::INTERNAL, KeyT::HOBJ);
-APPEND_TEMPLATE(node_fields_1_t, node_type_t::INTERNAL, KeyT::HOBJ);
-APPEND_TEMPLATE(node_fields_2_t, node_type_t::INTERNAL, KeyT::HOBJ);
-APPEND_TEMPLATE(internal_fields_3_t, node_type_t::INTERNAL, KeyT::HOBJ);
-APPEND_TEMPLATE(node_fields_0_t, node_type_t::LEAF, KeyT::HOBJ);
-APPEND_TEMPLATE(node_fields_1_t, node_type_t::LEAF, KeyT::HOBJ);
-APPEND_TEMPLATE(node_fields_2_t, node_type_t::LEAF, KeyT::HOBJ);
-APPEND_TEMPLATE(leaf_fields_3_t, node_type_t::LEAF, KeyT::HOBJ);
 
 template <typename FieldType, node_type_t NODE_TYPE>
 template <KeyT KT>
@@ -312,5 +296,23 @@ char* APPEND_T::wrap() {
   p_mut->copy_in_absolute(p_start + offsetof(FieldType, num_keys), num_keys);
   return p_append_left;
 }
+
+#define APPEND_TEMPLATE(FT, NT, KT) template class node_extent_t<FT, NT>::Appender<KT>
+APPEND_TEMPLATE(node_fields_0_t, node_type_t::INTERNAL, KeyT::VIEW);
+APPEND_TEMPLATE(node_fields_1_t, node_type_t::INTERNAL, KeyT::VIEW);
+APPEND_TEMPLATE(node_fields_2_t, node_type_t::INTERNAL, KeyT::VIEW);
+APPEND_TEMPLATE(internal_fields_3_t, node_type_t::INTERNAL, KeyT::VIEW);
+APPEND_TEMPLATE(node_fields_0_t, node_type_t::LEAF, KeyT::VIEW);
+APPEND_TEMPLATE(node_fields_1_t, node_type_t::LEAF, KeyT::VIEW);
+APPEND_TEMPLATE(node_fields_2_t, node_type_t::LEAF, KeyT::VIEW);
+APPEND_TEMPLATE(leaf_fields_3_t, node_type_t::LEAF, KeyT::VIEW);
+APPEND_TEMPLATE(node_fields_0_t, node_type_t::INTERNAL, KeyT::HOBJ);
+APPEND_TEMPLATE(node_fields_1_t, node_type_t::INTERNAL, KeyT::HOBJ);
+APPEND_TEMPLATE(node_fields_2_t, node_type_t::INTERNAL, KeyT::HOBJ);
+APPEND_TEMPLATE(internal_fields_3_t, node_type_t::INTERNAL, KeyT::HOBJ);
+APPEND_TEMPLATE(node_fields_0_t, node_type_t::LEAF, KeyT::HOBJ);
+APPEND_TEMPLATE(node_fields_1_t, node_type_t::LEAF, KeyT::HOBJ);
+APPEND_TEMPLATE(node_fields_2_t, node_type_t::LEAF, KeyT::HOBJ);
+APPEND_TEMPLATE(leaf_fields_3_t, node_type_t::LEAF, KeyT::HOBJ);
 
 }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.cc
@@ -28,10 +28,6 @@ void node_header_t::update_is_level_tail(
 
 #define F013_T _node_fields_013_t<SlotType>
 #define F013_INST(ST) _node_fields_013_t<ST>
-#define F013_TEMPLATE(ST) template struct F013_INST(ST)
-F013_TEMPLATE(slot_0_t);
-F013_TEMPLATE(slot_1_t);
-F013_TEMPLATE(slot_3_t);
 
 template <typename SlotType>
 void F013_T::update_size_at(
@@ -85,6 +81,11 @@ IA_TEMPLATE(slot_3_t, KeyT::VIEW);
 IA_TEMPLATE(slot_0_t, KeyT::HOBJ);
 IA_TEMPLATE(slot_1_t, KeyT::HOBJ);
 IA_TEMPLATE(slot_3_t, KeyT::HOBJ);
+
+#define F013_TEMPLATE(ST) template struct F013_INST(ST)
+F013_TEMPLATE(slot_0_t);
+F013_TEMPLATE(slot_1_t);
+F013_TEMPLATE(slot_3_t);
 
 void node_fields_2_t::append_offset(
     NodeExtentMutable& mut, node_offset_t offset_to_right, char*& p_append) {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.cc
@@ -38,9 +38,6 @@ node_offset_t internal_sub_items_t::trim_until(
   return ret;
 }
 
-template class internal_sub_items_t::Appender<KeyT::VIEW>;
-template class internal_sub_items_t::Appender<KeyT::HOBJ>;
-
 template <KeyT KT>
 void internal_sub_items_t::Appender<KT>::append(
     const internal_sub_items_t& src, size_t from, size_t items) {
@@ -135,13 +132,13 @@ node_offset_t leaf_sub_items_t::trim_until(
   return ret;
 }
 
+template class internal_sub_items_t::Appender<KeyT::VIEW>;
+template class internal_sub_items_t::Appender<KeyT::HOBJ>;
+
 // helper type for the visitor
 template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 // explicit deduction guide
 template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
-
-template class leaf_sub_items_t::Appender<KeyT::VIEW>;
-template class leaf_sub_items_t::Appender<KeyT::HOBJ>;
 
 template <KeyT KT>
 char* leaf_sub_items_t::Appender<KT>::wrap() {
@@ -201,5 +198,8 @@ char* leaf_sub_items_t::Appender<KT>::wrap() {
   }
   return p_cur;
 }
+
+template class leaf_sub_items_t::Appender<KeyT::VIEW>;
+template class leaf_sub_items_t::Appender<KeyT::HOBJ>;
 
 }


### PR DESCRIPTION
Signed-off-by: Yingxin Cheng <yingxin.cheng@intel.com>

@ronen-fr Does it fix the link issue you met?
The only explanation I can find is that clang cannot recognize explicit template instantiations if they are placed before the according definitions, but g++ can.
see https://stackoverflow.com/questions/60225945/explicit-c-template-instantiation-with-clang

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
