### PR TITLE
crimson/onode-staged-tree: implement Cursor::get_next() and comparators for range query

### DIFF
--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -758,7 +758,7 @@ LeafNode::get_next_cursor(context_t c, const search_position_t& pos)
   if (next_pos.is_end()) {
     if (unlikely(is_level_tail())) {
       return node_ertr::make_ready_future<Ref<tree_cursor_t>>(
-          new tree_cursor_t(this));
+          tree_cursor_t::create_end(this));
     } else {
       return get_next_cursor_from_parent(c);
     }
@@ -796,7 +796,7 @@ LeafNode::lookup_smallest(context_t)
   if (unlikely(impl->is_empty())) {
     assert(is_root());
     return node_ertr::make_ready_future<Ref<tree_cursor_t>>(
-        new tree_cursor_t(this));
+        tree_cursor_t::create_end(this));
   }
   auto pos = search_position_t::begin();
   key_view_t index_key;
@@ -811,7 +811,7 @@ LeafNode::lookup_largest(context_t)
   if (unlikely(impl->is_empty())) {
     assert(is_root());
     return node_ertr::make_ready_future<Ref<tree_cursor_t>>(
-        new tree_cursor_t(this));
+        tree_cursor_t::create_end(this));
   }
   search_position_t pos;
   const value_header_t* p_value_header = nullptr;
@@ -830,7 +830,7 @@ LeafNode::lower_bound_tracked(
   Ref<tree_cursor_t> cursor;
   if (result.position.is_end()) {
     assert(!result.p_value);
-    cursor = new tree_cursor_t(this);
+    cursor = tree_cursor_t::create_end(this);
   } else {
     cursor = get_or_track_cursor(result.position, index_key, result.p_value);
   }
@@ -955,7 +955,7 @@ Ref<tree_cursor_t> LeafNode::get_or_track_cursor(
   Ref<tree_cursor_t> p_cursor;
   auto found = tracked_cursors.find(position);
   if (found == tracked_cursors.end()) {
-    p_cursor = new tree_cursor_t(this, position, key, p_value_header);
+    p_cursor = tree_cursor_t::create(this, position, key, p_value_header);
   } else {
     p_cursor = found->second;
     assert(p_cursor->get_leaf_node() == this);
@@ -1000,7 +1000,7 @@ Ref<tree_cursor_t> LeafNode::track_insert(
   // track insert
   // TODO: getting key_view_t from stage::proceed_insert() and
   // stage::append_insert() has not supported yet
-  return new tree_cursor_t(this, insert_pos);
+  return tree_cursor_t::create(this, insert_pos);
 }
 
 void LeafNode::track_split(

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -145,7 +145,7 @@ void tree_cursor_t::Cache::validate_is_latest(const LeafNode& node,
   assert(is_latest());
 #ifndef NDEBUG
   auto [_key_view, _p_value_header] = node.get_kv(pos);
-  assert(*key_view == _key_view);
+  assert(key_view->compare_to(_key_view) == MatchKindCMP::EQ);
   assert(p_value_header == _p_value_header);
 #endif
 }
@@ -634,7 +634,8 @@ void InternalNode::validate_child(const Node& child) const
     assert(child.impl->is_level_tail());
   } else {
     assert(!child.impl->is_level_tail());
-    assert(impl->get_key_view(child_pos) == child.impl->get_largest_key_view());
+    assert(impl->get_key_view(child_pos).compare_to(
+           child.impl->get_largest_key_view()) == MatchKindCMP::EQ);
   }
   // XXX(multi-type)
   assert(impl->field_type() <= child.impl->field_type());
@@ -874,7 +875,7 @@ void LeafNode::validate_cursor(const tree_cursor_t& cursor) const
   assert(!cursor.is_end());
   auto [key, p_value_header] = get_kv(cursor.get_position());
   auto magic = p_value_header->magic;
-  assert(key == cursor.get_key_view(magic));
+  assert(key.compare_to(cursor.get_key_view(magic)) == MatchKindCMP::EQ);
   assert(p_value_header == cursor.read_value_header(magic));
 #endif
 }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -91,6 +91,26 @@ void tree_cursor_t::assert_next_to(
 #endif
 }
 
+MatchKindCMP tree_cursor_t::compare_to(
+    const tree_cursor_t& o, value_magic_t magic) const
+{
+  // singleton
+  if (this == &o) {
+    return MatchKindCMP::EQ;
+  }
+
+  MatchKindCMP ret;
+  if (ref_leaf_node == o.ref_leaf_node) {
+    ret = position.compare_to(o.position);
+  } else {
+    auto key = get_key_view(magic);
+    auto o_key = o.get_key_view(magic);
+    ret = key.compare_to(o_key);
+  }
+  assert(ret != MatchKindCMP::EQ);
+  return ret;
+}
+
 tree_cursor_t::future<>
 tree_cursor_t::extend_value(context_t c, value_size_t extend_size)
 {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -137,6 +137,19 @@ class tree_cursor_t final
   void update_cache(LeafNode&, const key_view_t&, const value_header_t*) const;
   void maybe_update_cache(value_magic_t magic) const;
 
+  static Ref<tree_cursor_t> create(Ref<LeafNode> node, const search_position_t& pos) {
+    return new tree_cursor_t(node, pos);
+  }
+
+  static Ref<tree_cursor_t> create(Ref<LeafNode> node, const search_position_t& pos,
+                                   const key_view_t& key, const value_header_t* p_header) {
+    return new tree_cursor_t(node, pos, key, p_header);
+  }
+
+  static Ref<tree_cursor_t> create_end(Ref<LeafNode> node) {
+    return new tree_cursor_t(node);
+  }
+
   /**
    * Reversed resource management (tree_cursor_t)
    *

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -100,6 +100,8 @@ class tree_cursor_t final
   /// Check that this is next to prv
   void assert_next_to(const tree_cursor_t&, value_magic_t) const;
 
+  MatchKindCMP compare_to(const tree_cursor_t&, value_magic_t) const;
+
   // public to Value
 
   /// Get the latest value_header_t pointer for read.

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -350,7 +350,7 @@ class Node
     Ref<InternalNode> ptr;
   };
   const parent_info_t& parent_info() const { return *_parent_info; }
-  node_future<> insert_parent(context_t, Ref<Node> right_node);
+  node_future<> insert_parent(context_t, const key_view_t&, Ref<Node> right_node);
   node_future<Ref<tree_cursor_t>> get_next_cursor_from_parent(context_t);
 
  private:
@@ -398,7 +398,8 @@ class InternalNode final : public Node {
   node_future<Ref<tree_cursor_t>> get_next_cursor(context_t, const search_position_t&);
 
   node_future<> apply_child_split(
-      context_t, const search_position_t&, Ref<Node> left, Ref<Node> right);
+      context_t, const search_position_t&, const key_view_t& left_key,
+      Ref<Node> left, Ref<Node> right);
 
   template <bool VALIDATE>
   void do_track_child(Node& child) {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
@@ -76,7 +76,6 @@ class NodeImpl {
   virtual node_offset_t free_size() const = 0;
   virtual key_view_t get_key_view(const search_position_t&) const = 0;
   virtual key_view_t get_largest_key_view() const = 0;
-  virtual void next_position(search_position_t&) const = 0;
 
   virtual node_stats_t get_stats() const = 0;
   virtual std::ostream& dump(std::ostream&) const = 0;
@@ -101,6 +100,20 @@ class InternalNodeImpl : public NodeImpl {
   virtual ~InternalNodeImpl() = default;
 
   #pragma GCC diagnostic ignored "-Woverloaded-virtual"
+  virtual void get_slot(const search_position_t&,                 // IN
+                        key_view_t* = nullptr,                    // OUT
+                        const laddr_packed_t** = nullptr) const { // OUT
+    ceph_abort("impossible path");
+  }
+
+  #pragma GCC diagnostic ignored "-Woverloaded-virtual"
+  virtual void get_next_slot(search_position_t&,                       // IN&OUT
+                             key_view_t* = nullptr,                    // OUT
+                             const laddr_packed_t** = nullptr) const { // OUT
+    ceph_abort("impossible path");
+  }
+
+  #pragma GCC diagnostic ignored "-Woverloaded-virtual"
   virtual const laddr_packed_t* get_p_value(
       const search_position_t&,
       key_view_t* = nullptr, internal_marker_t = {}) const {
@@ -123,6 +136,8 @@ class InternalNodeImpl : public NodeImpl {
       search_position_t&, match_stage_t&, node_offset_t&) {
     ceph_abort("impossible path");
   }
+
+  virtual const laddr_packed_t* get_tail_value() const = 0;
 
   virtual void replace_child_addr(const search_position_t&, laddr_t dst, laddr_t src) = 0;
   virtual std::tuple<match_stage_t, node_offset_t> evaluate_insert(
@@ -151,6 +166,20 @@ class LeafNodeImpl : public NodeImpl {
  public:
   struct leaf_marker_t {};
   virtual ~LeafNodeImpl() = default;
+
+  #pragma GCC diagnostic ignored "-Woverloaded-virtual"
+  virtual void get_slot(const search_position_t&,                 // IN
+                        key_view_t* = nullptr,                    // OUT
+                        const value_header_t** = nullptr) const { // OUT
+    ceph_abort("impossible path");
+  }
+
+  #pragma GCC diagnostic ignored "-Woverloaded-virtual"
+  virtual void get_next_slot(search_position_t&,                       // IN&OUT
+                             key_view_t* = nullptr,                    // OUT
+                             const value_header_t** = nullptr) const { // OUT
+    ceph_abort("impossible path");
+  }
 
   #pragma GCC diagnostic ignored "-Woverloaded-virtual"
   virtual const value_header_t* get_p_value(

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
@@ -67,6 +67,7 @@ class NodeImpl {
    >;
   virtual ~NodeImpl() = default;
 
+  virtual node_type_t node_type() const = 0;
   virtual field_type_t field_type() const = 0;
   virtual laddr_t laddr() const = 0;
   virtual void prepare_mutate(context_t) = 0;
@@ -74,8 +75,7 @@ class NodeImpl {
   virtual bool is_empty() const = 0;
   virtual level_t level() const = 0;
   virtual node_offset_t free_size() const = 0;
-  virtual key_view_t get_key_view(const search_position_t&) const = 0;
-  virtual key_view_t get_largest_key_view() const = 0;
+  virtual std::optional<key_view_t> get_pivot_index() const = 0;
 
   virtual node_stats_t get_stats() const = 0;
   virtual std::ostream& dump(std::ostream&) const = 0;
@@ -114,22 +114,25 @@ class InternalNodeImpl : public NodeImpl {
   }
 
   #pragma GCC diagnostic ignored "-Woverloaded-virtual"
-  virtual const laddr_packed_t* get_p_value(
-      const search_position_t&,
-      key_view_t* = nullptr, internal_marker_t = {}) const {
+  virtual void get_largest_slot(search_position_t* = nullptr,             // OUT
+                                key_view_t* = nullptr,                    // OUT
+                                const laddr_packed_t** = nullptr) const { // OUT
     ceph_abort("impossible path");
   }
+
   #pragma GCC diagnostic ignored "-Woverloaded-virtual"
   virtual lookup_result_t<node_type_t::INTERNAL> lower_bound(
       const key_hobj_t&, MatchHistory&,
       key_view_t* = nullptr, internal_marker_t = {}) const {
     ceph_abort("impossible path");
   }
+
   #pragma GCC diagnostic ignored "-Woverloaded-virtual"
   virtual const laddr_packed_t* insert(
       const key_view_t&, const laddr_t&, search_position_t&, match_stage_t&, node_offset_t&) {
     ceph_abort("impossible path");
   }
+
   #pragma GCC diagnostic ignored "-Woverloaded-virtual"
   virtual std::tuple<search_position_t, bool, const laddr_packed_t*> split_insert(
       NodeExtentMutable&, NodeImpl&, const key_view_t&, const laddr_t&,
@@ -140,6 +143,7 @@ class InternalNodeImpl : public NodeImpl {
   virtual const laddr_packed_t* get_tail_value() const = 0;
 
   virtual void replace_child_addr(const search_position_t&, laddr_t dst, laddr_t src) = 0;
+
   virtual std::tuple<match_stage_t, node_offset_t> evaluate_insert(
       const key_view_t&, const laddr_t&, search_position_t&) const = 0;
 
@@ -151,6 +155,7 @@ class InternalNodeImpl : public NodeImpl {
     }
   };
   static alloc_ertr::future<fresh_impl_t> allocate(context_t, field_type_t, bool, level_t);
+
   static InternalNodeImplURef load(NodeExtentRef, field_type_t, bool);
 
  protected:
@@ -182,31 +187,31 @@ class LeafNodeImpl : public NodeImpl {
   }
 
   #pragma GCC diagnostic ignored "-Woverloaded-virtual"
-  virtual const value_header_t* get_p_value(
-      const search_position_t&,
-      key_view_t* = nullptr, leaf_marker_t={}) const {
+  virtual void get_largest_slot(search_position_t* = nullptr,             // OUT
+                                key_view_t* = nullptr,                    // OUT
+                                const value_header_t** = nullptr) const { // OUT
     ceph_abort("impossible path");
   }
+
   #pragma GCC diagnostic ignored "-Woverloaded-virtual"
   virtual lookup_result_t<node_type_t::LEAF> lower_bound(
       const key_hobj_t&, MatchHistory&,
       key_view_t* = nullptr, leaf_marker_t = {}) const {
     ceph_abort("impossible path");
   }
+
   #pragma GCC diagnostic ignored "-Woverloaded-virtual"
   virtual const value_header_t* insert(
       const key_hobj_t&, const value_config_t&, search_position_t&, match_stage_t&, node_offset_t&) {
     ceph_abort("impossible path");
   }
+
   #pragma GCC diagnostic ignored "-Woverloaded-virtual"
   virtual std::tuple<search_position_t, bool, const value_header_t*> split_insert(
       NodeExtentMutable&, NodeImpl&, const key_hobj_t&, const value_config_t&,
       search_position_t&, match_stage_t&, node_offset_t&) {
     ceph_abort("impossible path");
   }
-
-  virtual void get_largest_slot(
-      search_position_t&, key_view_t&, const value_header_t**) const = 0;
 
   virtual std::tuple<match_stage_t, node_offset_t> evaluate_insert(
       const key_hobj_t&, const value_config_t&,
@@ -223,6 +228,7 @@ class LeafNodeImpl : public NodeImpl {
     }
   };
   static alloc_ertr::future<fresh_impl_t> allocate(context_t, field_type_t, bool);
+
   static LeafNodeImplURef load(NodeExtentRef, field_type_t, bool);
 
  protected:

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -86,6 +86,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
   /*
    * NodeImpl
    */
+  node_type_t node_type() const override { return NODE_TYPE; }
   field_type_t field_type() const override { return FIELD_TYPE; }
   laddr_t laddr() const override { return extent.get_laddr(); }
   void prepare_mutate(context_t c) override { return extent.prepare_mutate(c); }
@@ -94,17 +95,16 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
   level_t level() const override { return extent.read().level(); }
   node_offset_t free_size() const override { return extent.read().free_size(); }
 
-  key_view_t get_key_view(const search_position_t& position) const override {
-    key_view_t ret;
-    STAGE_T::get_key_view(extent.read(), cast_down<STAGE>(position), ret);
-    return ret;
-  }
-
-  key_view_t get_largest_key_view() const override {
-    key_view_t index_key;
-    STAGE_T::template lookup_largest_slot<false, true, false>(
-        extent.read(), nullptr, &index_key, nullptr);
-    return index_key;
+  std::optional<key_view_t> get_pivot_index() const override {
+    assert(!is_empty());
+    if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
+      if (is_level_tail()) {
+        return std::nullopt;
+      }
+    }
+    key_view_t pivot_index;
+    get_largest_slot(nullptr, &pivot_index, nullptr);
+    return {pivot_index};
   }
 
   node_stats_t get_stats() const override {
@@ -195,11 +195,17 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
                 const value_t** pp_value = nullptr) const override {
     assert(!is_empty());
     assert(!pos.is_end());
-    if (!p_index_key && pp_value) {
+    if (p_index_key && pp_value) {
+      STAGE_T::template get_slot<true, true>(
+          extent.read(), cast_down<STAGE>(pos), p_index_key, pp_value);
+    } else if (!p_index_key && pp_value) {
       STAGE_T::template get_slot<false, true>(
           extent.read(), cast_down<STAGE>(pos), nullptr, pp_value);
+    } else if (p_index_key && !pp_value) {
+      STAGE_T::template get_slot<true, false>(
+          extent.read(), cast_down<STAGE>(pos), p_index_key, nullptr);
     } else {
-      ceph_abort("not implemented");
+      ceph_abort("impossible path");
     }
   }
 
@@ -223,25 +229,24 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     }
   }
 
-  const value_t* get_p_value(const search_position_t& position,
-                             key_view_t* index_key=nullptr, marker_t={}) const override {
-    auto& node_stage = extent.read();
+  void get_largest_slot(search_position_t* p_pos = nullptr,
+                        key_view_t* p_index_key = nullptr,
+                        const value_t** pp_value = nullptr) const override {
+    assert(!is_empty());
     if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
-      assert(!index_key);
-      if (position.is_end()) {
-        assert(is_level_tail());
-        return node_stage.get_end_p_laddr();
-      }
-    } else {
-      assert(!position.is_end());
+      assert(!is_level_tail());
     }
-    if (index_key) {
-      return STAGE_T::template get_p_value<true>(
-          node_stage, cast_down<STAGE>(position), index_key);
+    if (p_pos && p_index_key && pp_value) {
+      STAGE_T::template get_largest_slot<true, true, true>(
+          extent.read(), &cast_down_fill_0<STAGE>(*p_pos), p_index_key, pp_value);
+    } else if (!p_pos && p_index_key && !pp_value) {
+      STAGE_T::template get_largest_slot<false, true, false>(
+          extent.read(), nullptr, p_index_key, nullptr);
     } else {
-      return STAGE_T::get_p_value(node_stage, cast_down<STAGE>(position));
+      ceph_abort("not implemented");
     }
   }
+
 
   lookup_result_t<NODE_TYPE> lower_bound(
       const key_hobj_t& key, MatchHistory& history,
@@ -261,7 +266,8 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
 #ifndef NDEBUG
       if (!result_raw.is_end()) {
         full_key_t<KeyT::VIEW> index;
-        STAGE_T::get_key_view(node_stage, result_raw.position, index);
+        STAGE_T::template get_slot<true, false>(
+            node_stage, result_raw.position, &index, nullptr);
         assert(index.compare_to(*index_key) == MatchKindCMP::EQ);
       }
 #endif
@@ -273,7 +279,8 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
       assert(result_raw.mstat == MSTAT_END);
     } else {
       full_key_t<KeyT::VIEW> index;
-      STAGE_T::get_key_view(node_stage, result_raw.position, index);
+      STAGE_T::template get_slot<true, false>(
+          node_stage, result_raw.position, &index, nullptr);
       assert_mstat(key, index, result_raw.mstat);
     }
 #endif
@@ -329,15 +336,22 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
       logger().trace("OTree::Layout::Insert: -- dump\n{}", sos.str());
     }
     validate_layout();
-    assert(get_key_view(insert_pos).compare_to(key) == MatchKindCMP::EQ);
+#ifndef NDEBUG
+    full_key_t<KeyT::VIEW> index;
+    get_slot(insert_pos, &index, nullptr);
+    assert(index.compare_to(key) == MatchKindCMP::EQ);
+#endif
     return ret;
   }
 
   std::tuple<search_position_t, bool, const value_t*> split_insert(
-      NodeExtentMutable& right_mut, NodeImpl& right_impl,
+      NodeExtentMutable& right_mut, NodeImpl& _right_impl,
       const full_key_t<KEY_TYPE>& key, const value_input_t& value,
       search_position_t& _insert_pos, match_stage_t& insert_stage,
       node_offset_t& insert_size) override {
+    assert(_right_impl.node_type() == NODE_TYPE);
+    assert(_right_impl.field_type() == FIELD_TYPE);
+    auto& right_impl = dynamic_cast<NodeLayoutT&>(_right_impl);
     logger().info("OTree::Layout::Split: begin at "
                   "insert_pos({}), insert_stage={}, insert_size={}B, "
                   "{:#x}=>{:#x} ...",
@@ -499,10 +513,18 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
                      insert_pos, insert_stage);
       p_value = extent.template split_insert_replayable<KEY_TYPE>(
           split_at, key, value, insert_pos, insert_stage, insert_size);
-      assert(get_key_view(_insert_pos).compare_to(key) == MatchKindCMP::EQ);
+#ifndef NDEBUG
+      full_key_t<KeyT::VIEW> index;
+      get_slot(_insert_pos, &index, nullptr);
+      assert(index.compare_to(key) == MatchKindCMP::EQ);
+#endif
     } else {
       logger().debug("OTree::Layout::Split: -- left trim ...");
-      assert(right_impl.get_key_view(_insert_pos).compare_to(key) == MatchKindCMP::EQ);
+#ifndef NDEBUG
+      full_key_t<KeyT::VIEW> index;
+      right_impl.get_slot(_insert_pos, &index, nullptr);
+      assert(index.compare_to(key) == MatchKindCMP::EQ);
+#endif
       extent.split_replayable(split_at);
     }
     if (unlikely(logger().is_enabled(seastar::log_level::debug))) {
@@ -525,11 +547,11 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     InsertType insert_type;
     search_position_t last_pos;
     if (is_insert_left) {
-      STAGE_T::template lookup_largest_slot<true, false, false>(
+      STAGE_T::template get_largest_slot<true, false, false>(
           extent.read(), &cast_down_fill_0<STAGE>(last_pos), nullptr, nullptr);
     } else {
       node_stage_t right_stage{reinterpret_cast<FieldType*>(right_mut.get_write())};
-      STAGE_T::template lookup_largest_slot<true, false, false>(
+      STAGE_T::template get_largest_slot<true, false, false>(
           right_stage, &cast_down_fill_0<STAGE>(last_pos), nullptr, nullptr);
     }
     if (_insert_pos == search_position_t::begin()) {
@@ -559,7 +581,13 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
   void replace_child_addr(
       const search_position_t& pos, laddr_t dst, laddr_t src) override {
     if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
-      const laddr_packed_t* p_value = get_p_value(pos);
+      const laddr_packed_t* p_value;
+      if (pos.is_end()) {
+        assert(is_level_tail());
+        p_value = get_tail_value();
+      } else {
+        get_slot(pos, nullptr, &p_value);
+      }
       assert(p_value->value == src);
       extent.update_child_addr_replayable(dst, const_cast<laddr_packed_t*>(p_value));
     } else {
@@ -591,17 +619,6 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
   /*
    * LeafNodeImpl
    */
-  void get_largest_slot(search_position_t& pos,
-                        key_view_t& index_key,
-                        const value_header_t** pp_value) const override {
-    if constexpr (NODE_TYPE == node_type_t::LEAF) {
-      STAGE_T::template lookup_largest_slot<true, true, true>(
-          extent.read(), &cast_down_fill_0<STAGE>(pos), &index_key, pp_value);
-    } else {
-      ceph_abort("impossible path");
-    }
-  }
-
   std::tuple<match_stage_t, node_offset_t> evaluate_insert(
       const key_hobj_t& key, const value_config_t& value,
       const MatchHistory& history, match_stat_t mstat,

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -237,7 +237,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
       if (!result_raw.is_end()) {
         full_key_t<KeyT::VIEW> index;
         STAGE_T::get_key_view(node_stage, result_raw.position, index);
-        assert(index == *index_key);
+        assert(index.compare_to(*index_key) == MatchKindCMP::EQ);
       }
 #endif
     } else {
@@ -304,7 +304,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
       logger().trace("OTree::Layout::Insert: -- dump\n{}", sos.str());
     }
     validate_layout();
-    assert(get_key_view(insert_pos) == key);
+    assert(get_key_view(insert_pos).compare_to(key) == MatchKindCMP::EQ);
     return ret;
   }
 
@@ -474,10 +474,10 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
                      insert_pos, insert_stage);
       p_value = extent.template split_insert_replayable<KEY_TYPE>(
           split_at, key, value, insert_pos, insert_stage, insert_size);
-      assert(get_key_view(_insert_pos) == key);
+      assert(get_key_view(_insert_pos).compare_to(key) == MatchKindCMP::EQ);
     } else {
       logger().debug("OTree::Layout::Split: -- left trim ...");
-      assert(right_impl.get_key_view(_insert_pos) == key);
+      assert(right_impl.get_key_view(_insert_pos).compare_to(key) == MatchKindCMP::EQ);
       extent.split_replayable(split_at);
     }
     if (unlikely(logger().is_enabled(seastar::log_level::debug))) {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
@@ -858,17 +858,21 @@ struct staged {
 
   template <bool GET_KEY>
   static result_t smallest_result(
-      const iterator_t& iter, full_key_t<KeyT::VIEW>* index_key) {
+      const iterator_t& iter, full_key_t<KeyT::VIEW>* p_index_key) {
     static_assert(!IS_BOTTOM);
     assert(!iter.is_end());
-    auto pos_smallest = NXT_STAGE_T::position_t::begin();
     auto nxt_container = iter.get_nxt_container();
-    auto value_ptr = NXT_STAGE_T::template get_p_value<GET_KEY>(
-        nxt_container, pos_smallest, index_key);
+    auto pos_smallest = NXT_STAGE_T::position_t::begin();
+    const value_t* p_value;
+    NXT_STAGE_T::template get_slot<GET_KEY, true>(
+        nxt_container, pos_smallest, p_index_key, &p_value);
     if constexpr (GET_KEY) {
-      index_key->set(iter.get_key());
+      assert(p_index_key);
+      p_index_key->set(iter.get_key());
+    } else {
+      assert(!p_index_key);
     }
-    return result_t{{iter.index(), pos_smallest}, value_ptr, STAGE};
+    return result_t{{iter.index(), pos_smallest}, p_value, STAGE};
   }
 
   template <bool GET_KEY>
@@ -895,51 +899,41 @@ struct staged {
   }
 
   template <bool GET_POS, bool GET_KEY, bool GET_VAL>
-  static void lookup_largest_slot(
-      const container_t& container, position_t* p_position,
-      full_key_t<KeyT::VIEW>* p_index_key, const value_t** pp_value) {
+  static void get_largest_slot(
+      const container_t& container,        // IN
+      position_t* p_position,              // OUT
+      full_key_t<KeyT::VIEW>* p_index_key, // OUT
+      const value_t** pp_value) {          // OUT
     auto iter = iterator_t(container);
     iter.seek_last();
     if constexpr (GET_KEY) {
       assert(p_index_key);
       p_index_key->set(iter.get_key());
+    } else {
+      assert(!p_index_key);
     }
     if constexpr (GET_POS) {
       assert(p_position);
       p_position->index = iter.index();
+    } else {
+      assert(!p_position);
     }
     if constexpr (IS_BOTTOM) {
       if constexpr (GET_VAL) {
         assert(pp_value);
         *pp_value = iter.get_p_value();
+      } else {
+        assert(!pp_value);
       }
     } else {
       auto nxt_container = iter.get_nxt_container();
       if constexpr (GET_POS) {
-        NXT_STAGE_T::template lookup_largest_slot<true, GET_KEY, GET_VAL>(
+        NXT_STAGE_T::template get_largest_slot<true, GET_KEY, GET_VAL>(
             nxt_container, &p_position->nxt, p_index_key, pp_value);
       } else {
-        NXT_STAGE_T::template lookup_largest_slot<false, GET_KEY, GET_VAL>(
+        NXT_STAGE_T::template get_largest_slot<false, GET_KEY, GET_VAL>(
             nxt_container, nullptr, p_index_key, pp_value);
       }
-    }
-  }
-
-  template <bool GET_KEY = false>
-  static const value_t* get_p_value(
-      const container_t& container, const position_t& position,
-      full_key_t<KeyT::VIEW>* index_key = nullptr) {
-    auto iter = iterator_t(container);
-    iter.seek_at(position.index);
-    if constexpr (GET_KEY) {
-      index_key->set(iter.get_key());
-    }
-    if constexpr (!IS_BOTTOM) {
-      auto nxt_container = iter.get_nxt_container();
-      return NXT_STAGE_T::template get_p_value<GET_KEY>(
-          nxt_container, position.nxt, index_key);
-    } else {
-      return iter.get_p_value();
     }
   }
 
@@ -970,19 +964,6 @@ struct staged {
       } else {
         assert(!pp_value);
       }
-    }
-  }
-
-  static void get_key_view(
-      const container_t& container,
-      const position_t& position,
-      full_key_t<KeyT::VIEW>& index_key) {
-    auto iter = iterator_t(container);
-    iter.seek_at(position.index);
-    index_key.set(iter.get_key());
-    if constexpr (!IS_BOTTOM) {
-      auto nxt_container = iter.get_nxt_container();
-      return NXT_STAGE_T::get_key_view(nxt_container, position.nxt, index_key);
     }
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
@@ -165,6 +165,22 @@ struct staged_position_t {
   bool operator==(const me_t& o) const { return cmp(o) == 0; }
   bool operator!=(const me_t& o) const { return cmp(o) != 0; }
 
+  void assert_next_to(const me_t& prv) const {
+#ifndef NDEBUG
+    if (is_end()) {
+      assert(!prv.is_end());
+    } else if (index == prv.index) {
+      assert(!nxt.is_end());
+      nxt.assert_next_to(prv.nxt);
+    } else if (index == prv.index + 1) {
+      assert(!prv.nxt.is_end());
+      assert(nxt == nxt_t::begin());
+    } else {
+      assert(false);
+    }
+#endif
+  }
+
   me_t& operator-=(const me_t& o) {
     assert(is_valid_index(o.index));
     assert(index >= o.index);
@@ -251,6 +267,16 @@ struct staged_position_t<STAGE_BOTTOM> {
       index -= o.index;
     }
     return *this;
+  }
+
+  void assert_next_to(const me_t& prv) const {
+#ifndef NDEBUG
+    if (is_end()) {
+      assert(!prv.is_end());
+    } else {
+      assert(index == prv.index + 1);
+    }
+#endif
   }
 
   void encode(ceph::bufferlist& encoded) const {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
@@ -149,21 +149,21 @@ struct staged_position_t {
     }
   }
 
-  int cmp(const me_t& o) const {
+  MatchKindCMP compare_to(const me_t& o) const {
     if (index > o.index) {
-      return 1;
+      return MatchKindCMP::GT;
     } else if (index < o.index) {
-      return -1;
+      return MatchKindCMP::LT;
     } else {
-      return nxt.cmp(o.nxt);
+      return nxt.compare_to(o.nxt);
     }
   }
-  bool operator>(const me_t& o) const { return cmp(o) > 0; }
-  bool operator>=(const me_t& o) const { return cmp(o) >= 0; }
-  bool operator<(const me_t& o) const { return cmp(o) < 0; }
-  bool operator<=(const me_t& o) const { return cmp(o) <= 0; }
-  bool operator==(const me_t& o) const { return cmp(o) == 0; }
-  bool operator!=(const me_t& o) const { return cmp(o) != 0; }
+  bool operator>(const me_t& o) const { return (int)compare_to(o) > 0; }
+  bool operator>=(const me_t& o) const { return (int)compare_to(o) >= 0; }
+  bool operator<(const me_t& o) const { return (int)compare_to(o) < 0; }
+  bool operator<=(const me_t& o) const { return (int)compare_to(o) <= 0; }
+  bool operator==(const me_t& o) const { return (int)compare_to(o) == 0; }
+  bool operator!=(const me_t& o) const { return (int)compare_to(o) != 0; }
 
   void assert_next_to(const me_t& prv) const {
 #ifndef NDEBUG
@@ -243,21 +243,21 @@ struct staged_position_t<STAGE_BOTTOM> {
     return index;
   }
 
-  int cmp(const staged_position_t<STAGE_BOTTOM>& o) const {
+  MatchKindCMP compare_to(const staged_position_t<STAGE_BOTTOM>& o) const {
     if (index > o.index) {
-      return 1;
+      return MatchKindCMP::GT;
     } else if (index < o.index) {
-      return -1;
+      return MatchKindCMP::LT;
     } else {
-      return 0;
+      return MatchKindCMP::EQ;
     }
   }
-  bool operator>(const me_t& o) const { return cmp(o) > 0; }
-  bool operator>=(const me_t& o) const { return cmp(o) >= 0; }
-  bool operator<(const me_t& o) const { return cmp(o) < 0; }
-  bool operator<=(const me_t& o) const { return cmp(o) <= 0; }
-  bool operator==(const me_t& o) const { return cmp(o) == 0; }
-  bool operator!=(const me_t& o) const { return cmp(o) != 0; }
+  bool operator>(const me_t& o) const { return (int)compare_to(o) > 0; }
+  bool operator>=(const me_t& o) const { return (int)compare_to(o) >= 0; }
+  bool operator<(const me_t& o) const { return (int)compare_to(o) < 0; }
+  bool operator<=(const me_t& o) const { return (int)compare_to(o) <= 0; }
+  bool operator==(const me_t& o) const { return (int)compare_to(o) == 0; }
+  bool operator!=(const me_t& o) const { return (int)compare_to(o) != 0; }
 
   me_t& operator-=(const me_t& o) {
     assert(is_valid_index(o.index));

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
@@ -96,14 +96,15 @@ class Btree {
       return !(*this == x);
     }
 
-    Cursor& operator++() {
-      // TODO
-      return *this;
-    }
-    Cursor operator++(int) {
-      Cursor tmp = *this;
-      ++*this;
-      return tmp;
+    btree_future<Cursor> get_next(Transaction& t) {
+      assert(!is_end());
+      auto this_obj = *this;
+      return p_cursor->get_next(p_tree->get_context(t)
+      ).safe_then([this_obj] (Ref<tree_cursor_t> next_cursor) {
+        next_cursor->assert_next_to(
+            *this_obj.p_cursor, this_obj.p_tree->value_builder.get_header_magic());
+        return Cursor{this_obj.p_tree, next_cursor};
+      });
     }
 
    private:

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
@@ -89,12 +89,12 @@ class Btree {
           *p_tree->nm, p_tree->value_builder, p_cursor);
     }
 
-    bool operator==(const Cursor& x) const {
-      return p_cursor == x.p_cursor;
-    }
-    bool operator!=(const Cursor& x) const {
-      return !(*this == x);
-    }
+    bool operator>(const Cursor& o) const { return (int)compare_to(o) > 0; }
+    bool operator>=(const Cursor& o) const { return (int)compare_to(o) >= 0; }
+    bool operator<(const Cursor& o) const { return (int)compare_to(o) < 0; }
+    bool operator<=(const Cursor& o) const { return (int)compare_to(o) <= 0; }
+    bool operator==(const Cursor& o) const { return (int)compare_to(o) != 0; }
+    bool operator!=(const Cursor& o) const { return (int)compare_to(o) == 0; }
 
     btree_future<Cursor> get_next(Transaction& t) {
       assert(!is_end());
@@ -103,7 +103,9 @@ class Btree {
       ).safe_then([this_obj] (Ref<tree_cursor_t> next_cursor) {
         next_cursor->assert_next_to(
             *this_obj.p_cursor, this_obj.p_tree->value_builder.get_header_magic());
-        return Cursor{this_obj.p_tree, next_cursor};
+        auto ret = Cursor{this_obj.p_tree, next_cursor};
+        assert(this_obj < ret);
+        return ret;
       });
     }
 
@@ -116,6 +118,20 @@ class Btree {
       }
     }
     Cursor(Btree* p_tree) : p_tree{p_tree} {}
+
+    MatchKindCMP compare_to(const Cursor& o) const {
+      assert(p_tree == o.p_tree);
+      if (p_cursor && o.p_cursor) {
+        return p_cursor->compare_to(
+            *o.p_cursor, p_tree->value_builder.get_header_magic());
+      } else if (!p_cursor && !o.p_cursor) {
+        return MatchKindCMP::EQ;
+      } else if (!p_cursor) {
+        return MatchKindCMP::GT;
+      } else { // !o.p_cursor
+        return MatchKindCMP::LT;
+      }
+    }
 
     static Cursor make_end(Btree* p_tree) {
       return {p_tree};

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -716,8 +716,6 @@ class DummyChildPool {
       ceph_abort("impossible path"); }
     key_view_t get_key_view(const search_position_t&) const override {
       ceph_abort("impossible path"); }
-    void next_position(search_position_t&) const override {
-      ceph_abort("impossible path"); }
     node_stats_t get_stats() const override {
       ceph_abort("impossible path"); }
     std::ostream& dump(std::ostream&) const override {

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -703,18 +703,17 @@ class DummyChildPool {
    public:
     laddr_t laddr() const override { return _laddr; }
     bool is_level_tail() const override { return _is_level_tail; }
+    std::optional<key_view_t> get_pivot_index() const override { return {key_view}; }
 
    protected:
+    node_type_t node_type() const override { return node_type_t::LEAF; }
     field_type_t field_type() const override { return field_type_t::N0; }
     level_t level() const override { return 0u; }
-    key_view_t get_largest_key_view() const override { return key_view; }
     void prepare_mutate(context_t) override {
       ceph_abort("impossible path"); }
     bool is_empty() const override {
       ceph_abort("impossible path"); }
     node_offset_t free_size() const override {
-      ceph_abort("impossible path"); }
-    key_view_t get_key_view(const search_position_t&) const override {
       ceph_abort("impossible path"); }
     node_stats_t get_stats() const override {
       ceph_abort("impossible path"); }
@@ -768,7 +767,7 @@ class DummyChildPool {
       if (right_child->can_split()) {
         splitable_nodes.insert(right_child);
       }
-      return insert_parent(c, right_child);
+      return insert_parent(c, *impl->get_pivot_index(), right_child);
     }
 
     node_future<> insert_and_split(

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -345,11 +345,28 @@ TEST_F(b_dummy_tree_test_t, 3_random_insert_leaf_node)
       Values::validate_cursor(cursor, largest_key, largest_value);
     }
 
+    // validate range query
+    {
+      kvs.clear();
+      for (auto& [k, v, c] : insert_history) {
+        kvs.emplace_back(k, v);
+      }
+      insert_history.clear();
+      std::sort(kvs.begin(), kvs.end(), [](auto& l, auto& r) {
+        return l.first < r.first;
+      });
+      auto cursor = tree.begin(t).unsafe_get0();
+      for (auto& [k, v] : kvs) {
+        ASSERT_FALSE(cursor.is_end());
+        Values::validate_cursor(cursor, k, v);
+        cursor = cursor.get_next(t).unsafe_get0();
+      }
+      ASSERT_TRUE(cursor.is_end());
+    }
+
     std::ostringstream oss;
     tree.dump(t, oss);
     logger().info("\n{}\n", oss.str());
-
-    insert_history.clear();
   });
 }
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
