### PR TITLE
nautilus: pybind/cephfs: fix missing terminating NULL char in readlink()'s C string

### DIFF
--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -1401,7 +1401,7 @@ cdef class LibCephFS(object):
                 ret = ceph_readlink(self.cluster, _path, buf, _size)
             if ret < 0:
                 raise make_ex(ret, "error in readlink")
-            return buf
+            return buf[:ret]
         finally:
             free(buf)
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48518

---

backport of https://github.com/ceph/ceph/pull/38367
parent tracker: https://tracker.ceph.com/issues/48408

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh