### PR TITLE
mgr/alerts: interval can be None

### DIFF
--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -21,6 +21,9 @@ ignore_missing_imports = True
 [mypy-mgr_util]
 disallow_untyped_defs = True
 
+[mypy-alerts.*]
+disallow_untyped_defs = True
+
 [mypy-cephadm.*]
 disallow_untyped_defs = True
 

--- a/src/pybind/mgr/alerts/module.py
+++ b/src/pybind/mgr/alerts/module.py
@@ -180,8 +180,8 @@ class Alerts(MgrModule):
                     self._send_alert(new_status, diff)
                 last_status = new_status
 
-            self.log.debug('Sleeping for %d seconds', self.interval)
-            ret = self.event.wait(self.interval)
+            self.log.debug('Sleeping for %s seconds', self.interval)
+            ret = self.event.wait(self.interval or 60)
             self.event.clear()
 
     def shutdown(self):

--- a/src/pybind/mgr/alerts/module.py
+++ b/src/pybind/mgr/alerts/module.py
@@ -5,7 +5,7 @@ A simple cluster health alerting module.
 
 from mgr_module import MgrModule, HandleCommandResult
 from threading import Event
-import errno
+from typing import Any, Optional, Dict, List, TYPE_CHECKING, Union
 import json
 import smtplib
 
@@ -18,7 +18,8 @@ class Alerts(MgrModule):
         },
     ]
 
-    MODULE_OPTIONS = [
+    # ´# type: ignore` due to the introduction of the Option type.
+    MODULE_OPTIONS: List[Dict[str, Any]] = [  # type: ignore
         {
             'name': 'interval',
             'type': 'secs',
@@ -80,10 +81,10 @@ class Alerts(MgrModule):
     ]
 
     # These are "native" Ceph options that this module cares about.
-    NATIVE_OPTIONS = [
+    NATIVE_OPTIONS: List[str] = [
     ]
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(Alerts, self).__init__(*args, **kwargs)
 
         # set up some members to enable the serve() method and shutdown()
@@ -95,8 +96,18 @@ class Alerts(MgrModule):
 
         self.log.info("Init")
 
+        if TYPE_CHECKING:
+            self.interval = 60
+            self.smtp_host = ''
+            self.smtp_destination = ''
+            self.smtp_port = 0
+            self.smtp_ssl = True
+            self.smtp_user = ''
+            self.smtp_password = ''
+            self.smtp_sender = ''
+            self.smtp_from_name = ''
 
-    def config_notify(self):
+    def config_notify(self) -> None:
         """
         This method is called whenever one of our config options is changed.
         """
@@ -116,7 +127,7 @@ class Alerts(MgrModule):
                     self.get_ceph_option(opt))
             self.log.debug(' native option %s = %s', opt, getattr(self, opt))
 
-    def handle_command(self, inbuf, cmd):
+    def handle_command(self, inbuf: Optional[str], cmd: Dict[str, Any]) -> HandleCommandResult:
         ret = 0
         out = ''
         err = ''
@@ -128,8 +139,8 @@ class Alerts(MgrModule):
             stdout=out,   # stdout
             stderr=err)
 
-    def _diff(self, last, new):
-        d = {}
+    def _diff(self, last: Dict[str, Any], new: Dict[str, Any]) -> Dict[str, Any]:
+        d: Dict[str, Any] = {}
         for code, alert in new.get('checks', {}).items():
             self.log.debug('new code %s alert %s' % (code, alert))
             if code not in last.get('checks', {}):
@@ -149,7 +160,7 @@ class Alerts(MgrModule):
                 d['cleared'][code] = alert
         return d
 
-    def _send_alert(self, status, diff):
+    def _send_alert(self, status: Dict[str, Any], diff: Dict[str, Any]) -> None:
         checks = {}
         if self.smtp_host:
             r = self._send_alert_smtp(status, diff)
@@ -160,13 +171,13 @@ class Alerts(MgrModule):
             self.log.warning('Alert is not sent because smtp_host is not configured')
         self.set_health_checks(checks)
 
-    def serve(self):
+    def serve(self) -> None:
         """
         This method is called by the mgr when the module starts and can be
         used for any background activity.
         """
         self.log.info("Starting")
-        last_status = {}
+        last_status: Dict[str, Any] = {}
         while self.run:
             # Do some useful background work here.
             new_status = json.loads(self.get('health')['json'])
@@ -184,7 +195,7 @@ class Alerts(MgrModule):
             ret = self.event.wait(self.interval or 60)
             self.event.clear()
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         """
         This method is called by the mgr when the module needs to shut
         down (i.e., when the serve() function needs to exit).
@@ -194,7 +205,7 @@ class Alerts(MgrModule):
         self.event.set()
 
     # SMTP
-    def _smtp_format_alert(self, code, alert):
+    def _smtp_format_alert(self, code: str, alert: Dict[str, Any]) -> str:
         r = '[{sev}] {code}: {summary}\n'.format(
             code=code,
             sev=alert['severity'].split('_')[1],
@@ -204,7 +215,7 @@ class Alerts(MgrModule):
                 message=detail['message'])
         return r
 
-    def _send_alert_smtp(self, status, diff):
+    def _send_alert_smtp(self, status: Dict[str, Any], diff: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         # message
         self.log.debug('_send_alert_smtp')
         message = ('From: {from_name} <{sender}>\n'
@@ -239,7 +250,7 @@ class Alerts(MgrModule):
         # send
         try:
             if self.smtp_ssl:
-                server = smtplib.SMTP_SSL(self.smtp_host, self.smtp_port)
+                server: Union[smtplib.SMTP_SSL, smtplib.SMTP] = smtplib.SMTP_SSL(self.smtp_host, self.smtp_port)
             else:
                 server = smtplib.SMTP(self.smtp_host, self.smtp_port)
             if self.smtp_password:

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -55,6 +55,7 @@ deps =
     mypy==0.790
 commands =
     mypy --config-file=../../mypy.ini \
+           -m alerts \
            -m cephadm \
            -m dashboard \
            -m devicehealth \


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/48972

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
