### PR TITLE
librbd: remove the first if  at api::group::list

### DIFF
--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -583,9 +583,6 @@ int Group<I>::list(IoCtx& io_ctx, vector<string> *names)
     map<string, string> groups;
     r = cls_client::group_dir_list(&io_ctx, RBD_GROUP_DIRECTORY, last_read,
                                    max_read, &groups);
-    if (r == -ENOENT) {
-      return 0; // Ignore missing rbd group directory. It means we don't have any groups yet.
-    }
     if (r < 0) {
       if (r != -ENOENT) {
         lderr(cct) << "error listing group in directory: "


### PR DESCRIPTION
At librbd::api::group::list,the code is redundant,like:
if (r == -ENOENT) {
    return 0; // Ignore missing rbd group directory. It means we don't have any groups yet.
}
I think the first if  can be removed.
fixed:https://tracker.ceph.com/issues/48866
Signed-off-by: lijiawei1@chinatelecom.cn
Reviewed-by: wuxuehan@chinatelecom.cn

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
