### PR TITLE
pacific: qa: rgw tests target ceph-pacific branches instead of ceph-master

### DIFF
--- a/qa/suites/rgw/crypt/4-tests/s3tests.yaml
+++ b/qa/suites/rgw/crypt/4-tests/s3tests.yaml
@@ -1,7 +1,7 @@
 tasks:
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-pacific
       barbican:
         kms_key: my-key-1
         kms_key2: my-key-2

--- a/qa/suites/rgw/multifs/tasks/rgw_ragweed.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_ragweed.yaml
@@ -4,12 +4,12 @@ tasks:
 - rgw: [client.0]
 - ragweed:
     client.0:
-      default-branch: ceph-master
+      default-branch: ceph-pacific
       rgw_server: client.0
       stages: prepare
 - ragweed:
     client.0:
-      default-branch: ceph-master
+      default-branch: ceph-pacific
       rgw_server: client.0
       stages: check
 overrides:

--- a/qa/suites/rgw/multifs/tasks/rgw_s3tests.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_s3tests.yaml
@@ -4,7 +4,7 @@ tasks:
 - rgw: [client.0]
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-pacific
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/suites/rgw/sts/tasks/ststests.yaml
+++ b/qa/suites/rgw/sts/tasks/ststests.yaml
@@ -3,7 +3,7 @@ tasks:
     client.0:
       sts_tests: True
       extra_attrs: ["test_of_sts"]
-      force-branch: ceph-master
+      force-branch: ceph-pacific
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/suites/rgw/sts/tasks/webidentity.yaml
+++ b/qa/suites/rgw/sts/tasks/webidentity.yaml
@@ -6,7 +6,7 @@ tasks:
 - s3tests:
     client.0:
       sts_tests: True
-      force-branch: ceph-master
+      force-branch: ceph-pacific
       rgw_server: client.0
       extra_attrs: ['webidentity_test']
 overrides:

--- a/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
@@ -1,7 +1,7 @@
 tasks:
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-pacific
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/suites/rgw/verify/tasks/ragweed.yaml
+++ b/qa/suites/rgw/verify/tasks/ragweed.yaml
@@ -1,6 +1,6 @@
 tasks:
 - ragweed:
     client.0:
-      default-branch: ceph-master
+      default-branch: ceph-pacific
       rgw_server: client.0
       stages: prepare,check

--- a/qa/suites/rgw/verify/tasks/s3tests.yaml
+++ b/qa/suites/rgw/verify/tasks/s3tests.yaml
@@ -1,5 +1,5 @@
 tasks:
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-pacific
       rgw_server: client.0

--- a/qa/suites/rgw/website/tasks/s3tests-website.yaml
+++ b/qa/suites/rgw/website/tasks/s3tests-website.yaml
@@ -12,6 +12,6 @@ tasks:
       dns-s3website-name: s3-website.
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-pacific
       rgw_server: client.0
       rgw_website_server: client.1

--- a/qa/suites/smoke/basic/tasks/test/rgw_ec_s3tests.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rgw_ec_s3tests.yaml
@@ -8,7 +8,7 @@ tasks:
 - rgw: [client.0]
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-pacific
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/suites/smoke/basic/tasks/test/rgw_s3tests.yaml
+++ b/qa/suites/smoke/basic/tasks/test/rgw_s3tests.yaml
@@ -4,7 +4,7 @@ tasks:
 - rgw: [client.0]
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-pacific
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/suites/teuthology/rgw/tasks/s3tests-civetweb.yaml
+++ b/qa/suites/teuthology/rgw/tasks/s3tests-civetweb.yaml
@@ -11,7 +11,7 @@ tasks:
 - s3tests:
     client.0:
       rgw_server: client.0
-      force-branch: ceph-master
+      force-branch: ceph-pacific
 overrides:
   ceph:
     fs: xfs

--- a/qa/suites/teuthology/rgw/tasks/s3tests-fastcgi.yaml
+++ b/qa/suites/teuthology/rgw/tasks/s3tests-fastcgi.yaml
@@ -11,7 +11,7 @@ tasks:
 - s3tests:
     client.0:
       rgw_server: client.0
-      force-branch: ceph-master
+      force-branch: ceph-pacific
 overrides:
   ceph:
     fs: xfs

--- a/qa/suites/teuthology/rgw/tasks/s3tests-fcgi.yaml
+++ b/qa/suites/teuthology/rgw/tasks/s3tests-fcgi.yaml
@@ -12,7 +12,7 @@ tasks:
 - s3tests:
     client.0:
       rgw_server: client.0
-      force-branch: ceph-master
+      force-branch: ceph-pacific
 overrides:
   ceph:
     fs: xfs

--- a/qa/suites/upgrade/nautilus-x/parallel/2-workload/rgw_ragweed_prepare.yaml
+++ b/qa/suites/upgrade/nautilus-x/parallel/2-workload/rgw_ragweed_prepare.yaml
@@ -6,7 +6,7 @@ workload:
   - sequential:
     - ragweed:
         client.1:
-          default-branch: ceph-master
+          default-branch: ceph-pacific
           rgw_server: client.1
           stages: prepare
     - print: "**** done rgw ragweed prepare 2-workload"

--- a/qa/suites/upgrade/nautilus-x/parallel/5-final-workload/rgw_ragweed_check.yaml
+++ b/qa/suites/upgrade/nautilus-x/parallel/5-final-workload/rgw_ragweed_check.yaml
@@ -5,7 +5,7 @@ rgw-final-workload:
   full_sequential:
   - ragweed:
       client.1:
-        default-branch: ceph-master
+        default-branch: ceph-pacific
         rgw_server: client.1
         stages: check
   - print: "**** done ragweed check 4-final-workload"

--- a/qa/suites/upgrade/octopus-x/parallel-no-cephadm/5-final-workload/rgw_ragweed_check.yaml
+++ b/qa/suites/upgrade/octopus-x/parallel-no-cephadm/5-final-workload/rgw_ragweed_check.yaml
@@ -5,7 +5,7 @@ rgw-final-workload:
   full_sequential:
   - ragweed:
       client.1:
-        default-branch: ceph-master
+        default-branch: ceph-pacific
         rgw_server: client.1
         stages: check
   - print: "**** done ragweed check 4-final-workload"


### PR DESCRIPTION
s3test and ragweed tests now use ceph-pacific branch. this commit diverges from master, so is applied directly to the pacific branch

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
