### PR TITLE
octopus: cmake: detect and use sigdescr_np() if available

### DIFF
--- a/cmake/modules/CephChecks.cmake
+++ b/cmake/modules/CephChecks.cmake
@@ -24,6 +24,7 @@ check_function_exists(strerror_r HAVE_Strerror_R)
 check_function_exists(name_to_handle_at HAVE_NAME_TO_HANDLE_AT)
 check_function_exists(pipe2 HAVE_PIPE2)
 check_function_exists(accept4 HAVE_ACCEPT4)
+check_function_exists(sigdescr_np HAVE_SIGDESCR_NP)
 
 include(CMakePushCheckState)
 cmake_push_check_state(RESET)

--- a/src/global/signal_handler.h
+++ b/src/global/signal_handler.h
@@ -20,10 +20,12 @@
 
 typedef void (*signal_handler_t)(int);
 
-#ifndef HAVE_REENTRANT_STRSIGNAL
-# define sig_str(signum) sys_siglist[signum]
-#else
+#ifdef HAVE_SIGDESCR_NP
+# define sig_str(signum) sigdescr_np(signum)
+#elif HAVE_REENTRANT_STRSIGNAL
 # define sig_str(signum) strsignal(signum)
+#else
+# define sig_str(signum) sys_siglist[signum]
 #endif
 
 void install_sighandler(int signum, signal_handler_t handler, int flags);

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -220,6 +220,9 @@
 /* Define to 1 if you have sched.h. */
 #cmakedefine HAVE_SCHED 1
 
+/* Define to 1 if you have sigdescr_np. */
+#cmakedefine HAVE_SIGDESCR_NP 1
+
 /* Support SSE (Streaming SIMD Extensions) instructions */
 #cmakedefine HAVE_SSE
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48888

---

backport of https://github.com/ceph/ceph/pull/36924
parent tracker: https://tracker.ceph.com/issues/47187

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh