### PR TITLE
cephadm: enable exporter deployment at bootstrap

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -216,7 +216,8 @@ $CEPHADM bootstrap \
       --output-pub-ssh-key $TMPDIR/ceph.pub \
       --allow-overwrite \
       --skip-mon-network \
-      --skip-monitoring-stack
+      --skip-monitoring-stack \
+      --with-exporter
 test -e $CONFIG
 test -e $KEYRING
 rm -f $ORIG_CONFIG
@@ -388,6 +389,20 @@ cond="$CEPHADM enter --fsid $FSID --name container.alertmanager.a -- test -f \
 is_available "alertmanager.yml" "$cond" 10
 cond="curl 'http://localhost:9093' | grep -q 'Alertmanager'"
 is_available "alertmanager" "$cond" 10
+
+# Fetch the token we need to access the exporter API
+token=$($CEPHADM shell --fsid $FSID --config $CONFIG --keyring $KEYRING ceph cephadm get-exporter-config | jq -r '.token')
+[[ ! -z "$token" ]]
+
+# check all exporter threads active
+cond="curl -k -s -H \"Authorization: Bearer $token\" \
+      https://localhost:9443/v1/metadata/health | \
+      jq -r '.tasks | select(.disks == \"active\" and .daemons == \"active\" and .host == \"active\")'"
+is_available "exporter_threads_active" "$cond" 3
+
+# check we deployed for all hosts
+host_pattern=$($CEPHADM shell --fsid $FSID --config $CONFIG --keyring $KEYRING ceph orch ls cephadm-exporter --format json | jq -r '.[0].placement.host_pattern')
+[[ "$host_pattern" = "*" ]]
 
 ## run
 # WRITE ME

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3284,8 +3284,8 @@ def command_bootstrap():
             cli(['cephadm', 'generate-exporter-config'])
         #
         # deploy the service (commented out until the cephadm changes are in the ceph container build)
-        # logger.info('Deploying cephadm exporter service with default placement...')
-        # cli(['orch', 'apply', 'cephadm-exporter'])
+        logger.info('Deploying cephadm exporter service with default placement...')
+        cli(['orch', 'apply', 'cephadm-exporter'])
 
 
     if not args.skip_dashboard:


### PR DESCRIPTION
Bootstrap supports --with-exporter, this change just
issues the apply to the existing configuration of the
exporter service to deploy the exporter with a new
cluster

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>

