### PR TITLE
pacific: qa/*/thrash_cache_writeback_proxy_none.yaml: disable writeback overlay tests

### DIFF
--- a/qa/suites/rados/singleton/all/thrash_cache_writeback_proxy_none.yaml
+++ b/qa/suites/rados/singleton/all/thrash_cache_writeback_proxy_none.yaml
@@ -48,12 +48,13 @@ tasks:
       - echo remove overlay
       - sudo ceph osd tier remove-overlay base
       - sleep 20
-      - echo add writeback overlay
-      - sudo ceph osd tier cache-mode cache writeback
-      - sudo ceph osd pool set cache cache_target_full_ratio .8
-      - sudo ceph osd tier set-overlay base cache
-      - sleep 30
-      - sudo ceph osd tier cache-mode cache readproxy
+      # Disabled due to https://tracker.ceph.com/issues/46323
+      #- echo add writeback overlay
+      #- sudo ceph osd tier cache-mode cache writeback
+      #- sudo ceph osd pool set cache cache_target_full_ratio .8
+      #- sudo ceph osd tier set-overlay base cache
+      #- sleep 30
+      #- sudo ceph osd tier cache-mode cache readproxy
       - done
 - rados:
     clients: [client.0]


### PR DESCRIPTION
thrash_cache_writeback_proxy_none tests have been failing consistently. Some investigation
shows that the writeback overlay tests are reponsible for it. Instead of removing these
cache tiering tests entirely, we'll disable them for now.

Related to: https://tracker.ceph.com/issues/46323
Signed-off-by: Neha Ojha <nojha@redhat.com>
(cherry picked from commit be710cdf39d1d6a3d3880f9d2f85568dd1c67859)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
