### PR TITLE
doc: fix the spelling mistake of “Rersult”

### DIFF
--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -205,7 +205,7 @@ Response will have the following format:
 ::
 
     <GetTopicAttributesResponse>
-        <GetTopicAttributesRersult>
+        <GetTopicAttributesResult>
             <Attributes>
                 <entry>
                     <key>User</key>
@@ -263,7 +263,7 @@ Response will have the following format:
 ::
 
     <GetTopicResponse>
-        <GetTopicRersult>
+        <GetTopicResult>
             <Topic>
                 <User></User>
                 <Name></Name>
@@ -336,7 +336,7 @@ Response will have the following format:
 ::
 
     <ListTopicdResponse xmlns="https://sns.amazonaws.com/doc/2010-03-31/">
-        <ListTopicsRersult>
+        <ListTopicsResult>
             <Topics>
                 <member>
                     <User></User>


### PR DESCRIPTION
“Rersult” is a spelling mistake of "Result".

Signed-off-by: Alex Wang  wangdashuai@inspur.com