### PR TITLE
cephadm: make host add failure message more friendly

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4521,7 +4521,7 @@ def command_check_host():
             except Exception as e:
                 logger.debug('Could not locate %s: %s' % (i, e))
         if not container_path:
-            errors.append('Unable to locate any of %s' % CONTAINER_PREFERENCE)
+            errors.append('ERROR: Unable to locate a supported container engine ({})'.format(' or '.join(CONTAINER_PREFERENCE)))
         else:
             logger.info('podman|docker (%s) is present' % container_path)
 
@@ -4530,15 +4530,15 @@ def command_check_host():
             find_program(command)
             logger.info('%s is present' % command)
         except ValueError:
-            errors.append('%s binary does not appear to be installed' % command)
+            errors.append('ERROR: %s binary does not appear to be installed' % command)
 
     # check for configured+running chronyd or ntp
     if not check_time_sync():
-        errors.append('No time synchronization is active')
+        errors.append('ERROR: No time synchronization is active')
 
     if 'expect_hostname' in args and args.expect_hostname:
         if get_hostname().lower() != args.expect_hostname.lower():
-            errors.append('hostname "%s" does not match expected hostname "%s"' % (
+            errors.append('ERROR: hostname "%s" does not match expected hostname "%s"' % (
                 get_hostname(), args.expect_hostname))
         logger.info('Hostname "%s" matches what is expected.',
                     args.expect_hostname)

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1306,8 +1306,11 @@ To check that the host is reachable:
                                            addr=spec.addr,
                                            error_ok=True, no_fsid=True)
         if code:
-            raise OrchestratorError('New host %s (%s) failed check: %s' % (
-                spec.hostname, spec.addr, err))
+            # err will contain stdout and stderr, so we filter on the message text to 
+            # only show the errors
+            errors = [_i.replace("ERROR: ", "") for _i in err if _i.startswith('ERROR')]
+            raise OrchestratorError('New host %s (%s) failed check(s): %s' % (
+                spec.hostname, spec.addr, errors))
 
         self.inventory.add_host(spec)
         self.cache.prime_empty_host(spec.hostname)


### PR DESCRIPTION
When a host add fails, the output was showing passed
and failed checks. This patch uses an ERROR prefix for
all failed checks, and then filters on them when showing
the result, so the admin sees only the failed items. The
text has also been tidied up to remove the [] within a
[] syntax

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
