### PR TITLE
octopus: rgw: lc: correctly dimension lc shard index vector

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1655,7 +1655,7 @@ int RGWLC::list_lc_progress(string& marker, uint32_t max_entries,
 
 static inline vector<int> random_sequence(uint32_t n)
 {
-  vector<int> v(n-1, 0);
+  vector<int> v(n, 0);
   std::generate(v.begin(), v.end(),
     [ix = 0]() mutable {
       return ix++;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48546

---

backport of https://github.com/ceph/ceph/pull/38131
parent tracker: https://tracker.ceph.com/issues/48255

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh