### PR TITLE
nautilus: rgw: avoid expiration early triggering caused by overflow

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -303,11 +303,11 @@ static bool obj_has_expired(CephContext *cct, ceph::real_time mtime, int days, c
   utime_t base_time;
   if (cct->_conf->rgw_lc_debug_interval <= 0) {
     /* Normal case, run properly */
-    cmp = days*24*60*60;
+    cmp = (double)days*24*60*60;
     base_time = ceph_clock_now().round_to_day();
   } else {
     /* We're in debug mode; Treat each rgw_lc_debug_interval seconds as a day */
-    cmp = days*cct->_conf->rgw_lc_debug_interval;
+    cmp = (double)days*cct->_conf->rgw_lc_debug_interval;
     base_time = ceph_clock_now();
   }
   timediff = base_time - ceph::real_clock::to_time_t(mtime);
@@ -1640,7 +1640,7 @@ std::string s3_expiration_header(
       if (rule_expiration.has_days()) {
 	rule_expiration_date =
 	  boost::optional<ceph::real_time>(
-	    mtime + make_timespan(rule_expiration.get_days()*24*60*60));
+	    mtime + make_timespan((double)rule_expiration.get_days()*24*60*60));
 	rule_id = id;
       }
     }

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -303,11 +303,11 @@ static bool obj_has_expired(CephContext *cct, ceph::real_time mtime, int days, c
   utime_t base_time;
   if (cct->_conf->rgw_lc_debug_interval <= 0) {
     /* Normal case, run properly */
-    cmp = (double)days*24*60*60;
+    cmp = double(days)*24*60*60;
     base_time = ceph_clock_now().round_to_day();
   } else {
     /* We're in debug mode; Treat each rgw_lc_debug_interval seconds as a day */
-    cmp = (double)days*cct->_conf->rgw_lc_debug_interval;
+    cmp = double(days)*cct->_conf->rgw_lc_debug_interval;
     base_time = ceph_clock_now();
   }
   timediff = base_time - ceph::real_clock::to_time_t(mtime);
@@ -1640,7 +1640,7 @@ std::string s3_expiration_header(
       if (rule_expiration.has_days()) {
 	rule_expiration_date =
 	  boost::optional<ceph::real_time>(
-	    mtime + make_timespan((double)rule_expiration.get_days()*24*60*60));
+	    mtime + make_timespan(double(rule_expiration.get_days())*24*60*60));
 	rule_id = id;
       }
     }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48428

---

backport of https://github.com/ceph/ceph/pull/31393
parent tracker: https://tracker.ceph.com/issues/42634

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh