### PR TITLE
osd: add has_manifest_chunk to count chunks in snapshot

### DIFF
--- a/src/cls/cas/cls_cas.cc
+++ b/src/cls/cas/cls_cas.cc
@@ -199,9 +199,9 @@ static int references_chunk(cls_method_context_t hctx,
   }
   CLS_LOG(10, "fp_oid: %s \n", fp_oid.c_str());
 
-  bool ret = cls_has_chunk(hctx, fp_oid);
+  int ret = cls_get_manifest_ref_count(hctx, fp_oid);
   if (ret) {
-    return 0;
+    return ret;
   }
   return -ENOLINK;
 }

--- a/src/crimson/osd/objclass.cc
+++ b/src/crimson/osd/objclass.cc
@@ -473,7 +473,7 @@ int cls_cxx_chunk_write_and_set(cls_method_context_t hctx,
   return 0;
 }
 
-bool cls_has_chunk(cls_method_context_t hctx, string fp_oid)
+int cls_get_manifest_ref_count(cls_method_context_t hctx, string fp_oid)
 {
   return 0;
 }

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -157,7 +157,7 @@ extern int cls_get_snapset_seq(cls_method_context_t hctx, uint64_t *snap_seq);
 int cls_cxx_chunk_write_and_set(cls_method_context_t hctx, int ofs, int len,
                    ceph::buffer::list *write_inbl, uint32_t op_flags, ceph::buffer::list *set_inbl,
 		   int set_len);
-bool cls_has_chunk(cls_method_context_t hctx, std::string fp_oid);
+int cls_get_manifest_ref_count(cls_method_context_t hctx, std::string fp_oid);
 
 extern uint64_t cls_get_osd_min_alloc_size(cls_method_context_t hctx);
 extern uint64_t cls_get_pool_stripe_width(cls_method_context_t hctx);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3356,11 +3356,9 @@ int PrimaryLogPG::get_manifest_ref_count(ObjectContextRef obc, std::string& fp_o
       obc_g ? &(obc_g->obs.oi.manifest) : nullptr ,
       nullptr,
       refs);
-    if (!refs.is_empty()) {
-      for (auto p = refs.begin(); p != refs.end(); ++p) {
-	if (p->first.oid.name == fp_oid && p->second > 0) {
-	  cnt += p->second;
-	}
+    for (auto p = refs.begin(); p != refs.end(); ++p) {
+      if (p->first.oid.name == fp_oid && p->second > 0) {
+	cnt += p->second;
       }
     }
   }

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3328,6 +3328,34 @@ void PrimaryLogPG::cancel_manifest_ops(bool requeue, vector<ceph_tid_t> *tids)
   }
 }
 
+bool PrimaryLogPG::has_manifest_chunk(ObjectContextRef obc, std::string& fp_oid) 
+{
+  // head
+  for (auto &p : obc->obs.oi.manifest.chunk_map) {
+    if (p.second.oid.oid.name == fp_oid) {
+      return true;
+    }
+  }
+  // snap
+  SnapSet& ss = obc->ssc->snapset;
+  for (vector<snapid_t>::const_iterator p = ss.clones.begin();
+      p != ss.clones.end();
+      ++p) {
+    hobject_t clone_oid = obc->obs.oi.soid;
+    clone_oid.snap = *p;
+    ObjectContextRef clone_obc = get_object_context(clone_oid, false);
+    if (clone_obc && clone_obc->obs.oi.has_manifest()) {
+      for (auto &p : clone_obc->obs.oi.manifest.chunk_map) {
+	if (p.second.oid.oid.name == fp_oid) {
+	  return true;
+	}
+      }
+    }
+  }
+
+  return false;
+}
+
 ObjectContextRef PrimaryLogPG::get_prev_clone_obc(ObjectContextRef obc)
 {
   auto s = std::find(obc->ssc->snapset.clones.begin(), obc->ssc->snapset.clones.end(),

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3328,32 +3328,44 @@ void PrimaryLogPG::cancel_manifest_ops(bool requeue, vector<ceph_tid_t> *tids)
   }
 }
 
-bool PrimaryLogPG::has_manifest_chunk(ObjectContextRef obc, std::string& fp_oid) 
+int PrimaryLogPG::get_manifest_ref_count(ObjectContextRef obc, std::string& fp_oid) 
 {
+  int cnt = 0;
   // head
   for (auto &p : obc->obs.oi.manifest.chunk_map) {
     if (p.second.oid.oid.name == fp_oid) {
-      return true;
+      cnt++;
     }
   }
   // snap
   SnapSet& ss = obc->ssc->snapset;
-  for (vector<snapid_t>::const_iterator p = ss.clones.begin();
-      p != ss.clones.end();
+  for (vector<snapid_t>::const_reverse_iterator p = ss.clones.rbegin();
+      p != ss.clones.rend();
       ++p) {
+    object_ref_delta_t refs;
+    ObjectContextRef obc_l = nullptr;
+    ObjectContextRef obc_g = nullptr;
     hobject_t clone_oid = obc->obs.oi.soid;
     clone_oid.snap = *p;
     ObjectContextRef clone_obc = get_object_context(clone_oid, false);
-    if (clone_obc && clone_obc->obs.oi.has_manifest()) {
-      for (auto &p : clone_obc->obs.oi.manifest.chunk_map) {
-	if (p.second.oid.oid.name == fp_oid) {
-	  return true;
+    if (!clone_obc) {
+      break;
+    }
+    get_adjacent_clones(clone_obc, obc_l, obc_g);
+    clone_obc->obs.oi.manifest.calc_refs_to_inc_on_set(
+      obc_g ? &(obc_g->obs.oi.manifest) : nullptr ,
+      nullptr,
+      refs);
+    if (!refs.is_empty()) {
+      for (auto p = refs.begin(); p != refs.end(); ++p) {
+	if (p->first.oid.name == fp_oid && p->second > 0) {
+	  cnt += p->second;
 	}
       }
     }
   }
 
-  return false;
+  return cnt;
 }
 
 ObjectContextRef PrimaryLogPG::get_prev_clone_obc(ObjectContextRef obc)

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1848,6 +1848,8 @@ public:
   void maybe_kick_recovery(const hobject_t &soid);
   void wait_for_unreadable_object(const hobject_t& oid, OpRequestRef op);
 
+  bool has_manifest_chunk(ObjectContextRef obc, std::string& fp_oid);
+
   bool check_laggy(OpRequestRef& op);
   bool check_laggy_requeue(OpRequestRef& op);
   void recheck_readable() override;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1848,7 +1848,7 @@ public:
   void maybe_kick_recovery(const hobject_t &soid);
   void wait_for_unreadable_object(const hobject_t& oid, OpRequestRef op);
 
-  bool has_manifest_chunk(ObjectContextRef obc, std::string& fp_oid);
+  int get_manifest_ref_count(ObjectContextRef obc, std::string& fp_oid);
 
   bool check_laggy(OpRequestRef& op);
   bool check_laggy_requeue(OpRequestRef& op);

--- a/src/osd/objclass.cc
+++ b/src/osd/objclass.cc
@@ -685,17 +685,7 @@ int cls_cxx_chunk_write_and_set(cls_method_context_t hctx, int ofs, int len,
 bool cls_has_chunk(cls_method_context_t hctx, string fp_oid)
 {
   PrimaryLogPG::OpContext *ctx = *(PrimaryLogPG::OpContext **)hctx;
-  if (!ctx->obc->obs.oi.has_manifest()) {
-    return false;
-  }
-
-  for (auto &p : ctx->obc->obs.oi.manifest.chunk_map) {
-    if (p.second.oid.oid.name == fp_oid) {
-      return true;
-    }
-  }
-
-  return false;
+  return ctx->pg->has_manifest_chunk(ctx->obc, fp_oid);
 }
 
 uint64_t cls_get_osd_min_alloc_size(cls_method_context_t hctx) {

--- a/src/osd/objclass.cc
+++ b/src/osd/objclass.cc
@@ -682,10 +682,10 @@ int cls_cxx_chunk_write_and_set(cls_method_context_t hctx, int ofs, int len,
   return (*pctx)->pg->do_osd_ops(*pctx, ops);
 }
 
-bool cls_has_chunk(cls_method_context_t hctx, string fp_oid)
+int cls_get_manifest_ref_count(cls_method_context_t hctx, string fp_oid)
 {
   PrimaryLogPG::OpContext *ctx = *(PrimaryLogPG::OpContext **)hctx;
-  return ctx->pg->has_manifest_chunk(ctx->obc, fp_oid);
+  return ctx->pg->get_manifest_ref_count(ctx->obc, fp_oid);
 }
 
 uint64_t cls_get_osd_min_alloc_size(cls_method_context_t hctx) {

--- a/src/test/librados/CMakeLists.txt
+++ b/src/test/librados/CMakeLists.txt
@@ -130,7 +130,7 @@ add_executable(ceph_test_rados_api_tier_pp
   $<TARGET_OBJECTS:unit-main>)
 target_link_libraries(ceph_test_rados_api_tier_pp
   librados global ${UNITTEST_LIBS} Boost::system radostest-cxx cls_cas_internal
-  spawn)
+  cls_cas_client spawn)
 
 add_executable(ceph_test_rados_api_snapshots
   snapshots.cc)

--- a/src/test/librados/tier_cxx.cc
+++ b/src/test/librados/tier_cxx.cc
@@ -5488,7 +5488,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestSnapHasChunk) {
   // create object
   {
     bufferlist bl;
-    bl.append("there hiHI");
+    bl.append("there HIHI");
     ObjectWriteOperation op;
     op.write_full(bl);
     ASSERT_EQ(0, ioctx.operate("foo", &op));
@@ -5573,7 +5573,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestSnapHasChunk) {
   }
 
   // set-chunk (dedup)
-  manifest_set_chunk(cluster, cache_ioctx, ioctx, 6, 2, hi_fp_oid, "foo");
+  manifest_set_chunk(cluster, cache_ioctx, ioctx, 6, 2, HI_fp_oid, "foo");
   // set-chunk (dedup)
   manifest_set_chunk(cluster, cache_ioctx, ioctx, 8, 2, HI_fp_oid, "foo");
 
@@ -5634,19 +5634,18 @@ TEST_F(LibRadosTwoPoolsPP, ManifestSnapHasChunk) {
     ASSERT_EQ(0, ioctx.write("foo", bl, 1, 6));
   }
 
-  // foo snap[1]:      [hi] [HI]
+  // foo snap[1]:      [HI] [HI]
   // foo snap[0]: [er] [ai] [SI]
   // foo head   : [er] [bi] [SI]
 
   // set-chunk (dedup)
   manifest_set_chunk(cluster, cache_ioctx, ioctx, 6, 2, bi_fp_oid, "foo");
 
-
   {
-    ASSERT_EQ(0, cls_cas_references_chunk(ioctx, "foo", SI_fp_oid));
-    ASSERT_EQ(0, cls_cas_references_chunk(ioctx, "foo", er_fp_oid));
-    ASSERT_EQ(0, cls_cas_references_chunk(ioctx, "foo", ai_fp_oid));
-    ASSERT_EQ(0, cls_cas_references_chunk(ioctx, "foo", HI_fp_oid));
+    ASSERT_EQ(1, cls_cas_references_chunk(ioctx, "foo", SI_fp_oid));
+    ASSERT_EQ(1, cls_cas_references_chunk(ioctx, "foo", er_fp_oid));
+    ASSERT_EQ(1, cls_cas_references_chunk(ioctx, "foo", ai_fp_oid));
+    ASSERT_EQ(2, cls_cas_references_chunk(ioctx, "foo", HI_fp_oid));
     ASSERT_EQ(-ENOLINK, cls_cas_references_chunk(ioctx, "foo", Hi_fp_oid));
   }
 }


### PR DESCRIPTION
cls_has_chunk does not cover snapshotted manifest object.
This leads to unexpected behavior during chunk scrub.

Signed-off-by: Myoungwon Oh <myoungwon.oh@samsung.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
