### PR TITLE
Windows DLL support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,16 @@ endif()
 if(MINGW)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-allow-multiple-definition")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-allow-multiple-definition")
+
+  # By default, cmake generates import libs for executables. The issue is that
+  # for rados and rbd, the executable import lib overrides the library import lib.
+  # For example, for rados.exe, it will end up generating a librados.dll.a import lib.
+  # We're providing custom rules to disable import libs for executables.
+  set(CMAKE_C_LINK_EXECUTABLE
+    "<CMAKE_C_COMPILER> <FLAGS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> ${CMAKE_GNULD_IMAGE_VERSION} <LINK_LIBRARIES>")
+  set(CMAKE_CXX_LINK_EXECUTABLE
+    "<CMAKE_CXX_COMPILER> <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> ${CMAKE_GNULD_IMAGE_VERSION} <LINK_LIBRARIES>")
+
 endif()
 
 option(WITH_CCACHE "Build with ccache.")
@@ -340,7 +350,8 @@ else(ALLOCATOR)
   endif(gperftools_FOUND)
 endif(ALLOCATOR)
 
-if(HAVE_LIBTCMALLOC AND WITH_STATIC_LIBSTDCXX)
+# Mingw generates incorrect entry points when using "-pie".
+if(WIN32 OR (HAVE_LIBTCMALLOC AND WITH_STATIC_LIBSTDCXX))
   set(EXE_LINKER_USE_PIE FALSE)
 else()
   set(EXE_LINKER_USE_PIE ${ENABLE_SHARED})

--- a/README.windows.rst
+++ b/README.windows.rst
@@ -24,30 +24,31 @@ account different package managers, package names or paths (e.g. mingw paths).
 
 The script accepts the following flags:
 
-============  ===============================  ===============================
-Flag          Description                      Default value
-============  ===============================  ===============================
-OS            Host OS distribution, for mingw  ubuntu (also valid: suse)
-              and other OS specific settings.
-CEPH_DIR      The Ceph source code directory.  The same as the script.
-BUILD_DIR     The directory where the          $CEPH_DIR/build
-              generated artifacts will be
-              placed.
-DEPS_DIR      The directory where the Ceph     $CEPH_DIR/build.deps
-              dependencies will be built.
-NUM_WORKERS   The number of workers to use     The number of vcpus
-              when building Ceph.              available
-CLEAN_BUILD   Clean the build directory.
-SKIP_BUILD    Run cmake without actually
-              performing the build.
-SKIP_TESTS    Skip building Ceph tests.
-BUILD_ZIP     Build a zip archive containing
-              the generated binaries.
-ZIP_DEST      Where to put a zip containing    $BUILD_DIR/ceph.zip
-              the generated binaries.
-STRIP_ZIPPED  If set, the zip will contain
-              stripped binaries.
-============  ===============================  ===============================
+=============  ===============================  ===============================
+Flag           Description                      Default value
+=============  ===============================  ===============================
+OS             Host OS distribution, for mingw  ubuntu (also valid: suse)
+               and other OS specific settings.
+CEPH_DIR       The Ceph source code directory.  The same as the script.
+BUILD_DIR      The directory where the          $CEPH_DIR/build
+               generated artifacts will be
+               placed.
+DEPS_DIR       The directory where the Ceph     $CEPH_DIR/build.deps
+               dependencies will be built.
+NUM_WORKERS    The number of workers to use     The number of vcpus
+               when building Ceph.              available
+CLEAN_BUILD    Clean the build directory.
+SKIP_BUILD     Run cmake without actually
+               performing the build.
+SKIP_TESTS     Skip building Ceph tests.
+BUILD_ZIP      Build a zip archive containing
+               the generated binaries.
+ZIP_DEST       Where to put a zip containing    $BUILD_DIR/ceph.zip
+               the generated binaries.
+STRIP_ZIPPED   If set, the zip will contain
+               stripped binaries.
+ENABLE_SHARED  Dynamically link Ceph libs.      False
+=============  ===============================  ===============================
 
 In order to build debug binaries as well as an archive containing stripped
 binaries that may be easily moved around, one may use the following:
@@ -85,10 +86,6 @@ in userspace, pretty much like Fuse.
 
 RBD images can be mounted using the ``rbd`` or ``rbd-wnbd`` commands. The
 ``WNBD`` driver is required for mapping RBD images on Windows.
-
-The libraries have to be built statically at the moment. The reason is that
-there are a few circular library dependencies or unspecified dependencies,
-which isn't supported when building DLLs. This mostly affects ``cls`` libraries.
 
 A significant number of tests from the ``tests`` directory have been ported,
 providing adequate coverage.

--- a/src/librados/CMakeLists.txt
+++ b/src/librados/CMakeLists.txt
@@ -20,7 +20,7 @@ if(ENABLE_SHARED)
     set_property(TARGET librados APPEND_STRING PROPERTY
       LINK_FLAGS " -Wl,--exclude-libs,ALL")
   endif()
-  if(HAVE_LINK_VERSION_SCRIPT)
+  if(HAVE_LINK_VERSION_SCRIPT AND NOT WIN32)
     set_property(TARGET librados APPEND_STRING PROPERTY
       LINK_FLAGS " -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/librados.map")
   endif()

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -326,11 +326,11 @@ target_link_libraries(librbd PRIVATE
   rbd_internal
   rbd_types
   journal
-  libneorados
-  librados
   cls_rbd_client
   cls_lock_client
   cls_journal_client
+  libneorados
+  librados
   ceph-common
   pthread
   ${CMAKE_DL_LIBS}

--- a/src/tools/rbd/CMakeLists.txt
+++ b/src/tools/rbd/CMakeLists.txt
@@ -58,10 +58,11 @@ set(rbd_srcs
 add_executable(rbd ${rbd_srcs}
   $<TARGET_OBJECTS:common_texttable_obj>)
 set_target_properties(rbd PROPERTIES OUTPUT_NAME rbd)
-target_link_libraries(rbd librbd
+target_link_libraries(rbd
   cls_journal_client
   cls_rbd_client
   rbd_types
+  librbd
   journal
   libneorados
   librados

--- a/win32_build.sh
+++ b/win32_build.sh
@@ -55,6 +55,9 @@ ALLOCATOR=${ALLOCATOR:-libc}
 # can't close <file>: File too big
 # -Wa,-mbig-obj does not help.
 CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-RelWithDebInfo}
+# Some tests can't use shared libraries yet due to unspecified dependencies.
+# We'll do a static build by default for now.
+ENABLE_SHARED=${ENABLE_SHARED:-OFF}
 
 binDir="$BUILD_DIR/bin"
 strippedBinDir="$BUILD_DIR/bin_stripped"
@@ -136,7 +139,7 @@ cmake -D CMAKE_PREFIX_PATH=$depsDirs \
       -D WITH_LTTNG=OFF -D WITH_BABELTRACE=OFF \
       -D WITH_SYSTEM_BOOST=ON -D WITH_MGR=OFF -D WITH_KVS=OFF \
       -D WITH_LIBCEPHFS=OFF -D WITH_KRBD=OFF -D WITH_RADOSGW=OFF \
-      -D ENABLE_SHARED=OFF -D WITH_RBD=ON -D BUILD_GMOCK=ON \
+      -D ENABLE_SHARED=$ENABLE_SHARED -D WITH_RBD=ON -D BUILD_GMOCK=ON \
       -D WITH_CEPHFS=OFF -D WITH_MANPAGE=OFF \
       -D WITH_MGR_DASHBOARD_FRONTEND=OFF -D WITH_SYSTEMD=OFF -D WITH_TESTS=ON \
       -D LZ4_INCLUDE_DIR=$lz4Include -D LZ4_LIBRARY=$lz4Lib \
@@ -163,7 +166,6 @@ if [[ -z $SKIP_BUILD ]]; then
     make_targets["src/tools/rbd"]="all"
     make_targets["src/tools/rbd_wnbd"]="all"
     make_targets["src/compressor"]="all"
-    make_targets["src/test"]="all"
 
     if [[ -z $SKIP_TESTS ]]; then
       make_targets["src/tools"]+=" ceph_radosacl ceph_scratchtool"
@@ -185,7 +187,8 @@ if [[ -z $SKIP_DLL_COPY ]]; then
         $sslDir/bin/libssl-1_1-x64.dll
         $mingwTargetLibDir/libstdc++-6.dll
         $mingwTargetLibDir/libgcc_s_seh-1.dll
-        $mingwLibpthreadDir/libwinpthread-1.dll)
+        $mingwLibpthreadDir/libwinpthread-1.dll
+        $boostDir/lib/*.dll)
     echo "Copying required dlls to $binDir."
     cp ${required_dlls[@]} $binDir
 fi

--- a/win32_deps_build.sh
+++ b/win32_deps_build.sh
@@ -301,11 +301,12 @@ EOL
 
 ./b2 install --user-config=user-config.jam toolset=gcc-mingw32 \
     target-os=windows release \
+    link=static,shared \
     threadapi=pthread --prefix=$boostDir \
     address-model=64 architecture=x86 \
     binary-format=pe abi=ms -j $NUM_WORKERS \
     -sZLIB_INCLUDE=$zlibDir/include -sZLIB_LIBRARY_PATH=$zlibDir/lib \
-    --without-python --without-mpi
+    --without-python --without-mpi --without-log --without-wave
 
 cd $depsSrcDir
 if [[ ! -d $backtraceSrcDir ]]; then


### PR DESCRIPTION
Windows DLL support

At the moment, the Windows binaries can only be linked statically.
This is less than ideal since:

* the resulting binaries can be quite large, especially when
including debug symbols
* librados and librbd cannot be used directly by 3rd party apps
* the build duration is increased

In order to do a dynamic build, we'll:

* add an option to win32_build.sh
* fix link order
* dynamically link boost
* disable the "-pie" flag when using Mingw, which generates incorrect
  executable entry points
* by default, cmake generates import libs for executables. The issue
  is that for rados.exe, it generates librados.dll.a, thus overriding
  the librados.dll import library, which breaks the build process.
  We'll configure cmake to skip generating import libs for executables. 
