### PR TITLE
cephadm: remove redundant `ERROR` during check-host

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -5120,21 +5120,21 @@ def command_check_host(ctx: CephadmContext) -> None:
             find_program(command)
             logger.info('%s is present' % command)
         except ValueError:
-            errors.append('ERROR: %s binary does not appear to be installed' % command)
+            errors.append('%s binary does not appear to be installed' % command)
 
     # check for configured+running chronyd or ntp
     if not check_time_sync(ctx):
-        errors.append('ERROR: No time synchronization is active')
+        errors.append('No time synchronization is active')
 
     if "expect_hostname" in ctx and ctx.expect_hostname:
         if get_hostname().lower() != ctx.expect_hostname.lower():
-            errors.append('ERROR: hostname "%s" does not match expected hostname "%s"' % (
+            errors.append('hostname "%s" does not match expected hostname "%s"' % (
                 get_hostname(), ctx.expect_hostname))
         logger.info('Hostname "%s" matches what is expected.',
                     ctx.expect_hostname)
 
     if errors:
-        raise Error('\n'.join(errors))
+        raise Error('\nERROR: '.join(errors))
 
     logger.info('Host looks OK')
 


### PR DESCRIPTION
```
ERROR: ERROR: No time synchronization is active
```

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
