### PR TITLE
mgr/cephadm: mypy says: dd.status can be None 

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -197,7 +197,7 @@ class CephadmServe:
             health_changed = True
         failed_daemons = []
         for dd in self.mgr.cache.get_daemons():
-            if dd.status < 0:
+            if dd.status is not None and dd.status < 0:
                 failed_daemons.append('daemon %s on %s is in %s state' % (
                     dd.name(), dd.hostname, dd.status_desc
                 ))

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -24,7 +24,8 @@ from typing import TypeVar, Generic, List, Optional, Union, Tuple, Iterator, Cal
 try:
     from typing import Protocol  # Protocol was added in Python 3.8
 except ImportError:
-    class Protocol: pass  # type: ignore
+    class Protocol:  # type: ignore
+        pass
 
 
 import yaml
@@ -115,6 +116,7 @@ def handle_exception(prefix: str, perm: str, func: FuncT) -> FuncT:
 
 class InnerCliCommandCallable(Protocol):
     def __call__(self, prefix: str) -> Callable[[FuncT], FuncT]: ...
+
 
 def _cli_command(perm: str) -> InnerCliCommandCallable:
     def inner_cli_command(prefix: str) -> Callable[[FuncT], FuncT]:
@@ -665,6 +667,7 @@ class TrivialReadCompletion(Completion[T]):
 def _hide_in_features(f: FuncT) -> FuncT:
     f._hide_in_features = True  # type: ignore
     return f
+
 
 class Orchestrator(object):
     """


### PR DESCRIPTION
`DaemonDescription.status` is annotated
as `Optional[int]` and thus can be `None`

This is a conflict between c95ba87
and 01f60cf

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
