### PR TITLE
octopus: python-common/drivegroups: avoid dropping "rotational: 0" from Device Selection

### DIFF
--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -99,7 +99,7 @@ class DeviceSelection(object):
             ret['vendor'] = self.vendor
         if self.size:
             ret['size'] = self.size
-        if self.rotational:
+        if self.rotational is not None:
             ret['rotational'] = self.rotational
         if self.limit:
             ret['limit'] = self.limit


### PR DESCRIPTION
Backport of #39083