### PR TITLE
octopus: mgr/cephadm: tolerate old host inventory without 'hostname' key

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -33,6 +33,10 @@ class Inventory:
         i = self.mgr.get_store('inventory')
         if i:
             self._inventory: Dict[str, dict] = json.loads(i)
+            # handle old clusters missing 'hostname' key from hostspec
+            for k, v in self._inventory.items():
+                if 'hostname' not in v:
+                    v['hostname'] = k
         else:
             self._inventory = dict()
         logger.debug('Loaded inventory %s' % self._inventory)


### PR DESCRIPTION
Backport of #38850