### PR TITLE
doc: fix the spelling mistake of “Topicd”

### DIFF
--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -335,7 +335,7 @@ Response will have the following format:
 
 ::
 
-    <ListTopicdResponse xmlns="https://sns.amazonaws.com/doc/2010-03-31/">
+    <ListTopicsResponse xmlns="https://sns.amazonaws.com/doc/2010-03-31/">
         <ListTopicsResult>
             <Topics>
                 <member>


### PR DESCRIPTION
“Topicd” is a spelling mistake of "Topics".

Signed-off-by: Alex Wang wangdashuai@inspur.com