### PR TITLE
cephadm: also print occupying process of port in use

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -985,6 +985,34 @@ def check_ip_port(ctx, ip, port):
         except OSError as e:
             raise Error(e)
 
+def _parse_ss_lpnt(data:str):
+    # ss doen't support json output. Thus we have to parse it.
+    # https://unix.stackexchange.com/questions/157823/list-ports-a-process-pid-is-listening-on-preferably-using-iproute2-tools
+    out = []
+    for line in data.splitlines():
+        if line.startswith('STATE'):
+            if ' '.join(line.split()) != 'State Recv-Q Send-Q Local Address:Port Peer Address:Port':
+                logger.warning('ss -lpnt: unable to parse header "{line}"')
+                return {}
+        if 'users:((' not in line:
+            continue
+        before, after = line.split('users:((')
+        data = dict(zip('State,Recv-Q,Send-Q,Local Address:Port,Peer Address:Port'.split(','), before.split()))
+
+        users = after.rstrip('))').split(',')
+        data.update(dict(zip('name pid'.split(), users[:2])))
+        out.append(data)
+    return out
+
+def port_in_use_by(ctx, port_num: int) -> str:
+    out, err, code = call(ctx, ['ss', '-l', '-p', '-n', '-t'])
+    data = _parse_ss_lpnt(out)
+    for item in data:
+        if f':{port_num}' in item['Local Address:Port']:
+            return f'{item["name"]} {item["pid"]}'
+    return ''
+
+
 ##################################
 
 # this is an abbreviated version of
@@ -2478,7 +2506,16 @@ def deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid,
 
     ports = ports or []
     if any([port_in_use(ctx, port) for port in ports]):
-        raise Error("TCP Port(s) '{}' required for {} already in use".format(",".join(map(str, ports)), daemon_type))
+        if len(ports) == 1:
+            used_by = port_in_use_by(ctx, ports[0])
+            if used_by:
+                used_by = f'by {used_by}'
+            raise Error(f"TCP Port '{ports[0]}' required for {daemon_type} already in use {used_by}")
+        else:
+            used_bys = [port_in_use_by(ctx, port) for port in ports]
+            used_by = ', '.join(f'Port {p[0]} used by {p[1]}' for p in zip(ports, used_bys) if p[1])
+            raise Error(f"TCP Ports '{ports[0]}' required for {daemon_type} already in use ({used_by})")
+
 
     data_dir = get_data_dir(fsid, ctx.data_dir, daemon_type, daemon_id)
     if reconfig and not os.path.exists(data_dir):

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -305,6 +305,138 @@ docker.io/ceph/daemon-base:octopus
         image = cd._filter_last_local_ceph_image(out)
         assert image == 'docker.io/ceph/ceph:v15.2.5'
 
+    def test_parse_ss_lpnt(self):
+        out = '''
+State    Recv-Q    Send-Q        Local Address:Port        Peer Address:Port
+LISTEN   0         128                 0.0.0.0:43309            0.0.0.0:*        users:(("rpc.mountd",pid=1287,fd=9))
+LISTEN   0         128               127.0.0.1:63342            0.0.0.0:*        users:(("java",pid=17507,fd=308))
+LISTEN   0         128                 0.0.0.0:43599            0.0.0.0:*        users:(("rpc.mountd",pid=1287,fd=13))
+LISTEN   0         128                 0.0.0.0:111              0.0.0.0:*        users:(("rpcbind",pid=1101,fd=8))
+LISTEN   0         50                  0.0.0.0:43793            0.0.0.0:*        users:(("java",pid=17507,fd=159))
+LISTEN   0         128           127.0.0.53%lo:53               0.0.0.0:*        users:(("systemd-resolve",pid=28617,fd=13))
+LISTEN   0         32            192.168.122.1:53               0.0.0.0:*        users:(("dnsmasq",pid=5060,fd=6))
+LISTEN   0         32               10.20.85.1:53               0.0.0.0:*        users:(("dnsmasq",pid=4804,fd=6))
+LISTEN   0         32               10.20.11.1:53               0.0.0.0:*        users:(("dnsmasq",pid=4476,fd=6))
+LISTEN   0         128                 0.0.0.0:22               0.0.0.0:*        users:(("sshd",pid=1286,fd=3))
+LISTEN   0         5                 127.0.0.1:631              0.0.0.0:*        users:(("cupsd",pid=1596,fd=7))
+LISTEN   0         128               127.0.0.1:5432             0.0.0.0:*        users:(("postgres",pid=1225,fd=6))
+LISTEN   0         128               127.0.0.1:41689            0.0.0.0:*        users:(("containerd",pid=1292,fd=6))
+LISTEN   0         128               127.0.0.1:5433             0.0.0.0:*        users:(("postgres",pid=1226,fd=8))
+LISTEN   0         128                 0.0.0.0:36219            0.0.0.0:*        users:(("rpc.mountd",pid=1287,fd=17))
+LISTEN   0         128               127.0.0.1:6942             0.0.0.0:*        users:(("java",pid=17507,fd=153))
+LISTEN   0         64                  0.0.0.0:37023            0.0.0.0:*
+LISTEN   0         50                  0.0.0.0:32961            0.0.0.0:*        users:(("java",pid=17507,fd=175))
+LISTEN   0         50                  0.0.0.0:42689            0.0.0.0:*        users:(("java",pid=17507,fd=160))
+LISTEN   0         50                127.0.0.1:33953            0.0.0.0:*        users:(("jetbrains-toolb",pid=6143,fd=17))
+LISTEN   0         64                  0.0.0.0:2049             0.0.0.0:*
+LISTEN   0         50                  0.0.0.0:39939            0.0.0.0:*        users:(("java",pid=17507,fd=157))
+LISTEN   0         50                  0.0.0.0:45927            0.0.0.0:*        users:(("java",pid=17507,fd=325))
+LISTEN   0         128                    [::]:111                 [::]:*        users:(("rpcbind",pid=1101,fd=11))
+LISTEN   0         50                        *:1716                   *:*        users:(("kdeconnectd",pid=5980,fd=14))
+LISTEN   0         128                    [::]:22                  [::]:*        users:(("sshd",pid=1286,fd=4))
+LISTEN   0         5                     [::1]:631                 [::]:*        users:(("cupsd",pid=1596,fd=6))
+LISTEN   0         128                   [::1]:5432                [::]:*        users:(("postgres",pid=1225,fd=3))
+LISTEN   0         128                   [::1]:5433                [::]:*        users:(("postgres",pid=1226,fd=7))
+LISTEN   0         64                     [::]:42779               [::]:*
+LISTEN   0         128                    [::]:53439               [::]:*        users:(("rpc.mountd",pid=1287,fd=11))
+LISTEN   0         64                     [::]:2049                [::]:*
+LISTEN   0         128                    [::]:55745               [::]:*        users:(("rpc.mountd",pid=1287,fd=15))
+LISTEN   0         128                    [::]:51299               [::]:*        users:(("rpc.mountd",pid=1287,fd=19))
+LISTEN   0         5                         *:6600                   *:*        users:(("mpd",pid=1279,fd=4),("systemd",pid=1,fd=118)) 
+'''
+        assert cd._parse_ss_lpnt(out) == [
+            {'Local Address:Port': '0.0.0.0:43309', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '128', 'State': 'LISTEN', 'name': '"rpc.mountd"',
+             'pid': 'pid=1287'},
+            {'Local Address:Port': '127.0.0.1:63342', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '128', 'State': 'LISTEN', 'name': '"java"',
+             'pid': 'pid=17507'},
+            {'Local Address:Port': '0.0.0.0:43599', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '128', 'State': 'LISTEN', 'name': '"rpc.mountd"',
+             'pid': 'pid=1287'},
+            {'Local Address:Port': '0.0.0.0:111', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '128', 'State': 'LISTEN', 'name': '"rpcbind"',
+             'pid': 'pid=1101'},
+            {'Local Address:Port': '0.0.0.0:43793', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '50', 'State': 'LISTEN', 'name': '"java"',
+             'pid': 'pid=17507'},
+            {'Local Address:Port': '127.0.0.53%lo:53', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '128', 'State': 'LISTEN', 'name': '"systemd-resolve"',
+             'pid': 'pid=28617'},
+            {'Local Address:Port': '192.168.122.1:53', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '32', 'State': 'LISTEN', 'name': '"dnsmasq"',
+             'pid': 'pid=5060'},
+            {'Local Address:Port': '10.20.85.1:53', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '32', 'State': 'LISTEN', 'name': '"dnsmasq"',
+             'pid': 'pid=4804'},
+            {'Local Address:Port': '10.20.11.1:53', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '32', 'State': 'LISTEN', 'name': '"dnsmasq"',
+             'pid': 'pid=4476'},
+            {'Local Address:Port': '0.0.0.0:22', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '128', 'State': 'LISTEN', 'name': '"sshd"',
+             'pid': 'pid=1286'},
+            {'Local Address:Port': '127.0.0.1:631', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '5', 'State': 'LISTEN', 'name': '"cupsd"', 'pid': 'pid=1596'},
+            {'Local Address:Port': '127.0.0.1:5432', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '128', 'State': 'LISTEN', 'name': '"postgres"',
+             'pid': 'pid=1225'},
+            {'Local Address:Port': '127.0.0.1:41689', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '128', 'State': 'LISTEN', 'name': '"containerd"',
+             'pid': 'pid=1292'},
+            {'Local Address:Port': '127.0.0.1:5433', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '128', 'State': 'LISTEN', 'name': '"postgres"',
+             'pid': 'pid=1226'},
+            {'Local Address:Port': '0.0.0.0:36219', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '128', 'State': 'LISTEN', 'name': '"rpc.mountd"',
+             'pid': 'pid=1287'},
+            {'Local Address:Port': '127.0.0.1:6942', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '128', 'State': 'LISTEN', 'name': '"java"',
+             'pid': 'pid=17507'},
+            {'Local Address:Port': '0.0.0.0:32961', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '50', 'State': 'LISTEN', 'name': '"java"',
+             'pid': 'pid=17507'},
+            {'Local Address:Port': '0.0.0.0:42689', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '50', 'State': 'LISTEN', 'name': '"java"',
+             'pid': 'pid=17507'},
+            {'Local Address:Port': '127.0.0.1:33953', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '50', 'State': 'LISTEN', 'name': '"jetbrains-toolb"',
+             'pid': 'pid=6143'},
+            {'Local Address:Port': '0.0.0.0:39939', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '50', 'State': 'LISTEN', 'name': '"java"',
+             'pid': 'pid=17507'},
+            {'Local Address:Port': '0.0.0.0:45927', 'Peer Address:Port': '0.0.0.0:*',
+             'Recv-Q': '0', 'Send-Q': '50', 'State': 'LISTEN', 'name': '"java"',
+             'pid': 'pid=17507'},
+            {'Local Address:Port': '[::]:111', 'Peer Address:Port': '[::]:*',
+             'Recv-Q': '0', 'Send-Q': '128', 'State': 'LISTEN', 'name': '"rpcbind"',
+             'pid': 'pid=1101'},
+            {'Local Address:Port': '*:1716', 'Peer Address:Port': '*:*',
+             'Recv-Q': '0', 'Send-Q': '50', 'State': 'LISTEN', 'name': '"kdeconnectd"',
+             'pid': 'pid=5980'},
+            {'Local Address:Port': '[::]:22', 'Peer Address:Port': '[::]:*',
+             'Recv-Q': '0', 'Send-Q': '128', 'State': 'LISTEN', 'name': '"sshd"',
+             'pid': 'pid=1286'},
+            {'Local Address:Port': '[::1]:631', 'Peer Address:Port': '[::]:*',
+             'Recv-Q': '0', 'Send-Q': '5', 'State': 'LISTEN', 'name': '"cupsd"', 'pid': 'pid=1596'},
+            {'Local Address:Port': '[::1]:5432', 'Peer Address:Port': '[::]:*',
+             'Recv-Q': '0', 'Send-Q': '128', 'State': 'LISTEN', 'name': '"postgres"',
+             'pid': 'pid=1225'},
+            {'Local Address:Port': '[::1]:5433', 'Peer Address:Port': '[::]:*',
+             'Recv-Q': '0', 'Send-Q': '128', 'State': 'LISTEN', 'name': '"postgres"',
+             'pid': 'pid=1226'},
+            {'Local Address:Port': '[::]:53439', 'Peer Address:Port': '[::]:*',
+             'Recv-Q': '0', 'Send-Q': '128', 'State': 'LISTEN', 'name': '"rpc.mountd"',
+             'pid': 'pid=1287'},
+            {'Local Address:Port': '[::]:55745', 'Peer Address:Port': '[::]:*',
+             'Recv-Q': '0', 'Send-Q': '128', 'State': 'LISTEN', 'name': '"rpc.mountd"',
+             'pid': 'pid=1287'},
+            {'Local Address:Port': '[::]:51299', 'Peer Address:Port': '[::]:*',
+             'Recv-Q': '0', 'Send-Q': '128', 'State': 'LISTEN', 'name': '"rpc.mountd"',
+             'pid': 'pid=1287'},
+            {'Local Address:Port': '*:6600', 'Peer Address:Port': '*:*',
+             'Recv-Q': '0', 'Send-Q': '5', 'State': 'LISTEN', 'name': '"mpd"', 'pid': 'pid=1279'},
+        ]
+
 
 class TestCustomContainer(unittest.TestCase):
     cc: cd.CustomContainer


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
