### PR TITLE
luminous: rgw: Replace COMPLETE_MULTIPART_MAX_LEN with configurable rgw_max_put_param_size

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1632,8 +1632,8 @@ int RGWCompleteMultipart_ObjStore::get_params()
     return op_ret;
   }
 
-#define COMPLETE_MULTIPART_MAX_LEN (1024 * 1024) /* api defines max 10,000 parts, this should be enough */
-  op_ret = rgw_rest_read_all_input(s, &data, &len, COMPLETE_MULTIPART_MAX_LEN);
+  const auto max_size = s->cct->_conf->rgw_max_put_param_size;
+  op_ret = rgw_rest_read_all_input(s, &data, &len, max_size);
   if (op_ret < 0)
     return op_ret;
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48741

---

parent tracker: https://tracker.ceph.com/issues/38002

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh