### PR TITLE
blk: avoid temporary bptrs on aio paths; use ptr_node instead.

### DIFF
--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -958,8 +958,8 @@ int KernelDevice::aio_write(
       ioc->pending_aios.push_back(aio_t(ioc, choose_fd(false, write_hint)));
       ++ioc->num_pending;
       auto& aio = ioc->pending_aios.back();
-      bufferptr p = ceph::buffer::create_small_page_aligned(len);
-      aio.bl.append(std::move(p));
+      aio.bl.push_back(
+        ceph::buffer::ptr_node::create(ceph::buffer::create_small_page_aligned(len)));
       aio.bl.prepare_iov(&aio.iov);
       aio.preadv(off, len);
       ++injecting_crash;
@@ -1092,8 +1092,8 @@ int KernelDevice::aio_read(
     ioc->pending_aios.push_back(aio_t(ioc, fd_directs[WRITE_LIFE_NOT_SET]));
     ++ioc->num_pending;
     aio_t& aio = ioc->pending_aios.back();
-    bufferptr p = ceph::buffer::create_small_page_aligned(len);
-    aio.bl.append(std::move(p));
+    aio.bl.push_back(
+      ceph::buffer::ptr_node::create(ceph::buffer::create_small_page_aligned(len)));
     aio.bl.prepare_iov(&aio.iov);
     aio.preadv(off, len);
     dout(30) << aio << dendl;


### PR DESCRIPTION
This is a slight optimization for the `HAVE_LIBAIO` paths of the kernel-based `BlockDevice` implementation. The overall idea is to squeeze temporary, short-living instances of `ceph::bufferptr` as `ceph::bufferlist` actually aggregates `ptr_node` (`bufferptr` with the extra `next` pointer field to form a list). It can be created directly and this commit switches to exactly this behavior.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
