### PR TITLE
doc/dev: Teuthology guide PR#37949 grammar edit

### DIFF
--- a/doc/dev/developer_guide/testing_integration_tests/tests-integration-testing-teuthology-intro.rst
+++ b/doc/dev/developer_guide/testing_integration_tests/tests-integration-testing-teuthology-intro.rst
@@ -4,8 +4,8 @@ Testing - Integration Tests - Introduction
 ==========================================
 
 Ceph has two types of tests: :ref:`make check <make-check>` tests and
-integration tests. When a test requires multiple machines, root access or lasts
-for a longer time (for example, to simulate a realistic Ceph deployment), it is
+integration tests. When a test requires multiple machines, root access, or lasts
+for a long time (for example, to simulate a realistic Ceph workload), it is
 deemed to be an integration test. Integration tests are organized into "suites",
 which are defined in the `ceph/qa sub-directory`_ and run with the
 ``teuthology-suite`` command.
@@ -39,10 +39,10 @@ branch and the stable branches). Traditionally, these tests are called "the
 nightlies" because the Ceph core developers used to live and work in
 the same time zone and from their perspective the tests were run overnight.
 
-The results of the nightlies are published at http://pulpito.ceph.com/. The
-developer nick shows in the test results URL and in the first column of the
-Pulpito dashboard.  The results are also reported on the `ceph-qa mailing list
-<https://ceph.com/irc/>`_ for analysis.
+The results of nightly test runs are published at http://pulpito.ceph.com/
+under the user ``teuthology``. The developer nick appears in URL of the the
+test results and in the first column of the Pulpito dashboard.  The results are
+also reported on the `ceph-qa mailing list <https://ceph.com/irc/>`_.
 
 Testing Priority
 ----------------
@@ -79,10 +79,9 @@ Job priority should be selected based on the following recommendations:
 * **200 <= Priority < 1000:** Use this priority for large test runs that can
   be done over the course of a week.
 
-In case you don't know how many jobs would be triggered by ``teuthology-suite``
-command, use ``--dry-run`` to get a count first and then issue
-``teuthology-suite`` command again, this time without ``--dry-run`` and with
-``-p`` and an appropriate number as an argument to it.
+To learn how many jobs the ``teuthology-suite`` command will trigger, use the
+``--dry-run`` flag. If you are happy with the number of jobs, issue the ``teuthology-suite`` command again without
+``--dry-run`` and with ``-p`` and an appropriate number as an argument. 
 
 To skip the priority check, use ``--force-priority``. In order to be sensitive
 to the runs of other developers who also need to do testing, please use it in
@@ -92,14 +91,14 @@ Suites Inventory
 ----------------
 
 The ``suites`` directory of the `ceph/qa sub-directory`_ contains all the
-integration tests, for all the Ceph components.
+integration tests for all the Ceph components.
 
 `ceph-deploy <https://github.com/ceph/ceph/tree/master/qa/suites/ceph-deploy>`_
   install a Ceph cluster with ``ceph-deploy`` (`ceph-deploy man page`_)
 
 `dummy <https://github.com/ceph/ceph/tree/master/qa/suites/dummy>`_
   get a machine, do nothing and return success (commonly used to
-  verify the integration testing infrastructure works as expected)
+  verify that the integration testing infrastructure works as expected)
 
 `fs <https://github.com/ceph/ceph/tree/master/qa/suites/fs>`_
   test CephFS mounted using FUSE
@@ -145,20 +144,20 @@ teuthology-describe-tests
 ``teuthology-describe`` was added to the `teuthology framework`_ to facilitate
 documentation and better understanding of integration tests.
 
-The upshot is that tests can be documented by embedding ``meta:``
-annotations in the yaml files used to define the tests. The results can be
-seen in the `teuthology-desribe usecases`_
+Tests can be documented by embedding ``meta:`` annotations in the yaml files
+used to define the tests. The results can be seen in the `teuthology-desribe
+usecases`_
 
 Since this is a new feature, many yaml files have yet to be annotated.
-Developers are encouraged to improve the documentation, in terms of both
-coverage and quality.
+Developers are encouraged to improve the coverage and the quality of the
+documentation. 
 
 How integration tests are run
 -----------------------------
 
-Given that - as a new Ceph developer - you will typically not have access
-to the `Sepia lab`_, you may rightly ask how you can run the integration
-tests in your own environment.
+As a new Ceph developer you will probably not have access to the `Sepia lab`_.
+You might however be able to run some integration tests in your own
+environment. Ask members from the relevant team how to do this. 
 
 One option is to set up a teuthology cluster on bare metal. Though this is a
 non-trivial task, it `is` possible. Here are `some notes

--- a/doc/dev/developer_guide/testing_integration_tests/tests-integration-testing-teuthology-workflow.rst
+++ b/doc/dev/developer_guide/testing_integration_tests/tests-integration-testing-teuthology-workflow.rst
@@ -53,13 +53,8 @@ teuthology. This procedure explains how to run tests using teuthology.
 
        ssh <username>@teuthology.front.sepia.ceph.com
 
-   This requires that you have access to the Sepia lab. Learn about requesting
-   access here: 
-   
-       https://ceph.github.io/sepia/adding_users/
-
-#. Install teuthology in a virtual environment and activate that virtual
-   environment. Follow the relevant instructions in `Running Your First Test`_.
+   This requires Sepia lab access. To request access to the Sepia lab, see:
+   https://ceph.github.io/sepia/adding_users/
 
 #. Run the ``teuthology-suite`` command:
 
@@ -112,6 +107,11 @@ teuthology. This procedure explains how to run tests using teuthology.
 
 
 
+Other frequently used/useful options are ``-d`` (or ``--distro``),
+``--distroversion``, ``--filter-out``, ``--timeout``, ``flavor``, ``-rerun``,
+``-l`` (for limiting number of jobs) , ``-n`` (for how many times the job will
+run). Run ``teuthology-suite --help`` to read descriptions of these and other
+options.
 
 .. _teuthology_testing_qa_changes:
 
@@ -124,12 +124,14 @@ rebuild the binaries before you re-run tests. If you make changes only in
 You just have to make sure to tell the ``teuthology-suite`` command to use a
 separate branch for running the tests.
 
-The separate branch can be passed to the command by using ``--suite-repo`` and
-``--suite-branch``. The first option (``--suite-repo``) accepts the link to the GitHub fork where your PR branch exists and the second option (``--suite-branch``) accepts the name of the PR branch.
+If you made changes only in ``qa/``
+(https://github.com/ceph/ceph/tree/master/qa), you do not need to rebuild the
+binaries. You can use existing binaries that are built periodically for master and other stable branches and run your test changes against them.
+Your branch with the qa changes can be tested by passing two extra arguments to the ``teuthology-suite`` command: (1) ``--suite-repo``, specifying your ceph repo, and (2) ``--suite-branch``, specifying your branch name. 
 
 For example, if you want to make changes in ``qa/`` after testing ``branch-x``
-(which shows up in ceph-ci as a branch named ``wip-username-branch-x``), you
-can do so by running following command:
+(for which the ceph-ci branch is ``wip-username-branch-x``), run the following
+command::
 
 .. prompt:: bash $
 
@@ -191,28 +193,26 @@ Viewing Tests Results
 Pulpito Dashboard
 *****************
 
-Once the teuthology job is scheduled, the status/results for test run could
-be checked from https://pulpito.ceph.com/.
-It could be used for quickly checking out job logs, their status, etc.
+After the teuthology job is scheduled, the status and results of the test run 
+can be checked at https://pulpito.ceph.com/.
 
 Teuthology Archives
 *******************
 
-Once the tests have finished running, the log for the job can be obtained by
-clicking on job ID at the Pulpito page for your tests. It's more convenient to
-download the log and then view it rather than viewing it in an internet browser
-since these logs can easily be up to size of 1 GB. It is easier to
-ssh into the teuthology machine again (``teuthology.front.sepia.ceph.com``), and
-access the following path::
+After the tests have finished running, the log for the job can be obtained by
+clicking on the job ID at the Pulpito page associated with your tests. It's
+more convenient to download the log and then view it rather than viewing it in
+an internet browser since these logs can easily be up to 1 GB in size. It is
+easier to ssh into the teuthology machine (``teuthology.front.sepia.ceph.com``)
+and access the following path::
 
     /ceph/teuthology-archive/<test-id>/<job-id>/teuthology.log
 
-For example, for above test ID path is::
+For example: for the above test ID, the path is::
 
    /ceph/teuthology-archive/teuthology-2019-12-10_05:00:03-smoke-master-testing-basic-smithi/4588482/teuthology.log
 
-This way the log can be viewed remotely without having to wait too
-much.
+This method can be used to view the log more quickly than would be possible through a browser.
 
 .. note:: To access archives more conveniently, ``/a/`` has been symbolically
    linked to ``/ceph/teuthology-archive/``. For instance, to access the previous
@@ -222,13 +222,15 @@ much.
 
 Killing Tests
 -------------
-Sometimes a teuthology job might not complete running for several minutes or
-even hours after tests that were trigged have completed running and other
-times wrong set of tests can be triggered is filter wasn't chosen carefully.
-To save resource it's better to termniate such a job. Following is the command
-to terminate a job::
+``teuthology-kill`` can be used to kill jobs that have been running
+unexpectedly for several hours, or when developers want to terminate tests
+before they complete.
 
-      teuthology-kill -r teuthology-2019-12-10_05:00:03-smoke-master-testing-basic-smithi
+Here is the command that terminates jobs:
+
+.. prompt:: bash $
+
+   teuthology-kill -r teuthology-2019-12-10_05:00:03-smoke-master-testing-basic-smithi
 
 Let's call the argument passed to ``-r`` as test ID. It can be found
 easily in the link to the Pulpito page for the tests you triggered. For


### PR DESCRIPTION
This PR improves the wording of the technical
information added to the documentation in PR#37949.
This is the second in a series of two PRs, which series
is dedicated to testing a workflow wherein developers
add technical information to the documentation and then
technical writers improve its presentation.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
