### PR TITLE
os/blkdev: Allow setting disk drive hdd/ssd to work around RAID card improper hd…

### DIFF
--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -236,6 +236,13 @@ int KernelDevice::open(const string& p)
       this->devname = devname;
       _detect_vdo();
     }
+
+    auto rotational_type = cct->_conf.get_val<string>("bluestore_debug_enforce_settings");
+    if (rotational_type.compare("hdd") == 0) {
+      rotational = true;
+    } else if (rotational_type.compare("ssd") == 0) {
+      rotational = false;
+    }
   }
 
   r = _aio_start();


### PR DESCRIPTION
…d/ssd setting.
 
src/common/blkdev.cc will read /sys/block/dm-N/queue/rotational to tell if it's a HDD or SSD.  
While some of the RAID cards return 1 for SSD even when the single disk drive is added into RAID0.  
This misleading behavior will influence all the hdd/ssd configuration and thus influence performance as I tested on some SSD.  
This fix allows setting OSD as HDD or SSD. By default, it still read /sys/block/dm-N/queue/rotational . 

Signed-off-by: Alice Zhao <brucen1030@163.com>

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
