### PR TITLE
nautilus: cephfs: client: check rdonly file handle on truncate

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9813,6 +9813,8 @@ int Client::ftruncate(int fd, loff_t length, const UserPerm& perms)
   if (f->flags & O_PATH)
     return -EBADF;
 #endif
+  if ((f->mode & CEPH_FILE_MODE_WR) == 0)
+    return -EBADF;
   struct stat attr;
   attr.st_size = length;
   return _setattr(f->inode, &attr, CEPH_SETATTR_SIZE, perms);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48376

---

backport of https://github.com/ceph/ceph/pull/38031
parent tracker: https://tracker.ceph.com/issues/48202

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh