### PR TITLE
rgw/aws/build: AWS submodule packaging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -79,6 +79,5 @@
 	branch = 0.13.0
 [submodule "src/aws-sdk-cpp"]
 	path = src/aws-sdk-cpp
-	url = https://github.com/ceph/aws-sdk-cpp
-	depth = 1
-	shallow = true
+	url = https://github.com/yuvalif/aws-sdk-cpp.git
+	branch = install_only_runtime

--- a/.gitmodules
+++ b/.gitmodules
@@ -77,3 +77,8 @@
 	path = src/jaegertracing/thrift
 	url = https://github.com/apache/thrift.git
 	branch = 0.13.0
+[submodule "src/aws-sdk-cpp"]
+	path = src/aws-sdk-cpp
+	url = https://github.com/ceph/aws-sdk-cpp
+	depth = 1
+	shallow = true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,6 +399,7 @@ option(WITH_RADOSGW_BEAST_OPENSSL "Rados Gateway's Beast frontend uses OpenSSL" 
 option(WITH_RADOSGW_AMQP_ENDPOINT "Rados Gateway's pubsub support for AMQP push endpoint" ON)
 option(WITH_RADOSGW_KAFKA_ENDPOINT "Rados Gateway's pubsub support for Kafka push endpoint" ON)
 option(WITH_RADOSGW_LUA_PACKAGES "Rados Gateway's support for dynamically adding lua packagess" ON)
+option(WITH_RADOSGW_AWS_ENDPOINT "Rados Gateway's pubsub support for AWS push endpoint" ON)
 
 if(WITH_RADOSGW)
   find_package(EXPAT REQUIRED)

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -717,6 +717,7 @@ Requires:	mailcap
 %if 0%{?weak_deps}
 Recommends:	gawk
 %endif
+Requires: ceph-aws-cpp-sdk = %{_epoch_prefix}%{version}-%{release}
 %description radosgw
 RADOS is a distributed object store used by the Ceph distributed
 storage system.  This package provides a REST gateway to the
@@ -1148,6 +1149,29 @@ BuildArch:      noarch
 Group:          System/Monitoring
 %description prometheus-alerts
 This package provides Ceph default alerts for Prometheus.
+
+%package -n ceph-aws-cpp-sdk
+Summary: Runtime libraries for AWS C++ SDK
+Provides: libaws-c-common.so()(64bit)
+Provides: libaws-c-common.so.1.0.0()(64bit)
+Provides: libaws-c-event-stream.so()(64bit)
+Provides: libaws-c-event-stream.so.1.0.0()(64bit)
+Provides: libaws-checksums.so()(64bit)
+Provides: libaws-cpp-sdk-access-management.so()(64bit)
+Provides: libaws-cpp-sdk-cognito-identity.so()(64bit)
+Provides: libaws-cpp-sdk-core.so()(64bit)
+Provides: libaws-cpp-sdk-iam.so()(64bit)
+Provides: libaws-cpp-sdk-kinesis.so()(64bit)
+Provides: libaws-cpp-sdk-lambda.so()(64bit)
+Provides: libaws-cpp-sdk-sns.so()(64bit)
+%files -n ceph-aws-cpp-sdk
+/usr/lib64/libaws*.so*
+%post -n ceph-aws-cpp-sdk -p /sbin/ldconfig
+%postun -n ceph-aws-cpp-sdk -p /sbin/ldconfig
+%description -n ceph-aws-cpp-sdk
+This package provides runtime libraries for AWS C++ SDK.
+These libraries enables sending bucket notifications from the
+radosgw to AWS SNS and Lambda.
 
 #################################################################################
 # common

--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -7,7 +7,7 @@ Bucket Notifications
 .. contents::
 
 Bucket notifications provide a mechanism for sending information out of the radosgw when certain events are happening on the bucket.
-Currently, notifications could be sent to: HTTP, AMQP0.9.1 and Kafka endpoints.
+Currently, notifications could be sent to: HTTP, AMQP0.9.1, Kafka, AWS lambda and AWS SNS endpoints.
 
 Note, that if the events should be stored in Ceph, in addition, or instead of being pushed to an endpoint,
 the `PubSub Module`_ should be used instead of the bucket notification mechanism.
@@ -121,6 +121,11 @@ To update a topic, use the same command used for topic creation, with the topic 
    [&Attributes.entry.7.key=OpaqueData&Attributes.entry.7.value=<opaque data>]
    [&Attributes.entry.8.key=push-endpoint&Attributes.entry.8.value=<endpoint>]
    [&Attributes.entry.9.key=persistent&Attributes.entry.9.value=true|false]
+   [&Attributes.entry.10.key=aws-ack-level&Attributes.entry.9.value=<none|server>]
+   [&Attributes.entry.11.key=AwsArn&Attributes.entry.10.value=<AWS ARN of resource to push to>]
+   [&Attributes.entry.12.key=AccessKey&Attributes.entry.11.value=<Access key>]
+   [&Attributes.entry.13.key=SecretKey&Attributes.entry.12.value=<Access Secret>]
+
 
 Request parameters:
 
@@ -162,6 +167,20 @@ Request parameters:
 
   - "none": message is considered "delivered" if sent to broker
   - "broker": message is considered "delivered" if acked by broker (default)
+
+- AWS Endpoint
+
+ - push-endpoint: ``aws://sns.<region>.amazonaws.com`` for AWS SNS and ``aws://lambda.<region>amazonaws.com`` for AWS lambda. E.g. ``aws://sns.us-east-1.amazonaws.com``
+ - use-ssl: if "true" then secure connection will be used for connecting with the server
+ - AccessKey: Access Key for access to AWS services
+ - SecretKey: Secret Access Key for access to AWS services
+ - AwsArn: ARN of the resource to push notification to. The ARN is expected to be in the format based on: ``arn:aws:<sns|lambda>:[region]:<account-id>:<topic name|function name>``. E.g. ``arn:aws:sns:us-east-1:123456789012:gsoc20-ceph``
+ - verify-ssl: indicate whether the server certificate is validated by the client or not ("false" by default)
+ - aws-ack-level: In case of SNS message is considered delivered when pushed into SNS and does not have to be notified to the end recipients. In case of lambda, we ignore the success/fail of the execution of the function, and consider the message delivered when the function is successfully triggered. Two ack methods exist:
+
+  - "none": message is considered "delivered" if sent to server
+  - "server": message is considered "delivered" if acked by server (default)
+
 
 .. note::
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -300,6 +300,11 @@ add_subdirectory(json_spirit)
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/xxHash")
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/rapidjson/include")
 
+if(WITH_RADOSGW AND WITH_RADOSGW_AWS_ENDPOINT)
+  set(AWS_DEPS_INSTALL_DIR "${CMAKE_BINARY_DIR}/.deps" )
+  add_subdirectory(aws-sdk-cpp)
+endif()
+
 find_package(fmt 6.0.0 QUIET)
 if(fmt_FOUND)
   include_directories(SYSTEM "${fmt_INCLUDE_DIR}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -301,7 +301,6 @@ include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/xxHash")
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/rapidjson/include")
 
 if(WITH_RADOSGW AND WITH_RADOSGW_AWS_ENDPOINT)
-  set(AWS_DEPS_INSTALL_DIR "${CMAKE_BINARY_DIR}/.deps" )
   add_subdirectory(aws-sdk-cpp)
 endif()
 

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -348,6 +348,9 @@
 /* Defined if lua packages can be installed by radosgw */
 #cmakedefine WITH_RADOSGW_LUA_PACKAGES
 
+/* Defined if aws-sdk-cpp is available for rgw aws push endpoint */
+#cmakedefine WITH_RADOSGW_AWS_ENDPOINT
+
 /* Defined if std::map::merge() is supported */
 #cmakedefine HAVE_STDLIB_MAP_SPLICING
 

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -164,6 +164,10 @@ set(librgw_common_srcs
   rgw_lua.cc
   rgw_lua_request.cc)
 
+if(WITH_RADOSGW_AWS_ENDPOINT)
+  list(APPEND librgw_common_srcs rgw_aws.cc)
+endif()
+
 if(WITH_RADOSGW_AMQP_ENDPOINT)
   list(APPEND librgw_common_srcs rgw_amqp.cc)
 endif()
@@ -268,6 +272,14 @@ endif()
 target_link_libraries(rgw_a PRIVATE ${LUA_LIBRARIES})
 target_link_libraries(rgw_a PUBLIC spawn)
 
+if(WITH_RADOSGW_AWS_ENDPOINT)
+  target_include_directories(rgw_common PRIVATE "${CMAKE_SOURCE_DIR}/src/aws-sdk-cpp/aws-cpp-sdk-lambda/include")
+  target_include_directories(rgw_common PRIVATE "${CMAKE_SOURCE_DIR}/src/aws-sdk-cpp/aws-cpp-sdk-sns/include")
+  target_include_directories(rgw_common PRIVATE "${CMAKE_SOURCE_DIR}/src/aws-sdk-cpp/aws-cpp-sdk-core/include")
+  target_include_directories(rgw_common PRIVATE "${CMAKE_SOURCE_DIR}/src/aws-sdk-cpp/aws-cpp-sdk-iam/include")
+  target_link_libraries(rgw_a PRIVATE aws-cpp-sdk-core aws-cpp-sdk-lambda aws-cpp-sdk-sns)
+endif()
+
 set(rgw_libs rgw_a)
 if(WITH_RADOSGW_AMQP_ENDPOINT)
   # used by rgw_amqp.cc
@@ -282,6 +294,10 @@ list(APPEND rgw_libs ${LUA_LIBRARIES})
 
 if(WITH_RADOSGW_LUA_PACKAGES)
   list(APPEND rgw_libs Boost::filesystem)
+endif()
+
+if(WITH_RADOSGW_AWS_ENDPOINT)
+  list(APPEND rgw_libs aws-cpp-sdk-lambda aws-cpp-sdk-sns)
 endif()
 
 set(rgw_schedulers_srcs

--- a/src/rgw/rgw_aws.cc
+++ b/src/rgw/rgw_aws.cc
@@ -1,0 +1,315 @@
+#include "rgw_url.h"
+#include "rgw_aws.h"
+#include "rgw_arn.h"
+#include <string>
+#include <iostream>
+#include <utility>
+#include "common/dout.h"
+#include <aws/core/Aws.h>
+#include <aws/sns/SNSClient.h>
+#include <aws/lambda/LambdaClient.h>
+#include <aws/lambda/model/InvokeRequest.h>
+#include <boost/lockfree/queue.hpp>
+#include <aws/core/utils/ARN.h>
+#include <aws/core/auth/AWSCredentials.h>
+#include <aws/sns/model/PublishRequest.h>
+
+#define dout_subsys ceph_subsys_rgw
+
+namespace rgw::aws {
+  static const int STATUS_OK = 0x0;
+  static const int STATUS_FULL = -0x1003;
+  static const int STATUS_MANAGER_STOPPED = -0x1005;
+  static const int STATUS_CLIENT_CLOSED = -0x1002;
+
+  struct client_id_t {
+    const std::string access_key;
+    const std::string access_secret;
+    const std::string arn;
+    const bool use_ssl;
+
+    client_id_t(const std::string &access_key, const std::string &access_secret,
+                const std::string &arn, bool useSsl) : access_key(access_key),
+                                                       access_secret(access_secret),
+                                                       arn(arn), use_ssl(useSsl) {}
+
+    bool operator==(const client_id_t &other) const {
+      return access_key == other.access_key &&
+             access_secret == other.access_secret &&
+             arn == other.arn && use_ssl == other.use_ssl;
+    }
+
+    struct hasher {
+      std::size_t operator()(const client_id_t &k) const {
+        return ((std::hash<std::string>()(k.access_key)
+                 ^ (std::hash<std::string>()(k.access_secret) << 1)) >> 1)
+               ^ (std::hash<std::string>()(k.arn) << 1)
+               ^ (std::hash<bool>()(k.use_ssl) << 1);
+      }
+    };
+
+
+  };
+  class AsyncCallerContext: public Aws::Client::AsyncCallerContext{
+  public:
+    const reply_callback_t cb;
+    CephContext* const cct;
+    AsyncCallerContext(reply_callback_t cb, CephContext* cct):cb(cb), cct(cct){}
+  };
+
+  void invoke_callback(const Aws::Lambda::LambdaClient* client,
+                              const Aws::Lambda::Model::InvokeRequest& request,
+                              const Aws::Lambda::Model::InvokeOutcome & outcome,
+                              const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context){
+
+    auto ctx = static_cast<const AsyncCallerContext*>(context.get());
+    CephContext* cct = ctx->cct;
+    if (outcome.IsSuccess()) {
+      ldout(cct, 20) << "Invoke function: " << request.GetFunctionName() << " Response: " << outcome.GetResult().GetLogResult() << dendl;
+      if(ctx && ctx->cb) {
+        ctx->cb(STATUS_OK);
+      }
+    }
+    else {
+      const auto& error = outcome.GetError();
+      ldout(cct, 20) << "ERROR: " << error.GetExceptionName() << ": "
+                << error.GetMessage() << dendl;
+      if(ctx && ctx->cb) {
+        ctx->cb(-static_cast<int>(error.GetErrorType()));
+      }
+    }
+
+  }
+  void publish_callback(const Aws::SNS::SNSClient* client,
+                        const Aws::SNS::Model::PublishRequest& request,
+                        const Aws::SNS::Model::PublishOutcome & outcome,
+                        const std::shared_ptr<const Aws::Client::AsyncCallerContext>& context){
+
+    auto ctx = static_cast<const AsyncCallerContext*>(context.get());
+    CephContext* cct = ctx->cct;
+    if (outcome.IsSuccess()) {
+      ldout(cct, 20) << "SNS: published to topic: " << request.GetTopicArn() << dendl;
+      if(ctx && ctx->cb) {
+        ctx->cb(STATUS_OK);
+      }
+
+    }
+    else {
+      const auto& error = outcome.GetError();
+      ldout(cct, 20) << "ERROR: " << error.GetExceptionName() << ": "
+                << error.GetMessage() << dendl;
+      if(ctx && ctx->cb) {
+        ctx->cb(-static_cast<int>(error.GetErrorType()));
+      }
+    }
+  }
+
+  struct message_t {
+    const AwsClient client;
+    const std::string resource_arn;
+    const std::string payload;
+    const reply_callback_t cb;
+
+    message_t(const AwsClient client, const std::string& resource_arn, const std::string& payload, reply_callback_t cb) :
+            client(client),
+            resource_arn(resource_arn),
+            payload(payload),
+            cb(cb) {};
+  };
+
+  typedef std::unordered_map<client_id_t, AwsClient, client_id_t::hasher> ClientList;
+
+
+  typedef boost::lockfree::queue<message_t *, boost::lockfree::fixed_sized<true>> MessageQueue;
+
+  class Manager {
+  private:
+    MessageQueue message_queue;
+    ClientList client_list;
+    std::thread runner;
+    bool stopped;
+    mutable std::mutex clients_lock;
+    CephContext *cct;
+    const ceph::coarse_real_clock::duration idle_time;
+    const int MAX_CONNECTIONS = 25;
+    const int REQUEST_TIMEOUT_MS = 3000;
+    const int CONNECT_TIMEOUT_MS = 3000;
+    Aws::SDKOptions options;
+
+    void publish_internal_wrapper(message_t *msg) {
+      const std::unique_ptr<message_t> msg_owner(msg);
+
+      std::visit([&msg, this](auto &&arg) { this->publish_internal(arg, msg->resource_arn, msg->payload, msg->cb); }, msg->client);
+    }
+
+    void publish_internal(Aws::SNS::SNSClient *client, const std::string &resource_arn, const std::string &payload, reply_callback_t cb) {
+      Aws::SNS::Model::PublishRequest req;
+      req.SetMessage(Aws::String(payload));
+      req.SetTopicArn(Aws::String(resource_arn));
+
+      auto context = Aws::MakeShared<AsyncCallerContext>("PublishAllocationTag", cb, cct);
+      client->PublishAsync(req, publish_callback, context);
+    }
+
+    void publish_internal(Aws::Lambda::LambdaClient *client, const std::string &resource_arn, const std::string &payload, reply_callback_t cb) {
+      Aws::Lambda::Model::InvokeRequest invokeRequest;
+      Aws::Utils::ARN arn((Aws::String(resource_arn)));
+      invokeRequest.SetInvocationType(Aws::Lambda::Model::InvocationType::RequestResponse);
+      invokeRequest.SetLogType(Aws::Lambda::Model::LogType::Tail);
+      boost::optional<ARNResource> resourceParsed = ARNResource::parse(std::string(arn.GetResource()));
+      if(!resourceParsed) {
+        invokeRequest.SetFunctionName("");
+      }else{
+        invokeRequest.SetFunctionName(Aws::String(resourceParsed.get().resource));
+      }
+      std::shared_ptr<Aws::IOStream> body = Aws::MakeShared<Aws::StringStream>("Simple Allocation Tag");
+      *body << payload;
+      invokeRequest.SetBody(body);
+      invokeRequest.SetContentType("application/json");
+      auto context = Aws::MakeShared<AsyncCallerContext>("InvokeAllocationTag", cb, cct);
+      client->InvokeAsync(invokeRequest, invoke_callback, context);
+    }
+
+//    Works on messages in the queque
+    void run() {
+      while (!stopped) {
+        const auto count = message_queue.consume_all(
+                std::bind(&Manager::publish_internal_wrapper, this, std::placeholders::_1));
+        if (count == 0) {
+          std::this_thread::sleep_for(idle_time);
+        }
+      }
+    }
+
+    // used in the dtor for message cleanup
+    static void delete_message(const message_t *message) {
+      delete message;
+    }
+
+  public:
+    Manager(size_t _max_clients, size_t max_queue_size,unsigned idle_time_ms, CephContext *_cct) : message_queue(max_queue_size),
+                                                                                                   client_list(_max_clients),
+                                                                                                   runner(&Manager::run, this),
+                                                                                                   stopped(false), cct(_cct),
+                                                                                                   idle_time(std::chrono::milliseconds(idle_time_ms)){
+          options = Aws::SDKOptions();
+          Aws::InitAPI(options);
+    }
+    // dtor wait for thread to stop
+    // then connection are cleaned-up
+    ~Manager() {
+      stopped = true;
+      runner.join();
+      message_queue.consume_all(delete_message);
+      Aws::ShutdownAPI(options);
+    }
+
+
+    AwsClient connect(const std::string &access_key,
+                      const std::string &access_secret,
+                      const std::string &arn,
+                      const std::string &endpoint,
+                      bool verify_ssl,
+                      bool use_ssl) {
+      if (stopped) {
+        return NO_CLIENT;
+      }
+      const client_id_t id(access_key, access_secret, arn, use_ssl);
+      std::lock_guard lock(clients_lock);
+      const auto it = client_list.find(id);
+      if (it != client_list.end()) {
+        return it->second;
+      }
+
+      // connection not found, creating a new one
+      Aws::Client::ClientConfiguration configuration;
+      if (use_ssl) {
+        configuration.scheme = Aws::Http::Scheme::HTTPS;
+      } else {
+        configuration.scheme = Aws::Http::Scheme::HTTP;
+      }
+      configuration.verifySSL = verify_ssl;
+      Aws::Utils::ARN arnAWS((Aws::String(arn)));
+      configuration.region = Aws::String(arnAWS.GetRegion());
+      configuration.maxConnections = MAX_CONNECTIONS;
+      configuration.requestTimeoutMs = REQUEST_TIMEOUT_MS;
+      configuration.connectTimeoutMs = CONNECT_TIMEOUT_MS;
+      std::string host, user, password;
+      rgw::parse_url_authority(endpoint, host, user, password);
+      configuration.endpointOverride = Aws::String(host);
+      Aws::Auth::AWSCredentials credentials;
+      credentials.SetAWSAccessKeyId(Aws::String(access_key));
+      credentials.SetAWSSecretKey(Aws::String(access_secret));
+      AwsClient client;
+      if (arnAWS.GetService() == "lambda") {
+        client = new Aws::Lambda::LambdaClient(credentials, configuration);
+      } else if (arnAWS.GetService() == "sns") {
+        client = new Aws::SNS::SNSClient(credentials, configuration);
+      } else {
+        return NO_CLIENT;
+      }
+      return client_list.emplace(id, client).first->second;
+    }
+
+    int publish(AwsClient client,
+                const std::string &payload,
+                const std::string &resource_arn,
+                reply_callback_t cb) {
+      if (stopped) {
+        return STATUS_MANAGER_STOPPED;
+      }
+      if (client == NO_CLIENT) {
+        return STATUS_CLIENT_CLOSED;
+      }
+      if (message_queue.push(new message_t(client, resource_arn, payload, cb))) {
+        return STATUS_OK;
+      }
+
+
+      return STATUS_FULL;
+    }
+
+    void stop() {
+      stopped = true;
+    }
+
+  };
+
+  static Manager *manager = nullptr;
+  static const unsigned IDLE_TIME_MS = 100;
+  static const size_t MAX_QUEUE_DEFAULT = 8192;
+  static const size_t MAX_CLIENTS_DEFAULT = 256;
+
+  bool init(CephContext *cct) {
+    if (manager) {
+      return false;
+    }
+    manager = new Manager(MAX_CLIENTS_DEFAULT, MAX_QUEUE_DEFAULT, IDLE_TIME_MS, cct);
+    return true;
+  }
+
+  void shutdown() {
+    delete manager;
+    manager = nullptr;
+  }
+
+  AwsClient connect(const std::string &access_key,
+                    const std::string &access_secret,
+                    const std::string &arn,
+                    const std::string &endpoint,
+                    bool verifySSL,
+                    bool useSSL) {
+    if (!manager) return NO_CLIENT;
+    return manager->connect(access_key, access_secret, arn, endpoint, verifySSL, useSSL);
+  }
+
+  // Publishes the message to the queue
+  int publish(const AwsClient client,
+              const std::string &payload,
+              const std::string &resource_arn,
+              reply_callback_t cb) {
+    if (!manager)
+      return STATUS_MANAGER_STOPPED;
+    return manager->publish(client, payload, resource_arn, cb);
+  }
+}

--- a/src/rgw/rgw_aws.h
+++ b/src/rgw/rgw_aws.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <string>
+#include <variant>
+#include <functional>
+#include "include/common_fwd.h"
+
+namespace Aws {
+  namespace Lambda {
+    class LambdaClient;
+  }
+  namespace SNS {
+    class SNSClient;
+  }
+}
+
+namespace rgw::aws {
+
+  typedef std::variant<Aws::Lambda::LambdaClient *, Aws::SNS::SNSClient *> AwsClient;
+  typedef std::function<void(int)> reply_callback_t;
+
+  static const AwsClient NO_CLIENT = AwsClient();
+
+  AwsClient connect(const std::string &access_key,
+                    const std::string &access_secret,
+                    const std::string &arn,
+                    const std::string &endpoint,
+                    bool verifySSL,
+                    bool useSSL);
+
+  int publish(AwsClient client,
+              const std::string &payload,
+              const std::string &resource_arn,
+              reply_callback_t cb);
+
+  bool init(CephContext *cct);
+
+  void shutdown();
+}
+

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -54,6 +54,7 @@
 #endif
 
 #include "services/svc_zone.h"
+#include "rgw_aws.h"
 
 #ifdef HAVE_SYS_PRCTL_H
 #include <sys/prctl.h>
@@ -406,6 +407,11 @@ int radosgw_Main(int argc, const char **argv)
         dout(1) << "ERROR: failed to initialize Kafka manager" << dendl;
     }
 #endif
+#ifdef WITH_RADOSGW_AWS_ENDPOINT
+  if (!rgw::aws::init(cct.get())) {
+        dout(1) << "ERROR: failed to initialize AWS manager" << dendl;
+    }
+#endif
   }
 
   const auto& luarocks_path = g_conf().get_val<std::string>("rgw_luarocks_location");
@@ -687,6 +693,9 @@ int radosgw_Main(int argc, const char **argv)
 #endif
 #ifdef WITH_RADOSGW_KAFKA_ENDPOINT
   rgw::kafka::shutdown();
+#endif
+#ifdef WITH_RADOSGW_AWS_ENDPOINT
+  rgw::aws::shutdown();
 #endif
 
   rgw_perf_stop(g_ceph_context);

--- a/src/rgw/rgw_pubsub_push.cc
+++ b/src/rgw/rgw_pubsub_push.cc
@@ -18,10 +18,15 @@
 #ifdef WITH_RADOSGW_KAFKA_ENDPOINT
 #include "rgw_kafka.h"
 #endif
+#ifdef WITH_RADOSGW_AWS_ENDPOINT
+#include "rgw_aws.h"
+#endif
 #include <boost/asio/yield.hpp>
 #include <boost/algorithm/string.hpp>
 #include <functional>
 #include "rgw_perf_counters.h"
+
+#define dout_subsys ceph_subsys_rgw
 
 using namespace rgw;
 
@@ -98,7 +103,7 @@ private:
   };
 
 public:
-  RGWPubSubHTTPEndpoint(const std::string& _endpoint, 
+  RGWPubSubHTTPEndpoint(const std::string& _endpoint,
     const RGWHTTPArgs& args) : endpoint(_endpoint) {
     bool exists;
 
@@ -249,7 +254,7 @@ private:
       reenter(this) {
         yield {
           init_new_io(this);
-          const auto rc = amqp::publish_with_confirm(conn, 
+          const auto rc = amqp::publish_with_confirm(conn,
               topic,
               message,
               std::bind(&AckPublishCR::request_complete, this, std::placeholders::_1));
@@ -277,7 +282,7 @@ private:
       io_complete();
       if (perfcounter) perfcounter->dec(l_rgw_pubsub_push_pending);
     }
-   
+
     // TODO: why are these mandatory in RGWIOProvider?
     void set_io_user_info(void *_user_info) override {
     }
@@ -286,19 +291,19 @@ private:
       return nullptr;
     }
   };
-  
+
 public:
   RGWPubSubAMQPEndpoint(const std::string& _endpoint,
       const std::string& _topic,
       const RGWHTTPArgs& args,
-      CephContext* _cct) : 
+      CephContext* _cct) :
         cct(_cct),
-        endpoint(_endpoint), 
+        endpoint(_endpoint),
         topic(_topic),
         exchange(get_exchange(args)),
         ack_level(get_ack_level(args)),
         conn(amqp::connect(endpoint, exchange, (ack_level == ack_level_t::Broker))) {
-    if (!conn) { 
+    if (!conn) {
       throw configuration_error("AMQP: failed to create connection to: " + endpoint);
     }
   }
@@ -383,7 +388,7 @@ public:
       // TODO: currently broker and routable are the same - this will require different flags but the same mechanism
       // note: dynamic allocation of Waiter is needed when this is invoked from a beast coroutine
       auto w = std::unique_ptr<Waiter>(new Waiter);
-      const auto rc = amqp::publish_with_confirm(conn, 
+      const auto rc = amqp::publish_with_confirm(conn,
         topic,
         json_format_pubsub_event(event),
         std::bind(&Waiter::finish, w.get(), std::placeholders::_1));
@@ -500,7 +505,7 @@ private:
   };
 
   // AckPublishCR implements async kafka publishing via coroutine
-  // This coroutine ends when an ack is received from the borker 
+  // This coroutine ends when an ack is received from the borker
   // note that it does not wait for an ack fron the end client
   class AckPublishCR : public RGWCoroutine, public RGWIOProvider {
   private:
@@ -521,7 +526,7 @@ private:
       reenter(this) {
         yield {
           init_new_io(this);
-          const auto rc = kafka::publish_with_confirm(conn, 
+          const auto rc = kafka::publish_with_confirm(conn,
               topic,
               message,
               std::bind(&AckPublishCR::request_complete, this, std::placeholders::_1));
@@ -549,7 +554,7 @@ private:
       io_complete();
       if (perfcounter) perfcounter->dec(l_rgw_pubsub_push_pending);
     }
-   
+
     // TODO: why are these mandatory in RGWIOProvider?
     void set_io_user_info(void *_user_info) override {
     }
@@ -563,12 +568,12 @@ public:
   RGWPubSubKafkaEndpoint(const std::string& _endpoint,
       const std::string& _topic,
       const RGWHTTPArgs& args,
-      CephContext* _cct) : 
+      CephContext* _cct) :
         cct(_cct),
         topic(_topic),
         conn(kafka::connect(_endpoint, get_use_ssl(args), get_verify_ssl(args), args.get_optional("ca-location"))) ,
         ack_level(get_ack_level(args)) {
-    if (!conn) { 
+    if (!conn) {
       throw configuration_error("Kafka: failed to create connection to: " + _endpoint);
     }
   }
@@ -652,7 +657,7 @@ public:
     } else {
       // note: dynamic allocation of Waiter is needed when this is invoked from a beast coroutine
       auto w = std::unique_ptr<Waiter>(new Waiter);
-      const auto rc = kafka::publish_with_confirm(conn, 
+      const auto rc = kafka::publish_with_confirm(conn,
         topic,
         json_format_pubsub_event(event),
         std::bind(&Waiter::finish, w.get(), std::placeholders::_1));
@@ -675,13 +680,210 @@ public:
 static const std::string KAFKA_SCHEMA("kafka");
 #endif	// ifdef WITH_RADOSGW_KAFKA_ENDPOINT
 
+#ifdef WITH_RADOSGW_AWS_ENDPOINT
+class RGWPubSubAWSEndpoint : public RGWPubSubEndpoint {
+private:
+  enum class ack_level_t {
+    None,
+    Server
+  };
+  CephContext* const cct;
+  const std::string arn;
+  ack_level_t ack_level;
+  rgw::aws::AwsClient client;
+
+  ack_level_t get_ack_level(const RGWHTTPArgs& args) {
+    bool exists;
+    // get ack level
+    const auto str_ack_level = args.get("aws-ack-level", &exists);
+    if (!exists || str_ack_level == "server") {
+      // "server" is default
+      return ack_level_t::Server;
+    }
+    if (str_ack_level == "none") {
+      return ack_level_t::None;
+    }
+    throw configuration_error("AWS: invalid aws-ack-level: " + str_ack_level);
+  }
+
+  bool get_verify_ssl(const RGWHTTPArgs& args) {
+    bool exists;
+    auto str_verify_ssl = args.get("verify-ssl", &exists);
+    if (!exists) {
+      // verify server certificate by default
+      return true;
+    }
+    boost::algorithm::to_lower(str_verify_ssl);
+    if (str_verify_ssl == "true") {
+      return true;
+    }
+    if (str_verify_ssl == "false") {
+      return false;
+    }
+    throw configuration_error("'verify-ssl' must be true/false, not: " + str_verify_ssl);
+  }
+
+  bool get_use_ssl(const RGWHTTPArgs& args) {
+    bool exists;
+    auto str_use_ssl = args.get("use-ssl", &exists);
+    if (!exists) {
+      // by default ssl not used
+      return false;
+    }
+    boost::algorithm::to_lower(str_use_ssl);
+    if (str_use_ssl == "true") {
+      return true;
+    }
+    if (str_use_ssl == "false") {
+      return false;
+    }
+    throw configuration_error("'use-ssl' must be true/false, not: " + str_use_ssl);
+  }
+
+  std::string get_arn(const RGWHTTPArgs& args){
+    bool exists;
+    auto arnString = args.get("AwsArn", &exists);
+    boost::optional<ARN> arnParsed = ARN::parse(arnString);
+    if(!arnParsed) {
+      throw configuration_error("incorrect arn format");
+    }
+    if(arnParsed->service != Service::sns && arnParsed->service != Service::lambda){
+      throw configuration_error("only sns and lambda aws services allowed");
+    }
+    return arnParsed->to_string();
+  }
+
+  std::string get_access_key(const RGWHTTPArgs& args){
+    bool exists;
+    auto accessKey = args.get("AccessKey", &exists);
+    if(!exists) {
+      throw configuration_error("secret key cannot be empty");
+    }
+    return accessKey;
+  }
+
+  std::string get_access_secret(const RGWHTTPArgs& args){
+    bool exists;
+    auto accessSecret = args.get("SecretKey", &exists);
+    if(!exists) {
+      throw configuration_error("access secret cannot be empty");
+    }
+    return accessSecret;
+  }
+
+public:
+  RGWPubSubAWSEndpoint(const std::string& _endpoint,
+      const RGWHTTPArgs& args,
+      CephContext* _cct) :
+        cct(_cct),
+        arn(get_arn(args)),
+        ack_level(get_ack_level(args)),
+        client(rgw::aws::connect(get_access_key(args), get_access_secret(args), arn, _endpoint, get_verify_ssl(args), get_use_ssl(args))){
+    if (client == rgw::aws::NO_CLIENT) {
+      throw configuration_error("AWS: failed to create connection to: " + _endpoint);
+    }
+  }
+
+  RGWCoroutine* send_to_completion_async(const rgw_pubsub_s3_event& event, RGWDataSyncEnv* env) override {
+    ceph_assert(false);
+    return nullptr;
+  }
+  RGWCoroutine* send_to_completion_async(const rgw_pubsub_event& event, RGWDataSyncEnv* env) override {
+    ceph_assert(false);
+    return nullptr;
+  }
+
+  // this allows waiting untill "finish()" is called from a different thread
+  // waiting could be blocking the waiting thread or yielding, depending
+  // with compilation flag support and whether the optional_yield is set
+  class Waiter {
+    using Signature = void(boost::system::error_code);
+    using Completion = ceph::async::Completion<Signature>;
+    std::unique_ptr<Completion> completion = nullptr;
+    int ret;
+
+    std::atomic<bool> done = false;
+    std::mutex lock;
+    std::condition_variable cond;
+
+    template <typename ExecutionContext, typename CompletionToken>
+    auto async_wait(ExecutionContext& ctx, CompletionToken&& token) {
+      boost::asio::async_completion<CompletionToken, Signature> init(token);
+      auto& handler = init.completion_handler;
+      {
+        std::unique_lock l{lock};
+        completion = Completion::create(ctx.get_executor(), std::move(handler));
+      }
+      return init.result.get();
+    }
+
+  public:
+    int wait(optional_yield y) {
+      if (done) {
+        return ret;
+      }
+#ifdef HAVE_BOOST_CONTEXT
+      if (y) {
+        auto& io_ctx = y.get_io_context();
+        auto& yield_ctx = y.get_yield_context();
+        boost::system::error_code ec;
+        async_wait(io_ctx, yield_ctx[ec]);
+        return -ec.value();
+      }
+#endif
+      std::unique_lock l(lock);
+      cond.wait(l, [this]{return (done==true);});
+      return ret;
+    }
+
+    void finish(int r) {
+      std::unique_lock l{lock};
+      ret = r;
+      done = true;
+      if (completion) {
+        boost::system::error_code ec(-ret, boost::system::system_category());
+        Completion::post(std::move(completion), ec);
+      } else {
+        cond.notify_all();
+      }
+    }
+  };
+
+
+  int send_to_completion_async(CephContext* cct, const rgw_pubsub_s3_event& event, optional_yield y) override {
+    ceph_assert(client != rgw::aws::NO_CLIENT);
+    if (ack_level == ack_level_t::None) {
+      return rgw::aws::publish(client, json_format_pubsub_event(event), arn, nullptr);
+    } else {
+//       note: dynamic allocation of Waiter is needed when this is invoked from a beast coroutine
+      auto w = std::unique_ptr<Waiter>(new Waiter);
+      const auto rc = aws::publish(client, json_format_pubsub_event(event), arn,
+                                                 std::bind(&Waiter::finish, w.get(), std::placeholders::_1));
+      if (rc < 0) {
+//         failed to publish, does not wait for reply
+        return rc;
+      }
+      return w->wait(y);
+    }
+  }
+
+  std::string to_str() const override {
+    std::string str("AWS Endpoint");
+    str += "\nArn: " + arn;
+    return str;
+  }
+};
+
+static const std::string AWS_SCHEMA("aws");
+#endif	// ifdef WITH_RADOSGW_AWS_ENDPOINT
+
 static const std::string WEBHOOK_SCHEMA("webhook");
 static const std::string UNKNOWN_SCHEMA("unknown");
 static const std::string NO_SCHEMA("");
 
 const std::string& get_schema(const std::string& endpoint) {
   if (endpoint.empty()) {
-    return NO_SCHEMA; 
+    return NO_SCHEMA;
   }
   const auto pos = endpoint.find(':');
   if (pos == std::string::npos) {
@@ -698,12 +900,16 @@ const std::string& get_schema(const std::string& endpoint) {
   } else if (schema == "kafka") {
     return KAFKA_SCHEMA;
 #endif
+#ifdef WITH_RADOSGW_AWS_ENDPOINT
+  }else if(schema == "aws"){
+    return AWS_SCHEMA;
+#endif
   }
   return UNKNOWN_SCHEMA;
 }
 
-RGWPubSubEndpoint::Ptr RGWPubSubEndpoint::create(const std::string& endpoint, 
-    const std::string& topic, 
+RGWPubSubEndpoint::Ptr RGWPubSubEndpoint::create(const std::string& endpoint,
+    const std::string& topic,
     const RGWHTTPArgs& args,
     CephContext* cct) {
   const auto& schema = get_schema(endpoint);
@@ -732,6 +938,10 @@ RGWPubSubEndpoint::Ptr RGWPubSubEndpoint::create(const std::string& endpoint,
 #ifdef WITH_RADOSGW_KAFKA_ENDPOINT
   } else if (schema == KAFKA_SCHEMA) {
       return Ptr(new RGWPubSubKafkaEndpoint(endpoint, topic, args, cct));
+#endif
+#ifdef WITH_RADOSGW_AWS_ENDPOINT
+  }else if (schema == AWS_SCHEMA){
+      return Ptr(new RGWPubSubAWSEndpoint(endpoint, args, cct));
 #endif
   }
 

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -222,8 +222,4 @@ if(WITH_RADOSGW_AWS_ENDPOINT)
   add_executable(unittest_rgw_aws test_rgw_aws.cc)
   target_include_directories(unittest_rgw_aws PRIVATE "${CMAKE_SOURCE_DIR}/src/aws-sdk-cpp/aws-cpp-sdk-core/include")
   target_link_libraries(unittest_rgw_aws ${rgw_libs} ${UNITTEST_LIBS})
-  install(TARGETS
-          unittest_rgw_aws
-          DESTINATION ${CMAKE_INSTALL_BINDIR})
-
 endif()

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -217,3 +217,13 @@ add_executable(unittest_rgw_lua test_rgw_lua.cc)
 add_ceph_unittest(unittest_rgw_lua)
 target_link_libraries(unittest_rgw_lua ${rgw_libs} ${LUA_LIBRARIES})
 
+if(WITH_RADOSGW_AWS_ENDPOINT)
+  # unittest_rgw_aws
+  add_executable(unittest_rgw_aws test_rgw_aws.cc)
+  target_include_directories(unittest_rgw_aws PRIVATE "${CMAKE_SOURCE_DIR}/src/aws-sdk-cpp/aws-cpp-sdk-core/include")
+  target_link_libraries(unittest_rgw_aws ${rgw_libs} ${UNITTEST_LIBS})
+  install(TARGETS
+          unittest_rgw_aws
+          DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+endif()

--- a/src/test/rgw/test_rgw_aws.cc
+++ b/src/test/rgw/test_rgw_aws.cc
@@ -1,0 +1,61 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <gtest/gtest.h>
+#include <aws/core/Aws.h>
+#include <rgw/rgw_aws.h>
+#include <chrono>
+#include <thread>
+#include "common/ceph_context.h"
+#include <aws/core/auth/AWSCredentialsProvider.h>
+/*
+for running the unit tests, please install moto_server using
+pip install moto
+See http://docs.getmoto.org/en/latest/docs/server_mode.html for  more details.
+Note: lambda mock server requires you to setup docker.
+run the server using
+> moto_server lambda -p5555
+> moto_server sns -p4444
+
+ Now create sns topic, and lambda function in moto_server using
+  aws sns --region=us-east-1 --endpoint-url=http://localhost:4444 create-topic --name gsoc20-ceph
+
+  Create the zip file from a python file index.py having handler() function, named file.zip
+  aws lambda --region=us-east-1 --endpoint-url=http://localhost:5555 create-function --function-name gsoc20 --zip-file fileb://file.zip --handler index.handler --runtime python3.7 --role lambda-ex
+ */
+
+class TestAWS : public ::testing::Test {
+protected:
+
+  void SetUp() override {
+    auto cct = new CephContext(CEPH_ENTITY_TYPE_CLIENT);
+    ASSERT_TRUE(rgw::aws::init(cct));
+  }
+
+  void TearDown() override {
+    rgw::aws::shutdown();
+  }
+
+};
+void callback(int status){
+  if(status == 1){
+    std::cout << "Successful" << std::endl;
+  }else{
+    std::cout << "Failed" << std::endl;
+  }
+
+}
+
+TEST_F(TestAWS, SNS) {
+  auto client = rgw::aws::connect("", "", "arn:aws:sns:us-east-1:123456789012:gsoc20-ceph", "aws://localhost:4444", false, false);
+  EXPECT_EQ(rgw::aws::publish(client, "body", "arn:aws:sns:us-east-1:123456789012:gsoc20-ceph", nullptr), 0);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+}
+
+TEST_F(TestAWS, Lambda) {
+  auto client = rgw::aws::connect("", "", "arn:aws:lambda:us-east-1:123456789012:gsoc20", "aws://localhost:5555", false, false);
+  EXPECT_EQ(rgw::aws::publish(client, R"({ "name": "Bob" })", "arn:aws:lambda:us-east-1:123456789012:function:gsoc20", callback), 0);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+}


### PR DESCRIPTION
* in this PR the `src/aws-sdk-cpp/` submodule points to the `install_only_runtime` branch in my fork of the `aws-sdk-cpp` repo (https://github.com/yuvalif/aws-sdk-cpp.git). this is done temporarily until https://github.com/ceph/aws-sdk-cpp/pull/2 is merged.
* this PR is only draft, and used to figure out the packing parts of the original PR: https://github.com/ceph/ceph/pull/36062

to test locally:
* call "make-dist" on the ceph root directory to generate srpm
* use "mock" to build packages based on that:
```
mock -r fedora-32-x86_64 --rootdir=<mock root dir> --rebuild <srpm file>
```