### PR TITLE
octopus: rgw: adding user related web token claims to ops log

### DIFF
--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -742,6 +742,11 @@ void rgw::auth::RoleApplier::modify_request_state(const DoutPrefixProvider *dpp,
   string condition = "aws:userid";
   string value = role.id + ":" + role_session_name;
   s->env.emplace(condition, value);
+
+  s->token_claims.emplace_back("sts");
+  for (auto& it : token_claims) {
+    s->token_claims.emplace_back(it);
+  }
 }
 
 rgw::auth::Engine::result_t

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -638,6 +638,7 @@ protected:
   const rgw_user user_id;
   string token_policy;
   string role_session_name;
+  std::vector<string> token_claims;
 
 public:
 
@@ -645,11 +646,13 @@ public:
                const Role& role,
                const rgw_user& user_id,
                const string& token_policy,
-               const string& role_session_name)
+               const string& role_session_name,
+               const std::vector<string>& token_claims)
     : role(role),
       user_id(user_id),
       token_policy(token_policy),
-      role_session_name(role_session_name) {}
+      role_session_name(role_session_name),
+      token_claims(token_claims) {}
 
   uint32_t get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const override {
     return 0;
@@ -678,7 +681,8 @@ public:
                                       const rgw::auth::RoleApplier::Role& role_name,
                                       const rgw_user& user_id,
                                       const std::string& token_policy,
-                                      const std::string& role_session) const = 0;
+                                      const std::string& role_session,
+                                      const std::vector<string>& token_claims) const = 0;
     };
 };
 

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -68,9 +68,10 @@ class STSAuthStrategy : public rgw::auth::Strategy,
                             const rgw::auth::RoleApplier::Role& role,
                             const rgw_user& user_id,
                             const std::string& token_policy,
-                            const std::string& role_session_name) const override {
+                            const std::string& role_session_name,
+                            const std::vector<string>& token_claims) const override {
     auto apl = rgw::auth::add_sysreq(cct, ctl, s,
-      rgw::auth::RoleApplier(cct, role, user_id, token_policy, role_session_name));
+      rgw::auth::RoleApplier(cct, role, user_id, token_policy, role_session_name, token_claims));
     return aplptr_t(new decltype(apl)(std::move(apl)));
   }
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1747,6 +1747,9 @@ struct req_state : DoutPrefixProvider {
   /// optional coroutine context
   optional_yield yield{null_yield};
 
+  //token claims from STS token for ops log (can be used for Keystone token also)
+  std::vector<string> token_claims;
+
   req_state(CephContext* _cct, RGWEnv* e, rgw::sal::RGWUser* u, uint64_t id);
   ~req_state();
 

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -35,9 +35,10 @@ struct rgw_log_entry {
   string bucket_id;
   headers_map x_headers;
   string trans_id;
+  std::vector<string> token_claims;
 
   void encode(bufferlist &bl) const {
-    ENCODE_START(10, 5, bl);
+    ENCODE_START(11, 5, bl);
     encode(object_owner.id, bl);
     encode(bucket_owner.id, bl);
     encode(bucket, bl);
@@ -61,10 +62,11 @@ struct rgw_log_entry {
     encode(bucket_owner, bl);
     encode(x_headers, bl);
     encode(trans_id, bl);
+    encode(token_claims, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator &p) {
-    DECODE_START_LEGACY_COMPAT_LEN(10, 5, 5, p);
+    DECODE_START_LEGACY_COMPAT_LEN(11, 5, 5, p);
     decode(object_owner.id, p);
     if (struct_v > 3)
       decode(bucket_owner.id, p);
@@ -112,6 +114,9 @@ struct rgw_log_entry {
     }
     if (struct_v >= 10) {
       decode(trans_id, p);
+    }
+    if (struct_v >= 11) {
+      decode(token_claims, p);
     }
     DECODE_FINISH(p);
   }

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -5942,7 +5942,7 @@ rgw::auth::s3::STSEngine::authenticate(
                                             get_creds_info(token));
     return result_t::grant(std::move(apl), completer_factory(boost::none));
   } else if (token.acct_type == TYPE_ROLE) {
-    auto apl = role_apl_factory->create_apl_role(cct, s, r, user_id, token.policy, token.role_session);
+    auto apl = role_apl_factory->create_apl_role(cct, s, r, user_id, token.policy, token.role_session, token.token_claims);
     return result_t::grant(std::move(apl), completer_factory(token.secret_access_key));
   } else { // This is for all local users of type TYPE_RGW or TYPE_NONE
     string subuser;

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -45,6 +45,7 @@ int Credentials::generateCredentials(CephContext* cct,
                           const boost::optional<string>& policy,
                           const boost::optional<string>& roleId,
                           const boost::optional<string>& role_session,
+                          const boost::optional<std::vector<string>> token_claims,
                           boost::optional<rgw_user> user,
                           rgw::auth::Identity* identity)
 {
@@ -106,6 +107,10 @@ int Credentials::generateCredentials(CephContext* cct,
   else {
     rgw_user u({}, {});
     token.user = u;
+  }
+
+  if (token_claims) {
+    token.token_claims = std::move(*token_claims);
   }
 
   if (identity) {
@@ -295,12 +300,17 @@ AssumeRoleWithWebIdentityResponse STSService::assumeRoleWithWebIdentity(AssumeRo
 {
   AssumeRoleWithWebIdentityResponse response;
   response.assumeRoleResp.packedPolicySize = 0;
+  std::vector<string> token_claims;
 
   if (req.getProviderId().empty()) {
     response.providerId = req.getIss();
   }
   response.aud = req.getAud();
   response.sub = req.getSub();
+
+  token_claims.emplace_back(string("iss") + ":" + req.getIss());
+  token_claims.emplace_back(string("aud") + ":" + req.getAud());
+  token_claims.emplace_back(string("sub") + ":" + req.getSub());
 
   //Get the role info which is being assumed
   boost::optional<rgw::ARN> r_arn = rgw::ARN::parse(req.getRoleARN());
@@ -338,6 +348,7 @@ AssumeRoleWithWebIdentityResponse STSService::assumeRoleWithWebIdentity(AssumeRo
   response.assumeRoleResp.retCode = response.assumeRoleResp.creds.generateCredentials(cct, req.getDuration(),
                                                                                       req.getPolicy(), roleId,
                                                                                       req.getRoleSessionName(),
+                                                                                      token_claims,
                                                                                       user_id, nullptr);
   if (response.assumeRoleResp.retCode < 0) {
     return response;
@@ -384,6 +395,7 @@ AssumeRoleResponse STSService::assumeRole(AssumeRoleRequest& req)
   response.retCode = response.creds.generateCredentials(cct, req.getDuration(),
                                               req.getPolicy(), roleId,
                                               req.getRoleSessionName(),
+                                              boost::none,
                                               user_id, nullptr);
   if (response.retCode < 0) {
     return response;
@@ -419,6 +431,7 @@ GetSessionTokenResponse STSService::getSessionToken(GetSessionTokenRequest& req)
   //Generate Credentials
   if (ret = cred.generateCredentials(cct,
                                       req.getDuration(),
+                                      boost::none,
                                       boost::none,
                                       boost::none,
                                       boost::none,

--- a/src/rgw/rgw_sts.h
+++ b/src/rgw/rgw_sts.h
@@ -129,11 +129,12 @@ struct SessionToken {
   bool is_admin;
   uint32_t acct_type;
   string role_session;
+  std::vector<string> token_claims;
 
   SessionToken() {}
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     encode(access_key_id, bl);
     encode(secret_access_key, bl);
     encode(expiration, bl);
@@ -145,11 +146,12 @@ struct SessionToken {
     encode(is_admin, bl);
     encode(acct_type, bl);
     encode(role_session, bl);
+    encode(token_claims, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
     decode(access_key_id, bl);
     decode(secret_access_key, bl);
     decode(expiration, bl);
@@ -162,6 +164,9 @@ struct SessionToken {
     decode(acct_type, bl);
     if (struct_v >= 2) {
       decode(role_session, bl);
+    }
+    if (struct_v >= 3) {
+      decode(token_claims, bl);
     }
     DECODE_FINISH(bl);
   }
@@ -181,6 +186,7 @@ public:
                           const boost::optional<string>& policy,
                           const boost::optional<string>& roleId,
                           const boost::optional<string>& role_session,
+                          const boost::optional<std::vector<string> > token_claims,
                           boost::optional<rgw_user> user,
                           rgw::auth::Identity* identity);
   const string& getAccessKeyId() const { return accessKeyId; }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48693

---

backport of https://github.com/ceph/ceph/pull/35465
parent tracker: https://tracker.ceph.com/issues/45989

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh