### PR TITLE
qa/cephadm: Add ha-rgw

### DIFF
--- a/qa/suites/rados/cephadm/smoke/fixed-2.yaml
+++ b/qa/suites/rados/cephadm/smoke/fixed-2.yaml
@@ -10,6 +10,7 @@ roles:
   - ceph.rgw.realm.zone.a
   - node-exporter.a
   - alertmanager.a
+  - ha-rgw.haproxy_for_rgw.a
 - - mon.b
   - mgr.x
   - osd.4


### PR DESCRIPTION
Signed-off-by: Adam King <adking@redhat.com>

Attempting to add a basic deployment test for new a service in cephadm added here #38615.
Mostly trying to follow existing format for these tests, however ha-rgw has some unique issues:

- can ONLY be deployed using a spec file
- has a couple system prereqs that must be dealt with for service to deploy properly.
- daemon types are NOT the same as service type (service is ha-rgw, daemons are haproxy and keepalived)

I don't have any experience with making teuthology tests so reviews and suggestions are greatly appreciated.

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
