### PR TITLE
nautilus: rbd: librbd: update hidden global config when removing pool config override

### DIFF
--- a/src/librbd/api/PoolMetadata.cc
+++ b/src/librbd/api/PoolMetadata.cc
@@ -15,6 +15,32 @@
 namespace librbd {
 namespace api {
 
+namespace {
+
+void update_pool_timestamp(librados::IoCtx& io_ctx) {
+  CephContext *cct = (CephContext *)io_ctx.cct();
+
+  auto now = ceph_clock_now();
+  std::string cmd =
+    R"({)"
+      R"("prefix": "config set", )"
+      R"("who": "global", )"
+      R"("name": "rbd_config_pool_override_update_timestamp", )"
+      R"("value": ")" + stringify(now.sec()) + R"(")"
+    R"(})";
+
+  librados::Rados rados(io_ctx);
+  bufferlist in_bl;
+  std::string ss;
+  int r = rados.mon_command(cmd, in_bl, nullptr, &ss);
+  if (r < 0) {
+    lderr(cct) << "failed to notify clients of pool config update: "
+               << cpp_strerror(r) << dendl;
+  }
+}
+
+} // anonymous namespace
+
 template <typename I>
 int PoolMetadata<I>::get(librados::IoCtx& io_ctx,
                      const std::string &key, std::string *value) {
@@ -34,7 +60,7 @@ int PoolMetadata<I>::set(librados::IoCtx& io_ctx, const std::string &key,
                          const std::string &value) {
   CephContext *cct = (CephContext *)io_ctx.cct();
 
-  bool update_pool_timestamp = false;
+  bool need_update_pool_timestamp = false;
 
   std::string config_key;
   if (util::is_metadata_config_override(key, &config_key)) {
@@ -50,7 +76,7 @@ int PoolMetadata<I>::set(librados::IoCtx& io_ctx, const std::string &key,
       return -EINVAL;
     }
 
-    update_pool_timestamp = true;
+    need_update_pool_timestamp = true;
   }
 
   ceph::bufferlist bl;
@@ -63,24 +89,8 @@ int PoolMetadata<I>::set(librados::IoCtx& io_ctx, const std::string &key,
     return r;
   }
 
-  if (update_pool_timestamp) {
-    auto now = ceph_clock_now();
-    std::string cmd =
-      R"({)"
-        R"("prefix": "config set", )"
-        R"("who": "global", )"
-        R"("name": "rbd_config_pool_override_update_timestamp", )"
-        R"("value": ")" + stringify(now.sec()) + R"(")"
-      R"(})";
-
-    librados::Rados rados(io_ctx);
-    bufferlist in_bl;
-    std::string ss;
-    r = rados.mon_command(cmd, in_bl, nullptr, &ss);
-    if (r < 0) {
-      lderr(cct) << "failed to notify clients of pool config update: "
-                 << cpp_strerror(r) << dendl;
-    }
+  if (need_update_pool_timestamp) {
+    update_pool_timestamp(io_ctx);
   }
 
   return 0;
@@ -107,6 +117,11 @@ int PoolMetadata<I>::remove(librados::IoCtx& io_ctx, const std::string &key) {
     lderr(cct) << "failed removing metadata " << key << ": " << cpp_strerror(r)
                << dendl;
     return r;
+  }
+
+  std::string config_key;
+  if (util::is_metadata_config_override(key, &config_key)) {
+    update_pool_timestamp(io_ctx);
   }
 
   return 0;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48224

---

backport of https://github.com/ceph/ceph/pull/37977
parent tracker: https://tracker.ceph.com/issues/48145

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh