### PR TITLE
octopus: librbd: clear implicitly enabled feature bits when creating images

### DIFF
--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -548,7 +548,7 @@ int Image<I>::deep_copy(I *src, librados::IoCtx& dest_md_ctx,
       return -EBUSY;
     }
 
-    features = (src->features & ~RBD_FEATURES_IMPLICIT_ENABLE);
+    features = src->features;
     src_size = src->get_image_size(src->snap_id);
   }
   uint64_t format = 2;

--- a/src/librbd/api/Migration.cc
+++ b/src/librbd/api/Migration.cc
@@ -459,8 +459,6 @@ int Migration<I>::prepare(librados::IoCtx& io_ctx,
                       cls::rbd::MIGRATION_STATE_PREPARING, "", nullptr);
   r = migration.prepare();
 
-  opts.set(RBD_IMAGE_OPTION_FEATURES, features);
-
   return r;
 }
 

--- a/src/librbd/api/Migration.cc
+++ b/src/librbd/api/Migration.cc
@@ -427,7 +427,6 @@ int Migration<I>::prepare(librados::IoCtx& io_ctx,
     return -ENOSYS;
   }
   features &= ~RBD_FEATURES_INTERNAL;
-  features |= RBD_FEATURE_MIGRATING;
   opts.set(RBD_IMAGE_OPTION_FEATURES, features);
 
   uint64_t order = image_ctx->order;
@@ -460,7 +459,6 @@ int Migration<I>::prepare(librados::IoCtx& io_ctx,
                       cls::rbd::MIGRATION_STATE_PREPARING, "", nullptr);
   r = migration.prepare();
 
-  features &= ~RBD_FEATURE_MIGRATING;
   opts.set(RBD_IMAGE_OPTION_FEATURES, features);
 
   return r;

--- a/src/librbd/image/CreateRequest.cc
+++ b/src/librbd/image/CreateRequest.cc
@@ -155,6 +155,7 @@ CreateRequest<I>::CreateRequest(const ConfigProxy& config, IoCtx &ioctx,
   m_features |= features_set;
   m_features &= ~features_clear;
 
+  m_features &= ~RBD_FEATURES_IMPLICIT_ENABLE;
   if ((m_features & RBD_FEATURE_OBJECT_MAP) == RBD_FEATURE_OBJECT_MAP) {
       m_features |= RBD_FEATURE_FAST_DIFF;
   }
@@ -200,14 +201,11 @@ CreateRequest<I>::CreateRequest(const ConfigProxy& config, IoCtx &ioctx,
     m_features |= RBD_FEATURE_DATA_POOL;
   } else {
     m_data_pool.clear();
-    m_features &= ~RBD_FEATURE_DATA_POOL;
   }
 
   if ((m_stripe_unit != 0 && m_stripe_unit != (1ULL << m_order)) ||
       (m_stripe_count != 0 && m_stripe_count != 1)) {
     m_features |= RBD_FEATURE_STRIPINGV2;
-  } else {
-    m_features &= ~RBD_FEATURE_STRIPINGV2;
   }
 
   ldout(m_cct, 10) << "name=" << m_image_name << ", "

--- a/src/librbd/image/CreateRequest.cc
+++ b/src/librbd/image/CreateRequest.cc
@@ -38,7 +38,7 @@ int validate_features(CephContext *cct, uint64_t features) {
     lderr(cct) << "librbd does not support requested features." << dendl;
     return -ENOSYS;
   }
-  if ((features & RBD_FEATURE_OPERATIONS) != 0) {
+  if ((features & RBD_FEATURES_INTERNAL) != 0) {
     lderr(cct) << "cannot use internally controlled features" << dendl;
     return -EINVAL;
   }

--- a/src/test/librbd/test_DeepCopy.cc
+++ b/src/test/librbd/test_DeepCopy.cc
@@ -411,7 +411,6 @@ struct TestDeepCopy : public TestFixture {
         int order = m_src_ictx->order;
         uint64_t features;
         ASSERT_EQ(0, librbd::get_features(m_src_ictx, &features));
-        features &= ~RBD_FEATURES_IMPLICIT_ENABLE;
 
         std::cout << "clone " << m_src_ictx->name << " -> " << clone_name
                   << std::endl;

--- a/src/test/librbd/test_Migration.cc
+++ b/src/test/librbd/test_Migration.cc
@@ -293,7 +293,6 @@ struct TestMigration : public TestFixture {
     int order = m_ref_ictx->order;
     uint64_t features;
     ASSERT_EQ(0, librbd::get_features(m_ref_ictx, &features));
-    features &= ~RBD_FEATURES_IMPLICIT_ENABLE;
 
     std::string ref_clone_name = get_temp_image_name();
     std::string clone_name = get_temp_image_name();
@@ -406,7 +405,6 @@ struct TestMigration : public TestFixture {
     int order = m_ictx->order;
     uint64_t features;
     ASSERT_EQ(0, librbd::get_features(m_ictx, &features));
-    features &= ~RBD_FEATURES_IMPLICIT_ENABLE;
 
     std::string clone_name = get_temp_image_name();
     ASSERT_EQ(0, librbd::clone(m_ictx->md_ctx, m_ictx->name.c_str(), "snap1",

--- a/src/test/rbd_mirror/test_ImageDeleter.cc
+++ b/src/test/rbd_mirror/test_ImageDeleter.cc
@@ -73,8 +73,7 @@ public:
 
     m_local_image_id = librbd::util::generate_image_id(m_local_io_ctx);
     librbd::ImageOptions image_opts;
-    image_opts.set(RBD_IMAGE_OPTION_FEATURES,
-                   (RBD_FEATURES_ALL & ~RBD_FEATURES_IMPLICIT_ENABLE));
+    image_opts.set(RBD_IMAGE_OPTION_FEATURES, RBD_FEATURES_ALL);
     EXPECT_EQ(0, librbd::create(m_local_io_ctx, m_image_name, m_local_image_id,
                                 1 << 20, image_opts, GLOBAL_IMAGE_ID,
                                 m_remote_mirror_uuid, true));

--- a/src/test/rbd_mirror/test_fixture.cc
+++ b/src/test/rbd_mirror/test_fixture.cc
@@ -89,9 +89,7 @@ void TestFixture::TearDown() {
 int TestFixture::create_image(librbd::RBD &rbd, librados::IoCtx &ioctx,
                               const std::string &name, uint64_t size) {
   int order = 18;
-  return rbd.create2(ioctx, name.c_str(), size,
-                     (RBD_FEATURES_ALL & ~RBD_FEATURES_IMPLICIT_ENABLE),
-                     &order);
+  return rbd.create2(ioctx, name.c_str(), size, RBD_FEATURES_ALL, &order);
 }
 
 int TestFixture::open_image(librados::IoCtx &io_ctx,

--- a/src/tools/rbd_mirror/image_replayer/CreateImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/CreateImageRequest.cc
@@ -404,8 +404,7 @@ template <typename I>
 void CreateImageRequest<I>::populate_image_options(
     librbd::ImageOptions* image_options) {
   image_options->set(RBD_IMAGE_OPTION_FEATURES,
-                     (m_remote_image_ctx->features &
-                        ~RBD_FEATURES_IMPLICIT_ENABLE));
+                     m_remote_image_ctx->features);
   image_options->set(RBD_IMAGE_OPTION_ORDER, m_remote_image_ctx->order);
   image_options->set(RBD_IMAGE_OPTION_STRIPE_UNIT,
                      m_remote_image_ctx->stripe_unit);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48692

---

backport of https://github.com/ceph/ceph/pull/38653
parent tracker: https://tracker.ceph.com/issues/48647

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh