### PR TITLE
cephadm: splits bootstrap function, add context, drop global variables

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3097,9 +3097,9 @@ def is_ipv6(ctx, address):
         return False
 
 
-def obtain_mon_ip(
+def prepare_mon_addresses(
     ctx: CephadmContext
-) -> Tuple[str, str, bool]:
+) -> Tuple[str, bool, Optional[str]]:
     r = re.compile(r':(\d+)$')
     base_ip = ""
     ipv6 = False
@@ -3145,7 +3145,23 @@ def obtain_mon_ip(
     else:
         raise Error('must specify --mon-ip or --mon-addrv')
     logger.debug('Base mon IP is %s, final addrv is %s' % (base_ip, addr_arg))
-    return (base_ip, addr_arg, ipv6)
+
+    mon_network = None
+    if not ctx.args.skip_mon_network:
+        # make sure IP is configured locally, and then figure out the
+        # CIDR network
+        for net, ips in list_networks(ctx).items():
+            if ipaddress.ip_address(unicode(unwrap_ipv6(base_ip))) in \
+                    [ipaddress.ip_address(unicode(ip)) for ip in ips]:
+                mon_network = net
+                logger.info('Mon IP %s is in CIDR network %s' % (base_ip,
+                                                                 mon_network))
+                break
+        if not mon_network:
+            raise Error('Failed to infer CIDR network for mon ip %s; pass '
+                        '--skip-mon-network to configure it later' % base_ip)
+
+    return (addr_arg, ipv6, mon_network)
 
 
 def create_initial_keys(
@@ -3599,24 +3615,7 @@ def command_bootstrap(ctx):
     l = FileLock(ctx, fsid)
     l.acquire()
 
-    # ip
-    (base_ip, addr_arg, ipv6) = obtain_mon_ip(ctx)    
-
-    mon_network = None
-    if not ctx.args.skip_mon_network:
-        # make sure IP is configured locally, and then figure out the
-        # CIDR network
-        for net, ips in list_networks(ctx).items():
-            if ipaddress.ip_address(unicode(unwrap_ipv6(base_ip))) in \
-                    [ipaddress.ip_address(unicode(ip)) for ip in ips]:
-                mon_network = net
-                logger.info('Mon IP %s is in CIDR network %s' % (base_ip,
-                                                                 mon_network))
-                break
-        if not mon_network:
-            raise Error('Failed to infer CIDR network for mon ip %s; pass '
-                        '--skip-mon-network to configure it later' % base_ip)
-
+    (addr_arg, ipv6, mon_network) = prepare_mon_addresses(ctx)
     config = prepare_bootstrap_config(ctx, fsid, addr_arg, ctx.args.image)
 
     logger.info('Extracting ceph user uid/gid from container image...')

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -7361,14 +7361,11 @@ def _parse_args(av):
     return args
 
 
-def main():
+def cephadm_init(args: List[str]) -> Optional[CephadmContext]:
 
     global logger
-
-    # root?
-    if os.geteuid() != 0:
-        sys.stderr.write('ERROR: cephadm should be run as root\n')
-        sys.exit(1)
+    ctx = CephadmContext()
+    ctx.args = _parse_args(args)
 
     # Logger configuration
     if not os.path.exists(LOG_DIR):
@@ -7376,50 +7373,56 @@ def main():
     dictConfig(logging_config)
     logger = logging.getLogger()
 
-    # allow argv to be injected
+    if ctx.args.verbose:
+        for handler in logger.handlers:
+            if handler.name == "console":
+                handler.setLevel(logging.DEBUG)
+
+    if "func" not in ctx.args:
+        sys.stderr.write("No command specified; pass -h or --help for usage\n")
+        return None
+
+    ctx.container_path = ""
+    if ctx.args.func != command_check_host:
+        if ctx.args.docker:
+            ctx.container_path = find_program("docker")
+        else:
+            for i in CONTAINER_PREFERENCE:
+                try:
+                    ctx.container_path = find_program(i)
+                    break
+                except Exception as e:
+                    logger.debug("Could not locate %s: %s" % (i, e))
+            if not ctx.container_path and ctx.args.func != command_prepare_host\
+                    and ctx.args.func != command_add_repo:
+                sys.stderr.write("Unable to locate any of %s\n" %
+                     CONTAINER_PREFERENCE)
+                return None
+
+    return ctx
+
+
+def main():
+
+    # root?
+    if os.geteuid() != 0:
+        sys.stderr.write('ERROR: cephadm should be run as root\n')
+        sys.exit(1)
+
+    av: List[str] = []
     try:
         av = injected_argv  # type: ignore
     except NameError:
         av = sys.argv[1:]
-    logger.debug("%s\ncephadm %s" % ("-" * 80, av))
-    args = _parse_args(av)
 
-    # More verbose console output
-    if args.verbose:
-        for handler in logger.handlers:
-          if handler.name == "console":
-               handler.setLevel(logging.DEBUG)
-
-    if 'func' not in args:
-        sys.stderr.write('No command specified; pass -h or --help for usage\n')
+    ctx = cephadm_init(av)
+    if not ctx: # error, exit
         sys.exit(1)
 
-    container_path = ""
-
-    # podman or docker?
-    if args.func != command_check_host:
-        if args.docker:
-            container_path = find_program('docker')
-        else:
-            for i in CONTAINER_PREFERENCE:
-                try:
-                    container_path = find_program(i)
-                    break
-                except Exception as e:
-                    logger.debug('Could not locate %s: %s' % (i, e))
-            if not container_path and args.func != command_prepare_host\
-                    and args.func != command_add_repo:
-                sys.stderr.write('Unable to locate any of %s\n' % CONTAINER_PREFERENCE)
-                sys.exit(1)
-
-    ctx = CephadmContext()
-    ctx.args = args
-    ctx.container_path = container_path
-
     try:
-        r = args.func(ctx)
+        r = ctx.args.func(ctx)
     except Error as e:
-        if args.verbose:
+        if ctx.args.verbose:
             raise
         sys.stderr.write('ERROR: %s\n' % e)
         sys.exit(1)

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3097,9 +3097,13 @@ def is_ipv6(ctx, address):
         return False
 
 
-def obtain_mon_ip(ctx: CephadmContext) -> Tuple[str, str]:
+def obtain_mon_ip(
+    ctx: CephadmContext
+) -> Tuple[str, str, bool]:
     r = re.compile(r':(\d+)$')
     base_ip = ""
+    ipv6 = False
+
     if ctx.args.mon_ip:
         ipv6 = is_ipv6(ctx, ctx.args.mon_ip)
         if ipv6:
@@ -3141,7 +3145,7 @@ def obtain_mon_ip(ctx: CephadmContext) -> Tuple[str, str]:
     else:
         raise Error('must specify --mon-ip or --mon-addrv')
     logger.debug('Base mon IP is %s, final addrv is %s' % (base_ip, addr_arg))
-    return (base_ip, addr_arg)
+    return (base_ip, addr_arg, ipv6)
 
 
 def create_initial_keys(
@@ -3591,13 +3595,12 @@ def command_bootstrap(ctx):
     mon_id = ctx.args.mon_id or hostname
     mgr_id = ctx.args.mgr_id or generate_service_id()
     logger.info('Cluster fsid: %s' % fsid)
-    ipv6 = False
 
     l = FileLock(ctx, fsid)
     l.acquire()
 
     # ip
-    (base_ip, addr_arg) = obtain_mon_ip(ctx)    
+    (base_ip, addr_arg, ipv6) = obtain_mon_ip(ctx)    
 
     mon_network = None
     if not ctx.args.skip_mon_network:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3097,6 +3097,170 @@ def is_ipv6(ctx, address):
         return False
 
 
+def obtain_mon_ip(ctx: CephadmContext) -> Tuple[str, str]:
+    r = re.compile(r':(\d+)$')
+    base_ip = ""
+    if ctx.args.mon_ip:
+        ipv6 = is_ipv6(ctx, ctx.args.mon_ip)
+        if ipv6:
+            ctx.args.mon_ip = wrap_ipv6(ctx.args.mon_ip)
+        hasport = r.findall(ctx.args.mon_ip)
+        if hasport:
+            port = int(hasport[0])
+            if port == 6789:
+                addr_arg = '[v1:%s]' % ctx.args.mon_ip
+            elif port == 3300:
+                addr_arg = '[v2:%s]' % ctx.args.mon_ip
+            else:
+                logger.warning('Using msgr2 protocol for unrecognized port %d' %
+                               port)
+                addr_arg = '[v2:%s]' % ctx.args.mon_ip
+            base_ip = ctx.args.mon_ip[0:-(len(str(port)))-1]
+            check_ip_port(ctx, base_ip, port)
+        else:
+            base_ip = ctx.args.mon_ip
+            addr_arg = '[v2:%s:3300,v1:%s:6789]' % (ctx.args.mon_ip, ctx.args.mon_ip)
+            check_ip_port(ctx, ctx.args.mon_ip, 3300)
+            check_ip_port(ctx, ctx.args.mon_ip, 6789)
+    elif ctx.args.mon_addrv:
+        addr_arg = ctx.args.mon_addrv
+        if addr_arg[0] != '[' or addr_arg[-1] != ']':
+            raise Error('--mon-addrv value %s must use square backets' %
+                        addr_arg)
+        ipv6 = addr_arg.count('[') > 1
+        for addr in addr_arg[1:-1].split(','):
+            hasport = r.findall(addr)
+            if not hasport:
+                raise Error('--mon-addrv value %s must include port number' %
+                            addr_arg)
+            port = int(hasport[0])
+            # strip off v1: or v2: prefix
+            addr = re.sub(r'^\w+:', '', addr)
+            base_ip = addr[0:-(len(str(port)))-1]
+            check_ip_port(ctx, base_ip, port)
+    else:
+        raise Error('must specify --mon-ip or --mon-addrv')
+    logger.debug('Base mon IP is %s, final addrv is %s' % (base_ip, addr_arg))
+    return (base_ip, addr_arg)
+
+
+def create_initial_keys(
+    ctx: CephadmContext,
+    uid: int, gid: int,
+    mgr_id: str
+) -> Tuple[str, str, str, Any, Any]: # type: ignore
+
+    _image = ctx.args.image
+
+    # create some initial keys
+    logger.info('Creating initial keys...')
+    mon_key = CephContainer(
+        ctx,
+        image=_image,
+        entrypoint='/usr/bin/ceph-authtool',
+        args=['--gen-print-key'],
+    ).run().strip()
+    admin_key = CephContainer(
+        ctx,
+        image=_image,
+        entrypoint='/usr/bin/ceph-authtool',
+        args=['--gen-print-key'],
+    ).run().strip()
+    mgr_key = CephContainer(
+        ctx,
+        image=_image,
+        entrypoint='/usr/bin/ceph-authtool',
+        args=['--gen-print-key'],
+    ).run().strip()
+
+    keyring = ('[mon.]\n'
+               '\tkey = %s\n'
+               '\tcaps mon = allow *\n'
+               '[client.admin]\n'
+               '\tkey = %s\n'
+               '\tcaps mon = allow *\n'
+               '\tcaps mds = allow *\n'
+               '\tcaps mgr = allow *\n'
+               '\tcaps osd = allow *\n'
+               '[mgr.%s]\n'
+               '\tkey = %s\n'
+               '\tcaps mon = profile mgr\n'
+               '\tcaps mds = allow *\n'
+               '\tcaps osd = allow *\n'
+               % (mon_key, admin_key, mgr_id, mgr_key))
+
+    admin_keyring = write_tmp('[client.admin]\n'
+                                  '\tkey = ' + admin_key + '\n',
+                                       uid, gid)
+
+    # tmp keyring file
+    bootstrap_keyring = write_tmp(keyring, uid, gid)
+    return (mon_key, mgr_key, admin_key,
+            bootstrap_keyring, admin_keyring)
+
+
+def create_initial_monmap(
+    ctx: CephadmContext,
+    uid: int, gid: int,
+    fsid: str,
+    mon_id: str, mon_addr: str
+) -> Any:
+    logger.info('Creating initial monmap...')
+    monmap = write_tmp('', 0, 0)
+    out = CephContainer(
+        ctx,
+        image=ctx.args.image,
+        entrypoint='/usr/bin/monmaptool',
+        args=['--create',
+              '--clobber',
+              '--fsid', fsid,
+              '--addv', mon_id, mon_addr,
+              '/tmp/monmap'
+        ],
+        volume_mounts={
+            monmap.name: '/tmp/monmap:z',
+        },
+    ).run()
+    logger.debug(f"monmaptool for {mon_id} {mon_addr} on {out}")
+
+    # pass monmap file to ceph user for use by ceph-mon --mkfs below
+    os.fchown(monmap.fileno(), uid, gid)
+    return monmap
+
+
+def create_mon(
+    ctx: CephadmContext,
+    uid: int, gid: int,
+    fsid: str, mon_id: str,
+    bootstrap_keyring_path: str,
+    monmap_path: str
+):
+    logger.info('Creating mon...')
+    create_daemon_dirs(ctx, fsid, 'mon', mon_id, uid, gid)
+    mon_dir = get_data_dir(fsid, ctx.args.data_dir, 'mon', mon_id)
+    log_dir = get_log_dir(fsid, ctx.args.log_dir)
+    out = CephContainer(
+        ctx,
+        image=ctx.args.image,
+        entrypoint='/usr/bin/ceph-mon',
+        args=['--mkfs',
+              '-i', mon_id,
+              '--fsid', fsid,
+              '-c', '/dev/null',
+              '--monmap', '/tmp/monmap',
+              '--keyring', '/tmp/keyring',
+        ] + get_daemon_args(ctx, fsid, 'mon', mon_id),
+        volume_mounts={
+            log_dir: '/var/log/ceph:z',
+            mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % (mon_id),
+            bootstrap_keyring_path: '/tmp/keyring:z',
+            monmap_path: '/tmp/monmap:z',
+        },
+    ).run()
+    logger.debug(f"create mon.{mon_id} on {out}")
+    return (mon_dir, log_dir)
+
+
 @default_image
 def command_bootstrap(ctx):
     # type: (CephadmContext) -> int
@@ -3149,49 +3313,7 @@ def command_bootstrap(ctx):
     l.acquire()
 
     # ip
-    r = re.compile(r':(\d+)$')
-    base_ip = ''
-    if ctx.args.mon_ip:
-        ipv6 = is_ipv6(ctx, ctx.args.mon_ip)
-        if ipv6:
-            ctx.args.mon_ip = wrap_ipv6(ctx.args.mon_ip)
-        hasport = r.findall(ctx.args.mon_ip)
-        if hasport:
-            port = int(hasport[0])
-            if port == 6789:
-                addr_arg = '[v1:%s]' % ctx.args.mon_ip
-            elif port == 3300:
-                addr_arg = '[v2:%s]' % ctx.args.mon_ip
-            else:
-                logger.warning('Using msgr2 protocol for unrecognized port %d' %
-                               port)
-                addr_arg = '[v2:%s]' % ctx.args.mon_ip
-            base_ip = ctx.args.mon_ip[0:-(len(str(port)))-1]
-            check_ip_port(ctx, base_ip, port)
-        else:
-            base_ip = ctx.args.mon_ip
-            addr_arg = '[v2:%s:3300,v1:%s:6789]' % (ctx.args.mon_ip, ctx.args.mon_ip)
-            check_ip_port(ctx, args.mon_ip, 3300)
-            check_ip_port(ctx, args.mon_ip, 6789)
-    elif ctx.args.mon_addrv:
-        addr_arg = ctx.args.mon_addrv
-        if addr_arg[0] != '[' or addr_arg[-1] != ']':
-            raise Error('--mon-addrv value %s must use square backets' %
-                        addr_arg)
-        ipv6 = addr_arg.count('[') > 1
-        for addr in addr_arg[1:-1].split(','):
-            hasport = r.findall(addr)
-            if not hasport:
-                raise Error('--mon-addrv value %s must include port number' %
-                            addr_arg)
-            port = int(hasport[0])
-            # strip off v1: or v2: prefix
-            addr = re.sub(r'^\w+:', '', addr)
-            base_ip = addr[0:-(len(str(port)))-1]
-            check_ip_port(ctx, base_ip, port)
-    else:
-        raise Error('must specify --mon-ip or --mon-addrv')
-    logger.debug('Base mon IP is %s, final addrv is %s' % (base_ip, addr_arg))
+    (base_ip, addr_arg) = obtain_mon_ip(ctx)    
 
     mon_network = None
     if not ctx.args.skip_mon_network:
@@ -3229,89 +3351,15 @@ def command_bootstrap(ctx):
     (uid, gid) = extract_uid_gid(ctx)
 
     # create some initial keys
-    logger.info('Creating initial keys...')
-    mon_key = CephContainer(
-        ctx,
-        image=ctx.args.image,
-        entrypoint='/usr/bin/ceph-authtool',
-        args=['--gen-print-key'],
-    ).run().strip()
-    admin_key = CephContainer(
-        ctx,
-        image=ctx.args.image,
-        entrypoint='/usr/bin/ceph-authtool',
-        args=['--gen-print-key'],
-    ).run().strip()
-    mgr_key = CephContainer(
-        ctx,
-        image=ctx.args.image,
-        entrypoint='/usr/bin/ceph-authtool',
-        args=['--gen-print-key'],
-    ).run().strip()
+    (mon_key, mgr_key, admin_key,
+     bootstrap_keyring, admin_keyring
+    ) = \
+        create_initial_keys(ctx, uid, gid, mgr_id)
 
-    keyring = ('[mon.]\n'
-               '\tkey = %s\n'
-               '\tcaps mon = allow *\n'
-               '[client.admin]\n'
-               '\tkey = %s\n'
-               '\tcaps mon = allow *\n'
-               '\tcaps mds = allow *\n'
-               '\tcaps mgr = allow *\n'
-               '\tcaps osd = allow *\n'
-               '[mgr.%s]\n'
-               '\tkey = %s\n'
-               '\tcaps mon = profile mgr\n'
-               '\tcaps mds = allow *\n'
-               '\tcaps osd = allow *\n'
-               % (mon_key, admin_key, mgr_id, mgr_key))
-
-    # tmp keyring file
-    tmp_bootstrap_keyring = write_tmp(keyring, uid, gid)
-
-    # create initial monmap, tmp monmap file
-    logger.info('Creating initial monmap...')
-    tmp_monmap = write_tmp('', 0, 0)
-    out = CephContainer(
-        ctx,
-        image=ctx.args.image,
-        entrypoint='/usr/bin/monmaptool',
-        args=['--create',
-              '--clobber',
-              '--fsid', fsid,
-              '--addv', mon_id, addr_arg,
-              '/tmp/monmap'
-        ],
-        volume_mounts={
-            tmp_monmap.name: '/tmp/monmap:z',
-        },
-    ).run()
-
-    # pass monmap file to ceph user for use by ceph-mon --mkfs below
-    os.fchown(tmp_monmap.fileno(), uid, gid)
-
-    # create mon
-    logger.info('Creating mon...')
-    create_daemon_dirs(ctx, fsid, 'mon', mon_id, uid, gid)
-    mon_dir = get_data_dir(fsid, ctx.args.data_dir, 'mon', mon_id)
-    log_dir = get_log_dir(fsid, ctx.args.log_dir)
-    out = CephContainer(
-        ctx,
-        image=ctx.args.image,
-        entrypoint='/usr/bin/ceph-mon',
-        args=['--mkfs',
-              '-i', mon_id,
-              '--fsid', fsid,
-              '-c', '/dev/null',
-              '--monmap', '/tmp/monmap',
-              '--keyring', '/tmp/keyring',
-        ] + get_daemon_args(ctx, fsid, 'mon', mon_id),
-        volume_mounts={
-            log_dir: '/var/log/ceph:z',
-            mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % (mon_id),
-            tmp_bootstrap_keyring.name: '/tmp/keyring:z',
-            tmp_monmap.name: '/tmp/monmap:z',
-        },
-    ).run()
+    monmap = create_initial_monmap(ctx, uid, gid, fsid, mon_id, addr_arg)
+    (mon_dir, log_dir) = \
+        create_mon(ctx, uid, gid, fsid, mon_id,
+                   bootstrap_keyring.name, monmap.name)
 
     with open(mon_dir + '/config', 'w') as f:
         os.fchown(f.fileno(), uid, gid)
@@ -3323,10 +3371,7 @@ def command_bootstrap(ctx):
     deploy_daemon(ctx, fsid, 'mon', mon_id, mon_c, uid, gid,
                   config=None, keyring=None)
 
-    # client.admin key + config to issue various CLI commands
-    tmp_admin_keyring = write_tmp('[client.admin]\n'
-                                  '\tkey = ' + admin_key + '\n',
-                                       uid, gid)
+    # config to issue various CLI commands
     tmp_config = write_tmp(config, uid, gid)
 
     # a CLI helper to reduce our typing
@@ -3334,7 +3379,7 @@ def command_bootstrap(ctx):
         # type: (List[str], Dict[str, str], Optional[int]) -> str
         mounts = {
             log_dir: '/var/log/ceph:z',
-            tmp_admin_keyring.name: '/etc/ceph/ceph.client.admin.keyring:z',
+            admin_keyring.name: '/etc/ceph/ceph.client.admin.keyring:z',
             tmp_config.name: '/etc/ceph/ceph.conf:z',
         }
         for k, v in extra_mounts.items():
@@ -3357,7 +3402,7 @@ def command_bootstrap(ctx):
             'status'],
         volume_mounts={
             mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % (mon_id),
-            tmp_admin_keyring.name: '/etc/ceph/ceph.client.admin.keyring:z',
+            admin_keyring.name: '/etc/ceph/ceph.client.admin.keyring:z',
             tmp_config.name: '/etc/ceph/ceph.conf:z',
         },
     )

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -104,19 +104,63 @@ logger: logging.Logger = None # type: ignore
 
 ##################################
 
+class BaseConfig:
+
+    def __init__(self):
+        self.image: str = ""
+        self.docker: bool = False
+        self.data_dir: str = DATA_DIR
+        self.log_dir: str = LOG_DIR
+        self.logrotate_dir: str = LOGROTATE_DIR
+        self.unit_dir: str = UNIT_DIR
+        self.verbose: bool = False
+        self.timeout: Optional[int] = DEFAULT_TIMEOUT
+        self.retry: int = DEFAULT_RETRY
+        self.env: List[str] = []
+
+        self.container_path: str = ""
+
+    def set_from_args(self, args: argparse.Namespace):
+        argdict: Dict[str, Any] = vars(args)
+        for k, v in argdict.items():
+            if hasattr(self, k):
+                setattr(self, k, v)
+
+
 class CephadmContext:
 
     def __init__(self):
-        self._args: argparse.Namespace = None # type: ignore
-        self.container_path: str = None # type: ignore
 
-    @property
-    def args(self) -> argparse.Namespace:
-        return self._args
+        self.__dict__["_args"] = None
+        self.__dict__["_conf"] = BaseConfig()
 
-    @args.setter
-    def args(self, args: argparse.Namespace) -> None:
+
+    def set_args(self, args: argparse.Namespace) -> None:
+        self._conf.set_from_args(args)
         self._args = args
+
+
+    def has_function(self) -> bool:
+        return "func" in self._args
+
+
+    def __getattr__(self, name: str) -> Any:
+        if "_conf" in self.__dict__ and \
+             hasattr(self._conf, name):
+            return getattr(self._conf, name)
+        elif "_args" in self.__dict__ and \
+           hasattr(self._args, name):
+            return getattr(self._args, name)        
+        else:
+            return super().__getattribute__(name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if hasattr(self._conf, name):
+            setattr(self._conf, name, value)
+        elif hasattr(self._args, name):
+            setattr(self._args, name, value)
+        else:
+            super().__setattr__(name, value)
 
 
 ##################################  
@@ -289,8 +333,8 @@ class NFSGanesha(object):
     @classmethod
     def init(cls, ctx, fsid, daemon_id):
         # type: (CephadmContext, str, Union[int, str]) -> NFSGanesha
-        return cls(ctx, fsid, daemon_id, get_parm(ctx.args.config_json),
-                                                  ctx.args.image)
+        return cls(ctx, fsid, daemon_id, get_parm(ctx.config_json),
+                                                  ctx.image)
 
     def get_container_mounts(self, data_dir):
         # type: (str) -> Dict[str, str]
@@ -399,7 +443,7 @@ class NFSGanesha(object):
             args += ['--userid', self.userid]
         args += [action, self.get_daemon_name()]
 
-        data_dir = get_data_dir(self.fsid, self.ctx.args.data_dir,
+        data_dir = get_data_dir(self.fsid, self.ctx.data_dir,
                                 self.daemon_type, self.daemon_id)
         volume_mounts = self.get_container_mounts(data_dir)
         envs = self.get_container_envs()
@@ -449,7 +493,7 @@ class CephIscsi(object):
     def init(cls, ctx, fsid, daemon_id):
         # type: (CephadmContext, str, Union[int, str]) -> CephIscsi
         return cls(ctx, fsid, daemon_id,
-                   get_parm(ctx.args.config_json), ctx.args.image)
+                   get_parm(ctx.config_json), ctx.image)
 
     @staticmethod
     def get_container_mounts(data_dir, log_dir):
@@ -571,8 +615,8 @@ class HAproxy(object):
     @classmethod
     def init(cls, ctx: CephadmContext,
              fsid: str, daemon_id: Union[int, str]) -> 'HAproxy':
-        return cls(ctx, fsid, daemon_id, get_parm(ctx.args.config_json),
-                   ctx.args.image)
+        return cls(ctx, fsid, daemon_id, get_parm(ctx.config_json),
+                   ctx.image)
 
     def create_daemon_dirs(self, data_dir: str, uid: int, gid: int) -> None:
         """Create files under the container data dir"""
@@ -652,7 +696,7 @@ class Keepalived(object):
     def init(cls, ctx: CephadmContext, fsid: str,
              daemon_id: Union[int, str]) -> 'Keepalived':
         return cls(ctx, fsid, daemon_id,
-                   get_parm(ctx.args.config_json), ctx.args.image)
+                   get_parm(ctx.config_json), ctx.image)
 
     def create_daemon_dirs(self, data_dir: str, uid: int, gid: int) -> None:
         """Create files under the container data dir"""
@@ -744,7 +788,7 @@ class CustomContainer(object):
     def init(cls, ctx: CephadmContext,
              fsid: str, daemon_id: Union[int, str]) -> 'CustomContainer':
         return cls(fsid, daemon_id,
-                   get_parm(ctx.args.config_json), ctx.args.image)
+                   get_parm(ctx.config_json), ctx.image)
 
     def create_daemon_dirs(self, data_dir: str, uid: int, gid: int) -> None:
         """
@@ -921,7 +965,7 @@ def port_in_use(ctx, port_num):
 
 def check_ip_port(ctx, ip, port):
     # type: (CephadmContext, str, int) -> None
-    if not ctx.args.skip_ping_check:
+    if not ctx.skip_ping_check:
         logger.info('Verifying IP %s port %d ...' % (ip, port))
         if is_ipv6(ip):
             s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
@@ -1155,7 +1199,7 @@ def call(ctx: CephadmContext,
         desc = command[0]
     if desc:
         desc += ': '
-    timeout = timeout or ctx.args.timeout
+    timeout = timeout or ctx.timeout
 
     logger.debug("Running command: %s" % ' '.join(command))
     process = subprocess.Popen(
@@ -1328,7 +1372,7 @@ def is_available(ctx, what, func):
     :param what: the name of the service
     :param func: the callable object that determines availability
     """
-    retry = ctx.args.retry
+    retry = ctx.retry
     logger.info('Waiting for %s...' % what)
     num = 1
     while True:
@@ -1510,8 +1554,8 @@ def infer_fsid(func):
     """
     @wraps(func)
     def _infer_fsid(ctx: CephadmContext):
-        if ctx.args.fsid:
-            logger.debug('Using specified fsid: %s' % ctx.args.fsid)
+        if ctx.fsid:
+            logger.debug('Using specified fsid: %s' % ctx.fsid)
             return func(ctx)
 
         fsids_set = set()
@@ -1520,11 +1564,11 @@ def infer_fsid(func):
             if not is_fsid(daemon['fsid']):
                 # 'unknown' fsid
                 continue
-            elif 'name' not in ctx.args or not ctx.args.name:
-                # ctx.args.name not specified
+            elif 'name' not in ctx.args or not ctx.name:
+                # ctx.name not specified
                 fsids_set.add(daemon['fsid'])
-            elif daemon['name'] == ctx.args.name:
-                # ctx.args.name is a match
+            elif daemon['name'] == ctx.name:
+                # ctx.name is a match
                 fsids_set.add(daemon['fsid'])
         fsids = sorted(fsids_set)
 
@@ -1533,7 +1577,7 @@ def infer_fsid(func):
             pass
         elif len(fsids) == 1:
             logger.info('Inferring fsid %s' % fsids[0])
-            ctx.args.fsid = fsids[0]
+            ctx.fsid = fsids[0]
         else:
             raise Error('Cannot infer an fsid, one must be specified: %s' % fsids)
         return func(ctx)
@@ -1547,12 +1591,12 @@ def infer_config(func):
     """
     @wraps(func)
     def _infer_config(ctx: CephadmContext):
-        if ctx.args.config:
-            logger.debug('Using specified config: %s' % ctx.args.config)
+        if ctx.config:
+            logger.debug('Using specified config: %s' % ctx.config)
             return func(ctx)
         config = None
-        if ctx.args.fsid:
-            name = ctx.args.name
+        if ctx.fsid:
+            name = ctx.name
             if not name:
                 daemon_list = list_daemons(ctx, detail=False)
                 for daemon in daemon_list:
@@ -1560,14 +1604,14 @@ def infer_config(func):
                         name = daemon['name']
                         break
             if name:
-                config = '/var/lib/ceph/{}/{}/config'.format(ctx.args.fsid, 
+                config = '/var/lib/ceph/{}/{}/config'.format(ctx.fsid, 
                                                              name)
         if config:
             logger.info('Inferring config %s' % config)
-            ctx.args.config = config
+            ctx.config = config
         elif os.path.exists(SHELL_DEFAULT_CONF):
             logger.debug('Using default config: %s' % SHELL_DEFAULT_CONF)
-            ctx.args.config = SHELL_DEFAULT_CONF
+            ctx.config = SHELL_DEFAULT_CONF
         return func(ctx)
 
     return _infer_config
@@ -1590,12 +1634,12 @@ def infer_image(func):
     """
     @wraps(func)
     def _infer_image(ctx: CephadmContext):
-        if not ctx.args.image:
-            ctx.args.image = os.environ.get('CEPHADM_IMAGE')
-        if not ctx.args.image:
-            ctx.args.image = get_last_local_ceph_image(ctx, ctx.container_path)
-        if not ctx.args.image:
-            ctx.args.image = _get_default_image(ctx)
+        if not ctx.image:
+            ctx.image = os.environ.get('CEPHADM_IMAGE')
+        if not ctx.image:
+            ctx.image = get_last_local_ceph_image(ctx, ctx.container_path)
+        if not ctx.image:
+            ctx.image = _get_default_image(ctx)
         return func(ctx)
 
     return _infer_image
@@ -1604,19 +1648,19 @@ def infer_image(func):
 def default_image(func):
     @wraps(func)
     def _default_image(ctx: CephadmContext):
-        if not ctx.args.image:
-            if 'name' in ctx.args and ctx.args.name:
-                type_ = ctx.args.name.split('.', 1)[0]
+        if not ctx.image:
+            if 'name' in ctx.args and ctx.name:
+                type_ = ctx.name.split('.', 1)[0]
                 if type_ in Monitoring.components:
-                    ctx.args.image = Monitoring.components[type_]['image']
+                    ctx.image = Monitoring.components[type_]['image']
                 if type_ == 'haproxy':
-                    ctx.args.image = HAproxy.default_image
+                    ctx.image = HAproxy.default_image
                 if type_ == 'keepalived':
-                    ctx.args.image = Keepalived.default_image
-            if not ctx.args.image:
-                ctx.args.image = os.environ.get('CEPHADM_IMAGE')
-            if not ctx.args.image:
-                ctx.args.image = _get_default_image(ctx)
+                    ctx.image = Keepalived.default_image
+            if not ctx.image:
+                ctx.image = os.environ.get('CEPHADM_IMAGE')
+            if not ctx.image:
+                ctx.image = _get_default_image(ctx)
 
         return func(ctx)
 
@@ -1689,8 +1733,8 @@ def make_data_dir(ctx, fsid, daemon_type, daemon_id, uid=None, gid=None):
     # type: (CephadmContext, str, str, Union[int, str], Optional[int], Optional[int]) -> str
     if uid is None or gid is None:
         uid, gid = extract_uid_gid(ctx)
-    make_data_dir_base(fsid, ctx.args.data_dir, uid, gid)
-    data_dir = get_data_dir(fsid, ctx.args.data_dir, daemon_type, daemon_id)
+    make_data_dir_base(fsid, ctx.data_dir, uid, gid)
+    data_dir = get_data_dir(fsid, ctx.data_dir, daemon_type, daemon_id)
     makedirs(data_dir, uid, gid, DATA_DIR_MODE)
     return data_dir
 
@@ -1699,7 +1743,7 @@ def make_log_dir(ctx, fsid, uid=None, gid=None):
     # type: (CephadmContext, str, Optional[int], Optional[int]) -> str
     if uid is None or gid is None:
         uid, gid = extract_uid_gid(ctx)
-    log_dir = get_log_dir(fsid, ctx.args.log_dir)
+    log_dir = get_log_dir(fsid, ctx.log_dir)
     makedirs(log_dir, uid, gid, LOG_DIR_MODE)
     return log_dir
 
@@ -1917,7 +1961,7 @@ def get_legacy_daemon_fsid(ctx, cluster,
     fsid = None
     if daemon_type == 'osd':
         try:
-            fsid_file = os.path.join(ctx.args.data_dir,
+            fsid_file = os.path.join(ctx.data_dir,
                                      daemon_type,
                                      'ceph-%s' % daemon_id,
                                      'ceph_fsid')
@@ -1953,7 +1997,7 @@ def get_daemon_args(ctx, fsid, daemon_type, daemon_id):
         metadata = Monitoring.components[daemon_type]
         r += metadata.get('args', list())
         if daemon_type == 'alertmanager':
-            config = get_parm(ctx.args.config_json)
+            config = get_parm(ctx.config_json)
             peers = config.get('peers', list())  # type: ignore
             for peer in peers:
                 r += ["--cluster.peer={}".format(peer)]
@@ -1993,21 +2037,21 @@ def create_daemon_dirs(ctx, fsid, daemon_type, daemon_id, uid, gid,
             f.write(keyring)
 
     if daemon_type in Monitoring.components.keys():
-        config_json: Dict[str, Any] = get_parm(ctx.args.config_json)
+        config_json: Dict[str, Any] = get_parm(ctx.config_json)
         required_files = Monitoring.components[daemon_type].get('config-json-files', list())
 
         # Set up directories specific to the monitoring component
         config_dir = ''
         data_dir_root = ''
         if daemon_type == 'prometheus':
-            data_dir_root = get_data_dir(fsid, ctx.args.data_dir,
+            data_dir_root = get_data_dir(fsid, ctx.data_dir,
                                          daemon_type, daemon_id)
             config_dir = 'etc/prometheus'
             makedirs(os.path.join(data_dir_root, config_dir), uid, gid, 0o755)
             makedirs(os.path.join(data_dir_root, config_dir, 'alerting'), uid, gid, 0o755)
             makedirs(os.path.join(data_dir_root, 'data'), uid, gid, 0o755)
         elif daemon_type == 'grafana':
-            data_dir_root = get_data_dir(fsid, ctx.args.data_dir,
+            data_dir_root = get_data_dir(fsid, ctx.data_dir,
                                          daemon_type, daemon_id)
             config_dir = 'etc/grafana'
             makedirs(os.path.join(data_dir_root, config_dir), uid, gid, 0o755)
@@ -2015,7 +2059,7 @@ def create_daemon_dirs(ctx, fsid, daemon_type, daemon_id, uid, gid,
             makedirs(os.path.join(data_dir_root, config_dir, 'provisioning/datasources'), uid, gid, 0o755)
             makedirs(os.path.join(data_dir_root, 'data'), uid, gid, 0o755)
         elif daemon_type == 'alertmanager':
-            data_dir_root = get_data_dir(fsid, ctx.args.data_dir,
+            data_dir_root = get_data_dir(fsid, ctx.data_dir,
                                          daemon_type, daemon_id)
             config_dir = 'etc/alertmanager'
             makedirs(os.path.join(data_dir_root, config_dir), uid, gid, 0o755)
@@ -2091,19 +2135,19 @@ def get_config_and_keyring(ctx):
     config = None
     keyring = None
 
-    if 'config_json' in ctx.args and ctx.args.config_json:
-        d = get_parm(ctx.args.config_json)
+    if 'config_json' in ctx.args and ctx.config_json:
+        d = get_parm(ctx.config_json)
         config = d.get('config')
         keyring = d.get('keyring')
 
-    if 'config' in ctx.args and ctx.args.config:
-        with open(ctx.args.config, 'r') as f:
+    if 'config' in ctx.args and ctx.config:
+        with open(ctx.config, 'r') as f:
             config = f.read()
 
-    if 'key' in ctx.args and ctx.args.key:
-        keyring = '[%s]\n\tkey = %s\n' % (ctx.args.name, ctx.args.key)
-    elif 'keyring' in ctx.args and ctx.args.keyring:
-        with open(ctx.args.keyring, 'r') as f:
+    if 'key' in ctx.args and ctx.key:
+        keyring = '[%s]\n\tkey = %s\n' % (ctx.name, ctx.key)
+    elif 'keyring' in ctx.args and ctx.keyring:
+        with open(ctx.keyring, 'r') as f:
             keyring = f.read()
 
     return config, keyring
@@ -2118,7 +2162,7 @@ def get_container_binds(ctx, fsid, daemon_type, daemon_id):
     elif daemon_type == CustomContainer.daemon_type:
         assert daemon_id
         cc = CustomContainer.init(ctx, fsid, daemon_id)
-        data_dir = get_data_dir(fsid, ctx.args.data_dir, daemon_type, daemon_id)
+        data_dir = get_data_dir(fsid, ctx.data_dir, daemon_type, daemon_id)
         binds.extend(cc.get_container_binds(data_dir))
 
     return binds
@@ -2134,14 +2178,14 @@ def get_container_mounts(ctx, fsid, daemon_type, daemon_id,
             run_path = os.path.join('/var/run/ceph', fsid);
             if os.path.exists(run_path):
                 mounts[run_path] = '/var/run/ceph:z'
-            log_dir = get_log_dir(fsid, ctx.args.log_dir)
+            log_dir = get_log_dir(fsid, ctx.log_dir)
             mounts[log_dir] = '/var/log/ceph:z'
             crash_dir = '/var/lib/ceph/%s/crash' % fsid
             if os.path.exists(crash_dir):
                 mounts[crash_dir] = '/var/lib/ceph/crash:z'
 
     if daemon_type in Ceph.daemons and daemon_id:
-        data_dir = get_data_dir(fsid, ctx.args.data_dir, daemon_type, daemon_id)
+        data_dir = get_data_dir(fsid, ctx.data_dir, daemon_type, daemon_id)
         if daemon_type == 'rgw':
             cdata_dir = '/var/lib/ceph/radosgw/ceph-rgw.%s' % (daemon_id)
         else:
@@ -2163,8 +2207,8 @@ def get_container_mounts(ctx, fsid, daemon_type, daemon_id,
         mounts['/run/lock/lvm'] = '/run/lock/lvm'
 
     try:
-        if ctx.args.shared_ceph_folder:  # make easy manager modules/ceph-volume development
-            ceph_folder = pathify(ctx.args.shared_ceph_folder)
+        if ctx.shared_ceph_folder:  # make easy manager modules/ceph-volume development
+            ceph_folder = pathify(ctx.shared_ceph_folder)
             if os.path.exists(ceph_folder):
                 mounts[ceph_folder + '/src/ceph-volume/ceph_volume'] = '/usr/lib/python3.6/site-packages/ceph_volume'
                 mounts[ceph_folder + '/src/pybind/mgr'] = '/usr/share/ceph/mgr'
@@ -2179,7 +2223,7 @@ def get_container_mounts(ctx, fsid, daemon_type, daemon_id,
         pass
 
     if daemon_type in Monitoring.components and daemon_id:
-        data_dir = get_data_dir(fsid, ctx.args.data_dir, daemon_type, daemon_id)
+        data_dir = get_data_dir(fsid, ctx.data_dir, daemon_type, daemon_id)
         if daemon_type == 'prometheus':
             mounts[os.path.join(data_dir, 'etc/prometheus')] = '/etc/prometheus:Z'
             mounts[os.path.join(data_dir, 'data')] = '/prometheus:Z'
@@ -2196,7 +2240,7 @@ def get_container_mounts(ctx, fsid, daemon_type, daemon_id,
 
     if daemon_type == NFSGanesha.daemon_type:
         assert daemon_id
-        data_dir = get_data_dir(fsid, ctx.args.data_dir, daemon_type, daemon_id)
+        data_dir = get_data_dir(fsid, ctx.data_dir, daemon_type, daemon_id)
         nfs_ganesha = NFSGanesha.init(ctx, fsid, daemon_id)
         mounts.update(nfs_ganesha.get_container_mounts(data_dir))
 
@@ -2207,8 +2251,8 @@ def get_container_mounts(ctx, fsid, daemon_type, daemon_id,
 
     if daemon_type == CephIscsi.daemon_type:
         assert daemon_id
-        data_dir = get_data_dir(fsid, ctx.args.data_dir, daemon_type, daemon_id)
-        log_dir = get_log_dir(fsid, ctx.args.log_dir)
+        data_dir = get_data_dir(fsid, ctx.data_dir, daemon_type, daemon_id)
+        log_dir = get_log_dir(fsid, ctx.log_dir)
         mounts.update(CephIscsi.get_container_mounts(data_dir, log_dir))
 
     if daemon_type == Keepalived.daemon_type:
@@ -2219,7 +2263,7 @@ def get_container_mounts(ctx, fsid, daemon_type, daemon_id,
     if daemon_type == CustomContainer.daemon_type:
         assert daemon_id
         cc = CustomContainer.init(ctx, fsid, daemon_id)
-        data_dir = get_data_dir(fsid, ctx.args.data_dir, daemon_type, daemon_id)
+        data_dir = get_data_dir(fsid, ctx.data_dir, daemon_type, daemon_id)
         mounts.update(cc.get_container_mounts(data_dir))
 
     return mounts
@@ -2304,7 +2348,7 @@ def get_container(ctx: CephadmContext,
 
     return CephContainer(
         ctx,
-        image=ctx.args.image,
+        image=ctx.image,
         entrypoint=entrypoint,
         args=ceph_args + get_daemon_args(ctx, fsid, daemon_type, daemon_id),
         container_args=container_args,
@@ -2314,7 +2358,7 @@ def get_container(ctx: CephadmContext,
         envs=envs,
         privileged=privileged,
         ptrace=ptrace,
-        init=ctx.args.container_init,
+        init=ctx.container_init,
         host_network=host_network,
     )
 
@@ -2323,7 +2367,7 @@ def extract_uid_gid(ctx, img='', file_path='/var/lib/ceph'):
     # type: (CephadmContext, str, Union[str, List[str]]) -> Tuple[int, int]
 
     if not img:
-        img = ctx.args.image
+        img = ctx.image
 
     if isinstance(file_path, str):
         paths = [file_path]
@@ -2356,7 +2400,7 @@ def deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid,
     if any([port_in_use(ctx, port) for port in ports]):
         raise Error("TCP Port(s) '{}' required for {} already in use".format(",".join(map(str, ports)), daemon_type))
 
-    data_dir = get_data_dir(fsid, ctx.args.data_dir, daemon_type, daemon_id)
+    data_dir = get_data_dir(fsid, ctx.data_dir, daemon_type, daemon_id)
     if reconfig and not os.path.exists(data_dir):
         raise Error('cannot reconfig, data path %s does not exist' % data_dir)
     if daemon_type == 'mon' and not os.path.exists(data_dir):
@@ -2370,11 +2414,11 @@ def deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid,
 
         # --mkfs
         create_daemon_dirs(ctx, fsid, daemon_type, daemon_id, uid, gid)
-        mon_dir = get_data_dir(fsid, ctx.args.data_dir, 'mon', daemon_id)
-        log_dir = get_log_dir(fsid, ctx.args.log_dir)
+        mon_dir = get_data_dir(fsid, ctx.data_dir, 'mon', daemon_id)
+        log_dir = get_log_dir(fsid, ctx.log_dir)
         out = CephContainer(
             ctx,
-            image=ctx.args.image,
+            image=ctx.image,
             entrypoint='/usr/bin/ceph-mon',
             args=['--mkfs',
                   '-i', str(daemon_id),
@@ -2407,10 +2451,10 @@ def deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid,
         if daemon_type == CephadmDaemon.daemon_type:
             port = next(iter(ports), None)  # get first tcp port provided or None
 
-            if ctx.args.config_json == '-':
+            if ctx.config_json == '-':
                 config_js = get_parm('-')
             else:
-                config_js = get_parm(ctx.args.config_json)
+                config_js = get_parm(ctx.config_json)
             assert isinstance(config_js, dict)
 
             cephadm_exporter = CephadmDaemon(ctx, fsid, daemon_id, port)
@@ -2470,7 +2514,7 @@ def deploy_daemon_units(ctx, fsid, uid, gid, daemon_type, daemon_id, c,
                         osd_fsid=None):
     # type: (CephadmContext, str, int, int, str, Union[int, str], CephContainer, bool, bool, Optional[str]) -> None
     # cmd
-    data_dir = get_data_dir(fsid, ctx.args.data_dir, daemon_type, daemon_id)
+    data_dir = get_data_dir(fsid, ctx.data_dir, daemon_type, daemon_id)
     with open(data_dir + '/unit.run.new', 'w') as f:
         f.write('set -e\n')
 
@@ -2492,7 +2536,7 @@ def deploy_daemon_units(ctx, fsid, uid, gid, daemon_type, daemon_id, c,
             else:
                 prestart = CephContainer(
                     ctx,
-                    image=ctx.args.image,
+                    image=ctx.image,
                     entrypoint='/usr/sbin/ceph-volume',
                     args=[
                         'lvm', 'activate',
@@ -2527,7 +2571,7 @@ def deploy_daemon_units(ctx, fsid, uid, gid, daemon_type, daemon_id, c,
             assert osd_fsid
             poststop = CephContainer(
                 ctx,
-                image=ctx.args.image,
+                image=ctx.image,
                 entrypoint='/usr/sbin/ceph-volume',
                 args=[
                     'lvm', 'deactivate',
@@ -2566,10 +2610,10 @@ def deploy_daemon_units(ctx, fsid, uid, gid, daemon_type, daemon_id, c,
     install_base_units(ctx, fsid)
     unit = get_unit_file(ctx, fsid)
     unit_file = 'ceph-%s@.service' % (fsid)
-    with open(ctx.args.unit_dir + '/' + unit_file + '.new', 'w') as f:
+    with open(ctx.unit_dir + '/' + unit_file + '.new', 'w') as f:
         f.write(unit)
-        os.rename(ctx.args.unit_dir + '/' + unit_file + '.new',
-                  ctx.args.unit_dir + '/' + unit_file)
+        os.rename(ctx.unit_dir + '/' + unit_file + '.new',
+                  ctx.unit_dir + '/' + unit_file)
     call_throws(ctx, ['systemctl', 'daemon-reload'])
 
     unit_name = get_unit_name(fsid, daemon_type, daemon_id)
@@ -2710,15 +2754,15 @@ def install_base_units(ctx, fsid):
     Set up ceph.target and ceph-$fsid.target units.
     """
     # global unit
-    existed = os.path.exists(ctx.args.unit_dir + '/ceph.target')
-    with open(ctx.args.unit_dir + '/ceph.target.new', 'w') as f:
+    existed = os.path.exists(ctx.unit_dir + '/ceph.target')
+    with open(ctx.unit_dir + '/ceph.target.new', 'w') as f:
         f.write('[Unit]\n'
                 'Description=All Ceph clusters and services\n'
                 '\n'
                 '[Install]\n'
                 'WantedBy=multi-user.target\n')
-        os.rename(ctx.args.unit_dir + '/ceph.target.new',
-                  ctx.args.unit_dir + '/ceph.target')
+        os.rename(ctx.unit_dir + '/ceph.target.new',
+                  ctx.unit_dir + '/ceph.target')
     if not existed:
         # we disable before enable in case a different ceph.target
         # (from the traditional package) is present; while newer
@@ -2730,8 +2774,8 @@ def install_base_units(ctx, fsid):
         call_throws(ctx, ['systemctl', 'start', 'ceph.target'])
 
     # cluster unit
-    existed = os.path.exists(ctx.args.unit_dir + '/ceph-%s.target' % fsid)
-    with open(ctx.args.unit_dir + '/ceph-%s.target.new' % fsid, 'w') as f:
+    existed = os.path.exists(ctx.unit_dir + '/ceph-%s.target' % fsid)
+    with open(ctx.unit_dir + '/ceph-%s.target.new' % fsid, 'w') as f:
         f.write('[Unit]\n'
                 'Description=Ceph cluster {fsid}\n'
                 'PartOf=ceph.target\n'
@@ -2741,14 +2785,14 @@ def install_base_units(ctx, fsid):
                 'WantedBy=multi-user.target ceph.target\n'.format(
                     fsid=fsid)
         )
-        os.rename(ctx.args.unit_dir + '/ceph-%s.target.new' % fsid,
-                  ctx.args.unit_dir + '/ceph-%s.target' % fsid)
+        os.rename(ctx.unit_dir + '/ceph-%s.target.new' % fsid,
+                  ctx.unit_dir + '/ceph-%s.target' % fsid)
     if not existed:
         call_throws(ctx, ['systemctl', 'enable', 'ceph-%s.target' % fsid])
         call_throws(ctx, ['systemctl', 'start', 'ceph-%s.target' % fsid])
 
     # logrotate for the cluster
-    with open(ctx.args.logrotate_dir + '/ceph-%s' % fsid, 'w') as f:
+    with open(ctx.logrotate_dir + '/ceph-%s' % fsid, 'w') as f:
         """
         This is a bit sloppy in that the killall/pkill will touch all ceph daemons
         in all containers, but I don't see an elegant way to send SIGHUP *just* to
@@ -2816,7 +2860,7 @@ WantedBy=ceph-{fsid}.target
 """.format(
     container_path=ctx.container_path,
     fsid=fsid,
-    data_dir=ctx.args.data_dir,
+    data_dir=ctx.data_dir,
     extra_args=extra_args)
 
     return u
@@ -2983,7 +3027,7 @@ class CephContainer:
 @infer_image
 def command_version(ctx):
     # type: (CephadmContext) -> int
-    out = CephContainer(ctx, ctx.args.image, 'ceph', ['--version']).run()
+    out = CephContainer(ctx, ctx.image, 'ceph', ['--version']).run()
     print(out.strip())
     return 0
 
@@ -2994,7 +3038,7 @@ def command_version(ctx):
 def command_pull(ctx):
     # type: (CephadmContext) -> int
 
-    _pull_image(ctx, ctx.args.image)
+    _pull_image(ctx, ctx.image)
     return command_inspect_image(ctx)
 
 
@@ -3034,12 +3078,12 @@ def command_inspect_image(ctx):
     out, err, ret = call_throws(ctx, [
         ctx.container_path, 'inspect',
         '--format', '{{.ID}},{{json .RepoDigests}}',
-        ctx.args.image])
+        ctx.image])
     if ret:
         return errno.ENOENT
-    info_from = get_image_info_from_inspect(out.strip(), ctx.args.image)
+    info_from = get_image_info_from_inspect(out.strip(), ctx.image)
 
-    ver = CephContainer(ctx, ctx.args.image, 'ceph', ['--version']).run().strip()
+    ver = CephContainer(ctx, ctx.image, 'ceph', ['--version']).run().strip()
     info_from['ceph_version'] = ver
 
     print(json.dumps(info_from, indent=4, sort_keys=True))
@@ -3103,30 +3147,30 @@ def prepare_mon_addresses(
     base_ip = ""
     ipv6 = False
 
-    if ctx.args.mon_ip:
-        ipv6 = is_ipv6(ctx.args.mon_ip)
+    if ctx.mon_ip:
+        ipv6 = is_ipv6(ctx.mon_ip)
         if ipv6:
-            ctx.args.mon_ip = wrap_ipv6(ctx.args.mon_ip)
-        hasport = r.findall(ctx.args.mon_ip)
+            ctx.mon_ip = wrap_ipv6(ctx.mon_ip)
+        hasport = r.findall(ctx.mon_ip)
         if hasport:
             port = int(hasport[0])
             if port == 6789:
-                addr_arg = '[v1:%s]' % ctx.args.mon_ip
+                addr_arg = '[v1:%s]' % ctx.mon_ip
             elif port == 3300:
-                addr_arg = '[v2:%s]' % ctx.args.mon_ip
+                addr_arg = '[v2:%s]' % ctx.mon_ip
             else:
                 logger.warning('Using msgr2 protocol for unrecognized port %d' %
                                port)
-                addr_arg = '[v2:%s]' % ctx.args.mon_ip
-            base_ip = ctx.args.mon_ip[0:-(len(str(port)))-1]
+                addr_arg = '[v2:%s]' % ctx.mon_ip
+            base_ip = ctx.mon_ip[0:-(len(str(port)))-1]
             check_ip_port(ctx, base_ip, port)
         else:
-            base_ip = ctx.args.mon_ip
-            addr_arg = '[v2:%s:3300,v1:%s:6789]' % (ctx.args.mon_ip, ctx.args.mon_ip)
-            check_ip_port(ctx, ctx.args.mon_ip, 3300)
-            check_ip_port(ctx, ctx.args.mon_ip, 6789)
-    elif ctx.args.mon_addrv:
-        addr_arg = ctx.args.mon_addrv
+            base_ip = ctx.mon_ip
+            addr_arg = '[v2:%s:3300,v1:%s:6789]' % (ctx.mon_ip, ctx.mon_ip)
+            check_ip_port(ctx, ctx.mon_ip, 3300)
+            check_ip_port(ctx, ctx.mon_ip, 6789)
+    elif ctx.mon_addrv:
+        addr_arg = ctx.mon_addrv
         if addr_arg[0] != '[' or addr_arg[-1] != ']':
             raise Error('--mon-addrv value %s must use square backets' %
                         addr_arg)
@@ -3146,7 +3190,7 @@ def prepare_mon_addresses(
     logger.debug('Base mon IP is %s, final addrv is %s' % (base_ip, addr_arg))
 
     mon_network = None
-    if not ctx.args.skip_mon_network:
+    if not ctx.skip_mon_network:
         # make sure IP is configured locally, and then figure out the
         # CIDR network
         for net, ips in list_networks(ctx).items():
@@ -3169,7 +3213,7 @@ def create_initial_keys(
     mgr_id: str
 ) -> Tuple[str, str, str, Any, Any]: # type: ignore
 
-    _image = ctx.args.image
+    _image = ctx.image
 
     # create some initial keys
     logger.info('Creating initial keys...')
@@ -3228,7 +3272,7 @@ def create_initial_monmap(
     monmap = write_tmp('', 0, 0)
     out = CephContainer(
         ctx,
-        image=ctx.args.image,
+        image=ctx.image,
         entrypoint='/usr/bin/monmaptool',
         args=['--create',
               '--clobber',
@@ -3256,11 +3300,11 @@ def prepare_create_mon(
 ):
     logger.info('Creating mon...')
     create_daemon_dirs(ctx, fsid, 'mon', mon_id, uid, gid)
-    mon_dir = get_data_dir(fsid, ctx.args.data_dir, 'mon', mon_id)
-    log_dir = get_log_dir(fsid, ctx.args.log_dir)
+    mon_dir = get_data_dir(fsid, ctx.data_dir, 'mon', mon_id)
+    log_dir = get_log_dir(fsid, ctx.log_dir)
     out = CephContainer(
         ctx,
-        image=ctx.args.image,
+        image=ctx.image,
         entrypoint='/usr/bin/ceph-mon',
         args=['--mkfs',
               '-i', mon_id,
@@ -3298,7 +3342,7 @@ def wait_for_mon(
     logger.info('Waiting for mon to start...')
     c = CephContainer(
         ctx,
-        image=ctx.args.image,
+        image=ctx.image,
         entrypoint='/usr/bin/ceph',
         args=[
             'status'],
@@ -3312,7 +3356,7 @@ def wait_for_mon(
     # wait for the service to become available
     def is_mon_available():
         # type: () -> bool
-        timeout=ctx.args.timeout if ctx.args.timeout else 60 # seconds
+        timeout=ctx.timeout if ctx.timeout else 60 # seconds
         out, err, ret = call(ctx, c.run_cmd(),
                              desc=c.entrypoint,
                              timeout=timeout)
@@ -3338,7 +3382,7 @@ def create_mgr(
     logger.info('Waiting for mgr to start...')
     def is_mgr_available():
         # type: () -> bool
-        timeout=ctx.args.timeout if ctx.args.timeout else 60 # seconds
+        timeout=ctx.timeout if ctx.timeout else 60 # seconds
         try:
             out = clifunc(['status', '-f', 'json-pretty'], timeout=timeout)
             j = json.loads(out)
@@ -3354,7 +3398,7 @@ def prepare_ssh(
     cli: Callable, wait_for_mgr_restart: Callable
 ) -> None:
 
-    cli(['config-key', 'set', 'mgr/cephadm/ssh_user', ctx.args.ssh_user])
+    cli(['config-key', 'set', 'mgr/cephadm/ssh_user', ctx.ssh_user])
 
     logger.info('Enabling cephadm module...')
     cli(['mgr', 'module', 'enable', 'cephadm'])
@@ -3363,18 +3407,18 @@ def prepare_ssh(
     logger.info('Setting orchestrator backend to cephadm...')
     cli(['orch', 'set', 'backend', 'cephadm'])
 
-    if ctx.args.ssh_config:
+    if ctx.ssh_config:
         logger.info('Using provided ssh config...')
         mounts = {
-            pathify(ctx.args.ssh_config.name): '/tmp/cephadm-ssh-config:z',
+            pathify(ctx.ssh_config.name): '/tmp/cephadm-ssh-config:z',
         }
         cli(['cephadm', 'set-ssh-config', '-i', '/tmp/cephadm-ssh-config'], extra_mounts=mounts)
 
-    if ctx.args.ssh_private_key and ctx.args.ssh_public_key:
+    if ctx.ssh_private_key and ctx.ssh_public_key:
         logger.info('Using provided ssh keys...')
         mounts = {
-            pathify(ctx.args.ssh_private_key.name): '/tmp/cephadm-ssh-key:z',
-            pathify(ctx.args.ssh_public_key.name): '/tmp/cephadm-ssh-key.pub:z'
+            pathify(ctx.ssh_private_key.name): '/tmp/cephadm-ssh-key:z',
+            pathify(ctx.ssh_public_key.name): '/tmp/cephadm-ssh-key.pub:z'
         }
         cli(['cephadm', 'set-priv-key', '-i', '/tmp/cephadm-ssh-key'], extra_mounts=mounts)
         cli(['cephadm', 'set-pub-key', '-i', '/tmp/cephadm-ssh-key.pub'], extra_mounts=mounts)
@@ -3383,15 +3427,15 @@ def prepare_ssh(
         cli(['cephadm', 'generate-key'])
         ssh_pub = cli(['cephadm', 'get-pub-key'])
 
-        with open(ctx.args.output_pub_ssh_key, 'w') as f:
+        with open(ctx.output_pub_ssh_key, 'w') as f:
             f.write(ssh_pub)
-        logger.info('Wrote public SSH key to to %s' % ctx.args.output_pub_ssh_key)
+        logger.info('Wrote public SSH key to to %s' % ctx.output_pub_ssh_key)
 
-        logger.info('Adding key to %s@localhost\'s authorized_keys...' % ctx.args.ssh_user)
+        logger.info('Adding key to %s@localhost\'s authorized_keys...' % ctx.ssh_user)
         try:
-            s_pwd = pwd.getpwnam(ctx.args.ssh_user)
+            s_pwd = pwd.getpwnam(ctx.ssh_user)
         except KeyError as e:
-            raise Error('Cannot find uid/gid for ssh-user: %s' % (ctx.args.ssh_user))
+            raise Error('Cannot find uid/gid for ssh-user: %s' % (ctx.ssh_user))
         ssh_uid = s_pwd.pw_uid
         ssh_gid = s_pwd.pw_gid
         ssh_dir = os.path.join(s_pwd.pw_dir, '.ssh')
@@ -3424,12 +3468,12 @@ def prepare_ssh(
     except RuntimeError as e:
         raise Error('Failed to add host <%s>: %s' % (host, e))
 
-    if not ctx.args.orphan_initial_daemons:
+    if not ctx.orphan_initial_daemons:
         for t in ['mon', 'mgr', 'crash']:
             logger.info('Deploying %s service with default placement...' % t)
             cli(['orch', 'apply', t])
 
-    if not ctx.args.skip_monitoring_stack:
+    if not ctx.skip_monitoring_stack:
         logger.info('Enabling mgr prometheus module...')
         cli(['mgr', 'module', 'enable', 'prometheus'])
         for t in ['prometheus', 'grafana', 'node-exporter', 'alertmanager']:
@@ -3445,7 +3489,7 @@ def prepare_dashboard(
 
     # Configure SSL port (cephadm only allows to configure dashboard SSL port)
     # if the user does not want to use SSL he can change this setting once the cluster is up
-    cli(["config", "set",  "mgr", "mgr/dashboard/ssl_server_port" , str(ctx.args.ssl_dashboard_port)])
+    cli(["config", "set",  "mgr", "mgr/dashboard/ssl_server_port" , str(ctx.ssl_dashboard_port)])
 
     # configuring dashboard parameters
     logger.info('Enabling the dashboard module...')
@@ -3453,11 +3497,11 @@ def prepare_dashboard(
     wait_for_mgr_restart()
 
     # dashboard crt and key
-    if ctx.args.dashboard_key and ctx.args.dashboard_crt:
+    if ctx.dashboard_key and ctx.dashboard_crt:
         logger.info('Using provided dashboard certificate...')
         mounts = {
-            pathify(ctx.args.dashboard_crt.name): '/tmp/dashboard.crt:z',
-            pathify(ctx.args.dashboard_key.name): '/tmp/dashboard.key:z'
+            pathify(ctx.dashboard_crt.name): '/tmp/dashboard.crt:z',
+            pathify(ctx.dashboard_key.name): '/tmp/dashboard.key:z'
         }
         cli(['dashboard', 'set-ssl-certificate', '-i', '/tmp/dashboard.crt'], extra_mounts=mounts)
         cli(['dashboard', 'set-ssl-certificate-key', '-i', '/tmp/dashboard.key'], extra_mounts=mounts)
@@ -3466,10 +3510,10 @@ def prepare_dashboard(
         cli(['dashboard', 'create-self-signed-cert'])
 
     logger.info('Creating initial admin user...')
-    password = ctx.args.initial_dashboard_password or generate_password()
+    password = ctx.initial_dashboard_password or generate_password()
     tmp_password_file = write_tmp(password, uid, gid)
-    cmd = ['dashboard', 'ac-user-create', ctx.args.initial_dashboard_user, '-i', '/tmp/dashboard.pw', 'administrator', '--force-password']
-    if not ctx.args.dashboard_password_noupdate:
+    cmd = ['dashboard', 'ac-user-create', ctx.initial_dashboard_user, '-i', '/tmp/dashboard.pw', 'administrator', '--force-password']
+    if not ctx.dashboard_password_noupdate:
         cmd.append('--pwd-update-required')
     cli(cmd, extra_mounts={pathify(tmp_password_file.name): '/tmp/dashboard.pw:z'})
     logger.info('Fetching dashboard port number...')
@@ -3486,7 +3530,7 @@ def prepare_dashboard(
                 '\t    User: %s\n'
                 '\tPassword: %s\n' % (
                     get_fqdn(), port,
-                    ctx.args.initial_dashboard_user,
+                    ctx.initial_dashboard_user,
                     password))
 
 
@@ -3496,7 +3540,7 @@ def prepare_bootstrap_config(
 
 ) -> str:
 
-    cp = read_config(ctx.args.config)
+    cp = read_config(ctx.config)
     if not cp.has_section('global'):
         cp.add_section('global')
     cp.set('global', 'fsid', fsid)
@@ -3506,10 +3550,10 @@ def prepare_bootstrap_config(
     cp.write(cpf)
     config = cpf.getvalue()
 
-    if ctx.args.registry_json or ctx.args.registry_url:
+    if ctx.registry_json or ctx.registry_url:
         command_registry_login(ctx)
 
-    if not ctx.args.skip_pull:
+    if not ctx.skip_pull:
         _pull_image(ctx, image)
 
     return config
@@ -3524,7 +3568,7 @@ def finish_bootstrap_config(
     cli: Callable
 
 ) -> None:
-    if not ctx.args.no_minimize_config:
+    if not ctx.no_minimize_config:
         logger.info('Assimilating anything we can from ceph.conf...')
         cli([
             'config', 'assimilate-conf',
@@ -3558,9 +3602,9 @@ def finish_bootstrap_config(
         cli(['config', 'set', 'global', 'ms_bind_ipv6', 'true'])
 
 
-    with open(ctx.args.output_config, 'w') as f:
+    with open(ctx.output_config, 'w') as f:
         f.write(config)
-    logger.info('Wrote config to %s' % ctx.args.output_config)
+    logger.info('Wrote config to %s' % ctx.output_config)
     pass
 
 
@@ -3568,21 +3612,20 @@ def finish_bootstrap_config(
 def command_bootstrap(ctx):
     # type: (CephadmContext) -> int
 
-    args = ctx.args
     host: Optional[str] = None
 
-    if not ctx.args.output_config:
-        ctx.args.output_config = os.path.join(ctx.args.output_dir, 'ceph.conf')
-    if not ctx.args.output_keyring:
-        ctx.args.output_keyring = os.path.join(ctx.args.output_dir,
+    if not ctx.output_config:
+        ctx.output_config = os.path.join(ctx.output_dir, 'ceph.conf')
+    if not ctx.output_keyring:
+        ctx.output_keyring = os.path.join(ctx.output_dir,
                                            'ceph.client.admin.keyring')
-    if not ctx.args.output_pub_ssh_key:
-        ctx.args.output_pub_ssh_key = os.path.join(ctx.args.output_dir, 'ceph.pub')
+    if not ctx.output_pub_ssh_key:
+        ctx.output_pub_ssh_key = os.path.join(ctx.output_dir, 'ceph.pub')
 
     # verify output files
-    for f in [ctx.args.output_config, ctx.args.output_keyring,
-              ctx.args.output_pub_ssh_key]:
-        if not ctx.args.allow_overwrite:
+    for f in [ctx.output_config, ctx.output_keyring,
+              ctx.output_pub_ssh_key]:
+        if not ctx.allow_overwrite:
             if os.path.exists(f):
                 raise Error('%s already exists; delete or pass '
                               '--allow-overwrite to overwrite' % f)
@@ -3597,25 +3640,25 @@ def command_bootstrap(ctx):
                 raise Error(f"Unable to create {dirname} due to permissions failure. Retry with root, or sudo or preallocate the directory.")
 
 
-    if not ctx.args.skip_prepare_host:
+    if not ctx.skip_prepare_host:
         command_prepare_host(ctx)
     else:
         logger.info('Skip prepare_host')
 
     # initial vars
-    fsid = ctx.args.fsid or make_fsid()
+    fsid = ctx.fsid or make_fsid()
     hostname = get_hostname()
-    if '.' in hostname and not ctx.args.allow_fqdn_hostname:
+    if '.' in hostname and not ctx.allow_fqdn_hostname:
         raise Error('hostname is a fully qualified domain name (%s); either fix (e.g., "sudo hostname %s" or similar) or pass --allow-fqdn-hostname' % (hostname, hostname.split('.')[0]))
-    mon_id = ctx.args.mon_id or hostname
-    mgr_id = ctx.args.mgr_id or generate_service_id()
+    mon_id = ctx.mon_id or hostname
+    mgr_id = ctx.mgr_id or generate_service_id()
     logger.info('Cluster fsid: %s' % fsid)
 
     l = FileLock(ctx, fsid)
     l.acquire()
 
     (addr_arg, ipv6, mon_network) = prepare_mon_addresses(ctx)
-    config = prepare_bootstrap_config(ctx, fsid, addr_arg, ctx.args.image)
+    config = prepare_bootstrap_config(ctx, fsid, addr_arg, ctx.image)
 
     logger.info('Extracting ceph user uid/gid from container image...')
     (uid, gid) = extract_uid_gid(ctx)
@@ -3652,10 +3695,10 @@ def command_bootstrap(ctx):
         }
         for k, v in extra_mounts.items():
             mounts[k] = v
-        timeout = timeout or args.timeout
+        timeout = timeout or ctx.timeout
         return CephContainer(
             ctx,
-            image=ctx.args.image,
+            image=ctx.image,
             entrypoint='/usr/bin/ceph',
             args=cmd,
             volume_mounts=mounts,
@@ -3667,11 +3710,11 @@ def command_bootstrap(ctx):
                             mon_network, ipv6, cli)
 
     # output files
-    with open(ctx.args.output_keyring, 'w') as f:
+    with open(ctx.output_keyring, 'w') as f:
         os.fchmod(f.fileno(), 0o600)
         f.write('[client.admin]\n'
                 '\tkey = ' + admin_key + '\n')
-    logger.info('Wrote keyring to %s' % ctx.args.output_keyring)
+    logger.info('Wrote keyring to %s' % ctx.output_keyring)
 
     # create mgr
     create_mgr(ctx, uid, gid, fsid, mgr_id, mgr_key, config, cli)
@@ -3697,24 +3740,24 @@ def command_bootstrap(ctx):
 
     # ssh
     host = None
-    if not ctx.args.skip_ssh:
+    if not ctx.skip_ssh:
         prepare_ssh(ctx, cli, wait_for_mgr_restart)
 
-    if ctx.args.registry_url and ctx.args.registry_username and ctx.args.registry_password:
-        cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_url', ctx.args.registry_url, '--force'])
-        cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_username', ctx.args.registry_username, '--force'])
-        cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_password', ctx.args.registry_password, '--force'])
+    if ctx.registry_url and ctx.registry_username and ctx.registry_password:
+        cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_url', ctx.registry_url, '--force'])
+        cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_username', ctx.registry_username, '--force'])
+        cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_password', ctx.registry_password, '--force'])
 
-    if ctx.args.container_init:
-        cli(['config', 'set', 'mgr', 'mgr/cephadm/container_init', str(ctx.args.container_init), '--force'])
+    if ctx.container_init:
+        cli(['config', 'set', 'mgr', 'mgr/cephadm/container_init', str(ctx.container_init), '--force'])
 
-    if ctx.args.with_exporter:
+    if ctx.with_exporter:
         cli(['config-key', 'set', 'mgr/cephadm/exporter_enabled', 'true'])
-        if ctx.args.exporter_config:
+        if ctx.exporter_config:
             logger.info("Applying custom cephadm exporter settings")
             # validated within the parser, so we can just apply to the store
             with tempfile.NamedTemporaryFile(buffering=0) as tmp:
-                tmp.write(json.dumps(args.exporter_config).encode('utf-8'))
+                tmp.write(json.dumps(ctx.exporter_config).encode('utf-8'))
                 mounts = {
                     tmp.name: "/tmp/exporter-config.json:z"
                 }
@@ -3730,13 +3773,13 @@ def command_bootstrap(ctx):
         cli(['orch', 'apply', 'cephadm-exporter'])
 
 
-    if not ctx.args.skip_dashboard:
+    if not ctx.skip_dashboard:
         prepare_dashboard(ctx, uid, gid, cli, wait_for_mgr_restart)
 
-    if ctx.args.apply_spec:
-        logger.info('Applying %s to cluster' % ctx.args.apply_spec)
+    if ctx.apply_spec:
+        logger.info('Applying %s to cluster' % ctx.apply_spec)
 
-        with open(ctx.args.apply_spec) as f:
+        with open(ctx.apply_spec) as f:
             for line in f:
                 if 'hostname:' in line:
                     line = line.replace('\n', '')
@@ -3745,12 +3788,12 @@ def command_bootstrap(ctx):
                         logger.info('Adding ssh key to %s' % split[1])
 
                         ssh_key = '/etc/ceph/ceph.pub'
-                        if ctx.args.ssh_public_key:
-                            ssh_key = ctx.args.ssh_public_key.name
-                        out, err, code = call_throws(ctx, ['ssh-copy-id', '-f', '-i', ssh_key, '%s@%s' % (args.ssh_user, split[1])])
+                        if ctx.ssh_public_key:
+                            ssh_key = ctx.ssh_public_key.name
+                        out, err, code = call_throws(ctx, ['ssh-copy-id', '-f', '-i', ssh_key, '%s@%s' % (ctx.ssh_user, split[1])])
 
         mounts = {}
-        mounts[pathify(ctx.args.apply_spec)] = '/tmp/spec.yml:z'
+        mounts[pathify(ctx.apply_spec)] = '/tmp/spec.yml:z'
 
         out = cli(['orch', 'apply', '-i', '/tmp/spec.yml'], extra_mounts=mounts)
         logger.info(out)
@@ -3759,8 +3802,8 @@ def command_bootstrap(ctx):
                 '\tsudo %s shell --fsid %s -c %s -k %s\n' % (
                     sys.argv[0],
                     fsid,
-                    args.output_config,
-                    args.output_keyring))
+                    ctx.output_config,
+                    ctx.output_keyring))
     logger.info('Please consider enabling telemetry to help improve Ceph:\n\n'
                 '\tceph telemetry on\n\n'
                 'For more information see:\n\n'
@@ -3771,15 +3814,14 @@ def command_bootstrap(ctx):
 ##################################
 
 def command_registry_login(ctx: CephadmContext):
-    args = ctx.args
-    if args.registry_json:
-        logger.info("Pulling custom registry login info from %s." % args.registry_json)
-        d = get_parm(args.registry_json)
+    if ctx.registry_json:
+        logger.info("Pulling custom registry login info from %s." % ctx.registry_json)
+        d = get_parm(ctx.registry_json)
         if d.get('url') and d.get('username') and d.get('password'):
-            args.registry_url = d.get('url')
-            args.registry_username = d.get('username')
-            args.registry_password = d.get('password')
-            registry_login(ctx, args.registry_url, args.registry_username, args.registry_password)
+            ctx.registry_url = d.get('url')
+            ctx.registry_username = d.get('username')
+            ctx.registry_password = d.get('password')
+            registry_login(ctx, ctx.registry_url, ctx.registry_username, ctx.registry_password)
         else:
             raise Error("json provided for custom registry login did not include all necessary fields. "
                             "Please setup json file as\n"
@@ -3788,8 +3830,8 @@ def command_registry_login(ctx: CephadmContext):
                               " \"username\": \"REGISTRY_USERNAME\",\n"
                               " \"password\": \"REGISTRY_PASSWORD\"\n"
                             "}\n")
-    elif args.registry_url and args.registry_username and args.registry_password:
-        registry_login(ctx, args.registry_url, args.registry_username, args.registry_password)
+    elif ctx.registry_url and ctx.registry_username and ctx.registry_password:
+        registry_login(ctx, ctx.registry_url, ctx.registry_username, ctx.registry_password)
     else:
         raise Error("Invalid custom registry arguments received. To login to a custom registry include "
                         "--registry-url, --registry-username and --registry-password "
@@ -3809,7 +3851,7 @@ def registry_login(ctx: CephadmContext, url, username, password):
         if 'podman' in container_path:
             os.chmod('/etc/ceph/podman-auth.json', 0o600)
     except:
-        raise Error("Failed to login to custom registry @ %s as %s with given password" % (ctx.args.registry_url, ctx.args.registry_username))
+        raise Error("Failed to login to custom registry @ %s as %s with given password" % (ctx.registry_url, ctx.registry_username))
 
 ##################################
 
@@ -3833,54 +3875,53 @@ def extract_uid_gid_monitoring(ctx, daemon_type):
 @default_image
 def command_deploy(ctx):
     # type: (CephadmContext) -> None
-    args = ctx.args
-    daemon_type, daemon_id = args.name.split('.', 1)
+    daemon_type, daemon_id = ctx.name.split('.', 1)
 
-    l = FileLock(ctx, args.fsid)
+    l = FileLock(ctx, ctx.fsid)
     l.acquire()
 
     if daemon_type not in get_supported_daemons():
         raise Error('daemon type %s not recognized' % daemon_type)
 
     redeploy = False
-    unit_name = get_unit_name(args.fsid, daemon_type, daemon_id)
+    unit_name = get_unit_name(ctx.fsid, daemon_type, daemon_id)
     (_, state, _) = check_unit(ctx, unit_name)
     if state == 'running':
         redeploy = True
 
-    if args.reconfig:
-        logger.info('%s daemon %s ...' % ('Reconfig', args.name))
+    if ctx.reconfig:
+        logger.info('%s daemon %s ...' % ('Reconfig', ctx.name))
     elif redeploy:
-        logger.info('%s daemon %s ...' % ('Redeploy', args.name))
+        logger.info('%s daemon %s ...' % ('Redeploy', ctx.name))
     else:
-        logger.info('%s daemon %s ...' % ('Deploy', args.name))
+        logger.info('%s daemon %s ...' % ('Deploy', ctx.name))
 
     # Get and check ports explicitly required to be opened
     daemon_ports = [] # type: List[int]
-    if args.tcp_ports:
-        daemon_ports = list(map(int, args.tcp_ports.split()))
+    if ctx.tcp_ports:
+        daemon_ports = list(map(int, ctx.tcp_ports.split()))
 
     if daemon_type in Ceph.daemons:
         config, keyring = get_config_and_keyring(ctx)
         uid, gid = extract_uid_gid(ctx)
-        make_var_run(ctx, args.fsid, uid, gid)
+        make_var_run(ctx, ctx.fsid, uid, gid)
 
-        c = get_container(ctx, args.fsid, daemon_type, daemon_id,
-                          ptrace=args.allow_ptrace)
-        deploy_daemon(ctx, args.fsid, daemon_type, daemon_id, c, uid, gid,
+        c = get_container(ctx, ctx.fsid, daemon_type, daemon_id,
+                          ptrace=ctx.allow_ptrace)
+        deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c, uid, gid,
                       config=config, keyring=keyring,
-                      osd_fsid=args.osd_fsid,
-                      reconfig=args.reconfig,
+                      osd_fsid=ctx.osd_fsid,
+                      reconfig=ctx.reconfig,
                       ports=daemon_ports)
 
     elif daemon_type in Monitoring.components:
         # monitoring daemon - prometheus, grafana, alertmanager, node-exporter
         # Default Checks
-        if not args.reconfig and not redeploy:
+        if not ctx.reconfig and not redeploy:
             daemon_ports.extend(Monitoring.port_map[daemon_type])
 
         # make sure provided config-json is sufficient
-        config = get_parm(args.config_json) # type: ignore
+        config = get_parm(ctx.config_json) # type: ignore
         required_files = Monitoring.components[daemon_type].get('config-json-files', list())
         required_args = Monitoring.components[daemon_type].get('config-json-args', list())
         if required_files:
@@ -3893,73 +3934,73 @@ def command_deploy(ctx):
                             "contain arg for {}".format(daemon_type.capitalize(), ', '.join(required_args)))
 
         uid, gid = extract_uid_gid_monitoring(ctx, daemon_type)
-        c = get_container(ctx, args.fsid, daemon_type, daemon_id)
-        deploy_daemon(ctx, args.fsid, daemon_type, daemon_id, c, uid, gid,
-                      reconfig=args.reconfig,
+        c = get_container(ctx, ctx.fsid, daemon_type, daemon_id)
+        deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c, uid, gid,
+                      reconfig=ctx.reconfig,
                       ports=daemon_ports)
 
     elif daemon_type == NFSGanesha.daemon_type:
-        if not args.reconfig and not redeploy:
+        if not ctx.reconfig and not redeploy:
             daemon_ports.extend(NFSGanesha.port_map.values())
 
         config, keyring = get_config_and_keyring(ctx)
         # TODO: extract ganesha uid/gid (997, 994) ?
         uid, gid = extract_uid_gid(ctx)
-        c = get_container(ctx, args.fsid, daemon_type, daemon_id)
-        deploy_daemon(ctx, args.fsid, daemon_type, daemon_id, c, uid, gid,
+        c = get_container(ctx, ctx.fsid, daemon_type, daemon_id)
+        deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c, uid, gid,
                       config=config, keyring=keyring,
-                      reconfig=args.reconfig,
+                      reconfig=ctx.reconfig,
                       ports=daemon_ports)
 
     elif daemon_type == CephIscsi.daemon_type:
         config, keyring = get_config_and_keyring(ctx)
         uid, gid = extract_uid_gid(ctx)
-        c = get_container(ctx, args.fsid, daemon_type, daemon_id)
-        deploy_daemon(ctx, args.fsid, daemon_type, daemon_id, c, uid, gid,
+        c = get_container(ctx, ctx.fsid, daemon_type, daemon_id)
+        deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c, uid, gid,
                       config=config, keyring=keyring,
-                      reconfig=args.reconfig,
+                      reconfig=ctx.reconfig,
                       ports=daemon_ports)
 
     elif daemon_type == HAproxy.daemon_type:
-        haproxy = HAproxy.init(ctx, args.fsid, daemon_id)
+        haproxy = HAproxy.init(ctx, ctx.fsid, daemon_id)
         uid, gid = haproxy.extract_uid_gid_haproxy()
-        c = get_container(ctx, args.fsid, daemon_type, daemon_id)
-        deploy_daemon(ctx, args.fsid, daemon_type, daemon_id, c, uid, gid,
-                      reconfig=args.reconfig,
+        c = get_container(ctx, ctx.fsid, daemon_type, daemon_id)
+        deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c, uid, gid,
+                      reconfig=ctx.reconfig,
                       ports=daemon_ports)
 
     elif daemon_type == Keepalived.daemon_type:
-        keepalived = Keepalived.init(ctx, args.fsid, daemon_id)
+        keepalived = Keepalived.init(ctx, ctx.fsid, daemon_id)
         uid, gid = keepalived.extract_uid_gid_keepalived()
-        c = get_container(ctx, args.fsid, daemon_type, daemon_id)
-        deploy_daemon(ctx, args.fsid, daemon_type, daemon_id, c, uid, gid,
-                      reconfig=args.reconfig,
+        c = get_container(ctx, ctx.fsid, daemon_type, daemon_id)
+        deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c, uid, gid,
+                      reconfig=ctx.reconfig,
                       ports=daemon_ports)
 
     elif daemon_type == CustomContainer.daemon_type:
-        cc = CustomContainer.init(ctx, args.fsid, daemon_id)
-        if not args.reconfig and not redeploy:
+        cc = CustomContainer.init(ctx, ctx.fsid, daemon_id)
+        if not ctx.reconfig and not redeploy:
             daemon_ports.extend(cc.ports)
-        c = get_container(ctx, args.fsid, daemon_type, daemon_id,
+        c = get_container(ctx, ctx.fsid, daemon_type, daemon_id,
                           privileged=cc.privileged,
-                          ptrace=args.allow_ptrace)
-        deploy_daemon(ctx, args.fsid, daemon_type, daemon_id, c,
+                          ptrace=ctx.allow_ptrace)
+        deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, c,
                       uid=cc.uid, gid=cc.gid, config=None,
-                      keyring=None, reconfig=args.reconfig,
+                      keyring=None, reconfig=ctx.reconfig,
                       ports=daemon_ports)
 
     elif daemon_type == CephadmDaemon.daemon_type:
         # get current user gid and uid
         uid = os.getuid()
         gid = os.getgid()
-        config_js = get_parm(args.config_json)  # type: Dict[str, str]
+        config_js = get_parm(ctx.config_json)  # type: Dict[str, str]
         if not daemon_ports:
             logger.info("cephadm-exporter will use default port ({})".format(CephadmDaemon.default_port))
             daemon_ports =[CephadmDaemon.default_port]
            
         CephadmDaemon.validate_config(config_js)
         
-        deploy_daemon(ctx, args.fsid, daemon_type, daemon_id, None,
+        deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, None,
                       uid, gid, ports=daemon_ports)
     
     else:
@@ -3972,11 +4013,10 @@ def command_deploy(ctx):
 @infer_image
 def command_run(ctx):
     # type: (CephadmContext) -> int
-    args = ctx.args
-    (daemon_type, daemon_id) = args.name.split('.', 1)
-    c = get_container(ctx, args.fsid, daemon_type, daemon_id)
+    (daemon_type, daemon_id) = ctx.name.split('.', 1)
+    c = get_container(ctx, ctx.fsid, daemon_type, daemon_id)
     command = c.run_cmd()
-    return call_timeout(ctx, command, args.timeout)
+    return call_timeout(ctx, command, ctx.timeout)
 
 ##################################
 
@@ -3986,38 +4026,37 @@ def command_run(ctx):
 @infer_image
 def command_shell(ctx):
     # type: (CephadmContext) -> int
-    args = ctx.args
-    if args.fsid:
-        make_log_dir(ctx, args.fsid)
-    if args.name:
-        if '.' in args.name:
-            (daemon_type, daemon_id) = args.name.split('.', 1)
+    if ctx.fsid:
+        make_log_dir(ctx, ctx.fsid)
+    if ctx.name:
+        if '.' in ctx.name:
+            (daemon_type, daemon_id) = ctx.name.split('.', 1)
         else:
-            daemon_type = args.name
+            daemon_type = ctx.name
             daemon_id = None
     else:
         daemon_type = 'osd'  # get the most mounts
         daemon_id = None
 
-    if daemon_id and not args.fsid:
+    if daemon_id and not ctx.fsid:
         raise Error('must pass --fsid to specify cluster')
 
     # use /etc/ceph files by default, if present.  we do this instead of
     # making these defaults in the arg parser because we don't want an error
     # if they don't exist.
-    if not args.keyring and os.path.exists(SHELL_DEFAULT_KEYRING):
-        args.keyring = SHELL_DEFAULT_KEYRING
+    if not ctx.keyring and os.path.exists(SHELL_DEFAULT_KEYRING):
+        ctx.keyring = SHELL_DEFAULT_KEYRING
 
     container_args = [] # type: List[str]
-    mounts = get_container_mounts(ctx, args.fsid, daemon_type, daemon_id,
-                                  no_config=True if args.config else False)
-    binds = get_container_binds(ctx, args.fsid, daemon_type, daemon_id)
-    if args.config:
-        mounts[pathify(args.config)] = '/etc/ceph/ceph.conf:z'
-    if args.keyring:
-        mounts[pathify(args.keyring)] = '/etc/ceph/ceph.keyring:z'
-    if args.mount:
-        for _mount in args.mount:
+    mounts = get_container_mounts(ctx, ctx.fsid, daemon_type, daemon_id,
+                                  no_config=True if ctx.config else False)
+    binds = get_container_binds(ctx, ctx.fsid, daemon_type, daemon_id)
+    if ctx.config:
+        mounts[pathify(ctx.config)] = '/etc/ceph/ceph.conf:z'
+    if ctx.keyring:
+        mounts[pathify(ctx.keyring)] = '/etc/ceph/ceph.keyring:z'
+    if ctx.mount:
+        for _mount in ctx.mount:
             split_src_dst = _mount.split(':')
             mount = pathify(split_src_dst[0])
             filename = os.path.basename(split_src_dst[0])
@@ -4026,8 +4065,8 @@ def command_shell(ctx):
                 mounts[mount] = dst
             else:
                 mounts[mount] = '/mnt/{}:z'.format(filename)
-    if args.command:
-        command = args.command
+    if ctx.command:
+        command = ctx.command
     else:
         command = ['bash']
         container_args += [
@@ -4035,8 +4074,8 @@ def command_shell(ctx):
             '-e', 'LANG=C',
             '-e', "PS1=%s" % CUSTOM_PS1,
         ]
-        if args.fsid:
-            home = os.path.join(args.data_dir, args.fsid, 'home')
+        if ctx.fsid:
+            home = os.path.join(ctx.data_dir, ctx.fsid, 'home')
             if not os.path.exists(home):
                 logger.debug('Creating root home at %s' % home)
                 makedirs(home, 0, 0, 0o660)
@@ -4049,17 +4088,17 @@ def command_shell(ctx):
 
     c = CephContainer(
         ctx,
-        image=args.image,
+        image=ctx.image,
         entrypoint='doesnotmatter',
         args=[],
         container_args=container_args,
         volume_mounts=mounts,
         bind_mounts=binds,
-        envs=args.env,
+        envs=ctx.env,
         privileged=True)
     command = c.shell_cmd(command)
 
-    return call_timeout(ctx, command, args.timeout)
+    return call_timeout(ctx, command, ctx.timeout)
 
 ##################################
 
@@ -4067,13 +4106,12 @@ def command_shell(ctx):
 @infer_fsid
 def command_enter(ctx):
     # type: (CephadmContext) -> int
-    args = ctx.args
-    if not args.fsid:
+    if not ctx.fsid:
         raise Error('must pass --fsid to specify cluster')
-    (daemon_type, daemon_id) = args.name.split('.', 1)
+    (daemon_type, daemon_id) = ctx.name.split('.', 1)
     container_args = [] # type: List[str]
-    if args.command:
-        command = args.command
+    if ctx.command:
+        command = ctx.command
     else:
         command = ['sh']
         container_args += [
@@ -4083,13 +4121,13 @@ def command_enter(ctx):
         ]
     c = CephContainer(
         ctx,
-        image=args.image,
+        image=ctx.image,
         entrypoint='doesnotmatter',
         container_args=container_args,
-        cname='ceph-%s-%s.%s' % (args.fsid, daemon_type, daemon_id),
+        cname='ceph-%s-%s.%s' % (ctx.fsid, daemon_type, daemon_id),
     )
     command = c.exec_cmd(command)
-    return call_timeout(ctx, command, args.timeout)
+    return call_timeout(ctx, command, ctx.timeout)
 
 ##################################
 
@@ -4098,15 +4136,14 @@ def command_enter(ctx):
 @infer_image
 def command_ceph_volume(ctx):
     # type: (CephadmContext) -> None
-    args = ctx.args
-    if args.fsid:
-        make_log_dir(ctx, args.fsid)
+    if ctx.fsid:
+        make_log_dir(ctx, ctx.fsid)
 
-        l = FileLock(ctx, args.fsid)
+        l = FileLock(ctx, ctx.fsid)
         l.acquire()
 
     (uid, gid) = (0, 0) # ceph-volume runs as root
-    mounts = get_container_mounts(ctx, args.fsid, 'osd', None)
+    mounts = get_container_mounts(ctx, ctx.fsid, 'osd', None)
 
     tmp_config = None
     tmp_keyring = None
@@ -4125,14 +4162,14 @@ def command_ceph_volume(ctx):
 
     c = CephContainer(
         ctx,
-        image=args.image,
+        image=ctx.image,
         entrypoint='/usr/sbin/ceph-volume',
-        envs=args.env,
-        args=args.command,
+        envs=ctx.env,
+        args=ctx.command,
         privileged=True,
         volume_mounts=mounts,
     )
-    verbosity = CallVerbosity.VERBOSE if ctx.args.log_output else CallVerbosity.VERBOSE_ON_FAILURE
+    verbosity = CallVerbosity.VERBOSE if ctx.log_output else CallVerbosity.VERBOSE_ON_FAILURE
     out, err, code = call_throws(ctx, c.run_cmd(), verbosity=verbosity)
     if not code:
         print(out)
@@ -4143,15 +4180,14 @@ def command_ceph_volume(ctx):
 @infer_fsid
 def command_unit(ctx):
     # type: (CephadmContext) -> None
-    args = ctx.args
-    if not args.fsid:
+    if not ctx.fsid:
         raise Error('must pass --fsid to specify cluster')
 
-    unit_name = get_unit_name_by_daemon_name(ctx, args.fsid, args.name)
+    unit_name = get_unit_name_by_daemon_name(ctx, ctx.fsid, ctx.name)
 
     call_throws(ctx, [
         'systemctl',
-        args.command,
+        ctx.command,
         unit_name],
         verbosity=CallVerbosity.VERBOSE,
         desc=''
@@ -4163,16 +4199,15 @@ def command_unit(ctx):
 @infer_fsid
 def command_logs(ctx):
     # type: (CephadmContext) -> None
-    args = ctx.args
-    if not args.fsid:
+    if not ctx.fsid:
         raise Error('must pass --fsid to specify cluster')
 
-    unit_name = get_unit_name_by_daemon_name(ctx, args.fsid, args.name)
+    unit_name = get_unit_name_by_daemon_name(ctx, ctx.fsid, ctx.name)
 
     cmd = [find_program('journalctl')]
     cmd.extend(['-u', unit_name])
-    if args.command:
-        cmd.extend(args.command)
+    if ctx.command:
+        cmd.extend(ctx.command)
 
     # call this directly, without our wrapper, so that we get an unmolested
     # stdout with logger prefixing.
@@ -4264,9 +4299,8 @@ def command_list_networks(ctx):
 
 def command_ls(ctx):
     # type: (CephadmContext) -> None
-    args = ctx.args
-    ls = list_daemons(ctx, detail=not args.no_detail,
-                      legacy_dir=args.legacy_dir)
+    ls = list_daemons(ctx, detail=not ctx.no_detail,
+                      legacy_dir=ctx.legacy_dir)
     print(json.dumps(ls, indent=4))
 
 
@@ -4274,10 +4308,9 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
     # type: (CephadmContext, bool, Optional[str]) -> List[Dict[str, str]]
     host_version: Optional[str] = None
     ls = []
-    args = ctx.args
     container_path = ctx.container_path
 
-    data_dir = args.data_dir
+    data_dir = ctx.data_dir
     if legacy_dir is not None:
         data_dir = os.path.abspath(legacy_dir + data_dir)
 
@@ -4461,23 +4494,22 @@ def get_daemon_description(ctx, fsid, name, detail=False, legacy_dir=None):
 @default_image
 def command_adopt(ctx):
     # type: (CephadmContext) -> None
-    args = ctx.args
 
-    if not args.skip_pull:
-        _pull_image(ctx, args.image)
+    if not ctx.skip_pull:
+        _pull_image(ctx, ctx.image)
 
-    (daemon_type, daemon_id) = args.name.split('.', 1)
+    (daemon_type, daemon_id) = ctx.name.split('.', 1)
 
     # legacy check
-    if args.style != 'legacy':
-        raise Error('adoption of style %s not implemented' % args.style)
+    if ctx.style != 'legacy':
+        raise Error('adoption of style %s not implemented' % ctx.style)
 
     # lock
     fsid = get_legacy_daemon_fsid(ctx,
-                                  args.cluster,
+                                  ctx.cluster,
                                   daemon_type,
                                   daemon_id,
-                                  legacy_dir=args.legacy_dir)
+                                  legacy_dir=ctx.legacy_dir)
     if not fsid:
         raise Error('could not detect legacy fsid; set fsid in ceph.conf')
     l = FileLock(ctx, fsid)
@@ -4527,12 +4559,11 @@ class AdoptOsd(object):
 
     def check_offline_lvm_osd(self):
         # type: () -> Tuple[Optional[str], Optional[str]]
-        args = self.ctx.args
         osd_fsid, osd_type = None, None
 
         c = CephContainer(
             self.ctx,
-            image=args.image,
+            image=self.ctx.image,
             entrypoint='/usr/sbin/ceph-volume',
             args=['lvm', 'list', '--format=json'],
             privileged=True
@@ -4581,13 +4612,11 @@ class AdoptOsd(object):
 def command_adopt_ceph(ctx, daemon_type, daemon_id, fsid):
     # type: (CephadmContext, str, str, str) -> None
 
-    args = ctx.args
-
     (uid, gid) = extract_uid_gid(ctx)
 
     data_dir_src = ('/var/lib/ceph/%s/%s-%s' %
-                    (daemon_type, args.cluster, daemon_id))
-    data_dir_src = os.path.abspath(args.legacy_dir + data_dir_src)
+                    (daemon_type, ctx.cluster, daemon_id))
+    data_dir_src = os.path.abspath(ctx.legacy_dir + data_dir_src)
 
     if not os.path.exists(data_dir_src):
         raise Error("{}.{} data directory '{}' does not exist.  "
@@ -4675,16 +4704,16 @@ def command_adopt_ceph(ctx, daemon_type, daemon_id, fsid):
                   'ceph-volume@lvm-%s-%s.service' % (daemon_id, osd_fsid)])
 
     # config
-    config_src = '/etc/ceph/%s.conf' % (args.cluster)
-    config_src = os.path.abspath(args.legacy_dir + config_src)
+    config_src = '/etc/ceph/%s.conf' % (ctx.cluster)
+    config_src = os.path.abspath(ctx.legacy_dir + config_src)
     config_dst = os.path.join(data_dir_dst, 'config')
     copy_files(ctx, [config_src], config_dst, uid=uid, gid=gid)
 
     # logs
     logger.info('Moving logs...')
     log_dir_src = ('/var/log/ceph/%s-%s.%s.log*' %
-                    (args.cluster, daemon_type, daemon_id))
-    log_dir_src = os.path.abspath(args.legacy_dir + log_dir_src)
+                    (ctx.cluster, daemon_type, daemon_id))
+    log_dir_src = os.path.abspath(ctx.legacy_dir + log_dir_src)
     log_dir_dst = make_log_dir(ctx, fsid, uid=uid, gid=gid)
     move_files(ctx, glob(log_dir_src),
                log_dir_dst,
@@ -4695,14 +4724,13 @@ def command_adopt_ceph(ctx, daemon_type, daemon_id, fsid):
     c = get_container(ctx, fsid, daemon_type, daemon_id)
     deploy_daemon_units(ctx, fsid, uid, gid, daemon_type, daemon_id, c,
                         enable=True,  # unconditionally enable the new unit
-                        start=(state == 'running' or args.force_start),
+                        start=(state == 'running' or ctx.force_start),
                         osd_fsid=osd_fsid)
     update_firewalld(ctx, daemon_type)
 
 
 def command_adopt_prometheus(ctx, daemon_id, fsid):
     # type: (CephadmContext, str, str) -> None
-    args = ctx.args
     daemon_type = 'prometheus'
     (uid, gid) = extract_uid_gid_monitoring(ctx, daemon_type)
 
@@ -4713,14 +4741,14 @@ def command_adopt_prometheus(ctx, daemon_id, fsid):
 
     # config
     config_src = '/etc/prometheus/prometheus.yml'
-    config_src = os.path.abspath(args.legacy_dir + config_src)
+    config_src = os.path.abspath(ctx.legacy_dir + config_src)
     config_dst = os.path.join(data_dir_dst, 'etc/prometheus')
     makedirs(config_dst, uid, gid, 0o755)
     copy_files(ctx, [config_src], config_dst, uid=uid, gid=gid)
 
     # data
     data_src = '/var/lib/prometheus/metrics/'
-    data_src = os.path.abspath(args.legacy_dir + data_src)
+    data_src = os.path.abspath(ctx.legacy_dir + data_src)
     data_dst = os.path.join(data_dir_dst, 'data')
     copy_tree(ctx, [data_src], data_dst, uid=uid, gid=gid)
 
@@ -4733,8 +4761,6 @@ def command_adopt_prometheus(ctx, daemon_id, fsid):
 def command_adopt_grafana(ctx, daemon_id, fsid):
     # type: (CephadmContext, str, str) -> None
 
-    args = ctx.args
-
     daemon_type = 'grafana'
     (uid, gid) = extract_uid_gid_monitoring(ctx, daemon_type)
 
@@ -4745,13 +4771,13 @@ def command_adopt_grafana(ctx, daemon_id, fsid):
 
     # config
     config_src = '/etc/grafana/grafana.ini'
-    config_src = os.path.abspath(args.legacy_dir + config_src)
+    config_src = os.path.abspath(ctx.legacy_dir + config_src)
     config_dst = os.path.join(data_dir_dst, 'etc/grafana')
     makedirs(config_dst, uid, gid, 0o755)
     copy_files(ctx, [config_src], config_dst, uid=uid, gid=gid)
 
     prov_src = '/etc/grafana/provisioning/'
-    prov_src = os.path.abspath(args.legacy_dir + prov_src)
+    prov_src = os.path.abspath(ctx.legacy_dir + prov_src)
     prov_dst = os.path.join(data_dir_dst, 'etc/grafana')
     copy_tree(ctx, [prov_src], prov_dst, uid=uid, gid=gid)
 
@@ -4760,13 +4786,13 @@ def command_adopt_grafana(ctx, daemon_id, fsid):
     key = '/etc/grafana/grafana.key'
     if os.path.exists(cert) and os.path.exists(key):
         cert_src = '/etc/grafana/grafana.crt'
-        cert_src = os.path.abspath(args.legacy_dir + cert_src)
+        cert_src = os.path.abspath(ctx.legacy_dir + cert_src)
         makedirs(os.path.join(data_dir_dst, 'etc/grafana/certs'), uid, gid, 0o755)
         cert_dst = os.path.join(data_dir_dst, 'etc/grafana/certs/cert_file')
         copy_files(ctx, [cert_src], cert_dst, uid=uid, gid=gid)
 
         key_src = '/etc/grafana/grafana.key'
-        key_src = os.path.abspath(args.legacy_dir + key_src)
+        key_src = os.path.abspath(ctx.legacy_dir + key_src)
         key_dst = os.path.join(data_dir_dst, 'etc/grafana/certs/cert_key')
         copy_files(ctx, [key_src], key_dst, uid=uid, gid=gid)
 
@@ -4776,7 +4802,7 @@ def command_adopt_grafana(ctx, daemon_id, fsid):
 
     # data - possible custom dashboards/plugins
     data_src = '/var/lib/grafana/'
-    data_src = os.path.abspath(args.legacy_dir + data_src)
+    data_src = os.path.abspath(ctx.legacy_dir + data_src)
     data_dst = os.path.join(data_dir_dst, 'data')
     copy_tree(ctx, [data_src], data_dst, uid=uid, gid=gid)
 
@@ -4788,7 +4814,6 @@ def command_adopt_grafana(ctx, daemon_id, fsid):
 
 def command_adopt_alertmanager(ctx, daemon_id, fsid):
     # type: (CephadmContext, str, str) -> None
-    args = ctx.args
 
     daemon_type = 'alertmanager'
     (uid, gid) = extract_uid_gid_monitoring(ctx, daemon_type)
@@ -4800,14 +4825,14 @@ def command_adopt_alertmanager(ctx, daemon_id, fsid):
 
     # config
     config_src = '/etc/prometheus/alertmanager.yml'
-    config_src = os.path.abspath(args.legacy_dir + config_src)
+    config_src = os.path.abspath(ctx.legacy_dir + config_src)
     config_dst = os.path.join(data_dir_dst, 'etc/alertmanager')
     makedirs(config_dst, uid, gid, 0o755)
     copy_files(ctx, [config_src], config_dst, uid=uid, gid=gid)
 
     # data
     data_src = '/var/lib/prometheus/alertmanager/'
-    data_src = os.path.abspath(args.legacy_dir + data_src)
+    data_src = os.path.abspath(ctx.legacy_dir + data_src)
     data_dst = os.path.join(data_dir_dst, 'etc/alertmanager/data')
     copy_tree(ctx, [data_src], data_dst, uid=uid, gid=gid)
 
@@ -4859,13 +4884,12 @@ def _stop_and_disable(ctx, unit_name):
 
 def command_rm_daemon(ctx):
     # type: (CephadmContext) -> None
-    args = ctx.args
-    l = FileLock(ctx, args.fsid)
+    l = FileLock(ctx, ctx.fsid)
     l.acquire()
-    (daemon_type, daemon_id) = args.name.split('.', 1)
-    unit_name = get_unit_name_by_daemon_name(ctx, args.fsid, args.name)
+    (daemon_type, daemon_id) = ctx.name.split('.', 1)
+    unit_name = get_unit_name_by_daemon_name(ctx, ctx.fsid, ctx.name)
 
-    if daemon_type in ['mon', 'osd'] and not args.force:
+    if daemon_type in ['mon', 'osd'] and not ctx.force:
         raise Error('must pass --force to proceed: '
                       'this command may destroy precious data!')
 
@@ -4875,11 +4899,11 @@ def command_rm_daemon(ctx):
          verbosity=CallVerbosity.DEBUG)
     call(ctx, ['systemctl', 'disable', unit_name],
          verbosity=CallVerbosity.DEBUG)
-    data_dir = get_data_dir(args.fsid, ctx.args.data_dir, daemon_type, daemon_id)
+    data_dir = get_data_dir(ctx.fsid, ctx.data_dir, daemon_type, daemon_id)
     if daemon_type in ['mon', 'osd', 'prometheus'] and \
-       not args.force_delete_data:
+       not ctx.force_delete_data:
         # rename it out of the way -- do not delete
-        backup_dir = os.path.join(args.data_dir, args.fsid, 'removed')
+        backup_dir = os.path.join(ctx.data_dir, ctx.fsid, 'removed')
         if not os.path.exists(backup_dir):
             makedirs(backup_dir, 0, 0, DATA_DIR_MODE)
         dirname = '%s.%s_%s' % (daemon_type, daemon_id,
@@ -4888,7 +4912,7 @@ def command_rm_daemon(ctx):
                   os.path.join(backup_dir, dirname))
     else:
         if daemon_type == CephadmDaemon.daemon_type:
-            CephadmDaemon.uninstall(ctx, args.fsid, daemon_type, daemon_id)
+            CephadmDaemon.uninstall(ctx, ctx.fsid, daemon_type, daemon_id)
         call_throws(ctx, ['rm', '-rf', data_dir])
 
 ##################################
@@ -4896,21 +4920,20 @@ def command_rm_daemon(ctx):
 
 def command_rm_cluster(ctx):
     # type: (CephadmContext) -> None
-    args = ctx.args
-    if not args.force:
+    if not ctx.force:
         raise Error('must pass --force to proceed: '
                       'this command may destroy precious data!')
 
-    l = FileLock(ctx, args.fsid)
+    l = FileLock(ctx, ctx.fsid)
     l.acquire()
 
     # stop + disable individual daemon units
     for d in list_daemons(ctx, detail=False):
-        if d['fsid'] != args.fsid:
+        if d['fsid'] != ctx.fsid:
             continue
         if d['style'] != 'cephadm:v1':
             continue
-        unit_name = get_unit_name(args.fsid, d['name'])
+        unit_name = get_unit_name(ctx.fsid, d['name'])
         call(ctx, ['systemctl', 'stop', unit_name],
              verbosity=CallVerbosity.DEBUG)
         call(ctx, ['systemctl', 'reset-failed', unit_name],
@@ -4919,7 +4942,7 @@ def command_rm_cluster(ctx):
              verbosity=CallVerbosity.DEBUG)
 
     # cluster units
-    for unit_name in ['ceph-%s.target' % args.fsid]:
+    for unit_name in ['ceph-%s.target' % ctx.fsid]:
         call(ctx, ['systemctl', 'stop', unit_name],
              verbosity=CallVerbosity.DEBUG)
         call(ctx, ['systemctl', 'reset-failed', unit_name],
@@ -4927,26 +4950,26 @@ def command_rm_cluster(ctx):
         call(ctx, ['systemctl', 'disable', unit_name],
              verbosity=CallVerbosity.DEBUG)
 
-    slice_name = 'system-%s.slice' % (('ceph-%s' % args.fsid).replace('-',
+    slice_name = 'system-%s.slice' % (('ceph-%s' % ctx.fsid).replace('-',
                                                                       '\\x2d'))
     call(ctx, ['systemctl', 'stop', slice_name],
          verbosity=CallVerbosity.DEBUG)
 
     # rm units
-    call_throws(ctx, ['rm', '-f', args.unit_dir +
-                             '/ceph-%s@.service' % args.fsid])
-    call_throws(ctx, ['rm', '-f', args.unit_dir +
-                             '/ceph-%s.target' % args.fsid])
+    call_throws(ctx, ['rm', '-f', ctx.unit_dir +
+                             '/ceph-%s@.service' % ctx.fsid])
+    call_throws(ctx, ['rm', '-f', ctx.unit_dir +
+                             '/ceph-%s.target' % ctx.fsid])
     call_throws(ctx, ['rm', '-rf',
-                  args.unit_dir + '/ceph-%s.target.wants' % args.fsid])
+                  ctx.unit_dir + '/ceph-%s.target.wants' % ctx.fsid])
     # rm data
-    call_throws(ctx, ['rm', '-rf', args.data_dir + '/' + args.fsid])
+    call_throws(ctx, ['rm', '-rf', ctx.data_dir + '/' + ctx.fsid])
     # rm logs
-    call_throws(ctx, ['rm', '-rf', args.log_dir + '/' + args.fsid])
-    call_throws(ctx, ['rm', '-rf', args.log_dir +
-                             '/*.wants/ceph-%s@*' % args.fsid])
+    call_throws(ctx, ['rm', '-rf', ctx.log_dir + '/' + ctx.fsid])
+    call_throws(ctx, ['rm', '-rf', ctx.log_dir +
+                             '/*.wants/ceph-%s@*' % ctx.fsid])
     # rm logrotate config
-    call_throws(ctx, ['rm', '-f', args.logrotate_dir + '/ceph-%s' % args.fsid])
+    call_throws(ctx, ['rm', '-f', ctx.logrotate_dir + '/ceph-%s' % ctx.fsid])
 
     # clean up config, keyring, and pub key files
     files = ['/etc/ceph/ceph.conf', '/etc/ceph/ceph.pub', '/etc/ceph/ceph.client.admin.keyring']
@@ -4954,7 +4977,7 @@ def command_rm_cluster(ctx):
     if os.path.exists(files[0]):
         valid_fsid = False
         with open(files[0]) as f:
-            if args.fsid in f.read():
+            if ctx.fsid in f.read():
                 valid_fsid = True
         if valid_fsid:
             for n in range(0, len(files)):
@@ -4987,7 +5010,7 @@ def command_check_host(ctx: CephadmContext) -> None:
     errors = []
     commands = ['systemctl', 'lvcreate']
 
-    if args.docker:
+    if ctx.docker:
         container_path = find_program('docker')
     else:
         for i in CONTAINER_PREFERENCE:
@@ -5012,12 +5035,12 @@ def command_check_host(ctx: CephadmContext) -> None:
     if not check_time_sync(ctx):
         errors.append('ERROR: No time synchronization is active')
 
-    if 'expect_hostname' in args and args.expect_hostname:
-        if get_hostname().lower() != args.expect_hostname.lower():
+    if 'expect_hostname' in args and ctx.expect_hostname:
+        if get_hostname().lower() != ctx.expect_hostname.lower():
             errors.append('ERROR: hostname "%s" does not match expected hostname "%s"' % (
-                get_hostname(), args.expect_hostname))
+                get_hostname(), ctx.expect_hostname))
         logger.info('Hostname "%s" matches what is expected.',
-                    args.expect_hostname)
+                    ctx.expect_hostname)
 
     if errors:
         raise Error('\n'.join(errors))
@@ -5053,11 +5076,11 @@ def command_prepare_host(ctx: CephadmContext) -> None:
         # the service
         check_time_sync(ctx, enabler=pkg)
 
-    if 'expect_hostname' in args and args.expect_hostname and args.expect_hostname != get_hostname():
-        logger.warning('Adjusting hostname from %s -> %s...' % (get_hostname(), args.expect_hostname))
-        call_throws(ctx, ['hostname', args.expect_hostname])
+    if 'expect_hostname' in args and ctx.expect_hostname and ctx.expect_hostname != get_hostname():
+        logger.warning('Adjusting hostname from %s -> %s...' % (get_hostname(), ctx.expect_hostname))
+        call_throws(ctx, ['hostname', ctx.expect_hostname])
         with open('/etc/hostname', 'w') as f:
-            f.write(args.expect_hostname + '\n')
+            f.write(ctx.expect_hostname + '\n')
 
     logger.info('Repeating the final host check...')
     command_check_host(ctx)
@@ -5165,9 +5188,8 @@ class Packager(object):
         return chacra_response.read().decode('utf-8')
 
     def repo_gpgkey(self):
-        args = self.ctx.args
-        if args.gpg_url:
-            return args.gpg_url
+        if self.ctx.gpg_url:
+            return self.ctx.gpg_url
         if self.stable or self.version:
             return 'https://download.ceph.com/keys/release.asc', 'release'
         else:
@@ -5200,7 +5222,6 @@ class Apt(Packager):
         return '/etc/apt/sources.list.d/ceph.list'
 
     def add_repo(self):
-        args = self.ctx.args
 
         url, name = self.repo_gpgkey()
         logger.info('Installing repo GPG key from %s...' % url)
@@ -5216,10 +5237,10 @@ class Apt(Packager):
 
         if self.version:
             content = 'deb %s/debian-%s/ %s main\n' % (
-                args.repo_url, self.version, self.distro_codename)
+                self.ctx.repo_url, self.version, self.distro_codename)
         elif self.stable:
             content = 'deb %s/debian-%s/ %s main\n' % (
-                args.repo_url, self.stable, self.distro_codename)
+                self.ctx.repo_url, self.stable, self.distro_codename)
         else:
             content = self.query_shaman(self.distro, self.distro_codename, self.branch,
                                         self.commit)
@@ -5386,12 +5407,11 @@ class YumDnf(Packager):
 
     def repo_baseurl(self):
         assert self.stable or self.version
-        args = self.ctx.args
         if self.version:
-            return '%s/rpm-%s/%s' % (args.repo_url, self.version,
+            return '%s/rpm-%s/%s' % (self.ctx.repo_url, self.version,
                                      self.distro_code)
         else:
-            return '%s/rpm-%s/%s' % (args.repo_url, self.stable,
+            return '%s/rpm-%s/%s' % (self.ctx.repo_url, self.stable,
                                      self.distro_code)
 
     def add_repo(self):
@@ -5488,11 +5508,12 @@ class Zypper(Packager):
 
     def repo_baseurl(self):
         assert self.stable or self.version
-        args = self.ctx.args
         if self.version:
-            return '%s/rpm-%s/%s' % (args.repo_url, self.stable, self.distro)
+            return '%s/rpm-%s/%s' % (self.ctx.repo_url,
+                                     self.stable, self.distro)
         else:
-            return '%s/rpm-%s/%s' % (args.repo_url, self.stable, self.distro)
+            return '%s/rpm-%s/%s' % (self.ctx.repo_url,
+                                     self.stable, self.distro)
 
     def add_repo(self):
         if self.stable or self.version:
@@ -5551,21 +5572,20 @@ def create_packager(ctx: CephadmContext,
 
 
 def command_add_repo(ctx: CephadmContext):
-    args = ctx.args
-    if args.version and args.release:
+    if ctx.version and ctx.release:
         raise Error('you can specify either --release or --version but not both')
-    if not args.version and not args.release and not args.dev and not args.dev_commit:
+    if not ctx.version and not ctx.release and not ctx.dev and not ctx.dev_commit:
         raise Error('please supply a --release, --version, --dev or --dev-commit argument')
-    if args.version:
+    if ctx.version:
         try:
-            (x, y, z) = args.version.split('.')
+            (x, y, z) = ctx.version.split('.')
         except Exception as e:
             raise Error('version must be in the form x.y.z (e.g., 15.2.0)')
 
-    pkg = create_packager(ctx, stable=args.release,
-                          version=args.version,
-                          branch=args.dev,
-                          commit=args.dev_commit)
+    pkg = create_packager(ctx, stable=ctx.release,
+                          version=ctx.version,
+                          branch=ctx.dev,
+                          commit=ctx.dev_commit)
     pkg.add_repo()
 
 
@@ -5576,7 +5596,7 @@ def command_rm_repo(ctx: CephadmContext):
 
 def command_install(ctx: CephadmContext):
     pkg = create_packager(ctx)
-    pkg.install(ctx.args.packages)
+    pkg.install(ctx.packages)
 
 ##################################
 
@@ -6142,7 +6162,7 @@ def command_gather_facts(ctx: CephadmContext):
 
 def command_verify_prereqs(ctx: CephadmContext):
     args = ctx.args
-    if args.service_type == 'haproxy' or args.service_type == 'keepalived':
+    if ctx.service_type == 'haproxy' or ctx.service_type == 'keepalived':
         out, err, code = call(
             ctx, ['sysctl', '-n', 'net.ipv4.ip_nonlocal_bind']
         )
@@ -6434,7 +6454,7 @@ class CephadmDaemon():
     @property
     def daemon_path(self):
         return os.path.join(
-            self.ctx.args.data_dir,
+            self.ctx.data_dir,
             self.fsid,
             f'{self.daemon_type}.{self.daemon_id}'
         )
@@ -6442,7 +6462,7 @@ class CephadmDaemon():
     @property
     def binary_path(self):
         return os.path.join(
-            self.ctx.args.data_dir,
+            self.ctx.data_dir,
             self.fsid,
             CephadmDaemon.bin_name
         )
@@ -6508,10 +6528,9 @@ class CephadmDaemon():
     def _scrape_ceph_volume(self, refresh_interval=15):
         # we're invoking the ceph_volume command, so we need to set the args that it 
         # expects to use
-        args = self.ctx.args
-        args.command = "inventory --format=json".split()
-        args.fsid = self.fsid
-        args.log_output = False
+        self.ctx.command = "inventory --format=json".split()
+        self.ctx.fsid = self.fsid
+        self.ctx.log_output = False
 
         ctr = 0
         exception_encountered = False
@@ -6734,7 +6753,6 @@ WantedBy=ceph-{fsid}.target
         daemon since it's not a container, so we just create a
         simple service definition and add it to the fsid's target
         """
-        args = self.ctx.args
         if not config:
             raise Error("Attempting to deploy cephadm daemon without a config")
         assert isinstance(config, dict)
@@ -6754,11 +6772,14 @@ WantedBy=ceph-{fsid}.target
         with open(os.path.join(self.daemon_path, 'unit.run'), "w") as f:
             f.write(self.unit_run)
 
-        with open(os.path.join(args.unit_dir, f"{self.unit_name}.new"), "w") as f:
+        with open(os.path.join(self.ctx.unit_dir,
+                              f"{self.unit_name}.new"),
+                  "w"
+        ) as f:
             f.write(self.unit_file)
             os.rename(
-                os.path.join(args.unit_dir, f"{self.unit_name}.new"),
-                os.path.join(args.unit_dir, self.unit_name))
+                os.path.join(self.ctx.unit_dir, f"{self.unit_name}.new"),
+                os.path.join(self.ctx.unit_dir, self.unit_name))
         
         call_throws(self.ctx, ['systemctl', 'daemon-reload'])
         call(self.ctx, ['systemctl', 'stop', self.unit_name],
@@ -6771,8 +6792,8 @@ WantedBy=ceph-{fsid}.target
     def uninstall(cls, ctx: CephadmContext, fsid, daemon_type, daemon_id):
         args = ctx.args
         unit_name = CephadmDaemon._unit_name(fsid, daemon_id)
-        unit_path = os.path.join(args.unit_dir, unit_name)
-        unit_run = os.path.join(args.data_dir, fsid, f"{daemon_type}.{daemon_id}", "unit.run")
+        unit_path = os.path.join(ctx.unit_dir, unit_name)
+        unit_run = os.path.join(ctx.data_dir, fsid, f"{daemon_type}.{daemon_id}", "unit.run")
         port = None
         try:
             with open(unit_run, "r") as u:
@@ -6808,11 +6829,10 @@ WantedBy=ceph-{fsid}.target
 
 
 def command_exporter(ctx: CephadmContext):
-    args = ctx.args
-    exporter = CephadmDaemon(ctx, args.fsid, daemon_id=args.id, port=args.port)
+    exporter = CephadmDaemon(ctx, ctx.fsid, daemon_id=ctx.id, port=ctx.port)
 
-    if args.fsid not in os.listdir(args.data_dir):
-        raise Error(f"cluster fsid '{args.fsid}' not found in '{args.data_dir}'")
+    if ctx.fsid not in os.listdir(ctx.data_dir):
+        raise Error(f"cluster fsid '{ctx.fsid}' not found in '{ctx.data_dir}'")
             
     exporter.run()
         
@@ -6832,13 +6852,12 @@ def systemd_target_state(target_name: str, subsystem: str = 'ceph') -> bool:
 
 @infer_fsid
 def command_maintenance(ctx: CephadmContext):
-    args = ctx.args
-    if not args.fsid:
+    if not ctx.fsid:
         raise Error('must pass --fsid to specify cluster')
 
-    target = f"ceph-{args.fsid}.target"
+    target = f"ceph-{ctx.fsid}.target"
     
-    if args.maintenance_action.lower() == 'enter':
+    if ctx.maintenance_action.lower() == 'enter':
         logger.info("Requested to place host into maintenance")
         if systemd_target_state(target):
             _out, _err, code = call(ctx,
@@ -6888,7 +6907,6 @@ def command_maintenance(ctx: CephadmContext):
 
 
 ##################################
-
 
 def _get_parser():
     # type: () -> argparse.ArgumentParser
@@ -7481,11 +7499,18 @@ def _parse_args(av):
     return args
 
 
+def cephadm_init_ctx(args: List[str]) -> Optional[CephadmContext]:
+
+    ctx = CephadmContext()
+    ctx.set_args(_parse_args(args))
+    return ctx
+
+
 def cephadm_init(args: List[str]) -> Optional[CephadmContext]:
 
     global logger
-    ctx = CephadmContext()
-    ctx.args = _parse_args(args)
+    ctx = cephadm_init_ctx(args)
+    assert ctx is not None
 
     # Logger configuration
     if not os.path.exists(LOG_DIR):
@@ -7493,18 +7518,18 @@ def cephadm_init(args: List[str]) -> Optional[CephadmContext]:
     dictConfig(logging_config)
     logger = logging.getLogger()
 
-    if ctx.args.verbose:
+    if ctx.verbose:
         for handler in logger.handlers:
             if handler.name == "console":
                 handler.setLevel(logging.DEBUG)
 
-    if "func" not in ctx.args:
+    if not ctx.has_function():
         sys.stderr.write("No command specified; pass -h or --help for usage\n")
         return None
 
     ctx.container_path = ""
-    if ctx.args.func != command_check_host:
-        if ctx.args.docker:
+    if ctx.func != command_check_host:
+        if ctx.docker:
             ctx.container_path = find_program("docker")
         else:
             for i in CONTAINER_PREFERENCE:
@@ -7513,8 +7538,8 @@ def cephadm_init(args: List[str]) -> Optional[CephadmContext]:
                     break
                 except Exception as e:
                     logger.debug("Could not locate %s: %s" % (i, e))
-            if not ctx.container_path and ctx.args.func != command_prepare_host\
-                    and ctx.args.func != command_add_repo:
+            if not ctx.container_path and ctx.func != command_prepare_host\
+                    and ctx.func != command_add_repo:
                 sys.stderr.write("Unable to locate any of %s\n" %
                      CONTAINER_PREFERENCE)
                 return None
@@ -7540,9 +7565,9 @@ def main():
         sys.exit(1)
 
     try:
-        r = ctx.args.func(ctx)
+        r = ctx.func(ctx)
     except Error as e:
-        if ctx.args.verbose:
+        if ctx.verbose:
             raise
         sys.stderr.write('ERROR: %s\n' % e)
         sys.exit(1)

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3330,6 +3330,94 @@ def create_mgr(
     is_available(ctx, 'mgr', is_mgr_available)
 
 
+def prepare_ssh(
+    ctx: CephadmContext,
+    cli: Callable, wait_for_mgr_restart: Callable
+) -> None:
+
+    cli(['config-key', 'set', 'mgr/cephadm/ssh_user', ctx.args.ssh_user])
+
+    logger.info('Enabling cephadm module...')
+    cli(['mgr', 'module', 'enable', 'cephadm'])
+    wait_for_mgr_restart()
+
+    logger.info('Setting orchestrator backend to cephadm...')
+    cli(['orch', 'set', 'backend', 'cephadm'])
+
+    if ctx.args.ssh_config:
+        logger.info('Using provided ssh config...')
+        mounts = {
+            pathify(ctx.args.ssh_config.name): '/tmp/cephadm-ssh-config:z',
+        }
+        cli(['cephadm', 'set-ssh-config', '-i', '/tmp/cephadm-ssh-config'], extra_mounts=mounts)
+
+    if ctx.args.ssh_private_key and ctx.args.ssh_public_key:
+        logger.info('Using provided ssh keys...')
+        mounts = {
+            pathify(ctx.args.ssh_private_key.name): '/tmp/cephadm-ssh-key:z',
+            pathify(ctx.args.ssh_public_key.name): '/tmp/cephadm-ssh-key.pub:z'
+        }
+        cli(['cephadm', 'set-priv-key', '-i', '/tmp/cephadm-ssh-key'], extra_mounts=mounts)
+        cli(['cephadm', 'set-pub-key', '-i', '/tmp/cephadm-ssh-key.pub'], extra_mounts=mounts)
+    else:
+        logger.info('Generating ssh key...')
+        cli(['cephadm', 'generate-key'])
+        ssh_pub = cli(['cephadm', 'get-pub-key'])
+
+        with open(ctx.args.output_pub_ssh_key, 'w') as f:
+            f.write(ssh_pub)
+        logger.info('Wrote public SSH key to to %s' % ctx.args.output_pub_ssh_key)
+
+        logger.info('Adding key to %s@localhost\'s authorized_keys...' % ctx.args.ssh_user)
+        try:
+            s_pwd = pwd.getpwnam(ctx.args.ssh_user)
+        except KeyError as e:
+            raise Error('Cannot find uid/gid for ssh-user: %s' % (ctx.args.ssh_user))
+        ssh_uid = s_pwd.pw_uid
+        ssh_gid = s_pwd.pw_gid
+        ssh_dir = os.path.join(s_pwd.pw_dir, '.ssh')
+
+        if not os.path.exists(ssh_dir):
+            makedirs(ssh_dir, ssh_uid, ssh_gid, 0o700)
+
+        auth_keys_file = '%s/authorized_keys' % ssh_dir
+        add_newline = False
+
+        if os.path.exists(auth_keys_file):
+            with open(auth_keys_file, 'r') as f:
+                f.seek(0, os.SEEK_END)
+                if f.tell() > 0:
+                    f.seek(f.tell()-1, os.SEEK_SET) # go to last char
+                    if f.read() != '\n':
+                        add_newline = True
+
+        with open(auth_keys_file, 'a') as f:
+            os.fchown(f.fileno(), ssh_uid, ssh_gid) # just in case we created it
+            os.fchmod(f.fileno(), 0o600)  # just in case we created it
+            if add_newline:
+                f.write('\n')
+            f.write(ssh_pub.strip() + '\n')
+
+    host = get_hostname()
+    logger.info('Adding host %s...' % host)
+    try:
+        cli(['orch', 'host', 'add', host])
+    except RuntimeError as e:
+        raise Error('Failed to add host <%s>: %s' % (host, e))
+
+    if not ctx.args.orphan_initial_daemons:
+        for t in ['mon', 'mgr', 'crash']:
+            logger.info('Deploying %s service with default placement...' % t)
+            cli(['orch', 'apply', t])
+
+    if not ctx.args.skip_monitoring_stack:
+        logger.info('Enabling mgr prometheus module...')
+        cli(['mgr', 'module', 'enable', 'prometheus'])
+        for t in ['prometheus', 'grafana', 'node-exporter', 'alertmanager']:
+            logger.info('Deploying %s service with default placement...' % t)
+            cli(['orch', 'apply', t])
+
+
 @default_image
 def command_bootstrap(ctx):
     # type: (CephadmContext) -> int
@@ -3532,87 +3620,7 @@ def command_bootstrap(ctx):
     # ssh
     host = None
     if not ctx.args.skip_ssh:
-        cli(['config-key', 'set', 'mgr/cephadm/ssh_user', ctx.args.ssh_user])
-
-        logger.info('Enabling cephadm module...')
-        cli(['mgr', 'module', 'enable', 'cephadm'])
-        wait_for_mgr_restart()
-
-        logger.info('Setting orchestrator backend to cephadm...')
-        cli(['orch', 'set', 'backend', 'cephadm'])
-
-        if ctx.args.ssh_config:
-            logger.info('Using provided ssh config...')
-            mounts = {
-                pathify(ctx.args.ssh_config.name): '/tmp/cephadm-ssh-config:z',
-            }
-            cli(['cephadm', 'set-ssh-config', '-i', '/tmp/cephadm-ssh-config'], extra_mounts=mounts)
-
-        if ctx.args.ssh_private_key and ctx.args.ssh_public_key:
-            logger.info('Using provided ssh keys...')
-            mounts = {
-                pathify(ctx.args.ssh_private_key.name): '/tmp/cephadm-ssh-key:z',
-                pathify(ctx.args.ssh_public_key.name): '/tmp/cephadm-ssh-key.pub:z'
-            }
-            cli(['cephadm', 'set-priv-key', '-i', '/tmp/cephadm-ssh-key'], extra_mounts=mounts)
-            cli(['cephadm', 'set-pub-key', '-i', '/tmp/cephadm-ssh-key.pub'], extra_mounts=mounts)
-        else:
-            logger.info('Generating ssh key...')
-            cli(['cephadm', 'generate-key'])
-            ssh_pub = cli(['cephadm', 'get-pub-key'])
-
-            with open(ctx.args.output_pub_ssh_key, 'w') as f:
-                f.write(ssh_pub)
-            logger.info('Wrote public SSH key to to %s' % ctx.args.output_pub_ssh_key)
-
-            logger.info('Adding key to %s@localhost\'s authorized_keys...' % ctx.args.ssh_user)
-            try:
-                s_pwd = pwd.getpwnam(ctx.args.ssh_user)
-            except KeyError as e:
-                raise Error('Cannot find uid/gid for ssh-user: %s' % (ctx.args.ssh_user))
-            ssh_uid = s_pwd.pw_uid
-            ssh_gid = s_pwd.pw_gid
-            ssh_dir = os.path.join(s_pwd.pw_dir, '.ssh')
-
-            if not os.path.exists(ssh_dir):
-                makedirs(ssh_dir, ssh_uid, ssh_gid, 0o700)
-
-            auth_keys_file = '%s/authorized_keys' % ssh_dir
-            add_newline = False
-
-            if os.path.exists(auth_keys_file):
-                with open(auth_keys_file, 'r') as f:
-                    f.seek(0, os.SEEK_END)
-                    if f.tell() > 0:
-                        f.seek(f.tell()-1, os.SEEK_SET) # go to last char
-                        if f.read() != '\n':
-                            add_newline = True
-
-            with open(auth_keys_file, 'a') as f:
-                os.fchown(f.fileno(), ssh_uid, ssh_gid) # just in case we created it
-                os.fchmod(f.fileno(), 0o600)  # just in case we created it
-                if add_newline:
-                    f.write('\n')
-                f.write(ssh_pub.strip() + '\n')
-
-        host = get_hostname()
-        logger.info('Adding host %s...' % host)
-        try:
-            cli(['orch', 'host', 'add', host])
-        except RuntimeError as e:
-            raise Error('Failed to add host <%s>: %s' % (host, e))
-
-        if not ctx.args.orphan_initial_daemons:
-            for t in ['mon', 'mgr', 'crash']:
-                logger.info('Deploying %s service with default placement...' % t)
-                cli(['orch', 'apply', t])
-
-        if not ctx.args.skip_monitoring_stack:
-            logger.info('Enabling mgr prometheus module...')
-            cli(['mgr', 'module', 'enable', 'prometheus'])
-            for t in ['prometheus', 'grafana', 'node-exporter', 'alertmanager']:
-                logger.info('Deploying %s service with default placement...' % t)
-                cli(['orch', 'apply', t])
+        prepare_ssh(ctx, cli, wait_for_mgr_restart)
 
     if ctx.args.registry_url and ctx.args.registry_username and ctx.args.registry_password:
         cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_url', ctx.args.registry_url, '--force'])

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3261,6 +3261,37 @@ def create_mon(
     return (mon_dir, log_dir)
 
 
+def wait_for_mon(
+    ctx: CephadmContext,
+    mon_id: str, mon_dir: str,
+    admin_keyring_path: str, config_path: str
+):
+    logger.info('Waiting for mon to start...')
+    c = CephContainer(
+        ctx,
+        image=ctx.args.image,
+        entrypoint='/usr/bin/ceph',
+        args=[
+            'status'],
+        volume_mounts={
+            mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % (mon_id),
+            admin_keyring_path: '/etc/ceph/ceph.client.admin.keyring:z',
+            config_path: '/etc/ceph/ceph.conf:z',
+        },
+    )
+
+    # wait for the service to become available
+    def is_mon_available():
+        # type: () -> bool
+        timeout=ctx.args.timeout if ctx.args.timeout else 60 # seconds
+        out, err, ret = call(ctx, c.run_cmd(),
+                             desc=c.entrypoint,
+                             timeout=timeout)
+        return ret == 0
+
+    is_available(ctx, 'mon', is_mon_available)
+
+
 @default_image
 def command_bootstrap(ctx):
     # type: (CephadmContext) -> int
@@ -3393,29 +3424,7 @@ def command_bootstrap(ctx):
             volume_mounts=mounts,
         ).run(timeout=timeout)
 
-    logger.info('Waiting for mon to start...')
-    c = CephContainer(
-        ctx,
-        image=ctx.args.image,
-        entrypoint='/usr/bin/ceph',
-        args=[
-            'status'],
-        volume_mounts={
-            mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % (mon_id),
-            admin_keyring.name: '/etc/ceph/ceph.client.admin.keyring:z',
-            tmp_config.name: '/etc/ceph/ceph.conf:z',
-        },
-    )
-
-    # wait for the service to become available
-    def is_mon_available():
-        # type: () -> bool
-        timeout=ctx.args.timeout if ctx.args.timeout else 60 # seconds
-        out, err, ret = call(ctx, c.run_cmd(),
-                             desc=c.entrypoint,
-                             timeout=timeout)
-        return ret == 0
-    is_available(ctx, 'mon', is_mon_available)
+    wait_for_mon(ctx, mon_id, mon_dir, admin_keyring.name, tmp_config.name)
 
     # assimilate and minimize config
     if not ctx.args.no_minimize_config:
@@ -7484,3 +7493,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -95,10 +95,32 @@ else:
 if sys.version_info > (3, 0):
     unicode = str
 
-container_path = ''
 cached_stdin = None
 
 DATEFMT = '%Y-%m-%dT%H:%M:%S.%fZ'
+
+
+logger: logging.Logger = None # type: ignore
+
+##################################
+
+class CephadmContext:
+
+    def __init__(self):
+        self._args: argparse.Namespace = None # type: ignore
+        self.container_path: str = None # type: ignore
+
+    @property
+    def args(self) -> argparse.Namespace:
+        return self._args
+
+    @args.setter
+    def args(self, args: argparse.Namespace) -> None:
+        self._args = args
+
+
+##################################  
+
 
 # Log and console output config
 logging_config = {
@@ -242,11 +264,13 @@ class NFSGanesha(object):
     }
 
     def __init__(self,
+                 ctx,
                  fsid,
                  daemon_id,
                  config_json,
                  image=DEFAULT_IMAGE):
-        # type: (str, Union[int, str], Dict, str) -> None
+        # type: (CephadmContext, str, Union[int, str], Dict, str) -> None
+        self.ctx = ctx
         self.fsid = fsid
         self.daemon_id = daemon_id
         self.image = image
@@ -263,9 +287,10 @@ class NFSGanesha(object):
         self.validate()
 
     @classmethod
-    def init(cls, fsid, daemon_id):
-        # type: (str, Union[int, str]) -> NFSGanesha
-        return cls(fsid, daemon_id, get_parm(args.config_json), args.image)
+    def init(cls, ctx, fsid, daemon_id):
+        # type: (CephadmContext, str, Union[int, str]) -> NFSGanesha
+        return cls(ctx, fsid, daemon_id, get_parm(ctx.args.config_json),
+                                                  ctx.args.image)
 
     def get_container_mounts(self, data_dir):
         # type: (str) -> Dict[str, str]
@@ -289,11 +314,11 @@ class NFSGanesha(object):
         return envs
 
     @staticmethod
-    def get_version(container_id):
-        # type: (str) -> Optional[str]
+    def get_version(ctx, container_id):
+        # type: (CephadmContext, str) -> Optional[str]
         version = None
-        out, err, code = call(
-            [container_path, 'exec', container_id,
+        out, err, code = call(ctx,
+            [ctx.container_path, 'exec', container_id,
              NFSGanesha.entrypoint, '-v'])
         if code == 0:
             match = re.search(r'NFS-Ganesha Release\s*=\s*[V]*([\d.]+)', out)
@@ -374,12 +399,14 @@ class NFSGanesha(object):
             args += ['--userid', self.userid]
         args += [action, self.get_daemon_name()]
 
-        data_dir = get_data_dir(self.fsid, self.daemon_type, self.daemon_id)
+        data_dir = get_data_dir(self.fsid, self.ctx.args.data_dir,
+                                self.daemon_type, self.daemon_id)
         volume_mounts = self.get_container_mounts(data_dir)
         envs = self.get_container_envs()
 
         logger.info('Creating RADOS grace for action: %s' % action)
         c = CephContainer(
+            self.ctx,
             image=self.image,
             entrypoint=entrypoint,
             args=args,
@@ -401,11 +428,13 @@ class CephIscsi(object):
     required_files = ['iscsi-gateway.cfg']
 
     def __init__(self,
+                 ctx,
                  fsid,
                  daemon_id,
                  config_json,
                  image=DEFAULT_IMAGE):
-        # type: (str, Union[int, str], Dict, str) -> None
+        # type: (CephadmContext, str, Union[int, str], Dict, str) -> None
+        self.ctx = ctx
         self.fsid = fsid
         self.daemon_id = daemon_id
         self.image = image
@@ -417,9 +446,10 @@ class CephIscsi(object):
         self.validate()
 
     @classmethod
-    def init(cls, fsid, daemon_id):
-        # type: (str, Union[int, str]) -> CephIscsi
-        return cls(fsid, daemon_id, get_parm(args.config_json), args.image)
+    def init(cls, ctx, fsid, daemon_id):
+        # type: (CephadmContext, str, Union[int, str]) -> CephIscsi
+        return cls(ctx, fsid, daemon_id,
+                   get_parm(ctx.args.config_json), ctx.args.image)
 
     @staticmethod
     def get_container_mounts(data_dir, log_dir):
@@ -445,11 +475,11 @@ class CephIscsi(object):
         return binds
 
     @staticmethod
-    def get_version(container_id):
-        # type: (str) -> Optional[str]
+    def get_version(ctx, container_id):
+        # type: (CephadmContext, str) -> Optional[str]
         version = None
-        out, err, code = call(
-            [container_path, 'exec', container_id,
+        out, err, code = call(ctx,
+            [ctx.container_path, 'exec', container_id,
              '/usr/bin/python3', '-c', "import pkg_resources; print(pkg_resources.require('ceph_iscsi')[0].version)"])
         if code == 0:
             version = out.strip()
@@ -508,7 +538,7 @@ class CephIscsi(object):
 
     def get_tcmu_runner_container(self):
         # type: () -> CephContainer
-        tcmu_container = get_container(self.fsid, self.daemon_type, self.daemon_id)
+        tcmu_container = get_container(self.ctx, self.fsid, self.daemon_type, self.daemon_id)
         tcmu_container.entrypoint = "/usr/bin/tcmu-runner"
         tcmu_container.cname = self.get_container_name(desc='tcmu')
         # remove extra container args for tcmu container.
@@ -524,8 +554,11 @@ class HAproxy(object):
     required_files = ['haproxy.cfg']
     default_image = 'haproxy'
 
-    def __init__(self, fsid: str, daemon_id: Union[int, str],
+    def __init__(self,
+                 ctx: CephadmContext,
+                 fsid: str, daemon_id: Union[int, str],
                  config_json: Dict, image: str) -> None:
+        self.ctx = ctx
         self.fsid = fsid
         self.daemon_id = daemon_id
         self.image = image
@@ -536,8 +569,10 @@ class HAproxy(object):
         self.validate()
 
     @classmethod
-    def init(cls, fsid: str, daemon_id: Union[int, str]) -> 'HAproxy':
-        return cls(fsid, daemon_id, get_parm(args.config_json), args.image)
+    def init(cls, ctx: CephadmContext,
+             fsid: str, daemon_id: Union[int, str]) -> 'HAproxy':
+        return cls(ctx, fsid, daemon_id, get_parm(ctx.args.config_json),
+                   ctx.args.image)
 
     def create_daemon_dirs(self, data_dir: str, uid: int, gid: int) -> None:
         """Create files under the container data dir"""
@@ -582,7 +617,7 @@ class HAproxy(object):
 
     def extract_uid_gid_haproxy(self):
         # better directory for this?
-        return extract_uid_gid(file_path='/var/lib')
+        return extract_uid_gid(self.ctx, file_path='/var/lib')
 
     @staticmethod
     def get_container_mounts(data_dir: str) -> Dict[str, str]:
@@ -599,8 +634,11 @@ class Keepalived(object):
     required_files = ['keepalived.conf']
     default_image = 'arcts/keepalived'
 
-    def __init__(self, fsid: str, daemon_id: Union[int, str],
+    def __init__(self,
+                 ctx: CephadmContext,
+                 fsid: str, daemon_id: Union[int, str],
                  config_json: Dict, image: str) -> None:
+        self.ctx = ctx
         self.fsid = fsid
         self.daemon_id = daemon_id
         self.image = image
@@ -611,8 +649,10 @@ class Keepalived(object):
         self.validate()
 
     @classmethod
-    def init(cls, fsid: str, daemon_id: Union[int, str]) -> 'Keepalived':
-        return cls(fsid, daemon_id, get_parm(args.config_json), args.image)
+    def init(cls, ctx: CephadmContext, fsid: str,
+             daemon_id: Union[int, str]) -> 'Keepalived':
+        return cls(ctx, fsid, daemon_id,
+                   get_parm(ctx.args.config_json), ctx.args.image)
 
     def create_daemon_dirs(self, data_dir: str, uid: int, gid: int) -> None:
         """Create files under the container data dir"""
@@ -665,7 +705,7 @@ class Keepalived(object):
 
     def extract_uid_gid_keepalived(self):
         # better directory for this?
-        return extract_uid_gid(file_path='/var/lib')
+        return extract_uid_gid(self.ctx, file_path='/var/lib')
 
     @staticmethod
     def get_container_mounts(data_dir: str) -> Dict[str, str]:
@@ -680,8 +720,10 @@ class CustomContainer(object):
     """Defines a custom container"""
     daemon_type = 'container'
 
-    def __init__(self, fsid: str, daemon_id: Union[int, str],
+    def __init__(self, ctx: CephadmContext,
+                 fsid: str, daemon_id: Union[int, str],
                  config_json: Dict, image: str) -> None:
+        self.ctx = ctx
         self.fsid = fsid
         self.daemon_id = daemon_id
         self.image = image
@@ -700,8 +742,10 @@ class CustomContainer(object):
         self.files = dict_get(config_json, 'files', {})
 
     @classmethod
-    def init(cls, fsid: str, daemon_id: Union[int, str]) -> 'CustomContainer':
-        return cls(fsid, daemon_id, get_parm(args.config_json), args.image)
+    def init(cls, ctx: CephadmContext,
+             fsid: str, daemon_id: Union[int, str]) -> 'CustomContainer':
+        return cls(ctx, fsid, daemon_id,
+                   get_parm(ctx.args.config_json), ctx.args.image)
 
     def create_daemon_dirs(self, data_dir: str, uid: int, gid: int) -> None:
         """
@@ -844,8 +888,8 @@ def get_supported_daemons():
 ##################################
 
 
-def attempt_bind(s, address, port):
-    # type: (socket.socket, str, int) -> None
+def attempt_bind(ctx, s, address, port):
+    # type: (CephadmContext, socket.socket, str, int) -> None
     try:
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         s.bind((address, port))
@@ -860,33 +904,33 @@ def attempt_bind(s, address, port):
         s.close()
 
 
-def port_in_use(port_num):
-    # type: (int) -> bool
+def port_in_use(ctx, port_num):
+    # type: (CephadmContext, int) -> bool
     """Detect whether a port is in use on the local machine - IPv4 and IPv6"""
     logger.info('Verifying port %d ...' % port_num)
     try:
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        attempt_bind(s, '0.0.0.0', port_num)
+        attempt_bind(ctx, s, '0.0.0.0', port_num)
 
         s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-        attempt_bind(s, '::', port_num)
+        attempt_bind(ctx, s, '::', port_num)
     except OSError:
         return True
     else:
         return False
 
 
-def check_ip_port(ip, port):
-    # type: (str, int) -> None
-    if not args.skip_ping_check:
+def check_ip_port(ctx, ip, port):
+    # type: (CephadmContext, str, int) -> None
+    if not ctx.args.skip_ping_check:
         logger.info('Verifying IP %s port %d ...' % (ip, port))
-        if is_ipv6(ip):
+        if is_ipv6(ctx, ip):
             s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
             ip = unwrap_ipv6(ip)
         else:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
-            attempt_bind(s, ip, port)
+            attempt_bind(ctx, s, ip, port)
         except OSError as e:
             raise Error(e)
 
@@ -929,10 +973,11 @@ class _Acquire_ReturnProxy(object):
 
 
 class FileLock(object):
-    def __init__(self, name, timeout=-1):
+    def __init__(self, ctx: CephadmContext, name, timeout=-1):
         if not os.path.exists(LOCK_DIR):
             os.mkdir(LOCK_DIR, 0o700)
         self._lock_file = os.path.join(LOCK_DIR, name + '.lock')
+        self.ctx = ctx
 
         # The file descriptor for the *_lock_file* as it is returned by the
         # os.open() function.
@@ -977,6 +1022,7 @@ class FileLock(object):
             This method returns now a *proxy* object instead of *self*,
             so that it can be used in a with statement without side effects.
         """
+
         # Use the default timeout, if no timeout is provided.
         if timeout is None:
             timeout = self.timeout
@@ -1090,7 +1136,8 @@ class CallVerbosity(Enum):
     VERBOSE = 3
 
 
-def call(command: List[str],
+def call(ctx: CephadmContext,
+         command: List[str],
          desc: Optional[str] = None,
          verbosity: CallVerbosity = CallVerbosity.VERBOSE_ON_FAILURE,
          timeout: Optional[int] = DEFAULT_TIMEOUT,
@@ -1104,11 +1151,12 @@ def call(command: List[str],
 
     :param timeout: timeout in seconds
     """
+
     if desc is None:
         desc = command[0]
     if desc:
         desc += ': '
-    timeout = timeout or args.timeout
+    timeout = timeout or ctx.args.timeout
 
     logger.debug("Running command: %s" % ' '.join(command))
     process = subprocess.Popen(
@@ -1218,20 +1266,21 @@ def call(command: List[str],
     return out, err, returncode
 
 
-def call_throws(command: List[str],
+def call_throws(
+         ctx: CephadmContext,
+         command: List[str],
          desc: Optional[str] = None,
          verbosity: CallVerbosity = CallVerbosity.VERBOSE_ON_FAILURE,
          timeout: Optional[int] = DEFAULT_TIMEOUT,
          **kwargs) -> Tuple[str, str, int]:
-    out, err, ret = call(command, desc, verbosity, timeout, **kwargs)
+    out, err, ret = call(ctx, command, desc, verbosity, timeout, **kwargs)
     if ret:
         raise RuntimeError('Failed command: %s' % ' '.join(command))
     return out, err, ret
 
 
-def call_timeout(command, timeout):
-    # type: (List[str], int) -> int
-
+def call_timeout(ctx, command, timeout):
+    # type: (CephadmContext, List[str], int) -> int
     logger.debug('Running command (timeout=%s): %s'
             % (timeout, ' '.join(command)))
 
@@ -1271,15 +1320,15 @@ def call_timeout(command, timeout):
 ##################################
 
 
-def is_available(what, func):
-    # type: (str, Callable[[], bool]) -> None
+def is_available(ctx, what, func):
+    # type: (CephadmContext, str, Callable[[], bool]) -> None
     """
     Wait for a service to become available
 
     :param what: the name of the service
     :param func: the callable object that determines availability
     """
-    retry = args.retry
+    retry = ctx.args.retry
     logger.info('Waiting for %s...' % what)
     num = 1
     while True:
@@ -1379,11 +1428,11 @@ def try_convert_datetime(s):
     return None
 
 
-def get_podman_version():
-    # type: () -> Tuple[int, ...]
+def get_podman_version(ctx, container_path):
+    # type: (CephadmContext, str) -> Tuple[int, ...]
     if 'podman' not in container_path:
         raise ValueError('not using podman')
-    out, _, _ = call_throws([container_path, '--version'])
+    out, _, _ = call_throws(ctx, [container_path, '--version'])
     return _parse_podman_version(out)
 
 
@@ -1460,22 +1509,22 @@ def infer_fsid(func):
     If we only find a single fsid in /var/lib/ceph/*, use that
     """
     @wraps(func)
-    def _infer_fsid():
-        if args.fsid:
-            logger.debug('Using specified fsid: %s' % args.fsid)
-            return func()
+    def _infer_fsid(ctx: CephadmContext):
+        if ctx.args.fsid:
+            logger.debug('Using specified fsid: %s' % ctx.args.fsid)
+            return func(ctx)
 
         fsids_set = set()
-        daemon_list = list_daemons(detail=False)
+        daemon_list = list_daemons(ctx, detail=False)
         for daemon in daemon_list:
             if not is_fsid(daemon['fsid']):
                 # 'unknown' fsid
                 continue
-            elif 'name' not in args or not args.name:
-                # args.name not specified
+            elif 'name' not in ctx.args or not ctx.args.name:
+                # ctx.args.name not specified
                 fsids_set.add(daemon['fsid'])
-            elif daemon['name'] == args.name:
-                # args.name is a match
+            elif daemon['name'] == ctx.args.name:
+                # ctx.args.name is a match
                 fsids_set.add(daemon['fsid'])
         fsids = sorted(fsids_set)
 
@@ -1484,10 +1533,10 @@ def infer_fsid(func):
             pass
         elif len(fsids) == 1:
             logger.info('Inferring fsid %s' % fsids[0])
-            args.fsid = fsids[0]
+            ctx.args.fsid = fsids[0]
         else:
             raise Error('Cannot infer an fsid, one must be specified: %s' % fsids)
-        return func()
+        return func(ctx)
 
     return _infer_fsid
 
@@ -1497,33 +1546,34 @@ def infer_config(func):
     If we find a MON daemon, use the config from that container
     """
     @wraps(func)
-    def _infer_config():
-        if args.config:
-            logger.debug('Using specified config: %s' % args.config)
-            return func()
+    def _infer_config(ctx: CephadmContext):
+        if ctx.args.config:
+            logger.debug('Using specified config: %s' % ctx.args.config)
+            return func(ctx)
         config = None
-        if args.fsid:
-            name = args.name
+        if ctx.args.fsid:
+            name = ctx.args.name
             if not name:
-                daemon_list = list_daemons(detail=False)
+                daemon_list = list_daemons(ctx, detail=False)
                 for daemon in daemon_list:
                     if daemon['name'].startswith('mon.'):
                         name = daemon['name']
                         break
             if name:
-                config = '/var/lib/ceph/{}/{}/config'.format(args.fsid, name)
+                config = '/var/lib/ceph/{}/{}/config'.format(ctx.args.fsid, 
+                                                             name)
         if config:
             logger.info('Inferring config %s' % config)
-            args.config = config
+            ctx.args.config = config
         elif os.path.exists(SHELL_DEFAULT_CONF):
             logger.debug('Using default config: %s' % SHELL_DEFAULT_CONF)
-            args.config = SHELL_DEFAULT_CONF
-        return func()
+            ctx.args.config = SHELL_DEFAULT_CONF
+        return func(ctx)
 
     return _infer_config
 
 
-def _get_default_image():
+def _get_default_image(ctx: CephadmContext):
     if DEFAULT_IMAGE_IS_MASTER:
         warn = '''This is a development version of cephadm.
 For information regarding the latest stable release:
@@ -1539,54 +1589,54 @@ def infer_image(func):
     Use the most recent ceph image
     """
     @wraps(func)
-    def _infer_image():
-        if not args.image:
-            args.image = os.environ.get('CEPHADM_IMAGE')
-        if not args.image:
-            args.image = get_last_local_ceph_image()
-        if not args.image:
-            args.image = _get_default_image()
-        return func()
+    def _infer_image(ctx: CephadmContext):
+        if not ctx.args.image:
+            ctx.args.image = os.environ.get('CEPHADM_IMAGE')
+        if not ctx.args.image:
+            ctx.args.image = get_last_local_ceph_image(ctx, ctx.container_path)
+        if not ctx.args.image:
+            ctx.args.image = _get_default_image(ctx)
+        return func(ctx)
 
     return _infer_image
 
 
 def default_image(func):
     @wraps(func)
-    def _default_image():
-        if not args.image:
-            if 'name' in args and args.name:
-                type_ = args.name.split('.', 1)[0]
+    def _default_image(ctx: CephadmContext):
+        if not ctx.args.image:
+            if 'name' in ctx.args and ctx.args.name:
+                type_ = ctx.args.name.split('.', 1)[0]
                 if type_ in Monitoring.components:
-                    args.image = Monitoring.components[type_]['image']
+                    ctx.args.image = Monitoring.components[type_]['image']
                 if type_ == 'haproxy':
-                    args.image = HAproxy.default_image
+                    ctx.args.image = HAproxy.default_image
                 if type_ == 'keepalived':
-                    args.image = Keepalived.default_image
-            if not args.image:
-                args.image = os.environ.get('CEPHADM_IMAGE')
-            if not args.image:
-                args.image = _get_default_image()
+                    ctx.args.image = Keepalived.default_image
+            if not ctx.args.image:
+                ctx.args.image = os.environ.get('CEPHADM_IMAGE')
+            if not ctx.args.image:
+                ctx.args.image = _get_default_image(ctx)
 
-        return func()
+        return func(ctx)
 
     return _default_image
 
 
-def get_last_local_ceph_image():
+def get_last_local_ceph_image(ctx: CephadmContext, container_path: str):
     """
     :return: The most recent local ceph image (already pulled)
     """
-    out, _, _ = call_throws(
+    out, _, _ = call_throws(ctx,
         [container_path, 'images',
          '--filter', 'label=ceph=True',
          '--filter', 'dangling=false',
          '--format', '{{.Repository}}@{{.Digest}}'])
-    return _filter_last_local_ceph_image(out)
+    return _filter_last_local_ceph_image(ctx, out)
 
 
-def _filter_last_local_ceph_image(out):
-    # str -> Optional[str]
+def _filter_last_local_ceph_image(ctx, out):
+    # type: (CephadmContext, str) -> Optional[str]
     for image in out.splitlines():
         if image and not image.endswith('@'):
             logger.info('Using recent ceph image %s' % image)
@@ -1615,19 +1665,19 @@ def makedirs(dir, uid, gid, mode):
     os.chmod(dir, mode)   # the above is masked by umask...
 
 
-def get_data_dir(fsid, t, n):
-    # type: (str, str, Union[int, str]) -> str
-    return os.path.join(args.data_dir, fsid, '%s.%s' % (t, n))
+def get_data_dir(fsid, data_dir, t, n):
+    # type: (str, str, str, Union[int, str]) -> str
+    return os.path.join(data_dir, fsid, '%s.%s' % (t, n))
 
 
-def get_log_dir(fsid):
-    # type: (str) -> str
-    return os.path.join(args.log_dir, fsid)
+def get_log_dir(fsid, log_dir):
+    # type: (str, str) -> str
+    return os.path.join(log_dir, fsid)
 
 
-def make_data_dir_base(fsid, uid, gid):
-    # type: (str, int, int) -> str
-    data_dir_base = os.path.join(args.data_dir, fsid)
+def make_data_dir_base(fsid, data_dir, uid, gid):
+    # type: (str, str, int, int) -> str
+    data_dir_base = os.path.join(data_dir, fsid)
     makedirs(data_dir_base, uid, gid, DATA_DIR_MODE)
     makedirs(os.path.join(data_dir_base, 'crash'), uid, gid, DATA_DIR_MODE)
     makedirs(os.path.join(data_dir_base, 'crash', 'posted'), uid, gid,
@@ -1635,38 +1685,38 @@ def make_data_dir_base(fsid, uid, gid):
     return data_dir_base
 
 
-def make_data_dir(fsid, daemon_type, daemon_id, uid=None, gid=None):
-    # type: (str, str, Union[int, str], Optional[int], Optional[int]) -> str
+def make_data_dir(ctx, fsid, daemon_type, daemon_id, uid=None, gid=None):
+    # type: (CephadmContext, str, str, Union[int, str], Optional[int], Optional[int]) -> str
     if uid is None or gid is None:
-        uid, gid = extract_uid_gid()
-    make_data_dir_base(fsid, uid, gid)
-    data_dir = get_data_dir(fsid, daemon_type, daemon_id)
+        uid, gid = extract_uid_gid(ctx)
+    make_data_dir_base(fsid, ctx.args.data_dir, uid, gid)
+    data_dir = get_data_dir(fsid, ctx.args.data_dir, daemon_type, daemon_id)
     makedirs(data_dir, uid, gid, DATA_DIR_MODE)
     return data_dir
 
 
-def make_log_dir(fsid, uid=None, gid=None):
-    # type: (str, Optional[int], Optional[int]) -> str
+def make_log_dir(ctx, fsid, uid=None, gid=None):
+    # type: (CephadmContext, str, Optional[int], Optional[int]) -> str
     if uid is None or gid is None:
-        uid, gid = extract_uid_gid()
-    log_dir = get_log_dir(fsid)
+        uid, gid = extract_uid_gid(ctx)
+    log_dir = get_log_dir(fsid, ctx.args.log_dir)
     makedirs(log_dir, uid, gid, LOG_DIR_MODE)
     return log_dir
 
 
-def make_var_run(fsid, uid, gid):
-    # type: (str, int, int) -> None
-    call_throws(['install', '-d', '-m0770', '-o', str(uid), '-g', str(gid),
+def make_var_run(ctx, fsid, uid, gid):
+    # type: (CephadmContext, str, int, int) -> None
+    call_throws(ctx, ['install', '-d', '-m0770', '-o', str(uid), '-g', str(gid),
                  '/var/run/ceph/%s' % fsid])
 
 
-def copy_tree(src, dst, uid=None, gid=None):
-    # type: (List[str], str, Optional[int], Optional[int]) -> None
+def copy_tree(ctx, src, dst, uid=None, gid=None):
+    # type: (CephadmContext, List[str], str, Optional[int], Optional[int]) -> None
     """
     Copy a directory tree from src to dst
     """
     if uid is None or gid is None:
-        (uid, gid) = extract_uid_gid()
+        (uid, gid) = extract_uid_gid(ctx)
 
     for src_dir in src:
         dst_dir = dst
@@ -1685,13 +1735,13 @@ def copy_tree(src, dst, uid=None, gid=None):
                 os.chown(os.path.join(dirpath, filename), uid, gid)
 
 
-def copy_files(src, dst, uid=None, gid=None):
-    # type: (List[str], str, Optional[int], Optional[int]) -> None
+def copy_files(ctx, src, dst, uid=None, gid=None):
+    # type: (CephadmContext, List[str], str, Optional[int], Optional[int]) -> None
     """
     Copy a files from src to dst
     """
     if uid is None or gid is None:
-        (uid, gid) = extract_uid_gid()
+        (uid, gid) = extract_uid_gid(ctx)
 
     for src_file in src:
         dst_file = dst
@@ -1705,13 +1755,13 @@ def copy_files(src, dst, uid=None, gid=None):
         os.chown(dst_file, uid, gid)
 
 
-def move_files(src, dst, uid=None, gid=None):
-    # type: (List[str], str, Optional[int], Optional[int]) -> None
+def move_files(ctx, src, dst, uid=None, gid=None):
+    # type: (CephadmContext, List[str], str, Optional[int], Optional[int]) -> None
     """
     Move files from src to dst
     """
     if uid is None or gid is None:
-        (uid, gid) = extract_uid_gid()
+        (uid, gid) = extract_uid_gid(ctx)
 
     for src_file in src:
         dst_file = dst
@@ -1787,23 +1837,23 @@ def get_unit_name(fsid, daemon_type, daemon_id=None):
         return 'ceph-%s@%s' % (fsid, daemon_type)
 
 
-def get_unit_name_by_daemon_name(fsid, name):
-    daemon = get_daemon_description(fsid, name)
+def get_unit_name_by_daemon_name(ctx: CephadmContext, fsid, name):
+    daemon = get_daemon_description(ctx, fsid, name)
     try:
         return daemon['systemd_unit']
     except KeyError:
         raise Error('Failed to get unit name for {}'.format(daemon))
 
 
-def check_unit(unit_name):
-    # type: (str) -> Tuple[bool, str, bool]
+def check_unit(ctx, unit_name):
+    # type: (CephadmContext, str) -> Tuple[bool, str, bool]
     # NOTE: we ignore the exit code here because systemctl outputs
     # various exit codes based on the state of the service, but the
     # string result is more explicit (and sufficient).
     enabled = False
     installed = False
     try:
-        out, err, code = call(['systemctl', 'is-enabled', unit_name],
+        out, err, code = call(ctx, ['systemctl', 'is-enabled', unit_name],
                               verbosity=CallVerbosity.DEBUG)
         if code == 0:
             enabled = True
@@ -1817,7 +1867,7 @@ def check_unit(unit_name):
 
     state = 'unknown'
     try:
-        out, err, code = call(['systemctl', 'is-active', unit_name],
+        out, err, code = call(ctx, ['systemctl', 'is-active', unit_name],
                               verbosity=CallVerbosity.DEBUG)
         out = out.strip()
         if out in ['active']:
@@ -1834,10 +1884,10 @@ def check_unit(unit_name):
     return (enabled, state, installed)
 
 
-def check_units(units, enabler=None):
-    # type: (List[str], Optional[Packager]) -> bool
+def check_units(ctx, units, enabler=None):
+    # type: (CephadmContext, List[str], Optional[Packager]) -> bool
     for u in units:
-        (enabled, state, installed) = check_unit(u)
+        (enabled, state, installed) = check_unit(ctx, u)
         if enabled and state == 'running':
             logger.info('Unit %s is enabled and running' % u)
             return True
@@ -1861,12 +1911,13 @@ def get_legacy_config_fsid(cluster, legacy_dir=None):
     return None
 
 
-def get_legacy_daemon_fsid(cluster, daemon_type, daemon_id, legacy_dir=None):
-    # type: (str, str, Union[int, str], Optional[str]) -> Optional[str]
+def get_legacy_daemon_fsid(ctx, cluster,
+                           daemon_type, daemon_id, legacy_dir=None):
+    # type: (CephadmContext, str, str, Union[int, str], Optional[str]) -> Optional[str]
     fsid = None
     if daemon_type == 'osd':
         try:
-            fsid_file = os.path.join(args.data_dir,
+            fsid_file = os.path.join(ctx.args.data_dir,
                                      daemon_type,
                                      'ceph-%s' % daemon_id,
                                      'ceph_fsid')
@@ -1881,8 +1932,8 @@ def get_legacy_daemon_fsid(cluster, daemon_type, daemon_id, legacy_dir=None):
     return fsid
 
 
-def get_daemon_args(fsid, daemon_type, daemon_id):
-    # type: (str, str, Union[int, str]) -> List[str]
+def get_daemon_args(ctx, fsid, daemon_type, daemon_id):
+    # type: (CephadmContext, str, str, Union[int, str]) -> List[str]
     r = list()  # type: List[str]
 
     if daemon_type in Ceph.daemons and daemon_type != 'crash':
@@ -1902,30 +1953,30 @@ def get_daemon_args(fsid, daemon_type, daemon_id):
         metadata = Monitoring.components[daemon_type]
         r += metadata.get('args', list())
         if daemon_type == 'alertmanager':
-            config = get_parm(args.config_json)
+            config = get_parm(ctx.args.config_json)
             peers = config.get('peers', list())  # type: ignore
             for peer in peers:
                 r += ["--cluster.peer={}".format(peer)]
             # some alertmanager, by default, look elsewhere for a config
             r += ["--config.file=/etc/alertmanager/alertmanager.yml"]
     elif daemon_type == NFSGanesha.daemon_type:
-        nfs_ganesha = NFSGanesha.init(fsid, daemon_id)
+        nfs_ganesha = NFSGanesha.init(ctx, fsid, daemon_id)
         r += nfs_ganesha.get_daemon_args()
     elif daemon_type == HAproxy.daemon_type:
-        haproxy = HAproxy.init(fsid, daemon_id)
+        haproxy = HAproxy.init(ctx, fsid, daemon_id)
         r += haproxy.get_daemon_args()
     elif daemon_type == CustomContainer.daemon_type:
-        cc = CustomContainer.init(fsid, daemon_id)
+        cc = CustomContainer.init(ctx, fsid, daemon_id)
         r.extend(cc.get_daemon_args())
 
     return r
 
 
-def create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid,
+def create_daemon_dirs(ctx, fsid, daemon_type, daemon_id, uid, gid,
                        config=None, keyring=None):
-    # type: (str, str, Union[int, str], int, int, Optional[str], Optional[str]) ->  None
-    data_dir = make_data_dir(fsid, daemon_type, daemon_id, uid=uid, gid=gid)
-    make_log_dir(fsid, uid=uid, gid=gid)
+    # type: (CephadmContext, str, str, Union[int, str], int, int, Optional[str], Optional[str]) ->  None
+    data_dir = make_data_dir(ctx, fsid, daemon_type, daemon_id, uid=uid, gid=gid)
+    make_log_dir(ctx, fsid, uid=uid, gid=gid)
 
     if config:
         config_path = os.path.join(data_dir, 'config')
@@ -1942,27 +1993,30 @@ def create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid,
             f.write(keyring)
 
     if daemon_type in Monitoring.components.keys():
-        config_json: Dict[str, Any] = get_parm(args.config_json)
+        config_json: Dict[str, Any] = get_parm(ctx.args.config_json)
         required_files = Monitoring.components[daemon_type].get('config-json-files', list())
 
         # Set up directories specific to the monitoring component
         config_dir = ''
         data_dir_root = ''
         if daemon_type == 'prometheus':
-            data_dir_root = get_data_dir(fsid, daemon_type, daemon_id)
+            data_dir_root = get_data_dir(fsid, ctx.args.data_dir,
+                                         daemon_type, daemon_id)
             config_dir = 'etc/prometheus'
             makedirs(os.path.join(data_dir_root, config_dir), uid, gid, 0o755)
             makedirs(os.path.join(data_dir_root, config_dir, 'alerting'), uid, gid, 0o755)
             makedirs(os.path.join(data_dir_root, 'data'), uid, gid, 0o755)
         elif daemon_type == 'grafana':
-            data_dir_root = get_data_dir(fsid, daemon_type, daemon_id)
+            data_dir_root = get_data_dir(fsid, ctx.args.data_dir,
+                                         daemon_type, daemon_id)
             config_dir = 'etc/grafana'
             makedirs(os.path.join(data_dir_root, config_dir), uid, gid, 0o755)
             makedirs(os.path.join(data_dir_root, config_dir, 'certs'), uid, gid, 0o755)
             makedirs(os.path.join(data_dir_root, config_dir, 'provisioning/datasources'), uid, gid, 0o755)
             makedirs(os.path.join(data_dir_root, 'data'), uid, gid, 0o755)
         elif daemon_type == 'alertmanager':
-            data_dir_root = get_data_dir(fsid, daemon_type, daemon_id)
+            data_dir_root = get_data_dir(fsid, ctx.args.data_dir,
+                                         daemon_type, daemon_id)
             config_dir = 'etc/alertmanager'
             makedirs(os.path.join(data_dir_root, config_dir), uid, gid, 0o755)
             makedirs(os.path.join(data_dir_root, config_dir, 'data'), uid, gid, 0o755)
@@ -1977,23 +2031,23 @@ def create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid,
                     f.write(content)
 
     elif daemon_type == NFSGanesha.daemon_type:
-        nfs_ganesha = NFSGanesha.init(fsid, daemon_id)
+        nfs_ganesha = NFSGanesha.init(ctx, fsid, daemon_id)
         nfs_ganesha.create_daemon_dirs(data_dir, uid, gid)
 
     elif daemon_type == CephIscsi.daemon_type:
-        ceph_iscsi = CephIscsi.init(fsid, daemon_id)
+        ceph_iscsi = CephIscsi.init(ctx, fsid, daemon_id)
         ceph_iscsi.create_daemon_dirs(data_dir, uid, gid)
 
     elif daemon_type == HAproxy.daemon_type:
-        haproxy = HAproxy.init(fsid, daemon_id)
+        haproxy = HAproxy.init(ctx, fsid, daemon_id)
         haproxy.create_daemon_dirs(data_dir, uid, gid)
 
     elif daemon_type == Keepalived.daemon_type:
-        keepalived = Keepalived.init(fsid, daemon_id)
+        keepalived = Keepalived.init(ctx, fsid, daemon_id)
         keepalived.create_daemon_dirs(data_dir, uid, gid)
 
     elif daemon_type == CustomContainer.daemon_type:
-        cc = CustomContainer.init(fsid, daemon_id)
+        cc = CustomContainer.init(ctx, fsid, daemon_id)
         cc.create_daemon_dirs(data_dir, uid, gid)
 
 
@@ -2032,47 +2086,47 @@ def get_parm(option):
         return js
 
 
-def get_config_and_keyring():
-    # type: () -> Tuple[Optional[str], Optional[str]]
+def get_config_and_keyring(ctx):
+    # type: (CephadmContext) -> Tuple[Optional[str], Optional[str]]
     config = None
     keyring = None
 
-    if 'config_json' in args and args.config_json:
-        d = get_parm(args.config_json)
+    if 'config_json' in ctx.args and ctx.args.config_json:
+        d = get_parm(ctx.args.config_json)
         config = d.get('config')
         keyring = d.get('keyring')
 
-    if 'config' in args and args.config:
-        with open(args.config, 'r') as f:
+    if 'config' in ctx.args and ctx.args.config:
+        with open(ctx.args.config, 'r') as f:
             config = f.read()
 
-    if 'key' in args and args.key:
-        keyring = '[%s]\n\tkey = %s\n' % (args.name, args.key)
-    elif 'keyring' in args and args.keyring:
-        with open(args.keyring, 'r') as f:
+    if 'key' in ctx.args and ctx.args.key:
+        keyring = '[%s]\n\tkey = %s\n' % (ctx.args.name, ctx.args.key)
+    elif 'keyring' in ctx.args and ctx.args.keyring:
+        with open(ctx.args.keyring, 'r') as f:
             keyring = f.read()
 
     return config, keyring
 
 
-def get_container_binds(fsid, daemon_type, daemon_id):
-    # type: (str, str, Union[int, str, None]) -> List[List[str]]
+def get_container_binds(ctx, fsid, daemon_type, daemon_id):
+    # type: (CephadmContext, str, str, Union[int, str, None]) -> List[List[str]]
     binds = list()
 
     if daemon_type == CephIscsi.daemon_type:
         binds.extend(CephIscsi.get_container_binds())
     elif daemon_type == CustomContainer.daemon_type:
         assert daemon_id
-        cc = CustomContainer.init(fsid, daemon_id)
-        data_dir = get_data_dir(fsid, daemon_type, daemon_id)
+        cc = CustomContainer.init(ctx, fsid, daemon_id)
+        data_dir = get_data_dir(fsid, ctx.args.data_dir, daemon_type, daemon_id)
         binds.extend(cc.get_container_binds(data_dir))
 
     return binds
 
 
-def get_container_mounts(fsid, daemon_type, daemon_id,
+def get_container_mounts(ctx, fsid, daemon_type, daemon_id,
                          no_config=False):
-    # type: (str, str, Union[int, str, None], Optional[bool]) -> Dict[str, str]
+    # type: (CephadmContext, str, str, Union[int, str, None], Optional[bool]) -> Dict[str, str]
     mounts = dict()
 
     if daemon_type in Ceph.daemons:
@@ -2080,14 +2134,14 @@ def get_container_mounts(fsid, daemon_type, daemon_id,
             run_path = os.path.join('/var/run/ceph', fsid);
             if os.path.exists(run_path):
                 mounts[run_path] = '/var/run/ceph:z'
-            log_dir = get_log_dir(fsid)
+            log_dir = get_log_dir(fsid, ctx.args.log_dir)
             mounts[log_dir] = '/var/log/ceph:z'
             crash_dir = '/var/lib/ceph/%s/crash' % fsid
             if os.path.exists(crash_dir):
                 mounts[crash_dir] = '/var/lib/ceph/crash:z'
 
     if daemon_type in Ceph.daemons and daemon_id:
-        data_dir = get_data_dir(fsid, daemon_type, daemon_id)
+        data_dir = get_data_dir(fsid, ctx.args.data_dir, daemon_type, daemon_id)
         if daemon_type == 'rgw':
             cdata_dir = '/var/lib/ceph/radosgw/ceph-rgw.%s' % (daemon_id)
         else:
@@ -2109,8 +2163,8 @@ def get_container_mounts(fsid, daemon_type, daemon_id,
         mounts['/run/lock/lvm'] = '/run/lock/lvm'
 
     try:
-        if args.shared_ceph_folder:  # make easy manager modules/ceph-volume development
-            ceph_folder = pathify(args.shared_ceph_folder)
+        if ctx.args.shared_ceph_folder:  # make easy manager modules/ceph-volume development
+            ceph_folder = pathify(ctx.args.shared_ceph_folder)
             if os.path.exists(ceph_folder):
                 mounts[ceph_folder + '/src/ceph-volume/ceph_volume'] = '/usr/lib/python3.6/site-packages/ceph_volume'
                 mounts[ceph_folder + '/src/pybind/mgr'] = '/usr/share/ceph/mgr'
@@ -2125,7 +2179,7 @@ def get_container_mounts(fsid, daemon_type, daemon_id,
         pass
 
     if daemon_type in Monitoring.components and daemon_id:
-        data_dir = get_data_dir(fsid, daemon_type, daemon_id)
+        data_dir = get_data_dir(fsid, ctx.args.data_dir, daemon_type, daemon_id)
         if daemon_type == 'prometheus':
             mounts[os.path.join(data_dir, 'etc/prometheus')] = '/etc/prometheus:Z'
             mounts[os.path.join(data_dir, 'data')] = '/prometheus:Z'
@@ -2142,36 +2196,37 @@ def get_container_mounts(fsid, daemon_type, daemon_id,
 
     if daemon_type == NFSGanesha.daemon_type:
         assert daemon_id
-        data_dir = get_data_dir(fsid, daemon_type, daemon_id)
-        nfs_ganesha = NFSGanesha.init(fsid, daemon_id)
+        data_dir = get_data_dir(fsid, ctx.args.data_dir, daemon_type, daemon_id)
+        nfs_ganesha = NFSGanesha.init(ctx, fsid, daemon_id)
         mounts.update(nfs_ganesha.get_container_mounts(data_dir))
 
     if daemon_type == HAproxy.daemon_type:
         assert daemon_id
-        data_dir = get_data_dir(fsid, daemon_type, daemon_id)
+        data_dir = get_data_dir(fsid, daemon_type, daemon_type, daemon_id)
         mounts.update(HAproxy.get_container_mounts(data_dir))
 
     if daemon_type == CephIscsi.daemon_type:
         assert daemon_id
-        data_dir = get_data_dir(fsid, daemon_type, daemon_id)
-        log_dir = get_log_dir(fsid)
+        data_dir = get_data_dir(fsid, ctx.args.data_dir, daemon_type, daemon_id)
+        log_dir = get_log_dir(fsid, ctx.args.log_dir)
         mounts.update(CephIscsi.get_container_mounts(data_dir, log_dir))
 
     if daemon_type == Keepalived.daemon_type:
         assert daemon_id
-        data_dir = get_data_dir(fsid, daemon_type, daemon_id)
+        data_dir = get_data_dir(fsid, daemon_type, daemon_type, daemon_id)
         mounts.update(Keepalived.get_container_mounts(data_dir))
 
     if daemon_type == CustomContainer.daemon_type:
         assert daemon_id
-        cc = CustomContainer.init(fsid, daemon_id)
-        data_dir = get_data_dir(fsid, daemon_type, daemon_id)
+        cc = CustomContainer.init(ctx, fsid, daemon_id)
+        data_dir = get_data_dir(fsid, ctx.args.data_dir, daemon_type, daemon_id)
         mounts.update(cc.get_container_mounts(data_dir))
 
     return mounts
 
 
-def get_container(fsid: str, daemon_type: str, daemon_id: Union[int, str],
+def get_container(ctx: CephadmContext,
+                  fsid: str, daemon_type: str, daemon_id: Union[int, str],
                   privileged: bool = False,
                   ptrace: bool = False,
                   container_args: Optional[List[str]] = None) -> 'CephContainer':
@@ -2217,14 +2272,14 @@ def get_container(fsid: str, daemon_type: str, daemon_id: Union[int, str],
         # to configfs we need to make this a privileged container.
         privileged = True
     elif daemon_type == CustomContainer.daemon_type:
-        cc = CustomContainer.init(fsid, daemon_id)
+        cc = CustomContainer.init(ctx, fsid, daemon_id)
         entrypoint = cc.entrypoint
         host_network = False
         envs.extend(cc.get_container_envs())
         container_args.extend(cc.get_container_args())
 
     if daemon_type in Monitoring.components:
-        uid, gid = extract_uid_gid_monitoring(daemon_type)
+        uid, gid = extract_uid_gid_monitoring(ctx, daemon_type)
         monitoring_args = [
             '--user',
             str(uid),
@@ -2239,7 +2294,7 @@ def get_container(fsid: str, daemon_type: str, daemon_id: Union[int, str],
 
     # if using podman, set -d, --conmon-pidfile & --cidfile flags
     # so service can have Type=Forking
-    if 'podman' in container_path:
+    if 'podman' in ctx.container_path:
         runtime_dir = '/run'
         container_args.extend(['-d',
             '--conmon-pidfile',
@@ -2248,26 +2303,27 @@ def get_container(fsid: str, daemon_type: str, daemon_id: Union[int, str],
             runtime_dir + '/ceph-%s@%s.%s.service-cid' % (fsid, daemon_type, daemon_id)])
 
     return CephContainer(
-        image=args.image,
+        ctx,
+        image=ctx.args.image,
         entrypoint=entrypoint,
-        args=ceph_args + get_daemon_args(fsid, daemon_type, daemon_id),
+        args=ceph_args + get_daemon_args(ctx, fsid, daemon_type, daemon_id),
         container_args=container_args,
-        volume_mounts=get_container_mounts(fsid, daemon_type, daemon_id),
-        bind_mounts=get_container_binds(fsid, daemon_type, daemon_id),
+        volume_mounts=get_container_mounts(ctx, fsid, daemon_type, daemon_id),
+        bind_mounts=get_container_binds(ctx, fsid, daemon_type, daemon_id),
         cname='ceph-%s-%s.%s' % (fsid, daemon_type, daemon_id),
         envs=envs,
         privileged=privileged,
         ptrace=ptrace,
-        init=args.container_init,
+        init=ctx.args.container_init,
         host_network=host_network,
     )
 
 
-def extract_uid_gid(img='', file_path='/var/lib/ceph'):
-    # type: (str, Union[str, List[str]]) -> Tuple[int, int]
+def extract_uid_gid(ctx, img='', file_path='/var/lib/ceph'):
+    # type: (CephadmContext, str, Union[str, List[str]]) -> Tuple[int, int]
 
     if not img:
-        img = args.image
+        img = ctx.args.image
 
     if isinstance(file_path, str):
         paths = [file_path]
@@ -2277,6 +2333,7 @@ def extract_uid_gid(img='', file_path='/var/lib/ceph'):
     for fp in paths:
         try:
             out = CephContainer(
+                ctx,
                 image=img,
                 entrypoint='stat',
                 args=['-c', '%u %g', fp]
@@ -2288,18 +2345,18 @@ def extract_uid_gid(img='', file_path='/var/lib/ceph'):
     raise RuntimeError('uid/gid not found')
 
 
-def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
+def deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid,
                   config=None, keyring=None,
                   osd_fsid=None,
                   reconfig=False,
                   ports=None):
-    # type: (str, str, Union[int, str], Optional[CephContainer], int, int, Optional[str], Optional[str], Optional[str], Optional[bool], Optional[List[int]]) -> None
+    # type: (CephadmContext, str, str, Union[int, str], Optional[CephContainer], int, int, Optional[str], Optional[str], Optional[str], Optional[bool], Optional[List[int]]) -> None
 
     ports = ports or []
-    if any([port_in_use(port) for port in ports]):
+    if any([port_in_use(ctx, port) for port in ports]):
         raise Error("TCP Port(s) '{}' required for {} already in use".format(",".join(map(str, ports)), daemon_type))
 
-    data_dir = get_data_dir(fsid, daemon_type, daemon_id)
+    data_dir = get_data_dir(fsid, ctx.args.data_dir, daemon_type, daemon_id)
     if reconfig and not os.path.exists(data_dir):
         raise Error('cannot reconfig, data path %s does not exist' % data_dir)
     if daemon_type == 'mon' and not os.path.exists(data_dir):
@@ -2312,18 +2369,19 @@ def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
         tmp_config = write_tmp(config, uid, gid)
 
         # --mkfs
-        create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid)
-        mon_dir = get_data_dir(fsid, 'mon', daemon_id)
-        log_dir = get_log_dir(fsid)
+        create_daemon_dirs(ctx, fsid, daemon_type, daemon_id, uid, gid)
+        mon_dir = get_data_dir(fsid, ctx.args.data_dir, 'mon', daemon_id)
+        log_dir = get_log_dir(fsid, ctx.args.log_dir)
         out = CephContainer(
-            image=args.image,
+            ctx,
+            image=ctx.args.image,
             entrypoint='/usr/bin/ceph-mon',
             args=['--mkfs',
                   '-i', str(daemon_id),
                   '--fsid', fsid,
                   '-c', '/tmp/config',
                   '--keyring', '/tmp/keyring',
-            ] + get_daemon_args(fsid, 'mon', daemon_id),
+            ] + get_daemon_args(ctx, fsid, 'mon', daemon_id),
             volume_mounts={
                 log_dir: '/var/log/ceph:z',
                 mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % (daemon_id),
@@ -2340,6 +2398,7 @@ def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
     else:
         # dirs, conf, keyring
         create_daemon_dirs(
+            ctx,
             fsid, daemon_type, daemon_id,
             uid, gid,
             config, keyring)
@@ -2348,18 +2407,18 @@ def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
         if daemon_type == CephadmDaemon.daemon_type:
             port = next(iter(ports), None)  # get first tcp port provided or None
 
-            if args.config_json == '-':
+            if ctx.args.config_json == '-':
                 config_js = get_parm('-')
             else:
-                config_js = get_parm(args.config_json)
+                config_js = get_parm(ctx.args.config_json)
             assert isinstance(config_js, dict)
 
-            cephadm_exporter = CephadmDaemon(fsid, daemon_id, port)
+            cephadm_exporter = CephadmDaemon(ctx, fsid, daemon_id, port)
             cephadm_exporter.deploy_daemon_unit(config_js)
         else:
             if c:
-                deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
-                                    osd_fsid=osd_fsid)
+                deploy_daemon_units(ctx, fsid, uid, gid, daemon_type, daemon_id,
+                                    c, osd_fsid=osd_fsid)
             else:
                 raise RuntimeError("attempting to deploy a daemon without a container image") 
 
@@ -2374,24 +2433,24 @@ def deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid,
         os.fchmod(f.fileno(), 0o600)
         os.fchown(f.fileno(), uid, gid)
 
-    update_firewalld(daemon_type)
+    update_firewalld(ctx, daemon_type)
 
     # Open ports explicitly required for the daemon
     if ports:
-        fw = Firewalld()
+        fw = Firewalld(ctx)
         fw.open_ports(ports)
         fw.apply_rules()
 
     if reconfig and daemon_type not in Ceph.daemons:
         # ceph daemons do not need a restart; others (presumably) do to pick
         # up the new config
-        call_throws(['systemctl', 'reset-failed',
+        call_throws(ctx, ['systemctl', 'reset-failed',
                      get_unit_name(fsid, daemon_type, daemon_id)])
-        call_throws(['systemctl', 'restart',
+        call_throws(ctx, ['systemctl', 'restart',
                      get_unit_name(fsid, daemon_type, daemon_id)])
 
-def _write_container_cmd_to_bash(file_obj, container, comment=None, background=False):
-    # type: (IO[str], CephContainer, Optional[str], Optional[bool]) -> None
+def _write_container_cmd_to_bash(ctx, file_obj, container, comment=None, background=False):
+    # type: (CephadmContext, IO[str], CephContainer, Optional[str], Optional[bool]) -> None
     if comment:
         # Sometimes adding a comment, especially if there are multiple containers in one
         # unit file, makes it easier to read and grok.
@@ -2399,19 +2458,19 @@ def _write_container_cmd_to_bash(file_obj, container, comment=None, background=F
     # Sometimes, adding `--rm` to a run_cmd doesn't work. Let's remove the container manually
     file_obj.write('! '+ ' '.join(container.rm_cmd()) + '2> /dev/null\n')
     # Sometimes, `podman rm` doesn't find the container. Then you'll have to add `--storage`
-    if 'podman' in container_path:
+    if 'podman' in ctx.container_path:
         file_obj.write('! '+ ' '.join(container.rm_cmd(storage=True)) + '2> /dev/null\n')
 
     # container run command
     file_obj.write(' '.join(container.run_cmd()) + (' &' if background else '') + '\n')
 
 
-def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
+def deploy_daemon_units(ctx, fsid, uid, gid, daemon_type, daemon_id, c,
                         enable=True, start=True,
                         osd_fsid=None):
-    # type: (str, int, int, str, Union[int, str], CephContainer, bool, bool, Optional[str]) -> None
+    # type: (CephadmContext, str, int, int, str, Union[int, str], CephContainer, bool, bool, Optional[str]) -> None
     # cmd
-    data_dir = get_data_dir(fsid, daemon_type, daemon_id)
+    data_dir = get_data_dir(fsid, ctx.args.data_dir, daemon_type, daemon_id)
     with open(data_dir + '/unit.run.new', 'w') as f:
         f.write('set -e\n')
 
@@ -2432,7 +2491,8 @@ def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
                     f.write('[ ! -L {p} ] || chown {uid}:{gid} {p}\n'.format(p=p, uid=uid, gid=gid))
             else:
                 prestart = CephContainer(
-                    image=args.image,
+                    ctx,
+                    image=ctx.args.image,
                     entrypoint='/usr/sbin/ceph-volume',
                     args=[
                         'lvm', 'activate',
@@ -2440,23 +2500,23 @@ def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
                         '--no-systemd'
                     ],
                     privileged=True,
-                    volume_mounts=get_container_mounts(fsid, daemon_type, daemon_id),
-                    bind_mounts=get_container_binds(fsid, daemon_type, daemon_id),
+                    volume_mounts=get_container_mounts(ctx, fsid, daemon_type, daemon_id),
+                    bind_mounts=get_container_binds(ctx, fsid, daemon_type, daemon_id),
                     cname='ceph-%s-%s.%s-activate' % (fsid, daemon_type, daemon_id),
                 )
-                _write_container_cmd_to_bash(f, prestart, 'LVM OSDs use ceph-volume lvm activate')
+                _write_container_cmd_to_bash(ctx, f, prestart, 'LVM OSDs use ceph-volume lvm activate')
         elif daemon_type == NFSGanesha.daemon_type:
             # add nfs to the rados grace db
-            nfs_ganesha = NFSGanesha.init(fsid, daemon_id)
+            nfs_ganesha = NFSGanesha.init(ctx, fsid, daemon_id)
             prestart = nfs_ganesha.get_rados_grace_container('add')
-            _write_container_cmd_to_bash(f, prestart,  'add daemon to rados grace')
+            _write_container_cmd_to_bash(ctx, f, prestart,  'add daemon to rados grace')
         elif daemon_type == CephIscsi.daemon_type:
             f.write(' '.join(CephIscsi.configfs_mount_umount(data_dir, mount=True)) + '\n')
-            ceph_iscsi = CephIscsi.init(fsid, daemon_id)
+            ceph_iscsi = CephIscsi.init(ctx, fsid, daemon_id)
             tcmu_container = ceph_iscsi.get_tcmu_runner_container()
-            _write_container_cmd_to_bash(f, tcmu_container, 'iscsi tcmu-runnter container', background=True)
+            _write_container_cmd_to_bash(ctx, f, tcmu_container, 'iscsi tcmu-runnter container', background=True)
 
-        _write_container_cmd_to_bash(f, c, '%s.%s' % (daemon_type, str(daemon_id)))
+        _write_container_cmd_to_bash(ctx, f, c, '%s.%s' % (daemon_type, str(daemon_id)))
         os.fchmod(f.fileno(), 0o600)
         os.rename(data_dir + '/unit.run.new',
                   data_dir + '/unit.run')
@@ -2466,27 +2526,28 @@ def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
         if daemon_type == 'osd':
             assert osd_fsid
             poststop = CephContainer(
-                image=args.image,
+                ctx,
+                image=ctx.args.image,
                 entrypoint='/usr/sbin/ceph-volume',
                 args=[
                     'lvm', 'deactivate',
                     str(daemon_id), osd_fsid,
                 ],
                 privileged=True,
-                volume_mounts=get_container_mounts(fsid, daemon_type, daemon_id),
-                bind_mounts=get_container_binds(fsid, daemon_type, daemon_id),
+                volume_mounts=get_container_mounts(ctx, fsid, daemon_type, daemon_id),
+                bind_mounts=get_container_binds(ctx, fsid, daemon_type, daemon_id),
                 cname='ceph-%s-%s.%s-deactivate' % (fsid, daemon_type,
                                                     daemon_id),
             )
-            _write_container_cmd_to_bash(f, poststop, 'deactivate osd')
+            _write_container_cmd_to_bash(ctx, f, poststop, 'deactivate osd')
         elif daemon_type == NFSGanesha.daemon_type:
             # remove nfs from the rados grace db
-            nfs_ganesha = NFSGanesha.init(fsid, daemon_id)
+            nfs_ganesha = NFSGanesha.init(ctx, fsid, daemon_id)
             poststop = nfs_ganesha.get_rados_grace_container('remove')
-            _write_container_cmd_to_bash(f, poststop, 'remove daemon from rados grace')
+            _write_container_cmd_to_bash(ctx, f, poststop, 'remove daemon from rados grace')
         elif daemon_type == CephIscsi.daemon_type:
             # make sure we also stop the tcmu container
-            ceph_iscsi = CephIscsi.init(fsid, daemon_id)
+            ceph_iscsi = CephIscsi.init(ctx, fsid, daemon_id)
             tcmu_container = ceph_iscsi.get_tcmu_runner_container()
             f.write('! '+ ' '.join(tcmu_container.stop_cmd()) + '\n')
             f.write(' '.join(CephIscsi.configfs_mount_umount(data_dir, mount=False)) + '\n')
@@ -2502,30 +2563,31 @@ def deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
                     data_dir + '/unit.image')
 
     # systemd
-    install_base_units(fsid)
-    unit = get_unit_file(fsid)
+    install_base_units(ctx, fsid)
+    unit = get_unit_file(ctx, fsid)
     unit_file = 'ceph-%s@.service' % (fsid)
-    with open(args.unit_dir + '/' + unit_file + '.new', 'w') as f:
+    with open(ctx.args.unit_dir + '/' + unit_file + '.new', 'w') as f:
         f.write(unit)
-        os.rename(args.unit_dir + '/' + unit_file + '.new',
-                  args.unit_dir + '/' + unit_file)
-    call_throws(['systemctl', 'daemon-reload'])
+        os.rename(ctx.args.unit_dir + '/' + unit_file + '.new',
+                  ctx.args.unit_dir + '/' + unit_file)
+    call_throws(ctx, ['systemctl', 'daemon-reload'])
 
     unit_name = get_unit_name(fsid, daemon_type, daemon_id)
-    call(['systemctl', 'stop', unit_name],
+    call(ctx, ['systemctl', 'stop', unit_name],
          verbosity=CallVerbosity.DEBUG)
-    call(['systemctl', 'reset-failed', unit_name],
+    call(ctx, ['systemctl', 'reset-failed', unit_name],
          verbosity=CallVerbosity.DEBUG)
     if enable:
-        call_throws(['systemctl', 'enable', unit_name])
+        call_throws(ctx, ['systemctl', 'enable', unit_name])
     if start:
-        call_throws(['systemctl', 'start', unit_name])
+        call_throws(ctx, ['systemctl', 'start', unit_name])
 
 
 
 class Firewalld(object):
-    def __init__(self):
-        # type: () -> None
+    def __init__(self, ctx):
+        # type: (CephadmContext) -> None
+        self.ctx = ctx
         self.available = self.check()
 
     def check(self):
@@ -2534,7 +2596,7 @@ class Firewalld(object):
         if not self.cmd:
             logger.debug('firewalld does not appear to be present')
             return False
-        (enabled, state, _) = check_unit('firewalld.service')
+        (enabled, state, _) = check_unit(self.ctx, 'firewalld.service')
         if not enabled:
             logger.debug('firewalld.service is not enabled')
             return False
@@ -2563,10 +2625,10 @@ class Firewalld(object):
         if not self.cmd:
             raise RuntimeError("command not defined")
 
-        out, err, ret = call([self.cmd, '--permanent', '--query-service', svc], verbosity=CallVerbosity.DEBUG)
+        out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--query-service', svc], verbosity=CallVerbosity.DEBUG)
         if ret:
             logger.info('Enabling firewalld service %s in current zone...' % svc)
-            out, err, ret = call([self.cmd, '--permanent', '--add-service', svc])
+            out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--add-service', svc])
             if ret:
                 raise RuntimeError(
                     'unable to add service %s to current zone: %s' % (svc, err))
@@ -2584,10 +2646,10 @@ class Firewalld(object):
 
         for port in fw_ports:
             tcp_port = str(port) + '/tcp'
-            out, err, ret = call([self.cmd, '--permanent', '--query-port', tcp_port], verbosity=CallVerbosity.DEBUG)
+            out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--query-port', tcp_port], verbosity=CallVerbosity.DEBUG)
             if ret:
                 logger.info('Enabling firewalld port %s in current zone...' % tcp_port)
-                out, err, ret = call([self.cmd, '--permanent', '--add-port', tcp_port])
+                out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--add-port', tcp_port])
                 if ret:
                     raise RuntimeError('unable to add port %s to current zone: %s' %
                                     (tcp_port, err))
@@ -2605,10 +2667,10 @@ class Firewalld(object):
 
         for port in fw_ports:
             tcp_port = str(port) + '/tcp'
-            out, err, ret = call([self.cmd, '--permanent', '--query-port', tcp_port], verbosity=CallVerbosity.DEBUG)
+            out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--query-port', tcp_port], verbosity=CallVerbosity.DEBUG)
             if not ret:
                 logger.info('Disabling port %s in current zone...' % tcp_port)
-                out, err, ret = call([self.cmd, '--permanent', '--remove-port', tcp_port])
+                out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--remove-port', tcp_port])
                 if ret:
                     raise RuntimeError('unable to remove port %s from current zone: %s' %
                                     (tcp_port, err))
@@ -2625,12 +2687,12 @@ class Firewalld(object):
         if not self.cmd:
             raise RuntimeError("command not defined")
 
-        call_throws([self.cmd, '--reload'])
+        call_throws(self.ctx, [self.cmd, '--reload'])
 
 
-def update_firewalld(daemon_type):
-    # type: (str) -> None
-    firewall = Firewalld()
+def update_firewalld(ctx, daemon_type):
+    # type: (CephadmContext, str) -> None
+    firewall = Firewalld(ctx)
 
     firewall.enable_service_for(daemon_type)
 
@@ -2642,34 +2704,34 @@ def update_firewalld(daemon_type):
     firewall.open_ports(fw_ports)
     firewall.apply_rules()
 
-def install_base_units(fsid):
-    # type: (str) -> None
+def install_base_units(ctx, fsid):
+    # type: (CephadmContext, str) -> None
     """
     Set up ceph.target and ceph-$fsid.target units.
     """
     # global unit
-    existed = os.path.exists(args.unit_dir + '/ceph.target')
-    with open(args.unit_dir + '/ceph.target.new', 'w') as f:
+    existed = os.path.exists(ctx.args.unit_dir + '/ceph.target')
+    with open(ctx.args.unit_dir + '/ceph.target.new', 'w') as f:
         f.write('[Unit]\n'
                 'Description=All Ceph clusters and services\n'
                 '\n'
                 '[Install]\n'
                 'WantedBy=multi-user.target\n')
-        os.rename(args.unit_dir + '/ceph.target.new',
-                  args.unit_dir + '/ceph.target')
+        os.rename(ctx.args.unit_dir + '/ceph.target.new',
+                  ctx.args.unit_dir + '/ceph.target')
     if not existed:
         # we disable before enable in case a different ceph.target
         # (from the traditional package) is present; while newer
         # systemd is smart enough to disable the old
         # (/lib/systemd/...) and enable the new (/etc/systemd/...),
         # some older versions of systemd error out with EEXIST.
-        call_throws(['systemctl', 'disable', 'ceph.target'])
-        call_throws(['systemctl', 'enable', 'ceph.target'])
-        call_throws(['systemctl', 'start', 'ceph.target'])
+        call_throws(ctx, ['systemctl', 'disable', 'ceph.target'])
+        call_throws(ctx, ['systemctl', 'enable', 'ceph.target'])
+        call_throws(ctx, ['systemctl', 'start', 'ceph.target'])
 
     # cluster unit
-    existed = os.path.exists(args.unit_dir + '/ceph-%s.target' % fsid)
-    with open(args.unit_dir + '/ceph-%s.target.new' % fsid, 'w') as f:
+    existed = os.path.exists(ctx.args.unit_dir + '/ceph-%s.target' % fsid)
+    with open(ctx.args.unit_dir + '/ceph-%s.target.new' % fsid, 'w') as f:
         f.write('[Unit]\n'
                 'Description=Ceph cluster {fsid}\n'
                 'PartOf=ceph.target\n'
@@ -2679,14 +2741,14 @@ def install_base_units(fsid):
                 'WantedBy=multi-user.target ceph.target\n'.format(
                     fsid=fsid)
         )
-        os.rename(args.unit_dir + '/ceph-%s.target.new' % fsid,
-                  args.unit_dir + '/ceph-%s.target' % fsid)
+        os.rename(ctx.args.unit_dir + '/ceph-%s.target.new' % fsid,
+                  ctx.args.unit_dir + '/ceph-%s.target' % fsid)
     if not existed:
-        call_throws(['systemctl', 'enable', 'ceph-%s.target' % fsid])
-        call_throws(['systemctl', 'start', 'ceph-%s.target' % fsid])
+        call_throws(ctx, ['systemctl', 'enable', 'ceph-%s.target' % fsid])
+        call_throws(ctx, ['systemctl', 'start', 'ceph-%s.target' % fsid])
 
     # logrotate for the cluster
-    with open(args.logrotate_dir + '/ceph-%s' % fsid, 'w') as f:
+    with open(ctx.args.logrotate_dir + '/ceph-%s' % fsid, 'w') as f:
         """
         This is a bit sloppy in that the killall/pkill will touch all ceph daemons
         in all containers, but I don't see an elegant way to send SIGHUP *just* to
@@ -2711,10 +2773,10 @@ def install_base_units(fsid):
 """ % fsid)
 
 
-def get_unit_file(fsid):
-    # type: (str) -> str
+def get_unit_file(ctx, fsid):
+    # type: (CephadmContext, str) -> str
     extra_args = ''
-    if 'podman' in container_path:
+    if 'podman' in ctx.container_path:
         extra_args = ('ExecStartPre=-/bin/rm -f /%t/%n-pid /%t/%n-cid\n'
             'ExecStopPost=-/bin/rm -f /%t/%n-pid /%t/%n-cid\n'
             'Type=forking\n'
@@ -2752,9 +2814,9 @@ StartLimitBurst=5
 [Install]
 WantedBy=ceph-{fsid}.target
 """.format(
-    container_path=container_path,
+    container_path=ctx.container_path,
     fsid=fsid,
-    data_dir=args.data_dir,
+    data_dir=ctx.args.data_dir,
     extra_args=extra_args)
 
     return u
@@ -2764,6 +2826,7 @@ WantedBy=ceph-{fsid}.target
 
 class CephContainer:
     def __init__(self,
+                 ctx: CephadmContext,
                  image: str,
                  entrypoint: str,
                  args: List[str] = [],
@@ -2777,6 +2840,7 @@ class CephContainer:
                  init: bool = False,
                  host_network: bool = True,
                  ) -> None:
+        self.ctx = ctx
         self.image = image
         self.entrypoint = entrypoint
         self.args = args
@@ -2792,13 +2856,14 @@ class CephContainer:
 
     def run_cmd(self) -> List[str]:
         cmd_args: List[str] = [
-            str(container_path),
+            str(self.ctx.container_path),
             'run',
             '--rm',
             '--ipc=host',
         ]
 
-        if 'podman' in container_path and os.path.exists('/etc/ceph/podman-auth.json'):
+        if 'podman' in self.ctx.container_path and \
+           os.path.exists('/etc/ceph/podman-auth.json'):
             cmd_args.append('--authfile=/etc/ceph/podman-auth.json')
 
         envs: List[str] = [
@@ -2842,7 +2907,7 @@ class CephContainer:
 
     def shell_cmd(self, cmd: List[str]) -> List[str]:
         cmd_args: List[str] = [
-            str(container_path),
+            str(self.ctx.container_path),
             'run',
             '--rm',
             '--ipc=host',
@@ -2880,7 +2945,7 @@ class CephContainer:
     def exec_cmd(self, cmd):
         # type: (List[str]) -> List[str]
         return [
-            str(container_path),
+            str(self.ctx.container_path),
             'exec',
         ] + self.container_args + [
             self.cname,
@@ -2889,7 +2954,7 @@ class CephContainer:
     def rm_cmd(self, storage=False):
         # type: (bool) -> List[str]
         ret = [
-            str(container_path),
+            str(self.ctx.container_path),
             'rm', '-f',
         ]
         if storage:
@@ -2900,7 +2965,7 @@ class CephContainer:
     def stop_cmd(self):
         # type () -> List[str]
         ret = [
-            str(container_path),
+            str(self.ctx.container_path),
             'stop', self.cname,
         ]
         return ret
@@ -2908,6 +2973,7 @@ class CephContainer:
     def run(self, timeout=DEFAULT_TIMEOUT):
         # type: (Optional[int]) -> str
         out, _, _ = call_throws(
+                self.ctx,
                 self.run_cmd(), desc=self.entrypoint, timeout=timeout)
         return out
 
@@ -2915,9 +2981,9 @@ class CephContainer:
 
 
 @infer_image
-def command_version():
-    # type: () -> int
-    out = CephContainer(args.image, 'ceph', ['--version']).run()
+def command_version(ctx):
+    # type: (CephadmContext) -> int
+    out = CephContainer(ctx, ctx.args.image, 'ceph', ['--version']).run()
     print(out.strip())
     return 0
 
@@ -2925,15 +2991,15 @@ def command_version():
 
 
 @infer_image
-def command_pull():
-    # type: () -> int
+def command_pull(ctx):
+    # type: (CephadmContext) -> int
 
-    _pull_image(args.image)
-    return command_inspect_image()
+    _pull_image(ctx, ctx.args.image)
+    return command_inspect_image(ctx)
 
 
-def _pull_image(image):
-    # type: (str) -> None
+def _pull_image(ctx, image):
+    # type: (CephadmContext, str) -> None
     logger.info('Pulling container image %s...' % image)
 
     ignorelist = [
@@ -2942,13 +3008,13 @@ def _pull_image(image):
         "Digest did not match, expected",
     ]
 
-    cmd = [container_path, 'pull', image]
-    if 'podman' in container_path and os.path.exists('/etc/ceph/podman-auth.json'):
+    cmd = [ctx.container_path, 'pull', image]
+    if 'podman' in ctx.container_path and os.path.exists('/etc/ceph/podman-auth.json'):
             cmd.append('--authfile=/etc/ceph/podman-auth.json')
     cmd_str = ' '.join(cmd)
 
     for sleep_secs in [1, 4, 25]:
-        out, err, ret = call(cmd)
+        out, err, ret = call(ctx, cmd)
         if not ret:
             return
 
@@ -2963,17 +3029,17 @@ def _pull_image(image):
 
 
 @infer_image
-def command_inspect_image():
-    # type: () -> int
-    out, err, ret = call_throws([
-        container_path, 'inspect',
+def command_inspect_image(ctx):
+    # type: (CephadmContext) -> int
+    out, err, ret = call_throws(ctx, [
+        ctx.container_path, 'inspect',
         '--format', '{{.ID}},{{json .RepoDigests}}',
-        args.image])
+        ctx.args.image])
     if ret:
         return errno.ENOENT
-    info_from = get_image_info_from_inspect(out.strip(), args.image)
+    info_from = get_image_info_from_inspect(out.strip(), ctx.args.image)
 
-    ver = CephContainer(args.image, 'ceph', ['--version']).run().strip()
+    ver = CephContainer(ctx, ctx.args.image, 'ceph', ['--version']).run().strip()
     info_from['ceph_version'] = ver
 
     print(json.dumps(info_from, indent=4, sort_keys=True))
@@ -3020,8 +3086,8 @@ def wrap_ipv6(address):
     return address
 
 
-def is_ipv6(address):
-    # type: (str) -> bool
+def is_ipv6(ctx, address):
+    # type: (CephadmContext, str) -> bool
     address = unwrap_ipv6(address)
     try:
         return ipaddress.ip_address(unicode(address)).version == 6
@@ -3031,20 +3097,23 @@ def is_ipv6(address):
 
 
 @default_image
-def command_bootstrap():
-    # type: () -> int
+def command_bootstrap(ctx):
+    # type: (CephadmContext) -> int
 
-    if not args.output_config:
-        args.output_config = os.path.join(args.output_dir, 'ceph.conf')
-    if not args.output_keyring:
-        args.output_keyring = os.path.join(args.output_dir,
+    args = ctx.args
+
+    if not ctx.args.output_config:
+        ctx.args.output_config = os.path.join(ctx.args.output_dir, 'ceph.conf')
+    if not ctx.args.output_keyring:
+        ctx.args.output_keyring = os.path.join(ctx.args.output_dir,
                                            'ceph.client.admin.keyring')
-    if not args.output_pub_ssh_key:
-        args.output_pub_ssh_key = os.path.join(args.output_dir, 'ceph.pub')
+    if not ctx.args.output_pub_ssh_key:
+        ctx.args.output_pub_ssh_key = os.path.join(ctx.args.output_dir, 'ceph.pub')
 
     # verify output files
-    for f in [args.output_config, args.output_keyring, args.output_pub_ssh_key]:
-        if not args.allow_overwrite:
+    for f in [ctx.args.output_config, ctx.args.output_keyring,
+              ctx.args.output_pub_ssh_key]:
+        if not ctx.args.allow_overwrite:
             if os.path.exists(f):
                 raise Error('%s already exists; delete or pass '
                               '--allow-overwrite to overwrite' % f)
@@ -3059,51 +3128,51 @@ def command_bootstrap():
                 raise Error(f"Unable to create {dirname} due to permissions failure. Retry with root, or sudo or preallocate the directory.")
 
 
-    if not args.skip_prepare_host:
-        command_prepare_host()
+    if not ctx.args.skip_prepare_host:
+        command_prepare_host(ctx)
     else:
         logger.info('Skip prepare_host')
 
     # initial vars
-    fsid = args.fsid or make_fsid()
+    fsid = ctx.args.fsid or make_fsid()
     hostname = get_hostname()
-    if '.' in hostname and not args.allow_fqdn_hostname:
+    if '.' in hostname and not ctx.args.allow_fqdn_hostname:
         raise Error('hostname is a fully qualified domain name (%s); either fix (e.g., "sudo hostname %s" or similar) or pass --allow-fqdn-hostname' % (hostname, hostname.split('.')[0]))
-    mon_id = args.mon_id or hostname
-    mgr_id = args.mgr_id or generate_service_id()
+    mon_id = ctx.args.mon_id or hostname
+    mgr_id = ctx.args.mgr_id or generate_service_id()
     logger.info('Cluster fsid: %s' % fsid)
     ipv6 = False
 
-    l = FileLock(fsid)
+    l = FileLock(ctx, fsid)
     l.acquire()
 
     # ip
     r = re.compile(r':(\d+)$')
     base_ip = ''
-    if args.mon_ip:
-        ipv6 = is_ipv6(args.mon_ip)
+    if ctx.args.mon_ip:
+        ipv6 = is_ipv6(ctx, ctx.args.mon_ip)
         if ipv6:
-            args.mon_ip = wrap_ipv6(args.mon_ip)
-        hasport = r.findall(args.mon_ip)
+            ctx.args.mon_ip = wrap_ipv6(ctx.args.mon_ip)
+        hasport = r.findall(ctx.args.mon_ip)
         if hasport:
             port = int(hasport[0])
             if port == 6789:
-                addr_arg = '[v1:%s]' % args.mon_ip
+                addr_arg = '[v1:%s]' % ctx.args.mon_ip
             elif port == 3300:
-                addr_arg = '[v2:%s]' % args.mon_ip
+                addr_arg = '[v2:%s]' % ctx.args.mon_ip
             else:
                 logger.warning('Using msgr2 protocol for unrecognized port %d' %
                                port)
-                addr_arg = '[v2:%s]' % args.mon_ip
-            base_ip = args.mon_ip[0:-(len(str(port)))-1]
-            check_ip_port(base_ip, port)
+                addr_arg = '[v2:%s]' % ctx.args.mon_ip
+            base_ip = ctx.args.mon_ip[0:-(len(str(port)))-1]
+            check_ip_port(ctx, base_ip, port)
         else:
-            base_ip = args.mon_ip
-            addr_arg = '[v2:%s:3300,v1:%s:6789]' % (args.mon_ip, args.mon_ip)
-            check_ip_port(args.mon_ip, 3300)
-            check_ip_port(args.mon_ip, 6789)
-    elif args.mon_addrv:
-        addr_arg = args.mon_addrv
+            base_ip = ctx.args.mon_ip
+            addr_arg = '[v2:%s:3300,v1:%s:6789]' % (ctx.args.mon_ip, ctx.args.mon_ip)
+            check_ip_port(ctx, args.mon_ip, 3300)
+            check_ip_port(ctx, args.mon_ip, 6789)
+    elif ctx.args.mon_addrv:
+        addr_arg = ctx.args.mon_addrv
         if addr_arg[0] != '[' or addr_arg[-1] != ']':
             raise Error('--mon-addrv value %s must use square backets' %
                         addr_arg)
@@ -3117,16 +3186,16 @@ def command_bootstrap():
             # strip off v1: or v2: prefix
             addr = re.sub(r'^\w+:', '', addr)
             base_ip = addr[0:-(len(str(port)))-1]
-            check_ip_port(base_ip, port)
+            check_ip_port(ctx, base_ip, port)
     else:
         raise Error('must specify --mon-ip or --mon-addrv')
     logger.debug('Base mon IP is %s, final addrv is %s' % (base_ip, addr_arg))
 
     mon_network = None
-    if not args.skip_mon_network:
+    if not ctx.args.skip_mon_network:
         # make sure IP is configured locally, and then figure out the
         # CIDR network
-        for net, ips in list_networks().items():
+        for net, ips in list_networks(ctx).items():
             if ipaddress.ip_address(unicode(unwrap_ipv6(base_ip))) in \
                     [ipaddress.ip_address(unicode(ip)) for ip in ips]:
                 mon_network = net
@@ -3138,39 +3207,42 @@ def command_bootstrap():
                         '--skip-mon-network to configure it later' % base_ip)
 
     # config
-    cp = read_config(args.config)
+    cp = read_config(ctx.args.config)
     if not cp.has_section('global'):
         cp.add_section('global')
     cp.set('global', 'fsid', fsid);
     cp.set('global', 'mon host', addr_arg)
-    cp.set('global', 'container_image', args.image)
+    cp.set('global', 'container_image', ctx.args.image)
     cpf = StringIO()
     cp.write(cpf)
     config = cpf.getvalue()
 
-    if args.registry_json or args.registry_url:
-        command_registry_login()
+    if ctx.args.registry_json or ctx.args.registry_url:
+        command_registry_login(ctx)
 
-    if not args.skip_pull:
-        _pull_image(args.image)
+    if not ctx.args.skip_pull:
+        _pull_image(ctx, ctx.args.image)
 
     logger.info('Extracting ceph user uid/gid from container image...')
-    (uid, gid) = extract_uid_gid()
+    (uid, gid) = extract_uid_gid(ctx)
 
     # create some initial keys
     logger.info('Creating initial keys...')
     mon_key = CephContainer(
-        image=args.image,
+        ctx,
+        image=ctx.args.image,
         entrypoint='/usr/bin/ceph-authtool',
         args=['--gen-print-key'],
     ).run().strip()
     admin_key = CephContainer(
-        image=args.image,
+        ctx,
+        image=ctx.args.image,
         entrypoint='/usr/bin/ceph-authtool',
         args=['--gen-print-key'],
     ).run().strip()
     mgr_key = CephContainer(
-        image=args.image,
+        ctx,
+        image=ctx.args.image,
         entrypoint='/usr/bin/ceph-authtool',
         args=['--gen-print-key'],
     ).run().strip()
@@ -3198,7 +3270,8 @@ def command_bootstrap():
     logger.info('Creating initial monmap...')
     tmp_monmap = write_tmp('', 0, 0)
     out = CephContainer(
-        image=args.image,
+        ctx,
+        image=ctx.args.image,
         entrypoint='/usr/bin/monmaptool',
         args=['--create',
               '--clobber',
@@ -3216,11 +3289,12 @@ def command_bootstrap():
 
     # create mon
     logger.info('Creating mon...')
-    create_daemon_dirs(fsid, 'mon', mon_id, uid, gid)
-    mon_dir = get_data_dir(fsid, 'mon', mon_id)
-    log_dir = get_log_dir(fsid)
+    create_daemon_dirs(ctx, fsid, 'mon', mon_id, uid, gid)
+    mon_dir = get_data_dir(fsid, ctx.args.data_dir, 'mon', mon_id)
+    log_dir = get_log_dir(fsid, ctx.args.log_dir)
     out = CephContainer(
-        image=args.image,
+        ctx,
+        image=ctx.args.image,
         entrypoint='/usr/bin/ceph-mon',
         args=['--mkfs',
               '-i', mon_id,
@@ -3228,7 +3302,7 @@ def command_bootstrap():
               '-c', '/dev/null',
               '--monmap', '/tmp/monmap',
               '--keyring', '/tmp/keyring',
-        ] + get_daemon_args(fsid, 'mon', mon_id),
+        ] + get_daemon_args(ctx, fsid, 'mon', mon_id),
         volume_mounts={
             log_dir: '/var/log/ceph:z',
             mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % (mon_id),
@@ -3242,9 +3316,9 @@ def command_bootstrap():
         os.fchmod(f.fileno(), 0o600)
         f.write(config)
 
-    make_var_run(fsid, uid, gid)
-    mon_c = get_container(fsid, 'mon', mon_id)
-    deploy_daemon(fsid, 'mon', mon_id, mon_c, uid, gid,
+    make_var_run(ctx, fsid, uid, gid)
+    mon_c = get_container(ctx, fsid, 'mon', mon_id)
+    deploy_daemon(ctx, fsid, 'mon', mon_id, mon_c, uid, gid,
                   config=None, keyring=None)
 
     # client.admin key + config to issue various CLI commands
@@ -3265,7 +3339,8 @@ def command_bootstrap():
             mounts[k] = v
         timeout = timeout or args.timeout
         return CephContainer(
-            image=args.image,
+            ctx,
+            image=ctx.args.image,
             entrypoint='/usr/bin/ceph',
             args=cmd,
             volume_mounts=mounts,
@@ -3273,7 +3348,8 @@ def command_bootstrap():
 
     logger.info('Waiting for mon to start...')
     c = CephContainer(
-        image=args.image,
+        ctx,
+        image=ctx.args.image,
         entrypoint='/usr/bin/ceph',
         args=[
             'status'],
@@ -3287,15 +3363,15 @@ def command_bootstrap():
     # wait for the service to become available
     def is_mon_available():
         # type: () -> bool
-        timeout=args.timeout if args.timeout else 60 # seconds
-        out, err, ret = call(c.run_cmd(),
+        timeout=ctx.args.timeout if ctx.args.timeout else 60 # seconds
+        out, err, ret = call(ctx, c.run_cmd(),
                              desc=c.entrypoint,
                              timeout=timeout)
         return ret == 0
-    is_available('mon', is_mon_available)
+    is_available(ctx, 'mon', is_mon_available)
 
     # assimilate and minimize config
-    if not args.no_minimize_config:
+    if not ctx.args.no_minimize_config:
         logger.info('Assimilating anything we can from ceph.conf...')
         cli([
             'config', 'assimilate-conf',
@@ -3314,7 +3390,7 @@ def command_bootstrap():
         with open(mon_dir + '/config', 'r') as f:
             config = f.read()
         logger.info('Restarting the monitor...')
-        call_throws([
+        call_throws(ctx, [
             'systemctl',
             'restart',
             get_unit_name(fsid, 'mon', mon_id)
@@ -3331,27 +3407,27 @@ def command_bootstrap():
     # create mgr
     logger.info('Creating mgr...')
     mgr_keyring = '[mgr.%s]\n\tkey = %s\n' % (mgr_id, mgr_key)
-    mgr_c = get_container(fsid, 'mgr', mgr_id)
+    mgr_c = get_container(ctx, fsid, 'mgr', mgr_id)
     # Note:the default port used by the Prometheus node exporter is opened in fw
-    deploy_daemon(fsid, 'mgr', mgr_id, mgr_c, uid, gid,
+    deploy_daemon(ctx, fsid, 'mgr', mgr_id, mgr_c, uid, gid,
                   config=config, keyring=mgr_keyring, ports=[9283])
 
     # output files
-    with open(args.output_keyring, 'w') as f:
+    with open(ctx.args.output_keyring, 'w') as f:
         os.fchmod(f.fileno(), 0o600)
         f.write('[client.admin]\n'
                 '\tkey = ' + admin_key + '\n')
-    logger.info('Wrote keyring to %s' % args.output_keyring)
+    logger.info('Wrote keyring to %s' % ctx.args.output_keyring)
 
-    with open(args.output_config, 'w') as f:
+    with open(ctx.args.output_config, 'w') as f:
         f.write(config)
-    logger.info('Wrote config to %s' % args.output_config)
+    logger.info('Wrote config to %s' % ctx.args.output_config)
 
     # wait for the service to become available
     logger.info('Waiting for mgr to start...')
     def is_mgr_available():
         # type: () -> bool
-        timeout=args.timeout if args.timeout else 60 # seconds
+        timeout=ctx.args.timeout if ctx.args.timeout else 60 # seconds
         try:
             out = cli(['status', '-f', 'json-pretty'], timeout=timeout)
             j = json.loads(out)
@@ -3359,7 +3435,7 @@ def command_bootstrap():
         except Exception as e:
             logger.debug('status failed: %s' % e)
             return False
-    is_available('mgr', is_mgr_available)
+    is_available(ctx, 'mgr', is_mgr_available)
 
     # wait for mgr to restart (after enabling a module)
     def wait_for_mgr_restart():
@@ -3378,12 +3454,12 @@ def command_bootstrap():
             except Exception as e:
                 logger.debug('tell mgr mgr_status failed: %s' % e)
                 return False
-        is_available('mgr epoch %d' % epoch, mgr_has_latest_epoch)
+        is_available(ctx, 'mgr epoch %d' % epoch, mgr_has_latest_epoch)
 
     # ssh
     host: Optional[str] = None
-    if not args.skip_ssh:
-        cli(['config-key', 'set', 'mgr/cephadm/ssh_user', args.ssh_user])
+    if not ctx.args.skip_ssh:
+        cli(['config-key', 'set', 'mgr/cephadm/ssh_user', ctx.args.ssh_user])
 
         logger.info('Enabling cephadm module...')
         cli(['mgr', 'module', 'enable', 'cephadm'])
@@ -3392,18 +3468,18 @@ def command_bootstrap():
         logger.info('Setting orchestrator backend to cephadm...')
         cli(['orch', 'set', 'backend', 'cephadm'])
 
-        if args.ssh_config:
+        if ctx.args.ssh_config:
             logger.info('Using provided ssh config...')
             mounts = {
-                pathify(args.ssh_config.name): '/tmp/cephadm-ssh-config:z',
+                pathify(ctx.args.ssh_config.name): '/tmp/cephadm-ssh-config:z',
             }
             cli(['cephadm', 'set-ssh-config', '-i', '/tmp/cephadm-ssh-config'], extra_mounts=mounts)
 
-        if args.ssh_private_key and args.ssh_public_key:
+        if ctx.args.ssh_private_key and ctx.args.ssh_public_key:
             logger.info('Using provided ssh keys...')
             mounts = {
-                pathify(args.ssh_private_key.name): '/tmp/cephadm-ssh-key:z',
-                pathify(args.ssh_public_key.name): '/tmp/cephadm-ssh-key.pub:z'
+                pathify(ctx.args.ssh_private_key.name): '/tmp/cephadm-ssh-key:z',
+                pathify(ctx.args.ssh_public_key.name): '/tmp/cephadm-ssh-key.pub:z'
             }
             cli(['cephadm', 'set-priv-key', '-i', '/tmp/cephadm-ssh-key'], extra_mounts=mounts)
             cli(['cephadm', 'set-pub-key', '-i', '/tmp/cephadm-ssh-key.pub'], extra_mounts=mounts)
@@ -3412,15 +3488,15 @@ def command_bootstrap():
             cli(['cephadm', 'generate-key'])
             ssh_pub = cli(['cephadm', 'get-pub-key'])
 
-            with open(args.output_pub_ssh_key, 'w') as f:
+            with open(ctx.args.output_pub_ssh_key, 'w') as f:
                 f.write(ssh_pub)
-            logger.info('Wrote public SSH key to to %s' % args.output_pub_ssh_key)
+            logger.info('Wrote public SSH key to to %s' % ctx.args.output_pub_ssh_key)
 
-            logger.info('Adding key to %s@localhost\'s authorized_keys...' % args.ssh_user)
+            logger.info('Adding key to %s@localhost\'s authorized_keys...' % ctx.args.ssh_user)
             try:
-                s_pwd = pwd.getpwnam(args.ssh_user)
+                s_pwd = pwd.getpwnam(ctx.args.ssh_user)
             except KeyError as e:
-                raise Error('Cannot find uid/gid for ssh-user: %s' % (args.ssh_user))
+                raise Error('Cannot find uid/gid for ssh-user: %s' % (ctx.args.ssh_user))
             ssh_uid = s_pwd.pw_uid
             ssh_gid = s_pwd.pw_gid
             ssh_dir = os.path.join(s_pwd.pw_dir, '.ssh')
@@ -3453,29 +3529,29 @@ def command_bootstrap():
         except RuntimeError as e:
             raise Error('Failed to add host <%s>: %s' % (host, e))
 
-        if not args.orphan_initial_daemons:
+        if not ctx.args.orphan_initial_daemons:
             for t in ['mon', 'mgr', 'crash']:
                 logger.info('Deploying %s service with default placement...' % t)
                 cli(['orch', 'apply', t])
 
-        if not args.skip_monitoring_stack:
+        if not ctx.args.skip_monitoring_stack:
             logger.info('Enabling mgr prometheus module...')
             cli(['mgr', 'module', 'enable', 'prometheus'])
             for t in ['prometheus', 'grafana', 'node-exporter', 'alertmanager']:
                 logger.info('Deploying %s service with default placement...' % t)
                 cli(['orch', 'apply', t])
 
-    if args.registry_url and args.registry_username and args.registry_password:
-        cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_url', args.registry_url, '--force'])
-        cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_username', args.registry_username, '--force'])
-        cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_password', args.registry_password, '--force'])
+    if ctx.args.registry_url and ctx.args.registry_username and ctx.args.registry_password:
+        cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_url', ctx.args.registry_url, '--force'])
+        cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_username', ctx.args.registry_username, '--force'])
+        cli(['config', 'set', 'mgr', 'mgr/cephadm/registry_password', ctx.args.registry_password, '--force'])
 
-    if args.container_init:
-        cli(['config', 'set', 'mgr', 'mgr/cephadm/container_init', str(args.container_init), '--force'])
+    if ctx.args.container_init:
+        cli(['config', 'set', 'mgr', 'mgr/cephadm/container_init', str(ctx.args.container_init), '--force'])
 
-    if args.with_exporter:
+    if ctx.args.with_exporter:
         cli(['config-key', 'set', 'mgr/cephadm/exporter_enabled', 'true'])
-        if args.exporter_config:
+        if ctx.args.exporter_config:
             logger.info("Applying custom cephadm exporter settings")
             # validated within the parser, so we can just apply to the store
             with tempfile.NamedTemporaryFile(buffering=0) as tmp:
@@ -3495,10 +3571,10 @@ def command_bootstrap():
         cli(['orch', 'apply', 'cephadm-exporter'])
 
 
-    if not args.skip_dashboard:
+    if not ctx.args.skip_dashboard:
         # Configure SSL port (cephadm only allows to configure dashboard SSL port)
         # if the user does not want to use SSL he can change this setting once the cluster is up
-        cli(["config", "set",  "mgr", "mgr/dashboard/ssl_server_port" , str(args.ssl_dashboard_port)])
+        cli(["config", "set",  "mgr", "mgr/dashboard/ssl_server_port" , str(ctx.args.ssl_dashboard_port)])
 
         # configuring dashboard parameters
         logger.info('Enabling the dashboard module...')
@@ -3506,11 +3582,11 @@ def command_bootstrap():
         wait_for_mgr_restart()
 
         # dashboard crt and key
-        if args.dashboard_key and args.dashboard_crt:
+        if ctx.args.dashboard_key and ctx.args.dashboard_crt:
             logger.info('Using provided dashboard certificate...')
             mounts = {
-                pathify(args.dashboard_crt.name): '/tmp/dashboard.crt:z',
-                pathify(args.dashboard_key.name): '/tmp/dashboard.key:z'
+                pathify(ctx.args.dashboard_crt.name): '/tmp/dashboard.crt:z',
+                pathify(ctx.args.dashboard_key.name): '/tmp/dashboard.key:z'
             }
             cli(['dashboard', 'set-ssl-certificate', '-i', '/tmp/dashboard.crt'], extra_mounts=mounts)
             cli(['dashboard', 'set-ssl-certificate-key', '-i', '/tmp/dashboard.key'], extra_mounts=mounts)
@@ -3521,8 +3597,8 @@ def command_bootstrap():
         logger.info('Creating initial admin user...')
         password = args.initial_dashboard_password or generate_password()
         tmp_password_file = write_tmp(password, uid, gid)
-        cmd = ['dashboard', 'ac-user-create', args.initial_dashboard_user, '-i', '/tmp/dashboard.pw', 'administrator', '--force-password']
-        if not args.dashboard_password_noupdate:
+        cmd = ['dashboard', 'ac-user-create', ctx.args.initial_dashboard_user, '-i', '/tmp/dashboard.pw', 'administrator', '--force-password']
+        if not ctx.args.dashboard_password_noupdate:
             cmd.append('--pwd-update-required')
         cli(cmd, extra_mounts={pathify(tmp_password_file.name): '/tmp/dashboard.pw:z'})
         logger.info('Fetching dashboard port number...')
@@ -3530,7 +3606,7 @@ def command_bootstrap():
         port = int(out)
 
         # Open dashboard port
-        fw = Firewalld()
+        fw = Firewalld(ctx)
         fw.open_ports([port])
         fw.apply_rules()
 
@@ -3539,13 +3615,13 @@ def command_bootstrap():
                     '\t    User: %s\n'
                     '\tPassword: %s\n' % (
                         get_fqdn(), port,
-                        args.initial_dashboard_user,
+                        ctx.args.initial_dashboard_user,
                         password))
 
-    if args.apply_spec:
-        logger.info('Applying %s to cluster' % args.apply_spec)
+    if ctx.args.apply_spec:
+        logger.info('Applying %s to cluster' % ctx.args.apply_spec)
 
-        with open(args.apply_spec) as f:
+        with open(ctx.args.apply_spec) as f:
             for line in f:
                 if 'hostname:' in line:
                     line = line.replace('\n', '')
@@ -3554,12 +3630,12 @@ def command_bootstrap():
                         logger.info('Adding ssh key to %s' % split[1])
 
                         ssh_key = '/etc/ceph/ceph.pub'
-                        if args.ssh_public_key:
-                            ssh_key = args.ssh_public_key.name
-                        out, err, code = call_throws(['ssh-copy-id', '-f', '-i', ssh_key, '%s@%s' % (args.ssh_user, split[1])])
+                        if ctx.args.ssh_public_key:
+                            ssh_key = ctx.args.ssh_public_key.name
+                        out, err, code = call_throws(ctx, ['ssh-copy-id', '-f', '-i', ssh_key, '%s@%s' % (args.ssh_user, split[1])])
 
         mounts = {}
-        mounts[pathify(args.apply_spec)] = '/tmp/spec.yml:z'
+        mounts[pathify(ctx.args.apply_spec)] = '/tmp/spec.yml:z'
 
         out = cli(['orch', 'apply', '-i', '/tmp/spec.yml'], extra_mounts=mounts)
         logger.info(out)
@@ -3579,7 +3655,8 @@ def command_bootstrap():
 
 ##################################
 
-def command_registry_login():
+def command_registry_login(ctx: CephadmContext):
+    args = ctx.args
     if args.registry_json:
         logger.info("Pulling custom registry login info from %s." % args.registry_json)
         d = get_parm(args.registry_json)
@@ -3587,7 +3664,7 @@ def command_registry_login():
             args.registry_url = d.get('url')
             args.registry_username = d.get('username')
             args.registry_password = d.get('password')
-            registry_login(args.registry_url, args.registry_username, args.registry_password)
+            registry_login(ctx, args.registry_url, args.registry_username, args.registry_password)
         else:
             raise Error("json provided for custom registry login did not include all necessary fields. "
                             "Please setup json file as\n"
@@ -3597,52 +3674,54 @@ def command_registry_login():
                               " \"password\": \"REGISTRY_PASSWORD\"\n"
                             "}\n")
     elif args.registry_url and args.registry_username and args.registry_password:
-        registry_login(args.registry_url, args.registry_username, args.registry_password)
+        registry_login(ctx, args.registry_url, args.registry_username, args.registry_password)
     else:
         raise Error("Invalid custom registry arguments received. To login to a custom registry include "
                         "--registry-url, --registry-username and --registry-password "
                         "options or --registry-json option")
     return 0
 
-def registry_login(url, username, password):
+def registry_login(ctx: CephadmContext, url, username, password):
     logger.info("Logging into custom registry.")
     try:
+        container_path = ctx.container_path
         cmd = [container_path, 'login',
                '-u', username, '-p', password,
                url]
         if 'podman' in container_path:
             cmd.append('--authfile=/etc/ceph/podman-auth.json')
-        out, _, _ = call_throws(cmd)
+        out, _, _ = call_throws(ctx, cmd)
         if 'podman' in container_path:
             os.chmod('/etc/ceph/podman-auth.json', 0o600)
     except:
-        raise Error("Failed to login to custom registry @ %s as %s with given password" % (args.registry_url, args.registry_username))
+        raise Error("Failed to login to custom registry @ %s as %s with given password" % (ctx.args.registry_url, ctx.args.registry_username))
 
 ##################################
 
 
-def extract_uid_gid_monitoring(daemon_type):
-    # type: (str) -> Tuple[int, int]
+def extract_uid_gid_monitoring(ctx, daemon_type):
+    # type: (CephadmContext, str) -> Tuple[int, int]
 
     if daemon_type == 'prometheus':
-        uid, gid = extract_uid_gid(file_path='/etc/prometheus')
+        uid, gid = extract_uid_gid(ctx, file_path='/etc/prometheus')
     elif daemon_type == 'node-exporter':
         uid, gid = 65534, 65534
     elif daemon_type == 'grafana':
-        uid, gid = extract_uid_gid(file_path='/var/lib/grafana')
+        uid, gid = extract_uid_gid(ctx, file_path='/var/lib/grafana')
     elif daemon_type == 'alertmanager':
-        uid, gid = extract_uid_gid(file_path=['/etc/alertmanager', '/etc/prometheus'])
+        uid, gid = extract_uid_gid(ctx, file_path=['/etc/alertmanager', '/etc/prometheus'])
     else:
         raise Error("{} not implemented yet".format(daemon_type))
     return uid, gid
 
 
 @default_image
-def command_deploy():
-    # type: () -> None
+def command_deploy(ctx):
+    # type: (CephadmContext) -> None
+    args = ctx.args
     daemon_type, daemon_id = args.name.split('.', 1)
 
-    l = FileLock(args.fsid)
+    l = FileLock(ctx, args.fsid)
     l.acquire()
 
     if daemon_type not in get_supported_daemons():
@@ -3650,7 +3729,7 @@ def command_deploy():
 
     redeploy = False
     unit_name = get_unit_name(args.fsid, daemon_type, daemon_id)
-    (_, state, _) = check_unit(unit_name)
+    (_, state, _) = check_unit(ctx, unit_name)
     if state == 'running':
         redeploy = True
 
@@ -3667,13 +3746,13 @@ def command_deploy():
         daemon_ports = list(map(int, args.tcp_ports.split()))
 
     if daemon_type in Ceph.daemons:
-        config, keyring = get_config_and_keyring()
-        uid, gid = extract_uid_gid()
-        make_var_run(args.fsid, uid, gid)
+        config, keyring = get_config_and_keyring(ctx)
+        uid, gid = extract_uid_gid(ctx)
+        make_var_run(ctx, args.fsid, uid, gid)
 
-        c = get_container(args.fsid, daemon_type, daemon_id,
+        c = get_container(ctx, args.fsid, daemon_type, daemon_id,
                           ptrace=args.allow_ptrace)
-        deploy_daemon(args.fsid, daemon_type, daemon_id, c, uid, gid,
+        deploy_daemon(ctx, args.fsid, daemon_type, daemon_id, c, uid, gid,
                       config=config, keyring=keyring,
                       osd_fsid=args.osd_fsid,
                       reconfig=args.reconfig,
@@ -3698,9 +3777,9 @@ def command_deploy():
                 raise Error("{} deployment requires config-json which must "
                             "contain arg for {}".format(daemon_type.capitalize(), ', '.join(required_args)))
 
-        uid, gid = extract_uid_gid_monitoring(daemon_type)
-        c = get_container(args.fsid, daemon_type, daemon_id)
-        deploy_daemon(args.fsid, daemon_type, daemon_id, c, uid, gid,
+        uid, gid = extract_uid_gid_monitoring(ctx, daemon_type)
+        c = get_container(ctx, args.fsid, daemon_type, daemon_id)
+        deploy_daemon(ctx, args.fsid, daemon_type, daemon_id, c, uid, gid,
                       reconfig=args.reconfig,
                       ports=daemon_ports)
 
@@ -3708,48 +3787,48 @@ def command_deploy():
         if not args.reconfig and not redeploy:
             daemon_ports.extend(NFSGanesha.port_map.values())
 
-        config, keyring = get_config_and_keyring()
+        config, keyring = get_config_and_keyring(ctx)
         # TODO: extract ganesha uid/gid (997, 994) ?
-        uid, gid = extract_uid_gid()
-        c = get_container(args.fsid, daemon_type, daemon_id)
-        deploy_daemon(args.fsid, daemon_type, daemon_id, c, uid, gid,
+        uid, gid = extract_uid_gid(ctx)
+        c = get_container(ctx, args.fsid, daemon_type, daemon_id)
+        deploy_daemon(ctx, args.fsid, daemon_type, daemon_id, c, uid, gid,
                       config=config, keyring=keyring,
                       reconfig=args.reconfig,
                       ports=daemon_ports)
 
     elif daemon_type == CephIscsi.daemon_type:
-        config, keyring = get_config_and_keyring()
-        uid, gid = extract_uid_gid()
-        c = get_container(args.fsid, daemon_type, daemon_id)
-        deploy_daemon(args.fsid, daemon_type, daemon_id, c, uid, gid,
+        config, keyring = get_config_and_keyring(ctx)
+        uid, gid = extract_uid_gid(ctx)
+        c = get_container(ctx, args.fsid, daemon_type, daemon_id)
+        deploy_daemon(ctx, args.fsid, daemon_type, daemon_id, c, uid, gid,
                       config=config, keyring=keyring,
                       reconfig=args.reconfig,
                       ports=daemon_ports)
 
     elif daemon_type == HAproxy.daemon_type:
-        haproxy = HAproxy.init(args.fsid, daemon_id)
+        haproxy = HAproxy.init(ctx, args.fsid, daemon_id)
         uid, gid = haproxy.extract_uid_gid_haproxy()
-        c = get_container(args.fsid, daemon_type, daemon_id)
-        deploy_daemon(args.fsid, daemon_type, daemon_id, c, uid, gid,
+        c = get_container(ctx, args.fsid, daemon_type, daemon_id)
+        deploy_daemon(ctx, args.fsid, daemon_type, daemon_id, c, uid, gid,
                       reconfig=args.reconfig,
                       ports=daemon_ports)
 
     elif daemon_type == Keepalived.daemon_type:
-        keepalived = Keepalived.init(args.fsid, daemon_id)
+        keepalived = Keepalived.init(ctx, args.fsid, daemon_id)
         uid, gid = keepalived.extract_uid_gid_keepalived()
-        c = get_container(args.fsid, daemon_type, daemon_id)
-        deploy_daemon(args.fsid, daemon_type, daemon_id, c, uid, gid,
+        c = get_container(ctx, args.fsid, daemon_type, daemon_id)
+        deploy_daemon(ctx, args.fsid, daemon_type, daemon_id, c, uid, gid,
                       reconfig=args.reconfig,
                       ports=daemon_ports)
 
     elif daemon_type == CustomContainer.daemon_type:
-        cc = CustomContainer.init(args.fsid, daemon_id)
+        cc = CustomContainer.init(ctx, args.fsid, daemon_id)
         if not args.reconfig and not redeploy:
             daemon_ports.extend(cc.ports)
-        c = get_container(args.fsid, daemon_type, daemon_id,
+        c = get_container(ctx, args.fsid, daemon_type, daemon_id,
                           privileged=cc.privileged,
                           ptrace=args.allow_ptrace)
-        deploy_daemon(args.fsid, daemon_type, daemon_id, c,
+        deploy_daemon(ctx, args.fsid, daemon_type, daemon_id, c,
                       uid=cc.uid, gid=cc.gid, config=None,
                       keyring=None, reconfig=args.reconfig,
                       ports=daemon_ports)
@@ -3765,7 +3844,7 @@ def command_deploy():
            
         CephadmDaemon.validate_config(config_js)
         
-        deploy_daemon(args.fsid, daemon_type, daemon_id, None,
+        deploy_daemon(ctx, args.fsid, daemon_type, daemon_id, None,
                       uid, gid, ports=daemon_ports)
     
     else:
@@ -3776,12 +3855,13 @@ def command_deploy():
 
 
 @infer_image
-def command_run():
-    # type: () -> int
+def command_run(ctx):
+    # type: (CephadmContext) -> int
+    args = ctx.args
     (daemon_type, daemon_id) = args.name.split('.', 1)
-    c = get_container(args.fsid, daemon_type, daemon_id)
+    c = get_container(ctx, args.fsid, daemon_type, daemon_id)
     command = c.run_cmd()
-    return call_timeout(command, args.timeout)
+    return call_timeout(ctx, command, args.timeout)
 
 ##################################
 
@@ -3789,10 +3869,11 @@ def command_run():
 @infer_fsid
 @infer_config
 @infer_image
-def command_shell():
-    # type: () -> int
+def command_shell(ctx):
+    # type: (CephadmContext) -> int
+    args = ctx.args
     if args.fsid:
-        make_log_dir(args.fsid)
+        make_log_dir(ctx, args.fsid)
     if args.name:
         if '.' in args.name:
             (daemon_type, daemon_id) = args.name.split('.', 1)
@@ -3813,9 +3894,9 @@ def command_shell():
         args.keyring = SHELL_DEFAULT_KEYRING
 
     container_args = [] # type: List[str]
-    mounts = get_container_mounts(args.fsid, daemon_type, daemon_id,
+    mounts = get_container_mounts(ctx, args.fsid, daemon_type, daemon_id,
                                   no_config=True if args.config else False)
-    binds = get_container_binds(args.fsid, daemon_type, daemon_id)
+    binds = get_container_binds(ctx, args.fsid, daemon_type, daemon_id)
     if args.config:
         mounts[pathify(args.config)] = '/etc/ceph/ceph.conf:z'
     if args.keyring:
@@ -3852,6 +3933,7 @@ def command_shell():
             mounts[home] = '/root'
 
     c = CephContainer(
+        ctx,
         image=args.image,
         entrypoint='doesnotmatter',
         args=[],
@@ -3862,14 +3944,15 @@ def command_shell():
         privileged=True)
     command = c.shell_cmd(command)
 
-    return call_timeout(command, args.timeout)
+    return call_timeout(ctx, command, args.timeout)
 
 ##################################
 
 
 @infer_fsid
-def command_enter():
-    # type: () -> int
+def command_enter(ctx):
+    # type: (CephadmContext) -> int
+    args = ctx.args
     if not args.fsid:
         raise Error('must pass --fsid to specify cluster')
     (daemon_type, daemon_id) = args.name.split('.', 1)
@@ -3884,34 +3967,36 @@ def command_enter():
             '-e', "PS1=%s" % CUSTOM_PS1,
         ]
     c = CephContainer(
+        ctx,
         image=args.image,
         entrypoint='doesnotmatter',
         container_args=container_args,
         cname='ceph-%s-%s.%s' % (args.fsid, daemon_type, daemon_id),
     )
     command = c.exec_cmd(command)
-    return call_timeout(command, args.timeout)
+    return call_timeout(ctx, command, args.timeout)
 
 ##################################
 
 
 @infer_fsid
 @infer_image
-def command_ceph_volume():
-    # type: () -> None
+def command_ceph_volume(ctx):
+    # type: (CephadmContext) -> None
+    args = ctx.args
     if args.fsid:
-        make_log_dir(args.fsid)
+        make_log_dir(ctx, args.fsid)
 
-        l = FileLock(args.fsid)
+        l = FileLock(ctx, args.fsid)
         l.acquire()
 
     (uid, gid) = (0, 0) # ceph-volume runs as root
-    mounts = get_container_mounts(args.fsid, 'osd', None)
+    mounts = get_container_mounts(ctx, args.fsid, 'osd', None)
 
     tmp_config = None
     tmp_keyring = None
 
-    (config, keyring) = get_config_and_keyring()
+    (config, keyring) = get_config_and_keyring(ctx)
 
     if config:
         # tmp config file
@@ -3924,6 +4009,7 @@ def command_ceph_volume():
         mounts[tmp_keyring.name] = '/var/lib/ceph/bootstrap-osd/ceph.keyring:z'
 
     c = CephContainer(
+        ctx,
         image=args.image,
         entrypoint='/usr/sbin/ceph-volume',
         envs=args.env,
@@ -3931,8 +4017,8 @@ def command_ceph_volume():
         privileged=True,
         volume_mounts=mounts,
     )
-    verbosity = CallVerbosity.VERBOSE if args.log_output else CallVerbosity.VERBOSE_ON_FAILURE
-    out, err, code = call_throws(c.run_cmd(), verbosity=verbosity)
+    verbosity = CallVerbosity.VERBOSE if ctx.args.log_output else CallVerbosity.VERBOSE_ON_FAILURE
+    out, err, code = call_throws(ctx, c.run_cmd(), verbosity=verbosity)
     if not code:
         print(out)
 
@@ -3940,14 +4026,15 @@ def command_ceph_volume():
 
 
 @infer_fsid
-def command_unit():
-    # type: () -> None
+def command_unit(ctx):
+    # type: (CephadmContext) -> None
+    args = ctx.args
     if not args.fsid:
         raise Error('must pass --fsid to specify cluster')
 
-    unit_name = get_unit_name_by_daemon_name(args.fsid, args.name)
+    unit_name = get_unit_name_by_daemon_name(ctx, args.fsid, args.name)
 
-    call_throws([
+    call_throws(ctx, [
         'systemctl',
         args.command,
         unit_name],
@@ -3959,12 +4046,13 @@ def command_unit():
 
 
 @infer_fsid
-def command_logs():
-    # type: () -> None
+def command_logs(ctx):
+    # type: (CephadmContext) -> None
+    args = ctx.args
     if not args.fsid:
         raise Error('must pass --fsid to specify cluster')
 
-    unit_name = get_unit_name_by_daemon_name(args.fsid, args.name)
+    unit_name = get_unit_name_by_daemon_name(ctx, args.fsid, args.name)
 
     cmd = [find_program('journalctl')]
     cmd.extend(['-u', unit_name])
@@ -3979,8 +4067,8 @@ def command_logs():
 ##################################
 
 
-def list_networks():
-    # type: () -> Dict[str,List[str]]
+def list_networks(ctx):
+    # type: (CephadmContext) -> Dict[str,List[str]]
 
     ## sadly, 18.04's iproute2 4.15.0-2ubun doesn't support the -j flag,
     ## so we'll need to use a regex to parse 'ip' command output.
@@ -3988,16 +4076,16 @@ def list_networks():
     #j = json.loads(out)
     #for x in j:
 
-    res = _list_ipv4_networks()
-    res.update(_list_ipv6_networks())
+    res = _list_ipv4_networks(ctx)
+    res.update(_list_ipv6_networks(ctx))
     return res
 
 
-def _list_ipv4_networks():
+def _list_ipv4_networks(ctx: CephadmContext):
     execstr: Optional[str] = find_executable('ip')
     if not execstr:
         raise FileNotFoundError("unable to find 'ip' command")
-    out, _, _ = call_throws([execstr, 'route', 'ls'])
+    out, _, _ = call_throws(ctx, [execstr, 'route', 'ls'])
     return _parse_ipv4_route(out)
 
 
@@ -4016,12 +4104,12 @@ def _parse_ipv4_route(out):
     return r
 
 
-def _list_ipv6_networks():
+def _list_ipv6_networks(ctx: CephadmContext):
     execstr: Optional[str] = find_executable('ip')
     if not execstr:
         raise FileNotFoundError("unable to find 'ip' command")
-    routes, _, _ = call_throws([execstr, '-6', 'route', 'ls'])
-    ips, _, _ = call_throws([execstr, '-6', 'addr', 'ls'])
+    routes, _, _ = call_throws(ctx, [execstr, '-6', 'route', 'ls'])
+    ips, _, _ = call_throws(ctx, [execstr, '-6', 'addr', 'ls'])
     return _parse_ipv6_route(routes, ips)
 
 
@@ -4051,26 +4139,28 @@ def _parse_ipv6_route(routes, ips):
     return r
 
 
-def command_list_networks():
-    # type: () -> None
-    r = list_networks()
+def command_list_networks(ctx):
+    # type: (CephadmContext) -> None
+    r = list_networks(ctx)
     print(json.dumps(r, indent=4))
 
 ##################################
 
 
-def command_ls():
-    # type: () -> None
-
-    ls = list_daemons(detail=not args.no_detail,
+def command_ls(ctx):
+    # type: (CephadmContext) -> None
+    args = ctx.args
+    ls = list_daemons(ctx, detail=not args.no_detail,
                       legacy_dir=args.legacy_dir)
     print(json.dumps(ls, indent=4))
 
 
-def list_daemons(detail=True, legacy_dir=None):
-    # type: (bool, Optional[str]) -> List[Dict[str, str]]
+def list_daemons(ctx, detail=True, legacy_dir=None):
+    # type: (CephadmContext, bool, Optional[str]) -> List[Dict[str, str]]
     host_version = None
     ls = []
+    args = ctx.args
+    container_path = ctx.container_path
 
     data_dir = args.data_dir
     if legacy_dir is not None:
@@ -4089,6 +4179,7 @@ def list_daemons(detail=True, legacy_dir=None):
                         continue
                     (cluster, daemon_id) = j.split('-', 1)
                     fsid = get_legacy_daemon_fsid(
+                            ctx,
                             cluster, daemon_type, daemon_id,
                             legacy_dir=legacy_dir)
                     legacy_unit_name = 'ceph-%s@%s' % (daemon_type, daemon_id)
@@ -4099,10 +4190,11 @@ def list_daemons(detail=True, legacy_dir=None):
                         'systemd_unit': legacy_unit_name,
                     }
                     if detail:
-                        (val['enabled'], val['state'], _) = check_unit(legacy_unit_name)
+                        (val['enabled'], val['state'], _) = \
+                            check_unit(ctx, legacy_unit_name)
                         if not host_version:
                             try:
-                                out, err, code = call(['ceph', '-v'])
+                                out, err, code = call(ctx, ['ceph', '-v'])
                                 if not code and out.startswith('ceph version '):
                                     host_version = out.split(' ')[2]
                             except Exception:
@@ -4128,19 +4220,21 @@ def list_daemons(detail=True, legacy_dir=None):
                     }
                     if detail:
                         # get container id
-                        (val['enabled'], val['state'], _) = check_unit(unit_name)
+                        (val['enabled'], val['state'], _) = \
+                            check_unit(ctx, unit_name)
                         container_id = None
                         image_name = None
                         image_id = None
                         version = None
                         start_stamp = None
 
-                        if 'podman' in container_path and get_podman_version() < (1, 6, 2):
+                        if 'podman' in container_path and \
+                            get_podman_version(ctx, container_path) < (1, 6, 2):
                             image_field = '.ImageID'
                         else:
                             image_field = '.Image'
 
-                        out, err, code = call(
+                        out, err, code = call(ctx,
                             [
                                 container_path, 'inspect',
                                 '--format', '{{.Id}},{{.Config.Image}},{{%s}},{{.Created}},{{index .Config.Labels "io.ceph.version"}}' % image_field,
@@ -4156,12 +4250,12 @@ def list_daemons(detail=True, legacy_dir=None):
                             if not version or '.' not in version:
                                 version = seen_versions.get(image_id, None)
                             if daemon_type == NFSGanesha.daemon_type:
-                                version = NFSGanesha.get_version(container_id)
+                                version = NFSGanesha.get_version(ctx,container_id)
                             if daemon_type == CephIscsi.daemon_type:
-                                version = CephIscsi.get_version(container_id)
+                                version = CephIscsi.get_version(ctx,container_id)
                             elif not version:
                                 if daemon_type in Ceph.daemons:
-                                    out, err, code = call(
+                                    out, err, code = call(ctx,
                                         [container_path, 'exec', container_id,
                                          'ceph', '-v'])
                                     if not code and \
@@ -4169,7 +4263,7 @@ def list_daemons(detail=True, legacy_dir=None):
                                         version = out.split(' ')[2]
                                         seen_versions[image_id] = version
                                 elif daemon_type == 'grafana':
-                                    out, err, code = call(
+                                    out, err, code = call(ctx,
                                         [container_path, 'exec', container_id,
                                          'grafana-server', '-v'])
                                     if not code and \
@@ -4180,7 +4274,7 @@ def list_daemons(detail=True, legacy_dir=None):
                                                      'alertmanager',
                                                      'node-exporter']:
                                     cmd = daemon_type.replace('-', '_')
-                                    out, err, code = call(
+                                    out, err, code = call(ctx,
                                         [container_path, 'exec', container_id,
                                          cmd, '--version'])
                                     if not code and \
@@ -4188,7 +4282,7 @@ def list_daemons(detail=True, legacy_dir=None):
                                         version = err.split(' ')[2]
                                         seen_versions[image_id] = version
                                 elif daemon_type == 'haproxy':
-                                    out, err, code = call(
+                                    out, err, code = call(ctx,
                                         [container_path, 'exec', container_id,
                                          'haproxy', '-v'])
                                     if not code and \
@@ -4196,7 +4290,7 @@ def list_daemons(detail=True, legacy_dir=None):
                                         version = out.split(' ')[2]
                                         seen_versions[image_id] = version
                                 elif daemon_type == 'keepalived':
-                                    out, err, code = call(
+                                    out, err, code = call(ctx,
                                         [container_path, 'exec', container_id,
                                          'keepalived', '--version'])
                                     if not code and \
@@ -4235,10 +4329,10 @@ def list_daemons(detail=True, legacy_dir=None):
     return ls
 
 
-def get_daemon_description(fsid, name, detail=False, legacy_dir=None):
-    # type: (str, str, bool, Optional[str]) -> Dict[str, str]
+def get_daemon_description(ctx, fsid, name, detail=False, legacy_dir=None):
+    # type: (CephadmContext, str, str, bool, Optional[str]) -> Dict[str, str]
 
-    for d in list_daemons(detail=detail, legacy_dir=legacy_dir):
+    for d in list_daemons(ctx, detail=detail, legacy_dir=legacy_dir):
         if d['fsid'] != fsid:
             continue
         if d['name'] != name:
@@ -4250,11 +4344,12 @@ def get_daemon_description(fsid, name, detail=False, legacy_dir=None):
 ##################################
 
 @default_image
-def command_adopt():
-    # type: () -> None
+def command_adopt(ctx):
+    # type: (CephadmContext) -> None
+    args = ctx.args
 
     if not args.skip_pull:
-        _pull_image(args.image)
+        _pull_image(ctx, args.image)
 
     (daemon_type, daemon_id) = args.name.split('.', 1)
 
@@ -4263,33 +4358,35 @@ def command_adopt():
         raise Error('adoption of style %s not implemented' % args.style)
 
     # lock
-    fsid = get_legacy_daemon_fsid(args.cluster,
+    fsid = get_legacy_daemon_fsid(ctx,
+                                  args.cluster,
                                   daemon_type,
                                   daemon_id,
                                   legacy_dir=args.legacy_dir)
     if not fsid:
         raise Error('could not detect legacy fsid; set fsid in ceph.conf')
-    l = FileLock(fsid)
+    l = FileLock(ctx, fsid)
     l.acquire()
 
     # call correct adoption
     if daemon_type in Ceph.daemons:
-        command_adopt_ceph(daemon_type, daemon_id, fsid);
+        command_adopt_ceph(ctx, daemon_type, daemon_id, fsid);
     elif daemon_type == 'prometheus':
-        command_adopt_prometheus(daemon_id, fsid)
+        command_adopt_prometheus(ctx, daemon_id, fsid)
     elif daemon_type == 'grafana':
-        command_adopt_grafana(daemon_id, fsid)
+        command_adopt_grafana(ctx, daemon_id, fsid)
     elif daemon_type == 'node-exporter':
         raise Error('adoption of node-exporter not implemented')
     elif daemon_type == 'alertmanager':
-        command_adopt_alertmanager(daemon_id, fsid)
+        command_adopt_alertmanager(ctx, daemon_id, fsid)
     else:
         raise Error('daemon type %s not recognized' % daemon_type)
 
 
 class AdoptOsd(object):
-    def __init__(self, osd_data_dir, osd_id):
-        # type: (str, str) -> None
+    def __init__(self, ctx, osd_data_dir, osd_id):
+        # type: (CephadmContext, str, str) -> None
+        self.ctx = ctx
         self.osd_data_dir = osd_data_dir
         self.osd_id = osd_id
 
@@ -4315,16 +4412,17 @@ class AdoptOsd(object):
 
     def check_offline_lvm_osd(self):
         # type: () -> Tuple[Optional[str], Optional[str]]
-
+        args = self.ctx.args
         osd_fsid, osd_type = None, None
 
         c = CephContainer(
+            self.ctx,
             image=args.image,
             entrypoint='/usr/sbin/ceph-volume',
             args=['lvm', 'list', '--format=json'],
             privileged=True
         )
-        out, err, code = call_throws(c.run_cmd())
+        out, err, code = call_throws(self.ctx, c.run_cmd())
         if not code:
             try:
                 js = json.loads(out)
@@ -4345,7 +4443,6 @@ class AdoptOsd(object):
 
     def check_offline_simple_osd(self):
         # type: () -> Tuple[Optional[str], Optional[str]]
-
         osd_fsid, osd_type = None, None
 
         osd_file = glob("/etc/ceph/osd/{}-[a-f0-9-]*.json".format(self.osd_id))
@@ -4359,17 +4456,19 @@ class AdoptOsd(object):
                     if osd_type != "filestore":
                         # need this to be mounted for the adopt to work, as it
                         # needs to move files from this directory
-                        call_throws(['mount', js["data"]["path"], self.osd_data_dir])
+                        call_throws(self.ctx, ['mount', js["data"]["path"], self.osd_data_dir])
                 except ValueError as e:
                     logger.info("Invalid JSON in {}: {}".format(osd_file, e))
 
         return osd_fsid, osd_type
 
 
-def command_adopt_ceph(daemon_type, daemon_id, fsid):
-    # type: (str, str, str) -> None
+def command_adopt_ceph(ctx, daemon_type, daemon_id, fsid):
+    # type: (CephadmContext, str, str, str) -> None
 
-    (uid, gid) = extract_uid_gid()
+    args = ctx.args
+
+    (uid, gid) = extract_uid_gid(ctx)
 
     data_dir_src = ('/var/lib/ceph/%s/%s-%s' %
                     (daemon_type, args.cluster, daemon_id))
@@ -4382,7 +4481,7 @@ def command_adopt_ceph(daemon_type, daemon_id, fsid):
 
     osd_fsid = None
     if daemon_type == 'osd':
-        adopt_osd = AdoptOsd(data_dir_src, daemon_id)
+        adopt_osd = AdoptOsd(ctx, data_dir_src, daemon_id)
         osd_fsid, osd_type = adopt_osd.check_online_osd()
         if not osd_fsid:
             osd_fsid, osd_type = adopt_osd.check_offline_lvm_osd()
@@ -4399,28 +4498,28 @@ def command_adopt_ceph(daemon_type, daemon_id, fsid):
     # cluster we are adopting based on the /etc/{defaults,sysconfig}/ceph
     # CLUSTER field.
     unit_name = 'ceph-%s@%s' % (daemon_type, daemon_id)
-    (enabled, state, _) = check_unit(unit_name)
+    (enabled, state, _) = check_unit(ctx, unit_name)
     if state == 'running':
         logger.info('Stopping old systemd unit %s...' % unit_name)
-        call_throws(['systemctl', 'stop', unit_name])
+        call_throws(ctx, ['systemctl', 'stop', unit_name])
     if enabled:
         logger.info('Disabling old systemd unit %s...' % unit_name)
-        call_throws(['systemctl', 'disable', unit_name])
+        call_throws(ctx, ['systemctl', 'disable', unit_name])
 
     # data
     logger.info('Moving data...')
-    data_dir_dst = make_data_dir(fsid, daemon_type, daemon_id,
+    data_dir_dst = make_data_dir(ctx, fsid, daemon_type, daemon_id,
                                  uid=uid, gid=gid)
-    move_files(glob(os.path.join(data_dir_src, '*')),
+    move_files(ctx, glob(os.path.join(data_dir_src, '*')),
                data_dir_dst,
                uid=uid, gid=gid)
     logger.debug('Remove dir \'%s\'' % (data_dir_src))
     if os.path.ismount(data_dir_src):
-        call_throws(['umount', data_dir_src])
+        call_throws(ctx, ['umount', data_dir_src])
     os.rmdir(data_dir_src)
 
     logger.info('Chowning content...')
-    call_throws(['chown', '-c', '-R', '%d.%d' % (uid, gid), data_dir_dst])
+    call_throws(ctx, ['chown', '-c', '-R', '%d.%d' % (uid, gid), data_dir_dst])
 
     if daemon_type == 'mon':
         # rename *.ldb -> *.sst, in case they are coming from ubuntu
@@ -4451,50 +4550,50 @@ def command_adopt_ceph(daemon_type, daemon_id, fsid):
             logger.info('Renaming %s -> %s', simple_fn, new_fn)
             os.rename(simple_fn, new_fn)
             logger.info('Disabling host unit ceph-volume@ simple unit...')
-            call(['systemctl', 'disable',
+            call(ctx, ['systemctl', 'disable',
                   'ceph-volume@simple-%s-%s.service' % (daemon_id, osd_fsid)])
         else:
             # assume this is an 'lvm' c-v for now, but don't error
             # out if it's not.
             logger.info('Disabling host unit ceph-volume@ lvm unit...')
-            call(['systemctl', 'disable',
+            call(ctx, ['systemctl', 'disable',
                   'ceph-volume@lvm-%s-%s.service' % (daemon_id, osd_fsid)])
 
     # config
     config_src = '/etc/ceph/%s.conf' % (args.cluster)
     config_src = os.path.abspath(args.legacy_dir + config_src)
     config_dst = os.path.join(data_dir_dst, 'config')
-    copy_files([config_src], config_dst, uid=uid, gid=gid)
+    copy_files(ctx, [config_src], config_dst, uid=uid, gid=gid)
 
     # logs
     logger.info('Moving logs...')
     log_dir_src = ('/var/log/ceph/%s-%s.%s.log*' %
                     (args.cluster, daemon_type, daemon_id))
     log_dir_src = os.path.abspath(args.legacy_dir + log_dir_src)
-    log_dir_dst = make_log_dir(fsid, uid=uid, gid=gid)
-    move_files(glob(log_dir_src),
+    log_dir_dst = make_log_dir(ctx, fsid, uid=uid, gid=gid)
+    move_files(ctx, glob(log_dir_src),
                log_dir_dst,
                uid=uid, gid=gid)
 
     logger.info('Creating new units...')
-    make_var_run(fsid, uid, gid)
-    c = get_container(fsid, daemon_type, daemon_id)
-    deploy_daemon_units(fsid, uid, gid, daemon_type, daemon_id, c,
+    make_var_run(ctx, fsid, uid, gid)
+    c = get_container(ctx, fsid, daemon_type, daemon_id)
+    deploy_daemon_units(ctx, fsid, uid, gid, daemon_type, daemon_id, c,
                         enable=True,  # unconditionally enable the new unit
                         start=(state == 'running' or args.force_start),
                         osd_fsid=osd_fsid)
-    update_firewalld(daemon_type)
+    update_firewalld(ctx, daemon_type)
 
 
-def command_adopt_prometheus(daemon_id, fsid):
-    # type: (str, str) -> None
-
+def command_adopt_prometheus(ctx, daemon_id, fsid):
+    # type: (CephadmContext, str, str) -> None
+    args = ctx.args
     daemon_type = 'prometheus'
-    (uid, gid) = extract_uid_gid_monitoring(daemon_type)
+    (uid, gid) = extract_uid_gid_monitoring(ctx, daemon_type)
 
-    _stop_and_disable('prometheus')
+    _stop_and_disable(ctx, 'prometheus')
 
-    data_dir_dst = make_data_dir(fsid, daemon_type, daemon_id,
+    data_dir_dst = make_data_dir(ctx, fsid, daemon_type, daemon_id,
                                      uid=uid, gid=gid)
 
     # config
@@ -4502,29 +4601,31 @@ def command_adopt_prometheus(daemon_id, fsid):
     config_src = os.path.abspath(args.legacy_dir + config_src)
     config_dst = os.path.join(data_dir_dst, 'etc/prometheus')
     makedirs(config_dst, uid, gid, 0o755)
-    copy_files([config_src], config_dst, uid=uid, gid=gid)
+    copy_files(ctx, [config_src], config_dst, uid=uid, gid=gid)
 
     # data
     data_src = '/var/lib/prometheus/metrics/'
     data_src = os.path.abspath(args.legacy_dir + data_src)
     data_dst = os.path.join(data_dir_dst, 'data')
-    copy_tree([data_src], data_dst, uid=uid, gid=gid)
+    copy_tree(ctx, [data_src], data_dst, uid=uid, gid=gid)
 
-    make_var_run(fsid, uid, gid)
-    c = get_container(fsid, daemon_type, daemon_id)
-    deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid)
-    update_firewalld(daemon_type)
+    make_var_run(ctx, fsid, uid, gid)
+    c = get_container(ctx, fsid, daemon_type, daemon_id)
+    deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid)
+    update_firewalld(ctx, daemon_type)
 
 
-def command_adopt_grafana(daemon_id, fsid):
-    # type: (str, str) -> None
+def command_adopt_grafana(ctx, daemon_id, fsid):
+    # type: (CephadmContext, str, str) -> None
+
+    args = ctx.args
 
     daemon_type = 'grafana'
-    (uid, gid) = extract_uid_gid_monitoring(daemon_type)
+    (uid, gid) = extract_uid_gid_monitoring(ctx, daemon_type)
 
-    _stop_and_disable('grafana-server')
+    _stop_and_disable(ctx, 'grafana-server')
 
-    data_dir_dst = make_data_dir(fsid, daemon_type, daemon_id,
+    data_dir_dst = make_data_dir(ctx, fsid, daemon_type, daemon_id,
                                      uid=uid, gid=gid)
 
     # config
@@ -4532,12 +4633,12 @@ def command_adopt_grafana(daemon_id, fsid):
     config_src = os.path.abspath(args.legacy_dir + config_src)
     config_dst = os.path.join(data_dir_dst, 'etc/grafana')
     makedirs(config_dst, uid, gid, 0o755)
-    copy_files([config_src], config_dst, uid=uid, gid=gid)
+    copy_files(ctx, [config_src], config_dst, uid=uid, gid=gid)
 
     prov_src = '/etc/grafana/provisioning/'
     prov_src = os.path.abspath(args.legacy_dir + prov_src)
     prov_dst = os.path.join(data_dir_dst, 'etc/grafana')
-    copy_tree([prov_src], prov_dst, uid=uid, gid=gid)
+    copy_tree(ctx, [prov_src], prov_dst, uid=uid, gid=gid)
 
     # cert
     cert = '/etc/grafana/grafana.crt'
@@ -4547,12 +4648,12 @@ def command_adopt_grafana(daemon_id, fsid):
         cert_src = os.path.abspath(args.legacy_dir + cert_src)
         makedirs(os.path.join(data_dir_dst, 'etc/grafana/certs'), uid, gid, 0o755)
         cert_dst = os.path.join(data_dir_dst, 'etc/grafana/certs/cert_file')
-        copy_files([cert_src], cert_dst, uid=uid, gid=gid)
+        copy_files(ctx, [cert_src], cert_dst, uid=uid, gid=gid)
 
         key_src = '/etc/grafana/grafana.key'
         key_src = os.path.abspath(args.legacy_dir + key_src)
         key_dst = os.path.join(data_dir_dst, 'etc/grafana/certs/cert_key')
-        copy_files([key_src], key_dst, uid=uid, gid=gid)
+        copy_files(ctx, [key_src], key_dst, uid=uid, gid=gid)
 
         _adjust_grafana_ini(os.path.join(config_dst, 'grafana.ini'))
     else:
@@ -4562,23 +4663,24 @@ def command_adopt_grafana(daemon_id, fsid):
     data_src = '/var/lib/grafana/'
     data_src = os.path.abspath(args.legacy_dir + data_src)
     data_dst = os.path.join(data_dir_dst, 'data')
-    copy_tree([data_src], data_dst, uid=uid, gid=gid)
+    copy_tree(ctx, [data_src], data_dst, uid=uid, gid=gid)
 
-    make_var_run(fsid, uid, gid)
-    c = get_container(fsid, daemon_type, daemon_id)
-    deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid)
-    update_firewalld(daemon_type)
+    make_var_run(ctx, fsid, uid, gid)
+    c = get_container(ctx, fsid, daemon_type, daemon_id)
+    deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid)
+    update_firewalld(ctx, daemon_type)
 
 
-def command_adopt_alertmanager(daemon_id, fsid):
-    # type: (str, str) -> None
+def command_adopt_alertmanager(ctx, daemon_id, fsid):
+    # type: (CephadmContext, str, str) -> None
+    args = ctx.args
 
     daemon_type = 'alertmanager'
-    (uid, gid) = extract_uid_gid_monitoring(daemon_type)
+    (uid, gid) = extract_uid_gid_monitoring(ctx, daemon_type)
 
-    _stop_and_disable('prometheus-alertmanager')
+    _stop_and_disable(ctx, 'prometheus-alertmanager')
 
-    data_dir_dst = make_data_dir(fsid, daemon_type, daemon_id,
+    data_dir_dst = make_data_dir(ctx, fsid, daemon_type, daemon_id,
                                      uid=uid, gid=gid)
 
     # config
@@ -4586,18 +4688,18 @@ def command_adopt_alertmanager(daemon_id, fsid):
     config_src = os.path.abspath(args.legacy_dir + config_src)
     config_dst = os.path.join(data_dir_dst, 'etc/alertmanager')
     makedirs(config_dst, uid, gid, 0o755)
-    copy_files([config_src], config_dst, uid=uid, gid=gid)
+    copy_files(ctx, [config_src], config_dst, uid=uid, gid=gid)
 
     # data
     data_src = '/var/lib/prometheus/alertmanager/'
     data_src = os.path.abspath(args.legacy_dir + data_src)
     data_dst = os.path.join(data_dir_dst, 'etc/alertmanager/data')
-    copy_tree([data_src], data_dst, uid=uid, gid=gid)
+    copy_tree(ctx, [data_src], data_dst, uid=uid, gid=gid)
 
-    make_var_run(fsid, uid, gid)
-    c = get_container(fsid, daemon_type, daemon_id)
-    deploy_daemon(fsid, daemon_type, daemon_id, c, uid, gid)
-    update_firewalld(daemon_type)
+    make_var_run(ctx, fsid, uid, gid)
+    c = get_container(ctx, fsid, daemon_type, daemon_id)
+    deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid)
+    update_firewalld(ctx, daemon_type)
 
 
 def _adjust_grafana_ini(filename):
@@ -4626,39 +4728,39 @@ def _adjust_grafana_ini(filename):
         raise Error("Cannot update {}: {}".format(filename, err))
 
 
-def _stop_and_disable(unit_name):
-    # type: (str) -> None
+def _stop_and_disable(ctx, unit_name):
+    # type: (CephadmContext, str) -> None
 
-    (enabled, state, _) = check_unit(unit_name)
+    (enabled, state, _) = check_unit(ctx, unit_name)
     if state == 'running':
         logger.info('Stopping old systemd unit %s...' % unit_name)
-        call_throws(['systemctl', 'stop', unit_name])
+        call_throws(ctx, ['systemctl', 'stop', unit_name])
     if enabled:
         logger.info('Disabling old systemd unit %s...' % unit_name)
-        call_throws(['systemctl', 'disable', unit_name])
+        call_throws(ctx, ['systemctl', 'disable', unit_name])
 
 
 ##################################
 
-def command_rm_daemon():
-    # type: () -> None
-
-    l = FileLock(args.fsid)
+def command_rm_daemon(ctx):
+    # type: (CephadmContext) -> None
+    args = ctx.args
+    l = FileLock(ctx, args.fsid)
     l.acquire()
     (daemon_type, daemon_id) = args.name.split('.', 1)
-    unit_name = get_unit_name_by_daemon_name(args.fsid, args.name)
+    unit_name = get_unit_name_by_daemon_name(ctx, args.fsid, args.name)
 
     if daemon_type in ['mon', 'osd'] and not args.force:
         raise Error('must pass --force to proceed: '
                       'this command may destroy precious data!')
 
-    call(['systemctl', 'stop', unit_name],
+    call(ctx, ['systemctl', 'stop', unit_name],
          verbosity=CallVerbosity.DEBUG)
-    call(['systemctl', 'reset-failed', unit_name],
+    call(ctx, ['systemctl', 'reset-failed', unit_name],
          verbosity=CallVerbosity.DEBUG)
-    call(['systemctl', 'disable', unit_name],
+    call(ctx, ['systemctl', 'disable', unit_name],
          verbosity=CallVerbosity.DEBUG)
-    data_dir = get_data_dir(args.fsid, daemon_type, daemon_id)
+    data_dir = get_data_dir(args.fsid, ctx.args.data_dir, daemon_type, daemon_id)
     if daemon_type in ['mon', 'osd', 'prometheus'] and \
        not args.force_delete_data:
         # rename it out of the way -- do not delete
@@ -4671,64 +4773,65 @@ def command_rm_daemon():
                   os.path.join(backup_dir, dirname))
     else:
         if daemon_type == CephadmDaemon.daemon_type:
-            CephadmDaemon.uninstall(args.fsid, daemon_type, daemon_id)
-        call_throws(['rm', '-rf', data_dir])
+            CephadmDaemon.uninstall(ctx, args.fsid, daemon_type, daemon_id)
+        call_throws(ctx, ['rm', '-rf', data_dir])
 
 ##################################
 
 
-def command_rm_cluster():
-    # type: () -> None
+def command_rm_cluster(ctx):
+    # type: (CephadmContext) -> None
+    args = ctx.args
     if not args.force:
         raise Error('must pass --force to proceed: '
                       'this command may destroy precious data!')
 
-    l = FileLock(args.fsid)
+    l = FileLock(ctx, args.fsid)
     l.acquire()
 
     # stop + disable individual daemon units
-    for d in list_daemons(detail=False):
+    for d in list_daemons(ctx, detail=False):
         if d['fsid'] != args.fsid:
             continue
         if d['style'] != 'cephadm:v1':
             continue
         unit_name = get_unit_name(args.fsid, d['name'])
-        call(['systemctl', 'stop', unit_name],
+        call(ctx, ['systemctl', 'stop', unit_name],
              verbosity=CallVerbosity.DEBUG)
-        call(['systemctl', 'reset-failed', unit_name],
+        call(ctx, ['systemctl', 'reset-failed', unit_name],
              verbosity=CallVerbosity.DEBUG)
-        call(['systemctl', 'disable', unit_name],
+        call(ctx, ['systemctl', 'disable', unit_name],
              verbosity=CallVerbosity.DEBUG)
 
     # cluster units
     for unit_name in ['ceph-%s.target' % args.fsid]:
-        call(['systemctl', 'stop', unit_name],
+        call(ctx, ['systemctl', 'stop', unit_name],
              verbosity=CallVerbosity.DEBUG)
-        call(['systemctl', 'reset-failed', unit_name],
+        call(ctx, ['systemctl', 'reset-failed', unit_name],
              verbosity=CallVerbosity.DEBUG)
-        call(['systemctl', 'disable', unit_name],
+        call(ctx, ['systemctl', 'disable', unit_name],
              verbosity=CallVerbosity.DEBUG)
 
     slice_name = 'system-%s.slice' % (('ceph-%s' % args.fsid).replace('-',
                                                                       '\\x2d'))
-    call(['systemctl', 'stop', slice_name],
+    call(ctx, ['systemctl', 'stop', slice_name],
          verbosity=CallVerbosity.DEBUG)
 
     # rm units
-    call_throws(['rm', '-f', args.unit_dir +
+    call_throws(ctx, ['rm', '-f', args.unit_dir +
                              '/ceph-%s@.service' % args.fsid])
-    call_throws(['rm', '-f', args.unit_dir +
+    call_throws(ctx, ['rm', '-f', args.unit_dir +
                              '/ceph-%s.target' % args.fsid])
-    call_throws(['rm', '-rf',
+    call_throws(ctx, ['rm', '-rf',
                   args.unit_dir + '/ceph-%s.target.wants' % args.fsid])
     # rm data
-    call_throws(['rm', '-rf', args.data_dir + '/' + args.fsid])
+    call_throws(ctx, ['rm', '-rf', args.data_dir + '/' + args.fsid])
     # rm logs
-    call_throws(['rm', '-rf', args.log_dir + '/' + args.fsid])
-    call_throws(['rm', '-rf', args.log_dir +
+    call_throws(ctx, ['rm', '-rf', args.log_dir + '/' + args.fsid])
+    call_throws(ctx, ['rm', '-rf', args.log_dir +
                              '/*.wants/ceph-%s@*' % args.fsid])
     # rm logrotate config
-    call_throws(['rm', '-f', args.logrotate_dir + '/ceph-%s' % args.fsid])
+    call_throws(ctx, ['rm', '-f', args.logrotate_dir + '/ceph-%s' % args.fsid])
 
     # clean up config, keyring, and pub key files
     files = ['/etc/ceph/ceph.conf', '/etc/ceph/ceph.pub', '/etc/ceph/ceph.client.admin.keyring']
@@ -4746,8 +4849,8 @@ def command_rm_cluster():
 
 ##################################
 
-def check_time_sync(enabler=None):
-    # type: (Optional[Packager]) -> bool
+def check_time_sync(ctx, enabler=None):
+    # type: (CephadmContext, Optional[Packager]) -> bool
     units = [
         'chrony.service',  # 18.04 (at least)
         'chronyd.service', # el / opensuse
@@ -4756,15 +4859,15 @@ def check_time_sync(enabler=None):
         'ntp.service',  # 18.04 (at least)
         'ntpsec.service',  # 20.04 (at least) / buster
     ]
-    if not check_units(units, enabler):
+    if not check_units(ctx, units, enabler):
         logger.warning('No time sync service is running; checked for %s' % units)
         return False
     return True
 
 
-def command_check_host():
-    # type: () -> None
-    global container_path
+def command_check_host(ctx: CephadmContext) -> None:
+    container_path = ctx.container_path
+    args = ctx.args
 
     errors = []
     commands = ['systemctl', 'lvcreate']
@@ -4791,7 +4894,7 @@ def command_check_host():
             errors.append('ERROR: %s binary does not appear to be installed' % command)
 
     # check for configured+running chronyd or ntp
-    if not check_time_sync():
+    if not check_time_sync(ctx):
         errors.append('ERROR: No time synchronization is active')
 
     if 'expect_hostname' in args and args.expect_hostname:
@@ -4809,38 +4912,40 @@ def command_check_host():
 ##################################
 
 
-def command_prepare_host():
-    # type: () -> None
+def command_prepare_host(ctx: CephadmContext) -> None:
+    args = ctx.args
+    container_path = ctx.container_path
+
     logger.info('Verifying podman|docker is present...')
     pkg = None
     if not container_path:
         if not pkg:
-            pkg = create_packager()
+            pkg = create_packager(ctx)
         pkg.install_podman()
 
     logger.info('Verifying lvm2 is present...')
     if not find_executable('lvcreate'):
         if not pkg:
-            pkg = create_packager()
+            pkg = create_packager(ctx)
         pkg.install(['lvm2'])
 
     logger.info('Verifying time synchronization is in place...')
-    if not check_time_sync():
+    if not check_time_sync(ctx):
         if not pkg:
-            pkg = create_packager()
+            pkg = create_packager(ctx)
         pkg.install(['chrony'])
         # check again, and this time try to enable
         # the service
-        check_time_sync(enabler=pkg)
+        check_time_sync(ctx, enabler=pkg)
 
     if 'expect_hostname' in args and args.expect_hostname and args.expect_hostname != get_hostname():
         logger.warning('Adjusting hostname from %s -> %s...' % (get_hostname(), args.expect_hostname))
-        call_throws(['hostname', args.expect_hostname])
+        call_throws(ctx, ['hostname', args.expect_hostname])
         with open('/etc/hostname', 'w') as f:
             f.write(args.expect_hostname + '\n')
 
     logger.info('Repeating the final host check...')
-    command_check_host()
+    command_check_host(ctx)
 
 ##################################
 
@@ -4901,12 +5006,14 @@ def get_distro():
 
 
 class Packager(object):
-    def __init__(self, stable=None, version=None, branch=None, commit=None):
+    def __init__(self, ctx: CephadmContext,
+                 stable=None, version=None, branch=None, commit=None):
         assert \
             (stable and not version and not branch and not commit) or \
             (not stable and version and not branch and not commit) or \
             (not stable and not version and branch) or \
             (not stable and not version and not branch and not commit)
+        self.ctx = ctx
         self.stable = stable
         self.version = version
         self.branch = branch
@@ -4943,6 +5050,7 @@ class Packager(object):
         return chacra_response.read().decode('utf-8')
 
     def repo_gpgkey(self):
+        args = self.ctx.args
         if args.gpg_url:
             return args.gpg_url
         if self.stable or self.version:
@@ -4954,7 +5062,7 @@ class Packager(object):
         """
         Start and enable the service (typically using systemd).
         """
-        call_throws(['systemctl', 'enable', '--now', service])
+        call_throws(self.ctx, ['systemctl', 'enable', '--now', service])
 
 
 class Apt(Packager):
@@ -4963,10 +5071,12 @@ class Apt(Packager):
         'debian': 'debian',
     }
 
-    def __init__(self, stable, version, branch, commit,
+    def __init__(self, ctx: CephadmContext,
+                 stable, version, branch, commit,
                  distro, distro_version, distro_codename):
-        super(Apt, self).__init__(stable=stable, version=version,
+        super(Apt, self).__init__(ctx, stable=stable, version=version,
                                   branch=branch, commit=commit)
+        self.ctx = ctx
         self.distro = self.DISTRO_NAMES[distro]
         self.distro_codename = distro_codename
         self.distro_version = distro_version
@@ -4975,6 +5085,8 @@ class Apt(Packager):
         return '/etc/apt/sources.list.d/ceph.list'
 
     def add_repo(self):
+        args = self.ctx.args
+
         url, name = self.repo_gpgkey()
         logger.info('Installing repo GPG key from %s...' % url)
         try:
@@ -5016,13 +5128,13 @@ class Apt(Packager):
 
     def install(self, ls):
         logger.info('Installing packages %s...' % ls)
-        call_throws(['apt', 'install', '-y'] + ls)
+        call_throws(self.ctx, ['apt', 'install', '-y'] + ls)
 
     def install_podman(self):
         if self.distro == 'ubuntu':
             logger.info('Setting up repo for podman...')
             self.add_kubic_repo()
-            call_throws(['apt', 'update'])
+            call_throws(self.ctx, ['apt', 'update'])
 
         logger.info('Attempting podman install...')
         try:
@@ -5056,7 +5168,7 @@ class Apt(Packager):
         key = response.read().decode('utf-8')
         tmp_key = write_tmp(key, 0, 0)
         keyring = self.kubric_repo_gpgkey_path()
-        call_throws(['apt-key', '--keyring', keyring, 'add', tmp_key.name])
+        call_throws(self.ctx, ['apt-key', '--keyring', keyring, 'add', tmp_key.name])
 
         logger.info('Installing repo file at %s...' % self.kubic_repo_path())
         content = 'deb %s /\n' % self.kubic_repo_url()
@@ -5083,10 +5195,12 @@ class YumDnf(Packager):
         'fedora': ('fedora', 'fc'),
     }
 
-    def __init__(self, stable, version, branch, commit,
+    def __init__(self, ctx: CephadmContext,
+                 stable, version, branch, commit,
                  distro, distro_version):
-        super(YumDnf, self).__init__(stable=stable, version=version,
+        super(YumDnf, self).__init__(ctx, stable=stable, version=version,
                                      branch=branch, commit=commit)
+        self.ctx = ctx
         self.major = int(distro_version.split('.')[0])
         self.distro_normalized = self.DISTRO_NAMES[distro][0]
         self.distro_code = self.DISTRO_NAMES[distro][1] + str(self.major)
@@ -5157,6 +5271,7 @@ class YumDnf(Packager):
 
     def repo_baseurl(self):
         assert self.stable or self.version
+        args = self.ctx.args
         if self.version:
             return '%s/rpm-%s/%s' % (args.repo_url, self.version,
                                      self.distro_code)
@@ -5191,7 +5306,7 @@ class YumDnf(Packager):
 
         if self.distro_code.startswith('el'):
             logger.info('Enabling EPEL...')
-            call_throws([self.tool, 'install', '-y', 'epel-release'])
+            call_throws(self.ctx, [self.tool, 'install', '-y', 'epel-release'])
 
     def rm_repo(self):
         if os.path.exists(self.repo_path()):
@@ -5199,7 +5314,7 @@ class YumDnf(Packager):
 
     def install(self, ls):
         logger.info('Installing packages %s...' % ls)
-        call_throws([self.tool, 'install', '-y'] + ls)
+        call_throws(self.ctx, [self.tool, 'install', '-y'] + ls)
 
     def install_podman(self):
         self.install(['podman'])
@@ -5212,10 +5327,12 @@ class Zypper(Packager):
         'opensuse-leap'
     ]
 
-    def __init__(self, stable, version, branch, commit,
+    def __init__(self, ctx: CephadmContext,
+                 stable, version, branch, commit,
                  distro, distro_version):
-        super(Zypper, self).__init__(stable=stable, version=version,
+        super(Zypper, self).__init__(ctx, stable=stable, version=version,
                                      branch=branch, commit=commit)
+        self.ctx = ctx
         self.tool = 'zypper'
         self.distro = 'opensuse'
         self.distro_version = '15.1'
@@ -5256,6 +5373,7 @@ class Zypper(Packager):
 
     def repo_baseurl(self):
         assert self.stable or self.version
+        args = self.ctx.args
         if self.version:
             return '%s/rpm-%s/%s' % (args.repo_url, self.stable, self.distro)
         else:
@@ -5292,31 +5410,33 @@ class Zypper(Packager):
 
     def install(self, ls):
         logger.info('Installing packages %s...' % ls)
-        call_throws([self.tool, 'in', '-y'] + ls)
+        call_throws(self.ctx, [self.tool, 'in', '-y'] + ls)
 
     def install_podman(self):
         self.install(['podman'])
 
 
-def create_packager(stable=None, version=None, branch=None, commit=None):
+def create_packager(ctx: CephadmContext, 
+                    stable=None, version=None, branch=None, commit=None):
     distro, distro_version, distro_codename = get_distro()
     if distro in YumDnf.DISTRO_NAMES:
-        return YumDnf(stable=stable, version=version,
+        return YumDnf(ctx, stable=stable, version=version,
                       branch=branch, commit=commit,
                    distro=distro, distro_version=distro_version)
     elif distro in Apt.DISTRO_NAMES:
-        return Apt(stable=stable, version=version,
+        return Apt(ctx, stable=stable, version=version,
                    branch=branch, commit=commit,
                    distro=distro, distro_version=distro_version,
                    distro_codename=distro_codename)
     elif distro in Zypper.DISTRO_NAMES:
-        return Zypper(stable=stable, version=version,
+        return Zypper(ctx, stable=stable, version=version,
                       branch=branch, commit=commit,
                       distro=distro, distro_version=distro_version)
     raise Error('Distro %s version %s not supported' % (distro, distro_version))
 
 
-def command_add_repo():
+def command_add_repo(ctx: CephadmContext):
+    args = ctx.args
     if args.version and args.release:
         raise Error('you can specify either --release or --version but not both')
     if not args.version and not args.release and not args.dev and not args.dev_commit:
@@ -5327,21 +5447,21 @@ def command_add_repo():
         except Exception as e:
             raise Error('version must be in the form x.y.z (e.g., 15.2.0)')
 
-    pkg = create_packager(stable=args.release,
+    pkg = create_packager(ctx, stable=args.release,
                           version=args.version,
                           branch=args.dev,
                           commit=args.dev_commit)
     pkg.add_repo()
 
 
-def command_rm_repo():
-    pkg = create_packager()
+def command_rm_repo(ctx: CephadmContext):
+    pkg = create_packager(ctx)
     pkg.rm_repo()
 
 
-def command_install():
-    pkg = create_packager()
-    pkg.install(args.packages)
+def command_install(ctx: CephadmContext):
+    pkg = create_packager(ctx)
+    pkg.install(ctx.args.packages)
 
 ##################################
 
@@ -5449,7 +5569,8 @@ class HostFacts():
         "0x1af4": "Virtio Block Device"
     }
 
-    def __init__(self):
+    def __init__(self, ctx: CephadmContext):
+        self.ctx = ctx
         self.cpu_model = 'Unknown'
         self.cpu_count = 0
         self.cpu_cores = 0
@@ -5869,7 +5990,7 @@ class HostFacts():
         """Get kernel parameters required/used in Ceph clusters"""
 
         k_param = {}
-        out, _, _ = call_throws(['sysctl', '-a'], verbosity=CallVerbosity.SILENT)
+        out, _, _ = call_throws(self.ctx, ['sysctl', '-a'], verbosity=CallVerbosity.SILENT)
         if out:
             param_list = out.split('\n')
             param_dict = { param.split(" = ")[0]:param.split(" = ")[-1] for param in param_list}
@@ -5892,17 +6013,20 @@ class HostFacts():
 
 ##################################
 
-def command_gather_facts():
+def command_gather_facts(ctx: CephadmContext):
     """gather_facts is intended to provide host releated metadata to the caller"""
-    host = HostFacts()
+    host = HostFacts(ctx)
     print(host.dump())
 
 
 ##################################
 
-def command_verify_prereqs():
+def command_verify_prereqs(ctx: CephadmContext):
+    args = ctx.args
     if args.service_type == 'haproxy' or args.service_type == 'keepalived':
-        out, err, code = call(['sysctl', '-n', 'net.ipv4.ip_nonlocal_bind'])
+        out, err, code = call(
+            ctx, ['sysctl', '-n', 'net.ipv4.ip_nonlocal_bind']
+        )
         if out.strip() != "1":
             raise Error('net.ipv4.ip_nonlocal_bind not set to 1')
 
@@ -5976,6 +6100,7 @@ class CephadmDaemonHandler(BaseHTTPRequestHandler):
         f'/{api_version}/metadata/daemons',
         f'/{api_version}/metadata/host',
     ]
+
     class Decorators:
         @classmethod
         def authorize(cls, f):
@@ -6114,7 +6239,8 @@ class CephadmDaemon():
     loop_delay = 1
     thread_check_interval = 5
 
-    def __init__(self, fsid, daemon_id=None, port=None):
+    def __init__(self, ctx: CephadmContext, fsid, daemon_id=None, port=None):
+        self.ctx = ctx
         self.fsid = fsid
         self.daemon_id = daemon_id 
         if not port:
@@ -6163,7 +6289,7 @@ class CephadmDaemon():
 
     @property
     def port_active(self):
-        return port_in_use(self.port)
+        return port_in_use(self.ctx, self.port)
 
     @property
     def can_run(self):
@@ -6189,7 +6315,7 @@ class CephadmDaemon():
     @property
     def daemon_path(self):
         return os.path.join(
-            args.data_dir,
+            self.ctx.args.data_dir,
             self.fsid,
             f'{self.daemon_type}.{self.daemon_id}'
         )
@@ -6197,7 +6323,7 @@ class CephadmDaemon():
     @property
     def binary_path(self):
         return os.path.join(
-            args.data_dir,
+            self.ctx.args.data_dir,
             self.fsid,
             CephadmDaemon.bin_name
         )
@@ -6233,7 +6359,7 @@ class CephadmDaemon():
                 s_time = time.time()
 
                 try:
-                    facts = HostFacts()
+                    facts = HostFacts(self.ctx)
                 except Exception as e:
                     self._handle_thread_exception(e, 'host')
                     exception_encountered = True
@@ -6263,6 +6389,7 @@ class CephadmDaemon():
     def _scrape_ceph_volume(self, refresh_interval=15):
         # we're invoking the ceph_volume command, so we need to set the args that it 
         # expects to use
+        args = self.ctx.args
         args.command = "inventory --format=json".split()
         args.fsid = self.fsid
         args.log_output = False
@@ -6282,7 +6409,7 @@ class CephadmDaemon():
                 stream = io.StringIO()
                 try:
                     with redirect_stdout(stream):
-                        command_ceph_volume()
+                        command_ceph_volume(self.ctx)
                 except Exception as e:
                     self._handle_thread_exception(e, 'disks')
                     exception_encountered = True
@@ -6335,7 +6462,7 @@ class CephadmDaemon():
                 
                 try:
                     # list daemons should ideally be invoked with a fsid
-                    data = list_daemons()
+                    data = list_daemons(self.ctx)
                 except Exception as e:
                     self._handle_thread_exception(e, 'daemons')
                     exception_encountered = True
@@ -6488,6 +6615,7 @@ WantedBy=ceph-{fsid}.target
         daemon since it's not a container, so we just create a
         simple service definition and add it to the fsid's target
         """
+        args = self.ctx.args
         if not config:
             raise Error("Attempting to deploy cephadm daemon without a config")
         assert isinstance(config, dict)
@@ -6513,15 +6641,16 @@ WantedBy=ceph-{fsid}.target
                 os.path.join(args.unit_dir, f"{self.unit_name}.new"),
                 os.path.join(args.unit_dir, self.unit_name))
         
-        call_throws(['systemctl', 'daemon-reload'])
-        call(['systemctl', 'stop', self.unit_name],
+        call_throws(self.ctx, ['systemctl', 'daemon-reload'])
+        call(self.ctx, ['systemctl', 'stop', self.unit_name],
             verbosity=CallVerbosity.DEBUG)
-        call(['systemctl', 'reset-failed', self.unit_name],
+        call(self.ctx, ['systemctl', 'reset-failed', self.unit_name],
             verbosity=CallVerbosity.DEBUG)
-        call_throws(['systemctl', 'enable', '--now', self.unit_name])
+        call_throws(self.ctx, ['systemctl', 'enable', '--now', self.unit_name])
 
     @classmethod
-    def uninstall(cls, fsid, daemon_type, daemon_id):
+    def uninstall(cls, ctx: CephadmContext, fsid, daemon_type, daemon_id):
+        args = ctx.args
         unit_name = CephadmDaemon._unit_name(fsid, daemon_id)
         unit_path = os.path.join(args.unit_dir, unit_name)
         unit_run = os.path.join(args.data_dir, fsid, f"{daemon_type}.{daemon_id}", "unit.run")
@@ -6544,23 +6673,23 @@ WantedBy=ceph-{fsid}.target
                 break
 
         if port:
-            fw = Firewalld()
+            fw = Firewalld(ctx)
             try:
                 fw.close_ports([port])
             except RuntimeError:
                 logger.error(f"Unable to close port {port}")
 
-        stdout, stderr, rc = call(["rm", "-f", unit_path])
+        stdout, stderr, rc = call(ctx, ["rm", "-f", unit_path])
         if rc:
             logger.error(f"Unable to remove the systemd file @ {unit_path}")
         else:
             logger.info(f"removed systemd unit file @ {unit_path}")
-            stdout, stderr, rc = call(["systemctl", "daemon-reload"])
+            stdout, stderr, rc = call(ctx, ["systemctl", "daemon-reload"])
 
 
-def command_exporter():
-    
-    exporter = CephadmDaemon(args.fsid, daemon_id=args.id, port=args.port)
+def command_exporter(ctx: CephadmContext):
+    args = ctx.args
+    exporter = CephadmDaemon(ctx, args.fsid, daemon_id=args.id, port=args.port)
 
     if args.fsid not in os.listdir(args.data_dir):
         raise Error(f"cluster fsid '{args.fsid}' not found in '{args.data_dir}'")
@@ -6582,7 +6711,8 @@ def systemd_target_state(target_name: str, subsystem: str = 'ceph') -> bool:
 
 
 @infer_fsid
-def command_maintenance():
+def command_maintenance(ctx: CephadmContext):
+    args = ctx.args
     if not args.fsid:
         raise Error('must pass --fsid to specify cluster')
 
@@ -6591,7 +6721,7 @@ def command_maintenance():
     if args.maintenance_action.lower() == 'enter':
         logger.info("Requested to place host into maintenance")
         if systemd_target_state(target):
-            _out, _err, code = call(
+            _out, _err, code = call(ctx,
                 ['systemctl', 'disable', target],
                 verbosity=CallVerbosity.DEBUG
             )
@@ -6600,7 +6730,7 @@ def command_maintenance():
                 return "failed - to disable the target"
             else:
                 # stopping a target waits by default
-                _out, _err, code = call(
+                _out, _err, code = call(ctx,
                     ['systemctl', 'stop', target],
                     verbosity=CallVerbosity.DEBUG
                 )
@@ -6617,7 +6747,7 @@ def command_maintenance():
         logger.info("Requested to exit maintenance state")
         # exit maintenance request
         if not systemd_target_state(target):
-            _out, _err, code = call(
+            _out, _err, code = call(ctx,
                 ['systemctl', 'enable', target],
                 verbosity=CallVerbosity.DEBUG
             )
@@ -6626,7 +6756,7 @@ def command_maintenance():
                 return "failed - unable to enable the target"
             else:
                 # starting a target waits by default
-                _out, _err, code = call(
+                _out, _err, code = call(ctx,
                     ['systemctl', 'start', target],
                     verbosity=CallVerbosity.DEBUG
                 )
@@ -7231,7 +7361,9 @@ def _parse_args(av):
     return args
 
 
-if __name__ == "__main__":
+def main():
+
+    global logger
 
     # root?
     if os.geteuid() != 0:
@@ -7262,6 +7394,8 @@ if __name__ == "__main__":
         sys.stderr.write('No command specified; pass -h or --help for usage\n')
         sys.exit(1)
 
+    container_path = ""
+
     # podman or docker?
     if args.func != command_check_host:
         if args.docker:
@@ -7278,8 +7412,12 @@ if __name__ == "__main__":
                 sys.stderr.write('Unable to locate any of %s\n' % CONTAINER_PREFERENCE)
                 sys.exit(1)
 
+    ctx = CephadmContext()
+    ctx.args = args
+    ctx.container_path = container_path
+
     try:
-        r = args.func()
+        r = args.func(ctx)
     except Error as e:
         if args.verbose:
             raise
@@ -7288,3 +7426,6 @@ if __name__ == "__main__":
     if not r:
         r = 0
     sys.exit(r)
+
+if __name__ == "__main__":
+    main()

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1026,7 +1026,7 @@ class FileLock(object):
         # os.open() function.
         # This file lock is only NOT None, if the object currently holds the
         # lock.
-        self._lock_file_fd = None
+        self._lock_file_fd: Optional[int] = None
         self.timeout = timeout
         # The lock counter is used for implementing the nested locking
         # mechanism. Whenever the lock is acquired, the counter is increased and

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -849,7 +849,7 @@ def dict_get(d: Dict, key: str, default: Any = None, require: bool = False) -> A
     """
     if require and key not in d.keys():
         raise Error('{} missing from dict'.format(key))
-    return d.get(key, default)
+    return d.get(key, default) # type: ignore
 
 ##################################
 
@@ -1201,6 +1201,7 @@ def call(ctx: CephadmContext,
             )
         for fd in reads:
             try:
+                message = str()
                 message_b = os.read(fd, 1024)
                 if isinstance(message_b, bytes):
                     message = message_b.decode('utf-8')
@@ -1645,7 +1646,7 @@ def _filter_last_local_ceph_image(ctx, out):
 
 
 def write_tmp(s, uid, gid):
-    # type: (str, int, int) -> Any
+    # type: (str, int, int) -> IO[str]
     tmp_f = tempfile.NamedTemporaryFile(mode='w',
                                         prefix='ceph-tmp')
     os.fchown(tmp_f.fileno(), uid, gid)
@@ -3101,6 +3102,7 @@ def command_bootstrap(ctx):
     # type: (CephadmContext) -> int
 
     args = ctx.args
+    host: Optional[str] = None
 
     if not ctx.args.output_config:
         ctx.args.output_config = os.path.join(ctx.args.output_dir, 'ceph.conf')
@@ -3457,7 +3459,7 @@ def command_bootstrap(ctx):
         is_available(ctx, 'mgr epoch %d' % epoch, mgr_has_latest_epoch)
 
     # ssh
-    host: Optional[str] = None
+    host = None
     if not ctx.args.skip_ssh:
         cli(['config-key', 'set', 'mgr/cephadm/ssh_user', ctx.args.ssh_user])
 
@@ -4157,7 +4159,7 @@ def command_ls(ctx):
 
 def list_daemons(ctx, detail=True, legacy_dir=None):
     # type: (CephadmContext, bool, Optional[str]) -> List[Dict[str, str]]
-    host_version = None
+    host_version: Optional[str] = None
     ls = []
     args = ctx.args
     container_path = ctx.container_path
@@ -5570,18 +5572,18 @@ class HostFacts():
     }
 
     def __init__(self, ctx: CephadmContext):
-        self.ctx = ctx
-        self.cpu_model = 'Unknown'
-        self.cpu_count = 0
-        self.cpu_cores = 0
-        self.cpu_threads = 0
-        self.interfaces = {}
+        self.ctx: CephadmContext = ctx
+        self.cpu_model: str = 'Unknown'
+        self.cpu_count: int = 0
+        self.cpu_cores: int = 0
+        self.cpu_threads: int = 0
+        self.interfaces: Dict[str, Any] = {}
 
-        self._meminfo = read_file(['/proc/meminfo']).splitlines()
+        self._meminfo: List[str] = read_file(['/proc/meminfo']).splitlines()
         self._get_cpuinfo()
         self._process_nics()
-        self.arch = platform.processor()
-        self.kernel = platform.release()
+        self.arch: str = platform.processor()
+        self.kernel: str = platform.release()
 
     def _get_cpuinfo(self):
         # type: () -> None
@@ -5967,18 +5969,22 @@ class HostFacts():
                     return security
             return None
 
+        ret = None
         if os.path.exists('/sys/kernel/security/lsm'):
             lsm = read_file(['/sys/kernel/security/lsm']).strip()
             if 'selinux' in lsm:
-                return _fetch_selinux()
+                ret = _fetch_selinux()
             elif 'apparmor' in lsm:
-                return _fetch_apparmor()
+                ret = _fetch_apparmor()
             else:
                 return {
                     "type": "Unknown",
                     "description": "Linux Security Module framework is active, but is not using SELinux or AppArmor"
                 }
 
+        if ret is not None:
+            return ret
+        
         return {
             "type": "None",
             "description": "Linux Security Module framework is not available"
@@ -6247,11 +6253,11 @@ class CephadmDaemon():
             self.port = CephadmDaemon.default_port
         else:
             self.port = port
-        self.workers = []
+        self.workers: List[Thread] = []
         self.http_server: CephadmHTTPServer
         self.stop = False
         self.cephadm_cache = CephadmCache()
-        self.errors = []
+        self.errors: List[str] = []
         self.token = read_file([os.path.join(self.daemon_path, CephadmDaemon.token_name)])
 
     @classmethod
@@ -6654,7 +6660,8 @@ WantedBy=ceph-{fsid}.target
         unit_name = CephadmDaemon._unit_name(fsid, daemon_id)
         unit_path = os.path.join(args.unit_dir, unit_name)
         unit_run = os.path.join(args.data_dir, fsid, f"{daemon_type}.{daemon_id}", "unit.run")
-        try: 
+        port = None
+        try:
             with open(unit_run, "r") as u:
                 contents = u.read().strip(" &")
         except OSError:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -720,10 +720,9 @@ class CustomContainer(object):
     """Defines a custom container"""
     daemon_type = 'container'
 
-    def __init__(self, ctx: CephadmContext,
+    def __init__(self,
                  fsid: str, daemon_id: Union[int, str],
                  config_json: Dict, image: str) -> None:
-        self.ctx = ctx
         self.fsid = fsid
         self.daemon_id = daemon_id
         self.image = image
@@ -744,7 +743,7 @@ class CustomContainer(object):
     @classmethod
     def init(cls, ctx: CephadmContext,
              fsid: str, daemon_id: Union[int, str]) -> 'CustomContainer':
-        return cls(ctx, fsid, daemon_id,
+        return cls(fsid, daemon_id,
                    get_parm(ctx.args.config_json), ctx.args.image)
 
     def create_daemon_dirs(self, data_dir: str, uid: int, gid: int) -> None:
@@ -924,7 +923,7 @@ def check_ip_port(ctx, ip, port):
     # type: (CephadmContext, str, int) -> None
     if not ctx.args.skip_ping_check:
         logger.info('Verifying IP %s port %d ...' % (ip, port))
-        if is_ipv6(ctx, ip):
+        if is_ipv6(ip):
             s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
             ip = unwrap_ipv6(ip)
         else:
@@ -1633,11 +1632,11 @@ def get_last_local_ceph_image(ctx: CephadmContext, container_path: str):
          '--filter', 'label=ceph=True',
          '--filter', 'dangling=false',
          '--format', '{{.Repository}}@{{.Digest}}'])
-    return _filter_last_local_ceph_image(ctx, out)
+    return _filter_last_local_ceph_image(out)
 
 
-def _filter_last_local_ceph_image(ctx, out):
-    # type: (CephadmContext, str) -> Optional[str]
+def _filter_last_local_ceph_image(out):
+    # type: (str) -> Optional[str]
     for image in out.splitlines():
         if image and not image.endswith('@'):
             logger.info('Using recent ceph image %s' % image)
@@ -3087,8 +3086,8 @@ def wrap_ipv6(address):
     return address
 
 
-def is_ipv6(ctx, address):
-    # type: (CephadmContext, str) -> bool
+def is_ipv6(address):
+    # type: (str) -> bool
     address = unwrap_ipv6(address)
     try:
         return ipaddress.ip_address(unicode(address)).version == 6
@@ -3105,7 +3104,7 @@ def prepare_mon_addresses(
     ipv6 = False
 
     if ctx.args.mon_ip:
-        ipv6 = is_ipv6(ctx, ctx.args.mon_ip)
+        ipv6 = is_ipv6(ctx.args.mon_ip)
         if ipv6:
             ctx.args.mon_ip = wrap_ipv6(ctx.args.mon_ip)
         hasport = r.findall(ctx.args.mon_ip)

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -44,6 +44,7 @@ import ipaddress
 import json
 import logging
 from logging.config import dictConfig
+from operator import truediv
 import os
 import platform
 import pwd
@@ -142,6 +143,10 @@ class CephadmContext:
 
     def has_function(self) -> bool:
         return "func" in self._args
+
+
+    def has(self, name: str) -> bool:
+        return hasattr(self, name)
 
 
     def __getattr__(self, name: str) -> Any:
@@ -1564,7 +1569,7 @@ def infer_fsid(func):
             if not is_fsid(daemon['fsid']):
                 # 'unknown' fsid
                 continue
-            elif 'name' not in ctx.args or not ctx.name:
+            elif ctx.has("name") or not ctx.name:
                 # ctx.name not specified
                 fsids_set.add(daemon['fsid'])
             elif daemon['name'] == ctx.name:
@@ -1649,7 +1654,7 @@ def default_image(func):
     @wraps(func)
     def _default_image(ctx: CephadmContext):
         if not ctx.image:
-            if 'name' in ctx.args and ctx.name:
+            if ctx.has("name") and ctx.name:
                 type_ = ctx.name.split('.', 1)[0]
                 if type_ in Monitoring.components:
                     ctx.image = Monitoring.components[type_]['image']
@@ -2135,18 +2140,18 @@ def get_config_and_keyring(ctx):
     config = None
     keyring = None
 
-    if 'config_json' in ctx.args and ctx.config_json:
+    if ctx.has("config_json") and ctx.config_json:
         d = get_parm(ctx.config_json)
         config = d.get('config')
         keyring = d.get('keyring')
 
-    if 'config' in ctx.args and ctx.config:
+    if ctx.has("config") and ctx.config:
         with open(ctx.config, 'r') as f:
             config = f.read()
 
-    if 'key' in ctx.args and ctx.key:
+    if ctx.has("key") and ctx.key:
         keyring = '[%s]\n\tkey = %s\n' % (ctx.name, ctx.key)
-    elif 'keyring' in ctx.args and ctx.keyring:
+    elif ctx.has("keyring") and ctx.keyring:
         with open(ctx.keyring, 'r') as f:
             keyring = f.read()
 
@@ -5005,7 +5010,6 @@ def check_time_sync(ctx, enabler=None):
 
 def command_check_host(ctx: CephadmContext) -> None:
     container_path = ctx.container_path
-    args = ctx.args
 
     errors = []
     commands = ['systemctl', 'lvcreate']
@@ -5035,7 +5039,7 @@ def command_check_host(ctx: CephadmContext) -> None:
     if not check_time_sync(ctx):
         errors.append('ERROR: No time synchronization is active')
 
-    if 'expect_hostname' in args and ctx.expect_hostname:
+    if ctx.has("expect_hostname") and ctx.expect_hostname:
         if get_hostname().lower() != ctx.expect_hostname.lower():
             errors.append('ERROR: hostname "%s" does not match expected hostname "%s"' % (
                 get_hostname(), ctx.expect_hostname))
@@ -5051,7 +5055,6 @@ def command_check_host(ctx: CephadmContext) -> None:
 
 
 def command_prepare_host(ctx: CephadmContext) -> None:
-    args = ctx.args
     container_path = ctx.container_path
 
     logger.info('Verifying podman|docker is present...')
@@ -5076,7 +5079,7 @@ def command_prepare_host(ctx: CephadmContext) -> None:
         # the service
         check_time_sync(ctx, enabler=pkg)
 
-    if 'expect_hostname' in args and ctx.expect_hostname and ctx.expect_hostname != get_hostname():
+    if ctx.has("expect_hostname") and ctx.expect_hostname and ctx.expect_hostname != get_hostname():
         logger.warning('Adjusting hostname from %s -> %s...' % (get_hostname(), ctx.expect_hostname))
         call_throws(ctx, ['hostname', ctx.expect_hostname])
         with open('/etc/hostname', 'w') as f:
@@ -6161,7 +6164,6 @@ def command_gather_facts(ctx: CephadmContext):
 ##################################
 
 def command_verify_prereqs(ctx: CephadmContext):
-    args = ctx.args
     if ctx.service_type == 'haproxy' or ctx.service_type == 'keepalived':
         out, err, code = call(
             ctx, ['sysctl', '-n', 'net.ipv4.ip_nonlocal_bind']
@@ -6790,7 +6792,6 @@ WantedBy=ceph-{fsid}.target
 
     @classmethod
     def uninstall(cls, ctx: CephadmContext, fsid, daemon_type, daemon_id):
-        args = ctx.args
         unit_name = CephadmDaemon._unit_name(fsid, daemon_id)
         unit_path = os.path.join(ctx.unit_dir, unit_name)
         unit_run = os.path.join(ctx.data_dir, fsid, f"{daemon_type}.{daemon_id}", "unit.run")

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3302,6 +3302,34 @@ def wait_for_mon(
     is_available(ctx, 'mon', is_mon_available)
 
 
+def create_mgr(
+    ctx: CephadmContext,
+    uid: int, gid: int,
+    fsid: str, mgr_id: str, mgr_key: str,
+    config: str, clifunc: Callable
+) -> None:
+    logger.info('Creating mgr...')
+    mgr_keyring = '[mgr.%s]\n\tkey = %s\n' % (mgr_id, mgr_key)
+    mgr_c = get_container(ctx, fsid, 'mgr', mgr_id)
+    # Note:the default port used by the Prometheus node exporter is opened in fw
+    deploy_daemon(ctx, fsid, 'mgr', mgr_id, mgr_c, uid, gid,
+                  config=config, keyring=mgr_keyring, ports=[9283])
+
+    # wait for the service to become available
+    logger.info('Waiting for mgr to start...')
+    def is_mgr_available():
+        # type: () -> bool
+        timeout=ctx.args.timeout if ctx.args.timeout else 60 # seconds
+        try:
+            out = clifunc(['status', '-f', 'json-pretty'], timeout=timeout)
+            j = json.loads(out)
+            return j.get('mgrmap', {}).get('available', False)
+        except Exception as e:
+            logger.debug('status failed: %s' % e)
+            return False
+    is_available(ctx, 'mgr', is_mgr_available)
+
+
 @default_image
 def command_bootstrap(ctx):
     # type: (CephadmContext) -> int
@@ -3480,26 +3508,7 @@ def command_bootstrap(ctx):
     logger.info('Wrote config to %s' % ctx.args.output_config)
 
     # create mgr
-    logger.info('Creating mgr...')
-    mgr_keyring = '[mgr.%s]\n\tkey = %s\n' % (mgr_id, mgr_key)
-    mgr_c = get_container(ctx, fsid, 'mgr', mgr_id)
-    # Note:the default port used by the Prometheus node exporter is opened in fw
-    deploy_daemon(ctx, fsid, 'mgr', mgr_id, mgr_c, uid, gid,
-                  config=config, keyring=mgr_keyring, ports=[9283])
-
-    # wait for the service to become available
-    logger.info('Waiting for mgr to start...')
-    def is_mgr_available():
-        # type: () -> bool
-        timeout=ctx.args.timeout if ctx.args.timeout else 60 # seconds
-        try:
-            out = cli(['status', '-f', 'json-pretty'], timeout=timeout)
-            j = json.loads(out)
-            return j.get('mgrmap', {}).get('available', False)
-        except Exception as e:
-            logger.debug('status failed: %s' % e)
-            return False
-    is_available(ctx, 'mgr', is_mgr_available)
+    create_mgr(ctx, uid, gid, fsid, mgr_id, mgr_key, config, cli)
 
     # wait for mgr to restart (after enabling a module)
     def wait_for_mgr_restart():

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3460,14 +3460,6 @@ def command_bootstrap(ctx):
         logger.info('Enabling IPv6 (ms_bind_ipv6)')
         cli(['config', 'set', 'global', 'ms_bind_ipv6', 'true'])
 
-    # create mgr
-    logger.info('Creating mgr...')
-    mgr_keyring = '[mgr.%s]\n\tkey = %s\n' % (mgr_id, mgr_key)
-    mgr_c = get_container(ctx, fsid, 'mgr', mgr_id)
-    # Note:the default port used by the Prometheus node exporter is opened in fw
-    deploy_daemon(ctx, fsid, 'mgr', mgr_id, mgr_c, uid, gid,
-                  config=config, keyring=mgr_keyring, ports=[9283])
-
     # output files
     with open(ctx.args.output_keyring, 'w') as f:
         os.fchmod(f.fileno(), 0o600)
@@ -3478,6 +3470,14 @@ def command_bootstrap(ctx):
     with open(ctx.args.output_config, 'w') as f:
         f.write(config)
     logger.info('Wrote config to %s' % ctx.args.output_config)
+
+    # create mgr
+    logger.info('Creating mgr...')
+    mgr_keyring = '[mgr.%s]\n\tkey = %s\n' % (mgr_id, mgr_key)
+    mgr_c = get_container(ctx, fsid, 'mgr', mgr_id)
+    # Note:the default port used by the Prometheus node exporter is opened in fw
+    deploy_daemon(ctx, fsid, 'mgr', mgr_id, mgr_c, uid, gid,
+                  config=config, keyring=mgr_keyring, ports=[9283])
 
     # wait for the service to become available
     logger.info('Waiting for mgr to start...')

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3418,6 +3418,59 @@ def prepare_ssh(
             cli(['orch', 'apply', t])
 
 
+def prepare_dashboard(
+    ctx: CephadmContext,
+    uid: int, gid: int,
+    cli: Callable, wait_for_mgr_restart: Callable
+) -> None:
+
+    # Configure SSL port (cephadm only allows to configure dashboard SSL port)
+    # if the user does not want to use SSL he can change this setting once the cluster is up
+    cli(["config", "set",  "mgr", "mgr/dashboard/ssl_server_port" , str(ctx.args.ssl_dashboard_port)])
+
+    # configuring dashboard parameters
+    logger.info('Enabling the dashboard module...')
+    cli(['mgr', 'module', 'enable', 'dashboard'])
+    wait_for_mgr_restart()
+
+    # dashboard crt and key
+    if ctx.args.dashboard_key and ctx.args.dashboard_crt:
+        logger.info('Using provided dashboard certificate...')
+        mounts = {
+            pathify(ctx.args.dashboard_crt.name): '/tmp/dashboard.crt:z',
+            pathify(ctx.args.dashboard_key.name): '/tmp/dashboard.key:z'
+        }
+        cli(['dashboard', 'set-ssl-certificate', '-i', '/tmp/dashboard.crt'], extra_mounts=mounts)
+        cli(['dashboard', 'set-ssl-certificate-key', '-i', '/tmp/dashboard.key'], extra_mounts=mounts)
+    else:
+        logger.info('Generating a dashboard self-signed certificate...')
+        cli(['dashboard', 'create-self-signed-cert'])
+
+    logger.info('Creating initial admin user...')
+    password = ctx.args.initial_dashboard_password or generate_password()
+    tmp_password_file = write_tmp(password, uid, gid)
+    cmd = ['dashboard', 'ac-user-create', ctx.args.initial_dashboard_user, '-i', '/tmp/dashboard.pw', 'administrator', '--force-password']
+    if not ctx.args.dashboard_password_noupdate:
+        cmd.append('--pwd-update-required')
+    cli(cmd, extra_mounts={pathify(tmp_password_file.name): '/tmp/dashboard.pw:z'})
+    logger.info('Fetching dashboard port number...')
+    out = cli(['config', 'get', 'mgr', 'mgr/dashboard/ssl_server_port'])
+    port = int(out)
+
+    # Open dashboard port
+    fw = Firewalld(ctx)
+    fw.open_ports([port])
+    fw.apply_rules()
+
+    logger.info('Ceph Dashboard is now available at:\n\n'
+                '\t     URL: https://%s:%s/\n'
+                '\t    User: %s\n'
+                '\tPassword: %s\n' % (
+                    get_fqdn(), port,
+                    ctx.args.initial_dashboard_user,
+                    password))
+
+
 @default_image
 def command_bootstrap(ctx):
     # type: (CephadmContext) -> int
@@ -3653,51 +3706,7 @@ def command_bootstrap(ctx):
 
 
     if not ctx.args.skip_dashboard:
-        # Configure SSL port (cephadm only allows to configure dashboard SSL port)
-        # if the user does not want to use SSL he can change this setting once the cluster is up
-        cli(["config", "set",  "mgr", "mgr/dashboard/ssl_server_port" , str(ctx.args.ssl_dashboard_port)])
-
-        # configuring dashboard parameters
-        logger.info('Enabling the dashboard module...')
-        cli(['mgr', 'module', 'enable', 'dashboard'])
-        wait_for_mgr_restart()
-
-        # dashboard crt and key
-        if ctx.args.dashboard_key and ctx.args.dashboard_crt:
-            logger.info('Using provided dashboard certificate...')
-            mounts = {
-                pathify(ctx.args.dashboard_crt.name): '/tmp/dashboard.crt:z',
-                pathify(ctx.args.dashboard_key.name): '/tmp/dashboard.key:z'
-            }
-            cli(['dashboard', 'set-ssl-certificate', '-i', '/tmp/dashboard.crt'], extra_mounts=mounts)
-            cli(['dashboard', 'set-ssl-certificate-key', '-i', '/tmp/dashboard.key'], extra_mounts=mounts)
-        else:
-            logger.info('Generating a dashboard self-signed certificate...')
-            cli(['dashboard', 'create-self-signed-cert'])
-
-        logger.info('Creating initial admin user...')
-        password = args.initial_dashboard_password or generate_password()
-        tmp_password_file = write_tmp(password, uid, gid)
-        cmd = ['dashboard', 'ac-user-create', ctx.args.initial_dashboard_user, '-i', '/tmp/dashboard.pw', 'administrator', '--force-password']
-        if not ctx.args.dashboard_password_noupdate:
-            cmd.append('--pwd-update-required')
-        cli(cmd, extra_mounts={pathify(tmp_password_file.name): '/tmp/dashboard.pw:z'})
-        logger.info('Fetching dashboard port number...')
-        out = cli(['config', 'get', 'mgr', 'mgr/dashboard/ssl_server_port'])
-        port = int(out)
-
-        # Open dashboard port
-        fw = Firewalld(ctx)
-        fw.open_ports([port])
-        fw.apply_rules()
-
-        logger.info('Ceph Dashboard is now available at:\n\n'
-                    '\t     URL: https://%s:%s/\n'
-                    '\t    User: %s\n'
-                    '\tPassword: %s\n' % (
-                        get_fqdn(), port,
-                        ctx.args.initial_dashboard_user,
-                        password))
+        prepare_dashboard(ctx, uid, gid, cli, wait_for_mgr_restart)
 
     if ctx.args.apply_spec:
         logger.info('Applying %s to cluster' % ctx.args.apply_spec)

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3471,6 +3471,80 @@ def prepare_dashboard(
                     password))
 
 
+def prepare_bootstrap_config(
+    ctx: CephadmContext,
+    fsid: str, mon_addr: str, image: str
+
+) -> str:
+
+    cp = read_config(ctx.args.config)
+    if not cp.has_section('global'):
+        cp.add_section('global')
+    cp.set('global', 'fsid', fsid)
+    cp.set('global', 'mon host', mon_addr)
+    cp.set('global', 'container_image', image)
+    cpf = StringIO()
+    cp.write(cpf)
+    config = cpf.getvalue()
+
+    if ctx.args.registry_json or ctx.args.registry_url:
+        command_registry_login(ctx)
+
+    if not ctx.args.skip_pull:
+        _pull_image(ctx, image)
+
+    return config
+
+
+def finish_bootstrap_config(
+    ctx: CephadmContext,
+    fsid: str,
+    config: str,
+    mon_id: str, mon_dir: str,
+    mon_network: Optional[str], ipv6: bool,
+    cli: Callable
+
+) -> None:
+    if not ctx.args.no_minimize_config:
+        logger.info('Assimilating anything we can from ceph.conf...')
+        cli([
+            'config', 'assimilate-conf',
+            '-i', '/var/lib/ceph/mon/ceph-%s/config' % mon_id
+        ], {
+            mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % mon_id
+        })
+        logger.info('Generating new minimal ceph.conf...')
+        cli([
+            'config', 'generate-minimal-conf',
+            '-o', '/var/lib/ceph/mon/ceph-%s/config' % mon_id
+        ], {
+            mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % mon_id
+        })
+        # re-read our minimized config
+        with open(mon_dir + '/config', 'r') as f:
+            config = f.read()
+        logger.info('Restarting the monitor...')
+        call_throws(ctx, [
+            'systemctl',
+            'restart',
+            get_unit_name(fsid, 'mon', mon_id)
+        ])
+
+    if mon_network:
+        logger.info('Setting mon public_network...')
+        cli(['config', 'set', 'mon', 'public_network', mon_network])
+
+    if ipv6:
+        logger.info('Enabling IPv6 (ms_bind_ipv6)')
+        cli(['config', 'set', 'global', 'ms_bind_ipv6', 'true'])
+
+
+    with open(ctx.args.output_config, 'w') as f:
+        f.write(config)
+    logger.info('Wrote config to %s' % ctx.args.output_config)
+    pass
+
+
 @default_image
 def command_bootstrap(ctx):
     # type: (CephadmContext) -> int
@@ -3540,22 +3614,7 @@ def command_bootstrap(ctx):
             raise Error('Failed to infer CIDR network for mon ip %s; pass '
                         '--skip-mon-network to configure it later' % base_ip)
 
-    # config
-    cp = read_config(ctx.args.config)
-    if not cp.has_section('global'):
-        cp.add_section('global')
-    cp.set('global', 'fsid', fsid);
-    cp.set('global', 'mon host', addr_arg)
-    cp.set('global', 'container_image', ctx.args.image)
-    cpf = StringIO()
-    cp.write(cpf)
-    config = cpf.getvalue()
-
-    if ctx.args.registry_json or ctx.args.registry_url:
-        command_registry_login(ctx)
-
-    if not ctx.args.skip_pull:
-        _pull_image(ctx, ctx.args.image)
+    config = prepare_bootstrap_config(ctx, fsid, addr_arg, ctx.args.image)
 
     logger.info('Extracting ceph user uid/gid from container image...')
     (uid, gid) = extract_uid_gid(ctx)
@@ -3603,39 +3662,8 @@ def command_bootstrap(ctx):
 
     wait_for_mon(ctx, mon_id, mon_dir, admin_keyring.name, tmp_config.name)
 
-    # assimilate and minimize config
-    if not ctx.args.no_minimize_config:
-        logger.info('Assimilating anything we can from ceph.conf...')
-        cli([
-            'config', 'assimilate-conf',
-            '-i', '/var/lib/ceph/mon/ceph-%s/config' % mon_id
-        ], {
-            mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % mon_id
-        })
-        logger.info('Generating new minimal ceph.conf...')
-        cli([
-            'config', 'generate-minimal-conf',
-            '-o', '/var/lib/ceph/mon/ceph-%s/config' % mon_id
-        ], {
-            mon_dir: '/var/lib/ceph/mon/ceph-%s:z' % mon_id
-        })
-        # re-read our minimized config
-        with open(mon_dir + '/config', 'r') as f:
-            config = f.read()
-        logger.info('Restarting the monitor...')
-        call_throws(ctx, [
-            'systemctl',
-            'restart',
-            get_unit_name(fsid, 'mon', mon_id)
-        ])
-
-    if mon_network:
-        logger.info('Setting mon public_network...')
-        cli(['config', 'set', 'mon', 'public_network', mon_network])
-
-    if ipv6:
-        logger.info('Enabling IPv6 (ms_bind_ipv6)')
-        cli(['config', 'set', 'global', 'ms_bind_ipv6', 'true'])
+    finish_bootstrap_config(ctx, fsid, config, mon_id, mon_dir,
+                            mon_network, ipv6, cli)
 
     # output files
     with open(ctx.args.output_keyring, 'w') as f:
@@ -3643,10 +3671,6 @@ def command_bootstrap(ctx):
         f.write('[client.admin]\n'
                 '\tkey = ' + admin_key + '\n')
     logger.info('Wrote keyring to %s' % ctx.args.output_keyring)
-
-    with open(ctx.args.output_config, 'w') as f:
-        f.write(config)
-    logger.info('Wrote config to %s' % ctx.args.output_config)
 
     # create mgr
     create_mgr(ctx, uid, gid, fsid, mgr_id, mgr_key, config, cli)

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3228,7 +3228,7 @@ def create_initial_monmap(
     return monmap
 
 
-def create_mon(
+def prepare_create_mon(
     ctx: CephadmContext,
     uid: int, gid: int,
     fsid: str, mon_id: str,
@@ -3259,6 +3259,16 @@ def create_mon(
     ).run()
     logger.debug(f"create mon.{mon_id} on {out}")
     return (mon_dir, log_dir)
+
+
+def create_mon(
+    ctx: CephadmContext,
+    uid: int, gid: int,
+    fsid: str, mon_id: str
+) -> None:
+    mon_c = get_container(ctx, fsid, 'mon', mon_id)
+    deploy_daemon(ctx, fsid, 'mon', mon_id, mon_c, uid, gid,
+                  config=None, keyring=None)
 
 
 def wait_for_mon(
@@ -3389,7 +3399,7 @@ def command_bootstrap(ctx):
 
     monmap = create_initial_monmap(ctx, uid, gid, fsid, mon_id, addr_arg)
     (mon_dir, log_dir) = \
-        create_mon(ctx, uid, gid, fsid, mon_id,
+        prepare_create_mon(ctx, uid, gid, fsid, mon_id,
                    bootstrap_keyring.name, monmap.name)
 
     with open(mon_dir + '/config', 'w') as f:
@@ -3398,9 +3408,7 @@ def command_bootstrap(ctx):
         f.write(config)
 
     make_var_run(ctx, fsid, uid, gid)
-    mon_c = get_container(ctx, fsid, 'mon', mon_id)
-    deploy_daemon(ctx, fsid, 'mon', mon_id, mon_c, uid, gid,
-                  config=None, keyring=None)
+    create_mon(ctx, uid, gid, fsid, mon_id)
 
     # config to issue various CLI commands
     tmp_config = write_tmp(config, uid, gid)

--- a/src/cephadm/tests/fixtures.py
+++ b/src/cephadm/tests/fixtures.py
@@ -36,6 +36,7 @@ def exporter():
        mock.patch('cephadm.CephadmDaemon.run', _mock_run), \
        mock.patch('cephadm.CephadmDaemon._scrape_host_facts', _mock_scrape_host):
 
-        exporter = cd.CephadmDaemon(fsid='foobar', daemon_id='test')
+        ctx = cd.CephadmContext()
+        exporter = cd.CephadmDaemon(ctx, fsid='foobar', daemon_id='test')
         assert exporter.token == 'MyAccessToken' 
         yield exporter


### PR DESCRIPTION
On a quest to be able to use cephadm as a library, this patchset proposes pushing some of the global state (in particularly `args`) to a context class, passed to functions that might need it.

I'm not the biggest fan of the current approach, but it seemed the less of two evils. Ideally, we'll move to something a bit more sane.

In addition, this patchset also splits the `command_bootstrap()` function into smaller pieces. More work could be done, but I think that it currently holds a reasonable amount of lines, and that further splits may not be as logical and/or significantly beneficial.

Finally, I'm not sure how to test this other than the manual tests I've run. Suggestions welcome.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
