### PR TITLE
doc/rbd: Immutable object cache doc

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -48,6 +48,10 @@
 * An AWS-compliant API: "GetTopicAttributes" was added to replace the existing "GetTopic" API. The new API
   should be used to fetch information about topics used for bucket notifications.
 
+* librbd: The shared, read-only parent cache's config option ``immutable_object_cache_watermark`` now has been updated
+  to property reflect the upper cache utilization before space is reclaimed. The default ``immutable_object_cache_watermark``
+  now is ``0.9``. If the capacity reaches 90% the daemon will delete cold cache.
+
 >=15.0.0
 --------
 

--- a/doc/rbd/rbd-persistent-read-only-cache.rst
+++ b/doc/rbd/rbd-persistent-read-only-cache.rst
@@ -116,8 +116,8 @@ The ``ceph-immutable-object-cache`` daemon is available within the optional
 .. important:: ``ceph-immutable-object-cache`` daemon requires the ability to
    connect RADOS clusters.
 
-Run Daemon
-----------
+Running the Immutable Object Cache Daemon
+-----------------------------------------
 
 ``ceph-immutable-object-cache`` daemon should use a unique Ceph user ID.
 To `create a Ceph user`_, with ``ceph`` specify the ``auth get-or-create``
@@ -137,7 +137,7 @@ The ``ceph-immutable-object-cache`` can also be run in foreground by ``ceph-immu
 QOS Settings
 ------------
 
-Immutable object cache supports throttle, controlled by the following settings.
+The immutable object cache supports throttling, controlled by the following settings:
 
 ``immutable_object_cache_qos_schedule_tick_min``
 

--- a/doc/rbd/rbd-persistent-read-only-cache.rst
+++ b/doc/rbd/rbd-persistent-read-only-cache.rst
@@ -46,6 +46,9 @@ need to added in the ``[client]`` `section`_ of your ``ceph.conf`` file::
 Immutable Object Cache Daemon
 =============================
 
+Introduction and Generic Settings
+---------------------------------
+
 The ``ceph-immutable-object-cache`` daemon is responsible for caching parent
 image content within its local caching directory. For better performance it's
 recommended to use SSDs as the underlying storage.
@@ -73,23 +76,48 @@ capacity pressure it will evict cold cache files as needed.
 
 Here are some important cache configuration settings:
 
-- ``immutable_object_cache_sock`` The path to the domain socket used for
-  communication between librbd clients and the ceph-immutable-object-cache
-  daemon.
+``immutable_object_cache_sock``
 
-- ``immutable_object_cache_path`` The immutable object cache data directory.
+:Description: The path to the domain socket used for communication between
+              librbd clients and the ceph-immutable-object-cache daemon.
+:Type: String
+:Required: No
+:Default: ``/var/run/ceph/immutable_object_cache_sock``
 
-- ``immutable_object_cache_max_size`` The max size for immutable cache.
 
-- ``immutable_object_cache_watermark`` The high-water mark for the cache. If the
-  capacity reaches this threshold the daemon will delete cold cache based
-  on LRU statistics.
+``immutable_object_cache_path``
+
+:Description: The immutable object cache data directory.
+:Type: String
+:Required: No
+:Default: ``/tmp/ceph_immutable_object_cache``
+
+
+``immutable_object_cache_max_size``
+
+:Description: The max size for immutable cache.
+:Type: Size
+:Required: No
+:Default: ``1G``
+
+
+``immutable_object_cache_watermark``
+
+:Description: The high-water mark for the cache. The value is between (0, 1).
+              If the cache size reaches this threshold the daemon will start
+              to delete cold cache based on LRU statistics.
+:Type: Float
+:Required: No
+:Default: ``0.9``
 
 The ``ceph-immutable-object-cache`` daemon is available within the optional
 ``ceph-immutable-object-cache`` distribution package.
 
 .. important:: ``ceph-immutable-object-cache`` daemon requires the ability to
    connect RADOS clusters.
+
+Run Daemon
+----------
 
 ``ceph-immutable-object-cache`` daemon should use a unique Ceph user ID.
 To `create a Ceph user`_, with ``ceph`` specify the ``auth get-or-create``
@@ -105,6 +133,66 @@ ID as the daemon instance::
 The ``ceph-immutable-object-cache`` can also be run in foreground by ``ceph-immutable-object-cache`` command::
 
   ceph-immutable-object-cache -f --log-file={log_path}
+
+QOS Settings
+------------
+
+Immutable object cache supports throttle, controlled by the following settings.
+
+``immutable_object_cache_qos_schedule_tick_min``
+
+:Description: Minimum schedule tick for immutable object cache.
+:Type: Milliseconds
+:Required: No
+:Default: ``50``
+
+
+``immutable_object_cache_qos_iops_limit``
+
+:Description: The desired immutable object cache IO operations limit per second.
+:Type: Unsigned Integer
+:Required: No
+:Default: ``0``
+
+
+``immutable_object_cache_qos_iops_burst``
+
+:Description: The desired burst limit of immutable object cache IO operations.
+:Type: Unsigned Integer
+:Required: No
+:Default: ``0``
+
+
+``immutable_object_cache_qos_iops_burst_seconds``
+
+:Description: The desired burst duration in seconds of immutable object cache IO operations.
+:Type: Seconds
+:Required: No
+:Default: ``1``
+
+
+``immutable_object_cache_qos_bps_limit``
+
+:Description: The desired immutable object cache IO bytes limit per second.
+:Type: Unsigned Integer
+:Required: No
+:Default: ``0``
+
+
+``immutable_object_cache_qos_bps_burst``
+
+:Description: The desired burst limit of immutable object cache IO bytes.
+:Type: Unsigned Integer
+:Required: No
+:Default: ``0``
+
+
+``immutable_object_cache_qos_bps_burst_seconds``
+
+:Description: The desired burst duration in seconds of immutable object cache IO bytes.
+:Type: Seconds
+:Required: No
+:Default: ``1``
 
 .. _Cloned RBD Images: ../rbd-snapshot/#layering
 .. _section: ../../rados/configuration/ceph-conf/#configuration-sections

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7910,7 +7910,7 @@ static std::vector<Option> get_immutable_object_cache_options() {
     .set_description("immutable object cache client dedicated thread number"),
 
     Option("immutable_object_cache_watermark", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(0.1)
+    .set_default(0.9)
     .set_description("immutable object cache water mark"),
 
     Option("immutable_object_cache_qos_schedule_tick_min", Option::TYPE_MILLISECS, Option::LEVEL_ADVANCED)

--- a/src/test/immutable_object_cache/test_SimplePolicy.cc
+++ b/src/test/immutable_object_cache/test_SimplePolicy.cc
@@ -30,7 +30,7 @@ public:
   static void SetUpTestCase() {}
   static void TearDownTestCase() {}
   void SetUp() override {
-    m_simple_policy = new SimplePolicy(g_ceph_context, m_cache_size, 128, 0.1);
+    m_simple_policy = new SimplePolicy(g_ceph_context, m_cache_size, 128, 0.9);
     // populate 50 entries
     for (uint64_t i = 0; i < m_cache_size / 2; i++, m_entry_index++) {
       insert_entry_into_promoted_lru(generate_file_name(m_entry_index));
@@ -210,7 +210,7 @@ TEST_F(TestSimplePolicy, test_update_state_from_promoting_to_promoted) {
 
 TEST_F(TestSimplePolicy, test_evict_list_0) {
   std::list<std::string> evict_entry_list;
-  // 0.1 is watermark
+  // the default water mark is 0.9
   ASSERT_TRUE((float)m_simple_policy->get_free_size() > m_cache_size*0.1);
   m_simple_policy->get_evict_list(&evict_entry_list);
   ASSERT_TRUE(evict_entry_list.size() == 0);

--- a/src/tools/immutable_object_cache/ObjectCacheStore.cc
+++ b/src/tools/immutable_object_cache/ObjectCacheStore.cc
@@ -88,6 +88,10 @@ ObjectCacheStore::ObjectCacheStore(CephContext *cct)
                    ("immutable_object_cache_qos_bps_burst_seconds"));
   }
 
+  if ((cache_watermark <= 0) || (cache_watermark > 1)) {
+    lderr(m_cct) << "Invalid water mark provided, set it to default." << dendl;
+    cache_watermark = 0.9;
+  }
   m_policy = new SimplePolicy(m_cct, cache_max_size, max_inflight_ops,
                               cache_watermark);
 }
@@ -161,7 +165,8 @@ int ObjectCacheStore::do_promote(std::string pool_nspace, uint64_t pool_id,
                    << " snapshot: " << snap_id << dendl;
 
   int ret = 0;
-  std::string cache_file_name = get_cache_file_name(pool_nspace, pool_id, snap_id, object_name);
+  std::string cache_file_name =
+    get_cache_file_name(pool_nspace, pool_id, snap_id, object_name);
   librados::IoCtx ioctx;
   {
     std::lock_guard _locker{m_ioctx_map_lock};
@@ -247,7 +252,8 @@ int ObjectCacheStore::lookup_object(std::string pool_nspace, uint64_t pool_id,
                    << " in pool ID : " << pool_id << dendl;
 
   int pret = -1;
-  std::string cache_file_name = get_cache_file_name(pool_nspace, pool_id, snap_id, object_name);
+  std::string cache_file_name =
+    get_cache_file_name(pool_nspace, pool_id, snap_id, object_name);
 
   cache_status_t ret = m_policy->lookup_object(cache_file_name);
 

--- a/src/tools/immutable_object_cache/SimplePolicy.cc
+++ b/src/tools/immutable_object_cache/SimplePolicy.cc
@@ -170,7 +170,7 @@ void SimplePolicy::get_evict_list(std::list<std::string>* obj_list) {
 
   std::unique_lock locker{m_cache_map_lock};
   // check free ratio, pop entries from LRU
-  if ((double)m_cache_size / m_max_cache_size > (1 - m_watermark)) {
+  if ((double)m_cache_size > m_max_cache_size * m_watermark) {
     // TODO(dehao): make this configurable
     int evict_num = m_cache_map.size() * 0.1;
     for (int i = 0; i < evict_num; i++) {


### PR DESCRIPTION
[doc/rbd]:  add the configuration description of immutable object cache throttle feature

With the merge of the throttle feature, I updated the document and added the throttle section. 

[tools]:  update immutable object cache water mark

In the process of update doc, I find that the default value of watermark is 0.1, which is puzzling. Daemon code still use 0.9(1-0.1) , so I directly change it to 0.9 as a high water mark.

Signed-off-by: Yin Congmin <congmin.yin@intel.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
