### PR TITLE
doc/cephfs: add data pool-MDS instructions link

### DIFF
--- a/doc/cephfs/createfs.rst
+++ b/doc/cephfs/createfs.rst
@@ -77,6 +77,12 @@ If you have created more than one file system, and a client does not
 specify a file system when mounting, you can control which file system
 they will see by using the `ceph fs set-default` command.
 
+Adding a Data Pool to the File System 
+-------------------------------------
+
+See :ref:`adding-data-pool-to-file-system`.
+
+
 Using Erasure Coded pools with CephFS
 =====================================
 

--- a/doc/cephfs/file-layouts.rst
+++ b/doc/cephfs/file-layouts.rst
@@ -202,9 +202,11 @@ directories do not have layouts set:
     # file: dir/childdir/grandchild
     ceph.file.layout="stripe_unit=4194304 stripe_count=4 object_size=4194304 pool=cephfs_data"
 
+
+.. _adding-data-pool-to-file-system:
     
-Adding a data pool to the MDS
------------------------------
+Adding a data pool to the File System 
+-------------------------------------
 
 Before you can use a pool with CephFS you have to add it to the Metadata Servers.
 


### PR DESCRIPTION
This commit adds a link to the "Create a Ceph
File System" page. The link that it adds is to the
"Adding a data pool to the MDS" subsection of the
file layouts page.

Fixes: https://tracker.ceph.com/issues/48531
Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
