### PR TITLE
pacific: mgr/dashboard: trigger alert if some nodes have a MTU different than the median value

### DIFF
--- a/monitoring/prometheus/alerts/ceph_default_alerts.yml
+++ b/monitoring/prometheus/alerts/ceph_default_alerts.yml
@@ -214,6 +214,17 @@ groups:
             will be full in less than 5 days assuming the average fill-up
             rate of the past 48 hours.
 
+      - alert: MTU Mismatch
+        expr: node_network_mtu_bytes{device!="lo"} != on(device) group_left() (quantile(0.5, node_network_mtu_bytes{device!="lo"}) by (device))
+        labels:
+          severity: warning
+          type: ceph_default
+          oid: 1.3.6.1.4.1.50495.15.1.2.8.5
+        annotations:
+          description: >
+            Node {{ $labels.instance }} has a different MTU size ({{ $value }})
+            than the median value on device {{ $labels.device }}.
+
   - name: pools
     rules:
       - alert: pool full


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49021

---

backport of https://github.com/ceph/ceph/pull/38764
parent tracker: https://tracker.ceph.com/issues/48748

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh