### PR TITLE
cmake: install rook-client-python using ExternalProject

### DIFF
--- a/src/pybind/mgr/rook/CMakeLists.txt
+++ b/src/pybind/mgr/rook/CMakeLists.txt
@@ -1,12 +1,15 @@
-add_custom_command(
-  OUTPUT rook_client/__init__.py
-  COMMAND ./generate_rook_ceph_client.sh
-  COMMENT "generating mgr/rook/rook_client"
-  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/src/pybind/mgr/rook")
+include(ExternalProject)
 
-add_custom_target(mgr-rook-client
-  DEPENDS rook_client/__init__.py
-  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/src/pybind/mgr/rook"
-)
+ExternalProject_Add(mgr-rook-client
+  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/rook-client-python/rook_client"
+  # use INSTALL_DIR for destination dir
+  INSTALL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/rook_client"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ${CMAKE_COMMAND} -E make_directory <INSTALL_DIR>
+  COMMAND       ${CMAKE_COMMAND} -E copy_directory <SOURCE_DIR>/ceph <INSTALL_DIR>/ceph
+  COMMAND       ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/__init__.py <INSTALL_DIR>
+  COMMAND       ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/_helper.py <INSTALL_DIR>
+  BUILD_BYPRODUCTS "<INSTALL_DIR>/__init__.py"
+  INSTALL_COMMAND "")
 
 add_dependencies(ceph-mgr mgr-rook-client)


### PR DESCRIPTION
so we don't need to rerun the generate_rook_ceph_client.sh script
everytime when building the script. cmake creates a stamp file for
tracking the dependencies and the time of modification of dependencies.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
