### PR TITLE
mon: fix a ceph df status bug

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -916,7 +916,13 @@ void PGMapDigest::dump_object_stat_sum(
   }
 
   uint64_t used_data_bytes = pool_stat.get_allocated_data_bytes(per_pool);
+  if (!per_pool) {
+    used_data_bytes *= raw_used_rate;
+  }
   uint64_t used_omap_bytes = pool_stat.get_allocated_omap_bytes(per_pool_omap);
+  if (!per_pool_omap) {
+    used_omap_bytes *= raw_used_rate;
+  }
   uint64_t used_bytes = used_data_bytes + used_omap_bytes;
 
   float used = 0.0;


### PR DESCRIPTION
if _per_pool/per_pool_omap_ is true，then _store_stats.allocated/store_stats.omap_allocated_ will be used to get _used_bytes_, but they are not raw， so may be need to multiply _raw_used_rate_

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
