### PR TITLE
rbd: change rbd showmapped output format of image name

### DIFF
--- a/src/cls/rbd/cls_rbd.h
+++ b/src/cls/rbd/cls_rbd.h
@@ -194,8 +194,8 @@ struct cls_rbd_snap {
   }
 
   void dump(ceph::Formatter *f) const {
-    f->dump_unsigned("id", id);
-    f->dump_string("name", name);
+    f->dump_unsigned("image_id", id);
+    f->dump_string("image", name);
     f->dump_unsigned("image_size", image_size);
     if (parent.exists()) {
       f->open_object_section("parent");

--- a/src/cls/rbd/cls_rbd_types.cc
+++ b/src/cls/rbd/cls_rbd_types.cc
@@ -867,12 +867,12 @@ void SnapshotInfo::decode(bufferlist::const_iterator& it) {
 }
 
 void SnapshotInfo::dump(Formatter *f) const {
-  f->dump_unsigned("id", id);
+  f->dump_unsigned("snapshot_id", id);
   f->open_object_section("namespace");
   boost::apply_visitor(DumpSnapshotNamespaceVisitor(f, "type"),
                        snapshot_namespace);
   f->close_section();
-  f->dump_string("name", name);
+  f->dump_string("snapshot", name);
   f->dump_unsigned("image_size", image_size);
   f->dump_stream("timestamp") << timestamp;
 }
@@ -1119,7 +1119,7 @@ void TrashImageSpec::decode(bufferlist::const_iterator &it) {
 
 void TrashImageSpec::dump(Formatter *f) const {
   f->dump_stream("source") << source;
-  f->dump_string("name", name);
+  f->dump_string("image", name);
   f->dump_unsigned("deletion_time", deletion_time);
   f->dump_unsigned("deferment_end_time", deferment_end_time);
 }

--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -939,11 +939,11 @@ static bool dump_one_image(Formatter *f, TextTable *tbl,
 
   if (f) {
     f->open_object_section("device");
-    f->dump_string("id", id);
+    f->dump_string("image_id", id);
     f->dump_string("pool", spec->pool_name);
     f->dump_string("namespace", spec->nspace_name);
-    f->dump_string("name", spec->image_name);
-    f->dump_string("snap", spec->snap_name);
+    f->dump_string("image", spec->image_name);
+    f->dump_string("snapshot", spec->snap_name);
     f->dump_string("device", devnode);
     f->close_section();
   } else {

--- a/src/librbd/mirror/snapshot/Types.cc
+++ b/src/librbd/mirror/snapshot/Types.cc
@@ -42,7 +42,7 @@ void SnapState::dump(Formatter *f) const {
   f->open_object_section("namespace");
   snap_namespace.dump(f);
   f->close_section();
-  f->dump_string("name", name);
+  f->dump_string("snapshot", name);
   f->dump_unsigned("protection_status", protection_status);
 }
 
@@ -76,7 +76,7 @@ void ImageState::decode(bufferlist::const_iterator& bl) {
 }
 
 void ImageState::dump(Formatter *f) const {
-  f->dump_string("name", name);
+  f->dump_string("snapshot", name);
   f->dump_unsigned("features", features);
   f->dump_unsigned("snap_limit", snap_limit);
   f->open_array_section("snapshots");

--- a/src/rbd_replay/ActionTypes.cc
+++ b/src/rbd_replay/ActionTypes.cc
@@ -225,8 +225,8 @@ void OpenImageAction::decode(__u8 version, bufferlist::const_iterator &it) {
 
 void OpenImageAction::dump(Formatter *f) const {
   ImageActionBase::dump(f);
-  f->dump_string("name", name);
-  f->dump_string("snap_name", snap_name);
+  f->dump_string("image", name);
+  f->dump_string("snapshot", snap_name);
   f->dump_bool("read_only", read_only);
 }
 
@@ -253,8 +253,8 @@ void AioOpenImageAction::decode(__u8 version, bufferlist::const_iterator &it) {
 
 void AioOpenImageAction::dump(Formatter *f) const {
   ImageActionBase::dump(f);
-  f->dump_string("name", name);
-  f->dump_string("snap_name", snap_name);
+  f->dump_string("image", name);
+  f->dump_string("snapshot", snap_name);
   f->dump_bool("read_only", read_only);
 }
 

--- a/src/tools/rbd/Schedule.cc
+++ b/src/tools/rbd/Schedule.cc
@@ -356,4 +356,3 @@ std::ostream& operator<<(std::ostream& os, ScheduleList &l) {
 }
 
 } // namespace rbd
-

--- a/src/tools/rbd/action/Children.cc
+++ b/src/tools/rbd/action/Children.cc
@@ -39,15 +39,15 @@ int do_list_children(librados::IoCtx &io_ctx, librbd::Image &image,
       if (all_flag) {
         f->open_object_section("child");
         f->dump_string("pool", child.pool_name);
-        f->dump_string("pool_namespace", child.pool_namespace);
+        f->dump_string("namespace", child.pool_namespace);
         f->dump_string("image", child.image_name);
-        f->dump_string("id", child.image_id);
+        f->dump_string("image_id", child.image_id);
         f->dump_bool("trash", child.trash);
         f->close_section();
       } else if (!trash) {
         f->open_object_section("child");
         f->dump_string("pool", child.pool_name);
-        f->dump_string("pool_namespace", child.pool_namespace);
+        f->dump_string("namespace", child.pool_namespace);
         f->dump_string("image", child.image_name);
         f->close_section();
       }

--- a/src/tools/rbd/action/DiskUsage.cc
+++ b/src/tools/rbd/action/DiskUsage.cc
@@ -78,8 +78,8 @@ void format_image_disk_usage(const std::string& name,
                               TextTable& tbl, Formatter *f) {
   if (f) {
     f->open_object_section("image");
-    f->dump_string("name", name);
-    f->dump_string("id", id);
+    f->dump_string("image", name);
+    f->dump_string("image_id", id);
     if (!snap_name.empty()) {
       f->dump_string("snapshot", snap_name);
       f->dump_unsigned("snapshot_id", snap_id);

--- a/src/tools/rbd/action/Info.cc
+++ b/src/tools/rbd/action/Info.cc
@@ -224,8 +224,8 @@ static int do_show_info(librados::IoCtx &io_ctx, librbd::Image& image,
 
   if (f) {
     f->open_object_section("image");
-    f->dump_string("name", imgname);
-    f->dump_string("id", imgid);
+    f->dump_string("image", imgname);
+    f->dump_string("image_id", imgid);
     f->dump_unsigned("size", info.size);
     f->dump_unsigned("objects", info.num_objs);
     f->dump_int("order", info.order);
@@ -326,9 +326,9 @@ static int do_show_info(librados::IoCtx &io_ctx, librbd::Image& image,
     if (f) {
       f->open_object_section("parent");
       f->dump_string("pool", parent_image_spec.pool_name);
-      f->dump_string("pool_namespace", parent_image_spec.pool_namespace);
+      f->dump_string("namespace", parent_image_spec.pool_namespace);
       f->dump_string("image", parent_image_spec.image_name);
-      f->dump_string("id", parent_image_spec.image_id);
+      f->dump_string("image_id", parent_image_spec.image_id);
       f->dump_string("snapshot", parent_snap_spec.name);
       f->dump_bool("trash", parent_image_spec.trash);
       f->dump_unsigned("overlap", overlap);

--- a/src/tools/rbd/action/List.cc
+++ b/src/tools/rbd/action/List.cc
@@ -88,12 +88,12 @@ int list_process_image(librados::Rados* rados, WorkerEntry* w, bool lflag, Forma
   if (f) {
     f->open_object_section("image");
     f->dump_string("image", w->name);
-    f->dump_string("id", w->id);
+    f->dump_string("image_id", w->id);
     f->dump_unsigned("size", info.size);
     if (has_parent) {
       f->open_object_section("parent");
       f->dump_string("pool", parent_image_spec.pool_name);
-      f->dump_string("pool_namespace", parent_image_spec.pool_namespace);
+      f->dump_string("namespace", parent_image_spec.pool_namespace);
       f->dump_string("image", parent_image_spec.image_name);
       f->dump_string("snapshot", parent_snap_spec.name);
       f->close_section();
@@ -137,7 +137,7 @@ int list_process_image(librados::Rados* rados, WorkerEntry* w, bool lflag, Forma
       }
       if (f) {
         f->open_object_section("snapshot");
-        f->dump_string("image", w->name);
+        f->dump_string("name", w->name);
         f->dump_string("id", w->id);
         f->dump_string("snapshot", s->name);
         f->dump_unsigned("snapshot_id", s->id);
@@ -145,7 +145,7 @@ int list_process_image(librados::Rados* rados, WorkerEntry* w, bool lflag, Forma
         if (has_parent) {
           f->open_object_section("parent");
           f->dump_string("pool", parent_image_spec.pool_name);
-          f->dump_string("pool_namespace", parent_image_spec.pool_namespace);
+          f->dump_string("namespace", parent_image_spec.pool_namespace);
           f->dump_string("image", parent_image_spec.image_name);
           f->dump_string("snapshot", parent_snap_spec.name);
           f->close_section();
@@ -200,7 +200,7 @@ int do_list(const std::string &pool_name, const std::string& namespace_name,
       f->open_array_section("images");
     for (auto& image : images) {
        if (f)
-	 f->dump_string("name", image.name);
+	 f->dump_string("image", image.name);
        else
 	 std::cout << image.name << std::endl;
     }

--- a/src/tools/rbd/action/Perf.cc
+++ b/src/tools/rbd/action/Perf.cc
@@ -301,7 +301,7 @@ void format(const ImageStats& image_stats, Formatter* f, bool global_search) {
     if (f)  {
       f->open_object_section("image");
       f->dump_string("pool", image_stat.pool_name);
-      f->dump_string("pool_namespace", image_stat.pool_namespace);
+      f->dump_string("namespace", image_stat.pool_namespace);
       f->dump_string("image", image_stat.image_name);
       for (auto& pair : STAT_DESCRIPTORS.left) {
         f->dump_float(pair.second.c_str(),

--- a/src/tools/rbd/action/Snap.cc
+++ b/src/tools/rbd/action/Snap.cc
@@ -145,8 +145,8 @@ int do_list_snaps(librbd::Image& image, Formatter *f, bool all_snaps, librados::
     if (f) {
       protected_str = snap_protected ? "true" : "false";
       f->open_object_section("snapshot");
-      f->dump_unsigned("id", s->id);
-      f->dump_string("name", s->name);
+      f->dump_unsigned("snapshot_id", s->id);
+      f->dump_string("snapshot", s->name);
       f->dump_unsigned("size", s->size);
       f->dump_string("protected", protected_str);
       f->dump_string("timestamp", tt_str);

--- a/src/tools/rbd/action/Trash.cc
+++ b/src/tools/rbd/action/Trash.cc
@@ -216,8 +216,8 @@ int do_list(librbd::RBD &rbd, librados::IoCtx& io_ctx, bool long_flag,
     for (const auto& entry : trash_entries) {
        if (f) {
          f->open_object_section("image");
-         f->dump_string("id", entry.id);
-         f->dump_string("name", entry.name);
+         f->dump_string("image_id", entry.id);
+         f->dump_string("image", entry.name);
          f->close_section();
        } else {
          std::cout << entry.id << " " << entry.name << std::endl;
@@ -302,8 +302,8 @@ int do_list(librbd::RBD &rbd, librados::IoCtx& io_ctx, bool long_flag,
 
     if (f) {
       f->open_object_section("image");
-      f->dump_string("id", entry.id);
-      f->dump_string("name", entry.name);
+      f->dump_string("image_id", entry.id);
+      f->dump_string("image", entry.name);
       f->dump_string("source", del_source);
       f->dump_string("deleted_at", time_str);
       f->dump_string("status",
@@ -311,7 +311,7 @@ int do_list(librbd::RBD &rbd, librados::IoCtx& io_ctx, bool long_flag,
       if (has_parent) {
         f->open_object_section("parent");
         f->dump_string("pool", parent_image.pool_name);
-        f->dump_string("pool_namespace", parent_image.pool_namespace);
+        f->dump_string("namespace", parent_image.pool_namespace);
         f->dump_string("image", parent_image.image_name);
         f->dump_string("snapshot", parent_snap.name);
         f->close_section();

--- a/src/tools/rbd_ggate/main.cc
+++ b/src/tools/rbd_ggate/main.cc
@@ -369,11 +369,11 @@ static int do_list(const std::string &format, bool pretty_format)
 
     if (f) {
       f->open_object_section("device");
-      f->dump_string("id", id);
+      f->dump_string("image_id", id);
       f->dump_string("pool", poolname);
       f->dump_string("namespace", nsname);
       f->dump_string("image", imgname);
-      f->dump_string("snap", snapname);
+      f->dump_string("snapshot", snapname);
       f->dump_string("device", "/dev/" + name);
       f->close_section();
     } else {

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -662,7 +662,7 @@ void ImageReplayer<I>::print_status(Formatter *f)
   std::lock_guard l{m_lock};
 
   f->open_object_section("image_replayer");
-  f->dump_string("name", m_image_spec);
+  f->dump_string("image", m_image_spec);
   f->dump_string("state", to_string(m_state));
   f->close_section();
 }

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -1913,7 +1913,7 @@ static int do_list_mapped_devices(const std::string &format, bool pretty_format)
       f->dump_string("pool", cfg.poolname);
       f->dump_string("namespace", cfg.nsname);
       f->dump_string("image", cfg.imgname);
-      f->dump_string("snap", cfg.snapname);
+      f->dump_string("snapshot", cfg.snapname);
       f->dump_string("device", cfg.devpath);
       f->close_section();
     } else {

--- a/src/tools/rbd_wnbd/rbd_wnbd.cc
+++ b/src/tools/rbd_wnbd/rbd_wnbd.cc
@@ -1278,7 +1278,7 @@ static int do_list_mapped_devices(const std::string &format, bool pretty_format)
       f->dump_string("pool", cfg.poolname);
       f->dump_string("namespace", cfg.nsname);
       f->dump_string("image", cfg.imgname);
-      f->dump_string("snap", cfg.snapname);
+      f->dump_string("snapshot", cfg.snapname);
       f->dump_int("disk_number", cfg.disk_number ? cfg.disk_number : -1);
       f->dump_string("status", status);
       f->close_section();
@@ -1350,7 +1350,7 @@ static int do_show_mapped_device(std::string format, bool pretty_format,
   f->dump_string("pool", cfg.poolname);
   f->dump_string("namespace", cfg.nsname);
   f->dump_string("image", cfg.imgname);
-  f->dump_string("snap", cfg.snapname);
+  f->dump_string("snapshot", cfg.snapname);
   f->dump_int("persistent", cfg.persistent);
   f->dump_int("disk_number", conn_info.DiskNumber ? conn_info.DiskNumber : -1);
   f->dump_string("status", cfg.active ? WNBD_STATUS_ACTIVE : WNBD_STATUS_INACTIVE);


### PR DESCRIPTION
When format is plain, for both rbd showmapped -t krbd and -t nbd, image name column is "image",
when format is json, only for -t nbd, the key is "image". For -t rbd, it's "name", maybe can
change them to a same pattern.

Signed-off-by: haoyixing <haoyixing@kuaishou.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
