### PR TITLE
mgr/orchestrator: useful message when no service type in "ceph orch apply"

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1099,7 +1099,8 @@ Usage:
                 specs.append(spec)
         else:
             placementspec = PlacementSpec.from_string(placement)
-            assert service_type
+            if not service_type:
+                raise OrchestratorValidationError(usage)
             specs = [ServiceSpec(service_type.value, placement=placementspec,
                                  unmanaged=unmanaged, preview_only=dry_run)]
 


### PR DESCRIPTION
Right now it just gives a traceback. A message telling users they have
not provided a proper service type would be more useful

Signed-off-by: Adam King <adking@redhat.com>

current output:

```
[ceph: root@magna094 /]# ceph orch apply
Error EINVAL: Traceback (most recent call last):
  File "/usr/share/ceph/mgr/mgr_module.py", line 1195, in _handle_command
    return self.handle_command(inbuf, cmd)
  File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 141, in handle_command
    return dispatch[cmd['prefix']].call(self, cmd, inbuf)
  File "/usr/share/ceph/mgr/mgr_module.py", line 332, in call
    return self.func(mgr, **kwargs)
  File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 103, in <lambda>
    wrapper_copy = lambda *l_args, **l_kwargs: wrapper(*l_args, **l_kwargs)
  File "/usr/share/ceph/mgr/orchestrator/_interface.py", line 92, in wrapper
    return func(*args, **kwargs)
  File "/usr/share/ceph/mgr/orchestrator/module.py", line 1080, in _apply_misc
    assert service_type
AssertionError
```

new output:

```
[ceph: root@vm-00 /]# ceph orch apply
Error EINVAL: Improper use of 'ceph orch apply'. No valid service type provided.
Usage:
  ceph orch apply -i <yaml spec> [--dry-run]
  ceph orch apply <service_type> [--placement=<placement_string>] [--unmanaged]
        where <service_type> must be: mon|mgr|rbd-mirror|crash|alertmanager|grafana|node-exporter|prometheus|mds|rgw|nfs|iscsi|cephadm-exporter
```

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
