### PR TITLE
mgr/dashboard: Monitoring alert badge includes suppressed alerts

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -156,8 +156,8 @@
             *ngIf="permissions.prometheus.read">
           <a routerLink="/monitoring">
             <ng-container i18n>Monitoring</ng-container>
-            <small *ngIf="prometheusAlertService.alerts.length > 0"
-                   class="badge badge-danger">{{ prometheusAlertService.alerts.length }}</small>
+            <small *ngIf="prometheusAlertService.activeAlerts > 0"
+                   class="badge badge-danger">{{ prometheusAlertService.activeAlerts }}</small>
           </a>
         </li>
       </ul>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.spec.ts
@@ -183,4 +183,26 @@ describe('PrometheusAlertService', () => {
       expect(notificationService.show).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('alert badge', () => {
+    beforeEach(() => {
+      service = TestBed.inject(PrometheusAlertService);
+
+      prometheusService = TestBed.inject(PrometheusService);
+      spyOn(prometheusService, 'ifAlertmanagerConfigured').and.callFake((fn) => fn());
+      spyOn(prometheusService, 'getAlerts').and.callFake(() => of(alerts));
+
+      alerts = [
+        prometheus.createAlert('alert0', 'active'),
+        prometheus.createAlert('alert1', 'suppressed'),
+        prometheus.createAlert('alert2', 'suppressed')
+      ];
+      service.refresh();
+    });
+
+    it('should count active alerts', () => {
+      service.refresh();
+      expect(service.activeAlerts).toBe(1);
+    });
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert.service.ts
@@ -17,6 +17,7 @@ export class PrometheusAlertService {
   private canAlertsBeNotified = false;
   alerts: AlertmanagerAlert[] = [];
   rules: PrometheusRule[] = [];
+  activeAlerts: number;
 
   constructor(
     private alertFormatter: PrometheusAlertFormatter,
@@ -60,6 +61,11 @@ export class PrometheusAlertService {
     if (this.canAlertsBeNotified) {
       this.notifyOnAlertChanges(alerts, this.alerts);
     }
+    this.activeAlerts = _.reduce<AlertmanagerAlert, number>(
+      this.alerts,
+      (result, alert) => (alert.status.state === 'active' ? ++result : result),
+      0
+    );
     this.alerts = alerts;
     this.canAlertsBeNotified = true;
   }


### PR DESCRIPTION
On a cluster with alerting enabled, when alerts are triggered, even if they are silenced, the vertical navigation item (Cluster > Monitoring) displays the total number of alerts, including the ones suppressed.This PR intends to fix this issue.

Before-
![alerts](https://user-images.githubusercontent.com/66050535/103503535-981dd280-4e7a-11eb-9ba5-01354ee34cb4.png)

After-
![Screenshot from 2021-01-04 10-08-54](https://user-images.githubusercontent.com/66050535/103503603-c3082680-4e7a-11eb-9be5-8d6c4ffd7798.png)


Fixes: https://tracker.ceph.com/issues/48591
Signed-off-by: Aashish Sharma <aasharma@redhat.com>


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
