### PR TITLE
python-common: fix test_datetime_to_str_2 on non-UTC hosts

### DIFF
--- a/src/python-common/ceph/tests/test_datetime.py
+++ b/src/python-common/ceph/tests/test_datetime.py
@@ -11,8 +11,11 @@ def test_datetime_to_str_1():
 
 
 def test_datetime_to_str_2():
-    dt = datetime.datetime.strptime('2019-04-24T17:06:53.039991',
-                                    '%Y-%m-%dT%H:%M:%S.%f')
+    # note: tz isn't specified in the string, so explicitly store this as UTC
+    dt = datetime.datetime.strptime(
+        '2019-04-24T17:06:53.039991',
+        '%Y-%m-%dT%H:%M:%S.%f'
+    ).replace(tzinfo=datetime.timezone.utc)
     assert datetime_to_str(dt) == '2019-04-24T17:06:53.039991Z'
 
 


### PR DESCRIPTION
The old test parsed to a datetime without a tz, which was interpreted as
the local time zone when rendering back to a string.  Specify that it's a
UTC datetime so that behavior is consistent regardless of the test host
timezone.

Signed-off-by: Sage Weil <sage@newdream.net>