### PR TITLE
mgr/ActivePyModules.cc: always release GIL before attempting to acquire a lock

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -65,7 +65,9 @@ void ActivePyModules::dump_server(const std::string &hostname,
   std::string ceph_version;
 
   for (const auto &[key, state] : dmc) {
+    PyThreadState *tstate = PyEval_SaveThread();
     std::lock_guard l(state->lock);
+    PyEval_RestoreThread(tstate);
     // TODO: pick the highest version, and make sure that
     // somewhere else (during health reporting?) we are
     // indicating to the user if we see mixed versions
@@ -131,7 +133,9 @@ PyObject *ActivePyModules::get_metadata_python(
     Py_RETURN_NONE;
   }
 
+  PyThreadState *tstate = PyEval_SaveThread();
   std::lock_guard l(metadata->lock);
+  PyEval_RestoreThread(tstate);
   PyFormatter f;
   f.dump_string("hostname", metadata->hostname);
   for (const auto &[key, val] : metadata->metadata) {
@@ -150,8 +154,9 @@ PyObject *ActivePyModules::get_daemon_status_python(
     derr << "Requested missing service " << svc_type << "." << svc_id << dendl;
     Py_RETURN_NONE;
   }
-
+  PyThreadState *tstate = PyEval_SaveThread();
   std::lock_guard l(metadata->lock);
+  PyEval_RestoreThread(tstate);
   PyFormatter f;
   for (const auto &[daemon, status] : metadata->service_status) {
     f.dump_string(daemon, status);
@@ -195,7 +200,6 @@ PyObject *ActivePyModules::get_python(const std::string &what)
     });
     return f.get();
   } else if (what == "modified_config_options") {
-    PyEval_RestoreThread(tstate);
     auto all_daemons = daemon_state.get_all();
     set<string> names;
     for (auto& [key, daemon] : all_daemons) {
@@ -204,6 +208,7 @@ PyObject *ActivePyModules::get_python(const std::string &what)
 	names.insert(name);
       }
     }
+    PyEval_RestoreThread(tstate);
     f.open_array_section("options");
     for (auto& name : names) {
       f.dump_string("name", name);
@@ -236,31 +241,35 @@ PyObject *ActivePyModules::get_python(const std::string &what)
     return f.get();
   } else if (what == "osd_metadata") {
     auto dmc = daemon_state.get_by_service("osd");
-    PyEval_RestoreThread(tstate);
 
     for (const auto &[key, state] : dmc) {
       std::lock_guard l(state->lock);
+      PyEval_RestoreThread(tstate);
       f.open_object_section(key.name.c_str());
       f.dump_string("hostname", state->hostname);
       for (const auto &[name, val] : state->metadata) {
         f.dump_string(name.c_str(), val);
       }
       f.close_section();
+      tstate = PyEval_SaveThread();
     }
+    PyEval_RestoreThread(tstate);
     return f.get();
   } else if (what == "mds_metadata") {
     auto dmc = daemon_state.get_by_service("mds");
-    PyEval_RestoreThread(tstate);
 
     for (const auto &[key, state] : dmc) {
       std::lock_guard l(state->lock);
+      PyEval_RestoreThread(tstate);
       f.open_object_section(key.name.c_str());
       f.dump_string("hostname", state->hostname);
       for (const auto &[name, val] : state->metadata) {
         f.dump_string(name.c_str(), val);
       }
       f.close_section();
+      tstate = PyEval_SaveThread();
     }
+    PyEval_RestoreThread(tstate);
     return f.get();
   } else if (what == "pg_summary") {
     cluster_state.with_pgmap(
@@ -507,8 +516,8 @@ void ActivePyModules::notify_all(const std::string &notify_type,
     dout(15) << "queuing notify to " << name << dendl;
     // workaround for https://bugs.llvm.org/show_bug.cgi?id=35984
     finisher.queue(new LambdaContext([module=module, notify_type, notify_id]
-      (int r){ 
-        module->notify(notify_type, notify_id); 
+      (int r){
+        module->notify(notify_type, notify_id);
     }));
   }
 }
@@ -726,7 +735,9 @@ PyObject* ActivePyModules::with_perf_counters(
 
   auto metadata = daemon_state.get(DaemonKey{svc_name, svc_id});
   if (metadata) {
+    tstate = PyEval_SaveThread();
     std::lock_guard l2(metadata->lock);
+    PyEval_RestoreThread(tstate);
     if (metadata->perf_counters.instances.count(path)) {
       auto counter_instance = metadata->perf_counters.instances.at(path);
       auto counter_type = metadata->perf_counters.types.at(path);
@@ -830,8 +841,9 @@ PyObject* ActivePyModules::get_perf_schema_python(
   if (!daemons.empty()) {
     for (auto& [key, state] : daemons) {
       f.open_object_section(ceph::to_string(key).c_str());
-
+      tstate = PyEval_SaveThread();
       std::lock_guard l(state->lock);
+      PyEval_RestoreThread(tstate);
       for (auto ctr_inst_iter : state->perf_counters.instances) {
         const auto &counter_name = ctr_inst_iter.first;
 	f.open_object_section(counter_name.c_str());


### PR DESCRIPTION
This PR addresses a deadlock scenario that our team is able to consistently reproduce on a cluster running v15.2.7. We believe that it addresses the underlying issue that is identified in the following tracker: https://tracker.ceph.com/issues/39264. Refer to my colleague's comment on that tracker for more information about our cluster: https://tracker.ceph.com/issues/39264#note-22.

We are using the Prometheus module to monitor the cluster and one symptom of the deadlock was that the Prometheus HTTP endpoint would become unresponsive. We later observed that the mgr process was unresponsive in many other ways as well. The deadlock often occurred within an hour of starting the mgr process and was only rectified by restarting it. During a deadlock, we were able to connect to the process with GDB and we noticed that all of the Python module threads were forever waiting on the GIL (including the CherryPy threads that power the Prometheus module HTTP server). We found that the thread that was holding the GIL was blocked in an attempt to acquire a mutex that was owned by another thread that was waiting on the GIL. The deadlock between these two threads severely impacts the mgr process because the GIL is never released and all threads attempting to use the Python interpreter are deadlocked as well.

We witnessed this deadlock occurring in multiple different code locations but I'll provide one specific scenario to illustrate the point. Thread A enters the `get_python` method and lands in the `what == "osd_metadata"` branch on [line 237](https://github.com/ceph/ceph/compare/master...ilanddev:mgr-deadlock-fix?expand=1#diff-50ab66411d9293d402a15e00ed6843a4d37889c616873e69534e609c210f72ecL237). Thread A acquires the GIL on [line 239](https://github.com/ceph/ceph/compare/master...ilanddev:mgr-deadlock-fix?expand=1#diff-50ab66411d9293d402a15e00ed6843a4d37889c616873e69534e609c210f72ecL239) and iteratively acquires the locks associated with individual OSD daemon states on [line 242](https://github.com/ceph/ceph/compare/master...ilanddev:mgr-deadlock-fix?expand=1#diff-50ab66411d9293d402a15e00ed6843a4d37889c616873e69534e609c210f72ecL242). In some iteration of the loop, thread A gives up the GIL because Python happens to do some GC, uses the interpreter, and is ultimately preempted. Thread A is now waiting on the GIL in order to proceed. At this point, Thread B had entered the same branch and was able to acquire the GIL on [line 239](https://github.com/ceph/ceph/compare/master...ilanddev:mgr-deadlock-fix?expand=1#diff-50ab66411d9293d402a15e00ed6843a4d37889c616873e69534e609c210f72ecL239) when it was released by Thread A. Thread B then iteratively acquires the OSD daemon state locks on [line 242](https://github.com/ceph/ceph/compare/master...ilanddev:mgr-deadlock-fix?expand=1#diff-50ab66411d9293d402a15e00ed6843a4d37889c616873e69534e609c210f72ecL242) until it attempts to obtain the one that is still held by Thread A, at which point it is blocked. Now Thread A is waiting on the GIL that is held by Thread B and Thread B is waiting on the mutex that is held by Thread A - deadlock.

The solution to this deadlock scenario is to always release the GIL before attempting to acquire a mutex. This patch has been deployed in our v15.2.7 cluster and has resolved the issues that we were experiencing with regular unresponsiveness and required restarts.