### PR TITLE
octopus: do_cmake.sh: use python-3.9 with fedora version 33

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -17,8 +17,10 @@ if [ -r /etc/os-release ]; then
   case "$ID" in
       fedora)
           PYBUILD="3.7"
-          if [ "$VERSION_ID" -ge "32" ] ; then
+          if [ "$VERSION_ID" -eq "32" ] ; then
               PYBUILD="3.8"
+          elif [ "$VERSION_ID" -ge "33" ] ; then
+              PYBUILD="3.9"
           fi
           ;;
       rhel|centos)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48889

---

backport of https://github.com/ceph/ceph/pull/37773
parent tracker: https://tracker.ceph.com/issues/47971

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh