### PR TITLE
cephadm: refactor call() using asyncio.asyncio.StreamReader

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -38,6 +38,7 @@ You can invoke cephadm in two ways:
        injected_stdin = '...'
 """
 import asyncio
+import asyncio.subprocess
 import argparse
 import datetime
 import fcntl
@@ -64,17 +65,17 @@ from socketserver import ThreadingMixIn
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import signal
 import io
-from contextlib import closing, redirect_stdout
+from contextlib import redirect_stdout
 import ssl
 from enum import Enum
 
 
-from typing import cast, Dict, List, Tuple, Optional, Union, Any, NoReturn, Callable, IO
+from typing import Dict, List, Tuple, Optional, Union, Any, NoReturn, Callable, IO
 
 import re
 import uuid
 
-from functools import partial, wraps
+from functools import wraps
 from glob import glob
 from threading import Thread, RLock
 
@@ -1185,38 +1186,108 @@ class CallVerbosity(Enum):
     VERBOSE = 3
 
 
-class StreamReaderProto(asyncio.SubprocessProtocol):
-    def __init__(self,
-                 exited: asyncio.Future,
-                 desc: str,
-                 verbosity: CallVerbosity) -> None:
-        self.exited = exited
-        self.desc = desc
-        self.verbosity = verbosity
-        self.stdout = ''
-        self.stderr = ''
+if sys.version_info < (3, 8):
+    import itertools
+    import threading
+    import warnings
+    from asyncio import events
 
-    def pipe_data_received(self, fd: int, data: bytes) -> None:
-        prefix = ''
-        lines = data.decode('utf-8')
+    class ThreadedChildWatcher(asyncio.AbstractChildWatcher):
+        """Threaded child watcher implementation.
+        The watcher uses a thread per process
+        for waiting for the process finish.
+        It doesn't require subscription on POSIX signal
+        but a thread creation is not free.
+        The watcher has O(1) complexity, its performance doesn't depend
+        on amount of spawn processes.
+        """
 
-        if fd == sys.stdout.fileno():
-            prefix = self.desc + 'stdout'
-            self.stdout += lines
-        elif fd == sys.stderr.fileno():
-            prefix = self.desc + 'stderr'
-            self.stderr += lines
-        else:
-            assert False, f"unknown data received from fd: {fd}"
+        def __init__(self):
+            self._pid_counter = itertools.count(0)
+            self._threads = {}
 
-        for line in lines.split('\n'):
-            if self.verbosity == CallVerbosity.VERBOSE:
-                logger.info(prefix + line)
-            elif self.verbosity != CallVerbosity.SILENT:
-                logger.debug(prefix + line)
+        def is_active(self):
+                return True
 
-    def process_exited(self) -> None:
-        self.exited.set_result(True)
+        def close(self):
+            self._join_threads()
+
+        def _join_threads(self):
+            """Internal: Join all non-daemon threads"""
+            threads = [thread for thread in list(self._threads.values())
+                       if thread.is_alive() and not thread.daemon]
+            for thread in threads:
+                thread.join()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+        def __del__(self, _warn=warnings.warn):
+            threads = [thread for thread in list(self._threads.values())
+                       if thread.is_alive()]
+            if threads:
+                _warn(f"{self.__class__} has registered but not finished child processes",
+                      ResourceWarning,
+                      source=self)
+
+        def add_child_handler(self, pid, callback, *args):
+            loop = events.get_event_loop()
+            thread = threading.Thread(target=self._do_waitpid,
+                                      name=f"waitpid-{next(self._pid_counter)}",
+                                      args=(loop, pid, callback, args),
+                                      daemon=True)
+            self._threads[pid] = thread
+            thread.start()
+
+        def remove_child_handler(self, pid):
+            # asyncio never calls remove_child_handler() !!!
+            # The method is no-op but is implemented because
+            # abstract base classe requires it
+            return True
+
+        def attach_loop(self, loop):
+            pass
+
+        def _do_waitpid(self, loop, expected_pid, callback, args):
+            assert expected_pid > 0
+
+            try:
+                pid, status = os.waitpid(expected_pid, 0)
+            except ChildProcessError:
+                # The child process is already reaped
+                # (may happen if waitpid() is called elsewhere).
+                pid = expected_pid
+                returncode = 255
+                logger.warning(
+                    "Unknown child process pid %d, will report returncode 255",
+                    pid)
+            else:
+                if os.WIFEXITED(status):
+                    returncode = os.WEXITSTATUS(status)
+                elif os.WIFSIGNALED(status):
+                    returncode = -os.WTERMSIG(status)
+                else:
+                    raise ValueError(f'unknown wait status {status}')
+                if loop.get_debug():
+                    logger.debug('process %s exited with returncode %s',
+                                 expected_pid, returncode)
+
+            if loop.is_closed():
+                logger.warning("Loop %r that handles pid %r is closed", loop, pid)
+            else:
+                loop.call_soon_threadsafe(callback, pid, returncode, *args)
+
+            self._threads.pop(expected_pid)
+
+    # unlike SafeChildWatcher which handles SIGCHLD in the main thread,
+    # ThreadedChildWatcher runs in a separated thread, hence allows us to
+    # run create_subprocess_exec() in non-main thread, see
+    # https://bugs.python.org/issue35621
+    asyncio.set_child_watcher(ThreadedChildWatcher())
+
 
 try:
     from asyncio import run as async_run   # type: ignore[attr-defined]
@@ -1227,8 +1298,11 @@ except ImportError:
             asyncio.set_event_loop(loop)
             return loop.run_until_complete(coro)
         finally:
-            asyncio.set_event_loop(None)
-            loop.close()
+            try:
+                loop.run_until_complete(loop.shutdown_asyncgens())
+            finally:
+                asyncio.set_event_loop(None)
+                loop.close()
 
 def call(ctx: CephadmContext,
          command: List[str],
@@ -1253,47 +1327,43 @@ def call(ctx: CephadmContext,
 
     logger.debug("Running command: %s" % ' '.join(command))
 
-    async def run_with_timeout():
-        loop = asyncio.get_event_loop()
-        proc_exited = loop.create_future()
-        protocol_factory = partial(StreamReaderProto,
-                                   proc_exited,
-                                   prefix, verbosity)
-        transport, protocol = await loop.subprocess_exec(
-            protocol_factory,
+    async def tee(reader: asyncio.StreamReader) -> str:
+        collected = StringIO()
+        async for line in reader:
+            message = line.decode('utf-8')
+            collected.write(message)
+            if verbosity == CallVerbosity.VERBOSE:
+                logger.info(prefix + message.rstrip())
+            elif verbosity != CallVerbosity.SILENT:
+                logger.debug(prefix + message.rstrip())
+        return collected.getvalue()
+
+    async def run_with_timeout() -> Tuple[str, str, int]:
+        process = await asyncio.create_subprocess_exec(
             *command,
-            close_fds=True,
-            **kwargs)
-        proc_transport = cast(asyncio.SubprocessTransport, transport)
-        proc_protocol = cast(StreamReaderProto, protocol)
-        returncode = 0
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE)
+        assert process.stdout
+        assert process.stderr
         try:
-            if timeout:
-                await asyncio.wait_for(proc_exited, timeout)
-            else:
-                await proc_exited
+            stdout, stderr = await asyncio.gather(tee(process.stdout),
+                                                  tee(process.stderr))
+            returncode = await asyncio.wait_for(process.wait(), timeout)
         except asyncio.TimeoutError:
             logger.info(prefix + f'timeout after {timeout} seconds')
-            returncode = 124
+            return '', '', 124
         else:
-            returncode = cast(int, proc_transport.get_returncode())
-        finally:
-            proc_transport.close()
-        return (returncode,
-                proc_protocol.stdout,
-                proc_protocol.stderr)
+            return stdout, stderr, returncode
 
-    returncode, out, err = async_run(run_with_timeout())
+    stdout, stderr, returncode = async_run(run_with_timeout())
     if returncode != 0 and verbosity == CallVerbosity.VERBOSE_ON_FAILURE:
-        # dump stdout + stderr
         logger.info('Non-zero exit code %d from %s',
                     returncode, ' '.join(command))
-        for line in out.splitlines():
+        for line in stdout.splitlines():
             logger.info(prefix + 'stdout ' + line)
-        for line in err.splitlines():
+        for line in stderr.splitlines():
             logger.info(prefix + 'stderr ' + line)
-
-    return out, err, returncode
+    return stdout, stderr, returncode
 
 
 def call_throws(


### PR DESCRIPTION
the cephadm test in master is much better with #39035. see https://pulpito.ceph.com/kchai-2021-01-24_03:08:04-rados-wip-kefu-testing-2021-01-23-2059-distro-basic-smithi/

but there is still a failure caused by the trimmed json string issue:
```
2021-01-24T03:41:00.457 INFO:teuthology.orchestra.run.smithi089.stderr:  File "/home/ubuntu/cephtest/cephadm", line 7561, in <module>
2021-01-24T03:41:00.457 INFO:teuthology.orchestra.run.smithi089.stderr:    main()
2021-01-24T03:41:00.457 INFO:teuthology.orchestra.run.smithi089.stderr:  File "/home/ubuntu/cephtest/cephadm", line 7550, in main
2021-01-24T03:41:00.457 INFO:teuthology.orchestra.run.smithi089.stderr:    r = ctx.func(ctx)
2021-01-24T03:41:00.458 INFO:teuthology.orchestra.run.smithi089.stderr:  File "/home/ubuntu/cephtest/cephadm", line 1651, in _default_image
2021-01-24T03:41:00.458 INFO:teuthology.orchestra.run.smithi089.stderr:    return func(ctx)
2021-01-24T03:41:00.458 INFO:teuthology.orchestra.run.smithi089.stderr:  File "/home/ubuntu/cephtest/cephadm", line 3763, in command_bootstrap
2021-01-24T03:41:00.458 INFO:teuthology.orchestra.run.smithi089.stderr:    prepare_dashboard(ctx, uid, gid, cli, wait_for_mgr_restart)
2021-01-24T03:41:00.458 INFO:teuthology.orchestra.run.smithi089.stderr:  File "/home/ubuntu/cephtest/cephadm", line 3483, in prepare_dashboard
2021-01-24T03:41:00.459 INFO:teuthology.orchestra.run.smithi089.stderr:    wait_for_mgr_restart()
2021-01-24T03:41:00.459 INFO:teuthology.orchestra.run.smithi089.stderr:  File "/home/ubuntu/cephtest/cephadm", line 3712, in wait_for_mgr_restart
2021-01-24T03:41:00.459 INFO:teuthology.orchestra.run.smithi089.stderr:    j = json.loads(out)
2021-01-24T03:41:00.459 INFO:teuthology.orchestra.run.smithi089.stderr:  File "/usr/lib/python3.6/json/__init__.py", line 354, in loads
2021-01-24T03:41:00.459 INFO:teuthology.orchestra.run.smithi089.stderr:    return _default_decoder.decode(s)
2021-01-24T03:41:00.460 INFO:teuthology.orchestra.run.smithi089.stderr:  File "/usr/lib/python3.6/json/decoder.py", line 339, in decode
2021-01-24T03:41:00.460 INFO:teuthology.orchestra.run.smithi089.stderr:    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
2021-01-24T03:41:00.460 INFO:teuthology.orchestra.run.smithi089.stderr:  File "/usr/lib/python3.6/json/decoder.py", line 355, in raw_decode
2021-01-24T03:41:00.460 INFO:teuthology.orchestra.run.smithi089.stderr:    obj, end = self.scan_once(s, idx)
2021-01-24T03:41:00.461 INFO:teuthology.orchestra.run.smithi089.stderr:json.decoder.JSONDecodeError: Expecting ',' delimiter: line 3454 column 31 (char 122880)
```
see https://pulpito.ceph.com/kchai-2021-01-24_03:08:04-rados-wip-kefu-testing-2021-01-23-2059-distro-basic-smithi/

so, in hope to take advantage of Python standard library, and have less chance to introduce a bug, i created this change.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
