### PR TITLE
pacific: qa/tasks/ceph:  do not update info.yaml if ctx.archive is not set

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -78,6 +78,8 @@ def update_archive_setting(ctx, key, value):
     """
     Add logs directory to job's info log file
     """
+    if ctx.archive is None:
+        return
     with open(os.path.join(ctx.archive, 'info.yaml'), 'r+') as info_file:
         info_yaml = yaml.safe_load(info_file)
         info_file.seek(0)


### PR DESCRIPTION
Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>
(cherry picked from commit c5b1d0ac46527dd77d143d538395eff2be0fef44)