### PR TITLE
qa/distros: Don't let focal sleep

### DIFF
--- a/qa/distros/all/ubuntu_20.04.yaml
+++ b/qa/distros/all/ubuntu_20.04.yaml
@@ -1,2 +1,7 @@
 os_type: ubuntu
 os_version: "20.04"
+
+tasks:
+- exec:
+    all:
+      - sudo systemctl mask sleep.target suspend.target hibernate.target hybrid-sleep.target


### PR DESCRIPTION
Seems we may have chosen a workstation fog image for ubuntu focal 20.04 that is going to sleep during teuthology tests resulting in an apparent 'hang' scenario. This PR disables all system sleep/suspend/hibernation on that distro.

This is a quick hack to get us by until we can organise a new image/config.

Fixes: https://tracker.ceph.com/issues/49152

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
