### PR TITLE
Crush: indep algorithm perfer select osd from the same failure-domain when osd failed

### DIFF
--- a/src/crush/mapper.c
+++ b/src/crush/mapper.c
@@ -700,6 +700,7 @@ static void crush_choose_indep(const struct crush_map *map,
 			dprintk("\n");
 		}
 #endif
+		int rechoose_bucket = 0;
 		for (rep = outpos; rep < endpos; rep++) {
 			if (out[rep] != CRUSH_ITEM_UNDEF)
 				continue;
@@ -804,8 +805,10 @@ static void crush_choose_indep(const struct crush_map *map,
 
 				/* out? */
 				if (itemtype == 0 &&
-				    is_out(map, weight, weight_max, item, x))
+				    is_out(map, weight, weight_max, item, x)) {
+				        rechoose_bucket = 1;
 					break;
+                                }
 
 				/* yay! */
 				out[rep] = item;
@@ -813,6 +816,8 @@ static void crush_choose_indep(const struct crush_map *map,
 				break;
 			}
 		}
+		if (rechoose_bucket == 1)
+                        break;
 	}
 	for (rep = outpos; rep < endpos; rep++) {
 		if (out[rep] == CRUSH_ITEM_UNDEF) {


### PR DESCRIPTION
Scenes: EC (2 + 1), the failure domain is host.

We found an interesting point about the erasure code crush algorithm. When an osd is marked out, most PGs of the osd will be rebalanced to other OSDs in the same host, instead of cross-node rebalancing. This will lead to recovery bottleneck (a single node may become a performance bottleneck).
The reason is that after the osd selected by CRUSH is eliminated (eg. osd is out), it will continue to select other osd under the current bucket.

Crush log:
```
CHOOSE_LEAF INDEP bucket -1 x -113899774 outpos 0 numrep 3
 crush_bucket_choose -1 x=-113899774 r=0
weight 0x4bb7 item -5
weight 0x4bb7 item -6
weight 0x4bb7 item -7
weight 0x4bb7 item -8
weight 0x4bb7 item -9
  item -5 type 1
CHOOSE INDEP bucket -5 x -113899774 outpos 0 numrep 3
 crush_bucket_choose -5 x=-113899774 r=0
weight 0x193d item 0
weight 0x193d item 1
weight 0x193d item 2
  item 2 type 0                                                     # --> osd.2 is out
 crush_bucket_choose -5 x=-113899774 r=3
weight 0x193d item 0
weight 0x193d item 1
weight 0x193d item 2
  item 0 type 0                                                     # --> got osd.0
 crush_bucket_choose -1 x=-113899774 r=1
weight 0x4bb7 item -5
weight 0x4bb7 item -6
weight 0x4bb7 item -7
weight 0x4bb7 item -8
weight 0x4bb7 item -9
  item -7 type 1
CHOOSE INDEP bucket -7 x -113899774 outpos 1 numrep 3
......
```

We have no idea if this was **intentional** or **a bug**?
If it is a bug, this patch tries to fix it, though the PGs still has a high probability of rebalancing in the current bucket.

Before:
```
[root@ceph178 /ceph/build]# ceph osd df tree
ID CLASS WEIGHT  REWEIGHT SIZE    USE     AVAIL   %USE VAR  PGS STATUS TYPE NAME
-1       1.47881        - 1.5 TiB  30 GiB 1.5 TiB 1.98 1.00   -        root default
-5       0.29576        - 303 GiB 6.0 GiB 297 GiB 1.98 1.00   -            host host1
 0   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 103     up         osd.0
 1   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.1
 2   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.2
-6       0.29576        - 303 GiB 6.0 GiB 297 GiB 1.98 1.00   -            host host2
 3   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.3
 4   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 103     up         osd.4
 5   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.5
-7       0.29576        - 303 GiB 6.0 GiB 297 GiB 1.98 1.00   -            host host3
 6   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 103     up         osd.6
 7   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 103     up         osd.7
 8   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.8
-8       0.29576        - 303 GiB 6.0 GiB 297 GiB 1.98 1.00   -            host host4
 9   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 103     up         osd.9
10   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 103     up         osd.10
11   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.11
-9       0.29576        - 303 GiB 6.0 GiB 297 GiB 1.98 1.00   -            host host5
12   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.12
13   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.13
14   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.14
                    TOTAL 1.5 TiB  30 GiB 1.5 TiB 1.98
MIN/MAX VAR: 1.00/1.00  STDDEV: 0
[root@ceph178 /ceph/build]# ceph balancer off
[root@ceph178 /ceph/build]# ceph osd out 2
marked out osd.2.
[root@ceph178 /ceph/build]# ceph osd df tree
ID CLASS WEIGHT  REWEIGHT SIZE    USE     AVAIL   %USE VAR  PGS STATUS TYPE NAME
-1       1.47881        - 1.4 TiB  28 GiB 1.4 TiB 1.98 1.00   -        root default
-5       0.29576        - 202 GiB 4.0 GiB 198 GiB 1.98 1.00   -            host host1
 0   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 164     up         osd.0
 1   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 142     up         osd.1
 2   ssd 0.09859        0     0 B     0 B     0 B    0    0   0     up         osd.2
-6       0.29576        - 303 GiB 6.0 GiB 297 GiB 1.98 1.00   -            host host2
 3   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.3
 4   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 103     up         osd.4
 5   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 103     up         osd.5
-7       0.29576        - 303 GiB 6.0 GiB 297 GiB 1.98 1.00   -            host host3
 6   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 103     up         osd.6
 7   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 103     up         osd.7
 8   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 103     up         osd.8
-8       0.29576        - 303 GiB 6.0 GiB 297 GiB 1.98 1.00   -            host host4
 9   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 103     up         osd.9
10   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 103     up         osd.10
11   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.11
-9       0.29576        - 303 GiB 6.0 GiB 297 GiB 1.98 1.00   -            host host5
12   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.12
13   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.13
14   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 101     up         osd.14
                    TOTAL 1.5 TiB  30 GiB 1.5 TiB 1.98
MIN/MAX VAR: 1.00/1.00  STDDEV: 0
[root@ceph178 /ceph/build]#
```

After:
```
[root@ceph178 /ceph/build]# ceph osd df tree
ID CLASS WEIGHT  REWEIGHT SIZE    USE     AVAIL   %USE VAR  PGS STATUS TYPE NAME
-1       1.47881        - 1.5 TiB  30 GiB 1.5 TiB 1.98 1.00   -        root default
-5       0.29576        - 303 GiB 6.0 GiB 297 GiB 1.98 1.00   -            host host1
 0   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.0
 1   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.1
 2   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 103     up         osd.2
-6       0.29576        - 303 GiB 6.0 GiB 297 GiB 1.98 1.00   -            host host2
 3   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.3
 4   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 103     up         osd.4
 5   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.5
-7       0.29576        - 303 GiB 6.0 GiB 297 GiB 1.98 1.00   -            host host3
 6   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 103     up         osd.6
 7   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 103     up         osd.7
 8   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 103     up         osd.8
-8       0.29576        - 303 GiB 6.0 GiB 297 GiB 1.98 1.00   -            host host4
 9   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.9
10   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 103     up         osd.10
11   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.11
-9       0.29576        - 303 GiB 6.0 GiB 297 GiB 1.98 1.00   -            host host5
12   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.12
13   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.13
14   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 102     up         osd.14
                    TOTAL 1.5 TiB  30 GiB 1.5 TiB 1.98
MIN/MAX VAR: 1.00/1.00  STDDEV: 0
[root@ceph178 /ceph/build]# ceph balancer off
[root@ceph178 /ceph/build]# ceph osd out 2
marked out osd.2.
[root@ceph178 /ceph/build]# ceph osd df tree
ID CLASS WEIGHT  REWEIGHT SIZE    USE     AVAIL   %USE VAR  PGS STATUS TYPE NAME
-1       1.47881        - 1.4 TiB  28 GiB 1.4 TiB 1.98 1.00   -        root default
-5       0.29576        - 202 GiB 4.0 GiB 198 GiB 1.98 1.00   -            host host1
 0   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 122     up         osd.0
 1   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 116     up         osd.1
 2   ssd 0.09859        0     0 B     0 B     0 B    0    0   0     up         osd.2
-6       0.29576        - 303 GiB 6.0 GiB 297 GiB 1.98 1.00   -            host host2
 3   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 106     up         osd.3
 4   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 106     up         osd.4
 5   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 112     up         osd.5
-7       0.29576        - 303 GiB 6.0 GiB 297 GiB 1.98 1.00   -            host host3
 6   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 105     up         osd.6
 7   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 112     up         osd.7
 8   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 111     up         osd.8
-8       0.29576        - 303 GiB 6.0 GiB 297 GiB 1.98 1.00   -            host host4
 9   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 106     up         osd.9
10   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 108     up         osd.10
11   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 109     up         osd.11
-9       0.29576        - 303 GiB 6.0 GiB 297 GiB 1.98 1.00   -            host host5
12   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 108     up         osd.12
13   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 106     up         osd.13
14   ssd 0.09859  1.00000 101 GiB 2.0 GiB  99 GiB 1.98 1.00 109     up         osd.14
                    TOTAL 1.5 TiB  30 GiB 1.5 TiB 1.98
MIN/MAX VAR: 1.00/1.00  STDDEV: 0
[root@ceph178 /ceph/build]#
```

Signed-off-by: guoyong guo.yong33@zte.com.cn
Signed-off-by: songweibin <song.weibin@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
