### PR TITLE
qa: get pool holding file data from file layout

### DIFF
--- a/qa/workunits/fs/misc/direct_io.py
+++ b/qa/workunits/fs/misc/direct_io.py
@@ -1,24 +1,16 @@
 #!/usr/bin/python3
 
-import json
 import mmap
 import os
 import subprocess
 
-
-def get_data_pool():
-    cmd = ['ceph', 'fs', 'ls', '--format=json-pretty']
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-    out = proc.communicate()[0]
-    return json.loads(out)[0]['data_pools'][0]
-
-
 def main():
-    fd = os.open("testfile", os.O_RDWR | os.O_CREAT | os.O_TRUNC | os.O_DIRECT, 0o644)
+    path = "testfile"
+    fd = os.open(path, os.O_RDWR | os.O_CREAT | os.O_TRUNC | os.O_DIRECT, 0o644)
 
     ino = os.fstat(fd).st_ino
     obj_name = "{ino:x}.00000000".format(ino=ino)
-    pool_name = get_data_pool()
+    pool_name = os.getxattr(path, "ceph.file.layout.pool")
 
     buf = mmap.mmap(-1, 1)
     buf.write(b'1')


### PR DESCRIPTION
Otherwise it always looks at the default data pool. For ec pools, this
may not be where the file data is.

Fixes: https://tracker.ceph.com/issues/48756
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
