### PR TITLE
mgr/cephadm:fix bug in orch apply osd --dry-run where empty table printed

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1793,9 +1793,9 @@ To check that the host is reachable:
         if not matching_hosts:
             return {'n/a': [{'error': True,
                              'message': 'No OSDSpec or matching hosts found.'}]}
-        # Is any host still loading previews
+        # Is any host still loading previews or still in the queue to be previewed
         pending_hosts = {h for h in self.cache.loading_osdspec_preview if h in matching_hosts}
-        if pending_hosts:
+        if pending_hosts or any(item in self.cache.osdspec_previews_refresh_queue for item in matching_hosts):
             # Report 'pending' when any of the matching hosts is still loading previews (flag is True)
             return {'n/a': [{'error': True,
                              'message': 'Preview data is being generated.. '

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -70,14 +70,26 @@ def to_format(what, format: str, many: bool, cls):
         raise OrchestratorError(f'unsupported format type: {format}')
 
 
-def generate_preview_tables(data):
+def generate_preview_tables(data, osd_only=False):
     error = [x.get('error') for x in data if x.get('error')]
     if error:
         return json.dumps(error)
     warning = [x.get('warning') for x in data if x.get('warning')]
     osd_table = preview_table_osd(data)
     service_table = preview_table_services(data)
-    tables = f"""
+
+    if osd_only:
+        tables = f"""
+{''.join(warning)}
+
+################
+OSDSPEC PREVIEWS
+################
+{osd_table}
+"""
+        return tables
+    else:
+        tables = f"""
 {''.join(warning)}
 
 ####################
@@ -90,7 +102,7 @@ OSDSPEC PREVIEWS
 ################
 {osd_table}
 """
-    return tables
+        return tables
 
 
 def preview_table_osd(data):
@@ -703,7 +715,7 @@ Examples:
                 raise_if_exception(completion)
                 data = completion.result
                 if format == 'plain':
-                    out = preview_table_osd(data)
+                    out = generate_preview_tables(data, True)
                 else:
                     out = to_format(data, format, many=True, cls=None)
             return HandleCommandResult(stdout=out)
@@ -730,7 +742,7 @@ Examples:
                 self._orchestrator_wait([completion])
                 data = completion.result
                 if format == 'plain':
-                    out = preview_table_osd(data)
+                    out = generate_preview_tables(data , True)
                 else:
                     out = to_format(data, format, many=True, cls=None)
             return HandleCommandResult(stdout=out)


### PR DESCRIPTION
ceph orch apply osd ---dry-run could print out an empty table 

```
[ceph: root@magna057 /]# ceph orch apply osd -i osds_noencr.yaml --dry-run 
+---------+------+------+------+----+-----+
|SERVICE  |NAME  |HOST  |DATA  |DB  |WAL  |
+---------+------+------+------+----+-----+
+---------+------+------+------+----+-----+

```

because the osd preview had not started yet. The host(s) was still in the cache.osdspec_previews_refresh_queue so the pending_host check did not catch that.

So a table with no info was printed out.

Additionally the --dry-run warning was not being printed like it is in ceph orch apply --dry-run.

Signed-off-by: Daniel-Pivonka <dpivonka@redhat.com>