### PR TITLE
mgr/MetricTypes: condition encoding on feature bits

### DIFF
--- a/src/messages/MMgrConfigure.h
+++ b/src/messages/MMgrConfigure.h
@@ -59,7 +59,12 @@ public:
     encode(stats_period, payload);
     encode(stats_threshold, payload);
     encode(osd_perf_metric_queries, payload);
-    encode(metric_config_message, payload);
+    if (metric_config_message && metric_config_message->should_encode(features)) {
+      encode(metric_config_message, payload);
+    } else {
+      boost::optional<MetricConfigMessage> empty;
+      encode(empty, payload);
+    }
   }
 
   std::string_view get_type_name() const override { return "mgrconfigure"; }

--- a/src/messages/MMgrReport.h
+++ b/src/messages/MMgrReport.h
@@ -157,7 +157,12 @@ public:
     encode(config_bl, payload);
     encode(osd_perf_metric_reports, payload);
     encode(task_status, payload);
-    encode(metric_report_message, payload);
+    if (metric_report_message && metric_report_message->should_encode(features)) {
+      encode(metric_report_message, payload);
+    } else {
+      boost::optional<MetricReportMessage> empty;
+      encode(empty, payload);
+    }
   }
 
   std::string_view get_type_name() const override { return "mgrreport"; }

--- a/src/mgr/MetricTypes.h
+++ b/src/mgr/MetricTypes.h
@@ -6,6 +6,7 @@
 
 #include <boost/variant.hpp>
 #include "include/denc.h"
+#include "include/ceph_features.h"
 #include "mgr/OSDPerfMetricTypes.h"
 #include "mgr/MDSPerfMetricTypes.h"
 
@@ -102,6 +103,14 @@ struct MetricReportMessage {
 
   MetricReportMessage(const MetricPayload &payload = UnknownMetricPayload())
     : payload(payload) {
+  }
+
+  bool should_encode(uint64_t features) const {
+    if (!HAVE_FEATURE(features, SERVER_PACIFIC) &&
+	boost::get<MDSMetricPayload>(&payload)) {
+      return false;
+    }
+    return true;
   }
 
   void encode(ceph::buffer::list &bl) const {
@@ -227,6 +236,14 @@ struct MetricConfigMessage {
 
   MetricConfigMessage(const ConfigPayload &payload = UnknownConfigPayload())
     : payload(payload) {
+  }
+
+  bool should_encode(uint64_t features) const {
+    if (!HAVE_FEATURE(features, SERVER_PACIFIC) &&
+	boost::get<MDSConfigPayload>(&payload)) {
+      return false;
+    }
+    return true;
   }
 
   void encode(ceph::buffer::list &bl) const {


### PR DESCRIPTION
Do not encode new metric|config types for older peers.

The combination of boost::optional and boost::variant make this super
awkward to condition on the features. :(

Fixes: https://tracker.ceph.com/issues/49069
Signed-off-by: Sage Weil <sage@newdream.net>