### PR TITLE
qa/rgw: don't add a certificate for nonexistent rgw.client.1

### DIFF
--- a/qa/suites/rgw/verify/proto/https.yaml
+++ b/qa/suites/rgw/verify/proto/https.yaml
@@ -4,17 +4,11 @@ overrides:
       client: client.0
       key-type: rsa:4096
       cn: teuthology
-      install: [client.0, client.1]
+      install: [client.0]
     rgw.client.0:
       client: client.0
-      ca: root
-      embed-key: true
-    rgw.client.1:
-      client: client.1
       ca: root
       embed-key: true
   rgw:
     client.0:
       ssl certificate: rgw.client.0
-    client.1:
-      ssl certificate: rgw.client.1


### PR DESCRIPTION
this override to the rgw task is causing the rgw/verify suite to start an extra radosgw

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
