### PR TITLE
common/ConfUtils: pass string_view instead of string

### DIFF
--- a/src/common/ConfUtils.cc
+++ b/src/common/ConfUtils.cc
@@ -282,7 +282,7 @@ int ConfFile::parse_bufferlist(ceph::bufferlist *bl,
   return parse_buffer({bl->c_str(), bl->length()}, warnings) ? 0 : -EINVAL;
 }
 
-int ConfFile::read(const std::string& section_name,
+int ConfFile::read(std::string_view section_name,
 		   std::string_view key,
 		   std::string &val) const
 {

--- a/src/common/ConfUtils.h
+++ b/src/common/ConfUtils.h
@@ -58,8 +58,8 @@ public:
   friend std::ostream& operator<<(std::ostream& os, const conf_section_t&);
 };
 
-class ConfFile : public std::map<std::string, conf_section_t> {
-  using base_type = std::map<std::string, conf_section_t>;
+class ConfFile : public std::map<std::string, conf_section_t, std::less<>> {
+  using base_type = std::map<std::string, conf_section_t, std::less<>>;
 public:
   ConfFile()
     : ConfFile{std::vector<conf_section_t>{}}
@@ -71,7 +71,7 @@ public:
   int parse_file(const std::string &fname, std::ostream *warnings);
   int parse_bufferlist(ceph::bufferlist *bl, std::ostream *warnings);
   bool parse_buffer(std::string_view buf, std::ostream* warning);
-  int read(const std::string& section, std::string_view key,
+  int read(std::string_view section, std::string_view key,
 	   std::string &val) const;
   static std::string normalize_key_name(std::string_view key);
   // print warnings to os if any old-style section name is found

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -1368,7 +1368,7 @@ int md_config_t::_get_val_from_conf_file(
   std::string &out) const
 {
   for (auto &s : sections) {
-    int ret = cf.read(s.c_str(), std::string{key}, out);
+    int ret = cf.read(s, key, out);
     if (ret == 0) {
       return 0;
     } else if (ret != -ENOENT) {


### PR DESCRIPTION
pass string_view as the section_name when reading options from a
ConfFile. as there is no need to create a temporary string object
if the section name is a `const char*` literal.

also, update the caller site in `common/config.cc` accordingly as a
cleanup. as it's not necessary to pass a `const char*` for the section
name even without this change.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
