### PR TITLE
mgr/orchestrator: remove 'host' arg for 'orch ls'

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -531,7 +531,6 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
 
     @_cli_read_command('orch ls')
     def _list_services(self,
-                       host: Optional[str] = None,
                        service_type: Optional[str] = None,
                        service_name: Optional[str] = None,
                        export: bool = False,


### PR DESCRIPTION
The host arg is unused, and also missing from the documentation.

Signed-off-by: Sage Weil <sage@newdream.net>