### PR TITLE
octopus: cmake: add empty RPATH to ceph-diff-sorted

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -90,6 +90,9 @@ install(TARGETS osdmaptool DESTINATION bin)
 
 set(ceph-diff-sorted_srcs ceph-diff-sorted.cc)
 add_executable(ceph-diff-sorted ${ceph-diff-sorted_srcs})
+set_target_properties(ceph-diff-sorted PROPERTIES
+  SKIP_RPATH TRUE
+  INSTALL_RPATH "")
 install(TARGETS ceph-diff-sorted DESTINATION bin)
 
 if(WITH_TESTS)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48828

---

backport of https://github.com/ceph/ceph/pull/36120
parent tracker: https://tracker.ceph.com/issues/46553

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh