### PR TITLE
mgr/rook: Remove service_type param from remove_service()

### DIFF
--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -451,12 +451,13 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
 
     def _service_rm_decorate(self, typename, name, func):
         return write_completion(
-            on_complete=lambda : func(name),
+            on_complete=lambda : func(),
             message="Removing {} services for {}".format(typename, name),
             mgr=self
         )
 
-    def remove_service(self, service_type, service_name):
+    def remove_service(self, service_name):
+        service_type, service_name = service_name.split('.', 1)
         if service_type == 'mds':
             return self._service_rm_decorate(
                 'MDS', service_name, lambda: self.rook_cluster.rm_service(


### PR DESCRIPTION
Orchestrator defines service name as "<service_type>.<service_id>". The
remove_service method requires only service_name as parameter. Removing
service_type parameter fixes the type error.

Fixes: https://tracker.ceph.com/issues/47968
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---
-->

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
