### PR TITLE
octopus: mgr/dashboard: add `--ssl` to `ng serve`

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "ng": "ng",
-    "start": "npm run env_build && ng serve --host 0.0.0.0",
+    "start": "npm run env_build && ng serve --host 0.0.0.0 --ssl",
     "build": "export _locale=${LOCALE:-$npm_package_config_locale}; if [ ${_locale} = $npm_package_config_locale ]; then export _file=; else export _file=src/locale/messages.${_locale}.xlf; fi; ng build --outputPath=dist/${_locale} --i18nFile=${_file} --i18nLocale=${_locale}",
     "prebuild": "npm run env_build",
     "build:cs": "LOCALE=cs npm run build",


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48928

---

backport of https://github.com/ceph/ceph/pull/38865
parent tracker: https://tracker.ceph.com/issues/48847

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh