### PR TITLE
cephadm: rewrite call() to be more robust

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -1262,6 +1262,9 @@ def main():
         if outs:
             print(prefix + outs, file=sys.stderr)
 
+        if outbuf:
+            print(f"outbuf is {len(outbuf)} chars", file=sys.stderr)
+
         sys.stdout.flush()
 
         if parsed_args.output_file:
@@ -1301,6 +1304,8 @@ def main():
     if parsed_args.output_file and parsed_args.output_file != '-':
         outf.close()
 
+    time.sleep(1)
+        
     if final_ret:
         return final_ret
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1232,37 +1232,33 @@ def call(ctx: CephadmContext,
     end_time = None
     if timeout:
         end_time = start_time + timeout
-    while not stop:
-        if end_time and (time.time() >= end_time):
-            stop = True
-            if process.poll() is None:
+    stopped = False
+    read_some = False
+    while not stopped or read_some:
+        if not stopped:
+            if process.poll() is not None:
+                stopped = True
+            elif end_time and (time.time() >= end_time):
                 logger.info(desc + 'timeout after %s seconds' % timeout)
                 process.kill()
-        if reads and process.poll() is not None:
-            # we want to stop, but first read off anything remaining
-            # on stdout/stderr
-            stop = True
-        else:
-            reads, _, _ = select.select(
-                [process.stdout.fileno(), process.stderr.fileno()],
-                [], [], timeout
-            )
+        reads, _, _ = select.select(
+            [process.stdout.fileno(), process.stderr.fileno()],
+            [], [], timeout
+        )
+        read_some = False
         for fd in reads:
             try:
                 message = str()
                 message_b = os.read(fd, 1024)
+                if not message_b:
+                    continue
                 if isinstance(message_b, bytes):
                     message = message_b.decode('utf-8')
                 elif isinstance(message_b, str):
                     message = message_b
                 else:
                     assert False
-                if stop and message:
-                    # process has terminated, but have more to read still, so not stopping yet
-                    # (os.read returns '' when it encounters EOF)
-                    stop = False
-                if not message:
-                    continue
+                read_some = True
                 if fd == process.stdout.fileno():
                     out += message
                     message = out_buffer + message

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1237,6 +1237,7 @@ def call(ctx: CephadmContext,
     while not stopped or read_some:
         if not stopped:
             if process.poll() is not None:
+                logger.debug(f"stopped")
                 stopped = True
             elif end_time and (time.time() >= end_time):
                 logger.info(desc + 'timeout after %s seconds' % timeout)
@@ -1245,6 +1246,7 @@ def call(ctx: CephadmContext,
             [process.stdout.fileno(), process.stderr.fileno()],
             [], [], timeout
         )
+        logger.debug(f"reads {reads}")
         read_some = False
         for fd in reads:
             try:
@@ -1260,6 +1262,7 @@ def call(ctx: CephadmContext,
                     assert False
                 read_some = True
                 if fd == process.stdout.fileno():
+                    logger.debug(f"got {len(message)} for stdout")
                     out += message
                     message = out_buffer + message
                     lines = message.split('\n')
@@ -1270,6 +1273,7 @@ def call(ctx: CephadmContext,
                         elif verbosity != CallVerbosity.SILENT:
                             logger.debug(desc + 'stdout ' + line)
                 elif fd == process.stderr.fileno():
+                    logger.debug(f"got {len(message)} for stderr")
                     err += message
                     message = err_buffer + message
                     lines = message.split('\n')


### PR DESCRIPTION
This resolves the failures parsing ceph mgr dump output.

I see similarish failures that are unrelated to this function, though, where 'ceph pg dump' output is not being parsed by teuthology.  I'm not sure what the common path there would be except the ceph CLI tool itself.  In any case, though, this seems to eliminate some of the qa failures.