### PR TITLE
os/bluestore: be more protective in _deferred_queue

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12268,13 +12268,10 @@ void BlueStore::_deferred_queue(TransContext *txc)
   dout(20) << __func__ << " txc " << txc << " osr " << txc->osr << dendl;
 
   DeferredBatch *tmp;
-  bool need_lock_again = false;
   txc->osr->deferred_lock.lock();
   {
     if (!txc->osr->deferred_pending) {
       tmp = new DeferredBatch(cct, txc->osr.get());
-      txc->osr->deferred_lock.unlock();
-      need_lock_again = true;
     } else {
       tmp  = txc->osr->deferred_pending;
     }
@@ -12292,9 +12289,6 @@ void BlueStore::_deferred_queue(TransContext *txc)
   }
 
   {
-    if (need_lock_again) {
-      txc->osr->deferred_lock.lock();
-    }
     ++deferred_queue_size;
     txc->osr->deferred_pending = tmp;
     // condition "tmp->txcs.size() == 1" mean deferred_pending was originally empty.


### PR DESCRIPTION
This is an addendum to 
https://github.com/ceph/ceph/pull/38934
which has slipped into the code base before the final make up.
As per https://github.com/ceph/ceph/pull/38934#issuecomment-763256087 we should unconditionally keep the lock for the whole duration of the function's execution. The original patch violates this requirement for when txc->osr->deferred_pending == null, see
    if (!txc->osr->deferred_pending) {
      tmp = new DeferredBatch(cct, txc->osr.get());
      txc->osr->deferred_lock.unlock();
      need_lock_again = true;

Hence the new patch fixes that. 
Sorry for inconvenience.

Signed-off-by: Igor Fedotov <ifedotov@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]


[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
