### PR TITLE
common/ceph_time: allow wait_until() mono time

### DIFF
--- a/src/common/ceph_time.h
+++ b/src/common/ceph_time.h
@@ -276,8 +276,20 @@ public:
   static time_point zero() {
     return time_point::min();
   }
-};
 
+  static void to_timespec(const time_point& t, struct timespec& ts) {
+    auto s = std::chrono::time_point_cast<std::chrono::seconds>(t);
+    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t - s);
+    ts = {static_cast<std::time_t>(s.time_since_epoch().count()),
+          static_cast<long>(ns.count())};
+  }
+
+  static struct timespec to_timespec(const time_point& t) {
+    struct timespec ts;
+    to_timespec(t, ts);
+    return ts;
+  }
+};
 // Low-resolution but, I would hope or there's no point, faster
 // monotonic clock
 class coarse_mono_clock {

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -565,7 +565,7 @@ int MonClient::authenticate(double timeout)
   if (!_opened())
     _reopen_session();
 
-  auto until = ceph::real_clock::now();
+  auto until = ceph::mono_clock::now();
   until += ceph::make_timespan(timeout);
   if (timeout > 0.0)
     ldout(cct, 10) << "authenticate will time out at " << until << dendl;


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
