### PR TITLE
rgw: fix user.rgw.user-policy attr remove by assume_role or modify user info

### DIFF
--- a/src/rgw/driver/rados/rgw_user.cc
+++ b/src/rgw/driver/rados/rgw_user.cc
@@ -290,6 +290,15 @@ void RGWUserAdminOpState::set_user_info(RGWUserInfo& user_info)
   user->get_info() = user_info;
 }
 
+void RGWUserAdminOpState::set_attrs(rgw::sal::Attrs& attrs)
+{
+  user->get_attrs() = attrs;
+}
+
+rgw::sal::Attrs RGWUserAdminOpState::get_attrs() {
+  return user->get_attrs();
+}
+
 void RGWUserAdminOpState::set_user_version_tracker(RGWObjVersionTracker& objv_tracker)
 {
   user->get_version_tracker() = objv_tracker;
@@ -1386,6 +1395,7 @@ int RGWUser::init(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state, 
   
   op_state.set_existing_user(found);
   if (found) {
+    op_state.set_attrs(user->get_attrs());
     op_state.set_user_info(user->get_info());
     op_state.set_populated();
     op_state.objv = user->get_version_tracker();
@@ -2640,6 +2650,7 @@ int RGWUserCtl::get_info_by_email(const DoutPrefixProvider *dpp,
                                             info,
                                             params.objv_tracker,
                                             params.mtime,
+                                            params.attrs,
                                             y,
                                             dpp);
   });
@@ -2656,6 +2667,7 @@ int RGWUserCtl::get_info_by_swift(const DoutPrefixProvider *dpp,
                                             info,
                                             params.objv_tracker,
                                             params.mtime,
+                                            params.attrs,
                                             y,
                                             dpp);
   });
@@ -2672,6 +2684,7 @@ int RGWUserCtl::get_info_by_access_key(const DoutPrefixProvider *dpp,
                                                  info,
                                                  params.objv_tracker,
                                                  params.mtime,
+                                                 params.attrs,
                                                  y,
                                                  dpp);
   });

--- a/src/rgw/driver/rados/rgw_user.h
+++ b/src/rgw/driver/rados/rgw_user.h
@@ -298,6 +298,10 @@ struct RGWUserAdminOpState {
 
   void set_user_info(RGWUserInfo& user_info);
 
+  rgw::sal::Attrs get_attrs();
+
+  void set_attrs(rgw::sal::Attrs& attrs);
+
   void set_user_version_tracker(RGWObjVersionTracker& objv_tracker);
 
   void set_max_buckets(int32_t mb) {

--- a/src/rgw/services/svc_user.h
+++ b/src/rgw/services/svc_user.h
@@ -71,21 +71,21 @@ public:
   virtual int get_user_info_by_email(RGWSI_MetaBackend::Context *ctx,
                              const std::string& email, RGWUserInfo *info,
                              RGWObjVersionTracker *objv_tracker,
-                             real_time *pmtime,
+                             real_time *pmtime, std::map<std::string, bufferlist> *pattrs,
                              optional_yield y,
                              const DoutPrefixProvider *dpp) = 0;
   virtual int get_user_info_by_swift(RGWSI_MetaBackend::Context *ctx,
                              const std::string& swift_name,
                              RGWUserInfo *info,        /* out */
                              RGWObjVersionTracker * const objv_tracker,
-                             real_time * const pmtime,
+                             real_time * const pmtime, std::map<std::string, bufferlist> *pattrs,
                              optional_yield y,
                              const DoutPrefixProvider *dpp) = 0;
   virtual int get_user_info_by_access_key(RGWSI_MetaBackend::Context *ctx,
                                   const std::string& access_key,
                                   RGWUserInfo *info,
                                   RGWObjVersionTracker* objv_tracker,
-                                  real_time *pmtime,
+                                  real_time *pmtime, std::map<std::string, bufferlist> *pattrs,
                                   optional_yield y,
                                   const DoutPrefixProvider *dpp) = 0;
 

--- a/src/rgw/services/svc_user_rados.h
+++ b/src/rgw/services/svc_user_rados.h
@@ -61,7 +61,7 @@ class RGWSI_User_RADOS : public RGWSI_User
                                const rgw_pool& pool,
                                RGWUserInfo *info,
                                RGWObjVersionTracker * const objv_tracker,
-                               real_time * const pmtime,
+                               real_time * const pmtime, std::map<std::string, bufferlist> *pattrs,
                                optional_yield y,
                                const DoutPrefixProvider *dpp);
 
@@ -149,21 +149,21 @@ public:
   int get_user_info_by_email(RGWSI_MetaBackend::Context *ctx,
                              const std::string& email, RGWUserInfo *info,
                              RGWObjVersionTracker *objv_tracker,
-                             real_time *pmtime,
+                             real_time *pmtime, std::map<std::string, bufferlist> *pattrs,
                              optional_yield y,
                              const DoutPrefixProvider *dpp) override;
   int get_user_info_by_swift(RGWSI_MetaBackend::Context *ctx,
                              const std::string& swift_name,
                              RGWUserInfo *info,        /* out */
                              RGWObjVersionTracker * const objv_tracker,
-                             real_time * const pmtime,
+                             real_time * const pmtime, std::map<std::string, bufferlist> *pattrs,
                              optional_yield y,
                              const DoutPrefixProvider *dpp) override;
   int get_user_info_by_access_key(RGWSI_MetaBackend::Context *ctx,
                                   const std::string& access_key,
                                   RGWUserInfo *info,
                                   RGWObjVersionTracker* objv_tracker,
-                                  real_time *pmtime,
+                                  real_time *pmtime, std::map<std::string, bufferlist> *pattrs,
                                   optional_yield y,
                                   const DoutPrefixProvider *dpp) override;
 


### PR DESCRIPTION
fix https://tracker.ceph.com/issues/48761

Signed-off-by: yuliyang_yewu <yuliyang_yewu@cmss.chinamobile.com>

```
when put user policy on user yly by the follow boto3 script

import boto3
import botocore
botocore.session.Session().set_debug_logger()
access_key = 'admin'
secret_key = 'admin'
config_dict = { 'signature_version' : 's3', 'connect_timeout': 30000, 'read_timeout': 30000}
configuration = boto3.session.Config(**config_dict)

client = boto3.client('iam',
aws_access_key_id=access_key,
aws_secret_access_key=secret_key,
endpoint_url='http://127.0.0.1:8000',
region_name='',
use_ssl = False,
config = configuration,
)

policy = '''{
  "Version": "2012-10-17",
  "Statement": [{
    "Effect": "Allow",
    "Action": "sts:GetSessionToken",
    "Resource": "*"
  }]
}'''

response = client.put_user_policy(
    UserName='yly',
    PolicyName='yly-sts',
    PolicyDocument= policy
)


./bin/rados -p default.rgw.meta listxattr yly --namespace users.uid -c ceph.conf
ceph.objclass.version
user.rgw.user-policy <= we have new attr here

but when we modify user info by

./bin/radosgw-admin user modify --uid=yly --max-buckets=200 -c ceph.conf

the user.rgw.user-policy attr will be removed

and if we assume_role, the user.rgw.user-policy attr will be remove too

./bin/radosgw-admin role create --role-name role1 --path / --assume-role-policy-doc \{\"Version\":\"2012-10-17\",\"Statement\":\[\{\"Effect\":\"Allow\",\"Principal\":\{\"AWS\":\[\"arn:aws:iam:::user/yly\"\]\},\"Action\":\[\"sts:AssumeRole\"\]\}\]\}

./bin/radosgw-admin role-policy put --role-name=role1 --policy-name=Policy1 --policy-doc=\{\"Version\":\"2012-10-17\",\"Statement\":\[\{\"Effect\":\"Allow\",\"Action\":\[\"s3:*\"\],\"Resource\":\"arn:aws:s3:::test1\"\}\]\}


import boto3
import botocore
botocore.session.Session().set_debug_logger()
access_key = 'yly'
secret_key = 'yly'
config_dict = { 'signature_version' : 's3', 'connect_timeout': 30000, 'read_timeout': 30000}
configuration = boto3.session.Config(**config_dict)

client = boto3.client('sts',
aws_access_key_id=access_key,
aws_secret_access_key=secret_key,
endpoint_url='http://127.0.0.1',
region_name='',
use_ssl = False,
config = configuration,
)

response = client.assume_role(
RoleArn='arn:aws:iam:::role/role1',
RoleSessionName='my-session-1',
DurationSeconds=3600,
)

after call assume_role, the user.rgw.user-policy will be remove and user can not call get_session_token which we defined in put_user_policy

```
