### PR TITLE
qa/suites/rados/dashboard: whitelist TELEMETRY_CHANGED

### DIFF
--- a/qa/suites/rados/dashboard/tasks/dashboard.yaml
+++ b/qa/suites/rados/dashboard/tasks/dashboard.yaml
@@ -23,6 +23,7 @@ tasks:
         - \(POOL_APP_NOT_ENABLED\)
         - \(OSDMAP_FLAGS\)
         - \(OSD_FLAGS\)
+        - \(TELEMETRY_CHANGED\)
         - pauserd,pausewr flag\(s\) set
         - Monitor daemon marked osd\.[[:digit:]]+ down, but it is still running
         - evicting unresponsive client .+


### PR DESCRIPTION
test_enable_module_empty_license fiddles with this.

Fixes: https://tracker.ceph.com/issues/48990
Signed-off-by: Sage Weil <sage@newdream.net>