### PR TITLE
qa/suites/rados/cephadm: drop rhel_8.0 tests

### DIFF
--- a/qa/suites/rados/cephadm/smoke/distro/rhel_8.0.yaml
+++ b/qa/suites/rados/cephadm/smoke/distro/rhel_8.0.yaml
@@ -1,1 +1,0 @@
-.qa/distros/all/rhel_8.0.yaml

--- a/qa/suites/rados/cephadm/with-work/distro/rhel_8.0.yaml
+++ b/qa/suites/rados/cephadm/with-work/distro/rhel_8.0.yaml
@@ -1,1 +1,0 @@
-.qa/distros/all/rhel_8.0.yaml


### PR DESCRIPTION
We have centos_8.0 still. No rhel 8.0 image for gibba.