### PR TITLE
mgr/dashboard: trigger alert if some nodes have a MTU different than the median value

### DIFF
--- a/monitoring/prometheus/alerts/ceph_default_alerts.yml
+++ b/monitoring/prometheus/alerts/ceph_default_alerts.yml
@@ -214,6 +214,17 @@ groups:
             will be full in less than 5 days assuming the average fill-up
             rate of the past 48 hours.
 
+      - alert: MTU Mismatch
+        expr: node_network_mtu_bytes{device!="lo"} != on(device) group_left() (quantile(0.5, node_network_mtu_bytes{device!="lo"}) by (device))
+        labels:
+          severity: warning
+          type: ceph_default
+          oid: 1.3.6.1.4.1.50495.15.1.2.8.5
+        annotations:
+          description: >
+            Node {{ $labels.instance }} has a different MTU size ({{ $value }})
+            than the median value on device {{ $labels.device }}.
+
   - name: pools
     rules:
       - alert: pool full


### PR DESCRIPTION
This PR intends to alert a user if a specific network is configured with a custom MTU.

Fixes: https://tracker.ceph.com/issues/48748
Signed-off-by: Aashish Sharma <aasharma@redhat.com>

![Screenshot from 2021-01-05 14-31-18](https://user-images.githubusercontent.com/66050535/103627575-d642f100-4f63-11eb-9924-20216550b817.png)

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
