### PR TITLE
qa: add delays only for osd/mds

### DIFF
--- a/qa/suites/fs/thrash/multifs/msgr-failures/osd-mds-delay.yaml
+++ b/qa/suites/fs/thrash/multifs/msgr-failures/osd-mds-delay.yaml
@@ -1,9 +1,15 @@
 overrides:
   ceph:
     conf:
-      global:
+      osd:
         ms inject socket failures: 2500
-        ms inject delay type: osd mds
+        ms inject delay type: client mds
+        ms inject delay probability: .005
+        ms inject delay max: 1
+        mon client directed command retry: 5
+      mds:
+        ms inject socket failures: 2500
+        ms inject delay type: client mds osd
         ms inject delay probability: .005
         ms inject delay max: 1
         mon client directed command retry: 5

--- a/qa/suites/fs/thrash/workloads/msgr-failures/osd-mds-delay.yaml
+++ b/qa/suites/fs/thrash/workloads/msgr-failures/osd-mds-delay.yaml
@@ -1,9 +1,15 @@
 overrides:
   ceph:
     conf:
-      global:
+      osd:
         ms inject socket failures: 2500
-        ms inject delay type: osd mds
+        ms inject delay type: client mds
+        ms inject delay probability: .005
+        ms inject delay max: 1
+        mon client directed command retry: 5
+      mds:
+        ms inject socket failures: 2500
+        ms inject delay type: client mds osd
         ms inject delay probability: .005
         ms inject delay max: 1
         mon client directed command retry: 5


### PR DESCRIPTION
The delays were applied everywhere and needlessly interfere with test
commands sent to mons from the ceph admin command. Furthermore, the
delays would not affect the kernel client. Now the delays are performed
by the MDS on clients.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
