### PR TITLE
qa/rgw: reenable valgrind in rgw/verify suite

### DIFF
--- a/qa/suites/rgw/verify/tasks/0-install.yaml
+++ b/qa/suites/rgw/verify/tasks/0-install.yaml
@@ -1,14 +1,9 @@
-# see http://tracker.ceph.com/issues/20360 and http://tracker.ceph.com/issues/18126
-os_type: centos
-
 tasks:
 - install:
-#    flavor: notcmalloc
 - ceph:
 - openssl_keys:
 - rgw:
     client.0:
-#      valgrind: [--tool=memcheck, --max-threads=1024] # http://tracker.ceph.com/issues/25214
 
 overrides:
   ceph:

--- a/qa/suites/rgw/verify/validater/valgrind.yaml
+++ b/qa/suites/rgw/verify/validater/valgrind.yaml
@@ -5,11 +5,11 @@ os_version: "8.0"
 overrides:
   install:
     ceph:
-#      flavor: notcmalloc
+      flavor: notcmalloc
       #debuginfo: true
   rgw:
     client.0:
-      #valgrind: [--tool=memcheck, --max-threads=1024] # http://tracker.ceph.com/issues/25214
+      valgrind: [--tool=memcheck, --max-threads=1024] # http://tracker.ceph.com/issues/25214
   ceph:
     conf:
       global:

--- a/qa/suites/rgw/verify/validater/valgrind.yaml
+++ b/qa/suites/rgw/verify/validater/valgrind.yaml
@@ -7,6 +7,9 @@ overrides:
     ceph:
 #      flavor: notcmalloc
       #debuginfo: true
+  rgw:
+    client.0:
+      #valgrind: [--tool=memcheck, --max-threads=1024] # http://tracker.ceph.com/issues/25214
   ceph:
     conf:
       global:


### PR DESCRIPTION
this had been disabled during py3 conversion when we had to pin ubuntu, but never turned back on when we switched back to centos

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
