### PR TITLE
doc/rados: remove unused osd heartbeat option

### DIFF
--- a/doc/rados/configuration/mon-osd-interaction.rst
+++ b/doc/rados/configuration/mon-osd-interaction.rst
@@ -351,13 +351,6 @@ Monitor Settings
 OSD Settings
 ------------
 
-``osd_heartbeat_address``
-
-:Description: An Ceph OSD Daemon's network address for heartbeats.
-:Type: Address
-:Default: The host address.
-
-
 ``osd_heartbeat_interval``
 
 :Description: How often an Ceph OSD Daemon pings its peers (in seconds).
@@ -401,12 +394,3 @@ OSD Settings
 
 :Type: 32-bit Integer
 :Default: ``5``
-
-
-``osd_mon_ack_timeout``
-
-:Description: The number of seconds to wait for a Ceph Monitor to acknowledge a
-              request for statistics.
-
-:Type: 32-bit Integer
-:Default: ``30``


### PR DESCRIPTION
Since commit a5f9ca, option osd_mon_ack_timeout was removed, change
doc accordingly.

Signed-off-by: haoyixing <haoyixing@kuaishou.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
