### PR TITLE
octopus: ocf: add support for mapping images within an RBD namespace

### DIFF
--- a/src/ocf/rbd.in
+++ b/src/ocf/rbd.in
@@ -41,6 +41,12 @@ resource. Maps and unmaps RBDs as needed.
       <shortdesc lang="en">RBD device name</shortdesc>
       <content type="string"/>
     </parameter>
+    <parameter name="pool_namespace" unique="0" required="0">
+      <longdesc lang="en">
+      Name of the RADOS pool namespace where the RBD has been created
+      </longdesc>
+      <shortdesc lang="en">RADOS pool namespace name</shortdesc>
+    </parameter>
     <parameter name="pool" unique="0" required="0">
       <longdesc lang="en">
       Name of the RADOS pool where the RBD has been created
@@ -108,9 +114,7 @@ Expects to have a fully populated OCF RA-compliant environment set.
 EOF
 }
 
-# rbd command wrapper: builds an option string for invoking RBD based
-# on resource parameters, and invokes rbd through ocf_run.
-do_rbd() {
+get_rbd_options() {
     local rbd_options
 
     if [ -n "${OCF_RESKEY_cephconf}" ]; then
@@ -120,25 +124,36 @@ do_rbd() {
         rbd_options="$rbd_options -m ${OCF_RESKEY_mon}"
     fi
 
+    echo "${rbd_options}"
+}
+
+
+# rbd command wrapper: builds an option string for invoking RBD based
+# on resource parameters, and invokes rbd through ocf_run.
+do_rbd() {
+    local rbd_options="$(get_rbd_options)"
+
     ocf_run rbd $rbd_options $@
 }
 
 # Convenience function that uses "rbd device list" to retrieve the
 # mapped device name from the pool, RBD name, and snapshot.
 find_rbd_dev() {
+    local rbd_options="$(get_rbd_options)"
     local sedpat
 
     # Example output from "rbd device list" (tab separated):
-    # id        pool    image   snap    device
-    # 0         rbd     test    -       /dev/rbd0
+    # id        pool    namespace	image   snap    device
+    # 0         rbd     		test    -       /dev/rbd0
+    # 1         rbd     ns1		test    -       /dev/rbd1
 
     # Build the sed pattern, substituting "-" for the snapshot name if
     # it's unset
-    sedpat="[0-9]\+[ \t]\+${OCF_RESKEY_pool}[ \t]\+${OCF_RESKEY_name}[ \t]\+${OCF_RESKEY_snap:--}[ \t]\+\(/dev/rbd[0-9]\+\).*"
+    sedpat="[0-9]\+[ \t]\+${OCF_RESKEY_pool}[ \t]\+${OCF_RESKEY_pool_namespace}[ \t]\+${OCF_RESKEY_name}[ \t]\+${OCF_RESKEY_snap:--}[ \t]\+\(/dev/rbd[0-9]\+\).*"
 
     # Run "rbd device list", filter out the header line, then try to
     # extract the device name
-    rbd device list | tail -n +2 | sed -n -e "s,$sedpat,\1,p"
+    rbd $rbd_options device list | tail -n +2 | sed -n -e "s,$sedpat,\1,p"
 }
 
 rbd_validate_all() {
@@ -206,9 +221,13 @@ rbd_start() {
         rbd_map_options="$rbd_map_options --keyfile ${OCF_RESKEY_secret}"
     fi
 
-    rbd_name="${OCF_RESKEY_pool}/${OCF_RESKEY_name}"
+    rbd_name="${OCF_RESKEY_pool}"
+    if [ -n "${OCF_RESKEY_pool_namespace}" ]; then
+        rbd_name="${rbd_name}/${OCF_RESKEY_pool_namespace}"
+    fi
+    rbd_name="${rbd_name}/${OCF_RESKEY_name}"
     if [ -n "${OCF_RESKEY_snap}" ]; then
-        rbd_name="$rbd_name@${OCF_RESKEY_snap}"
+        rbd_name="${rbd_name}@${OCF_RESKEY_snap}"
     fi
 
     do_rbd device map $rbd_name $rbd_map_options || exit $OCF_ERR_GENERIC


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48968

---

backport of https://github.com/ceph/ceph/pull/39029
parent tracker: https://tracker.ceph.com/issues/48964

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh