### PR TITLE
rgw: keep underscore in metatdata key

### DIFF
--- a/src/rgw/rgw_asio_client.cc
+++ b/src/rgw/rgw_asio_client.cc
@@ -54,6 +54,8 @@ int ClientIO::init_env(CephContext *cct)
     for (auto src = name.begin(); src != name.end(); ++src, ++dest) {
       if (*src == '-') {
         *dest = '_';
+      } else if (*src == '_') {
+        *dest = '-';
       } else {
         *dest = std::toupper(*src);
       }

--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -562,7 +562,7 @@ get_v4_canonical_headers(const req_info& info,
 
     std::transform(std::begin(token), std::end(token),
                    std::back_inserter(token_env), [](const int c) {
-                     return c == '-' ? '_' : std::toupper(c);
+                     return c == '-' ? '_' : c == '_' ? '-' : std::toupper(c);
                    });
 
     if (token_env == "HTTP_CONTENT_LENGTH") {

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -410,10 +410,12 @@ void req_info::init_meta_info(bool *found_bad_meta)
         snprintf(name_low, meta_prefixes[0].len - 5 + name_len + 1, "%s%s", meta_prefixes[0].str + 5 /* skip HTTP_ */, name); // normalize meta prefix
         int j;
         for (j = 0; name_low[j]; j++) {
-          if (name_low[j] != '_')
-            name_low[j] = tolower(name_low[j]);
-          else
+          if (name_low[j] == '_')
             name_low[j] = '-';
+          else if (name_low[j] == '-')
+            name_low[j] = '_';
+          else
+            name_low[j] = tolower(name_low[j]);
         }
         name_low[j] = 0;
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/48716

Signed-off-by: Ilsoo Byun <ilsoobyun@linecorp.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
