### PR TITLE
nautilus: rbd-nbd: reexpand the conf meta in child process

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,25 +1,6 @@
-14.2.16
+14.2.17
 -------
 
-* The structured output of ``ceph status`` or ``ceph -s`` is now more
-  concise, particularly the ``mgrmap`` and ``monmap`` sections, and the
-  structure of the ``osdmap`` section has been cleaned up.
-
-* MON: The cluster log now logs health detail every ``mon_health_to_clog_interval``,
-  which has been changed from 1hr to 10min. Logging of health detail will be
-  skipped if there is no change in health summary since last known.
-
-
-14.2.15
--------
-
-* MGR: progress module can now be turned on/off, using the commands:
-  ``ceph progress on`` and ``ceph progress off``.
-
-
-14.2.13
--------
-
-* This release fixes a regression introduced in 14.2.12 which broke deployments
-  that referred to MON hosts using DNS names instead of IP addresses in the
-  ``mon_host`` parameter in ``/etc/ceph/ceph.conf``.
+* $pid expansion in config paths like `admin_socket` will now properly expand
+  to the daemon pid for commands like `ceph-mds` or `ceph-osd`. Previously only
+  `ceph-fuse`/`rbd-nbd` expanded `$pid` with the actual daemon pid.

--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -167,9 +167,8 @@ int main(int argc, const char **argv, const char *envp[]) {
   }
 
   {
-    g_ceph_context->_conf.finalize_reexpand_meta();
     common_init_finish(g_ceph_context);
-   
+
     init_async_signal_handler();
     register_async_signal_handler(SIGHUP, sighup_handler);
 

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -101,7 +101,7 @@ public:
   std::map<std::string,std::string> ignored_mon_values;
 
   /// original raw values saved that may need to re-expand at certain time
-  mutable std::map<std::string, std::string> may_reexpand_meta;
+  mutable std::vector<std::string> may_reexpand_meta;
 
   /// encoded, cached copy of of values + ignored_mon_values
   bufferlist values_bl;

--- a/src/common/config_proxy.h
+++ b/src/common/config_proxy.h
@@ -193,7 +193,6 @@ public:
     rev_obs_map_t rev_obs;
     if (config.finalize_reexpand_meta(values, obs_mgr)) {
       _gather_changes(values.changed, &rev_obs, nullptr);
-      values.changed.clear();
     }
 
     call_observers(locker, rev_obs);
@@ -250,7 +249,6 @@ public:
     if (!values.cluster.empty()) {
       // meta expands could have modified anything.  Copy it all out again.
       _gather_changes(values.changed, &rev_obs, oss);
-      values.changed.clear();
     }
 
     call_observers(locker, rev_obs);
@@ -262,6 +260,7 @@ public:
       [this, rev_obs](md_config_obs_t *obs, const std::string &key) {
         map_observer_changes(obs, key, rev_obs);
       }, oss);
+      changes.clear();
   }
   int set_val(const std::string& key, const std::string& s,
               std::stringstream* err_ss=nullptr) {
@@ -284,7 +283,6 @@ public:
 
     rev_obs_map_t rev_obs;
     _gather_changes(values.changed, &rev_obs, nullptr);
-    values.changed.clear();
 
     call_observers(locker, rev_obs);
     return ret;
@@ -295,7 +293,6 @@ public:
 
     rev_obs_map_t rev_obs;
     _gather_changes(values.changed, &rev_obs, oss);
-    values.changed.clear();
 
     call_observers(locker, rev_obs);
     return ret;

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -480,6 +480,9 @@ int reopen_as_null(CephContext *cct, int fd)
 
 void global_init_postfork_start(CephContext *cct)
 {
+  // reexpand the meta in child process
+  cct->_conf.finalize_reexpand_meta();
+
   // restart log thread
   cct->_log->start();
   cct->notify_post_fork();

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -1159,7 +1159,6 @@ static int do_map(int argc, const char *argv[], Config *cfg)
     global_init_postfork_start(g_ceph_context);
   }
 
-  g_ceph_context->_conf.finalize_reexpand_meta();
   common_init_finish(g_ceph_context);
   global_init_chdir(g_ceph_context);
 

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -1159,6 +1159,7 @@ static int do_map(int argc, const char *argv[], Config *cfg)
     global_init_postfork_start(g_ceph_context);
   }
 
+  g_ceph_context->_conf.finalize_reexpand_meta();
   common_init_finish(g_ceph_context);
   global_init_chdir(g_ceph_context);
 


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/48083
* https://tracker.ceph.com/issues/49036

---

backport of

* https://github.com/ceph/ceph/pull/37898
* https://github.com/ceph/ceph/pull/38058

parent trackers:

* https://tracker.ceph.com/issues/48046
* https://tracker.ceph.com/issues/48240

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh