### PR TITLE
octopus: mgr/dashboard: fix Reads/Writes ratio of Clients IOPS donut chart

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.spec.ts
@@ -220,15 +220,16 @@ describe('HealthComponent', () => {
   });
 
   it('event binding "prepareReadWriteRatio" is called', () => {
-    const prepareReadWriteRatio = spyOn(component, 'prepareReadWriteRatio');
+    const prepareReadWriteRatio = spyOn(component, 'prepareReadWriteRatio').and.callThrough();
 
     const payload = _.cloneDeep(healthPayload);
     payload.client_perf['read_op_per_sec'] = 1;
-    payload.client_perf['write_op_per_sec'] = 1;
+    payload.client_perf['write_op_per_sec'] = 3;
     getHealthSpy.and.returnValue(of(payload));
     fixture.detectChanges();
 
     expect(prepareReadWriteRatio).toHaveBeenCalled();
+    expect(prepareReadWriteRatio.calls.mostRecent().args[0].dataset[0].data).toEqual([25, 75]);
   });
 
   it('event binding "prepareRawUsage" is called', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
@@ -94,7 +94,7 @@ export class HealthComponent implements OnInit, OnDestroy {
         this.healthData.client_perf.read_op_per_sec
       )} ${this.i18n(`/s`)}`
     );
-    ratioData.push(this.healthData.client_perf.read_op_per_sec);
+    ratioData.push(this.calcPercentage(this.healthData.client_perf.read_op_per_sec, total));
     ratioLabels.push(
       `${this.i18n(`Writes`)}: ${this.dimless.transform(
         this.healthData.client_perf.write_op_per_sec


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48809

---

backport of https://github.com/ceph/ceph/pull/38720
parent tracker: https://tracker.ceph.com/issues/48717

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh