### PR TITLE
crimson: make the number of alien threads configurable.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5519,6 +5519,11 @@ std::vector<Option> get_global_options() {
     .set_default(0)
     .set_description("The maximum number concurrent IO operations, 0 for unlimited"),
 
+    Option("crimson_alien_op_num_threads", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(16)
+    .set_flag(Option::FLAG_STARTUP)
+    .set_description("The number of threads for serving alienized ObjectStore"),
+
     // ----------------------------
     // blk specific options
     Option("bdev_type", Option::TYPE_STR, Option::LEVEL_ADVANCED)

--- a/src/crimson/os/alienstore/alien_store.cc
+++ b/src/crimson/os/alienstore/alien_store.cc
@@ -71,7 +71,9 @@ AlienStore::AlienStore(const std::string& path, const ConfigValues& values)
     logger().error("{}: unable to get nproc: {}", __func__, errno);
     cpu_id = -1;
   }
-  tp = std::make_unique<crimson::os::ThreadPool>(1, 128, cpu_id);
+  const auto num_threads =
+    cct->_conf.get_val<uint64_t>("crimson_alien_op_num_threads");
+  tp = std::make_unique<crimson::os::ThreadPool>(num_threads, 128, cpu_id);
 }
 
 seastar::future<> AlienStore::start()


### PR DESCRIPTION
It's particularly important for reads to have large-enough thread pool in `AlienStore` as they are synchronous; that is, e.g. `BlueStore` blocks on IO when handling them.

This commit introduces a configurable allowing operators to increase the number from `1` which we were limited to
before the change.

Naming similarity with `osd_op_num_threads_per_shard` is intentional.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
