### PR TITLE
octopus: rgw: cls/user: set from_index for reset stats calls

### DIFF
--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -414,6 +414,9 @@ static int cls_user_reset_stats(cls_method_context_t hctx,
       }
       add_header_stats(&header.stats, e);
     }
+    if (!keys.empty()) {
+      from_index = keys.rbegin()->first;
+    }
   } while (truncated);
 
   bufferlist bl;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48804

---

backport of https://github.com/ceph/ceph/pull/38242
parent tracker: https://tracker.ceph.com/issues/48327

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh