### PR TITLE
Windows RBD fixes

### DIFF
--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -313,7 +313,25 @@ int win_socketpair(int socks[2]);
 
 #ifdef __MINGW32__
 extern _CRTIMP errno_t __cdecl _putenv_s(const char *_Name,const char *_Value);
-#endif
+
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#define htobe16(x) __builtin_bswap16(x)
+#define htole16(x) (x)
+#define be16toh(x) __builtin_bswap16(x)
+#define le16toh(x) (x)
+
+#define htobe32(x) __builtin_bswap32(x)
+#define htole32(x) (x)
+#define be32toh(x) __builtin_bswap32(x)
+#define le32toh(x) (x)
+
+#define htobe64(x) __builtin_bswap64(x)
+#define htole64(x) (x)
+#define be64toh(x) __builtin_bswap64(x)
+#define le64toh(x) (x)
+#endif // defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+
+#endif // __MINGW32__
 
 #ifdef __cplusplus
 }

--- a/src/tools/rbd/action/Encryption.cc
+++ b/src/tools/rbd/action/Encryption.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "include/compat.h"
 #include "include/scope_guard.h"
 #include "tools/rbd/ArgumentTypes.h"
 #include "tools/rbd/Shell.h"
@@ -66,7 +67,7 @@ int execute(const po::variables_map &vm,
   std::string passphrase((std::istreambuf_iterator<char>(file)),
                          (std::istreambuf_iterator<char>()));
   auto sg = make_scope_guard([&] {
-      explicit_bzero(&passphrase[0], passphrase.size()); });
+      ceph_memzero_s(&passphrase[0], passphrase.size(), passphrase.size()); });
   file.close();
   if (!passphrase.empty() && passphrase[passphrase.length() - 1] == '\n') {
     passphrase.erase(passphrase.length() - 1);

--- a/src/tools/rbd_wnbd/wnbd_handler.h
+++ b/src/tools/rbd_wnbd/wnbd_handler.h
@@ -128,8 +128,8 @@ private:
     WnbdRequestType req_type = WnbdReqTypeUnknown;
     uint64_t req_handle = 0;
     uint32_t err_code = 0;
-    uint32_t req_size;
-    uint32_t req_from;
+    size_t req_size;
+    uint64_t req_from;
     bufferlist data;
 
     IOContext()


### PR DESCRIPTION
This PR fixes a few Windows RBD issues:

* use the portable ``ceph_memzero_s`` function instead of ``explicit_bzero``
* add missing endianness helpers
* fix rbd-wnbd IO offset overflow