### PR TITLE
qa/tests: octopus-x suite added more workloads

### DIFF
--- a/qa/suites/upgrade/octopus-x/workload/ec-rados-default.yaml
+++ b/qa/suites/upgrade/octopus-x/workload/ec-rados-default.yaml
@@ -1,0 +1,25 @@
+meta:
+- desc: |
+   run run randomized correctness test for rados operations
+   on an erasure-coded pool
+workload:
+  full_sequential:
+  - print: "**** done start ec-rados-default.yaml"
+  - rados:
+      clients: [client.0]
+      ops: 4000
+      objects: 50
+      ec_pool: true
+      write_append_excl: false
+      op_weights:
+        read: 100
+        write: 0
+        append: 100
+        delete: 50
+        snap_create: 50
+        snap_remove: 50
+        rollback: 50
+        copy_from: 50
+        setattr: 25
+        rmattr: 25
+  - print: "**** done end ec-rados-default.yaml"

--- a/qa/suites/upgrade/octopus-x/workload/rados_loadgenbig.yaml
+++ b/qa/suites/upgrade/octopus-x/workload/rados_loadgenbig.yaml
@@ -3,9 +3,10 @@ meta:
    generate read/write load with rados objects ranging from 1MB to 25MB
 workload:
   full_sequential:
+    - print: "**** done start rados_loadgenbig.yaml"
     - workunit:
         branch: octopus
         clients:
           client.0:
             - rados/load-gen-big.sh
-    - print: "**** done rados/load-gen-big.sh workload"
+    - print: "**** done end rados_loadgenbig.yaml"

--- a/qa/suites/upgrade/octopus-x/workload/test_rbd_api.yaml
+++ b/qa/suites/upgrade/octopus-x/workload/test_rbd_api.yaml
@@ -3,10 +3,10 @@ meta:
    librbd C and C++ api tests
 workload:
   full_sequential:
-    - print: "**** done start rbd/test_librbd.sh"
+    - print: "**** done start test_rbd_api.yaml"
     - workunit:
         branch: octopus
         clients:
           client.0:
               - rbd/test_librbd.sh
-    - print: "**** done end rbd/test_librbd.sh"
+    - print: "**** done end test_rbd_api.yaml"

--- a/qa/suites/upgrade/octopus-x/workload/test_rbd_python.disable
+++ b/qa/suites/upgrade/octopus-x/workload/test_rbd_python.disable
@@ -1,0 +1,18 @@
+
+
+##### This is disabled due to https://tracker.ceph.com/issues/48759
+
+
+meta:
+- desc: |
+   librbd python api tests
+workload:
+  full_sequential:
+    - print: "**** done start test_rbd_python.yaml"
+    - workunit:
+        branch: octopus
+        clients:
+          client.0:
+            - rbd/test_librbd_python.sh
+    - print: "**** done end test_rbd_python.yaml"
+


### PR DESCRIPTION
Signed-off-by: Yuri Weinstein <yweinste@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
