### PR TITLE
client/fuse_ll.cc: use uint64_t for fuse_ll_forget() nlookup argument

### DIFF
--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -192,8 +192,14 @@ static void fuse_ll_lookup(fuse_req_t req, fuse_ino_t parent, const char *name)
   cfuse->iput(i1);
 }
 
+// fuse3 has changed forget function signature
+#if FUSE_VERSION >= FUSE_MAKE_VERSION(3, 0)
+static void fuse_ll_forget(fuse_req_t req, fuse_ino_t ino,
+			   uint64_t nlookup)
+#else
 static void fuse_ll_forget(fuse_req_t req, fuse_ino_t ino,
 			   long unsigned nlookup)
+#endif
 {
   CephFuse::Handle *cfuse = fuse_ll_req_prepare(req);
   cfuse->client->ll_forget(cfuse->iget(ino), nlookup+1);


### PR DESCRIPTION
FUSE has changed the definition of forget function in fuse.

In fuse2 it is defined as:

void (*forget) (fuse_req_t req, fuse_ino_t ino, unsigned long nlookup);

In fuse3 it is defined as:

void (*forget) (fuse_req_t req, fuse_ino_t ino, uint64_t nlookup);

Apparently FUSE fixed the issue of nlookup becoming 32 bit value on 32 bit systems as nlookup should be 64 bit value at all times.

This change does not cause any issues with fuse2 on 64 bit systems as unsigned long then is 64 bit long. After this change fuse_ll.cc compiles correctly on both 32 bit and 64 bit systems with either fuse2 and fuse3.

Signed-off-by: Vladimir Bashkirtsev <vladimir@bashkirtsev.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
