### PR TITLE
octopus: rgw/multisite: Verify if the synced object is identical to source

### DIFF
--- a/qa/suites/rgw/multisite/overrides.yaml
+++ b/qa/suites/rgw/multisite/overrides.yaml
@@ -13,5 +13,6 @@ overrides:
         rgw curl low speed time: 300
         rgw md log max shards: 4
         rgw data log num shards: 4
+        rgw sync obj etag verify: true
   rgw:
     compression type: random

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1446,7 +1446,7 @@ OPTION(rgw_curl_low_speed_limit, OPT_INT) // low speed limit for certain curl ca
 OPTION(rgw_curl_low_speed_time, OPT_INT) // low speed time for certain curl calls
 OPTION(rgw_copy_obj_progress, OPT_BOOL) // should dump progress during long copy operations?
 OPTION(rgw_copy_obj_progress_every_bytes, OPT_INT) // min bytes between copy progress output
-OPTION(rgw_copy_verify_object, OPT_BOOL) // verify if the copied object is identical to source
+OPTION(rgw_sync_obj_integrity, OPT_BOOL) // verify if the copied object from remote is identical to source
 OPTION(rgw_obj_tombstone_cache_size, OPT_INT) // how many objects in tombstone cache, which is used in multi-zone sync to keep
                                                     // track of removed objects' mtime
 

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1446,6 +1446,7 @@ OPTION(rgw_curl_low_speed_limit, OPT_INT) // low speed limit for certain curl ca
 OPTION(rgw_curl_low_speed_time, OPT_INT) // low speed time for certain curl calls
 OPTION(rgw_copy_obj_progress, OPT_BOOL) // should dump progress during long copy operations?
 OPTION(rgw_copy_obj_progress_every_bytes, OPT_INT) // min bytes between copy progress output
+OPTION(rgw_copy_verify_object, OPT_BOOL) // verify if the copied object is identical to source
 OPTION(rgw_obj_tombstone_cache_size, OPT_INT) // how many objects in tombstone cache, which is used in multi-zone sync to keep
                                                     // track of removed objects' mtime
 

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1446,7 +1446,7 @@ OPTION(rgw_curl_low_speed_limit, OPT_INT) // low speed limit for certain curl ca
 OPTION(rgw_curl_low_speed_time, OPT_INT) // low speed time for certain curl calls
 OPTION(rgw_copy_obj_progress, OPT_BOOL) // should dump progress during long copy operations?
 OPTION(rgw_copy_obj_progress_every_bytes, OPT_INT) // min bytes between copy progress output
-OPTION(rgw_sync_obj_integrity, OPT_BOOL) // verify if the copied object from remote is identical to source
+OPTION(rgw_sync_obj_etag_verify, OPT_BOOL) // verify if the copied object from remote is identical to source
 OPTION(rgw_obj_tombstone_cache_size, OPT_INT) // how many objects in tombstone cache, which is used in multi-zone sync to keep
                                                     // track of removed objects' mtime
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6390,6 +6390,13 @@ std::vector<Option> get_rgw_options() {
     .set_default(1_M)
     .set_description("Send copy-object progress info after these many bytes"),
 
+    Option("rgw_copy_verify_object", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("Verify if the object copied is identical to its source")
+    .set_long_description(
+        "If true, this option computes the MD5 checksum of the data which is written at the"
+	"destination and checks if it is identical to the ETAG stored in the source."),
+
     Option("rgw_obj_tombstone_cache_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(1000)
     .set_description("Max number of entries to keep in tombstone cache")

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6390,7 +6390,7 @@ std::vector<Option> get_rgw_options() {
     .set_default(1_M)
     .set_description("Send copy-object progress info after these many bytes"),
 
-    Option("rgw_sync_obj_integrity", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    Option("rgw_sync_obj_etag_verify", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
     .set_description("Verify if the object copied from remote is identical to its source")
     .set_long_description(

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6390,12 +6390,14 @@ std::vector<Option> get_rgw_options() {
     .set_default(1_M)
     .set_description("Send copy-object progress info after these many bytes"),
 
-    Option("rgw_copy_verify_object", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    Option("rgw_sync_obj_integrity", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
-    .set_description("Verify if the object copied is identical to its source")
+    .set_description("Verify if the object copied from remote is identical to its source")
     .set_long_description(
-        "If true, this option computes the MD5 checksum of the data which is written at the"
-	"destination and checks if it is identical to the ETAG stored in the source."),
+        "If true, this option computes the MD5 checksum of the data which is written at the "
+	"destination and checks if it is identical to the ETAG stored in the source. "
+        "It ensures integrity of the objects fetched from a remote server over HTTP including "
+        "multisite sync."),
 
     Option("rgw_obj_tombstone_cache_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(1000)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -62,6 +62,7 @@ set(librgw_common_srcs
   rgw_cache.cc
   rgw_common.cc
   rgw_compression.cc
+  rgw_etag_verifier.cc
   rgw_cors.cc
   rgw_cors_s3.cc
   rgw_dencoder.cc

--- a/src/rgw/rgw_compression.cc
+++ b/src/rgw/rgw_compression.cc
@@ -5,29 +5,36 @@
 
 #define dout_subsys ceph_subsys_rgw
 
-int rgw_compression_info_from_attrset(map<string, bufferlist>& attrs,
+int rgw_compression_info_from_attr(const bufferlist& attr,
+                                   bool& need_decompress,
+                                   RGWCompressionInfo& cs_info)
+{
+  auto bliter = attr.cbegin();
+  try {
+    decode(cs_info, bliter);
+  } catch (buffer::error& err) {
+    return -EIO;
+  }
+  if (cs_info.blocks.size() == 0) {
+    return -EIO;
+  }
+  if (cs_info.compression_type != "none")
+    need_decompress = true;
+  else
+    need_decompress = false;
+  return 0;
+}
+
+int rgw_compression_info_from_attrset(const map<string, bufferlist>& attrs,
                                       bool& need_decompress,
-                                      RGWCompressionInfo& cs_info) {
-  map<string, bufferlist>::iterator value = attrs.find(RGW_ATTR_COMPRESSION);
-  if (value != attrs.end()) {
-    auto bliter = value->second.cbegin();
-    try {
-      decode(cs_info, bliter);
-    } catch (buffer::error& err) {
-      return -EIO;
-    }
-    if (cs_info.blocks.size() == 0) {
-      return -EIO;
-    }
-    if (cs_info.compression_type != "none")
-      need_decompress = true;
-    else
-      need_decompress = false;
-    return 0;
-  } else {
+                                      RGWCompressionInfo& cs_info)
+{
+  auto value = attrs.find(RGW_ATTR_COMPRESSION);
+  if (value == attrs.end()) {
     need_decompress = false;
     return 0;
   }
+  return rgw_compression_info_from_attr(value->second, need_decompress, cs_info);
 }
 
 //------------RGWPutObj_Compress---------------

--- a/src/rgw/rgw_compression.h
+++ b/src/rgw/rgw_compression.h
@@ -11,7 +11,12 @@
 #include "rgw_op.h"
 #include "rgw_compression_types.h"
 
-int rgw_compression_info_from_attrset(map<string, bufferlist>& attrs, bool& need_decompress, RGWCompressionInfo& cs_info);
+int rgw_compression_info_from_attr(const bufferlist& attr,
+                                   bool& need_decompress,
+                                   RGWCompressionInfo& cs_info);
+int rgw_compression_info_from_attrset(const map<string, bufferlist>& attrs,
+                                      bool& need_decompress,
+                                      RGWCompressionInfo& cs_info);
 
 class RGWGetObj_Decompress : public RGWGetObj_Filter
 {

--- a/src/rgw/rgw_etag_verifier.cc
+++ b/src/rgw/rgw_etag_verifier.cc
@@ -1,0 +1,111 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+#include "rgw_etag_verifier.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+int RGWPutObj_ETagVerifier_Atomic::process(bufferlist&& in, uint64_t logical_offset)
+{
+  bufferlist out;
+  if (in.length() > 0)
+    hash.Update((const unsigned char *)in.c_str(), in.length());
+
+  return Pipe::process(std::move(in), logical_offset);
+}
+
+void RGWPutObj_ETagVerifier_Atomic::calculate_etag()
+{
+  unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
+  char calc_md5[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
+
+  /* Return early if ETag has already been calculated */
+  if (!calculated_etag.empty())
+    return;
+
+  hash.Final(m);
+  buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5);
+  ldout(cct, 20) << "Single part object: " << " etag:" << calculated_etag
+          << dendl;
+  calculated_etag = calc_md5;
+}
+
+void RGWPutObj_ETagVerifier_MPU::process_end_of_MPU_part(bufferlist in)
+{
+  unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
+  char calc_md5_part[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
+  std::string calculated_etag_part;
+
+  hash.Final(m);
+  mpu_etag_hash.Update((const unsigned char *)m, sizeof(m));
+  hash.Restart();
+
+  /* Debugging begin */
+  buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5_part);
+  calculated_etag_part = calc_md5_part;
+  ldout(cct, 20) << "Part etag: " << calculated_etag_part << dendl;
+  /* Debugging end */
+
+  cur_part_index++;
+  next_part_index++;
+}
+
+int RGWPutObj_ETagVerifier_MPU::process(bufferlist&& in, uint64_t logical_offset)
+{
+  uint64_t bl_end = in.length() + logical_offset;
+
+  /* Handle the last MPU part */
+  if (next_part_index == part_ofs.size()) {
+    hash.Update((const unsigned char *)in.c_str(), in.length());
+    goto done;
+  }
+
+  /* Incoming bufferlist spans two MPU parts. Calculate separate ETags */
+  if (bl_end > part_ofs[next_part_index]) {
+
+    uint64_t part_one_len = part_ofs[next_part_index] - logical_offset;
+    hash.Update((const unsigned char *)in.c_str(), part_one_len);
+    process_end_of_MPU_part(in);
+
+    hash.Update((const unsigned char *)in.c_str() + part_one_len,
+      bl_end - part_ofs[cur_part_index]);
+    /*
+     * If we've moved to the last part of the MPU, avoid usage of
+     * parts_ofs[next_part_index] as it will lead to our-of-range access.
+     */
+    if (next_part_index == part_ofs.size())
+      goto done;
+  } else {
+    hash.Update((const unsigned char *)in.c_str(), in.length());
+  }
+
+  /* Update the MPU Etag if the current part has ended */
+  if (logical_offset + in.length() + 1 == part_ofs[next_part_index])
+    process_end_of_MPU_part(in);
+
+done:
+  return Pipe::process(std::move(in), logical_offset);
+}
+
+void RGWPutObj_ETagVerifier_MPU::calculate_etag()
+{
+  unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE], mpu_m[CEPH_CRYPTO_MD5_DIGESTSIZE];
+  char final_etag_str[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 16];
+
+  /* Return early if ETag has already been calculated */
+  if (!calculated_etag.empty())
+    return;
+
+  hash.Final(m);
+  mpu_etag_hash.Update((const unsigned char *)m, sizeof(m));
+
+  /* Refer RGWCompleteMultipart::execute() for ETag calculation for MPU object */
+  mpu_etag_hash.Final(mpu_m);
+  buf_to_hex(mpu_m, CEPH_CRYPTO_MD5_DIGESTSIZE, final_etag_str);
+  snprintf(&final_etag_str[CEPH_CRYPTO_MD5_DIGESTSIZE * 2],
+           sizeof(final_etag_str) - CEPH_CRYPTO_MD5_DIGESTSIZE * 2,
+           "-%lld", (long long)(part_ofs.size()));
+
+  ldout(cct, 20) << "MPU calculated ETag:" << calculated_etag << dendl;
+  calculated_etag = final_etag_str;
+}

--- a/src/rgw/rgw_etag_verifier.cc
+++ b/src/rgw/rgw_etag_verifier.cc
@@ -10,8 +10,7 @@ namespace rgw::putobj {
 int create_etag_verifier(CephContext* cct, DataProcessor* filter,
                          const bufferlist& manifest_bl,
                          const std::optional<RGWCompressionInfo>& compression,
-                         boost::optional<ETagVerifier_Atomic>& etag_verifier_atomic,
-                         boost::optional<ETagVerifier_MPU>& etag_verifier_mpu)
+                         etag_verifier_ptr& verifier)
 {
   RGWObjManifest manifest;
 
@@ -32,8 +31,7 @@ int create_etag_verifier(CephContext* cct, DataProcessor* filter,
 
   if (rule.part_size == 0) {
     /* Atomic object */
-    etag_verifier_atomic = boost::in_place(cct, filter);
-    filter = &*etag_verifier_atomic;
+    verifier.emplace<ETagVerifier_Atomic>(cct, filter);
     return 0;
   }
 
@@ -75,7 +73,7 @@ int create_etag_verifier(CephContext* cct, DataProcessor* filter,
     }
   }
 
-  etag_verifier_mpu = boost::in_place(cct, std::move(part_ofs), filter);
+  verifier.emplace<ETagVerifier_MPU>(cct, std::move(part_ofs), filter);
   return 0;
 }
 

--- a/src/rgw/rgw_etag_verifier.cc
+++ b/src/rgw/rgw_etag_verifier.cc
@@ -5,7 +5,9 @@
 
 #define dout_subsys ceph_subsys_rgw
 
-int RGWPutObj_ETagVerifier_Atomic::process(bufferlist&& in, uint64_t logical_offset)
+namespace rgw::putobj {
+
+int ETagVerifier_Atomic::process(bufferlist&& in, uint64_t logical_offset)
 {
   bufferlist out;
   if (in.length() > 0)
@@ -14,7 +16,7 @@ int RGWPutObj_ETagVerifier_Atomic::process(bufferlist&& in, uint64_t logical_off
   return Pipe::process(std::move(in), logical_offset);
 }
 
-void RGWPutObj_ETagVerifier_Atomic::calculate_etag()
+void ETagVerifier_Atomic::calculate_etag()
 {
   unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
   char calc_md5[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
@@ -30,7 +32,7 @@ void RGWPutObj_ETagVerifier_Atomic::calculate_etag()
           << dendl;
 }
 
-void RGWPutObj_ETagVerifier_MPU::process_end_of_MPU_part()
+void ETagVerifier_MPU::process_end_of_MPU_part()
 {
   unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
   char calc_md5_part[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
@@ -50,7 +52,7 @@ void RGWPutObj_ETagVerifier_MPU::process_end_of_MPU_part()
   next_part_index++;
 }
 
-int RGWPutObj_ETagVerifier_MPU::process(bufferlist&& in, uint64_t logical_offset)
+int ETagVerifier_MPU::process(bufferlist&& in, uint64_t logical_offset)
 {
   uint64_t bl_end = in.length() + logical_offset;
 
@@ -87,7 +89,7 @@ done:
   return Pipe::process(std::move(in), logical_offset);
 }
 
-void RGWPutObj_ETagVerifier_MPU::calculate_etag()
+void ETagVerifier_MPU::calculate_etag()
 {
   unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE], mpu_m[CEPH_CRYPTO_MD5_DIGESTSIZE];
   char final_etag_str[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 16];
@@ -109,3 +111,5 @@ void RGWPutObj_ETagVerifier_MPU::calculate_etag()
   calculated_etag = final_etag_str;
   ldout(cct, 20) << "MPU calculated ETag:" << calculated_etag << dendl;
 }
+
+} // namespace rgw::putobj

--- a/src/rgw/rgw_etag_verifier.h
+++ b/src/rgw/rgw_etag_verifier.h
@@ -18,6 +18,12 @@
 #include "rgw_putobj.h"
 #include "rgw_op.h"
 
+enum SourceObjType {
+  OBJ_TYPE_UNINIT, /* Object type is not initialised yet */
+  OBJ_TYPE_ATOMIC,
+  OBJ_TYPE_MPU, /* Object at source was created through MPU */
+};
+
 class RGWPutObj_ETagVerifier : public rgw::putobj::Pipe
 {
 protected:

--- a/src/rgw/rgw_etag_verifier.h
+++ b/src/rgw/rgw_etag_verifier.h
@@ -1,0 +1,68 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab ft=cpp
+
+/*
+ * RGW Etag Verifier is an RGW filter which enables the objects copied using
+ * multisite sync to be verified using their ETag from source i.e. the MD5
+ * checksum of the object is computed at the destination and is verified to be
+ * identical to the ETag stored in the object HEAD at source cluster.
+ * 
+ * For MPU objects, a different filter named RGWMultipartEtagFilter is applied
+ * which re-computes ETag using RGWObjManifest. This computes the ETag using the
+ * same algorithm used at the source cluster i.e. MD5 sum of the individual ETag
+ * on the MPU parts.
+ */
+#ifndef CEPH_RGW_ETAG_VERIFIER_H
+#define CEPH_RGW_ETAG_VERIFIER_H
+
+#include "rgw_putobj.h"
+#include "rgw_op.h"
+
+class RGWPutObj_ETagVerifier : public rgw::putobj::Pipe
+{
+protected:
+  CephContext* cct;
+  MD5 hash;
+  string calculated_etag;
+
+public:
+  RGWPutObj_ETagVerifier(CephContext* cct_, rgw::putobj::DataProcessor *next)
+    : Pipe(next), cct(cct_) {}
+
+  virtual void calculate_etag() = 0;
+  string get_calculated_etag() { return calculated_etag;}
+  virtual void append_part_ofs(uint64_t ofs) = 0;
+
+}; /* RGWPutObj_ETagVerifier */
+
+class RGWPutObj_ETagVerifier_Atomic : public RGWPutObj_ETagVerifier
+{
+public:
+  RGWPutObj_ETagVerifier_Atomic(CephContext* cct_, rgw::putobj::DataProcessor *next)
+    : RGWPutObj_ETagVerifier(cct_, next) {}
+
+  int process(bufferlist&& data, uint64_t logical_offset) override;
+  void calculate_etag() override;
+  void append_part_ofs(uint64_t ofs) override {}
+
+}; /* RGWPutObj_ETagVerifier_Atomic */
+
+class RGWPutObj_ETagVerifier_MPU : public RGWPutObj_ETagVerifier
+{
+  std::vector<uint64_t> part_ofs;
+  int cur_part_index{0}, next_part_index{1};
+  MD5 mpu_etag_hash;
+ 
+  void process_end_of_MPU_part(bufferlist in);
+
+public:
+  RGWPutObj_ETagVerifier_MPU(CephContext* cct_, rgw::putobj::DataProcessor *next)
+    : RGWPutObj_ETagVerifier(cct_, next) {}
+
+  int process(bufferlist&& data, uint64_t logical_offset) override;
+  void calculate_etag() override;
+  void append_part_ofs(uint64_t ofs) override { part_ofs.emplace_back(ofs); }
+
+}; /* RGWPutObj_ETagVerifier_MPU */
+
+#endif /* CEPH_RGW_ETAG_VERIFIER_H */

--- a/src/rgw/rgw_etag_verifier.h
+++ b/src/rgw/rgw_etag_verifier.h
@@ -31,7 +31,6 @@ public:
 
   virtual void calculate_etag() = 0;
   string get_calculated_etag() { return calculated_etag;}
-  virtual void append_part_ofs(uint64_t ofs) = 0;
 
 }; /* RGWPutObj_ETagVerifier */
 
@@ -43,7 +42,6 @@ public:
 
   int process(bufferlist&& data, uint64_t logical_offset) override;
   void calculate_etag() override;
-  void append_part_ofs(uint64_t ofs) override {}
 
 }; /* RGWPutObj_ETagVerifier_Atomic */
 
@@ -53,7 +51,7 @@ class RGWPutObj_ETagVerifier_MPU : public RGWPutObj_ETagVerifier
   int cur_part_index{0}, next_part_index{1};
   MD5 mpu_etag_hash;
  
-  void process_end_of_MPU_part(bufferlist in);
+  void process_end_of_MPU_part();
 
 public:
   RGWPutObj_ETagVerifier_MPU(CephContext* cct_, rgw::putobj::DataProcessor *next)
@@ -61,7 +59,7 @@ public:
 
   int process(bufferlist&& data, uint64_t logical_offset) override;
   void calculate_etag() override;
-  void append_part_ofs(uint64_t ofs) override { part_ofs.emplace_back(ofs); }
+  void append_part_ofs(uint64_t ofs) { part_ofs.emplace_back(ofs); }
 
 }; /* RGWPutObj_ETagVerifier_MPU */
 

--- a/src/rgw/rgw_etag_verifier.h
+++ b/src/rgw/rgw_etag_verifier.h
@@ -18,12 +18,6 @@
 #include "rgw_putobj.h"
 #include "rgw_op.h"
 
-enum SourceObjType {
-  OBJ_TYPE_UNINIT, /* Object type is not initialised yet */
-  OBJ_TYPE_ATOMIC,
-  OBJ_TYPE_MPU, /* Object at source was created through MPU */
-};
-
 class RGWPutObj_ETagVerifier : public rgw::putobj::Pipe
 {
 protected:

--- a/src/rgw/rgw_etag_verifier.h
+++ b/src/rgw/rgw_etag_verifier.h
@@ -17,6 +17,7 @@
 
 #include "rgw_putobj.h"
 #include "rgw_op.h"
+#include "common/static_ptr.h"
 
 namespace rgw::putobj {
 
@@ -68,11 +69,16 @@ public:
 
 }; /* ETagVerifier_MPU */
 
-int create_etag_verifier(CephContext* cct, DataProcessor* filter,
+constexpr auto max_etag_verifier_size = std::max(
+    sizeof(ETagVerifier_Atomic),
+    sizeof(ETagVerifier_MPU)
+  );
+using etag_verifier_ptr = ceph::static_ptr<ETagVerifier, max_etag_verifier_size>;
+
+int create_etag_verifier(CephContext* cct, DataProcessor* next,
                          const bufferlist& manifest_bl,
                          const std::optional<RGWCompressionInfo>& compression,
-                         boost::optional<ETagVerifier_Atomic>& etag_verifier_atomic,
-                         boost::optional<ETagVerifier_MPU>& etag_verifier_mpu);
+                         etag_verifier_ptr& verifier);
 
 } // namespace rgw::putobj
 

--- a/src/rgw/rgw_etag_verifier.h
+++ b/src/rgw/rgw_etag_verifier.h
@@ -60,12 +60,15 @@ class RGWPutObj_ETagVerifier_MPU : public RGWPutObj_ETagVerifier
   void process_end_of_MPU_part();
 
 public:
-  RGWPutObj_ETagVerifier_MPU(CephContext* cct_, rgw::putobj::DataProcessor *next)
-    : RGWPutObj_ETagVerifier(cct_, next) {}
+  RGWPutObj_ETagVerifier_MPU(CephContext* cct,
+                             std::vector<uint64_t> part_ofs,
+                             rgw::putobj::DataProcessor *next)
+    : RGWPutObj_ETagVerifier(cct, next),
+      part_ofs(std::move(part_ofs))
+  {}
 
   int process(bufferlist&& data, uint64_t logical_offset) override;
   void calculate_etag() override;
-  void append_part_ofs(uint64_t ofs) { part_ofs.emplace_back(ofs); }
 
 }; /* RGWPutObj_ETagVerifier_MPU */
 

--- a/src/rgw/rgw_etag_verifier.h
+++ b/src/rgw/rgw_etag_verifier.h
@@ -68,6 +68,12 @@ public:
 
 }; /* ETagVerifier_MPU */
 
+int create_etag_verifier(CephContext* cct, DataProcessor* filter,
+                         const bufferlist& manifest_bl,
+                         const std::optional<RGWCompressionInfo>& compression,
+                         boost::optional<ETagVerifier_Atomic>& etag_verifier_atomic,
+                         boost::optional<ETagVerifier_MPU>& etag_verifier_mpu);
+
 } // namespace rgw::putobj
 
 #endif /* CEPH_RGW_ETAG_VERIFIER_H */

--- a/src/rgw/rgw_obj_manifest.h
+++ b/src/rgw/rgw_obj_manifest.h
@@ -466,6 +466,10 @@ public:
       return location;
     }
 
+    int get_cur_part_id() const {
+      return cur_part_id;
+    }
+
     /* start of current stripe */
     uint64_t get_stripe_ofs() {
       if (manifest->explicit_objs) {

--- a/src/rgw/rgw_obj_manifest.h
+++ b/src/rgw/rgw_obj_manifest.h
@@ -466,8 +466,9 @@ public:
       return location;
     }
 
-    int get_cur_part_id() const {
-      return cur_part_id;
+    /* where current part starts */
+    uint64_t get_part_ofs() const {
+      return part_ofs;
     }
 
     /* start of current stripe */

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3261,7 +3261,7 @@ class RGWRadosPutObj : public RGWHTTPStreamRWRequest::ReceiveCB
   rgw::putobj::ObjectProcessor *processor;
   void (*progress_cb)(off_t, void *);
   void *progress_data;
-  bufferlist extra_data_bl, full_obj;
+  bufferlist extra_data_bl, full_obj, manifest_bl;
   uint64_t extra_data_left{0};
   bool need_to_process_attrs{true};
   uint64_t data_len{0};
@@ -3298,7 +3298,8 @@ public:
       JSONDecoder::decode_json("attrs", src_attrs, &jp);
 
       src_attrs.erase(RGW_ATTR_COMPRESSION);
-      src_attrs.erase(RGW_ATTR_MANIFEST); // not interested in original object layout
+      /* We need the manifest to recompute the ETag for verification */
+      manifest_bl = src_attrs[RGW_ATTR_MANIFEST];
 
       // filter out olh attributes
       auto iter = src_attrs.lower_bound(RGW_ATTR_OLH_PREFIX);
@@ -3396,15 +3397,84 @@ public:
   }
 
   string get_calculated_etag() {
-    MD5 hash;
-    unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
+    MD5 hash, mpu_etag_hash;
+    unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE], mpu_m[CEPH_CRYPTO_MD5_DIGESTSIZE];
     char calc_md5[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
+    char calc_md5_part[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
+    char final_etag_str[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 16];
+    RGWObjManifest manifest;
+    std::string calculated_etag_part;
+    int prev_part_id = 1, cur_part_id = 1;
 
-    hash.Update((const unsigned char *)full_obj.c_str(), data_len);
+    auto miter = manifest_bl.cbegin();
+    try {
+      decode(manifest, miter);
+    } catch (buffer::error& err) {
+      ldout(cct, 0) << "ERROR: couldn't decode manifest" << dendl;
+      return std::string();
+    }
+    RGWObjManifest::obj_iterator mi;
+
+    RGWObjManifestRule rule;
+    bool found = manifest.get_rule(0, &rule);
+    if (!found) {
+      lderr(cct) << "ERROR: manifest->get_rule() could not find rule" << dendl;
+      return std::string();
+    }
+
+    /*
+     * Check if the object was created using multipart upload. This check is
+     * required as MPU objects' ETag != MD5sum.
+     */
+    if (rule.part_size == 0) {
+      hash.Update((const unsigned char *)full_obj.c_str(), data_len);
+      hash.Final(m);
+      buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5);
+      calculated_etag = calc_md5;
+      ldout(cct, 20) << "Single part object: " << manifest.get_obj().get_oid() <<
+	      " size:" << manifest.get_obj_size() << " etag:" <<
+	      calculated_etag << dendl;
+      return calculated_etag;
+    }
+
+    for (mi = manifest.obj_begin(); mi != manifest.obj_end(); ++mi) {
+      bufferlist obj_stripe;
+
+      cur_part_id = mi.get_cur_part_id();
+      if (cur_part_id != prev_part_id) {
+        hash.Final(m);
+        mpu_etag_hash.Update((const unsigned char *)m, sizeof(m));
+	hash.Restart();
+        buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5_part);
+        calculated_etag_part = calc_md5_part;
+        ldout(cct, 20) << "Part " << prev_part_id << " etag: " <<
+	       calculated_etag_part << dendl;
+	prev_part_id = cur_part_id;
+      }
+      full_obj.splice(0, mi.get_stripe_size(), &obj_stripe);
+      hash.Update((const unsigned char *)obj_stripe.c_str(), mi.get_stripe_size());
+    }
+
     hash.Final(m);
-    buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5);
-    calculated_etag = calc_md5;
+    mpu_etag_hash.Update((const unsigned char *)m, sizeof(m));
+
+    buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5_part);
+    calculated_etag_part = calc_md5_part;
+    ldout(cct, 20) << "Part " << prev_part_id << " etag: " << calculated_etag_part << dendl;
+
+    /* Refer RGWCompleteMultipart::execute() for ETag calculation for MPU object */
+    mpu_etag_hash.Final(mpu_m);
+    buf_to_hex(mpu_m, CEPH_CRYPTO_MD5_DIGESTSIZE, final_etag_str);
+    snprintf(&final_etag_str[CEPH_CRYPTO_MD5_DIGESTSIZE * 2],
+	     sizeof(final_etag_str) - CEPH_CRYPTO_MD5_DIGESTSIZE * 2,
+             "-%lld", (long long)(mi.get_cur_part_id() - 1));
+    calculated_etag = final_etag_str;
+
+    ldout(cct, 20) << "MPU calculated ETag:"<< calculated_etag << " Object:" <<
+	   manifest.get_obj().get_oid() <<
+	   " size:" << manifest.get_obj_size() << dendl;
     return calculated_etag;
+
   }
 };
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3258,8 +3258,8 @@ class RGWRadosPutObj : public RGWHTTPStreamRWRequest::ReceiveCB
   rgw::putobj::DataProcessor *filter;
   boost::optional<RGWPutObj_Compress>& compressor;
   bool try_etag_verify;
-  boost::optional<RGWPutObj_ETagVerifier_Atomic> etag_verifier_atomic;
-  boost::optional<RGWPutObj_ETagVerifier_MPU> etag_verifier_mpu;
+  boost::optional<rgw::putobj::ETagVerifier_Atomic> etag_verifier_atomic;
+  boost::optional<rgw::putobj::ETagVerifier_MPU> etag_verifier_mpu;
   boost::optional<rgw::putobj::ChunkProcessor> buffering;
   CompressorRef& plugin;
   rgw::putobj::ObjectProcessor *processor;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3269,7 +3269,6 @@ class RGWRadosPutObj : public RGWHTTPStreamRWRequest::ReceiveCB
   std::optional<RGWCompressionInfo> compression_info;
   uint64_t extra_data_left{0};
   bool need_to_process_attrs{true};
-  SourceObjType obj_type{OBJ_TYPE_UNINIT};
   uint64_t data_len{0};
   map<string, bufferlist> src_attrs;
   uint64_t ofs{0};
@@ -3382,7 +3381,6 @@ public:
 
       if (rule.part_size == 0) {
         /* Atomic object */
-        obj_type = OBJ_TYPE_ATOMIC;
         etag_verifier_atomic = boost::in_place(cct, filter);
         filter = &*etag_verifier_atomic;
       } else {
@@ -3428,7 +3426,6 @@ public:
         if (part_ofs.empty()) {
           try_etag_verify = false;
         } else {
-          obj_type = OBJ_TYPE_MPU;
           etag_verifier_mpu = boost::in_place(cct, std::move(part_ofs), filter);
           filter = &*etag_verifier_mpu;
         }
@@ -3502,20 +3499,16 @@ public:
     return data_len;
   }
 
-  string get_calculated_etag() {
-    if (obj_type == OBJ_TYPE_ATOMIC) {
+  std::string get_verifier_etag() {
+    if (etag_verifier_atomic) {
       etag_verifier_atomic->calculate_etag();
       return etag_verifier_atomic->get_calculated_etag();
-    } else if (obj_type == OBJ_TYPE_MPU) {
+    } else if (etag_verifier_mpu) {
       etag_verifier_mpu->calculate_etag();
       return etag_verifier_mpu->get_calculated_etag();
     } else {
       return "";
     }
-  }
-
-  SourceObjType get_obj_type() {
-    return obj_type;
   }
 };
 
@@ -4071,17 +4064,18 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
   }
 
   /* Perform ETag verification is we have computed the object's MD5 sum at our end */
-  if (cb.get_obj_type() != OBJ_TYPE_UNINIT) {
+  if (const auto& verifier_etag = cb.get_verifier_etag();
+      !verifier_etag.empty()) {
     string trimmed_etag = etag;
 
     /* Remove the leading and trailing double quotes from etag */
     trimmed_etag.erase(std::remove(trimmed_etag.begin(), trimmed_etag.end(),'\"'),
       trimmed_etag.end());
 
-    if (cb.get_calculated_etag().compare(trimmed_etag)) {
+    if (verifier_etag != trimmed_etag) {
       ret = -EIO;
       ldout(cct, 0) << "ERROR: source and destination objects don't match. Expected etag:"
-        << trimmed_etag << " Computed etag:" << cb.get_calculated_etag() << dendl;
+        << trimmed_etag << " Computed etag:" << verifier_etag << dendl;
       goto set_err_state;
     }
   }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3301,10 +3301,14 @@ public:
 
       src_attrs.erase(RGW_ATTR_COMPRESSION);
       /* We need the manifest to recompute the ETag for verification */
-      manifest_bl = src_attrs[RGW_ATTR_MANIFEST];
+      auto iter = src_attrs.find(RGW_ATTR_MANIFEST);
+      if (iter != src_attrs.end()) {
+        manifest_bl = std::move(iter->second);
+        src_attrs.erase(iter);
+      }
 
       // filter out olh attributes
-      auto iter = src_attrs.lower_bound(RGW_ATTR_OLH_PREFIX);
+      iter = src_attrs.lower_bound(RGW_ATTR_OLH_PREFIX);
       while (iter != src_attrs.end()) {
         if (!boost::algorithm::starts_with(iter->first, RGW_ATTR_OLH_PREFIX)) {
           break;
@@ -3330,11 +3334,11 @@ public:
     }
 
     /*
-     * Presently we don't support ETag based verification if compression or
-     * encryption is requested. We can enable simultaneous support once we have
-     * a mechanism to know the sequence in which the filters must be applied.
+     * Presently we don't support ETag based verification if encryption is
+     * requested. We can enable simultaneous support once we have a mechanism
+     * to know the sequence in which the filters must be applied.
      */
-    if (cct->_conf->rgw_copy_verify_object && !plugin &&
+    if (cct->_conf->rgw_sync_obj_integrity &&
         src_attrs.find(RGW_ATTR_CRYPT_MODE) == src_attrs.end()) {
 
       RGWObjManifest manifest;
@@ -3361,8 +3365,6 @@ public:
       } else {
         is_mpu_obj = true;
         etag_verifier_mpu = boost::in_place(cct, filter);
-
-        RGWObjManifest::obj_iterator mi;
         uint64_t cur_part_ofs = UINT64_MAX;
 
         /*
@@ -3370,7 +3372,7 @@ public:
          * MPU part. These part ETags then become the input for the MPU object
          * Etag.
          */
-        for (mi = manifest.obj_begin(); mi != manifest.obj_end(); ++mi) {
+        for (auto mi = manifest.obj_begin(); mi != manifest.obj_end(); ++mi) {
           if (cur_part_ofs == mi.get_part_ofs())
             continue;
           cur_part_ofs = mi.get_part_ofs();
@@ -3449,6 +3451,9 @@ public:
   }
 
   string get_calculated_etag() {
+    if (!cct->_conf->rgw_sync_obj_integrity)
+      return "";
+
     if (is_mpu_obj) {
       etag_verifier_mpu->calculate_etag();
       return etag_verifier_mpu->get_calculated_etag();
@@ -4010,6 +4015,21 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
     set_mtime_weight.init(set_mtime, svc.zone->get_zone_short_id(), pg_ver);
   }
 
+  if (cct->_conf->rgw_sync_obj_integrity) {
+    string trimmed_etag = etag;
+
+    /* Remove the leading and trailing double quotes from etag */
+    trimmed_etag.erase(std::remove(trimmed_etag.begin(), trimmed_etag.end(),'\"'),
+      trimmed_etag.end());
+
+    if (cb.get_calculated_etag().compare(trimmed_etag)) {
+      ret = -EIO;
+      ldout(cct, 0) << "ERROR: source and destination objects don't match. Expected etag:"
+        << trimmed_etag << " Computed etag:" << cb.get_calculated_etag() << dendl;
+      goto set_err_state;
+    }
+  }
+
 #define MAX_COMPLETE_RETRY 100
   for (i = 0; i < MAX_COMPLETE_RETRY; i++) {
     bool canceled = false;
@@ -4019,21 +4039,6 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
     if (ret < 0) {
       goto set_err_state;
     }
-
-    if (cct->_conf->rgw_copy_verify_object) {
-      string trimmed_etag = etag;
-
-      /* Remove the leading and trailing double quotes from etag */
-      trimmed_etag.erase(std::remove(trimmed_etag.begin(), trimmed_etag.end(),'\"'),
-        trimmed_etag.end());
-
-      if (cb.get_calculated_etag().compare(trimmed_etag)) {
-        ret = -EIO;
-        ldout(cct, 0) << "ERROR: source and destination objects don't match. Expected etag:"
-          << trimmed_etag << " Computed etag:" << cb.get_calculated_etag() << dendl;
-        goto set_err_state;
-     }
-   }
 
     if (copy_if_newer && canceled) {
       ldout(cct, 20) << "raced with another write of obj: " << dest_obj << dendl;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3338,7 +3338,7 @@ public:
      * requested. We can enable simultaneous support once we have a mechanism
      * to know the sequence in which the filters must be applied.
      */
-    if (cct->_conf->rgw_sync_obj_integrity &&
+    if (cct->_conf->rgw_sync_obj_etag_verify &&
         src_attrs.find(RGW_ATTR_CRYPT_MODE) == src_attrs.end()) {
 
       RGWObjManifest manifest;
@@ -3451,7 +3451,7 @@ public:
   }
 
   string get_calculated_etag() {
-    if (!cct->_conf->rgw_sync_obj_integrity)
+    if (!cct->_conf->rgw_sync_obj_etag_verify)
       return "";
 
     if (is_mpu_obj) {
@@ -4015,7 +4015,7 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
     set_mtime_weight.init(set_mtime, svc.zone->get_zone_short_id(), pg_ver);
   }
 
-  if (cct->_conf->rgw_sync_obj_integrity) {
+  if (cct->_conf->rgw_sync_obj_etag_verify) {
     string trimmed_etag = etag;
 
     /* Remove the leading and trailing double quotes from etag */

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -43,6 +43,7 @@
 #include "rgw_tools.h"
 #include "rgw_coroutine.h"
 #include "rgw_compression.h"
+#include "rgw_etag_verifier.h"
 #include "rgw_worker.h"
 
 #undef fork // fails to compile RGWPeriod::fork() below
@@ -3256,20 +3257,21 @@ class RGWRadosPutObj : public RGWHTTPStreamRWRequest::ReceiveCB
   rgw_obj obj;
   rgw::putobj::DataProcessor *filter;
   boost::optional<RGWPutObj_Compress>& compressor;
+  boost::optional<RGWPutObj_ETagVerifier_Atomic> etag_verifier_atomic;
+  boost::optional<RGWPutObj_ETagVerifier_MPU> etag_verifier_mpu;
   boost::optional<rgw::putobj::ChunkProcessor> buffering;
   CompressorRef& plugin;
   rgw::putobj::ObjectProcessor *processor;
   void (*progress_cb)(off_t, void *);
   void *progress_data;
-  bufferlist extra_data_bl, full_obj, manifest_bl;
+  bufferlist extra_data_bl, manifest_bl;
   uint64_t extra_data_left{0};
-  bool need_to_process_attrs{true};
+  bool need_to_process_attrs{true}, is_mpu_obj{false};
   uint64_t data_len{0};
   map<string, bufferlist> src_attrs;
   uint64_t ofs{0};
   uint64_t lofs{0}; /* logical ofs */
   std::function<int(map<string, bufferlist>&)> attrs_handler;
-  string calculated_etag;
 public:
   RGWRadosPutObj(CephContext* cct,
                  CompressorRef& plugin,
@@ -3327,6 +3329,58 @@ public:
       filter = &*buffering;
     }
 
+    /*
+     * Presently we don't support ETag based verification if compression or
+     * encryption is requested. We can enable simultaneous support once we have
+     * a mechanism to know the sequence in which the filters must be applied.
+     */
+    if (cct->_conf->rgw_copy_verify_object && !plugin &&
+        src_attrs.find(RGW_ATTR_CRYPT_MODE) == src_attrs.end()) {
+
+      RGWObjManifest manifest;
+
+      auto miter = manifest_bl.cbegin();
+      try {
+        decode(manifest, miter);
+      } catch (buffer::error& err) {
+        ldout(cct, 0) << "ERROR: couldn't decode manifest" << dendl;
+        return -EIO;
+      }
+
+      RGWObjManifestRule rule;
+      bool found = manifest.get_rule(0, &rule);
+      if (!found) {
+        lderr(cct) << "ERROR: manifest->get_rule() could not find rule" << dendl;
+        return -EIO;
+      }
+
+      if (rule.part_size == 0) {
+        /* Atomic object */
+        etag_verifier_atomic = boost::in_place(cct, filter);
+        filter = &*etag_verifier_atomic;
+      } else {
+        is_mpu_obj = true;
+        etag_verifier_mpu = boost::in_place(cct, filter);
+
+        RGWObjManifest::obj_iterator mi;
+        uint64_t cur_part_ofs = UINT64_MAX;
+
+        /*
+         * We must store the offset of each part to calculate the ETAGs for each
+         * MPU part. These part ETags then become the input for the MPU object
+         * Etag.
+         */
+        for (mi = manifest.obj_begin(); mi != manifest.obj_end(); ++mi) {
+          if (cur_part_ofs == mi.get_part_ofs())
+            continue;
+          cur_part_ofs = mi.get_part_ofs();
+          ldout(cct, 20) << "MPU Part offset:" << cur_part_ofs << dendl;
+          etag_verifier_mpu->append_part_ofs(cur_part_ofs);
+        }
+        filter = &*etag_verifier_mpu;
+      }
+    }
+
     need_to_process_attrs = false;
 
     return 0;
@@ -3373,8 +3427,6 @@ public:
 
     const uint64_t lofs = data_len;
     data_len += size;
-    if (cct->_conf->rgw_copy_verify_object)
-      full_obj.append(bl);
 
     return filter->process(std::move(bl), lofs);
   }
@@ -3397,84 +3449,13 @@ public:
   }
 
   string get_calculated_etag() {
-    MD5 hash, mpu_etag_hash;
-    unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE], mpu_m[CEPH_CRYPTO_MD5_DIGESTSIZE];
-    char calc_md5[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
-    char calc_md5_part[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
-    char final_etag_str[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 16];
-    RGWObjManifest manifest;
-    std::string calculated_etag_part;
-    int prev_part_id = 1, cur_part_id = 1;
-
-    auto miter = manifest_bl.cbegin();
-    try {
-      decode(manifest, miter);
-    } catch (buffer::error& err) {
-      ldout(cct, 0) << "ERROR: couldn't decode manifest" << dendl;
-      return std::string();
+    if (is_mpu_obj) {
+      etag_verifier_mpu->calculate_etag();
+      return etag_verifier_mpu->get_calculated_etag();
+    } else {
+      etag_verifier_atomic->calculate_etag();
+      return etag_verifier_atomic->get_calculated_etag();
     }
-    RGWObjManifest::obj_iterator mi;
-
-    RGWObjManifestRule rule;
-    bool found = manifest.get_rule(0, &rule);
-    if (!found) {
-      lderr(cct) << "ERROR: manifest->get_rule() could not find rule" << dendl;
-      return std::string();
-    }
-
-    /*
-     * Check if the object was created using multipart upload. This check is
-     * required as MPU objects' ETag != MD5sum.
-     */
-    if (rule.part_size == 0) {
-      hash.Update((const unsigned char *)full_obj.c_str(), data_len);
-      hash.Final(m);
-      buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5);
-      calculated_etag = calc_md5;
-      ldout(cct, 20) << "Single part object: " << manifest.get_obj().get_oid() <<
-	      " size:" << manifest.get_obj_size() << " etag:" <<
-	      calculated_etag << dendl;
-      return calculated_etag;
-    }
-
-    for (mi = manifest.obj_begin(); mi != manifest.obj_end(); ++mi) {
-      bufferlist obj_stripe;
-
-      cur_part_id = mi.get_cur_part_id();
-      if (cur_part_id != prev_part_id) {
-        hash.Final(m);
-        mpu_etag_hash.Update((const unsigned char *)m, sizeof(m));
-	hash.Restart();
-        buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5_part);
-        calculated_etag_part = calc_md5_part;
-        ldout(cct, 20) << "Part " << prev_part_id << " etag: " <<
-	       calculated_etag_part << dendl;
-	prev_part_id = cur_part_id;
-      }
-      full_obj.splice(0, mi.get_stripe_size(), &obj_stripe);
-      hash.Update((const unsigned char *)obj_stripe.c_str(), mi.get_stripe_size());
-    }
-
-    hash.Final(m);
-    mpu_etag_hash.Update((const unsigned char *)m, sizeof(m));
-
-    buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5_part);
-    calculated_etag_part = calc_md5_part;
-    ldout(cct, 20) << "Part " << prev_part_id << " etag: " << calculated_etag_part << dendl;
-
-    /* Refer RGWCompleteMultipart::execute() for ETag calculation for MPU object */
-    mpu_etag_hash.Final(mpu_m);
-    buf_to_hex(mpu_m, CEPH_CRYPTO_MD5_DIGESTSIZE, final_etag_str);
-    snprintf(&final_etag_str[CEPH_CRYPTO_MD5_DIGESTSIZE * 2],
-	     sizeof(final_etag_str) - CEPH_CRYPTO_MD5_DIGESTSIZE * 2,
-             "-%lld", (long long)(mi.get_cur_part_id() - 1));
-    calculated_etag = final_etag_str;
-
-    ldout(cct, 20) << "MPU calculated ETag:"<< calculated_etag << " Object:" <<
-	   manifest.get_obj().get_oid() <<
-	   " size:" << manifest.get_obj_size() << dendl;
-    return calculated_etag;
-
   }
 };
 
@@ -4040,10 +4021,16 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
     }
 
     if (cct->_conf->rgw_copy_verify_object) {
-      if (cb.get_calculated_etag().compare(etag)) {
+      string trimmed_etag = etag;
+
+      /* Remove the leading and trailing double quotes from etag */
+      trimmed_etag.erase(std::remove(trimmed_etag.begin(), trimmed_etag.end(),'\"'),
+        trimmed_etag.end());
+
+      if (cb.get_calculated_etag().compare(trimmed_etag)) {
         ret = -EIO;
         ldout(cct, 0) << "ERROR: source and destination objects don't match. Expected etag:"
-          << etag << " Computed etag:" << cb.get_calculated_etag() << dendl;
+          << trimmed_etag << " Computed etag:" << cb.get_calculated_etag() << dendl;
         goto set_err_state;
      }
    }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3266,7 +3266,8 @@ class RGWRadosPutObj : public RGWHTTPStreamRWRequest::ReceiveCB
   void *progress_data;
   bufferlist extra_data_bl, manifest_bl;
   uint64_t extra_data_left{0};
-  bool need_to_process_attrs{true}, is_mpu_obj{false};
+  bool need_to_process_attrs{true};
+  SourceObjType obj_type{OBJ_TYPE_UNINIT};
   uint64_t data_len{0};
   map<string, bufferlist> src_attrs;
   uint64_t ofs{0};
@@ -3360,10 +3361,11 @@ public:
 
       if (rule.part_size == 0) {
         /* Atomic object */
+        obj_type = OBJ_TYPE_ATOMIC;
         etag_verifier_atomic = boost::in_place(cct, filter);
         filter = &*etag_verifier_atomic;
       } else {
-        is_mpu_obj = true;
+        obj_type = OBJ_TYPE_MPU;
         etag_verifier_mpu = boost::in_place(cct, filter);
         uint64_t cur_part_ofs = UINT64_MAX;
 
@@ -3451,15 +3453,14 @@ public:
   }
 
   string get_calculated_etag() {
-    if (!cct->_conf->rgw_sync_obj_etag_verify)
-      return "";
-
-    if (is_mpu_obj) {
+    if (obj_type == OBJ_TYPE_ATOMIC) {
+      etag_verifier_atomic->calculate_etag();
+      return etag_verifier_atomic->get_calculated_etag();
+    } else if (obj_type == OBJ_TYPE_MPU) {
       etag_verifier_mpu->calculate_etag();
       return etag_verifier_mpu->get_calculated_etag();
     } else {
-      etag_verifier_atomic->calculate_etag();
-      return etag_verifier_atomic->get_calculated_etag();
+      return "";
     }
   }
 };

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3361,74 +3361,17 @@ public:
      * to know the sequence in which the filters must be applied.
      */
     if (try_etag_verify && src_attrs.find(RGW_ATTR_CRYPT_MODE) == src_attrs.end()) {
-
-      RGWObjManifest manifest;
-
-      auto miter = manifest_bl.cbegin();
-      try {
-        decode(manifest, miter);
-      } catch (buffer::error& err) {
-        ldout(cct, 0) << "ERROR: couldn't decode manifest" << dendl;
-        return -EIO;
-      }
-
-      RGWObjManifestRule rule;
-      bool found = manifest.get_rule(0, &rule);
-      if (!found) {
-        lderr(cct) << "ERROR: manifest->get_rule() could not find rule" << dendl;
-        return -EIO;
-      }
-
-      if (rule.part_size == 0) {
-        /* Atomic object */
-        etag_verifier_atomic = boost::in_place(cct, filter);
+      ret = rgw::putobj::create_etag_verifier(cct, filter, manifest_bl,
+                                              compression_info,
+                                              etag_verifier_atomic,
+                                              etag_verifier_mpu);
+      if (ret < 0) {
+        ldout(cct, 4) << "failed to initial etag verifier, "
+            "disabling etag verification" << dendl;
+      } else if (etag_verifier_atomic) {
         filter = &*etag_verifier_atomic;
-      } else {
-        uint64_t cur_part_ofs = UINT64_MAX;
-        std::vector<uint64_t> part_ofs;
-
-        /*
-         * We must store the offset of each part to calculate the ETAGs for each
-         * MPU part. These part ETags then become the input for the MPU object
-         * Etag.
-         */
-        for (auto mi = manifest.obj_begin(); mi != manifest.obj_end(); ++mi) {
-          if (cur_part_ofs == mi.get_part_ofs())
-            continue;
-          cur_part_ofs = mi.get_part_ofs();
-          ldout(cct, 20) << "MPU Part offset:" << cur_part_ofs << dendl;
-          part_ofs.push_back(cur_part_ofs);
-        }
-
-        if (compression_info) {
-          // if the source object was compressed, the manifest is storing
-          // compressed part offsets. transform the compressed offsets back to
-          // their original offsets by finding the first block of each part
-          const auto& blocks = compression_info->blocks;
-          auto block = blocks.begin();
-          for (auto& ofs : part_ofs) {
-            // find the compression_block with new_ofs == ofs
-            constexpr auto less = [] (const compression_block& block, uint64_t ofs) {
-              return block.new_ofs < ofs;
-            };
-            block = std::lower_bound(block, blocks.end(), ofs, less);
-            if (block == blocks.end() || block->new_ofs != ofs) {
-              ldout(cct, 4) << "no match for compressed offset " << ofs
-                  << ", disabling etag verification" << dendl;
-              part_ofs.clear();
-              break;
-            }
-            ofs = block->old_ofs;
-            ldout(cct, 20) << "MPU Part uncompressed offset:" << ofs << dendl;
-          }
-        }
-
-        if (part_ofs.empty()) {
-          try_etag_verify = false;
-        } else {
-          etag_verifier_mpu = boost::in_place(cct, std::move(part_ofs), filter);
-          filter = &*etag_verifier_mpu;
-        }
+      } else if (etag_verifier_mpu) {
+        filter = &*etag_verifier_mpu;
       }
     }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3365,9 +3365,8 @@ public:
         etag_verifier_atomic = boost::in_place(cct, filter);
         filter = &*etag_verifier_atomic;
       } else {
-        obj_type = OBJ_TYPE_MPU;
-        etag_verifier_mpu = boost::in_place(cct, filter);
         uint64_t cur_part_ofs = UINT64_MAX;
+        std::vector<uint64_t> part_ofs;
 
         /*
          * We must store the offset of each part to calculate the ETAGs for each
@@ -3379,8 +3378,11 @@ public:
             continue;
           cur_part_ofs = mi.get_part_ofs();
           ldout(cct, 20) << "MPU Part offset:" << cur_part_ofs << dendl;
-          etag_verifier_mpu->append_part_ofs(cur_part_ofs);
+          part_ofs.push_back(cur_part_ofs);
         }
+
+        obj_type = OBJ_TYPE_MPU;
+        etag_verifier_mpu = boost::in_place(cct, std::move(part_ofs), filter);
         filter = &*etag_verifier_mpu;
       }
     }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3261,7 +3261,7 @@ class RGWRadosPutObj : public RGWHTTPStreamRWRequest::ReceiveCB
   rgw::putobj::ObjectProcessor *processor;
   void (*progress_cb)(off_t, void *);
   void *progress_data;
-  bufferlist extra_data_bl;
+  bufferlist extra_data_bl, full_obj;
   uint64_t extra_data_left{0};
   bool need_to_process_attrs{true};
   uint64_t data_len{0};
@@ -3269,6 +3269,7 @@ class RGWRadosPutObj : public RGWHTTPStreamRWRequest::ReceiveCB
   uint64_t ofs{0};
   uint64_t lofs{0}; /* logical ofs */
   std::function<int(map<string, bufferlist>&)> attrs_handler;
+  string calculated_etag;
 public:
   RGWRadosPutObj(CephContext* cct,
                  CompressorRef& plugin,
@@ -3371,6 +3372,8 @@ public:
 
     const uint64_t lofs = data_len;
     data_len += size;
+    if (cct->_conf->rgw_copy_verify_object)
+      full_obj.append(bl);
 
     return filter->process(std::move(bl), lofs);
   }
@@ -3390,6 +3393,18 @@ public:
 
   uint64_t get_data_len() {
     return data_len;
+  }
+
+  string get_calculated_etag() {
+    MD5 hash;
+    unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
+    char calc_md5[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
+
+    hash.Update((const unsigned char *)full_obj.c_str(), data_len);
+    hash.Final(m);
+    buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5);
+    calculated_etag = calc_md5;
+    return calculated_etag;
   }
 };
 
@@ -3953,6 +3968,16 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
     if (ret < 0) {
       goto set_err_state;
     }
+
+    if (cct->_conf->rgw_copy_verify_object) {
+      if (cb.get_calculated_etag().compare(etag)) {
+        ret = -EIO;
+        ldout(cct, 0) << "ERROR: source and destination objects don't match. Expected etag:"
+          << etag << " Computed etag:" << cb.get_calculated_etag() << dendl;
+        goto set_err_state;
+     }
+   }
+
     if (copy_if_newer && canceled) {
       ldout(cct, 20) << "raced with another write of obj: " << dest_obj << dendl;
       obj_ctx.invalidate(dest_obj); /* object was overwritten */

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3463,6 +3463,10 @@ public:
       return "";
     }
   }
+
+  SourceObjType get_obj_type() {
+    return obj_type;
+  }
 };
 
 /*
@@ -4016,7 +4020,8 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
     set_mtime_weight.init(set_mtime, svc.zone->get_zone_short_id(), pg_ver);
   }
 
-  if (cct->_conf->rgw_sync_obj_etag_verify) {
+  /* Perform ETag verification is we have computed the object's MD5 sum at our end */
+  if (cb.get_obj_type() != OBJ_TYPE_UNINIT) {
     string trimmed_etag = etag;
 
     /* Remove the leading and trailing double quotes from etag */


### PR DESCRIPTION
backport trackers:

* https://tracker.ceph.com/issues/48864
* https://tracker.ceph.com/issues/49046

---

backport of:

* https://github.com/ceph/ceph/pull/33492
* https://github.com/ceph/ceph/pull/37238

parent trackers:

* https://tracker.ceph.com/issues/48801
* https://tracker.ceph.com/issues/45992

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh