### PR TITLE
doc: `tee -i` to replace `tee` in libvirt config

### DIFF
--- a/doc/rbd/libvirt.rst
+++ b/doc/rbd/libvirt.rst
@@ -247,7 +247,7 @@ commands, refer to `Virsh Command Reference`_.
 
 #. Get the ``client.libvirt`` key and save the key string to a file. ::
 
-	ceph auth get-key client.libvirt | sudo tee client.libvirt.key
+	ceph auth get-key client.libvirt | sudo tee -i client.libvirt.key
 
 #. Set the UUID of the secret. :: 
 


### PR DESCRIPTION
[component]: [short description]
doc: `tee -i` to replace `tee` in libvirt config

[A longer multiline description]
while exporting a key to a file, `tee` escapes at characters like `/` which can be part of the key, `tee -i` prevents this.

Fixes: a document issue
Signed-off-by: Dennis TGC <12065502+dennisTGC@users.noreply.github.com>

