### PR TITLE
pacific: mgr: update mon metadata when monmap is updated

### DIFF
--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -521,6 +521,16 @@ void Mgr::handle_mon_map()
       names_exist.insert(monmap.get_name(i));
     }
   });
+  for (const auto& name : names_exist) {
+    const auto k = DaemonKey{"osd", name};
+    if (daemon_state.is_updating(k)) {
+      continue;
+    }
+    auto c = new MetadataUpdate(daemon_state, k);
+    const char* cmd = R"(P{{"prefix": "mon metadata", "id": "{}"}})";
+    monc->start_mon_command({fmt::format(cmd, name)}, {},
+			    &c->outbl, &c->outs, c);
+  }
   daemon_state.cull("mon", names_exist);
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49006

---

backport of https://github.com/ceph/ceph/pull/38932
parent tracker: https://tracker.ceph.com/issues/48905

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh