### PR TITLE
octopus: rgw: fix bucket limit check fill_status warnings

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1540,32 +1540,28 @@ int RGWBucketAdminOp::limit_check(rgw::sal::RGWRadosStore *store,
 	  continue;
 
 	for (const auto& s : stats) {
-	    num_objects += s.second.num_objects;
+	  num_objects += s.second.num_objects;
 	}
 
 	num_shards = info.num_shards;
 	uint64_t objs_per_shard =
 	  (num_shards) ? num_objects/num_shards : num_objects;
 	{
-	  bool warn = false;
+	  bool warn;
 	  stringstream ss;
-	  if (objs_per_shard > safe_max_objs_per_shard) {
-	    double over =
-	      100 - (safe_max_objs_per_shard/objs_per_shard * 100);
-	      ss << boost::format("OVER %4f%%") % over;
-	      warn = true;
+	  uint64_t fill_pct = objs_per_shard * 100 / safe_max_objs_per_shard;
+	  if (fill_pct > 100) {
+	    ss << "OVER " << fill_pct << "%";
+	    warn = true;
+	  } else if (fill_pct >= shard_warn_pct) {
+	    ss << "WARN " << fill_pct << "%";
+	    warn = true;
 	  } else {
-	    double fill_pct =
-	      objs_per_shard / safe_max_objs_per_shard * 100;
-	    if (fill_pct >= shard_warn_pct) {
-	      ss << boost::format("WARN %4f%%") % fill_pct;
-	      warn = true;
-	    } else {
-	      ss << "OK";
-	    }
+	    ss << "OK";
+	    warn = false;
 	  }
 
-	  if (warn || (! warnings_only)) {
+	  if (warn || !warnings_only) {
 	    formatter->open_object_section("bucket");
 	    formatter->dump_string("bucket", bucket->get_name());
 	    formatter->dump_string("tenant", bucket->get_tenant());


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48725

---

backport of https://github.com/ceph/ceph/pull/28489
parent tracker: https://tracker.ceph.com/issues/40255

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh