### PR TITLE
libradosstriper: use RefCountedObject for ref management

### DIFF
--- a/src/libradosstriper/MultiAioCompletionImpl.cc
+++ b/src/libradosstriper/MultiAioCompletionImpl.cc
@@ -30,7 +30,7 @@ void libradosstriper::MultiAioCompletionImpl::complete_request(ssize_t r)
   if (!count && !building) {
     complete();
   }
-  put_unlock();
+  put();
 }
 
 void libradosstriper::MultiAioCompletionImpl::safe_request(ssize_t r)
@@ -45,7 +45,7 @@ void libradosstriper::MultiAioCompletionImpl::safe_request(ssize_t r)
   if (!count && !building) {
     safe();
   }
-  put_unlock();
+  put();
 }
 
 void libradosstriper::MultiAioCompletionImpl::finish_adding_requests()

--- a/src/libradosstriper/MultiAioCompletionImpl.h
+++ b/src/libradosstriper/MultiAioCompletionImpl.h
@@ -18,38 +18,22 @@
 #include <list>
 #include <mutex>
 #include "common/ceph_mutex.h"
+#include "common/RefCountedObj.h"
 #include "include/radosstriper/libradosstriper.hpp"
 
 namespace libradosstriper {
 
-struct MultiAioCompletionImpl {
-
+class MultiAioCompletionImpl : public RefCountedObject {
+public:
   ceph::mutex lock = ceph::make_mutex("MultiAioCompletionImpl lock", false);
   ceph::condition_variable cond;
-  int ref, rval;
-  int pending_complete, pending_safe;
-  rados_callback_t callback_complete, callback_safe;
-  void *callback_complete_arg, *callback_safe_arg;
-  bool building;       ///< true if we are still building this completion
-  bufferlist bl;       /// only used for read case in C api of rados striper
+  int rval = 0;
+  int pending_complete = 0, pending_safe = 0;
+  rados_callback_t callback_complete = 0, callback_safe = 0;
+  void *callback_complete_arg = nullptr, *callback_safe_arg = nullptr;
+  bool building = true;  ///< true if we are still building this completion
+  bufferlist bl;         /// only used for read case in C api of rados striper
   std::list<bufferlist*> bllist; /// keep temporary buffer lists used for destriping
-
-  MultiAioCompletionImpl()
-  : ref(1), rval(0),
-    pending_complete(0), pending_safe(0),
-    callback_complete(0), callback_safe(0),
-    callback_complete_arg(0), callback_safe_arg(0),
-    building(true) {};
-
-  ~MultiAioCompletionImpl() {
-    // deallocate temporary buffer lists
-    for (std::list<bufferlist*>::iterator it = bllist.begin();
-	 it != bllist.end();
-	 it++) {
-      delete *it;
-    }
-    bllist.clear();
-  }
 
   int set_complete_callback(void *cb_arg, rados_callback_t cb) {
     std::scoped_lock l{lock};
@@ -101,37 +85,17 @@ struct MultiAioCompletionImpl {
     std::scoped_lock l{lock};
     return rval;
   }
-  void get() {
-    std::scoped_lock l{lock};
-    _get();
-  }
-  void _get() {
-    ceph_assert(ceph_mutex_is_locked(lock));
-    ceph_assert(ref > 0);
-    ++ref;
-  }
-  void put() {
-    lock.lock();
-    put_unlock();
-  }
-  void put_unlock() {
-    ceph_assert(ref > 0);
-    int n = --ref;
-    lock.unlock();
-    if (!n)
-      delete this;
-  }
   void add_request() {
     std::scoped_lock l{lock};
     pending_complete++;
-    _get();
+    get();
     pending_safe++;
-    _get();
+    get();
   }
   void add_safe_request() {
     std::scoped_lock l{lock};
     pending_complete++;
-    _get();
+    get();
   }
   void complete() {
     ceph_assert(ceph_mutex_is_locked(lock));
@@ -153,17 +117,19 @@ struct MultiAioCompletionImpl {
   void complete_request(ssize_t r);
   void safe_request(ssize_t r);
   void finish_adding_requests();
+
+protected:
+  FRIEND_MAKE_REF(MultiAioCompletionImpl);
+  MultiAioCompletionImpl() = default;
+  ~MultiAioCompletionImpl() {
+    // deallocate temporary buffer lists
+    for (auto& blp : bllist) {
+      delete blp;
+    }
+    bllist.clear();
+  }
 };
 
-inline void intrusive_ptr_add_ref(MultiAioCompletionImpl* ptr)
-{
-  ptr->get();
-}
-
-inline void intrusive_ptr_release(MultiAioCompletionImpl* ptr)
-{
-  ptr->put();
-}
 }
 
 #endif // CEPH_LIBRADOSSTRIPERSTRIPER_MULTIAIOCOMPLETIONIMPL_H

--- a/src/libradosstriper/RadosStriperImpl.h
+++ b/src/libradosstriper/RadosStriperImpl.h
@@ -32,9 +32,6 @@
 
 namespace libradosstriper {
 
-using MultiAioCompletionImplPtr =
-    boost::intrusive_ptr<MultiAioCompletionImpl>;
-
 struct RadosStriperImpl {
 
   /**
@@ -154,7 +151,7 @@ struct RadosStriperImpl {
 			       size_t len,
 			       uint64_t off);
   int internal_aio_write(const std::string& soid,
-			 MultiAioCompletionImplPtr c,
+			 ceph::ref_t<MultiAioCompletionImpl> c,
 			 const bufferlist& bl,
 			 size_t len,
 			 uint64_t off,
@@ -173,7 +170,7 @@ struct RadosStriperImpl {
 				   uint64_t *size);
 
   int internal_aio_remove(const std::string& soid,
-			  MultiAioCompletionImplPtr multi_completion,
+			  ceph::ref_t<MultiAioCompletionImpl> multi_completion,
 			  int flags=0);
 
   /**
@@ -236,7 +233,7 @@ struct RadosStriperImpl {
    * point is synchronous for lack of asynchronous truncation in the rados layer
    */
   int aio_truncate(const std::string& soid,
-		   MultiAioCompletionImplPtr c,
+		   ceph::ref_t<MultiAioCompletionImpl> c,
 		   uint64_t original_size,
 		   uint64_t size,
 		   ceph_file_layout &layout);

--- a/src/libradosstriper/libradosstriper.cc
+++ b/src/libradosstriper/libradosstriper.cc
@@ -153,7 +153,6 @@ int libradosstriper::RadosStriper::striper_create(librados::IoCtx& ioctx,
 {
   try {
     striper->rados_striper_impl = new libradosstriper::RadosStriperImpl(ioctx, ioctx.io_ctx_impl);
-    striper->rados_striper_impl->get();
   } catch (int rc) {
     return rc;
   }

--- a/src/libradosstriper/libradosstriper.cc
+++ b/src/libradosstriper/libradosstriper.cc
@@ -34,7 +34,7 @@
 
 libradosstriper::MultiAioCompletion::~MultiAioCompletion()
 {
-  ceph_assert(pc->ref == 1);
+  ceph_assert(pc->get_nref() == 1);
   pc->put();
 }
 
@@ -326,8 +326,8 @@ int libradosstriper::RadosStriper::aio_flush()
 
 libradosstriper::MultiAioCompletion* libradosstriper::RadosStriper::multi_aio_create_completion()
 {
-  MultiAioCompletionImpl *c = new MultiAioCompletionImpl;
-  return new MultiAioCompletion(c);
+  auto c = ceph::make_ref<MultiAioCompletionImpl>();
+  return new MultiAioCompletion(c.detach());
 }
 
 libradosstriper::MultiAioCompletion*
@@ -537,12 +537,12 @@ extern "C" int rados_striper_multi_aio_create_completion(void *cb_arg,
 							 rados_callback_t cb_safe,
 							 rados_striper_multi_completion_t *pc)
 {
-  libradosstriper::MultiAioCompletionImpl *c = new libradosstriper::MultiAioCompletionImpl;
+  auto c = ceph::make_ref<libradosstriper::MultiAioCompletionImpl>();
   if (cb_complete)
     c->set_complete_callback(cb_arg, cb_complete);
   if (cb_safe)
     c->set_safe_callback(cb_arg, cb_safe);
-  *pc = c;
+  *pc = c.detach();
   return 0;
 }
 


### PR DESCRIPTION
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
