### PR TITLE
mgr/cephadm: only apply osd specs if the devices have changed

### DIFF
--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -298,7 +298,7 @@ class HostCache():
     def update_host_facts(self, host, facts):
         # type: (str, Dict[str, Dict[str, Any]]) -> None
         self.facts[host] = facts
-        self.last_facts_update[host] = datetime.datetime.utcnow()
+        self.last_facts_update[host] = datetime_now()
 
     def devices_changed(self, host: str, b: List[inventory.Device]) -> bool:
         a = self.devices[host]
@@ -544,7 +544,7 @@ class HostCache():
         if host in self.mgr.offline_hosts:
             logger.debug(f'Host "{host}" marked as offline. Skipping gather facts refresh')
             return False
-        cutoff = datetime.datetime.utcnow() - datetime.timedelta(
+        cutoff = datetime_now() - datetime.timedelta(
             seconds=self.mgr.facts_cache_timeout)
         if host not in self.last_facts_update or self.last_facts_update[host] < cutoff:
             return True

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -50,7 +50,7 @@ class OSDService(CephService):
                     drive_group.service_id))
                 return None
 
-            logger.info('Applying drive group %s on host %s...' % (
+            logger.info('Applying service osd.%s on host %s...' % (
                 drive_group.service_id, host
             ))
             start_ts = datetime_now()

--- a/src/python-common/ceph/deployment/inventory.py
+++ b/src/python-common/ceph/deployment/inventory.py
@@ -79,6 +79,8 @@ class Device(object):
                 if key != 'human_readable_type'
             }
         )
+        if ret.rejected_reasons:
+            ret.rejected_reasons = sorted(ret.rejected_reasons)
         return ret
 
     @property


### PR DESCRIPTION
This adds tracking for (1) when the host devices change and (2) when osd specs were last applied to a host.  And then skips the apply if it makes sense.