### PR TITLE
nautilus: mon: validate crush-failure-domain

### DIFF
--- a/qa/standalone/mon/osd-erasure-code-profile.sh
+++ b/qa/standalone/mon/osd-erasure-code-profile.sh
@@ -222,6 +222,17 @@ function TEST_profile_k_sanity() {
         m=1 || return 1
 }
 
+function TEST_invalid_crush_failure_domain() {
+    local dir=$1
+
+    run_mon $dir a || return 1
+
+    local profile=ec_profile
+    local crush_failure_domain=invalid_failure_domain
+
+    ! ceph osd erasure-code-profile set $profile k=4 m=2 crush-failure-domain=$crush_failure_domain 2>&1 || return 1
+}
+
 main osd-erasure-code-profile "$@"
 
 # Local Variables:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48379

---

backport of https://github.com/ceph/ceph/pull/37150
parent tracker: https://tracker.ceph.com/issues/47452

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh