### PR TITLE
librbd: encryption API

### DIFF
--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -369,6 +369,9 @@
 /* Define if libcryptsetup version < 2.0.5 */
 #cmakedefine LIBCRYPTSETUP_LEGACY_DATA_ALIGNMENT
 
+/* Define if libcryptsetup can be used (linux only) */
+#cmakedefine HAVE_LIBCRYPTSETUP
+
 /* Shared library extension, such as .so, .dll or .dylib */
 #cmakedefine CMAKE_SHARED_LIBRARY_SUFFIX "@CMAKE_SHARED_LIBRARY_SUFFIX@"
 

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -372,6 +372,30 @@ enum {
   RBD_WRITE_ZEROES_FLAG_THICK_PROVISION = (1U<<0), /* fully allocated zeroed extent */
 };
 
+typedef enum {
+    RBD_ENCRYPTION_FORMAT_LUKS1 = 0,
+    RBD_ENCRYPTION_FORMAT_LUKS2 = 1
+} rbd_encryption_format_t;
+
+typedef enum {
+    RBD_ENCRYPTION_ALGORITHM_AES128 = 0,
+    RBD_ENCRYPTION_ALGORITHM_AES256 = 1
+} rbd_encryption_algorithm_t;
+
+typedef void *rbd_encryption_options_t;
+
+typedef struct {
+    rbd_encryption_algorithm_t alg;
+    const char* passphrase;
+    size_t passphrase_size;
+} rbd_encryption_luks1_format_options_t;
+
+typedef struct {
+    rbd_encryption_algorithm_t alg;
+    const char* passphrase;
+    size_t passphrase_size;
+} rbd_encryption_luks2_format_options_t;
+
 CEPH_RBD_API void rbd_image_options_create(rbd_image_options_t* opts);
 CEPH_RBD_API void rbd_image_options_destroy(rbd_image_options_t opts);
 CEPH_RBD_API int rbd_image_options_set_string(rbd_image_options_t opts,
@@ -790,6 +814,16 @@ CEPH_RBD_API int rbd_deep_copy_with_progress(rbd_image_t image,
                                              rbd_image_options_t dest_opts,
                                              librbd_progress_fn_t cb,
                                              void *cbdata);
+
+/* encryption */
+CEPH_RBD_API int rbd_encryption_format(rbd_image_t image,
+                                       rbd_encryption_format_t format,
+                                       rbd_encryption_options_t opts,
+                                       size_t opts_size);
+CEPH_RBD_API int rbd_encryption_load(rbd_image_t image,
+                                     rbd_encryption_format_t format,
+                                     rbd_encryption_options_t opts,
+                                     size_t opts_size);
 
 /* snapshots */
 CEPH_RBD_API int rbd_snap_list(rbd_image_t image, rbd_snap_info_t *snaps,

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -214,6 +214,20 @@ namespace librbd {
     config_source_t source;
   } config_option_t;
 
+  typedef rbd_encryption_format_t encryption_format_t;
+  typedef rbd_encryption_algorithm_t encryption_algorithm_t;
+  typedef rbd_encryption_options_t encryption_options_t;
+
+  typedef struct {
+    encryption_algorithm_t alg;
+    std::string passphrase;
+  } encryption_luks1_format_options_t;
+
+  typedef struct {
+    encryption_algorithm_t alg;
+    std::string passphrase;
+  } encryption_luks2_format_options_t;
+
 class CEPH_RBD_API RBD
 {
 public:
@@ -575,6 +589,12 @@ public:
   int deep_copy(IoCtx& dest_io_ctx, const char *destname, ImageOptions& opts);
   int deep_copy_with_progress(IoCtx& dest_io_ctx, const char *destname,
                               ImageOptions& opts, ProgressContext &prog_ctx);
+
+  /* encryption */
+  int encryption_format(encryption_format_t format, encryption_options_t opts,
+                        size_t opts_size);
+  int encryption_load(encryption_format_t format, encryption_options_t opts,
+                      size_t opts_size);
 
   /* striping */
   uint64_t get_stripe_unit() const;

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -54,6 +54,7 @@ set(librbd_internal_srcs
   api/PoolMetadata.cc
   api/Snapshot.cc
   api/Trash.cc
+  api/Utils.cc
   asio/ContextWQ.cc
   cache/ImageWriteback.cc
   cache/ObjectCacherObjectDispatch.cc
@@ -63,6 +64,8 @@ set(librbd_internal_srcs
   crypto/CryptoContextPool.cc
   crypto/CryptoImageDispatch.cc
   crypto/CryptoObjectDispatch.cc
+  crypto/FormatRequest.cc
+  crypto/LoadRequest.cc
   crypto/openssl/DataCryptor.cc
   deep_copy/ImageCopyRequest.cc
   deep_copy/MetadataCopyRequest.cc
@@ -209,6 +212,7 @@ endif()
 
 if(LINUX AND HAVE_LIBCRYPTSETUP)
   list(APPEND librbd_internal_srcs
+          crypto/luks/EncryptionFormat.cc
           crypto/luks/Header.cc
           crypto/luks/FormatRequest.cc
           crypto/luks/LoadRequest.cc)

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -534,6 +534,18 @@ librados::IoCtx duplicate_io_ctx(librados::IoCtx& io_ctx) {
     return 0;
   }
 
+  uint64_t ImageCtx::get_effective_image_size(snap_t in_snap_id) const {
+    auto raw_size = get_image_size(in_snap_id);
+    if (raw_size == 0) {
+      return 0;
+    }
+
+    io::Extents extents = {{raw_size, 0}};
+    io_image_dispatcher->remap_extents(
+            extents, io::IMAGE_EXTENTS_MAP_TYPE_PHYSICAL_TO_LOGICAL);
+    return extents.front().first;
+  }
+
   uint64_t ImageCtx::get_object_count(snap_t in_snap_id) const {
     ceph_assert(ceph_mutex_is_locked(image_lock));
     uint64_t image_size = get_image_size(in_snap_id);

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -301,6 +301,7 @@ namespace librbd {
 		 std::string in_snap_name,
 		 librados::snap_t id);
     uint64_t get_image_size(librados::snap_t in_snap_id) const;
+    uint64_t get_effective_image_size(librados::snap_t in_snap_id) const;
     uint64_t get_object_count(librados::snap_t in_snap_id) const;
     bool test_features(uint64_t test_features) const;
     bool test_features(uint64_t test_features,

--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -17,10 +17,15 @@
 #include "librbd/Utils.h"
 #include "librbd/api/Config.h"
 #include "librbd/api/Trash.h"
+#include "librbd/api/Utils.h"
+#include "librbd/crypto/FormatRequest.h"
+#include "librbd/crypto/LoadRequest.h"
 #include "librbd/deep_copy/Handler.h"
 #include "librbd/image/CloneRequest.h"
 #include "librbd/image/RemoveRequest.h"
 #include "librbd/image/PreRemoveRequest.h"
+#include "librbd/io/ImageDispatcherInterface.h"
+#include "librbd/io/ObjectDispatcherInterface.h"
 #include <boost/scope_exit.hpp>
 
 #define dout_subsys ceph_subsys_rbd
@@ -397,7 +402,8 @@ int Image<I>::list_descendants(
     }
 
     IoCtx ioctx;
-    r = util::create_ioctx(ictx->md_ctx, "child image", it.first, {}, &ioctx);
+    r = librbd::util::create_ioctx(
+            ictx->md_ctx, "child image", it.first, {}, &ioctx);
     if (r == -ENOENT) {
       continue;
     } else if (r < 0) {
@@ -425,16 +431,17 @@ int Image<I>::list_descendants(
 
   // retrieve clone v2 children attached to this snapshot
   IoCtx parent_io_ctx;
-  r = util::create_ioctx(ictx->md_ctx, "parent image", parent_spec.pool_id,
-                         parent_spec.pool_namespace, &parent_io_ctx);
+  r = librbd::util::create_ioctx(
+          ictx->md_ctx, "parent image",parent_spec.pool_id,
+          parent_spec.pool_namespace, &parent_io_ctx);
   if (r < 0) {
     return r;
   }
 
   cls::rbd::ChildImageSpecs child_images;
-  r = cls_client::children_list(&parent_io_ctx,
-                                util::header_name(parent_spec.image_id),
-                                parent_spec.snap_id, &child_images);
+  r = cls_client::children_list(
+          &parent_io_ctx, librbd::util::header_name(parent_spec.image_id),
+          parent_spec.snap_id, &child_images);
   if (r < 0 && r != -ENOENT && r != -EOPNOTSUPP) {
     lderr(cct) << "error retrieving children: " << cpp_strerror(r) << dendl;
     return r;
@@ -446,8 +453,9 @@ int Image<I>::list_descendants(
       child_image.image_id, "", false});
     if (!child_max_level || *child_max_level > 0) {
       IoCtx ioctx;
-      r = util::create_ioctx(ictx->md_ctx, "child image", child_image.pool_id,
-                             child_image.pool_namespace, &ioctx);
+      r = librbd::util::create_ioctx(
+              ictx->md_ctx, "child image", child_image.pool_id,
+              child_image.pool_namespace, &ioctx);
       if (r == -ENOENT) {
         continue;
       } else if (r < 0) {
@@ -470,8 +478,9 @@ int Image<I>::list_descendants(
   for (auto& image : *images) {
     if (child_pool_id == -1 || child_pool_id != image.pool_id ||
         child_io_ctx.get_namespace() != image.pool_namespace) {
-      r = util::create_ioctx(ictx->md_ctx, "child image", image.pool_id,
-                             image.pool_namespace, &child_io_ctx);
+      r = librbd::util::create_ioctx(
+              ictx->md_ctx, "child image", image.pool_id, image.pool_namespace,
+              &child_io_ctx);
       if (r == -ENOENT) {
         image.pool_name = "";
         image.image_name = "";
@@ -604,8 +613,9 @@ int Image<I>::deep_copy(I *src, librados::IoCtx& dest_md_ctx,
     r = create(dest_md_ctx, destname, "", src_size, opts, "", "", false);
   } else {
     librados::IoCtx parent_io_ctx;
-    r = util::create_ioctx(src->md_ctx, "parent image", parent_spec.pool_id,
-                           parent_spec.pool_namespace, &parent_io_ctx);
+    r = librbd::util::create_ioctx(
+            src->md_ctx, "parent image", parent_spec.pool_id,
+            parent_spec.pool_namespace, &parent_io_ctx);
     if (r < 0) {
       return r;
     }
@@ -614,7 +624,7 @@ int Image<I>::deep_copy(I *src, librados::IoCtx& dest_md_ctx,
     api::Config<I>::apply_pool_overrides(dest_md_ctx, &config);
 
     C_SaferCond ctx;
-    std::string dest_id = util::generate_image_id(dest_md_ctx);
+    std::string dest_id = librbd::util::generate_image_id(dest_md_ctx);
     auto *req = image::CloneRequest<I>::create(
       config, parent_io_ctx, parent_spec.image_id, "", {}, parent_spec.snap_id,
       dest_md_ctx, destname, dest_id, opts, cls::rbd::MIRROR_IMAGE_MODE_JOURNAL,
@@ -874,9 +884,9 @@ int Image<I>::flatten_children(I *ictx, const char* snap_name,
     if (child_pool_id == -1 ||
         child_pool_id != child_image.pool_id ||
         child_io_ctx.get_namespace() != child_image.pool_namespace) {
-      r = util::create_ioctx(ictx->md_ctx, "child image",
-                             child_image.pool_id, child_image.pool_namespace,
-                             &child_io_ctx);
+      r = librbd::util::create_ioctx(
+              ictx->md_ctx, "child image", child_image.pool_id,
+              child_image.pool_namespace, &child_io_ctx);
       if (r < 0) {
         return r;
       }
@@ -922,6 +932,44 @@ int Image<I>::flatten_children(I *ictx, const char* snap_name,
   }
 
   return 0;
+}
+
+template <typename I>
+int Image<I>::encryption_format(I* ictx, encryption_format_t format,
+                                encryption_options_t opts, size_t opts_size,
+                                bool c_api) {
+  crypto::EncryptionFormat<I>* result_format;
+  auto r = util::create_encryption_format(
+          ictx->cct, format, opts, opts_size, c_api, &result_format);
+  if (r != 0) {
+    return r;
+  }
+
+  C_SaferCond cond;
+  auto req = librbd::crypto::FormatRequest<I>::create(
+          ictx, std::unique_ptr<crypto::EncryptionFormat<I>>(result_format),
+          &cond);
+  req->send();
+  return cond.wait();
+}
+
+template <typename I>
+int Image<I>::encryption_load(I* ictx, encryption_format_t format,
+                              encryption_options_t opts, size_t opts_size,
+                              bool c_api) {
+  crypto::EncryptionFormat<I>* result_format;
+  auto r = util::create_encryption_format(
+          ictx->cct, format, opts, opts_size, c_api, &result_format);
+  if (r != 0) {
+    return r;
+  }
+
+  C_SaferCond cond;
+  auto req = librbd::crypto::LoadRequest<I>::create(
+          ictx, std::unique_ptr<crypto::EncryptionFormat<I>>(result_format),
+          &cond);
+  req->send();
+  return cond.wait();
 }
 
 } // namespace api

--- a/src/librbd/api/Image.h
+++ b/src/librbd/api/Image.h
@@ -70,6 +70,13 @@ struct Image {
 
   static int flatten_children(ImageCtxT *ictx, const char* snap_name, ProgressContext& pctx);
 
+  static int encryption_format(ImageCtxT *ictx, encryption_format_t format,
+                               encryption_options_t opts, size_t opts_size,
+                               bool c_api);
+  static int encryption_load(ImageCtxT *ictx, encryption_format_t format,
+                             encryption_options_t opts, size_t opts_size,
+                             bool c_api);
+
 };
 
 } // namespace api

--- a/src/librbd/api/Utils.cc
+++ b/src/librbd/api/Utils.cc
@@ -1,0 +1,84 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/api/Utils.h"
+#include "common/dout.h"
+
+#if defined(HAVE_LIBCRYPTSETUP)
+#include "librbd/crypto/luks/EncryptionFormat.h"
+#endif
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::api::util: " << __func__ << ": "
+
+namespace librbd {
+namespace api {
+namespace util {
+
+template <typename I>
+int create_encryption_format(
+        CephContext* cct, encryption_format_t format,
+        encryption_options_t opts, size_t opts_size, bool c_api,
+        crypto::EncryptionFormat<I>** result_format) {
+  size_t expected_opts_size;
+  switch (format) {
+#if defined(HAVE_LIBCRYPTSETUP)
+    case RBD_ENCRYPTION_FORMAT_LUKS1: {
+      if (c_api) {
+        expected_opts_size = sizeof(rbd_encryption_luks1_format_options_t);
+        if (expected_opts_size == opts_size) {
+          auto c_opts = (rbd_encryption_luks1_format_options_t*)opts;
+          *result_format = new crypto::luks::LUKS1EncryptionFormat<I>(
+                  c_opts->alg, {c_opts->passphrase, c_opts->passphrase_size});
+        }
+      } else {
+        expected_opts_size = sizeof(encryption_luks1_format_options_t);
+        if (expected_opts_size == opts_size) {
+          auto cpp_opts = (encryption_luks1_format_options_t*)opts;
+          *result_format = new crypto::luks::LUKS1EncryptionFormat<I>(
+                  cpp_opts->alg, std::move(cpp_opts->passphrase));
+        }
+      }
+      break;
+    }
+    case RBD_ENCRYPTION_FORMAT_LUKS2: {
+      if (c_api) {
+        expected_opts_size = sizeof(rbd_encryption_luks2_format_options_t);
+        if (expected_opts_size == opts_size) {
+          auto c_opts = (rbd_encryption_luks2_format_options_t*)opts;
+          *result_format = new crypto::luks::LUKS2EncryptionFormat<I>(
+                  c_opts->alg, {c_opts->passphrase, c_opts->passphrase_size});
+        }
+      } else {
+        expected_opts_size = sizeof(encryption_luks2_format_options_t);
+        if (expected_opts_size == opts_size) {
+          auto cpp_opts = (encryption_luks2_format_options_t*)opts;
+          *result_format = new crypto::luks::LUKS2EncryptionFormat<I>(
+                  cpp_opts->alg, std::move(cpp_opts->passphrase));
+        }
+      }
+      break;
+    }
+#endif
+    default:
+      lderr(cct) << "unsupported encryption format: " << format << dendl;
+      return -ENOTSUP;
+  }
+
+  if (expected_opts_size != opts_size) {
+    lderr(cct) << "expected opts_size: " << expected_opts_size << dendl;
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+} // namespace util
+} // namespace api
+} // namespace librbd
+
+template int librbd::api::util::create_encryption_format(
+    CephContext* cct, encryption_format_t format, encryption_options_t opts,
+    size_t opts_size, bool c_api,
+    crypto::EncryptionFormat<librbd::ImageCtx>** result_format);

--- a/src/librbd/api/Utils.h
+++ b/src/librbd/api/Utils.h
@@ -1,0 +1,28 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_API_UTILS_H
+#define CEPH_LIBRBD_API_UTILS_H
+
+#include "include/rbd/librbd.hpp"
+#include "librbd/ImageCtx.h"
+#include "librbd/crypto/EncryptionFormat.h"
+
+namespace librbd {
+
+struct ImageCtx;
+
+namespace api {
+namespace util {
+
+template <typename ImageCtxT = librbd::ImageCtx>
+int create_encryption_format(
+        CephContext* cct, encryption_format_t format,
+        encryption_options_t opts, size_t opts_size, bool c_api,
+        crypto::EncryptionFormat<ImageCtxT>** result_format);
+
+} // namespace util
+} // namespace api
+} // namespace librbd
+
+#endif // CEPH_LIBRBD_API_UTILS_H

--- a/src/librbd/crypto/BlockCrypto.cc
+++ b/src/librbd/crypto/BlockCrypto.cc
@@ -38,6 +38,7 @@ int BlockCrypto<T>::crypt(ceph::bufferlist* data, uint64_t image_offset,
 
   bufferlist src = *data;
   data->clear();
+  src.rebuild_aligned_size_and_memory(m_block_size, CEPH_PAGE_SIZE);
 
   auto ctx = m_data_cryptor->get_context(mode);
   if (ctx == nullptr) {

--- a/src/librbd/crypto/BlockCrypto.cc
+++ b/src/librbd/crypto/BlockCrypto.cc
@@ -20,6 +20,14 @@ BlockCrypto<T>::BlockCrypto(CephContext* cct, DataCryptor<T>* data_cryptor,
 }
 
 template <typename T>
+BlockCrypto<T>::~BlockCrypto() {
+  if (m_data_cryptor != nullptr) {
+    delete m_data_cryptor;
+    m_data_cryptor = nullptr;
+  }
+}
+
+template <typename T>
 int BlockCrypto<T>::crypt(ceph::bufferlist* data, uint64_t image_offset,
                            CipherMode mode) {
   if (image_offset % m_block_size != 0) {

--- a/src/librbd/crypto/BlockCrypto.h
+++ b/src/librbd/crypto/BlockCrypto.h
@@ -21,6 +21,7 @@ public:
     }
     BlockCrypto(CephContext* cct, DataCryptor<T>* data_cryptor,
                 uint64_t block_size, uint64_t data_offset);
+    ~BlockCrypto();
 
     int encrypt(ceph::bufferlist* data, uint64_t image_offset) override;
     int decrypt(ceph::bufferlist* data, uint64_t image_offset) override;

--- a/src/librbd/crypto/CryptoImageDispatch.cc
+++ b/src/librbd/crypto/CryptoImageDispatch.cc
@@ -12,7 +12,7 @@ CryptoImageDispatch::CryptoImageDispatch(
 
 
 void CryptoImageDispatch::remap_extents(
-        io::Extents&& image_extents, io::ImageExtentsMapType type) {
+        io::Extents& image_extents, io::ImageExtentsMapType type) {
   if (type == io::IMAGE_EXTENTS_MAP_TYPE_LOGICAL_TO_PHYSICAL) {
     for (auto& extent: image_extents) {
       extent.first += m_data_offset;

--- a/src/librbd/crypto/CryptoImageDispatch.h
+++ b/src/librbd/crypto/CryptoImageDispatch.h
@@ -11,6 +11,9 @@ namespace crypto {
 
 class CryptoImageDispatch : public io::ImageDispatchInterface {
 public:
+  static CryptoImageDispatch* create(uint64_t data_offset) {
+    return new CryptoImageDispatch(data_offset);
+  }
   CryptoImageDispatch(uint64_t data_offset);
 
   io::ImageDispatchLayer get_dispatch_layer() const override {
@@ -87,6 +90,10 @@ public:
       uint64_t tid, std::atomic<uint32_t>* image_dispatch_flags,
       io::DispatchResult* dispatch_result, Context** on_finish,
       Context* on_dispatched) override {
+    return false;
+  }
+
+  bool invalidate_cache(Context* on_finish) override {
     return false;
   }
 

--- a/src/librbd/crypto/CryptoImageDispatch.h
+++ b/src/librbd/crypto/CryptoImageDispatch.h
@@ -90,7 +90,7 @@ public:
     return false;
   }
 
-  void remap_extents(io::Extents&& image_extents,
+  void remap_extents(io::Extents& image_extents,
                      io::ImageExtentsMapType type) override;
 
 private:

--- a/src/librbd/crypto/CryptoInterface.h
+++ b/src/librbd/crypto/CryptoInterface.h
@@ -60,7 +60,7 @@ public:
 
   inline int decrypt_aligned_extent(io::ReadExtent& extent,
                                     uint64_t image_offset) {
-    if (extent.length == 0) {
+    if (extent.length == 0 || extent.bl.length() == 0) {
       return 0;
     }
 

--- a/src/librbd/crypto/CryptoObjectDispatch.cc
+++ b/src/librbd/crypto/CryptoObjectDispatch.cc
@@ -590,7 +590,7 @@ bool CryptoObjectDispatch<I>::discard(
   *dispatch_result = io::DISPATCH_RESULT_COMPLETE;
   auto req = io::ObjectDispatchSpec::create_write_same(
           m_image_ctx, PREVIOUS_LAYER, object_no, object_off, object_len,
-          {{0, buffer_size}}, std::move(bl), io_context,
+          {{0, object_len}}, std::move(bl), io_context,
           *object_dispatch_flags, 0, parent_trace, ctx);
   req->send();
   return true;

--- a/src/librbd/crypto/CryptoObjectDispatch.cc
+++ b/src/librbd/crypto/CryptoObjectDispatch.cc
@@ -352,6 +352,7 @@ struct C_UnalignedObjectWriteRequest : public Context {
         if (io::util::trigger_copyup(image_ctx, object_no, io_context, ctx)) {
           return;
         }
+        delete ctx;
         object_exists = false;
       } else if (r < 0) {
         complete(r);

--- a/src/librbd/crypto/CryptoObjectDispatch.cc
+++ b/src/librbd/crypto/CryptoObjectDispatch.cc
@@ -132,8 +132,13 @@ struct C_UnalignedObjectReadRequest : public Context {
         auto& extent = (*extents)[i];
         auto& aligned_extent = aligned_extents[i];
         if (aligned_extent.extent_map.empty()) {
-          aligned_extent.bl.splice(extent.offset - aligned_extent.offset,
-                                   extent.length, &extent.bl);
+          uint64_t cut_offset = extent.offset - aligned_extent.offset;
+          int64_t padding_count =
+                  cut_offset + extent.length - aligned_extent.bl.length();
+          if (padding_count > 0) {
+            aligned_extent.bl.append_zero(padding_count);
+          }
+          aligned_extent.bl.splice(cut_offset, extent.length, &extent.bl);
         } else {
           for (auto [off, len]: aligned_extent.extent_map) {
             ceph::bufferlist tmp;

--- a/src/librbd/crypto/CryptoObjectDispatch.cc
+++ b/src/librbd/crypto/CryptoObjectDispatch.cc
@@ -70,12 +70,13 @@ struct C_AlignedObjectReadRequest : public Context {
     }
 
     void finish(int r) override {
+      ldout(image_ctx->cct, 20) << "aligned read r=" << r << dendl;
       on_finish->complete(r);
     }
 
     void handle_read(int r) {
       auto cct = image_ctx->cct;
-      ldout(cct, 20) << "r=" << r << dendl;
+      ldout(cct, 20) << "aligned read r=" << r << dendl;
       if (r == 0) {
         for (auto& extent: *extents) {
           auto crypto_ret = crypto->decrypt_aligned_extent(
@@ -171,7 +172,7 @@ struct C_UnalignedObjectReadRequest : public Context {
     }
 
     void finish(int r) override {
-      ldout(cct, 20) << "r=" << r << dendl;
+      ldout(cct, 20) << "unaligned read r=" << r << dendl;
       if (r >= 0) {
         remove_alignment_data();
 
@@ -342,7 +343,7 @@ struct C_UnalignedObjectWriteRequest : public Context {
     }
 
     void handle_read(int r) {
-      ldout(image_ctx->cct, 20) << "r=" << r << dendl;
+      ldout(image_ctx->cct, 20) << "unaligned write r=" << r << dendl;
 
       if (r == -ENOENT) {
         auto ctx = create_context_callback<
@@ -397,6 +398,7 @@ struct C_UnalignedObjectWriteRequest : public Context {
     }
 
     void handle_write(int r) {
+      ldout(image_ctx->cct, 20) << "r=" << r << dendl;
       bool exclusive = write_flags & io::OBJECT_WRITE_FLAG_CREATE_EXCLUSIVE;
       bool restart = false;
       if (r == -ERANGE && !assert_version.has_value()) {
@@ -413,6 +415,7 @@ struct C_UnalignedObjectWriteRequest : public Context {
     }
 
     void finish(int r) override {
+      ldout(image_ctx->cct, 20) << "unaligned write r=" << r << dendl;
       on_finish->complete(r);
     }
 };

--- a/src/librbd/crypto/CryptoObjectDispatch.h
+++ b/src/librbd/crypto/CryptoObjectDispatch.h
@@ -17,8 +17,9 @@ namespace crypto {
 template <typename ImageCtxT = librbd::ImageCtx>
 class CryptoObjectDispatch : public io::ObjectDispatchInterface {
 public:
-  static CryptoObjectDispatch* create(ImageCtxT* image_ctx) {
-    return new CryptoObjectDispatch(image_ctx, nullptr);
+  static CryptoObjectDispatch* create(
+          ImageCtxT* image_ctx, ceph::ref_t<CryptoInterface> crypto) {
+    return new CryptoObjectDispatch(image_ctx, crypto);
   }
 
   CryptoObjectDispatch(ImageCtxT* image_ctx,
@@ -27,8 +28,6 @@ public:
   io::ObjectDispatchLayer get_dispatch_layer() const override {
     return io::OBJECT_DISPATCH_LAYER_CRYPTO;
   }
-
-  void init(Context* on_finish);
 
   void shut_down(Context* on_finish) override;
 
@@ -103,7 +102,6 @@ public:
       io::SnapshotSparseBufferlist* snapshot_sparse_bufferlist) override;
 
 private:
-
   ImageCtxT* m_image_ctx;
   ceph::ref_t<CryptoInterface> m_crypto;
 

--- a/src/librbd/crypto/EncryptionFormat.h
+++ b/src/librbd/crypto/EncryptionFormat.h
@@ -1,0 +1,30 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_CRYPTO_ENCRYPTION_FORMAT_H
+#define CEPH_LIBRBD_CRYPTO_ENCRYPTION_FORMAT_H
+
+#include "common/ref.h"
+
+struct Context;
+
+namespace librbd {
+namespace crypto {
+
+struct CryptoInterface;
+
+template <typename ImageCtxT>
+struct EncryptionFormat {
+  virtual ~EncryptionFormat() {
+  }
+
+  virtual void format(ImageCtxT* ictx, Context* on_finish) = 0;
+  virtual void load(ImageCtxT* ictx,
+                    ceph::ref_t<CryptoInterface>* result_crypto,
+                    Context* on_finish) = 0;
+};
+
+} // namespace crypto
+} // namespace librbd
+
+#endif // CEPH_LIBRBD_CRYPTO_ENCRYPTION_FORMAT_H

--- a/src/librbd/crypto/FormatRequest.cc
+++ b/src/librbd/crypto/FormatRequest.cc
@@ -1,0 +1,66 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "FormatRequest.h"
+
+#include "common/dout.h"
+#include "common/errno.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Utils.h"
+#include "librbd/io/ObjectDispatcherInterface.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::crypto::FormatRequest: " << this \
+                           << " " << __func__ << ": "
+
+namespace librbd {
+namespace crypto {
+
+using librbd::util::create_context_callback;
+
+template <typename I>
+FormatRequest<I>::FormatRequest(
+        I* image_ctx, std::unique_ptr<EncryptionFormat<I>> format,
+        Context* on_finish) : m_image_ctx(image_ctx),
+                              m_format(std::move(format)),
+                              m_on_finish(on_finish) {
+}
+
+template <typename I>
+void FormatRequest<I>::send() {
+  if (m_image_ctx->io_object_dispatcher->exists(
+          io::OBJECT_DISPATCH_LAYER_CRYPTO)) {
+    lderr(m_image_ctx->cct) << "cannot format with already loaded encryption"
+                            << dendl;
+    finish(-EEXIST);
+    return;
+  }
+
+  if (m_image_ctx->parent != nullptr) {
+    lderr(m_image_ctx->cct) << "cannot format a cloned image" << dendl;
+    finish(-ENOTSUP);
+    return;
+  }
+
+  if (m_image_ctx->test_features(RBD_FEATURE_JOURNALING)) {
+    lderr(m_image_ctx->cct) << "cannot use encryption with journal" << dendl;
+    finish(-ENOTSUP);
+    return;
+  }
+
+  auto ctx = create_context_callback<
+          FormatRequest<I>, &FormatRequest<I>::finish>(this);
+  m_format->format(m_image_ctx, ctx);
+}
+
+template <typename I>
+void FormatRequest<I>::finish(int r) {
+  m_on_finish->complete(r);
+  delete this;
+}
+
+} // namespace crypto
+} // namespace librbd
+
+template class librbd::crypto::FormatRequest<librbd::ImageCtx>;

--- a/src/librbd/crypto/FormatRequest.h
+++ b/src/librbd/crypto/FormatRequest.h
@@ -1,0 +1,44 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_CRYPTO_FORMAT_REQUEST_H
+#define CEPH_LIBRBD_CRYPTO_FORMAT_REQUEST_H
+
+#include "include/rbd/librbd.hpp"
+#include "librbd/crypto/EncryptionFormat.h"
+
+struct Context;
+
+namespace librbd {
+
+class ImageCtx;
+
+namespace crypto {
+
+template <typename I>
+class FormatRequest {
+public:
+    static FormatRequest* create(
+            I* image_ctx, std::unique_ptr<EncryptionFormat<I>> format,
+            Context* on_finish) {
+      return new FormatRequest(image_ctx, std::move(format), on_finish);
+    }
+
+    FormatRequest(I* image_ctx, std::unique_ptr<EncryptionFormat<I>> format,
+                  Context* on_finish);
+    void send();
+    void finish(int r);
+
+private:
+    I* m_image_ctx;
+
+    std::unique_ptr<EncryptionFormat<I>> m_format;
+    Context* m_on_finish;
+};
+
+} // namespace crypto
+} // namespace librbd
+
+extern template class librbd::crypto::FormatRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_CRYPTO_FORMAT_REQUEST_H

--- a/src/librbd/crypto/LoadRequest.cc
+++ b/src/librbd/crypto/LoadRequest.cc
@@ -1,0 +1,82 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "LoadRequest.h"
+
+#include "common/dout.h"
+#include "common/errno.h"
+#include "librbd/Utils.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/crypto/CryptoImageDispatch.h"
+#include "librbd/crypto/CryptoObjectDispatch.h"
+#include "librbd/io/ImageDispatcherInterface.h"
+#include "librbd/io/ObjectDispatcherInterface.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::crypto::LoadRequest: " << this \
+                           << " " << __func__ << ": "
+
+namespace librbd {
+namespace crypto {
+
+using librbd::util::create_context_callback;
+
+template <typename I>
+LoadRequest<I>::LoadRequest(
+        I* image_ctx, std::unique_ptr<EncryptionFormat<I>> format,
+        Context* on_finish) : m_image_ctx(image_ctx),
+                              m_format(std::move(format)),
+                              m_on_finish(on_finish) {
+}
+
+template <typename I>
+void LoadRequest<I>::send() {
+  if (m_image_ctx->io_object_dispatcher->exists(
+          io::OBJECT_DISPATCH_LAYER_CRYPTO)) {
+    lderr(m_image_ctx->cct) << "encryption already loaded" << dendl;
+    finish(-EEXIST);
+    return;
+  }
+
+  auto ictx = m_image_ctx;
+  while (ictx != nullptr) {
+    if (ictx->test_features(RBD_FEATURE_JOURNALING)) {
+      lderr(m_image_ctx->cct) << "cannot use encryption with journal."
+                              << " image name: " << ictx->name << dendl;
+      finish(-ENOTSUP);
+      return;
+    }
+    ictx = ictx->parent;
+  }
+
+  auto ctx = create_context_callback<
+          LoadRequest<I>, &LoadRequest<I>::finish>(this);
+  m_format->load(m_image_ctx, &m_crypto, ctx);
+}
+
+template <typename I>
+void LoadRequest<I>::finish(int r) {
+  if (r == 0) {
+    // load crypto layers to image and its ancestors
+    auto image_dispatch = CryptoImageDispatch::create(
+            m_crypto->get_data_offset());
+    auto ictx = m_image_ctx;
+    while (ictx != nullptr) {
+      auto object_dispatch = CryptoObjectDispatch<I>::create(
+              ictx, m_crypto);
+      ictx->io_object_dispatcher->register_dispatch(object_dispatch);
+      ictx->io_image_dispatcher->register_dispatch(image_dispatch);
+
+      ictx = ictx->parent;
+    }
+  }
+
+  m_on_finish->complete(r);
+  delete this;
+}
+
+} // namespace crypto
+} // namespace librbd
+
+template class librbd::crypto::LoadRequest<librbd::ImageCtx>;

--- a/src/librbd/crypto/LoadRequest.h
+++ b/src/librbd/crypto/LoadRequest.h
@@ -1,0 +1,45 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_CRYPTO_LOAD_REQUEST_H
+#define CEPH_LIBRBD_CRYPTO_LOAD_REQUEST_H
+
+#include "include/rbd/librbd.hpp"
+#include "librbd/crypto/CryptoInterface.h"
+#include "librbd/crypto/EncryptionFormat.h"
+
+struct Context;
+
+namespace librbd {
+
+class ImageCtx;
+
+namespace crypto {
+
+template <typename I>
+class LoadRequest {
+public:
+    static LoadRequest* create(
+            I* image_ctx, std::unique_ptr<EncryptionFormat<I>> format,
+            Context* on_finish) {
+      return new LoadRequest(image_ctx, std::move(format), on_finish);
+    }
+
+    LoadRequest(I* image_ctx, std::unique_ptr<EncryptionFormat<I>> format,
+                Context* on_finish);
+    void send();
+    void finish(int r);
+
+private:
+    I* m_image_ctx;
+    std::unique_ptr<EncryptionFormat<I>> m_format;
+    Context* m_on_finish;
+    ceph::ref_t<crypto::CryptoInterface> m_crypto;
+};
+
+} // namespace crypto
+} // namespace librbd
+
+extern template class librbd::crypto::LoadRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_CRYPTO_LOAD_REQUEST_H

--- a/src/librbd/crypto/Types.h
+++ b/src/librbd/crypto/Types.h
@@ -12,16 +12,6 @@ enum CipherMode {
     CIPHER_MODE_DEC,
 };
 
-enum DiskEncryptionFormat {
-    DISK_ENCRYPTION_FORMAT_LUKS1,
-    DISK_ENCRYPTION_FORMAT_LUKS2,
-};
-
-enum CipherAlgorithm {
-    CIPHER_ALGORITHM_AES128,
-    CIPHER_ALGORITHM_AES256,
-};
-
 } // namespace crypto
 } // namespace librbd
 

--- a/src/librbd/crypto/luks/EncryptionFormat.cc
+++ b/src/librbd/crypto/luks/EncryptionFormat.cc
@@ -1,0 +1,43 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "EncryptionFormat.h"
+#include "librbd/crypto/luks/FormatRequest.h"
+#include "librbd/crypto/luks/LoadRequest.h"
+
+namespace librbd {
+namespace crypto {
+namespace luks {
+
+template <typename I>
+EncryptionFormat<I>::EncryptionFormat(
+        encryption_algorithm_t alg,
+        std::string&& passphrase) : m_alg(alg),
+                                    m_passphrase(std::move(passphrase)) {
+}
+
+template <typename I>
+void EncryptionFormat<I>::format(I* image_ctx, Context* on_finish) {
+  auto req = luks::FormatRequest<I>::create(
+          image_ctx, get_format(), m_alg, std::move(m_passphrase), on_finish,
+          false);
+  req->send();
+}
+
+template <typename I>
+void EncryptionFormat<I>::load(
+        I* image_ctx, ceph::ref_t<CryptoInterface>* result_crypto,
+        Context* on_finish) {
+  auto req = luks::LoadRequest<I>::create(
+          image_ctx, get_format(), std::move(m_passphrase), result_crypto,
+          on_finish);
+  req->send();
+}
+
+} // namespace luks
+} // namespace crypto
+} // namespace librbd
+
+template class librbd::crypto::luks::EncryptionFormat<librbd::ImageCtx>;
+template class librbd::crypto::luks::LUKS1EncryptionFormat<librbd::ImageCtx>;
+template class librbd::crypto::luks::LUKS2EncryptionFormat<librbd::ImageCtx>;

--- a/src/librbd/crypto/luks/EncryptionFormat.h
+++ b/src/librbd/crypto/luks/EncryptionFormat.h
@@ -1,0 +1,62 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_CRYPTO_LUKS_ENCRYPTION_FORMAT_H
+#define CEPH_LIBRBD_CRYPTO_LUKS_ENCRYPTION_FORMAT_H
+
+#include "include/rbd/librbd.hpp"
+#include "librbd/crypto/EncryptionFormat.h"
+
+namespace librbd {
+
+struct ImageCtx;
+
+namespace crypto {
+namespace luks {
+
+template <typename ImageCtxT>
+class EncryptionFormat : public crypto::EncryptionFormat<ImageCtxT> {
+
+public:
+    EncryptionFormat(encryption_algorithm_t alg, std::string&& passphrase);
+
+    void format(ImageCtxT* ictx, Context* on_finish) override;
+    void load(ImageCtxT* ictx, ceph::ref_t<CryptoInterface>* result_crypto,
+              Context* on_finish) override;
+
+private:
+    virtual encryption_format_t get_format() = 0;
+
+    encryption_algorithm_t m_alg;
+    std::string m_passphrase;
+};
+
+template <typename ImageCtxT>
+class LUKS1EncryptionFormat : public EncryptionFormat<ImageCtxT> {
+    using EncryptionFormat<ImageCtxT>::EncryptionFormat;
+
+    encryption_format_t get_format() override {
+      return RBD_ENCRYPTION_FORMAT_LUKS1;
+    }
+};
+
+template <typename ImageCtxT>
+class LUKS2EncryptionFormat : public EncryptionFormat<ImageCtxT> {
+    using EncryptionFormat<ImageCtxT>::EncryptionFormat;
+
+    encryption_format_t get_format() override {
+      return RBD_ENCRYPTION_FORMAT_LUKS2;
+    }
+};
+
+} // namespace luks
+} // namespace crypto
+} // namespace librbd
+
+extern template class librbd::crypto::luks::EncryptionFormat<librbd::ImageCtx>;
+extern template class librbd::crypto::luks::LUKS1EncryptionFormat<
+        librbd::ImageCtx>;
+extern template class librbd::crypto::luks::LUKS2EncryptionFormat<
+        librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_CRYPTO_LUKS_ENCRYPTION_FORMAT_H

--- a/src/librbd/crypto/luks/FormatRequest.cc
+++ b/src/librbd/crypto/luks/FormatRequest.cc
@@ -9,7 +9,6 @@
 #include "librbd/crypto/luks/Header.h"
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/ImageDispatchSpec.h"
-#include "librbd/io/ObjectDispatcherInterface.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
@@ -24,54 +23,49 @@ using librbd::util::create_context_callback;
 
 template <typename I>
 FormatRequest<I>::FormatRequest(
-        I* image_ctx, DiskEncryptionFormat type, CipherAlgorithm cipher,
+        I* image_ctx, encryption_format_t format, encryption_algorithm_t alg,
         std::string&& passphrase, Context* on_finish,
-        bool insecure_fast_mode) : m_image_ctx(image_ctx), m_type(type),
-                                   m_cipher(cipher), m_on_finish(on_finish),
+        bool insecure_fast_mode) : m_image_ctx(image_ctx), m_format(format),
+                                   m_alg(alg),
+                                   m_passphrase(std::move(passphrase)),
+                                   m_on_finish(on_finish),
                                    m_insecure_fast_mode(insecure_fast_mode),
-                                   m_header(image_ctx->cct),
-                                   m_passphrase(std::move(passphrase)) {
+                                   m_header(image_ctx->cct) {
 }
 
 template <typename I>
 void FormatRequest<I>::send() {
-  if (m_image_ctx->io_object_dispatcher->exists(
-          io::OBJECT_DISPATCH_LAYER_CRYPTO)) {
-    finish(-EEXIST);
-    return;
-  }
-
   const char* type;
   size_t sector_size;
-  switch(m_type) {
-    case DISK_ENCRYPTION_FORMAT_LUKS1:
+  switch (m_format) {
+    case RBD_ENCRYPTION_FORMAT_LUKS1:
       type = CRYPT_LUKS1;
       sector_size = 512;
       break;
-    case DISK_ENCRYPTION_FORMAT_LUKS2:
+    case RBD_ENCRYPTION_FORMAT_LUKS2:
       type = CRYPT_LUKS2;
       sector_size = 4096;
       break;
     default:
-      lderr(m_image_ctx->cct) << "unsupported disk encryption type: " << m_type
+      lderr(m_image_ctx->cct) << "unsupported format type: " << m_format
                               << dendl;
       finish(-EINVAL);
       return;
   }
 
-  const char* alg;
+  const char* cipher;
   size_t key_size;
-  switch (m_cipher) {
-    case CIPHER_ALGORITHM_AES128:
-      alg = "aes";
+  switch (m_alg) {
+    case RBD_ENCRYPTION_ALGORITHM_AES128:
+      cipher = "aes";
       key_size = 32;
       break;
-    case CIPHER_ALGORITHM_AES256:
-      alg = "aes";
+    case RBD_ENCRYPTION_ALGORITHM_AES256:
+      cipher = "aes";
       key_size = 64;
       break;
     default:
-      lderr(m_image_ctx->cct) << "unsupported cipher algorithm: " << m_cipher
+      lderr(m_image_ctx->cct) << "unsupported cipher algorithm: " << m_alg
                               << dendl;
       finish(-EINVAL);
       return;
@@ -85,7 +79,7 @@ void FormatRequest<I>::send() {
   }
 
   // format (create LUKS header)
-  r = m_header.format(type, alg, key_size, "xts-plain64", sector_size,
+  r = m_header.format(type, cipher, key_size, "xts-plain64", sector_size,
                       m_image_ctx->get_object_size(), m_insecure_fast_mode);
   if (r != 0) {
     finish(r);

--- a/src/librbd/crypto/luks/FormatRequest.h
+++ b/src/librbd/crypto/luks/FormatRequest.h
@@ -4,8 +4,8 @@
 #ifndef CEPH_LIBRBD_CRYPTO_LUKS_FORMAT_REQUEST_H
 #define CEPH_LIBRBD_CRYPTO_LUKS_FORMAT_REQUEST_H
 
+#include "include/rbd/librbd.hpp"
 #include "librbd/ImageCtx.h"
-#include "librbd/crypto/Types.h"
 #include "librbd/crypto/luks/Header.h"
 
 namespace librbd {
@@ -19,15 +19,15 @@ template <typename I>
 class FormatRequest {
 public:
     static FormatRequest* create(
-            I* image_ctx, DiskEncryptionFormat type, CipherAlgorithm cipher,
-            std::string&& passphrase, Context* on_finish,
-            bool insecure_fast_mode) {
-      return new FormatRequest(image_ctx, type, cipher, std::move(passphrase),
+            I* image_ctx, encryption_format_t format,
+            encryption_algorithm_t alg, std::string&& passphrase,
+            Context* on_finish, bool insecure_fast_mode) {
+      return new FormatRequest(image_ctx, format, alg, std::move(passphrase),
                                on_finish, insecure_fast_mode);
     }
 
-    FormatRequest(I* image_ctx, DiskEncryptionFormat type,
-                  CipherAlgorithm cipher, std::string&& passphrase,
+    FormatRequest(I* image_ctx, encryption_format_t format,
+                  encryption_algorithm_t alg, std::string&& passphrase,
                   Context* on_finish, bool insecure_fast_mode);
     void send();
     void finish(int r);
@@ -35,12 +35,12 @@ public:
 private:
     I* m_image_ctx;
 
-    DiskEncryptionFormat m_type;
-    CipherAlgorithm m_cipher;
+    encryption_format_t m_format;
+    encryption_algorithm_t m_alg;
+    std::string m_passphrase;
     Context* m_on_finish;
     bool m_insecure_fast_mode;
     Header m_header;
-    std::string m_passphrase;
 
     void handle_write_header(int r);
 };

--- a/src/librbd/crypto/luks/Header.h
+++ b/src/librbd/crypto/luks/Header.h
@@ -25,7 +25,7 @@ public:
                const char* cipher_mode, uint32_t sector_size,
                uint32_t data_alignment, bool insecure_fast_mode);
     int add_keyslot(const char* passphrase, size_t passphrase_size);
-    int load();
+    int load(const char* type);
     int read_volume_key(const char* passphrase, size_t passphrase_size,
                         char* volume_key, size_t* volume_key_size);
 

--- a/src/librbd/crypto/luks/LoadRequest.h
+++ b/src/librbd/crypto/luks/LoadRequest.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_LIBRBD_CRYPTO_LUKS_LOAD_REQUEST_H
 #define CEPH_LIBRBD_CRYPTO_LUKS_LOAD_REQUEST_H
 
+#include "include/rbd/librbd.hpp"
 #include "librbd/ImageCtx.h"
 #include "librbd/crypto/CryptoInterface.h"
 #include "librbd/crypto/luks/Header.h"
@@ -24,13 +25,14 @@ template <typename I>
 class LoadRequest {
 public:
     static LoadRequest* create(
-            I* image_ctx, std::string&& passphrase,
+            I* image_ctx, encryption_format_t format, std::string&& passphrase,
             ceph::ref_t<CryptoInterface>* result_crypto, Context* on_finish) {
-      return new LoadRequest(image_ctx, std::move(passphrase), result_crypto,
-                             on_finish);
+      return new LoadRequest(image_ctx, format, std::move(passphrase),
+                             result_crypto, on_finish);
     }
 
-    LoadRequest(I* image_ctx, std::string&& passphrase,
+    LoadRequest(I* image_ctx, encryption_format_t format,
+                std::string&& passphrase,
                 ceph::ref_t<CryptoInterface>* result_crypto,
                 Context* on_finish);
     void send();
@@ -39,13 +41,14 @@ public:
 
 private:
     I* m_image_ctx;
+    encryption_format_t m_format;
+    std::string m_passphrase;
     Context* m_on_finish;
     ceph::bufferlist m_bl;
     ceph::ref_t<CryptoInterface>* m_result_crypto;
     uint64_t m_initial_read_size;
     Header m_header;
     uint64_t m_offset;
-    std::string m_passphrase;
 
     void read(uint64_t end_offset, Context* on_finish);
     bool handle_read(int r);

--- a/src/librbd/crypto/openssl/DataCryptor.cc
+++ b/src/librbd/crypto/openssl/DataCryptor.cc
@@ -49,7 +49,7 @@ DataCryptor::~DataCryptor() {
   if (m_key != nullptr) {
     ceph_memzero_s(m_key, EVP_CIPHER_key_length(m_cipher),
                    EVP_CIPHER_key_length(m_cipher));
-    delete m_key;
+    delete [] m_key;
     m_key = nullptr;
   }
 }

--- a/src/librbd/io/ImageDispatchInterface.h
+++ b/src/librbd/io/ImageDispatchInterface.h
@@ -81,7 +81,7 @@ struct ImageDispatchInterface {
 
   virtual bool invalidate_cache(Context* on_finish) = 0;
   
-  virtual void remap_extents(Extents&& image_extents,
+  virtual void remap_extents(Extents& image_extents,
                              ImageExtentsMapType type) {}
 
 };

--- a/src/librbd/io/ImageDispatcher.cc
+++ b/src/librbd/io/ImageDispatcher.cc
@@ -261,13 +261,13 @@ void ImageDispatcher<I>::wait_on_writes_unblocked(Context *on_unblocked) {
 }
 
 template <typename I>
-void ImageDispatcher<I>::remap_extents(Extents&& image_extents,
+void ImageDispatcher<I>::remap_extents(Extents& image_extents,
                                        ImageExtentsMapType type) {
   auto loop = [&image_extents, type](auto begin, auto end) {
       for (auto it = begin; it != end; ++it) {
         auto& image_dispatch_meta = it->second;
         auto image_dispatch = image_dispatch_meta.dispatch;
-        image_dispatch->remap_extents(std::move(image_extents), type);
+        image_dispatch->remap_extents(image_extents, type);
       }
   };
 

--- a/src/librbd/io/ImageDispatcher.h
+++ b/src/librbd/io/ImageDispatcher.h
@@ -45,7 +45,7 @@ public:
   void unblock_writes() override;
   void wait_on_writes_unblocked(Context *on_unblocked) override;
 
-  void remap_extents(Extents&& image_extents,
+  void remap_extents(Extents& image_extents,
                      ImageExtentsMapType type) override;
 
 protected:

--- a/src/librbd/io/ImageDispatcherInterface.h
+++ b/src/librbd/io/ImageDispatcherInterface.h
@@ -29,7 +29,7 @@ public:
   virtual void wait_on_writes_unblocked(Context *on_unblocked) = 0;
 
   virtual void invalidate_cache(Context* on_finish) = 0;
-  virtual void remap_extents(Extents&& image_extents,
+  virtual void remap_extents(Extents& image_extents,
                              ImageExtentsMapType type) = 0;
 };
 

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -145,7 +145,7 @@ void readahead(I *ictx, const Extents& image_extents, IOContext io_context) {
     return;
   }
 
-  uint64_t image_size = ictx->get_image_size(ictx->snap_id);
+  uint64_t image_size = ictx->get_effective_image_size(ictx->snap_id);
   ictx->image_lock.unlock_shared();
 
   auto readahead_extent = ictx->readahead.update(image_extents, image_size);

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -647,12 +647,17 @@ void AbstractObjectWriteRequest<I>::handle_post_write_object_map_update(int r) {
 }
 
 template <typename I>
-void ObjectWriteRequest<I>::add_write_ops(neorados::WriteOp* wr) {
+void ObjectWriteRequest<I>::add_write_hint(neorados::WriteOp* wr) {
   if ((m_write_flags & OBJECT_WRITE_FLAG_CREATE_EXCLUSIVE) != 0) {
     wr->create(true);
   } else if (m_assert_version.has_value()) {
     wr->assert_version(m_assert_version.value());
   }
+  AbstractObjectWriteRequest<I>::add_write_hint(wr);
+}
+
+template <typename I>
+void ObjectWriteRequest<I>::add_write_ops(neorados::WriteOp* wr) {
   if (this->m_full_object) {
     wr->write_full(bufferlist{m_write_data});
   } else {

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -258,6 +258,9 @@ template <typename I>
 void ObjectReadRequest<I>::handle_read_object(int r) {
   I *image_ctx = this->m_ictx;
   ldout(image_ctx->cct, 20) << "r=" << r << dendl;
+  if (m_version != nullptr) {
+    ldout(image_ctx->cct, 20) << "version=" << *m_version << dendl;
+  }
 
   if (r == -ENOENT) {
     read_parent();

--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -280,6 +280,7 @@ public:
 
 protected:
   void add_write_ops(neorados::WriteOp *wr) override;
+  void add_write_hint(neorados::WriteOp *wr) override;
 
 private:
   ceph::bufferlist m_write_data;

--- a/src/librbd/io/SimpleSchedulerObjectDispatch.cc
+++ b/src/librbd/io/SimpleSchedulerObjectDispatch.cc
@@ -269,6 +269,8 @@ bool SimpleSchedulerObjectDispatch<I>::write(
   ldout(cct, 20) << data_object_name(m_image_ctx, object_no) << " "
                  << object_off << "~" << data.length() << dendl;
 
+  std::lock_guard locker{m_lock};
+
   // don't try to batch assert version writes
   if (assert_version.has_value() ||
       (write_flags & OBJECT_WRITE_FLAG_CREATE_EXCLUSIVE) != 0) {
@@ -276,7 +278,6 @@ bool SimpleSchedulerObjectDispatch<I>::write(
     return false;
   }
 
-  std::lock_guard locker{m_lock};
   if (try_delay_write(object_no, object_off, std::move(data), io_context,
                       op_flags, *object_dispatch_flags, on_dispatched)) {
 

--- a/src/librbd/io/Utils.cc
+++ b/src/librbd/io/Utils.cc
@@ -187,7 +187,7 @@ void file_to_extents(I* image_ctx, uint64_t offset, uint64_t length,
                      striper::LightweightObjectExtents* object_extents) {
   Extents extents = {{offset, length}};
   image_ctx->io_image_dispatcher->remap_extents(
-          std::move(extents), IMAGE_EXTENTS_MAP_TYPE_LOGICAL_TO_PHYSICAL);
+          extents, IMAGE_EXTENTS_MAP_TYPE_LOGICAL_TO_PHYSICAL);
   for (auto [off, len] : extents) {
     Striper::file_to_extents(image_ctx->cct, &image_ctx->layout, off, len, 0,
                              buffer_offset, object_extents);
@@ -201,7 +201,7 @@ void extent_to_file(I* image_ctx, uint64_t object_no, uint64_t offset,
   Striper::extent_to_file(image_ctx->cct, &image_ctx->layout, object_no,
                           offset, length, extents);
   image_ctx->io_image_dispatcher->remap_extents(
-          std::move(extents), IMAGE_EXTENTS_MAP_TYPE_PHYSICAL_TO_LOGICAL);
+          extents, IMAGE_EXTENTS_MAP_TYPE_PHYSICAL_TO_LOGICAL);
 }
 
 template <typename I>
@@ -210,7 +210,7 @@ uint64_t get_file_offset(I* image_ctx, uint64_t object_no, uint64_t offset) {
                                       object_no, offset);
   Extents extents = {{off, 0}};
   image_ctx->io_image_dispatcher->remap_extents(
-          std::move(extents), IMAGE_EXTENTS_MAP_TYPE_PHYSICAL_TO_LOGICAL);
+          extents, IMAGE_EXTENTS_MAP_TYPE_PHYSICAL_TO_LOGICAL);
   return extents[0].first;
 }
 

--- a/src/librbd/io/Utils.h
+++ b/src/librbd/io/Utils.h
@@ -68,6 +68,10 @@ template <typename ImageCtxT = librbd::ImageCtx>
 uint64_t get_file_offset(ImageCtxT *image_ctx, uint64_t object_no,
                          uint64_t offset);
 
+inline ObjectDispatchLayer get_previous_layer(ObjectDispatchLayer layer) {
+  return (ObjectDispatchLayer)(((int)layer) - 1);
+}
+
 } // namespace util
 } // namespace io
 } // namespace librbd

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -2045,6 +2045,24 @@ namespace librbd {
     return r;
   }
 
+  int Image::encryption_format(encryption_format_t format,
+                               encryption_options_t opts,
+                               size_t opts_size)
+  {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    return librbd::api::Image<>::encryption_format(
+            ictx, format, opts, opts_size, false);
+  }
+
+  int Image::encryption_load(encryption_format_t format,
+                             encryption_options_t opts,
+                             size_t opts_size)
+  {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    return librbd::api::Image<>::encryption_load(
+            ictx, format, opts, opts_size, false);
+  }
+
   int Image::flatten()
   {
     ImageCtx *ictx = (ImageCtx *)ctx;
@@ -4312,6 +4330,26 @@ extern "C" int rbd_deep_copy_with_progress(rbd_image_t image,
                                             prog_ctx);
   tracepoint(librbd, deep_copy_exit, ret);
   return ret;
+}
+
+extern "C" int rbd_encryption_format(rbd_image_t image,
+                                     rbd_encryption_format_t format,
+                                     rbd_encryption_options_t opts,
+                                     size_t opts_size)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  return librbd::api::Image<>::encryption_format(
+          ictx, format, opts, opts_size, true);
+}
+
+extern "C" int rbd_encryption_load(rbd_image_t image,
+                                   rbd_encryption_format_t format,
+                                   rbd_encryption_options_t opts,
+                                   size_t opts_size)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  return librbd::api::Image<>::encryption_load(
+          ictx, format, opts, opts_size, true);
 }
 
 extern "C" int rbd_flatten(rbd_image_t image)

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -431,7 +431,7 @@ int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   TestObjectOperationImpl *ops = reinterpret_cast<TestObjectOperationImpl*>(op->impl);
   return ctx->aio_operate_read(oid, *ops, c->pc, flags, pbl,
-                               ctx->get_snap_read());
+                               ctx->get_snap_read(), nullptr);
 }
 
 int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
@@ -619,7 +619,7 @@ int IoCtx::read(const std::string& oid, bufferlist& bl, size_t len,
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   return ctx->execute_operation(
     oid, std::bind(&TestIoCtxImpl::read, _1, _2, len, off, &bl,
-                     ctx->get_snap_read()));
+                     ctx->get_snap_read(), nullptr));
 }
 
 int IoCtx::remove(const std::string& oid) {
@@ -843,7 +843,7 @@ void ObjectOperation::cmpext(uint64_t off, const bufferlist& cmp_bl,
                                            cmp_bl, _4);
   if (prval != NULL) {
     op = std::bind(save_operation_result,
-                     std::bind(op, _1, _2, _3, _4, _5), prval);
+                     std::bind(op, _1, _2, _3, _4, _5, _6), prval);
   }
   o->ops.push_back(op);
 }
@@ -855,7 +855,7 @@ void ObjectReadOperation::list_snaps(snap_set_t *out_snaps, int *prval) {
                                            out_snaps);
   if (prval != NULL) {
     op = std::bind(save_operation_result,
-                     std::bind(op, _1, _2, _3, _4, _5), prval);
+                     std::bind(op, _1, _2, _3, _4, _5, _6), prval);
   }
   o->ops.push_back(op);
 }
@@ -868,7 +868,7 @@ void ObjectReadOperation::list_watchers(std::list<obj_watch_t> *out_watchers,
                                            _2, out_watchers);
   if (prval != NULL) {
     op = std::bind(save_operation_result,
-                     std::bind(op, _1, _2, _3, _4, _5), prval);
+                     std::bind(op, _1, _2, _3, _4, _5, _6), prval);
   }
   o->ops.push_back(op);
 }
@@ -879,14 +879,14 @@ void ObjectReadOperation::read(size_t off, uint64_t len, bufferlist *pbl,
 
   ObjectOperationTestImpl op;
   if (pbl != NULL) {
-    op = std::bind(&TestIoCtxImpl::read, _1, _2, len, off, pbl, _4);
+    op = std::bind(&TestIoCtxImpl::read, _1, _2, len, off, pbl, _4, nullptr);
   } else {
-    op = std::bind(&TestIoCtxImpl::read, _1, _2, len, off, _3, _4);
+    op = std::bind(&TestIoCtxImpl::read, _1, _2, len, off, _3, _4, nullptr);
   }
 
   if (prval != NULL) {
     op = std::bind(save_operation_result,
-                     std::bind(op, _1, _2, _3, _4, _5), prval);
+                     std::bind(op, _1, _2, _3, _4, _5, _6), prval);
   }
   o->ops.push_back(op);
 }
@@ -905,7 +905,7 @@ void ObjectReadOperation::sparse_read(uint64_t off, uint64_t len,
 
   if (prval != NULL) {
     op = std::bind(save_operation_result,
-                     std::bind(op, _1, _2, _3, _4, _5), prval);
+                     std::bind(op, _1, _2, _3, _4, _5, _6), prval);
   }
   o->ops.push_back(op);
 }
@@ -918,7 +918,7 @@ void ObjectReadOperation::stat(uint64_t *psize, time_t *pmtime, int *prval) {
 
   if (prval != NULL) {
     op = std::bind(save_operation_result,
-                     std::bind(op, _1, _2, _3, _4, _5), prval);
+                     std::bind(op, _1, _2, _3, _4, _5, _6), prval);
   }
   o->ops.push_back(op);
 }
@@ -1381,7 +1381,8 @@ int cls_cxx_read2(cls_method_context_t hctx, int ofs, int len,
                   bufferlist *outbl, uint32_t op_flags) {
   librados::TestClassHandler::MethodContext *ctx =
     reinterpret_cast<librados::TestClassHandler::MethodContext*>(hctx);
-  return ctx->io_ctx_impl->read(ctx->oid, len, ofs, outbl, ctx->snap_id);
+  return ctx->io_ctx_impl->read(
+          ctx->oid, len, ofs, outbl, ctx->snap_id, nullptr);
 }
 
 int cls_cxx_setxattr(cls_method_context_t hctx, const char *name,

--- a/src/test/librados_test_stub/MockTestMemIoCtxImpl.h
+++ b/src/test/librados_test_stub/MockTestMemIoCtxImpl.h
@@ -140,13 +140,13 @@ public:
      return TestMemIoCtxImpl::sparse_read(oid, off, len, m, bl, snap_id);
   }
 
-  MOCK_METHOD5(read, int(const std::string& oid,
+  MOCK_METHOD6(read, int(const std::string& oid,
                          size_t len,
                          uint64_t off,
-                         bufferlist *bl, uint64_t snap_id));
+                         bufferlist *bl, uint64_t snap_id, uint64_t* objver));
   int do_read(const std::string& oid, size_t len, uint64_t off,
-              bufferlist *bl, uint64_t snap_id) {
-    return TestMemIoCtxImpl::read(oid, len, off, bl, snap_id);
+              bufferlist *bl, uint64_t snap_id, uint64_t* objver) {
+    return TestMemIoCtxImpl::read(oid, len, off, bl, snap_id, objver);
   }
 
   MOCK_METHOD2(remove, int(const std::string& oid, const SnapContext &snapc));
@@ -226,7 +226,7 @@ public:
     ON_CALL(*this, list_snaps(_, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_list_snaps));
     ON_CALL(*this, list_watchers(_, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_list_watchers));
     ON_CALL(*this, notify(_, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_notify));
-    ON_CALL(*this, read(_, _, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_read));
+    ON_CALL(*this, read(_, _, _, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_read));
     ON_CALL(*this, set_snap_read(_)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_set_snap_read));
     ON_CALL(*this, sparse_read(_, _, _, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_sparse_read));
     ON_CALL(*this, remove(_, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_remove));

--- a/src/test/librados_test_stub/TestIoCtxImpl.h
+++ b/src/test/librados_test_stub/TestIoCtxImpl.h
@@ -22,8 +22,9 @@ class TestRadosClient;
 typedef boost::function<int(TestIoCtxImpl*,
 			    const std::string&,
 			    bufferlist *,
-                            uint64_t,
-                            const SnapContext &)> ObjectOperationTestImpl;
+          uint64_t,
+          const SnapContext &,
+          uint64_t*)> ObjectOperationTestImpl;
 typedef std::list<ObjectOperationTestImpl> ObjectOperations;
 
 struct TestObjectOperationImpl {
@@ -90,7 +91,8 @@ public:
                           int flags);
   virtual int aio_operate_read(const std::string& oid, TestObjectOperationImpl &ops,
                                AioCompletionImpl *c, int flags,
-                               bufferlist *pbl, uint64_t snap_id);
+                               bufferlist *pbl, uint64_t snap_id,
+                               uint64_t* objver);
   virtual int aio_remove(const std::string& oid, AioCompletionImpl *c,
                          int flags = 0) = 0;
   virtual int aio_watch(const std::string& o, AioCompletionImpl *c,
@@ -133,7 +135,7 @@ public:
   virtual int operate_read(const std::string& oid, TestObjectOperationImpl &ops,
                            bufferlist *pbl);
   virtual int read(const std::string& oid, size_t len, uint64_t off,
-                   bufferlist *bl, uint64_t snap_id) = 0;
+                   bufferlist *bl, uint64_t snap_id, uint64_t* objver) = 0;
   virtual int remove(const std::string& oid, const SnapContext &snapc) = 0;
   virtual int selfmanaged_snap_create(uint64_t *snapid) = 0;
   virtual void aio_selfmanaged_snap_create(uint64_t *snapid,
@@ -186,7 +188,8 @@ protected:
   int execute_aio_operations(const std::string& oid,
                              TestObjectOperationImpl *ops,
                              bufferlist *pbl, uint64_t,
-                             const SnapContext &snapc);
+                             const SnapContext &snapc,
+                             uint64_t* objver);
 
 private:
   struct C_AioNotify : public Context {

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.cc
@@ -356,7 +356,8 @@ int TestMemIoCtxImpl::omap_set(const std::string& oid,
 }
 
 int TestMemIoCtxImpl::read(const std::string& oid, size_t len, uint64_t off,
-                           bufferlist *bl, uint64_t snap_id) {
+                           bufferlist *bl, uint64_t snap_id,
+                           uint64_t* objver) {
   if (m_client->is_blocklisted()) {
     return -EBLOCKLISTED;
   }
@@ -379,6 +380,9 @@ int TestMemIoCtxImpl::read(const std::string& oid, size_t len, uint64_t off,
     bufferlist bit;
     bit.substr_of(file->data, off, len);
     append_clone(bit, bl);
+  }
+  if (objver != nullptr) {
+    *objver = file->objver;
   }
   return len;
 }

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.h
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.h
@@ -48,7 +48,7 @@ public:
   int omap_set(const std::string& oid, const std::map<std::string,
                bufferlist> &map) override;
   int read(const std::string& oid, size_t len, uint64_t off,
-           bufferlist *bl, uint64_t snap_id) override;
+           bufferlist *bl, uint64_t snap_id, uint64_t* objver) override;
   int remove(const std::string& oid, const SnapContext &snapc) override;
   int selfmanaged_snap_create(uint64_t *snapid) override;
   int selfmanaged_snap_remove(uint64_t snapid) override;

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -56,6 +56,8 @@ set(unittest_librbd_srcs
   crypto/test_mock_BlockCrypto.cc
   crypto/test_mock_CryptoContextPool.cc
   crypto/test_mock_CryptoObjectDispatch.cc
+  crypto/test_mock_FormatRequest.cc
+  crypto/test_mock_LoadRequest.cc
   crypto/openssl/test_DataCryptor.cc
   deep_copy/test_mock_ImageCopyRequest.cc
   deep_copy/test_mock_MetadataCopyRequest.cc

--- a/src/test/librbd/crypto/luks/test_mock_LoadRequest.cc
+++ b/src/test/librbd/crypto/luks/test_mock_LoadRequest.cc
@@ -49,7 +49,8 @@ struct TestMockCryptoLuksLoadRequest : public TestMockFixture {
     mock_image_ctx = new MockImageCtx(*ictx);
     crypto = nullptr;
     mock_load_request = MockLoadRequest::create(
-            mock_image_ctx, std::move(passphrase), &crypto, on_finish);
+            mock_image_ctx, RBD_ENCRYPTION_FORMAT_LUKS2, std::move(passphrase),
+            &crypto, on_finish);
   }
 
   void TearDown() override {
@@ -74,12 +75,7 @@ struct TestMockCryptoLuksLoadRequest : public TestMockFixture {
     data_offset = header.get_data_offset();
   }
 
-    void expect_crypto_layer_exists_check(bool exists = false) {
-      EXPECT_CALL(*mock_image_ctx->io_object_dispatcher, exists(
-              io::OBJECT_DISPATCH_LAYER_CRYPTO)).WillOnce(Return(exists));
-    }
-
-    void expect_image_read(uint64_t offset, uint64_t length) {
+  void expect_image_read(uint64_t offset, uint64_t length) {
     EXPECT_CALL(*mock_image_ctx->io_image_dispatcher, send(_))
             .WillOnce(Invoke([this, offset,
                               length](io::ImageDispatchSpec* spec) {
@@ -109,7 +105,6 @@ struct TestMockCryptoLuksLoadRequest : public TestMockFixture {
 
 TEST_F(TestMockCryptoLuksLoadRequest, AES128) {
   generate_header(CRYPT_LUKS2, "aes", 32, "xts-plain64", 4096);
-  expect_crypto_layer_exists_check();
   expect_image_read(0, DEFAULT_INITIAL_READ_SIZE);
   mock_load_request->send();
   image_read_request->complete(DEFAULT_INITIAL_READ_SIZE);
@@ -119,7 +114,6 @@ TEST_F(TestMockCryptoLuksLoadRequest, AES128) {
 
 TEST_F(TestMockCryptoLuksLoadRequest, AES256) {
   generate_header(CRYPT_LUKS2, "aes", 64, "xts-plain64", 4096);
-  expect_crypto_layer_exists_check();
   expect_image_read(0, DEFAULT_INITIAL_READ_SIZE);
   mock_load_request->send();
   image_read_request->complete(DEFAULT_INITIAL_READ_SIZE);
@@ -128,8 +122,11 @@ TEST_F(TestMockCryptoLuksLoadRequest, AES256) {
 }
 
 TEST_F(TestMockCryptoLuksLoadRequest, LUKS1) {
+  delete mock_load_request;
+  mock_load_request = MockLoadRequest::create(
+          mock_image_ctx, RBD_ENCRYPTION_FORMAT_LUKS1, {passphrase_cstr},
+          &crypto, on_finish);
   generate_header(CRYPT_LUKS1, "aes", 32, "xts-plain64", 512);
-  expect_crypto_layer_exists_check();
   expect_image_read(0, DEFAULT_INITIAL_READ_SIZE);
   mock_load_request->send();
   image_read_request->complete(DEFAULT_INITIAL_READ_SIZE);
@@ -137,9 +134,23 @@ TEST_F(TestMockCryptoLuksLoadRequest, LUKS1) {
   ASSERT_NE(crypto, nullptr);
 }
 
+TEST_F(TestMockCryptoLuksLoadRequest, WrongFormat) {
+  generate_header(CRYPT_LUKS1, "aes", 32, "xts-plain64", 512);
+  expect_image_read(0, DEFAULT_INITIAL_READ_SIZE);
+  mock_load_request->send();
+
+  expect_image_read(DEFAULT_INITIAL_READ_SIZE,
+                    MAXIMUM_HEADER_SIZE - DEFAULT_INITIAL_READ_SIZE);
+  image_read_request->complete(DEFAULT_INITIAL_READ_SIZE); // complete 1st read
+
+  image_read_request->complete(
+          MAXIMUM_HEADER_SIZE - DEFAULT_INITIAL_READ_SIZE);
+  ASSERT_EQ(-EINVAL, finished_cond.wait());
+  ASSERT_EQ(crypto, nullptr);
+}
+
 TEST_F(TestMockCryptoLuksLoadRequest, UnsupportedAlgorithm) {
   generate_header(CRYPT_LUKS2, "twofish", 32, "xts-plain64", 4096);
-  expect_crypto_layer_exists_check();
   expect_image_read(0, DEFAULT_INITIAL_READ_SIZE);
   mock_load_request->send();
   image_read_request->complete(DEFAULT_INITIAL_READ_SIZE);
@@ -149,7 +160,6 @@ TEST_F(TestMockCryptoLuksLoadRequest, UnsupportedAlgorithm) {
 
 TEST_F(TestMockCryptoLuksLoadRequest, UnsupportedCipherMode) {
   generate_header(CRYPT_LUKS2, "aes", 32, "cbc-essiv:sha256", 4096);
-  expect_crypto_layer_exists_check();
   expect_image_read(0, DEFAULT_INITIAL_READ_SIZE);
   mock_load_request->send();
   image_read_request->complete(DEFAULT_INITIAL_READ_SIZE);
@@ -160,7 +170,6 @@ TEST_F(TestMockCryptoLuksLoadRequest, UnsupportedCipherMode) {
 TEST_F(TestMockCryptoLuksLoadRequest, HeaderBiggerThanInitialRead) {
   generate_header(CRYPT_LUKS2, "aes", 64, "xts-plain64", 4096);
   mock_load_request->set_initial_read_size(4096);
-  expect_crypto_layer_exists_check();
   expect_image_read(0, 4096);
   mock_load_request->send();
 
@@ -175,7 +184,6 @@ TEST_F(TestMockCryptoLuksLoadRequest, HeaderBiggerThanInitialRead) {
 TEST_F(TestMockCryptoLuksLoadRequest, KeyslotsBiggerThanInitialRead) {
   generate_header(CRYPT_LUKS2, "aes", 64, "xts-plain64", 4096);
   mock_load_request->set_initial_read_size(16384);
-  expect_crypto_layer_exists_check();
   expect_image_read(0, 16384);
   mock_load_request->send();
 
@@ -190,10 +198,10 @@ TEST_F(TestMockCryptoLuksLoadRequest, KeyslotsBiggerThanInitialRead) {
 TEST_F(TestMockCryptoLuksLoadRequest, WrongPassphrase) {
   delete mock_load_request;
   mock_load_request = MockLoadRequest::create(
-        mock_image_ctx, "wrong", &crypto, on_finish);
+        mock_image_ctx, RBD_ENCRYPTION_FORMAT_LUKS2, "wrong", &crypto,
+        on_finish);
 
   generate_header(CRYPT_LUKS2, "aes", 64, "xts-plain64", 4096);
-  expect_crypto_layer_exists_check();
   expect_image_read(0, DEFAULT_INITIAL_READ_SIZE);
   mock_load_request->send();
 
@@ -204,14 +212,6 @@ TEST_F(TestMockCryptoLuksLoadRequest, WrongPassphrase) {
 
   image_read_request->complete(data_offset - DEFAULT_INITIAL_READ_SIZE);
   ASSERT_EQ(-EPERM, finished_cond.wait());
-  ASSERT_EQ(crypto, nullptr);
-}
-
-TEST_F(TestMockCryptoLuksLoadRequest, CryptoAlreadyLoaded) {
-  generate_header(CRYPT_LUKS2, "aes", 32, "xts-plain64", 4096);
-  expect_crypto_layer_exists_check(true);
-  mock_load_request->send();
-  ASSERT_EQ(-EEXIST, finished_cond.wait());
   ASSERT_EQ(crypto, nullptr);
 }
 

--- a/src/test/librbd/crypto/test_mock_BlockCrypto.cc
+++ b/src/test/librbd/crypto/test_mock_BlockCrypto.cc
@@ -91,11 +91,9 @@ TEST_F(TestMockCryptoBlockCrypto, Encrypt) {
 
   expect_get_context(CipherMode::CIPHER_MODE_ENC);
   expect_init_context(std::string("\x34\x12\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 16));
-  expect_update_context("123", 0);
-  expect_update_context("4", 4);
+  expect_update_context("1234", 4);
   expect_init_context(std::string("\x35\x12\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 16));
-  expect_update_context("56", 0);
-  expect_update_context("78", 4);
+  expect_update_context("5678", 4);
   EXPECT_CALL(cryptor, return_context(_, CipherMode::CIPHER_MODE_ENC));
 
   ASSERT_EQ(0, bc->encrypt(&data, image_offset));

--- a/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
+++ b/src/test/librbd/crypto/test_mock_CryptoObjectDispatch.cc
@@ -387,7 +387,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedRead) {
   ASSERT_EQ(on_finish, &finished_cond);
   ASSERT_EQ(ETIMEDOUT, dispatched_cond.wait_for(0));
 
-  dispatcher_ctx->complete(0);
+  dispatcher_ctx->complete(4096*8);
   ASSERT_EQ(3 + 4096 * 5 - 2, dispatched_cond.wait());
   ASSERT_TRUE(extents[0].bl.to_str() == std::string("1"));
   ASSERT_TRUE(extents[1].bl.to_str() == std::string("2"));
@@ -431,7 +431,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWrite) {
   auto expected_data =
           std::string("2") + std::string(8192, '1') + std::string(4095, '3');
   expect_object_write(0, expected_data, 0, std::make_optional(version));
-  dispatcher_ctx->complete(0); // complete read
+  dispatcher_ctx->complete(8192); // complete read
   ASSERT_EQ(ETIMEDOUT, dispatched_cond.wait_for(0));
   dispatcher_ctx->complete(0); // complete write
   ASSERT_EQ(0, dispatched_cond.wait());
@@ -492,7 +492,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteFailCreate) {
   auto expected_data2 =
         std::string("2") + std::string(8192, '1') + std::string(4095, '3');
   expect_object_write(0, expected_data2, 0, std::make_optional(version));
-  dispatcher_ctx->complete(0); // complete read
+  dispatcher_ctx->complete(8192); // complete read
   ASSERT_EQ(ETIMEDOUT, dispatched_cond.wait_for(0));
   dispatcher_ctx->complete(0); // complete write
   ASSERT_EQ(0, dispatched_cond.wait());
@@ -537,7 +537,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteCopyup) {
   auto expected_data =
         std::string("2") + std::string(8192, '1') + std::string(4095, '3');
   expect_object_write(0, expected_data, 0, std::make_optional(version));
-  dispatcher_ctx->complete(0); // complete second read
+  dispatcher_ctx->complete(8192); // complete second read
   ASSERT_EQ(ETIMEDOUT, dispatched_cond.wait_for(0));
   dispatcher_ctx->complete(0); // complete write
   ASSERT_EQ(0, dispatched_cond.wait());
@@ -561,7 +561,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteFailVersionCheck) {
   auto expected_data =
           std::string("2") + std::string(8192, '1') + std::string(4095, '3');
   expect_object_write(0, expected_data, 0, std::make_optional(version));
-  dispatcher_ctx->complete(0); // complete read
+  dispatcher_ctx->complete(8192); // complete read
   ASSERT_EQ(ETIMEDOUT, dispatched_cond.wait_for(0));
 
   version = 1235;
@@ -572,7 +572,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteFailVersionCheck) {
   ASSERT_EQ(ETIMEDOUT, dispatched_cond.wait_for(0));
 
   expect_object_write(0, expected_data, 0, std::make_optional(version));
-  dispatcher_ctx->complete(0); // complete read
+  dispatcher_ctx->complete(8192); // complete read
   ASSERT_EQ(ETIMEDOUT, dispatched_cond.wait_for(0));
   dispatcher_ctx->complete(0); // complete write
   ASSERT_EQ(0, dispatched_cond.wait());
@@ -594,7 +594,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteWithAssertVersion) {
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish, &finished_cond);
 
-  dispatcher_ctx->complete(0); // complete read
+  dispatcher_ctx->complete(8192); // complete read
   ASSERT_EQ(-ERANGE, dispatched_cond.wait());
 }
 
@@ -612,7 +612,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, UnalignedWriteWithExclusiveCreate) {
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish, &finished_cond);
 
-  dispatcher_ctx->complete(0); // complete read
+  dispatcher_ctx->complete(8192); // complete read
   ASSERT_EQ(-EEXIST, dispatched_cond.wait());
 }
 
@@ -638,7 +638,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, CompareAndWrite) {
   auto expected_data =
           std::string("2") + std::string(8192, '1') + std::string(4095, '3');
   expect_object_write(0, expected_data, 0, std::make_optional(version));
-  dispatcher_ctx->complete(0); // complete read
+  dispatcher_ctx->complete(4096*4); // complete read
   ASSERT_EQ(ETIMEDOUT, dispatched_cond.wait_for(0));
   dispatcher_ctx->complete(0); // complete write
   ASSERT_EQ(0, dispatched_cond.wait());
@@ -664,7 +664,7 @@ TEST_F(TestMockCryptoCryptoObjectDispatch, CompareAndWriteFail) {
   ASSERT_EQ(dispatch_result, io::DISPATCH_RESULT_COMPLETE);
   ASSERT_EQ(on_finish, &finished_cond);
 
-  dispatcher_ctx->complete(0); // complete read
+  dispatcher_ctx->complete(4096*4); // complete read
   ASSERT_EQ(-EILSEQ, dispatched_cond.wait());
   ASSERT_EQ(mismatch_offset, 4094);
 }

--- a/src/test/librbd/crypto/test_mock_FormatRequest.cc
+++ b/src/test/librbd/crypto/test_mock_FormatRequest.cc
@@ -1,0 +1,122 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_mock_fixture.h"
+#include "test/librbd/test_support.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/librbd/mock/crypto/MockEncryptionFormat.h"
+
+#include "librbd/crypto/FormatRequest.cc"
+
+namespace librbd {
+namespace crypto {
+
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::WithArg;
+
+struct TestMockCryptoFormatRequest : public TestMockFixture {
+  typedef FormatRequest<librbd::MockImageCtx> MockFormatRequest;
+
+  MockImageCtx* mock_image_ctx;
+  C_SaferCond finished_cond;
+  Context *on_finish = &finished_cond;
+  MockEncryptionFormat* mock_encryption_format;
+  Context* format_context;
+
+  void SetUp() override {
+    TestMockFixture::SetUp();
+
+    librbd::ImageCtx *ictx;
+    ASSERT_EQ(0, open_image(m_image_name, &ictx));
+    mock_image_ctx = new MockImageCtx(*ictx);
+    mock_encryption_format = new MockEncryptionFormat();
+  }
+
+  void TearDown() override {
+    delete mock_image_ctx;
+    TestMockFixture::TearDown();
+  }
+
+  void expect_crypto_layer_exists_check(bool exists) {
+    EXPECT_CALL(*mock_image_ctx->io_object_dispatcher, exists(
+            io::OBJECT_DISPATCH_LAYER_CRYPTO)).WillOnce(Return(exists));
+  }
+
+  void expect_test_journal_feature(bool has_journal=false) {
+    EXPECT_CALL(*mock_image_ctx, test_features(
+            RBD_FEATURE_JOURNALING)).WillOnce(Return(has_journal));
+  }
+
+  void expect_encryption_format() {
+    EXPECT_CALL(*mock_encryption_format, format(
+            mock_image_ctx, _)).WillOnce(
+                    WithArg<1>(Invoke([this](Context* ctx) {
+                      format_context = ctx;
+    })));
+  }
+};
+
+TEST_F(TestMockCryptoFormatRequest, CryptoAlreadyLoaded) {
+  auto mock_format_request = MockFormatRequest::create(
+          mock_image_ctx,
+          std::unique_ptr<MockEncryptionFormat>(mock_encryption_format),
+          on_finish);
+  expect_crypto_layer_exists_check(true);
+  mock_format_request->send();
+  ASSERT_EQ(-EEXIST, finished_cond.wait());
+}
+
+TEST_F(TestMockCryptoFormatRequest, JournalEnabled) {
+  auto mock_format_request = MockFormatRequest::create(
+          mock_image_ctx,
+          std::unique_ptr<MockEncryptionFormat>(mock_encryption_format),
+          on_finish);
+  expect_crypto_layer_exists_check(false);
+  expect_test_journal_feature(true);
+  mock_format_request->send();
+  ASSERT_EQ(-ENOTSUP, finished_cond.wait());
+}
+
+TEST_F(TestMockCryptoFormatRequest, CloneFormat) {
+  mock_image_ctx->parent = mock_image_ctx;
+  auto mock_format_request = MockFormatRequest::create(
+          mock_image_ctx,
+          std::unique_ptr<MockEncryptionFormat>(mock_encryption_format),
+          on_finish);
+  expect_crypto_layer_exists_check(false);
+  mock_format_request->send();
+  ASSERT_EQ(-ENOTSUP, finished_cond.wait());
+}
+
+TEST_F(TestMockCryptoFormatRequest, FormatFail) {
+  auto mock_format_request = MockFormatRequest::create(
+          mock_image_ctx,
+          std::unique_ptr<MockEncryptionFormat>(mock_encryption_format),
+          on_finish);
+  expect_crypto_layer_exists_check(false);
+  expect_test_journal_feature(false);
+  expect_encryption_format();
+  mock_format_request->send();
+  ASSERT_EQ(ETIMEDOUT, finished_cond.wait_for(0));
+  format_context->complete(-EIO);
+  ASSERT_EQ(-EIO, finished_cond.wait());
+}
+
+TEST_F(TestMockCryptoFormatRequest, Success) {
+  auto mock_format_request = MockFormatRequest::create(
+          mock_image_ctx,
+          std::unique_ptr<MockEncryptionFormat>(mock_encryption_format),
+          on_finish);
+  expect_crypto_layer_exists_check(false);
+  expect_test_journal_feature(false);
+  expect_encryption_format();
+  mock_format_request->send();
+  ASSERT_EQ(ETIMEDOUT, finished_cond.wait_for(0));
+  format_context->complete(0);
+  ASSERT_EQ(0, finished_cond.wait());
+}
+
+} // namespace crypto
+} // namespace librbd

--- a/src/test/librbd/crypto/test_mock_LoadRequest.cc
+++ b/src/test/librbd/crypto/test_mock_LoadRequest.cc
@@ -1,0 +1,137 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/crypto/CryptoObjectDispatch.h"
+#include "test/librbd/test_mock_fixture.h"
+#include "test/librbd/test_support.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/librbd/mock/crypto/MockCryptoInterface.h"
+#include "test/librbd/mock/crypto/MockEncryptionFormat.h"
+#include "test/librbd/mock/io/MockObjectDispatch.h"
+
+namespace librbd {
+namespace crypto {
+
+template <>
+struct CryptoObjectDispatch<MockImageCtx> : public io::MockObjectDispatch {
+
+  static CryptoObjectDispatch* create(
+          MockImageCtx* image_ctx,ceph::ref_t<CryptoInterface> crypto) {
+    return new CryptoObjectDispatch();
+  }
+
+  CryptoObjectDispatch() {
+  }
+};
+
+} // namespace crypto
+} // namespace librbd
+
+#include "librbd/crypto/LoadRequest.cc"
+
+namespace librbd {
+namespace crypto {
+
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::WithArgs;
+
+struct TestMockCryptoLoadRequest : public TestMockFixture {
+  typedef LoadRequest<librbd::MockImageCtx> MockLoadRequest;
+
+  MockImageCtx* mock_image_ctx;
+  C_SaferCond finished_cond;
+  Context *on_finish = &finished_cond;
+  MockEncryptionFormat* mock_encryption_format;
+  Context* load_context;
+
+  void SetUp() override {
+    TestMockFixture::SetUp();
+
+    librbd::ImageCtx *ictx;
+    ASSERT_EQ(0, open_image(m_image_name, &ictx));
+    mock_image_ctx = new MockImageCtx(*ictx);
+    mock_encryption_format = new MockEncryptionFormat();
+  }
+
+  void TearDown() override {
+    delete mock_image_ctx;
+    TestMockFixture::TearDown();
+  }
+
+  void expect_crypto_layer_exists_check(bool exists) {
+    EXPECT_CALL(*mock_image_ctx->io_object_dispatcher, exists(
+            io::OBJECT_DISPATCH_LAYER_CRYPTO)).WillOnce(Return(exists));
+  }
+
+  void expect_test_journal_feature(bool has_journal=false) {
+    EXPECT_CALL(*mock_image_ctx, test_features(
+            RBD_FEATURE_JOURNALING)).WillOnce(Return(has_journal));
+  }
+
+  void expect_encryption_load() {
+    EXPECT_CALL(*mock_encryption_format, load(
+            mock_image_ctx, _, _)).WillOnce(
+                    WithArgs<1, 2>(Invoke([this](
+                            ceph::ref_t<CryptoInterface>* result_crypto,
+                            Context* ctx) {
+                      load_context = ctx;
+                      *result_crypto = new MockCryptoInterface();
+    })));
+  }
+};
+
+TEST_F(TestMockCryptoLoadRequest, CryptoAlreadyLoaded) {
+  auto mock_load_request = MockLoadRequest::create(
+          mock_image_ctx,
+          std::unique_ptr<MockEncryptionFormat>(mock_encryption_format),
+          on_finish);
+  expect_crypto_layer_exists_check(true);
+  mock_load_request->send();
+  ASSERT_EQ(-EEXIST, finished_cond.wait());
+}
+
+TEST_F(TestMockCryptoLoadRequest, JournalEnabled) {
+  auto mock_load_request = MockLoadRequest::create(
+          mock_image_ctx,
+          std::unique_ptr<MockEncryptionFormat>(mock_encryption_format),
+          on_finish);
+  expect_crypto_layer_exists_check(false);
+  expect_test_journal_feature(true);
+  mock_load_request->send();
+  ASSERT_EQ(-ENOTSUP, finished_cond.wait());
+}
+
+TEST_F(TestMockCryptoLoadRequest, LoadFail) {
+  auto mock_load_request = MockLoadRequest::create(
+          mock_image_ctx,
+          std::unique_ptr<MockEncryptionFormat>(mock_encryption_format),
+          on_finish);
+  expect_crypto_layer_exists_check(false);
+  expect_test_journal_feature(false);
+  expect_encryption_load();
+  mock_load_request->send();
+  ASSERT_EQ(ETIMEDOUT, finished_cond.wait_for(0));
+  load_context->complete(-EIO);
+  ASSERT_EQ(-EIO, finished_cond.wait());
+}
+
+TEST_F(TestMockCryptoLoadRequest, Success) {
+  auto mock_load_request = MockLoadRequest::create(
+          mock_image_ctx,
+          std::unique_ptr<MockEncryptionFormat>(mock_encryption_format),
+          on_finish);
+  expect_crypto_layer_exists_check(false);
+  expect_test_journal_feature(false);
+  expect_encryption_load();
+  mock_load_request->send();
+  ASSERT_EQ(ETIMEDOUT, finished_cond.wait_for(0));
+  EXPECT_CALL(*mock_image_ctx->io_object_dispatcher, register_dispatch(_));
+  EXPECT_CALL(*mock_image_ctx->io_image_dispatcher, register_dispatch(_));
+  load_context->complete(0);
+  ASSERT_EQ(0, finished_cond.wait());
+}
+
+} // namespace crypto
+} // namespace librbd

--- a/src/test/librbd/image/test_mock_RefreshRequest.cc
+++ b/src/test/librbd/image/test_mock_RefreshRequest.cc
@@ -168,7 +168,7 @@ public:
 
   void expect_v1_read_header(MockRefreshImageCtx &mock_image_ctx, int r) {
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                               read(mock_image_ctx.header_oid, _, _, _, _));
+                               read(mock_image_ctx.header_oid, _, _, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {

--- a/src/test/librbd/image/test_mock_ValidatePoolRequest.cc
+++ b/src/test/librbd/image/test_mock_ValidatePoolRequest.cc
@@ -53,7 +53,8 @@ public:
 
   void expect_read_rbd_info(librados::MockTestMemIoCtxImpl &mock_io_ctx,
                             const std::string& data, int r) {
-    auto& expect = EXPECT_CALL(mock_io_ctx, read(StrEq(RBD_INFO), 0, 0, _, _));
+    auto& expect = EXPECT_CALL(
+            mock_io_ctx, read(StrEq(RBD_INFO), 0, 0, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {

--- a/src/test/librbd/io/test_mock_ObjectRequest.cc
+++ b/src/test/librbd/io/test_mock_ObjectRequest.cc
@@ -215,7 +215,7 @@ struct TestMockIoObjectRequest : public TestMockFixture {
 
     auto& mock_io_ctx = librados::get_mock_io_ctx(
       mock_image_ctx.rados_api, *mock_image_ctx.get_data_io_context());
-    auto& expect = EXPECT_CALL(mock_io_ctx, read(oid, len, off, _, _));
+    auto& expect = EXPECT_CALL(mock_io_ctx, read(oid, len, off, _, _, _));
     if (r < 0) {
       expect.WillOnce(Return(r));
     } else {

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -154,6 +154,7 @@ struct MockImageCtx {
   MOCK_CONST_METHOD0(get_object_size, uint64_t());
   MOCK_CONST_METHOD0(get_current_size, uint64_t());
   MOCK_CONST_METHOD1(get_image_size, uint64_t(librados::snap_t));
+  MOCK_CONST_METHOD1(get_effective_image_size, uint64_t(librados::snap_t));
   MOCK_CONST_METHOD1(get_object_count, uint64_t(librados::snap_t));
   MOCK_CONST_METHOD1(get_read_flags, int(librados::snap_t));
   MOCK_CONST_METHOD2(get_flags, int(librados::snap_t in_snap_id,

--- a/src/test/librbd/mock/crypto/MockEncryptionFormat.h
+++ b/src/test/librbd/mock/crypto/MockEncryptionFormat.h
@@ -1,0 +1,42 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_TEST_LIBRBD_MOCK_CRYPTO_MOCK_ENCRYPTION_FORMAT_H
+#define CEPH_TEST_LIBRBD_MOCK_CRYPTO_MOCK_ENCRYPTION_FORMAT_H
+
+#include "gmock/gmock.h"
+#include "librbd/crypto/EncryptionFormat.h"
+#include "test/librbd/mock/MockImageCtx.h"
+
+namespace librbd {
+namespace crypto {
+
+struct MockEncryptionFormat : EncryptionFormat<MockImageCtx> {
+
+  MOCK_METHOD2(format, void(MockImageCtx* ictx, Context* on_finish));
+  MOCK_METHOD3(load, void(MockImageCtx* ictx,
+                          ceph::ref_t<CryptoInterface>* result_crypto,
+                          Context* on_finish));
+};
+
+} // namespace crypto
+
+namespace api {
+namespace util {
+
+inline int create_encryption_format(
+        CephContext* cct, encryption_format_t format,
+        encryption_options_t opts, size_t opts_size, bool c_api,
+        crypto::EncryptionFormat<MockImageCtx>** result_format) {
+  if (opts == nullptr) {
+    return -ENOTSUP;
+  }
+  *result_format = (crypto::MockEncryptionFormat*)opts;
+  return 0;
+}
+
+} // namespace util
+} // namespace api
+} // namespace librbd
+
+#endif // CEPH_TEST_LIBRBD_MOCK_CRYPTO_MOCK_ENCRYPTION_FORMAT_H

--- a/src/test/librbd/mock/io/MockImageDispatcher.h
+++ b/src/test/librbd/mock/io/MockImageDispatcher.h
@@ -39,7 +39,7 @@ public:
   MOCK_METHOD0(unblock_writes, void());
   MOCK_METHOD1(wait_on_writes_unblocked, void(Context*));
 
-  MOCK_METHOD2(remap_extents, void(Extents&&, ImageExtentsMapType));
+  MOCK_METHOD2(remap_extents, void(Extents&, ImageExtentsMapType));
 };
 
 } // namespace io

--- a/src/test/librbd/object_map/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/object_map/test_mock_SnapshotCreateRequest.cc
@@ -33,11 +33,11 @@ public:
     if (r < 0) {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
                   read(ObjectMap<>::object_map_name(ictx->id, CEPH_NOSNAP),
-                       0, 0, _, _)).WillOnce(Return(r));
+                       0, 0, _, _, _)).WillOnce(Return(r));
     } else {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
                   read(ObjectMap<>::object_map_name(ictx->id, CEPH_NOSNAP),
-                       0, 0, _, _)).WillOnce(DoDefault());
+                       0, 0, _, _, _)).WillOnce(DoDefault());
     }
   }
 

--- a/src/test/librbd/object_map/test_mock_SnapshotRollbackRequest.cc
+++ b/src/test/librbd/object_map/test_mock_SnapshotRollbackRequest.cc
@@ -25,11 +25,11 @@ public:
     if (r < 0) {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
                   read(ObjectMap<>::object_map_name(ictx->id, snap_id),
-                       0, 0, _, _)).WillOnce(Return(r));
+                       0, 0, _, _, _)).WillOnce(Return(r));
     } else {
       EXPECT_CALL(get_mock_io_ctx(ictx->md_ctx),
                   read(ObjectMap<>::object_map_name(ictx->id, snap_id),
-                       0, 0, _, _)).WillOnce(DoDefault());
+                       0, 0, _, _, _)).WillOnce(DoDefault());
     }
   }
 


### PR DESCRIPTION
This PR contains one main commit which adds the crypto APIs to librbd (currently c/c++).
The api unit test (copied from an existing TestIo) discovered some bugs/incompatibilities which are addressed in additional commits in this PR.

While this PR is being reviewed, I am continuing to work on integration of the crypto feature to the qemu workloads tests.