### PR TITLE
msg: using switch-case in place of if-else.

### DIFF
--- a/src/msg/Connection.cc
+++ b/src/msg/Connection.cc
@@ -7,8 +7,17 @@
 
 bool Connection::is_blackhole() const {
   auto& conf = msgr->cct->_conf;
-  return ((conf->ms_blackhole_mon && peer_type == CEPH_ENTITY_TYPE_MON) ||
-      (conf->ms_blackhole_osd && peer_type == CEPH_ENTITY_TYPE_OSD) ||
-      (conf->ms_blackhole_mds && peer_type == CEPH_ENTITY_TYPE_MDS) ||
-      (conf->ms_blackhole_client && peer_type == CEPH_ENTITY_TYPE_CLIENT));
+
+  switch (peer_type) {
+  case CEPH_ENTITY_TYPE_MON:
+    return conf->ms_blackhole_mon;
+  case CEPH_ENTITY_TYPE_OSD:
+    return conf->ms_blackhole_osd;
+  case CEPH_ENTITY_TYPE_MDS:
+    return conf->ms_blackhole_mds;
+  case CEPH_ENTITY_TYPE_CLIENT:
+    return conf->ms_blackhole_client;
+  default:
+    return false;
+  }
 }


### PR DESCRIPTION
For point of performance, swith-case is better than if-else for blackhole check.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
