### PR TITLE
osd/PGLog: merge divergent entries before append log and update missing

### DIFF
--- a/qa/standalone/osd/divergent-priors.sh
+++ b/qa/standalone/osd/divergent-priors.sh
@@ -602,8 +602,8 @@ function TEST_divergent_2() {
     rm -f $dir/existing
 
     grep _merge_object_divergent_entries $(find $dir -name '*osd*log')
-    # Check for _merge_object_divergent_entries for case #1
-    if ! grep -q "_merge_object_divergent_entries: more recent entry found:" $(find $dir -name '*osd*log')
+    # Check for _merge_object_divergent_entries for case #5
+    if ! grep -q "_merge_object_divergent_entries.*cannot roll back, removing and adding to missing" $(find $dir -name '*osd*log')
     then
 	    echo failure
 	    return 1
@@ -812,8 +812,8 @@ function TEST_divergent_3() {
     rm -f $dir/existing
 
     grep _merge_object_divergent_entries $(find $dir -name '*osd*log')
-    # Check for _merge_object_divergent_entries for case #1
-    if ! grep -q "_merge_object_divergent_entries: more recent entry found:" $(find $dir -name '*osd*log')
+    # Check for _merge_object_divergent_entries for case #5
+    if ! grep -q "_merge_object_divergent_entries.*cannot roll back, removing and adding to missing" $(find $dir -name '*osd*log')
     then
 	    echo failure
 	    return 1

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -457,20 +457,21 @@ void PGLog::merge_log(pg_info_t &oinfo, pg_log_t&& olog, pg_shard_t fromosd,
 
     mempool::osd_pglog::list<pg_log_entry_t> new_entries;
     new_entries.splice(new_entries.end(), olog.log, from, to);
-    append_log_entries_update_missing(
-      info.last_backfill,
-      new_entries,
-      false,
-      &log,
-      missing,
-      rollbacker,
-      this);
 
     _merge_divergent_entries(
       log,
       divergent,
       info,
       original_crt,
+      missing,
+      rollbacker,
+      this);
+
+    append_log_entries_update_missing(
+      info.last_backfill,
+      new_entries,
+      false,
+      &log,
       missing,
       rollbacker,
       this);

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -1057,27 +1057,7 @@ protected:
       /// Case 1)
       ldpp_dout(dpp, 10) << __func__ << ": more recent entry found: "
 			 << *objiter->second << ", already merged" << dendl;
-
-      ceph_assert(objiter->second->version > last_divergent_update);
-
-      // ensure missing has been updated appropriately
-      if (objiter->second->is_update() ||
-	  (missing.may_include_deletes && objiter->second->is_delete())) {
-	ceph_assert(missing.is_missing(hoid) &&
-	       missing.get_items().at(hoid).need == objiter->second->version);
-      } else {
-	ceph_assert(!missing.is_missing(hoid));
-      }
-      missing.revise_have(hoid, eversion_t());
-      missing.mark_fully_dirty(hoid);
-      if (rollbacker) {
-	if (!object_not_in_store) {
-	  rollbacker->remove(hoid);
-	}
-	for (auto &&i: entries) {
-	  rollbacker->trim(i);
-	}
-      }
+      ceph_abort_msg("unexpected error, actually we shouldn't have gotten here!");
       return;
     }
 


### PR DESCRIPTION
    Scenes(EC): Primary log(387'58, 404'59) 
                Replica log(387'58, 401'59)
                divergent log(401'59)  // The divergent log(401'59) and primary log(404'59) modified the same object

    *Issue:*
      The Primary matched _merge_divergent_entries's case 4 when call
    proc_replica_log trigger by receive MLogRec msg in GetMissing. In
    this case, we can rollback all of the entries, and the object does
    not go into missing.
      After Primary exit GetMissing and enter Active state, then will
    call all pgs to activate, and send auth log to it which exist missing
    objects, the Replica pg received auth log and call merger_log to
    process, howerver it will matched _merge_divergent_entries's case 1.
    In this case, there is a more recent update, we remove the object
    and add missing for recovery.
      At last, we can find the Primary and Replica process divergent
    entries cause difference result, and then do_recovery only can
    recovery partion data, so in our scenes will lead to object's data
    losse in Replica.

    *Analysis:*
      When Primary call _merge_divergent_entries, we can find the
    argments of log and entries always from remote peer, and Replica
    use local log and divergent entries for _merge_divergent_entries's
    in argments, so Primary and Replica should obtain identical result,
    but the Replica first call append_log_entries_update_missing to add
    auth log and update missing before process divergent entries.
      In our scenes, the auth log compared to divergent entry have newest
    version entry for same object, then Replica's local log will add it,
    and lead to match case 1. So, I think Replica shoud first merge
    divergent entries before add log and update missing, to ensure
    Primary and Replica get identical result for our scenses.

Signed-off-by: guoyong <guo.yong33@zte.com.cn>
Signed-off-by: songweibin <song.weibin@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
