### PR TITLE
qa/tasks/mgr/test_progress.py: wait longer for event to pop up

### DIFF
--- a/qa/tasks/mgr/test_progress.py
+++ b/qa/tasks/mgr/test_progress.py
@@ -388,7 +388,7 @@ class TestProgress(MgrTestCase):
 
         # Wait for a progress event to pop up
         self.wait_until_equal(lambda: self._osd_in_out_events_count('out'), 1,
-                              timeout=self.EVENT_CREATION_PERIOD*2,
+                              timeout=self.RECOVERY_PERIOD,
                               period=1)
 
         ev1 = self._get_osd_in_out_events('out')[0]
@@ -397,4 +397,5 @@ class TestProgress(MgrTestCase):
 
         self.wait_until_true(lambda: self._is_complete(ev1['id']),
                              timeout=self.RECOVERY_PERIOD)
-        self.assertTrue(self._is_quiet())
+
+        self.assertEqual(self._osd_in_out_events_count(), 0)


### PR DESCRIPTION
In test_turn_off_module() increase timeout from 10 seconds
to 40 seconds for event to pop up after progress module is
turned back on

Fixes: https://tracker.ceph.com/issues/48841

Signed-off-by: Kamoltat <ksirivad@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
