### PR TITLE
rgw: add json encode/decode to bucket layout types

### DIFF
--- a/src/common/ceph_json.cc
+++ b/src/common/ceph_json.cc
@@ -519,6 +519,11 @@ void decode_json_obj(ceph_dir_layout& i, JSONObj *obj){
     i.dl_unused3 = tmp;
 }
 
+void encode_json(const char *name, std::string_view val, Formatter *f)
+{
+  f->dump_string(name, val);
+}
+
 void encode_json(const char *name, const string& val, Formatter *f)
 {
   f->dump_string(name, val);

--- a/src/common/ceph_json.h
+++ b/src/common/ceph_json.h
@@ -512,6 +512,7 @@ static void encode_json(const char *name, const T& val, ceph::Formatter *f)
 
 class utime_t;
 
+void encode_json(const char *name, std::string_view val, ceph::Formatter *f);
 void encode_json(const char *name, const std::string& val, ceph::Formatter *f);
 void encode_json(const char *name, const char *val, ceph::Formatter *f);
 void encode_json(const char *name, bool val, ceph::Formatter *f);

--- a/src/rgw/rgw_bucket_layout.cc
+++ b/src/rgw/rgw_bucket_layout.cc
@@ -13,10 +13,71 @@
  *
  */
 
+#include <boost/algorithm/string.hpp>
 #include "rgw_bucket_layout.h"
 
 namespace rgw {
 
+// BucketIndexType
+std::string_view to_string(const BucketIndexType& t)
+{
+  switch (t) {
+  case BucketIndexType::Normal: return "Normal";
+  case BucketIndexType::Indexless: return "Indexless";
+  default: return "Unknown";
+  }
+}
+bool parse(std::string_view str, BucketIndexType& t)
+{
+  if (boost::iequals(str, "Normal")) {
+    t = BucketIndexType::Normal;
+    return true;
+  }
+  if (boost::iequals(str, "Indexless")) {
+    t = BucketIndexType::Indexless;
+    return true;
+  }
+  return false;
+}
+void encode_json_impl(const char *name, const BucketIndexType& t, ceph::Formatter *f)
+{
+  encode_json(name, to_string(t), f);
+}
+void decode_json_obj(BucketIndexType& t, JSONObj *obj)
+{
+  std::string str;
+  decode_json_obj(str, obj);
+  parse(str, t);
+}
+
+// BucketHashType
+std::string_view to_string(const BucketHashType& t)
+{
+  switch (t) {
+  case BucketHashType::Mod: return "Mod";
+  default: return "Unknown";
+  }
+}
+bool parse(std::string_view str, BucketHashType& t)
+{
+  if (boost::iequals(str, "Mod")) {
+    t = BucketHashType::Mod;
+    return true;
+  }
+  return false;
+}
+void encode_json_impl(const char *name, const BucketHashType& t, ceph::Formatter *f)
+{
+  encode_json(name, to_string(t), f);
+}
+void decode_json_obj(BucketHashType& t, JSONObj *obj)
+{
+  std::string str;
+  decode_json_obj(str, obj);
+  parse(str, t);
+}
+
+// bucket_index_normal_layout
 void encode(const bucket_index_normal_layout& l, bufferlist& bl, uint64_t f)
 {
   ENCODE_START(1, 1, bl);
@@ -31,7 +92,20 @@ void decode(bucket_index_normal_layout& l, bufferlist::const_iterator& bl)
   decode(l.hash_type, bl);
   DECODE_FINISH(bl);
 }
+void encode_json_impl(const char *name, const bucket_index_normal_layout& l, ceph::Formatter *f)
+{
+  f->open_object_section(name);
+  encode_json("num_shards", l.num_shards, f);
+  encode_json("hash_type", l.hash_type, f);
+  f->close_section();
+}
+void decode_json_obj(bucket_index_normal_layout& l, JSONObj *obj)
+{
+  JSONDecoder::decode_json("num_shards", l.num_shards, obj);
+  JSONDecoder::decode_json("hash_type", l.hash_type, obj);
+}
 
+// bucket_index_layout
 void encode(const bucket_index_layout& l, bufferlist& bl, uint64_t f)
 {
   ENCODE_START(1, 1, bl);
@@ -58,7 +132,20 @@ void decode(bucket_index_layout& l, bufferlist::const_iterator& bl)
   }
   DECODE_FINISH(bl);
 }
+void encode_json_impl(const char *name, const bucket_index_layout& l, ceph::Formatter *f)
+{
+  f->open_object_section(name);
+  encode_json("type", l.type, f);
+  encode_json("normal", l.normal, f);
+  f->close_section();
+}
+void decode_json_obj(bucket_index_layout& l, JSONObj *obj)
+{
+  JSONDecoder::decode_json("type", l.type, obj);
+  JSONDecoder::decode_json("normal", l.normal, obj);
+}
 
+// bucket_index_layout_generation
 void encode(const bucket_index_layout_generation& l, bufferlist& bl, uint64_t f)
 {
   ENCODE_START(1, 1, bl);
@@ -73,7 +160,47 @@ void decode(bucket_index_layout_generation& l, bufferlist::const_iterator& bl)
   decode(l.layout, bl);
   DECODE_FINISH(bl);
 }
+void encode_json_impl(const char *name, const bucket_index_layout_generation& l, ceph::Formatter *f)
+{
+  f->open_object_section(name);
+  encode_json("gen", l.gen, f);
+  encode_json("layout", l.layout, f);
+  f->close_section();
+}
+void decode_json_obj(bucket_index_layout_generation& l, JSONObj *obj)
+{
+  JSONDecoder::decode_json("gen", l.gen, obj);
+  JSONDecoder::decode_json("layout", l.layout, obj);
+}
 
+// BucketLogType
+std::string_view to_string(const BucketLogType& t)
+{
+  switch (t) {
+  case BucketLogType::InIndex: return "InIndex";
+  default: return "Unknown";
+  }
+}
+bool parse(std::string_view str, BucketLogType& t)
+{
+  if (boost::iequals(str, "InIndex")) {
+    t = BucketLogType::InIndex;
+    return true;
+  }
+  return false;
+}
+void encode_json_impl(const char *name, const BucketLogType& t, ceph::Formatter *f)
+{
+  encode_json(name, to_string(t), f);
+}
+void decode_json_obj(BucketLogType& t, JSONObj *obj)
+{
+  std::string str;
+  decode_json_obj(str, obj);
+  parse(str, t);
+}
+
+// bucket_index_log_layout
 void encode(const bucket_index_log_layout& l, bufferlist& bl, uint64_t f)
 {
   ENCODE_START(1, 1, bl);
@@ -88,7 +215,20 @@ void decode(bucket_index_log_layout& l, bufferlist::const_iterator& bl)
   decode(l.layout, bl);
   DECODE_FINISH(bl);
 }
+void encode_json_impl(const char *name, const bucket_index_log_layout& l, ceph::Formatter *f)
+{
+  f->open_object_section(name);
+  encode_json("gen", l.gen, f);
+  encode_json("layout", l.layout, f);
+  f->close_section();
+}
+void decode_json_obj(bucket_index_log_layout& l, JSONObj *obj)
+{
+  JSONDecoder::decode_json("gen", l.gen, obj);
+  JSONDecoder::decode_json("layout", l.layout, obj);
+}
 
+// bucket_log_layout
 void encode(const bucket_log_layout& l, bufferlist& bl, uint64_t f)
 {
   ENCODE_START(1, 1, bl);
@@ -111,7 +251,22 @@ void decode(bucket_log_layout& l, bufferlist::const_iterator& bl)
   }
   DECODE_FINISH(bl);
 }
+void encode_json_impl(const char *name, const bucket_log_layout& l, ceph::Formatter *f)
+{
+  f->open_object_section(name);
+  encode_json("type", l.type, f);
+  if (l.type == BucketLogType::InIndex) {
+    encode_json("in_index", l.in_index, f);
+  }
+  f->close_section();
+}
+void decode_json_obj(bucket_log_layout& l, JSONObj *obj)
+{
+  JSONDecoder::decode_json("type", l.type, obj);
+  JSONDecoder::decode_json("in_index", l.in_index, obj);
+}
 
+// bucket_log_layout_generation
 void encode(const bucket_log_layout_generation& l, bufferlist& bl, uint64_t f)
 {
   ENCODE_START(1, 1, bl);
@@ -126,7 +281,53 @@ void decode(bucket_log_layout_generation& l, bufferlist::const_iterator& bl)
   decode(l.layout, bl);
   DECODE_FINISH(bl);
 }
+void encode_json_impl(const char *name, const bucket_log_layout_generation& l, ceph::Formatter *f)
+{
+  f->open_object_section(name);
+  encode_json("gen", l.gen, f);
+  encode_json("layout", l.layout, f);
+  f->close_section();
+}
+void decode_json_obj(bucket_log_layout_generation& l, JSONObj *obj)
+{
+  JSONDecoder::decode_json("gen", l.gen, obj);
+  JSONDecoder::decode_json("layout", l.layout, obj);
+}
 
+// BucketReshardState
+std::string_view to_string(const BucketReshardState& s)
+{
+  switch (s) {
+  case BucketReshardState::None: return "None";
+  case BucketReshardState::InProgress: return "InProgress";
+  default: return "Unknown";
+  }
+}
+bool parse(std::string_view str, BucketReshardState& s)
+{
+  if (boost::iequals(str, "None")) {
+    s = BucketReshardState::None;
+    return true;
+  }
+  if (boost::iequals(str, "InProgress")) {
+    s = BucketReshardState::InProgress;
+    return true;
+  }
+  return false;
+}
+void encode_json_impl(const char *name, const BucketReshardState& s, ceph::Formatter *f)
+{
+  encode_json(name, to_string(s), f);
+}
+void decode_json_obj(BucketReshardState& s, JSONObj *obj)
+{
+  std::string str;
+  decode_json_obj(str, obj);
+  parse(str, s);
+}
+
+
+// BucketLayout
 void encode(const BucketLayout& l, bufferlist& bl, uint64_t f)
 {
   ENCODE_START(2, 1, bl);
@@ -154,6 +355,28 @@ void decode(BucketLayout& l, bufferlist::const_iterator& bl)
     decode(l.logs, bl);
   }
   DECODE_FINISH(bl);
+}
+void encode_json_impl(const char *name, const BucketLayout& l, ceph::Formatter *f)
+{
+  f->open_object_section(name);
+  encode_json("resharding", l.resharding, f);
+  encode_json("current_index", l.current_index, f);
+  if (l.target_index) {
+    encode_json("target_index", *l.target_index, f);
+  }
+  f->open_array_section("logs");
+  for (const auto& log : l.logs) {
+    encode_json("log", log, f);
+  }
+  f->close_section(); // logs[]
+  f->close_section();
+}
+void decode_json_obj(BucketLayout& l, JSONObj *obj)
+{
+  JSONDecoder::decode_json("resharding", l.resharding, obj);
+  JSONDecoder::decode_json("current_index", l.current_index, obj);
+  JSONDecoder::decode_json("target_index", l.target_index, obj);
+  JSONDecoder::decode_json("logs", l.logs, obj);
 }
 
 } // namespace rgw

--- a/src/rgw/rgw_bucket_layout.h
+++ b/src/rgw/rgw_bucket_layout.h
@@ -18,6 +18,7 @@
 #include <optional>
 #include <string>
 #include "include/encoding.h"
+#include "common/ceph_json.h"
 
 namespace rgw {
 
@@ -26,21 +27,24 @@ enum class BucketIndexType : uint8_t {
   Indexless, // no bucket index, so listing is unsupported
 };
 
+std::string_view to_string(const BucketIndexType& t);
+bool parse(std::string_view str, BucketIndexType& t);
+void encode_json_impl(const char *name, const BucketIndexType& t, ceph::Formatter *f);
+void decode_json_obj(BucketIndexType& t, JSONObj *obj);
+
+inline std::ostream& operator<<(std::ostream& out, const BucketIndexType& t)
+{
+  return out << to_string(t);
+}
+
 enum class BucketHashType : uint8_t {
   Mod, // rjenkins hash of object name, modulo num_shards
 };
 
-inline std::ostream& operator<<(std::ostream& out, const BucketIndexType &index_type)
-{
-  switch (index_type) {
-    case BucketIndexType::Normal:
-      return out << "Normal";
-    case BucketIndexType::Indexless:
-      return out << "Indexless";
-    default:
-      return out << "Unknown";
-  }
-}
+std::string_view to_string(const BucketHashType& t);
+bool parse(std::string_view str, BucketHashType& t);
+void encode_json_impl(const char *name, const BucketHashType& t, ceph::Formatter *f);
+void decode_json_obj(BucketHashType& t, JSONObj *obj);
 
 struct bucket_index_normal_layout {
   uint32_t num_shards = 1;
@@ -50,7 +54,8 @@ struct bucket_index_normal_layout {
 
 void encode(const bucket_index_normal_layout& l, bufferlist& bl, uint64_t f=0);
 void decode(bucket_index_normal_layout& l, bufferlist::const_iterator& bl);
-
+void encode_json_impl(const char *name, const bucket_index_normal_layout& l, ceph::Formatter *f);
+void decode_json_obj(bucket_index_normal_layout& l, JSONObj *obj);
 
 struct bucket_index_layout {
   BucketIndexType type = BucketIndexType::Normal;
@@ -61,6 +66,8 @@ struct bucket_index_layout {
 
 void encode(const bucket_index_layout& l, bufferlist& bl, uint64_t f=0);
 void decode(bucket_index_layout& l, bufferlist::const_iterator& bl);
+void encode_json_impl(const char *name, const bucket_index_layout& l, ceph::Formatter *f);
+void decode_json_obj(bucket_index_layout& l, JSONObj *obj);
 
 
 struct bucket_index_layout_generation {
@@ -70,12 +77,19 @@ struct bucket_index_layout_generation {
 
 void encode(const bucket_index_layout_generation& l, bufferlist& bl, uint64_t f=0);
 void decode(bucket_index_layout_generation& l, bufferlist::const_iterator& bl);
+void encode_json_impl(const char *name, const bucket_index_layout_generation& l, ceph::Formatter *f);
+void decode_json_obj(bucket_index_layout_generation& l, JSONObj *obj);
 
 
 enum class BucketLogType : uint8_t {
   // colocated with bucket index, so the log layout matches the index layout
   InIndex,
 };
+
+std::string_view to_string(const BucketLogType& t);
+bool parse(std::string_view str, BucketLogType& t);
+void encode_json_impl(const char *name, const BucketLogType& t, ceph::Formatter *f);
+void decode_json_obj(BucketLogType& t, JSONObj *obj);
 
 inline std::ostream& operator<<(std::ostream& out, const BucketLogType &log_type)
 {
@@ -94,6 +108,8 @@ struct bucket_index_log_layout {
 
 void encode(const bucket_index_log_layout& l, bufferlist& bl, uint64_t f=0);
 void decode(bucket_index_log_layout& l, bufferlist::const_iterator& bl);
+void encode_json_impl(const char *name, const bucket_index_log_layout& l, ceph::Formatter *f);
+void decode_json_obj(bucket_index_log_layout& l, JSONObj *obj);
 
 struct bucket_log_layout {
   BucketLogType type = BucketLogType::InIndex;
@@ -103,6 +119,8 @@ struct bucket_log_layout {
 
 void encode(const bucket_log_layout& l, bufferlist& bl, uint64_t f=0);
 void decode(bucket_log_layout& l, bufferlist::const_iterator& bl);
+void encode_json_impl(const char *name, const bucket_log_layout& l, ceph::Formatter *f);
+void decode_json_obj(bucket_log_layout& l, JSONObj *obj);
 
 
 struct bucket_log_layout_generation {
@@ -112,6 +130,8 @@ struct bucket_log_layout_generation {
 
 void encode(const bucket_log_layout_generation& l, bufferlist& bl, uint64_t f=0);
 void decode(bucket_log_layout_generation& l, bufferlist::const_iterator& bl);
+void encode_json_impl(const char *name, const bucket_log_layout_generation& l, ceph::Formatter *f);
+void decode_json_obj(bucket_log_layout_generation& l, JSONObj *obj);
 
 // return a log layout that shares its layout with the index
 inline bucket_log_layout_generation log_layout_from_index(
@@ -124,6 +144,10 @@ enum class BucketReshardState : uint8_t {
   None,
   InProgress,
 };
+std::string_view to_string(const BucketReshardState& s);
+bool parse(std::string_view str, BucketReshardState& s);
+void encode_json_impl(const char *name, const BucketReshardState& s, ceph::Formatter *f);
+void decode_json_obj(BucketReshardState& s, JSONObj *obj);
 
 // describes the layout of bucket index objects
 struct BucketLayout {
@@ -142,5 +166,7 @@ struct BucketLayout {
 
 void encode(const BucketLayout& l, bufferlist& bl, uint64_t f=0);
 void decode(BucketLayout& l, bufferlist::const_iterator& bl);
+void encode_json_impl(const char *name, const BucketLayout& l, ceph::Formatter *f);
+void decode_json_obj(BucketLayout& l, JSONObj *obj);
 
 } // namespace rgw

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -796,6 +796,7 @@ void RGWBucketInfo::dump(Formatter *f) const
   if (!empty_sync_policy()) {
     encode_json("sync_policy", *sync_policy, f);
   }
+  encode_json("layout", layout, f);
 }
 
 void RGWBucketInfo::decode_json(JSONObj *obj) {
@@ -839,6 +840,7 @@ void RGWBucketInfo::decode_json(JSONObj *obj) {
   if (!sp.empty()) {
     set_sync_policy(std::move(sp));
   }
+  JSONDecoder::decode_json("layout", layout, obj);
 }
 
 void rgw_sync_directional_rule::dump(Formatter *f) const


### PR DESCRIPTION
adds a "layout" section to RGWBucketInfo:
```json
            "layout": {
                "resharding": "None",
                "current_index": {
                    "gen": 0,
                    "layout": {
                        "type": "Normal",
                        "normal": {
                            "num_shards": 11,
                            "hash_type": "Mod"
                        }
                    }
                },
                "logs": [
                    {
                        "gen": 0,
                        "layout": {
                            "type": "InIndex",
                            "in_index": {
                                "gen": 0,
                                "layout": {
                                    "num_shards": 11,
                                    "hash_type": "Mod"
                                }
                            }
                        }
                    }
                ]
            }
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
