### PR TITLE
crimson/onode-staged-tree: support empty ns and oid

### DIFF
--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.cc
@@ -23,9 +23,9 @@ void string_key_view_t::append_dedup(
 {
   p_append -= sizeof(string_size_t);
   if (dedup_type == Type::MIN) {
-    mut.copy_in_absolute(p_append, MIN);
+    mut.copy_in_absolute(p_append, MARKER_MIN);
   } else if (dedup_type == Type::MAX) {
-    mut.copy_in_absolute(p_append, MAX);
+    mut.copy_in_absolute(p_append, MARKER_MAX);
   } else {
     ceph_abort("impossible path");
   }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
@@ -128,9 +128,9 @@ inline MatchKindCMP compare_to(const snap_gen_t& l, const snap_gen_t& r) {
  * The layout to store char array as an oid or an ns string which may be
  * compressed.
  *
- * (TODO) If compressed, the physical block only stores an unsigned
- * int of string_size_t, with value MIN denoting Type::MIN, and value MAX
- * denoting Type::MAX.
+ * (TODO) If compressed, the physical block only stores an unsigned int of
+ * string_size_t, with value MARKER_MIN denoting Type::MIN, and value
+ * MARKER_MAX denoting Type::MAX.
  *
  * If not compressed (Type::STR), the physical block stores the char array and
  * a valid string_size_t value.
@@ -139,10 +139,11 @@ struct string_key_view_t {
   enum class Type {MIN, STR, MAX};
   // presumably the maximum string length is 2KiB
   using string_size_t = uint16_t;
-  static constexpr auto MAX = std::numeric_limits<string_size_t>::max();
-  static constexpr auto MIN = MAX - 1;
+  static constexpr auto MARKER_MAX = std::numeric_limits<string_size_t>::max();
+  static constexpr auto MARKER_MIN = std::numeric_limits<string_size_t>::max() - 1;
+  static constexpr auto VALID_UPPER_BOUND = std::numeric_limits<string_size_t>::max() - 2;
   static bool is_valid_size(size_t size) {
-    return size < MIN;
+    return size <= VALID_UPPER_BOUND;
   }
 
   string_key_view_t(const char* p_end) {
@@ -152,14 +153,14 @@ struct string_key_view_t {
       auto _p_key = p_length - length;
       p_key = static_cast<const char*>(_p_key);
     } else {
-      assert(length == MAX || length == MIN);
+      assert(length == MARKER_MAX || length == MARKER_MIN);
       p_key = nullptr;
     }
   }
   Type type() const {
-    if (length == MIN) {
+    if (length == MARKER_MIN) {
       return Type::MIN;
-    } else if (length == MAX) {
+    } else if (length == MARKER_MAX) {
       return Type::MAX;
     } else {
       assert(is_valid_size(length));
@@ -230,9 +231,9 @@ struct string_key_view_t {
     p_append -= sizeof(string_size_t);
     string_size_t len;
     if (dedup_type == Type::MIN) {
-      len = MIN;
+      len = MARKER_MIN;
     } else if (dedup_type == Type::MAX) {
-      len = MAX;
+      len = MARKER_MAX;
     } else {
       ceph_abort("impossible path");
     }
@@ -290,9 +291,9 @@ class string_view_masked_t {
   bool operator!=(const string_view_masked_t& x) const { return !(*this == x); }
   void encode(ceph::bufferlist& bl) const {
     if (get_type() == Type::MIN) {
-      ceph::encode(string_key_view_t::MIN, bl);
+      ceph::encode(string_key_view_t::MARKER_MIN, bl);
     } else if (get_type() == Type::MAX) {
-      ceph::encode(string_key_view_t::MAX, bl);
+      ceph::encode(string_key_view_t::MARKER_MAX, bl);
     } else {
       ceph::encode(size(), bl);
       ceph::encode_nohead(view, bl);
@@ -304,9 +305,9 @@ class string_view_masked_t {
       std::string& str_storage, ceph::bufferlist::const_iterator& delta) {
     string_size_t size;
     ceph::decode(size, delta);
-    if (size == string_key_view_t::MIN) {
+    if (size == string_key_view_t::MARKER_MIN) {
       return min();
-    } else if (size == string_key_view_t::MAX) {
+    } else if (size == string_key_view_t::MARKER_MAX) {
       return max();
     } else {
       ceph::decode_nohead(size, str_storage, delta);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
@@ -102,9 +102,9 @@ class Values {
 
 class KVPool {
   struct kv_conf_t {
-    unsigned index2;
-    unsigned index1;
-    unsigned index0;
+    index_t index2;
+    index_t index1;
+    index_t index0;
     size_t ns_size;
     size_t oid_size;
     value_item_t value;
@@ -112,16 +112,21 @@ class KVPool {
     ghobject_t get_ghobj() const {
       assert(index1 < 10);
       std::ostringstream os_ns;
-      os_ns << "ns" << index1;
-      unsigned current_size = (unsigned)os_ns.tellp();
-      assert(ns_size >= current_size);
-      os_ns << std::string(ns_size - current_size, '_');
-
       std::ostringstream os_oid;
-      os_oid << "oid" << index1;
-      current_size = (unsigned)os_oid.tellp();
-      assert(oid_size >= current_size);
-      os_oid << std::string(oid_size - current_size, '_');
+      if (index1 == 0) {
+        assert(!ns_size);
+        assert(!oid_size);
+      } else {
+        os_ns << "ns" << index1;
+        auto current_size = (size_t)os_ns.tellp();
+        assert(ns_size >= current_size);
+        os_ns << std::string(ns_size - current_size, '_');
+
+        os_oid << "oid" << index1;
+        current_size = (size_t)os_oid.tellp();
+        assert(oid_size >= current_size);
+        os_oid << std::string(oid_size - current_size, '_');
+      }
 
       return ghobject_t(shard_id_t(index2), index2, index2,
                         os_ns.str(), os_oid.str(), index0, index0);
@@ -134,22 +139,31 @@ class KVPool {
 
   KVPool(const std::vector<size_t>& str_sizes,
          const std::vector<size_t>& value_sizes,
-         const std::pair<unsigned, unsigned>& range2,
-         const std::pair<unsigned, unsigned>& range1,
-         const std::pair<unsigned, unsigned>& range0)
+         const std::pair<index_t, index_t>& range2,
+         const std::pair<index_t, index_t>& range1,
+         const std::pair<index_t, index_t>& range0)
       : str_sizes{str_sizes}, values{value_sizes} {
     ceph_assert(range2.first < range2.second);
-    ceph_assert(range2.second - 1 <= (unsigned)std::numeric_limits<shard_t>::max());
+    ceph_assert(range2.second - 1 <= (index_t)std::numeric_limits<shard_t>::max());
     ceph_assert(range2.second - 1 <= std::numeric_limits<crush_hash_t>::max());
     ceph_assert(range1.first < range1.second);
     ceph_assert(range1.second - 1 <= 9);
     ceph_assert(range0.first < range0.second);
     std::random_device rd;
-    for (unsigned i = range2.first; i < range2.second; ++i) {
-      for (unsigned j = range1.first; j < range1.second; ++j) {
-        auto ns_size = (unsigned)str_sizes[rd() % str_sizes.size()];
-        auto oid_size = (unsigned)str_sizes[rd() % str_sizes.size()];
-        for (unsigned k = range0.first; k < range0.second; ++k) {
+    for (index_t i = range2.first; i < range2.second; ++i) {
+      for (index_t j = range1.first; j < range1.second; ++j) {
+        size_t ns_size;
+        size_t oid_size;
+        if (j == 0) {
+          // store ns0, oid0 as empty strings for test purposes
+          ns_size = 0;
+          oid_size = 0;
+        } else {
+          ns_size = str_sizes[rd() % str_sizes.size()];
+          oid_size = str_sizes[rd() % str_sizes.size()];
+          assert(ns_size && oid_size);
+        }
+        for (index_t k = range0.first; k < range0.second; ++k) {
           kvs.emplace_back(kv_conf_t{i, j, k, ns_size, oid_size, values.pick()});
         }
       }
@@ -172,7 +186,7 @@ class KVPool {
       return std::make_pair(conf.get_ghobj(), conf.value);
     }
     bool is_end() const { return !p_kvs || i >= p_kvs->size(); }
-    size_t index() const { return i; }
+    index_t index() const { return i; }
 
     iterator_t& operator++() {
       assert(!is_end());
@@ -190,7 +204,7 @@ class KVPool {
     iterator_t(const kv_vector_t& kvs) : p_kvs{&kvs} {}
 
     const kv_vector_t* p_kvs = nullptr;
-    size_t i = 0;
+    index_t i = 0;
     friend class KVPool;
   };
 


### PR DESCRIPTION
Signed-off-by: Yingxin Cheng <yingxin.cheng@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
