### PR TITLE
os/bluestore: fixing a dangling pointer

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8600,7 +8600,8 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
       for (it->lower_bound(string()); it->valid(); it->next()) {
         uint64_t pool;
         uint64_t omap_head;
-        const char *c = it->key().c_str();
+        string k = it->key();
+        const char *c = k.c_str();
         c = _key_decode_u64(c, &pool);
         c = _key_decode_u64(c, &omap_head);
         if (used_omap_head.count(omap_head) == 0 &&
@@ -8620,7 +8621,8 @@ int BlueStore::_fsck_on_open(BlueStore::FSCKDepth depth, bool repair)
         uint64_t pool;
         uint32_t hash;
         uint64_t omap_head;
-        const char* c = it->key().c_str();
+        string k = it->key();
+        const char* c = k.c_str();
         c = _key_decode_u64(c, &pool);
         c = _key_decode_u32(c, &hash);
         c = _key_decode_u64(c, &omap_head);


### PR DESCRIPTION
... and silencing compiler warnings:

Building CXX object src/os/CMakeFiles/os.dir/bluestore/BlueStore.cc.o
../src/os/bluestore/BlueStore.cc:8603:25: warning: object backing the pointer will be destroyed at the end of the full-expression [-Wdangling-gsl]
        const char *c = it->key().c_str();
                        ^~~~~~~~~
../src/os/bluestore/BlueStore.cc:8623:25: warning: object backing the pointer will be destroyed at the end of the full-expression [-Wdangling-gsl]
        const char* c = it->key().c_str();
                        ^~~~~~~~~
(reverting a very minor part of f9c95fa7fc7b0ee992c0249ff090fa7f751e9719)

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>

