### PR TITLE
osd/PG: fix no exit() call for PeeringState::Deleting state

### DIFF
--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -308,12 +308,12 @@ void PG::prepare_write(pg_info_t &info,
   }
 }
 
-ghobject_t PG::do_delete_work(ceph::os::Transaction &t,
-  ghobject_t _next)
+std::pair<ghobject_t, bool>
+PG::do_delete_work(ceph::os::Transaction &t, ghobject_t _next)
 {
   // TODO
   shard_services.dec_pg_num();
-  return _next;
+  return {_next, false};
 }
 
 void PG::scrub_requested(scrub_level_t scrub_level, scrub_type_t scrub_type)

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -328,8 +328,8 @@ public:
   void on_removal(ceph::os::Transaction &t) final {
     // TODO
   }
-  ghobject_t do_delete_work(ceph::os::Transaction &t,
-    ghobject_t _next) final;
+  std::pair<ghobject_t, bool>
+  do_delete_work(ceph::os::Transaction &t, ghobject_t _next) final;
 
   // merge/split not ready
   void clear_ready_to_merge() final {}

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -485,7 +485,7 @@ public:
     return std::make_unique<PG::PGLogEntryHandler>(this, &t);
   }
 
-  ghobject_t do_delete_work(ObjectStore::Transaction &t,
+  std::pair<ghobject_t, bool> do_delete_work(ObjectStore::Transaction &t,
     ghobject_t _next) override;
 
   void clear_ready_to_merge() override;

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -377,8 +377,8 @@ public:
     /// Notification of removal complete, t must be populated to complete removal
     virtual void on_removal(ObjectStore::Transaction &t) = 0;
     /// Perform incremental removal work
-    virtual ghobject_t do_delete_work(ObjectStore::Transaction &t,
-      ghobject_t _next) = 0;
+    virtual std::pair<ghobject_t, bool> do_delete_work(
+      ObjectStore::Transaction &t, ghobject_t _next) = 0;
 
     // ======================= PG Merge =========================
     virtual void clear_ready_to_merge() = 0;
@@ -1244,7 +1244,6 @@ public:
       boost::statechart::transition<DeleteInterrupted, WaitDeleteReserved>
       > reactions;
     ghobject_t next;
-    ceph::mono_clock::time_point start;
     explicit Deleting(my_context ctx);
     boost::statechart::result react(const DeleteSome &evt);
     void exit();


### PR DESCRIPTION
In fact we lacked the exit() call for PeeringState::Deleting before this patch. Presumably the instance was terminated within some exception handler which bypassed exit() call. 
The patch implements proper indication on removal completion hence forcing proper PeeringState::Deleting instance and overall state machine termination.

Signed-off-by: Igor Fedotov <ifedotov@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
