### PR TITLE
nautilus: mgr/prometheus: Fix 'pool filling up' with >50% usage

### DIFF
--- a/monitoring/prometheus/alerts/ceph_default_alerts.yml
+++ b/monitoring/prometheus/alerts/ceph_default_alerts.yml
@@ -215,8 +215,8 @@ groups:
       - alert: pool filling up
         expr: |
           (
-            predict_linear(ceph_pool_stored[2d], 3600 * 24 * 5) >=
-            ceph_pool_max_avail
+            predict_linear(ceph_pool_stored[2d], 3600 * 24 * 5)
+            >= ceph_pool_stored + ceph_pool_max_avail
           ) * on(pool_id) group_left(name) ceph_pool_metadata
         labels:
           severity: warning


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48957

---

backport of https://github.com/ceph/ceph/pull/38282
parent tracker: https://tracker.ceph.com/issues/48354

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh