### PR TITLE
mgr/cephadm: Improve command <ceph orch apply> output with placement info

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2279,11 +2279,14 @@ Then run the following:
             allow_colo=self.cephadm_services[spec.service_type].allow_colo(),
         ).validate()
 
-        self.log.info('Saving service %s spec with placement %s' % (
-            spec.service_name(), spec.placement.pretty_str()))
+        msg = 'Saving service %s spec with placement <%s>' % (
+            spec.service_name(),
+            spec.placement.pretty_str())
+        self.log.info(msg)
         self.spec_store.save(spec)
         self._kick_serve_loop()
-        return "Scheduled %s update..." % spec.service_name()
+
+        return '%s\nScheduled %s update...' % (msg, spec.service_name())
 
     @handle_orch_error
     def apply(self, specs: Sequence[GenericSpec], no_overwrite: bool = False) -> List[str]:

--- a/src/pybind/mgr/cephadm/tests/test_migration.py
+++ b/src/pybind/mgr/cephadm/tests/test_migration.py
@@ -15,10 +15,14 @@ def test_migrate_scheduler(cephadm_module: CephadmOrchestrator):
         with with_host(cephadm_module, 'host2', refresh_hosts=False):
 
             # emulate the old scheduler:
-            c = cephadm_module.apply_rgw(
-                ServiceSpec('rgw', 'r.z', placement=PlacementSpec(host_pattern='*', count=2))
-            )
-            assert wait(cephadm_module, c) == 'Scheduled rgw.r.z update...'
+            spec = ServiceSpec('rgw',
+                               'r.z',
+                               placement=PlacementSpec(host_pattern='*', count=2))
+            c = cephadm_module.apply_rgw(spec)
+            expected_result = f'Saving service rgw.r.z spec with placement ' \
+                              f'<{spec.placement.pretty_str()}>\nScheduled ' \
+                              'rgw.r.z update...'
+            assert wait(cephadm_module, c) == expected_result
 
             # with pytest.raises(OrchestratorError, match="cephadm migration still ongoing. Please wait, until the migration is complete."):
             CephadmServe(cephadm_module)._apply_all_services()
@@ -36,10 +40,12 @@ def test_migrate_scheduler(cephadm_module: CephadmOrchestrator):
             out = {o.hostname for o in wait(cephadm_module, cephadm_module.list_daemons())}
             assert out == {'host1', 'host2'}
 
-            c = cephadm_module.apply_rgw(
-                ServiceSpec('rgw', 'r.z', placement=PlacementSpec(host_pattern='host1', count=2))
-            )
-            assert wait(cephadm_module, c) == 'Scheduled rgw.r.z update...'
+            spec = ServiceSpec('rgw', 'r.z', placement=PlacementSpec(host_pattern='host1', count=2))
+            c = cephadm_module.apply_rgw(spec)
+            expected_result = f'Saving service rgw.r.z spec with placement ' \
+                              f'<{spec.placement.pretty_str()}>\nScheduled ' \
+                              'rgw.r.z update...'
+            assert wait(cephadm_module, c) == expected_result
 
             # Sorry, for this hack, but I need to make sure, Migration thinks,
             # we have updated all daemons already.


### PR DESCRIPTION
Include information about placement in the output of the  <ceph orch apply>  command. This contributes to clarify what is going to be the result, overall if  the command is using default placements ( each service has its own defaults)

Fixes: https://tracker.ceph.com/issues/50592

Ex:

```
[ceph: root@cephLab2-node-00 /]# ceph orch apply mon
Saving service mon spec with placement count:5
Scheduled mon update...

[ceph: root@cephLab2-node-00 /]# ceph orch apply mgr
Saving service mgr spec with placement count:2
Scheduled mgr update...
```

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>