### PR TITLE
octopus: rpm: require smartmontools on SUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -474,7 +474,11 @@ Provides:	ceph-test:/usr/bin/ceph-monstore-tool
 Requires:	ceph-base = %{_epoch_prefix}%{version}-%{release}
 %if 0%{?weak_deps}
 Recommends:	nvme-cli
+%if 0%{?suse_version}
+Requires:       smartmontools
+%else
 Recommends:	smartmontools
+%endif
 %endif
 %description mon
 ceph-mon is the cluster monitor daemon for the Ceph distributed file
@@ -754,7 +758,11 @@ Requires:	libstoragemgmt
 Requires:	python%{python3_pkgversion}-ceph-common = %{_epoch_prefix}%{version}-%{release}
 %if 0%{?weak_deps}
 Recommends:	nvme-cli
+%if 0%{?suse_version}
+Requires:       smartmontools
+%else
 Recommends:	smartmontools
+%endif
 %endif
 %description osd
 ceph-osd is the object storage daemon for the Ceph distributed file


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48737

---

backport of https://github.com/ceph/ceph/pull/38603
parent tracker: https://tracker.ceph.com/issues/48604

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh