### PR TITLE
cephadm:add missing kernel_security property

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -6112,6 +6112,7 @@ class HostFacts():
         up_secs, _ = raw_time.split()
         return float(up_secs)
 
+    @property
     def kernel_security(self):
         # type: () -> Optional[Dict[str, str]]
         """Determine the security features enabled in the kernel - SELinux, AppArmor"""


### PR DESCRIPTION
The propery decorator had gone missing which meant
the dump of host facts was missing the kernel security
(LSM) settings. This patch just adds the @property
decorator back

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>
