### PR TITLE
osd/pg_scrubber: do not print log in dtors

### DIFF
--- a/src/osd/pg_scrubber.cc
+++ b/src/osd/pg_scrubber.cc
@@ -1790,10 +1790,7 @@ void PgScrubber::handle_query_state(ceph::Formatter* f)
   f->close_section();
 }
 
-PgScrubber::~PgScrubber()
-{
-  dout(10) << __func__ << dendl;
-}
+PgScrubber::~PgScrubber() = default;
 
 PgScrubber::PgScrubber(PG* pg)
     : m_pg{pg}
@@ -2041,8 +2038,6 @@ ReplicaReservations::~ReplicaReservations()
   // send un-reserve messages to all reserved replicas. We do not wait for answer (there
   // wouldn't be one). Other incoming messages will be discarded on the way, by our
   // owner.
-  dout(10) << __func__ << " " << m_reserved_peers << dendl;
-
   epoch_t epoch = m_pg->get_osdmap_epoch();
 
   for (auto& p : m_reserved_peers) {
@@ -2149,7 +2144,6 @@ LocalReservation::~LocalReservation()
   if (m_holding_local_reservation) {
     m_holding_local_reservation = false;
     m_osds->dec_scrubs_local();
-    dout(20) << __func__ << ": local OSD scrub resources freed" << dendl;
   }
 }
 
@@ -2179,7 +2173,6 @@ ReservedByRemotePrimary::~ReservedByRemotePrimary()
   if (m_reserved_by_remote_primary) {
     m_reserved_by_remote_primary = false;
     m_osds->dec_scrubs_remote();
-    dout(20) << __func__ << ": scrub resources held for Primary were freed" << dendl;
   }
 }
 

--- a/src/osd/scrub_machine.cc
+++ b/src/osd/scrub_machine.cc
@@ -413,10 +413,7 @@ ScrubMachine::ScrubMachine(PG* pg, ScrubMachineListener* pg_scrub)
   dout(15) << "ScrubMachine created " << m_pg_id << dendl;
 }
 
-ScrubMachine::~ScrubMachine()
-{
-  dout(20) << "~ScrubMachine " << m_pg_id << dendl;
-}
+ScrubMachine::~ScrubMachine() = default;
 
 // -------- for replicas -----------------------------------------------------
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
