### PR TITLE
librbd/migration: removing an unused capture

### DIFF
--- a/src/test/librbd/migration/test_mock_RawFormat.cc
+++ b/src/test/librbd/migration/test_mock_RawFormat.cc
@@ -127,7 +127,7 @@ public:
 
   void expect_close(MockTestImageCtx &mock_image_ctx, int r) {
     EXPECT_CALL(*mock_image_ctx.state, close(_))
-      .WillOnce(Invoke([this, r](Context* ctx) {
+      .WillOnce(Invoke([r](Context* ctx) {
                   ctx->complete(r);
                 }));
   }


### PR DESCRIPTION
...silencing a compiler warning.

```
ceph/src/test/librbd/migration/test_mock_RawFormat.cc:130:25: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
      .WillOnce(Invoke([this, r](Context* ctx) {
                        ^~~~~
```


Signed-off-by: Ronen Friedman <rfriedma@redhat.com>

