### PR TITLE
rgw: fix 'this->ondisk_version' will always evaluate to 'true'

### DIFF
--- a/src/rgw/rgw_rest_metadata.cc
+++ b/src/rgw/rgw_rest_metadata.cc
@@ -264,7 +264,7 @@ void RGWOp_Metadata_Put::execute(optional_yield y) {
   }
 
   op_ret = store->ctl()->meta.mgr->put(metadata_key, bl, s->yield, sync_type,
-				       &ondisk_version);
+				       false, &ondisk_version);
   if (op_ret < 0) {
     dout(5) << "ERROR: can't put key: " << cpp_strerror(op_ret) << dendl;
     return;


### PR DESCRIPTION
fix:
```
src/rgw/CMakeFiles/radosgw.dir/rgw_rest_metadata.cc.o
../src/rgw/rgw_rest_metadata.cc:267:13: warning: address of
'this->ondisk_version' will always evaluate to 'true'
[-Wpointer-bool-conversion]
                                       &ondisk_version);
```
Fixes: https://tracker.ceph.com/issues/48688

Signed-off-by: Mark Kogan <mkogan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
