### PR TITLE
mds: don't use dentry_key_t in C_IO_Dir_Commit_Ops

### DIFF
--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -58,7 +58,7 @@ public:
   }
 
   struct dentry_commit_item {
-    dentry_key_t key;
+    string key;
     snapid_t first;
     bool is_remote = false;
 
@@ -673,7 +673,7 @@ protected:
   void _commit(version_t want, int op_prio);
   void _omap_commit_ops(int r, int op_prio, int64_t metapool, version_t version, bool _new,
 			vector<dentry_commit_item> &to_set, bufferlist &dfts,
-			vector<dentry_key_t> &to_remove,
+			vector<string> &to_remove,
 			mempool::mds_co::compact_set<mempool::mds_co::string> &_stale);
   void _omap_commit(int op_prio);
   void _parse_dentry(CDentry *dn, dentry_commit_item &item,


### PR DESCRIPTION
dentry_key_t uses std::string_view to access corresponding dentry's name.
C_IO_Dir_Commit_Ops() is executed by worker thread. It's possible dentry
gets freed before C_IO_Dir_Commit_Ops() gets executed.

Signed-off-by: "Yan, Zheng" <ukernel@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
