### PR TITLE
qa/tasks/barbican.py: fix year2021 problem

### DIFF
--- a/qa/tasks/barbican.py
+++ b/qa/tasks/barbican.py
@@ -6,6 +6,8 @@ import contextlib
 import logging
 import http
 import json
+import time
+import math
 
 from urllib.parse import urlparse
 
@@ -326,12 +328,16 @@ def create_secrets(ctx, config):
                     token_resp.status < 300):
                 raise Exception("Cannot authenticate user "+secret["username"]+" for secret creation")
 
+            expire = time.time() + 5400		# now + 90m
+            (expire_fract,dummy) = math.modf(expire)
+            expire_format = "%%FT%%T.%06d" % (round(expire_fract*1000000))
+            expiration = time.strftime(expire_format, time.gmtime(expire))
             token_id = token_resp.getheader('x-subject-token')
 
             key1_json = json.dumps(
                 {
                     "name": secret['name'],
-                    "expiration": "2020-12-31T19:14:44.180394",
+                    "expiration": expiration,
                     "algorithm": "aes",
                     "bit_length": 256,
                     "mode": "cbc",


### PR DESCRIPTION
The expiration timestamp was hard-coded as
2020-12-31T19:14:44.180394
which is now in the past.  Instead, use a timestamp
90 minutes in the future.

Fixes: https://tracker.ceph.com/issues/48919
Signed-off-by: Marcus Watts <mwatts@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
