### PR TITLE
osd: Remove override for osd_async_recovery_min_cost for mclock profiles

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9917,7 +9917,6 @@ const char** OSD::get_tracked_conf_keys() const
     "osd_recovery_max_active",
     "osd_recovery_max_active_hdd",
     "osd_recovery_max_active_ssd",
-    "osd_async_recovery_min_cost",
     // clog & admin clog
     "clog_to_monitors",
     "clog_to_syslog",
@@ -9954,13 +9953,10 @@ void OSD::handle_conf_change(const ConfigProxy& conf,
       changed.count("osd_recovery_sleep_hybrid") ||
       changed.count("osd_recovery_max_active") ||
       changed.count("osd_recovery_max_active_hdd") ||
-      changed.count("osd_recovery_max_active_ssd") ||
-      changed.count("osd_async_recovery_min_cost")) {
+      changed.count("osd_recovery_max_active_ssd")) {
     if (cct->_conf.get_val<std::string>("osd_op_queue") == "mclock_scheduler" &&
         cct->_conf.get_val<std::string>("osd_mclock_profile") != "custom") {
       // Set ceph config option to meet QoS goals
-      // Set async_recovery_min_cost
-      cct->_conf.set_val("osd_async_recovery_min_cost", std::to_string(100));
       // Set high value for recovery max active
       uint32_t recovery_max_active = 1000;
       if (cct->_conf->osd_recovery_max_active) {

--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -276,9 +276,6 @@ void mClockScheduler::set_high_client_ops_profile_config()
 
 void mClockScheduler::set_global_recovery_options()
 {
-  // Set low recovery min cost
-  cct->_conf.set_val("osd_async_recovery_min_cost", stringify(100));
-
   // Set high value for recovery max active and max backfill
   int rec_max_active = 1000;
   int max_backfills = 1000;


### PR DESCRIPTION
Overriding osd_async_recovery_min_cost as part of enabling a built-in
mclock profile has the undesirable side effect of peers not choosing
the correct async recovery targets if osds are using mixed schedulers
(this could happen during upgrades or if "debug_random" is set for
osd_op_queue config option). Due to the above, osds get into a
"choose_acting" loop during peering.

The solution is to remove the override of osd_async_recovery_min_cost.

Fixes: https://tracker.ceph.com/issues/48906
Signed-off-by: Sridhar Seshasayee <sseshasa@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
