### PR TITLE
nautilus: mgr/dashboard: Fix for datatable item not showing details after getting selected

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -295,6 +295,21 @@ describe('TableComponent', () => {
     });
   });
 
+  describe('select row', () => {
+    beforeEach(() => {
+      component.ngOnInit();
+      component.data = [];
+    });
+
+    it('should select the row item', () => {
+      spyOn(component, 'onSelect').and.callThrough();
+      component.data = createFakeData(3);
+      component.selection.selected = [_.clone(component.data[1])];
+      component.onSelect(new Event('click'));
+      expect(component.selection.hasSelection).toBeTruthy();
+    });
+  });
+
   describe('reload data', () => {
     beforeEach(() => {
       component.ngOnInit();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -460,6 +460,7 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
     if (_.has($event, 'selected')) {
       this.selection.selected = $event['selected'];
     }
+    this.selection.update();
     this.updateSelection.emit(_.clone(this.selection));
   }
 


### PR DESCRIPTION
**Regression in nautilus**

Datatable items are not showing the details even if an item in the list is selected. This is happening because of this backport (https://github.com/ceph/ceph/pull/37756/files) which backports the line `this.selection.selected = $event['selected'];` but this feature was not implemented in the nautilus branch. (https://github.com/ceph/ceph/pull/30594/commits/75ac96df6f4e547498a1f21a50419ed3316d3d8b). 

**BEFORE** 
![chrome-capture (8)](https://user-images.githubusercontent.com/71764184/103987845-1c41c400-51b3-11eb-87cc-9eaa4109e173.gif)

**AFTER**
![chrome-capture (9)](https://user-images.githubusercontent.com/71764184/103987834-1946d380-51b3-11eb-8309-b462f1211a76.gif)


Fixes: https://tracker.ceph.com/issues/48796
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
