### PR TITLE
mgr: fix deadlock in ActivePyModules::get_osdmap()

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -930,7 +930,6 @@ PyObject *ActivePyModules::get_osdmap()
 
   PyThreadState *tstate = PyEval_SaveThread();
   {
-    std::lock_guard l(lock);
     cluster_state.with_osdmap([&](const OSDMap& o) {
         newmap->deepish_copy_from(o);
       });


### PR DESCRIPTION
 In function "ActivePyModules::get_osdmap()", We do not read or write to object "ActivePyModules", so it is safe to delete lock "ActivePyModules::lock", and it can avoid other thread waiting for lock  "ActivePyModules::lock"

Fixes: https://tracker.ceph.com/issues/48852

Signed-off-by: peng jiaqi <peng.jiaqi@zte.com.cn>
