### PR TITLE
install-deps.sh: add libyaml-cpp-dev build deps for debian if with_jaeger

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -62,11 +62,12 @@ function munge_debian_control {
 	    ;;
     esac
     if $with_seastar; then
-	sed -i -e 's/^# Crimson[[:space:]]//g' $control
+        sed -i -e 's/^# Crimson[[:space:]]//g' $control
     fi
     if $with_jaeger; then
-	sed -i -e 's/^# Jaeger[[:space:]]//g' $control
-	sed -i -e 's/^# Crimson      libyaml-cpp-dev,/d' $control
+        sed -i -e 's/^# Jaeger[[:space:]]\+/               /g' $control
+        sed -i -e '/^# Crimson[[:space:]]\+libyaml-cpp-dev,/d' $control
+        sed -i -e 's/^[[:space:]]\+Built-Using:/Built-Using:/' $control
     fi
     if $for_make_check; then
         sed -i 's/^# Make-Check[[:space:]]/             /g' $control


### PR DESCRIPTION
Fixed a bug in sed for removing Crimson from libyaml-cpp-dev

Signed-off-by: Seena Fallah <seenafallah@gmail.com>