### PR TITLE
octopus: rgw: fix trailing null in object names of multipart reuploads

### DIFF
--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -340,8 +340,7 @@ int MultipartObjectProcessor::process_first_chunk(bufferlist&& data,
   int r = writer.write_exclusive(data);
   if (r == -EEXIST) {
     // randomize the oid prefix and reprepare the head/manifest
-    std::string oid_rand(32, 0);
-    gen_rand_alphanumeric(store->ctx(), oid_rand.data(), oid_rand.size());
+    std::string oid_rand = gen_rand_alphanumeric(store->ctx(), 32);
 
     mp.init(target_obj.key.name, upload_id, oid_rand);
     manifest.set_prefix(target_obj.key.name + "." + oid_rand);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49131

---

backport of https://github.com/ceph/ceph/pull/38905
parent tracker: https://tracker.ceph.com/issues/48874

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh