### PR TITLE
cmake: partial revert of BOOST_USE_VALGRIND when ALLOCATOR=libc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,13 +350,6 @@ else(ALLOCATOR)
   endif(gperftools_FOUND)
 endif(ALLOCATOR)
 
-if(${ALLOCATOR} STREQUAL "libc" AND WITH_SYSTEM_BOOST)
-  # valgrind can only work with libc allocator
-  # if system boost is not used, valgrind use should
-  #   be indicated via the WITH_BOOST_VALGRIND parameter
-  add_definitions(-DBOOST_USE_VALGRIND)
-endif()
-
 # Mingw generates incorrect entry points when using "-pie".
 if(WIN32 OR (HAVE_LIBTCMALLOC AND WITH_STATIC_LIBSTDCXX))
   set(EXE_LINKER_USE_PIE FALSE)


### PR DESCRIPTION
the WITH_SYSTEM_BOOST binaries are not built with BOOST_USE_VALGRIND, so it probably isn't safe to define for the headers only

this flag is needed for teuthology testing, and the shaman builds use WITH_SYSTEM_BOOST=OFF. so the better fix is to enable WITH_BOOST_VALGRIND so BuildBoost.cmake will build the libraries with valgrind support and add -DBOOST_USE_VALGRIND to the necessary targets

this change was merged in https://github.com/ceph/ceph-build/pull/1736

Fixes: https://tracker.ceph.com/issues/48963

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
