### PR TITLE
crimson/osd: do not splice osd_op indata

### DIFF
--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -760,7 +760,6 @@ seastar::future<> PGBackend::setxattr(
     auto bp = osd_op.indata.cbegin();
     bp.copy(osd_op.op.xattr.name_len, name);
     bp.copy(osd_op.op.xattr.value_len, val);
-    osd_op.indata.splice(0, bp.get_off());
   }
   logger().debug("setxattr on obj={} for attr={}", os.oi.soid, name);
 
@@ -780,7 +779,6 @@ PGBackend::get_attr_errorator::future<> PGBackend::getxattr(
     std::string aname;
     bp.copy(osd_op.op.xattr.name_len, aname);
     name = "_" + aname;
-    osd_op.indata.splice(0, bp.get_off());
   }
   logger().debug("getxattr on obj={} for attr={}", os.oi.soid, name);
   return getxattr(os.oi.soid, name).safe_then([&osd_op] (ceph::bufferptr val) {
@@ -841,7 +839,6 @@ PGBackend::rm_xattr_ertr::future<> PGBackend::rm_xattr(
   auto bp = osd_op.indata.cbegin();
   string attr_name{"_"};
   bp.copy(osd_op.op.xattr.name_len, attr_name);
-  osd_op.indata.splice(0, bp.get_off());
   txn.rmattr(coll->get_cid(), ghobject_t{os.oi.soid}, attr_name);
   return rm_xattr_ertr::now();
 }
@@ -917,7 +914,6 @@ PGBackend::omap_get_keys(
     auto p = osd_op.indata.cbegin();
     decode(start_after, p);
     decode(max_return, p);
-    osd_op.indata.splice(0, p.get_off());
   } catch (buffer::error&) {
     throw crimson::osd::invalid_argument{};
   }
@@ -975,7 +971,6 @@ PGBackend::omap_get_vals(
     decode(start_after, p);
     decode(max_return, p);
     decode(filter_prefix, p);
-    osd_op.indata.splice(0, p.get_off());
   } catch (buffer::error&) {
     throw crimson::osd::invalid_argument{};
   }
@@ -1041,7 +1036,6 @@ PGBackend::omap_get_vals_by_keys(
   try {
     auto p = osd_op.indata.cbegin();
     decode(keys_to_get, p);
-    osd_op.indata.splice(0, p.get_off());
   } catch (buffer::error&) {
     throw crimson::osd::invalid_argument();
   }
@@ -1075,7 +1069,6 @@ seastar::future<> PGBackend::omap_set_vals(
   try {
     auto p = osd_op.indata.cbegin();
     decode_str_str_map_to_bl(p, &to_set_bl);
-    osd_op.indata.splice(0, p.get_off());
   } catch (buffer::error&) {
     throw crimson::osd::invalid_argument{};
   }
@@ -1119,7 +1112,6 @@ seastar::future<> PGBackend::omap_remove_range(
     auto p = osd_op.indata.cbegin();
     decode(key_begin, p);
     decode(key_end, p);
-    osd_op.indata.splice(0, p.get_off());
   } catch (buffer::error& e) {
     throw crimson::osd::invalid_argument{};
   }

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -738,7 +738,7 @@ PGBackend::list_objects(const hobject_t& start, uint64_t limit) const
 
 seastar::future<> PGBackend::setxattr(
   ObjectState& os,
-  OSDOp& osd_op,
+  const OSDOp& osd_op,
   ceph::os::Transaction& txn)
 {
   if (local_conf()->osd_max_attr_size > 0 &&
@@ -826,7 +826,7 @@ PGBackend::get_attr_errorator::future<> PGBackend::get_xattrs(
 
 PGBackend::rm_xattr_ertr::future<> PGBackend::rm_xattr(
   ObjectState& os,
-  OSDOp& osd_op,
+  const OSDOp& osd_op,
   ceph::os::Transaction& txn)
 {
   if (__builtin_expect(stopping, false)) {
@@ -1059,7 +1059,7 @@ PGBackend::omap_get_vals_by_keys(
 
 seastar::future<> PGBackend::omap_set_vals(
   ObjectState& os,
-  OSDOp& osd_op,
+  const OSDOp& osd_op,
   ceph::os::Transaction& txn,
   osd_op_params_t& osd_op_params)
 {
@@ -1104,7 +1104,7 @@ seastar::future<> PGBackend::omap_set_header(
 
 seastar::future<> PGBackend::omap_remove_range(
   ObjectState& os,
-  OSDOp& osd_op,
+  const OSDOp& osd_op,
   ceph::os::Transaction& txn)
 {
   std::string key_begin, key_end;

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -132,7 +132,7 @@ public:
     uint64_t limit) const;
   seastar::future<> setxattr(
     ObjectState& os,
-    OSDOp& osd_op,
+    const OSDOp& osd_op,
     ceph::os::Transaction& trans);
   using get_attr_errorator = crimson::os::FuturizedStore::get_attr_errorator;
   get_attr_errorator::future<> getxattr(
@@ -147,7 +147,7 @@ public:
   using rm_xattr_ertr = crimson::errorator<crimson::ct_error::enoent>;
   rm_xattr_ertr::future<> rm_xattr(
     ObjectState& os,
-    OSDOp& osd_op,
+    const OSDOp& osd_op,
     ceph::os::Transaction& trans);
   seastar::future<struct stat> stat(
     CollectionRef c,
@@ -170,7 +170,7 @@ public:
     OSDOp& osd_op) const;
   seastar::future<> omap_set_vals(
     ObjectState& os,
-    OSDOp& osd_op,
+    const OSDOp& osd_op,
     ceph::os::Transaction& trans,
     osd_op_params_t& osd_op_params);
   seastar::future<ceph::bufferlist> omap_get_header(
@@ -185,7 +185,7 @@ public:
     ceph::os::Transaction& trans);
   seastar::future<> omap_remove_range(
     ObjectState& os,
-    OSDOp& osd_op,
+    const OSDOp& osd_op,
     ceph::os::Transaction& trans);
   using omap_clear_ertr = crimson::errorator<crimson::ct_error::enoent>;
   omap_clear_ertr::future<> omap_clear(


### PR DESCRIPTION
As each osd_op's indata holds only its own data, there's no need to drop their it.
On the other hand, indata is still needed when osd_op needs to be redone in case of
acting set change.

Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
