### PR TITLE
rgw: dynamic resharding modifies existing bucket instance

### DIFF
--- a/qa/workunits/rgw/run-reshard.sh
+++ b/qa/workunits/rgw/run-reshard.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -ex
 
+# this test uses fault injection to abort during 'radosgw-admin bucket reshard'
+# disable coredumps so teuthology won't mark a failure
+ulimit -c 0
+
 #assume working ceph environment (radosgw-admin in path) and rgw on localhost:80
 # localhost::443 for ssl
 

--- a/qa/workunits/rgw/test_rgw_reshard.py
+++ b/qa/workunits/rgw/test_rgw_reshard.py
@@ -5,6 +5,8 @@ import time
 import subprocess
 import json
 import boto3
+from pprint import pprint
+import re
 
 """
 Rgw manual and dynamic resharding  testing against a running instance
@@ -16,7 +18,7 @@ Rgw manual and dynamic resharding  testing against a running instance
 #
 #
 
-log.basicConfig(level=log.DEBUG)
+log.basicConfig(format = '%(message)s', level=log.DEBUG)
 log.getLogger('botocore').setLevel(log.CRITICAL)
 log.getLogger('boto3').setLevel(log.CRITICAL)
 log.getLogger('urllib3').setLevel(log.CRITICAL)
@@ -26,33 +28,35 @@ USER = 'tester'
 DISPLAY_NAME = 'Testing'
 ACCESS_KEY = 'NX5QOQKC6BH2IDN8HC7A'
 SECRET_KEY = 'LnEsqNNqZIpkzauboDcLXLcYaWwLQ3Kop0zAnKIn'
-BUCKET_NAME1 = 'myfoo'
-BUCKET_NAME2 = 'mybar'
+BUCKET_NAME1 = 'a-bucket'
+BUCKET_NAME2 = 'b-bucket'
+BUCKET_NAME3 = 'c-bucket'
+BUCKET_NAME4 = 'd-bucket'
+BUCKET_NAME5 = 'e-bucket'
 VER_BUCKET_NAME = 'myver'
-
 
 def exec_cmd(cmd):
     try:
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         out, err = proc.communicate()
+        log.info(proc.args)
         if proc.returncode == 0:
-            log.info('command succeeded')
-            if out is not None: log.info(out)
+            if out is not None: log.debug('{} \n {}'.format(out.decode('utf-8'), err.decode('utf-8')))
             return out
         else:
-            raise Exception("error: %s \nreturncode: %s" % (err, proc.returncode))
+            raise Exception("error: {} \nreturncode: {}".format(err, proc.returncode))
     except Exception as e:
-        log.error('command failed')
+        log.error('command failed\n')
         log.error(e)
         return False
 
 
 def get_radosgw_port():
     out = exec_cmd('sudo netstat -nltp | grep radosgw')
-    log.debug('output: %s' % out)
+    log.debug('output: {}'.format(out))
     x = out.decode('utf8').split(" ")
     port = [i for i in x if ':' in i][0].split(':')[1]
-    log.info('radosgw port: %s' % port)
+    log.info('radosgw port: {}'.format(port))
     return port
 
 
@@ -72,19 +76,20 @@ def get_bucket_stats(bucket_name):
     """
     function to get bucket stats
     """
-    cmd = exec_cmd("radosgw-admin bucket stats --bucket %s" % bucket_name)
+    cmd = exec_cmd("radosgw-admin bucket stats --bucket {}".format(bucket_name))
     json_op = json.loads(cmd)
+    #print(json.dumps(json_op, indent = 4, sort_keys=True))
     bucket_id = json_op['id']
-    num_shards_op = json_op['num_shards']
+    num_shards = json_op['num_shards']
     if len(json_op['usage']) > 0:
         num_objects = json_op['usage']['rgw.main']['num_objects']
         size_kb = json_op['usage']['rgw.main']['size_kb']
     else:
         num_objects = 0
         size_kb = 0
-    log.debug("bucket %s id %s num_objects %d size_kb %d num_shards %d", bucket_name, bucket_id,
-              num_objects, size_kb, num_shards_op)
-    return BucketStats(bucket_name, bucket_id, num_objects, size_kb, num_shards_op)
+    log.debug(" \nBUCKET_STATS: \nbucket: {} id: {} num_objects: {} size_kb: {} num_shards: {}\n".format(bucket_name, bucket_id,
+              num_objects, size_kb, num_shards))
+    return BucketStats(bucket_name, bucket_id, num_objects, size_kb, num_shards)
 
 
 def get_bucket_num_shards(bucket_name, bucket_id):
@@ -92,21 +97,29 @@ def get_bucket_num_shards(bucket_name, bucket_id):
     function to get bucket num shards
     """
     metadata = 'bucket.instance:' + bucket_name + ':' + bucket_id
-    log.debug("metadata %s", metadata)
-    cmd = exec_cmd('radosgw-admin metadata get %s' % metadata)
+    cmd = exec_cmd('radosgw-admin metadata get {}'.format(metadata))
     json_op = json.loads(cmd)
     num_shards = json_op['data']['bucket_info']['num_shards']
-    log.debug("bucket %s id %s num_shards %d", bucket_name, bucket_id, num_shards)
     return num_shards
 
+def run_bucket_reshard_cmd(bucket_name, num_shards, **location):
+
+    # TODO: Get rid of duplication. use list
+    if ('error_location' in location):
+        return exec_cmd('radosgw-admin bucket reshard --bucket {} --num-shards {} --inject-error-at {}'.format(bucket_name,
+                        num_shards, location.get('error_location', None)))
+    elif ('abort_location' in location):
+        return exec_cmd('radosgw-admin bucket reshard --bucket {} --num-shards {} --inject-abort-at {}'.format(bucket_name,
+                        num_shards, location.get('abort_location', None)))
+    else:
+        return exec_cmd('radosgw-admin bucket reshard --bucket {} --num-shards {}'.format(bucket_name, num_shards))
 
 def main():
     """
     execute manual and dynamic resharding commands
     """
     # create user
-    exec_cmd('radosgw-admin user create --uid %s --display-name %s --access-key %s --secret %s'
-                   % (USER, DISPLAY_NAME, ACCESS_KEY, SECRET_KEY))
+    exec_cmd('radosgw-admin user create --uid {} --display-name {} --access-key {} --secret {}'.format(USER, DISPLAY_NAME, ACCESS_KEY, SECRET_KEY))
 
     def boto_connect(portnum, ssl, proto):
         endpoint = proto + '://localhost:' + portnum
@@ -122,90 +135,227 @@ def main():
 
     port = get_radosgw_port()
 
-    if port == '80':
-        connection = boto_connect(port, ssl=False, proto='http')
-    elif port == '443':
-        connection = boto_connect(port, ssl=True, proto='https')
+    proto = ('https' if port == '443' else 'http')
+    connection = boto_connect(port, ssl=False, proto='http')
 
     # create a bucket
     bucket1 = connection.create_bucket(Bucket=BUCKET_NAME1)
     bucket2 = connection.create_bucket(Bucket=BUCKET_NAME2)
+    bucket3 = connection.create_bucket(Bucket=BUCKET_NAME3)
+    bucket4 = connection.create_bucket(Bucket=BUCKET_NAME4)
+    bucket5 = connection.create_bucket(Bucket=BUCKET_NAME5)
     ver_bucket = connection.create_bucket(Bucket=VER_BUCKET_NAME)
     connection.BucketVersioning('ver_bucket')
-
-    bucket_stats1 = get_bucket_stats(BUCKET_NAME1)
-    bucket_stats2 = get_bucket_stats(BUCKET_NAME2)
-    ver_bucket_stats = get_bucket_stats(VER_BUCKET_NAME)
 
     bucket1_acl = connection.BucketAcl(BUCKET_NAME1).load()
     bucket2_acl = connection.BucketAcl(BUCKET_NAME2).load()
     ver_bucket_acl = connection.BucketAcl(VER_BUCKET_NAME).load()
 
     # TESTCASE 'reshard-add','reshard','add','add bucket to resharding queue','succeeds'
-    log.debug(' test: reshard add')
-    num_shards_expected = bucket_stats1.num_shards + 1
-    cmd = exec_cmd('radosgw-admin reshard add --bucket %s --num-shards %s' % (BUCKET_NAME1, num_shards_expected))
+    log.debug('TEST: reshard add\n')
+    
+    num_shards_expected = get_bucket_stats(BUCKET_NAME1).num_shards + 1
+    cmd = exec_cmd('radosgw-admin reshard add --bucket {} --num-shards {}'.format(BUCKET_NAME1, num_shards_expected))
     cmd = exec_cmd('radosgw-admin reshard list')
     json_op = json.loads(cmd)
-    log.debug('bucket name %s', json_op[0]['bucket_name'])
+    log.debug('bucket name {}'.format(json_op[0]['bucket_name']))
     assert json_op[0]['bucket_name'] == BUCKET_NAME1
     assert json_op[0]['new_num_shards'] == num_shards_expected
 
     # TESTCASE 'reshard-process','reshard','','process bucket resharding','succeeds'
-    log.debug(' test: reshard process')
+    log.debug('TEST: reshard process\n')
     cmd = exec_cmd('radosgw-admin reshard process')
     time.sleep(5)
     # check bucket shards num
     bucket_stats1 = get_bucket_stats(BUCKET_NAME1)
-    bucket_stats1.get_num_shards()
     if bucket_stats1.num_shards != num_shards_expected:
-        log.error("Resharding failed on bucket %s. Expected number of shards are not created" % BUCKET_NAME1)
+        log.error("Resharding failed on bucket {}. Expected number of shards are not created\n".format(BUCKET_NAME1))
 
     # TESTCASE 'reshard-add','reshard','add','add non empty bucket to resharding queue','succeeds'
-    log.debug(' test: reshard add non empty bucket')
+    log.debug('TEST: reshard add non empty bucket\n')
     # create objs
     num_objs = 8
     for i in range(0, num_objs):
         connection.Object(BUCKET_NAME1, ('key'+str(i))).put(Body=b"some_data")
 
-    num_shards_expected = bucket_stats1.num_shards + 1
-    cmd = exec_cmd('radosgw-admin reshard add --bucket %s --num-shards %s' % (BUCKET_NAME1, num_shards_expected))
+    num_shards_expected = get_bucket_stats(BUCKET_NAME1).num_shards + 1
+    cmd = exec_cmd('radosgw-admin reshard add --bucket {} --num-shards {}'.format(BUCKET_NAME1, num_shards_expected))
     cmd = exec_cmd('radosgw-admin reshard list')
     json_op = json.loads(cmd)
-    log.debug('bucket name %s', json_op[0]['bucket_name'])
     assert json_op[0]['bucket_name'] == BUCKET_NAME1
     assert json_op[0]['new_num_shards'] == num_shards_expected
 
     # TESTCASE 'reshard process ,'reshard','process','reshard non empty bucket','succeeds'
-    log.debug(' test: reshard process non empty bucket')
+    log.debug(' TEST: reshard process non empty bucket\n')
     cmd = exec_cmd('radosgw-admin reshard process')
     # check bucket shards num
     bucket_stats1 = get_bucket_stats(BUCKET_NAME1)
-    bucket_stats1.get_num_shards()
     if bucket_stats1.num_shards != num_shards_expected:
-        log.error("Resharding failed on bucket %s. Expected number of shards are not created" % BUCKET_NAME1)
+        log.error("Resharding failed on bucket {}. Expected number of shards are not created\n".format(BUCKET_NAME1))
 
-    # TESTCASE 'manual resharding','bucket', 'reshard','','manual bucket resharding','succeeds'
-    log.debug(' test: manual reshard bucket')
+    # TESTCASE 'manual bucket resharding','inject error','fail','check bucket accessibility', 'retry reshard'
+    log.debug('TEST: reshard bucket with error injection\n')
     # create objs
     num_objs = 11
     for i in range(0, num_objs):
         connection.Object(BUCKET_NAME2, ('key' + str(i))).put(Body=b"some_data")
 
-    time.sleep(10)
-    num_shards_expected = bucket_stats2.num_shards + 1
-    cmd = exec_cmd('radosgw-admin bucket reshard --bucket %s --num-shards %s' % (BUCKET_NAME2,
-                                                                                 num_shards_expected))
+    time.sleep(5)
+    old_shard_count = get_bucket_stats(BUCKET_NAME2).num_shards
+    num_shards_expected = old_shard_count + 1
+    run_bucket_reshard_cmd(BUCKET_NAME2, num_shards_expected, error_location = "before_target_shard_entry")
+
     # check bucket shards num
-    bucket_stats2 = get_bucket_stats(BUCKET_NAME2)
-    bucket_stats2.get_num_shards()
-    if bucket_stats2.num_shards != num_shards_expected:
-        log.error("Resharding failed on bucket %s. Expected number of shards are not created" % BUCKET_NAME2)
+    cur_shard_count = get_bucket_stats(BUCKET_NAME2).num_shards
+    assert(cur_shard_count == old_shard_count)
+
+    #verify if bucket is accessible
+    log.info('List objects from bucket: {}'.format(BUCKET_NAME2))
+    for key in bucket2.objects.all():
+        print(key.key)
+
+    #verify if new objects can be added
+    num_objs = 5
+    for i in range(0, num_objs):
+        connection.Object(BUCKET_NAME2, ('key' + str(i))).put(Body=b"some_data")
+
+    #retry reshard
+    run_bucket_reshard_cmd(BUCKET_NAME2, num_shards_expected)
+
+    #TESTCASE 'manual bucket resharding','inject error','fail','check bucket accessibility', 'retry reshard'
+    log.debug('TEST: reshard bucket with error injection')
+    # create objs
+    num_objs = 11
+    for i in range(0, num_objs):
+        connection.Object(BUCKET_NAME3, ('key' + str(i))).put(Body=b"some_data")
+
+    time.sleep(5)
+    old_shard_count = get_bucket_stats(BUCKET_NAME3).num_shards
+    num_shards_expected = old_shard_count + 1
+    run_bucket_reshard_cmd(BUCKET_NAME3, num_shards_expected, error_location = "after_target_shard_entry")
+    # check bucket shards num
+    bucket_stats3 = get_bucket_stats(BUCKET_NAME3)
+    cur_shard_count = bucket_stats3.num_shards
+    assert(cur_shard_count == old_shard_count)
+
+    #verify if bucket is accessible
+    log.info('List objects from bucket: {}'.format(BUCKET_NAME3))
+    for key in bucket3.objects.all():
+        print(key.key)
+
+    #verify if new objects can be added
+    num_objs = 5
+    for i in range(0, num_objs):
+        connection.Object(BUCKET_NAME3, ('key' + str(i))).put(Body=b"some_data")
+
+    #retry reshard
+    run_bucket_reshard_cmd(BUCKET_NAME3, num_shards_expected)
+    
+    #TESTCASE 'manual bucket resharding','inject error','fail','check bucket accessibility', 'retry reshard'
+    log.debug('TEST: reshard bucket with error injection')
+    # create objs
+    num_objs = 11
+    for i in range(0, num_objs):
+        connection.Object(BUCKET_NAME4, ('key' + str(i))).put(Body=b"some_data")
+
+    time.sleep(10)
+    old_shard_count = get_bucket_stats(BUCKET_NAME4).num_shards
+    num_shards_expected = old_shard_count + 1
+    run_bucket_reshard_cmd(BUCKET_NAME4, num_shards_expected, error_location = "before_layout_overwrite")
+
+    # check bucket shards num
+    cur_shard_count = get_bucket_stats(BUCKET_NAME4).num_shards
+    assert(cur_shard_count == old_shard_count)
+
+    #verify if bucket is accessible
+    log.info('List objects from bucket: {}'.format(BUCKET_NAME3))
+    for key in bucket4.objects.all():
+        print(key.key)
+
+    #verify if new objects can be added
+    num_objs = 5
+    for i in range(0, num_objs):
+        connection.Object(BUCKET_NAME4, ('key' + str(i))).put(Body=b"some_data")
+
+    #retry reshard
+    run_bucket_reshard_cmd(BUCKET_NAME4, num_shards_expected)
+
+    # TESTCASE 'manual bucket resharding','inject crash','fail','check bucket accessibility', 'retry reshard'
+    log.debug('TEST: reshard bucket with crash injection\n')
+
+    old_shard_count = get_bucket_stats(BUCKET_NAME2).num_shards
+    num_shards_expected = old_shard_count + 1
+    run_bucket_reshard_cmd(BUCKET_NAME2, num_shards_expected, abort_location = "before_target_shard_entry")
+
+    # check bucket shards num
+    cur_shard_count = get_bucket_stats(BUCKET_NAME2).num_shards
+    assert(cur_shard_count == old_shard_count)
+
+    #verify if bucket is accessible
+    log.info('List objects from bucket: {}'.format(BUCKET_NAME2))
+    for key in bucket2.objects.all():
+        print(key.key)
+
+    #verify if new objects can be added
+    num_objs = 5
+    for i in range(0, num_objs):
+        connection.Object(BUCKET_NAME2, ('key' + str(i))).put(Body=b"some_data")
+
+    #retry reshard
+    run_bucket_reshard_cmd(BUCKET_NAME2, num_shards_expected)
+
+    #TESTCASE 'manual bucket resharding','inject crash','fail','check bucket accessibility', 'retry reshard'
+    log.debug('TEST: reshard bucket with error injection')
+
+    old_shard_count = get_bucket_stats(BUCKET_NAME3).num_shards
+    num_shards_expected = old_shard_count + 1
+    run_bucket_reshard_cmd(BUCKET_NAME3, num_shards_expected, abort_location = "after_target_shard_entry")
+
+    # check bucket shards num
+    cur_shard_count = get_bucket_stats(BUCKET_NAME3).num_shards
+    assert(cur_shard_count == old_shard_count)
+
+    #verify if bucket is accessible
+    log.info('List objects from bucket: {}'.format(BUCKET_NAME3))
+    for key in bucket3.objects.all():
+        print(key.key)
+
+    #verify if new objects can be added
+    num_objs = 5
+    for i in range(0, num_objs):
+        connection.Object(BUCKET_NAME3, ('key' + str(i))).put(Body=b"some_data")
+
+    #retry reshard
+    run_bucket_reshard_cmd(BUCKET_NAME3, num_shards_expected)
+
+    #TESTCASE 'manual bucket resharding','inject error','fail','check bucket accessibility', 'retry reshard'
+    log.debug('TEST: reshard bucket with error injection')
+
+    old_shard_count = get_bucket_stats(BUCKET_NAME4).num_shards
+    num_shards_expected = old_shard_count + 1
+    run_bucket_reshard_cmd(BUCKET_NAME4, num_shards_expected, abort_location = "before_layout_overwrite")
+    # check bucket shards num
+    bucket_stats4 = get_bucket_stats(BUCKET_NAME4)
+    cur_shard_count = bucket_stats4.num_shards
+    assert(cur_shard_count == old_shard_count)
+
+    #verify if bucket is accessible
+    log.info('List objects from bucket: {}'.format(BUCKET_NAME3))
+    for key in bucket4.objects.all():
+        print(key.key)
+
+    #verify if new objects can be added
+    num_objs = 5
+    for i in range(0, num_objs):
+        connection.Object(BUCKET_NAME4, ('key' + str(i))).put(Body=b"some_data")
+
+    #retry reshard
+    run_bucket_reshard_cmd(BUCKET_NAME4, num_shards_expected)
 
     # TESTCASE 'versioning reshard-','bucket', reshard','versioning reshard','succeeds'
     log.debug(' test: reshard versioned bucket')
-    num_shards_expected = ver_bucket_stats.num_shards + 1
-    cmd = exec_cmd('radosgw-admin bucket reshard --bucket %s --num-shards %s' % (VER_BUCKET_NAME,
+    num_shards_expected = get_bucket_stats(VER_BUCKET_NAME).num_shards + 1
+    cmd = exec_cmd('radosgw-admin bucket reshard --bucket {} --num-shards {}'.format(VER_BUCKET_NAME,
                                                                                  num_shards_expected))
     # check bucket shards num
     ver_bucket_stats = get_bucket_stats(VER_BUCKET_NAME)
@@ -220,13 +370,13 @@ def main():
     assert new_ver_bucket_acl == ver_bucket_acl
 
     # Clean up
-    log.debug("Deleting bucket %s", BUCKET_NAME1)
+    log.debug("Deleting bucket {}".format(BUCKET_NAME1))
     bucket1.objects.all().delete()
     bucket1.delete()
-    log.debug("Deleting bucket %s", BUCKET_NAME2)
+    log.debug("Deleting bucket {}".format(BUCKET_NAME2))
     bucket2.objects.all().delete()
     bucket2.delete()
-    log.debug("Deleting bucket %s", VER_BUCKET_NAME)
+    log.debug("Deleting bucket {}".format(VER_BUCKET_NAME))
     ver_bucket.delete()
 
 

--- a/qa/workunits/rgw/test_rgw_reshard.py
+++ b/qa/workunits/rgw/test_rgw_reshard.py
@@ -29,11 +29,7 @@ USER = 'tester'
 DISPLAY_NAME = 'Testing'
 ACCESS_KEY = 'NX5QOQKC6BH2IDN8HC7A'
 SECRET_KEY = 'LnEsqNNqZIpkzauboDcLXLcYaWwLQ3Kop0zAnKIn'
-BUCKET_NAME1 = 'a-bucket'
-BUCKET_NAME2 = 'b-bucket'
-BUCKET_NAME3 = 'c-bucket'
-BUCKET_NAME4 = 'd-bucket'
-BUCKET_NAME5 = 'e-bucket'
+BUCKET_NAME = 'a-bucket'
 VER_BUCKET_NAME = 'myver'
 
 def exec_cmd(cmd, **kwargs):
@@ -99,17 +95,55 @@ def get_bucket_num_shards(bucket_name, bucket_id):
     num_shards = json_op['data']['bucket_info']['num_shards']
     return num_shards
 
-def run_bucket_reshard_cmd(bucket_name, num_shards, **location):
+def run_bucket_reshard_cmd(bucket_name, num_shards, **kwargs):
+    cmd = 'radosgw-admin bucket reshard --bucket {} --num-shards {}'.format(bucket_name, num_shards)
+    cmd += ' --rgw-reshard-bucket-lock-duration 30' # reduce to minimum
+    if 'error_at' in kwargs:
+        cmd += ' --inject-error-at {}'.format(kwargs.pop('error_at'))
+    elif 'abort_at' in kwargs:
+        cmd += ' --inject-abort-at {}'.format(kwargs.pop('abort_at'))
+    return exec_cmd(cmd, **kwargs)
 
-    # TODO: Get rid of duplication. use list
-    if ('error_location' in location):
-        return exec_cmd('radosgw-admin bucket reshard --bucket {} --num-shards {} --inject-error-at {}'.format(bucket_name,
-                        num_shards, location.get('error_location', None)))
-    elif ('abort_location' in location):
-        return exec_cmd('radosgw-admin bucket reshard --bucket {} --num-shards {} --inject-abort-at {}'.format(bucket_name,
-                        num_shards, location.get('abort_location', None)))
-    else:
-        return exec_cmd('radosgw-admin bucket reshard --bucket {} --num-shards {}'.format(bucket_name, num_shards))
+def test_bucket_reshard(conn, name, **fault):
+    bucket = conn.create_bucket(Bucket=name)
+    objs = []
+    try:
+        # create objs
+        for i in range(0, 20):
+            objs += [bucket.put_object(Key='key' + str(i), Body=b"some_data")]
+
+        old_shard_count = get_bucket_stats(name).num_shards
+        num_shards_expected = old_shard_count + 1
+
+        # try reshard with fault injection
+        _, ret = run_bucket_reshard_cmd(name, num_shards_expected, check_retcode=False, **fault)
+        assert(ret != 0 and ret != errno.EBUSY)
+
+        # check shard count
+        cur_shard_count = get_bucket_stats(name).num_shards
+        assert(cur_shard_count == old_shard_count)
+
+        # verify that the bucket is writeable by deleting an object
+        objs.pop().delete()
+
+        # retry reshard without fault injection. if radosgw-admin aborted,
+        # we'll have to retry until the reshard lock expires
+        while True:
+            _, ret = run_bucket_reshard_cmd(name, num_shards_expected, check_retcode=False)
+            if ret == errno.EBUSY:
+                log.info('waiting 30 seconds for reshard lock to expire...')
+                time.sleep(30)
+                continue
+            assert(ret == 0)
+            break
+
+        # recheck shard count
+        final_shard_count = get_bucket_stats(name).num_shards
+        assert(final_shard_count == num_shards_expected)
+    finally:
+        # cleanup on resharded bucket must succeed
+        bucket.delete_objects(Delete={'Objects':[{'Key':o.key} for o in objs]})
+        bucket.delete()
 
 def main():
     """
@@ -137,27 +171,22 @@ def main():
     connection = boto_connect(port, ssl=False, proto='http')
 
     # create a bucket
-    bucket1 = connection.create_bucket(Bucket=BUCKET_NAME1)
-    bucket2 = connection.create_bucket(Bucket=BUCKET_NAME2)
-    bucket3 = connection.create_bucket(Bucket=BUCKET_NAME3)
-    bucket4 = connection.create_bucket(Bucket=BUCKET_NAME4)
-    bucket5 = connection.create_bucket(Bucket=BUCKET_NAME5)
+    bucket = connection.create_bucket(Bucket=BUCKET_NAME)
     ver_bucket = connection.create_bucket(Bucket=VER_BUCKET_NAME)
     connection.BucketVersioning('ver_bucket')
 
-    bucket1_acl = connection.BucketAcl(BUCKET_NAME1).load()
-    bucket2_acl = connection.BucketAcl(BUCKET_NAME2).load()
+    bucket_acl = connection.BucketAcl(BUCKET_NAME).load()
     ver_bucket_acl = connection.BucketAcl(VER_BUCKET_NAME).load()
 
     # TESTCASE 'reshard-add','reshard','add','add bucket to resharding queue','succeeds'
     log.debug('TEST: reshard add\n')
     
-    num_shards_expected = get_bucket_stats(BUCKET_NAME1).num_shards + 1
-    cmd = exec_cmd('radosgw-admin reshard add --bucket {} --num-shards {}'.format(BUCKET_NAME1, num_shards_expected))
+    num_shards_expected = get_bucket_stats(BUCKET_NAME).num_shards + 1
+    cmd = exec_cmd('radosgw-admin reshard add --bucket {} --num-shards {}'.format(BUCKET_NAME, num_shards_expected))
     cmd = exec_cmd('radosgw-admin reshard list')
     json_op = json.loads(cmd)
     log.debug('bucket name {}'.format(json_op[0]['bucket_name']))
-    assert json_op[0]['bucket_name'] == BUCKET_NAME1
+    assert json_op[0]['bucket_name'] == BUCKET_NAME
     assert json_op[0]['new_num_shards'] == num_shards_expected
 
     # TESTCASE 'reshard-process','reshard','','process bucket resharding','succeeds'
@@ -165,190 +194,52 @@ def main():
     cmd = exec_cmd('radosgw-admin reshard process')
     time.sleep(5)
     # check bucket shards num
-    bucket_stats1 = get_bucket_stats(BUCKET_NAME1)
+    bucket_stats1 = get_bucket_stats(BUCKET_NAME)
     if bucket_stats1.num_shards != num_shards_expected:
-        log.error("Resharding failed on bucket {}. Expected number of shards are not created\n".format(BUCKET_NAME1))
+        log.error("Resharding failed on bucket {}. Expected number of shards are not created\n".format(BUCKET_NAME))
 
     # TESTCASE 'reshard-add','reshard','add','add non empty bucket to resharding queue','succeeds'
     log.debug('TEST: reshard add non empty bucket\n')
     # create objs
     num_objs = 8
     for i in range(0, num_objs):
-        connection.Object(BUCKET_NAME1, ('key'+str(i))).put(Body=b"some_data")
+        connection.Object(BUCKET_NAME, ('key'+str(i))).put(Body=b"some_data")
 
-    num_shards_expected = get_bucket_stats(BUCKET_NAME1).num_shards + 1
-    cmd = exec_cmd('radosgw-admin reshard add --bucket {} --num-shards {}'.format(BUCKET_NAME1, num_shards_expected))
+    num_shards_expected = get_bucket_stats(BUCKET_NAME).num_shards + 1
+    cmd = exec_cmd('radosgw-admin reshard add --bucket {} --num-shards {}'.format(BUCKET_NAME, num_shards_expected))
     cmd = exec_cmd('radosgw-admin reshard list')
     json_op = json.loads(cmd)
-    assert json_op[0]['bucket_name'] == BUCKET_NAME1
+    assert json_op[0]['bucket_name'] == BUCKET_NAME
     assert json_op[0]['new_num_shards'] == num_shards_expected
 
     # TESTCASE 'reshard process ,'reshard','process','reshard non empty bucket','succeeds'
     log.debug(' TEST: reshard process non empty bucket\n')
     cmd = exec_cmd('radosgw-admin reshard process')
     # check bucket shards num
-    bucket_stats1 = get_bucket_stats(BUCKET_NAME1)
+    bucket_stats1 = get_bucket_stats(BUCKET_NAME)
     if bucket_stats1.num_shards != num_shards_expected:
-        log.error("Resharding failed on bucket {}. Expected number of shards are not created\n".format(BUCKET_NAME1))
+        log.error("Resharding failed on bucket {}. Expected number of shards are not created\n".format(BUCKET_NAME))
 
     # TESTCASE 'manual bucket resharding','inject error','fail','check bucket accessibility', 'retry reshard'
-    log.debug('TEST: reshard bucket with error injection\n')
-    # create objs
-    num_objs = 11
-    for i in range(0, num_objs):
-        connection.Object(BUCKET_NAME2, ('key' + str(i))).put(Body=b"some_data")
+    log.debug('TEST: reshard bucket with EIO injected at set_target_layout\n')
+    test_bucket_reshard(connection, 'error-at-set-target-layout', error_at='set_target_layout')
+    log.debug('TEST: reshard bucket with abort at set_target_layout\n')
+    test_bucket_reshard(connection, 'abort-at-set-target-layout', abort_at='set_target_layout')
 
-    time.sleep(5)
-    old_shard_count = get_bucket_stats(BUCKET_NAME2).num_shards
-    num_shards_expected = old_shard_count + 1
-    run_bucket_reshard_cmd(BUCKET_NAME2, num_shards_expected, error_location = "before_target_shard_entry")
+    log.debug('TEST: reshard bucket with EIO injected at block_writes\n')
+    test_bucket_reshard(connection, 'error-at-block-writes', error_at='block_writes')
+    log.debug('TEST: reshard bucket with abort at block_writes\n')
+    test_bucket_reshard(connection, 'abort-at-block-writes', abort_at='block_writes')
 
-    # check bucket shards num
-    cur_shard_count = get_bucket_stats(BUCKET_NAME2).num_shards
-    assert(cur_shard_count == old_shard_count)
+    log.debug('TEST: reshard bucket with EIO injected at commit_target_layout\n')
+    test_bucket_reshard(connection, 'error-at-commit-target-layout', error_at='commit_target_layout')
+    log.debug('TEST: reshard bucket with abort at commit_target_layout\n')
+    test_bucket_reshard(connection, 'abort-at-commit-target-layout', abort_at='commit_target_layout')
 
-    #verify if bucket is accessible
-    log.info('List objects from bucket: {}'.format(BUCKET_NAME2))
-    for key in bucket2.objects.all():
-        print(key.key)
-
-    #verify if new objects can be added
-    num_objs = 5
-    for i in range(0, num_objs):
-        connection.Object(BUCKET_NAME2, ('key' + str(i))).put(Body=b"some_data")
-
-    #retry reshard
-    run_bucket_reshard_cmd(BUCKET_NAME2, num_shards_expected)
-
-    #TESTCASE 'manual bucket resharding','inject error','fail','check bucket accessibility', 'retry reshard'
-    log.debug('TEST: reshard bucket with error injection')
-    # create objs
-    num_objs = 11
-    for i in range(0, num_objs):
-        connection.Object(BUCKET_NAME3, ('key' + str(i))).put(Body=b"some_data")
-
-    time.sleep(5)
-    old_shard_count = get_bucket_stats(BUCKET_NAME3).num_shards
-    num_shards_expected = old_shard_count + 1
-    run_bucket_reshard_cmd(BUCKET_NAME3, num_shards_expected, error_location = "after_target_shard_entry")
-    # check bucket shards num
-    bucket_stats3 = get_bucket_stats(BUCKET_NAME3)
-    cur_shard_count = bucket_stats3.num_shards
-    assert(cur_shard_count == old_shard_count)
-
-    #verify if bucket is accessible
-    log.info('List objects from bucket: {}'.format(BUCKET_NAME3))
-    for key in bucket3.objects.all():
-        print(key.key)
-
-    #verify if new objects can be added
-    num_objs = 5
-    for i in range(0, num_objs):
-        connection.Object(BUCKET_NAME3, ('key' + str(i))).put(Body=b"some_data")
-
-    #retry reshard
-    run_bucket_reshard_cmd(BUCKET_NAME3, num_shards_expected)
-    
-    #TESTCASE 'manual bucket resharding','inject error','fail','check bucket accessibility', 'retry reshard'
-    log.debug('TEST: reshard bucket with error injection')
-    # create objs
-    num_objs = 11
-    for i in range(0, num_objs):
-        connection.Object(BUCKET_NAME4, ('key' + str(i))).put(Body=b"some_data")
-
-    time.sleep(10)
-    old_shard_count = get_bucket_stats(BUCKET_NAME4).num_shards
-    num_shards_expected = old_shard_count + 1
-    run_bucket_reshard_cmd(BUCKET_NAME4, num_shards_expected, error_location = "before_layout_overwrite")
-
-    # check bucket shards num
-    cur_shard_count = get_bucket_stats(BUCKET_NAME4).num_shards
-    assert(cur_shard_count == old_shard_count)
-
-    #verify if bucket is accessible
-    log.info('List objects from bucket: {}'.format(BUCKET_NAME3))
-    for key in bucket4.objects.all():
-        print(key.key)
-
-    #verify if new objects can be added
-    num_objs = 5
-    for i in range(0, num_objs):
-        connection.Object(BUCKET_NAME4, ('key' + str(i))).put(Body=b"some_data")
-
-    #retry reshard
-    run_bucket_reshard_cmd(BUCKET_NAME4, num_shards_expected)
-
-    # TESTCASE 'manual bucket resharding','inject crash','fail','check bucket accessibility', 'retry reshard'
-    log.debug('TEST: reshard bucket with crash injection\n')
-
-    old_shard_count = get_bucket_stats(BUCKET_NAME2).num_shards
-    num_shards_expected = old_shard_count + 1
-    run_bucket_reshard_cmd(BUCKET_NAME2, num_shards_expected, abort_location = "before_target_shard_entry")
-
-    # check bucket shards num
-    cur_shard_count = get_bucket_stats(BUCKET_NAME2).num_shards
-    assert(cur_shard_count == old_shard_count)
-
-    #verify if bucket is accessible
-    log.info('List objects from bucket: {}'.format(BUCKET_NAME2))
-    for key in bucket2.objects.all():
-        print(key.key)
-
-    #verify if new objects can be added
-    num_objs = 5
-    for i in range(0, num_objs):
-        connection.Object(BUCKET_NAME2, ('key' + str(i))).put(Body=b"some_data")
-
-    #retry reshard
-    run_bucket_reshard_cmd(BUCKET_NAME2, num_shards_expected)
-
-    #TESTCASE 'manual bucket resharding','inject crash','fail','check bucket accessibility', 'retry reshard'
-    log.debug('TEST: reshard bucket with error injection')
-
-    old_shard_count = get_bucket_stats(BUCKET_NAME3).num_shards
-    num_shards_expected = old_shard_count + 1
-    run_bucket_reshard_cmd(BUCKET_NAME3, num_shards_expected, abort_location = "after_target_shard_entry")
-
-    # check bucket shards num
-    cur_shard_count = get_bucket_stats(BUCKET_NAME3).num_shards
-    assert(cur_shard_count == old_shard_count)
-
-    #verify if bucket is accessible
-    log.info('List objects from bucket: {}'.format(BUCKET_NAME3))
-    for key in bucket3.objects.all():
-        print(key.key)
-
-    #verify if new objects can be added
-    num_objs = 5
-    for i in range(0, num_objs):
-        connection.Object(BUCKET_NAME3, ('key' + str(i))).put(Body=b"some_data")
-
-    #retry reshard
-    run_bucket_reshard_cmd(BUCKET_NAME3, num_shards_expected)
-
-    #TESTCASE 'manual bucket resharding','inject error','fail','check bucket accessibility', 'retry reshard'
-    log.debug('TEST: reshard bucket with error injection')
-
-    old_shard_count = get_bucket_stats(BUCKET_NAME4).num_shards
-    num_shards_expected = old_shard_count + 1
-    run_bucket_reshard_cmd(BUCKET_NAME4, num_shards_expected, abort_location = "before_layout_overwrite")
-    # check bucket shards num
-    bucket_stats4 = get_bucket_stats(BUCKET_NAME4)
-    cur_shard_count = bucket_stats4.num_shards
-    assert(cur_shard_count == old_shard_count)
-
-    #verify if bucket is accessible
-    log.info('List objects from bucket: {}'.format(BUCKET_NAME3))
-    for key in bucket4.objects.all():
-        print(key.key)
-
-    #verify if new objects can be added
-    num_objs = 5
-    for i in range(0, num_objs):
-        connection.Object(BUCKET_NAME4, ('key' + str(i))).put(Body=b"some_data")
-
-    #retry reshard
-    run_bucket_reshard_cmd(BUCKET_NAME4, num_shards_expected)
+    log.debug('TEST: reshard bucket with EIO injected at do_reshard\n')
+    test_bucket_reshard(connection, 'error-at-do-reshard', error_at='do_reshard')
+    log.debug('TEST: reshard bucket with abort at do_reshard\n')
+    test_bucket_reshard(connection, 'abort-at-do-reshard', abort_at='do_reshard')
 
     # TESTCASE 'versioning reshard-','bucket', reshard','versioning reshard','succeeds'
     log.debug(' test: reshard versioned bucket')
@@ -360,20 +251,15 @@ def main():
     assert ver_bucket_stats.num_shards == num_shards_expected
 
     # TESTCASE 'check acl'
-    new_bucket1_acl = connection.BucketAcl(BUCKET_NAME1).load()
-    assert new_bucket1_acl == bucket1_acl
-    new_bucket2_acl = connection.BucketAcl(BUCKET_NAME2).load()
-    assert new_bucket2_acl == bucket2_acl
+    new_bucket_acl = connection.BucketAcl(BUCKET_NAME).load()
+    assert new_bucket_acl == bucket_acl
     new_ver_bucket_acl = connection.BucketAcl(VER_BUCKET_NAME).load()
     assert new_ver_bucket_acl == ver_bucket_acl
 
     # Clean up
-    log.debug("Deleting bucket {}".format(BUCKET_NAME1))
-    bucket1.objects.all().delete()
-    bucket1.delete()
-    log.debug("Deleting bucket {}".format(BUCKET_NAME2))
-    bucket2.objects.all().delete()
-    bucket2.delete()
+    log.debug("Deleting bucket {}".format(BUCKET_NAME))
+    bucket.objects.all().delete()
+    bucket.delete()
     log.debug("Deleting bucket {}".format(VER_BUCKET_NAME))
     ver_bucket.delete()
 

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -3981,7 +3981,7 @@ static int rgw_set_bucket_resharding(cls_method_context_t hctx, bufferlist *in, 
     return rc;
   }
 
-  header.new_instance.set_status(op.entry.bucket_instance_id, op.entry.num_shards, op.entry.reshard_status);
+  header.new_instance.set_status(op.entry.reshard_status);
 
   return write_bucket_header(hctx, &header);
 }

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -3981,7 +3981,7 @@ static int rgw_set_bucket_resharding(cls_method_context_t hctx, bufferlist *in, 
     return rc;
   }
 
-  header.new_instance.set_status(op.entry.new_bucket_instance_id, op.entry.num_shards, op.entry.reshard_status);
+  header.new_instance.set_status(op.entry.bucket_instance_id, op.entry.num_shards, op.entry.reshard_status);
 
   return write_bucket_header(hctx, &header);
 }

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -720,9 +720,10 @@ void cls_rgw_reshard_entry::dump(Formatter *f) const
   encode_json("tenant", tenant, f);
   encode_json("bucket_name", bucket_name, f);
   encode_json("bucket_id", bucket_id, f);
-  encode_json("new_instance_id", new_instance_id, f);
+  encode_json("instance_id", instance_id, f);
   encode_json("old_num_shards", old_num_shards, f);
   encode_json("new_num_shards", new_num_shards, f);
+
 
 }
 
@@ -734,7 +735,7 @@ void cls_rgw_reshard_entry::generate_test_instances(list<cls_rgw_reshard_entry*>
   ls.back()->tenant = "tenant";
   ls.back()->bucket_name = "bucket1""";
   ls.back()->bucket_id = "bucket_id";
-  ls.back()->new_instance_id = "new_instance_id";
+  ls.back()->instance_id = "instance_id";
   ls.back()->old_num_shards = 8;
   ls.back()->new_num_shards = 64;
 }
@@ -742,7 +743,7 @@ void cls_rgw_reshard_entry::generate_test_instances(list<cls_rgw_reshard_entry*>
 void cls_rgw_bucket_instance_entry::dump(Formatter *f) const
 {
   encode_json("reshard_status", to_string(reshard_status), f);
-  encode_json("new_bucket_instance_id", new_bucket_instance_id, f);
+  encode_json("bucket_instance_id", bucket_instance_id, f);
   encode_json("num_shards", num_shards, f);
 
 }
@@ -753,7 +754,7 @@ void cls_rgw_bucket_instance_entry::generate_test_instances(
   ls.push_back(new cls_rgw_bucket_instance_entry);
   ls.push_back(new cls_rgw_bucket_instance_entry);
   ls.back()->reshard_status = RESHARD_STATUS::IN_PROGRESS;
-  ls.back()->new_bucket_instance_id = "new_instance_id";
+  ls.back()->bucket_instance_id = "instance_id";
 }
   
 void cls_rgw_lc_obj_head::dump(Formatter *f) const 

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -720,7 +720,6 @@ void cls_rgw_reshard_entry::dump(Formatter *f) const
   encode_json("tenant", tenant, f);
   encode_json("bucket_name", bucket_name, f);
   encode_json("bucket_id", bucket_id, f);
-  encode_json("instance_id", instance_id, f);
   encode_json("old_num_shards", old_num_shards, f);
   encode_json("new_num_shards", new_num_shards, f);
 
@@ -735,7 +734,6 @@ void cls_rgw_reshard_entry::generate_test_instances(list<cls_rgw_reshard_entry*>
   ls.back()->tenant = "tenant";
   ls.back()->bucket_name = "bucket1""";
   ls.back()->bucket_id = "bucket_id";
-  ls.back()->instance_id = "instance_id";
   ls.back()->old_num_shards = 8;
   ls.back()->new_num_shards = 64;
 }

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -743,9 +743,6 @@ void cls_rgw_reshard_entry::generate_test_instances(list<cls_rgw_reshard_entry*>
 void cls_rgw_bucket_instance_entry::dump(Formatter *f) const
 {
   encode_json("reshard_status", to_string(reshard_status), f);
-  encode_json("bucket_instance_id", bucket_instance_id, f);
-  encode_json("num_shards", num_shards, f);
-
 }
 
 void cls_rgw_bucket_instance_entry::generate_test_instances(
@@ -754,7 +751,6 @@ void cls_rgw_bucket_instance_entry::generate_test_instances(
   ls.push_back(new cls_rgw_bucket_instance_entry);
   ls.push_back(new cls_rgw_bucket_instance_entry);
   ls.back()->reshard_status = RESHARD_STATUS::IN_PROGRESS;
-  ls.back()->bucket_instance_id = "instance_id";
 }
   
 void cls_rgw_lc_obj_head::dump(Formatter *f) const 

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -722,8 +722,6 @@ void cls_rgw_reshard_entry::dump(Formatter *f) const
   encode_json("bucket_id", bucket_id, f);
   encode_json("old_num_shards", old_num_shards, f);
   encode_json("new_num_shards", new_num_shards, f);
-
-
 }
 
 void cls_rgw_reshard_entry::generate_test_instances(list<cls_rgw_reshard_entry*>& ls)

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -9,6 +9,7 @@
 #include "common/Formatter.h"
 
 #include "rgw/rgw_basic_types.h"
+#include "rgw/rgw_bucket_layout.h"
 
 #define CEPH_RGW_REMOVE 'r'
 #define CEPH_RGW_UPDATE 'u'
@@ -718,36 +719,30 @@ struct rgw_bucket_category_stats {
 };
 WRITE_CLASS_ENCODER(rgw_bucket_category_stats)
 
-enum class cls_rgw_reshard_status : uint8_t {
-  NOT_RESHARDING  = 0,
-  IN_PROGRESS     = 1,
-  DONE            = 2
-};
-
-inline std::string to_string(const cls_rgw_reshard_status status)
+inline std::string to_string(const rgw::BucketReshardState status)
 {
   switch (status) {
-  case cls_rgw_reshard_status::NOT_RESHARDING:
+  case rgw::BucketReshardState::NOT_RESHARDING:
     return "not-resharding";
-  case cls_rgw_reshard_status::IN_PROGRESS:
+  case rgw::BucketReshardState::IN_PROGRESS:
     return "in-progress";
-  case cls_rgw_reshard_status::DONE:
+  case rgw::BucketReshardState::DONE:
     return "done";
   };
   return "Unknown reshard status";
 }
 
 struct cls_rgw_bucket_instance_entry {
-  using RESHARD_STATUS = cls_rgw_reshard_status;
+  using RESHARD_STATUS = rgw::BucketReshardState;
   
-  cls_rgw_reshard_status reshard_status{RESHARD_STATUS::NOT_RESHARDING};
-  std::string new_bucket_instance_id;
+  rgw::BucketReshardState reshard_status{RESHARD_STATUS::NOT_RESHARDING};
+  std::string bucket_instance_id;
   int32_t num_shards{-1};
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode((uint8_t)reshard_status, bl);
-    encode(new_bucket_instance_id, bl);
+    encode(bucket_instance_id, bl);
     encode(num_shards, bl);
     ENCODE_FINISH(bl);
   }
@@ -756,8 +751,8 @@ struct cls_rgw_bucket_instance_entry {
     DECODE_START(1, bl);
     uint8_t s;
     decode(s, bl);
-    reshard_status = (cls_rgw_reshard_status)s;
-    decode(new_bucket_instance_id, bl);
+    reshard_status = (rgw::BucketReshardState)s;
+    decode(bucket_instance_id, bl);
     decode(num_shards, bl);
     DECODE_FINISH(bl);
   }
@@ -767,14 +762,14 @@ struct cls_rgw_bucket_instance_entry {
 
   void clear() {
     reshard_status = RESHARD_STATUS::NOT_RESHARDING;
-    new_bucket_instance_id.clear();
+    //bucket_instance_id.clear();
   }
 
-  void set_status(const std::string& new_instance_id,
-		  int32_t new_num_shards,
-		  cls_rgw_reshard_status s) {
+  void set_status(const std::string& instance_id,
+                 int32_t new_num_shards, 
+                 rgw::BucketReshardState s) {
     reshard_status = s;
-    new_bucket_instance_id = new_instance_id;
+    bucket_instance_id = instance_id;
     num_shards = new_num_shards;
   }
 
@@ -1246,7 +1241,7 @@ struct cls_rgw_reshard_entry
   std::string tenant;
   std::string bucket_name;
   std::string bucket_id;
-  std::string new_instance_id;
+  std::string instance_id;
   uint32_t old_num_shards{0};
   uint32_t new_num_shards{0};
 
@@ -1258,7 +1253,7 @@ struct cls_rgw_reshard_entry
     encode(tenant, bl);
     encode(bucket_name, bl);
     encode(bucket_id, bl);
-    encode(new_instance_id, bl);
+    encode(instance_id, bl);
     encode(old_num_shards, bl);
     encode(new_num_shards, bl);
     ENCODE_FINISH(bl);
@@ -1270,7 +1265,7 @@ struct cls_rgw_reshard_entry
     decode(tenant, bl);
     decode(bucket_name, bl);
     decode(bucket_id, bl);
-    decode(new_instance_id, bl);
+    decode(instance_id, bl);
     decode(old_num_shards, bl);
     decode(new_num_shards, bl);
     DECODE_FINISH(bl);

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -741,6 +741,8 @@ struct cls_rgw_bucket_instance_entry {
   using RESHARD_STATUS = cls_rgw_reshard_status;
   
   cls_rgw_reshard_status reshard_status{RESHARD_STATUS::NOT_RESHARDING};
+  std::string new_bucket_instance_id;
+  int32_t num_shards{-1};
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);
@@ -753,6 +755,10 @@ struct cls_rgw_bucket_instance_entry {
     uint8_t s;
     decode(s, bl);
     reshard_status = (cls_rgw_reshard_status)s;
+    if (struct_v < 2) {
+      decode(new_bucket_instance_id, bl);
+      decode(num_shards, bl);
+    }
     DECODE_FINISH(bl);
   }
 
@@ -1235,6 +1241,7 @@ struct cls_rgw_reshard_entry
   std::string tenant;
   std::string bucket_name;
   std::string bucket_id;
+  std::string new_instance_id;
   uint32_t old_num_shards{0};
   uint32_t new_num_shards{0};
 
@@ -1259,6 +1266,9 @@ struct cls_rgw_reshard_entry
     decode(bucket_id, bl);
     decode(old_num_shards, bl);
     decode(new_num_shards, bl);
+    if (struct_v < 2) {
+      decode(new_instance_id, bl);
+    }
     DECODE_FINISH(bl);
   }
 

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -762,7 +762,6 @@ struct cls_rgw_bucket_instance_entry {
 
   void clear() {
     reshard_status = RESHARD_STATUS::NOT_RESHARDING;
-    //bucket_instance_id.clear();
   }
 
   void set_status(const std::string& instance_id,

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -743,13 +743,13 @@ struct cls_rgw_bucket_instance_entry {
   cls_rgw_reshard_status reshard_status{RESHARD_STATUS::NOT_RESHARDING};
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     encode((uint8_t)reshard_status, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     uint8_t s;
     decode(s, bl);
     reshard_status = (cls_rgw_reshard_status)s;
@@ -1241,7 +1241,7 @@ struct cls_rgw_reshard_entry
   cls_rgw_reshard_entry() {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     encode(time, bl);
     encode(tenant, bl);
     encode(bucket_name, bl);
@@ -1252,7 +1252,7 @@ struct cls_rgw_reshard_entry
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     decode(time, bl);
     decode(tenant, bl);
     decode(bucket_name, bl);

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -9,7 +9,6 @@
 #include "common/Formatter.h"
 
 #include "rgw/rgw_basic_types.h"
-#include "rgw/rgw_bucket_layout.h"
 
 #define CEPH_RGW_REMOVE 'r'
 #define CEPH_RGW_UPDATE 'u'
@@ -719,31 +718,33 @@ struct rgw_bucket_category_stats {
 };
 WRITE_CLASS_ENCODER(rgw_bucket_category_stats)
 
-inline std::string to_string(const rgw::BucketReshardState status)
+enum class cls_rgw_reshard_status : uint8_t {
+  NOT_RESHARDING  = 0,
+  IN_PROGRESS     = 1,
+  DONE            = 2
+};
+
+inline std::string to_string(const cls_rgw_reshard_status status)
 {
   switch (status) {
-  case rgw::BucketReshardState::NOT_RESHARDING:
+  case cls_rgw_reshard_status::NOT_RESHARDING:
     return "not-resharding";
-  case rgw::BucketReshardState::IN_PROGRESS:
+  case cls_rgw_reshard_status::IN_PROGRESS:
     return "in-progress";
-  case rgw::BucketReshardState::DONE:
+  case cls_rgw_reshard_status::DONE:
     return "done";
   };
   return "Unknown reshard status";
 }
 
 struct cls_rgw_bucket_instance_entry {
-  using RESHARD_STATUS = rgw::BucketReshardState;
+  using RESHARD_STATUS = cls_rgw_reshard_status;
   
-  rgw::BucketReshardState reshard_status{RESHARD_STATUS::NOT_RESHARDING};
-  std::string bucket_instance_id;
-  int32_t num_shards{-1};
+  cls_rgw_reshard_status reshard_status{RESHARD_STATUS::NOT_RESHARDING};
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(1, 1, bl);
     encode((uint8_t)reshard_status, bl);
-    encode(bucket_instance_id, bl);
-    encode(num_shards, bl);
     ENCODE_FINISH(bl);
   }
 
@@ -751,9 +752,7 @@ struct cls_rgw_bucket_instance_entry {
     DECODE_START(1, bl);
     uint8_t s;
     decode(s, bl);
-    reshard_status = (rgw::BucketReshardState)s;
-    decode(bucket_instance_id, bl);
-    decode(num_shards, bl);
+    reshard_status = (cls_rgw_reshard_status)s;
     DECODE_FINISH(bl);
   }
 
@@ -764,12 +763,8 @@ struct cls_rgw_bucket_instance_entry {
     reshard_status = RESHARD_STATUS::NOT_RESHARDING;
   }
 
-  void set_status(const std::string& instance_id,
-                 int32_t new_num_shards, 
-                 rgw::BucketReshardState s) {
+  void set_status(cls_rgw_reshard_status s) {
     reshard_status = s;
-    bucket_instance_id = instance_id;
-    num_shards = new_num_shards;
   }
 
   bool resharding() const {

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -1235,7 +1235,6 @@ struct cls_rgw_reshard_entry
   std::string tenant;
   std::string bucket_name;
   std::string bucket_id;
-  std::string instance_id;
   uint32_t old_num_shards{0};
   uint32_t new_num_shards{0};
 
@@ -1247,7 +1246,6 @@ struct cls_rgw_reshard_entry
     encode(tenant, bl);
     encode(bucket_name, bl);
     encode(bucket_id, bl);
-    encode(instance_id, bl);
     encode(old_num_shards, bl);
     encode(new_num_shards, bl);
     ENCODE_FINISH(bl);
@@ -1259,7 +1257,6 @@ struct cls_rgw_reshard_entry
     decode(tenant, bl);
     decode(bucket_name, bl);
     decode(bucket_id, bl);
-    decode(instance_id, bl);
     decode(old_num_shards, bl);
     decode(new_num_shards, bl);
     DECODE_FINISH(bl);

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -741,8 +741,6 @@ struct cls_rgw_bucket_instance_entry {
   using RESHARD_STATUS = cls_rgw_reshard_status;
   
   cls_rgw_reshard_status reshard_status{RESHARD_STATUS::NOT_RESHARDING};
-  std::string new_bucket_instance_id;
-  int32_t num_shards{-1};
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);
@@ -756,7 +754,9 @@ struct cls_rgw_bucket_instance_entry {
     decode(s, bl);
     reshard_status = (cls_rgw_reshard_status)s;
     if (struct_v < 2) {
+      std::string new_bucket_instance_id;
       decode(new_bucket_instance_id, bl);
+      int32_t num_shards{-1};
       decode(num_shards, bl);
     }
     DECODE_FINISH(bl);
@@ -1241,7 +1241,6 @@ struct cls_rgw_reshard_entry
   std::string tenant;
   std::string bucket_name;
   std::string bucket_id;
-  std::string new_instance_id;
   uint32_t old_num_shards{0};
   uint32_t new_num_shards{0};
 
@@ -1264,11 +1263,12 @@ struct cls_rgw_reshard_entry
     decode(tenant, bl);
     decode(bucket_name, bl);
     decode(bucket_id, bl);
-    decode(old_num_shards, bl);
-    decode(new_num_shards, bl);
     if (struct_v < 2) {
+      std::string new_instance_id; // removed in v2
       decode(new_instance_id, bl);
     }
+    decode(old_num_shards, bl);
+    decode(new_num_shards, bl);
     DECODE_FINISH(bl);
   }
 

--- a/src/common/fault_injector.h
+++ b/src/common/fault_injector.h
@@ -1,0 +1,135 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <type_traits>
+#include <boost/type_traits/has_equal_to.hpp>
+#include <boost/type_traits/has_left_shift.hpp>
+#include <variant>
+#include "include/ceph_assert.h"
+#include "common/dout.h"
+
+/// @file
+
+/// A failure type that aborts the process with a failed assertion.
+struct InjectAbort {};
+
+/// A failure type that injects an error code and optionally logs a message.
+struct InjectError {
+  /// error code to inject
+  int error;
+  /// an optional log channel to print an error message
+  const DoutPrefixProvider* dpp = nullptr;
+};
+
+/** @class FaultInjector
+ * @brief Used to instrument a code path with deterministic fault injection
+ * by making one or more calls to check().
+ *
+ * A default-constructed FaultInjector contains no failure. It can also be
+ * constructed with a failure of type InjectAbort or InjectError, along with
+ * a location to inject that failure.
+ *
+ * The contained failure can be overwritten with a call to inject() or clear().
+ * This is not thread-safe with respect to other member functions on the same
+ * instance.
+ *
+ * @tparam Key  The location can be represented by any Key type that is
+ * movable, default-constructible, inequality-comparable and stream-outputable.
+ * A string or string_view Key may be preferable when the location comes from
+ * user input, or to describe the steps like "before-foo" and "after-foo".
+ * An integer Key may be preferable for a code path with many steps, where you
+ * just want to check 1, 2, 3, etc. without inventing names for each.
+ */
+template <typename Key>
+class FaultInjector {
+ public:
+  /// Default-construct with no injected failure.
+  constexpr FaultInjector() noexcept : location() {}
+
+  /// Construct with an injected assertion failure at the given location.
+  constexpr FaultInjector(Key location, InjectAbort a)
+    : location(std::move(location)), failure(a) {}
+
+  /// Construct with an injected error code at the given location.
+  constexpr FaultInjector(Key location, InjectError e)
+    : location(std::move(location)), failure(e) {}
+
+  /// Inject an assertion failure at the given location.
+  void inject(Key location, InjectAbort a) {
+    this->location = std::move(location);
+    this->failure = a;
+  }
+
+  /// Inject an error at the given location.
+  void inject(Key location, InjectError e) {
+    this->location = std::move(location);
+    this->failure = e;
+  }
+
+  /// Clear any injected failure.
+  void clear() {
+    this->failure = Empty{};
+  }
+
+  /// Check for an injected failure at the given location. If the location
+  /// matches an InjectAbort failure, the process aborts here with an assertion
+  /// failure.
+  /// @returns 0 or InjectError::error if the location matches an InjectError
+  /// failure
+  [[nodiscard]] constexpr int check(const Key& location) const {
+    struct visitor {
+      const Key& check_location;
+      const Key& this_location;
+      constexpr int operator()(const std::monostate&) const {
+        return 0;
+      }
+      int operator()(const InjectAbort&) const {
+        if (check_location == this_location) {
+          ceph_assert_always(!"FaultInjector");
+        }
+        return 0;
+      }
+      int operator()(const InjectError& e) const {
+        if (check_location == this_location) {
+          ldpp_dout(e.dpp, -1) << "Injecting error=" << e.error
+              << " at location=" << this_location << dendl;
+          return e.error;
+        }
+        return 0;
+      }
+    };
+    return std::visit(visitor{location, this->location}, failure);
+  }
+
+ private:
+  // Key requirements:
+  static_assert(std::is_default_constructible_v<Key>,
+                "Key must be default-constrible");
+  static_assert(std::is_move_constructible_v<Key>,
+                "Key must be move-constructible");
+  static_assert(std::is_move_assignable_v<Key>,
+                "Key must be move-assignable");
+  static_assert(boost::has_equal_to<Key, Key, bool>::value,
+                "Key must be equality-comparable");
+  static_assert(boost::has_left_shift<std::ostream, Key, std::ostream&>::value,
+                "Key must have an ostream operator<<");
+
+  Key location; // location of the check that should fail
+
+  using Empty = std::monostate; // empty state for std::variant
+
+  std::variant<Empty, InjectAbort, InjectError> failure;
+};

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -405,8 +405,6 @@ void usage()
   cout << "   --trim-delay-ms           time interval in msec to limit the frequency of sync error log entries trimming operations,\n";
   cout << "                             the trimming process will sleep the specified msec for every 1000 entries trimmed\n";
   cout << "   --max-concurrent-ios      maximum concurrent ios for bucket operations (default: 32)\n";
-  cout << "   --fault-inject-at         for testing fault injection\n";
-  cout << "   --fault-abort-at          for testing fault abort\n";
   cout << "\n";
   cout << "<date> := \"YYYY-MM-DD[ hh:mm:ss]\"\n";
   cout << "\nQuota options:\n";

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1092,8 +1092,8 @@ static void show_reshard_status(
   for (const auto& entry : status) {
     formatter->open_object_section("entry");
     formatter->dump_string("reshard_status", to_string(entry.reshard_status));
-    formatter->dump_string("new_bucket_instance_id",
-			   entry.new_bucket_instance_id);
+    formatter->dump_string("bucket_instance_id",
+			   entry.bucket_instance_id);
     formatter->dump_int("num_shards", entry.num_shards);
     formatter->close_section();
   }

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6573,7 +6573,7 @@ next:
       RGWRados::BucketShard bs(store->getRados());
       int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
       const auto& current = bucket_info.layout.current_index;
-      int ret = bs.init(bucket, shard_id, current, std::nullopt, nullptr /* no RGWBucketInfo */);
+      int ret = bs.init(bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
       marker.clear();
 
       if (ret < 0) {
@@ -6638,7 +6638,7 @@ next:
       RGWRados::BucketShard bs(store->getRados());
       int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
       const auto& current = bucket_info.layout.current_index;
-      int ret = bs.init(bucket, shard_id, current, std::nullopt, nullptr /* no RGWBucketInfo */);
+      int ret = bs.init(bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
       if (ret < 0) {
         cerr << "ERROR: bs.init(bucket=" << bucket << ", shard=" << shard_id << "): " << cpp_strerror(-ret) << std::endl;
         return -ret;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -22,6 +22,7 @@ extern "C" {
 #include "common/Formatter.h"
 #include "common/errno.h"
 #include "common/safe_io.h"
+#include "common/fault_injector.h"
 
 #include "include/util.h"
 
@@ -404,6 +405,8 @@ void usage()
   cout << "   --trim-delay-ms           time interval in msec to limit the frequency of sync error log entries trimming operations,\n";
   cout << "                             the trimming process will sleep the specified msec for every 1000 entries trimmed\n";
   cout << "   --max-concurrent-ios      maximum concurrent ios for bucket operations (default: 32)\n";
+  cout << "   --fault-inject-at         for testing fault injection\n";
+  cout << "   --fault-abort-at          for testing fault abort\n";
   cout << "\n";
   cout << "<date> := \"YYYY-MM-DD[ hh:mm:ss]\"\n";
   cout << "\nQuota options:\n";
@@ -3222,6 +3225,9 @@ int main(int argc, const char **argv)
   ceph::timespan opt_retry_delay_ms = std::chrono::milliseconds(2000);
   ceph::timespan opt_timeout_sec = std::chrono::seconds(60);
 
+  std::optional<std::string> inject_error_at;
+  std::optional<std::string> inject_abort_at;
+
   SimpleCmd cmd(all_cmds, cmd_aliases);
 
   for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
@@ -3639,6 +3645,10 @@ int main(int argc, const char **argv)
       opt_retry_delay_ms = std::chrono::milliseconds(atoi(val.c_str()));
     } else if (ceph_argparse_witharg(args, i, &val, "--timeout-sec", (char*)NULL)) {
       opt_timeout_sec = std::chrono::seconds(atoi(val.c_str()));
+    } else if (ceph_argparse_witharg(args, i, &val, "--inject-error-at", (char*)NULL)) {
+      inject_error_at = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--inject-abort-at", (char*)NULL)) {
+      inject_abort_at = val;
     } else if (ceph_argparse_binary_flag(args, i, &detail, NULL, "--detail", (char*)NULL)) {
       // do nothing
     } else if (ceph_argparse_witharg(args, i, &val, "--context", (char*)NULL)) {
@@ -5442,6 +5452,9 @@ int main(int argc, const char **argv)
       return EINVAL;
   }
 
+  // to test using FaultInjector
+  FaultInjector<std::string_view> fault;
+
   if (!user_id.empty()) {
     user_op.set_user_id(user_id);
     bucket_op.set_user_id(user_id);
@@ -6913,8 +6926,12 @@ next:
       max_entries = DEFAULT_RESHARD_MAX_ENTRIES;
     }
 
-    return br.execute(num_shards, max_entries,
-                      verbose, &cout, formatter.get());
+    if (inject_error_at) {
+      fault.inject(*inject_error_at, InjectError{-EIO, dpp()});
+    } else if (inject_abort_at) {
+      fault.inject(*inject_abort_at, InjectAbort{});
+    }
+    return br.execute(num_shards, fault, max_entries, verbose, &cout, formatter.get());
   }
 
   if (opt_cmd == OPT::RESHARD_ADD) {

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6919,7 +6919,7 @@ next:
       return ret;
     }
 
-    RGWBucketReshard br(store, bucket_info, attrs, nullptr /* no callback */);
+    RGWBucketReshard br(store, bucket_info, nullptr /* no callback */);
 
 #define DEFAULT_RESHARD_MAX_ENTRIES 1000
     if (max_entries < 1) {
@@ -7018,14 +7018,13 @@ next:
 
     rgw_bucket bucket;
     RGWBucketInfo bucket_info;
-    map<string, bufferlist> attrs;
-    ret = init_bucket(tenant, bucket_name, bucket_id, bucket_info, bucket, &attrs);
+    ret = init_bucket(tenant, bucket_name, bucket_id, bucket_info, bucket);
     if (ret < 0) {
       cerr << "ERROR: could not init bucket: " << cpp_strerror(-ret) << std::endl;
       return -ret;
     }
 
-    RGWBucketReshard br(store, bucket_info, attrs, nullptr /* no callback */);
+    RGWBucketReshard br(store, bucket_info, nullptr /* no callback */);
     list<cls_rgw_bucket_instance_entry> status;
     int r = br.get_status(&status);
     if (r < 0) {
@@ -7055,10 +7054,8 @@ next:
 
     rgw_bucket bucket;
     RGWBucketInfo bucket_info;
-    map<string, bufferlist> attrs;
     bool bucket_initable = true;
-    ret = init_bucket(tenant, bucket_name, bucket_id, bucket_info, bucket,
-                      &attrs);
+    ret = init_bucket(tenant, bucket_name, bucket_id, bucket_info, bucket);
     if (ret < 0) {
       if (yes_i_really_mean_it) {
         bucket_initable = false;
@@ -7072,8 +7069,7 @@ next:
 
     if (bucket_initable) {
       // we did not encounter an error, so let's work with the bucket
-      RGWBucketReshard br(store, bucket_info, attrs,
-                          nullptr /* no callback */);
+      RGWBucketReshard br(store, bucket_info, nullptr /* no callback */);
       int ret = br.cancel();
       if (ret < 0) {
         if (ret == -EBUSY) {

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6584,7 +6584,7 @@ next:
       do {
         entries.clear();
         ret = store->getRados()->bi_list(bs, object, marker, max_entries, &entries, &is_truncated);
-        if (ret < 0) {            
+        if (ret < 0) {
           cerr << "ERROR: bi_list(): " << cpp_strerror(-ret) << std::endl;
           return -ret;
         }

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -5452,9 +5452,6 @@ int main(int argc, const char **argv)
       return EINVAL;
   }
 
-  // to test using FaultInjector
-  FaultInjector<std::string_view> fault;
-
   if (!user_id.empty()) {
     user_op.set_user_id(user_id);
     bucket_op.set_user_id(user_id);
@@ -6926,6 +6923,7 @@ next:
       max_entries = DEFAULT_RESHARD_MAX_ENTRIES;
     }
 
+    ReshardFaultInjector fault;
     if (inject_error_at) {
       fault.inject(*inject_error_at, InjectError{-EIO, dpp()});
     } else if (inject_abort_at) {

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6573,7 +6573,7 @@ next:
       RGWRados::BucketShard bs(store->getRados());
       int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
       const auto& current = bucket_info.layout.current_index;
-      int ret = bs.init(bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
+      int ret = bs.init(bucket, shard_id, current, std::nullopt, nullptr /* no RGWBucketInfo */);
       marker.clear();
 
       if (ret < 0) {
@@ -6638,7 +6638,7 @@ next:
       RGWRados::BucketShard bs(store->getRados());
       int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
       const auto& current = bucket_info.layout.current_index;
-      int ret = bs.init(bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
+      int ret = bs.init(bucket, shard_id, current, std::nullopt, nullptr /* no RGWBucketInfo */);
       if (ret < 0) {
         cerr << "ERROR: bs.init(bucket=" << bucket << ", shard=" << shard_id << "): " << cpp_strerror(-ret) << std::endl;
         return -ret;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6584,7 +6584,7 @@ next:
       do {
         entries.clear();
         ret = store->getRados()->bi_list(bs, object, marker, max_entries, &entries, &is_truncated);
-        if (ret < 0) {
+        if (ret < 0) {            
           cerr << "ERROR: bi_list(): " << cpp_strerror(-ret) << std::endl;
           return -ret;
         }

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2713,7 +2713,7 @@ int check_reshard_bucket_params(rgw::sal::RGWRadosStore *store,
     return ret;
   }
 
-  if (bucket_info.reshard_status != cls_rgw_reshard_status::NOT_RESHARDING) {
+  if (bucket_info.reshard_status != rgw::BucketReshardState::NOT_RESHARDING) {
     // if in_progress or done then we have an old BucketInfo
     cerr << "ERROR: the bucket is currently undergoing resharding and "
       "cannot be added to the reshard list at this time" << std::endl;
@@ -6575,8 +6575,8 @@ next:
     for (; i < max_shards; i++) {
       RGWRados::BucketShard bs(store->getRados());
       int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
-
-      int ret = bs.init(bucket, shard_id, bucket_info.layout.current_index, nullptr /* no RGWBucketInfo */);
+      const auto& current = bucket_info.layout.current_index;
+      int ret = bs.init(bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
       marker.clear();
 
       if (ret < 0) {
@@ -6640,7 +6640,8 @@ next:
     for (int i = 0; i < max_shards; i++) {
       RGWRados::BucketShard bs(store->getRados());
       int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
-      int ret = bs.init(bucket, shard_id, bucket_info.layout.current_index, nullptr /* no RGWBucketInfo */);
+      const auto& current = bucket_info.layout.current_index;
+      int ret = bs.init(bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
       if (ret < 0) {
         cerr << "ERROR: bs.init(bucket=" << bucket << ", shard=" << shard_id << "): " << cpp_strerror(-ret) << std::endl;
         return -ret;
@@ -6946,6 +6947,7 @@ next:
     entry.tenant = tenant;
     entry.bucket_name = bucket_name;
     entry.bucket_id = bucket_info.bucket.bucket_id;
+    entry.instance_id = bucket_info.bucket_instance_id;
     entry.old_num_shards = num_source_shards;
     entry.new_num_shards = num_shards;
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1092,9 +1092,6 @@ static void show_reshard_status(
   for (const auto& entry : status) {
     formatter->open_object_section("entry");
     formatter->dump_string("reshard_status", to_string(entry.reshard_status));
-    formatter->dump_string("bucket_instance_id",
-			   entry.bucket_instance_id);
-    formatter->dump_int("num_shards", entry.num_shards);
     formatter->close_section();
   }
   formatter->close_section();
@@ -2713,7 +2710,7 @@ int check_reshard_bucket_params(rgw::sal::RGWRadosStore *store,
     return ret;
   }
 
-  if (bucket_info.reshard_status != rgw::BucketReshardState::NOT_RESHARDING) {
+  if (bucket_info.reshard_status != cls_rgw_reshard_status::NOT_RESHARDING) {
     // if in_progress or done then we have an old BucketInfo
     cerr << "ERROR: the bucket is currently undergoing resharding and "
       "cannot be added to the reshard list at this time" << std::endl;
@@ -6947,7 +6944,6 @@ next:
     entry.tenant = tenant;
     entry.bucket_name = bucket_name;
     entry.bucket_id = bucket_info.bucket.bucket_id;
-    entry.instance_id = bucket_info.bucket_instance_id;
     entry.old_num_shards = num_source_shards;
     entry.new_num_shards = num_shards;
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6581,13 +6581,11 @@ next:
     int i = (specified_shard_id ? shard_id : 0);
     for (; i < max_shards; i++) {
       RGWRados::BucketShard bs(store->getRados());
-      int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
-      int ret = bs.init(bucket, shard_id, bucket_info.layout.current_index,
-      nullptr /* no RGWBucketInfo */);
+      int ret = bs.init(bucket_info, bucket_info.layout.current_index, i);
       marker.clear();
 
       if (ret < 0) {
-        cerr << "ERROR: bs.init(bucket=" << bucket << ", shard=" << shard_id << "): " << cpp_strerror(-ret) << std::endl;
+        cerr << "ERROR: bs.init(bucket=" << bucket << ", shard=" << i << "): " << cpp_strerror(-ret) << std::endl;
         return -ret;
       }
 
@@ -6646,11 +6644,9 @@ next:
 
     for (int i = 0; i < max_shards; i++) {
       RGWRados::BucketShard bs(store->getRados());
-      int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
-      int ret = bs.init(bucket, shard_id, bucket_info.layout.current_index,
-      nullptr /* no RGWBucketInfo */);
+      int ret = bs.init(bucket_info, bucket_info.layout.current_index, i);
       if (ret < 0) {
-        cerr << "ERROR: bs.init(bucket=" << bucket << ", shard=" << shard_id << "): " << cpp_strerror(-ret) << std::endl;
+        cerr << "ERROR: bs.init(bucket=" << bucket << ", shard=" << i << "): " << cpp_strerror(-ret) << std::endl;
         return -ret;
       }
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6572,8 +6572,8 @@ next:
     for (; i < max_shards; i++) {
       RGWRados::BucketShard bs(store->getRados());
       int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
-      const auto& current = bucket_info.layout.current_index;
-      int ret = bs.init(bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
+      int ret = bs.init(bucket, shard_id, bucket_info.layout.current_index,
+      nullptr /* no RGWBucketInfo */);
       marker.clear();
 
       if (ret < 0) {
@@ -6637,8 +6637,8 @@ next:
     for (int i = 0; i < max_shards; i++) {
       RGWRados::BucketShard bs(store->getRados());
       int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
-      const auto& current = bucket_info.layout.current_index;
-      int ret = bs.init(bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
+      int ret = bs.init(bucket, shard_id, bucket_info.layout.current_index,
+      nullptr /* no RGWBucketInfo */);
       if (ret < 0) {
         cerr << "ERROR: bs.init(bucket=" << bucket << ", shard=" << shard_id << "): " << cpp_strerror(-ret) << std::endl;
         return -ret;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6929,7 +6929,8 @@ next:
     } else if (inject_abort_at) {
       fault.inject(*inject_abort_at, InjectAbort{});
     }
-    return br.execute(num_shards, fault, max_entries, verbose, &cout, formatter.get());
+    ret = br.execute(num_shards, fault, max_entries, verbose, &cout, formatter.get());
+    return -ret;
   }
 
   if (opt_cmd == OPT::RESHARD_ADD) {

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2717,7 +2717,7 @@ int check_reshard_bucket_params(rgw::sal::RGWRadosStore *store,
     return -EBUSY;
   }
 
-  int num_source_shards = (bucket_info.layout.current_index.layout.normal.num_shards > 0 ? bucket_info.layout.current_index.layout.normal.num_shards : 1);
+  int num_source_shards = rgw::current_num_shards(bucket_info.layout);
 
   if (num_shards <= num_source_shards && !yes_i_really_mean_it) {
     cerr << "num shards is less or equal to current shards count" << std::endl
@@ -6564,7 +6564,7 @@ next:
       max_entries = 1000;
     }
 
-    int max_shards = (bucket_info.layout.current_index.layout.normal.num_shards > 0 ? bucket_info.layout.current_index.layout.normal.num_shards : 1);
+    int max_shards = rgw::current_num_shards(bucket_info.layout);
 
     formatter->open_array_section("entries");
 
@@ -6632,7 +6632,7 @@ next:
       return EINVAL;
     }
 
-    int max_shards = (bucket_info.layout.current_index.layout.normal.num_shards > 0 ? bucket_info.layout.current_index.layout.normal.num_shards : 1);
+    int max_shards = rgw::current_num_shards(bucket_info.layout);
 
     for (int i = 0; i < max_shards; i++) {
       RGWRados::BucketShard bs(store->getRados());
@@ -6936,7 +6936,7 @@ next:
       return ret;
     }
 
-    int num_source_shards = (bucket_info.layout.current_index.layout.normal.num_shards > 0 ? bucket_info.layout.current_index.layout.normal.num_shards : 1);
+    int num_source_shards = rgw::current_num_shards(bucket_info.layout);
 
     RGWReshard reshard(store);
     cls_rgw_reshard_entry entry;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1604,7 +1604,8 @@ static int purge_bucket_instance(rgw::sal::RGWRadosStore *store, const RGWBucket
   for (int i = 0; i < max_shards; i++) {
     RGWRados::BucketShard bs(store->getRados());
     int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
-    int ret = bs.init(bucket_info.bucket, shard_id, bucket_info.layout.current_index, nullptr);
+    const auto& current = bucket_info.layout.current_index;
+    int ret = bs.init(bucket_info.bucket, shard_id, current, nullptr);
     if (ret < 0) {
       cerr << "ERROR: bs.init(bucket=" << bucket_info.bucket << ", shard=" << shard_id
            << "): " << cpp_strerror(-ret) << std::endl;
@@ -1649,7 +1650,7 @@ void get_stale_instances(rgw::sal::RGWRadosStore *store, const std::string& buck
                           << cpp_strerror(-r) << dendl;
       continue;
     }
-    if (binfo.reshard_status == cls_rgw_reshard_status::DONE)
+    if (binfo.reshard_status == rgw::BucketReshardState::DONE)
       stale_instances.emplace_back(std::move(binfo));
     else {
       other_instances.emplace_back(std::move(binfo));

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1604,7 +1604,7 @@ static int purge_bucket_instance(rgw::sal::RGWRadosStore *store, const RGWBucket
   for (int i = 0; i < max_shards; i++) {
     RGWRados::BucketShard bs(store->getRados());
     int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
-    int ret = bs.init(bucket_info.bucket, shard_id, bucket_info.layout.current_index, nullptr);
+    int ret = bs.init(bucket_info, bucket_info.layout.current_index, shard_id);
     if (ret < 0) {
       cerr << "ERROR: bs.init(bucket=" << bucket_info.bucket << ", shard=" << shard_id
            << "): " << cpp_strerror(-ret) << std::endl;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -2623,7 +2623,7 @@ int RGWMetadataHandlerPut_BucketInstance::put_post()
 
   objv_tracker = bci.info.objv_tracker;
 
-  int ret = bihandler->svc.bi->init_index(bci.info);
+  int ret = bihandler->svc.bi->init_index(bci.info, bci.info.layout.current_index);
   if (ret < 0) {
     return ret;
   }

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1605,7 +1605,7 @@ static int purge_bucket_instance(rgw::sal::RGWRadosStore *store, const RGWBucket
     RGWRados::BucketShard bs(store->getRados());
     int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
     const auto& current = bucket_info.layout.current_index;
-    int ret = bs.init(bucket_info.bucket, shard_id, current, nullptr);
+    int ret = bs.init(bucket_info.bucket, shard_id, current, std::nullopt, nullptr);
     if (ret < 0) {
       cerr << "ERROR: bs.init(bucket=" << bucket_info.bucket << ", shard=" << shard_id
            << "): " << cpp_strerror(-ret) << std::endl;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1650,7 +1650,7 @@ void get_stale_instances(rgw::sal::RGWRadosStore *store, const std::string& buck
                           << cpp_strerror(-r) << dendl;
       continue;
     }
-    if (binfo.reshard_status == rgw::BucketReshardState::DONE)
+    if (binfo.reshard_status == cls_rgw_reshard_status::DONE)
       stale_instances.emplace_back(std::move(binfo));
     else {
       other_instances.emplace_back(std::move(binfo));

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1604,8 +1604,7 @@ static int purge_bucket_instance(rgw::sal::RGWRadosStore *store, const RGWBucket
   for (int i = 0; i < max_shards; i++) {
     RGWRados::BucketShard bs(store->getRados());
     int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
-    const auto& current = bucket_info.layout.current_index;
-    int ret = bs.init(bucket_info.bucket, shard_id, current, nullptr);
+    int ret = bs.init(bucket_info.bucket, shard_id, bucket_info.layout.current_index, nullptr);
     if (ret < 0) {
       cerr << "ERROR: bs.init(bucket=" << bucket_info.bucket << ", shard=" << shard_id
            << "): " << cpp_strerror(-ret) << std::endl;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1600,7 +1600,7 @@ int RGWBucketAdminOp::set_quota(rgw::sal::RGWRadosStore *store, RGWBucketAdminOp
 
 static int purge_bucket_instance(rgw::sal::RGWRadosStore *store, const RGWBucketInfo& bucket_info)
 {
-  int max_shards = (bucket_info.layout.current_index.layout.normal.num_shards > 0 ? bucket_info.layout.current_index.layout.normal.num_shards : 1);
+  int max_shards = rgw::current_num_shards(bucket_info.layout);
   for (int i = 0; i < max_shards; i++) {
     RGWRados::BucketShard bs(store->getRados());
     int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1605,7 +1605,7 @@ static int purge_bucket_instance(rgw::sal::RGWRadosStore *store, const RGWBucket
     RGWRados::BucketShard bs(store->getRados());
     int shard_id = (bucket_info.layout.current_index.layout.normal.num_shards > 0  ? i : -1);
     const auto& current = bucket_info.layout.current_index;
-    int ret = bs.init(bucket_info.bucket, shard_id, current, std::nullopt, nullptr);
+    int ret = bs.init(bucket_info.bucket, shard_id, current, nullptr);
     if (ret < 0) {
       cerr << "ERROR: bs.init(bucket=" << bucket_info.bucket << ", shard=" << shard_id
            << "): " << cpp_strerror(-ret) << std::endl;

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -66,7 +66,6 @@ void decode(bucket_index_layout& l, bufferlist::const_iterator& bl);
 struct bucket_index_layout_generation {
   uint64_t gen = 0;
   bucket_index_layout layout;
-
 };
 
 void encode(const bucket_index_layout_generation& l, bufferlist& bl, uint64_t f=0);

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -66,6 +66,7 @@ void decode(bucket_index_layout& l, bufferlist::const_iterator& bl);
 struct bucket_index_layout_generation {
   uint64_t gen = 0;
   bucket_index_layout layout;
+
 };
 
 void encode(const bucket_index_layout_generation& l, bufferlist& bl, uint64_t f=0);

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -121,13 +121,14 @@ inline bucket_log_layout_generation log_layout_from_index(
 }
 
 enum class BucketReshardState : uint8_t {
-  None,
-  InProgress,
+  NOT_RESHARDING,
+  IN_PROGRESS,
+  DONE,
 };
 
 // describes the layout of bucket index objects
 struct BucketLayout {
-  BucketReshardState resharding = BucketReshardState::None;
+  BucketReshardState resharding = BucketReshardState::NOT_RESHARDING;
 
   // current bucket index layout
   bucket_index_layout_generation current_index;

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -143,4 +143,8 @@ struct BucketLayout {
 void encode(const BucketLayout& l, bufferlist& bl, uint64_t f=0);
 void decode(BucketLayout& l, bufferlist::const_iterator& bl);
 
+inline uint32_t current_num_shards(const BucketLayout& layout) {
+  return std::max(layout.current_index.layout.normal.num_shards, 1u);
+  }
+
 } // namespace rgw

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -121,13 +121,13 @@ inline bucket_log_layout_generation log_layout_from_index(
 }
 
 enum class BucketReshardState : uint8_t {
-  NONE,
-  IN_PROGRESS,
+  None,
+  InProgress,
 };
 
 // describes the layout of bucket index objects
 struct BucketLayout {
-  BucketReshardState resharding = BucketReshardState::NONE;
+  BucketReshardState resharding = BucketReshardState::None;
 
   // current bucket index layout
   bucket_index_layout_generation current_index;

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -145,6 +145,6 @@ void decode(BucketLayout& l, bufferlist::const_iterator& bl);
 
 inline uint32_t current_num_shards(const BucketLayout& layout) {
   return std::max(layout.current_index.layout.normal.num_shards, 1u);
-  }
+}
 
 } // namespace rgw

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -121,14 +121,13 @@ inline bucket_log_layout_generation log_layout_from_index(
 }
 
 enum class BucketReshardState : uint8_t {
-  NOT_RESHARDING,
+  NONE,
   IN_PROGRESS,
-  DONE,
 };
 
 // describes the layout of bucket index objects
 struct BucketLayout {
-  BucketReshardState resharding = BucketReshardState::NOT_RESHARDING;
+  BucketReshardState resharding = BucketReshardState::NONE;
 
   // current bucket index layout
   bucket_index_layout_generation current_index;

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -2161,7 +2161,7 @@ void RGWBucketInfo::decode(bufferlist::const_iterator& bl) {
     decode(swift_versioning, bl);
     if (swift_versioning) {
       decode(swift_ver_location, bl);
-    }
+   }
   }
   if (struct_v >= 17) {
     decode(creation_time, bl);

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -997,11 +997,6 @@ struct RGWBucketInfo {
   // layout of bucket index objects
   rgw::BucketLayout layout;
 
-  // Represents the number of bucket index object shards:
-  //   - value of 0 indicates there is no sharding (this is by default
-  //     before this feature is implemented).
-  //   - value of UINT32_T::MAX indicates this is a blind bucket.
-
   // Represents the shard number for blind bucket.
   const static uint32_t NUM_SHARDS_BLIND_BUCKET;
 

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -520,7 +520,7 @@ int RGWOrphanSearch::build_linked_oids_for_bucket(const string& bucket_instance_
     return 0;
   }
 
-  if (cur_bucket_info.reshard_status == rgw::BucketReshardState::IN_PROGRESS) {
+  if (cur_bucket_info.reshard_status == cls_rgw_reshard_status::IN_PROGRESS) {
     ldout(store->ctx(), 0) << __func__ << ": reshard in progress. Skipping "
                            << orphan_bucket.name << ": "
                            << orphan_bucket.bucket_id << dendl;

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -520,7 +520,7 @@ int RGWOrphanSearch::build_linked_oids_for_bucket(const string& bucket_instance_
     return 0;
   }
 
-  if (cur_bucket_info.reshard_status == cls_rgw_reshard_status::IN_PROGRESS) {
+  if (cur_bucket_info.reshard_status == rgw::BucketReshardState::IN_PROGRESS) {
     ldout(store->ctx(), 0) << __func__ << ": reshard in progress. Skipping "
                            << orphan_bucket.name << ": "
                            << orphan_bucket.bucket_id << dendl;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2285,7 +2285,7 @@ int RGWRados::create_bucket(const RGWUserInfo& owner, rgw_bucket& bucket,
 
       /* only remove it if it's a different bucket instance */
       if (orig_info.bucket.bucket_id != bucket.bucket_id) {
-	int r = svc.bi->clean_index(info, info.layout.current_index.gen);
+	int r = svc.bi->clean_index(info, info.layout.current_index);
         if (r < 0) {
 	  ldout(cct, 0) << "WARNING: could not remove bucket index (r=" << r << ")" << dendl;
 	}

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2285,7 +2285,7 @@ int RGWRados::create_bucket(const RGWUserInfo& owner, rgw_bucket& bucket,
 
       /* only remove it if it's a different bucket instance */
       if (orig_info.bucket.bucket_id != bucket.bucket_id) {
-	int r = svc.bi->clean_index(info);
+	int r = svc.bi->clean_index(info, std::nullopt);
         if (r < 0) {
 	  ldout(cct, 0) << "WARNING: could not remove bucket index (r=" << r << ")" << dendl;
 	}
@@ -2658,7 +2658,7 @@ int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
 }
 
 int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
-				int sid, const rgw::bucket_index_layout_generation& idx_layout,
+				int sid, const rgw::bucket_index_layout_generation& target_layout,
 				RGWBucketInfo* bucket_info_out)
 {
   bucket = _bucket;
@@ -2677,7 +2677,7 @@ int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
 
   string oid;
 
-  ret = store->svc.bi_rados->open_bucket_index_shard(*bucket_info_p, shard_id, idx_layout, &bucket_obj);
+  ret = store->svc.bi_rados->open_bucket_index_shard(*bucket_info_p, shard_id, target_layout, &bucket_obj);
   if (ret < 0) {
     ldout(store->ctx(), 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
     return ret;
@@ -2705,12 +2705,12 @@ int RGWRados::BucketShard::init(const RGWBucketInfo& bucket_info,
   return 0;
 }
 
-int RGWRados::BucketShard::init(const RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout, int sid)
+int RGWRados::BucketShard::init(const RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& target_layout, int sid)
 {
   bucket = bucket_info.bucket;
   shard_id = sid;
 
-  int ret = store->svc.bi_rados->open_bucket_index_shard(bucket_info, shard_id, idx_layout, &bucket_obj);
+  int ret = store->svc.bi_rados->open_bucket_index_shard(bucket_info, shard_id, target_layout, &bucket_obj);
   if (ret < 0) {
     ldout(store->ctx(), 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
     return ret;
@@ -8109,7 +8109,8 @@ int RGWRados::bi_remove(BucketShard& bs)
 int RGWRados::bi_list(const RGWBucketInfo& bucket_info, int shard_id, const string& filter_obj, const string& marker, uint32_t max, list<rgw_cls_bi_entry> *entries, bool *is_truncated)
 {
   BucketShard bs(this);
-  int ret = bs.init(bucket_info.bucket, shard_id, bucket_info.layout.current_index, nullptr /* no RGWBucketInfo */);
+  const auto& current = bucket_info.layout.current_index;
+  int ret = bs.init(bucket_info.bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
   if (ret < 0) {
     ldout(cct, 5) << "bs.init() returned ret=" << ret << dendl;
     return ret;
@@ -8315,6 +8316,7 @@ int RGWRados::cls_bucket_list_ordered(RGWBucketInfo& bucket_info,
     "[" << start_after.instance <<
     "]\", prefix=\"" << prefix <<
     "\" num_entries=" << num_entries <<
+    ", shard_id=" << shard_id <<
     ", list_versions=" << list_versions <<
     ", expansion_factor=" << expansion_factor << dendl;
 
@@ -8947,6 +8949,7 @@ int RGWRados::cls_bucket_head(const RGWBucketInfo& bucket_info, int shard_id, ve
   map<int, string> oids;
   map<int, struct rgw_cls_list_ret> list_results;
   int r = svc.bi_rados->open_bucket_index(bucket_info, shard_id, &index_pool, &oids, bucket_instance_ids);
+  ldout(cct, 20) << "open_bucket_index() run" << dendl;
   if (r < 0) {
     ldout(cct, 20) << "cls_bucket_head: open_bucket_index() returned "
                    << r << dendl;
@@ -8954,6 +8957,7 @@ int RGWRados::cls_bucket_head(const RGWBucketInfo& bucket_info, int shard_id, ve
   }
 
   r = CLSRGWIssueGetDirHeader(index_pool.ioctx(), oids, list_results, cct->_conf->rgw_bucket_index_max_aio)();
+  ldout(cct, 20) << "CLSRGWIssueGetDirHeader issued" << dendl;
   if (r < 0) {
     ldout(cct, 20) << "cls_bucket_head: CLSRGWIssueGetDirHeader() returned "
                    << r << dendl;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6017,22 +6017,15 @@ int RGWRados::Bucket::UpdateIndex::guard_reshard(BucketShard **pbs, std::functio
       break;
     }
     ldout(store->ctx(), 0) << "NOTICE: resharding operation on bucket index detected, blocking" << dendl;
-    string new_bucket_id;
-    r = store->block_while_resharding(bs, &new_bucket_id,
-                                      target->bucket_info, null_yield);
+    r = store->block_while_resharding(bs, target->bucket_info, null_yield);
     if (r == -ERR_BUSY_RESHARDING) {
       continue;
     }
     if (r < 0) {
       return r;
     }
-    ldout(store->ctx(), 20) << "reshard completion identified, new_bucket_id=" << new_bucket_id << dendl;
+    ldout(store->ctx(), 20) << "reshard completion identified" << dendl;
     i = 0; /* resharding is finished, make sure we can retry */
-    r = target->update_bucket_id(new_bucket_id);
-    if (r < 0) {
-      ldout(store->ctx(), 0) << "ERROR: update_bucket_id() new_bucket_id=" << new_bucket_id << " returned r=" << r << dendl;
-      return r;
-    }
     invalidate_bs();
   } // for loop
 
@@ -6630,7 +6623,7 @@ int RGWRados::olh_init_modification(const RGWBucketInfo& bucket_info, RGWObjStat
 
 int RGWRados::guard_reshard(BucketShard *bs,
 			    const rgw_obj& obj_instance,
-			    const RGWBucketInfo& bucket_info,
+			    RGWBucketInfo& bucket_info,
 			    std::function<int(BucketShard *)> call)
 {
   rgw_obj obj;
@@ -6648,20 +6641,15 @@ int RGWRados::guard_reshard(BucketShard *bs,
       break;
     }
     ldout(cct, 0) << "NOTICE: resharding operation on bucket index detected, blocking" << dendl;
-    string new_bucket_id;
-    r = block_while_resharding(bs, &new_bucket_id, bucket_info, null_yield);
+    r = block_while_resharding(bs, bucket_info, null_yield);
     if (r == -ERR_BUSY_RESHARDING) {
       continue;
     }
     if (r < 0) {
       return r;
     }
-    ldout(cct, 20) << "reshard completion identified, new_bucket_id=" << new_bucket_id << dendl;
+    ldout(cct, 20) << "reshard completion identified" << dendl;
     i = 0; /* resharding is finished, make sure we can retry */
-
-    obj = *pobj;
-    obj.bucket.update_bucket_id(new_bucket_id);
-    pobj = &obj;
   } // for loop
 
   if (r < 0) {
@@ -6672,8 +6660,7 @@ int RGWRados::guard_reshard(BucketShard *bs,
 }
 
 int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
-				     string *new_bucket_id,
-                                     const RGWBucketInfo& bucket_info,
+                                     RGWBucketInfo& bucket_info,
                                      optional_yield y)
 {
   int ret = 0;
@@ -6684,18 +6671,15 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
   // lambda successfully fetches a new bucket id, it sets
   // new_bucket_id and returns 0, otherwise it returns a negative
   // error code
-  auto fetch_new_bucket_id =
-    [this, &bucket_info](const std::string& log_tag,
-			 std::string* new_bucket_id) -> int {
-      RGWBucketInfo fresh_bucket_info = bucket_info;
-      int ret = try_refresh_bucket_info(fresh_bucket_info, nullptr);
+  auto fetch_new_bucket_info =
+    [this, &bucket_info](const std::string& log_tag) -> int {
+      int ret = try_refresh_bucket_info(bucket_info, nullptr);
       if (ret < 0) {
 	ldout(cct, 0) << __func__ <<
 	  " ERROR: failed to refresh bucket info after reshard at " <<
 	  log_tag << ": " << cpp_strerror(-ret) << dendl;
 	return ret;
       }
-      *new_bucket_id = fresh_bucket_info.bucket.bucket_id;
       return 0;
     };
 
@@ -6704,7 +6688,7 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
     auto& ref = bs->bucket_obj.get_ref();
     ret = cls_rgw_get_bucket_resharding(ref.pool.ioctx(), ref.obj.oid, &entry);
     if (ret == -ENOENT) {
-      return fetch_new_bucket_id("get_bucket_resharding_failed", new_bucket_id);
+      return fetch_new_bucket_info("get_bucket_resharding_failed");
     } else if (ret < 0) {
       ldout(cct, 0) << __func__ <<
 	" ERROR: failed to get bucket resharding : " << cpp_strerror(-ret) <<
@@ -6713,8 +6697,7 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
     }
 
     if (!entry.resharding_in_progress()) {
-      return fetch_new_bucket_id("get_bucket_resharding_succeeded",
-				 new_bucket_id);
+      return fetch_new_bucket_info("get_bucket_resharding_succeeded");
     }
 
     ldout(cct, 20) << "NOTICE: reshard still in progress; " <<
@@ -6774,7 +6757,7 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
   return -ERR_BUSY_RESHARDING;
 }
 
-int RGWRados::bucket_index_link_olh(const RGWBucketInfo& bucket_info, RGWObjState& olh_state, const rgw_obj& obj_instance,
+int RGWRados::bucket_index_link_olh(RGWBucketInfo bucket_info, RGWObjState& olh_state, const rgw_obj& obj_instance,
                                     bool delete_marker,
                                     const string& op_tag,
                                     struct rgw_bucket_dir_entry_meta *meta,
@@ -6827,7 +6810,7 @@ void RGWRados::bucket_index_guard_olh_op(RGWObjState& olh_state, ObjectOperation
   op.cmpxattr(RGW_ATTR_OLH_ID_TAG, CEPH_OSD_CMPXATTR_OP_EQ, olh_state.olh_tag);
 }
 
-int RGWRados::bucket_index_unlink_instance(const RGWBucketInfo& bucket_info, const rgw_obj& obj_instance,
+int RGWRados::bucket_index_unlink_instance(RGWBucketInfo bucket_info, const rgw_obj& obj_instance,
                                            const string& op_tag, const string& olh_tag, uint64_t olh_epoch, rgw_zone_set *_zones_trace)
 {
   rgw_rados_ref ref;
@@ -6862,7 +6845,7 @@ int RGWRados::bucket_index_unlink_instance(const RGWBucketInfo& bucket_info, con
   return 0;
 }
 
-int RGWRados::bucket_index_read_olh_log(const RGWBucketInfo& bucket_info, RGWObjState& state,
+int RGWRados::bucket_index_read_olh_log(RGWBucketInfo bucket_info, RGWObjState& state,
                                         const rgw_obj& obj_instance, uint64_t ver_marker,
                                         map<uint64_t, vector<rgw_bucket_olh_log_entry> > *log,
                                         bool *is_truncated)
@@ -6970,7 +6953,7 @@ int RGWRados::repair_olh(RGWObjState* state, const RGWBucketInfo& bucket_info,
   return 0;
 }
 
-int RGWRados::bucket_index_trim_olh_log(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& obj_instance, uint64_t ver)
+int RGWRados::bucket_index_trim_olh_log(RGWBucketInfo bucket_info, RGWObjState& state, const rgw_obj& obj_instance, uint64_t ver)
 {
   rgw_rados_ref ref;
   int r = get_obj_head_ref(bucket_info, obj_instance, &ref);
@@ -7005,7 +6988,7 @@ int RGWRados::bucket_index_trim_olh_log(const RGWBucketInfo& bucket_info, RGWObj
   return 0;
 }
 
-int RGWRados::bucket_index_clear_olh(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& obj_instance)
+int RGWRados::bucket_index_clear_olh(RGWBucketInfo bucket_info, RGWObjState& state, const rgw_obj& obj_instance)
 {
   rgw_rados_ref ref;
   int r = get_obj_head_ref(bucket_info, obj_instance, &ref);
@@ -7708,6 +7691,7 @@ int RGWRados::try_refresh_bucket_info(RGWBucketInfo& info,
 				      .set_mtime(pmtime)
 				      .set_attrs(pattrs)
 				      .set_refresh_version(rv));
+            
 }
 
 int RGWRados::put_bucket_instance_info(RGWBucketInfo& info, bool exclusive,

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2550,7 +2550,7 @@ done_err:
  * fixes an issue where head objects were supposed to have a locator created, but ended
  * up without one
  */
-int RGWRados::fix_tail_obj_locator(const RGWBucketInfo& bucket_info, rgw_obj_key& key, bool fix, bool *need_fix, optional_yield y)
+int RGWRados::fix_tail_obj_locator(RGWBucketInfo& bucket_info, rgw_obj_key& key, bool fix, bool *need_fix, optional_yield y)
 {
   const rgw_bucket& bucket = bucket_info.bucket;
   rgw_obj obj(bucket, key);
@@ -2658,8 +2658,7 @@ int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
 }
 
 int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
-				int sid, const rgw::bucket_index_layout_generation& current_layout,
-        std::optional<rgw::bucket_index_layout_generation> target_layout,
+				int sid, std::optional<rgw::bucket_index_layout_generation> idx_layout,
 				RGWBucketInfo* bucket_info_out)
 {
   bucket = _bucket;
@@ -2678,13 +2677,9 @@ int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
 
   string oid;
 
-  if (target_layout) {
-    ret = store->svc.bi_rados->open_bucket_index_shard(*bucket_info_p, shard_id, target_layout->layout.normal.num_shards,
-                                                      target_layout->gen, &bucket_obj);
-  } else {
-    ret = store->svc.bi_rados->open_bucket_index_shard(*bucket_info_p, shard_id, current_layout.layout.normal.num_shards,
-                                                      current_layout.gen, &bucket_obj);
-  }
+  ret = store->svc.bi_rados->open_bucket_index_shard(*bucket_info_p, shard_id, idx_layout->layout.normal.num_shards,
+                                                    idx_layout->gen, &bucket_obj);
+
   if (ret < 0) {
   ldout(store->ctx(), 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
   return ret;
@@ -4918,7 +4913,7 @@ int RGWRados::bucket_set_reshard(const RGWBucketInfo& bucket_info, const cls_rgw
   return CLSRGWIssueSetBucketResharding(index_pool.ioctx(), bucket_objs, entry, cct->_conf->rgw_bucket_index_max_aio)();
 }
 
-int RGWRados::defer_gc(void *ctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj, optional_yield y)
+int RGWRados::defer_gc(void *ctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, optional_yield y)
 {
   RGWObjectCtx *rctx = static_cast<RGWObjectCtx *>(ctx);
   std::string oid, key;
@@ -5286,7 +5281,7 @@ static bool has_olh_tag(map<string, bufferlist>& attrs)
   return (iter != attrs.end());
 }
 
-int RGWRados::get_olh_target_state(RGWObjectCtx& obj_ctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj,
+int RGWRados::get_olh_target_state(RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_info, const rgw_obj& obj,
                                    RGWObjState *olh_state, RGWObjState **target_state, optional_yield y)
 {
   ceph_assert(olh_state->is_olh);
@@ -5304,7 +5299,7 @@ int RGWRados::get_olh_target_state(RGWObjectCtx& obj_ctx, const RGWBucketInfo& b
   return 0;
 }
 
-int RGWRados::get_obj_state_impl(RGWObjectCtx *rctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj,
+int RGWRados::get_obj_state_impl(RGWObjectCtx *rctx, RGWBucketInfo& bucket_info, const rgw_obj& obj,
                                  RGWObjState **state, bool follow_olh, optional_yield y, bool assume_noent)
 {
   if (obj.empty()) {
@@ -5482,7 +5477,7 @@ int RGWRados::get_obj_state_impl(RGWObjectCtx *rctx, const RGWBucketInfo& bucket
   return 0;
 }
 
-int RGWRados::get_obj_state(RGWObjectCtx *rctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWObjState **state,
+int RGWRados::get_obj_state(RGWObjectCtx *rctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWObjState **state,
                             bool follow_olh, optional_yield y, bool assume_noent)
 {
   int ret;
@@ -5601,7 +5596,7 @@ int RGWRados::Object::Stat::finish()
 }
 
 int RGWRados::append_atomic_test(RGWObjectCtx *rctx,
-                                 const RGWBucketInfo& bucket_info, const rgw_obj& obj,
+                                 RGWBucketInfo& bucket_info, const rgw_obj& obj,
                                  ObjectOperation& op, RGWObjState **pstate, optional_yield y)
 {
   if (!rctx)
@@ -5741,14 +5736,14 @@ int RGWRados::Object::prepare_atomic_modification(ObjectWriteOperation& op, bool
  * bl: the contents of the attr
  * Returns: 0 on success, -ERR# otherwise.
  */
-int RGWRados::set_attr(void *ctx, const RGWBucketInfo& bucket_info, rgw_obj& obj, const char *name, bufferlist& bl)
+int RGWRados::set_attr(void *ctx, RGWBucketInfo& bucket_info, rgw_obj& obj, const char *name, bufferlist& bl)
 {
   map<string, bufferlist> attrs;
   attrs[name] = bl;
   return set_attrs(ctx, bucket_info, obj, attrs, NULL, null_yield);
 }
 
-int RGWRados::set_attrs(void *ctx, const RGWBucketInfo& bucket_info, rgw_obj& src_obj,
+int RGWRados::set_attrs(void *ctx, RGWBucketInfo& bucket_info, rgw_obj& src_obj,
                         map<string, bufferlist>& attrs,
                         map<string, bufferlist>* rmattrs,
                         optional_yield y)
@@ -6433,7 +6428,7 @@ int RGWRados::Object::Read::iterate(int64_t ofs, int64_t end, RGWGetDataCB *cb,
 }
 
 int RGWRados::iterate_obj(RGWObjectCtx& obj_ctx,
-                          const RGWBucketInfo& bucket_info, const rgw_obj& obj,
+                          RGWBucketInfo& bucket_info, const rgw_obj& obj,
                           off_t ofs, off_t end, uint64_t max_chunk_size,
                           iterate_obj_cb cb, void *arg, optional_yield y)
 {
@@ -6764,7 +6759,7 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
   return -ERR_BUSY_RESHARDING;
 }
 
-int RGWRados::bucket_index_link_olh(RGWBucketInfo bucket_info, RGWObjState& olh_state, const rgw_obj& obj_instance,
+int RGWRados::bucket_index_link_olh(RGWBucketInfo& bucket_info, RGWObjState& olh_state, const rgw_obj& obj_instance,
                                     bool delete_marker,
                                     const string& op_tag,
                                     struct rgw_bucket_dir_entry_meta *meta,
@@ -6817,7 +6812,7 @@ void RGWRados::bucket_index_guard_olh_op(RGWObjState& olh_state, ObjectOperation
   op.cmpxattr(RGW_ATTR_OLH_ID_TAG, CEPH_OSD_CMPXATTR_OP_EQ, olh_state.olh_tag);
 }
 
-int RGWRados::bucket_index_unlink_instance(RGWBucketInfo bucket_info, const rgw_obj& obj_instance,
+int RGWRados::bucket_index_unlink_instance(RGWBucketInfo& bucket_info, const rgw_obj& obj_instance,
                                            const string& op_tag, const string& olh_tag, uint64_t olh_epoch, rgw_zone_set *_zones_trace)
 {
   rgw_rados_ref ref;
@@ -6852,7 +6847,7 @@ int RGWRados::bucket_index_unlink_instance(RGWBucketInfo bucket_info, const rgw_
   return 0;
 }
 
-int RGWRados::bucket_index_read_olh_log(RGWBucketInfo bucket_info, RGWObjState& state,
+int RGWRados::bucket_index_read_olh_log(RGWBucketInfo& bucket_info, RGWObjState& state,
                                         const rgw_obj& obj_instance, uint64_t ver_marker,
                                         map<uint64_t, vector<rgw_bucket_olh_log_entry> > *log,
                                         bool *is_truncated)
@@ -6960,7 +6955,7 @@ int RGWRados::repair_olh(RGWObjState* state, const RGWBucketInfo& bucket_info,
   return 0;
 }
 
-int RGWRados::bucket_index_trim_olh_log(RGWBucketInfo bucket_info, RGWObjState& state, const rgw_obj& obj_instance, uint64_t ver)
+int RGWRados::bucket_index_trim_olh_log(RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& obj_instance, uint64_t ver)
 {
   rgw_rados_ref ref;
   int r = get_obj_head_ref(bucket_info, obj_instance, &ref);
@@ -6995,7 +6990,7 @@ int RGWRados::bucket_index_trim_olh_log(RGWBucketInfo bucket_info, RGWObjState& 
   return 0;
 }
 
-int RGWRados::bucket_index_clear_olh(RGWBucketInfo bucket_info, RGWObjState& state, const rgw_obj& obj_instance)
+int RGWRados::bucket_index_clear_olh(RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& obj_instance)
 {
   rgw_rados_ref ref;
   int r = get_obj_head_ref(bucket_info, obj_instance, &ref);
@@ -7037,7 +7032,7 @@ static int decode_olh_info(CephContext* cct, const bufferlist& bl, RGWOLHInfo *o
   }
 }
 
-int RGWRados::apply_olh_log(RGWObjectCtx& obj_ctx, RGWObjState& state, const RGWBucketInfo& bucket_info, const rgw_obj& obj,
+int RGWRados::apply_olh_log(RGWObjectCtx& obj_ctx, RGWObjState& state, RGWBucketInfo& bucket_info, const rgw_obj& obj,
                             bufferlist& olh_tag, map<uint64_t, vector<rgw_bucket_olh_log_entry> >& log,
                             uint64_t *plast_ver, rgw_zone_set* zones_trace)
 {
@@ -7204,7 +7199,7 @@ int RGWRados::apply_olh_log(RGWObjectCtx& obj_ctx, RGWObjState& state, const RGW
 /*
  * read olh log and apply it
  */
-int RGWRados::update_olh(RGWObjectCtx& obj_ctx, RGWObjState *state, const RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_zone_set *zones_trace)
+int RGWRados::update_olh(RGWObjectCtx& obj_ctx, RGWObjState *state, RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_zone_set *zones_trace)
 {
   map<uint64_t, vector<rgw_bucket_olh_log_entry> > log;
   bool is_truncated;
@@ -7224,7 +7219,7 @@ int RGWRados::update_olh(RGWObjectCtx& obj_ctx, RGWObjState *state, const RGWBuc
   return 0;
 }
 
-int RGWRados::set_olh(RGWObjectCtx& obj_ctx, const RGWBucketInfo& bucket_info, const rgw_obj& target_obj, bool delete_marker, rgw_bucket_dir_entry_meta *meta,
+int RGWRados::set_olh(RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_info, const rgw_obj& target_obj, bool delete_marker, rgw_bucket_dir_entry_meta *meta,
                       uint64_t olh_epoch, real_time unmod_since, bool high_precision_time,
                       optional_yield y, rgw_zone_set *zones_trace, bool log_data_change)
 {
@@ -7454,7 +7449,7 @@ int RGWRados::remove_olh_pending_entries(const RGWBucketInfo& bucket_info, RGWOb
   return 0;
 }
 
-int RGWRados::follow_olh(const RGWBucketInfo& bucket_info, RGWObjectCtx& obj_ctx, RGWObjState *state, const rgw_obj& olh_obj, rgw_obj *target)
+int RGWRados::follow_olh(RGWBucketInfo& bucket_info, RGWObjectCtx& obj_ctx, RGWObjState *state, const rgw_obj& olh_obj, rgw_obj *target)
 {
   map<string, bufferlist> pending_entries;
   rgw_filter_attrset(state->attrset, RGW_ATTR_OLH_PENDING_PREFIX, &pending_entries);
@@ -8101,7 +8096,7 @@ int RGWRados::bi_list(const RGWBucketInfo& bucket_info, int shard_id, const stri
 {
   BucketShard bs(this);
   const auto& current = bucket_info.layout.current_index;
-  int ret = bs.init(bucket_info.bucket, shard_id, current, std::nullopt, nullptr /* no RGWBucketInfo */);
+  int ret = bs.init(bucket_info.bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
   if (ret < 0) {
     ldout(cct, 5) << "bs.init() returned ret=" << ret << dendl;
     return ret;
@@ -8824,7 +8819,7 @@ int RGWRados::remove_objs_from_index(RGWBucketInfo& bucket_info, list<rgw_obj_in
 }
 
 int RGWRados::check_disk_state(librados::IoCtx io_ctx,
-                               const RGWBucketInfo& bucket_info,
+                               RGWBucketInfo& bucket_info,
                                rgw_bucket_dir_entry& list_state,
                                rgw_bucket_dir_entry& object,
                                bufferlist& suggested_updates,

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8984,8 +8984,7 @@ int RGWRados::check_bucket_shards(const RGWBucketInfo& bucket_info,
   }
 
   bool need_resharding = false;
-  uint32_t num_source_shards =
-    (bucket_info.layout.current_index.layout.normal.num_shards > 0 ? bucket_info.layout.current_index.layout.normal.num_shards : 1);
+  uint32_t num_source_shards = rgw::current_num_shards(bucket_info.layout);
   const uint32_t max_dynamic_shards =
     uint32_t(cct->_conf.get_val<uint64_t>("rgw_max_dynamic_shards"));
 
@@ -9023,7 +9022,7 @@ int RGWRados::add_bucket_to_reshard(const RGWBucketInfo& bucket_info, uint32_t n
 {
   RGWReshard reshard(this->store);
 
-  uint32_t num_source_shards = (bucket_info.layout.current_index.layout.normal.num_shards > 0 ? bucket_info.layout.current_index.layout.normal.num_shards : 1);
+  uint32_t num_source_shards = rgw::current_num_shards(bucket_info.layout);
 
   new_num_shards = std::min(new_num_shards, get_max_bucket_shards());
   if (new_num_shards <= num_source_shards) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8949,7 +8949,6 @@ int RGWRados::cls_bucket_head(const RGWBucketInfo& bucket_info, int shard_id, ve
   map<int, string> oids;
   map<int, struct rgw_cls_list_ret> list_results;
   int r = svc.bi_rados->open_bucket_index(bucket_info, shard_id, &index_pool, &oids, bucket_instance_ids);
-  ldout(cct, 20) << "open_bucket_index() run" << dendl;
   if (r < 0) {
     ldout(cct, 20) << "cls_bucket_head: open_bucket_index() returned "
                    << r << dendl;
@@ -8957,7 +8956,6 @@ int RGWRados::cls_bucket_head(const RGWBucketInfo& bucket_info, int shard_id, ve
   }
 
   r = CLSRGWIssueGetDirHeader(index_pool.ioctx(), oids, list_results, cct->_conf->rgw_bucket_index_max_aio)();
-  ldout(cct, 20) << "CLSRGWIssueGetDirHeader issued" << dendl;
   if (r < 0) {
     ldout(cct, 20) << "cls_bucket_head: CLSRGWIssueGetDirHeader() returned "
                    << r << dendl;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2658,7 +2658,8 @@ int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
 }
 
 int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
-				int sid, const rgw::bucket_index_layout_generation& target_layout,
+				int sid, const rgw::bucket_index_layout_generation& current_layout,
+        std::optional<rgw::bucket_index_layout_generation> target_layout,
 				RGWBucketInfo* bucket_info_out)
 {
   bucket = _bucket;
@@ -2677,10 +2678,16 @@ int RGWRados::BucketShard::init(const rgw_bucket& _bucket,
 
   string oid;
 
-  ret = store->svc.bi_rados->open_bucket_index_shard(*bucket_info_p, shard_id, target_layout, &bucket_obj);
+  if (target_layout) {
+    ret = store->svc.bi_rados->open_bucket_index_shard(*bucket_info_p, shard_id, target_layout->layout.normal.num_shards,
+                                                      target_layout->gen, &bucket_obj);
+  } else {
+    ret = store->svc.bi_rados->open_bucket_index_shard(*bucket_info_p, shard_id, current_layout.layout.normal.num_shards,
+                                                      current_layout.gen, &bucket_obj);
+  }
   if (ret < 0) {
-    ldout(store->ctx(), 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
-    return ret;
+  ldout(store->ctx(), 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
+  return ret;
   }
   ldout(store->ctx(), 20) << " bucket index oid: " << bucket_obj.get_raw_obj() << dendl;
 
@@ -2705,12 +2712,12 @@ int RGWRados::BucketShard::init(const RGWBucketInfo& bucket_info,
   return 0;
 }
 
-int RGWRados::BucketShard::init(const RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& target_layout, int sid)
+int RGWRados::BucketShard::init(const RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& current_layout, int sid)
 {
   bucket = bucket_info.bucket;
   shard_id = sid;
 
-  int ret = store->svc.bi_rados->open_bucket_index_shard(bucket_info, shard_id, target_layout, &bucket_obj);
+  int ret = store->svc.bi_rados->open_bucket_index_shard(bucket_info, shard_id, current_layout.layout.normal.num_shards, std::nullopt, &bucket_obj);
   if (ret < 0) {
     ldout(store->ctx(), 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
     return ret;
@@ -8094,7 +8101,7 @@ int RGWRados::bi_list(const RGWBucketInfo& bucket_info, int shard_id, const stri
 {
   BucketShard bs(this);
   const auto& current = bucket_info.layout.current_index;
-  int ret = bs.init(bucket_info.bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
+  int ret = bs.init(bucket_info.bucket, shard_id, current, std::nullopt, nullptr /* no RGWBucketInfo */);
   if (ret < 0) {
     ldout(cct, 5) << "bs.init() returned ret=" << ret << dendl;
     return ret;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7693,7 +7693,6 @@ int RGWRados::try_refresh_bucket_info(RGWBucketInfo& info,
 				      .set_mtime(pmtime)
 				      .set_attrs(pattrs)
 				      .set_refresh_version(rv));
-            
 }
 
 int RGWRados::put_bucket_instance_info(RGWBucketInfo& info, bool exclusive,

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2262,7 +2262,7 @@ int RGWRados::create_bucket(const RGWUserInfo& owner, rgw_bucket& bucket,
       info.quota = *pquota_info;
     }
 
-    int r = svc.bi->init_index(info);
+    int r = svc.bi->init_index(info, info.layout.current_index);
     if (r < 0) {
       return r;
     }
@@ -2285,7 +2285,7 @@ int RGWRados::create_bucket(const RGWUserInfo& owner, rgw_bucket& bucket,
 
       /* only remove it if it's a different bucket instance */
       if (orig_info.bucket.bucket_id != bucket.bucket_id) {
-	int r = svc.bi->clean_index(info, std::nullopt);
+	int r = svc.bi->clean_index(info, info.layout.current_index.gen);
         if (r < 0) {
 	  ldout(cct, 0) << "WARNING: could not remove bucket index (r=" << r << ")" << dendl;
 	}
@@ -2712,7 +2712,7 @@ int RGWRados::BucketShard::init(const RGWBucketInfo& bucket_info, const rgw::buc
   bucket = bucket_info.bucket;
   shard_id = sid;
 
-  int ret = store->svc.bi_rados->open_bucket_index_shard(bucket_info, shard_id, current_layout.layout.normal.num_shards, std::nullopt, &bucket_obj);
+  int ret = store->svc.bi_rados->open_bucket_index_shard(bucket_info, shard_id, current_layout.layout.normal.num_shards, current_layout.gen, &bucket_obj);
   if (ret < 0) {
     ldout(store->ctx(), 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
     return ret;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8094,8 +8094,8 @@ int RGWRados::bi_remove(BucketShard& bs)
 int RGWRados::bi_list(const RGWBucketInfo& bucket_info, int shard_id, const string& filter_obj, const string& marker, uint32_t max, list<rgw_cls_bi_entry> *entries, bool *is_truncated)
 {
   BucketShard bs(this);
-  const auto& current = bucket_info.layout.current_index;
-  int ret = bs.init(bucket_info.bucket, shard_id, current, nullptr /* no RGWBucketInfo */);
+  int ret = bs.init(bucket_info.bucket, shard_id, bucket_info.layout.current_index,
+  nullptr /* no RGWBucketInfo */);
   if (ret < 0) {
     ldout(cct, 5) << "bs.init() returned ret=" << ret << dendl;
     return ret;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -690,10 +690,9 @@ public:
 
     explicit BucketShard(RGWRados *_store) : store(_store), shard_id(-1) {}
     int init(const rgw_bucket& _bucket, const rgw_obj& obj, RGWBucketInfo* out);
-    int init(const rgw_bucket& _bucket, int sid, std::optional<rgw::bucket_index_layout_generation> current_layout,
-            RGWBucketInfo* out);
     int init(const RGWBucketInfo& bucket_info, const rgw_obj& obj);
-    int init(const RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout, int sid);
+    int init(const RGWBucketInfo& bucket_info,
+             const rgw::bucket_index_layout_generation& index, int sid);
   };
 
   class Object {

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -690,7 +690,8 @@ public:
 
     explicit BucketShard(RGWRados *_store) : store(_store), shard_id(-1) {}
     int init(const rgw_bucket& _bucket, const rgw_obj& obj, RGWBucketInfo* out);
-    int init(const rgw_bucket& _bucket, int sid, const rgw::bucket_index_layout_generation& idx_layout, RGWBucketInfo* out);
+    int init(const rgw_bucket& _bucket, int sid, const rgw::bucket_index_layout_generation& current_layout,
+            std::optional<rgw::bucket_index_layout_generation> target_layout, RGWBucketInfo* out);
     int init(const RGWBucketInfo& bucket_info, const rgw_obj& obj);
     int init(const RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout, int sid);
   };

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1285,28 +1285,27 @@ public:
 
   int guard_reshard(BucketShard *bs,
 		    const rgw_obj& obj_instance,
-		    const RGWBucketInfo& bucket_info,
+		    RGWBucketInfo& bucket_info,
 		    std::function<int(BucketShard *)> call);
   int block_while_resharding(RGWRados::BucketShard *bs,
-			     string *new_bucket_id,
-			     const RGWBucketInfo& bucket_info,
+			     RGWBucketInfo& bucket_info,
                              optional_yield y);
 
   void bucket_index_guard_olh_op(RGWObjState& olh_state, librados::ObjectOperation& op);
   int olh_init_modification(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& olh_obj, string *op_tag);
   int olh_init_modification_impl(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& olh_obj, string *op_tag);
-  int bucket_index_link_olh(const RGWBucketInfo& bucket_info, RGWObjState& olh_state,
+  int bucket_index_link_olh(RGWBucketInfo bucket_info, RGWObjState& olh_state,
                             const rgw_obj& obj_instance, bool delete_marker,
                             const string& op_tag, struct rgw_bucket_dir_entry_meta *meta,
                             uint64_t olh_epoch,
                             ceph::real_time unmod_since, bool high_precision_time,
                             rgw_zone_set *zones_trace = nullptr,
                             bool log_data_change = false);
-  int bucket_index_unlink_instance(const RGWBucketInfo& bucket_info, const rgw_obj& obj_instance, const string& op_tag, const string& olh_tag, uint64_t olh_epoch, rgw_zone_set *zones_trace = nullptr);
-  int bucket_index_read_olh_log(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& obj_instance, uint64_t ver_marker,
+  int bucket_index_unlink_instance(RGWBucketInfo bucket_info, const rgw_obj& obj_instance, const string& op_tag, const string& olh_tag, uint64_t olh_epoch, rgw_zone_set *zones_trace = nullptr);
+  int bucket_index_read_olh_log(RGWBucketInfo bucket_info, RGWObjState& state, const rgw_obj& obj_instance, uint64_t ver_marker,
                                 map<uint64_t, vector<rgw_bucket_olh_log_entry> > *log, bool *is_truncated);
-  int bucket_index_trim_olh_log(const RGWBucketInfo& bucket_info, RGWObjState& obj_state, const rgw_obj& obj_instance, uint64_t ver);
-  int bucket_index_clear_olh(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& obj_instance);
+  int bucket_index_trim_olh_log(RGWBucketInfo bucket_info, RGWObjState& obj_state, const rgw_obj& obj_instance, uint64_t ver);
+  int bucket_index_clear_olh(RGWBucketInfo bucket_info, RGWObjState& state, const rgw_obj& obj_instance);
   int apply_olh_log(RGWObjectCtx& ctx, RGWObjState& obj_state, const RGWBucketInfo& bucket_info, const rgw_obj& obj,
                     bufferlist& obj_tag, map<uint64_t, vector<rgw_bucket_olh_log_entry> >& log,
                     uint64_t *plast_ver, rgw_zone_set *zones_trace = nullptr);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -464,11 +464,11 @@ class RGWRados
   int get_system_obj_ref(const rgw_raw_obj& obj, rgw_rados_ref *ref);
   uint64_t max_bucket_id;
 
-  int get_olh_target_state(RGWObjectCtx& rctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj,
+  int get_olh_target_state(RGWObjectCtx& rctx, RGWBucketInfo& bucket_info, const rgw_obj& obj,
                            RGWObjState *olh_state, RGWObjState **target_state, optional_yield y);
-  int get_obj_state_impl(RGWObjectCtx *rctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWObjState **state,
+  int get_obj_state_impl(RGWObjectCtx *rctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWObjState **state,
                          bool follow_olh, optional_yield y, bool assume_noent = false);
-  int append_atomic_test(RGWObjectCtx *rctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj,
+  int append_atomic_test(RGWObjectCtx *rctx, RGWBucketInfo& bucket_info, const rgw_obj& obj,
                          librados::ObjectOperation& op, RGWObjState **state, optional_yield y);
   int append_atomic_test(const RGWObjState* astate, librados::ObjectOperation& op);
 
@@ -690,8 +690,8 @@ public:
 
     explicit BucketShard(RGWRados *_store) : store(_store), shard_id(-1) {}
     int init(const rgw_bucket& _bucket, const rgw_obj& obj, RGWBucketInfo* out);
-    int init(const rgw_bucket& _bucket, int sid, const rgw::bucket_index_layout_generation& current_layout,
-            std::optional<rgw::bucket_index_layout_generation> target_layout, RGWBucketInfo* out);
+    int init(const rgw_bucket& _bucket, int sid, std::optional<rgw::bucket_index_layout_generation> current_layout,
+            RGWBucketInfo* out);
     int init(const RGWBucketInfo& bucket_info, const rgw_obj& obj);
     int init(const RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout, int sid);
   };
@@ -1246,23 +1246,23 @@ public:
    * bl: the contents of the attr
    * Returns: 0 on success, -ERR# otherwise.
    */
-  int set_attr(void *ctx, const RGWBucketInfo& bucket_info, rgw_obj& obj, const char *name, bufferlist& bl);
+  int set_attr(void *ctx, RGWBucketInfo& bucket_info, rgw_obj& obj, const char *name, bufferlist& bl);
 
-  int set_attrs(void *ctx, const RGWBucketInfo& bucket_info, rgw_obj& obj,
+  int set_attrs(void *ctx, RGWBucketInfo& bucket_info, rgw_obj& obj,
                         map<string, bufferlist>& attrs,
                         map<string, bufferlist>* rmattrs,
                         optional_yield y);
 
-  int get_obj_state(RGWObjectCtx *rctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWObjState **state,
+  int get_obj_state(RGWObjectCtx *rctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWObjState **state,
                     bool follow_olh, optional_yield y, bool assume_noent = false);
-  int get_obj_state(RGWObjectCtx *rctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWObjState **state, optional_yield y) {
+  int get_obj_state(RGWObjectCtx *rctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWObjState **state, optional_yield y) {
     return get_obj_state(rctx, bucket_info, obj, state, true, y);
   }
 
   using iterate_obj_cb = int (*)(const rgw_raw_obj&, off_t, off_t,
                                  off_t, bool, RGWObjState*, void*);
 
-  int iterate_obj(RGWObjectCtx& ctx, const RGWBucketInfo& bucket_info,
+  int iterate_obj(RGWObjectCtx& ctx, RGWBucketInfo& bucket_info,
                   const rgw_obj& obj, off_t ofs, off_t end,
                   uint64_t max_chunk_size, iterate_obj_cb cb, void *arg,
                   optional_yield y);
@@ -1295,23 +1295,23 @@ public:
   void bucket_index_guard_olh_op(RGWObjState& olh_state, librados::ObjectOperation& op);
   int olh_init_modification(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& olh_obj, string *op_tag);
   int olh_init_modification_impl(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& olh_obj, string *op_tag);
-  int bucket_index_link_olh(RGWBucketInfo bucket_info, RGWObjState& olh_state,
+  int bucket_index_link_olh(RGWBucketInfo& bucket_info, RGWObjState& olh_state,
                             const rgw_obj& obj_instance, bool delete_marker,
                             const string& op_tag, struct rgw_bucket_dir_entry_meta *meta,
                             uint64_t olh_epoch,
                             ceph::real_time unmod_since, bool high_precision_time,
                             rgw_zone_set *zones_trace = nullptr,
                             bool log_data_change = false);
-  int bucket_index_unlink_instance(RGWBucketInfo bucket_info, const rgw_obj& obj_instance, const string& op_tag, const string& olh_tag, uint64_t olh_epoch, rgw_zone_set *zones_trace = nullptr);
-  int bucket_index_read_olh_log(RGWBucketInfo bucket_info, RGWObjState& state, const rgw_obj& obj_instance, uint64_t ver_marker,
+  int bucket_index_unlink_instance(RGWBucketInfo& bucket_info, const rgw_obj& obj_instance, const string& op_tag, const string& olh_tag, uint64_t olh_epoch, rgw_zone_set *zones_trace = nullptr);
+  int bucket_index_read_olh_log(RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& obj_instance, uint64_t ver_marker,
                                 map<uint64_t, vector<rgw_bucket_olh_log_entry> > *log, bool *is_truncated);
-  int bucket_index_trim_olh_log(RGWBucketInfo bucket_info, RGWObjState& obj_state, const rgw_obj& obj_instance, uint64_t ver);
-  int bucket_index_clear_olh(RGWBucketInfo bucket_info, RGWObjState& state, const rgw_obj& obj_instance);
-  int apply_olh_log(RGWObjectCtx& ctx, RGWObjState& obj_state, const RGWBucketInfo& bucket_info, const rgw_obj& obj,
+  int bucket_index_trim_olh_log(RGWBucketInfo& bucket_info, RGWObjState& obj_state, const rgw_obj& obj_instance, uint64_t ver);
+  int bucket_index_clear_olh(RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& obj_instance);
+  int apply_olh_log(RGWObjectCtx& ctx, RGWObjState& obj_state, RGWBucketInfo& bucket_info, const rgw_obj& obj,
                     bufferlist& obj_tag, map<uint64_t, vector<rgw_bucket_olh_log_entry> >& log,
                     uint64_t *plast_ver, rgw_zone_set *zones_trace = nullptr);
-  int update_olh(RGWObjectCtx& obj_ctx, RGWObjState *state, const RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_zone_set *zones_trace = nullptr);
-  int set_olh(RGWObjectCtx& obj_ctx, const RGWBucketInfo& bucket_info, const rgw_obj& target_obj, bool delete_marker, rgw_bucket_dir_entry_meta *meta,
+  int update_olh(RGWObjectCtx& obj_ctx, RGWObjState *state, RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_zone_set *zones_trace = nullptr);
+  int set_olh(RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_info, const rgw_obj& target_obj, bool delete_marker, rgw_bucket_dir_entry_meta *meta,
               uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time,
               optional_yield y, rgw_zone_set *zones_trace = nullptr, bool log_data_change = false);
   int repair_olh(RGWObjState* state, const RGWBucketInfo& bucket_info,
@@ -1321,7 +1321,7 @@ public:
 
   void check_pending_olh_entries(map<string, bufferlist>& pending_entries, map<string, bufferlist> *rm_pending_entries);
   int remove_olh_pending_entries(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& olh_obj, map<string, bufferlist>& pending_attrs);
-  int follow_olh(const RGWBucketInfo& bucket_info, RGWObjectCtx& ctx, RGWObjState *state, const rgw_obj& olh_obj, rgw_obj *target);
+  int follow_olh(RGWBucketInfo& bucket_info, RGWObjectCtx& ctx, RGWObjState *state, const rgw_obj& olh_obj, rgw_obj *target);
   int get_olh(const RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWOLHInfo *olh);
 
   void gen_rand_obj_instance_name(rgw_obj_key *target_key);
@@ -1446,7 +1446,7 @@ public:
   int list_gc_objs(int *index, string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated, bool& processing_queue);
   int process_gc(bool expired_only);
   bool process_expire_objects();
-  int defer_gc(void *ctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj, optional_yield y);
+  int defer_gc(void *ctx, RGWBucketInfo& bucket_info, const rgw_obj& obj, optional_yield y);
 
   int process_lc();
   int list_lc_progress(string& marker, uint32_t max_entries,
@@ -1463,7 +1463,7 @@ public:
 	             librados::IoCtx& dst_ioctx,
 		     const string& dst_oid, const string& dst_locator);
   int fix_head_obj_locator(const RGWBucketInfo& bucket_info, bool copy_obj, bool remove_bad, rgw_obj_key& key);
-  int fix_tail_obj_locator(const RGWBucketInfo& bucket_info, rgw_obj_key& key, bool fix, bool *need_fix, optional_yield y);
+  int fix_tail_obj_locator(RGWBucketInfo& bucket_info, rgw_obj_key& key, bool fix, bool *need_fix, optional_yield y);
 
   int check_quota(const rgw_user& bucket_owner, rgw_bucket& bucket,
                   RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota, uint64_t obj_size,
@@ -1499,7 +1499,7 @@ public:
    * will encode that info as a suggested update.)
    */
   int check_disk_state(librados::IoCtx io_ctx,
-                       const RGWBucketInfo& bucket_info,
+                       RGWBucketInfo& bucket_info,
                        rgw_bucket_dir_entry& list_state,
                        rgw_bucket_dir_entry& object,
                        bufferlist& suggested_updates,

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -317,20 +317,28 @@ int RGWBucketReshard::clear_index_shard_reshard_status(rgw::sal::RGWRadosStore* 
 
 static int set_target_layout(rgw::sal::RGWRadosStore *store,
 				      int new_num_shards,
-				      RGWBucketInfo& bucket_info,
-				      map<string, bufferlist>& attrs)
+				      RGWBucketInfo& bucket_info)
 {
   assert(!bucket_info.layout.target_index);
   bucket_info.layout.target_index.emplace();
 
   bucket_info.layout.target_index->layout.normal.num_shards = new_num_shards;
+  
+  //increment generation number
+  bucket_info.layout.target_index->gen = bucket_info.layout.current_index.gen;
+  bucket_info.layout.target_index->gen++;
 
   bucket_info.layout.resharding = rgw::BucketReshardState::IN_PROGRESS;
 
-  int ret = store->getRados()->put_bucket_instance_info(bucket_info, true, real_time(), &attrs);
+  int ret = store->getRados()->put_bucket_instance_info(bucket_info, true, real_time(), nullptr);
   if (ret < 0) {
     cerr << "ERROR: failed to store updated bucket instance info: " << cpp_strerror(-ret) << std::endl;
     return ret;
+  }
+
+    ret = store->svc()->bi->init_index(bucket_info, *(bucket_info.layout.target_index));
+  if (ret < 0) {
+      return ret;
   }
 
   return 0;
@@ -339,7 +347,7 @@ static int set_target_layout(rgw::sal::RGWRadosStore *store,
 int RGWBucketReshard::set_target_layout(int new_num_shards)
 {
   return ::set_target_layout(store, new_num_shards,
-				      bucket_info, bucket_attrs);
+				      bucket_info);
 }
 
 int RGWBucketReshard::cancel()
@@ -359,13 +367,12 @@ class BucketInfoReshardUpdate
 {
   rgw::sal::RGWRadosStore *store;
   RGWBucketInfo& bucket_info;
-  std::map<string, bufferlist> bucket_attrs;
 
   bool in_progress{false};
 
   int set_status(rgw::BucketReshardState s) {
     bucket_info.layout.resharding = s;
-    int ret = store->getRados()->put_bucket_instance_info(bucket_info, false, real_time(), &bucket_attrs);
+    int ret = store->getRados()->put_bucket_instance_info(bucket_info, false, real_time(), nullptr);
     if (ret < 0) {
       ldout(store->ctx(), 0) << "ERROR: failed to write bucket info, ret=" << ret << dendl;
       return ret;
@@ -375,11 +382,9 @@ class BucketInfoReshardUpdate
 
 public:
   BucketInfoReshardUpdate(rgw::sal::RGWRadosStore *_store,
-			  RGWBucketInfo& _bucket_info,
-                          map<string, bufferlist>& _bucket_attrs) :
+			  RGWBucketInfo& _bucket_info) :
     store(_store),
-    bucket_info(_bucket_info),
-    bucket_attrs(_bucket_attrs)
+    bucket_info(_bucket_info)
   {}
 
   ~BucketInfoReshardUpdate() {
@@ -514,7 +519,7 @@ int RGWBucketReshard::do_reshard(int num_shards,
 
   // NB: destructor cleans up sharding state if reshard does not
   // complete successfully
-  BucketInfoReshardUpdate bucket_info_updater(store, bucket_info, bucket_attrs);
+  BucketInfoReshardUpdate bucket_info_updater(store, bucket_info);
 
 
   int ret = bucket_info_updater.start();
@@ -522,10 +527,6 @@ int RGWBucketReshard::do_reshard(int num_shards,
     ldout(store->ctx(), 0) << __func__ << ": failed to update bucket info ret=" << ret << dendl;
     return ret;
   }
-
-  //increment generation number
-  bucket_info.layout.target_index->gen = bucket_info.layout.current_index.gen;
-  bucket_info.layout.target_index->gen++;
 
   auto target_shards = bucket_info.layout.target_index->layout.normal.num_shards;
   int num_target_shards = (target_shards > 0 ? num_shards : 1);
@@ -639,17 +640,13 @@ int RGWBucketReshard::do_reshard(int num_shards,
   }
 
   //overwrite current_index for the next reshard process
+  const auto prev_index = bucket_info.layout.current_index;
   bucket_info.layout.current_index = *bucket_info.layout.target_index;
   bucket_info.layout.target_index = std::nullopt; // target_layout doesn't need to exist after reshard
   bucket_info.layout.resharding = rgw::BucketReshardState::NONE;
-  ret = store->getRados()->put_bucket_instance_info(bucket_info, false, real_time(), &bucket_attrs);
+  ret = store->getRados()->put_bucket_instance_info(bucket_info, false, real_time(), nullptr);
   if (ret < 0) {
     lderr(store->ctx()) << "ERROR: failed writing bucket instance info: " << dendl;
-      return ret;
-  }
-
-  ret = store->svc()->bi->init_index(bucket_info, bucket_info.layout.current_index);
-  if (ret < 0) {
       return ret;
   }
 
@@ -735,7 +732,7 @@ error_out:
 
   // restore old index if reshard fails
   bucket_info.layout.current_index = prev_index;
-  ret = store->getRados()->put_bucket_instance_info(bucket_info, false, real_time(), &bucket_attrs);
+  ret = store->getRados()->put_bucket_instance_info(bucket_info, false, real_time(), nullptr);
   if (ret < 0) {
     lderr(store->ctx()) << "ERROR: failed writing bucket instance info: " << dendl;
       return ret;

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -648,6 +648,12 @@ int RGWBucketReshard::do_reshard(int num_shards,
       return ret;
   }
 
+  ret = bucket_info_updater.complete();
+  if (ret < 0) {
+    ldout(store->ctx(), 0) << __func__ << ": failed to update bucket info ret=" << ret << dendl;
+    /* don't error out, reshard process succeeded */
+  }
+
   return 0;
   // NB: some error clean-up is done by ~BucketInfoReshardUpdate
 } // RGWBucketReshard::do_reshard

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -639,6 +639,7 @@ int RGWBucketReshard::do_reshard(int num_shards,
   }
 
   //overwrite current_index for the next reshard process
+  const auto prev_index = bucket_info.layout.current_index;
   bucket_info.layout.current_index = *bucket_info.layout.target_index;
   bucket_info.layout.target_index = std::nullopt; // target_layout doesn't need to exist after reshard
   bucket_info.layout.resharding = rgw::BucketReshardState::NONE;
@@ -652,6 +653,18 @@ int RGWBucketReshard::do_reshard(int num_shards,
   if (ret < 0) {
       return ret;
   }
+
+  // resharding successful, so remove old bucket index shards; use
+  // best effort and don't report out an error; the lock isn't needed
+  // at this point since all we're using a best effor to to remove old
+  // shard objects
+
+  ret = store->svc()->bi->clean_index(bucket_info, prev_index);
+  if (ret < 0) {
+    lderr(store->ctx()) << "Error: " << __func__ <<
+    " failed to clean up old shards; " <<
+    "RGWRados::clean_bucket_index returned " << ret << dendl;
+}
 
   return 0;
   // NB: some error clean-up is done by ~BucketInfoReshardUpdate
@@ -698,18 +711,6 @@ int RGWBucketReshard::execute(int num_shards, int max_op_entries,
 
   reshard_lock.unlock();
 
-   // resharding successful, so remove old bucket index shards; use
-   // best effort and don't report out an error; the lock isn't needed
-   // at this point since all we're using a best effor to to remove old
-   // shard objects
-
-   ret = store->svc()->bi->clean_index(bucket_info, (bucket_info.layout.current_index.gen - 1));
-   if (ret < 0) {
-     lderr(store->ctx()) << "Error: " << __func__ <<
-      " failed to clean up old shards; " <<
-     "RGWRados::clean_bucket_index returned " << ret << dendl;
-  }
-
   ldout(store->ctx(), 1) << __func__ <<
     " INFO: reshard of bucket \"" << bucket_info.bucket.name << "\" completed successfully" << dendl;
 
@@ -724,7 +725,7 @@ error_out:
   // since the real problem is the issue that led to this error code
   // path, we won't touch ret and instead use another variable to
   // temporarily error codes
-  int ret2 = store->svc()->bi->clean_index(bucket_info, bucket_info.layout.target_index->gen);
+  int ret2 = store->svc()->bi->clean_index(bucket_info, bucket_info.layout.current_index);
   if (ret2 < 0) {
     lderr(store->ctx()) << "Error: " << __func__ <<
       " failed to clean up shards from failed incomplete resharding; " <<

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -259,12 +259,10 @@ RGWBucketReshard::RGWBucketReshard(rgw::sal::RGWRadosStore *_store,
 
 int RGWBucketReshard::set_resharding_status(rgw::sal::RGWRadosStore* store,
 					    const RGWBucketInfo& bucket_info,
-					    const string& instance_id,
-					    int32_t num_shards,
-					    rgw::BucketReshardState status)
+					    cls_rgw_reshard_status status)
 {
   cls_rgw_bucket_instance_entry instance_entry;
-  instance_entry.set_status(instance_id, num_shards, status);
+  instance_entry.set_status(status);
 
   int ret = store->getRados()->bucket_set_reshard(bucket_info, instance_entry);
   if (ret < 0) {
@@ -306,9 +304,7 @@ int RGWBucketReshard::clear_index_shard_reshard_status(rgw::sal::RGWRadosStore* 
 
   if (num_shards < std::numeric_limits<uint32_t>::max()) {
     int ret = set_resharding_status(store, bucket_info,
-				    bucket_info.bucket.bucket_id,
-				    (num_shards < 1 ? 1 : num_shards),
-				    rgw::BucketReshardState::NOT_RESHARDING);
+				    cls_rgw_reshard_status::NOT_RESHARDING);
     if (ret < 0) {
       ldout(store->ctx(), 0) << "RGWBucketReshard::" << __func__ <<
 	" ERROR: error clearing reshard status from index shard " <<
@@ -394,9 +390,6 @@ public:
 	lderr(store->ctx()) << "Error: " << __func__ <<
 	  " clear_index_shard_status returned " << ret << dendl;
       }
-
-      // clears new_bucket_instance as well
-      set_status(rgw::BucketReshardState::NOT_RESHARDING);
     }
   }
 
@@ -410,7 +403,7 @@ public:
   }
 
   int complete() {
-    int ret = set_status(rgw::BucketReshardState::DONE);
+    int ret = set_status(rgw::BucketReshardState::NONE);
     if (ret < 0) {
       return ret;
     }
@@ -689,8 +682,7 @@ int RGWBucketReshard::execute(int num_shards, int max_op_entries,
 
   // set resharding status of current bucket_info & shards with
   // information about planned resharding
-  ret = set_resharding_status(bucket_info.bucket.bucket_id,
-			      num_shards, rgw::BucketReshardState::IN_PROGRESS);
+  ret = set_resharding_status(cls_rgw_reshard_status::IN_PROGRESS);
   if (ret < 0) {
     return ret;
     goto error_out;

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -385,13 +385,13 @@ public:
     if (in_progress) {
       // resharding must not have ended correctly, clean up
       int ret =
-	RGWBucketReshard::clear_index_shard_reshard_status(store, bucket_info);
+       RGWBucketReshard::clear_index_shard_reshard_status(store, bucket_info);
       if (ret < 0) {
 	lderr(store->ctx()) << "Error: " << __func__ <<
 	  " clear_index_shard_status returned " << ret << dendl;
       }
     }
-  }
+  } 
 
   int start() {
     int ret = set_status(rgw::BucketReshardState::IN_PROGRESS);
@@ -648,12 +648,6 @@ int RGWBucketReshard::do_reshard(int num_shards,
       return ret;
   }
 
-  ret = bucket_info_updater.complete();
-  if (ret < 0) {
-    ldout(store->ctx(), 0) << __func__ << ": failed to update bucket info ret=" << ret << dendl;
-    /* don't error out, reshard process succeeded */
-  }
-
   return 0;
   // NB: some error clean-up is done by ~BucketInfoReshardUpdate
 } // RGWBucketReshard::do_reshard
@@ -686,13 +680,6 @@ int RGWBucketReshard::execute(int num_shards, int max_op_entries,
     }
   }
 
-  // set resharding status of current bucket_info & shards with
-  // information about planned resharding
-  ret = set_resharding_status(cls_rgw_reshard_status::IN_PROGRESS);
-  if (ret < 0) {
-    return ret;
-    goto error_out;
-  }
 
   ret = do_reshard(num_shards,
 		   max_op_entries,

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -62,7 +62,7 @@ class BucketReshardShard {
   rgw::sal::RGWRadosStore *store;
   const RGWBucketInfo& bucket_info;
   int num_shard;
-  const rgw::bucket_index_layout_generation& idx_layout;
+  const rgw::bucket_index_layout_generation& target_layout;
   RGWRados::BucketShard bs;
   vector<rgw_cls_bi_entry> entries;
   map<RGWObjCategory, rgw_bucket_category_stats> stats;
@@ -103,14 +103,14 @@ class BucketReshardShard {
 
 public:
   BucketReshardShard(rgw::sal::RGWRadosStore *_store, const RGWBucketInfo& _bucket_info,
-                     int _num_shard, const rgw::bucket_index_layout_generation& _idx_layout,
+                     int _num_shard, const rgw::bucket_index_layout_generation& _target_layout,
                      deque<librados::AioCompletion *>& _completions) :
-    store(_store), bucket_info(_bucket_info), idx_layout(_idx_layout), bs(store->getRados()),
+    store(_store), bucket_info(_bucket_info), target_layout(_target_layout), bs(store->getRados()),
     aio_completions(_completions)
   {
-    num_shard = (idx_layout.layout.normal.num_shards > 0 ? _num_shard : -1);
+    num_shard = (target_layout.layout.normal.num_shards > 0 ? _num_shard : -1);
 
-    bs.init(bucket_info.bucket, num_shard, idx_layout, nullptr /* no RGWBucketInfo */);
+    bs.init(bucket_info.bucket, num_shard, target_layout, nullptr /* no RGWBucketInfo */);
 
     max_aio_completions =
       store->ctx()->_conf.get_val<uint64_t>("rgw_reshard_max_aio");
@@ -195,10 +195,10 @@ public:
     store(_store), target_bucket_info(_target_bucket_info),
     num_target_shards(_num_target_shards)
   { 
-    const auto& idx_layout = target_bucket_info.layout.current_index;
+    const auto& target_layout = target_bucket_info.layout.target_index;
     target_shards.resize(num_target_shards);
     for (int i = 0; i < num_target_shards; ++i) {
-      target_shards[i] = new BucketReshardShard(store, target_bucket_info, i, idx_layout, completions);
+      target_shards[i] = new BucketReshardShard(store, target_bucket_info, i, target_layout, completions);
     }
   }
 
@@ -320,41 +320,29 @@ int RGWBucketReshard::clear_index_shard_reshard_status(rgw::sal::RGWRadosStore* 
   return 0;
 }
 
-static int create_new_bucket_instance(rgw::sal::RGWRadosStore *store,
+static int update_num_shards(rgw::sal::RGWRadosStore *store,
 				      int new_num_shards,
-				      const RGWBucketInfo& bucket_info,
-				      map<string, bufferlist>& attrs,
-				      RGWBucketInfo& new_bucket_info)
+				      RGWBucketInfo& bucket_info,
+				      map<string, bufferlist>& attrs)
 {
-  new_bucket_info = bucket_info;
 
-  store->getRados()->create_bucket_id(&new_bucket_info.bucket.bucket_id);
+  bucket_info.layout.target_index.layout.normal.num_shards = new_num_shards;
 
   bucket_info.layout.resharding = rgw::BucketReshardState::NONE;
 
-  new_bucket_info.new_bucket_instance_id.clear();
-  new_bucket_info.reshard_status = cls_rgw_reshard_status::NOT_RESHARDING;
-
-  int ret = store->svc()->bi->init_index(new_bucket_info);
+  int ret = store->getRados()->put_bucket_instance_info(bucket_info, true, real_time(), &attrs);
   if (ret < 0) {
-    cerr << "ERROR: failed to init new bucket indexes: " << cpp_strerror(-ret) << std::endl;
-    return ret;
-  }
-
-  ret = store->getRados()->put_bucket_instance_info(new_bucket_info, true, real_time(), &attrs);
-  if (ret < 0) {
-    cerr << "ERROR: failed to store new bucket instance info: " << cpp_strerror(-ret) << std::endl;
+    cerr << "ERROR: failed to store updated bucket instance info: " << cpp_strerror(-ret) << std::endl;
     return ret;
   }
 
   return 0;
 }
 
-int RGWBucketReshard::create_new_bucket_instance(int new_num_shards,
-                                                 RGWBucketInfo& new_bucket_info)
+int RGWBucketReshard::update_num_shards(int new_num_shards)
 {
-  return ::create_new_bucket_instance(store, new_num_shards,
-				      bucket_info, bucket_attrs, new_bucket_info);
+  return ::update_num_shards(store, new_num_shards,
+				      bucket_info, bucket_attrs);
 }
 
 int RGWBucketReshard::cancel()
@@ -391,14 +379,11 @@ class BucketInfoReshardUpdate
 public:
   BucketInfoReshardUpdate(rgw::sal::RGWRadosStore *_store,
 			  RGWBucketInfo& _bucket_info,
-                          map<string, bufferlist>& _bucket_attrs,
-			  const string& new_bucket_id) :
+                          map<string, bufferlist>& _bucket_attrs) :
     store(_store),
     bucket_info(_bucket_info),
     bucket_attrs(_bucket_attrs)
-  {
-    bucket_info.new_bucket_instance_id = new_bucket_id;
-  }
+  {}
 
   ~BucketInfoReshardUpdate() {
     if (in_progress) {
@@ -409,15 +394,14 @@ public:
 	lderr(store->ctx()) << "Error: " << __func__ <<
 	  " clear_index_shard_status returned " << ret << dendl;
       }
-      bucket_info.new_bucket_instance_id.clear();
 
       // clears new_bucket_instance as well
-      set_status(cls_rgw_reshard_status::NOT_RESHARDING);
+      set_status(rgw::BucketReshardState::NOT_RESHARDING);
     }
   }
 
   int start() {
-    int ret = set_status(cls_rgw_reshard_status::IN_PROGRESS);
+    int ret = set_status(rgw::BucketReshardState::IN_PROGRESS);
     if (ret < 0) {
       return ret;
     }
@@ -426,7 +410,7 @@ public:
   }
 
   int complete() {
-    int ret = set_status(cls_rgw_reshard_status::DONE);
+    int ret = set_status(rgw::BucketReshardState::DONE);
     if (ret < 0) {
       return ret;
     }
@@ -544,9 +528,13 @@ int RGWBucketReshard::do_reshard(int num_shards,
     return ret;
   }
 
-  int num_target_shards = (new_bucket_info.layout.current_index.layout.normal.num_shards > 0 ? new_bucket_info.layout.current_index.layout.normal.num_shards : 1);
+  //increment generation number
+  bucket_info.layout.target_index.gen++;
 
-  BucketReshardManager target_shards_mgr(store, new_bucket_info, num_target_shards);
+  auto target_shards = bucket_info.layout.target_index.layout.normal.num_shards;
+  int num_target_shards = (target_shards > 0 ? num_shards : 1);
+
+  BucketReshardManager target_shards_mgr(store, bucket_info, num_target_shards);
 
   bool verbose_json_out = verbose && (formatter != nullptr) && (out != nullptr);
 
@@ -560,8 +548,9 @@ int RGWBucketReshard::do_reshard(int num_shards,
     (*out) << "total entries:";
   }
 
+  auto current_shards = bucket_info.layout.current_index.layout.normal.num_shards;
   const int num_source_shards =
-    (bucket_info.layout.current_index.layout.normal.num_shards > 0 ? bucket_info.layout.current_index.layout.normal.num_shards : 1);
+    (current_shards > 0 ? current_shards : 1);
   string marker;
   for (int i = 0; i < num_source_shards; ++i) {
     bool is_truncated = true;
@@ -569,10 +558,14 @@ int RGWBucketReshard::do_reshard(int num_shards,
     while (is_truncated) {
       entries.clear();
       ret = store->getRados()->bi_list(bucket_info, i, string(), marker, max_entries, &entries, &is_truncated);
-      if (ret < 0 && ret != -ENOENT) {
-	derr << "ERROR: bi_list(): " << cpp_strerror(-ret) << dendl;
-	return ret;
-      }
+      if (ret < 0) {
+		if (ret == -ENOENT && i < (num_source_shards - 1)) {
+		  continue;
+		} else {
+		  derr << "ERROR: bi_list(): " << cpp_strerror(-ret) << dendl;
+		  return ret;
+		}
+	  }
 
       for (auto iter = entries.begin(); iter != entries.end(); ++iter) {
 	rgw_cls_bi_entry& entry = *iter;

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -341,7 +341,7 @@ int RGWBucketReshard::set_target_layout(int new_num_shards)
 {
   int ret = RGWBucketReshard::set_reshard_status(rgw::BucketReshardState::IN_PROGRESS);
   if (ret < 0) {
-    cerr << "ERROR: failed to store updated bucket instance info: " << cpp_strerror(-ret) << std::endl;
+    lderr(store->ctx()) << "ERROR: failed to store updated bucket instance info: " << dendl;
     return ret;
   }
   return ::set_target_layout(store, new_num_shards,
@@ -583,8 +583,10 @@ int RGWBucketReshard::do_reshard(int num_shards,
 	  // place the multipart .meta object on the same shard as its head object
 	  obj.index_hash_source = mp.get_key();
 	}
-	int ret = store->getRados()->get_target_shard_id(bucket_info.layout.target_index->layout.normal,
-                                                   obj.get_hash_object(), &target_shard_id);
+	int ret = store->getRados()->get_target_shard_id(
+    bucket_info.layout.target_index->layout.normal,
+    obj.get_hash_object(),
+    &target_shard_id);
 	if (ret < 0) {
 	  lderr(store->ctx()) << "ERROR: get_target_shard_id() returned ret=" << ret << dendl;
 	  return ret;
@@ -704,7 +706,7 @@ int RGWBucketReshard::execute(int num_shards, int max_op_entries,
 
   // resharding successful, so remove old bucket index shards; use
   // best effort and don't report out an error; the lock isn't needed
-  // at this point since all we're using a best effor to to remove old
+  // at this point since all we're using a best effort to remove old
   // shard objects
 
   ret = store->svc()->bi->clean_index(bucket_info, prev_index);
@@ -746,7 +748,7 @@ error_out:
 
   ret = RGWBucketReshard::set_reshard_status(rgw::BucketReshardState::NONE);
   if (ret < 0) {
-    cerr << "ERROR: failed to store updated bucket instance info: " << cpp_strerror(-ret) << std::endl;
+    lderr(store->ctx()) << "ERROR: failed to store updated bucket instance info: " << dendl;
     return ret;
   }
   

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -556,7 +556,7 @@ int RGWBucketReshard::do_reshard(int num_shards,
       if (ret < 0 && ret != -ENOENT) {
         derr << "ERROR: bi_list(): " << cpp_strerror(-ret) << dendl;
         return ret;
-		}
+		    }
 
       for (auto iter = entries.begin(); iter != entries.end(); ++iter) {
 	rgw_cls_bi_entry& entry = *iter;
@@ -583,8 +583,8 @@ int RGWBucketReshard::do_reshard(int num_shards,
 	  // place the multipart .meta object on the same shard as its head object
 	  obj.index_hash_source = mp.get_key();
 	}
-	int ret = store->getRados()->get_target_shard_id(bucket_info.layout.target_index->layout.normal, obj
-	.get_hash_object(),	&target_shard_id);
+	int ret = store->getRados()->get_target_shard_id(bucket_info.layout.target_index->layout.normal,
+                                                   obj.get_hash_object(), &target_shard_id);
 	if (ret < 0) {
 	  lderr(store->ctx()) << "ERROR: get_target_shard_id() returned ret=" << ret << dendl;
 	  return ret;
@@ -1020,37 +1020,37 @@ int RGWReshard::process_single_logshard(int logshard_num)
 	}
 
 	{
-	RGWBucketReshard br(store, bucket_info, attrs, nullptr);
-	ret = br.execute(entry.new_num_shards, max_entries, false, nullptr,
-			 nullptr, this);
-	if (ret < 0) {
-	  ldout(store->ctx(), 0) <<  __func__ <<
-	    ": Error during resharding bucket " << entry.bucket_name << ":" <<
-	    cpp_strerror(-ret)<< dendl;
-	  return ret;
-	}
+    RGWBucketReshard br(store, bucket_info, attrs, nullptr);
+    ret = br.execute(entry.new_num_shards, max_entries, false, nullptr,
+        nullptr, this);
+    if (ret < 0) {
+      ldout(store->ctx(), 0) <<  __func__ <<
+        ": Error during resharding bucket " << entry.bucket_name << ":" <<
+        cpp_strerror(-ret)<< dendl;
+      return ret;
+    }
 
-	ldout(store->ctx(), 20) << __func__ <<
-	  " removing reshard queue entry for bucket " << entry.bucket_name <<
-	  dendl;
+    ldout(store->ctx(), 20) << __func__ <<
+      " removing reshard queue entry for bucket " << entry.bucket_name <<
+      dendl;
 
-      	ret = remove(entry);
-	if (ret < 0) {
-	  ldout(cct, 0) << __func__ << ": Error removing bucket " <<
-	    entry.bucket_name << " from resharding queue: " <<
-	    cpp_strerror(-ret) << dendl;
-	  return ret;
-	  }
+    ret = remove(entry);
+    if (ret < 0) {
+      ldout(cct, 0) << __func__ << ": Error removing bucket " <<
+        entry.bucket_name << " from resharding queue: " <<
+        cpp_strerror(-ret) << dendl;
+      return ret;
+      }
 	}
 
     finished_entry:
 
       Clock::time_point now = Clock::now();
       if (logshard_lock.should_renew(now)) {
-	ret = logshard_lock.renew(now);
-	if (ret < 0) {
-	  return ret;
-	}
+	      ret = logshard_lock.renew(now);
+	      if (ret < 0) {
+	        return ret;
+	      }
       }
 
       entry.get_key(&marker);

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -108,8 +108,7 @@ public:
   {
     num_shard = (bucket_info.layout.target_index->layout.normal.num_shards > 0 ? _num_shard : -1);
 
-    bs.init(bucket_info.bucket, num_shard, bucket_info.layout.target_index,
-            nullptr /* no RGWBucketInfo */);
+    bs.init(bucket_info, *bucket_info.layout.target_index, shard_id);
 
     max_aio_completions =
       store->ctx()->_conf.get_val<uint64_t>("rgw_reshard_max_aio");

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -491,7 +491,7 @@ int RGWBucketReshardLock::renew(const Clock::time_point& now) {
 
 int RGWBucketReshard::do_reshard(int num_shards,
 				 int max_entries,
-         FaultInjector<std::string_view>& f,
+                                 const ReshardFaultInjector& f,
 				 bool verbose,
 				 ostream *out,
 				 Formatter *formatter)
@@ -670,7 +670,7 @@ int RGWBucketReshard::update_bucket(rgw::BucketReshardState s) {
 }
 
 int RGWBucketReshard::execute(int num_shards,
-                              FaultInjector<std::string_view>& f,
+                              const ReshardFaultInjector& f,
                               int max_op_entries,
                               bool verbose, ostream *out,
                               Formatter *formatter,
@@ -1021,7 +1021,7 @@ int RGWReshard::process_single_logshard(int logshard_num)
 	{
 	RGWBucketReshard br(store, bucket_info, nullptr);
 
-  FaultInjector<std::string_view> f;
+  ReshardFaultInjector f;
 	ret = br.execute(entry.new_num_shards, f, max_entries, false, nullptr,
 			 nullptr, this);
 	if (ret < 0) {

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -496,6 +496,7 @@ int RGWBucketReshardLock::renew(const Clock::time_point& now) {
 
 int RGWBucketReshard::do_reshard(int num_shards,
 				 int max_entries,
+         FaultInjector<std::string_view>& f,
 				 bool verbose,
 				 ostream *out,
 				 Formatter *formatter)
@@ -591,6 +592,8 @@ int RGWBucketReshard::do_reshard(int num_shards,
 	  return ret;
 	}
 
+  if (ret = f.check("before_target_shard_entry"); ret < 0) { return ret; }
+
 	int shard_index = (target_shard_id > 0 ? target_shard_id : 0);
 
 	ret = target_shards_mgr.add_entry(shard_index, entry, account,
@@ -598,6 +601,8 @@ int RGWBucketReshard::do_reshard(int num_shards,
 	if (ret < 0) {
 	  return ret;
 	}
+
+  if (ret = f.check("after_target_shard_entry"); ret < 0) { return ret; }
 
 	Clock::time_point now = Clock::now();
 	if (reshard_lock.should_renew(now)) {
@@ -638,6 +643,8 @@ int RGWBucketReshard::do_reshard(int num_shards,
     return -EIO;
   }
 
+  if (ret = f.check("before_layout_overwrite"); ret < 0) { return ret; }
+
   //overwrite current_index for the next reshard process
   bucket_info.layout.current_index = *bucket_info.layout.target_index;
   bucket_info.layout.target_index = std::nullopt; // target_layout doesn't need to exist after reshard
@@ -667,9 +674,12 @@ int RGWBucketReshard::update_bucket(rgw::BucketReshardState s) {
     return 0;
 }
 
-int RGWBucketReshard::execute(int num_shards, int max_op_entries,
-                              bool verbose, ostream *out, Formatter *formatter,
-			      RGWReshard* reshard_log)
+int RGWBucketReshard::execute(int num_shards,
+                              FaultInjector<std::string_view>& f,
+                              int max_op_entries,
+                              bool verbose, ostream *out,
+                              Formatter *formatter,
+                              RGWReshard* reshard_log)
 {
   int ret = reshard_lock.lock();
   if (ret < 0) {
@@ -692,9 +702,7 @@ int RGWBucketReshard::execute(int num_shards, int max_op_entries,
   // keep a copy of old index layout
   prev_index = bucket_info.layout.current_index;
 
-  ret = do_reshard(num_shards,
-		   max_op_entries,
-                   verbose, out, formatter);
+  ret = do_reshard(num_shards, max_op_entries, f, verbose, out, formatter);
   if (ret < 0) {
     goto error_out;
   }
@@ -1017,15 +1025,17 @@ int RGWReshard::process_single_logshard(int logshard_num)
 	}
 
 	{
-    RGWBucketReshard br(store, bucket_info, attrs, nullptr);
-    ret = br.execute(entry.new_num_shards, max_entries, false, nullptr,
-        nullptr, this);
-    if (ret < 0) {
-      ldout(store->ctx(), 0) <<  __func__ <<
-        ": Error during resharding bucket " << entry.bucket_name << ":" <<
-        cpp_strerror(-ret)<< dendl;
-      return ret;
-    }
+	RGWBucketReshard br(store, bucket_info, attrs, nullptr);
+
+  FaultInjector<std::string_view> f;
+	ret = br.execute(entry.new_num_shards, f, max_entries, false, nullptr,
+			 nullptr, this);
+	if (ret < 0) {
+	  ldout(store->ctx(), 0) <<  __func__ <<
+	    ": Error during resharding bucket " << entry.bucket_name << ":" <<
+	    cpp_strerror(-ret)<< dendl;
+	  return ret;
+	}
 
     ldout(store->ctx(), 20) << __func__ <<
       " removing reshard queue entry for bucket " << entry.bucket_name <<

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -249,9 +249,8 @@ public:
 
 RGWBucketReshard::RGWBucketReshard(rgw::sal::RGWRadosStore *_store,
 				   const RGWBucketInfo& _bucket_info,
-				   const map<string, bufferlist>& _bucket_attrs,
 				   RGWBucketReshardLock* _outer_reshard_lock) :
-  store(_store), bucket_info(_bucket_info), bucket_attrs(_bucket_attrs),
+  store(_store), bucket_info(_bucket_info),
   reshard_lock(store, bucket_info, true),
   outer_reshard_lock(_outer_reshard_lock)
 { }
@@ -984,12 +983,11 @@ int RGWReshard::process_single_logshard(int logshard_num)
 
 	rgw_bucket bucket;
 	RGWBucketInfo bucket_info;
-	map<string, bufferlist> attrs;
 
 	ret = store->getRados()->get_bucket_info(store->svc(),
 						 entry.tenant, entry.bucket_name,
 						 bucket_info, nullptr,
-						 null_yield, &attrs);
+						 null_yield, nullptr);
 	if (ret < 0 || bucket_info.bucket.bucket_id != entry.bucket_id) {
 	  if (ret < 0) {
 	    ldout(cct, 0) <<  __func__ <<
@@ -1025,7 +1023,7 @@ int RGWReshard::process_single_logshard(int logshard_num)
 	}
 
 	{
-	RGWBucketReshard br(store, bucket_info, attrs, nullptr);
+	RGWBucketReshard br(store, bucket_info, nullptr);
 
   FaultInjector<std::string_view> f;
 	ret = br.execute(entry.new_num_shards, f, max_entries, false, nullptr,

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -61,7 +61,7 @@ const std::initializer_list<uint16_t> RGWBucketReshard::reshard_primes = {
 class BucketReshardShard {
   rgw::sal::RGWRadosStore *store;
   const RGWBucketInfo& bucket_info;
-  int num_shard;
+  int shard_id;
   RGWRados::BucketShard bs;
   vector<rgw_cls_bi_entry> entries;
   map<RGWObjCategory, rgw_bucket_category_stats> stats;
@@ -102,13 +102,12 @@ class BucketReshardShard {
 
 public:
   BucketReshardShard(rgw::sal::RGWRadosStore *_store, const RGWBucketInfo& _bucket_info,
-                     int _num_shard, deque<librados::AioCompletion *>& _completions) :
-    store(_store), bucket_info(_bucket_info), bs(store->getRados()),
-    aio_completions(_completions)
+                     const rgw::bucket_index_layout_generation& index,
+                     int shard_id, deque<librados::AioCompletion *>& _completions) :
+    store(_store), bucket_info(_bucket_info), shard_id(shard_id),
+    bs(store->getRados()), aio_completions(_completions)
   {
-    num_shard = (bucket_info.layout.target_index->layout.normal.num_shards > 0 ? _num_shard : -1);
-
-    bs.init(bucket_info, *bucket_info.layout.target_index, shard_id);
+    bs.init(bucket_info, index, shard_id);
 
     max_aio_completions =
       store->ctx()->_conf.get_val<uint64_t>("rgw_reshard_max_aio");
@@ -116,8 +115,8 @@ public:
       store->ctx()->_conf.get_val<uint64_t>("rgw_reshard_batch_size");
   }
 
-  int get_num_shard() {
-    return num_shard;
+  int get_shard_id() const {
+    return shard_id;
   }
 
   int add_entry(rgw_cls_bi_entry& entry, bool account, RGWObjCategory category,
@@ -181,19 +180,19 @@ public:
 
 class BucketReshardManager {
   rgw::sal::RGWRadosStore *store;
-  const RGWBucketInfo& target_bucket_info;
   deque<librados::AioCompletion *> completions;
   vector<BucketReshardShard> target_shards;
 
 public:
   BucketReshardManager(rgw::sal::RGWRadosStore *_store,
-		       const RGWBucketInfo& _target_bucket_info,
-		       int num_target_shards)
-    : store(_store), target_bucket_info(_target_bucket_info)
+		       const RGWBucketInfo& bucket_info,
+                       const rgw::bucket_index_layout_generation& target)
+    : store(_store)
   {
-    target_shards.reserve(num_target_shards);
-    for (int i = 0; i < num_target_shards; ++i) {
-      target_shards.emplace_back(store, target_bucket_info, i, completions);
+    const int num_shards = target.layout.normal.num_shards;
+    target_shards.reserve(num_shards);
+    for (int i = 0; i < num_shards; ++i) {
+      target_shards.emplace_back(store, bucket_info, target, i, completions);
     }
   }
 
@@ -226,14 +225,14 @@ public:
     for (auto& shard : target_shards) {
       int r = shard.flush();
       if (r < 0) {
-        derr << "ERROR: target_shards[" << shard.get_num_shard() << "].flush() returned error: " << cpp_strerror(-r) << dendl;
+        derr << "ERROR: target_shards[" << shard.get_shard_id() << "].flush() returned error: " << cpp_strerror(-r) << dendl;
         ret = r;
       }
     }
     for (auto& shard : target_shards) {
       int r = shard.wait_all_aio();
       if (r < 0) {
-        derr << "ERROR: target_shards[" << shard.get_num_shard() << "].wait_all_aio() returned error: " << cpp_strerror(-r) << dendl;
+        derr << "ERROR: target_shards[" << shard.get_shard_id() << "].wait_all_aio() returned error: " << cpp_strerror(-r) << dendl;
         ret = r;
       }
     }
@@ -574,8 +573,9 @@ int RGWBucketReshardLock::renew(const Clock::time_point& now) {
 }
 
 
-int RGWBucketReshard::do_reshard(int num_shards,
-				 int max_entries,
+int RGWBucketReshard::do_reshard(const rgw::bucket_index_layout_generation& current,
+                                 const rgw::bucket_index_layout_generation& target,
+                                 int max_entries,
 				 bool verbose,
 				 ostream *out,
 				 Formatter *formatter)
@@ -594,10 +594,7 @@ int RGWBucketReshard::do_reshard(int num_shards,
     return -EINVAL;
   }
 
-  auto target_shards = bucket_info.layout.target_index->layout.normal.num_shards;
-  int num_target_shards = (target_shards > 0 ? num_shards : 1);
-
-  BucketReshardManager target_shards_mgr(store, bucket_info, num_target_shards);
+  BucketReshardManager target_shards_mgr(store, bucket_info, target);
 
   bool verbose_json_out = verbose && (formatter != nullptr) && (out != nullptr);
 
@@ -611,9 +608,7 @@ int RGWBucketReshard::do_reshard(int num_shards,
     (*out) << "total entries:";
   }
 
-  auto current_shards = bucket_info.layout.current_index.layout.normal.num_shards;
-  const int num_source_shards =
-    (current_shards > 0 ? current_shards : 1);
+  const int num_source_shards = current.layout.normal.num_shards;
   string marker;
   for (int i = 0; i < num_source_shards; ++i) {
     bool is_truncated = true;
@@ -744,8 +739,9 @@ int RGWBucketReshard::execute(int num_shards,
  
   if (ret = fault.check("do_reshard");
       ret == 0) { // no fault injected, do the reshard
-    ret = do_reshard(num_shards, max_op_entries,
-                     verbose, out, formatter);
+    ret = do_reshard(bucket_info.layout.current_index,
+                     *bucket_info.layout.target_index,
+                     max_op_entries, verbose, out, formatter);
   }
 
   if (ret < 0) {

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -259,17 +259,12 @@ RGWBucketReshard::RGWBucketReshard(rgw::sal::RGWRadosStore *_store,
 
 int RGWBucketReshard::set_resharding_status(rgw::sal::RGWRadosStore* store,
 					    const RGWBucketInfo& bucket_info,
-					    const string& new_instance_id,
+					    const string& instance_id,
 					    int32_t num_shards,
-					    cls_rgw_reshard_status status)
+					    rgw::BucketReshardState status)
 {
-  if (new_instance_id.empty()) {
-    ldout(store->ctx(), 0) << __func__ << " missing new bucket instance id" << dendl;
-    return -EINVAL;
-  }
-
   cls_rgw_bucket_instance_entry instance_entry;
-  instance_entry.set_status(new_instance_id, num_shards, status);
+  instance_entry.set_status(instance_id, num_shards, status);
 
   int ret = store->getRados()->bucket_set_reshard(bucket_info, instance_entry);
   if (ret < 0) {
@@ -313,7 +308,7 @@ int RGWBucketReshard::clear_index_shard_reshard_status(rgw::sal::RGWRadosStore* 
     int ret = set_resharding_status(store, bucket_info,
 				    bucket_info.bucket.bucket_id,
 				    (num_shards < 1 ? 1 : num_shards),
-				    cls_rgw_reshard_status::NOT_RESHARDING);
+				    rgw::BucketReshardState::NOT_RESHARDING);
     if (ret < 0) {
       ldout(store->ctx(), 0) << "RGWBucketReshard::" << __func__ <<
 	" ERROR: error clearing reshard status from index shard " <<
@@ -335,8 +330,7 @@ static int create_new_bucket_instance(rgw::sal::RGWRadosStore *store,
 
   store->getRados()->create_bucket_id(&new_bucket_info.bucket.bucket_id);
 
-  new_bucket_info.layout.current_index.layout.normal.num_shards = new_num_shards;
-  new_bucket_info.objv_tracker.clear();
+  bucket_info.layout.resharding = rgw::BucketReshardState::NONE;
 
   new_bucket_info.new_bucket_instance_id.clear();
   new_bucket_info.reshard_status = cls_rgw_reshard_status::NOT_RESHARDING;
@@ -384,8 +378,8 @@ class BucketInfoReshardUpdate
 
   bool in_progress{false};
 
-  int set_status(cls_rgw_reshard_status s) {
-    bucket_info.reshard_status = s;
+  int set_status(rgw::BucketReshardState s) {
+    bucket_info.layout.resharding = s;
     int ret = store->getRados()->put_bucket_instance_info(bucket_info, false, real_time(), &bucket_attrs);
     if (ret < 0) {
       ldout(store->ctx(), 0) << "ERROR: failed to write bucket info, ret=" << ret << dendl;
@@ -521,20 +515,14 @@ int RGWBucketReshardLock::renew(const Clock::time_point& now) {
 
 
 int RGWBucketReshard::do_reshard(int num_shards,
-				 RGWBucketInfo& new_bucket_info,
 				 int max_entries,
 				 bool verbose,
 				 ostream *out,
 				 Formatter *formatter)
 {
   if (out) {
-    const rgw_bucket& bucket = bucket_info.bucket;
-    (*out) << "tenant: " << bucket.tenant << std::endl;
-    (*out) << "bucket name: " << bucket.name << std::endl;
-    (*out) << "old bucket instance id: " << bucket.bucket_id <<
-      std::endl;
-    (*out) << "new bucket instance id: " << new_bucket_info.bucket.bucket_id <<
-      std::endl;
+    (*out) << "tenant: " << bucket_info.bucket.tenant << std::endl;
+    (*out) << "bucket name: " << bucket_info.bucket.name << std::endl;
   }
 
   /* update bucket info -- in progress*/
@@ -548,7 +536,7 @@ int RGWBucketReshard::do_reshard(int num_shards,
 
   // NB: destructor cleans up sharding state if reshard does not
   // complete successfully
-  BucketInfoReshardUpdate bucket_info_updater(store, bucket_info, bucket_attrs, new_bucket_info.bucket.bucket_id);
+  BucketInfoReshardUpdate bucket_info_updater(store, bucket_info, bucket_attrs);
 
   int ret = bucket_info_updater.start();
   if (ret < 0) {
@@ -605,13 +593,14 @@ int RGWBucketReshard::do_reshard(int num_shards,
 	rgw_bucket_category_stats stats;
 	bool account = entry.get_info(&cls_key, &category, &stats);
 	rgw_obj_key key(cls_key);
-	rgw_obj obj(new_bucket_info.bucket, key);
+	rgw_obj obj(bucket_info.bucket, key);
 	RGWMPObj mp;
 	if (key.ns == RGW_OBJ_NS_MULTIPART && mp.from_meta(key.name)) {
 	  // place the multipart .meta object on the same shard as its head object
 	  obj.index_hash_source = mp.get_key();
 	}
-	int ret = store->getRados()->get_target_shard_id(new_bucket_info.layout.current_index.layout.normal, obj.get_hash_object(), &target_shard_id);
+	int ret = store->getRados()->get_target_shard_id(bucket_info.layout.target_index.layout.normal, obj
+	.get_hash_object(),	&target_shard_id);
 	if (ret < 0) {
 	  lderr(store->ctx()) << "ERROR: get_target_shard_id() returned ret=" << ret << dendl;
 	  return ret;
@@ -664,16 +653,13 @@ int RGWBucketReshard::do_reshard(int num_shards,
     return -EIO;
   }
 
-  ret = store->ctl()->bucket->link_bucket(new_bucket_info.owner, new_bucket_info.bucket, bucket_info.creation_time, null_yield);
+  //overwrite current_index for the next reshard process
+  bucket_info.layout.current_index = bucket_info.layout.target_index;
+  bucket_info.layout.resharding = rgw::BucketReshardState::NONE;
+  ret = store->getRados()->put_bucket_instance_info(bucket_info, false, real_time(), &bucket_attrs);
   if (ret < 0) {
-    lderr(store->ctx()) << "failed to link new bucket instance (bucket_id=" << new_bucket_info.bucket.bucket_id << ": " << cpp_strerror(-ret) << ")" << dendl;
-    return ret;
-  }
-
-  ret = bucket_info_updater.complete();
-  if (ret < 0) {
-    ldout(store->ctx(), 0) << __func__ << ": failed to update bucket info ret=" << ret << dendl;
-    /* don't error out, reshard process succeeded */
+    lderr(store->ctx()) << "ERROR: failed writing bucket instance info: " << dendl;
+      return ret;
   }
 
   return 0;
@@ -695,30 +681,30 @@ int RGWBucketReshard::execute(int num_shards, int max_op_entries,
     return ret;
   }
 
-  RGWBucketInfo new_bucket_info;
-  ret = create_new_bucket_instance(num_shards, new_bucket_info);
+  ret = update_num_shards(num_shards); //modifies existing bucket
   if (ret < 0) {
-    // shard state is uncertain, but this will attempt to remove them anyway
+    return ret;
     goto error_out;
   }
 
   if (reshard_log) {
-    ret = reshard_log->update(bucket_info, new_bucket_info);
+    ret = reshard_log->update(bucket_info);
     if (ret < 0) {
+      return ret;
       goto error_out;
     }
   }
 
   // set resharding status of current bucket_info & shards with
   // information about planned resharding
-  ret = set_resharding_status(new_bucket_info.bucket.bucket_id,
-			      num_shards, cls_rgw_reshard_status::IN_PROGRESS);
+  ret = set_resharding_status(bucket_info.bucket.bucket_id,
+			      num_shards, rgw::BucketReshardState::IN_PROGRESS);
   if (ret < 0) {
+    return ret;
     goto error_out;
   }
 
   ret = do_reshard(num_shards,
-		   new_bucket_info,
 		   max_op_entries,
                    verbose, out, formatter);
   if (ret < 0) {
@@ -730,30 +716,20 @@ int RGWBucketReshard::execute(int num_shards, int max_op_entries,
 
   reshard_lock.unlock();
 
-  // resharding successful, so remove old bucket index shards; use
-  // best effort and don't report out an error; the lock isn't needed
-  // at this point since all we're using a best effor to to remove old
-  // shard objects
-  ret = store->svc()->bi->clean_index(bucket_info);
-  if (ret < 0) {
-    lderr(store->ctx()) << "Error: " << __func__ <<
-      " failed to clean up old shards; " <<
-      "RGWRados::clean_bucket_index returned " << ret << dendl;
-  }
+   // resharding successful, so remove old bucket index shards; use
+   // best effort and don't report out an error; the lock isn't needed
+   // at this point since all we're using a best effor to to remove old
+   // shard objects
 
-  ret = store->ctl()->bucket->remove_bucket_instance_info(bucket_info.bucket,
-                                                       bucket_info, null_yield);
-  if (ret < 0) {
-    lderr(store->ctx()) << "Error: " << __func__ <<
-      " failed to clean old bucket info object \"" <<
-      bucket_info.bucket.get_key() <<
-      "\"created after successful resharding with error " << ret << dendl;
+   ret = store->svc()->bi->clean_index(bucket_info, (bucket_info.layout.current_index.gen - 1));
+   if (ret < 0) {
+     lderr(store->ctx()) << "Error: " << __func__ <<
+      " failed to clean up old shards; " <<
+     "RGWRados::clean_bucket_index returned " << ret << dendl;
   }
 
   ldout(store->ctx(), 1) << __func__ <<
-    " INFO: reshard of bucket \"" << bucket_info.bucket.name << "\" from \"" <<
-    bucket_info.bucket.get_key() << "\" to \"" <<
-    new_bucket_info.bucket.get_key() << "\" completed successfully" << dendl;
+    " INFO: reshard of bucket \"" << bucket_info.bucket.name << "\" completed successfully" << dendl;
 
   return 0;
 
@@ -761,24 +737,16 @@ error_out:
 
   reshard_lock.unlock();
 
+
+  //TODO: Cleanup failed incomplete resharding
   // since the real problem is the issue that led to this error code
   // path, we won't touch ret and instead use another variable to
   // temporarily error codes
-  int ret2 = store->svc()->bi->clean_index(new_bucket_info);
+  int ret2 = store->svc()->bi->clean_index(bucket_info, bucket_info.layout.target_index.gen);
   if (ret2 < 0) {
     lderr(store->ctx()) << "Error: " << __func__ <<
       " failed to clean up shards from failed incomplete resharding; " <<
       "RGWRados::clean_bucket_index returned " << ret2 << dendl;
-  }
-
-  ret2 = store->ctl()->bucket->remove_bucket_instance_info(new_bucket_info.bucket,
-                                                        new_bucket_info,
-							null_yield);
-  if (ret2 < 0) {
-    lderr(store->ctx()) << "Error: " << __func__ <<
-      " failed to clean bucket info object \"" <<
-      new_bucket_info.bucket.get_key() <<
-      "\"created during incomplete resharding with error " << ret2 << dendl;
   }
 
   return ret;
@@ -814,10 +782,6 @@ void RGWReshard::get_bucket_logshard_oid(const string& tenant, const string& buc
 
 int RGWReshard::add(cls_rgw_reshard_entry& entry)
 {
-  if (!store->svc()->zone->can_reshard()) {
-    ldout(store->ctx(), 20) << __func__ << " Resharding is disabled"  << dendl;
-    return 0;
-  }
 
   string logshard_oid;
 
@@ -834,7 +798,7 @@ int RGWReshard::add(cls_rgw_reshard_entry& entry)
   return 0;
 }
 
-int RGWReshard::update(const RGWBucketInfo& bucket_info, const RGWBucketInfo& new_bucket_info)
+int RGWReshard::update(const RGWBucketInfo& bucket_info)
 {
   cls_rgw_reshard_entry entry;
   entry.bucket_name = bucket_info.bucket.name;
@@ -845,8 +809,6 @@ int RGWReshard::update(const RGWBucketInfo& bucket_info, const RGWBucketInfo& ne
   if (ret < 0) {
     return ret;
   }
-
-  entry.new_instance_id = new_bucket_info.bucket.name + ":"  + new_bucket_info.bucket.bucket_id;
 
   ret = add(entry);
   if (ret < 0) {
@@ -1006,7 +968,6 @@ int RGWReshard::process_single_logshard(int logshard_num)
     }
 
     for(auto& entry: entries) { // logshard entries
-      if(entry.new_instance_id.empty()) {
 
 	ldout(store->ctx(), 20) << __func__ << " resharding " <<
 	  entry.bucket_name  << dendl;
@@ -1053,6 +1014,7 @@ int RGWReshard::process_single_logshard(int logshard_num)
 	  goto finished_entry;
 	}
 
+	{
 	RGWBucketReshard br(store, bucket_info, attrs, nullptr);
 	ret = br.execute(entry.new_num_shards, max_entries, false, nullptr,
 			 nullptr, this);
@@ -1073,8 +1035,8 @@ int RGWReshard::process_single_logshard(int logshard_num)
 	    entry.bucket_name << " from resharding queue: " <<
 	    cpp_strerror(-ret) << dendl;
 	  return ret;
+	  }
 	}
-      } // if new instance id is empty
 
     finished_entry:
 
@@ -1106,10 +1068,6 @@ void  RGWReshard::get_logshard_oid(int shard_num, string *logshard)
 
 int RGWReshard::process_all_logshards()
 {
-  if (!store->svc()->zone->can_reshard()) {
-    ldout(store->ctx(), 20) << __func__ << " Resharding is disabled"  << dendl;
-    return 0;
-  }
   int ret = 0;
 
   for (int i = 0; i < num_logshards; i++) {

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -334,7 +334,7 @@ static int set_target_layout(rgw::sal::RGWRadosStore *store,
 
 int RGWBucketReshard::set_target_layout(int new_num_shards)
 {
-  int ret = RGWBucketReshard::update_bucket(rgw::BucketReshardState::IN_PROGRESS);
+  int ret = RGWBucketReshard::update_bucket(rgw::BucketReshardState::InProgress);
   if (ret < 0) {
     lderr(store->ctx()) << "ERROR: failed to store updated bucket instance info: " << dendl;
     return ret;
@@ -392,7 +392,7 @@ public:
   }
 
   int start() {
-    int ret = set_status(rgw::BucketReshardState::IN_PROGRESS);
+    int ret = set_status(rgw::BucketReshardState::InProgress);
     if (ret < 0) {
       return ret;
     }
@@ -401,7 +401,7 @@ public:
   }
 
   int complete() {
-    int ret = set_status(rgw::BucketReshardState::NONE);
+    int ret = set_status(rgw::BucketReshardState::None);
     if (ret < 0) {
       return ret;
     }
@@ -644,7 +644,7 @@ int RGWBucketReshard::do_reshard(int num_shards,
   bucket_info.layout.current_index = *bucket_info.layout.target_index;
   bucket_info.layout.target_index = std::nullopt; // target_layout doesn't need to exist after reshard
 
-  ret = RGWBucketReshard::update_bucket(rgw::BucketReshardState::NONE);
+  ret = RGWBucketReshard::update_bucket(rgw::BucketReshardState::None);
   if (ret < 0) {
     lderr(store->ctx()) << "ERROR: failed writing bucket instance info: " << dendl;
       return ret;
@@ -744,7 +744,7 @@ error_out:
     // restore old index
   bucket_info.layout.current_index = prev_index;
 
-  ret = RGWBucketReshard::update_bucket(rgw::BucketReshardState::NONE);
+  ret = RGWBucketReshard::update_bucket(rgw::BucketReshardState::None);
   if (ret < 0) {
     lderr(store->ctx()) << "ERROR: failed to store updated bucket instance info: " << dendl;
     return ret;

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -184,26 +184,23 @@ class BucketReshardManager {
   rgw::sal::RGWRadosStore *store;
   const RGWBucketInfo& target_bucket_info;
   deque<librados::AioCompletion *> completions;
-  int num_target_shards;
-  vector<BucketReshardShard *> target_shards;
+  vector<BucketReshardShard> target_shards;
 
 public:
   BucketReshardManager(rgw::sal::RGWRadosStore *_store,
 		       const RGWBucketInfo& _target_bucket_info,
-		       int _num_target_shards) :
-    store(_store), target_bucket_info(_target_bucket_info),
-    num_target_shards(_num_target_shards)
+		       int num_target_shards)
+    : store(_store), target_bucket_info(_target_bucket_info)
   {
-
-    target_shards.resize(num_target_shards);
+    target_shards.reserve(num_target_shards);
     for (int i = 0; i < num_target_shards; ++i) {
-      target_shards[i] = new BucketReshardShard(store, target_bucket_info, i, completions);
+      target_shards.emplace_back(store, target_bucket_info, i, completions);
     }
   }
 
   ~BucketReshardManager() {
     for (auto& shard : target_shards) {
-      int ret = shard->wait_all_aio();
+      int ret = shard.wait_all_aio();
       if (ret < 0) {
         ldout(store->ctx(), 20) << __func__ <<
 	  ": shard->wait_all_aio() returned ret=" << ret << dendl;
@@ -214,8 +211,8 @@ public:
   int add_entry(int shard_index,
                 rgw_cls_bi_entry& entry, bool account, RGWObjCategory category,
                 const rgw_bucket_category_stats& entry_stats) {
-    int ret = target_shards[shard_index]->add_entry(entry, account, category,
-						    entry_stats);
+    int ret = target_shards[shard_index].add_entry(entry, account, category,
+						   entry_stats);
     if (ret < 0) {
       derr << "ERROR: target_shards.add_entry(" << entry.idx <<
 	") returned error: " << cpp_strerror(-ret) << dendl;
@@ -228,19 +225,18 @@ public:
   int finish() {
     int ret = 0;
     for (auto& shard : target_shards) {
-      int r = shard->flush();
+      int r = shard.flush();
       if (r < 0) {
-        derr << "ERROR: target_shards[" << shard->get_num_shard() << "].flush() returned error: " << cpp_strerror(-r) << dendl;
+        derr << "ERROR: target_shards[" << shard.get_num_shard() << "].flush() returned error: " << cpp_strerror(-r) << dendl;
         ret = r;
       }
     }
     for (auto& shard : target_shards) {
-      int r = shard->wait_all_aio();
+      int r = shard.wait_all_aio();
       if (r < 0) {
-        derr << "ERROR: target_shards[" << shard->get_num_shard() << "].wait_all_aio() returned error: " << cpp_strerror(-r) << dendl;
+        derr << "ERROR: target_shards[" << shard.get_num_shard() << "].wait_all_aio() returned error: " << cpp_strerror(-r) << dendl;
         ret = r;
       }
-      delete shard;
     }
     target_shards.clear();
     return ret;

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -268,6 +268,23 @@ static int set_resharding_status(rgw::sal::RGWRadosStore* store,
   return 0;
 }
 
+static int remove_old_reshard_instance(rgw::sal::RGWRadosStore* store,
+                                       const rgw_bucket& bucket)
+{
+  RGWBucketInfo info;
+  auto obj_ctx = store->svc()->sysobj->init_obj_ctx();
+  int r = store->getRados()->get_bucket_instance_info(obj_ctx, bucket, info,
+                                                      nullptr, nullptr, null_yield);
+  if (r < 0) {
+    return r;
+  }
+
+  // delete its shard objects (ignore errors)
+  store->svc()->bi->clean_index(info, info.layout.current_index);
+  // delete the bucket instance metadata
+  return store->ctl()->bucket->remove_bucket_instance_info(bucket, info, null_yield);
+}
+
 // initialize a target index layout, create its bucket index shard objects, and
 // write the target layout to the bucket instance metadata
 static int init_target_layout(rgw::sal::RGWRadosStore* store,
@@ -276,6 +293,20 @@ static int init_target_layout(rgw::sal::RGWRadosStore* store,
                               uint32_t new_num_shards)
 {
   uint64_t gen = bucket_info.layout.current_index.gen + 1;
+
+  if (bucket_info.reshard_status == cls_rgw_reshard_status::IN_PROGRESS) {
+    // backward-compatible cleanup of old reshards, where the target was in a
+    // different bucket instance
+    if (!bucket_info.new_bucket_instance_id.empty()) {
+      rgw_bucket new_bucket = bucket_info.bucket;
+      new_bucket.bucket_id = bucket_info.new_bucket_instance_id;
+      ldout(store->ctx(), 10) << __func__ << " removing target bucket instance "
+          "from a previous reshard attempt" << dendl;
+      // ignore errors
+      remove_old_reshard_instance(store, new_bucket);
+    }
+    bucket_info.reshard_status = cls_rgw_reshard_status::NOT_RESHARDING;
+  }
 
   auto& target = bucket_info.layout.target_index;
   if (target) {

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -68,14 +68,10 @@ public:
 }; // class RGWBucketReshardLock
 
 class RGWBucketReshard {
-public:
-
-  friend class RGWReshard;
-
+ public:
   using Clock = ceph::coarse_mono_clock;
 
-private:
-
+ private:
   rgw::sal::RGWRadosStore *store;
   RGWBucketInfo bucket_info;
 

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -84,10 +84,8 @@ private:
   // allocated in at once
   static const std::initializer_list<uint16_t> reshard_primes;
 
-  int create_new_bucket_instance(int new_num_shards,
-				 RGWBucketInfo& new_bucket_info);
+  int update_num_shards(int new_num_shards);
   int do_reshard(int num_shards,
-		 RGWBucketInfo& new_bucket_info,
 		 int max_entries,
                  bool verbose,
                  ostream *os,
@@ -228,7 +226,7 @@ protected:
 public:
   RGWReshard(rgw::sal::RGWRadosStore* _store, bool _verbose = false, ostream *_out = nullptr, Formatter *_formatter = nullptr);
   int add(cls_rgw_reshard_entry& entry);
-  int update(const RGWBucketInfo& bucket_info, const RGWBucketInfo& new_bucket_info);
+  int update(const RGWBucketInfo& bucket_info);
   int get(cls_rgw_reshard_entry& entry);
   int remove(cls_rgw_reshard_entry& entry);
   int list(int logshard_num, string& marker, uint32_t max, std::list<cls_rgw_reshard_entry>& entries, bool *is_truncated);

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -76,6 +76,7 @@ private:
   rgw::sal::RGWRadosStore *store;
   RGWBucketInfo bucket_info;
   std::map<string, bufferlist> bucket_attrs;
+  rgw::bucket_index_layout_generation prev_index;
 
   RGWBucketReshardLock reshard_lock;
   RGWBucketReshardLock* outer_reshard_lock;

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -84,7 +84,7 @@ private:
   // allocated in at once
   static const std::initializer_list<uint16_t> reshard_primes;
 
-  int update_num_shards(int new_num_shards);
+  int set_target_layout(int new_num_shards);
   int do_reshard(int num_shards,
 		 int max_entries,
                  bool verbose,

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -116,14 +116,14 @@ public:
   }
   static int set_resharding_status(rgw::sal::RGWRadosStore* store,
 				   const RGWBucketInfo& bucket_info,
-				   const string& new_instance_id,
+				   const string& instance_id,
 				   int32_t num_shards,
-				   cls_rgw_reshard_status status);
-  int set_resharding_status(const string& new_instance_id,
+				   rgw::BucketReshardState status);
+  int set_resharding_status(const string& instance_id,
 			    int32_t num_shards,
-			    cls_rgw_reshard_status status) {
+			    rgw::BucketReshardState status) {
     return set_resharding_status(store, bucket_info,
-				 new_instance_id, num_shards, status);
+			instance_id, num_shards, status);
   }
 
   static uint32_t get_max_prime_shards() {

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -86,6 +86,8 @@ private:
   static const std::initializer_list<uint16_t> reshard_primes;
 
   int set_target_layout(int new_num_shards);
+  int set_reshard_status(rgw::BucketReshardState s);
+  
   int do_reshard(int num_shards,
 		 int max_entries,
                  bool verbose,

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -116,14 +116,9 @@ public:
   }
   static int set_resharding_status(rgw::sal::RGWRadosStore* store,
 				   const RGWBucketInfo& bucket_info,
-				   const string& instance_id,
-				   int32_t num_shards,
-				   rgw::BucketReshardState status);
-  int set_resharding_status(const string& instance_id,
-			    int32_t num_shards,
-			    rgw::BucketReshardState status) {
-    return set_resharding_status(store, bucket_info,
-			instance_id, num_shards, status);
+				   cls_rgw_reshard_status status);
+  int set_resharding_status(cls_rgw_reshard_status status) {
+    return set_resharding_status(store, bucket_info, status);
   }
 
   static uint32_t get_max_prime_shards() {

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -21,6 +21,7 @@
 #include "cls/lock/cls_lock_client.h"
 
 #include "rgw_common.h"
+#include "common/fault_injector.h"
 
 
 class RGWReshard;
@@ -87,12 +88,11 @@ private:
 
   int set_target_layout(int new_num_shards);
   int update_bucket(rgw::BucketReshardState s);
-  
   int do_reshard(int num_shards,
-		 int max_entries,
+                 int max_entries, FaultInjector<std::string_view>& f,
                  bool verbose,
                  ostream *os,
-		 Formatter *formatter);
+                 Formatter *formatter);
 public:
 
   // pass nullptr for the final parameter if no outer reshard lock to
@@ -101,7 +101,7 @@ public:
 		   const RGWBucketInfo& _bucket_info,
                    const std::map<string, bufferlist>& _bucket_attrs,
 		   RGWBucketReshardLock* _outer_reshard_lock);
-  int execute(int num_shards, int max_op_entries,
+  int execute(int num_shards, FaultInjector<std::string_view>& f, int max_op_entries,
               bool verbose = false, ostream *out = nullptr,
               Formatter *formatter = nullptr,
 	      RGWReshard *reshard_log = nullptr);

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -86,7 +86,7 @@ private:
   static const std::initializer_list<uint16_t> reshard_primes;
 
   int set_target_layout(int new_num_shards);
-  int set_reshard_status(rgw::BucketReshardState s);
+  int update_bucket(rgw::BucketReshardState s);
   
   int do_reshard(int num_shards,
 		 int max_entries,

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -88,7 +88,8 @@ private:
 
   int set_target_layout(int new_num_shards);
   int update_bucket(rgw::BucketReshardState s);
-  int do_reshard(int num_shards,
+  int do_reshard(const rgw::bucket_index_layout_generation& current,
+                 const rgw::bucket_index_layout_generation& target,
                  int max_entries,
                  bool verbose,
                  ostream *os,

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -29,6 +29,8 @@ namespace rgw { namespace sal {
   class RGWRadosStore;
 } }
 
+using ReshardFaultInjector = FaultInjector<std::string_view>;
+
 class RGWBucketReshardLock {
   using Clock = ceph::coarse_mono_clock;
 
@@ -88,7 +90,7 @@ private:
   int set_target_layout(int new_num_shards);
   int update_bucket(rgw::BucketReshardState s);
   int do_reshard(int num_shards,
-                 int max_entries, FaultInjector<std::string_view>& f,
+                 int max_entries, const ReshardFaultInjector& f,
                  bool verbose,
                  ostream *os,
                  Formatter *formatter);
@@ -99,7 +101,7 @@ public:
   RGWBucketReshard(rgw::sal::RGWRadosStore *_store,
 		   const RGWBucketInfo& _bucket_info,
 		   RGWBucketReshardLock* _outer_reshard_lock);
-  int execute(int num_shards, FaultInjector<std::string_view>& f, int max_op_entries,
+  int execute(int num_shards, const ReshardFaultInjector& f, int max_op_entries,
               bool verbose = false, ostream *out = nullptr,
               Formatter *formatter = nullptr,
 	      RGWReshard *reshard_log = nullptr);

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -78,7 +78,6 @@ private:
 
   rgw::sal::RGWRadosStore *store;
   RGWBucketInfo bucket_info;
-  rgw::bucket_index_layout_generation prev_index;
 
   RGWBucketReshardLock reshard_lock;
   RGWBucketReshardLock* outer_reshard_lock;
@@ -90,7 +89,7 @@ private:
   int set_target_layout(int new_num_shards);
   int update_bucket(rgw::BucketReshardState s);
   int do_reshard(int num_shards,
-                 int max_entries, const ReshardFaultInjector& f,
+                 int max_entries,
                  bool verbose,
                  ostream *os,
                  Formatter *formatter);
@@ -107,22 +106,9 @@ public:
 	      RGWReshard *reshard_log = nullptr);
   int get_status(std::list<cls_rgw_bucket_instance_entry> *status);
   int cancel();
+
   static int clear_resharding(rgw::sal::RGWRadosStore* store,
-			      const RGWBucketInfo& bucket_info);
-  int clear_resharding() {
-    return clear_resharding(store, bucket_info);
-  }
-  static int clear_index_shard_reshard_status(rgw::sal::RGWRadosStore* store,
-					      const RGWBucketInfo& bucket_info);
-  int clear_index_shard_reshard_status() {
-    return clear_index_shard_reshard_status(store, bucket_info);
-  }
-  static int set_resharding_status(rgw::sal::RGWRadosStore* store,
-				   const RGWBucketInfo& bucket_info,
-				   cls_rgw_reshard_status status);
-  int set_resharding_status(cls_rgw_reshard_status status) {
-    return set_resharding_status(store, bucket_info, status);
-  }
+			      RGWBucketInfo& bucket_info);
 
   static uint32_t get_max_prime_shards() {
     return *std::crbegin(reshard_primes);

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -76,7 +76,6 @@ private:
 
   rgw::sal::RGWRadosStore *store;
   RGWBucketInfo bucket_info;
-  std::map<string, bufferlist> bucket_attrs;
   rgw::bucket_index_layout_generation prev_index;
 
   RGWBucketReshardLock reshard_lock;
@@ -99,7 +98,6 @@ public:
   // manage
   RGWBucketReshard(rgw::sal::RGWRadosStore *_store,
 		   const RGWBucketInfo& _bucket_info,
-                   const std::map<string, bufferlist>& _bucket_attrs,
 		   RGWBucketReshardLock* _outer_reshard_lock);
   int execute(int num_shards, FaultInjector<std::string_view>& f, int max_op_entries,
               bool verbose = false, ostream *out = nullptr,

--- a/src/rgw/services/svc_bi.h
+++ b/src/rgw/services/svc_bi.h
@@ -29,8 +29,8 @@ public:
   RGWSI_BucketIndex(CephContext *cct) : RGWServiceInstance(cct) {}
   virtual ~RGWSI_BucketIndex() {}
 
-  virtual int init_index(RGWBucketInfo& bucket_info) = 0;
-  virtual int clean_index(RGWBucketInfo& bucket_info, std::optional<uint64_t> gen) = 0;
+  virtual int init_index(RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout) = 0;
+  virtual int clean_index(RGWBucketInfo& bucket_info, uint64_t gen) = 0;
 
   virtual int read_stats(const RGWBucketInfo& bucket_info,
                          RGWBucketEnt *stats,

--- a/src/rgw/services/svc_bi.h
+++ b/src/rgw/services/svc_bi.h
@@ -30,7 +30,7 @@ public:
   virtual ~RGWSI_BucketIndex() {}
 
   virtual int init_index(RGWBucketInfo& bucket_info) = 0;
-  virtual int clean_index(RGWBucketInfo& bucket_info) = 0;
+  virtual int clean_index(RGWBucketInfo& bucket_info, std::optional<uint64_t> gen) = 0;
 
   virtual int read_stats(const RGWBucketInfo& bucket_info,
                          RGWBucketEnt *stats,

--- a/src/rgw/services/svc_bi.h
+++ b/src/rgw/services/svc_bi.h
@@ -30,7 +30,7 @@ public:
   virtual ~RGWSI_BucketIndex() {}
 
   virtual int init_index(RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout) = 0;
-  virtual int clean_index(RGWBucketInfo& bucket_info, uint64_t gen) = 0;
+  virtual int clean_index(RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout) = 0;
 
   virtual int read_stats(const RGWBucketInfo& bucket_info,
                          RGWBucketEnt *stats,

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -150,33 +150,6 @@ static void get_bucket_index_objects(const string& bucket_oid_base,
   }
 }
 
-/*
-static void get_bucket_index_objects(const string& bucket_oid_base,
-                                     uint32_t num_shards,
-                                     map<int, string> *_bucket_objects,
-                                     int shard_id = -1)
-{
-  auto& bucket_objects = *_bucket_objects;
-  if (!num_shards) {
-    bucket_objects[0] = bucket_oid_base;
-  } else {
-    char buf[bucket_oid_base.size() + 32];
-    if (shard_id < 0) {
-      for (uint32_t i = 0; i < num_shards; ++i) {
-        snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), i);
-        bucket_objects[i] = buf;
-      }
-    } else {
-      if ((uint32_t)shard_id > num_shards) {
-        return;
-      }
-      snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), shard_id);
-      bucket_objects[shard_id] = buf;
-    }
-  }
-}
-*/
-
 static void get_bucket_instance_ids(const RGWBucketInfo& bucket_info,
                                     int shard_id,
                                     map<int, string> *result)

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -203,15 +203,16 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index(const RGWBucketInfo& bucket_info,
 void RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_base,
                                                       uint32_t num_shards,
                                                       int shard_id,
-                                                      uint64_t gen_id,
+                                                      std::optional<uint64_t> _gen_id,
                                                       string *bucket_obj)
 {
+  auto gen_id = _gen_id.value_or(0);
   if (!num_shards) {
     // By default with no sharding, we use the bucket oid as itself
     (*bucket_obj) = bucket_oid_base;
   } else {
     char buf[bucket_oid_base.size() + 64];
-    if (gen_id != 0) {
+    if (gen_id) {
       snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, shard_id);
       (*bucket_obj) = buf;
 	  ldout(cct, 10) << "bucket_obj is " << (*bucket_obj) << dendl;
@@ -284,7 +285,8 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const RGWBucketInfo& bucket
 
 int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const RGWBucketInfo& bucket_info,
                                                      int shard_id,
-                                                     const rgw::bucket_index_layout_generation& target_layout,
+                                                     uint32_t num_shards,
+                                                     std::optional<uint64_t> gen,
                                                      RGWSI_RADOS::Obj *bucket_obj)
 {
   RGWSI_RADOS::Pool index_pool;
@@ -298,8 +300,8 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const RGWBucketInfo& bucket
 
   string oid;
 
-  get_bucket_index_object(bucket_oid_base, target_layout.layout.normal.num_shards,
-                          shard_id, target_layout.gen, &oid);
+  get_bucket_index_object(bucket_oid_base, num_shards,
+                          shard_id, gen, &oid);
 
   *bucket_obj = svc.rados->obj(index_pool, oid);
 

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -224,7 +224,7 @@ void RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_b
 
 int RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_base, const string& obj_key,
                                                      uint32_t num_shards, rgw::BucketHashType hash_type,
-                                                     string *bucket_obj, int *shard_id)
+                                                     uint64_t gen_id, string *bucket_obj, int *shard_id)
 {
   int r = 0;
   switch (hash_type) {
@@ -237,8 +237,12 @@ int RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_ba
         }
       } else {
         uint32_t sid = bucket_shard_index(obj_key, num_shards);
-        char buf[bucket_oid_base.size() + 32];
-        snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), sid);
+        char buf[bucket_oid_base.size() + 64];
+        if (gen_id) {
+          snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, sid);
+        } else {
+          snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), sid);
+        }
         (*bucket_obj) = buf;
         if (shard_id) {
           *shard_id = (int)sid;
@@ -270,7 +274,7 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const RGWBucketInfo& bucket
   string oid;
 
   ret = get_bucket_index_object(bucket_oid_base, obj_key, bucket_info.layout.current_index.layout.normal.num_shards,
-        bucket_info.layout.current_index.layout.normal.hash_type, &oid, shard_id);
+        bucket_info.layout.current_index.layout.normal.hash_type, bucket_info.layout.current_index.gen, &oid, shard_id);
   if (ret < 0) {
     ldout(cct, 10) << "get_bucket_index_object() returned ret=" << ret << dendl;
     return ret;
@@ -355,7 +359,7 @@ int RGWSI_BucketIndex_RADOS::init_index(RGWBucketInfo& bucket_info, const rgw::b
 }
 
 
-int RGWSI_BucketIndex_RADOS::clean_index(RGWBucketInfo& bucket_info, uint64_t gen)
+int RGWSI_BucketIndex_RADOS::clean_index(RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout)
 {
   RGWSI_RADOS::Pool index_pool;
 
@@ -368,8 +372,8 @@ int RGWSI_BucketIndex_RADOS::clean_index(RGWBucketInfo& bucket_info, uint64_t ge
   dir_oid.append(bucket_info.bucket.bucket_id);
 
   std::map<int, std::string> bucket_objs;
-  get_bucket_index_objects(dir_oid, bucket_info.layout.current_index.layout.normal.num_shards,
-                          gen, &bucket_objs);
+  get_bucket_index_objects(dir_oid, idx_layout.layout.normal.num_shards,
+                          idx_layout.gen, &bucket_objs);
 
   return CLSRGWIssueBucketIndexClean(index_pool.ioctx(),
 				     bucket_objs,

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -113,6 +113,45 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index(const RGWBucketInfo& bucket_info,
 }
 
 static void get_bucket_index_objects(const string& bucket_oid_base,
+                                     uint32_t num_shards, std::optional<uint64_t> _gen_id,
+                                     map<int, string> *_bucket_objects,
+                                     int shard_id = -1)
+{
+  auto& bucket_objects = *_bucket_objects;
+  auto gen_id = _gen_id.value_or(0);
+  if (!num_shards) {
+    bucket_objects[0] = bucket_oid_base;
+  } else {
+    char buf[bucket_oid_base.size() + 64];
+    if (shard_id < 0) {
+      for (uint32_t i = 0; i < num_shards; ++i) {
+        if (gen_id) {
+          snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, i);
+          bucket_objects[i] = buf;
+          } else {
+            snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), i);
+            bucket_objects[i] = buf;
+          }
+      }
+    } else {
+      if ((uint32_t)shard_id > num_shards) {
+        return;
+      } else {
+		if (gen_id) {
+		  snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, shard_id);
+		  bucket_objects[shard_id] = buf;
+		} else {
+		  // for backward compatibility, gen_id(0) will not be added in the object name
+		  snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), shard_id);
+		  bucket_objects[shard_id] = buf;
+		}
+      }
+    }
+  }
+}
+
+/*
+static void get_bucket_index_objects(const string& bucket_oid_base,
                                      uint32_t num_shards,
                                      map<int, string> *_bucket_objects,
                                      int shard_id = -1)
@@ -136,6 +175,7 @@ static void get_bucket_index_objects(const string& bucket_oid_base,
     }
   }
 }
+*/
 
 static void get_bucket_instance_ids(const RGWBucketInfo& bucket_info,
                                     int shard_id,
@@ -178,7 +218,9 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index(const RGWBucketInfo& bucket_info,
     return ret;
   }
 
-  get_bucket_index_objects(bucket_oid_base, bucket_info.layout.current_index.layout.normal.num_shards, bucket_objs, shard_id);
+  auto gen = bucket_info.layout.current_index.gen;
+
+  get_bucket_index_objects(bucket_oid_base, bucket_info.layout.current_index.layout.normal.num_shards, gen, bucket_objs, shard_id);
   if (bucket_instance_ids) {
     get_bucket_instance_ids(bucket_info, shard_id, bucket_instance_ids);
   }
@@ -197,8 +239,9 @@ void RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_b
   } else {
     char buf[bucket_oid_base.size() + 64];
     if (gen_id != 0) {
-      snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, shard_id); 
+      snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, shard_id);
       (*bucket_obj) = buf;
+	  ldout(cct, 10) << "bucket_obj is " << (*bucket_obj) << dendl;
     } else {
       // for backward compatibility, gen_id(0) will not be added in the object name
       snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), shard_id);
@@ -268,7 +311,7 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const RGWBucketInfo& bucket
 
 int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const RGWBucketInfo& bucket_info,
                                                      int shard_id,
-                                                     const rgw::bucket_index_layout_generation& idx_layout,
+                                                     const rgw::bucket_index_layout_generation& target_layout,
                                                      RGWSI_RADOS::Obj *bucket_obj)
 {
   RGWSI_RADOS::Pool index_pool;
@@ -282,8 +325,8 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index_shard(const RGWBucketInfo& bucket
 
   string oid;
 
-  get_bucket_index_object(bucket_oid_base, idx_layout.layout.normal.num_shards,
-                          shard_id, idx_layout.gen, &oid);
+  get_bucket_index_object(bucket_oid_base, target_layout.layout.normal.num_shards,
+                          shard_id, target_layout.gen, &oid);
 
   *bucket_obj = svc.rados->obj(index_pool, oid);
 
@@ -318,7 +361,6 @@ int RGWSI_BucketIndex_RADOS::cls_bucket_head(const RGWBucketInfo& bucket_info,
   return 0;
 }
 
-
 int RGWSI_BucketIndex_RADOS::init_index(RGWBucketInfo& bucket_info)
 {
   RGWSI_RADOS::Pool index_pool;
@@ -332,14 +374,15 @@ int RGWSI_BucketIndex_RADOS::init_index(RGWBucketInfo& bucket_info)
   dir_oid.append(bucket_info.bucket.bucket_id);
 
   map<int, string> bucket_objs;
-  get_bucket_index_objects(dir_oid, bucket_info.layout.current_index.layout.normal.num_shards, &bucket_objs);
+  get_bucket_index_objects(dir_oid, bucket_info.layout.current_index.layout.normal.num_shards, std::nullopt, &bucket_objs);
 
   return CLSRGWIssueBucketIndexInit(index_pool.ioctx(),
 				    bucket_objs,
 				    cct->_conf->rgw_bucket_index_max_aio)();
 }
 
-int RGWSI_BucketIndex_RADOS::clean_index(RGWBucketInfo& bucket_info)
+
+int RGWSI_BucketIndex_RADOS::clean_index(RGWBucketInfo& bucket_info, std::optional<uint64_t> gen)
 {
   RGWSI_RADOS::Pool index_pool;
 

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -352,7 +352,8 @@ int RGWSI_BucketIndex_RADOS::clean_index(RGWBucketInfo& bucket_info)
   dir_oid.append(bucket_info.bucket.bucket_id);
 
   std::map<int, std::string> bucket_objs;
-  get_bucket_index_objects(dir_oid, bucket_info.layout.current_index.layout.normal.num_shards, &bucket_objs);
+  get_bucket_index_objects(dir_oid, bucket_info.layout.current_index.layout.normal.num_shards,
+  gen, &bucket_objs);
 
   return CLSRGWIssueBucketIndexClean(index_pool.ioctx(),
 				     bucket_objs,

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -455,7 +455,7 @@ int RGWSI_BucketIndex_RADOS::handle_overwrite(const RGWBucketInfo& info,
   bool old_sync_enabled = orig_info.datasync_flag_enabled();
 
   if (old_sync_enabled != new_sync_enabled) {
-    int shards_num = info.layout.current_index.layout.normal.num_shards? info.layout.current_index.layout.normal.num_shards : 1;
+    int shards_num = rgw::current_num_shards(info.layout);
     int shard_id = info.layout.current_index.layout.normal.num_shards? 0 : -1;
 
     int ret;

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -112,6 +112,17 @@ int RGWSI_BucketIndex_RADOS::open_bucket_index(const RGWBucketInfo& bucket_info,
   return 0;
 }
 
+static char bucket_obj_with_generation(char *buf, size_t len, const string& bucket_oid_base, uint64_t gen_id,
+                                    uint32_t shard_id)
+{
+  return snprintf(buf, len, "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, shard_id);
+}
+
+static char bucket_obj_without_generation(char *buf, size_t len, const string& bucket_oid_base, uint32_t shard_id)
+{
+  return snprintf(buf, len, "%s.%d", bucket_oid_base.c_str(), shard_id);
+}
+
 static void get_bucket_index_objects(const string& bucket_oid_base,
                                      uint32_t num_shards, uint64_t gen_id,
                                      map<int, string> *_bucket_objects,
@@ -125,25 +136,23 @@ static void get_bucket_index_objects(const string& bucket_oid_base,
     if (shard_id < 0) {
       for (uint32_t i = 0; i < num_shards; ++i) {
         if (gen_id) {
-          snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, i);
-          bucket_objects[i] = buf;
-          } else {
-            snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), i);
-            bucket_objects[i] = buf;
-          }
+          bucket_obj_with_generation(buf, sizeof(buf), bucket_oid_base, gen_id, i);
+        } else {
+          bucket_obj_without_generation(buf, sizeof(buf), bucket_oid_base, i);
+        }
+        bucket_objects[i] = buf;
       }
     } else {
-      if ((uint32_t)shard_id > num_shards) {
+      if (static_cast<uint32_t>(shard_id) > num_shards) {
         return;
       } else {
-		if (gen_id) {
-		  snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, shard_id);
-		  bucket_objects[shard_id] = buf;
-		} else {
-		  // for backward compatibility, gen_id(0) will not be added in the object name
-		  snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), shard_id);
-		  bucket_objects[shard_id] = buf;
-		}
+        if (gen_id) {
+          bucket_obj_with_generation(buf, sizeof(buf), bucket_oid_base, gen_id, shard_id);
+        } else {
+          // for backward compatibility, gen_id(0) will not be added in the object name
+          bucket_obj_without_generation(buf, sizeof(buf), bucket_oid_base, shard_id);
+        }
+        bucket_objects[shard_id] = buf;
       }
     }
   }
@@ -166,7 +175,7 @@ static void get_bucket_instance_ids(const RGWBucketInfo& bucket_info,
         (*result)[i] = plain_id + buf;
       }
     } else {
-      if ((uint32_t)shard_id > bucket_info.layout.current_index.layout.normal.num_shards) {
+      if (static_cast<uint32_t>(shard_id) > bucket_info.layout.current_index.layout.normal.num_shards) {
         return;
       }
       snprintf(buf, sizeof(buf), ":%d", shard_id);
@@ -211,12 +220,12 @@ void RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_b
   } else {
     char buf[bucket_oid_base.size() + 64];
     if (gen_id) {
-      snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, shard_id);
+      bucket_obj_with_generation(buf, sizeof(buf), bucket_oid_base, gen_id, shard_id);
       (*bucket_obj) = buf;
 	  ldout(cct, 10) << "bucket_obj is " << (*bucket_obj) << dendl;
     } else {
       // for backward compatibility, gen_id(0) will not be added in the object name
-      snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), shard_id);
+      bucket_obj_without_generation(buf, sizeof(buf), bucket_oid_base, shard_id);
       (*bucket_obj) = buf;
     }
   }
@@ -239,9 +248,9 @@ int RGWSI_BucketIndex_RADOS::get_bucket_index_object(const string& bucket_oid_ba
         uint32_t sid = bucket_shard_index(obj_key, num_shards);
         char buf[bucket_oid_base.size() + 64];
         if (gen_id) {
-          snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%d", bucket_oid_base.c_str(), gen_id, sid);
+          bucket_obj_with_generation(buf, sizeof(buf), bucket_oid_base, gen_id, sid);
         } else {
-          snprintf(buf, sizeof(buf), "%s.%d", bucket_oid_base.c_str(), sid);
+          bucket_obj_without_generation(buf, sizeof(buf), bucket_oid_base, sid);
         }
         (*bucket_obj) = buf;
         if (shard_id) {

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -53,7 +53,7 @@ class RGWSI_BucketIndex_RADOS : public RGWSI_BucketIndex
                                string *bucket_obj);
   int get_bucket_index_object(const string& bucket_oid_base, const string& obj_key,
                               uint32_t num_shards, rgw::BucketHashType hash_type,
-                              string *bucket_obj, int *shard_id);
+                              uint64_t gen_id, string *bucket_obj, int *shard_id);
 
   int cls_bucket_head(const RGWBucketInfo& bucket_info,
                       int shard_id,
@@ -93,7 +93,7 @@ public:
   }
 
   int init_index(RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout);
-  int clean_index(RGWBucketInfo& bucket_info, uint64_t gen);
+  int clean_index(RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout);
 
   /* RADOS specific */
 

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -93,8 +93,7 @@ public:
   }
 
   int init_index(RGWBucketInfo& bucket_info);
-  int clean_index(RGWBucketInfo& bucket_info);
-
+  int clean_index(RGWBucketInfo& bucket_info, std::optional<uint64_t> gen);
 
   /* RADOS specific */
 

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -49,7 +49,7 @@ class RGWSI_BucketIndex_RADOS : public RGWSI_BucketIndex
   void get_bucket_index_object(const string& bucket_oid_base,
                                uint32_t num_shards,
                                int shard_id,
-                               std::optional<uint64_t> gen_id,
+                               uint64_t gen_id,
                                string *bucket_obj);
   int get_bucket_index_object(const string& bucket_oid_base, const string& obj_key,
                               uint32_t num_shards, rgw::BucketHashType hash_type,
@@ -92,8 +92,8 @@ public:
     return rgw_shards_mod(sid2, num_shards);
   }
 
-  int init_index(RGWBucketInfo& bucket_info);
-  int clean_index(RGWBucketInfo& bucket_info, std::optional<uint64_t> gen);
+  int init_index(RGWBucketInfo& bucket_info, const rgw::bucket_index_layout_generation& idx_layout);
+  int clean_index(RGWBucketInfo& bucket_info, uint64_t gen);
 
   /* RADOS specific */
 
@@ -115,7 +115,7 @@ public:
   int open_bucket_index_shard(const RGWBucketInfo& bucket_info,
                               int shard_id,
                               uint32_t num_shards,
-                              std::optional<uint64_t> gen,
+                              uint64_t gen,
                               RGWSI_RADOS::Obj *bucket_obj);
 
   int open_bucket_index(const RGWBucketInfo& bucket_info,

--- a/src/rgw/services/svc_bi_rados.h
+++ b/src/rgw/services/svc_bi_rados.h
@@ -49,7 +49,7 @@ class RGWSI_BucketIndex_RADOS : public RGWSI_BucketIndex
   void get_bucket_index_object(const string& bucket_oid_base,
                                uint32_t num_shards,
                                int shard_id,
-                               uint64_t gen_id,
+                               std::optional<uint64_t> gen_id,
                                string *bucket_obj);
   int get_bucket_index_object(const string& bucket_oid_base, const string& obj_key,
                               uint32_t num_shards, rgw::BucketHashType hash_type,
@@ -114,7 +114,8 @@ public:
 
   int open_bucket_index_shard(const RGWBucketInfo& bucket_info,
                               int shard_id,
-                              const rgw::bucket_index_layout_generation& idx_layout,
+                              uint32_t num_shards,
+                              std::optional<uint64_t> gen,
                               RGWSI_RADOS::Obj *bucket_obj);
 
   int open_bucket_index(const RGWBucketInfo& bucket_info,

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -351,9 +351,8 @@ add_ceph_unittest(unittest_cdc)
 add_executable(unittest_ceph_timer test_ceph_timer.cc)
 add_ceph_unittest(unittest_ceph_timer)
 
-add_executable(unittest_fault_injector test_fault_injector.cc
-  $<TARGET_OBJECTS:unit-main>)
-target_link_libraries(unittest_fault_injector global)
+add_executable(unittest_fault_injector test_fault_injector.cc)
+target_link_libraries(unittest_fault_injector common)
 add_ceph_unittest(unittest_fault_injector)
 
 add_executable(unittest_blocked_completion test_blocked_completion.cc)

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -351,6 +351,10 @@ add_ceph_unittest(unittest_cdc)
 add_executable(unittest_ceph_timer test_ceph_timer.cc)
 add_ceph_unittest(unittest_ceph_timer)
 
+add_executable(unittest_fault_injector test_fault_injector.cc
+  $<TARGET_OBJECTS:unit-main>)
+target_link_libraries(unittest_fault_injector global)
+add_ceph_unittest(unittest_fault_injector)
 
 add_executable(unittest_blocked_completion test_blocked_completion.cc)
 add_ceph_unittest(unittest_blocked_completion)

--- a/src/test/common/test_fault_injector.cc
+++ b/src/test/common/test_fault_injector.cc
@@ -1,0 +1,224 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "common/fault_injector.h"
+#include <gtest/gtest.h>
+
+static const DoutPrefixProvider* dpp() {
+  static NoDoutPrefix d{g_ceph_context, ceph_subsys_context};
+  return &d;
+}
+
+TEST(FaultInjectorDeathTest, InjectAbort)
+{
+  constexpr FaultInjector f{false, InjectAbort{}};
+  EXPECT_EQ(f.check(true), 0);
+  EXPECT_DEATH([[maybe_unused]] int r = f.check(false), "FaultInjector");
+}
+
+TEST(FaultInjectorDeathTest, AssignAbort)
+{
+  FaultInjector<bool> f;
+  ASSERT_EQ(f.check(false), 0);
+  f.inject(false, InjectAbort{});
+  EXPECT_DEATH([[maybe_unused]] int r = f.check(false), "FaultInjector");
+}
+
+// test int as a Key type
+TEST(FaultInjectorInt, Default)
+{
+  constexpr FaultInjector<int> f;
+  EXPECT_EQ(f.check(0), 0);
+  EXPECT_EQ(f.check(1), 0);
+  EXPECT_EQ(f.check(2), 0);
+  EXPECT_EQ(f.check(3), 0);
+}
+
+TEST(FaultInjectorInt, InjectError)
+{
+  constexpr FaultInjector f{2, InjectError{-EINVAL}};
+  EXPECT_EQ(f.check(0), 0);
+  EXPECT_EQ(f.check(1), 0);
+  EXPECT_EQ(f.check(2), -EINVAL);
+  EXPECT_EQ(f.check(3), 0);
+}
+
+TEST(FaultInjectorInt, InjectErrorMessage)
+{
+  FaultInjector f{2, InjectError{-EINVAL, dpp()}};
+  EXPECT_EQ(f.check(0), 0);
+  EXPECT_EQ(f.check(1), 0);
+  EXPECT_EQ(f.check(2), -EINVAL);
+  EXPECT_EQ(f.check(3), 0);
+}
+
+TEST(FaultInjectorInt, AssignError)
+{
+  FaultInjector<int> f;
+  ASSERT_EQ(f.check(0), 0);
+  f.inject(0, InjectError{-EINVAL});
+  EXPECT_EQ(f.check(0), -EINVAL);
+}
+
+TEST(FaultInjectorInt, AssignErrorMessage)
+{
+  FaultInjector<int> f;
+  ASSERT_EQ(f.check(0), 0);
+  f.inject(0, InjectError{-EINVAL, dpp()});
+  EXPECT_EQ(f.check(0), -EINVAL);
+}
+
+// test std::string_view as a Key type
+TEST(FaultInjectorString, Default)
+{
+  constexpr FaultInjector<std::string_view> f;
+  EXPECT_EQ(f.check("Red"), 0);
+  EXPECT_EQ(f.check("Green"), 0);
+  EXPECT_EQ(f.check("Blue"), 0);
+}
+
+TEST(FaultInjectorString, InjectError)
+{
+  FaultInjector<std::string_view> f{"Red", InjectError{-EIO}};
+  EXPECT_EQ(f.check("Red"), -EIO);
+  EXPECT_EQ(f.check("Green"), 0);
+  EXPECT_EQ(f.check("Blue"), 0);
+}
+
+TEST(FaultInjectorString, InjectErrorMessage)
+{
+  FaultInjector<std::string_view> f{"Red", InjectError{-EIO, dpp()}};
+  EXPECT_EQ(f.check("Red"), -EIO);
+  EXPECT_EQ(f.check("Green"), 0);
+  EXPECT_EQ(f.check("Blue"), 0);
+}
+
+TEST(FaultInjectorString, AssignError)
+{
+  FaultInjector<std::string_view> f;
+  ASSERT_EQ(f.check("Red"), 0);
+  f.inject("Red", InjectError{-EINVAL});
+  EXPECT_EQ(f.check("Red"), -EINVAL);
+}
+
+TEST(FaultInjectorString, AssignErrorMessage)
+{
+  FaultInjector<std::string_view> f;
+  ASSERT_EQ(f.check("Red"), 0);
+  f.inject("Red", InjectError{-EINVAL, dpp()});
+  EXPECT_EQ(f.check("Red"), -EINVAL);
+}
+
+// test enum class as a Key type
+enum class Color { Red, Green, Blue };
+
+static std::ostream& operator<<(std::ostream& out, const Color& c) {
+  switch (c) {
+    case Color::Red: return out << "Red";
+    case Color::Green: return out << "Green";
+    case Color::Blue: return out << "Blue";
+  }
+  return out;
+}
+
+TEST(FaultInjectorEnum, Default)
+{
+  constexpr FaultInjector<Color> f;
+  EXPECT_EQ(f.check(Color::Red), 0);
+  EXPECT_EQ(f.check(Color::Green), 0);
+  EXPECT_EQ(f.check(Color::Blue), 0);
+}
+
+TEST(FaultInjectorEnum, InjectError)
+{
+  FaultInjector f{Color::Red, InjectError{-EIO}};
+  EXPECT_EQ(f.check(Color::Red), -EIO);
+  EXPECT_EQ(f.check(Color::Green), 0);
+  EXPECT_EQ(f.check(Color::Blue), 0);
+}
+
+TEST(FaultInjectorEnum, InjectErrorMessage)
+{
+  FaultInjector f{Color::Red, InjectError{-EIO, dpp()}};
+  EXPECT_EQ(f.check(Color::Red), -EIO);
+  EXPECT_EQ(f.check(Color::Green), 0);
+  EXPECT_EQ(f.check(Color::Blue), 0);
+}
+
+TEST(FaultInjectorEnum, AssignError)
+{
+  FaultInjector<Color> f;
+  ASSERT_EQ(f.check(Color::Red), 0);
+  f.inject(Color::Red, InjectError{-EINVAL});
+  EXPECT_EQ(f.check(Color::Red), -EINVAL);
+}
+
+TEST(FaultInjectorEnum, AssignErrorMessage)
+{
+  FaultInjector<Color> f;
+  ASSERT_EQ(f.check(Color::Red), 0);
+  f.inject(Color::Red, InjectError{-EINVAL, dpp()});
+  EXPECT_EQ(f.check(Color::Red), -EINVAL);
+}
+
+// test custom move-only Key type
+struct MoveOnlyKey {
+  MoveOnlyKey() = default;
+  MoveOnlyKey(const MoveOnlyKey&) = delete;
+  MoveOnlyKey& operator=(const MoveOnlyKey&) = delete;
+  MoveOnlyKey(MoveOnlyKey&&) = default;
+  MoveOnlyKey& operator=(MoveOnlyKey&&) = default;
+  ~MoveOnlyKey() = default;
+};
+
+static bool operator==(const MoveOnlyKey&, const MoveOnlyKey&) {
+  return true; // all keys are equal
+}
+static std::ostream& operator<<(std::ostream& out, const MoveOnlyKey&) {
+  return out;
+}
+
+TEST(FaultInjectorMoveOnly, Default)
+{
+  constexpr FaultInjector<MoveOnlyKey> f;
+  EXPECT_EQ(f.check(MoveOnlyKey{}), 0);
+}
+
+TEST(FaultInjectorMoveOnly, InjectError)
+{
+  FaultInjector f{MoveOnlyKey{}, InjectError{-EIO}};
+  EXPECT_EQ(f.check(MoveOnlyKey{}), -EIO);
+}
+
+TEST(FaultInjectorMoveOnly, InjectErrorMessage)
+{
+  FaultInjector f{MoveOnlyKey{}, InjectError{-EIO, dpp()}};
+  EXPECT_EQ(f.check(MoveOnlyKey{}), -EIO);
+}
+
+TEST(FaultInjectorMoveOnly, AssignError)
+{
+  FaultInjector<MoveOnlyKey> f;
+  ASSERT_EQ(f.check({}), 0);
+  f.inject({}, InjectError{-EINVAL});
+  EXPECT_EQ(f.check({}), -EINVAL);
+}
+
+TEST(FaultInjectorMoveOnly, AssignErrorMessage)
+{
+  FaultInjector<MoveOnlyKey> f;
+  ASSERT_EQ(f.check({}), 0);
+  f.inject({}, InjectError{-EINVAL, dpp()});
+  EXPECT_EQ(f.check({}), -EINVAL);
+}


### PR DESCRIPTION
builds on https://github.com/ceph/ceph/pull/35175

* refactors the reshard logic into separate functions to better compose the fault injection and error handling
* adds cleanup of old-style reshards that were in progress
* refactors the test coverage into a test_bucket_reshard() function that's parameterized on the fault to inject

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
