### PR TITLE
mgr/dashboard: improve rbd listing

### DIFF
--- a/src/pybind/mgr/dashboard/services/rbd.py
+++ b/src/pybind/mgr/dashboard/services/rbd.py
@@ -8,11 +8,14 @@ import rbd
 from .. import mgr
 from ..tools import ViewCache
 from .ceph_service import CephService
+from ..plugins.ttl_cache import ttl_cache
 
 try:
     from typing import List
 except ImportError:
     pass  # For typing only
+
+RBD_IMAGE_CACHE_TTL = 10
 
 
 RBD_FEATURES_NAME_MAPPING = {
@@ -82,22 +85,19 @@ def parse_image_spec(image_spec):
 
 
 def rbd_call(pool_name, namespace, func, *args, **kwargs):
-    with mgr.rados.open_ioctx(pool_name) as ioctx:
-        ioctx.set_namespace(namespace if namespace is not None else '')
-        func(ioctx, *args, **kwargs)
+    ioctx = RbdService.cached_get_ioctx(pool_name, namespace)
+    func(ioctx, *args, **kwargs)
 
 
 def rbd_image_call(pool_name, namespace, image_name, func, *args, **kwargs):
     def _ioctx_func(ioctx, image_name, func, *args, **kwargs):
-        with rbd.Image(ioctx, image_name) as img:
-            func(ioctx, img, *args, **kwargs)
+        img = RbdService.cached_get_rbd_image(ioctx, image_name)
+        func(ioctx, img, *args, **kwargs)
 
     return rbd_call(pool_name, namespace, _ioctx_func, image_name, func, *args, **kwargs)
 
 
 class RbdConfiguration(object):
-    _rbd = rbd.RBD()
-
     def __init__(self, pool_name='', namespace='', image_name='', pool_ioctx=None,
                  image_ioctx=None):
         # type: (str, str, str, object, object) -> None
@@ -115,48 +115,43 @@ class RbdConfiguration(object):
 
     def list(self):
         # type: () -> List[dict]
-        def _list(ioctx):
-            if self._image_name:  # image config
-                try:
-                    with rbd.Image(ioctx, self._image_name) as image:
-                        result = image.config_list()
-                except rbd.ImageNotFound:
-                    result = []
-            else:  # pool config
-                pg_status = list(CephService.get_pool_pg_status(self._pool_name).keys())
-                if len(pg_status) == 1 and 'incomplete' in pg_status[0]:
-                    # If config_list would be called with ioctx if it's a bad pool,
-                    # the dashboard would stop working, waiting for the response
-                    # that would not happen.
-                    #
-                    # This is only a workaround for https://tracker.ceph.com/issues/43771 which
-                    # already got rejected as not worth the effort.
-                    #
-                    # Are more complete workaround for the dashboard will be implemented with
-                    # https://tracker.ceph.com/issues/44224
-                    #
-                    # @TODO: If #44224 is addressed remove this workaround
-                    return []
-                result = self._rbd.config_list(ioctx)
-            return list(result)
-
         if self._pool_name:
-            ioctx = mgr.rados.open_ioctx(self._pool_name)
-            ioctx.set_namespace(self._namespace)
+            ioctx = RbdService.cached_get_ioctx(self._pool_name, self._namespace)
         else:
             ioctx = self._pool_ioctx
 
-        return _list(ioctx)
+        if self._image_name:  # image config
+            try:
+                image = RbdService.cached_get_rbd_image(ioctx, self._image_name)
+                result = image.config_list()
+            except rbd.ImageNotFound:
+                result = []
+        else:  # pool config
+            pg_status = list(CephService.get_pool_pg_status(self._pool_name).keys())
+            if len(pg_status) == 1 and 'incomplete' in pg_status[0]:
+                # If config_list would be called with ioctx if it's a bad pool,
+                # the dashboard would stop working, waiting for the response
+                # that would not happen.
+                #
+                # This is only a workaround for https://tracker.ceph.com/issues/43771 which
+                # already got rejected as not worth the effort.
+                #
+                # Are more complete workaround for the dashboard will be implemented with
+                # https://tracker.ceph.com/issues/44224
+                #
+                # @TODO: If #44224 is addressed remove this workaround
+                return []
+            result = RbdService.rbd_inst.config_list(ioctx)
+        return list(result)
 
     def get(self, option_name):
         # type: (str) -> str
         option_name = self._ensure_prefix(option_name)
-        with mgr.rados.open_ioctx(self._pool_name) as pool_ioctx:
-            pool_ioctx.set_namespace(self._namespace)
-            if self._image_name:
-                with rbd.Image(pool_ioctx, self._image_name) as image:
-                    return image.metadata_get(option_name)
-            return self._rbd.pool_metadata_get(pool_ioctx, option_name)
+        ioctx = RbdService.cached_get_rbd_image(self._pool_name, self._namespace)
+        if self._image_name:
+            image = RbdService.cached_get_rbd_image(pool_ioctx, self._image_name)
+            return image.metadata_get(option_name)
+        return RbdService.rbd_inst.pool_metadata_get(pool_ioctx, option_name)
 
     def set(self, option_name, option_value):
         # type: (str, str) -> None
@@ -166,24 +161,16 @@ class RbdConfiguration(object):
 
         pool_ioctx = self._pool_ioctx
         if self._pool_name:  # open ioctx
-            pool_ioctx = mgr.rados.open_ioctx(self._pool_name)
-            pool_ioctx.__enter__()  # type: ignore
-            pool_ioctx.set_namespace(self._namespace)  # type: ignore
+            pool_ioctx = RbdService.cached_get_ioctx(self._pool_name, self._namespace)
 
         image_ioctx = self._image_ioctx
         if self._image_name:
-            image_ioctx = rbd.Image(pool_ioctx, self._image_name)
-            image_ioctx.__enter__()  # type: ignore
+            image_ioctx = RbdService.cached_get_rbd_image(pool_ioctx, self._image_name)
 
         if image_ioctx:
             image_ioctx.metadata_set(option_name, option_value)  # type: ignore
         else:
-            self._rbd.pool_metadata_set(pool_ioctx, option_name, option_value)
-
-        if self._image_name:  # Name provided, so we opened it and now have to close it
-            image_ioctx.__exit__(None, None, None)  # type: ignore
-        if self._pool_name:
-            pool_ioctx.__exit__(None, None, None)  # type: ignore
+            RbdService.rbd_inst.pool_metadata_set(pool_ioctx, option_name, option_value)
 
     def remove(self, option_name):
         """
@@ -193,19 +180,18 @@ class RbdConfiguration(object):
         def _remove(ioctx):
             try:
                 if self._image_name:
-                    with rbd.Image(ioctx, self._image_name) as image:
-                        image.metadata_remove(option_name)
+                    image = RbdService.cached_get_rbd_image(ioctx, self._image_name)
+                    image.metadata_remove(option_name)
                 else:
-                    self._rbd.pool_metadata_remove(ioctx, option_name)
+                    RbdService.rbd_inst.pool_metadata_remove(ioctx, option_name)
             except KeyError:
                 pass
 
         option_name = self._ensure_prefix(option_name)
 
         if self._pool_name:
-            with mgr.rados.open_ioctx(self._pool_name) as pool_ioctx:
-                pool_ioctx.set_namespace(self._namespace)
-                _remove(pool_ioctx)
+            ioctx = RbdService.cached_get_rbd_image(self._pool_name, self._namespace)
+            _remove(pool_ioctx)
         else:
             _remove(self._pool_ioctx)
 
@@ -219,6 +205,7 @@ class RbdConfiguration(object):
 
 
 class RbdService(object):
+    rbd_inst = rbd.RBD()
 
     @classmethod
     def _rbd_disk_usage(cls, image, snaps, whole_object=True):
@@ -246,129 +233,138 @@ class RbdService(object):
 
     @classmethod
     def _rbd_image(cls, ioctx, pool_name, namespace, image_name):
-        with rbd.Image(ioctx, image_name) as img:
+        img = cls.cached_get_rbd_image(ioctx, image_name)
 
-            stat = img.stat()
-            stat['name'] = image_name
-            if img.old_format():
-                stat['unique_id'] = get_image_spec(pool_name, namespace, stat['block_name_prefix'])
-                stat['id'] = stat['unique_id']
-                stat['image_format'] = 1
-            else:
-                stat['unique_id'] = get_image_spec(pool_name, namespace, img.id())
-                stat['id'] = img.id()
-                stat['image_format'] = 2
+        stat = img.stat()
+        stat['name'] = image_name
+        if img.old_format():
+            stat['unique_id'] = get_image_spec(pool_name, namespace, stat['block_name_prefix'])
+            stat['id'] = stat['unique_id']
+            stat['image_format'] = 1
+        else:
+            stat['unique_id'] = get_image_spec(pool_name, namespace, img.id())
+            stat['id'] = img.id()
+            stat['image_format'] = 2
 
-            stat['pool_name'] = pool_name
-            stat['namespace'] = namespace
-            features = img.features()
-            stat['features'] = features
-            stat['features_name'] = format_bitmask(features)
+        stat['pool_name'] = pool_name
+        stat['namespace'] = namespace
+        features = img.features()
+        stat['features'] = features
+        stat['features_name'] = format_bitmask(features)
 
-            # the following keys are deprecated
-            del stat['parent_pool']
-            del stat['parent_name']
+        # the following keys are deprecated
+        del stat['parent_pool']
+        del stat['parent_name']
 
-            stat['timestamp'] = "{}Z".format(img.create_timestamp()
-                                             .isoformat())
+        stat['timestamp'] = "{}Z".format(img.create_timestamp()
+                                         .isoformat())
 
-            stat['stripe_count'] = img.stripe_count()
-            stat['stripe_unit'] = img.stripe_unit()
+        stat['stripe_count'] = img.stripe_count()
+        stat['stripe_unit'] = img.stripe_unit()
 
-            data_pool_name = CephService.get_pool_name_from_id(
-                img.data_pool_id())
-            if data_pool_name == pool_name:
-                data_pool_name = None
-            stat['data_pool'] = data_pool_name
+        data_pool_name = CephService.get_pool_name_from_id(
+            img.data_pool_id())
+        if data_pool_name == pool_name:
+            data_pool_name = None
+        stat['data_pool'] = data_pool_name
 
-            try:
-                stat['parent'] = img.get_parent_image_spec()
-            except rbd.ImageNotFound:
-                # no parent image
-                stat['parent'] = None
+        try:
+            stat['parent'] = img.get_parent_image_spec()
+        except rbd.ImageNotFound:
+            # no parent image
+            stat['parent'] = None
 
-            # snapshots
-            stat['snapshots'] = []
-            for snap in img.list_snaps():
-                snap['timestamp'] = "{}Z".format(
-                    img.get_snap_timestamp(snap['id']).isoformat())
-                snap['is_protected'] = img.is_protected_snap(snap['name'])
-                snap['used_bytes'] = None
-                snap['children'] = []
-                img.set_snap(snap['name'])
-                for child_pool_name, child_image_name in img.list_children():
-                    snap['children'].append({
-                        'pool_name': child_pool_name,
-                        'image_name': child_image_name
-                    })
-                stat['snapshots'].append(snap)
+        # snapshots
+        stat['snapshots'] = []
+        for snap in img.list_snaps():
+            snap['timestamp'] = "{}Z".format(
+                img.get_snap_timestamp(snap['id']).isoformat())
+            snap['is_protected'] = img.is_protected_snap(snap['name'])
+            snap['used_bytes'] = None
+            snap['children'] = []
+            img.set_snap(snap['name'])
+            for child_pool_name, child_image_name in img.list_children():
+                snap['children'].append({
+                    'pool_name': child_pool_name,
+                    'image_name': child_image_name
+                })
+            stat['snapshots'].append(snap)
 
-            # disk usage
-            img_flags = img.flags()
-            if 'fast-diff' in stat['features_name'] and \
-                    not rbd.RBD_FLAG_FAST_DIFF_INVALID & img_flags:
-                snaps = [(s['id'], s['size'], s['name'])
-                         for s in stat['snapshots']]
-                snaps.sort(key=lambda s: s[0])
-                snaps += [(snaps[-1][0] + 1 if snaps else 0, stat['size'], None)]
-                total_prov_bytes, snaps_prov_bytes = cls._rbd_disk_usage(
-                    img, snaps, True)
-                stat['total_disk_usage'] = total_prov_bytes
-                for snap, prov_bytes in snaps_prov_bytes.items():
-                    if snap is None:
-                        stat['disk_usage'] = prov_bytes
-                        continue
-                    for ss in stat['snapshots']:
-                        if ss['name'] == snap:
-                            ss['disk_usage'] = prov_bytes
-                            break
-            else:
-                stat['total_disk_usage'] = None
-                stat['disk_usage'] = None
+        # disk usage
+        img_flags = img.flags()
+        if 'fast-diff' in stat['features_name'] and \
+                not rbd.RBD_FLAG_FAST_DIFF_INVALID & img_flags:
+            snaps = [(s['id'], s['size'], s['name'])
+                     for s in stat['snapshots']]
+            snaps.sort(key=lambda s: s[0])
+            snaps += [(snaps[-1][0] + 1 if snaps else 0, stat['size'], None)]
+            total_prov_bytes, snaps_prov_bytes = cls._rbd_disk_usage(
+                img, snaps, True)
+            stat['total_disk_usage'] = total_prov_bytes
+            for snap, prov_bytes in snaps_prov_bytes.items():
+                if snap is None:
+                    stat['disk_usage'] = prov_bytes
+                    continue
+                for ss in stat['snapshots']:
+                    if ss['name'] == snap:
+                        ss['disk_usage'] = prov_bytes
+                        break
+        else:
+            stat['total_disk_usage'] = None
+            stat['disk_usage'] = None
 
-            stat['configuration'] = RbdConfiguration(pool_ioctx=ioctx, image_name=image_name).list()
+        stat['configuration'] = RbdConfiguration(pool_ioctx=ioctx, image_name=image_name).list()
 
-            return stat
+        return stat
 
     @classmethod
     def _rbd_image_names(cls, ioctx):
-        rbd_inst = rbd.RBD()
-        return rbd_inst.list(ioctx)
+        return cls.rbd_inst.list(ioctx)
 
     @classmethod
     def _rbd_image_stat(cls, ioctx, pool_name, namespace, image_name):
         return cls._rbd_image(ioctx, pool_name, namespace, image_name)
 
     @classmethod
+    @ttl_cache(ttl=RBD_IMAGE_CACHE_TTL*10, maxsize=8*8)
+    def cached_get_ioctx(cls, pool_name, namespace=None):
+        ioctx = mgr.rados.open_ioctx(pool_name)
+        if namespace:
+            ioctx.set_namespace(namespace)
+        return ioctx
+
+    @classmethod
+    @ttl_cache(ttl=RBD_IMAGE_CACHE_TTL, maxsize=1024)
+    def cached_get_rbd_image(cls, ioctx, image_name):
+        return rbd.Image(ioctx, image_name)
+
+    @classmethod
     @ViewCache()
     def rbd_pool_list(cls, pool_name, namespace=None):
-        rbd_inst = rbd.RBD()
-        with mgr.rados.open_ioctx(pool_name) as ioctx:
-            result = []
-            if namespace:
-                namespaces = [namespace]
-            else:
-                namespaces = rbd_inst.namespace_list(ioctx)
-                # images without namespace
-                namespaces.append('')
-            for current_namespace in namespaces:
-                ioctx.set_namespace(current_namespace)
-                names = cls._rbd_image_names(ioctx)
-                for name in names:
-                    try:
-                        stat = cls._rbd_image_stat(ioctx, pool_name, current_namespace, name)
-                    except rbd.ImageNotFound:
-                        # may have been removed in the meanwhile
-                        continue
-                    result.append(stat)
-            return result
+        ioctx = cls.cached_get_ioctx(pool_name)
+        result = []
+        if namespace:
+            namespaces = [namespace]
+        else:
+            namespaces = cls.rbd_inst.namespace_list(ioctx)
+            # images without namespace
+            namespaces.append('')
+        for current_namespace in namespaces:
+            ioctx = cls.cached_get_ioctx(pool_name, current_namespace)
+            names = cls._rbd_image_names(ioctx)
+            for name in names:
+                try:
+                    stat = cls._rbd_image_stat(ioctx, pool_name, current_namespace, name)
+                except rbd.ImageNotFound:
+                    # may have been removed in the meanwhile
+                    continue
+                result.append(stat)
+        return result
 
     @classmethod
     def get_image(cls, image_spec):
         pool_name, namespace, image_name = parse_image_spec(image_spec)
-        ioctx = mgr.rados.open_ioctx(pool_name)
-        if namespace:
-            ioctx.set_namespace(namespace)
+        ioctx = cls.cached_get_ioctx(pool_name, namespace)
         try:
             return cls._rbd_image(ioctx, pool_name, namespace, image_name)
         except rbd.ImageNotFound:


### PR DESCRIPTION
Adds TTL caching to ioctx and RBD images in order to speed up listing of many RBD images (> hundreds). Instantiating RBD images is one of the bottlenecks, so by reusing those, only when the TTL cache is cold this method takes longer to complete.

In order to improve the TTL caching, a `ttl_spread` has been added to the cache, so the items start to progressively expire from `ttl*(1 - ttl_spread)/2` to `ttl*(1 + ttl_spread)/2`.

## CAVEATS 
* This assumes that ioctx and RBD image objects will be automatically deallocated by the Python ref-counting mechanism (as no context manager is used or explicit close is called).
* This still does not fix the underlying issue: since the number of RBD images may be a scaling factor for a Ceph cluster, the latency might sooner or later exceed the poll period.
* The only fix for that is to introduce pagination. However, that will break some Dashboard features, like the ability to sort RBD images by any property (size, number of objects, provisioned size, etc.), or the ability to filter those images by the same properties. A possibility, already applied in other endpoints, is to disable the periodic polling, while allowing the user to manually refresh the table.

Fixes: http://tracker.ceph.com/issues/39140
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug
- [ ] Asynchronous expiration in the ttl cache.

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
