### PR TITLE
nautilus: mgr: fix deadlock in ActivePyModules::get_osdmap()

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -912,7 +912,6 @@ PyObject *ActivePyModules::get_osdmap()
 
   PyThreadState *tstate = PyEval_SaveThread();
   {
-    std::lock_guard l(lock);
     cluster_state.with_osdmap([&](const OSDMap& o) {
         newmap->deepish_copy_from(o);
       });


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48897

---

backport of https://github.com/ceph/ceph/pull/38762
parent tracker: https://tracker.ceph.com/issues/48852

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh