### PR TITLE
test/librbd: add luks encryption cli test

### DIFF
--- a/qa/suites/rbd/cli/workloads/rbd_cli_luks_encryption.yaml
+++ b/qa/suites/rbd/cli/workloads/rbd_cli_luks_encryption.yaml
@@ -1,0 +1,9 @@
+overrides:
+  install:
+    ceph:
+      extra_packages: [rbd-nbd]
+tasks:
+- workunit:
+    clients:
+      client.0:
+        - rbd/luks-encryption.sh

--- a/qa/workunits/rbd/luks-encryption.sh
+++ b/qa/workunits/rbd/luks-encryption.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -ex
+
+CEPH_ID=${CEPH_ID:-admin}
+TMP_FILES="/tmp/passphrase /tmp/testdata1 /tmp/testdata2"
+
+function drop_caches {
+  echo 3 | sudo tee /proc/sys/vm/drop_caches
+}
+
+function test_encryption_format() {
+  local format=$1
+  clean_up_cryptsetup
+
+  # format
+  rbd encryption format testimg $format /tmp/passphrase
+  drop_caches
+
+  # open encryption with cryptsetup
+  sudo cryptsetup open $RAW_DEV --type $format cryptsetupdev -d /tmp/passphrase
+
+  # open encryption with librbd
+  LIBRBD_DEV=$(sudo rbd -p rbd map testimg -t nbd -o encryption-format=$format,encryption-passphrase-file=/tmp/passphrase)
+
+  # write via librbd && compare
+  sudo dd if=/tmp/testdata1 of=$LIBRBD_DEV conv=fdatasync
+  drop_caches
+  sudo cmp -n 16MB $LIBRBD_DEV /dev/mapper/cryptsetupdev
+
+  # write via cryptsetup && compare
+  sudo dd if=/tmp/testdata2 of=/dev/mapper/cryptsetupdev conv=fdatasync
+  drop_caches
+  sudo cmp -n 16MB $LIBRBD_DEV /dev/mapper/cryptsetupdev
+}
+
+function get_nbd_device_paths {
+	rbd device list -t nbd | tail -n +2 | egrep "\s+rbd\s+testimg\s+" | awk '{print $5;}'
+}
+
+function clean_up_cryptsetup() {
+  ls /dev/mapper/cryptsetupdev && sudo cryptsetup close cryptsetupdev || true
+}
+
+function clean_up {
+  sudo rm -f $TMP_FILES
+  clean_up_cryptsetup
+	for device in $(get_nbd_device_paths); do
+	  sudo rbd device unmap -t nbd $device
+  done
+	rbd ls | grep testimg > /dev/null && rbd rm testimg || true
+}
+
+if [[ $(uname) != "Linux" ]]; then
+	echo "LUKS encryption tests only supported on Linux"
+	exit 1
+fi
+
+
+if [[ $(($(ceph-conf --name client.${CEPH_ID} rbd_default_features) & 64)) != 0 ]]; then
+	echo "LUKS encryption tests not supported alongside image journaling feature"
+	exit 1
+fi
+
+clean_up
+
+trap clean_up INT TERM EXIT
+
+# generate test data
+dd if=/dev/urandom of=/tmp/testdata1 bs=4M count=4
+dd if=/dev/urandom of=/tmp/testdata2 bs=4M count=4
+
+# create passphrase file
+echo -n "password" > /tmp/passphrase
+
+# create an image
+rbd create testimg --size=32M
+
+# map raw data to nbd device
+RAW_DEV=$(sudo rbd -p rbd map testimg -t nbd)
+
+test_encryption_format luks1
+test_encryption_format luks2
+
+echo OK

--- a/src/test/run-rbd-tests
+++ b/src/test/run-rbd-tests
@@ -28,6 +28,8 @@ run_cli_tests() {
     $CEPH_SRC/../qa/workunits/rbd/cli_generic.sh
     recreate_pool rbd
     $CEPH_SRC/../qa/workunits/rbd/journal.sh
+    recreate_pool rbd
+    $CEPH_SRC/../qa/workunits/rbd/luks-encryption.sh
 }
 
 # tests that do not depend on image format / features


### PR DESCRIPTION
This test verifies that librbd encryption is compatible with cryptsetup (actual IO, not just header parsing).
It currently fails due to a bug, which is fixed in #39005.