### PR TITLE
mgr/dashboard: Fix for incorrect validation in rgw user form

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
@@ -7,7 +7,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgxPipeFunctionModule } from 'ngx-pipe-function';
 import { ToastrModule } from 'ngx-toastr';
-import { of as observableOf } from 'rxjs';
+import { of as observableOf, throwError } from 'rxjs';
 
 import { RgwUserService } from '~/app/shared/api/rgw-user.service';
 import { NotificationType } from '~/app/shared/enum/notification-type.enum';
@@ -155,21 +155,19 @@ describe('RgwUserFormComponent', () => {
   });
 
   describe('username validation', () => {
-    beforeEach(() => {
-      spyOn(rgwUserService, 'enumerate').and.returnValue(observableOf(['abc', 'xyz']));
-    });
-
     it('should validate that username is required', () => {
       formHelper.expectErrorChange('uid', '', 'required', true);
     });
 
     it('should validate that username is valid', fakeAsync(() => {
+      spyOn(rgwUserService, 'get').and.returnValue(throwError('foo'));
       formHelper.setValue('uid', 'ab', true);
       tick(500);
       formHelper.expectValid('uid');
     }));
 
     it('should validate that username is invalid', fakeAsync(() => {
+      spyOn(rgwUserService, 'get').and.returnValue(observableOf({}));
       formHelper.setValue('uid', 'abc', true);
       tick(500);
       formHelper.expectError('uid', 'notUnique');

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { of as observableOf } from 'rxjs';
+import { of as observableOf, throwError } from 'rxjs';
 
 import { configureTestBed } from '~/testing/unit-test-helper';
 import { RgwUserService } from './rgw-user.service';
@@ -138,21 +138,19 @@ describe('RgwUserService', () => {
     expect(req.request.method).toBe('DELETE');
   });
 
-  it('should call exists with an existent uid', () => {
-    spyOn(service, 'enumerate').and.returnValue(observableOf(['foo', 'bar']));
-    let result;
+  it('should call exists with an existent uid', (done) => {
+    spyOn(service, 'get').and.returnValue(observableOf({}));
     service.exists('foo').subscribe((res) => {
-      result = res;
+      expect(res).toBe(true);
+      done();
     });
-    expect(result).toBe(true);
   });
 
-  it('should call exists with a non existent uid', () => {
-    spyOn(service, 'enumerate').and.returnValue(observableOf(['foo', 'bar']));
-    let result;
+  it('should call exists with a non existent uid', (done) => {
+    spyOn(service, 'get').and.returnValue(throwError('bar'));
     service.exists('baz').subscribe((res) => {
-      result = res;
+      expect(res).toBe(false);
+      done();
     });
-    expect(result).toBe(false);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 
 import _ from 'lodash';
 import { forkJoin as observableForkJoin, Observable, of as observableOf } from 'rxjs';
-import { mergeMap } from 'rxjs/operators';
+import { catchError, mapTo, mergeMap } from 'rxjs/operators';
 
 import { cdEncode } from '../decorators/cd-encode';
 
@@ -131,10 +131,13 @@ export class RgwUserService {
    * @return {Observable<boolean>}
    */
   exists(uid: string): Observable<boolean> {
-    return this.enumerate().pipe(
-      mergeMap((resp: string[]) => {
-        const index = _.indexOf(resp, uid);
-        return observableOf(-1 !== index);
+    return this.get(uid).pipe(
+      mapTo(true),
+      catchError((error: Event) => {
+        if (_.isFunction(error.preventDefault)) {
+          error.preventDefault();
+        }
+        return observableOf(false);
       })
     );
   }


### PR DESCRIPTION
The rgw users create form doesnt validate the username correctly if the username is a tenated one. For eg. Consider there is a user called tenate$sample. Now I am trying to create another user and I entered tenate$sample as username. But it doesn't async validate the username as existing. Instead it just shows the green tick and once the submit button is clicked it'll show the user as existing.

![users](https://user-images.githubusercontent.com/71764184/104870715-2d3ac400-596f-11eb-93a3-995f47ab0bb3.png)

**BEFORE**
![validation](https://user-images.githubusercontent.com/71764184/104870712-2d3ac400-596f-11eb-9d7e-0e666e501065.png)
**AFTER**
![aftervalidation](https://user-images.githubusercontent.com/71764184/104870709-2c099700-596f-11eb-83a3-8236039b739a.png)

Fixes: https://tracker.ceph.com/issues/48907
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
