### PR TITLE
doc: don't mention osdtimeout option in mount.ceph man page

### DIFF
--- a/doc/man/8/mount.ceph.rst
+++ b/doc/man/8/mount.ceph.rst
@@ -143,9 +143,6 @@ Advanced
 :command:`osdkeepalive`
     int, Default: 5
 
-:command:`osdtimeout`
-    int (seconds), Default: 60
-
 :command:`osd_idle_ttl`
     int (seconds), Default: 60
 


### PR DESCRIPTION
It was deprecated over 8 years ago and will be entirely removed in
kernel 5.12.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>