### PR TITLE
nautilus: mgr/restful: fix TypeError occurring in _gather_osds()

### DIFF
--- a/src/pybind/mgr/restful/common.py
+++ b/src/pybind/mgr/restful/common.py
@@ -129,8 +129,7 @@ def crush_rule_osds(node_buckets, rule):
                 if node_id >= 0:
                     osds.add(node_id)
                 else:
-                    for desc_node in nodes_by_id[node_id]:
-                        osds |= _gather_osds(desc_node, steps[1:])
+                    osds |= _gather_osds(nodes_by_id[node_id], steps[1:])
         elif step['op'] == 'chooseleaf_firstn':
             # Choose all descendents of the current node of type 'type',
             # and select all leaves beneath those


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48558

---

backport of https://github.com/ceph/ceph/pull/38480
parent tracker: https://tracker.ceph.com/issues/48488

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh