### PR TITLE
pacific: ceph-volume: Fix usage of is_lv

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -760,7 +760,7 @@ def get_devices(_sys_block_path='/sys/block'):
 
         # If the mapper device is a logical volume it gets excluded
         if is_mapper_device(diskname):
-            if lvm.is_lv(diskname):
+            if lvm.get_device_lvs(diskname):
                 continue
 
         # all facts that have no defaults


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49095

---

backport of https://github.com/ceph/ceph/pull/38869
parent tracker: https://tracker.ceph.com/issues/48784

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh