### PR TITLE
cephadm: fix node-exporter path

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1965,6 +1965,8 @@ def create_daemon_dirs(fsid, daemon_type, daemon_id, uid, gid,
             config_dir = 'etc/alertmanager'
             makedirs(os.path.join(data_dir_root, config_dir), uid, gid, 0o755)
             makedirs(os.path.join(data_dir_root, config_dir, 'data'), uid, gid, 0o755)
+        elif daemon_type == 'node-exporter':
+            pass
         else:
             assert False
 


### PR DESCRIPTION
Fixes: 2ce828d5f3682d3eee61e4a4a07a9eedb6a3d04e
Signed-off-by: Sage Weil <sage@newdream.net>