### PR TITLE
qa/suites/rados/cephadm: drop ubuntu + podman from test matrix for now

### DIFF
--- a/qa/suites/rados/cephadm/smoke/distro/ubuntu_18.04_podman.yaml
+++ b/qa/suites/rados/cephadm/smoke/distro/ubuntu_18.04_podman.yaml
@@ -1,1 +1,0 @@
-.qa/distros/all/ubuntu_18.04_podman.yaml

--- a/qa/suites/rados/cephadm/smoke/distro/ubuntu_20.04_podman.yaml
+++ b/qa/suites/rados/cephadm/smoke/distro/ubuntu_20.04_podman.yaml
@@ -1,1 +1,0 @@
-.qa/distros/all/ubuntu_20.04_podman.yaml

--- a/qa/suites/rados/cephadm/with-work/distro/ubuntu_18.04_podman.yaml
+++ b/qa/suites/rados/cephadm/with-work/distro/ubuntu_18.04_podman.yaml
@@ -1,1 +1,0 @@
-.qa/distros/all/ubuntu_18.04_podman.yaml

--- a/qa/suites/rados/cephadm/with-work/distro/ubuntu_20.04_podman.yaml
+++ b/qa/suites/rados/cephadm/with-work/distro/ubuntu_20.04_podman.yaml
@@ -1,1 +1,0 @@
-.qa/distros/all/ubuntu_20.04_podman.yaml

--- a/qa/suites/rados/cephadm/workunits/distro/ubuntu_18.04_podman.yaml
+++ b/qa/suites/rados/cephadm/workunits/distro/ubuntu_18.04_podman.yaml
@@ -1,1 +1,0 @@
-.qa/distros/all/ubuntu_18.04_podman.yaml

--- a/qa/suites/rados/cephadm/workunits/distro/ubuntu_20.04_podman.yaml
+++ b/qa/suites/rados/cephadm/workunits/distro/ubuntu_20.04_podman.yaml
@@ -1,1 +1,0 @@
-.qa/distros/all/ubuntu_20.04_podman.yaml


### PR DESCRIPTION
We are hitting a bug in podman:

  https://github.com/containers/podman/issues/9096