### PR TITLE
cephadm: Add cluster network to bootstrap

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -121,6 +121,13 @@ The default bootstrap behavior will work for the vast majority of
 users.  See below for a few options that may be useful for some users,
 or run ``cephadm bootstrap -h`` to see all available options:
 
+* In production environments it is recommended to have network separation
+  between the public network traffic and the cluster traffic which handles
+  replication, recovery and heartbeats between OSD daemons. To define the 
+  `cluster network`_ you can supply the ``--cluster-network`` option. This
+  parameter must define a subnet in CIDR notation, for example
+  10.90.90.0/24 or fe80::/64.
+
 * Bootstrap writes the files needed to access the new cluster to ``/etc/ceph``,
   so that any Ceph packages installed on the host itself (e.g., to access the
   command line interface) can easily find them.
@@ -542,3 +549,5 @@ See :ref:`orchestrator-cli-placement-spec` for details of the placement specific
 Deploying custom containers
 ===========================
 It is also possible to choose different containers than the default containers to deploy Ceph. See :ref:`containers` for information about your options in this regard.
+
+.. _cluster network: ../rados/configuration/network-config-ref#cluster-network

--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -121,10 +121,11 @@ The default bootstrap behavior will work for the vast majority of
 users.  See below for a few options that may be useful for some users,
 or run ``cephadm bootstrap -h`` to see all available options:
 
-* In production environments it is recommended to have network separation
-  between the public network traffic and the cluster traffic which handles
-  replication, recovery and heartbeats between OSD daemons. To define the 
-  `cluster network`_ you can supply the ``--cluster-network`` option. This
+* In larger Ceph clusters, network separation between the public
+  network traffic and cluster traffic which handles replication,
+  recovery and heartbeats between OSD daemons, can lead to performance
+  improvements. To define the `cluster network`_ you can supply the
+  ``--cluster-network`` option to the ``bootstrap`` subcommand. This
   parameter must define a subnet in CIDR notation, for example
   10.90.90.0/24 or fe80::/64.
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3186,7 +3186,17 @@ def get_image_info_from_inspect(out, image):
 
 
 ##################################
-
+def check_subnet(subnet:str) -> Tuple[int, int, str]:
+    """Determine whether the given string is a valid subnet"""
+    version = 0
+    # ensure the format of the string is as expected address/netmask
+    if not re.search(r'\/\d+$', subnet):
+        return 1, 0, "subnet must be in CIDR format (address/netmask)"
+    try:
+        version = ipaddress.ip_network(unicode(subnet)).version
+    except ValueError as e:
+        return 1, 0, str(e)
+    return 0, version, ""
 
 def unwrap_ipv6(address):
     # type: (str) -> str
@@ -3283,6 +3293,19 @@ def prepare_mon_addresses(
         if not mon_network:
             raise Error('Failed to infer CIDR network for mon ip %s; pass '
                         '--skip-mon-network to configure it later' % base_ip)
+    
+    cluster_network = None
+    # the cluster network may not exist on this node, so all we can do is 
+    # validate that the address given is valid ipv4 or ipv6 subnet
+    if args.cluster_network:
+        rc, _cluster_ip_version, error = check_subnet(args.cluster_network)
+        if rc:
+            raise Error(f"Invalid --cluster-network parameter: {error}")
+        cluster_network = args.cluster_network
+    else:
+        logger.warning("{}{}{}".format(termcolor.yellow,
+                                       "Internal network (--cluster-network) has not been provided",
+                                       termcolor.end))
 
     return (addr_arg, ipv6, mon_network)
 
@@ -3674,8 +3697,12 @@ def finish_bootstrap_config(
         ])
 
     if mon_network:
-        logger.info('Setting mon public_network...')
+        logger.info(f"Setting mon public_network to {mon_network}")
         cli(['config', 'set', 'mon', 'public_network', mon_network])
+    
+    if cluster_network:
+        logger.info(f"Setting mon cluster_network to {cluster_network}")
+        cli(['config', 'set', 'mon', 'cluster_network', cluster_network])
 
     if ipv6:
         logger.info('Enabling IPv6 (ms_bind_ipv6)')
@@ -7398,6 +7425,9 @@ def _get_parser():
         '--exporter-config',
         action=CustomValidation,
         help=f'Exporter configuration information in JSON format (providing: {", ".join(CephadmDaemon.config_requirements)}, port information)')
+    parser_bootstrap.add_argument(
+        '--cluster-network',
+        help='subnet to use for cluster replication, recovery and heartbeats (in CIDR notation network/mask)')
 
     parser_deploy = subparsers.add_parser(
         'deploy', help='deploy a daemon')

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3308,22 +3308,26 @@ def prepare_mon_addresses(
             raise Error('Failed to infer CIDR network for mon ip %s; pass '
                         '--skip-mon-network to configure it later' % base_ip)
     
-    cluster_network = None
+    return (addr_arg, ipv6, mon_network)
+
+
+def prepare_cluster_network(ctx: CephadmContext) -> Tuple[str, bool]:
+    cluster_network = ""
     ipv6_cluster_network = False
     # the cluster network may not exist on this node, so all we can do is 
     # validate that the address given is valid ipv4 or ipv6 subnet
-    if args.cluster_network:
-        rc, versions, err_msg = check_subnet(args.cluster_network)
+    if ctx.cluster_network:
+        rc, versions, err_msg = check_subnet(ctx.cluster_network)
         if rc:
             raise Error(f"Invalid --cluster-network parameter: {err_msg}")
-        cluster_network = args.cluster_network
+        cluster_network = ctx.cluster_network
         ipv6_cluster_network = True if 6 in versions else False
     else:
-        logger.warning("{}{}{}".format(termcolor.yellow,
-                                       "Internal network (--cluster-network) has not been provided",
-                                       termcolor.end))
+        logger.info("- internal network (--cluster-network) has not "
+                       "been provided, OSD replication will default to "
+                       "the public_network")
 
-    return (addr_arg, ipv6, mon_network)
+    return cluster_network, ipv6_cluster_network
 
 
 def create_initial_keys(
@@ -3684,7 +3688,8 @@ def finish_bootstrap_config(
     config: str,
     mon_id: str, mon_dir: str,
     mon_network: Optional[str], ipv6: bool,
-    cli: Callable
+    cli: Callable,
+    cluster_network: Optional[str], ipv6_cluster_network: bool
 
 ) -> None:
     if not ctx.no_minimize_config:
@@ -3717,7 +3722,7 @@ def finish_bootstrap_config(
         cli(['config', 'set', 'mon', 'public_network', mon_network])
     
     if cluster_network:
-        logger.info(f"Setting 'global' cluster_network to {cluster_network}")
+        logger.info(f"Setting cluster_network to {cluster_network}")
         cli(['config', 'set', 'global', 'cluster_network', cluster_network])
 
     if ipv6 or ipv6_cluster_network:
@@ -3781,6 +3786,8 @@ def command_bootstrap(ctx):
     l.acquire()
 
     (addr_arg, ipv6, mon_network) = prepare_mon_addresses(ctx)
+    cluster_network, ipv6_cluster_network = prepare_cluster_network(ctx)
+
     config = prepare_bootstrap_config(ctx, fsid, addr_arg, ctx.image)
 
     logger.info('Extracting ceph user uid/gid from container image...')
@@ -3830,7 +3837,8 @@ def command_bootstrap(ctx):
     wait_for_mon(ctx, mon_id, mon_dir, admin_keyring.name, tmp_config.name)
 
     finish_bootstrap_config(ctx, fsid, config, mon_id, mon_dir,
-                            mon_network, ipv6, cli)
+                            mon_network, ipv6, cli,
+                            cluster_network, ipv6_cluster_network)
 
     # output files
     with open(ctx.output_keyring, 'w') as f:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3186,17 +3186,31 @@ def get_image_info_from_inspect(out, image):
 
 
 ##################################
-def check_subnet(subnet:str) -> Tuple[int, int, str]:
-    """Determine whether the given string is a valid subnet"""
-    version = 0
-    # ensure the format of the string is as expected address/netmask
-    if not re.search(r'\/\d+$', subnet):
-        return 1, 0, "subnet must be in CIDR format (address/netmask)"
-    try:
-        version = ipaddress.ip_network(unicode(subnet)).version
-    except ValueError as e:
-        return 1, 0, str(e)
-    return 0, version, ""
+def check_subnet(subnets:str) -> Tuple[int, List[int], str]:
+    """Determine whether the given string is a valid subnet
+
+    :param subnets: subnet string, a single definition or comma separated list of CIDR subnets
+    :returns: return code, IP version list of the subnets and msg describing any errors validation errors
+    """
+
+    rc = 0
+    versions = set() 
+    errors = []
+    subnet_list = subnets.split(',')
+    for subnet in subnet_list:
+        # ensure the format of the string is as expected address/netmask
+        if not re.search(r'\/\d+$', subnet):
+            rc = 1
+            errors.append(f"{subnet} is not in CIDR format (address/netmask)")
+            continue
+        try:
+            v = ipaddress.ip_network(unicode(subnet)).version
+            versions.add(v)
+        except ValueError as e:
+            rc = 1
+            errors.append(f"{subnet} invalid: {str(e)}")
+    
+    return rc, list(versions), ", ".join(errors)
 
 def unwrap_ipv6(address):
     # type: (str) -> str
@@ -3295,13 +3309,15 @@ def prepare_mon_addresses(
                         '--skip-mon-network to configure it later' % base_ip)
     
     cluster_network = None
+    ipv6_cluster_network = False
     # the cluster network may not exist on this node, so all we can do is 
     # validate that the address given is valid ipv4 or ipv6 subnet
     if args.cluster_network:
-        rc, _cluster_ip_version, error = check_subnet(args.cluster_network)
+        rc, versions, err_msg = check_subnet(args.cluster_network)
         if rc:
-            raise Error(f"Invalid --cluster-network parameter: {error}")
+            raise Error(f"Invalid --cluster-network parameter: {err_msg}")
         cluster_network = args.cluster_network
+        ipv6_cluster_network = True if 6 in versions else False
     else:
         logger.warning("{}{}{}".format(termcolor.yellow,
                                        "Internal network (--cluster-network) has not been provided",
@@ -3701,11 +3717,11 @@ def finish_bootstrap_config(
         cli(['config', 'set', 'mon', 'public_network', mon_network])
     
     if cluster_network:
-        logger.info(f"Setting mon cluster_network to {cluster_network}")
-        cli(['config', 'set', 'mon', 'cluster_network', cluster_network])
+        logger.info(f"Setting 'global' cluster_network to {cluster_network}")
+        cli(['config', 'set', 'global', 'cluster_network', cluster_network])
 
-    if ipv6:
-        logger.info('Enabling IPv6 (ms_bind_ipv6)')
+    if ipv6 or ipv6_cluster_network:
+        logger.info('Enabling IPv6 (ms_bind_ipv6) binding')
         cli(['config', 'set', 'global', 'ms_bind_ipv6', 'true'])
 
 

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -652,6 +652,22 @@ iMN28C2bKGao5UHvdER1rGy7
         with pytest.raises(HTTPError, match=r"HTTP Error 501: .*") as e:
             urlopen(req)
 
+    def test_ipv4_subnet(self):
+        rc, v, msg = cd.check_subnet('192.168.1.0/24')
+        assert rc == 0 and v == 4
+    
+    def test_ipv6_subnet(self):
+        rc, v, msg = cd.check_subnet('fe80::/64')
+        assert rc == 0 and v == 6
+    
+    def test_subnet_mask_missing(self):
+        rc, v, msg = cd.check_subnet('192.168.1.58')
+        assert rc == 1 and msg
+    
+    def test_subnet_mask_junk(self):
+        rc, v, msg = cd.check_subnet('wah')
+        assert rc == 1 and msg
+
 
 class TestMaintenance:
     systemd_target = "ceph.00000000-0000-0000-0000-000000c0ffee.target"

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -654,11 +654,23 @@ iMN28C2bKGao5UHvdER1rGy7
 
     def test_ipv4_subnet(self):
         rc, v, msg = cd.check_subnet('192.168.1.0/24')
-        assert rc == 0 and v == 4
+        assert rc == 0 and v[0] == 4
     
+    def test_ipv4_subnet_list(self):
+        rc, v, msg = cd.check_subnet('192.168.1.0/24,10.90.90.0/24')
+        assert rc == 0 and not msg
+    
+    def test_ipv4_subnet_badlist(self):
+        rc, v, msg = cd.check_subnet('192.168.1.0/24,192.168.1.1')
+        assert rc == 1 and msg
+
+    def test_ipv4_subnet_mixed(self):
+        rc, v, msg = cd.check_subnet('192.168.100.0/24,fe80::/64')
+        assert rc == 0 and v == [4,6]
+
     def test_ipv6_subnet(self):
         rc, v, msg = cd.check_subnet('fe80::/64')
-        assert rc == 0 and v == 6
+        assert rc == 0 and v[0] == 6
     
     def test_subnet_mask_missing(self):
         rc, v, msg = cd.check_subnet('192.168.1.58')


### PR DESCRIPTION
Adds a --cluster-network parameter to the bootstrap cmd to
set the internal cluster network.

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>
"""
