### PR TITLE
nautilus: rbd/bench: include used headers

### DIFF
--- a/src/tools/rbd/action/Bench.cc
+++ b/src/tools/rbd/action/Bench.cc
@@ -9,6 +9,8 @@
 #include "common/Cond.h"
 #include "common/Mutex.h"
 #include "global/signal_handler.h"
+#include <atomic>
+#include <chrono>
 #include <iostream>
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49026

---

backport of https://github.com/ceph/ceph/pull/39073
parent tracker: https://tracker.ceph.com/issues/48996

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh