### PR TITLE
octopus: install-deps.sh: Make powertools repo case insensitive

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -365,7 +365,8 @@ else
 			  --enable rhel-7-server-devtools-rpms
                     dts_ver=8
                 elif test $ID = centos -a $MAJOR_VERSION = 8 ; then
-                    $SUDO dnf config-manager --set-enabled PowerTools
+                    # Enable 'powertools' or 'PowerTools' repo
+                    $SUDO dnf config-manager --set-enabled $(dnf repolist --all 2>/dev/null|gawk 'tolower($0) ~ /^powertools\s/{print $1}')
 		    # before EPEL8 and PowerTools provide all dependencies, we use sepia for the dependencies
                     $SUDO dnf config-manager --add-repo http://apt-mirror.front.sepia.ceph.com/lab-extras/8/
                     $SUDO dnf config-manager --setopt=apt-mirror.front.sepia.ceph.com_lab-extras_8_.gpgcheck=0 --save


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48528

---

backport of https://github.com/ceph/ceph/pull/38001
parent tracker: https://tracker.ceph.com/issues/48174

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh