### PR TITLE
test/objectstore: include missing headerfile for get_csum_type_string

### DIFF
--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -6,6 +6,7 @@
 #include "gtest/gtest.h"
 #include "include/stringify.h"
 #include "common/ceph_time.h"
+#include "common/Checksummer.h"
 #include "os/bluestore/BlueStore.h"
 #include "os/bluestore/AvlAllocator.h"
 #include "common/ceph_argparse.h"


### PR DESCRIPTION
Otherwise during linking there is no matching definition:
```
[ 88%] Linking CXX executable ../../../bin/unittest_bluestore_types
/usr/local/bin/ld: CMakeFiles/unittest_bluestore_types.dir/test_bluestore_types.cc.o: in function `bluestore_blob_t_csum_bench_Test::TestBody()':
/home/jenkins/workspace/ceph-master-compile/src/test/objectstore/test_bluestore_types.cc:332: undefined reference to `std::__1::basic_ostream<char, std::__1::char_traits<char> >& std::operator<< <long long, std::__1::ratio<1l, 1000000000l> >(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > const&)'
```


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>