### PR TITLE
mgr/cephadm: Use our image for remote tool execution

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1741,7 +1741,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
     def zap_device(self, host: str, path: str) -> str:
         self.log.info('Zap device %s:%s' % (host, path))
         out, err, code = CephadmServe(self)._run_cephadm(
-            host, 'osd', 'ceph-volume',
+            host, self.this_daemon_name, 'ceph-volume',
             ['--', 'lvm', 'zap', '--destroy', path],
             error_ok=True)
         self.cache.invalidate_host_devices(host)
@@ -1776,7 +1776,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             cmd_args = shlex.split(cmd_line)
 
             out, err, code = CephadmServe(self)._run_cephadm(
-                host, 'osd', 'shell', ['--'] + cmd_args,
+                host, self.this_daemon_name, 'shell', ['--'] + cmd_args,
                 error_ok=True)
             if code:
                 raise OrchestratorError(

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1659,6 +1659,10 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         self.log.info(f'Schedule {action} daemon {daemon_name}')
         return self._schedule_daemon_action(daemon_name, action)
 
+    @property
+    def this_daemon_name(self) -> str:
+        return f'mgr.{self.get_mgr_id()}'
+
     def daemon_is_self(self, daemon_type: str, daemon_id: str) -> bool:
         return daemon_type == 'mgr' and daemon_id == self.get_mgr_id()
 

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -234,7 +234,7 @@ class CephadmServe:
 
     def _refresh_host_daemons(self, host: str) -> Optional[str]:
         try:
-            ls = self._run_cephadm_json(host, 'mon', 'ls', [], no_fsid=True)
+            ls = self._run_cephadm_json(host, cephadmNoImage, 'ls', [], no_fsid=True)
         except OrchestratorError as e:
             return str(e)
         dm = {}
@@ -294,11 +294,11 @@ class CephadmServe:
     def _refresh_host_devices(self, host: str) -> Optional[str]:
         try:
             try:
-                devices = self._run_cephadm_json(host, 'osd', 'ceph-volume',
+                devices = self._run_cephadm_json(host, self.mgr.this_daemon_name, 'ceph-volume',
                                                  ['--', 'inventory', '--format=json', '--filter-for-batch'])
             except OrchestratorError as e:
                 if 'unrecognized arguments: --filter-for-batch' in str(e):
-                    devices = self._run_cephadm_json(host, 'osd', 'ceph-volume',
+                    devices = self._run_cephadm_json(host, self.mgr.this_daemon_name, 'ceph-volume',
                                                      ['--', 'inventory', '--format=json'])
                 else:
                     raise
@@ -1028,7 +1028,7 @@ class CephadmServe:
             'password': password,
         })
         out, err, code = self._run_cephadm(
-            host, 'mon', 'registry-login',
+            host, cephadmNoImage, 'registry-login',
             ['--registry-json', '-'], stdin=args_str, error_ok=True)
         if code:
             return f"Host {host} failed to login to {url} as {username} with given password"

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -511,9 +511,9 @@ class MgrService(CephService):
     def fail_over(self) -> None:
         if not self.mgr_map_has_standby():
             raise OrchestratorError('Need standby mgr daemon', event_kind_subject=(
-                'daemon', 'mgr' + self.mgr.get_mgr_id()))
+                'daemon', self.mgr.this_daemon_name))
 
-        self.mgr.events.for_daemon('mgr' + self.mgr.get_mgr_id(),
+        self.mgr.events.for_daemon(self.mgr.this_daemon_name,
                                    'INFO', 'Failing over to other MGR')
         logger.info('Failing over to other MGR')
 

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -87,7 +87,7 @@ class OSDService(CephService):
 
         # check result
         out, err, code = CephadmServe(self.mgr)._run_cephadm(
-            host, 'osd', 'ceph-volume',
+            host, self.mgr.this_daemon_name, 'ceph-volume',
             [
                 '--',
                 'lvm', 'list',
@@ -283,7 +283,7 @@ class OSDService(CephService):
         _cmd = ['--config-json', '-', '--']
         _cmd.extend(split_cmd)
         out, err, code = CephadmServe(self.mgr)._run_cephadm(
-            host, 'osd', 'ceph-volume',
+            host, self.mgr.this_daemon_name, 'ceph-volume',
             _cmd,
             env_vars=env_vars,
             stdin=j,

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -419,12 +419,12 @@ class TestCephadm(object):
             assert CephadmServe(cephadm_module)._apply_all_services() is False
 
             _run_cephadm.assert_any_call(
-                'test', 'osd', 'ceph-volume',
+                'test', 'mgr.x', 'ceph-volume',
                 ['--config-json', '-', '--', 'lvm', 'batch',
                     '--no-auto', '/dev/sdb', '--yes', '--no-systemd'],
                 env_vars=['CEPH_VOLUME_OSDSPEC_AFFINITY=foo'], error_ok=True, stdin='{"config": "", "keyring": ""}')
             _run_cephadm.assert_called_with(
-                'test', 'osd', 'ceph-volume', ['--', 'lvm', 'list', '--format', 'json'])
+                'test', 'mgr.x', 'ceph-volume', ['--', 'lvm', 'list', '--format', 'json'])
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.module.SpecStore.save")
@@ -664,7 +664,7 @@ class TestCephadm(object):
             c = cephadm_module.blink_device_light(fault_ident, on_bool, [('test', '', 'dev')])
             on_off = 'on' if on_bool else 'off'
             assert wait(cephadm_module, c) == [f'Set {fault_ident} light for test: {on_off}']
-            _run_cephadm.assert_called_with('test', 'osd', 'shell', [
+            _run_cephadm.assert_called_with('test', 'mgr.x', 'shell', [
                                             '--', 'lsmcli', f'local-disk-{fault_ident}-led-{on_off}', '--path', 'dev'], error_ok=True)
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm")
@@ -674,7 +674,7 @@ class TestCephadm(object):
             cephadm_module.set_store('blink_device_light_cmd', 'echo hello')
             c = cephadm_module.blink_device_light('ident', True, [('test', '', '/dev/sda')])
             assert wait(cephadm_module, c) == ['Set ident light for test: on']
-            _run_cephadm.assert_called_with('test', 'osd', 'shell', [
+            _run_cephadm.assert_called_with('test', 'mgr.x', 'shell', [
                                             '--', 'echo', 'hello'], error_ok=True)
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm")
@@ -687,7 +687,7 @@ class TestCephadm(object):
                 'fault', True, [('mgr0', 'SanDisk_X400_M.2_2280_512GB_162924424784', '')])
             assert wait(cephadm_module, c) == [
                 'Set fault light for mgr0:SanDisk_X400_M.2_2280_512GB_162924424784 on']
-            _run_cephadm.assert_called_with('mgr0', 'osd', 'shell', [
+            _run_cephadm.assert_called_with('mgr0', 'mgr.x', 'shell', [
                 '--', 'xyz', '--foo', '--fault=on', 'SanDisk_X400_M.2_2280_512GB_162924424784'
             ], error_ok=True)
 
@@ -1000,10 +1000,10 @@ Traceback (most recent call last):
             assert s == 'host test `cephadm ceph-volume` failed: ' + error_message
 
             assert _run_cephadm.mock_calls == [
-                mock.call('test', 'osd', 'ceph-volume',
+                mock.call('test', 'mgr.x', 'ceph-volume',
                           ['--', 'inventory', '--format=json', '--filter-for-batch'], image='',
                           no_fsid=False),
-                mock.call('test', 'osd', 'ceph-volume',
+                mock.call('test', 'mgr.x', 'ceph-volume',
                           ['--', 'inventory', '--format=json'], image='',
                           no_fsid=False),
             ]

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -433,8 +433,8 @@ class CephadmUpgrade:
                 assert d.daemon_id is not None
 
                 if self.mgr.daemon_is_self(d.daemon_type, d.daemon_id):
-                    logger.info('Upgrade: Need to upgrade myself (mgr.%s)' %
-                                self.mgr.get_mgr_id())
+                    logger.info('Upgrade: Need to upgrade myself (%s)',
+                                self.mgr.this_daemon_name)
                     need_upgrade_self = True
                     continue
 

--- a/src/pybind/mgr/tests/__init__.py
+++ b/src/pybind/mgr/tests/__init__.py
@@ -174,7 +174,7 @@ if 'UNITTEST' in os.environ:
             self._unconfigure_logging = mock.MagicMock()
             self._ceph_log = mock.MagicMock()
             self._ceph_dispatch_remote = lambda *_: None
-            self._ceph_get_mgr_id = mock.MagicMock()
+            self._ceph_get_mgr_id = lambda *_: 'x'  # vstart uses "mgr.x" for the first mgr
 
 
     cm = mock.Mock()


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/48870

This deals with a cephadm upgrade issue:

1. user calls `ceph orch upgrade`
2. mgr/cephadm calls `ceph orch config set mgr.x container_image <new-container>`
3. standby mgr gets upgraded
4. mgr failover to new mgr
5. mgr/cephadm calls `_refresh_host_devices`
6. `_refresh_host_devices` calls` ceph orch config get osd container_image`.
  But this returns the old image
7. `_refresh_host_devices` calls `ceph-volume ... --filter-for-batch`
  with an image that doesn't support `filter-for-batch`

The idea is to _always_ call tools with the same container image as
run by the active mgr. This way we don't need to deal with CLI changes at all.
Downside is: tools need to be able to cope with being called
with alternating versions on the same host.

This is an alternative to #38927
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
