### PR TITLE
mgr/orchestrator: minor improvements to orch status

### DIFF
--- a/doc/mgr/orchestrator.rst
+++ b/doc/mgr/orchestrator.rst
@@ -53,7 +53,7 @@ Status
 
 ::
 
-    ceph orch status
+    ceph orch status [--detail]
 
 Show current orchestrator mode and high-level status (whether the orchestrator
 plugin is available and operational)

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -529,6 +529,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                     # start the process
                     self._kick_serve_loop()
 
+    def is_paused(self) -> bool:
+        return self.paused
+
+    def worker_pool_size(self) -> int:
+        return self._worker_pool._processes  # type: ignore
+
     def pause(self) -> None:
         if not self.paused:
             self.log.info('Paused')

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -532,9 +532,6 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
     def is_paused(self) -> bool:
         return self.paused
 
-    def worker_pool_size(self) -> int:
-        return self._worker_pool._processes  # type: ignore
-
     def pause(self) -> None:
         if not self.paused:
             self.log.info('Paused')
@@ -690,7 +687,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             return ok, err
         if not self.ssh_key or not self.ssh_pub:
             return False, 'SSH keys not set. Use `ceph cephadm set-priv-key` and `ceph cephadm set-pub-key` or `ceph cephadm generate-key`'
-        return True, ''
+
+        return True, str(self._worker_pool._processes)  # type: ignore
 
     def process(self, completions: List[CephadmCompletion]) -> None:  # type: ignore
         """

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -529,9 +529,6 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                     # start the process
                     self._kick_serve_loop()
 
-    def is_paused(self) -> bool:
-        return self.paused
-
     def pause(self) -> None:
         if not self.paused:
             self.log.info('Paused')
@@ -678,17 +675,24 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             return False, "loading remoto library:{}".format(
                 remoto_import_error)
 
-    def available(self) -> Tuple[bool, str]:
+    def available(self) -> Tuple[bool, str, Dict[str, Any]]:
         """
         The cephadm orchestrator is always available.
         """
         ok, err = self.can_run()
         if not ok:
-            return ok, err
+            return ok, err, {}
         if not self.ssh_key or not self.ssh_pub:
-            return False, 'SSH keys not set. Use `ceph cephadm set-priv-key` and `ceph cephadm set-pub-key` or `ceph cephadm generate-key`'
+            return False, 'SSH keys not set. Use `ceph cephadm set-priv-key` and `ceph cephadm set-pub-key` or `ceph cephadm generate-key`', {}
 
-        return True, str(self._worker_pool._processes)  # type: ignore
+        # mypy is unable to determine type for _processes since it's private
+        worker_count: int = self._worker_pool._processes  # type: ignore
+        ret = {
+            "workers": worker_count,
+            "paused": self.paused,
+        }
+
+        return True, err, ret
 
     def process(self, completions: List[CephadmCompletion]) -> None:  # type: ignore
         """

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -23,7 +23,7 @@ class OrchestratorAPI(OrchestratorClientMixin):
 
     def status(self):
         try:
-            status, message = super().available()
+            status, message, _module_details = super().available()
             logger.info("is orchestrator available: %s, %s", status, message)
             return dict(available=status, message=message)
         except (RuntimeError, OrchestratorError, ImportError) as e:

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -789,9 +789,6 @@ class Orchestrator(object):
     def is_paused(self) -> bool:
         raise NotImplementedError()
 
-    def worker_pool_size(self) -> int:
-        raise NotImplementedError()
-
     def add_host(self, host_spec: HostSpec) -> Completion[str]:
         """
         Add a host to the orchestrator inventory.

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -703,7 +703,7 @@ class Orchestrator(object):
         return True
 
     @_hide_in_features
-    def available(self) -> Tuple[bool, str]:
+    def available(self) -> Tuple[bool, str, Dict[str, Any]]:
         """
         Report whether we can talk to the orchestrator.  This is the
         place to give the user a meaningful message if the orchestrator
@@ -724,7 +724,9 @@ class Orchestrator(object):
                 ... if OrchestratorClientMixin().available()[0]:  # wrong.
                 ...     OrchestratorClientMixin().get_hosts()
 
-        :return: two-tuple of boolean, string
+        :return: boolean representing whether the module is available/usable
+        :return: string describing any error 
+        :return: dict containing any module specific information
         """
         raise NotImplementedError()
 
@@ -784,9 +786,6 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def resume(self) -> None:
-        raise NotImplementedError()
-
-    def is_paused(self) -> bool:
         raise NotImplementedError()
 
     def add_host(self, host_spec: HostSpec) -> Completion[str]:

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -786,6 +786,12 @@ class Orchestrator(object):
     def resume(self) -> None:
         raise NotImplementedError()
 
+    def is_paused(self) -> bool:
+        raise NotImplementedError()
+
+    def worker_pool_size(self) -> int:
+        raise NotImplementedError()
+
     def add_host(self, host_spec: HostSpec) -> Completion[str]:
         """
         Add a host to the orchestrator inventory.

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1351,8 +1351,17 @@ Usage:
 
         avail, why = self.available()
         result: Dict[str, Any] = {
-            "backend": o
+            "backend": o,
+            "paused": self.is_paused(),
         }
+
+        try:
+            num_workers = self.worker_pool_size()
+        except NotImplementedError:
+            pass
+        else:
+            result['workers'] = num_workers
+
         if avail is not None:
             result['available'] = avail
             if not avail:
@@ -1366,6 +1375,9 @@ Usage:
                 output += "\nAvailable: {0}".format(result['available'])
                 if 'reason' in result:
                     output += ' ({0})'.format(result['reason'])
+            output += f"\nPaused: {'Yes' if result['paused'] else 'No'}"
+            if 'workers' in result:
+                output += f"\nHost Parallelism: {result['workers']}"
         return HandleCommandResult(stdout=output)
 
     def self_test(self) -> None:

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1351,30 +1351,27 @@ Usage:
         if o is None:
             raise NoOrchestrator()
 
-        avail, msg = self.available()
+        avail, why, module_details = self.available()
         result: Dict[str, Any] = {
+            "available": avail,
             "backend": o,
-            "paused": self.is_paused(),
         }
 
-        if avail is not None:
-            result['available'] = avail
-            if avail:
-                if o == "cephadm" and detail:
-                    result['workers'] = msg
-            else:
-                result['reason'] = msg
+        if avail:
+            result.update(module_details)
+        else:
+            result['reason'] = why
 
         if format != Format.plain:
             output = to_format(result, format, many=False, cls=None)
         else:
             output = "Backend: {0}".format(result['backend'])
-            if 'available' in result:
-                output += f"\nAvailable: {'Yes' if result['available'] else 'No'}"
-                if 'reason' in result:
-                    output += ' ({0})'.format(result['reason'])
-            output += f"\nPaused: {'Yes' if result['paused'] else 'No'}"
-            if 'workers' in result:
+            output += f"\nAvailable: {'Yes' if result['available'] else 'No'}"
+            if 'reason' in result:
+                output += ' ({0})'.format(result['reason'])
+            if 'paused' in result:
+                output += f"\nPaused: {'Yes' if result['paused'] else 'No'}"
+            if 'workers' in result and detail:
                 output += f"\nHost Parallelism: {result['workers']}"
         return HandleCommandResult(stdout=output)
 

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1351,7 +1351,7 @@ Usage:
         if o is None:
             raise NoOrchestrator()
 
-        avail, why = self.available()
+        avail, msg = self.available()
         result: Dict[str, Any] = {
             "backend": o,
             "paused": self.is_paused(),

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1343,7 +1343,9 @@ Usage:
         return HandleCommandResult()
 
     @_cli_read_command('orch status')
-    def _status(self, format: Format = Format.plain) -> HandleCommandResult:
+    def _status(self,
+                detail: bool = False,
+                format: Format = Format.plain) -> HandleCommandResult:
         """Report configured backend and its status"""
         o = self._select_orchestrator()
         if o is None:
@@ -1355,24 +1357,20 @@ Usage:
             "paused": self.is_paused(),
         }
 
-        try:
-            num_workers = self.worker_pool_size()
-        except NotImplementedError:
-            pass
-        else:
-            result['workers'] = num_workers
-
         if avail is not None:
             result['available'] = avail
-            if not avail:
-                result['reason'] = why
+            if avail:
+                if o == "cephadm" and detail:
+                    result['workers'] = msg
+            else:
+                result['reason'] = msg
 
         if format != Format.plain:
             output = to_format(result, format, many=False, cls=None)
         else:
             output = "Backend: {0}".format(result['backend'])
             if 'available' in result:
-                output += "\nAvailable: {0}".format(result['available'])
+                output += f"\nAvailable: {'Yes' if result['available'] else 'No'}"
                 if 'reason' in result:
                     output += ' ({0})'.format(result['reason'])
             output += f"\nPaused: {'Yes' if result['paused'] else 'No'}"

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -125,18 +125,18 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             return False, "Rook version unsupported."
         return True, ''
 
-    def available(self) -> Tuple[bool, str]:
+    def available(self) -> Tuple[bool, str, Dict[str, Any]]:
         if not kubernetes_imported:
-            return False, "`kubernetes` python module not found"
+            return False, "`kubernetes` python module not found", {}
         elif not self._rook_env.has_namespace():
-            return False, "ceph-mgr not running in Rook cluster"
+            return False, "ceph-mgr not running in Rook cluster", {}
 
         try:
             self.k8s.list_namespaced_pod(self._rook_env.namespace)
         except ApiException as e:
-            return False, "Cannot reach Kubernetes API: {}".format(e)
+            return False, "Cannot reach Kubernetes API: {}".format(e), {}
         else:
-            return True, ""
+            return True, "", {}
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(RookOrchestrator, self).__init__(*args, **kwargs)

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -90,7 +90,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
             return HandleCommandResult(retval=-errno.EINVAL, stderr=str(e))
 
     def available(self):
-        return True, ""
+        return True, "", {}
 
     def __init__(self, *args, **kwargs):
         super(TestOrchestrator, self).__init__(*args, **kwargs)


### PR DESCRIPTION
The orch status command only shows the backend and
whether it was available. This has been updated to
include the paused state and the host parallelism (size
of the threadpool) to provide more info about the
orchestrator. host parallelism is only shown for cephadm

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>

