### PR TITLE
mgr/cephadm: s/yield_fixture/fixture/

### DIFF
--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -65,13 +65,13 @@ def with_cephadm_module(module_options=None, store=None):
         yield m
 
 
-@pytest.yield_fixture()
+@pytest.fixture()
 def cephadm_module():
     with with_cephadm_module({}) as m:
         yield m
 
 
-@pytest.yield_fixture()
+@pytest.fixture()
 def rm_util():
     with with_cephadm_module({}) as m:
         r = RemoveUtil.__new__(RemoveUtil)
@@ -79,7 +79,7 @@ def rm_util():
         yield r
 
 
-@pytest.yield_fixture()
+@pytest.fixture()
 def osd_obj():
     with mock.patch("cephadm.services.osd.RemoveUtil"):
         o = OSD(0, mock.MagicMock())


### PR DESCRIPTION
silences pytest warning. it complained:`

1: cephadm/tests/fixtures.py:68
1:   /var/ssd/ceph/src/pybind/mgr/cephadm/tests/fixtures.py:68: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
1:   Use @pytest.fixture instead; they are the same.
1:     @pytest.yield_fixture()


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
