### PR TITLE
common/Timer: use mono_clock for clock_t

### DIFF
--- a/src/common/Timer.cc
+++ b/src/common/Timer.cc
@@ -153,6 +153,18 @@ Context* SafeTimer::add_event_at(SafeTimer::clock_t::time_point when, Context *c
   return callback;
 }
 
+Context* SafeTimer::add_event_at(ceph::real_clock::time_point when, Context *callback)
+{
+  ceph_assert(ceph_mutex_is_locked(lock));
+  // convert from real_clock to mono_clock
+  auto mono_now = ceph::mono_clock::now();
+  auto real_now = ceph::real_clock::now();
+  const auto delta = when - real_now;
+  const auto mono_atime = (mono_now +
+			   std::chrono::ceil<clock_t::duration>(delta));
+  return add_event_at(mono_atime, callback);
+}
+
 bool SafeTimer::cancel_event(Context *callback)
 {
   ceph_assert(ceph_mutex_is_locked(lock));

--- a/src/common/Timer.h
+++ b/src/common/Timer.h
@@ -77,7 +77,7 @@ public:
   Context* add_event_after(ceph::timespan duration, Context *callback);
   Context* add_event_after(double seconds, Context *callback);
   Context* add_event_at(clock_t::time_point when, Context *callback);
-
+  Context* add_event_at(ceph::real_clock::time_point when, Context *callback);
   /* Cancel an event.
    * Call with the event_lock LOCKED
    *

--- a/src/common/Timer.h
+++ b/src/common/Timer.h
@@ -36,7 +36,7 @@ class SafeTimer
   void timer_thread();
   void _shutdown();
 
-  using clock_t = ceph::real_clock;
+  using clock_t = ceph::mono_clock;
   using scheduled_map_t = std::multimap<clock_t::time_point, Context*>;
   scheduled_map_t schedule;
   using event_lookup_map_t = std::map<Context*, scheduled_map_t::iterator>;

--- a/src/mgr/MgrClient.h
+++ b/src/mgr/MgrClient.h
@@ -76,7 +76,7 @@ protected:
 
   CommandTable<MgrCommand> command_table;
 
-  using clock_t = ceph::real_clock;
+  using clock_t = ceph::mono_clock;
   clock_t::time_point last_connect_attempt;
 
   uint64_t last_config_bl_version = 0;

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -567,7 +567,7 @@ int MonClient::authenticate(double timeout)
   if (!_opened())
     _reopen_session();
 
-  auto until = ceph::real_clock::now();
+  auto until = ceph::mono_clock::now();
   until += ceph::make_timespan(timeout);
   if (timeout > 0.0)
     ldout(cct, 10) << "authenticate will time out at " << until << dendl;


### PR DESCRIPTION
there is chance that the system is adjust by chrony or ntpd, so that
a timer scheduled at epoch time 12:34 would never get scheduled if
the system clock is changed to 12:35 when the system clock is still
12:33.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
