### PR TITLE
octopus: mon: paxos: Delete logger in destructor 

### DIFF
--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -1336,7 +1336,6 @@ void Paxos::shutdown()
   finish_contexts(g_ceph_context, committing_finishers, -ECANCELED);
   if (logger)
     g_ceph_context->get_perfcounters_collection()->remove(logger);
-  delete logger;
 }
 
 void Paxos::leader_init()

--- a/src/mon/Paxos.h
+++ b/src/mon/Paxos.h
@@ -1045,7 +1045,7 @@ public:
    * @param name A name for the paxos service. It serves as the naming space
    * of the underlying persistent storage for this service.
    */
-  Paxos(Monitor *m, const string &name) 
+  Paxos(Monitor *m, const string &name)
 		 : mon(m),
 		   logger(NULL),
 		   paxos_name(name),
@@ -1064,6 +1064,10 @@ public:
 		   accept_timeout_event(0),
 		   clock_drift_warned(0),
 		   trimming(false) { }
+
+  ~Paxos() {
+    delete logger;
+  }
 
   const string get_name() const {
     return paxos_name;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48496

---

backport of https://github.com/ceph/ceph/pull/38314
parent tracker: https://tracker.ceph.com/issues/48386

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh