### PR TITLE
cephadm: Make path to cephadm binary unique

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -6563,6 +6563,8 @@ class CephadmDaemon():
             self.errors.append(f"Certificate file '{CephadmDaemon.crt_name}' is missing from {self.daemon_path}")
         if self.token == "Unknown":
             self.errors.append(f"Authentication token '{CephadmDaemon.token_name}' is missing from {self.daemon_path}")
+        if not os.path.isfile(self.binary_path):
+            self.errors.append(f'cephadm binary {self.binary_path} not a file.')
         return len(self.errors) == 0
 
     @staticmethod

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2500,7 +2500,7 @@ def deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid,
                 config_js = get_parm(ctx.config_json)
             assert isinstance(config_js, dict)
 
-            cephadm_exporter = CephadmDaemon(ctx, fsid, daemon_id, port)
+            cephadm_exporter = CephadmDaemon(ctx, fsid, config_js['binary'], daemon_id, port)
             cephadm_exporter.deploy_daemon_unit(config_js)
         else:
             if c:
@@ -6488,7 +6488,6 @@ class CephadmDaemon():
 
     daemon_type = "cephadm-exporter"
     default_port = 9443
-    bin_name = 'cephadm'
     key_name = "key"
     crt_name = "crt"
     token_name = "token"
@@ -6500,9 +6499,10 @@ class CephadmDaemon():
     loop_delay = 1
     thread_check_interval = 5
 
-    def __init__(self, ctx: CephadmContext, fsid, daemon_id=None, port=None):
+    def __init__(self, ctx: CephadmContext, fsid, binary, daemon_id=None, port=None):
         self.ctx = ctx
         self.fsid = fsid
+        self.binary_path = binary
         self.daemon_id = daemon_id 
         if not port:
             self.port = CephadmDaemon.default_port
@@ -6521,7 +6521,7 @@ class CephadmDaemon():
         errors = []
 
         if not config or not all([k_name in config for k_name in CephadmDaemon.config_requirements]):
-            raise Error(f"config must contain the following fields : {reqs}")
+            raise Error(f"config must contain the following fields : {reqs} but got {config.keys()}")
         
         if not all([isinstance(config[k_name], str) for k_name in CephadmDaemon.config_requirements]):
             errors.append(f"the following fields must be strings: {reqs}")
@@ -6579,14 +6579,6 @@ class CephadmDaemon():
             self.ctx.data_dir,
             self.fsid,
             f'{self.daemon_type}.{self.daemon_id}'
-        )
-
-    @property
-    def binary_path(self):
-        return os.path.join(
-            self.ctx.data_dir,
-            self.fsid,
-            CephadmDaemon.bin_name
         )
 
     def _handle_thread_exception(self, exc, thread_type):
@@ -6950,7 +6942,7 @@ WantedBy=ceph-{fsid}.target
 
 
 def command_exporter(ctx: CephadmContext):
-    exporter = CephadmDaemon(ctx, ctx.fsid, daemon_id=ctx.id, port=ctx.port)
+    exporter = CephadmDaemon(ctx, ctx.fsid, binary=ctx.binary, daemon_id=ctx.id, port=ctx.port)
 
     if ctx.fsid not in os.listdir(ctx.data_dir):
         raise Error(f"cluster fsid '{ctx.fsid}' not found in '{ctx.data_dir}'")
@@ -7589,6 +7581,10 @@ def _get_parser():
         type=str,
         default=get_hostname().split('.')[0],
         help='daemon identifer for the exporter')
+    parser_exporter.add_argument(
+        '--binary',
+        type=str,
+        help='path to the cephadm binary')
     parser_exporter.set_defaults(func=command_exporter)
 
     parser_maintenance = subparsers.add_parser(

--- a/src/cephadm/tests/fixtures.py
+++ b/src/cephadm/tests/fixtures.py
@@ -32,7 +32,6 @@ def _mock_run(obj):
 @pytest.fixture
 def exporter():
     with mock.patch('cephadm.CephadmDaemon.daemon_path', _daemon_path()), \
-       mock.patch('cephadm.CephadmDaemon.can_run', return_value=True), \
        mock.patch('cephadm.CephadmDaemon.run', _mock_run), \
        mock.patch('cephadm.CephadmDaemon._scrape_host_facts', _mock_scrape_host):
 

--- a/src/cephadm/tests/fixtures.py
+++ b/src/cephadm/tests/fixtures.py
@@ -37,6 +37,6 @@ def exporter():
        mock.patch('cephadm.CephadmDaemon._scrape_host_facts', _mock_scrape_host):
 
         ctx = cd.CephadmContext()
-        exporter = cd.CephadmDaemon(ctx, fsid='foobar', daemon_id='test')
+        exporter = cd.CephadmDaemon(ctx, fsid='foobar', daemon_id='test', binary='/var/lib/ceph/foobar/cephadm')
         assert exporter.token == 'MyAccessToken' 
         yield exporter

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -484,9 +484,17 @@ iMN28C2bKGao5UHvdER1rGy7
         assert os.path.exists(os.path.join(os.getcwd(), 'key'))
         assert os.path.exists(os.path.join(os.getcwd(), 'token'))
 
-    def test_can_run(self, exporter):
-        assert exporter.can_run
-    
+    @mock.patch('socket.socket.bind', lambda *_: True)
+    def test_can_run(self, exporter, fs):
+        for file in (
+            f'{exporter.daemon_path}/crt',
+            f'{exporter.daemon_path}/key',
+            f'{exporter.daemon_path}/token',
+            exporter.binary_path,
+        ):
+            fs.create_file(file)
+        assert exporter.can_run, exporter.errors
+
     def test_token_valid(self, exporter):
         assert exporter.token == self.token
 

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -7,6 +7,7 @@ skip_install=true
 deps =
   pytest
   mock
+  pyfakefs
 commands=pytest {posargs}
 
 [testenv:mypy]

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -311,7 +311,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
     def __init__(self, *args: Any, **kwargs: Any):
         super(CephadmOrchestrator, self).__init__(*args, **kwargs)
-        self._cluster_fsid = self.get('mon_map')['fsid']
+        self._cluster_fsid: str = self.get('mon_map')['fsid']
         self.last_monmap: Optional[datetime.datetime] = None
 
         # for serve()
@@ -366,6 +366,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         except (IOError, TypeError) as e:
             raise RuntimeError("unable to read cephadm at '%s': %s" % (
                 path, str(e)))
+
+        self.cephadm_binary_path = self._get_cephadm_binary_path()
 
         self._worker_pool = multiprocessing.pool.ThreadPool(10)
 
@@ -454,6 +456,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
     def _get_cephadm_service(self, service_type: str) -> CephadmService:
         assert service_type in ServiceSpec.KNOWN_SERVICE_TYPES
         return self.cephadm_services[service_type]
+
+    def _get_cephadm_binary_path(self) -> str:
+        import hashlib
+        m = hashlib.sha256()
+        m.update(self._cephadm.encode())
+        return f'/var/lib/ceph/{self._cluster_fsid}/cephadm.{m.hexdigest()}'
 
     def _kick_serve_loop(self) -> None:
         self.log.debug('_kick_serve_loop')

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -994,7 +994,8 @@ class CephadmExporter(CephadmService):
         config = {
             "crt": cfg.crt,
             "key": cfg.key,
-            "token": cfg.token
+            "token": cfg.token,
+            'binary': self.mgr.cephadm_binary_path,
         }
         return config, deps
 

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -972,6 +972,8 @@ class CephadmExporter(CephadmService):
         if not daemon_spec.ports:
             daemon_spec.ports = [int(cfg.port)]
 
+        daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
+
         return daemon_spec
 
     def generate_config(self, daemon_spec: CephadmDaemonSpec) -> Tuple[Dict[str, Any], List[str]]:


### PR DESCRIPTION
right now, an upgrade might overwrite the existing
binary which would force us to have the CLI stable. Thus the path to cephadm is not safe for us. 

This PR changes the path to a location that depends on the content of cephadm and thus is safe for up and downgrades.

Required for #37495 



Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
