### PR TITLE
octopus: qa/cephadm: Add yaml output to smoke test

### DIFF
--- a/qa/suites/rados/cephadm/smoke/start.yaml
+++ b/qa/suites/rados/cephadm/smoke/start.yaml
@@ -11,3 +11,4 @@ tasks:
       - ceph orch ls
       - ceph orch host ls
       - ceph orch device ls
+      - ceph orch ls --format yaml


### PR DESCRIPTION
Backport of #38945