### PR TITLE
osd: add osd_fast_shutdown_notify_mon option (default false)

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -67,6 +67,11 @@
   to property reflect the upper cache utilization before space is reclaimed. The default ``immutable_object_cache_watermark``
   now is ``0.9``. If the capacity reaches 90% the daemon will delete cold cache.
 
+* OSD: the option ``osd_fast_shutdown_notify_mon`` has been introduced to allow
+  the OSD to notify the monitor it is shutting down even if ``osd_fast_shutdown``
+  is enabled. This helps with the monitor logs on larger clusters, that may get
+  many 'osd.X reported immediately failed by osd.Y' messages, and confuse tools.
+
 >=15.0.0
 --------
 

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -760,6 +760,7 @@ OPTION(osd_op_history_slow_op_threshold, OPT_DOUBLE) // track the op if over thi
 OPTION(osd_target_transaction_size, OPT_INT)     // to adjust various transactions that batch smaller items
 OPTION(osd_failsafe_full_ratio, OPT_FLOAT) // what % full makes an OSD "full" (failsafe)
 OPTION(osd_fast_shutdown, OPT_BOOL)
+OPTION(osd_fast_shutdown_notify_mon, OPT_BOOL) // tell mon the OSD is shutting down on osd_fast_shutdown
 OPTION(osd_fast_fail_on_connection_refused, OPT_BOOL) // immediately mark OSDs as down once they refuse to accept connections
 
 OPTION(osd_pg_object_context_cache_count, OPT_INT)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3711,6 +3711,12 @@ std::vector<Option> get_global_options() {
     .set_description("Fast, immediate shutdown")
     .set_long_description("Setting this to false makes the OSD do a slower teardown of all state when it receives a SIGINT or SIGTERM or when shutting down for any other reason.  That slow shutdown is primarilyy useful for doing memory leak checking with valgrind."),
 
+    Option("osd_fast_shutdown_notify_mon", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("Tell mon about OSD shutdown on immediate shutdown")
+    .set_long_description("Tell the monitor the OSD is shutting down on immediate shutdown. This helps with cluster log messages from other OSDs reporting it immediately failed.")
+    .add_see_also({"osd_fast_shutdown", "osd_mon_shutdown_timeout"}),
+
     Option("osd_fast_fail_on_connection_refused", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description(""),

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4154,6 +4154,8 @@ int OSD::shutdown()
 {
   if (cct->_conf->osd_fast_shutdown) {
     derr << "*** Immediate shutdown (osd_fast_shutdown=true) ***" << dendl;
+    if (cct->_conf->osd_fast_shutdown_notify_mon)
+      service.prepare_to_stop();
     cct->_log->flush();
     _exit(0);
   }


### PR DESCRIPTION
The `osd_fast_shutdown` option may cause the cluster log to receive
too many entries of `osd.X reported immediately failed by osd.Y`,
depending on cluster scale.

This might be an issue for LMA stacks/tools that check ceph logs
for failed lines, and then require additional logic to filter on
an intended OSD (fast) shutdown; might not be an option/possible,
and require an admin to analyze.

So, add `osd_fast_shutdown_notify_mon` option for OSD to also tell
the monitor it is shutting down (done in slow/non-fast shutdown)
under `osd_fast_shutdown`.

This introduces minimal delay (the ack from the mon is required
to prevent the messages), and addresses the cluster log issue.
Note: the `osd_mon_shutdown_timeout` option can be used to control
the maximum amount of time waiting for the monitor ack to arrive.

Fixes: http://tracker.ceph.com/issues/46978
Signed-off-by: Mauricio Faria de Oliveira `<mfo@canonical.com>`

## Testing

Note: for testing the option value has been changed to `true`, so to exercise the code path difference (otherwise it's a nop).

This passed `run-make-check.sh` (transient failures cleared w/ reruns: `unittest_bluefs` and `unittest_bluefs`).

And `qa/run-standalone.sh` reported 3 apparently unrelated failures (not rerun): `osd/osd-bluefs-volume-ops.sh`, `scrub/osd-recovery-scrub.sh`, `scrub/osd-scrub-snaps.sh`

Testing with `vstart.sh` (10 OSDs) shows that without the option (or `false`) the mon log gets multiple reports per OSD, and with the option (`true`) it remains quiet, as in the slow/non-fast shutdown case, as expected.

- Before / or with `osd_fast_shutdown_notify_mon = false`:

```
osd log:

2021-01-09T18:59:52.448+0000 7f937fcdc700 -1 received  signal: Terminated from -bash  (PID: 408) UID: 1000
2021-01-09T18:59:52.448+0000 7f937fcdc700 -1 osd.2 22 *** Got signal Terminated ***
2021-01-09T18:59:52.448+0000 7f937fcdc700 -1 osd.2 22 *** Immediate shutdown (osd_fast_shutdown=true) ***

mon log:

$ cat out/mon.a.log | grep '^2021-01-09T18:59:' | grep 'osd.0 reported immediately failed by osd.' | rev | cut -d: -f1 | rev | sort | uniq -c
      4  osd.0 reported immediately failed by osd.1
      4  osd.0 reported immediately failed by osd.2
      4  osd.0 reported immediately failed by osd.3
      4  osd.0 reported immediately failed by osd.4
      4  osd.0 reported immediately failed by osd.5
      4  osd.0 reported immediately failed by osd.6
      4  osd.0 reported immediately failed by osd.7
      4  osd.0 reported immediately failed by osd.8
      4  osd.0 reported immediately failed by osd.9
```

- After / with `osd_fast_shutdown_notify_mon = true`:

```
osd log:

2021-01-14T17:21:10.825+0000 7feceded1700 -1 received  signal: Terminated from -bash  (PID: 1750) UID: 1000
2021-01-14T17:21:10.825+0000 7feceded1700 -1 osd.0 80 *** Got signal Terminated ***
2021-01-14T17:21:10.825+0000 7feceded1700 -1 osd.0 80 *** Immediate shutdown (osd_fast_shutdown=true) ***
2021-01-14T17:21:10.825+0000 7feceded1700  0 osd.0 80 prepare_to_stop telling mon we are shutting down
...
2021-01-14T17:21:11.021+0000 7fecdac0c700  0 osd.0 80 got_stop_ack starting shutdown
2021-01-14T17:21:11.021+0000 7feceded1700  0 osd.0 80 prepare_to_stop starting shutdown

mon log:

2021-01-14T17:21:10.829+0000 7f62fce61700  0 log_channel(cluster) log [INF] : osd.0 marked itself down
2021-01-14T17:21:10.885+0000 7f62ff666700  1 mon.a@0(leader).osd e80 do_prune osdmap full prune enabled
2021-01-14T17:21:10.889+0000 7f62ff666700  0 log_channel(cluster) log [WRN] : Health check failed: 1 osds down (OSD_DOWN)
2021-01-14T17:21:10.957+0000 7f62fb65e700  1 mon.a@0(leader).osd e81 e81: 10 total, 9 up, 10 in
2021-01-14T17:21:11.013+0000 7f62fb65e700  0 log_channel(cluster) log [DBG] : osdmap e81: 10 total, 9 up, 10 in
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
