### PR TITLE
octopus: mgr/dashboard/monitoring: upgrade Grafana version due to CVE-2020-13379

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -182,7 +182,7 @@ class Monitoring(object):
             ],
         },
         "grafana": {
-            "image": "docker.io/ceph/ceph-grafana:6.6.2",
+            "image": "docker.io/ceph/ceph-grafana:6.7.4",
             "cpus": "2",
             "memory": "4GB",
             "args": [],

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -173,7 +173,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule):
         },
         {
             'name': 'container_image_grafana',
-            'default': 'docker.io/ceph/ceph-grafana:6.6.2',
+            'default': 'docker.io/ceph/ceph-grafana:6.7.4',
             'desc': 'Prometheus container image',
         },
         {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48829

---

backport of https://github.com/ceph/ceph/pull/38671
parent tracker: https://tracker.ceph.com/issues/48685

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh