### PR TITLE
qa: Fix a few mgr/volume test cases

### DIFF
--- a/qa/tasks/cephfs/test_volumes.py
+++ b/qa/tasks/cephfs/test_volumes.py
@@ -1441,7 +1441,7 @@ class TestSubvolumes(TestVolumesHelper):
         # list authorized-ids of the subvolume
         expected_auth_list = [{'alice': 'rw'}, {'guest1': 'rw'}, {'guest2': 'r'}]
         auth_list = json.loads(self._fs_cmd('subvolume', 'authorized_list', self.volname, subvolume, "--group_name", group))
-        self.assertListEqual(auth_list, expected_auth_list)
+        self.assertCountEqual(expected_auth_list, auth_list)
 
         # cleanup
         self._fs_cmd("subvolume", "deauthorize", self.volname, subvolume, authid1,
@@ -1626,7 +1626,7 @@ class TestSubvolumes(TestVolumesHelper):
         # created on authorizing 'guest1' access to the subvolume.
         auth_metadata_filename = "${0}.meta".format(guestclient_1["auth_id"])
         self.assertIn(auth_metadata_filename, guest_mount.ls("volumes"))
-        expected_auth_metadata_content = self.mount_a.run_shell(['cat', 'volumes/{0}'.format(auth_metadata_filename)]).stdout.getvalue().strip()
+        expected_auth_metadata_content = self._auth_metadata_get(self.mount_a.read_file("volumes/{0}".format(auth_metadata_filename)))
 
         # Induce partial auth update state by modifying the auth metadata file,
         # and then run authorize again.
@@ -1636,7 +1636,7 @@ class TestSubvolumes(TestVolumesHelper):
         self._fs_cmd("subvolume", "authorize", self.volname, subvolume, guestclient_1["auth_id"],
                      "--group_name", group, "--tenant_id", guestclient_1["tenant_id"])
 
-        auth_metadata_content = self.mount_a.run_shell(['cat', 'volumes/{0}'.format(auth_metadata_filename)]).stdout.getvalue().strip()
+        auth_metadata_content = self._auth_metadata_get(self.mount_a.read_file("volumes/{0}".format(auth_metadata_filename)))
         self.assertEqual(auth_metadata_content, expected_auth_metadata_content)
 
         # clean up
@@ -1678,7 +1678,7 @@ class TestSubvolumes(TestVolumesHelper):
         # created on authorizing 'guest1' access to the subvolume1.
         auth_metadata_filename = "${0}.meta".format(guestclient_1["auth_id"])
         self.assertIn(auth_metadata_filename, guest_mount.ls("volumes"))
-        expected_auth_metadata_content = self.mount_a.run_shell(['cat', 'volumes/{0}'.format(auth_metadata_filename)]).stdout.getvalue().strip()
+        expected_auth_metadata_content = self._auth_metadata_get(self.mount_a.read_file("volumes/{0}".format(auth_metadata_filename)))
 
         # Authorize 'guestclient_1' to access the subvolume2.
         self._fs_cmd("subvolume", "authorize", self.volname, subvolume2, guestclient_1["auth_id"],
@@ -1692,7 +1692,7 @@ class TestSubvolumes(TestVolumesHelper):
         self._fs_cmd("subvolume", "deauthorize", self.volname, subvolume2, guestclient_1["auth_id"],
                      "--group_name", group)
 
-        auth_metadata_content = self.mount_a.run_shell(['cat', 'volumes/{0}'.format(auth_metadata_filename)]).stdout.getvalue().strip()
+        auth_metadata_content = self._auth_metadata_get(self.mount_a.read_file("volumes/{0}".format(auth_metadata_filename)))
         self.assertEqual(auth_metadata_content, expected_auth_metadata_content)
 
         # clean up


### PR DESCRIPTION
Recovering dirty auth metadata file might not retain the order,
fixed the comparison in 'test_recover_auth_metadata_during_authorize'
and 'test_recover_auth_metadata_during_deauthorize'.

The json.loads doesn't keep the order as well, fixed the comparison
in 'test_subvolume_authorized_list'.

Fixes: https://tracker.ceph.com/issues/49192
Signed-off-by: Kotresh HR <khiremat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
