### PR TITLE
crimson/os/seastore: do not capture unused variables

### DIFF
--- a/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.cc
@@ -27,7 +27,7 @@ BtreeOMapManager::initialize_omap(Transaction &t)
 
   logger().debug("{}", __func__);
   return tm.alloc_extent<OMapLeafNode>(t, L_ADDR_MIN, OMAP_BLOCK_SIZE)
-    .safe_then([this](auto&& root_extent) {
+    .safe_then([](auto&& root_extent) {
       root_extent->set_size(0);
       omap_node_meta_t meta{1};
       root_extent->set_meta(meta);
@@ -49,7 +49,7 @@ BtreeOMapManager::handle_root_split(omap_root_t &omap_root, omap_context_t oc,
                                     OMapNode::mutation_result_t mresult)
 {
   return oc.tm.alloc_extent<OMapInnerNode>(oc.t, L_ADDR_MIN, OMAP_BLOCK_SIZE)
-    .safe_then([&omap_root, oc, mresult](auto&& nroot) {
+    .safe_then([&omap_root, mresult](auto&& nroot) {
     auto [left, right, pivot] = *(mresult.split_tuple);
     omap_node_meta_t meta{omap_root.depth + 1};
     nroot->set_meta(meta);
@@ -90,7 +90,7 @@ BtreeOMapManager::omap_get_value(const omap_root_t &omap_root, Transaction &t,
                                  const std::string &key)
 {
   logger().debug("{}: {}", __func__, key);
-  return get_omap_root(omap_root, t).safe_then([this, &omap_root, &t, &key](auto&& extent) {
+  return get_omap_root(omap_root, t).safe_then([this, &t, &key](auto&& extent) {
     return extent->get_value(get_omap_context(t), key);
   }).safe_then([](auto &&e) {
     logger().debug("{}: {} -> {}", __func__, e.first, e.second);
@@ -105,7 +105,7 @@ BtreeOMapManager::omap_set_key(omap_root_t &omap_root, Transaction &t,
                              const std::string &key, const std::string &value)
 {
   logger().debug("{}: {} -> {}", __func__, key, value);
-  return get_omap_root(omap_root, t).safe_then([this, &omap_root, &t, &key, &value](auto root) {
+  return get_omap_root(omap_root, t).safe_then([this, &t, &key, &value](auto root) {
     return root->insert(get_omap_context(t), key, value);
   }).safe_then([this, &omap_root, &t](auto mresult) {
     if (mresult.status == mutation_status_t::SUCCESS)
@@ -121,7 +121,7 @@ BtreeOMapManager::omap_rm_key_ret
 BtreeOMapManager::omap_rm_key(omap_root_t &omap_root, Transaction &t, const std::string &key)
 {
   logger().debug("{}: {}", __func__, key);
-  return get_omap_root(omap_root, t).safe_then([this, &omap_root, &t, &key](auto root) {
+  return get_omap_root(omap_root, t).safe_then([this, &t, &key](auto root) {
     return root->rm_key(get_omap_context(t), key);
   }).safe_then([this, &omap_root, &t](auto mresult) {
     if (mresult.status == mutation_status_t::SUCCESS)
@@ -146,7 +146,7 @@ BtreeOMapManager::omap_list_keys(const omap_root_t &omap_root, Transaction &t,
                                  std::string &start, size_t max_result_size)
 {
   logger().debug("{}", __func__);
-  return get_omap_root(omap_root, t).safe_then([this, &omap_root, &t, &start,
+  return get_omap_root(omap_root, t).safe_then([this, &t, &start,
     max_result_size] (auto extent) {
     return extent->list_keys(get_omap_context(t), start, max_result_size)
       .safe_then([](auto &&result) {
@@ -163,7 +163,7 @@ BtreeOMapManager::omap_list(const omap_root_t &omap_root, Transaction &t,
                             std::string &start, size_t max_result_size)
 {
   logger().debug("{}", __func__);
-  return get_omap_root(omap_root, t).safe_then([this, &omap_root, &t, &start, max_result_size]
+  return get_omap_root(omap_root, t).safe_then([this, &t, &start, max_result_size]
     (auto extent) {
     return extent->list(get_omap_context(t), start, max_result_size)
       .safe_then([](auto &&result) {
@@ -178,7 +178,7 @@ BtreeOMapManager::omap_clear_ret
 BtreeOMapManager::omap_clear(omap_root_t &omap_root, Transaction &t)
 {
   logger().debug("{}", __func__);
-  return get_omap_root(omap_root, t).safe_then([this, &omap_root, &t](auto extent) {
+  return get_omap_root(omap_root, t).safe_then([this, &t](auto extent) {
     return extent->clear(get_omap_context(t));
   }).safe_then([this, &omap_root, &t] {
     return tm.dec_ref(t, omap_root.omap_root_laddr).safe_then([&omap_root] (auto ret) {


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
