### PR TITLE
rgw: Fix spurious error on empty datalog shard

### DIFF
--- a/src/rgw/cls_fifo_legacy.cc
+++ b/src/rgw/cls_fifo_legacy.cc
@@ -39,7 +39,7 @@
 #include "cls_fifo_legacy.h"
 
 namespace rgw::cls::fifo {
-static constexpr auto dout_subsys = ceph_subsys_rgw;
+static constexpr auto dout_subsys = ceph_subsys_objclass;
 namespace cb = ceph::buffer;
 namespace fifo = rados::cls::fifo;
 

--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -192,6 +192,10 @@ public:
 			      max_entries, log_entries,
 			      std::string(marker.value_or("")),
 			      out_marker, truncated, null_yield);
+    if (r == -ENOENT) {
+      *truncated = false;
+      return 0;
+    }
     if (r < 0) {
       lderr(cct) << __PRETTY_FUNCTION__
 		 << ": failed to list " << oids[index]


### PR DESCRIPTION
`-ENOENT` on a shard simply means nothing has been written to it
yet. Return no entries and no error.

Also change `dout_subsys` target for fifo client so probes don't fill up
the logs.

Fixes: https://tracker.ceph.com/issues/48929
