### PR TITLE
common/options: Set pacific+ rocksdb column family options.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4530,7 +4530,7 @@ std::vector<Option> get_global_options() {
     .set_description("Enable use of rocksdb column families for bluestore metadata"),
 
     Option("bluestore_rocksdb_cfs", Option::TYPE_STR, Option::LEVEL_DEV)
-    .set_default("m(3) p(3,0-12) O(3,0-13) L")
+    .set_default("m(3) p(3,0-12) O(3,0-13) L P")
     .set_description("Definition of column families and their sharding")
     .set_long_description("Space separated list of elements: column_def [ '=' rocksdb_options ]. "
 			  "column_def := column_name [ '(' shard_count [ ',' hash_begin '-' [ hash_end ] ] ')' ]. "


### PR DESCRIPTION
This PR changes the default bluestore rocksdb column families for pacific to also include separate pgmeta and allocation CFs so that we can more easily tweak per-column family settings.  A variety of tests were performed with different memtable sizes.  First size is the global value, with any specific column family memtable sizes after.  These tests show performance/compaction stats for librbd 4KB random write performance on a single P4510 NVMe on o01 (centos stream, kernel 5.9.1).

Generally we see the same behavior as in previous tests.  Larger memtable sizes results in much lower write-amplification, but also result in higher CPU usage overhead (Which in this case results in lower performance but may not always depending on whether or not we are disk or CPU limited).  Changing specific column family memtable sizes does not yet result in a best-of-both-worlds (low CPU usage, low write-amp) result like we were hoping.  Thus, this PR does not attempt to change the default memtable size pending additional R&D by @benhanokh.

For reference the column families are mapped in master right now to these characters:

```
const string PREFIX_SUPER = "S";       // field -> value
const string PREFIX_STAT = "T";        // field -> value(int64 array)
const string PREFIX_COLL = "C";        // collection name -> cnode_t
const string PREFIX_OBJ = "O";         // object name -> onode_t
const string PREFIX_OMAP = "M";        // u64 + keyname -> value
const string PREFIX_PGMETA_OMAP = "P"; // u64 + keyname -> value(for meta coll)
const string PREFIX_PERPOOL_OMAP = "m"; // s64 + u64 + keyname -> value
const string PREFIX_PERPG_OMAP = "p";   // u64(pool) + u32(hash) + u64(id) + keyname -> value
const string PREFIX_DEFERRED = "L";    // id -> deferred_transaction_t
const string PREFIX_ALLOC = "B";       // u64 offset -> u64 length (freelist)
const string PREFIX_ALLOC_BITMAP = "b";// (see BitmapFreelistManager)
const string PREFIX_SHARED_BLOB = "X"; // u64 offset -> shared_blob_t
const string PREFIX_ZONED_FM_META = "Z";  // (see ZonedFreelistManager)
const string PREFIX_ZONED_FM_INFO = "z";  // (see ZonedFreelistManager)
const string PREFIX_ZONED_CL_INFO = "G";  // (per-zone cleaner metadata
```

512GB prefill + 5 minute test
Stat | Master (256M) | wip (256M) | wip (64M) | wip (16M) | wip (16M, P=256M) | wip (16M, O=256M) | wip (16M, b=256M)
-- | -- | -- | -- | -- | -- | -- | --
fio IOPs | 70567 | 70310 | 79477 | **83659** | 76929 | 77386 | 78569
fio Data Written (GB) | 86.8 | 86.4 | 97.7 | 102.8 | 94.5 | 95.0 | 96.6
Total OSD Log Duration (s) | 561.9 | 541.0 | 550.4 | 565.9 | 547.3 | 550.8 | 572.4
Number of Compaction Events | 82 | 100 | 227 | 714 | 523 | 379 | 687
Avg Compaction Time (s) | 0.83 | 0.63 | 0.56 | 0.45 | 0.50 | **0.37** | 0.44
Total Compaction Time (s) | 68.0 | **62.6** | 127.2 | 320.3 | 263.7 | 140.4 | 305.0
Avg Output Size: (MB) | 170.3 | 141.4 | 154.9 | 162.6 | 190.2 | 90.2 | 168.6
Total Output Size: (MB) | **13966.0** | **14137.2** | 35171.0 | 116105.4 | 99456.3 | 34192.2 | 115820.6
Total Input Records | 164901992 | **149334868** | 241820924 | 481170200 | 374639379 | 301355572 | 436425178
Total Output Records | 58376761 | **45085484** | 95567871 | 312373450 | 238077371 | 164414360 | 282619484
Avg Output Throughput (MB/s) | 240.2 | 221.8 | 267.8 | 343.1 | 365.0 | 243.9 | 358.8
Avg Input Records/s | 1898399 | 2405394 | 1972649 | 1591836 | 1344631 | 2137686 | 1536212
Avg Output Records/s | 757860 | 694818 | 733028 | 969363 | 851176 | 1154035 | 938992
Avg Output/Input Ratio | 0.475 | 0.407 | 0.474 | 0.666 | 0.721 | 0.515 | 0.675
_**DB Overhead (excl. WAL)**_ | _**15.71%**_ | _**15.98%**_ | _35.16%_ | _110.30%_ | _102.78%_ | _35.15%_ | _117.09%_




## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
