### PR TITLE
osd: fix to call nullptr when cancel_manifest_ops

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3283,7 +3283,9 @@ struct C_SetManifestRefCountDone : public Context {
       // raced with cancel_manifest_ops
       return;
     }
-    it->second->cb->complete(r);
+    if (it->second->cb) {
+      it->second->cb->complete(r);
+    }
     pg->manifest_ops.erase(it);
     mop.reset();
   }
@@ -3322,8 +3324,10 @@ void PrimaryLogPG::cancel_manifest_ops(bool requeue, vector<ceph_tid_t> *tids)
       tids->push_back(mop->objecter_tid);
       mop->objecter_tid = 0;
     }
-    mop->cb->set_requeue(requeue);
-    mop->cb->complete(-ECANCELED);
+    if (mop->cb) {
+      mop->cb->set_requeue(requeue);
+      mop->cb->complete(-ECANCELED);
+    }
     manifest_ops.erase(p++);
   }
 }


### PR DESCRIPTION
Segmentation fault can occur because
cancel_manifest_ops must call callback without checking
nullptr even though ManifestOp can be used with null callback
in start_dedup()

fixes: https://tracker.ceph.com/issues/48745

Signed-off-by: Myoungwon Oh <myoungwon.oh@samsumg.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
