### PR TITLE
cephadm: New tox environment for autopep8

### DIFF
--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -2,6 +2,13 @@
 envlist = py3, mypy
 skipsdist=true
 
+[autopep8]
+addopts =
+    --max-line-length 100
+    --select W291,W293
+    --in-place
+    --ignore-local-config
+
 [testenv]
 skip_install=true
 deps =
@@ -14,3 +21,12 @@ commands=pytest {posargs}
 basepython = python3
 deps = mypy==0.790
 commands = mypy --config-file ../mypy.ini {posargs:cephadm}
+
+[testenv:fix]
+basepython = python3
+deps =
+    autopep8
+commands =
+    python --version
+    autopep8 {[autopep8]addopts} {posargs: \
+        cephadm }


### PR DESCRIPTION
The new fix tox environment executes autopep8 to fix the code style problems
and cosmetic issues we decide to fix automatically.
We start with:
 - removing trailing spaces
 - set a max line length of 100 chars,

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
