### PR TITLE
librbd: do not share crypto image layers with ancestors

### DIFF
--- a/src/librbd/crypto/LoadRequest.cc
+++ b/src/librbd/crypto/LoadRequest.cc
@@ -59,12 +59,12 @@ template <typename I>
 void LoadRequest<I>::finish(int r) {
   if (r == 0) {
     // load crypto layers to image and its ancestors
-    auto image_dispatch = CryptoImageDispatch::create(
-            m_crypto->get_data_offset());
     auto ictx = m_image_ctx;
     while (ictx != nullptr) {
       auto object_dispatch = CryptoObjectDispatch<I>::create(
               ictx, m_crypto);
+      auto image_dispatch = CryptoImageDispatch::create(
+            m_crypto->get_data_offset());
       ictx->io_object_dispatcher->register_dispatch(object_dispatch);
       ictx->io_image_dispatcher->register_dispatch(image_dispatch);
 


### PR DESCRIPTION
I'm guessing this as a solution for:
https://tracker.ceph.com/issues/48958

My first guess was that I need to de-register the crypto layers explicitly, but I see that the Disaptcher::shut_down_dispatch already does that.