### PR TITLE
nautilus: mgr/telemetry: fix proxy usage

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -694,7 +694,7 @@ class Module(MgrModule):
             proxies['http'] = self.proxy
             proxies['https'] = self.proxy
         try:
-            resp = requests.put(url=url, json=report)
+            resp = requests.put(url=url, json=report, proxies=proxies)
             resp.raise_for_status()
         except Exception as e:
             fail_reason = 'Failed to send %s to %s: %s' % (what, url, str(e))


### PR DESCRIPTION
This nautilus-only commit is not cherry-picked from master because it fixes an
incomplete nautilus backport.

Commit

    5d7c79b079827dffdabf78bd18c2930cfed92286
    mgr/telemetry: fix and document proxy usage

targeting master was initially backported to nautilus by

    21b00799948f0863e169d45415fcc5dfb0fac02d

However, this initial backport omitted the "fix" part.

Fixes: 21b00799948f0863e169d45415fcc5dfb0fac02d
Signed-off-by: Nathan Cutler <ncutler@suse.com>
