### PR TITLE
mgr/cephadm: disentangle offline status and maintenance mode

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -54,7 +54,7 @@ class Inventory:
             raise OrchestratorError('host %s does not exist' % host)
 
     def add_host(self, spec: HostSpec) -> None:
-        self._inventory[spec.hostname] = spec.to_json()
+        self._inventory[spec.hostname] = spec.to_json(omit_offline=True)
         self.save()
 
     def rm_host(self, host: str) -> None:

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -111,8 +111,8 @@ class Inventory:
             hostname,
             addr=info.get('addr', hostname),
             labels=info.get('labels', []),
-            status='Offline' if hostname in self.mgr.offline_hosts else info.get('status', ''),
             maintenance=info.get('maintenance', False),
+            offline=hostname in self.mgr.offline_hosts
         )
 
     def all_specs(self) -> List[HostSpec]:

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -45,6 +45,10 @@ class Inventory:
     def __contains__(self, host: str) -> bool:
         return host in self._inventory
 
+    def __getitem__(self, host: str) -> HostSpec:
+        self.assert_host(host)
+        return self.spec_from_dict(self._inventory[host])
+
     def assert_host(self, host: str) -> None:
         if host not in self._inventory:
             raise OrchestratorError('host %s does not exist' % host)
@@ -85,6 +89,14 @@ class Inventory:
         self.assert_host(host)
         return self._inventory[host].get('addr', host)
 
+    def set_maintenance(self, host: str, val: bool) -> None:
+        self.assert_host(host)
+        if val:
+            self._inventory[host]['maintenance'] = True
+        elif 'maintenance' in self._inventory[host]:
+            del self._inventory[host]['maintenance']
+        self.save()
+
     def filter_by_label(self, label: Optional[str] = '', as_hostspec: bool = False) -> Iterator:
         for h, hostspec in self._inventory.items():
             if not label or label in hostspec.get('labels', []):
@@ -100,14 +112,11 @@ class Inventory:
             addr=info.get('addr', hostname),
             labels=info.get('labels', []),
             status='Offline' if hostname in self.mgr.offline_hosts else info.get('status', ''),
+            maintenance=info.get('maintenance', False),
         )
 
     def all_specs(self) -> List[HostSpec]:
         return list(map(self.spec_from_dict, self._inventory.values()))
-
-    def get_host_with_state(self, state: str = "") -> List[str]:
-        """return a list of host names in a specific state"""
-        return [h for h in self._inventory if self._inventory[h].get("status", "").lower() == state]
 
     def save(self) -> None:
         self.mgr.set_store('inventory', json.dumps(self._inventory))

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -54,7 +54,7 @@ class Inventory:
             raise OrchestratorError('host %s does not exist' % host)
 
     def add_host(self, spec: HostSpec) -> None:
-        self._inventory[spec.hostname] = spec.to_json(omit_offline=True)
+        self._inventory[spec.hostname] = spec.to_json(omit_offline=True, omit_status=True)
         self.save()
 
     def rm_host(self, host: str) -> None:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1178,7 +1178,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         return [
             h for h in self.inventory.all_specs()
             if self.cache.host_had_daemon_refresh(h.hostname)
-            and h.status.lower() not in ['maintenance', 'offline']
+            and h.status.lower() not in ['offline']
+            and not h.maintenance
         ]
 
     def _add_host(self, spec):
@@ -1307,7 +1308,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
     def _set_maintenance_healthcheck(self) -> None:
         """Raise/update or clear the maintenance health check as needed"""
 
-        in_maintenance = self.inventory.get_host_with_state("maintenance")
+        in_maintenance = [h for h in self.inventory.all_specs() if h.maintenance]
         if not in_maintenance:
             del self.health_checks["HOST_IN_MAINTENANCE"]
         else:
@@ -1341,8 +1342,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             raise OrchestratorError(
                 f"Unable to place {hostname} in maintenance with upgrade active/paused")
 
-        tgt_host = self.inventory._inventory[hostname]
-        if tgt_host.get("status", "").lower() == "maintenance":
+        tgt_host = self.inventory[hostname]
+        if tgt_host.maintenance:
             raise OrchestratorError(f"Host {hostname} is already in maintenance")
 
         host_daemons = self.cache.get_daemon_types(hostname)
@@ -1380,10 +1381,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                     self.log.info(
                         f"maintenance mode request for {hostname} has SET the noout group")
 
-        # update the host status in the inventory
-        tgt_host["status"] = "maintenance"
-        self.inventory._inventory[hostname] = tgt_host
-        self.inventory.save()
+        self.inventory.set_maintenance(hostname, True)
 
         self._set_maintenance_healthcheck()
 
@@ -1403,8 +1401,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         :raises OrchestratorError: Unable to return from maintenance, or unset the
                                    noout flag
         """
-        tgt_host = self.inventory._inventory[hostname]
-        if tgt_host['status'] != "maintenance":
+        tgt_host = self.inventory[hostname]
+        if not tgt_host.maintenance:
             raise OrchestratorError(f"Host {hostname} is not in maintenance mode")
 
         outs, errs, _code = CephadmServe(self)._run_cephadm(hostname, cephadmNoImage, 'host-maintenance',
@@ -1430,10 +1428,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                 self.log.info(
                     f"exit maintenance request has UNSET for the noout group on host {hostname}")
 
-        # update the host record status
-        tgt_host['status'] = ""
-        self.inventory._inventory[hostname] = tgt_host
-        self.inventory.save()
+        self.inventory.set_maintenance(hostname, False)
 
         self._set_maintenance_healthcheck()
 
@@ -2182,7 +2177,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
     @trivial_completion
     def upgrade_check(self, image: str, version: str) -> str:
-        if self.inventory.get_host_with_state("maintenance"):
+        if any(h.maintenance for h in self.inventory.all_specs()):
             raise OrchestratorError("check aborted - you have hosts in maintenance state")
 
         if version:
@@ -2223,7 +2218,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
     @trivial_completion
     def upgrade_start(self, image: str, version: str) -> str:
-        if self.inventory.get_host_with_state("maintenance"):
+        if any(h.maintenance for h in self.inventory.all_specs()):
             raise OrchestratorError("upgrade aborted - you have host(s) in maintenance state")
         return self.upgrade.upgrade_start(image, version)
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1178,7 +1178,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         return [
             h for h in self.inventory.all_specs()
             if self.cache.host_had_daemon_refresh(h.hostname)
-            and h.status.lower() not in ['offline']
+            and not h.offline
             and not h.maintenance
         ]
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1309,7 +1309,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         """Raise/update or clear the maintenance health check as needed"""
 
         in_maintenance = [h for h in self.inventory.all_specs() if h.maintenance]
-        if not in_maintenance:
+        if not in_maintenance and 'HOST_IN_MAINTENANCE' in self.health_checks:
             del self.health_checks["HOST_IN_MAINTENANCE"]
         else:
             s = "host is" if len(in_maintenance) == 1 else "hosts are"

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -89,7 +89,8 @@ class TestCephadm(object):
 
             # Be careful with backward compatibility when changing things here:
             assert json.loads(cephadm_module.get_store('inventory')) == \
-                {"test": {"hostname": "test", "addr": "test", "labels": [], "status": ""}}
+                {"test": {"hostname": "test", "addr": "test",
+                          "labels": []}}
 
             with with_host(cephadm_module, 'second'):
                 assert wait(cephadm_module, cephadm_module.get_hosts()) == [

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1008,3 +1008,16 @@ Traceback (most recent call last):
                           ['--', 'inventory', '--format=json'], image='',
                           no_fsid=False),
             ]
+
+    @mock.patch("cephadm.serve.CephadmServe._run_cephadm")
+    def test_maintenance(self, _run_cephadm, cephadm_module: CephadmOrchestrator):
+        _run_cephadm.return_value = '{}', '', 0
+        with with_host(cephadm_module, 'test', refresh_hosts=False):
+            with with_host(cephadm_module, 'test1', refresh_hosts=False):
+                out = wait(cephadm_module, cephadm_module.enter_host_maintenance('test'))
+                assert out == 'Ceph cluster fsid on test moved to maintenance'
+
+                _run_cephadm.return_value = '', '', 0
+                out = wait(cephadm_module, cephadm_module.exit_host_maintenance('test'))
+                assert out == 'Ceph cluster fsid on test has exited maintenance mode'
+

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -810,7 +810,7 @@ class TestCephadm(object):
             assert "Host 'test' not found" in err
 
             out = wait(cephadm_module, cephadm_module.get_hosts())[0].to_json()
-            assert out == HostSpec('test', 'test', status='Offline').to_json()
+            assert out == HostSpec('test', 'test', offline=True).to_json()
 
             _get_connection.side_effect = None
             assert CephadmServe(cephadm_module)._check_host('test') is None

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -809,8 +809,9 @@ class TestCephadm(object):
             assert out == ''
             assert "Host 'test' not found" in err
 
-            out = wait(cephadm_module, cephadm_module.get_hosts())[0].to_json()
-            assert out == HostSpec('test', 'test', offline=True).to_json()
+            out = wait(cephadm_module, cephadm_module.get_hosts())[0]
+            assert out.to_json() == HostSpec('test', 'test', offline=True).to_json()
+            assert out.status == 'Offline'
 
             _get_connection.side_effect = None
             assert CephadmServe(cephadm_module)._check_host('test') is None

--- a/src/python-common/ceph/deployment/hostspec.py
+++ b/src/python-common/ceph/deployment/hostspec.py
@@ -1,7 +1,4 @@
-try:
-    from typing import Optional, List, Any
-except ImportError:
-    pass  # just for type checking
+from typing import Optional, List, Any, Dict
 
 
 class HostSpec(object):
@@ -13,6 +10,7 @@ class HostSpec(object):
                  addr=None,  # type: Optional[str]
                  labels=None,  # type: Optional[List[str]]
                  status=None,  # type: Optional[str]
+                 maintenance: bool = False,
                  ):
         self.service_type = 'host'
 
@@ -28,20 +26,24 @@ class HostSpec(object):
         #: human readable status
         self.status = status or ''  # type: str
 
-    def to_json(self) -> dict:
-        return {
+        self.maintenance = maintenance
+
+    def to_json(self) -> Dict[str, Any]:
+        ret: Dict[str, Any] = {
             'hostname': self.hostname,
             'addr': self.addr,
             'labels': self.labels,
-            'status': self.status,
         }
+        if self.maintenance:
+            ret['maintenance'] = self.maintenance,
+        return ret
 
     @classmethod
     def from_json(cls, host_spec: dict) -> 'HostSpec':
         _cls = cls(host_spec['hostname'],
                    host_spec['addr'] if 'addr' in host_spec else None,
                    host_spec['labels'] if 'labels' in host_spec else None,
-                   host_spec['status'] if 'status' in host_spec else None)
+                   maintenance=host_spec.get('maintenance', False))
         return _cls
 
     def __repr__(self) -> str:
@@ -52,6 +54,8 @@ class HostSpec(object):
             args.append(self.labels)
         if self.status:
             args.append(self.status)
+        if self.maintenance:
+            args.append('maintenance=' + str(self.maintenance))
 
         return "HostSpec({})".format(', '.join(map(repr, args)))
 
@@ -64,4 +68,5 @@ class HostSpec(object):
         # Let's omit `status` for the moment, as it is still the very same host.
         return self.hostname == other.hostname and \
                self.addr == other.addr and \
-               self.labels == other.labels
+               self.labels == other.labels and \
+               self.maintenance == other.maintenance

--- a/src/python-common/ceph/deployment/hostspec.py
+++ b/src/python-common/ceph/deployment/hostspec.py
@@ -31,7 +31,7 @@ class HostSpec(object):
 
         self.offline = offline
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, omit_offline: bool = False) -> Dict[str, Any]:
         ret: Dict[str, Any] = {
             'hostname': self.hostname,
             'addr': self.addr,
@@ -39,7 +39,7 @@ class HostSpec(object):
         }
         if self.maintenance:
             ret['maintenance'] = self.maintenance,
-        if self.offline:
+        if not omit_offline and self.offline:
             ret['offline'] = self.offline,
         return ret
 

--- a/src/python-common/ceph/deployment/hostspec.py
+++ b/src/python-common/ceph/deployment/hostspec.py
@@ -11,6 +11,7 @@ class HostSpec(object):
                  labels=None,  # type: Optional[List[str]]
                  status=None,  # type: Optional[str]
                  maintenance: bool = False,
+                 offline: bool = False
                  ):
         self.service_type = 'host'
 
@@ -28,6 +29,8 @@ class HostSpec(object):
 
         self.maintenance = maintenance
 
+        self.offline = offline
+
     def to_json(self) -> Dict[str, Any]:
         ret: Dict[str, Any] = {
             'hostname': self.hostname,
@@ -36,6 +39,8 @@ class HostSpec(object):
         }
         if self.maintenance:
             ret['maintenance'] = self.maintenance,
+        if self.offline:
+            ret['offline'] = self.offline,
         return ret
 
     @classmethod
@@ -43,7 +48,8 @@ class HostSpec(object):
         _cls = cls(host_spec['hostname'],
                    host_spec['addr'] if 'addr' in host_spec else None,
                    host_spec['labels'] if 'labels' in host_spec else None,
-                   maintenance=host_spec.get('maintenance', False))
+                   maintenance=host_spec.get('maintenance', False),
+                   offline=host_spec.get('offline', False))
         return _cls
 
     def __repr__(self) -> str:
@@ -56,6 +62,8 @@ class HostSpec(object):
             args.append(self.status)
         if self.maintenance:
             args.append('maintenance=' + str(self.maintenance))
+        if self.offline:
+            args.append('offline=' + str(self.offline))
 
         return "HostSpec({})".format(', '.join(map(repr, args)))
 
@@ -69,4 +77,5 @@ class HostSpec(object):
         return self.hostname == other.hostname and \
                self.addr == other.addr and \
                self.labels == other.labels and \
-               self.maintenance == other.maintenance
+               self.maintenance == other.maintenance and \
+               self.offline == other.offline

--- a/src/python-common/ceph/deployment/hostspec.py
+++ b/src/python-common/ceph/deployment/hostspec.py
@@ -24,19 +24,28 @@ class HostSpec(object):
         #: label(s), if any
         self.labels = labels or []  # type: List[str]
 
-        #: human readable status
-        self.status = status or ''  # type: str
-
         self.maintenance = maintenance
 
         self.offline = offline
 
-    def to_json(self, omit_offline: bool = False) -> Dict[str, Any]:
+    @property
+    def status(self) -> str:
+        """human readable status"""
+        r = []
+        if self.maintenance:
+            r.append(f'maintenance mode')
+        if self.offline:
+            r.append(f'offline')
+        return ' and '.join(r).capitalize()
+
+    def to_json(self, omit_offline: bool = False, omit_status: bool = False) -> Dict[str, Any]:
         ret: Dict[str, Any] = {
             'hostname': self.hostname,
             'addr': self.addr,
             'labels': self.labels,
         }
+        if not omit_status:
+            ret['status'] = self.status,
         if self.maintenance:
             ret['maintenance'] = self.maintenance,
         if not omit_offline and self.offline:


### PR DESCRIPTION
This mainly fixes a bug in the code where the offline status overwrites the maintenance mode. 

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
