### PR TITLE
pacific: qa/suites/upgrade/octopus-x/parallel: include cephfs in upgrade cluster

### DIFF
--- a/qa/suites/upgrade/octopus-x/parallel/1-tasks.yaml
+++ b/qa/suites/upgrade/octopus-x/parallel/1-tasks.yaml
@@ -13,7 +13,13 @@ tasks:
         osd_class_default_list: "*"
 - print: "**** done end installing octopus cephadm ..."
 
-- print: "**** done start cephadm.shell ceph config set mgr..."
+- cephadm.shell:
+    mon.a:
+      - ceph fs volume create foo
+- ceph.healthy:
+
+- print: "**** done creating new fs"
+
 - cephadm.shell:
     mon.a:
       - ceph config set mgr mgr/cephadm/use_repo_digest true --force


### PR DESCRIPTION
backport of #39213

Signed-off-by: Sage Weil <sage@newdream.net>
(cherry picked from commit ab267d3577bb6a072daa6c8b57694f74c2eb4e73)