### PR TITLE
mgr/orchestrator: add maintenance mode for new hosts

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -322,7 +322,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         return cast(str, self.get_module_option("orchestrator"))
 
     @_cli_write_command('orch host add')
-    def _add_host(self, hostname: str, addr: Optional[str] = None, labels: Optional[List[str]] = None, maintenance: bool = False) -> HandleCommandResult:
+    def _add_host(self, hostname: str, addr: Optional[str] = None, labels: Optional[List[str]] = None, maintenance: Optional[bool] = False) -> HandleCommandResult:
         """Add a host"""
         _status = 'maintenance' if maintenance else ''
         s = HostSpec(hostname=hostname, addr=addr, labels=labels, status=_status)

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -322,9 +322,10 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         return cast(str, self.get_module_option("orchestrator"))
 
     @_cli_write_command('orch host add')
-    def _add_host(self, hostname: str, addr: Optional[str] = None, labels: Optional[List[str]] = None) -> HandleCommandResult:
+    def _add_host(self, hostname: str, addr: Optional[str] = None, labels: Optional[List[str]] = None, maintenance: bool = False) -> HandleCommandResult:
         """Add a host"""
-        s = HostSpec(hostname=hostname, addr=addr, labels=labels)
+        _status = 'maintenance' if maintenance else ''
+        s = HostSpec(hostname=hostname, addr=addr, labels=labels, status=_status)
         completion = self.add_host(s)
         self._orchestrator_wait([completion])
         raise_if_exception(completion)

--- a/src/python-common/ceph/deployment/hostspec.py
+++ b/src/python-common/ceph/deployment/hostspec.py
@@ -40,7 +40,8 @@ class HostSpec(object):
     def from_json(cls, host_spec):
         _cls = cls(host_spec['hostname'],
                    host_spec['addr'] if 'addr' in host_spec else None,
-                   host_spec['labels'] if 'labels' in host_spec else None)
+                   host_spec['labels'] if 'labels' in host_spec else None,
+                   host_spec['status'] if 'status' in host_spec else None)
         return _cls
 
     def __repr__(self):


### PR DESCRIPTION
This patch provides a --maintenance switch to the 'host add'
process so hosts can be immediately in maintenance and not
attract any service deployments until they exit maintenance.
This provides a simple way to drip feed new hosts into the
cluster.

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>