### PR TITLE
common: Fix assertion when disabling and re-enabling clog_to_monitors

### DIFF
--- a/src/common/LogClient.cc
+++ b/src/common/LogClient.cc
@@ -133,6 +133,10 @@ LogClient::LogClient(CephContext *cct, Messenger *m, MonMap *mm,
 {
 }
 
+void LogChannel::set_log_to_monitors(bool v) {
+  log_to_monitors = v;
+}
+
 void LogChannel::update_config(map<string,string> &log_to_monitors,
 			       map<string,string> &log_to_syslog,
 			       map<string,string> &log_channels,

--- a/src/common/LogClient.cc
+++ b/src/common/LogClient.cc
@@ -133,8 +133,12 @@ LogClient::LogClient(CephContext *cct, Messenger *m, MonMap *mm,
 {
 }
 
-void LogChannel::set_log_to_monitors(bool v) {
-  log_to_monitors = v;
+void LogChannel::set_log_to_monitors(bool v)
+{
+  if (log_to_monitors != v) {
+    parent->reset();
+    log_to_monitors = v;
+  }
 }
 
 void LogChannel::update_config(map<string,string> &log_to_monitors,
@@ -330,6 +334,15 @@ version_t LogClient::queue(LogEntry &entry)
   }
 
   return entry.seq;
+}
+
+void LogClient::reset()
+{
+  std::lock_guard l(log_lock);
+  if (log_queue.size()) {
+    log_queue.clear();
+  }
+  last_log_sent = last_log;
 }
 
 uint64_t LogClient::get_next_seq()

--- a/src/common/LogClient.h
+++ b/src/common/LogClient.h
@@ -232,6 +232,7 @@ public:
   const EntityName& get_myname();
   entity_name_t get_myrank();
   version_t queue(LogEntry &entry);
+  void reset();
 
 private:
   ceph::ref_t<Message> _get_mon_log_message();

--- a/src/common/LogClient.h
+++ b/src/common/LogClient.h
@@ -117,9 +117,7 @@ public:
     do_log(CLOG_SEC, s);
   }
 
-  void set_log_to_monitors(bool v) {
-    log_to_monitors = v;
-  }
+  void set_log_to_monitors(bool v);
   void set_log_to_syslog(bool v) {
     log_to_syslog = v;
   }


### PR DESCRIPTION
osd: Fix assertion when disabling and re-enabling clog_to_monitors

Steps to reproduce:

1. Disable clog_to_monitors for OSDs
ceph tell osd.* injectargs '--clog_to_monitors=true'

2. Wait for OSDs to generate some clogs

3. Re-enable clog_to_monitors
ceph tell osd.* injectargs '--clog_to_monitors=true'

This will trigger an assertion

When clog_to_monitors is disabled, "last_log" still keeps increasing by get_next_seq() if OSD writes info to clog
```c++
if (log_to_monitors) {
  e.seq = parent->queue(e);
} else {
  e.seq = parent->get_next_seq();
}
```
but "last_log_sent" doesn't increase, if we disable clog_to_monitors for a bit longer then re-enabling it
the num_unsent will be huge
unsigned num_unsent = last_log - last_log_sent;

even bigger than log_queue size and lead to the following assertion
ceph_assert(num_unsent <= log_queue.size());

This patch does the following
1. when disabling clog_to_monitors, clear log_queue
2. even logs are not sent to monitors, keep last_log_sent the same as last_log, so there won't be a lots of unsent logs when re-enabling clog_to_monitors

Fixes: https://tracker.ceph.com/issues/48946

Signed-off-by: Gerald Yang <gerald.yang@canonical.com>

