### PR TITLE
rgw: fix valgrind errors when protected_fixedsize_stack is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,6 +350,13 @@ else(ALLOCATOR)
   endif(gperftools_FOUND)
 endif(ALLOCATOR)
 
+if(${ALLOCATOR} STREQUAL "libc" AND WITH_SYSTEM_BOOST)
+  # valgrind can only work with libc allocator
+  # if system boost is not used, valgrind use should
+  #   be indicated via the WITH_BOOST_VALGRIND parameter
+  add_definitions(-DBOOST_USE_VALGRIND)
+endif()
+
 # Mingw generates incorrect entry points when using "-pie".
 if(WIN32 OR (HAVE_LIBTCMALLOC AND WITH_STATIC_LIBSTDCXX))
   set(EXE_LINKER_USE_PIE FALSE)


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/48963

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
