### PR TITLE
pacific: mgr/orchestrator: remove 'host' arg for 'orch ls'

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -531,7 +531,6 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
 
     @_cli_read_command('orch ls')
     def _list_services(self,
-                       host: Optional[str] = None,
                        service_type: Optional[str] = None,
                        service_name: Optional[str] = None,
                        export: bool = False,


### PR DESCRIPTION
Backport of #39172

The host arg is unused, and also missing from the documentation.

Signed-off-by: Sage Weil <sage@newdream.net>
(cherry picked from commit 38b3ca2a736995baf962997995f1334786c6e2cd)