### PR TITLE
common/TrackedOp: fix historic ops dump `age` calculation

### DIFF
--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -132,7 +132,7 @@ void OpHistory::dump_ops(utime_t now, Formatter *f, set<string> filters, bool by
 	if (!i->second->filter_out(filters))
 	  continue;
 	f->open_object_section("op");
-	i->second->dump(now, f);
+	i->second->dump(f);
 	f->close_section();
       }
     };
@@ -203,7 +203,7 @@ void OpHistory::dump_slow_ops(utime_t now, Formatter *f, set<string> filters)
       if (!i->second->filter_out(filters))
         continue;
       f->open_object_section("Op");
-      i->second->dump(now, f);
+      i->second->dump(f);
       f->close_section();
     }
     f->close_section();
@@ -242,7 +242,7 @@ bool OpTracker::dump_ops_in_flight(Formatter *f, bool print_only_blocked, set<st
       if (!op.filter_out(filters))
         continue;
       f->open_object_section("op");
-      op.dump(now, f);
+      op.dump(f);
       f->close_section(); // this TrackedOp
       total_ops_in_flight++;
     }
@@ -472,11 +472,12 @@ void TrackedOp::mark_event(std::string_view event, utime_t stamp)
   _event_marked();
 }
 
-void TrackedOp::dump(utime_t now, Formatter *f) const
+void TrackedOp::dump(Formatter *f) const
 {
   // Ignore if still in the constructor
   if (!state)
     return;
+  utime_t now = ceph_clock_now();
   f->dump_string("description", get_desc());
   f->dump_stream("initiated_at") << get_initiated();
   f->dump_float("age", now - get_initiated());

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -370,7 +370,7 @@ public:
     return events.empty() ? std::string_view() : std::string_view(events.rbegin()->str);
   }
 
-  void dump(utime_t now, ceph::Formatter *f) const;
+  void dump(ceph::Formatter *f) const;
 
   void tracking_start() {
     if (tracker->register_inflight_op(this)) {


### PR DESCRIPTION
verified initiated is same as get_recv_stamp(), which seems to be correct, this
implys `now` might be having a older value rather than the latest, shifting
utime `now` to actually being calculated while dumping ops will saving on
useless passing of now as argument as well, alongside fixing wrong calculation
for `age` dump.

test run: https://paste.centos.org/view/3351c7c5
fixes: https://tracker.ceph.com/issues/47813


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
