### PR TITLE
doc/mgr/orchestrator: Unify the content of command and yaml

### DIFF
--- a/doc/mgr/orchestrator.rst
+++ b/doc/mgr/orchestrator.rst
@@ -835,7 +835,7 @@ Or in YAML:
 
 To place a service on *all* hosts, use ``"*"``::
 
-    orch apply crash --placement='*'
+    orch apply node-exporter --placement='*'
 
 Or in YAML:
 


### PR DESCRIPTION
Hi, 

I think that It should be unifyed the command and yaml content. It should be better.

Regards,