### PR TITLE
tests/datetime.py: add timezone spec so compare is in same timezone

### DIFF
--- a/src/python-common/ceph/tests/test_datetime.py
+++ b/src/python-common/ceph/tests/test_datetime.py
@@ -11,8 +11,8 @@ def test_datetime_to_str_1():
 
 
 def test_datetime_to_str_2():
-    dt = datetime.datetime.strptime('2019-04-24T17:06:53.039991',
-                                    '%Y-%m-%dT%H:%M:%S.%f')
+    dt = datetime.datetime.strptime('2019-04-24T17:06:53.039991UTC',
+                                    '%Y-%m-%dT%H:%M:%S.%f%Z')
     assert datetime_to_str(dt) == '2019-04-24T17:06:53.039991Z'
 
 


### PR DESCRIPTION
Otherwise the compare errors like:
```
____________________________ test_datetime_to_str_2 ____________________________

    def test_datetime_to_str_2():
        dt = datetime.datetime.strptime('2019-04-24T17:06:53.039991',
                                        '%Y-%m-%dT%H:%M:%S.%f')
>       assert datetime_to_str(dt) == '2019-04-24T17:06:53.039991Z'
E       AssertionError: assert '2019-04-24T15:06:53.039991Z' == '2019-04-24T17:06:53.039991Z'
E         - 2019-04-24T17:06:53.039991Z
E         ?             ^
E         + 2019-04-24T15:06:53.039991Z
E         ?             ^
```
And 2 hours is exactly my offset from UTC


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>