### PR TITLE
osd, test: reworks for manifest dedup test cases

### DIFF
--- a/qa/suites/rados/thrash/workloads/dedup-io-mixed.yaml
+++ b/qa/suites/rados/thrash/workloads/dedup-io-mixed.yaml
@@ -1,0 +1,20 @@
+tasks:
+- exec:
+    client.0:
+      - sudo ceph osd pool create low_tier 4
+- rados:
+    clients: [client.0]
+    low_tier_pool: 'low_tier'
+    ops: 1500
+    objects: 50
+    set_chunk: true
+    enable_dedup: true
+    dedup_chunk_size: '131072'
+    dedup_chunk_algo: 'fastcdc'
+    op_weights:
+      read: 100
+      write: 50
+      set_chunk: 30
+      tier_promote: 10
+      tier_flush: 5
+      tier_evict: 10

--- a/qa/suites/rados/thrash/workloads/dedup-io-snaps.yaml
+++ b/qa/suites/rados/thrash/workloads/dedup-io-snaps.yaml
@@ -20,4 +20,4 @@ tasks:
       tier_evict: 10
       snap_create: 10
       snap_remove: 10
-      roll_back: 10
+      rollback: 10

--- a/qa/suites/rados/thrash/workloads/dedup-io-snaps.yaml
+++ b/qa/suites/rados/thrash/workloads/dedup-io-snaps.yaml
@@ -1,0 +1,23 @@
+tasks:
+- exec:
+    client.0:
+      - sudo ceph osd pool create low_tier 4
+- rados:
+    clients: [client.0]
+    low_tier_pool: 'low_tier'
+    ops: 1500
+    objects: 50
+    set_chunk: true
+    enable_dedup: true
+    dedup_chunk_size: '131072'
+    dedup_chunk_algo: 'fastcdc'
+    op_weights:
+      read: 100
+      write: 50
+      set_chunk: 30
+      tier_promote: 10
+      tier_flush: 5
+      tier_evict: 10
+      snap_create: 10
+      snap_remove: 10
+      roll_back: 10

--- a/qa/tasks/rados.py
+++ b/qa/tasks/rados.py
@@ -153,9 +153,9 @@ def task(ctx, config):
     if config.get('low_tier_pool', None):
         args.extend(['--low_tier_pool', config.get('low_tier_pool', None)])
     if config.get('dedup_chunk_size', False):
-        args.extend(['--dedup_chunk_size'])
+        args.extend(['--dedup_chunk_size', config.get('dedup_chunk_size', None)] )
     if config.get('dedup_chunk_algo', False):
-        args.extend(['--dedup_chunk_algo'])
+        args.extend(['--dedup_chunk_algo', config.get('dedup_chunk_algo', None)])
     if config.get('pool_snaps', False):
         args.extend(['--pool-snaps'])
     if config.get('balance_reads', False):
@@ -197,7 +197,12 @@ def task(ctx, config):
         "append",
         "write",
         "read",
-        "delete"
+        "delete",
+        "set_chunk",
+        "tier_promote",
+        "tier_evict",
+        "tier_promote",
+        "tier_flush"
         ]:
         if field in op_weights:
             weights[field] = op_weights[field]

--- a/qa/tasks/rados.py
+++ b/qa/tasks/rados.py
@@ -152,6 +152,10 @@ def task(ctx, config):
         args.extend(['--enable_dedup'])
     if config.get('low_tier_pool', None):
         args.extend(['--low_tier_pool', config.get('low_tier_pool', None)])
+    if config.get('dedup_chunk_size', False):
+        args.extend(['--dedup_chunk_size'])
+    if config.get('dedup_chunk_algo', False):
+        args.extend(['--dedup_chunk_algo'])
     if config.get('pool_snaps', False):
         args.extend(['--pool-snaps'])
     if config.get('balance_reads', False):

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -9664,11 +9664,12 @@ void PrimaryLogPG::process_copy_chunk_manifest(hobject_t oid, ceph_tid_t tid, in
     ctx->at_version = get_next_version();
     finish_ctx(ctx.get(), pg_log_entry_t::PROMOTE);
     simple_opc_submit(std::move(ctx));
+    obj_cop->chunk_cops.clear();
 
     auto p = cobc->obs.oi.manifest.chunk_map.rbegin();
     /* check remaining work */
     if (p != cobc->obs.oi.manifest.chunk_map.rend()) {
-      if (obj_cop->last_offset >= p->first + p->second.length) {
+      if (obj_cop->last_offset < p->first) {
 	for (auto &en : cobc->obs.oi.manifest.chunk_map) {
 	  if (obj_cop->last_offset < en.first) {
 	    _copy_some_manifest(cobc, obj_cop, en.first);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -8267,6 +8267,9 @@ int PrimaryLogPG::_rollback_to(OpContext *ctx, ceph_osd_op& op)
 
       if (obs.exists) {
 	t->remove(soid);
+	if (obs.oi.has_manifest()) {
+	  dec_all_refcount_manifest(obs.oi, ctx);
+	}
       }
       t->clone(soid, rollback_to_sobject);
       t->add_obc(rollback_to);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -8178,14 +8178,6 @@ inline int PrimaryLogPG::_delete_oid(
     oi.set_flag(object_info_t::FLAG_WHITEOUT);
     ctx->delta_stats.num_whiteouts++;
     t->create(soid);
-    if (oi.has_manifest()) {
-      // make no references
-      dec_all_refcount_manifest(oi, ctx);
-      oi.manifest.clear();
-      oi.manifest.type = object_manifest_t::TYPE_NONE;
-      oi.clear_flag(object_info_t::FLAG_MANIFEST);
-      ctx->delta_stats.num_objects_manifest--;
-    }
     osd->logger->inc(l_osd_tier_whiteout);
     return 0;
   }
@@ -8868,7 +8860,6 @@ void PrimaryLogPG::finish_ctx(OpContext *ctx, int log_op_type, int result)
   // Drop the reference if deduped chunk is modified
   if (ctx->new_obs.oi.is_dirty() &&
     (ctx->obs->oi.has_manifest() && ctx->obs->oi.manifest.is_chunked()) &&
-    ctx->new_obs.oi.size != 0 && // missing, redirect and delete
     !ctx->cache_operation &&
     log_op_type != pg_log_entry_t::PROMOTE) {
     update_chunk_map_by_dirty(ctx);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -8365,6 +8365,9 @@ void PrimaryLogPG::_do_rollback_to(OpContext *ctx, ObjectContextRef rollback_to,
     t->remove(soid);
     if (obs.oi.has_manifest()) {
       dec_all_refcount_manifest(obs.oi, ctx);
+      oi.manifest.clear();
+      oi.manifest.type = object_manifest_t::TYPE_NONE;
+      oi.clear_flag(object_info_t::FLAG_MANIFEST);
       ctx->delta_stats.num_objects_manifest--;
       ctx->cache_operation = true; // do not trigger to call ref function to calculate refcount
     }

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10450,6 +10450,7 @@ int PrimaryLogPG::finish_set_dedup(hobject_t oid, int r, ceph_tid_t tid, uint64_
     ctx->at_version = get_next_version();
     ctx->new_obs = obc->obs;
     ctx->new_obs.oi.clear_flag(object_info_t::FLAG_DIRTY);
+    --ctx->delta_stats.num_objects_dirty;
 
     /* 
     * Let's assume that there is a manifest snapshotted object, and we issue tier_flush() to head.

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -8191,11 +8191,16 @@ int PrimaryLogPG::_rollback_to(OpContext *ctx, ceph_osd_op& op)
     ObjectContextRef promote_obc;
     cache_result_t tier_mode_result;
     if (obs.exists && obs.oi.has_manifest()) {
-      tier_mode_result =
-	maybe_handle_manifest_detail(
-	  ctx->op,
-	  true,
-	  rollback_to);
+      if (!rollback_to->obs.oi.has_manifest()) {
+	// rollback_to is not manifest object
+	tier_mode_result = cache_result_t::NOOP;
+      } else {
+	tier_mode_result =
+	  maybe_handle_manifest_detail(
+	    ctx->op,
+	    true,
+	    rollback_to);
+      }
     } else {
       tier_mode_result =
 	maybe_handle_cache_detail(

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -8136,6 +8136,14 @@ inline int PrimaryLogPG::_delete_oid(
     oi.set_flag(object_info_t::FLAG_WHITEOUT);
     ctx->delta_stats.num_whiteouts++;
     t->create(soid);
+    if (oi.has_manifest()) {
+      // make no references
+      dec_all_refcount_manifest(oi, ctx);
+      oi.manifest.clear();
+      oi.manifest.type = object_manifest_t::TYPE_NONE;
+      oi.clear_flag(object_info_t::FLAG_MANIFEST);
+      ctx->delta_stats.num_objects_manifest--;
+    }
     osd->logger->inc(l_osd_tier_whiteout);
     return 0;
   }

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -9370,7 +9370,7 @@ void PrimaryLogPG::_copy_some_manifest(ObjectContextRef obc, CopyOpRef cop, uint
 	    << " length: " << length << " pool id: " << oloc.pool
 	    << " tid: " << tid << dendl;
 
-    if (last_offset < iter->first) {
+    if (last_offset <= iter->first) {
       break;
     }
   }

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2468,7 +2468,11 @@ PrimaryLogPG::cache_result_t PrimaryLogPG::maybe_handle_manifest_detail(
   bool write_ordered,
   ObjectContextRef obc)
 {
-  ceph_assert(obc);
+  if (!obc) {
+    dout(20) << __func__ << ": no obc " << dendl;
+    return cache_result_t::NOOP;
+  }
+
   if (!obc->obs.oi.has_manifest()) {
     dout(20) << __func__ << ": " << obc->obs.oi.soid 
 	     << " is not manifest object " << dendl;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -8329,6 +8329,12 @@ int PrimaryLogPG::_rollback_to(OpContext *ctx, ceph_osd_op& op)
       else
 	obs.oi.clear_omap_digest();
 
+      if (rollback_to->obs.oi.has_manifest() && rollback_to->obs.oi.manifest.is_chunked()) {
+	obs.oi.set_flag(object_info_t::FLAG_MANIFEST);
+	obs.oi.manifest.type = rollback_to->obs.oi.manifest.type;
+	obs.oi.manifest.chunk_map = rollback_to->obs.oi.manifest.chunk_map;
+      }
+
       if (rollback_to->obs.oi.is_omap()) {
 	dout(10) << __func__ << " setting omap flag on " << obs.oi.soid << dendl;
 	obs.oi.set_flag(object_info_t::FLAG_OMAP);

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1448,6 +1448,7 @@ protected:
   friend struct RefCountCallback;
   friend struct C_SetDedupChunks;
   friend struct C_SetManifestRefCountDone;
+  friend struct SetManifestFinisher;
 
 public:
   PrimaryLogPG(OSDService *o, OSDMapRef curmap,

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1440,12 +1440,14 @@ protected:
   int start_dedup(OpRequestRef op, ObjectContextRef obc);
   hobject_t get_fpoid_from_chunk(const hobject_t soid, bufferlist& chunk);
   int finish_set_dedup(hobject_t oid, int r, ceph_tid_t tid, uint64_t offset);
+  int finish_set_manifest_refcount(hobject_t oid, int r, ceph_tid_t tid, uint64_t offset);
 
   friend struct C_ProxyChunkRead;
   friend class PromoteManifestCallback;
   friend struct C_CopyChunk;
   friend struct RefCountCallback;
   friend struct C_SetDedupChunks;
+  friend struct C_SetManifestRefCountDone;
 
 public:
   PrimaryLogPG(OSDService *o, OSDMapRef curmap,

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1801,7 +1801,9 @@ private:
   // whiteout or no change.
   void maybe_create_new_object(OpContext *ctx, bool ignore_transaction=false);
   int _delete_oid(OpContext *ctx, bool no_whiteout, bool try_no_whiteout);
-  int _rollback_to(OpContext *ctx, ceph_osd_op& op);
+  int _rollback_to(OpContext *ctx, OSDOp& op);
+  void _do_rollback_to(OpContext *ctx, ObjectContextRef rollback_to,
+				    OSDOp& op);
 public:
   bool is_missing_object(const hobject_t& oid) const;
   bool is_unreadable_object(const hobject_t &oid) const {

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1427,6 +1427,7 @@ protected:
 			      Context *cb, std::optional<bufferlist> chunk);
   void dec_all_refcount_manifest(const object_info_t& oi, OpContext* ctx);
   void dec_refcount(const hobject_t& soid, const object_ref_delta_t& refs);
+  void update_chunk_map_by_dirty(OpContext* ctx);
   void dec_refcount_by_dirty(OpContext* ctx);
   ObjectContextRef get_prev_clone_obc(ObjectContextRef obc);
   bool recover_adjacent_clones(ObjectContextRef obc, OpRequestRef op);

--- a/src/test/librados/tier_cxx.cc
+++ b/src/test/librados/tier_cxx.cc
@@ -5037,6 +5037,7 @@ TEST_F(LibRadosTwoPoolsPP, ManifestFlushSnap) {
 
   // set-chunk (dedup)
   manifest_set_chunk(cluster, ioctx, cache_ioctx, 2, 2, "bar", "foo");
+  manifest_set_chunk(cluster, ioctx, cache_ioctx, 6, 2, "bar", "foo");
 
   // create a snapshot, clone
   vector<uint64_t> my_snaps(1);

--- a/src/test/librados/tier_cxx.cc
+++ b/src/test/librados/tier_cxx.cc
@@ -4627,6 +4627,101 @@ TEST_F(LibRadosTwoPoolsPP, ManifestEvict) {
 
 }
 
+TEST_F(LibRadosTwoPoolsPP, ManifestEvictPromote) {
+  // skip test if not yet octopus
+  if (_get_required_osd_release(cluster) < "octopus") {
+    cout << "cluster is not yet octopus, skipping test" << std::endl;
+    return;
+  }
+
+  // create object
+  {
+    bufferlist bl;
+    bl.append("there hiHI");
+    ObjectWriteOperation op;
+    op.write_full(bl);
+    ASSERT_EQ(0, ioctx.operate("foo", &op));
+  }
+  {
+    bufferlist bl;
+    bl.append("EREHT hiHI");
+    ObjectWriteOperation op;
+    op.write_full(bl);
+    ASSERT_EQ(0, cache_ioctx.operate("chunk1", &op));
+  }
+  {
+    bufferlist bl;
+    bl.append("there hiHI");
+    ObjectWriteOperation op;
+    op.write_full(bl);
+    ASSERT_EQ(0, cache_ioctx.operate("chunk2", &op));
+  }
+  {
+    bufferlist bl;
+    bl.append("THERE HIHI");
+    ObjectWriteOperation op;
+    op.write_full(bl);
+    ASSERT_EQ(0, cache_ioctx.operate("chunk3", &op));
+  }
+
+  // wait for maps to settle
+  cluster.wait_for_latest_osdmap();
+
+  // create a snapshot, clone
+  vector<uint64_t> my_snaps(1);
+  ASSERT_EQ(0, ioctx.selfmanaged_snap_create(&my_snaps[0]));
+  ASSERT_EQ(0, ioctx.selfmanaged_snap_set_write_ctx(my_snaps[0],
+	my_snaps));
+
+  {
+    bufferlist bl;
+    bl.append("there");
+    ASSERT_EQ(0, ioctx.write("foo", bl, bl.length(), 0));
+  }
+
+  // set-chunk 
+  manifest_set_chunk(cluster, cache_ioctx, ioctx, 0, 2, "chunk1", "foo");
+  manifest_set_chunk(cluster, cache_ioctx, ioctx, 8, 2, "chunk2", "foo");
+  // foo snap[0]:  
+  // foo head   :  [chunk1]                           [chunk2]
+
+  ioctx.snap_set_read(my_snaps[0]);
+  // set-chunk 
+  manifest_set_chunk(cluster, cache_ioctx, ioctx, 0, 10, "chunk3", "foo");
+  // foo snap[0]: [                  chunk3                   ] 
+  // foo head   : [chunk1]                             [chunk2]
+ 
+
+  {
+    ObjectReadOperation op, stat_op;
+    uint64_t size;
+    op.tier_evict();
+    librados::AioCompletion *completion = cluster.aio_create_completion();
+    ASSERT_EQ(0, ioctx.aio_operate(
+	"foo", completion, &op,
+	librados::OPERATION_IGNORE_OVERLAY, NULL));
+    completion->wait_for_complete();
+    ASSERT_EQ(0, completion->get_return_value());
+
+    stat_op.stat(&size, NULL, NULL);
+    ASSERT_EQ(0, ioctx.operate("foo", &stat_op, NULL));
+    ASSERT_EQ(10, size);
+    
+  }
+  {
+    bufferlist bl;
+    ASSERT_EQ(1, ioctx.read("foo", bl, 1, 0));
+    ASSERT_EQ('T', bl[0]);
+  }
+
+  ioctx.snap_set_read(librados::SNAP_HEAD);
+  {
+    bufferlist bl;
+    ASSERT_EQ(10, ioctx.read("foo", bl, 10, 0));
+    ASSERT_EQ('H', bl[8]);
+  }
+}
+
 
 TEST_F(LibRadosTwoPoolsPP, ManifestSnapSizeMismatch) {
   // skip test if not yet octopus

--- a/src/test/osd/CMakeLists.txt
+++ b/src/test/osd/CMakeLists.txt
@@ -12,6 +12,8 @@ target_link_libraries(ceph_test_rados
   ${CMAKE_DL_LIBS}
   ${EXTRALIBS}
   ${CMAKE_DL_LIBS}
+  cls_cas_internal
+  cls_cas_client
   )
 install(TARGETS
   ceph_test_rados

--- a/src/test/osd/Object.h
+++ b/src/test/osd/Object.h
@@ -316,10 +316,10 @@ class ObjectDesc {
 public:
   ObjectDesc()
     : exists(false), dirty(false),
-      version(0) {}
+      version(0), flushed(false) {}
   ObjectDesc(const ContDesc &init, ContentsGenerator *cont_gen)
     : exists(false), dirty(false),
-      version(0) {
+      version(0), flushed(false) {
     layers.push_front(std::pair<std::shared_ptr<ContentsGenerator>, ContDesc>(std::shared_ptr<ContentsGenerator>(cont_gen), init));
   }
 
@@ -532,6 +532,7 @@ public:
   uint64_t version;
   std::string redirect_target;
   std::map<uint64_t, ChunkDesc> chunk_info;
+  bool flushed;
 private:
   std::list<std::pair<std::shared_ptr<ContentsGenerator>, ContDesc> > layers;
 };

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -422,6 +422,7 @@ public:
       new_obj.attrs.erase(*i);
     }
     new_obj.dirty = true;
+    new_obj.flushed = false;
     pool_obj_cont[current_snap].insert_or_assign(oid, new_obj);
   }
 
@@ -430,6 +431,7 @@ public:
     ObjectDesc new_obj = get_most_recent(oid);
     new_obj.header = bufferlist();
     new_obj.dirty = true;
+    new_obj.flushed = false;
     pool_obj_cont[current_snap].insert_or_assign(oid, new_obj);
   }
 
@@ -440,6 +442,7 @@ public:
     new_obj.header = bl;
     new_obj.exists = true;
     new_obj.dirty = true;
+    new_obj.flushed = false;
     pool_obj_cont[current_snap].insert_or_assign(oid, new_obj);
   }
 
@@ -453,6 +456,7 @@ public:
     }
     new_obj.exists = true;
     new_obj.dirty = true;
+    new_obj.flushed = false;
     pool_obj_cont[current_snap].insert_or_assign(oid, new_obj);
   }
 
@@ -462,6 +466,7 @@ public:
     ObjectDesc new_obj = get_most_recent(oid);
     new_obj.exists = true;
     new_obj.dirty = true;
+    new_obj.flushed = false;
     new_obj.update(cont_gen,
 		   contents);
     pool_obj_cont[current_snap].insert_or_assign(oid, new_obj);
@@ -586,6 +591,7 @@ public:
     ObjectDesc contents;
     find_object(oid, &contents, snap);
     contents.dirty = true;
+    contents.flushed = false;
     pool_obj_cont.rbegin()->second.insert_or_assign(oid, contents);
   }
 

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -2346,9 +2346,10 @@ public:
 	  cout << num << ":  got expected ENOENT (src dne)" << std::endl;
 	} else if (r == -EOPNOTSUPP) {
 	  bool is_overlapped = false;
+	  interval_set<uint64_t> chunk;
+	  chunk.insert(offset, length);
 	  for (auto &p : src_value.chunk_info) {
-	    if ((p.first <= offset && p.first + p.second.length > offset) ||
-                (p.first > offset && p.first <= offset + length)) {
+	    if (chunk.intersects(p.first, p.second.length)) {
 	      cout << " range is overlapped  offset: " << offset << " length: " << length
 		    << " chunk_info offset: " << p.second.offset << " length " 
 		    << p.second.length << std::endl;
@@ -2367,10 +2368,7 @@ public:
 	  ceph_abort();
 	}
       } else {
-	ChunkDesc info;
-	info.offset = tgt_offset;
-	info.length = length;
-	info.oid = oid_tgt;
+	ChunkDesc info {tgt_offset, length, oid_tgt};
 	context->update_object_chunk_target(oid, offset, info);
 	context->update_object_version(oid, comp->get_version64());
       }

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -2377,6 +2377,9 @@ public:
       if ((r = comp->get_return_value())) {
 	if (r == -ENOENT && src_value.deleted()) {
 	  cout << num << ":  got expected ENOENT (src dne)" << std::endl;
+	} else if (r == -ENOENT && context->oid_set_chunk_tgt_pool.find(oid_tgt) != 
+		  context->oid_set_chunk_tgt_pool.end()) {
+	  cout << num << ": get expected ENOENT tgt oid " << oid_tgt << std::endl;
 	} else if (r == -EOPNOTSUPP) {
 	  bool is_overlapped = false;
 	  interval_set<uint64_t> chunk;

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -2399,23 +2399,9 @@ public:
 		  context->oid_set_chunk_tgt_pool.end()) {
 	  cout << num << ": get expected ENOENT tgt oid " << oid_tgt << std::endl;
 	} else if (r == -EOPNOTSUPP) {
-	  bool is_overlapped = false;
-	  interval_set<uint64_t> chunk;
-	  chunk.insert(offset, length);
-	  for (auto &p : src_value.chunk_info) {
-	    if (chunk.intersects(p.first, p.second.length)) {
-	      cout << " range is overlapped  offset: " << offset << " length: " << length
-		    << " chunk_info offset: " << p.second.offset << " length " 
-		    << p.second.length << std::endl;
-	      is_overlapped = true;
-	      context->update_object_version(oid, comp->get_version64());
-	    } 
-	  }
-	  if (!is_overlapped) {
-	    cerr << "Error: oid " << oid << " set_chunk " << oid_tgt << " returned error code "
-		  << r << " offset: " << offset << " length: " << length <<  std::endl;
-	    ceph_abort();
-	  }
+	  cout << "Range is overlapped: oid " << oid << " set_chunk " << oid_tgt << " returned error code "
+		<< r << " offset: " << offset << " length: " << length <<  std::endl;
+	  context->update_object_version(oid, comp->get_version64());
 	} else {
 	  cerr << "Error: oid " << oid << " set_chunk " << oid_tgt << " returned error code "
 	       << r << std::endl;

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -2295,14 +2295,14 @@ public:
   int r;
   uint64_t offset;
   uint32_t length;
-  uint64_t tgt_offset;
+  uint32_t tgt_offset;
   SetChunkOp(int n,
 	     RadosTestContext *context,
 	     const string &oid,
 	     uint64_t offset,
 	     uint32_t length,
 	     const string &oid_tgt,
-	     uint64_t tgt_offset,
+	     uint32_t tgt_offset,
 	     TestOpStat *stat = 0)
     : TestOp(n, context, stat),
       oid(oid), oid_tgt(oid_tgt),

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -275,6 +275,30 @@ public:
 	rados.shutdown();
 	return r;
       }
+      r = rados.mon_command(
+	"{\"prefix\": \"osd pool set\", \"pool\": \"" + pool_name +
+	"\", \"var\": \"dedup_tier\", \"val\": \"" + low_tier_pool_name + "\"}",
+	inbl, NULL, NULL);
+      if (r < 0) {
+	rados.shutdown();
+	return r;
+      }
+      r = rados.mon_command(
+	"{\"prefix\": \"osd pool set\", \"pool\": \"" + pool_name +
+	"\", \"var\": \"dedup_chunk_algorithm\", \"val\": \"" + "fastcdc" + "\"}",
+	inbl, NULL, NULL);
+      if (r < 0) {
+	rados.shutdown();
+	return r;
+      }
+      r = rados.mon_command(
+	"{\"prefix\": \"osd pool set\", \"pool\": \"" + pool_name +
+	"\", \"var\": \"dedup_cdc_chunk_size\", \"val\": \"" + "1024" + "\"}",
+	inbl, NULL, NULL);
+      if (r < 0) {
+	rados.shutdown();
+	return r;
+      }
     }
 
     char hostname_cstr[100];

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -2814,6 +2814,8 @@ public:
     cout << num << ":  got " << cpp_strerror(r) << std::endl;
     if (r == 0) {
       // sucess
+    } else if (r == -EBUSY) {
+      // could fail if snap is not oldest
     } else {
       ceph_abort_msg("shouldn't happen");
     }

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -197,6 +197,8 @@ public:
   int snapname_num;
   map<string,string > redirect_objs;
   bool enable_dedup;
+  string chunk_algo;
+  string chunk_size;
 
   RadosTestContext(const string &pool_name, 
 		   int max_in_flight,
@@ -209,6 +211,8 @@ public:
 		   bool write_fadvise_dontneed,
 		   const string &low_tier_pool_name,
 		   bool enable_dedup,
+		   string chunk_algo,
+		   string chunk_size,
 		   const char *id = 0) :
     pool_obj_cont(),
     current_snap(0),
@@ -227,7 +231,9 @@ public:
     write_fadvise_dontneed(write_fadvise_dontneed),
     low_tier_pool_name(low_tier_pool_name),
     snapname_num(0),
-    enable_dedup(enable_dedup)
+    enable_dedup(enable_dedup),
+    chunk_algo(chunk_algo),
+    chunk_size(chunk_size)
   {
   }
 
@@ -285,7 +291,7 @@ public:
       }
       r = rados.mon_command(
 	"{\"prefix\": \"osd pool set\", \"pool\": \"" + pool_name +
-	"\", \"var\": \"dedup_chunk_algorithm\", \"val\": \"" + "fastcdc" + "\"}",
+	"\", \"var\": \"dedup_chunk_algorithm\", \"val\": \"" + chunk_algo  + "\"}",
 	inbl, NULL, NULL);
       if (r < 0) {
 	rados.shutdown();
@@ -293,7 +299,7 @@ public:
       }
       r = rados.mon_command(
 	"{\"prefix\": \"osd pool set\", \"pool\": \"" + pool_name +
-	"\", \"var\": \"dedup_cdc_chunk_size\", \"val\": \"" + "1024" + "\"}",
+	"\", \"var\": \"dedup_cdc_chunk_size\", \"val\": \"" + chunk_size + "\"}",
 	inbl, NULL, NULL);
       if (r < 0) {
 	rados.shutdown();

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -2386,10 +2386,10 @@ public:
 
     string target_oid;
     if (!oid_tgt.empty()) {
-      target_oid = oid_tgt;
+      target_oid = context->prefix+oid_tgt;
     } else {
       bufferlist bl;
-      int r = context->io_ctx.read(context->prefix+oid, bl, offset, length);
+      int r = context->io_ctx.read(context->prefix+oid, bl, length, offset);
       ceph_assert(r > 0);
       string fp_oid = ceph::crypto::digest<ceph::crypto::SHA256>(bl).to_str();
       r = context->low_tier_io_ctx.write(fp_oid, bl, bl.length(), 0);
@@ -2403,7 +2403,7 @@ public:
 	  << " offset: " << tgt_offset << std::endl;
 
     op.set_chunk(offset, length, context->low_tier_io_ctx, 
-		 context->prefix+target_oid, tgt_offset, CEPH_OSD_OP_FLAG_WITH_REFERENCE);
+		 target_oid, tgt_offset, CEPH_OSD_OP_FLAG_WITH_REFERENCE);
 
     pair<TestOp*, TestOp::CallbackInfo*> *cb_arg =
       new pair<TestOp*, TestOp::CallbackInfo*>(this,

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -64,7 +64,8 @@ enum TestOpType {
   TEST_OP_UNSET_REDIRECT,
   TEST_OP_CHUNK_READ,
   TEST_OP_TIER_PROMOTE,
-  TEST_OP_TIER_FLUSH
+  TEST_OP_TIER_FLUSH,
+  TEST_OP_SET_CHUNK
 };
 
 class TestWatchContext : public librados::WatchCtx2 {
@@ -166,6 +167,7 @@ public:
   set<string> oid_not_flushing;
   set<string> oid_redirect_not_in_use;
   set<string> oid_redirect_in_use;
+  set<string> oid_set_chunk_tgt_pool;
   SharedPtrRegistry<int, int> snaps_in_use;
   int current_snap;
   string pool_name;
@@ -2375,6 +2377,7 @@ public:
     }
 
     if (++done == 1) {
+      context->oid_set_chunk_tgt_pool.insert(oid_tgt);
       context->oid_in_use.erase(oid);
       context->oid_not_in_use.insert(oid);
       context->kick();

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -2954,6 +2954,8 @@ public:
     cout << num << ":  got " << cpp_strerror(r) << std::endl;
     if (r == 0) {
       // sucess
+      context->update_object_tier_flushed(oid, snap);
+      context->update_object_version(oid, completion->get_version64(), snap);
     } else if (r == -EBUSY) {
       // could fail if snap is not oldest
       ceph_assert(!context->check_oldest_snap_flushed(oid, snap)); 
@@ -2971,8 +2973,6 @@ public:
       }	
       ceph_abort_msg("shouldn't happen");
     }
-    context->update_object_tier_flushed(oid, snap);
-    context->update_object_version(oid, completion->get_version64(), snap);
     context->oid_in_use.erase(oid);
     context->oid_not_in_use.insert(oid);
     context->kick();

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -2287,12 +2287,10 @@ public:
 
 class SetChunkOp : public TestOp {
 public:
-  string oid, oid_tgt, tgt_pool_name;
+  string oid, oid_tgt;
   ObjectDesc src_value, tgt_value;
   librados::ObjectReadOperation op;
-  librados::ObjectReadOperation rd_op;
   librados::AioCompletion *comp;
-  std::shared_ptr<int> in_use;
   int done;
   int r;
   uint64_t offset;
@@ -2304,11 +2302,10 @@ public:
 	     uint64_t offset,
 	     uint32_t length,
 	     const string &oid_tgt,
-	     const string &tgt_pool_name,
 	     uint64_t tgt_offset,
 	     TestOpStat *stat = 0)
     : TestOp(n, context, stat),
-      oid(oid), oid_tgt(oid_tgt), tgt_pool_name(tgt_pool_name),
+      oid(oid), oid_tgt(oid_tgt),
       comp(NULL), done(0), 
       r(0), offset(offset), length(length), 
       tgt_offset(tgt_offset)
@@ -2319,8 +2316,6 @@ public:
     std::lock_guard l{context->state_lock};
     context->oid_in_use.insert(oid);
     context->oid_not_in_use.erase(oid);
-
-    if (tgt_pool_name.empty()) ceph_abort();
 
     context->find_object(oid, &src_value); 
     context->find_object(oid_tgt, &tgt_value);

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -2957,9 +2957,18 @@ public:
     } else if (r == -EBUSY) {
       // could fail if snap is not oldest
       ceph_assert(!context->check_oldest_snap_flushed(oid, snap)); 
-    } else if (r == -ENOENT && src_value.deleted()) {
+    } else if (r == -ENOENT) {
       // could fail if object is removed
+      if (src_value.deleted()) {
+	cout << num << ":  got expected ENOENT (src dne)" << std::endl;
+      } else {
+	cerr << num << ": got unexpected ENOENT" << std::endl;
+	ceph_abort();
+      }
     } else {
+      if (r != -ENOENT && src_value.deleted()) {
+	cerr << num << ": src dne, but r is not ENOENT" << std::endl;
+      }	
       ceph_abort_msg("shouldn't happen");
     }
     context->update_object_tier_flushed(oid, snap);
@@ -3052,12 +3061,21 @@ public:
     if (r == 0) {
       // ok
     } else if (r == -EINVAL) {
-      // modifying manifeset object makes existing chunk_map clear
+      // modifying manifest object makes existing chunk_map clear
       // as a result, the modified object is no longer manifest object 
       // this casues to return -EINVAL
-    } else if (r == -ENOENT && src_value.deleted()) {
+    } else if (r == -ENOENT) {
       // could fail if object is removed
+      if (src_value.deleted()) {
+	cout << num << ":  got expected ENOENT (src dne)" << std::endl;
+      } else {
+	cerr << num << ": got unexpected ENOENT" << std::endl;
+	ceph_abort();
+      }
     } else {
+      if (r != -ENOENT && src_value.deleted()) {
+	cerr << num << ": src dne, but r is not ENOENT" << std::endl;
+      }	
       ceph_abort_msg("shouldn't happen");
     }
     context->oid_in_use.erase(oid);

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -3004,7 +3004,9 @@ public:
     if (r == 0) {
       // ok
     } else if (r == -EINVAL) {
-      // probably this is not manifest object 
+      // modifying manifeset object makes existing chunk_map clear
+      // as a result, the modified object is no longer manifest object 
+      // this casues to return -EINVAL
     } else if (r == -ENOENT) {
       // may have raced with a remove?
     } else {

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -660,7 +660,6 @@ public:
 
       for (const auto & i : result) {
 	auto oid = i.oid;
-	cout << oid << std::endl;
 	chunk_refs_t refs;
 	{
 	  bufferlist t;

--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -15,7 +15,6 @@
 
 #include "test/osd/RadosModel.h"
 
-
 using namespace std;
 
 class WeightedTestGenerator : public TestOpGenerator
@@ -716,6 +715,12 @@ int main(int argc, char **argv)
     exit(1);
   }
   context.loop(&gen);
+  if (enable_dedup) {
+    if (!context.check_chunks_refcount(context.low_tier_io_ctx, context.io_ctx)) {
+      cerr << " Invalid refcount " << std::endl;
+      exit(1);
+    }
+  }
 
   context.shutdown();
   cerr << context.errors << " errors." << std::endl;

--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -449,14 +449,12 @@ private:
       {
 	ceph_assert(m_enable_dedup);
 	oid = *(rand_choose(context.oid_not_in_use));
-	/* The intention here is to mark the source object as a manifest object */
-	oid2 = *(rand_choose(context.oid_set_chunk_tgt_pool));
 	uint32_t rand_offset = 0, rand_length = 0;
 	get_rand_off_len(context, oid, rand_offset, rand_length);
 	cout << m_op << ": " << "set_chunk oid " << oid << " offset: " << rand_offset 
-	     << " length: " << rand_length <<  " target oid " << oid2 
+	     << " length: " << rand_length <<  " target oid " << ""
 	     << " tgt_offset: " << rand_offset << std::endl;
-	return new SetChunkOp(m_op, &context, oid, rand_offset, rand_length, oid2, rand_offset, m_stats);
+	return new SetChunkOp(m_op, &context, oid, rand_offset, rand_length, "", rand_offset, m_stats);
       }
 
     case TEST_OP_TIER_EVICT:

--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -224,17 +224,9 @@ public:
 	  oid2 << " " << string(300, 'm');
 	}
 
-	/* make a chunk (random offset, random length --> 
-	 * target object's random offset)
-	 */
-	uint32_t rand_offset = 0, rand_length = 0;
-	get_rand_off_len(context, oid.str(), rand_offset, rand_length);
-	uint32_t rand_tgt_offset = rand_offset;
-	cout << m_op << ": " << "set_chunk oid " << oid.str() << " offset: " << rand_offset 
-	     << " length: " << rand_length <<  " target oid " << oid2.str() 
-	     << " tgt_offset: " << rand_tgt_offset << std::endl;
-	op = new SetChunkOp(m_op, &context, oid.str(), rand_offset, rand_length, oid2.str(), 
-			    rand_tgt_offset, m_stats);
+	cout << m_op << ": " << "set_chunk oid " << oid.str() 
+	     <<  " target oid " << oid2.str()  << std::endl;
+	op = new SetChunkOp(m_op, &context, oid.str(), oid2.str(), m_stats);
 	return true;
       }
     } else if (m_op == make_manifest_end + 1) {
@@ -260,23 +252,6 @@ public:
     } 
 
     return false;
-  }
-
-  void get_rand_off_len(RadosTestContext &context, string oid, uint32_t &rand_offset, uint32_t &rand_length) {
-    ObjectDesc contents;
-    context.find_object(oid, &contents);
-    uint32_t max_len = contents.most_recent_gen()->get_length(contents.most_recent());
-    rand_offset = rand() % max_len;
-    rand_length = rand() % max_len;
-    rand_offset = rand_offset - (rand_offset % 512);
-    rand_length = rand_length - (rand_length % 512);
-
-    while (rand_offset + rand_length > max_len || rand_length == 0) {
-      rand_offset = rand() % max_len;
-      rand_length = rand() % max_len;
-      rand_offset = rand_offset - (rand_offset % 512);
-      rand_length = rand_length - (rand_length % 512);
-    }
   }
 
 private:
@@ -449,12 +424,9 @@ private:
       {
 	ceph_assert(m_enable_dedup);
 	oid = *(rand_choose(context.oid_not_in_use));
-	uint32_t rand_offset = 0, rand_length = 0;
-	get_rand_off_len(context, oid, rand_offset, rand_length);
-	cout << m_op << ": " << "set_chunk oid " << oid << " offset: " << rand_offset 
-	     << " length: " << rand_length <<  " target oid " << ""
-	     << " tgt_offset: " << rand_offset << std::endl;
-	return new SetChunkOp(m_op, &context, oid, rand_offset, rand_length, "", rand_offset, m_stats);
+	cout << m_op << ": " << "set_chunk oid " << oid 
+	     <<  " target oid " << std::endl;
+	return new SetChunkOp(m_op, &context, oid, "", m_stats);
       }
 
     case TEST_OP_TIER_EVICT:

--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -246,7 +246,7 @@ public:
 	     << " length: " << rand_length <<  " target oid " << oid2.str() 
 	     << " tgt_offset: " << rand_tgt_offset << std::endl;
 	op = new SetChunkOp(m_op, &context, oid.str(), rand_offset, rand_length, oid2.str(), 
-			      context.low_tier_pool_name, rand_tgt_offset, m_stats);
+			    rand_tgt_offset, m_stats);
 	return true;
       }
     } else if (m_op == make_manifest_end + 1) {

--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -459,6 +459,11 @@ private:
 	return new SetChunkOp(m_op, &context, oid, rand_offset, rand_length, oid2, rand_offset, m_stats);
       }
 
+    case TEST_OP_TIER_EVICT:
+      oid = *(rand_choose(context.oid_not_in_use));
+      cout << m_op << ": " << "tier_evict oid " << oid << std::endl;
+      return new TierEvictOp(m_op, &context, oid, m_stats);
+
     default:
       cerr << m_op << ": Invalid op type " << type << std::endl;
       ceph_abort();
@@ -525,6 +530,7 @@ int main(int argc, char **argv)
     { TEST_OP_TIER_PROMOTE, "tier_promote", true },
     { TEST_OP_TIER_FLUSH, "tier_flush", true },
     { TEST_OP_SET_CHUNK, "set_chunk", true },
+    { TEST_OP_TIER_EVICT, "tier_evict", true },
     { TEST_OP_READ /* grr */, NULL },
   };
 


### PR DESCRIPTION
This PR is what we've planed here (https://docs.ceph.com/en/latest/dev/osd_internals/manifest/).
The purpose of this PR is to rework and add manifest ops tests based on current 
snapshot and flush scheme.

Signed-off-by: Myoungwon Oh <myoungwon.oh@samsung.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
