### PR TITLE
debian: fix Built-Using parse error with Jaeger

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -107,7 +107,7 @@ Build-Depends: automake,
 # Make-Check   xmlstarlet,
                nasm [amd64],
                zlib1g-dev,
-# Jaeger       Built-Using:   libyaml-cpp-dev (>= 0.6),
+# Jaeger Built-Using:   libyaml-cpp-dev (>= 0.6),
 Standards-Version: 4.4.0
 
 Package: ceph


### PR DESCRIPTION
Built-Using won't be parsed because of spacing

Signed-off-by: Seena Fallah <seenafallah@gmail.com>