### PR TITLE
nautilus: qa: krbd_stable_pages_required.sh: move to stable_writes attribute

### DIFF
--- a/qa/suites/krbd/wac/sysfs/tasks/stable_pages_required.yaml
+++ b/qa/suites/krbd/wac/sysfs/tasks/stable_pages_required.yaml
@@ -1,5 +1,0 @@
-tasks:
-- workunit:
-    clients:
-      all:
-        - rbd/krbd_stable_pages_required.sh

--- a/qa/suites/krbd/wac/sysfs/tasks/stable_writes.yaml
+++ b/qa/suites/krbd/wac/sysfs/tasks/stable_writes.yaml
@@ -1,0 +1,5 @@
+tasks:
+- workunit:
+    clients:
+      all:
+        - rbd/krbd_stable_writes.sh

--- a/qa/workunits/rbd/krbd_stable_writes.sh
+++ b/qa/workunits/rbd/krbd_stable_writes.sh
@@ -2,16 +2,17 @@
 
 set -ex
 
-IMAGE_NAME="stable-pages-required-test"
+IMAGE_NAME="stable-writes-test"
 
 rbd create --size 1 $IMAGE_NAME
 DEV=$(sudo rbd map $IMAGE_NAME)
 [[ $(blockdev --getsize64 $DEV) -eq 1048576 ]]
-grep -q 1 /sys/block/${DEV#/dev/}/bdi/stable_pages_required
+grep -q 1 /sys/block/${DEV#/dev/}/queue/stable_writes
 
 rbd resize --size 2 $IMAGE_NAME
 [[ $(blockdev --getsize64 $DEV) -eq 2097152 ]]
-grep -q 1 /sys/block/${DEV#/dev/}/bdi/stable_pages_required
+grep -q 1 /sys/block/${DEV#/dev/}/queue/stable_writes
+
 sudo rbd unmap $DEV
 
 echo OK


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48675

---

backport of https://github.com/ceph/ceph/pull/38638
parent tracker: https://tracker.ceph.com/issues/48232

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh