### PR TITLE
osd: Refinements to mclock built-in profiles implementation.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3081,7 +3081,7 @@ std::vector<Option> get_global_options() {
     .set_flag(Option::FLAG_RUNTIME),
 
     Option("osd_mclock_profile", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("balanced")
+    .set_default("high_client_ops")
     .set_enum_allowed( { "balanced", "high_recovery_ops", "high_client_ops", "custom" } )
     .set_description("Which mclock profile to use")
     .set_long_description("This option specifies the mclock profile to enable - one among the set of built-in profiles or a custom profile. Only considered for osd_op_queue = mclock_scheduler")

--- a/src/osd/scheduler/mClockScheduler.h
+++ b/src/osd/scheduler/mClockScheduler.h
@@ -69,8 +69,32 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
   bool is_rotational;
   double max_osd_capacity;
   uint64_t osd_mclock_cost_per_io_msec;
-  std::string mclock_profile = "balanced";
-  std::map<op_scheduler_class, double> client_allocs;
+  std::string mclock_profile = "high_client_ops";
+  struct ClientAllocs {
+    uint64_t res;
+    uint64_t wgt;
+    uint64_t lim;
+
+    ClientAllocs(uint64_t _res, uint64_t _wgt, uint64_t _lim) {
+      update(_res, _wgt, _lim);
+    }
+
+    inline void update(uint64_t _res, uint64_t _wgt, uint64_t _lim) {
+      res = _res;
+      wgt = _wgt;
+      lim = _lim;
+    }
+  };
+  std::array<
+    ClientAllocs,
+    static_cast<size_t>(op_scheduler_class::client) + 1
+  > client_allocs = {
+    // Placeholder, get replaced with configured values
+    ClientAllocs(1, 1, 1), // background_recovery
+    ClientAllocs(1, 1, 1), // background_best_effort
+    ClientAllocs(1, 1, 1), // immediate (not used)
+    ClientAllocs(1, 1, 1)  // client
+  };
   std::map<op_type_t, int> client_cost_infos;
   std::map<op_type_t, int> client_scaled_cost_infos;
   class ClientRegistry {
@@ -115,6 +139,7 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
 
 public:
   mClockScheduler(CephContext *cct, uint32_t num_shards, bool is_rotational);
+  ~mClockScheduler() override;
 
   // Set the max osd capacity in iops
   void set_max_osd_capacity();
@@ -122,26 +147,26 @@ public:
   // Set the cost per io for the osd
   void set_osd_mclock_cost_per_io();
 
-  // Set the mclock related config params based on the profile
-  void enable_mclock_profile();
+  // Set the mclock profile type to enable
+  void set_mclock_profile();
 
   // Get the active mclock profile
   std::string get_mclock_profile();
 
-  // Set client capacity allocations based on profile
-  void set_client_allocations();
+  // Set "balanced" profile allocations
+  void set_balanced_profile_allocations();
 
-  // Get client allocation
-  double get_client_allocation(op_type_t op_type);
+  // Set "high_recovery_ops" profile allocations
+  void set_high_recovery_ops_profile_allocations();
 
-  // Set "balanced" profile parameters
-  void set_balanced_profile_config();
+  // Set "high_client_ops" profile allocations
+  void set_high_client_ops_profile_allocations();
 
-  // Set "high_recovery_ops" profile parameters
-  void set_high_recovery_ops_profile_config();
+  // Set the mclock related config params based on the profile
+  void enable_mclock_profile_settings();
 
-  // Set "high_client_ops" profile parameters
-  void set_high_client_ops_profile_config();
+  // Set mclock config parameter based on allocations
+  void set_profile_config();
 
   // Set recovery specific Ceph settings for profiles
   void set_global_recovery_options();

--- a/src/osd/scheduler/mClockScheduler.h
+++ b/src/osd/scheduler/mClockScheduler.h
@@ -38,7 +38,6 @@ constexpr uint64_t default_max = 999999;
 
 using client_id_t = uint64_t;
 using profile_id_t = uint64_t;
-using op_type_t = OpSchedulerItem::OpQueueable::op_type_t;
 
 struct client_profile_id_t {
   client_id_t client_id;
@@ -68,6 +67,7 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
   const uint32_t num_shards;
   bool is_rotational;
   double max_osd_capacity;
+  double max_osd_bandwidth;
   uint64_t osd_mclock_cost_per_io_msec;
   std::string mclock_profile = "high_client_ops";
   struct ClientAllocs {
@@ -95,8 +95,6 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
     ClientAllocs(1, 1, 1), // immediate (not used)
     ClientAllocs(1, 1, 1)  // client
   };
-  std::map<op_type_t, int> client_cost_infos;
-  std::map<op_type_t, int> client_scaled_cost_infos;
   class ClientRegistry {
     std::array<
       crimson::dmclock::ClientInfo,
@@ -172,10 +170,7 @@ public:
   void set_global_recovery_options();
 
   // Calculate scale cost per item
-  int calc_scaled_cost(op_type_t op_type, int cost);
-
-  // Update mclock client cost info
-  bool maybe_update_client_cost_info(op_type_t op_type, int new_cost);
+  int calc_scaled_cost(int cost);
 
   // Enqueue op in the back of the regular queue
   void enqueue(OpSchedulerItem &&item) final;

--- a/src/test/osd/TestMClockScheduler.cc
+++ b/src/test/osd/TestMClockScheduler.cc
@@ -93,7 +93,7 @@ TEST_F(mClockSchedulerTest, TestEmpty) {
 
   for (unsigned i = 100; i < 105; i+=2) {
     q.enqueue(create_item(i, client1, op_scheduler_class::client));
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    std::this_thread::sleep_for(std::chrono::microseconds(1));
   }
 
   ASSERT_FALSE(q.empty());
@@ -126,7 +126,7 @@ TEST_F(mClockSchedulerTest, TestSingleClientOrderedEnqueueDequeue) {
 
   for (unsigned i = 100; i < 105; ++i) {
     q.enqueue(create_item(i, client1, op_scheduler_class::client));
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    std::this_thread::sleep_for(std::chrono::microseconds(1));
   }
 
   auto r = get_item(q.dequeue());
@@ -150,6 +150,7 @@ TEST_F(mClockSchedulerTest, TestMultiClientOrderedEnqueueDequeue) {
   for (unsigned i = 0; i < NUM; ++i) {
     for (auto &&c: {client1, client2, client3}) {
       q.enqueue(create_item(i, c));
+      std::this_thread::sleep_for(std::chrono::microseconds(1));
     }
   }
 


### PR DESCRIPTION
Add refinements to the mclock built-in profiles implementation. 

- Introduce a simple structure to hold mclock parameters associated
with the active profile (reservation, weight & limit) for each type of 
client class namely "client", "background_recovery" & 
"background_best_effort".
- Set "high_client_ops" as the default profile. 
- Fix the OpSchedulerItem cost scaling calculation.

Another important point to note is that for "high_recovery_ops"
and "balanced" profiles, multiple tests were run with different combinations
of reservation, weights and limits. Due to the current cost model, recovery
ops having high item costs (20MiB and beyond) experience higher latency
even if the mclock limit is set to the max_osd_capacity. Setting this to very
high values (for e.g. 999999) leads to other clients being starved which is
not desirable.

Due to the above, recovery throughput suffers. In order to address this,
the recovery  limits are set to 2x and 1.5x the max_osd_capacity. This
appears to resolve the latency issue for recovery ops and still allow
other mclock clients to have the desired throughputs.

The above issue will get resolved once we start using actual benchmark
data instead of the cost model currently employed.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
