### PR TITLE
Windows RBD fixes

### DIFF
--- a/README.windows.rst
+++ b/README.windows.rst
@@ -181,15 +181,20 @@ within ``ceph.conf`` for the time being.
 .. _windows_service:
 Windows service
 ===============
-In order to ensure that rbd-wnbd mappings survive host reboot, you'll have
-to configure it to run as a Windows service. Only one such service may run per
-host.
+On Windows, rbd-wnbd daemons are managed by a centralized service. This allows
+decoupling the daemons from the Windows session from which they originate. At
+the same time, the service is responsible of recreating persistent mappings,
+usually when the host boots.
 
-All mappings are currently persistent, being recreated when the service starts,
-unless explicitly unmapped. The service disconnects the mappings when being
-stopped. This also allows adjusting the Windows service start order so that rbd
-images can be mapped before starting services that may depend on it, such as
-VMMS.
+Note that only one such service may run per host.
+
+By default, all image mappings are persistent. Non-persistent mappings can be
+requested using the ``-onon-persistent`` ``rbd`` flag.
+
+Persistent mappings are recreated when the service starts, unless explicitly
+unmapped. The service disconnects the mappings when being stopped. This also
+allows adjusting the Windows service start order so that rbd images can be
+mapped before starting services that may depend on it, such as VMMS.
 
 In order to be able to reconnect the images, ``rbd-wnbd`` stores mapping
 information in the Windows registry at the following location:
@@ -322,7 +327,7 @@ initializes a partition.
 .. code:: PowerShell
 
     rbd create blank_image --size=1G
-    rbd device map blank_image
+    rbd device map blank_image -onon-persistent
 
     $mappingJson = rbd-wnbd show blank_image --format=json
     $mappingJson = $mappingJson | ConvertFrom-Json

--- a/README.windows.rst
+++ b/README.windows.rst
@@ -24,47 +24,46 @@ account different package managers, package names or paths (e.g. mingw paths).
 
 The script accepts the following flags:
 
-=============  ===============================  ===============================
-Flag           Description                      Default value
-=============  ===============================  ===============================
-OS             Host OS distribution, for mingw  ubuntu (also valid: suse)
-               and other OS specific settings.
-CEPH_DIR       The Ceph source code directory.  The same as the script.
-BUILD_DIR      The directory where the          $CEPH_DIR/build
-               generated artifacts will be
-               placed.
-DEPS_DIR       The directory where the Ceph     $CEPH_DIR/build.deps
-               dependencies will be built.
-NUM_WORKERS    The number of workers to use     The number of vcpus
-               when building Ceph.              available
-CLEAN_BUILD    Clean the build directory.
-SKIP_BUILD     Run cmake without actually
-               performing the build.
-SKIP_TESTS     Skip building Ceph tests.
-BUILD_ZIP      Build a zip archive containing
-               the generated binaries.
-ZIP_DEST       Where to put a zip containing    $BUILD_DIR/ceph.zip
-               the generated binaries.
-STRIP_ZIPPED   If set, the zip will contain
-               stripped binaries.
-ENABLE_SHARED  Dynamically link Ceph libs.      False
-=============  ===============================  ===============================
+=================  ===============================  ===============================
+Flag               Description                      Default value
+=================  ===============================  ===============================
+OS                 Host OS distribution, for mingw  ubuntu (also valid: suse)
+                   and other OS specific settings.
+CEPH_DIR           The Ceph source code directory.  The same as the script.
+BUILD_DIR          The directory where the          $CEPH_DIR/build
+                   generated artifacts will be
+                   placed.
+DEPS_DIR           The directory where the Ceph     $CEPH_DIR/build.deps
+                   dependencies will be built.
+NUM_WORKERS        The number of workers to use     The number of vcpus
+                   when building Ceph.              available
+CLEAN_BUILD        Clean the build directory.
+SKIP_BUILD         Run cmake without actually
+                   performing the build.
+SKIP_TESTS         Skip building Ceph tests.
+SKIP_ZIP           If unset, we'll build a zip
+                   archive containing the
+                   generated binaries.
+ZIP_DEST           Where to put a zip containing    $BUILD_DIR/ceph.zip
+                   the generated binaries.
+EMBEDDED_DBG_SYM   By default, the generated
+                   archive will contain a .debug
+                   subfolder, having the debug
+                   symbols. If this flag is set,
+                   the debug symbols will remain
+                   embedded in the executables.
+ENABLE_SHARED      Dynamically link Ceph libs.      False
+=================  ===============================  ===============================
 
-In order to build debug binaries as well as an archive containing stripped
-binaries that may be easily moved around, one may use the following:
+The following command will build the binaries and add them to a zip archive
+along with all the required DLLs. By default, the debug symbols are extracted
+from the binaries and placed in the ".debug" folder of the archive.
 
 .. code:: bash
 
-    BUILD_ZIP=1 STRIP_ZIPPED=1 SKIP_TESTS=1 ./win32_build.sh
+    SKIP_TESTS=1 ./win32_build.sh
 
 In order to disable a flag, such as ``CLEAN_BUILD``, leave it undefined.
-
-Debug binaries can be quite large, the following parameters may be passed to
-``win32_build.sh`` to reduce the amount of debug information:
-
-.. code:: bash
-
-    CFLAGS="-g1" CXXFLAGS="-g1" CMAKE_BUILD_TYPE="Release"
 
 ``win32_build.sh`` will fetch dependencies using ``win32_deps_build.sh``. If
 all dependencies are successfully prepared, this potentially time consuming

--- a/mingw_conf.sh
+++ b/mingw_conf.sh
@@ -16,6 +16,7 @@ MINGW_CPP="${MINGW_BASE}-c++"
 MINGW_DLLTOOL="${MINGW_BASE}-dlltool"
 MINGW_WINDRES="${MINGW_BASE}-windres"
 MINGW_STRIP="${MINGW_BASE}-strip"
+MINGW_OBJCOPY="${MINGW_BASE}-objcopy"
 # -Distribution specific mingw settings-
 case "$OS" in
     ubuntu)

--- a/src/common/win32/SubProcess.cc
+++ b/src/common/win32/SubProcess.cc
@@ -142,18 +142,20 @@ int SubProcess::join() {
   close(stdout_pipe_in_fd);
   close(stderr_pipe_in_fd);
 
-  DWORD status = 0;
+  int status = 0;
 
   if (WaitForSingleObject(proc_handle, INFINITE) != WAIT_FAILED) {
     if (!GetExitCodeProcess(proc_handle, &status)) {
       errstr << cmd << ": Could not get exit code: " << pid
              << ". Error code: " << GetLastError();
+      status = -ECHILD;
     } else if (status) {
       errstr << cmd << ": exit status: " << status;
     }
   } else {
     errstr << cmd << ": Waiting for child process failed: " << pid
            << ". Error code: " << GetLastError();
+    status = -ECHILD;
   }
 
   close_h(proc_handle);

--- a/src/common/win32/registry.cc
+++ b/src/common/win32/registry.cc
@@ -112,7 +112,17 @@ int RegistryKey::set(LPCTSTR lpValue, std::string data)
   return 0;
 }
 
-int RegistryKey::get(LPCTSTR lpValue, DWORD* value)
+int RegistryKey::get(LPCTSTR lpValue, bool& value)
+{
+  DWORD value_dw = 0;
+  int r = get(lpValue, value_dw);
+  if (!r) {
+    value = !!value_dw;
+  }
+  return r;
+}
+
+int RegistryKey::get(LPCTSTR lpValue, DWORD& value)
 {
   DWORD data;
   DWORD size = sizeof(data);
@@ -125,7 +135,7 @@ int RegistryKey::get(LPCTSTR lpValue, DWORD* value)
          << (char*)lpValue << dendl;
     return -EINVAL;
   }
-  *value = data;
+  value = data;
 
   return 0;
 }

--- a/src/common/win32/registry.h
+++ b/src/common/win32/registry.h
@@ -26,7 +26,8 @@ public:
   int set(LPCTSTR lpValue, DWORD data);
   int set(LPCTSTR lpValue, std::string data);
 
-  int get(LPCTSTR lpValue, DWORD* value);
+  int get(LPCTSTR lpValue, bool& value);
+  int get(LPCTSTR lpValue, DWORD& value);
   int get(LPCTSTR lpValue, std::string& value);
 
   HKEY hKey = NULL;

--- a/src/common/win32/service.h
+++ b/src/common/win32/service.h
@@ -24,7 +24,7 @@ protected:
   static void run();
   static void control_handler(DWORD request);
 
-  void shutdown();
+  void shutdown(bool ignore_errors = false);
   void stop();
 
   void set_status(DWORD current_state, DWORD exit_code = NO_ERROR);

--- a/src/tools/rbd/action/Wnbd.cc
+++ b/src/tools/rbd/action/Wnbd.cc
@@ -53,9 +53,11 @@ static int call_wnbd_cmd(const po::variables_map &vm,
   if (process.spawn()) {
     std::cerr << "rbd: failed to run rbd-wnbd: " << process.err() << std::endl;
     return -EINVAL;
-  } else if (process.join()) {
+  }
+  int exit_code = process.join();
+  if (exit_code) {
     std::cerr << "rbd: rbd-wnbd failed with error: " << process.err() << std::endl;
-    return -EINVAL;
+    return exit_code;
   }
 
   return 0;

--- a/src/tools/rbd_wnbd/rbd_wnbd.h
+++ b/src/tools/rbd_wnbd/rbd_wnbd.h
@@ -23,6 +23,11 @@
 #include "wnbd_handler.h"
 
 #define SERVICE_REG_KEY "SYSTEM\\CurrentControlSet\\Services\\rbd-wnbd"
+#define SERVICE_PIPE_NAME "\\\\.\\pipe\\rbd-wnbd"
+#define SERVICE_PIPE_TIMEOUT_MS 5000
+#define SERVICE_PIPE_BUFFSZ 4096
+
+#define DEFAULT_MAP_TIMEOUT_MS 30000
 
 #define RBD_WNBD_BLKSIZE 512UL
 
@@ -82,6 +87,15 @@ enum Command {
   Service,
   Stats
 };
+
+typedef struct {
+  Command command;
+  BYTE arguments[1];
+} ServiceRequest;
+
+typedef struct {
+  int status;
+} ServiceReply;
 
 bool is_process_running(DWORD pid);
 

--- a/src/tools/rbd_wnbd/rbd_wnbd.h
+++ b/src/tools/rbd_wnbd/rbd_wnbd.h
@@ -76,6 +76,9 @@ struct Config {
   int io_req_workers = DEFAULT_IO_WORKER_COUNT;
   int io_reply_workers = DEFAULT_IO_WORKER_COUNT;
   int service_thread_count = DEFAULT_SERVICE_THREAD_COUNT;
+
+  // register the mapping, recreating it when the Ceph service starts.
+  bool persistent = true;
 };
 
 enum Command {

--- a/src/tools/rbd_wnbd/rbd_wnbd.h
+++ b/src/tools/rbd_wnbd/rbd_wnbd.h
@@ -66,6 +66,7 @@ struct Config {
 
   int service_start_timeout = DEFAULT_SERVICE_START_TIMEOUT;
   int image_map_timeout = DEFAULT_IMAGE_MAP_TIMEOUT;
+  bool remap_failure_fatal = false;
 
   // TODO: consider moving those fields to a separate structure. Those
   // provide connection information without actually being configurable.

--- a/src/tools/rbd_wnbd/rbd_wnbd.h
+++ b/src/tools/rbd_wnbd/rbd_wnbd.h
@@ -31,6 +31,9 @@
 
 #define RBD_WNBD_BLKSIZE 512UL
 
+#define DEFAULT_SERVICE_START_TIMEOUT 120
+#define DEFAULT_IMAGE_MAP_TIMEOUT 20
+
 #define HELP_INFO 1
 #define VERSION_INFO 2
 
@@ -46,7 +49,7 @@ struct Config {
   bool exclusive = false;
   bool readonly = false;
 
-  intptr_t parent_pipe = 0;
+  std::string parent_pipe;
 
   std::string poolname;
   std::string nsname;
@@ -60,6 +63,9 @@ struct Config {
   bool hard_disconnect = false;
   int soft_disconnect_timeout = DEFAULT_SOFT_REMOVE_TIMEOUT;
   bool hard_disconnect_fallback = true;
+
+  int service_start_timeout = DEFAULT_SERVICE_START_TIMEOUT;
+  int image_map_timeout = DEFAULT_IMAGE_MAP_TIMEOUT;
 
   // TODO: consider moving those fields to a separate structure. Those
   // provide connection information without actually being configurable.
@@ -101,8 +107,6 @@ typedef struct {
 } ServiceReply;
 
 bool is_process_running(DWORD pid);
-
-void daemonize_complete(HANDLE parent_pipe);
 void unmap_at_exit();
 
 int disconnect_all_mappings(
@@ -110,7 +114,8 @@ int disconnect_all_mappings(
   bool hard_disconnect,
   int soft_disconnect_timeout,
   int worker_count);
-int restart_registered_mappings(int worker_count);
+int restart_registered_mappings(
+  int worker_count, int total_timeout, int image_map_timeout);
 int map_device_using_suprocess(std::string command_line);
 
 int construct_devpath_if_missing(Config* cfg);

--- a/src/tools/rbd_wnbd/wnbd_handler.h
+++ b/src/tools/rbd_wnbd/wnbd_handler.h
@@ -65,7 +65,7 @@ class WnbdHandler
 private:
   librbd::Image &image;
   std::string instance_name;
-  uint32_t block_count;
+  uint64_t block_count;
   uint32_t block_size;
   bool readonly;
   bool rbd_cache_enabled;
@@ -76,7 +76,7 @@ private:
 
 public:
   WnbdHandler(librbd::Image& _image, std::string _instance_name,
-              uint32_t _block_count, uint32_t _block_size,
+              uint64_t _block_count, uint32_t _block_size,
               bool _readonly, bool _rbd_cache_enabled,
               uint32_t _io_req_workers,
               uint32_t _io_reply_workers)


### PR DESCRIPTION
Windows RBD fixes

This PR includes a few fixes targeting ``rbd-wnbd``:

* New rbd mappings are now started by the ceph service, thus no longer being tied to the user session
* Fixed the block count overflow for image larger than 2TB
* Added a “--non-persistent” map option
* Limited the scope of the commands executed by the Ceph service
* Added configurable service start and image map timeouts. Also fixed an issue where the service would hang indefinitely when failing to remap images
* Changed the way in which the service handles remap failures. Previously, it was getting marked as stopped but already started daemons kept running. Now, by default, the service will keep running unless the “--remap-failure-fatal” option is set, in which case it will cleanup existing mappings before shutting down. 
* Fixed a few error propagation issues
* Moved debug symbols to separate files

Issue: https://tracker.ceph.com/issues/49102

Signed-off-by: Lucian Petrut lpetrut@cloudbasesolutions.com