### PR TITLE
mgr: use annotations for argdesc

### DIFF
--- a/doc/_ext/ceph_commands.py
+++ b/doc/_ext/ceph_commands.py
@@ -162,8 +162,8 @@ class Sig:
     @staticmethod
     def _parse_arg_desc(desc):
         try:
-            return {kv.split('=')[0]: kv.split('=')[1] for kv in desc.split(',') if kv}
-        except IndexError:
+            return dict(kv.split('=') for kv in desc.split(',') if kv)
+        except ValueError:
             return desc
 
     @staticmethod

--- a/doc/_ext/ceph_commands.py
+++ b/doc/_ext/ceph_commands.py
@@ -3,7 +3,6 @@ import os
 import sys
 import contextlib
 
-from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.parsers.rst import Directive
 from jinja2 import Template
@@ -81,7 +80,8 @@ class CmdParam(object):
         'CephFilepath': '/path/to/file',
     }
 
-    def __init__(self, type, name, who=None, n=None, req=True, range=None, strings=None,
+    def __init__(self, type, name,
+                 who=None, n=None, req=True, range=None, strings=None,
                  goodchars=None):
         self.type = type
         self.name = name
@@ -134,7 +134,8 @@ class CmdParam(object):
 
 
 class CmdCommand(object):
-    def __init__(self, prefix, args, desc, module=None, perm=None, flags=0, poll=None):
+    def __init__(self, prefix, args, desc,
+                 module=None, perm=None, flags=0, poll=None):
         self.prefix = prefix
         self.params = sorted([CmdParam(**arg) for arg in args],
                              key=lambda p: p.req, reverse=True)
@@ -213,6 +214,7 @@ Required Permissions:
 
 '''
 
+
 class CephMgrCommands(Directive):
     """
     extracts commands from specified mgr modules
@@ -281,6 +283,7 @@ class CephMgrCommands(Directive):
             logger.info(bold(f"loading mgr module '{name}'..."))
             mgr_mod = __import__(name, globals(), locals(), [], 0)
             from tests import M
+
             def subclass(x):
                 try:
                     return issubclass(x, M)
@@ -308,8 +311,8 @@ class CephMgrCommands(Directive):
         rendered = Template(TEMPLATE).render(commands=list(commands))
         lines = rendered.split("\n")
         assert lines
-        source = self.state_machine.input_lines.source(self.lineno -
-                                                       self.state_machine.input_offset - 1)
+        lineno = self.lineno - self.state_machine.input_offset - 1
+        source = self.state_machine.input_lines.source(lineno)
         self.state_machine.insert_input(lines, source)
 
     def run(self):
@@ -326,6 +329,7 @@ class CephMgrCommands(Directive):
         cmds = sorted(cmds, key=lambda cmd: cmd.prefix)
         self._render_cmds(cmds)
         return []
+
 
 class MyProcessor(Preprocessor):
     def __init__(self):
@@ -391,7 +395,6 @@ class CephMonCommands(Directive):
     optional_arguments = 0
     final_argument_whitespace = True
 
-
     def _src_dir(self):
         my_dir = os.path.dirname(os.path.realpath(__file__))
         return os.path.abspath(os.path.join(my_dir, '../..'))
@@ -412,8 +415,8 @@ class CephMonCommands(Directive):
         rendered = Template(TEMPLATE).render(commands=list(commands))
         lines = rendered.split("\n")
         assert lines
-        source = self.state_machine.input_lines.source(self.lineno -
-                                                       self.state_machine.input_offset - 1)
+        lineno = self.lineno - self.state_machine.input_offset - 1
+        source = self.state_machine.input_lines.source(lineno)
         self.state_machine.insert_input(lines, source)
 
     def run(self):

--- a/doc/_ext/ceph_commands.py
+++ b/doc/_ext/ceph_commands.py
@@ -245,8 +245,7 @@ class CephMgrCommands(Directive):
                         'dateutil',
                         'dateutil.parser']
         # make dashboard happy
-        mock_imports += ['ceph_argparse',
-                         'OpenSSL',
+        mock_imports += ['OpenSSL',
                          'jwt',
                          'bcrypt',
                          'scipy',

--- a/doc/_ext/ceph_commands.py
+++ b/doc/_ext/ceph_commands.py
@@ -221,6 +221,7 @@ class CephMgrCommands(Directive):
     required_arguments = 1
     optional_arguments = 0
     final_argument_whitespace = False
+    option_spec = {'python_path': directives.unchanged}
 
     def _normalize_path(self, dirname):
         my_dir = os.path.dirname(os.path.realpath(__file__))
@@ -315,6 +316,8 @@ class CephMgrCommands(Directive):
     def run(self):
         module_path = self._normalize_path(self.arguments[0])
         sys.path.insert(0, module_path)
+        for path in self.options.get('python_path', '').split(':'):
+            sys.path.insert(0, self._normalize_path(path))
         os.environ['UNITTEST'] = 'true'
         modules = [name for name in os.listdir(module_path)
                    if self._is_mgr_module(module_path, name)]

--- a/doc/api/mon_command_api.rst
+++ b/doc/api/mon_command_api.rst
@@ -1,2 +1,3 @@
 .. ceph-mgr-commands:: src/pybind/mgr
+   :python_path: src/pybind
 .. ceph-mon-commands:: src/mon/MonCommands.h src/mgr/MgrCommands.h

--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -65,3 +65,7 @@ ignore_missing_imports = True
 # Make volumes happy:
 [mypy-StringIO]
 ignore_missing_imports = True
+
+[mypy-ceph_argparse]
+# more work to do
+ignore_errors = True

--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -4,6 +4,7 @@ no_implicit_optional = True
 warn_incomplete_stub = True
 check_untyped_defs = True
 show_error_context = True
+allow_redefinition = True
 
 [mypy-rados]
 # This would require a rados.pyi file

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -10,6 +10,7 @@ Copyright (C) 2013 Inktank Storage, Inc.
 LGPL-2.1 or LGPL-3.0.  See file COPYING.
 """
 import copy
+import enum
 import math
 import json
 import os
@@ -21,7 +22,20 @@ import sys
 import threading
 import uuid
 
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from collections import abc
+from typing import Any, Callable, Dict, Generic, List, Optional, Sequence, Tuple, Union
+
+if sys.version_info >= (3, 8):
+    from typing import get_args, get_origin
+else:
+    def get_args(tp):
+        if tp is Generic:
+            return tp
+        else:
+            return getattr(tp, '__args__', ())
+
+    def get_origin(tp):
+        return getattr(tp, '__origin__', None)
 
 
 # Flags are from MonCommand.h
@@ -147,8 +161,58 @@ class CephArgtype(object):
         """
         return '<{0}>'.format(self.__class__.__name__)
 
+    def __call__(self, v):
+        return v
+
     def complete(self, s):
         return []
+
+    @staticmethod
+    def _compound_type_to_argdesc(tp, attrs):
+        # generate argdesc from Sequence[T], Tuple[T,..] and Optional[T]
+        orig_type = get_origin(tp)
+        type_args = get_args(tp)
+        if orig_type in (abc.Sequence, Sequence, List, list):
+            assert len(type_args) == 1
+            attrs['n'] = 'N'
+            return CephArgtype.to_argdesc(type_args[0], attrs)
+        elif orig_type is Tuple:
+            assert len(type_args) >= 1
+            inner_tp = type_args[0]
+            assert type_args.count(inner_tp) == len(type_args), \
+                f'all elements in {tp} should be identical'
+            attrs['n'] = str(len(type_args))
+            return CephArgtype.to_argdesc(inner_tp, attrs)
+        elif get_origin(tp) is Union:
+            # should be Union[t, NoneType]
+            assert len(type_args) == 2 and isinstance(None, type_args[1])
+            return CephArgtype.to_argdesc(type_args[0], attrs, True)
+        else:
+            raise ValueError(f"unknown type '{tp}': '{attrs}'")
+
+    @staticmethod
+    def to_argdesc(tp, attrs, has_default=False):
+        if has_default:
+            attrs['req'] = 'false'
+        CEPH_ARG_TYPES = {
+            str: CephString,
+            int: CephInt,
+            float: CephFloat,
+            bool: CephBool
+        }
+        try:
+            return CEPH_ARG_TYPES[tp]().argdesc(attrs)
+        except KeyError:
+            if isinstance(tp, CephArgtype):
+                return tp.argdesc(attrs)
+            elif isinstance(tp, type) and issubclass(tp, enum.Enum):
+                return CephChoices(tp=tp).argdesc(attrs)
+            else:
+                return CephArgtype._compound_type_to_argdesc(tp, attrs)
+
+    def argdesc(self, attrs):
+        attrs['type'] = type(self).__name__
+        return ','.join(f'{k}={v}' for k, v in attrs.items())
 
 
 class CephInt(CephArgtype):
@@ -185,6 +249,11 @@ class CephInt(CephArgtype):
 
         return '<int{0}>'.format(r)
 
+    def argdesc(self, attrs):
+        if self.range:
+            attrs['range'] = '|'.join(self.range)
+        return super().argdesc(attrs)
+
 
 class CephFloat(CephArgtype):
     """
@@ -218,6 +287,11 @@ class CephFloat(CephArgtype):
         if len(self.range) == 2:
             r = '[{0}-{1}]'.format(self.range[0], self.range[1])
         return '<float{0}>'.format(r)
+
+    def argdesc(self, attrs):
+        if self.range:
+            attrs['range'] = '|'.join(self.range)
+        return super().argdesc(attrs)
 
 
 class CephString(CephArgtype):
@@ -254,6 +328,11 @@ class CephString(CephArgtype):
             return []
         else:
             return [s]
+
+    def argdesc(self, attrs):
+        if self.goodchars:
+            attrs['goodchars'] = self.goodchars
+        return super().argdesc(attrs)
 
 
 class CephSocketpath(CephArgtype):
@@ -476,8 +555,11 @@ class CephChoices(CephArgtype):
     """
     Set of string literals; init with valid choices
     """
-    def __init__(self, strings='', **kwargs):
+    def __init__(self, strings='', tp=None, **kwargs):
         self.strings = strings.split('|')
+        self.enum = tp
+        if self.enum is not None:
+            self.strings = list(e.value for e in self.enum)
 
     def valid(self, s, partial=False):
         if not partial:
@@ -500,9 +582,19 @@ class CephChoices(CephArgtype):
         else:
             return '{0}'.format('|'.join(self.strings))
 
+    def __call__(self, v):
+        if self.enum is None:
+            return v
+        else:
+            return self.enum[v]
+
     def complete(self, s):
         all_elems = [token for token in self.strings if token.startswith(s)]
         return all_elems
+
+    def argdesc(self, attrs):
+        attrs['strings'] = '|'.join(self.strings)
+        return super().argdesc(attrs)
 
 
 class CephBool(CephArgtype):

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -698,12 +698,13 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                 p.evaluate()
 
     @orchestrator._cli_write_command(
-        prefix='cephadm set-ssh-config',
-        desc='Set the ssh_config file (use -i <ssh_config>)')
+        prefix='cephadm set-ssh-config')
     def _set_ssh_config(self, inbuf: Optional[str] = None) -> Tuple[int, str, str]:
         """
-        Set an ssh_config file provided from stdin
+        Set the ssh_config file (use -i <ssh_config>)
         """
+        # Set an ssh_config file provided from stdin
+
         if inbuf == self.ssh_config:
             return 0, "value unchanged", ""
         self.validate_ssh_config_content(inbuf)
@@ -712,24 +713,23 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         self._reconfig_ssh()
         return 0, "", ""
 
-    @orchestrator._cli_write_command(
-        prefix='cephadm clear-ssh-config',
-        desc='Clear the ssh_config file')
+    @orchestrator._cli_write_command('cephadm clear-ssh-config')
     def _clear_ssh_config(self) -> Tuple[int, str, str]:
         """
-        Clear the ssh_config file provided from stdin
+        Clear the ssh_config file
         """
+        # Clear the ssh_config file provided from stdin
         self.set_store("ssh_config", None)
         self.ssh_config_tmp = None
         self.log.info('Cleared ssh_config')
         self._reconfig_ssh()
         return 0, "", ""
 
-    @orchestrator._cli_read_command(
-        prefix='cephadm get-ssh-config',
-        desc='Returns the ssh config as used by cephadm'
-    )
+    @orchestrator._cli_read_command('cephadm get-ssh-config')
     def _get_ssh_config(self) -> HandleCommandResult:
+        """
+        Returns the ssh config as used by cephadm
+        """
         if self.ssh_config_file:
             self.validate_ssh_config_fname(self.ssh_config_file)
             with open(self.ssh_config_file) as f:
@@ -739,10 +739,11 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             return HandleCommandResult(stdout=ssh_config)
         return HandleCommandResult(stdout=DEFAULT_SSH_CONFIG)
 
-    @orchestrator._cli_write_command(
-        'cephadm generate-key',
-        desc='Generate a cluster SSH key (if not present)')
+    @orchestrator._cli_write_command('cephadm generate-key')
     def _generate_key(self) -> Tuple[int, str, str]:
+        """
+        Generate a cluster SSH key (if not present)
+        """
         if not self.ssh_pub or not self.ssh_key:
             self.log.info('Generating ssh key...')
             tmp_dir = TemporaryDirectory()
@@ -768,9 +769,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         return 0, '', ''
 
     @orchestrator._cli_write_command(
-        'cephadm set-priv-key',
-        desc='Set cluster SSH private key (use -i <private_key>)')
+        'cephadm set-priv-key')
     def _set_priv_key(self, inbuf: Optional[str] = None) -> Tuple[int, str, str]:
+        """Set cluster SSH private key (use -i <private_key>)"""
         if inbuf is None or len(inbuf) == 0:
             return -errno.EINVAL, "", "empty private ssh key provided"
         if inbuf == self.ssh_key:
@@ -781,9 +782,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         return 0, "", ""
 
     @orchestrator._cli_write_command(
-        'cephadm set-pub-key',
-        desc='Set cluster SSH public key (use -i <public_key>)')
+        'cephadm set-pub-key')
     def _set_pub_key(self, inbuf: Optional[str] = None) -> Tuple[int, str, str]:
+        """Set cluster SSH public key (use -i <public_key>)"""
         if inbuf is None or len(inbuf) == 0:
             return -errno.EINVAL, "", "empty public ssh key provided"
         if inbuf == self.ssh_pub:
@@ -794,9 +795,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         return 0, "", ""
 
     @orchestrator._cli_write_command(
-        'cephadm clear-key',
-        desc='Clear cluster SSH key')
+        'cephadm clear-key')
     def _clear_key(self) -> Tuple[int, str, str]:
+        """Clear cluster SSH key"""
         self.set_store('ssh_identity_key', None)
         self.set_store('ssh_identity_pub', None)
         self._reconfig_ssh()
@@ -804,25 +805,28 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         return 0, '', ''
 
     @orchestrator._cli_read_command(
-        'cephadm get-pub-key',
-        desc='Show SSH public key for connecting to cluster hosts')
+        'cephadm get-pub-key')
     def _get_pub_key(self) -> Tuple[int, str, str]:
+        """Show SSH public key for connecting to cluster hosts"""
         if self.ssh_pub:
             return 0, self.ssh_pub, ''
         else:
             return -errno.ENOENT, '', 'No cluster SSH key defined'
 
     @orchestrator._cli_read_command(
-        'cephadm get-user',
-        desc='Show user for SSHing to cluster hosts')
+        'cephadm get-user')
     def _get_user(self) -> Tuple[int, str, str]:
+        """
+        Show user for SSHing to cluster hosts
+        """
         return 0, self.ssh_user, ''
 
     @orchestrator._cli_read_command(
-        'cephadm set-user',
-        'name=user,type=CephString',
-        'Set user for SSHing to cluster hosts, passwordless sudo will be needed for non-root users')
+        'cephadm set-user')
     def set_ssh_user(self, user: str) -> Tuple[int, str, str]:
+        """
+        Set user for SSHing to cluster hosts, passwordless sudo will be needed for non-root users
+        """
         current_user = self.ssh_user
         if user == current_user:
             return 0, "value unchanged", ""
@@ -845,12 +849,11 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         return 0, msg, ''
 
     @orchestrator._cli_read_command(
-        'cephadm registry-login',
-        "name=url,type=CephString,req=false "
-        "name=username,type=CephString,req=false "
-        "name=password,type=CephString,req=false",
-        'Set custom registry login info by providing url, username and password or json file with login info (-i <file>)')
+        'cephadm registry-login')
     def registry_login(self, url: Optional[str] = None, username: Optional[str] = None, password: Optional[str] = None, inbuf: Optional[str] = None) -> Tuple[int, str, str]:
+        """
+        Set custom registry login info by providing url, username and password or json file with login info (-i <file>)
+        """
         # if password not given in command line, get it through file input
         if not (url and username and password) and (inbuf is None or len(inbuf) == 0):
             return -errno.EINVAL, "", ("Invalid arguments. Please provide arguments <url> <username> <password> "
@@ -889,12 +892,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         self.cache.distribute_new_registry_login_info()
         return 0, "registry login scheduled", ''
 
-    @orchestrator._cli_read_command(
-        'cephadm check-host',
-        'name=host,type=CephString '
-        'name=addr,type=CephString,req=false',
-        'Check whether we can access and manage a remote host')
+    @orchestrator._cli_read_command('cephadm check-host')
     def check_host(self, host: str, addr: Optional[str] = None) -> Tuple[int, str, str]:
+        """Check whether we can access and manage a remote host"""
         try:
             out, err, code = CephadmServe(self)._run_cephadm(host, cephadmNoImage, 'check-host',
                                                              ['--expect-hostname', host],
@@ -915,11 +915,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         return 0, '%s (%s) ok' % (host, addr), '\n'.join(err)
 
     @orchestrator._cli_read_command(
-        'cephadm prepare-host',
-        'name=host,type=CephString '
-        'name=addr,type=CephString,req=false',
-        'Prepare a remote host for use with cephadm')
+        'cephadm prepare-host')
     def _prepare_host(self, host: str, addr: Optional[str] = None) -> Tuple[int, str, str]:
+        """Prepare a remote host for use with cephadm"""
         out, err, code = CephadmServe(self)._run_cephadm(host, cephadmNoImage, 'prepare-host',
                                                          ['--expect-hostname', host],
                                                          addr=addr,
@@ -935,12 +933,15 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         return 0, '%s (%s) ok' % (host, addr), '\n'.join(err)
 
     @orchestrator._cli_write_command(
-        prefix='cephadm set-extra-ceph-conf',
-        desc="Text that is appended to all daemon's ceph.conf.\n"
-             "Mainly a workaround, till `config generate-minimal-conf` generates\n"
-             "a complete ceph.conf.\n\n"
-             "Warning: this is a dangerous operation.")
+        prefix='cephadm set-extra-ceph-conf')
     def _set_extra_ceph_conf(self, inbuf: Optional[str] = None) -> HandleCommandResult:
+        """
+        Text that is appended to all daemon's ceph.conf.
+        Mainly a workaround, till `config generate-minimal-conf` generates
+        a complete ceph.conf.
+             
+        Warning: this is a dangerous operation.
+        """
         if inbuf:
             # sanity check.
             cp = ConfigParser()
@@ -955,9 +956,11 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         return HandleCommandResult()
 
     @orchestrator._cli_read_command(
-        'cephadm get-extra-ceph-conf',
-        desc='Get extra ceph conf that is appended')
+        'cephadm get-extra-ceph-conf')
     def _get_extra_ceph_conf(self) -> HandleCommandResult:
+        """
+        Get extra ceph conf that is appended
+        """
         return HandleCommandResult(stdout=self.extra_ceph_conf().conf)
 
     def _set_exporter_config(self, config: Dict[str, str]) -> None:
@@ -976,10 +979,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         return self.get_store(kv_option)
 
     @orchestrator._cli_write_command(
-        prefix='cephadm generate-exporter-config',
-        desc='Generate default SSL crt/key and token for cephadm exporter daemons')
+        prefix='cephadm generate-exporter-config')
     @service_inactive('cephadm-exporter')
     def _generate_exporter_config(self) -> Tuple[int, str, str]:
+        """
+        Generate default SSL crt/key and token for cephadm exporter daemons
+        """
         self._set_exporter_defaults()
         self.log.info('Default settings created for cephadm exporter(s)')
         return 0, "", ""
@@ -1002,10 +1007,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         return secrets.token_hex(32)
 
     @orchestrator._cli_write_command(
-        prefix='cephadm clear-exporter-config',
-        desc='Clear the SSL configuration used by cephadm exporter daemons')
+        prefix='cephadm clear-exporter-config')
     @service_inactive('cephadm-exporter')
     def _clear_exporter_config(self) -> Tuple[int, str, str]:
+        """
+        Clear the SSL configuration used by cephadm exporter daemons
+        """
         self._clear_exporter_config_settings()
         self.log.info('Cleared cephadm exporter configuration')
         return 0, "", ""
@@ -1015,11 +1022,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         self._set_exporter_option('enabled', None)
 
     @orchestrator._cli_write_command(
-        prefix='cephadm set-exporter-config',
-        desc='Set custom cephadm-exporter configuration from a json file (-i <file>). JSON must contain crt, key, token and port')
+        prefix='cephadm set-exporter-config')
     @service_inactive('cephadm-exporter')
     def _store_exporter_config(self, inbuf: Optional[str] = None) -> Tuple[int, str, str]:
-
+        """
+        Set custom cephadm-exporter configuration from a json file (-i <file>). JSON must contain crt, key, token and port
+        """
         if not inbuf:
             return 1, "", "JSON configuration has not been provided (-i <filename>)"
 
@@ -1042,9 +1050,11 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         return 0, "", ""
 
     @orchestrator._cli_read_command(
-        'cephadm get-exporter-config',
-        desc='Show the current cephadm-exporter configuraion (JSON)')
+        'cephadm get-exporter-config')
     def _show_exporter_config(self) -> Tuple[int, str, str]:
+        """
+        Show the current cephadm-exporter configuraion (JSON)'
+        """
         cfg = self._get_exporter_config()
         return 0, json.dumps(cfg, indent=2), ""
 

--- a/src/pybind/mgr/dashboard/.pylintrc
+++ b/src/pybind/mgr/dashboard/.pylintrc
@@ -123,7 +123,8 @@ disable=import-star-module-level,
         relative-beyond-top-level,
         raise-missing-from,
         super-with-arguments,
-        import-outside-toplevel
+        import-outside-toplevel,
+        unsubscriptable-object
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/src/pybind/mgr/dashboard/awsauth.py
+++ b/src/pybind/mgr/dashboard/awsauth.py
@@ -32,20 +32,12 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import hmac
+from base64 import encodebytes as encodestring
 from email.utils import formatdate
 from hashlib import sha1 as sha
+from urllib.parse import unquote, urlparse
 
 from requests.auth import AuthBase
-
-py3k = False
-try:
-    from base64 import encodestring
-
-    from urlparse import unquote, urlparse
-except ImportError:
-    py3k = True
-    from base64 import encodebytes as encodestring
-    from urllib.parse import unquote, urlparse
 
 
 class S3Auth(AuthBase):
@@ -77,20 +69,15 @@ class S3Auth(AuthBase):
                 localtime=False,
                 usegmt=True)
         signature = self.get_signature(r)
-        if py3k:
-            signature = signature.decode('utf-8')
+        signature = signature.decode('utf-8')
         r.headers['Authorization'] = 'AWS %s:%s' % (self.access_key, signature)
         return r
 
     def get_signature(self, r):
         canonical_string = self.get_canonical_string(
             r.url, r.headers, r.method)
-        if py3k:
-            key = self.secret_key.encode('utf-8')
-            msg = canonical_string.encode('utf-8')
-        else:
-            key = self.secret_key  # type: ignore
-            msg = canonical_string
+        key = self.secret_key.encode('utf-8')
+        msg = canonical_string.encode('utf-8')
         h = hmac.new(key, msg, digestmod=sha)
         return encodestring(h.digest()).strip()
 
@@ -120,12 +107,8 @@ class S3Auth(AuthBase):
                 interesting_headers[lk] = headers[key].strip()
 
         # If x-amz-date is used it supersedes the date header.
-        if not py3k:
-            if 'x-amz-date' in interesting_headers:
-                interesting_headers['date'] = ''
-        else:
-            if 'x-amz-date' in interesting_headers:
-                interesting_headers['date'] = ''
+        if 'x-amz-date' in interesting_headers:
+            interesting_headers['date'] = ''
 
         buf = '%s\n' % method
         for key in sorted(interesting_headers.keys()):

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -14,6 +14,7 @@ import sys
 import tempfile
 import threading
 import time
+from typing import Optional
 
 from mgr_module import CLIWriteCommand, MgrModule, MgrStandbyModule, Option
 from mgr_util import ServerConfigException, create_self_signed_cert, \
@@ -358,9 +359,10 @@ class Module(MgrModule, CherryPyConfig):
         logger.info('Stopping engine...')
         self.shutdown_event.set()
 
-    @CLIWriteCommand("dashboard set-ssl-certificate",
-                     "name=mgr_id,type=CephString,req=false")
-    def set_ssl_certificate(self, mgr_id=None, inbuf=None):
+    @CLIWriteCommand("dashboard set-ssl-certificate")
+    def set_ssl_certificate(self,
+                            mgr_id: Optional[str] = None,
+                            inbuf: Optional[bytes] = None):
         if inbuf is None:
             return -errno.EINVAL, '',\
                 'Please specify the certificate file with "-i" option'
@@ -370,9 +372,10 @@ class Module(MgrModule, CherryPyConfig):
             self.set_store('crt', inbuf)
         return 0, 'SSL certificate updated', ''
 
-    @CLIWriteCommand("dashboard set-ssl-certificate-key",
-                     "name=mgr_id,type=CephString,req=false")
-    def set_ssl_certificate_key(self, mgr_id=None, inbuf=None):
+    @CLIWriteCommand("dashboard set-ssl-certificate-key")
+    def set_ssl_certificate_key(self,
+                                mgr_id: Optional[str] = None,
+                                inbuf: Optional[bytes] = None):
         if inbuf is None:
             return -errno.EINVAL, '',\
                 'Please specify the certificate key file with "-i" option'

--- a/src/pybind/mgr/dashboard/plugins/debug.py
+++ b/src/pybind/mgr/dashboard/plugins/debug.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 from __future__ import absolute_import
 
 import json
@@ -55,14 +56,14 @@ class Debug(SP, I.CanCherrypy, I.ConfiguresCherryPy,  # pylint: disable=too-many
         self._refresh_health_checks()
 
     @no_type_check
-    def handler(self, action):
+    def handler(self, action: Actions):
         '''
         Control and report debug status in Ceph-Dashboard
         '''
         ret = 0
         msg = ''
-        if action in [Actions.ENABLE.value, Actions.DISABLE.value]:
-            self.set_option(self.NAME, action == Actions.ENABLE.value)
+        if action in [Actions.ENABLE, Actions.DISABLE]:
+            self.set_option(self.NAME, action == Actions.ENABLE)
             self.mgr.update_cherrypy_config({})
             self._refresh_health_checks()
         else:
@@ -73,8 +74,6 @@ class Debug(SP, I.CanCherrypy, I.ConfiguresCherryPy,  # pylint: disable=too-many
     COMMANDS = [
         SP.Command(
             prefix="dashboard {name}".format(name=NAME),
-            args="name=action,type=CephChoices,strings={states}".format(
-                states="|".join(a.value for a in Actions)),
             handler=handler
         )
     ]

--- a/src/pybind/mgr/dashboard/plugins/feature_toggles.py
+++ b/src/pybind/mgr/dashboard/plugins/feature_toggles.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 from enum import Enum
+from typing import List, Optional
 
 import cherrypy
 from mgr_module import CLICommand, Option
@@ -77,13 +78,10 @@ class FeatureToggles(I.CanMgr, I.Setupable, I.HasOptions,
 
     @PM.add_hook
     def register_commands(self):
-        @CLICommand(
-            "dashboard feature",
-            "name=action,type=CephChoices,strings={} ".format(
-                "|".join(a.value for a in Actions))
-            + "name=features,type=CephChoices,strings={},req=false,n=N".format(
-                "|".join(f.value for f in Features)))
-        def cmd(mgr, action, features=None):
+        @CLICommand("dashboard feature")
+        def cmd(mgr,
+                action: Actions,
+                features: Optional[List[Features]] = None):
             '''
             Enable or disable features in Ceph-Mgr Dashboard
             '''

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -11,6 +11,7 @@ import threading
 import time
 from datetime import datetime, timedelta
 from string import ascii_lowercase, ascii_uppercase, digits, punctuation
+from typing import List, Optional, Sequence
 
 import bcrypt
 from mgr_module import CLICheckNonemptyFileInput, CLIReadCommand, CLIWriteCommand
@@ -579,10 +580,9 @@ def load_access_control_db():
 
 # CLI dashboard access control scope commands
 
-@CLIWriteCommand('dashboard set-login-credentials',
-                 'name=username,type=CephString')
+@CLIWriteCommand('dashboard set-login-credentials')
 @CLICheckNonemptyFileInput
-def set_login_credentials_cmd(_, username, inbuf):
+def set_login_credentials_cmd(_, username: str, inbuf: str):
     '''
     Set the login credentials. Password read from -i <file>
     '''
@@ -604,9 +604,8 @@ def set_login_credentials_cmd(_, username, inbuf):
 Username and password updated''', ''
 
 
-@CLIReadCommand('dashboard ac-role-show',
-                'name=rolename,type=CephString,req=false')
-def ac_role_show_cmd(_, rolename=None):
+@CLIReadCommand('dashboard ac-role-show')
+def ac_role_show_cmd(_, rolename: Optional[str] = None):
     '''
     Show role info
     '''
@@ -624,10 +623,8 @@ def ac_role_show_cmd(_, rolename=None):
     return 0, json.dumps(role.to_dict()), ''
 
 
-@CLIWriteCommand('dashboard ac-role-create',
-                 'name=rolename,type=CephString '
-                 'name=description,type=CephString,req=false')
-def ac_role_create_cmd(_, rolename, description=None):
+@CLIWriteCommand('dashboard ac-role-create')
+def ac_role_create_cmd(_, rolename: str, description: Optional[str] = None):
     '''
     Create a new access control role
     '''
@@ -639,9 +636,8 @@ def ac_role_create_cmd(_, rolename, description=None):
         return -errno.EEXIST, '', str(ex)
 
 
-@CLIWriteCommand('dashboard ac-role-delete',
-                 'name=rolename,type=CephString')
-def ac_role_delete_cmd(_, rolename):
+@CLIWriteCommand('dashboard ac-role-delete')
+def ac_role_delete_cmd(_, rolename: str):
     '''
     Delete an access control role
     '''
@@ -658,11 +654,11 @@ def ac_role_delete_cmd(_, rolename):
         return -errno.EPERM, '', str(ex)
 
 
-@CLIWriteCommand('dashboard ac-role-add-scope-perms',
-                 'name=rolename,type=CephString '
-                 'name=scopename,type=CephString '
-                 'name=permissions,type=CephString,n=N')
-def ac_role_add_scope_perms_cmd(_, rolename, scopename, permissions):
+@CLIWriteCommand('dashboard ac-role-add-scope-perms')
+def ac_role_add_scope_perms_cmd(_,
+                                rolename: str,
+                                scopename: str,
+                                permissions: Sequence[str]):
     '''
     Add the scope permissions for a role
     '''
@@ -687,10 +683,8 @@ def ac_role_add_scope_perms_cmd(_, rolename, scopename, permissions):
             .format(Permission.all_permissions())
 
 
-@CLIWriteCommand('dashboard ac-role-del-scope-perms',
-                 'name=rolename,type=CephString '
-                 'name=scopename,type=CephString')
-def ac_role_del_scope_perms_cmd(_, rolename, scopename):
+@CLIWriteCommand('dashboard ac-role-del-scope-perms')
+def ac_role_del_scope_perms_cmd(_, rolename: str, scopename: str):
     '''
     Delete the scope permissions for a role
     '''
@@ -709,9 +703,8 @@ def ac_role_del_scope_perms_cmd(_, rolename, scopename):
         return -errno.ENOENT, '', str(ex)
 
 
-@CLIReadCommand('dashboard ac-user-show',
-                'name=username,type=CephString,req=false')
-def ac_user_show_cmd(_, username=None):
+@CLIReadCommand('dashboard ac-user-show')
+def ac_user_show_cmd(_, username: Optional[str] = None):
     '''
     Show user info
     '''
@@ -726,19 +719,16 @@ def ac_user_show_cmd(_, username=None):
         return -errno.ENOENT, '', str(ex)
 
 
-@CLIWriteCommand('dashboard ac-user-create',
-                 'name=username,type=CephString '
-                 'name=rolename,type=CephString,req=false '
-                 'name=name,type=CephString,req=false '
-                 'name=email,type=CephString,req=false '
-                 'name=enabled,type=CephBool,req=false '
-                 'name=force_password,type=CephBool,req=false '
-                 'name=pwd_expiration_date,type=CephInt,req=false '
-                 'name=pwd_update_required,type=CephBool,req=false')
+@CLIWriteCommand('dashboard ac-user-create')
 @CLICheckNonemptyFileInput
-def ac_user_create_cmd(_, username, inbuf, rolename=None, name=None,
-                       email=None, enabled=True, force_password=False,
-                       pwd_expiration_date=None, pwd_update_required=False):
+def ac_user_create_cmd(_, username: str, inbuf: str,
+                       rolename: Optional[str] = None,
+                       name: Optional[str] = None,
+                       email: Optional[str] = None,
+                       enabled: bool = True,
+                       force_password: bool = False,
+                       pwd_expiration_date: Optional[int] = None,
+                       pwd_update_required: bool = False):
     '''
     Create a user. Password read from -i <file>
     '''
@@ -768,9 +758,8 @@ def ac_user_create_cmd(_, username, inbuf, rolename=None, name=None,
     return 0, json.dumps(user.to_dict()), ''
 
 
-@CLIWriteCommand('dashboard ac-user-enable',
-                 'name=username,type=CephString')
-def ac_user_enable(_, username):
+@CLIWriteCommand('dashboard ac-user-enable')
+def ac_user_enable(_, username: str):
     '''
     Enable a user
     '''
@@ -785,9 +774,8 @@ def ac_user_enable(_, username):
         return -errno.ENOENT, '', str(ex)
 
 
-@CLIWriteCommand('dashboard ac-user-disable',
-                 'name=username,type=CephString')
-def ac_user_disable(_, username):
+@CLIWriteCommand('dashboard ac-user-disable')
+def ac_user_disable(_, username: str):
     '''
     Disable a user
     '''
@@ -801,9 +789,8 @@ def ac_user_disable(_, username):
         return -errno.ENOENT, '', str(ex)
 
 
-@CLIWriteCommand('dashboard ac-user-delete',
-                 'name=username,type=CephString')
-def ac_user_delete_cmd(_, username):
+@CLIWriteCommand('dashboard ac-user-delete')
+def ac_user_delete_cmd(_, username: str):
     '''
     Delete user
     '''
@@ -815,15 +802,13 @@ def ac_user_delete_cmd(_, username):
         return -errno.ENOENT, '', str(ex)
 
 
-@CLIWriteCommand('dashboard ac-user-set-roles',
-                 'name=username,type=CephString '
-                 'name=roles,type=CephString,n=N')
-def ac_user_set_roles_cmd(_, username, roles):
+@CLIWriteCommand('dashboard ac-user-set-roles')
+def ac_user_set_roles_cmd(_, username: str, roles: Sequence[str]):
     '''
     Set user roles
     '''
     rolesname = roles
-    roles = []
+    roles: List[Role] = []
     for rolename in rolesname:
         try:
             roles.append(mgr.ACCESS_CTRL_DB.get_role(rolename))
@@ -840,15 +825,13 @@ def ac_user_set_roles_cmd(_, username, roles):
         return -errno.ENOENT, '', str(ex)
 
 
-@CLIWriteCommand('dashboard ac-user-add-roles',
-                 'name=username,type=CephString '
-                 'name=roles,type=CephString,n=N')
-def ac_user_add_roles_cmd(_, username, roles):
+@CLIWriteCommand('dashboard ac-user-add-roles')
+def ac_user_add_roles_cmd(_, username: str, roles: Sequence[str]):
     '''
     Add roles to user
     '''
     rolesname = roles
-    roles = []
+    roles: List[Role] = []
     for rolename in rolesname:
         try:
             roles.append(mgr.ACCESS_CTRL_DB.get_role(rolename))
@@ -865,15 +848,13 @@ def ac_user_add_roles_cmd(_, username, roles):
         return -errno.ENOENT, '', str(ex)
 
 
-@CLIWriteCommand('dashboard ac-user-del-roles',
-                 'name=username,type=CephString '
-                 'name=roles,type=CephString,n=N')
-def ac_user_del_roles_cmd(_, username, roles):
+@CLIWriteCommand('dashboard ac-user-del-roles')
+def ac_user_del_roles_cmd(_, username: str, roles: Sequence[str]):
     '''
     Delete roles from user
     '''
     rolesname = roles
-    roles = []
+    roles: List[Role] = []
     for rolename in rolesname:
         try:
             roles.append(mgr.ACCESS_CTRL_DB.get_role(rolename))
@@ -892,11 +873,10 @@ def ac_user_del_roles_cmd(_, username, roles):
         return -errno.ENOENT, '', str(ex)
 
 
-@CLIWriteCommand('dashboard ac-user-set-password',
-                 'name=username,type=CephString '
-                 'name=force_password,type=CephBool,req=false')
+@CLIWriteCommand('dashboard ac-user-set-password')
 @CLICheckNonemptyFileInput
-def ac_user_set_password(_, username, inbuf, force_password=False):
+def ac_user_set_password(_, username: str, inbuf: str,
+                         force_password: bool = False):
     '''
     Set user password from -i <file>
     '''
@@ -915,10 +895,9 @@ def ac_user_set_password(_, username, inbuf, force_password=False):
         return -errno.ENOENT, '', str(ex)
 
 
-@CLIWriteCommand('dashboard ac-user-set-password-hash',
-                 'name=username,type=CephString')
+@CLIWriteCommand('dashboard ac-user-set-password-hash')
 @CLICheckNonemptyFileInput
-def ac_user_set_password_hash(_, username, inbuf):
+def ac_user_set_password_hash(_, username: str, inbuf: str):
     '''
     Set user password bcrypt hash from -i <file>
     '''
@@ -937,11 +916,8 @@ def ac_user_set_password_hash(_, username, inbuf):
         return -errno.ENOENT, '', str(ex)
 
 
-@CLIWriteCommand('dashboard ac-user-set-info',
-                 'name=username,type=CephString '
-                 'name=name,type=CephString '
-                 'name=email,type=CephString')
-def ac_user_set_info(_, username, name, email):
+@CLIWriteCommand('dashboard ac-user-set-info')
+def ac_user_set_info(_, username: str, name: str, email: str):
     '''
     Set user info
     '''

--- a/src/pybind/mgr/dashboard/services/iscsi_cli.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_cli.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 import errno
 import json
+from typing import Optional
 
 from mgr_module import CLICheckNonemptyFileInput, CLIReadCommand, CLIWriteCommand
 
@@ -21,10 +22,9 @@ def list_iscsi_gateways(_):
     return 0, json.dumps(IscsiGatewaysConfig.get_gateways_config()), ''
 
 
-@CLIWriteCommand('dashboard iscsi-gateway-add',
-                 'name=name,type=CephString,req=false')
+@CLIWriteCommand('dashboard iscsi-gateway-add')
 @CLICheckNonemptyFileInput
-def add_iscsi_gateway(_, inbuf, name=None):
+def add_iscsi_gateway(_, inbuf, name: Optional[str] = None):
     '''
     Add iSCSI gateway configuration. Gateway URL read from -i <file>
     '''
@@ -45,9 +45,8 @@ def add_iscsi_gateway(_, inbuf, name=None):
         return -errno.EINVAL, '', str(ex)
 
 
-@CLIWriteCommand('dashboard iscsi-gateway-rm',
-                 'name=name,type=CephString')
-def remove_iscsi_gateway(_, name):
+@CLIWriteCommand('dashboard iscsi-gateway-rm')
+def remove_iscsi_gateway(_, name: str):
     '''
     Remove iSCSI gateway configuration
     '''

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -9,6 +9,7 @@ import operator
 import rados
 from threading import Event
 from datetime import datetime, timedelta
+from typing import Optional
 
 TIME_FORMAT = '%Y%m%d-%H%M%S'
 
@@ -106,9 +107,8 @@ class Module(MgrModule):
         self.log.error("handle_command")
 
     @CLICommand('device query-daemon-health-metrics',
-                args='name=who,type=CephString',
                 perm='r')
-    def do_query_daemon_health_metrics(self, who=''):
+    def do_query_daemon_health_metrics(self, who: str):
         '''
         Get device health metrics for a given daemon
         '''
@@ -123,9 +123,8 @@ class Module(MgrModule):
         return result.wait()
 
     @CLICommand('device scrape-daemon-health-metrics',
-                args='name=who,type=CephString',
                 perm='r')
-    def do_scrape_daemon_health_metrics(self, who=''):
+    def do_scrape_daemon_health_metrics(self, who: str):
         '''
         Scrape and store device health metrics for a given daemon
         '''
@@ -135,9 +134,8 @@ class Module(MgrModule):
         return self.scrape_daemon(daemon_type, daemon_id)
 
     @CLICommand('device scrape-daemon-health-metrics',
-                args='name=devid,type=CephString,req=False',
                 perm='r')
-    def do_scrape_health_metrics(self, devid=None):
+    def do_scrape_health_metrics(self, devid: Optional[str] = None):
         '''
         Scrape and store device health metrics
         '''
@@ -147,10 +145,8 @@ class Module(MgrModule):
             return self.scrape_device(devid)
 
     @CLICommand('device get-health-metrics',
-                args=('name=devid,type=CephString ' +
-                      'name=sample,type=CephString,req=False'),
                 perm='r')
-    def do_get_health_metrics(self, devid, sample=None):
+    def do_get_health_metrics(self, devid: str, sample: Optional[str] = None):
         '''
         Show stored device metrics for the device
         '''
@@ -183,9 +179,8 @@ class Module(MgrModule):
         self.set_health_checks({})  # avoid stuck health alerts
 
     @CLICommand('device predict-life-expectancy',
-                args='name=devid,type=CephString,req=true',
                 perm='r')
-    def do_predict_life_expectancy(self, devid):
+    def do_predict_life_expectancy(self, devid: str):
         '''
         Predict life expectancy with local predictor
         '''

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1264,13 +1264,13 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         """
         self._ceph_set_health_checks(checks)
 
-    def _handle_command(self, inbuf, cmd):
+    def _handle_command(self, inbuf: str, cmd: Dict[str, Any]):
         if cmd['prefix'] not in CLICommand.COMMANDS:
             return self.handle_command(inbuf, cmd)
 
         return CLICommand.COMMANDS[cmd['prefix']].call(self, cmd, inbuf)
 
-    def handle_command(self, inbuf, cmd):
+    def handle_command(self, inbuf: str, cmd: Dict[str, Any]):
         """
         Called by ceph-mgr to request the plugin to handle one
         of the commands that it declared in self.COMMANDS

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -369,7 +369,7 @@ class CLICommand(object):
                     continue
             kwargs_switch, k, v = self._get_arg_value(kwargs_switch,
                                                       name, raw_v)
-            kwargs[k] = v
+            kwargs[k] = CephArgtype.cast_to(tp, v)
         return kwargs
 
     def call(self, mgr, cmd_dict, inbuf):

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -408,6 +408,7 @@ def CLICheckNonemptyFileInput(func):
                                    and not kwargs['inbuf'].strip('\n')):
             return -errno.EINVAL, '', ERROR_MSG_EMPTY_INPUT_FILE
         return func(*args, **kwargs)
+    check.__signature__ = inspect.signature(func)  # type: ignore[attr-defined]
     return check
 
 
@@ -484,6 +485,7 @@ class Command(dict):
         def wrapper(mgr, *args, **kwargs):
             retval, stdout, stderr = f(instance or mgr, *args, **kwargs)
             return HandleCommandResult(retval, stdout, stderr)
+        wrapper.__signature__ = inspect.signature(f)  # type: ignore[attr-defined]
         return wrapper
 
     def register(self, instance=False):

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -328,7 +328,7 @@ class CLICommand(object):
             k, v = key, val
         return kwargs_switch, k.replace('-', '_'), v
 
-    def call(self, mgr, cmd_dict, inbuf):
+    def _collect_args(self, cmd_dict):
         kwargs = {}
         kwargs_switch = False
         for a, d in self.args_dict.items():
@@ -336,6 +336,10 @@ class CLICommand(object):
                 continue
             kwargs_switch, k, v = self._get_arg_value(kwargs_switch, a, cmd_dict[a])
             kwargs[k] = v
+        return kwargs
+
+    def call(self, mgr, cmd_dict, inbuf):
+        kwargs = self._collect_args(cmd_dict)
         if inbuf:
             kwargs['inbuf'] = inbuf
         assert self.func

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -319,10 +319,15 @@ class CLICommand(object):
         return self.func
 
     def _get_arg_value(self, kwargs_switch, key, val):
-        if isinstance(val, str) and '=' in val:
-            k, v = val.split('=', 1)
-            if self._is_arg_key(k):
-                kwargs_switch = True
+        def start_kwargs():
+            if isinstance(val, str) and '=' in val:
+                k, v = val.split('=', 1)
+                if self._is_arg_key(k):
+                    return True
+            else:
+                return False
+        if not kwargs_switch:
+            kwargs_switch = start_kwargs()
 
         if kwargs_switch:
             k, v = val.split('=', 1)

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -288,18 +288,19 @@ class CLICommand(object):
 
     def __init__(self, prefix, args="", desc="", perm="rw"):
         self.prefix = prefix
-        self.args = args
         self.args_dict = {}
         self.desc = desc
         self.perm = perm
         self.func = None  # type: Optional[Callable]
-        self._parse_args()
+        self.args = args
+        self.args_dict = self._parse_args(args)
 
-    def _parse_args(self):
-        if not self.args:
-            return
-        args = self.args.split(" ")
-        for arg in args:
+    @staticmethod
+    def _parse_args(args):
+        if not args:
+            return {}
+        args_dict = {}
+        for arg in args.split(" "):
             arg_desc = arg.strip().split(",")
             arg_d = {}
             for kv in arg_desc:
@@ -307,7 +308,8 @@ class CLICommand(object):
                 if k != "name":
                     arg_d[k] = v
                 else:
-                    self.args_dict[v] = arg_d
+                    args_dict[v] = arg_d
+        return args_dict
 
     def __call__(self, func):
         self.func = func
@@ -334,7 +336,8 @@ class CLICommand(object):
         for a, d in self.args_dict.items():
             if 'req' in d and d['req'] == "false" and a not in cmd_dict:
                 continue
-            kwargs_switch, k, v = self._get_arg_value(kwargs_switch, a, cmd_dict[a])
+            kwargs_switch, k, v = self._get_arg_value(kwargs_switch,
+                                                      a, cmd_dict[a])
             kwargs[k] = v
         return kwargs
 

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -425,7 +425,7 @@ def CLIWriteCommand(prefix, args=""):
 def CLICheckNonemptyFileInput(func):
     @functools.wraps(func)
     def check(*args, **kwargs):
-        if not 'inbuf' in kwargs:
+        if 'inbuf' not in kwargs:
             return -errno.EINVAL, '', ERROR_MSG_NO_INPUT_FILE
         if not kwargs['inbuf'] or (isinstance(kwargs['inbuf'], str)
                                    and not kwargs['inbuf'].strip('\n')):

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1,6 +1,6 @@
 import ceph_module  # noqa
 
-from typing import Set, Tuple, Iterator, Any, Dict, Optional, Callable, List, \
+from typing import Set, Tuple, Iterator, Any, Dict, Generic, Optional, Callable, List, \
     Union, TYPE_CHECKING, NamedTuple
 if TYPE_CHECKING:
     import sys
@@ -8,7 +8,6 @@ if TYPE_CHECKING:
         from typing import Literal
     else:
         from typing_extensions import Literal
-
 
 import inspect
 import logging
@@ -19,8 +18,23 @@ import threading
 from collections import defaultdict, namedtuple
 import rados
 import re
+import sys
 import time
+from ceph_argparse import CephArgtype
 from mgr_util import profile_method
+
+if sys.version_info >= (3, 8):
+    from typing import get_args, get_origin
+else:
+    def get_args(tp):
+        if tp is Generic:
+            return tp
+        else:
+            return getattr(tp, '__args__', ())
+
+    def get_origin(tp):
+        return getattr(tp, '__origin__', None)
+
 
 ERROR_MSG_EMPTY_INPUT_FILE = 'Empty content: please add a password/secret to the file.'
 ERROR_MSG_NO_INPUT_FILE = 'Please specify the file containing the password/secret with "-i" option.'
@@ -294,6 +308,8 @@ class CLICommand(object):
         self.func = None  # type: Optional[Callable]
         self.args = args
         self.args_dict = self._parse_args(args)
+        self.arg_spec = {}    # type: Dict[str, Any]
+        self.first_default = -1
 
     @staticmethod
     def _parse_args(args):
@@ -315,8 +331,13 @@ class CLICommand(object):
         self.func = func
         if not self.desc:
             self.desc = inspect.getdoc(func)
+        if not self.args_dict:
+            self.arg_spec = inspect.getfullargspec(func).annotations
         self.COMMANDS[self.prefix] = self
         return self.func
+
+    def _is_arg_key(self, k):
+        return k in self.args_dict or k in self.arg_spec
 
     def _get_arg_value(self, kwargs_switch, key, val):
         def start_kwargs():
@@ -335,7 +356,7 @@ class CLICommand(object):
             k, v = key, val
         return kwargs_switch, k.replace('-', '_'), v
 
-    def _collect_args(self, cmd_dict):
+    def _collect_args_by_argdesc(self, cmd_dict):
         kwargs = {}
         kwargs_switch = False
         for a, d in self.args_dict.items():
@@ -346,8 +367,27 @@ class CLICommand(object):
             kwargs[k] = v
         return kwargs
 
+    def _collect_args_by_argspec(self, cmd_dict):
+        kwargs = {}
+        kwargs_switch = False
+        for index, (name, tp) in enumerate(self.arg_spec.items()):
+            if name in CLICommand.KNOWN_ARGS:
+                continue
+            assert self.first_default >= 0
+            raw_v = cmd_dict.get(name)
+            if index >= self.first_default:
+                if raw_v is None:
+                    continue
+            kwargs_switch, k, v = self._get_arg_value(kwargs_switch,
+                                                      name, raw_v)
+            kwargs[k] = v
+        return kwargs
+
     def call(self, mgr, cmd_dict, inbuf):
-        kwargs = self._collect_args(cmd_dict)
+        if self.args_dict:
+            kwargs = self._collect_args_by_argdesc(cmd_dict)
+        else:
+            kwargs = self._collect_args_by_argspec(cmd_dict)
         if inbuf:
             kwargs['inbuf'] = inbuf
         assert self.func

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -311,6 +311,8 @@ class CLICommand(object):
         self.arg_spec = {}    # type: Dict[str, Any]
         self.first_default = -1
 
+    KNOWN_ARGS = '_', 'self', 'mgr', 'inbuf', 'return'
+
     @staticmethod
     def _parse_args(args):
         if not args:
@@ -332,7 +334,14 @@ class CLICommand(object):
         if not self.desc:
             self.desc = inspect.getdoc(func)
         if not self.args_dict:
-            self.arg_spec = inspect.getfullargspec(func).annotations
+            full_argspec = inspect.getfullargspec(func)
+            self.arg_spec = full_argspec.annotations
+            for arg in full_argspec.args:
+                assert arg in CLICommand.KNOWN_ARGS or arg in self.arg_spec, \
+                    f"'{arg}' is not annotated for {func}: {full_argspec}"
+            self.args = ' '.join(CephArgtype.to_argdesc(tp, dict(name=name))
+                                 for name, tp in self.arg_spec)
+
         self.COMMANDS[self.prefix] = self
         return self.func
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -98,7 +98,7 @@ def handle_exception(prefix, perm, func):
             msg = 'This Orchestrator does not support `{}`'.format(prefix)
             return HandleCommandResult(-errno.ENOENT, stderr=msg)
 
-    # misuse partial to copy `wrapper`
+    # misuse lambda to copy `wrapper`
     wrapper_copy = lambda *l_args, **l_kwargs: wrapper(*l_args, **l_kwargs)
     wrapper_copy._prefix = prefix  # type: ignore
     wrapper_copy._cli_command = CLICommand(prefix, perm)  # type: ignore

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -84,7 +84,7 @@ def set_exception_subject(kind, subject, overwrite=False):
         raise
 
 
-def handle_exception(prefix, cmd_args, desc, perm, func):
+def handle_exception(prefix, perm, func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         try:
@@ -101,15 +101,16 @@ def handle_exception(prefix, cmd_args, desc, perm, func):
     # misuse partial to copy `wrapper`
     wrapper_copy = lambda *l_args, **l_kwargs: wrapper(*l_args, **l_kwargs)
     wrapper_copy._prefix = prefix  # type: ignore
-    wrapper_copy._cli_command = CLICommand(prefix, cmd_args, desc, perm)  # type: ignore
+    wrapper_copy._cli_command = CLICommand(prefix, perm)  # type: ignore
+    wrapper_copy._cli_command.store_func_metadata(func)  # type: ignore
     wrapper_copy._cli_command.func = wrapper_copy  # type: ignore
 
     return wrapper_copy
 
 
 def _cli_command(perm):
-    def inner_cli_command(prefix, cmd_args="", desc=""):
-        return lambda func: handle_exception(prefix, cmd_args, desc, perm, func)
+    def inner_cli_command(prefix):
+        return lambda func: handle_exception(prefix, perm, func)
     return inner_cli_command
 
 

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1,3 +1,4 @@
+import enum
 import errno
 import json
 from typing import List, Set, Optional, Iterator, cast, Dict, Any, Union
@@ -29,7 +30,45 @@ def nice_delta(now, t, suffix=''):
         return '-'
 
 
-def to_format(what, format: str, many: bool, cls):
+class Format(enum.Enum):
+    plain = 'plain'
+    json = 'json'
+    json_pretty = 'json-pretty'
+    yaml = 'yaml'
+
+
+class ServiceType(enum.Enum):
+    mon = 'mon'
+    mgr = 'mgr'
+    rbd_mirror = 'rbd-mirror'
+    crash = 'crash'
+    alertmanager = 'alertmanager'
+    grafana = 'grafana'
+    node_exporter = 'node-exporter'
+    prometheus = 'prometheus'
+    mds = 'mds'
+    rgw = 'rgw'
+    nfs = 'nfs'
+    iscsi = 'iscsi'
+    cephadm_exporter = 'cephadm-exporter'
+
+
+class ServiceAction(enum.Enum):
+    start = 'start'
+    stop = 'stop'
+    restart = 'restart'
+    redeploy = 'redeploy'
+    reconfig = 'reconfig'
+
+
+class DaemonAction(enum.Enum):
+    start = 'start'
+    stop = 'stop'
+    restart = 'restart'
+    reconfig = 'reconfig'
+
+
+def to_format(what, format: Format, many: bool, cls):
     def to_json_1(obj):
         if hasattr(obj, 'to_json'):
             return obj.to_json()
@@ -40,11 +79,11 @@ def to_format(what, format: str, many: bool, cls):
 
     to_json = to_json_n if many else to_json_1
 
-    if format == 'json':
+    if format == Format.json:
         return json.dumps(to_json(what), sort_keys=True)
-    elif format == 'json-pretty':
+    elif format == Format.json_pretty:
         return json.dumps(to_json(what), indent=2, sort_keys=True)
-    elif format == 'yaml':
+    elif format == Format.yaml:
         # fun with subinterpreters again. pyyaml depends on object identity.
         # as what originates from a different subinterpreter we have to copy things here.
         if cls:
@@ -203,10 +242,9 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         locs = [d['location'] for d in self.get('devices')['devices'] if d['devid'] == dev_id]
         return [DeviceLightLoc(**l) for l in sum(locs, [])]
 
-    @_cli_read_command(
-        prefix='device ls-lights',
-        desc='List currently active device indicator lights')
+    @_cli_read_command(prefix='device ls-lights')
     def _device_ls(self):
+        """List currently active device indicator lights"""
         return HandleCommandResult(
             stdout=json.dumps({
                 'ident': list(self.ident),
@@ -257,69 +295,64 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
                 self._refresh_health()
             raise
 
-    @_cli_write_command(
-        prefix='device light',
-        cmd_args='name=enable,type=CephChoices,strings=on|off '
-                 'name=devid,type=CephString '
-                 'name=light_type,type=CephChoices,strings=ident|fault,req=false '
-                 'name=force,type=CephBool,req=false',
-        desc='Enable or disable the device light. Default type is `ident`\n'
-             'Usage: device light (on|off) <devid> [ident|fault] [--force]')
-    def _device_light(self, enable, devid, light_type=None, force=False):
-        # type: (str, str, Optional[str], bool) -> HandleCommandResult
-        light_type = light_type or 'ident'
-        on = enable == 'on'
-        if on:
-            return self.light_on(light_type, devid)
+    class DeviceLightEnable(enum.Enum):
+        on = 'on'
+        off = 'off'
+
+    class DeviceLightType(enum.Enum):
+        ident = 'ident'
+        fault = 'fault'
+
+    @_cli_write_command(prefix='device light')
+    def _device_light(self,
+                      enable: DeviceLightEnable,
+                      devid: str,
+                      light_type: DeviceLightType = DeviceLightType.ident,
+                      force: bool = False) -> HandleCommandResult:
+        """
+        Enable or disable the device light. Default type is `ident`
+        'Usage: device light (on|off) <devid> [ident|fault] [--force]'
+        """""
+        if enable == self.DeviceLightEnable.on:
+            return self.light_on(light_type.value, devid)
         else:
-            return self.light_off(light_type, devid, force)
+            return self.light_off(light_type.value, devid, force)
 
     def _select_orchestrator(self):
         return self.get_module_option("orchestrator")
 
-    @_cli_write_command(
-        'orch host add',
-        'name=hostname,type=CephString,req=true '
-        'name=addr,type=CephString,req=false '
-        'name=labels,type=CephString,n=N,req=false',
-        'Add a host')
+    @_cli_write_command('orch host add')
     def _add_host(self, hostname: str, addr: Optional[str] = None, labels: Optional[List[str]] = None):
+        """Add a host"""
         s = HostSpec(hostname=hostname, addr=addr, labels=labels)
         completion = self.add_host(s)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch host rm',
-        "name=hostname,type=CephString,req=true",
-        'Remove a host')
-    def _remove_host(self, hostname):
+    @_cli_write_command('orch host rm')
+    def _remove_host(self, hostname: str):
+        """Remove a host"""
         completion = self.remove_host(hostname)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch host set-addr',
-        'name=hostname,type=CephString '
-        'name=addr,type=CephString',
-        'Update a host address')
-    def _update_set_addr(self, hostname, addr):
+    @_cli_write_command('orch host set-addr')
+    def _update_set_addr(self, hostname: str, addr: str):
+        """Update a host address"""
         completion = self.update_host_addr(hostname, addr)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_read_command(
-        'orch host ls',
-        'name=format,type=CephChoices,strings=plain|json|json-pretty|yaml,req=false',
-        'List hosts')
-    def _get_hosts(self, format='plain'):
+    @_cli_read_command('orch host ls')
+    def _get_hosts(self, format: Format = Format.plain):
+        """List hosts"""
         completion = self.get_hosts()
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
-        if format != 'plain':
+        if format != Format.plain:
             output = to_format(completion.result, format, many=True, cls=HostSpec)
         else:
             table = PrettyTable(
@@ -334,43 +367,36 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
             output = table.get_string()
         return HandleCommandResult(stdout=output)
 
-    @_cli_write_command(
-        'orch host label add',
-        'name=hostname,type=CephString '
-        'name=label,type=CephString',
-        'Add a host label')
-    def _host_label_add(self, hostname, label):
+    @_cli_write_command('orch host label add')
+    def _host_label_add(self, hostname: str, label: str):
+        """Add a host label"""
         completion = self.add_host_label(hostname, label)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch host label rm',
-        'name=hostname,type=CephString '
-        'name=label,type=CephString',
-        'Remove a host label')
-    def _host_label_rm(self, hostname, label):
+    @_cli_write_command('orch host label rm')
+    def _host_label_rm(self, hostname: str, label: str):
+        """Remove a host label"""
         completion = self.remove_host_label(hostname, label)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch host ok-to-stop',
-        'name=hostname,type=CephString',
-        desc='Check if the specified host can be safely stopped without reducing availability')
+    @_cli_write_command('orch host ok-to-stop')
     def _host_ok_to_stop(self, hostname: str):
+        """Check if the specified host can be safely stopped without reducing availability"""""
         completion = self.host_ok_to_stop(hostname)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command(
-        'orch host maintenance enter',
-        'name=hostname,type=CephString',
-        desc='Prepare a host for maintenance by shutting down and disabling all Ceph daemons (cephadm only)')
+        'orch host maintenance enter')
     def _host_maintenance_enter(self, hostname: str):
+        """
+        Prepare a host for maintenance by shutting down and disabling all Ceph daemons (cephadm only)
+        """
         completion = self.enter_host_maintenance(hostname)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
@@ -378,32 +404,31 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         return HandleCommandResult(stdout=completion.result_str())
 
     @_cli_write_command(
-        'orch host maintenance exit',
-        'name=hostname,type=CephString',
-        desc='Return a host from maintenance, restarting all Ceph daemons (cephadm only)')
+        'orch host maintenance exit')
     def _host_maintenance_exit(self, hostname: str):
+        """
+        Return a host from maintenance, restarting all Ceph daemons (cephadm only)
+        """
         completion = self.exit_host_maintenance(hostname)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
 
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_read_command(
-        'orch device ls',
-        "name=hostname,type=CephString,n=N,req=false "
-        "name=format,type=CephChoices,strings=plain|json|json-pretty|yaml,req=false "
-        "name=refresh,type=CephBool,req=false "
-        "name=wide,type=CephBool,req=false",
-        'List devices on a host')
-    def _list_devices(self, hostname=None, format='plain', refresh=False, wide=False):
-        # type: (Optional[List[str]], str, bool, bool) -> HandleCommandResult
+    @_cli_read_command('orch device ls')
+    def _list_devices(self,
+                      hostname: Optional[List[str]] = None,
+                      format: Format = Format.plain,
+                      refresh: bool = False,
+                      wide: bool = False) -> HandleCommandResult:
         """
-        Provide information about storage devices present in cluster hosts
-
-        Note: this does not have to be completely synchronous. Slightly out of
-        date hardware inventory is fine as long as hardware ultimately appears
-        in the output of this command.
+        List devices on a host
         """
+        # Provide information about storage devices present in cluster hosts
+        #
+        # Note: this does not have to be completely synchronous. Slightly out of
+        # date hardware inventory is fine as long as hardware ultimately appears
+        # in the output of this command.
         nf = InventoryFilter(hosts=hostname) if hostname else None
 
         completion = self.get_inventory(host_filter=nf, refresh=refresh)
@@ -411,8 +436,11 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
 
-        if format != 'plain':
-            return HandleCommandResult(stdout=to_format(completion.result, format, many=True, cls=InventoryHost))
+        if format != Format.plain:
+            return HandleCommandResult(stdout=to_format(completion.result,
+                                                        format,
+                                                        many=True,
+                                                        cls=InventoryHost))
         else:
             display_map = {
                 "Unsupported": "N/A",
@@ -489,13 +517,11 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
             out.append(table.get_string())
             return HandleCommandResult(stdout='\n'.join(out))
 
-    @_cli_write_command(
-        'orch device zap',
-        'name=hostname,type=CephString '
-        'name=path,type=CephString '
-        'name=force,type=CephBool,req=false',
-        'Zap (erase!) a device so it can be re-used')
-    def _zap_device(self, hostname, path, force=False):
+    @_cli_write_command('orch device zap')
+    def _zap_device(self, hostname: str, path: str, force: bool = False):
+        """
+        Zap (erase!) a device so it can be re-used
+        """
         if not force:
             raise OrchestratorError('must pass --force to PERMANENTLY ERASE DEVICE DATA')
         completion = self.zap_device(hostname, path)
@@ -503,18 +529,19 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_read_command(
-        'orch ls',
-        "name=service_type,type=CephString,req=false "
-        "name=service_name,type=CephString,req=false "
-        "name=export,type=CephBool,req=false "
-        "name=format,type=CephChoices,strings=plain|json|json-pretty|yaml,req=false "
-        "name=refresh,type=CephBool,req=false",
-        'List services known to orchestrator')
-    def _list_services(self, host=None, service_type=None, service_name=None, export=False, format='plain', refresh=False):
-
-        if export and format == 'plain':
-            format = 'yaml'
+    @_cli_read_command('orch ls')
+    def _list_services(self,
+                       host: Optional[str] = None,
+                       service_type: Optional[str] = None,
+                       service_name: Optional[str] = None,
+                       export: bool = False,
+                       format: Format = Format.plain,
+                       refresh: bool = False):
+        """
+        List services known to orchestrator
+        """
+        if export and format == Format.plain:
+            format = Format.yaml
 
         completion = self.describe_service(service_type,
                                            service_name,
@@ -531,7 +558,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
 
         if len(services) == 0:
             return HandleCommandResult(stdout="No services reported")
-        elif format != 'plain':
+        elif format != Format.plain:
             if export:
                 data = [s.spec for s in services]
                 return HandleCommandResult(stdout=to_format(data, format, many=True, cls=ServiceSpec))
@@ -573,16 +600,17 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
 
             return HandleCommandResult(stdout=table.get_string())
 
-    @_cli_read_command(
-        'orch ps',
-        "name=hostname,type=CephString,req=false "
-        "name=service_name,type=CephString,req=false "
-        "name=daemon_type,type=CephString,req=false "
-        "name=daemon_id,type=CephString,req=false "
-        "name=format,type=CephChoices,strings=plain|json|json-pretty|yaml,req=false "
-        "name=refresh,type=CephBool,req=false",
-        'List daemons known to orchestrator')
-    def _list_daemons(self, hostname=None, service_name=None, daemon_type=None, daemon_id=None, format='plain', refresh=False):
+    @_cli_read_command('orch ps')
+    def _list_daemons(self,
+                      hostname: Optional[str] = None,
+                      service_name: Optional[str] = None,
+                      daemon_type: Optional[str] = None,
+                      daemon_id: Optional[str] = None,
+                      format: Format = Format.plain,
+                      refresh: bool = False):
+        """
+        List daemons known to orchestrator
+        """
         completion = self.list_daemons(service_name,
                                        daemon_type,
                                        daemon_id=daemon_id,
@@ -597,7 +625,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         # Sort the list for display
         daemons.sort(key=lambda s: (ukn(s.daemon_type), ukn(s.hostname), ukn(s.daemon_id)))
 
-        if format != 'plain':
+        if format != Format.plain:
             return HandleCommandResult(stdout=to_format(daemons, format, many=True, cls=DaemonDescription))
         else:
             if len(daemons) == 0:
@@ -649,20 +677,17 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
 
             return HandleCommandResult(stdout=table.get_string())
 
-    @_cli_write_command(
-        'orch apply osd',
-        'name=all_available_devices,type=CephBool,req=false '
-        'name=dry_run,type=CephBool,req=false '
-        'name=unmanaged,type=CephBool,req=false '
-        "name=format,type=CephChoices,strings=plain|json|json-pretty|yaml,req=false",
-        'Create OSD daemon(s) using a drive group spec')
+    @_cli_write_command('orch apply osd')
     def _apply_osd(self,
                    all_available_devices: bool = False,
-                   format: str = 'plain',
-                   unmanaged=None,
-                   dry_run=None,
+                   format: Format = Format.plain,
+                   unmanaged: Optional[bool] = None,
+                   dry_run: bool = False,
                    inbuf: Optional[str] = None) -> HandleCommandResult:
-        """Apply DriveGroupSpecs to create OSDs"""
+        """
+        Create OSD daemon(s) using a drive group spec
+        """
+        # Apply DriveGroupSpecs to create OSDs
         usage = """
 usage:
   ceph orch apply osd -i <json_file/yaml_file> [--dry-run]
@@ -737,7 +762,7 @@ Examples:
                 self._orchestrator_wait([completion])
                 raise_if_exception(completion)
                 data = completion.result
-                if format == 'plain':
+                if format == Format.plain:
                     out = generate_preview_tables(data, True)
                 else:
                     out = to_format(data, format, many=True, cls=None)
@@ -764,7 +789,7 @@ Examples:
                 completion = self.plan(dg_specs)
                 self._orchestrator_wait([completion])
                 data = completion.result
-                if format == 'plain':
+                if format == Format.plain:
                     out = generate_preview_tables(data, True)
                 else:
                     out = to_format(data, format, many=True, cls=None)
@@ -772,13 +797,10 @@ Examples:
 
         return HandleCommandResult(-errno.EINVAL, stderr=usage)
 
-    @_cli_write_command(
-        'orch daemon add osd',
-        "name=svc_arg,type=CephString,req=false",
-        'Create an OSD service. Either --svc_arg=host:drives')
-    def _daemon_add_osd(self, svc_arg=None):
-        # type: (Optional[str]) -> HandleCommandResult
-        """Create one or more OSDs"""
+    @_cli_write_command('orch daemon add osd')
+    def _daemon_add_osd(self, svc_arg: Optional[str] = None) -> HandleCommandResult:
+        """Create an OSD service. Either --svc_arg=host:drives"""
+        # Create one or more OSDs"""
 
         usage = """
 Usage:
@@ -801,36 +823,28 @@ Usage:
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch osd rm',
-        "name=svc_id,type=CephString,n=N "
-        "name=replace,type=CephBool,req=false "
-        "name=force,type=CephBool,req=false",
-        'Remove OSD services')
+    @_cli_write_command('orch osd rm')
     def _osd_rm_start(self,
                       svc_id: List[str],
                       replace: bool = False,
                       force: bool = False) -> HandleCommandResult:
+        """Remove OSD services"""
         completion = self.remove_osds(svc_id, replace=replace, force=force)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch osd rm stop',
-        "name=svc_id,type=CephString,n=N",
-        'Remove OSD services')
+    @_cli_write_command('orch osd rm stop')
     def _osd_rm_stop(self, svc_id: List[str]) -> HandleCommandResult:
+        """Remove OSD services"""
         completion = self.stop_remove_osds(svc_id)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch osd rm status',
-        "name=format,type=CephChoices,strings=plain|json|json-pretty|yaml,req=false",
-        desc='status of OSD removal operation')
-    def _osd_rm_status(self, format='plain') -> HandleCommandResult:
+    @_cli_write_command('orch osd rm status')
+    def _osd_rm_status(self, format: Format = Format.plain) -> HandleCommandResult:
+        """status of OSD removal operation"""
         completion = self.remove_osds_status()
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
@@ -839,7 +853,7 @@ Usage:
         if not report:
             return HandleCommandResult(stdout="No OSD remove/replace operations reported")
 
-        if format != 'plain':
+        if format != Format.plain:
             out = to_format(report, format, many=True, cls=None)
         else:
             table = PrettyTable(
@@ -855,15 +869,12 @@ Usage:
 
         return HandleCommandResult(stdout=out)
 
-    @_cli_write_command(
-        'orch daemon add',
-        'name=daemon_type,type=CephChoices,strings=mon|mgr|rbd-mirror|crash|alertmanager|grafana|node-exporter|prometheus|cephadm-exporter,req=false '
-        'name=placement,type=CephString,req=false',
-        'Add daemon(s)')
+    @_cli_write_command('orch daemon add')
     def _daemon_add_misc(self,
-                         daemon_type: Optional[str] = None,
+                         daemon_type: Optional[ServiceType] = None,
                          placement: Optional[str] = None,
                          inbuf: Optional[str] = None) -> HandleCommandResult:
+        """Add daemon(s)"""
         usage = f"""Usage:
     ceph orch daemon add -i <json_file>
     ceph orch daemon add {daemon_type or '<daemon_type>'} <placement>"""
@@ -874,52 +885,48 @@ Usage:
         else:
             spec = PlacementSpec.from_string(placement)
             assert daemon_type
-            spec = ServiceSpec(daemon_type, placement=spec)
+            spec = ServiceSpec(daemon_type.value, placement=spec)
 
-        daemon_type = spec.service_type
-
-        if daemon_type == 'mon':
+        if daemon_type == ServiceType.mon:
             completion = self.add_mon(spec)
-        elif daemon_type == 'mgr':
+        elif daemon_type == ServiceType.mgr:
             completion = self.add_mgr(spec)
-        elif daemon_type == 'rbd-mirror':
+        elif daemon_type == ServiceType.rbd_mirror:
             completion = self.add_rbd_mirror(spec)
-        elif daemon_type == 'crash':
+        elif daemon_type == ServiceType.crash:
             completion = self.add_crash(spec)
-        elif daemon_type == 'alertmanager':
+        elif daemon_type == ServiceType.alertmanager:
             completion = self.add_alertmanager(spec)
-        elif daemon_type == 'grafana':
+        elif daemon_type == ServiceType.grafana:
             completion = self.add_grafana(spec)
-        elif daemon_type == 'node-exporter':
+        elif daemon_type == ServiceType.node_exporter:
             completion = self.add_node_exporter(spec)
-        elif daemon_type == 'prometheus':
+        elif daemon_type == ServiceType.prometheus:
             completion = self.add_prometheus(spec)
-        elif daemon_type == 'mds':
+        elif daemon_type == ServiceType.mds:
             completion = self.add_mds(spec)
-        elif daemon_type == 'rgw':
+        elif daemon_type == ServiceType.rgw:
             completion = self.add_rgw(spec)
-        elif daemon_type == 'nfs':
+        elif daemon_type == ServiceType.nfs:
             completion = self.add_nfs(spec)
-        elif daemon_type == 'iscsi':
+        elif daemon_type == ServiceType.iscsi:
             completion = self.add_iscsi(spec)
-        elif daemon_type == 'cephadm-exporter':
+        elif daemon_type == ServiceType.cephadm_exporter:
             completion = self.add_cephadm_exporter(spec)
         else:
-            raise OrchestratorValidationError(f'unknown daemon type `{daemon_type}`')
+            tp = type(daemon_type)
+            raise OrchestratorValidationError(f'unknown daemon type `{tp}`')
 
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch daemon add mds',
-        'name=fs_name,type=CephString '
-        'name=placement,type=CephString,req=false',
-        'Start MDS daemon(s)')
+    @_cli_write_command('orch daemon add mds')
     def _mds_add(self,
                  fs_name: str,
                  placement: Optional[str] = None,
                  inbuf: Optional[str] = None) -> HandleCommandResult:
+        """Start MDS daemon(s)"""
         if inbuf:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
@@ -934,15 +941,7 @@ Usage:
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch daemon add rgw',
-        'name=realm_name,type=CephString '
-        'name=zone_name,type=CephString '
-        'name=subcluster,type=CephString,req=false '
-        'name=port,type=CephInt,req=false '
-        'name=ssl,type=CephBool,req=false '
-        'name=placement,type=CephString,req=false',
-        'Start RGW daemon(s)')
+    @_cli_write_command('orch daemon add rgw')
     def _rgw_add(self,
                  realm_name: str,
                  zone_name: str,
@@ -951,6 +950,7 @@ Usage:
                  ssl: bool = False,
                  placement: Optional[str] = None,
                  inbuf: Optional[str] = None) -> HandleCommandResult:
+        """Start RGW daemon(s)"""
         if inbuf:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
@@ -968,19 +968,14 @@ Usage:
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch daemon add nfs',
-        "name=svc_id,type=CephString "
-        "name=pool,type=CephString "
-        "name=namespace,type=CephString,req=false "
-        'name=placement,type=CephString,req=false',
-        'Start NFS daemon(s)')
+    @_cli_write_command('orch daemon add nfs')
     def _nfs_add(self,
                  svc_id: str,
                  pool: str,
                  namespace: Optional[str] = None,
                  placement: Optional[str] = None,
                  inbuf: Optional[str] = None) -> HandleCommandResult:
+        """Start NFS daemon(s)"""
         if inbuf:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
@@ -996,14 +991,7 @@ Usage:
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch daemon add iscsi',
-        'name=pool,type=CephString '
-        'name=api_user,type=CephString '
-        'name=api_password,type=CephString '
-        'name=trusted_ip_list,type=CephString,req=false '
-        'name=placement,type=CephString,req=false',
-        'Start iscsi daemon(s)')
+    @_cli_write_command('orch daemon add iscsi')
     def _iscsi_add(self,
                    pool: str,
                    api_user: str,
@@ -1011,6 +999,7 @@ Usage:
                    trusted_ip_list: Optional[str] = None,
                    placement: Optional[str] = None,
                    inbuf: Optional[str] = None) -> HandleCommandResult:
+        """Start iscsi daemon(s)"""
         if inbuf:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
@@ -1028,36 +1017,27 @@ Usage:
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch',
-        "name=action,type=CephChoices,strings=start|stop|restart|redeploy|reconfig "
-        "name=service_name,type=CephString",
-        'Start, stop, restart, redeploy, or reconfig an entire service (i.e. all daemons)')
-    def _service_action(self, action, service_name):
-        completion = self.service_action(action, service_name)
+    @_cli_write_command('orch')
+    def _service_action(self, action: ServiceAction, service_name: str):
+        """Start, stop, restart, redeploy, or reconfig an entire service (i.e. all daemons)"""
+        completion = self.service_action(action.value, service_name)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch daemon',
-        "name=action,type=CephChoices,strings=start|stop|restart|reconfig "
-        "name=name,type=CephString",
-        'Start, stop, restart, (redeploy,) or reconfig a specific daemon')
-    def _daemon_action(self, action, name):
+    @_cli_write_command('orch daemon')
+    def _daemon_action(self, action: DaemonAction, name: str):
+        """Start, stop, restart, (redeploy,) or reconfig a specific daemon"""
         if '.' not in name:
             raise OrchestratorError('%s is not a valid daemon name' % name)
-        completion = self.daemon_action(action, name)
+        completion = self.daemon_action(action.value, name)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch daemon redeploy',
-        "name=name,type=CephString "
-        "name=image,type=CephString,req=false",
-        'Redeploy a daemon (with a specifc image)')
+    @_cli_write_command('orch daemon redeploy')
     def _daemon_action_redeploy(self, name: str, image: Optional[str] = None) -> HandleCommandResult:
+        """Redeploy a daemon (with a specifc image)"""
         if '.' not in name:
             raise OrchestratorError('%s is not a valid daemon name' % name)
         completion = self.daemon_action("redeploy", name, image=image)
@@ -1065,12 +1045,11 @@ Usage:
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch daemon rm',
-        "name=names,type=CephString,n=N "
-        'name=force,type=CephBool,req=false',
-        'Remove specific daemon(s)')
-    def _daemon_rm(self, names, force=False):
+    @_cli_write_command('orch daemon rm')
+    def _daemon_rm(self,
+                   names: List[str],
+                   force: Optional[bool] = False):
+        """Remove specific daemon(s)"""
         for name in names:
             if '.' not in name:
                 raise OrchestratorError('%s is not a valid daemon name' % name)
@@ -1083,12 +1062,11 @@ Usage:
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch rm',
-        'name=service_name,type=CephString '
-        'name=force,type=CephBool,req=false',
-        'Remove a service')
-    def _service_rm(self, service_name, force=False):
+    @_cli_write_command('orch rm')
+    def _service_rm(self,
+                    service_name: str,
+                    force: bool = False):
+        """Remove a service"""
         if service_name in ['mon', 'mgr'] and not force:
             raise OrchestratorError('The mon and mgr services cannot be removed')
         completion = self.remove_service(service_name)
@@ -1096,21 +1074,15 @@ Usage:
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch apply',
-        'name=service_type,type=CephChoices,strings=mon|mgr|rbd-mirror|crash|alertmanager|grafana|node-exporter|prometheus|cephadm-exporter,req=false '
-        'name=placement,type=CephString,req=false '
-        'name=dry_run,type=CephBool,req=false '
-        'name=format,type=CephChoices,strings=plain|json|json-pretty|yaml,req=false '
-        'name=unmanaged,type=CephBool,req=false',
-        'Update the size or placement for a service or apply a large yaml spec')
+    @_cli_write_command('orch apply')
     def _apply_misc(self,
-                    service_type: Optional[str] = None,
+                    service_type: Optional[ServiceType] = None,
                     placement: Optional[str] = None,
                     dry_run: bool = False,
-                    format: str = 'plain',
+                    format: Format = Format.plain,
                     unmanaged: bool = False,
                     inbuf: Optional[str] = None) -> HandleCommandResult:
+        """Update the size or placement for a service or apply a large yaml spec"""
         usage = """Usage:
   ceph orch apply -i <yaml spec> [--dry-run]
   ceph orch apply <service_type> [--placement=<placement_string>] [--unmanaged]
@@ -1128,7 +1100,7 @@ Usage:
         else:
             placementspec = PlacementSpec.from_string(placement)
             assert service_type
-            specs = [ServiceSpec(service_type, placement=placementspec,
+            specs = [ServiceSpec(service_type.value, placement=placementspec,
                                  unmanaged=unmanaged, preview_only=dry_run)]
 
         completion = self.apply(specs)
@@ -1140,27 +1112,21 @@ Usage:
             self._orchestrator_wait([completion])
             raise_if_exception(completion)
             data = completion.result
-            if format == 'plain':
+            if format == Format.plain:
                 out = generate_preview_tables(data)
             else:
                 out = to_format(data, format, many=True, cls=None)
         return HandleCommandResult(stdout=out)
 
-    @_cli_write_command(
-        'orch apply mds',
-        'name=fs_name,type=CephString '
-        'name=placement,type=CephString,req=false '
-        'name=dry_run,type=CephBool,req=false '
-        'name=unmanaged,type=CephBool,req=false '
-        'name=format,type=CephChoices,strings=plain|json|json-pretty|yaml,req=false',
-        'Update the number of MDS instances for the given fs_name')
+    @_cli_write_command('orch apply mds')
     def _apply_mds(self,
                    fs_name: str,
                    placement: Optional[str] = None,
                    dry_run: bool = False,
                    unmanaged: bool = False,
-                   format: str = 'plain',
+                   format: Format = Format.plain,
                    inbuf: Optional[str] = None) -> HandleCommandResult:
+        """Update the number of MDS instances for the given fs_name"""
         if inbuf:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
@@ -1180,24 +1146,13 @@ Usage:
             self._orchestrator_wait([completion_plan])
             raise_if_exception(completion_plan)
             data = completion_plan.result
-            if format == 'plain':
+            if format == Format.plain:
                 out = preview_table_services(data)
             else:
                 out = to_format(data, format, many=True, cls=None)
         return HandleCommandResult(stdout=out)
 
-    @_cli_write_command(
-        'orch apply rgw',
-        'name=realm_name,type=CephString '
-        'name=zone_name,type=CephString '
-        'name=subcluster,type=CephString,req=false '
-        'name=port,type=CephInt,req=false '
-        'name=ssl,type=CephBool,req=false '
-        'name=placement,type=CephString,req=false '
-        'name=dry_run,type=CephBool,req=false '
-        'name=format,type=CephChoices,strings=plain|json|json-pretty|yaml,req=false '
-        'name=unmanaged,type=CephBool,req=false',
-        'Update the number of RGW instances for the given zone')
+    @_cli_write_command('orch apply rgw')
     def _apply_rgw(self,
                    realm_name: str,
                    zone_name: str,
@@ -1206,9 +1161,10 @@ Usage:
                    ssl: bool = False,
                    placement: Optional[str] = None,
                    dry_run: bool = False,
-                   format: str = 'plain',
+                   format: Format = Format.plain,
                    unmanaged: bool = False,
                    inbuf: Optional[str] = None) -> HandleCommandResult:
+        """Update the number of RGW instances for the given zone"""
         if inbuf:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
@@ -1232,31 +1188,23 @@ Usage:
             self._orchestrator_wait([completion_plan])
             raise_if_exception(completion_plan)
             data = completion_plan.result
-            if format == 'plain':
+            if format == Format.plain:
                 out = preview_table_services(data)
             else:
                 out = to_format(data, format, many=True, cls=None)
         return HandleCommandResult(stdout=out)
 
-    @_cli_write_command(
-        'orch apply nfs',
-        'name=svc_id,type=CephString '
-        'name=pool,type=CephString '
-        'name=namespace,type=CephString,req=false '
-        'name=placement,type=CephString,req=false '
-        'name=dry_run,type=CephBool,req=false '
-        'name=format,type=CephChoices,strings=plain|json|json-pretty|yaml,req=false '
-        'name=unmanaged,type=CephBool,req=false',
-        'Scale an NFS service')
+    @_cli_write_command('orch apply nfs')
     def _apply_nfs(self,
                    svc_id: str,
                    pool: str,
                    namespace: Optional[str] = None,
                    placement: Optional[str] = None,
-                   format: str = 'plain',
+                   format: Format = Format.plain,
                    dry_run: bool = False,
                    unmanaged: bool = False,
                    inbuf: Optional[str] = None) -> HandleCommandResult:
+        """Scale an NFS service"""
         if inbuf:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
@@ -1278,23 +1226,13 @@ Usage:
             self._orchestrator_wait([completion_plan])
             raise_if_exception(completion_plan)
             data = completion_plan.result
-            if format == 'plain':
+            if format == Format.plain:
                 out = preview_table_services(data)
             else:
                 out = to_format(data, format, many=True, cls=None)
         return HandleCommandResult(stdout=out)
 
-    @_cli_write_command(
-        'orch apply iscsi',
-        'name=pool,type=CephString '
-        'name=api_user,type=CephString '
-        'name=api_password,type=CephString '
-        'name=trusted_ip_list,type=CephString,req=false '
-        'name=placement,type=CephString,req=false '
-        'name=dry_run,type=CephBool,req=false '
-        'name=format,type=CephChoices,strings=plain|json|json-pretty|yaml,req=false '
-        'name=unmanaged,type=CephBool,req=false',
-        'Scale an iSCSI service')
+    @_cli_write_command('orch apply iscsi')
     def _apply_iscsi(self,
                      pool: str,
                      api_user: str,
@@ -1303,8 +1241,9 @@ Usage:
                      placement: Optional[str] = None,
                      unmanaged: bool = False,
                      dry_run: bool = False,
-                     format: str = 'plain',
+                     format: Format = Format.plain,
                      inbuf: Optional[str] = None) -> HandleCommandResult:
+        """Scale an iSCSI service"""
         if inbuf:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
@@ -1328,25 +1267,23 @@ Usage:
             self._orchestrator_wait([completion_plan])
             raise_if_exception(completion_plan)
             data = completion_plan.result
-            if format == 'plain':
+            if format == Format.plain:
                 out = preview_table_services(data)
             else:
                 out = to_format(data, format, many=True, cls=None)
         return HandleCommandResult(stdout=out)
 
-    @_cli_write_command(
-        'orch set backend',
-        "name=module_name,type=CephString,req=true",
-        'Select orchestrator module backend')
-    def _set_backend(self, module_name):
+    @_cli_write_command('orch set backend')
+    def _set_backend(self, module_name: Optional[str] = None):
         """
-        We implement a setter command instead of just having the user
-        modify the setting directly, so that we can validate they're setting
-        it to a module that really exists and is enabled.
+        Select orchestrator module backend
+        """
+        # We implement a setter command instead of just having the user
+        # modify the setting directly, so that we can validate they're setting
+        # it to a module that really exists and is enabled.
 
-        There isn't a mechanism for ensuring they don't *disable* the module
-        later, but this is better than nothing.
-        """
+        # There isn't a mechanism for ensuring they don't *disable* the module
+        # later, but this is better than nothing.
         mgr_map = self.get("mgr_map")
 
         if module_name is None or module_name == "":
@@ -1383,35 +1320,31 @@ Usage:
 
         return HandleCommandResult(-errno.EINVAL, stderr="Module '{0}' not found".format(module_name))
 
-    @_cli_write_command(
-        'orch pause',
-        desc='Pause orchestrator background work')
+    @_cli_write_command('orch pause')
     def _pause(self):
+        """Pause orchestrator background work"""
         self.pause()
         return HandleCommandResult()
 
-    @_cli_write_command(
-        'orch resume',
-        desc='Resume orchestrator background work (if paused)')
+    @_cli_write_command('orch resume')
     def _resume(self):
+        """Resume orchestrator background work (if paused)"""
         self.resume()
         return HandleCommandResult()
 
-    @_cli_write_command(
-        'orch cancel',
-        desc='cancels ongoing operations')
+    @_cli_write_command('orch cancel')
     def _cancel(self):
         """
+        cancels ongoing operations
+
         ProgressReferences might get stuck. Let's unstuck them.
         """
         self.cancel_completions()
         return HandleCommandResult()
 
-    @_cli_read_command(
-        'orch status',
-        'name=format,type=CephChoices,strings=plain|json|json-pretty|yaml,req=false',
-        desc='Report configured backend and its status')
-    def _status(self, format='plain'):
+    @_cli_read_command('orch status')
+    def _status(self, format: Format = Format.plain):
+        """Report configured backend and its status"""
         o = self._select_orchestrator()
         if o is None:
             raise NoOrchestrator()
@@ -1425,7 +1358,7 @@ Usage:
             if not avail:
                 result['reason'] = why
 
-        if format != 'plain':
+        if format != Format.plain:
             output = to_format(result, format, many=False, cls=None)
         else:
             output = "Backend: {0}".format(result['backend'])
@@ -1473,22 +1406,20 @@ Usage:
                 f"  Maybe you meant `--ceph-version {ver}`?"
             raise OrchestratorValidationError(s)
 
-    @_cli_write_command(
-        'orch upgrade check',
-        'name=image,type=CephString,req=false '
-        'name=ceph_version,type=CephString,req=false',
-        desc='Check service versions vs available and target containers')
-    def _upgrade_check(self, image=None, ceph_version=None):
+    @_cli_write_command('orch upgrade check')
+    def _upgrade_check(self,
+                       image: Optional[str] = None,
+                       ceph_version: Optional[str] = None):
+        """Check service versions vs available and target containers"""
         self._upgrade_check_image_name(image, ceph_version)
         completion = self.upgrade_check(image=image, version=ceph_version)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch upgrade status',
-        desc='Check service versions vs available and target containers')
+    @_cli_write_command('orch upgrade status')
     def _upgrade_status(self):
+        """Check service versions vs available and target containers"""
         completion = self.upgrade_status()
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
@@ -1501,40 +1432,36 @@ Usage:
         out = json.dumps(r, indent=4)
         return HandleCommandResult(stdout=out)
 
-    @_cli_write_command(
-        'orch upgrade start',
-        'name=image,type=CephString,req=false '
-        'name=ceph_version,type=CephString,req=false',
-        desc='Initiate upgrade')
-    def _upgrade_start(self, image=None, ceph_version=None):
+    @_cli_write_command('orch upgrade start')
+    def _upgrade_start(self,
+                       image: Optional[str] = None,
+                       ceph_version: Optional[str] = None):
+        """Initiate upgrade"""
         self._upgrade_check_image_name(image, ceph_version)
         completion = self.upgrade_start(image, ceph_version)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch upgrade pause',
-        desc='Pause an in-progress upgrade')
+    @_cli_write_command('orch upgrade pause')
     def _upgrade_pause(self):
+        """Pause an in-progress upgrade"""
         completion = self.upgrade_pause()
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch upgrade resume',
-        desc='Resume paused upgrade')
+    @_cli_write_command('orch upgrade resume')
     def _upgrade_resume(self):
+        """Resume paused upgrade"""
         completion = self.upgrade_resume()
         self._orchestrator_wait([completion])
         raise_if_exception(completion)
         return HandleCommandResult(stdout=completion.result_str())
 
-    @_cli_write_command(
-        'orch upgrade stop',
-        desc='Stop an in-progress upgrade')
+    @_cli_write_command('orch upgrade stop')
     def _upgrade_stop(self):
+        """Stop an in-progress upgrade"""
         completion = self.upgrade_stop()
         self._orchestrator_wait([completion])
         raise_if_exception(completion)

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -16,7 +16,7 @@ from tests import mock
 from orchestrator import raise_if_exception, Completion, ProgressReference
 from orchestrator import InventoryHost, DaemonDescription, ServiceDescription
 from orchestrator import OrchestratorValidationError
-from orchestrator.module import to_format, OrchestratorCli, preview_table_osd
+from orchestrator.module import to_format, Format, OrchestratorCli, preview_table_osd
 
 
 def _test_resource(data, resource_class, extra=None):
@@ -281,11 +281,11 @@ events:
         data = yaml.safe_load(y)
         object = cls.from_json(data)
 
-        assert to_format(object, 'yaml', False, cls) == y
-        assert to_format([object], 'yaml', True, cls) == y
+        assert to_format(object, Format.yaml, False, cls) == y
+        assert to_format([object], Format.yaml, True, cls) == y
 
-        j = json.loads(to_format(object, 'json', False, cls))
-        assert to_format(cls.from_json(j), 'yaml', False, cls) == y
+        j = json.loads(to_format(object, Format.json, False, cls))
+        assert to_format(cls.from_json(j), Format.yaml, False, cls) == y
 
 
 def test_event_multiline():

--- a/src/pybind/mgr/snap_schedule/module.py
+++ b/src/pybind/mgr/snap_schedule/module.py
@@ -6,6 +6,7 @@ LGPL2.1.  See file COPYING.
 import errno
 import json
 import sqlite3
+from typing import Sequence, Optional
 from .fs.schedule_client import SnapSchedClient
 from mgr_module import MgrModule, CLIReadCommand, CLIWriteCommand, Option
 from mgr_util import CephfsConnectionException
@@ -56,12 +57,12 @@ class Module(MgrModule):
         self._initialized.wait()
         return -errno.EINVAL, "", "Unknown command"
 
-    @CLIReadCommand('fs snap-schedule status',
-                    'name=path,type=CephString,req=false '
-                    'name=subvol,type=CephString,req=false '
-                    'name=fs,type=CephString,req=false '
-                    'name=format,type=CephString,req=false')
-    def snap_schedule_get(self, path='/', subvol=None, fs=None, format='plain'):
+    @CLIReadCommand('fs snap-schedule status')
+    def snap_schedule_get(self,
+                          path: Optional[str] = '/',
+                          subvol: Optional[str] = None,
+                          fs: Optional[str] = None,
+                          format: Optional[str] = 'plain'):
         '''
         List current snapshot schedules
         '''
@@ -75,14 +76,12 @@ class Module(MgrModule):
             return 0, f'{json_report}', ''
         return 0, '\n===\n'.join([ret_sched.report() for ret_sched in ret_scheds]), ''
 
-    @CLIReadCommand('fs snap-schedule list',
-                    'name=path,type=CephString '
-                    'name=recursive,type=CephString,req=false '
-                    'name=subvol,type=CephString,req=false '
-                    'name=fs,type=CephString,req=false '
-                    'name=format,type=CephString,req=false')
-    def snap_schedule_list(self, path, subvol=None, recursive=False, fs=None,
-                           format='plain'):
+    @CLIReadCommand('fs snap-schedule list')
+    def snap_schedule_list(self, path: str,
+                           subvol: Optional[str] = None,
+                           recursive: Optional[bool] = False,
+                           fs: Optional[str] = None,
+                           format: Optional[str] = 'plain'):
         '''
         Get current snapshot schedule for <path>
         '''
@@ -102,18 +101,13 @@ class Module(MgrModule):
             return 0, json.dumps(out), ''
         return 0, '\n'.join([str(sched) for sched in scheds]), ''
 
-    @CLIWriteCommand('fs snap-schedule add',
-                     'name=path,type=CephString '
-                     'name=snap-schedule,type=CephString '
-                     'name=start,type=CephString,req=false '
-                     'name=fs,type=CephString,req=false '
-                     'name=subvol,type=CephString,req=false')
+    @CLIWriteCommand('fs snap-schedule add')
     def snap_schedule_add(self,
-                          path,
-                          snap_schedule,
-                          start=None,
-                          fs=None,
-                          subvol=None):
+                          path: str,
+                          snap_schedule: Optional[str],
+                          start: Optional[str] = None,
+                          fs: Optional[str] = None,
+                          subvol: Optional[str] = None):
         '''
         Set a snapshot schedule for <path>
         '''
@@ -137,18 +131,13 @@ class Module(MgrModule):
             return e.to_tuple()
         return 0, suc_msg, ''
 
-    @CLIWriteCommand('fs snap-schedule remove',
-                     'name=path,type=CephString '
-                     'name=repeat,type=CephString,req=false '
-                     'name=start,type=CephString,req=false '
-                     'name=subvol,type=CephString,req=false '
-                     'name=fs,type=CephString,req=false')
+    @CLIWriteCommand('fs snap-schedule remove')
     def snap_schedule_rm(self,
-                         path,
-                         repeat=None,
-                         start=None,
-                         subvol=None,
-                         fs=None):
+                         path: str,
+                         repeat: Optional[str] = None,
+                         start: Optional[str] = None,
+                         subvol: Optional[str] = None,
+                         fs: Optional[str] = None):
         '''
         Remove a snapshot schedule for <path>
         '''
@@ -162,18 +151,13 @@ class Module(MgrModule):
             return -errno.ENOENT, '', str(e)
         return 0, 'Schedule removed for path {}'.format(path), ''
 
-    @CLIWriteCommand('fs snap-schedule retention add',
-                     'name=path,type=CephString '
-                     'name=retention-spec-or-period,type=CephString '
-                     'name=retention-count,type=CephString,req=false '
-                     'name=fs,type=CephString,req=false '
-                     'name=subvol,type=CephString,req=false')
+    @CLIWriteCommand('fs snap-schedule retention add')
     def snap_schedule_retention_add(self,
-                                    path,
-                                    retention_spec_or_period,
-                                    retention_count=None,
-                                    fs=None,
-                                    subvol=None):
+                                    path: str,
+                                    retention_spec_or_period: str,
+                                    retention_count: Optional[str] = None,
+                                    fs: Optional[str] = None,
+                                    subvol: Optional[str] = None):
         '''
         Set a retention specification for <path>
         '''
@@ -189,18 +173,13 @@ class Module(MgrModule):
             return -errno.ENOENT, '', str(e)
         return 0, 'Retention added to path {}'.format(path), ''
 
-    @CLIWriteCommand('fs snap-schedule retention remove',
-                     'name=path,type=CephString '
-                     'name=retention-spec-or-period,type=CephString '
-                     'name=retention-count,type=CephString,req=false '
-                     'name=fs,type=CephString,req=false '
-                     'name=subvol,type=CephString,req=false')
+    @CLIWriteCommand('fs snap-schedule retention remove')
     def snap_schedule_retention_rm(self,
-                                   path,
-                                   retention_spec_or_period,
-                                   retention_count=None,
-                                   fs=None,
-                                   subvol=None):
+                                   path: str,
+                                   retention_spec_or_period: str,
+                                   retention_count: Optional[str] = None,
+                                   fs: Optional[str] = None,
+                                   subvol: Optional[str] = None):
         '''
         Remove a retention specification for <path>
         '''
@@ -216,18 +195,13 @@ class Module(MgrModule):
             return -errno.ENOENT, '', str(e)
         return 0, 'Retention removed from path {}'.format(path), ''
 
-    @CLIWriteCommand('fs snap-schedule activate',
-                     'name=path,type=CephString '
-                     'name=repeat,type=CephString,req=false '
-                     'name=start,type=CephString,req=false '
-                     'name=subvol,type=CephString,req=false '
-                     'name=fs,type=CephString,req=false')
+    @CLIWriteCommand('fs snap-schedule activate')
     def snap_schedule_activate(self,
-                               path,
-                               repeat=None,
-                               start=None,
-                               subvol=None,
-                               fs=None):
+                               path: str,
+                               repeat: Optional[str] = None,
+                               start: Optional[str] = None,
+                               subvol: Optional[str] = None,
+                               fs: Optional[str] = None):
         '''
         Activate a snapshot schedule for <path>
         '''
@@ -241,18 +215,13 @@ class Module(MgrModule):
             return -errno.ENOENT, '', str(e)
         return 0, 'Schedule activated for path {}'.format(path), ''
 
-    @CLIWriteCommand('fs snap-schedule deactivate',
-                     'name=path,type=CephString '
-                     'name=repeat,type=CephString,req=false '
-                     'name=start,type=CephString,req=false '
-                     'name=subvol,type=CephString,req=false '
-                     'name=fs,type=CephString,req=false')
+    @CLIWriteCommand('fs snap-schedule deactivate')
     def snap_schedule_deactivate(self,
-                                 path,
-                                 repeat=None,
-                                 start=None,
-                                 subvol=None,
-                                 fs=None):
+                                 path: str,
+                                 repeat: Optional[str] = None,
+                                 start: Optional[str] = None,
+                                 subvol: Optional[str] = None,
+                                 fs: Optional[str] = None):
         '''
         Deactivate a snapshot schedule for <path>
         '''

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -75,7 +75,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
             for p in completions:
                 p.evaluate()
 
-    @CLICommand('test_orchestrator load_data', args='', perm='w')
+    @CLICommand('test_orchestrator load_data', perm='w')
     def _load_data(self, inbuf):
         """
         load dummy data into test orchestrator

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -28,6 +28,7 @@ addopts =
 [testenv]
 setenv =
     UNITTEST = true
+    PYTHONPATH = $PYTHONPATH:..
 deps =
     cython
     -rrequirements.txt
@@ -43,6 +44,10 @@ commands =
         snap_schedule}
 
 [testenv:mypy]
+setenv =
+    MYPYPATH = {toxinidir}/..
+passenv =
+    MYPYPATH
 basepython = python3
 deps =
     cython


### PR DESCRIPTION
this changeset is a superset of #38718. 

#38718 uses docstring for command description (the help message). and this change goes further. it uses annotations for command argument description as well.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
