### PR TITLE
Add command 'show-sharding' to ceph-bluestore-tool

### DIFF
--- a/doc/man/8/ceph-bluestore-tool.rst
+++ b/doc/man/8/ceph-bluestore-tool.rst
@@ -24,6 +24,7 @@ Synopsis
 | **ceph-bluestore-tool** bluefs-bdev-migrate --path *osd path* --dev-target *new-device* --devs-source *device1* [--devs-source *device2*]
 | **ceph-bluestore-tool** free-dump|free-score --path *osd path* [ --allocator block/bluefs-wal/bluefs-db/bluefs-slow ]
 | **ceph-bluestore-tool** reshard --path *osd path* --sharding *new sharding* [ --sharding-ctrl *control string* ]
+| **ceph-bluestore-tool** show-sharding --path *osd path*
 
 
 Description
@@ -108,6 +109,10 @@ Commands
    Interrupted resharding will prevent OSD from running.
    Interrupted resharding does not corrupt data. It is always possible to continue previous resharding,
    or select any other sharding scheme, including reverting to original one.
+
+:command:`show-sharding` --path *osd path*
+
+   Show sharding that is currently applied to BlueStore's RocksDB.
 
 Options
 =======

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -3317,3 +3317,22 @@ int RocksDBStore::reshard(const std::string& new_sharding, const RocksDBStore::r
 
   return r;
 }
+
+bool RocksDBStore::get_sharding(std::string& sharding) {
+  rocksdb::Status status;
+  std::string stored_sharding_text;
+  bool result = false;
+  sharding.clear();
+
+  status = env->FileExists(sharding_def_file);
+  if (status.ok()) {
+    status = rocksdb::ReadFileToString(env,
+				       sharding_def_file,
+				       &stored_sharding_text);
+    if(status.ok()) {
+      result = true;
+      sharding = stored_sharding_text;
+    }
+  }
+  return result;
+}

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -516,7 +516,7 @@ public:
     bool   unittest_fail_after_successful_processing = false;
   };
   int reshard(const std::string& new_sharding, const resharding_ctrl* ctrl = nullptr);
-
+  bool get_sharding(std::string& sharding);
 
 };
 

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -275,7 +275,8 @@ int main(int argc, char **argv)
         "free-dump, "
         "free-score, "
         "bluefs-stats, "
-        "reshard")
+        "reshard, "
+        "show-sharding")
     ;
   po::options_description po_all("All options");
   po_all.add(po_options).add(po_positional);
@@ -940,12 +941,8 @@ int main(int argc, char **argv)
       cerr << "error preparing db environment: " << cpp_strerror(r) << std::endl;
       exit(EXIT_FAILURE);
     }
-    if (r < 0) {
-      cerr << "error starting k-v inside bluestore: " << cpp_strerror(r) << std::endl;
-      exit(EXIT_FAILURE);
-    }
-    RocksDBStore* rocks_db = dynamic_cast<RocksDBStore*>(db_ptr);
     ceph_assert(db_ptr);
+    RocksDBStore* rocks_db = dynamic_cast<RocksDBStore*>(db_ptr);
     ceph_assert(rocks_db);
     r = rocks_db->reshard(new_sharding, &ctrl);
     if (r < 0) {
@@ -954,6 +951,25 @@ int main(int argc, char **argv)
       cout << "reshard success" << std::endl;
     }
     bluestore.close_db_environment();
+  } else if (action == "show-sharding") {
+    BlueStore bluestore(cct.get(), path);
+    KeyValueDB *db_ptr;
+    int r = bluestore.open_db_environment(&db_ptr, false);
+    if (r < 0) {
+      cerr << "error preparing db environment: " << cpp_strerror(r) << std::endl;
+      exit(EXIT_FAILURE);
+    }
+    ceph_assert(db_ptr);
+    RocksDBStore* rocks_db = dynamic_cast<RocksDBStore*>(db_ptr);
+    ceph_assert(rocks_db);
+    std::string sharding;
+    bool res = rocks_db->get_sharding(sharding);
+    bluestore.close_db_environment();
+    if (!res) {
+      cerr << "failed to retrieve sharding def" << std::endl;
+      exit(EXIT_FAILURE);
+    }
+    cout << sharding << std::endl;
   } else {
     cerr << "unrecognized action " << action << std::endl;
     return 1;


### PR DESCRIPTION
Add command 'show-sharding' to ceph-bluestore-tool.
It was impossible to check under what sharding we operated.