### PR TITLE
RFC: common/options: Make allowed enums case insensitive

### DIFF
--- a/src/common/options.h
+++ b/src/common/options.h
@@ -235,7 +235,7 @@ struct Option {
   int pre_validate(std::string *new_value, std::string *err) const;
 
   // Validate properly typed value against bounds
-  int validate(const Option::value_t &new_value, std::string *err) const;
+  int validate(Option::value_t &new_value, std::string *err) const;
 
   // const char * must be explicit to avoid it being treated as an int
   Option& set_value(value_t& v, const char *new_value) {


### PR DESCRIPTION
When using 'allowed enums' compare them case insensitively.

I realized today this doesn't happen, and it might be a good idea, though I don't know if there's code that depends on the current behavior or we think we'll want to keep case sensitivity for some other reason.

