### PR TITLE
ocf: add support for mapping images within an RBD namespace

### DIFF
--- a/src/ocf/rbd.in
+++ b/src/ocf/rbd.in
@@ -41,6 +41,12 @@ resource. Maps and unmaps RBDs as needed.
       <shortdesc lang="en">RBD device name</shortdesc>
       <content type="string"/>
     </parameter>
+    <parameter name="pool_namespace" unique="0" required="0">
+      <longdesc lang="en">
+      Name of the RADOS pool namespace where the RBD has been created
+      </longdesc>
+      <shortdesc lang="en">RADOS pool namespace name</shortdesc>
+    </parameter>
     <parameter name="pool" unique="0" required="0">
       <longdesc lang="en">
       Name of the RADOS pool where the RBD has been created
@@ -108,9 +114,7 @@ Expects to have a fully populated OCF RA-compliant environment set.
 EOF
 }
 
-# rbd command wrapper: builds an option string for invoking RBD based
-# on resource parameters, and invokes rbd through ocf_run.
-do_rbd() {
+get_rbd_options() {
     local rbd_options
 
     if [ -n "${OCF_RESKEY_cephconf}" ]; then
@@ -120,25 +124,36 @@ do_rbd() {
         rbd_options="$rbd_options -m ${OCF_RESKEY_mon}"
     fi
 
+    echo "${rbd_options}"
+}
+
+
+# rbd command wrapper: builds an option string for invoking RBD based
+# on resource parameters, and invokes rbd through ocf_run.
+do_rbd() {
+    local rbd_options="$(get_rbd_options)"
+
     ocf_run rbd $rbd_options $@
 }
 
 # Convenience function that uses "rbd device list" to retrieve the
 # mapped device name from the pool, RBD name, and snapshot.
 find_rbd_dev() {
+    local rbd_options="$(get_rbd_options)"
     local sedpat
 
     # Example output from "rbd device list" (tab separated):
-    # id        pool    image   snap    device
-    # 0         rbd     test    -       /dev/rbd0
+    # id        pool    namespace	image   snap    device
+    # 0         rbd     		test    -       /dev/rbd0
+    # 1         rbd     ns1		test    -       /dev/rbd1
 
     # Build the sed pattern, substituting "-" for the snapshot name if
     # it's unset
-    sedpat="[0-9]\+[ \t]\+${OCF_RESKEY_pool}[ \t]\+${OCF_RESKEY_name}[ \t]\+${OCF_RESKEY_snap:--}[ \t]\+\(/dev/rbd[0-9]\+\).*"
+    sedpat="[0-9]\+[ \t]\+${OCF_RESKEY_pool}[ \t]\+${OCF_RESKEY_pool_namespace}[ \t]\+${OCF_RESKEY_name}[ \t]\+${OCF_RESKEY_snap:--}[ \t]\+\(/dev/rbd[0-9]\+\).*"
 
     # Run "rbd device list", filter out the header line, then try to
     # extract the device name
-    rbd device list | tail -n +2 | sed -n -e "s,$sedpat,\1,p"
+    rbd $rbd_options device list | tail -n +2 | sed -n -e "s,$sedpat,\1,p"
 }
 
 rbd_validate_all() {
@@ -206,9 +221,13 @@ rbd_start() {
         rbd_map_options="$rbd_map_options --keyfile ${OCF_RESKEY_secret}"
     fi
 
-    rbd_name="${OCF_RESKEY_pool}/${OCF_RESKEY_name}"
+    rbd_name="${OCF_RESKEY_pool}"
+    if [ -n "${OCF_RESKEY_pool_namespace}" ]; then
+        rbd_name="${rbd_name}/${OCF_RESKEY_pool_namespace}"
+    fi
+    rbd_name="${rbd_name}/${OCF_RESKEY_name}"
     if [ -n "${OCF_RESKEY_snap}" ]; then
-        rbd_name="$rbd_name@${OCF_RESKEY_snap}"
+        rbd_name="${rbd_name}@${OCF_RESKEY_snap}"
     fi
 
     do_rbd device map $rbd_name $rbd_map_options || exit $OCF_ERR_GENERIC


### PR DESCRIPTION
Support for RBD namespaces was not added to the OCF resource agent.
This commit fixes this oversight and also fixes a bug in handling
of the "rbd device list" output.

Fixes: https://tracker.ceph.com/issues/48964
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
