### PR TITLE
[WIP] cls/msg_fifo: implementation of cls message fifo

### DIFF
--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -42,9 +42,12 @@ struct create_meta
   std::uint64_t max_entry_size{0};
 
   bool exclusive{false};
+  
+  std::uint64_t visibility_timeout{0};
+  std::uint64_t retention_period{0};
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     encode(id, bl);
     encode(version, bl);
     encode(pool.name, bl);
@@ -53,10 +56,12 @@ struct create_meta
     encode(max_part_size, bl);
     encode(max_entry_size, bl);
     encode(exclusive, bl);
+    encode(visibility_timeout, bl);
+    encode(retention_period, bl);
     ENCODE_FINISH(bl);
   }
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     decode(id, bl);
     decode(version, bl);
     decode(pool.name, bl);
@@ -65,6 +70,10 @@ struct create_meta
     decode(max_part_size, bl);
     decode(max_entry_size, bl);
     decode(exclusive, bl);
+    if (struct_v >= 2) {
+      decode(visibility_timeout, bl);
+      decode(retention_period, bl);
+    }
     DECODE_FINISH(bl);
   }
 };
@@ -294,6 +303,28 @@ struct get_part_info_reply
 };
 WRITE_CLASS_ENCODER(get_part_info_reply)
 
+using get_part_visible_offset = list_part;
+
+struct get_part_visible_offset_reply
+{
+  std::uint64_t ofs{0};
+  bool invisible_part{false};
+
+  void encode(ceph::buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(ofs, bl);
+    encode(invisible_part, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(ceph::buffer::list::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(ofs, bl);
+    decode(invisible_part, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(get_part_visible_offset_reply)
+
 inline constexpr auto CLASS = "fifo";
 inline constexpr auto CREATE_META = "create_meta";
 inline constexpr auto GET_META = "get_meta";
@@ -303,4 +334,5 @@ inline constexpr auto PUSH_PART = "push_part";
 inline constexpr auto TRIM_PART = "trim_part";
 inline constexpr auto LIST_PART = "part_list";
 inline constexpr auto GET_PART_INFO = "get_part_info";
+inline constexpr auto GET_PART_VISIBLE_OFFSET = "get_part_visible_offset";
 } // namespace rados::cls::fifo::op

--- a/src/cls/fifo/cls_fifo_ops.h
+++ b/src/cls/fifo/cls_fifo_ops.h
@@ -325,6 +325,49 @@ struct get_part_visible_offset_reply
 };
 WRITE_CLASS_ENCODER(get_part_visible_offset_reply)
 
+struct get_part_trim_offset
+{
+  std::optional<std::string> tag;
+  std::uint64_t start_ofs{0};
+  std::uint64_t end_ofs{0};
+  bool exclusive = false;
+
+  void encode(ceph::buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(tag, bl);
+    encode(start_ofs, bl);
+    encode(end_ofs, bl);
+    encode(exclusive, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(ceph::buffer::list::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(tag, bl);
+    decode(start_ofs, bl);
+    decode(end_ofs, bl);
+    decode(exclusive, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(get_part_trim_offset)
+
+struct get_part_trim_offset_reply
+{
+  std::uint64_t ofs{0};
+
+  void encode(ceph::buffer::list& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(ofs, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(ceph::buffer::list::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(ofs, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(get_part_trim_offset_reply)
+
 inline constexpr auto CLASS = "fifo";
 inline constexpr auto CREATE_META = "create_meta";
 inline constexpr auto GET_META = "get_meta";
@@ -335,4 +378,5 @@ inline constexpr auto TRIM_PART = "trim_part";
 inline constexpr auto LIST_PART = "part_list";
 inline constexpr auto GET_PART_INFO = "get_part_info";
 inline constexpr auto GET_PART_VISIBLE_OFFSET = "get_part_visible_offset";
+inline constexpr auto GET_PART_TRIM_OFFSET = "get_part_trim_offset";
 } // namespace rados::cls::fifo::op

--- a/src/cls/fifo/cls_fifo_types.h
+++ b/src/cls/fifo/cls_fifo_types.h
@@ -559,6 +559,7 @@ struct part_header {
   std::uint64_t max_index{0};
   ceph::real_time max_time;
   segment_map listed_segments;
+  segment_map trimmed_segments;
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 1, bl);
@@ -572,6 +573,7 @@ struct part_header {
     encode(max_index, bl);
     encode(max_time, bl);
     rados::cls::fifo::encode(listed_segments, bl);
+    rados::cls::fifo::encode(trimmed_segments, bl);
     ENCODE_FINISH(bl);
   }
   void decode(ceph::buffer::list::const_iterator& bl) {
@@ -587,6 +589,7 @@ struct part_header {
     decode(max_time, bl);
     if (struct_v >= 2) {
       rados::cls::fifo::decode(listed_segments, bl);
+      rados::cls::fifo::decode(trimmed_segments, bl);
     }
     DECODE_FINISH(bl);
   }
@@ -603,6 +606,7 @@ inline std::ostream& operator <<(std::ostream& m, const part_header& p) {
 	   << "min_index: " << p.min_index << ", "
 	   << "max_index: " << p.max_index << ", "
 	   << "max_time: " << p.max_time << ", "
-     << "listed_offsets: {" << p.listed_segments << "}";
+     << "listed_offsets: {" << p.listed_segments << ", "
+     << "trimmed_offsets: {" << p.trimmed_segments << "}";
 }
 } // namespace rados::cls::fifo


### PR DESCRIPTION
Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

> notes:
> - this PR is not meant to be merged, the cls_msg_fifo should have its own implementation and should not be added as new functionality to the `cls_fifo`. however, as this would require some refactoring (to prevent code duplication) this will be done separately
> - this PR should be used for:
>   - review and test the core functionality of the `cls_msg_fifo`
>   - guide the refactoring work needed to avoid code duplication with `cls_fifo`
>   - have an initial estimation of the performance overhead of `cls_msg_fifo` compared to 'cls_msg_fifo`

`cls_msg_fifo` functional requirements:
- [x] allow multiple readers to list elements from the queue without listing the same entry twice (under regular operations)
- [x] each reader can (and should) use markers for listing in the same way it is done in `cls_fifo`
- [x] allow readers to trim segments from the queue based on start/end offsets
- [ ] use [visibility timeout](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html) to garantee "at-least-once" handling of the entries in the queue
- [ ] use "retention period" to trim entries that were listed but never trimmed (note that this functionality is different than the "retention period" that handles all entries and not just listed ones)
- [ ] add API to provide **approximated** queue length
- [ ] all APIs should be compliant with the matching AWS SNS APIs

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
