### PR TITLE
octopus: mgr/dashboard: Fixing dashboard logs e2e test

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/logs.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/logs.e2e-spec.ts
@@ -1,14 +1,11 @@
 import { PoolPageHelper } from '../pools/pools.po';
-import { ConfigurationPageHelper } from './configuration.po';
 import { LogsPageHelper } from './logs.po';
 
 describe('Logs page', () => {
   const logs = new LogsPageHelper();
   const pools = new PoolPageHelper();
-  const configuration = new ConfigurationPageHelper();
 
   const poolname = 'e2e_logs_test_pool';
-  const configname = 'log_graylog_port';
   const today = new Date();
   let hour = today.getHours();
   if (hour > 12) {
@@ -55,19 +52,6 @@ describe('Logs page', () => {
       pools.navigateTo();
       pools.delete(poolname);
       logs.checkAuditForPoolFunction(poolname, 'delete', hour, minute);
-    });
-  });
-
-  describe('audit logs respond to editing configuration setting test', () => {
-    it('should change config settings and check audit logs reacted', () => {
-      configuration.navigateTo();
-      configuration.edit(configname, ['global', '5']);
-
-      logs.navigateTo();
-      logs.checkAuditForConfigChange(configname, 'global', hour, minute);
-
-      configuration.navigateTo();
-      configuration.configClear(configname);
     });
   });
 });


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48626

---

backport of https://github.com/ceph/ceph/pull/38606
parent tracker: https://tracker.ceph.com/issues/48623

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh