### PR TITLE
pacific: mgr/zabbix: format ceph.[{#POOL},percent_used as float

### DIFF
--- a/src/pybind/mgr/zabbix/module.py
+++ b/src/pybind/mgr/zabbix/module.py
@@ -226,7 +226,7 @@ class Module(MgrModule):
             data['[{0},wr_ops]'.format(pool['name'])] = pool['stats']['wr']
             data['[{0},bytes_used]'.format(pool['name'])] = pool['stats']['bytes_used']
             data['[{0},stored_raw]'.format(pool['name'])] = pool['stats']['stored_raw']
-            data['[{0},percent_used]'.format(pool['name'])] = pool['stats']['percent_used']
+            data['[{0},percent_used]'.format(pool['name'])] = pool['stats']['percent_used'] * 100
 
         data['wr_ops'] = wr_ops
         data['rd_ops'] = rd_ops

--- a/src/pybind/mgr/zabbix/zabbix_template.xml
+++ b/src/pybind/mgr/zabbix/zabbix_template.xml
@@ -2425,7 +2425,7 @@
                             <history>90</history>
                             <trends>365</trends>
                             <status>0</status>
-                            <value_type>3</value_type>
+                            <value_type>0</value_type>
                             <allowed_hosts/>
                             <units>%</units>
                             <delta>0</delta>


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49108

---

backport of https://github.com/ceph/ceph/pull/39227
parent tracker: https://tracker.ceph.com/issues/48825

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh