### PR TITLE
osd/PGLog: add roll_forward_to(to update crt) to PGLog update_missing

### DIFF
--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -1248,7 +1248,7 @@ public:
 		 pg_log_t&& olog,
 		 pg_shard_t from,
 		 pg_info_t &info, LogEntryHandler *rollbacker,
-		 bool &dirty_info, bool &dirty_big_info);
+		 bool &dirty_info, bool &dirty_big_info, bool *rollforwarded=nullptr);
 
   template <typename missing_type>
   static bool append_log_entries_update_missing(

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -1257,6 +1257,7 @@ public:
     bool maintain_rollback,
     IndexedLog *log,
     missing_type &missing,
+    bool *should_rollforward,
     LogEntryHandler *rollbacker,
     const DoutPrefixProvider *dpp) {
     bool invalidate_stats = false;
@@ -1266,8 +1267,11 @@ public:
     for (auto p = entries.begin(); p != entries.end(); ++p) {
       invalidate_stats = invalidate_stats || !p->is_error();
       if (log) {
-	ldpp_dout(dpp, 20) << "update missing, append " << *p << dendl;
-	log->add(*p);
+       log->add(*p);
+       ldpp_dout(dpp, 20) << "update missing, appended " << *p << dendl;
+       if (should_rollforward) {
+          *should_rollforward = true;
+       }
       }
       if (p->soid <= last_backfill &&
 	  !p->is_error()) {
@@ -1302,6 +1306,7 @@ public:
       true,
       &log,
       missing,
+      nullptr,
       rollbacker,
       this);
     if (!entries.empty()) {

--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -4114,6 +4114,7 @@ void PeeringState::merge_new_log_entries(
       NULL,
       pmissing,
       NULL,
+      nullptr,
       dpp);
     pinfo.last_update = info.last_update;
     pinfo.stats.stats_invalid = pinfo.stats.stats_invalid || invalidate_stats;

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -567,6 +567,7 @@ TEST_F(PGLogTest, merge_old_entry) {
     EXPECT_TRUE(t.empty());
     EXPECT_FALSE(missing.have_missing());
     EXPECT_TRUE(log.empty());
+    EXPECT_EQ(log.get_can_rollback_to(), eversion_t(0,0));
   }
 
   // the new entry (from the logs) has a version that is higher than
@@ -881,6 +882,7 @@ TEST_F(PGLogTest, merge_log) {
 
     EXPECT_FALSE(missing.have_missing());
     EXPECT_EQ(0U, log.log.size());
+    EXPECT_EQ(log.get_can_rollback_to(), eversion_t(0,0));
     EXPECT_EQ(stat_version, info.stats.version);
     EXPECT_TRUE(remove_snap.empty());
     EXPECT_EQ(last_backfill, info.last_backfill);
@@ -895,6 +897,7 @@ TEST_F(PGLogTest, merge_log) {
 
     EXPECT_FALSE(missing.have_missing());
     EXPECT_EQ(0U, log.log.size());
+    EXPECT_EQ(log.get_can_rollback_to(), eversion_t(0,0));
     EXPECT_EQ(stat_version, info.stats.version);
     EXPECT_TRUE(remove_snap.empty());
     EXPECT_TRUE(info.purged_snaps.empty());
@@ -907,6 +910,7 @@ TEST_F(PGLogTest, merge_log) {
   // copied from oinfo.stats but info.stats.reported_* is guaranteed to
   // never be replaced by a lower version
   {
+    //case: 1
     clear();
 
     pg_log_t olog;
@@ -930,6 +934,7 @@ TEST_F(PGLogTest, merge_log) {
     EXPECT_FALSE(missing.have_missing());
     EXPECT_EQ(0U, log.log.size());
     EXPECT_EQ(eversion_t(), info.stats.version);
+    EXPECT_EQ(log.get_can_rollback_to(), eversion_t(0,0));
     EXPECT_EQ(1ull, info.stats.reported_seq);
     EXPECT_EQ(10u, info.stats.reported_epoch);
     EXPECT_TRUE(remove_snap.empty());
@@ -945,6 +950,7 @@ TEST_F(PGLogTest, merge_log) {
 
     EXPECT_FALSE(missing.have_missing());
     EXPECT_EQ(0U, log.log.size());
+    EXPECT_EQ(log.get_can_rollback_to(), eversion_t(0,0));
     EXPECT_EQ(stat_version, info.stats.version);
     EXPECT_EQ(1ull, info.stats.reported_seq);
     EXPECT_EQ(10u, info.stats.reported_epoch);
@@ -992,6 +998,7 @@ TEST_F(PGLogTest, merge_log) {
             +--------+-------+
   */
   {
+    //case: 2
     clear();
 
     pg_log_t olog;
@@ -1036,6 +1043,7 @@ TEST_F(PGLogTest, merge_log) {
 
     EXPECT_FALSE(missing.have_missing());
     EXPECT_EQ(2U, log.log.size());
+    EXPECT_EQ(log.get_can_rollback_to(), eversion_t(0,0));
     EXPECT_EQ(stat_version, info.stats.version);
     EXPECT_TRUE(remove_snap.empty());
     EXPECT_EQ(last_backfill, info.last_backfill);
@@ -1050,6 +1058,7 @@ TEST_F(PGLogTest, merge_log) {
 
     EXPECT_FALSE(missing.have_missing());
     EXPECT_EQ(3U, log.log.size());
+    EXPECT_EQ(log.get_can_rollback_to(), eversion_t(0,0));
     EXPECT_EQ(stat_version, info.stats.version);
     EXPECT_TRUE(remove_snap.empty());
     EXPECT_TRUE(info.purged_snaps.empty());
@@ -1085,6 +1094,7 @@ TEST_F(PGLogTest, merge_log) {
 
   */
   {
+    //case: 3
     clear();
 
     pg_log_t olog;
@@ -1175,6 +1185,7 @@ TEST_F(PGLogTest, merge_log) {
     EXPECT_TRUE(is_dirty());
     EXPECT_TRUE(dirty_info);
     EXPECT_TRUE(dirty_big_info);
+    EXPECT_EQ(log.get_can_rollback_to(), log.head);
   }
 
   /*        +--------------------------+
@@ -1204,6 +1215,7 @@ TEST_F(PGLogTest, merge_log) {
 
   */
   {
+    //case: 4
     clear();
 
     pg_log_t olog;
@@ -1264,6 +1276,7 @@ TEST_F(PGLogTest, merge_log) {
     EXPECT_FALSE(missing.have_missing());
     EXPECT_EQ(1U, log.objects.count(divergent_object));
     EXPECT_EQ(3U, log.log.size());
+    EXPECT_EQ(log.get_can_rollback_to(), eversion_t(0,0));
     EXPECT_TRUE(remove_snap.empty());
     EXPECT_EQ(log.head, info.last_update);
     EXPECT_TRUE(info.purged_snaps.empty());
@@ -1284,6 +1297,7 @@ TEST_F(PGLogTest, merge_log) {
     EXPECT_TRUE(missing.is_missing(divergent_object));
     EXPECT_EQ(1U, log.objects.count(divergent_object));
     EXPECT_EQ(4U, log.log.size());
+    EXPECT_EQ(log.get_can_rollback_to(), olog.head);
     /* DELETE entries from olog that are appended to the hed of the
        log, and the divergent version of the object is removed (added
        to remove_snap). When peering handles deletes, it is the earlier
@@ -1319,6 +1333,7 @@ TEST_F(PGLogTest, merge_log) {
 
   */
   {
+    //case: 5
     clear();
 
     pg_log_t olog;
@@ -1365,6 +1380,7 @@ TEST_F(PGLogTest, merge_log) {
 
     EXPECT_FALSE(missing.have_missing());
     EXPECT_EQ(3U, log.log.size());
+    EXPECT_EQ(log.get_can_rollback_to(), eversion_t(0,0));
     EXPECT_EQ(stat_version, info.stats.version);
     EXPECT_TRUE(remove_snap.empty());
     EXPECT_EQ(last_backfill, info.last_backfill);
@@ -1380,6 +1396,7 @@ TEST_F(PGLogTest, merge_log) {
 
     EXPECT_FALSE(missing.have_missing());
     EXPECT_EQ(2U, log.log.size());
+    EXPECT_EQ(log.get_can_rollback_to(), eversion_t(0,0));
     EXPECT_EQ(stat_version, info.stats.version);
     EXPECT_EQ(0x9U, remove_snap.front().get_hash());
     EXPECT_TRUE(info.purged_snaps.empty());
@@ -1487,6 +1504,7 @@ TEST_F(PGLogTest, proc_replica_log) {
     proc_replica_log(oinfo, olog, omissing, from);
 
     EXPECT_FALSE(omissing.have_missing());
+    EXPECT_EQ(log.get_can_rollback_to(), eversion_t(0,0));
   }
 
  {


### PR DESCRIPTION
* adds can_roll_forward_to bool which checks if actually new entries
were added.
fixes: https://tracker.ceph.com/issues/48609

Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
