### PR TITLE
init-ceph: fix python and library paths for vstart

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -36,9 +36,9 @@ else
 	ETCDIR=.
 	ASSUME_DEV=1
 	CEPH_LIB=$CEPH_ROOT/${BUILD_DIR}/lib
-	echo "$PYTHONPATH" | grep -q $CEPH_LIB || export PYTHONPATH=$CEPH_LIB/cython_modules/lib.3:$PYTHONPATH
-	echo "$LD_LIBRARY_PATH" | grep -q $CEPH_LIB || export LD_LIBRARY_PATH=$CEPH_LIB:$LD_LIBRARY_PATH
-	echo "$DYLD_LIBRARY_PATH" | grep -q $CEPH_LIB || export DYLD_LIBRARY_PATH=$CEPH_LIB:$DYLD_LIBRARY_PATH
+	echo "$PYTHONPATH" | grep -q $CEPH_LIB || export PYTHONPATH=$CEPH_ROOT/src/pybind:$CEPH_LIB/cython_modules/lib.3:$CEPH_ROOT/src/python-common:$PYTHONPATH
+	echo "$LD_LIBRARY_PATH" | grep -q $CEPH_LIB || export LD_LIBRARY_PATH=$CEPH_LIB:$CEPH_ROOT/${BUILD_DIR}/external/lib:$LD_LIBRARY_PATH
+	echo "$DYLD_LIBRARY_PATH" | grep -q $CEPH_LIB || export DYLD_LIBRARY_PATH=$CEPH_LIB:$CEPH_ROOT/${BUILD_DIR}/external/lib:$DYLD_LIBRARY_PATH
     else
 	BINDIR=@bindir@
 	SBINDIR=@sbindir@


### PR DESCRIPTION
The current version does not result in a functional mgr after restarting
from a vstart cluster.

Signed-off-by: Sage Weil <sage@newdream.net>