### PR TITLE
mgr/cephadm: make `ceph orch {restart|...}` asynchronous

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1527,22 +1527,12 @@ To check that the host is reachable:
 
     @trivial_completion
     def service_action(self, action: str, service_name: str) -> List[str]:
-        args = []
-        for host, dm in self.cache.daemons.items():
-            for name, d in dm.items():
-                if d.matches_service(service_name):
-                    args.append((d.daemon_type, d.daemon_id,
-                                 d.hostname, action))
+        dds: List[DaemonDescription] = self.cache.get_daemons_by_service(service_name)
         self.log.info('%s service %s' % (action.capitalize(), service_name))
-        return self._daemon_actions(args)
-
-    @forall_hosts
-    def _daemon_actions(self, daemon_type: str, daemon_id: str, host: str, action: str) -> str:
-        with set_exception_subject('daemon', DaemonDescription(
-            daemon_type=daemon_type,
-            daemon_id=daemon_id
-        ).name()):
-            return self._daemon_action(daemon_type, daemon_id, host, action)
+        return [
+            self._schedule_daemon_action(dd.name(), action)
+            for dd in dds
+        ]
 
     def _daemon_action(self, daemon_type: str, daemon_id: str, host: str, action: str, image: Optional[str] = None) -> str:
         daemon_spec: CephadmDaemonSpec = CephadmDaemonSpec(


### PR DESCRIPTION
Othwerwiese we'd block the CLI handler thread.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

This is a single commit extracted from #38488 


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
