### PR TITLE
[RFC] mgr/cephadm: Add ServiceType and DaemonType

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -6,9 +6,9 @@ from typing import cast, TYPE_CHECKING, Dict, List, Iterator, Optional, Any, Tup
 
 import orchestrator
 from ceph.deployment import inventory
-from ceph.deployment.service_spec import ServiceSpec
+from ceph.deployment.service_spec import ServiceSpec, ServiceType
 from ceph.utils import str_to_datetime, datetime_to_str, datetime_now
-from orchestrator import OrchestratorError, HostSpec, OrchestratorEvent
+from orchestrator import OrchestratorError, HostSpec, OrchestratorEvent, DaemonType
 
 if TYPE_CHECKING:
     from .module import CephadmOrchestrator
@@ -452,6 +452,10 @@ class HostCache():
                     result.append(d)
         return result
 
+    def get_daemons_by_service_type(self, service_type: ServiceType) -> List[orchestrator.DaemonDescription]:
+        # type save version of get_daemons_by_service()
+        return self.get_daemons_by_service(str(service_type))
+
     def get_daemons_by_type(self, service_type):
         # type: (str) -> List[orchestrator.DaemonDescription]
         assert service_type not in ['keepalived', 'haproxy']
@@ -463,7 +467,7 @@ class HostCache():
                     result.append(d)
         return result
 
-    def get_daemon_types(self, hostname: str) -> List[str]:
+    def get_daemon_types(self, hostname: str) -> List[DaemonType]:
         """Provide a list of the types of daemons on the host"""
         result = set()
         for _d, dm in self.daemons[hostname].items():

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1927,10 +1927,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                                              forcename=name)
 
             if not did_config and config_func:
-                if daemon_type == 'rgw':
-                    config_func(spec, daemon_id)
-                else:
-                    config_func(spec)
+                config_func(spec, daemon_id)
                 did_config = True
 
             daemon_spec = self.cephadm_services[daemon_type_to_service(daemon_type)].make_daemon_spec(

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1459,7 +1459,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         self._kick_serve_loop()
 
     @trivial_completion
-    def describe_service(self, service_type: Optional[str] = None, service_name: Optional[str] = None,
+    def describe_service(self, service_type: Optional[ServiceType] = None, service_name: Optional[str] = None,
                          refresh: bool = False) -> List[orchestrator.ServiceDescription]:
         if refresh:
             self._invalidate_daemons_and_kick_serve()
@@ -1559,7 +1559,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
     @trivial_completion
     def list_daemons(self,
                      service_name: Optional[str] = None,
-                     daemon_type: Optional[str] = None,
+                     daemon_type: Optional[DaemonType] = None,
                      daemon_id: Optional[str] = None,
                      host: Optional[str] = None,
                      refresh: bool = False) -> List[orchestrator.DaemonDescription]:

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -553,7 +553,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         """
         Generate a unique random service name
         """
-        suffix = daemon_type not in [
+        suffix = daemon_type.value not in [
             'mon', 'crash', 'nfs',
             'prometheus', 'node-exporter', 'grafana', 'alertmanager',
             'container', 'cephadm-exporter',
@@ -561,7 +561,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         if forcename:
             if len([d for d in existing if d.daemon_id == forcename]):
                 raise orchestrator.OrchestratorValidationError(
-                    f'name {daemon_type}.{forcename} already in use')
+                    f'name {daemon_type.value}.{forcename} already in use')
             return forcename
 
         if '.' in host:
@@ -578,7 +578,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             if len([d for d in existing if d.daemon_id == name]):
                 if not suffix:
                     raise orchestrator.OrchestratorValidationError(
-                        f'name {daemon_type}.{name} already in use')
+                        f'name {daemon_type.value}.{name} already in use')
                 self.log.debug('name %s exists, trying again', name)
                 continue
             return name

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1897,7 +1897,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         Add (and place) a daemon. Require explicit host placement.  Do not
         schedule, and do not apply the related scheduling limitations.
         """
-        self.log.debug('_add_daemon %s spec %s' % (daemon_type, spec.placement))
+        self.log.debug('_add_daemon %s spec %s' % (daemon_type.value, spec.placement))
         if not spec.placement.hosts:
             raise OrchestratorError('must specify host(s) to deploy on')
         count = spec.placement.count or len(spec.placement.hosts)

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -3,7 +3,8 @@ import random
 from typing import List, Optional, Callable, Iterable, TypeVar, Set
 
 import orchestrator
-from ceph.deployment.service_spec import PlacementSpec, HostPlacementSpec, ServiceSpec
+from ceph.deployment.service_spec import PlacementSpec, HostPlacementSpec, ServiceSpec, \
+    ServiceType
 from orchestrator._interface import DaemonDescription
 from orchestrator import OrchestratorValidationError
 
@@ -123,13 +124,13 @@ class HostAssignment(object):
         if count is None:
             logger.debug('Provided hosts: %s' % candidates)
             # if asked to place even number of mons, deploy 1 less
-            if self.spec.service_type == 'mon' and (len(candidates) % 2) == 0:
+            if self.spec.service_type == ServiceType.mon and (len(candidates) % 2) == 0:
                 logger.info("deploying %s monitor(s) instead of %s so monitors may achieve consensus" % (
                     len(candidates) - 1, len(candidates)))
                 return candidates[0:len(candidates)-1]
 
             # do not deploy ha-rgw on hosts that don't support virtual ips
-            if self.spec.service_type == 'ha-rgw' and self.filter_new_host:
+            if self.spec.service_type == ServiceType.ha_rgw and self.filter_new_host:
                 old = candidates
                 candidates = [h for h in candidates if self.filter_new_host(h.hostname)]
                 for h in list(set(old) - set(candidates)):
@@ -139,7 +140,7 @@ class HostAssignment(object):
             return candidates
 
         # if asked to place even number of mons, deploy 1 less
-        if self.spec.service_type == 'mon':
+        if self.spec.service_type == ServiceType.mon:
             # if count >= number of candidates then number of candidates
             # is determining factor in how many mons will be placed
             if count >= len(candidates):
@@ -178,7 +179,7 @@ class HostAssignment(object):
                 old = others
                 others = [h for h in others if self.filter_new_host(h.hostname)]
                 for h in list(set(old) - set(others)):
-                    if self.spec.service_type == 'ha-rgw':
+                    if self.spec.service_type == ServiceType.ha_rgw:
                         logger.info(
                             f"Filtered out host {h.hostname} for ha-rgw. Could not verify host allowed virtual ips")
                 logger.info('filtered %s down to %s' % (old, others))

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -252,7 +252,7 @@ class CephadmServe:
                 v = d.get(k, None)
                 if v:
                     setattr(sd, k, str_to_datetime(d[k]))
-            sd.daemon_type = d['name'].split('.')[0]
+            sd.daemon_type = DaemonType(d['name'].split('.')[0])
             sd.daemon_id = '.'.join(d['name'].split('.')[1:])
             sd.hostname = host
             sd.container_id = d.get('container_id')
@@ -544,7 +544,7 @@ class CephadmServe:
                     r = True
                 except (RuntimeError, OrchestratorError) as e:
                     self.mgr.events.for_service(spec, 'ERROR',
-                                                f"Failed while placing {daemon_type}.{daemon_id}"
+                                                f"Failed while placing {daemon_type.value}.{daemon_id}"
                                                 f"on {host}: {e}")
                     # only return "no change" if no one else has already succeeded.
                     # later successes will also change to True

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -447,7 +447,7 @@ class CephadmServe:
 
         config_func = self._config_fn(service_type)
 
-        if service_type == 'osd':
+        if service_type == ServiceType.osd:
             self.mgr.osd_service.create_from_spec(cast(DriveGroupSpec, spec))
             # TODO: return True would result in a busy loop
             # can't know if daemon count changed; create_from_spec doesn't
@@ -457,7 +457,7 @@ class CephadmServe:
         daemons = self.mgr.cache.get_daemons_by_service(service_name)
 
         public_network = None
-        if service_type == 'mon':
+        if service_type == ServiceType.mon:
             ret, out, err = self.mgr.check_mon_command({
                 'prefix': 'config get',
                 'who': 'mon',

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -113,7 +113,7 @@ class CephadmService(metaclass=ABCMeta):
         raise NotImplementedError()
 
     def config(self, spec: ServiceSpec, daemon_id: str) -> None:
-        raise NotImplementedError()
+        assert spec.service_type.value == self.TYPE
 
     def daemon_check_post(self, daemon_descrs: List[DaemonDescription]) -> None:
         """The post actions needed to be done after daemons are checked"""
@@ -261,7 +261,7 @@ class CephadmService(metaclass=ABCMeta):
         Called before the daemon is removed.
         """
         assert daemon.daemon_type is not None
-        assert self.TYPE == daemon_type_to_service(daemon.daemon_type)
+        assert self.TYPE == daemon_type_to_service(daemon.daemon_type).value
         logger.debug(f'Pre remove daemon {self.TYPE}.{daemon.daemon_id}')
 
     def post_remove(self, daemon: DaemonDescription) -> None:
@@ -269,7 +269,7 @@ class CephadmService(metaclass=ABCMeta):
         Called after the daemon is removed.
         """
         assert daemon.daemon_type is not None
-        assert self.TYPE == daemon_type_to_service(daemon.daemon_type)
+        assert self.TYPE == daemon_type_to_service(daemon.daemon_type).value
         logger.debug(f'Post remove daemon {self.TYPE}.{daemon.daemon_id}')
 
     def purge(self) -> None:
@@ -366,7 +366,7 @@ class MonService(CephService):
         """
         Create a new monitor on the given host.
         """
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         name, host, network = daemon_spec.daemon_id, daemon_spec.host, daemon_spec.network
 
         # get mon. key
@@ -455,7 +455,7 @@ class MgrService(CephService):
         """
         Create a new manager instance on a host.
         """
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         mgr_id, host = daemon_spec.daemon_id, daemon_spec.host
 
         # get mgr. key
@@ -530,7 +530,7 @@ class MdsService(CephService):
     TYPE = 'mds'
 
     def config(self, spec: ServiceSpec, daemon_id: str) -> None:
-        assert self.TYPE == spec.service_type
+        assert self.TYPE == spec.service_type.value
         assert spec.service_id
 
         # ensure mds_join_fs is set for these daemons
@@ -542,7 +542,7 @@ class MdsService(CephService):
         })
 
     def prepare_create(self, daemon_spec: CephadmDaemonSpec) -> CephadmDaemonSpec:
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         mds_id, host = daemon_spec.daemon_id, daemon_spec.host
 
         # get mgr. key
@@ -577,7 +577,7 @@ class RgwService(CephService):
     TYPE = 'rgw'
 
     def config(self, spec: RGWSpec, rgw_id: str) -> None:  # type: ignore
-        assert self.TYPE == spec.service_type
+        assert self.TYPE == spec.service_type.value
 
         # create realm, zonegroup, and zone if needed
         self.create_realm_zonegroup_zone(spec, rgw_id)
@@ -637,7 +637,7 @@ class RgwService(CephService):
         self.mgr.spec_store.save(spec)
 
     def prepare_create(self, daemon_spec: CephadmDaemonSpec) -> CephadmDaemonSpec:
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         rgw_id, host = daemon_spec.daemon_id, daemon_spec.host
 
         keyring = self.get_keyring(rgw_id)
@@ -777,7 +777,7 @@ class RbdMirrorService(CephService):
     TYPE = 'rbd-mirror'
 
     def prepare_create(self, daemon_spec: CephadmDaemonSpec) -> CephadmDaemonSpec:
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         daemon_id, host = daemon_spec.daemon_id, daemon_spec.host
 
         ret, keyring, err = self.mgr.check_mon_command({
@@ -796,7 +796,7 @@ class CrashService(CephService):
     TYPE = 'crash'
 
     def prepare_create(self, daemon_spec: CephadmDaemonSpec) -> CephadmDaemonSpec:
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         daemon_id, host = daemon_spec.daemon_id, daemon_spec.host
 
         ret, keyring, err = self.mgr.check_mon_command({
@@ -895,7 +895,7 @@ class CephadmExporter(CephadmService):
     TYPE = 'cephadm-exporter'
 
     def prepare_create(self, daemon_spec: CephadmDaemonSpec) -> CephadmDaemonSpec:
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
 
         cfg = CephadmExporterConfig(self.mgr)
         cfg.load_from_store()
@@ -916,7 +916,7 @@ class CephadmExporter(CephadmService):
         return daemon_spec
 
     def generate_config(self, daemon_spec: CephadmDaemonSpec) -> Tuple[Dict[str, Any], List[str]]:
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         assert daemon_spec.spec
         deps: List[str] = []
 

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -12,7 +12,7 @@ from mgr_module import HandleCommandResult, MonCommandFailed
 
 from ceph.deployment.service_spec import ServiceSpec, RGWSpec
 from ceph.deployment.utils import is_ipv6, unwrap_ipv6
-from orchestrator import OrchestratorError, DaemonDescription
+from orchestrator import OrchestratorError, DaemonDescription, DaemonType
 from orchestrator._interface import daemon_type_to_service, service_to_daemon_types
 from cephadm import utils
 from mgr_util import create_self_signed_cert, ServerConfigException, verify_tls
@@ -35,7 +35,7 @@ class CephadmDaemonSpec(Generic[ServiceSpecs]):
                  extra_args: Optional[List[str]] = None,
                  ceph_conf: str = '',
                  extra_files: Optional[Dict[str, Any]] = None,
-                 daemon_type: Optional[str] = None,
+                 daemon_type: Optional[DaemonType] = None,
                  ports: Optional[List[int]] = None,):
         """
         Used for
@@ -46,9 +46,10 @@ class CephadmDaemonSpec(Generic[ServiceSpecs]):
         """
         self.host: str = host
         self.daemon_id = daemon_id
+
         daemon_type = daemon_type or (spec.service_type if spec else None)
         assert daemon_type is not None
-        self.daemon_type: str = daemon_type
+        self.daemon_type: DaemonType = daemon_type  # type: ignore
 
         # would be great to have the spec always available:
         self.spec: Optional[ServiceSpecs] = spec
@@ -96,7 +97,7 @@ class CephadmService(metaclass=ABCMeta):
                          daemon_id: str,
                          netowrk: str,
                          spec: ServiceSpecs,
-                         daemon_type: Optional[str] = None,) -> CephadmDaemonSpec:
+                         daemon_type: Optional[DaemonType] = None,) -> CephadmDaemonSpec:
         return CephadmDaemonSpec(
             host=host,
             daemon_id=daemon_id,
@@ -315,7 +316,7 @@ class CephService(CephadmService):
             raise OrchestratorError("unknown daemon type")
 
     def get_config_and_keyring(self,
-                               daemon_type: str,
+                               daemon_type: DaemonType,
                                daemon_id: str,
                                host: str,
                                keyring: Optional[str] = None,

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -70,7 +70,7 @@ class CephadmDaemonSpec(Generic[ServiceSpecs]):
         self.ports:  List[int] = ports or []
 
     def name(self) -> str:
-        return '%s.%s' % (self.daemon_type, self.daemon_id)
+        return '%s.%s' % (self.daemon_type.value, self.daemon_id)
 
     def config_get_files(self) -> Dict[str, Any]:
         files = self.extra_files

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -111,6 +111,9 @@ class CephadmService(metaclass=ABCMeta):
     def generate_config(self, daemon_spec: CephadmDaemonSpec) -> Tuple[Dict[str, Any], List[str]]:
         raise NotImplementedError()
 
+    def config(self, spec: ServiceSpec, daemon_id: str) -> None:
+        raise NotImplementedError()
+
     def daemon_check_post(self, daemon_descrs: List[DaemonDescription]) -> None:
         """The post actions needed to be done after daemons are checked"""
         if self.mgr.config_dashboard:
@@ -525,7 +528,7 @@ class MgrService(CephService):
 class MdsService(CephService):
     TYPE = 'mds'
 
-    def config(self, spec: ServiceSpec) -> None:
+    def config(self, spec: ServiceSpec, daemon_id: str) -> None:
         assert self.TYPE == spec.service_type
         assert spec.service_id
 
@@ -572,7 +575,7 @@ class MdsService(CephService):
 class RgwService(CephService):
     TYPE = 'rgw'
 
-    def config(self, spec: RGWSpec, rgw_id: str) -> None:
+    def config(self, spec: RGWSpec, rgw_id: str) -> None:  # type: ignore
         assert self.TYPE == spec.service_type
 
         # create realm, zonegroup, and zone if needed

--- a/src/pybind/mgr/cephadm/services/container.py
+++ b/src/pybind/mgr/cephadm/services/container.py
@@ -13,12 +13,12 @@ class CustomContainerService(CephadmService):
 
     def prepare_create(self, daemon_spec: CephadmDaemonSpec[CustomContainerSpec]) \
             -> CephadmDaemonSpec:
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         return daemon_spec
 
     def generate_config(self, daemon_spec: CephadmDaemonSpec[CustomContainerSpec]) \
             -> Tuple[Dict[str, Any], List[str]]:
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         assert daemon_spec.spec
         deps: List[str] = []
         spec: CustomContainerSpec = daemon_spec.spec

--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -16,7 +16,7 @@ class IscsiService(CephService):
     TYPE = 'iscsi'
 
     def config(self, spec: IscsiServiceSpec, daemon_id: str) -> None:  # type: ignore
-        assert self.TYPE == spec.service_type
+        assert self.TYPE == spec.service_type.value
         assert spec.pool
         self.mgr._check_pool_exists(spec.pool, spec.service_name())
 
@@ -25,7 +25,7 @@ class IscsiService(CephService):
         self.mgr.spec_store.save(spec)
 
     def prepare_create(self, daemon_spec: CephadmDaemonSpec[IscsiServiceSpec]) -> CephadmDaemonSpec:
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         assert daemon_spec.spec
 
         spec = daemon_spec.spec

--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class IscsiService(CephService):
     TYPE = 'iscsi'
 
-    def config(self, spec: IscsiServiceSpec) -> None:
+    def config(self, spec: IscsiServiceSpec, daemon_id: str) -> None:  # type: ignore
         assert self.TYPE == spec.service_type
         assert spec.pool
         self.mgr._check_pool_exists(spec.pool, spec.service_name())

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -18,11 +18,11 @@ class GrafanaService(CephadmService):
     DEFAULT_SERVICE_PORT = 3000
 
     def prepare_create(self, daemon_spec: CephadmDaemonSpec) -> CephadmDaemonSpec:
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         return daemon_spec
 
     def generate_config(self, daemon_spec: CephadmDaemonSpec) -> Tuple[Dict[str, Any], List[str]]:
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         deps = []  # type: List[str]
 
         prom_services = []  # type: List[str]
@@ -95,12 +95,12 @@ class AlertmanagerService(CephadmService):
     DEFAULT_SERVICE_PORT = 9093
 
     def prepare_create(self, daemon_spec: CephadmDaemonSpec[AlertManagerSpec]) -> CephadmDaemonSpec:
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         assert daemon_spec.spec
         return daemon_spec
 
     def generate_config(self, daemon_spec: CephadmDaemonSpec[AlertManagerSpec]) -> Tuple[Dict[str, Any], List[str]]:
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         deps: List[str] = []
         default_webhook_urls: List[str] = []
 
@@ -186,11 +186,11 @@ class PrometheusService(CephadmService):
     DEFAULT_SERVICE_PORT = 9095
 
     def prepare_create(self, daemon_spec: CephadmDaemonSpec) -> CephadmDaemonSpec:
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         return daemon_spec
 
     def generate_config(self, daemon_spec: CephadmDaemonSpec) -> Tuple[Dict[str, Any], List[str]]:
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         deps = []  # type: List[str]
 
         # scrape mgrs
@@ -289,11 +289,11 @@ class NodeExporterService(CephadmService):
     TYPE = 'node-exporter'
 
     def prepare_create(self, daemon_spec: CephadmDaemonSpec) -> CephadmDaemonSpec:
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         return daemon_spec
 
     def generate_config(self, daemon_spec: CephadmDaemonSpec) -> Tuple[Dict[str, Any], List[str]]:
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         return {}, []
 
     def ok_to_stop(self, daemon_ids: List[str], force: bool = False) -> HandleCommandResult:

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class NFSService(CephService):
     TYPE = 'nfs'
 
-    def config(self, spec: NFSServiceSpec) -> None:
+    def config(self, spec: NFSServiceSpec, daemon_id: str) -> None:  # type: ignore
         assert self.TYPE == spec.service_type
         assert spec.pool
         self.mgr._check_pool_exists(spec.pool, spec.service_name())

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -19,7 +19,7 @@ class NFSService(CephService):
     TYPE = 'nfs'
 
     def config(self, spec: NFSServiceSpec, daemon_id: str) -> None:  # type: ignore
-        assert self.TYPE == spec.service_type
+        assert self.TYPE == spec.service_type.value
         assert spec.pool
         self.mgr._check_pool_exists(spec.pool, spec.service_name())
 
@@ -28,7 +28,7 @@ class NFSService(CephService):
         self.mgr.spec_store.save(spec)
 
     def prepare_create(self, daemon_spec: CephadmDaemonSpec[NFSServiceSpec]) -> CephadmDaemonSpec:
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         assert daemon_spec.spec
 
         daemon_id = daemon_spec.daemon_id
@@ -40,7 +40,7 @@ class NFSService(CephService):
         return daemon_spec
 
     def generate_config(self, daemon_spec: CephadmDaemonSpec[NFSServiceSpec]) -> Tuple[Dict[str, Any], List[str]]:
-        assert self.TYPE == daemon_spec.daemon_type
+        assert self.TYPE == daemon_spec.daemon_type.value
         assert daemon_spec.spec
 
         daemon_type = daemon_spec.daemon_type

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -7,6 +7,7 @@ from ceph.deployment import translate
 from ceph.deployment.drive_group import DriveGroupSpec
 from ceph.deployment.drive_selection import DriveSelection
 from ceph.deployment.inventory import Device
+from ceph.deployment.service_spec import ServiceType
 from ceph.utils import datetime_to_str, str_to_datetime
 
 from datetime import datetime
@@ -238,7 +239,7 @@ class OSDService(CephService):
         self.mgr.log.debug(f"Finding OSDSpecs for host: <{host}>")
         if not specs:
             specs = [cast(DriveGroupSpec, spec) for (sn, spec) in self.mgr.spec_store.spec_preview.items()
-                     if spec.service_type == 'osd']
+                     if spec.service_type == ServiceType.osd]
         for spec in specs:
             if host in spec.placement.filter_matching_hostspecs(self.mgr.inventory.all_specs()):
                 self.mgr.log.debug(f"Found OSDSpecs for host: <{host}> -> <{spec}>")

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -13,7 +13,7 @@ from datetime import datetime
 import orchestrator
 from cephadm.serve import CephadmServe
 from cephadm.utils import forall_hosts
-from orchestrator import OrchestratorError
+from orchestrator import OrchestratorError, DaemonType
 from mgr_module import MonCommandFailed
 
 from cephadm.services.cephadmservice import CephadmDaemonSpec, CephService
@@ -106,7 +106,7 @@ class OSDService(CephService):
                 daemon_spec: CephadmDaemonSpec = CephadmDaemonSpec(
                     daemon_id=osd_id,
                     host=host,
-                    daemon_type='osd',
+                    daemon_type=DaemonType.osd,
                 )
                 CephadmServe(self.mgr)._create_daemon(
                     daemon_spec,

--- a/src/pybind/mgr/cephadm/tests/test_migration.py
+++ b/src/pybind/mgr/cephadm/tests/test_migration.py
@@ -2,7 +2,8 @@ import json
 
 import pytest
 
-from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, HostPlacementSpec
+from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, HostPlacementSpec, \
+    ServiceType
 from ceph.utils import datetime_to_str, datetime_now
 from cephadm import CephadmOrchestrator
 from cephadm.inventory import SPEC_STORE_PREFIX
@@ -20,7 +21,7 @@ def test_migrate_scheduler(cephadm_module: CephadmOrchestrator):
 
             # emulate the old scheduler:
             c = cephadm_module.apply_rgw(
-                ServiceSpec('rgw', 'r.z', placement=PlacementSpec(host_pattern='*', count=2))
+                ServiceSpec(ServiceType.rgw, 'r.z', placement=PlacementSpec(host_pattern='*', count=2))
             )
             assert wait(cephadm_module, c) == 'Scheduled rgw.r.z update...'
 
@@ -41,7 +42,7 @@ def test_migrate_scheduler(cephadm_module: CephadmOrchestrator):
             assert out == {'host1', 'host2'}
 
             c = cephadm_module.apply_rgw(
-                ServiceSpec('rgw', 'r.z', placement=PlacementSpec(host_pattern='host1', count=2))
+                ServiceSpec(ServiceType.rgw, 'r.z', placement=PlacementSpec(host_pattern='host1', count=2))
             )
             assert wait(cephadm_module, c) == 'Scheduled rgw.r.z update...'
 
@@ -86,7 +87,7 @@ def test_migrate_service_id_mon_one(cephadm_module: CephadmOrchestrator):
 
         assert len(cephadm_module.spec_store.specs) == 1
         assert cephadm_module.spec_store.specs['mon'] == ServiceSpec(
-            service_type='mon',
+            service_type=ServiceType.mon,
             unmanaged=True,
             placement=PlacementSpec(hosts=['host1'])
         )
@@ -129,7 +130,7 @@ def test_migrate_service_id_mon_two(cephadm_module: CephadmOrchestrator):
 
         assert len(cephadm_module.spec_store.specs) == 1
         assert cephadm_module.spec_store.specs['mon'] == ServiceSpec(
-            service_type='mon',
+            service_type=ServiceType.mon,
             unmanaged=True,
             placement=PlacementSpec(count=5)
         )

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -432,7 +432,7 @@ def test_node_assignment(service_type, placement, hosts, daemons, expected):
     if service_type == 'rgw':
         service_id = 'realm.zone'
 
-    spec = ServiceSpec(service_type=service_type,
+    spec = ServiceSpec(service_type=ServiceType(service_type),
                        service_id=service_id,
                        placement=placement)
 
@@ -515,7 +515,7 @@ class NodeAssignmentTest2(NamedTuple):
 def test_node_assignment2(service_type, placement, hosts,
                           daemons, expected_len, in_set):
     hosts = HostAssignment(
-        spec=ServiceSpec(service_type, placement=placement),
+        spec=ServiceSpec(ServiceType(service_type), placement=placement),
         hosts=[HostSpec(h, labels=['foo']) for h in hosts],
         get_daemons_func=lambda _: daemons).place()
     assert len(hosts) == expected_len
@@ -546,7 +546,7 @@ def test_node_assignment2(service_type, placement, hosts,
 def test_node_assignment3(service_type, placement, hosts,
                           daemons, expected_len, must_have):
     hosts = HostAssignment(
-        spec=ServiceSpec(service_type, placement=placement),
+        spec=ServiceSpec(ServiceType(service_type), placement=placement),
         hosts=[HostSpec(h) for h in hosts],
         get_daemons_func=lambda _: daemons).place()
     assert len(hosts) == expected_len
@@ -605,7 +605,7 @@ class NodeAssignmentTestBadSpec(NamedTuple):
 def test_bad_specs(service_type, placement, hosts, daemons, expected):
     with pytest.raises(OrchestratorValidationError) as e:
         hosts = HostAssignment(
-            spec=ServiceSpec(service_type, placement=placement),
+            spec=ServiceSpec(ServiceType(service_type), placement=placement),
             hosts=[HostSpec(h) for h in hosts],
             get_daemons_func=lambda _: daemons).place()
     assert str(e.value) == expected
@@ -749,7 +749,7 @@ class ActiveAssignmentTest(NamedTuple):
                          ])
 def test_active_assignment(service_type, placement, hosts, daemons, expected):
 
-    spec = ServiceSpec(service_type=service_type,
+    spec = ServiceSpec(service_type=ServiceType(service_type),
                        service_id=None,
                        placement=placement)
 
@@ -861,7 +861,7 @@ class OddMonsTest(NamedTuple):
                          ])
 def test_odd_mons(service_type, placement, hosts, daemons, expected_count):
 
-    spec = ServiceSpec(service_type=service_type,
+    spec = ServiceSpec(service_type=ServiceType(service_type),
                        service_id=None,
                        placement=placement)
 

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -6,10 +6,12 @@ from typing import NamedTuple, List
 import pytest
 
 from ceph.deployment.hostspec import HostSpec
-from ceph.deployment.service_spec import ServiceSpec, PlacementSpec, ServiceSpecValidationError
+from ceph.deployment.service_spec import ServiceSpec, PlacementSpec, ServiceSpecValidationError, \
+    ServiceType
 
 from cephadm.module import HostAssignment
-from orchestrator import DaemonDescription, OrchestratorValidationError, OrchestratorError, HostSpec
+from orchestrator import DaemonDescription, OrchestratorValidationError, OrchestratorError, HostSpec, \
+    DaemonType
 
 
 def wrapper(func):
@@ -89,12 +91,12 @@ def get_result(key, results):
 def mk_spec_and_host(spec_section, hosts, explicit_key, explicit, count):
 
     if spec_section == 'hosts':
-        mk_spec = lambda: ServiceSpec('mgr', placement=PlacementSpec(
+        mk_spec = lambda: ServiceSpec(ServiceType.mgr, placement=PlacementSpec(
                     hosts=explicit,
                     count=count,
                 ))
     elif spec_section == 'label':
-        mk_spec = lambda: ServiceSpec('mgr', placement=PlacementSpec(
+        mk_spec = lambda: ServiceSpec(ServiceType.mgr, placement=PlacementSpec(
             label='mylabel',
             count=count,
         ))
@@ -105,7 +107,7 @@ def mk_spec_and_host(spec_section, hosts, explicit_key, explicit, count):
             '12': '[1-2]',
             '123': '*',
         }[explicit_key]
-        mk_spec = lambda: ServiceSpec('mgr', placement=PlacementSpec(
+        mk_spec = lambda: ServiceSpec(ServiceType.mgr, placement=PlacementSpec(
                     host_pattern=pattern,
                     count=count,
                 ))
@@ -304,7 +306,7 @@ def test_scheduler_daemons(host_key, hosts,
                            spec_section_key, spec_section):
     mk_spec, hosts = mk_spec_and_host(spec_section, hosts, explicit_key, explicit, count)
     dds = [
-        DaemonDescription('mgr', d, d)
+        DaemonDescription(DaemonType.mgr, d, d)
         for d in daemons
     ]
     run_scheduler_test(
@@ -342,8 +344,8 @@ class NodeAssignmentTest(NamedTuple):
             PlacementSpec(host_pattern='*'),
             'host1 host2 host3'.split(),
             [
-                DaemonDescription('mgr', 'a', 'host1'),
-                DaemonDescription('mgr', 'b', 'host2'),
+                DaemonDescription(DaemonType.mgr, 'a', 'host1'),
+                DaemonDescription(DaemonType.mgr, 'b', 'host2'),
             ],
             ['host1', 'host2', 'host3']
         ),
@@ -362,8 +364,8 @@ class NodeAssignmentTest(NamedTuple):
             PlacementSpec(count=3, hosts=['host3']),
             'host1 host2 host3'.split(),
             [
-                DaemonDescription('mgr', 'a', 'host1'),
-                DaemonDescription('mgr', 'b', 'host2'),
+                DaemonDescription(DaemonType.mgr, 'a', 'host1'),
+                DaemonDescription(DaemonType.mgr, 'b', 'host2'),
             ],
             ['host3']
         ),
@@ -373,8 +375,8 @@ class NodeAssignmentTest(NamedTuple):
             PlacementSpec(count=1, hosts=['host3']),
             'host1 host2 host3'.split(),
             [
-                DaemonDescription('mgr', 'a', 'host1'),
-                DaemonDescription('mgr', 'b', 'host2'),
+                DaemonDescription(DaemonType.mgr, 'a', 'host1'),
+                DaemonDescription(DaemonType.mgr, 'b', 'host2'),
             ],
             ['host3']
         ),
@@ -384,7 +386,7 @@ class NodeAssignmentTest(NamedTuple):
             PlacementSpec(count=2, hosts=['host3']),
             'host1 host2 host3'.split(),
             [
-                DaemonDescription('mgr', 'a', 'host1'),
+                DaemonDescription(DaemonType.mgr, 'a', 'host1'),
             ],
             ['host3']
         ),
@@ -394,7 +396,7 @@ class NodeAssignmentTest(NamedTuple):
             PlacementSpec(count=2, hosts=['host1']),
             'host1 host2'.split(),
             [
-                DaemonDescription('mgr', 'a', 'host1'),
+                DaemonDescription(DaemonType.mgr, 'a', 'host1'),
             ],
             ['host1']
         ),
@@ -404,7 +406,7 @@ class NodeAssignmentTest(NamedTuple):
             PlacementSpec(count=2, hosts=['host1']),
             'host1 host2'.split(),
             [
-                DaemonDescription('mgr', 'a', 'host2'),
+                DaemonDescription(DaemonType.mgr, 'a', 'host2'),
             ],
             ['host1']
         ),
@@ -475,7 +477,7 @@ class NodeAssignmentTest2(NamedTuple):
             'mgr',
             PlacementSpec(count=1, hosts='host1 host2 host3'.split()),
             'host1 host2 host3'.split(),
-            [DaemonDescription('mgr', 'mgr.a', 'host1'),],
+            [DaemonDescription(DaemonType.mgr, 'mgr.a', 'host1'),],
             1,
             ['host1', 'host2', 'host3'],
         ),
@@ -485,8 +487,8 @@ class NodeAssignmentTest2(NamedTuple):
             PlacementSpec(count=1, hosts='host1 host2 host3'.split()),
             'host1 host2 host3'.split(),
             [
-                DaemonDescription('mgr', 'a', 'host1'),
-                DaemonDescription('mgr', 'b', 'host2'),
+                DaemonDescription(DaemonType.mgr, 'a', 'host1'),
+                DaemonDescription(DaemonType.mgr, 'b', 'host2'),
             ],
             1,
             ['host1', 'host2']
@@ -623,9 +625,9 @@ class ActiveAssignmentTest(NamedTuple):
                                  PlacementSpec(count=2),
                                  'host1 host2 host3'.split(),
                                  [
-                                     DaemonDescription('mgr', 'a', 'host1', is_active=True),
-                                     DaemonDescription('mgr', 'b', 'host2'),
-                                     DaemonDescription('mgr', 'c', 'host3'),
+                                     DaemonDescription(DaemonType.mgr, 'a', 'host1', is_active=True),
+                                     DaemonDescription(DaemonType.mgr, 'b', 'host2'),
+                                     DaemonDescription(DaemonType.mgr, 'c', 'host3'),
                                  ],
                                  [['host1', 'host2'], ['host1', 'host3']]
                              ),
@@ -634,9 +636,9 @@ class ActiveAssignmentTest(NamedTuple):
                                  PlacementSpec(count=2),
                                  'host1 host2 host3'.split(),
                                  [
-                                     DaemonDescription('mgr', 'a', 'host1'),
-                                     DaemonDescription('mgr', 'b', 'host2'),
-                                     DaemonDescription('mgr', 'c', 'host3', is_active=True),
+                                     DaemonDescription(DaemonType.mgr, 'a', 'host1'),
+                                     DaemonDescription(DaemonType.mgr, 'b', 'host2'),
+                                     DaemonDescription(DaemonType.mgr, 'c', 'host3', is_active=True),
                                  ],
                                  [['host1', 'host3'], ['host2', 'host3']]
                              ),
@@ -645,9 +647,9 @@ class ActiveAssignmentTest(NamedTuple):
                                  PlacementSpec(count=1),
                                  'host1 host2 host3'.split(),
                                  [
-                                     DaemonDescription('mgr', 'a', 'host1'),
-                                     DaemonDescription('mgr', 'b', 'host2', is_active=True),
-                                     DaemonDescription('mgr', 'c', 'host3'),
+                                     DaemonDescription(DaemonType.mgr, 'a', 'host1'),
+                                     DaemonDescription(DaemonType.mgr, 'b', 'host2', is_active=True),
+                                     DaemonDescription(DaemonType.mgr, 'c', 'host3'),
                                  ],
                                  [['host2']]
                              ),
@@ -656,9 +658,9 @@ class ActiveAssignmentTest(NamedTuple):
                                  PlacementSpec(count=1),
                                  'host1 host2 host3'.split(),
                                  [
-                                     DaemonDescription('mgr', 'a', 'host1'),
-                                     DaemonDescription('mgr', 'b', 'host2'),
-                                     DaemonDescription('mgr', 'c', 'host3', is_active=True),
+                                     DaemonDescription(DaemonType.mgr, 'a', 'host1'),
+                                     DaemonDescription(DaemonType.mgr, 'b', 'host2'),
+                                     DaemonDescription(DaemonType.mgr, 'c', 'host3', is_active=True),
                                  ],
                                  [['host3']]
                              ),
@@ -667,9 +669,9 @@ class ActiveAssignmentTest(NamedTuple):
                                  PlacementSpec(count=1),
                                  'host1 host2 host3'.split(),
                                  [
-                                     DaemonDescription('mgr', 'a', 'host1', is_active=True),
-                                     DaemonDescription('mgr', 'b', 'host2'),
-                                     DaemonDescription('mgr', 'c', 'host3', is_active=True),
+                                     DaemonDescription(DaemonType.mgr, 'a', 'host1', is_active=True),
+                                     DaemonDescription(DaemonType.mgr, 'b', 'host2'),
+                                     DaemonDescription(DaemonType.mgr, 'c', 'host3', is_active=True),
                                  ],
                                  [['host1'], ['host3']]
                              ),
@@ -678,9 +680,9 @@ class ActiveAssignmentTest(NamedTuple):
                                  PlacementSpec(count=2),
                                  'host1 host2 host3'.split(),
                                  [
-                                     DaemonDescription('mgr', 'a', 'host1'),
-                                     DaemonDescription('mgr', 'b', 'host2', is_active=True),
-                                     DaemonDescription('mgr', 'c', 'host3', is_active=True),
+                                     DaemonDescription(DaemonType.mgr, 'a', 'host1'),
+                                     DaemonDescription(DaemonType.mgr, 'b', 'host2', is_active=True),
+                                     DaemonDescription(DaemonType.mgr, 'c', 'host3', is_active=True),
                                  ],
                                  [['host2', 'host3']]
                              ),
@@ -689,9 +691,9 @@ class ActiveAssignmentTest(NamedTuple):
                                  PlacementSpec(count=1),
                                  'host1 host2 host3'.split(),
                                  [
-                                     DaemonDescription('mgr', 'a', 'host1', is_active=True),
-                                     DaemonDescription('mgr', 'b', 'host2', is_active=True),
-                                     DaemonDescription('mgr', 'c', 'host3', is_active=True),
+                                     DaemonDescription(DaemonType.mgr, 'a', 'host1', is_active=True),
+                                     DaemonDescription(DaemonType.mgr, 'b', 'host2', is_active=True),
+                                     DaemonDescription(DaemonType.mgr, 'c', 'host3', is_active=True),
                                  ],
                                  [['host1'], ['host2'], ['host3']]
                              ),
@@ -700,10 +702,10 @@ class ActiveAssignmentTest(NamedTuple):
                                  PlacementSpec(count=1),
                                  'host1 host2 host3'.split(),
                                  [
-                                     DaemonDescription('mgr', 'a', 'host1', is_active=True),
-                                     DaemonDescription('mgr', 'a2', 'host1'),
-                                     DaemonDescription('mgr', 'b', 'host2'),
-                                     DaemonDescription('mgr', 'c', 'host3'),
+                                     DaemonDescription(DaemonType.mgr, 'a', 'host1', is_active=True),
+                                     DaemonDescription(DaemonType.mgr, 'a2', 'host1'),
+                                     DaemonDescription(DaemonType.mgr, 'b', 'host2'),
+                                     DaemonDescription(DaemonType.mgr, 'c', 'host3'),
                                  ],
                                  [['host1']]
                              ),
@@ -712,10 +714,10 @@ class ActiveAssignmentTest(NamedTuple):
                                  PlacementSpec(count=1),
                                  'host1 host2 host3'.split(),
                                  [
-                                     DaemonDescription('mgr', 'a', 'host1', is_active=True),
-                                     DaemonDescription('mgr', 'a2', 'host1', is_active=True),
-                                     DaemonDescription('mgr', 'b', 'host2'),
-                                     DaemonDescription('mgr', 'c', 'host3'),
+                                     DaemonDescription(DaemonType.mgr, 'a', 'host1', is_active=True),
+                                     DaemonDescription(DaemonType.mgr, 'a2', 'host1', is_active=True),
+                                     DaemonDescription(DaemonType.mgr, 'b', 'host2'),
+                                     DaemonDescription(DaemonType.mgr, 'c', 'host3'),
                                  ],
                                  [['host1']]
                              ),
@@ -724,10 +726,10 @@ class ActiveAssignmentTest(NamedTuple):
                                  PlacementSpec(count=2),
                                  'host1 host2 host3'.split(),
                                  [
-                                     DaemonDescription('mgr', 'a', 'host1', is_active=True),
-                                     DaemonDescription('mgr', 'a2', 'host1'),
-                                     DaemonDescription('mgr', 'b', 'host2'),
-                                     DaemonDescription('mgr', 'c', 'host3', is_active=True),
+                                     DaemonDescription(DaemonType.mgr, 'a', 'host1', is_active=True),
+                                     DaemonDescription(DaemonType.mgr, 'a2', 'host1'),
+                                     DaemonDescription(DaemonType.mgr, 'b', 'host2'),
+                                     DaemonDescription(DaemonType.mgr, 'c', 'host3', is_active=True),
                                  ],
                                  [['host1', 'host3']]
                              ),
@@ -737,9 +739,9 @@ class ActiveAssignmentTest(NamedTuple):
                                  PlacementSpec(count=1, hosts=['host1']),
                                  'host1 host2 host3'.split(),
                                  [
-                                     DaemonDescription('mgr', 'a', 'host1'),
-                                     DaemonDescription('mgr', 'b', 'host2'),
-                                     DaemonDescription('mgr', 'c', 'host3', is_active=True),
+                                     DaemonDescription(DaemonType.mgr, 'a', 'host1'),
+                                     DaemonDescription(DaemonType.mgr, 'b', 'host2'),
+                                     DaemonDescription(DaemonType.mgr, 'c', 'host3', is_active=True),
                                  ],
                                  [['host1']]
                              ),
@@ -828,9 +830,9 @@ class OddMonsTest(NamedTuple):
                                  PlacementSpec(count=5),
                                  'host1 host2 host3 host4'.split(),
                                  [
-                                     DaemonDescription('mon', 'a', 'host1'),
-                                     DaemonDescription('mon', 'b', 'host2'),
-                                     DaemonDescription('mon', 'c', 'host3'),
+                                     DaemonDescription(DaemonType.mon, 'a', 'host1'),
+                                     DaemonDescription(DaemonType.mon, 'b', 'host2'),
+                                     DaemonDescription(DaemonType.mon, 'c', 'host3'),
                                  ],
                                  3
                              ),
@@ -839,8 +841,8 @@ class OddMonsTest(NamedTuple):
                                 PlacementSpec(count=5),
                                 'host1 host2 host3 host4'.split(),
                                 [
-                                   DaemonDescription('mon', 'a', 'host1'),
-                                   DaemonDescription('mon', 'b', 'host2'),
+                                   DaemonDescription(DaemonType.mon, 'a', 'host1'),
+                                   DaemonDescription(DaemonType.mon, 'b', 'host2'),
                                 ],
                                 3
                             ),
@@ -849,9 +851,9 @@ class OddMonsTest(NamedTuple):
                                 PlacementSpec(hosts='host1 host2 host3 host4'.split()),
                                 'host1 host2 host3 host4 host5'.split(),
                                 [
-                                   DaemonDescription('mon', 'a', 'host1'),
-                                   DaemonDescription('mon', 'b', 'host2'),
-                                   DaemonDescription('mon', 'c', 'host3'),
+                                   DaemonDescription(DaemonType.mon, 'a', 'host1'),
+                                   DaemonDescription(DaemonType.mon, 'b', 'host2'),
+                                   DaemonDescription(DaemonType.mon, 'c', 'host3'),
                                 ],
                                 3
                             ),

--- a/src/pybind/mgr/cephadm/tests/test_spec.py
+++ b/src/pybind/mgr/cephadm/tests/test_spec.py
@@ -598,7 +598,7 @@ def test_daemon_description_service_name(spec: ServiceSpec,
 
 def test_alertmanager_spec_1():
     spec = AlertManagerSpec()
-    assert spec.service_type == 'alertmanager'
+    assert spec.service_type.value == 'alertmanager'
     assert isinstance(spec.user_data, dict)
     assert len(spec.user_data.keys()) == 0
 
@@ -632,7 +632,7 @@ def test_custom_container_spec():
                                    'foo.conf': 'foo\nbar',
                                    'bar.conf': ['foo', 'bar']
                                })
-    assert spec.service_type == 'container'
+    assert spec.service_type.value == 'container'
     assert spec.entrypoint == '/usr/bin/bash'
     assert spec.uid == 1000
     assert spec.gid == 2000
@@ -683,7 +683,7 @@ spec:
 """
     yaml_file = yaml.safe_load(yaml_str)
     spec = ServiceSpec.from_json(yaml_file)
-    assert spec.service_type == "ha-rgw"
+    assert spec.service_type.value == "ha-rgw"
     assert spec.service_id == "haproxy_for_rgw"
     assert spec.virtual_ip_interface == "eth0"
     assert spec.virtual_ip_address == "192.168.20.1/24"

--- a/src/pybind/mgr/cephadm/tests/test_spec.py
+++ b/src/pybind/mgr/cephadm/tests/test_spec.py
@@ -10,9 +10,9 @@ import yaml
 
 from ceph.deployment.service_spec import ServiceSpec, NFSServiceSpec, RGWSpec, \
     IscsiServiceSpec, AlertManagerSpec, HostPlacementSpec, CustomContainerSpec, \
-    HA_RGWSpec
+    HA_RGWSpec, ServiceType
 
-from orchestrator import DaemonDescription, OrchestratorError
+from orchestrator import DaemonDescription, OrchestratorError, DaemonType
 
 
 @pytest.mark.parametrize(
@@ -300,7 +300,7 @@ def test_dd_octopus(dd_json):
             subcluster='1',
         ),
         DaemonDescription(
-            daemon_type='rgw',
+            daemon_type=DaemonType.rgw,
             daemon_id="default-rgw-realm.eu-central-1.1.ceph-001.ytywjo",
             hostname="ceph-001",
         ),
@@ -313,7 +313,7 @@ def test_dd_octopus(dd_json):
             rgw_zone="eu-central-1",
         ),
         DaemonDescription(
-            daemon_type='rgw',
+            daemon_type=DaemonType.rgw,
             daemon_id="default-rgw-realm.eu-central-1.ceph-001.ytywjo",
             hostname="ceph-001",
         ),
@@ -327,7 +327,7 @@ def test_dd_octopus(dd_json):
             subcluster='1',
         ),
         DaemonDescription(
-            daemon_type='rgw',
+            daemon_type=DaemonType.rgw,
             daemon_id="default-rgw-realm.eu-central-1.1.host.domain.tld.ytywjo",
             hostname="host.domain.tld",
         ),
@@ -340,7 +340,7 @@ def test_dd_octopus(dd_json):
             rgw_zone="zone",
         ),
         DaemonDescription(
-            daemon_type='rgw',
+            daemon_type=DaemonType.rgw,
             daemon_id="realm.zone.a",
             hostname="smithi028",
         ),
@@ -349,13 +349,13 @@ def test_dd_octopus(dd_json):
     (
         # without host
         RGWSpec(
-            service_type='rgw',
+            service_type=ServiceType.rgw,
             rgw_realm="default-rgw-realm",
             rgw_zone="eu-central-1",
             subcluster='1',
         ),
         DaemonDescription(
-            daemon_type='rgw',
+            daemon_type=DaemonType.rgw,
             daemon_id="default-rgw-realm.eu-central-1.1.hostname.ytywjo",
             hostname=None,
         ),
@@ -370,7 +370,7 @@ def test_dd_octopus(dd_json):
             subcluster='1',
         ),
         DaemonDescription(
-            daemon_type='rgw',
+            daemon_type=DaemonType.rgw,
             daemon_id="default.rgw.realm.ceph.001.1.ceph.001.ytywjo",
             hostname="ceph.001",
         ),
@@ -380,11 +380,11 @@ def test_dd_octopus(dd_json):
     # https://tracker.ceph.com/issues/45293
     (
         ServiceSpec(
-            service_type='mds',
+            ServiceType.mds,
             service_id="a",
         ),
         DaemonDescription(
-            daemon_type='mds',
+            DaemonType.mds,
             daemon_id="a.host1.abc123",
             hostname="host1",
         ),
@@ -393,11 +393,11 @@ def test_dd_octopus(dd_json):
     (
         # '.' char in service_id
         ServiceSpec(
-            service_type='mds',
+            ServiceType.mds,
             service_id="a.b.c",
         ),
         DaemonDescription(
-            daemon_type='mds',
+            DaemonType.mds,
             daemon_id="a.b.c.host1.abc123",
             hostname="host1",
         ),
@@ -408,11 +408,11 @@ def test_dd_octopus(dd_json):
     (
         # daemon_id does not contain hostname
         ServiceSpec(
-            service_type='mds',
+            ServiceType.mds,
             service_id="a",
         ),
         DaemonDescription(
-            daemon_type='mds',
+            DaemonType.mds,
             daemon_id="a",
             hostname="host1",
         ),
@@ -421,11 +421,11 @@ def test_dd_octopus(dd_json):
     (
         # daemon_id only contains hostname
         ServiceSpec(
-            service_type='mds',
+            ServiceType.mds,
             service_id="host1",
         ),
         DaemonDescription(
-            daemon_type='mds',
+            DaemonType.mds,
             daemon_id="host1",
             hostname="host1",
         ),
@@ -436,11 +436,11 @@ def test_dd_octopus(dd_json):
     (
         # daemon_id only contains hostname
         ServiceSpec(
-            service_type='mds',
+            ServiceType.mds,
             service_id="a",
         ),
         DaemonDescription(
-            daemon_type='mds',
+            DaemonType.mds,
             daemon_id="a.host1.abc123",
             hostname="host1.site",
         ),
@@ -451,7 +451,7 @@ def test_dd_octopus(dd_json):
             service_id="a",
         ),
         DaemonDescription(
-            daemon_type='nfs',
+            DaemonType.nfs,
             daemon_id="a.host1",
             hostname="host1.site",
         ),
@@ -464,7 +464,7 @@ def test_dd_octopus(dd_json):
             service_id="a",
         ),
         DaemonDescription(
-            daemon_type='nfs',
+            DaemonType.nfs,
             daemon_id="a.host1",
             hostname="host1",
         ),
@@ -476,7 +476,7 @@ def test_dd_octopus(dd_json):
             service_id="a.b.c",
         ),
         DaemonDescription(
-            daemon_type='nfs',
+            DaemonType.nfs,
             daemon_id="a.b.c.host1",
             hostname="host1",
         ),
@@ -488,7 +488,7 @@ def test_dd_octopus(dd_json):
             service_id="a.b.c",
         ),
         DaemonDescription(
-            daemon_type='nfs',
+            DaemonType.nfs,
             daemon_id="a.b.c.host1.abc123",
             hostname="host1",
         ),
@@ -500,7 +500,7 @@ def test_dd_octopus(dd_json):
             service_id="a",
         ),
         DaemonDescription(
-            daemon_type='nfs',
+            DaemonType.nfs,
             daemon_id="a.host1abc123",
             hostname="host1",
         ),
@@ -512,7 +512,7 @@ def test_dd_octopus(dd_json):
             service_id="a",
         ),
         DaemonDescription(
-            daemon_type='nfs',
+            DaemonType.nfs,
             daemon_id="ahost1.abc123",
             hostname="host1",
         ),
@@ -522,11 +522,11 @@ def test_dd_octopus(dd_json):
     # https://tracker.ceph.com/issues/45293
     (
         IscsiServiceSpec(
-            service_type='iscsi',
+            ServiceType.iscsi,
             service_id="a",
         ),
         DaemonDescription(
-            daemon_type='iscsi',
+            DaemonType.iscsi,
             daemon_id="a.host1.abc123",
             hostname="host1",
         ),
@@ -535,11 +535,11 @@ def test_dd_octopus(dd_json):
     (
         # '.' char in service_id
         IscsiServiceSpec(
-            service_type='iscsi',
+            ServiceType.iscsi,
             service_id="a.b.c",
         ),
         DaemonDescription(
-            daemon_type='iscsi',
+            DaemonType.iscsi,
             daemon_id="a.b.c.host1.abc123",
             hostname="host1",
         ),
@@ -548,11 +548,11 @@ def test_dd_octopus(dd_json):
     (
         # fixed daemon id for teuthology.
         IscsiServiceSpec(
-            service_type='iscsi',
+            ServiceType.iscsi,
             service_id='iscsi',
         ),
         DaemonDescription(
-            daemon_type='iscsi',
+            DaemonType.iscsi,
             daemon_id="iscsi.a",
             hostname="host1",
         ),
@@ -561,12 +561,12 @@ def test_dd_octopus(dd_json):
 
     (
         CustomContainerSpec(
-            service_type='container',
+            ServiceType.container,
             service_id='hello-world',
             image='docker.io/library/hello-world:latest',
         ),
         DaemonDescription(
-            daemon_type='container',
+            DaemonType.container,
             daemon_id='hello-world.mgr0',
             hostname='mgr0',
         ),
@@ -576,10 +576,10 @@ def test_dd_octopus(dd_json):
     (
         # daemon_id only contains hostname
         ServiceSpec(
-            service_type='cephadm-exporter',
+            ServiceType.cephadm_exporter,
         ),
         DaemonDescription(
-            daemon_type='cephadm-exporter',
+            DaemonType.cephadm_exporter,
             daemon_id="testhost",
             hostname="testhost",
         ),

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 
-from ceph.deployment.service_spec import ServiceSpec
+from ceph.deployment.service_spec import ServiceSpec, ServiceType
 from cephadm import CephadmOrchestrator
 from cephadm.upgrade import CephadmUpgrade
 from cephadm.serve import CephadmServe
@@ -37,7 +37,7 @@ def test_upgrade_run(use_repo_digest, cephadm_module: CephadmOrchestrator):
         cephadm_module.set_container_image('global', 'from_image')
         if use_repo_digest:
             cephadm_module.use_repo_digest = True
-        with with_service(cephadm_module, ServiceSpec('mgr'), CephadmOrchestrator.apply_mgr, 'test'):
+        with with_service(cephadm_module, ServiceSpec(ServiceType.mgr), CephadmOrchestrator.apply_mgr, 'test'):
             assert wait(cephadm_module, cephadm_module.upgrade_start(
                 'to_image', None)) == 'Initiating upgrade to to_image'
 

--- a/src/pybind/mgr/mds_autoscaler/module.py
+++ b/src/pybind/mgr/mds_autoscaler/module.py
@@ -5,7 +5,7 @@ Automatically scale MDSs based on status of the file-system using the FSMap
 import logging
 from typing import Optional, List, Set
 from mgr_module import MgrModule
-from ceph.deployment.service_spec import ServiceSpec
+from ceph.deployment.service_spec import ServiceSpec, ServiceType
 import orchestrator
 import copy
 
@@ -22,7 +22,7 @@ class MDSAutoscaler(orchestrator.OrchestratorClientMixin, MgrModule):
 
     def get_service(self, fs_name: str) -> List[orchestrator.ServiceDescription]:
         service = f"mds.{fs_name}"
-        completion = self.describe_service(service_type='mds',
+        completion = self.describe_service(service_type=ServiceType.mds,
                                            service_name=service,
                                            refresh=True)
         self._orchestrator_wait([completion])

--- a/src/pybind/mgr/mds_autoscaler/tests/test_autoscaler.py
+++ b/src/pybind/mgr/mds_autoscaler/tests/test_autoscaler.py
@@ -2,7 +2,7 @@ import pytest
 from unittest import mock
 
 from ceph.deployment.service_spec import ServiceSpec, PlacementSpec
-from orchestrator import DaemonDescription, Completion, ServiceDescription
+from orchestrator import DaemonDescription, Completion, ServiceDescription, DaemonType
 
 try:
     from typing import Any, List
@@ -32,12 +32,12 @@ class TestCephadm(object):
         daemons = Completion(value=[
             DaemonDescription(
                 hostname='myhost',
-                daemon_type='mds',
+                daemon_type=DaemonType.mds,
                 daemon_id='fs_name.myhost.a'
             ),
             DaemonDescription(
                 hostname='myhost',
-                daemon_type='mds',
+                daemon_type=DaemonType.mds,
                 daemon_id='fs_name.myhost.b'
             ),
         ])
@@ -47,7 +47,7 @@ class TestCephadm(object):
         services = Completion(value=[
             ServiceDescription(
                 spec=ServiceSpec(
-                    service_type='mds',
+                    service_type=DaemonType.mds,
                     service_id='fs_name',
                     placement=PlacementSpec(
                         count=2
@@ -87,7 +87,7 @@ class TestCephadm(object):
         mds_autoscaler_module.notify('fs_map', None)
 
         _apply_mds.assert_called_with(ServiceSpec(
-            service_type='mds',
+            service_type=DaemonType.mds,
             service_id='fs_name',
             placement=PlacementSpec(
                 count=3

--- a/src/pybind/mgr/orchestrator/__init__.py
+++ b/src/pybind/mgr/orchestrator/__init__.py
@@ -13,7 +13,7 @@ from ._interface import \
     Orchestrator, OrchestratorClientMixin, \
     OrchestratorValidationError, OrchestratorError, NoOrchestrator, \
     ServiceDescription, InventoryFilter, HostSpec, \
-    DaemonDescription, \
+    DaemonDescription, DaemonType, \
     OrchestratorEvent, set_exception_subject, \
     InventoryHost, DeviceLightLoc, \
     UpgradeStatusSpec, daemon_type_to_service, service_to_daemon_types

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1327,6 +1327,7 @@ class DaemonDescription(object):
         self.is_active = is_active
 
     def name(self) -> str:
+        assert self.daemon_type
         return '%s.%s' % (self.daemon_type.value, self.daemon_id)
 
     def matches_service(self, service_name: Optional[str]) -> bool:

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1327,7 +1327,7 @@ class DaemonDescription(object):
         self.is_active = is_active
 
     def name(self) -> str:
-        return '%s.%s' % (self.daemon_type, self.daemon_id)
+        return '%s.%s' % (self.daemon_type.value, self.daemon_id)
 
     def matches_service(self, service_name: Optional[str]) -> bool:
         assert self.daemon_id is not None
@@ -1339,7 +1339,7 @@ class DaemonDescription(object):
     def service_id(self) -> str:
         assert self.daemon_id is not None
         assert self.daemon_type is not None
-        if self.daemon_type == 'osd' and self.osdspec_affinity:
+        if self.daemon_type == DaemonType.osd and self.osdspec_affinity:
             return self.osdspec_affinity
 
         def _match() -> str:

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -860,7 +860,7 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def describe_service(self, service_type: Optional[str] = None, service_name: Optional[str] = None, refresh: bool = False) -> Completion[List['ServiceDescription']]:
+    def describe_service(self, service_type: Optional[ServiceType] = None, service_name: Optional[str] = None, refresh: bool = False) -> Completion[List['ServiceDescription']]:
         """
         Describe a service (of any kind) that is already configured in
         the orchestrator.  For example, when viewing an OSD in the dashboard
@@ -874,7 +874,7 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def list_daemons(self, service_name: Optional[str] = None, daemon_type: Optional[str] = None, daemon_id: Optional[str] = None, host: Optional[str] = None, refresh: bool = False) -> Completion[List['DaemonDescription']]:
+    def list_daemons(self, service_name: Optional[str] = None, daemon_type: Optional['DaemonType'] = None, daemon_id: Optional[str] = None, host: Optional[str] = None, refresh: bool = False) -> Completion[List['DaemonDescription']]:
         """
         Describe a daemon (of any kind) that is already configured in
         the orchestrator.

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -10,7 +10,7 @@ from prettytable import PrettyTable
 
 from ceph.deployment.inventory import Device
 from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection
-from ceph.deployment.service_spec import PlacementSpec, ServiceSpec
+from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, ServiceType
 from ceph.utils import datetime_now
 
 from mgr_util import format_bytes, to_pretty_timedelta, format_dimless
@@ -35,22 +35,6 @@ class Format(enum.Enum):
     json = 'json'
     json_pretty = 'json-pretty'
     yaml = 'yaml'
-
-
-class ServiceType(enum.Enum):
-    mon = 'mon'
-    mgr = 'mgr'
-    rbd_mirror = 'rbd-mirror'
-    crash = 'crash'
-    alertmanager = 'alertmanager'
-    grafana = 'grafana'
-    node_exporter = 'node-exporter'
-    prometheus = 'prometheus'
-    mds = 'mds'
-    rgw = 'rgw'
-    nfs = 'nfs'
-    iscsi = 'iscsi'
-    cephadm_exporter = 'cephadm-exporter'
 
 
 class ServiceAction(enum.Enum):
@@ -623,7 +607,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
         def ukn(s: Optional[str]) -> str:
             return '<unknown>' if s is None else s
         # Sort the list for display
-        daemons.sort(key=lambda s: (ukn(s.daemon_type), ukn(s.hostname), ukn(s.daemon_id)))
+        daemons.sort(key=lambda s: (ukn(str(s.daemon_type)), ukn(s.hostname), ukn(s.daemon_id)))
 
         if format != Format.plain:
             return HandleCommandResult(stdout=to_format(daemons, format, many=True, cls=DaemonDescription))
@@ -931,7 +915,7 @@ Usage:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
         spec = ServiceSpec(
-            service_type='mds',
+            service_type=ServiceType.mds,
             service_id=fs_name,
             placement=PlacementSpec.from_string(placement),
         )
@@ -1131,7 +1115,7 @@ Usage:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
         spec = ServiceSpec(
-            service_type='mds',
+            service_type=ServiceType.mds,
             service_id=fs_name,
             placement=PlacementSpec.from_string(placement),
             unmanaged=unmanaged,

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -20,7 +20,8 @@ from ._interface import OrchestratorClientMixin, DeviceLightLoc, _cli_read_comma
     raise_if_exception, _cli_write_command, TrivialReadCompletion, OrchestratorError, \
     NoOrchestrator, OrchestratorValidationError, NFSServiceSpec, HA_RGWSpec, \
     RGWSpec, InventoryFilter, InventoryHost, HostSpec, CLICommandMeta, \
-    ServiceDescription, DaemonDescription, IscsiServiceSpec, json_to_generic_spec, GenericSpec
+    ServiceDescription, DaemonDescription, IscsiServiceSpec, json_to_generic_spec, GenericSpec, \
+    DaemonType
 
 
 def nice_delta(now: datetime.datetime, t: Optional[datetime.datetime], suffix: str = '') -> str:
@@ -516,7 +517,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
 
     @_cli_read_command('orch ls')
     def _list_services(self,
-                       service_type: Optional[str] = None,
+                       service_type: Optional[ServiceType] = None,
                        service_name: Optional[str] = None,
                        export: bool = False,
                        format: Format = Format.plain,
@@ -588,7 +589,7 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
     def _list_daemons(self,
                       hostname: Optional[str] = None,
                       service_name: Optional[str] = None,
-                      daemon_type: Optional[str] = None,
+                      daemon_type: Optional[DaemonType] = None,
                       daemon_id: Optional[str] = None,
                       format: Format = Format.plain,
                       refresh: bool = False) -> HandleCommandResult:

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -5,7 +5,8 @@ import os
 import json
 
 from ceph.deployment import inventory
-from ceph.deployment.service_spec import ServiceSpec, NFSServiceSpec, RGWSpec, PlacementSpec
+from ceph.deployment.service_spec import ServiceSpec, NFSServiceSpec, RGWSpec, PlacementSpec, \
+    ServiceType
 
 from typing import List, Dict, Optional, Callable, Any, TypeVar, Tuple
 
@@ -276,7 +277,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         if service_type == 'mon' or service_type is None:
             spec['mon'] = orchestrator.ServiceDescription(
                     spec=ServiceSpec(
-                        'mon',
+                        ServiceType.mon,
                         placement=PlacementSpec(
                             count=cl['spec'].get('mon', {}).get('count', 1),
                             ),
@@ -288,7 +289,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         if service_type == 'mgr' or service_type is None:
             spec['mgr'] = orchestrator.ServiceDescription(
                     spec=ServiceSpec(
-                        'mgr',
+                        ServiceType.mgr,
                         placement=PlacementSpec.from_string('count:1'),
                         ),
                     size=1,
@@ -298,7 +299,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         if not cl['spec'].get('crashCollector', {}).get('disable', False):
             spec['crash'] = orchestrator.ServiceDescription(
                 spec=ServiceSpec(
-                    'crash',
+                    ServiceType.crash,
                     placement=PlacementSpec.from_string('*'),
                 ),
                 size=num_nodes,
@@ -322,7 +323,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
                     total_mds = active * 2
                     spec[svc] = orchestrator.ServiceDescription(
                             spec=ServiceSpec(
-                                service_type='mds',
+                                service_type=ServiceType.mds,
                                 service_id=fs['metadata']['name'],
                                 placement=PlacementSpec(count=active),
                                 ),

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -186,7 +186,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
             else:
                 raise AssertionError('Fail to determine daemon ID from {}'.format(p))
             daemon = orchestrator.DaemonDescription(
-                daemon_type=_daemon_type, daemon_id=daemon_id, hostname='localhost')
+                daemon_type=orchestrator.DaemonType(_daemon_type), daemon_id=daemon_id, hostname='localhost')
             daemons.append(daemon)
         return daemons
 

--- a/src/pybind/mgr/volumes/fs/fs_util.py
+++ b/src/pybind/mgr/volumes/fs/fs_util.py
@@ -2,7 +2,7 @@ import os
 import errno
 import logging
 
-from ceph.deployment.service_spec import ServiceSpec, PlacementSpec
+from ceph.deployment.service_spec import ServiceSpec, PlacementSpec, ServiceType
 
 import cephfs
 import orchestrator
@@ -36,7 +36,7 @@ def remove_filesystem(mgr, fs_name):
     return mgr.mon_command(command)
 
 def create_mds(mgr, fs_name, placement):
-    spec = ServiceSpec(service_type='mds',
+    spec = ServiceSpec(service_type=ServiceType.mds,
                                     service_id=fs_name,
                                     placement=PlacementSpec.from_string(placement))
     try:

--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -5,7 +5,7 @@ from typing import List
 import socket
 from os.path import isabs, normpath
 
-from ceph.deployment.service_spec import NFSServiceSpec, PlacementSpec
+from ceph.deployment.service_spec import NFSServiceSpec, PlacementSpec, ServiceType
 from rados import TimedOut
 
 import orchestrator
@@ -658,7 +658,7 @@ class NFSCluster:
         return f'userconf-nfs.{self.cluster_id}'
 
     def _call_orch_apply_nfs(self, placement):
-        spec = NFSServiceSpec(service_type='nfs', service_id=self.cluster_id,
+        spec = NFSServiceSpec(service_type=ServiceType.nfs, service_id=self.cluster_id,
                               pool=self.pool_name, namespace=self.pool_ns,
                               placement=PlacementSpec.from_string(placement))
         completion = self.mgr.apply_nfs(spec)

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -1,7 +1,8 @@
 import yaml
 
 from ceph.deployment.inventory import Device
-from ceph.deployment.service_spec import ServiceSpecValidationError, ServiceSpec, PlacementSpec
+from ceph.deployment.service_spec import ServiceSpecValidationError, ServiceSpec, PlacementSpec, \
+    ServiceType
 
 try:
     from typing import Optional, List, Dict, Any, Union
@@ -162,13 +163,13 @@ class DriveGroupSpec(ServiceSpec):
                  block_db_size=None,  # type: Union[int, str, None]
                  block_wal_size=None,  # type: Union[int, str, None]
                  journal_size=None,  # type: Union[int, str, None]
-                 service_type=None,  # type: Optional[str]
+                 service_type=None,  # type: Optional[ServiceType]
                  unmanaged=False,  # type: bool
                  filter_logic='AND',  # type: str
                  preview_only=False,  # type: bool
                  ):
-        assert service_type is None or service_type == 'osd'
-        super(DriveGroupSpec, self).__init__('osd', service_id=service_id,
+        assert service_type is None or service_type == ServiceType.osd
+        super(DriveGroupSpec, self).__init__(ServiceType.osd, service_id=service_id,
                                              placement=placement,
                                              unmanaged=unmanaged,
                                              preview_only=preview_only)
@@ -244,7 +245,7 @@ class DriveGroupSpec(ServiceSpec):
         except KeyError:
             raise DriveGroupValidationError('OSD spec needs a `placement` key.')
 
-        args['service_type'] = json_drive_group.pop('service_type', 'osd')
+        args['service_type'] = ServiceType(json_drive_group.pop('service_type', 'osd'))
 
         # service_id was not required in early octopus.
         args['service_id'] = json_drive_group.pop('service_id', '')

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -4,6 +4,7 @@ import re
 from collections import namedtuple, OrderedDict
 from functools import wraps
 from typing import Optional, Dict, Any, List, Union, Callable, Iterable
+import enum
 
 import yaml
 
@@ -368,6 +369,25 @@ tPlacementSpec(hostname='host2', network='', name='')])
         return ps
 
 
+class ServiceType(enum.Enum):
+    alertmanager = 'alertmanager'
+    container = 'container'
+    crash = 'crash'
+    grafana = 'grafana'
+    iscsi = 'iscsi'
+    mds = 'mds'
+    mgr = 'mgr'
+    mon = 'mon'
+    node_exporter = 'node-exporter'
+    nfs = 'nfs'
+    osd = 'osd'
+    prometheus = 'prometheus'
+    rbd_mirror = 'rbd-mirror'
+    rgw = 'rgw'
+    cephadm_exporter = 'cephadm-exporter'
+    ha_rgw = 'ha-rgw'
+
+
 class ServiceSpec(object):
     """
     Details of service creation.
@@ -379,10 +399,15 @@ class ServiceSpec(object):
     start the services.
 
     """
-    KNOWN_SERVICE_TYPES = 'alertmanager crash grafana iscsi mds mgr mon nfs ' \
-                          'node-exporter osd prometheus rbd-mirror rgw ' \
-                          'container cephadm-exporter ha-rgw'.split()
-    REQUIRES_SERVICE_ID = 'iscsi mds nfs osd rgw container ha-rgw '.split()
+    REQUIRES_SERVICE_ID = [
+        ServiceType.iscsi,
+        ServiceType.mds,
+        ServiceType.nfs,
+        ServiceType.osd,
+        ServiceType.rgw,
+        ServiceType.container,
+        ServiceType.ha_rgw,
+    ]
 
     @classmethod
     def _cls(cls, service_type):
@@ -417,7 +442,7 @@ class ServiceSpec(object):
         return object.__new__(sub_cls)
 
     def __init__(self,
-                 service_type: str,
+                 service_type: ServiceType,
                  service_id: Optional[str] = None,
                  placement: Optional[PlacementSpec] = None,
                  count: Optional[int] = None,
@@ -426,7 +451,7 @@ class ServiceSpec(object):
                  ):
         self.placement = PlacementSpec() if placement is None else placement  # type: PlacementSpec
 
-        assert service_type in ServiceSpec.KNOWN_SERVICE_TYPES, service_type
+        assert service_type in ServiceType, service_type
         self.service_type = service_type
         self.service_id = None
         if self.service_type in self.REQUIRES_SERVICE_ID:

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -431,7 +431,7 @@ class ServiceSpec(object):
         Some Python foo to make sure, we don't have an object
         like `ServiceSpec('rgw')` of type `ServiceSpec`. Now we have:
 
-        >>> type(ServiceSpec('rgw')) == type(RGWSpec('rgw'))
+        >>> type(ServiceSpec(ServiceType.rgw)) == type(RGWSpec(ServiceType.rgw))
         True
 
         """
@@ -513,7 +513,13 @@ class ServiceSpec(object):
                 c['service_id'] = service_type_id[1]
             del c['service_name']
 
-        service_type = ServiceType(c.get('service_type', ''))
+        try:
+            service_type = ServiceType(c.get('service_type', ''))
+        except ValueError:
+            t = c.get('service_type', None)
+            if t is None:
+                raise ServiceSpecValidationError('No service_type specified')
+            raise ServiceSpecValidationError(f'Unknown service type "{t}"')
         c['service_type'] = service_type
         _cls = cls._cls(service_type)
 

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -514,6 +514,7 @@ class ServiceSpec(object):
             del c['service_name']
 
         service_type = ServiceType(c.get('service_type', ''))
+        c['service_type'] = service_type
         _cls = cls._cls(service_type)
 
         if 'status' in c:
@@ -830,7 +831,7 @@ class HA_RGWSpec(ServiceSpec):
                  keepalived_container_image: Optional[str] = None,
                  definitive_host_list: Optional[List[HostPlacementSpec]] = None
                  ):
-        assert service_type == 'ha-rgw'
+        assert service_type == ServiceType.ha_rgw
         super(HA_RGWSpec, self).__init__(ServiceType.ha_rgw, service_id=service_id, placement=placement)
 
         self.virtual_ip_interface = virtual_ip_interface

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -5,7 +5,8 @@ import yaml
 import pytest
 
 from ceph.deployment.service_spec import HostPlacementSpec, PlacementSpec, \
-    ServiceSpec, ServiceSpecValidationError, RGWSpec, NFSServiceSpec, IscsiServiceSpec
+    ServiceSpec, ServiceSpecValidationError, RGWSpec, NFSServiceSpec, IscsiServiceSpec, \
+    ServiceType
 from ceph.deployment.drive_group import DriveGroupSpec
 
 
@@ -190,19 +191,19 @@ spec:
                          [
                              (
                                      ServiceSpec(
-                                         service_type='mon'
+                                         service_type=ServiceType.mon
                                      ),
                                      ServiceSpec(
-                                         service_type='mon'
+                                         service_type=ServiceType.mon
                                      ),
                                      True
                              ),
                              (
                                      ServiceSpec(
-                                         service_type='mon'
+                                         service_type=ServiceType.mon
                                      ),
                                      ServiceSpec(
-                                         service_type='mon',
+                                         service_type=ServiceType.mon,
                                          service_id='foo'
                                      ),
                                      True
@@ -210,33 +211,33 @@ spec:
                              # Add service_type='mgr'
                              (
                                      ServiceSpec(
-                                         service_type='osd'
+                                         service_type=ServiceType.osd
                                      ),
                                      ServiceSpec(
-                                         service_type='osd',
+                                         service_type=ServiceType.osd,
                                      ),
                                      True
                              ),
                              (
                                      ServiceSpec(
-                                         service_type='osd'
+                                         service_type=ServiceType.osd
                                      ),
                                      DriveGroupSpec(),
                                      True
                              ),
                              (
                                      ServiceSpec(
-                                         service_type='osd'
+                                         service_type=ServiceType.osd
                                      ),
                                      ServiceSpec(
-                                         service_type='osd',
+                                         service_type=ServiceType.osd,
                                          service_id='foo',
                                      ),
                                      False
                              ),
                              (
                                      ServiceSpec(
-                                         service_type='rgw'
+                                         service_type=ServiceType.rgw
                                      ),
                                      RGWSpec(),
                                      True


### PR DESCRIPTION
I wasn't really able to make the git history look nice, cause everything needed to be done in one go. 

Thoughts?

TODO: some squashing
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
