### PR TITLE
pacific: pybind/ceph_volume_client: Fix encode error on the eviction command

### DIFF
--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -167,10 +167,10 @@ class RankEvicter(threading.Thread):
             ))
             ret, outb, outs = self._volume_client.fs.mds_command(
                 "%s" % self.gid,
-                [json.dumps({
-                                "prefix": "session evict",
-                                "filters": self._client_spec
-                })], "")
+                json.dumps({
+                               "prefix": "session evict",
+                               "filters": self._client_spec
+                }), "")
             log.debug("mds_command: complete {0} {1}".format(ret, outs))
 
             # If we get a clean response, great, it's gone from that rank.


### PR DESCRIPTION
This change [0] in cephfs.pyx expects args to be of an encodeable type.
We are passing a list, which is not encodeable. We need to pass the string only.

Pass the args param as a string instead of a list to fix the encoding error.

[0] https://github.com/ceph/ceph/pull/38692

Fixes: https://tracker.ceph.com/issues/49035
Signed-off-by: Victoria Martinez de la Cruz <victoria@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
