### PR TITLE
src/script: utility script to open all failed jobs at once on teuthology server

### DIFF
--- a/src/script/open_failed_logs.py
+++ b/src/script/open_failed_logs.py
@@ -1,0 +1,33 @@
+#############################################################################################################################
+#
+# opens all failed(or dead) jobs on teuthology server using vim
+# usage: python3 log_to_vim.py $job_name
+# example: python3 log_to_vim.py yuriw-2021-01-06_21:20:32-rados-wip-yuri3-testing-2021-01-06-0820-octopus-distro-basic-smithi
+#
+##############################################################################################################################
+#!/usr/bin/env python3
+import re
+import os
+import sys
+
+if (len(sys.argv) == 2):
+	run_name = str(sys.argv[1])
+	archive = "/ceph/teuthology-archive/" + run_name + "/"
+	print(" opening failed/dead jobs for " + archive)
+	print(".......")
+
+	scrape = archive + "scrape.log"
+
+	with open(scrape,'r') as f:
+		job_id = re.findall(r"\'\b[0-9]{7}\b\'", f.read())
+		print("jobs that failed...")
+
+	for idx, item in enumerate(job_id):
+		job_id[idx] = archive + item.strip("'")+ "/teuthology.log"
+		print("job id" + job_id[idx])
+
+	os.system("vim -p " +" ".join(job_id))
+else:
+	print("please enter run name")
+	print("usage: python3 log_to_vim.py $job_name")
+


### PR DESCRIPTION
uses vim tabs + result.log from teuthology to open failed+dead jobs all
in vim tabs.
Been using it for rados batch analysis and it did help me simply workflow,
thought to share with other folks as well.
Note

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
