### PR TITLE
nautilus: mgr/dashboard: Display a warning message in Dashboard when debug mode is enabled

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1013,3 +1013,16 @@ To re-enable telemetry (and make this warning go away),::
 To disable telemetry (and make this warning go away),::
 
   ceph telemetry off
+
+DASHBOARD_DEBUG
+_______________
+
+The Dashboard debug mode is enabled. This means, if there is an error
+while processing a REST API request, the HTTP error response contains
+a Python traceback. This behaviour should be disabled in production
+environments because such a traceback might contain and expose sensible
+information.
+
+The debug mode can be disabled with::
+
+  ceph dashboard debug disable

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -271,9 +271,9 @@ class Module(MgrModule, CherryPyConfig):
 
         self._stopping = threading.Event()
         self.shutdown_event = threading.Event()
-
         self.ACCESS_CTRL_DB = None
         self.SSO_DB = None
+        self.health_checks = {}
 
     @classmethod
     def can_run(cls):
@@ -424,6 +424,15 @@ class Module(MgrModule, CherryPyConfig):
                 self.__pool_stats[pool_id][stat_name].append((now, stat_val))
 
         return self.__pool_stats
+
+    def config_notify(self):
+        """
+        This method is called whenever one of our config options is changed.
+        """
+        PLUGIN_MANAGER.hook.config_notify()
+
+    def refresh_health_checks(self):
+        self.set_health_checks(self.health_checks)
 
 
 class StandbyModule(MgrStandbyModule, CherryPyConfig):

--- a/src/pybind/mgr/dashboard/plugins/interfaces.py
+++ b/src/pybind/mgr/dashboard/plugins/interfaces.py
@@ -70,3 +70,13 @@ class FilterRequest(object):
     class BeforeHandler(Interface):
         @PM.add_abcspec
         def filter_request_before_handler(self, request): pass
+
+
+@PM.add_interface
+class ConfigNotify(Interface):
+    @PM.add_abcspec
+    def config_notify(self):
+        """
+        This method is called whenever a option of this mgr module has
+        been modified.
+        """


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48653

---

backport of https://github.com/ceph/ceph/pull/38473
parent tracker: https://tracker.ceph.com/issues/48475

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh