### PR TITLE
nautilus: crush/CrushWrapper: rebuild reverse maps after rebuilding crush map

### DIFF
--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -1321,6 +1321,7 @@ public:
       crush->max_devices = name_map.rbegin()->first + 1;
     }
     have_uniform_rules = !has_legacy_rule_ids();
+    build_rmaps();
   }
   int bucket_set_alg(int id, int alg);
 


### PR DESCRIPTION
https://tracker.ceph.com/issues/49073

---

backport of #36103
parent tracker: https://tracker.ceph.com/issues/44311

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
