### PR TITLE
qa/suites/rados/cephadm/upgrade: avoid allow_ptrace with old cephadm

### DIFF
--- a/qa/suites/rados/cephadm/upgrade/1-start.yaml
+++ b/qa/suites/rados/cephadm/upgrade/1-start.yaml
@@ -2,3 +2,5 @@ tasks:
 - cephadm:
     image: docker.io/ceph/ceph:v15.2.0
     cephadm_branch: v15.2.0
+    # avoid --cap-add=PTRACE + --privileged for older cephadm versions
+    allow_ptrace: false

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -402,8 +402,9 @@ def ceph_bootstrap(ctx, config, registry):
             'sudo chmod 0600 /root/.ssh/authorized_keys')
 
         # set options
-        _shell(ctx, cluster_name, bootstrap_remote,
-               ['ceph', 'config', 'set', 'mgr', 'mgr/cephadm/allow_ptrace', 'true'])
+        if config.get('allow_ptrace', True):
+            _shell(ctx, cluster_name, bootstrap_remote,
+                   ['ceph', 'config', 'set', 'mgr', 'mgr/cephadm/allow_ptrace', 'true'])
 
         # add other hosts
         for remote in ctx.cluster.remotes.keys():


### PR DESCRIPTION
Older cephadm is not smart enough to not combine --cap-add=SYS_PTRACE
and --privileged, which some version of podman cannot handle.

For upgrades, leave off the allow_ptrace behavior since we may be starting
on one of those old versions.

See also https://tracker.ceph.com/issues/46429
Signed-off-by: Sage Weil <sage@newdream.net>