### PR TITLE
octopus: mgr/dashboard: Temporary User Lockout if 10 Invalid Login attempts

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/auth.py
+++ b/src/pybind/mgr/dashboard/controllers/auth.py
@@ -7,8 +7,9 @@ import cherrypy
 from . import ApiController, RESTController, \
     allow_empty_body
 from .. import mgr
-from ..exceptions import DashboardException
+from ..exceptions import InvalidCredentialsError, UserDoesNotExist
 from ..services.auth import AuthManager, JwtManager
+from ..settings import Settings
 
 
 logger = logging.getLogger('controllers.auth')
@@ -19,33 +20,48 @@ class Auth(RESTController):
     """
     Provide authenticates and returns JWT token.
     """
-
     def create(self, username, password):
         user_data = AuthManager.authenticate(username, password)
         user_perms, pwd_expiration_date, pwd_update_required = None, None, None
-        if user_data:
-            user_perms = user_data.get('permissions')
-            pwd_expiration_date = user_data.get('pwdExpirationDate', None)
-            pwd_update_required = user_data.get('pwdUpdateRequired', False)
+        max_attempt = Settings.ACCOUNT_LOCKOUT_ATTEMPTS
+        if max_attempt == 0 or mgr.ACCESS_CTRL_DB.get_attempt(username) < max_attempt:
+            if user_data:
+                user_perms = user_data.get('permissions')
+                pwd_expiration_date = user_data.get('pwdExpirationDate', None)
+                pwd_update_required = user_data.get('pwdUpdateRequired', False)
 
-        if user_perms is not None:
-            logger.debug('Login successful')
-            token = JwtManager.gen_token(username)
-            token = token.decode('utf-8')
-            cherrypy.response.headers['Authorization'] = "Bearer: {}".format(token)
-            return {
-                'token': token,
-                'username': username,
-                'permissions': user_perms,
-                'pwdExpirationDate': pwd_expiration_date,
-                'sso': mgr.SSO_DB.protocol == 'saml2',
-                'pwdUpdateRequired': pwd_update_required
-            }
-
-        logger.debug('Login failed')
-        raise DashboardException(msg='Invalid credentials',
-                                 code='invalid_credentials',
-                                 component='auth')
+            if user_perms is not None:
+                logger.info('Login successful: %s', username)
+                mgr.ACCESS_CTRL_DB.reset_attempt(username)
+                mgr.ACCESS_CTRL_DB.save()
+                token = JwtManager.gen_token(username)
+                token = token.decode('utf-8')
+                cherrypy.response.headers['Authorization'] = "Bearer: {}".format(token)
+                return {
+                    'token': token,
+                    'username': username,
+                    'permissions': user_perms,
+                    'pwdExpirationDate': pwd_expiration_date,
+                    'sso': mgr.SSO_DB.protocol == 'saml2',
+                    'pwdUpdateRequired': pwd_update_required
+                }
+            mgr.ACCESS_CTRL_DB.increment_attempt(username)
+            mgr.ACCESS_CTRL_DB.save()
+        else:
+            try:
+                user = mgr.ACCESS_CTRL_DB.get_user(username)
+                user.enabled = False
+                mgr.ACCESS_CTRL_DB.save()
+                logging.warning('Maximum number of unsuccessful log-in attempts '
+                                '(%d) reached for '
+                                'username "%s" so the account was blocked. '
+                                'An administrator will need to re-enable the account',
+                                max_attempt, username)
+                raise InvalidCredentialsError
+            except UserDoesNotExist:
+                raise InvalidCredentialsError
+        logger.info('Login failed: %s', username)
+        raise InvalidCredentialsError
 
     @RESTController.Collection('POST')
     @allow_empty_body

--- a/src/pybind/mgr/dashboard/exceptions.py
+++ b/src/pybind/mgr/dashboard/exceptions.py
@@ -45,6 +45,13 @@ class DashboardException(Exception):
         return str(abs(self.errno)) if self.errno is not None else 'Error'
 
 
+class InvalidCredentialsError(DashboardException):
+    def __init__(self):
+        super().__init__(msg='Invalid credentials',
+                         code='invalid_credentials',
+                         component='auth')
+
+
 # access control module exceptions
 class RoleAlreadyExists(Exception):
     def __init__(self, name):

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -21,6 +21,9 @@ class Options(object):
     ENABLE_BROWSABLE_API = (True, bool)
     REST_REQUESTS_TIMEOUT = (45, int)
 
+    # AUTHENTICATION ATTEMPTS
+    ACCOUNT_LOCKOUT_ATTEMPTS = (10, int)
+
     # API auditing
     AUDIT_API_ENABLED = (False, bool)
     AUDIT_API_LOG_PAYLOAD = (True, bool)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48794

---

backport of https://github.com/ceph/ceph/pull/38316
parent tracker: https://tracker.ceph.com/issues/40914

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh