### PR TITLE
cephadm: use (new) 'mgr stat' instead of 'mgr dump' to check mgrmap epoch

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -751,6 +751,7 @@ function test_mon_misc()
   ceph log last 100 | grep "$mymsg"
   ceph_watch_wait "$mymsg"
 
+  ceph mgr stat
   ceph mgr dump
   ceph mgr module ls
   ceph mgr module enable restful

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3707,8 +3707,13 @@ def command_bootstrap(ctx):
 
     # wait for mgr to restart (after enabling a module)
     def wait_for_mgr_restart():
-        # first get latest mgrmap epoch from the mon
-        out = cli(['mgr', 'dump'])
+        # first get latest mgrmap epoch from the mon.  try newer 'mgr
+        # stat' command first, then fall back to 'mgr dump' if
+        # necessary
+        try:
+            out = cli(['mgr', 'stat'])
+        except Exception as e:
+            out = cli(['mgr', 'dump'])
         j = json.loads(out)
         epoch = j['epoch']
         # wait for mgr to have it

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -13,7 +13,7 @@ DATA_DIR_MODE = 0o700
 CONTAINER_PREFERENCE = ['podman', 'docker']  # prefer podman to docker
 CUSTOM_PS1 = r'[ceph: \u@\h \W]\$ '
 DEFAULT_TIMEOUT = None  # in seconds
-DEFAULT_RETRY = 10
+DEFAULT_RETRY = 15
 SHELL_DEFAULT_CONF = '/etc/ceph/ceph.conf'
 SHELL_DEFAULT_KEYRING = '/etc/ceph/ceph.client.admin.keyring'
 
@@ -1374,7 +1374,7 @@ def is_available(ctx, what, func):
                 % (what, num, retry))
 
         num += 1
-        time.sleep(1)
+        time.sleep(2)
 
 
 def read_config(fn):

--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -264,6 +264,7 @@ public:
   bool get_available() const { return available; }
   const std::string &get_active_name() const { return active_name; }
   const utime_t& get_active_change() const { return active_change; }
+  int get_num_standby() const { return standbys.size(); }
 
   bool all_support_module(const std::string& module) {
     if (!have_module(module)) {

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -953,7 +953,15 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
   cmd_getval(cmdmap, "prefix", prefix);
   int r = 0;
 
-  if (prefix == "mgr dump") {
+  if (prefix == "mgr stat") {
+    f->open_object_section("stat");
+    f->dump_unsigned("epoch", map.get_epoch());
+    f->dump_bool("available", map.get_available());
+    f->dump_string("active_name", map.get_active_name());
+    f->dump_unsigned("num_standby", map.get_num_standby());
+    f->close_section();
+    f->flush(rdata);
+  } else if (prefix == "mgr dump") {
     int64_t epoch = 0;
     cmd_getval(cmdmap, "epoch", epoch, (int64_t)map.get_epoch());
     if (epoch == (int64_t)map.get_epoch()) {

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1235,6 +1235,9 @@ COMMAND("config-key dump "
 /*
  * mon/MgrMonitor.cc
  */
+COMMAND("mgr stat",
+	"dump basic info about the mgr cluster state",
+	"mgr", "r")
 COMMAND("mgr dump "
 	"name=epoch,type=CephInt,range=0,req=false",
 	"dump the latest MgrMap",


### PR DESCRIPTION
The 'mgr dump' output is huuuge and makes the logs hard to read.  Also, there seems to be a bug when the output exceeds 180224 bytes.

This adds a 'mgr stat' command and makes cephadm use it when available (it'll fall back to 'mgr dump' as needed).

Also, bump up the timeouts a bit.