### PR TITLE
vstart: fix -o ceph.conf options processing

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -408,7 +408,8 @@ case $1 in
         shift
         ;;
     -o)
-        extra_conf="$extra_conf	$2"
+        extra_conf="$extra_conf	$2
+"
         shift
         ;;
     --cache)


### PR DESCRIPTION
options passed to vstart.sh via the -o param are bunched on the same
line without line termination between them
hence not being parsed.

ex:
```
cat ./ceph.conf
...
debug_ms=0 debug_objecter=0 bluestore_debug_enforce_settings=ssd
...
```

Fixes: https://tracker.ceph.com/issues/48708

Signed-off-by: Mark Kogan <mkogan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
