### PR TITLE
qa/tasks/cephadm.py: do not create rbd pool by default

### DIFF
--- a/qa/suites/upgrade/octopus-x/0-start.yaml
+++ b/qa/suites/upgrade/octopus-x/0-start.yaml
@@ -25,6 +25,7 @@ openstack:
     size: 10 # GB
 overrides:
   ceph:
+    create_rbd_pool: true
     conf:
       osd:
         osd shutdown pgref assert: true

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -1019,25 +1019,24 @@ def crush_setup(ctx, config):
 
 @contextlib.contextmanager
 def create_rbd_pool(ctx, config):
-    cluster_name = config['cluster']
-    log.info('Waiting for OSDs to come up')
-    teuthology.wait_until_osds_up(
-        ctx,
-        cluster=ctx.cluster,
-        remote=ctx.ceph[cluster_name].bootstrap_remote,
-        ceph_cluster=cluster_name,
-    )
-    if config.get('create_rbd_pool', True):
-        log.info('Creating RBD pool')
-        _shell(ctx, cluster_name, ctx.ceph[cluster_name].bootstrap_remote,
-            args=['sudo', 'ceph', '--cluster', cluster_name,
-                  'osd', 'pool', 'create', 'rbd', '8'])
-        _shell(ctx, cluster_name, ctx.ceph[cluster_name].bootstrap_remote,
-            args=[
-                'sudo', 'ceph', '--cluster', cluster_name,
+    if config.get('create_rbd_pool', False):
+      cluster_name = config['cluster']
+      log.info('Waiting for OSDs to come up')
+      teuthology.wait_until_osds_up(
+          ctx,
+          cluster=ctx.cluster,
+          remote=ctx.ceph[cluster_name].bootstrap_remote,
+          ceph_cluster=cluster_name,
+      )
+      log.info('Creating RBD pool')
+      _shell(ctx, cluster_name, ctx.ceph[cluster_name].bootstrap_remote,
+          args=['sudo', 'ceph', '--cluster', cluster_name,
+                'osd', 'pool', 'create', 'rbd', '8'])
+      _shell(ctx, cluster_name, ctx.ceph[cluster_name].bootstrap_remote,
+          args=['sudo', 'ceph', '--cluster', cluster_name,
                 'osd', 'pool', 'application', 'enable',
                 'rbd', 'rbd', '--yes-i-really-mean-it'
-            ])
+          ])
     yield
 
 @contextlib.contextmanager


### PR DESCRIPTION
rados/cephadm/smoke* does not use the install task and the adjust-ulimits
dependency is met as a part of it. create_rbd_pool needs adjust-ulimits,
so for now we will disable create_rbd_pool by default and only set it
to true for the upgrade suite.

Signed-off-by: Neha Ojha <nojha@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
