### PR TITLE
nautilus: mds: dir->mark_new() should together with dir->mark_dirty()

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -11676,6 +11676,7 @@ void MDCache::_fragment_logged(MDRequestRef& mdr)
     CDir *dir = *p;
     dout(10) << " storing result frag " << *dir << dendl;
 
+    dir->mark_dirty(dir->pre_dirty(), mdr->ls);
     dir->mark_new(mdr->ls);
 
     // freeze and store them too


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48371

---

backport of https://github.com/ceph/ceph/pull/38109
parent tracker: https://tracker.ceph.com/issues/48249

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh