### PR TITLE
mgr/cephadm: Put together default container images references

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1,7 +1,14 @@
 #!/usr/bin/python3
 
+# Default container images -----------------------------------------------------
 DEFAULT_IMAGE = 'docker.io/ceph/daemon-base:latest-master-devel'
 DEFAULT_IMAGE_IS_MASTER = True
+DEFAULT_PROMETHEUS_IMAGE = "docker.io/prom/prometheus:v2.18.1"
+DEFAULT_NODE_EXPORTER_IMAGE = "docker.io/prom/node-exporter:v0.18.1"
+DEFAULT_GRAFANA_IMAGE = "docker.io/ceph/ceph-grafana:6.7.4"
+DEFAULT_ALERT_MANAGER_IMAGE = "docker.io/prom/alertmanager:v0.20.0"
+# ------------------------------------------------------------------------------
+
 LATEST_STABLE_RELEASE = 'pacific'
 DATA_DIR = '/var/lib/ceph'
 LOG_DIR = '/var/log/ceph'
@@ -227,7 +234,7 @@ class Monitoring(object):
 
     components = {
         "prometheus": {
-            "image": "docker.io/prom/prometheus:v2.18.1",
+            "image": DEFAULT_PROMETHEUS_IMAGE,
             "cpus": '2',
             "memory": '4GB',
             "args": [
@@ -240,7 +247,7 @@ class Monitoring(object):
             ],
         },
         "node-exporter": {
-            "image": "docker.io/prom/node-exporter:v0.18.1",
+            "image": DEFAULT_NODE_EXPORTER_IMAGE,
             "cpus": "1",
             "memory": "1GB",
             "args": [
@@ -248,7 +255,7 @@ class Monitoring(object):
             ],
         },
         "grafana": {
-            "image": "docker.io/ceph/ceph-grafana:6.7.4",
+            "image": DEFAULT_GRAFANA_IMAGE,
             "cpus": "2",
             "memory": "4GB",
             "args": [],
@@ -260,7 +267,7 @@ class Monitoring(object):
             ],
         },
         "alertmanager": {
-            "image": "docker.io/prom/alertmanager:v0.20.0",
+            "image": DEFAULT_ALERT_MANAGER_IMAGE,
             "cpus": "2",
             "memory": "2GB",
             "args": [

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -86,6 +86,14 @@ Host *
 
 CEPH_TYPES = set(CEPH_UPGRADE_ORDER)
 
+# Default container images -----------------------------------------------------
+DEFAULT_IMAGE = 'docker.io/ceph/ceph'
+DEFAULT_PROMETHEUS_IMAGE = 'docker.io/prom/prometheus:v2.18.1'
+DEFAULT_NODE_EXPORTER_IMAGE = 'docker.io/prom/node-exporter:v0.18.1'
+DEFAULT_GRAFANA_IMAGE = 'docker.io/ceph/ceph-grafana:6.7.4'
+DEFAULT_ALERT_MANAGER_IMAGE = 'docker.io/prom/alertmanager:v0.20.0'
+# ------------------------------------------------------------------------------
+
 
 class CephadmCompletion(orchestrator.Completion[T]):
     def evaluate(self) -> None:
@@ -182,28 +190,28 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         ),
         Option(
             'container_image_base',
-            default='docker.io/ceph/ceph',
+            default=DEFAULT_IMAGE,
             desc='Container image name, without the tag',
             runtime=True,
         ),
         Option(
             'container_image_prometheus',
-            default='docker.io/prom/prometheus:v2.18.1',
+            default=DEFAULT_PROMETHEUS_IMAGE,
             desc='Prometheus container image',
         ),
         Option(
             'container_image_grafana',
-            default='docker.io/ceph/ceph-grafana:6.7.4',
+            default=DEFAULT_GRAFANA_IMAGE,
             desc='Prometheus container image',
         ),
         Option(
             'container_image_alertmanager',
-            default='docker.io/prom/alertmanager:v0.20.0',
+            default=DEFAULT_ALERT_MANAGER_IMAGE,
             desc='Prometheus container image',
         ),
         Option(
             'container_image_node_exporter',
-            default='docker.io/prom/node-exporter:v0.18.1',
+            default=DEFAULT_NODE_EXPORTER_IMAGE,
             desc='Prometheus container image',
         ),
         Option(


### PR DESCRIPTION
New constants for the default container images used for Ceph and the
monitoring stack.
Placed all in the same location in order to make easy downstream modifications
and future changes

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>