### PR TITLE
octopus: os/bluestore: introduce bluestore_rocksdb_options_annex config parame…

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -6,6 +6,10 @@
   This improves out of the box performance of Ceph by allowing more PGs 
   to be created for a given pool.
 
+* New bluestore_rocksdb_options_annex config parameter. Complements
+  bluestore_rocksdb_options and allows setting rocksdb options without repeating
+  the existing defaults.
+
 15.2.8
 ------
 * $pid expansion in config paths like `admin_socket` will now properly expand

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1014,6 +1014,7 @@ OPTION(bluestore_bitmapallocator_span_size, OPT_INT) // must be power of 2 align
 OPTION(bluestore_max_deferred_txc, OPT_U64)
 OPTION(bluestore_max_defer_interval, OPT_U64)
 OPTION(bluestore_rocksdb_options, OPT_STR)
+OPTION(bluestore_rocksdb_options_annex, OPT_STR)
 OPTION(bluestore_fsck_on_mount, OPT_BOOL)
 OPTION(bluestore_fsck_on_mount_deep, OPT_BOOL)
 OPTION(bluestore_fsck_quick_fix_on_mount, OPT_BOOL)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4434,7 +4434,11 @@ std::vector<Option> get_global_options() {
 
     Option("bluestore_rocksdb_options", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("compression=kNoCompression,max_write_buffer_number=4,min_write_buffer_number_to_merge=1,recycle_log_file_num=4,write_buffer_size=268435456,writable_file_max_buffer_size=0,compaction_readahead_size=2097152,max_background_compactions=2")
-    .set_description("Rocksdb options"),
+    .set_description("Full set of rocksdb settings to override"),
+
+    Option("bluestore_rocksdb_options_annex", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("")
+    .set_description("An addition to bluestore_rocksdb_options. Allows setting rocksdb options without repeating the existing defaults."),
 
     Option("bluestore_rocksdb_cf", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5771,6 +5771,14 @@ int BlueStore::_open_bluefs(bool create)
   if (bluefs_layout.shared_bdev == BlueFS::BDEV_SLOW) {
 
     string options = cct->_conf->bluestore_rocksdb_options;
+    string options_annex = cct->_conf->bluestore_rocksdb_options_annex;
+    if (!options_annex.empty()) {
+      if (!options.empty() &&
+        *options.rbegin() != ',') {
+        options += ',';
+      }
+      options += options_annex;
+    }
 
     rocksdb::Options rocks_opts;
     int r = RocksDBStore::ParseOptionsFromStringStatic(
@@ -5973,6 +5981,7 @@ int BlueStore::_open_db(bool create, bool to_repair_db, bool read_only)
   ceph_assert(!(create && read_only));
   string fn = path + "/db";
   string options;
+  string options_annex;
   stringstream err;
   std::shared_ptr<Int64ArrayMergeOperator> merge_op(new Int64ArrayMergeOperator);
 
@@ -6121,6 +6130,14 @@ int BlueStore::_open_db(bool create, bool to_repair_db, bool read_only)
 
   if (kv_backend == "rocksdb") {
     options = cct->_conf->bluestore_rocksdb_options;
+    options_annex = cct->_conf->bluestore_rocksdb_options_annex;
+    if (!options_annex.empty()) {
+      if (!options.empty() &&
+        *options.rbegin() != ',') {
+        options += ',';
+      }
+      options += options_annex;
+    }
 
     map<string,string> cf_map;
     cct->_conf.with_val<string>("bluestore_rocksdb_cfs",


### PR DESCRIPTION
…ter.

This simplifies modifying a subset of rocksdb settings since it
eliminates the need to re-provide bluestore's rocksdb settings.

Signed-off-by: Igor Fedotov <ifedotov@suse.com>
(cherry picked from commit 711505e8f9effbf4f0ada3bfe8d25dbc7e86861e)

 Conflicts:
  (trivial)	PendingReleaseNotes
  (trivial)	src/common/options.cc
  (trivial)	src/os/bluestore/BlueStore.cc


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
