### PR TITLE
octopus: mgr/dashboard: The /rgw/status endpoint does not check for running service

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -30,6 +30,8 @@ class Rgw(BaseController):
     def status(self):
         status = {'available': False, 'message': None}
         try:
+            if not CephService.get_service_list('rgw'):
+                raise LookupError('No RGW service is running.')
             instance = RgwClient.admin_instance()
             # Check if the service is online.
             if not instance.is_service_online():  # pragma: no cover - no complexity there

--- a/src/pybind/mgr/dashboard/tests/test_rgw.py
+++ b/src/pybind/mgr/dashboard/tests/test_rgw.py
@@ -3,8 +3,22 @@ try:
 except ImportError:
     import unittest.mock as mock
 
-from . import ControllerTestCase
-from ..controllers.rgw import RgwUser
+from .. import mgr
+from ..controllers.rgw import Rgw, RgwUser
+from . import ControllerTestCase  # pylint: disable=no-name-in-module
+
+
+class RgwControllerTestCase(ControllerTestCase):
+    @classmethod
+    def setup_server(cls):
+        Rgw._cp_config['tools.authenticate.on'] = False  # pylint: disable=protected-access
+        cls.setup_controllers([Rgw], '/test')
+
+    def test_status_no_service(self):
+        mgr.list_servers.return_value = []
+        self._get('/test/api/rgw/status')
+        self.assertStatus(200)
+        self.assertJsonBody({'available': False, 'message': 'No RGW service is running.'})
 
 
 class RgwUserControllerTestCase(ControllerTestCase):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48629

---

backport of https://github.com/ceph/ceph/pull/38534
parent tracker: https://tracker.ceph.com/issues/48542

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh