### PR TITLE
mgr/cephadm: Fix wrong argument type to HandleCommandResult

### DIFF
--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -86,8 +86,8 @@ class GrafanaService(CephadmService):
     def ok_to_stop(self, daemon_ids: List[str], force: bool = False) -> HandleCommandResult:
         warn, warn_message = self._enough_daemons_to_stop(self.TYPE, daemon_ids, 'Grafana', 1)
         if warn and not force:
-            return HandleCommandResult(-errno.EBUSY, None, warn_message)
-        return HandleCommandResult(0, warn_message, None)
+            return HandleCommandResult(-errno.EBUSY, '', warn_message)
+        return HandleCommandResult(0, warn_message, '')
 
 
 class AlertmanagerService(CephadmService):
@@ -177,8 +177,8 @@ class AlertmanagerService(CephadmService):
     def ok_to_stop(self, daemon_ids: List[str], force: bool = False) -> HandleCommandResult:
         warn, warn_message = self._enough_daemons_to_stop(self.TYPE, daemon_ids, 'Alertmanager', 1)
         if warn and not force:
-            return HandleCommandResult(-errno.EBUSY, None, warn_message)
-        return HandleCommandResult(0, warn_message, None)
+            return HandleCommandResult(-errno.EBUSY, '', warn_message)
+        return HandleCommandResult(0, warn_message, '')
 
 
 class PrometheusService(CephadmService):
@@ -281,8 +281,8 @@ class PrometheusService(CephadmService):
     def ok_to_stop(self, daemon_ids: List[str], force: bool = False) -> HandleCommandResult:
         warn, warn_message = self._enough_daemons_to_stop(self.TYPE, daemon_ids, 'Prometheus', 1)
         if warn and not force:
-            return HandleCommandResult(-errno.EBUSY, None, warn_message)
-        return HandleCommandResult(0, warn_message, None)
+            return HandleCommandResult(-errno.EBUSY, '', warn_message)
+        return HandleCommandResult(0, warn_message, '')
 
 
 class NodeExporterService(CephadmService):
@@ -300,4 +300,4 @@ class NodeExporterService(CephadmService):
         # since node exporter runs on each host and cannot compromise data, no extra checks required
         names = [f'{self.TYPE}.{d_id}' for d_id in daemon_ids]
         out = f'It is presumed safe to stop {names}'
-        return HandleCommandResult(0, out, None)
+        return HandleCommandResult(0, out, '')


### PR DESCRIPTION
the argument must be a string

Fixes: #38854

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
