### PR TITLE
pybind/mgr: change format_bytes unit color from black to yellow

### DIFF
--- a/src/pybind/ceph_daemon.py
+++ b/src/pybind/ceph_daemon.py
@@ -191,7 +191,7 @@ class DaemonWatcher(object):
         unit = 0
         while len("%s" % (int(n) // (1000**unit))) > width - 1:
             if unit >= len(units) - 1:
-                break;
+                break
             unit += 1
 
         if unit > 0:
@@ -208,7 +208,7 @@ class DaemonWatcher(object):
             else:
                 color = self.YELLOW, False
             return self.bold(self.colorize(formatted[0:-1], color[0], color[1])) \
-                + self.bold(self.colorize(formatted[-1], self.BLACK, False))
+                + self.bold(self.colorize(formatted[-1], self.YELLOW, False))
         else:
             return formatted
 

--- a/src/pybind/mgr/mgr_util.py
+++ b/src/pybind/mgr/mgr_util.py
@@ -331,7 +331,7 @@ def format_units(n, width, colored, decimal):
         else:
             color = YELLOW, False
         return bold(colorize(formatted[0:-1], color[0], color[1])) \
-            + bold(colorize(formatted[-1], BLACK, False))
+            + bold(colorize(formatted[-1], YELLOW, False))
     else:
         return formatted
 


### PR DESCRIPTION
Currently format_bytes output (such as ceph fs status) makes unit black, which is
hard to distinguish on black terminals, so change them as same as the data itself.

Signed-off-by: haoyixing <haoyixing@kuaishou.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
