### PR TITLE
mgr/orch: Make orchestrator interface synchronous. 

### DIFF
--- a/doc/mgr/orchestrator_modules.rst
+++ b/doc/mgr/orchestrator_modules.rst
@@ -98,9 +98,6 @@ Bootstrapping hosts and adding them to the underlying orchestration
 system is outside the scope of Ceph's orchestrator interface.  Ceph
 can only work on hosts when the orchestrator is already aware of them.
 
-Calls to orchestrator modules are all asynchronous, and return *completion*
-objects (see below) rather than returning values immediately.
-
 Where possible, placement of stateless services should be left up to the
 orchestrator.
 
@@ -108,11 +105,7 @@ Completions and batching
 ------------------------
 
 All methods that read or modify the state of the system can potentially
-be long running.  To handle that, all such methods return a *Completion*
-object.  Orchestrator modules
-must implement the *process* method: this takes a list of completions, and
-is responsible for checking if they're finished, and advancing the underlying
-operations as needed.
+be long running. Therefore the module needs to schedule those operations.
 
 Each orchestrator module implements its own underlying mechanisms
 for completions.  This might involve running the underlying operations
@@ -120,19 +113,6 @@ in threads, or batching the operations up before later executing
 in one go in the background.  If implementing such a batching pattern, the
 module would do no work on any operation until it appeared in a list
 of completions passed into *process*.
-
-Some operations need to show a progress. Those operations need to add
-a *ProgressReference* to the completion. At some point, the progress reference
-becomes *effective*, meaning that the operation has really happened
-(e.g. a service has actually been started).
-
-.. automethod:: Orchestrator.process
-
-.. autoclass:: Completion
-   :members:
-
-.. autoclass:: ProgressReference
-   :members:
 
 Error Handling
 --------------

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -34,7 +34,7 @@ from mgr_util import create_self_signed_cert
 import secrets
 import orchestrator
 from orchestrator import OrchestratorError, OrchestratorValidationError, HostSpec, \
-    CLICommandMeta, DaemonDescription, DaemonDescriptionStatus
+    CLICommandMeta, DaemonDescription, DaemonDescriptionStatus, handle_orch_error
 from orchestrator._interface import GenericSpec
 from orchestrator._interface import daemon_type_to_service
 
@@ -93,24 +93,6 @@ DEFAULT_NODE_EXPORTER_IMAGE = 'docker.io/prom/node-exporter:v0.18.1'
 DEFAULT_GRAFANA_IMAGE = 'docker.io/ceph/ceph-grafana:6.7.4'
 DEFAULT_ALERT_MANAGER_IMAGE = 'docker.io/prom/alertmanager:v0.20.0'
 # ------------------------------------------------------------------------------
-
-
-class CephadmCompletion(orchestrator.Completion[T]):
-    def evaluate(self) -> None:
-        self.finalize(None)
-
-
-def trivial_completion(f: Callable[..., T]) -> Callable[..., CephadmCompletion[T]]:
-    """
-    Decorator to make CephadmCompletion methods return
-    a completion object that executes themselves.
-    """
-
-    @wraps(f)
-    def wrapper(*args: Any, **kwargs: Any) -> CephadmCompletion:
-        return CephadmCompletion(on_complete=lambda _: f(*args, **kwargs))
-
-    return wrapper
 
 
 def service_inactive(spec_name: str) -> Callable:
@@ -384,8 +366,6 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         self.upgrade = CephadmUpgrade(self)
 
         self.health_checks: Dict[str, dict] = {}
-
-        self.all_progress_references = list()  # type: List[orchestrator.ProgressReference]
 
         self.inventory = Inventory(self)
 
@@ -694,17 +674,6 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         }
 
         return True, err, ret
-
-    def process(self, completions: List[CephadmCompletion]) -> None:  # type: ignore
-        """
-        Does nothing, as completions are processed in another thread.
-        """
-        if completions:
-            self.log.debug("process: completions={0}".format(
-                orchestrator.pretty_print(completions)))
-
-            for p in completions:
-                p.evaluate()
 
     @orchestrator._cli_write_command(
         prefix='cephadm set-ssh-config')
@@ -1213,11 +1182,11 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         self.log.info('Added host %s' % spec.hostname)
         return "Added host '{}'".format(spec.hostname)
 
-    @trivial_completion
+    @handle_orch_error
     def add_host(self, spec: HostSpec) -> str:
         return self._add_host(spec)
 
-    @trivial_completion
+    @handle_orch_error
     def remove_host(self, host):
         # type: (str) -> str
         """
@@ -1232,7 +1201,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         self.log.info('Removed host %s' % host)
         return "Removed host '{}'".format(host)
 
-    @trivial_completion
+    @handle_orch_error
     def update_host_addr(self, host: str, addr: str) -> str:
         self.inventory.set_addr(host, addr)
         self._reset_con(host)
@@ -1240,7 +1209,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         self.log.info('Set host %s addr to %s' % (host, addr))
         return "Updated host '{}' addr to '{}'".format(host, addr)
 
-    @trivial_completion
+    @handle_orch_error
     def get_hosts(self):
         # type: () -> List[orchestrator.HostSpec]
         """
@@ -1251,13 +1220,13 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         """
         return list(self.inventory.all_specs())
 
-    @trivial_completion
+    @handle_orch_error
     def add_host_label(self, host: str, label: str) -> str:
         self.inventory.add_label(host, label)
         self.log.info('Added label %s to host %s' % (label, host))
         return 'Added label %s to host %s' % (label, host)
 
-    @trivial_completion
+    @handle_orch_error
     def remove_host_label(self, host: str, label: str) -> str:
         self.inventory.rm_label(host, label)
         self.log.info('Removed label %s to host %s' % (label, host))
@@ -1298,7 +1267,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                        + 'Note the following:\n\n' + '\n'.join(notifications))
         return 0, f'It is presumed safe to stop host {hostname}'
 
-    @trivial_completion
+    @handle_orch_error
     def host_ok_to_stop(self, hostname: str) -> str:
         if hostname not in self.cache.get_hosts():
             raise OrchestratorError(f'Cannot find host "{hostname}"')
@@ -1325,7 +1294,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             }
         self.set_health_checks(self.health_checks)
 
-    @trivial_completion
+    @handle_orch_error
     @host_exists()
     def enter_host_maintenance(self, hostname: str, force: bool = False) -> str:
         """ Attempt to place a cluster host in maintenance
@@ -1395,7 +1364,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
         return f"Ceph cluster {self._cluster_fsid} on {hostname} moved to maintenance"
 
-    @trivial_completion
+    @handle_orch_error
     @host_exists()
     def exit_host_maintenance(self, hostname: str) -> str:
         """Exit maintenance mode and return a host to an operational state
@@ -1464,7 +1433,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
         self._kick_serve_loop()
 
-    @trivial_completion
+    @handle_orch_error
     def describe_service(self, service_type: Optional[str] = None, service_name: Optional[str] = None,
                          refresh: bool = False) -> List[orchestrator.ServiceDescription]:
         if refresh:
@@ -1564,7 +1533,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                 sm[n].size = sm[n].size * 2
         return list(sm.values())
 
-    @trivial_completion
+    @handle_orch_error
     def list_daemons(self,
                      service_name: Optional[str] = None,
                      daemon_type: Optional[str] = None,
@@ -1589,7 +1558,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                 result.append(dd)
         return result
 
-    @trivial_completion
+    @handle_orch_error
     def service_action(self, action: str, service_name: str) -> List[str]:
         dds: List[DaemonDescription] = self.cache.get_daemons_by_service(service_name)
         if not dds:
@@ -1661,7 +1630,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                 'who': utils.name_to_config_section(daemon_type + '.' + daemon_id),
             })
 
-    @trivial_completion
+    @handle_orch_error
     def daemon_action(self, action: str, daemon_name: str, image: Optional[str] = None) -> str:
         d = self.cache.get_daemon(daemon_name)
         assert d.daemon_type is not None
@@ -1694,7 +1663,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         self._kick_serve_loop()
         return msg
 
-    @trivial_completion
+    @handle_orch_error
     def remove_daemons(self, names):
         # type: (List[str]) -> List[str]
         args = []
@@ -1707,7 +1676,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         self.log.info('Remove daemons %s' % [a[0] for a in args])
         return self._remove_daemons(args)
 
-    @trivial_completion
+    @handle_orch_error
     def remove_service(self, service_name: str) -> str:
         self.log.info('Remove service %s' % service_name)
         self._trigger_preview_refresh(service_name=service_name)
@@ -1723,7 +1692,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             # must be idempotent: still a success.
             return f'Failed to remove service. <{service_name}> was not found.'
 
-    @trivial_completion
+    @handle_orch_error
     def get_inventory(self, host_filter: Optional[orchestrator.InventoryFilter] = None, refresh: bool = False) -> List[orchestrator.InventoryHost]:
         """
         Return the storage inventory of hosts matching the given filter.
@@ -1752,7 +1721,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                                                      inventory.Devices(dls)))
         return result
 
-    @trivial_completion
+    @handle_orch_error
     def zap_device(self, host: str, path: str) -> str:
         self.log.info('Zap device %s:%s' % (host, path))
         out, err, code = CephadmServe(self)._run_cephadm(
@@ -1764,7 +1733,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             raise OrchestratorError('Zap failed: %s' % '\n'.join(out + err))
         return '\n'.join(out + err)
 
-    @trivial_completion
+    @handle_orch_error
     def blink_device_light(self, ident_fault: str, on: bool, locs: List[orchestrator.DeviceLightLoc]) -> List[str]:
         """
         Blink a device light. Calling something like::
@@ -1843,7 +1812,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.log.info(f"Marking host: {host} for OSDSpec preview refresh.")
             self.cache.osdspec_previews_refresh_queue.append(host)
 
-    @trivial_completion
+    @handle_orch_error
     def apply_drivegroups(self, specs: List[DriveGroupSpec]) -> List[str]:
         """
         Deprecated. Please use `apply()` instead.
@@ -1852,7 +1821,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         """
         return [self._apply(spec) for spec in specs]
 
-    @trivial_completion
+    @handle_orch_error
     def create_osds(self, drive_group: DriveGroupSpec) -> str:
         return self.osd_service.create_from_spec(drive_group)
 
@@ -1974,16 +1943,16 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
         return create_func_map(args)
 
-    @trivial_completion
+    @handle_orch_error
     def apply_mon(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
 
-    @trivial_completion
+    @handle_orch_error
     def add_mon(self, spec):
         # type: (ServiceSpec) -> List[str]
         return self._add_daemon('mon', spec, self.mon_service.prepare_create)
 
-    @trivial_completion
+    @handle_orch_error
     def add_mgr(self, spec):
         # type: (ServiceSpec) -> List[str]
         return self._add_daemon('mgr', spec, self.mgr_service.prepare_create)
@@ -2023,7 +1992,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             'remove': [d.hostname for d in remove_daemon_hosts]
         }
 
-    @trivial_completion
+    @handle_orch_error
     def plan(self, specs: Sequence[GenericSpec]) -> List:
         results = [{'warning': 'WARNING! Dry-Runs are snapshots of a certain point in time and are bound \n'
                                'to the current inventory setup. If any on these conditions changes, the \n'
@@ -2074,59 +2043,59 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         self._kick_serve_loop()
         return "Scheduled %s update..." % spec.service_name()
 
-    @trivial_completion
+    @handle_orch_error
     def apply(self, specs: Sequence[GenericSpec]) -> List[str]:
         results = []
         for spec in specs:
             results.append(self._apply(spec))
         return results
 
-    @trivial_completion
+    @handle_orch_error
     def apply_mgr(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
 
-    @trivial_completion
+    @handle_orch_error
     def add_mds(self, spec: ServiceSpec) -> List[str]:
         return self._add_daemon('mds', spec, self.mds_service.prepare_create)
 
-    @trivial_completion
+    @handle_orch_error
     def apply_mds(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
 
-    @trivial_completion
+    @handle_orch_error
     def add_rgw(self, spec: ServiceSpec) -> List[str]:
         return self._add_daemon('rgw', spec, self.rgw_service.prepare_create)
 
-    @trivial_completion
+    @handle_orch_error
     def apply_rgw(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
 
-    @trivial_completion
+    @handle_orch_error
     def apply_ha_rgw(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
 
-    @trivial_completion
+    @handle_orch_error
     def add_iscsi(self, spec):
         # type: (ServiceSpec) -> List[str]
         return self._add_daemon('iscsi', spec, self.iscsi_service.prepare_create)
 
-    @trivial_completion
+    @handle_orch_error
     def apply_iscsi(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
 
-    @trivial_completion
+    @handle_orch_error
     def add_rbd_mirror(self, spec: ServiceSpec) -> List[str]:
         return self._add_daemon('rbd-mirror', spec, self.rbd_mirror_service.prepare_create)
 
-    @trivial_completion
+    @handle_orch_error
     def apply_rbd_mirror(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
 
-    @trivial_completion
+    @handle_orch_error
     def add_nfs(self, spec: ServiceSpec) -> List[str]:
         return self._add_daemon('nfs', spec, self.nfs_service.prepare_create)
 
-    @trivial_completion
+    @handle_orch_error
     def apply_nfs(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
 
@@ -2134,73 +2103,73 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         # type: () -> str
         return self.get('mgr_map').get('services', {}).get('dashboard', '')
 
-    @trivial_completion
+    @handle_orch_error
     def add_prometheus(self, spec: ServiceSpec) -> List[str]:
         return self._add_daemon('prometheus', spec, self.prometheus_service.prepare_create)
 
-    @trivial_completion
+    @handle_orch_error
     def apply_prometheus(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
 
-    @trivial_completion
+    @handle_orch_error
     def add_node_exporter(self, spec):
         # type: (ServiceSpec) -> List[str]
         return self._add_daemon('node-exporter', spec,
                                 self.node_exporter_service.prepare_create)
 
-    @trivial_completion
+    @handle_orch_error
     def apply_node_exporter(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
 
-    @trivial_completion
+    @handle_orch_error
     def add_crash(self, spec):
         # type: (ServiceSpec) -> List[str]
         return self._add_daemon('crash', spec,
                                 self.crash_service.prepare_create)
 
-    @trivial_completion
+    @handle_orch_error
     def apply_crash(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
 
-    @trivial_completion
+    @handle_orch_error
     def add_grafana(self, spec):
         # type: (ServiceSpec) -> List[str]
         return self._add_daemon('grafana', spec, self.grafana_service.prepare_create)
 
-    @trivial_completion
+    @handle_orch_error
     def apply_grafana(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
 
-    @trivial_completion
+    @handle_orch_error
     def add_alertmanager(self, spec):
         # type: (ServiceSpec) -> List[str]
         return self._add_daemon('alertmanager', spec, self.alertmanager_service.prepare_create)
 
-    @trivial_completion
+    @handle_orch_error
     def apply_alertmanager(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
 
-    @trivial_completion
+    @handle_orch_error
     def add_container(self, spec: ServiceSpec) -> List[str]:
         return self._add_daemon('container', spec,
                                 self.container_service.prepare_create)
 
-    @trivial_completion
+    @handle_orch_error
     def apply_container(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
 
-    @trivial_completion
+    @handle_orch_error
     def add_cephadm_exporter(self, spec):
         # type: (ServiceSpec) -> List[str]
         return self._add_daemon('cephadm-exporter',
                                 spec,
                                 self.cephadm_exporter_service.prepare_create)
 
-    @trivial_completion
+    @handle_orch_error
     def apply_cephadm_exporter(self, spec: ServiceSpec) -> str:
         return self._apply(spec)
 
-    @trivial_completion
+    @handle_orch_error
     def upgrade_check(self, image: str, version: str) -> str:
         if self.inventory.get_host_with_state("maintenance"):
             raise OrchestratorError("check aborted - you have hosts in maintenance state")
@@ -2237,29 +2206,29 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
         return json.dumps(r, indent=4, sort_keys=True)
 
-    @trivial_completion
+    @handle_orch_error
     def upgrade_status(self) -> orchestrator.UpgradeStatusSpec:
         return self.upgrade.upgrade_status()
 
-    @trivial_completion
+    @handle_orch_error
     def upgrade_start(self, image: str, version: str) -> str:
         if self.inventory.get_host_with_state("maintenance"):
             raise OrchestratorError("upgrade aborted - you have host(s) in maintenance state")
         return self.upgrade.upgrade_start(image, version)
 
-    @trivial_completion
+    @handle_orch_error
     def upgrade_pause(self) -> str:
         return self.upgrade.upgrade_pause()
 
-    @trivial_completion
+    @handle_orch_error
     def upgrade_resume(self) -> str:
         return self.upgrade.upgrade_resume()
 
-    @trivial_completion
+    @handle_orch_error
     def upgrade_stop(self) -> str:
         return self.upgrade.upgrade_stop()
 
-    @trivial_completion
+    @handle_orch_error
     def remove_osds(self, osd_ids: List[str],
                     replace: bool = False,
                     force: bool = False) -> str:
@@ -2293,7 +2262,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         self._kick_serve_loop()
         return "Scheduled OSD(s) for removal"
 
-    @trivial_completion
+    @handle_orch_error
     def stop_remove_osds(self, osd_ids: List[str]) -> str:
         """
         Stops a `removal` process for a List of OSDs.
@@ -2310,7 +2279,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         self._kick_serve_loop()
         return "Stopped OSD(s) removal"
 
-    @trivial_completion
+    @handle_orch_error
     def remove_osds_status(self) -> List[OSD]:
         """
         The CLI call to retrieve an osd removal report

--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -1,4 +1,3 @@
-import time
 import fnmatch
 from contextlib import contextmanager
 
@@ -12,7 +11,7 @@ except ImportError:
     pass
 
 from cephadm import CephadmOrchestrator
-from orchestrator import raise_if_exception, Completion, HostSpec
+from orchestrator import raise_if_exception, OrchResult, HostSpec
 from tests import mock
 
 
@@ -64,31 +63,8 @@ def with_cephadm_module(module_options=None, store=None):
 
 
 def wait(m, c):
-    # type: (CephadmOrchestrator, Completion) -> Any
-    m.process([c])
-
-    try:
-        # if in debugger
-        import pydevd  # noqa: F401
-        in_debug = True
-    except ImportError:
-        in_debug = False
-
-    if in_debug:
-        while True:    # don't timeout
-            if c.is_finished:
-                raise_if_exception(c)
-                return c.result
-            time.sleep(0.1)
-    else:
-        for i in range(30):
-            if i % 10 == 0:
-                m.process([c])
-            if c.is_finished:
-                raise_if_exception(c)
-                return c.result
-            time.sleep(0.1)
-    assert False, "timeout" + str(c._state)
+    # type: (CephadmOrchestrator, OrchResult) -> Any
+    return raise_if_exception(c)
 
 
 @contextmanager

--- a/src/pybind/mgr/cephadm/tests/test_completion.py
+++ b/src/pybind/mgr/cephadm/tests/test_completion.py
@@ -1,24 +1,9 @@
 import pytest
 
-from .fixtures import wait
-from ..module import trivial_completion, forall_hosts
+from ..module import forall_hosts
 
 
 class TestCompletion(object):
-
-    def test_trivial(self, cephadm_module):
-        @trivial_completion
-        def run(x):
-            return x + 1
-        assert wait(cephadm_module, run(1)) == 2
-
-    def test_exception(self, cephadm_module):
-        @trivial_completion
-        def run(x):
-            raise ValueError
-        c = run(1)
-        with pytest.raises(ValueError):
-            wait(cephadm_module, c)
 
     @pytest.mark.parametrize("input,expected", [
         ([], []),

--- a/src/pybind/mgr/mds_autoscaler/module.py
+++ b/src/pybind/mgr/mds_autoscaler/module.py
@@ -25,7 +25,6 @@ class MDSAutoscaler(orchestrator.OrchestratorClientMixin, MgrModule):
         completion = self.describe_service(service_type='mds',
                                            service_name=service,
                                            refresh=True)
-        self._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
         if completion.result:
             return completion.result[0]
@@ -80,7 +79,6 @@ class MDSAutoscaler(orchestrator.OrchestratorClientMixin, MgrModule):
             self.log.info(f"fs {fs_name}: adjusting daemon count from {svc.spec.placement.count} to {want}")
             newspec = self.update_daemon_count(svc.spec, fs_name, want)
             completion = self.apply_mds(newspec)
-            self._orchestrator_wait([completion])
             orchestrator.raise_if_exception(completion)
         except orchestrator.OrchestratorError as e:
             self.log.exception(f"fs {fs_name}: exception while updating service: {e}")

--- a/src/pybind/mgr/mds_autoscaler/tests/test_autoscaler.py
+++ b/src/pybind/mgr/mds_autoscaler/tests/test_autoscaler.py
@@ -12,11 +12,10 @@ except ImportError:
 from mds_autoscaler.module import MDSAutoscaler
 
 
-
-@pytest.yield_fixture()
+@pytest.fixture()
 def mds_autoscaler_module():
 
-    yield MDSAutoscaler('cephadm', 0, 0)
+    yield MDSAutoscaler('mds_autoscaler', 0, 0)
 
 
 class TestCephadm(object):
@@ -56,7 +55,6 @@ class TestCephadm(object):
         apply = OrchResult(result='')
         _apply_mds.return_value = apply
 
-
         _get.return_value = {
             'filesystems': [
                 {
@@ -68,6 +66,7 @@ class TestCephadm(object):
                             }
                         ],
                         'standby_count_wanted': 2,
+                        'max_mds': 1
                     }
                 }
             ],

--- a/src/pybind/mgr/mds_autoscaler/tests/test_autoscaler.py
+++ b/src/pybind/mgr/mds_autoscaler/tests/test_autoscaler.py
@@ -2,7 +2,7 @@ import pytest
 from unittest import mock
 
 from ceph.deployment.service_spec import ServiceSpec, PlacementSpec
-from orchestrator import DaemonDescription, Completion, ServiceDescription
+from orchestrator import DaemonDescription, OrchResult, ServiceDescription
 
 try:
     from typing import Any, List
@@ -16,10 +16,7 @@ from mds_autoscaler.module import MDSAutoscaler
 @pytest.yield_fixture()
 def mds_autoscaler_module():
 
-    with mock.patch("mds_autoscaler.module.MDSAutoscaler._orchestrator_wait"):
-        m = MDSAutoscaler('cephadm', 0, 0)
-
-        yield m
+    yield MDSAutoscaler('cephadm', 0, 0)
 
 
 class TestCephadm(object):
@@ -29,7 +26,7 @@ class TestCephadm(object):
     @mock.patch("mds_autoscaler.module.MDSAutoscaler.describe_service")
     @mock.patch("mds_autoscaler.module.MDSAutoscaler.apply_mds")
     def test_scale_up(self, _apply_mds, _describe_service, _list_daemons, _get, mds_autoscaler_module: MDSAutoscaler):
-        daemons = Completion(value=[
+        daemons = OrchResult(result=[
             DaemonDescription(
                 hostname='myhost',
                 daemon_type='mds',
@@ -41,10 +38,9 @@ class TestCephadm(object):
                 daemon_id='fs_name.myhost.b'
             ),
         ])
-        daemons.finalize()
         _list_daemons.return_value = daemons
 
-        services = Completion(value=[
+        services = OrchResult(result=[
             ServiceDescription(
                 spec=ServiceSpec(
                     service_type='mds',
@@ -55,11 +51,9 @@ class TestCephadm(object):
                 )
             )
         ])
-        services.finalize()
         _describe_service.return_value = services
 
-        apply = Completion(value='')
-        apply.finalize()
+        apply = OrchResult(result='')
         _apply_mds.return_value = apply
 
 

--- a/src/pybind/mgr/orchestrator/__init__.py
+++ b/src/pybind/mgr/orchestrator/__init__.py
@@ -4,7 +4,7 @@ from .module import OrchestratorCli
 
 # usage: E.g. `from orchestrator import StatelessServiceSpec`
 from ._interface import \
-    Completion, TrivialReadCompletion, raise_if_exception, ProgressReference, pretty_print, _Promise, \
+    OrchResult, raise_if_exception, \
     CLICommand, _cli_write_command, _cli_read_command, CLICommandMeta, \
     Orchestrator, OrchestratorClientMixin, \
     OrchestratorValidationError, OrchestratorError, NoOrchestrator, \

--- a/src/pybind/mgr/orchestrator/__init__.py
+++ b/src/pybind/mgr/orchestrator/__init__.py
@@ -4,7 +4,7 @@ from .module import OrchestratorCli
 
 # usage: E.g. `from orchestrator import StatelessServiceSpec`
 from ._interface import \
-    OrchResult, raise_if_exception, \
+    OrchResult, raise_if_exception, handle_orch_error, \
     CLICommand, _cli_write_command, _cli_read_command, CLICommandMeta, \
     Orchestrator, OrchestratorClientMixin, \
     OrchestratorValidationError, OrchestratorError, NoOrchestrator, \

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -12,12 +12,10 @@ import errno
 import logging
 import pickle
 import re
-import time
-import uuid
 
 from collections import namedtuple, OrderedDict
 from contextlib import contextmanager
-from functools import wraps
+from functools import wraps, reduce
 
 from typing import TypeVar, Generic, List, Optional, Union, Tuple, Iterator, Callable, Any, \
     Sequence, Dict, cast
@@ -115,6 +113,22 @@ def handle_exception(prefix: str, perm: str, func: FuncT) -> FuncT:
     return cast(FuncT, wrapper_copy)
 
 
+def handle_orch_error(f: Callable[..., T]) -> Callable[..., 'OrchResult[T]']:
+    """
+    Decorator to make Orchestrator methods return
+    an OrchResult.
+    """
+
+    @wraps(f)
+    def wrapper(*args: Any, **kwargs: Any) -> OrchResult[T]:
+        try:
+            return OrchResult(f(*args, **kwargs))
+        except Exception as e:
+            return OrchResult(None, exception=e)
+
+    return cast(Callable[..., OrchResult[T]], wrapper)
+
+
 class InnerCliCommandCallable(Protocol):
     def __call__(self, prefix: str) -> Callable[[FuncT], FuncT]:
         ...
@@ -156,57 +170,30 @@ class CLICommandMeta(type):
         cls.handle_command = handle_command
 
 
-def _no_result() -> None:
-    return object()  # type: ignore
-
-
-class _Promise(object):
+class OrchResult(Generic[T]):
     """
-    A completion may need multiple promises to be fulfilled. `_Promise` is one
-    step.
-
-    Typically ``Orchestrator`` implementations inherit from this class to
-    build their own way of finishing a step to fulfil a future.
-
-    They are not exposed in the orchestrator interface and can be seen as a
-    helper to build orchestrator modules.
+    Stores a result and an exception. Mainly to circumvent the
+    MgrModule.remote() method that hides all exceptions and for
+    handling different sub-interpreters.
     """
-    INITIALIZED = 1  # We have a parent completion and a next completion
-    RUNNING = 2
-    FINISHED = 3  # we have a final result
 
-    NO_RESULT: None = _no_result()  # type: ignore
-    ASYNC_RESULT = object()
+    def __init__(self, result: Optional[T], exception: Optional[Exception] = None) -> None:
+        self.result = result
+        self.serialized_exception: Optional[bytes] = None
+        self.exception_str: str = ''
+        self.set_exception(exception)
 
-    def __init__(self,
-                 _first_promise: Optional["_Promise"] = None,
-                 value: Optional[Any] = NO_RESULT,
-                 on_complete: Optional[Callable] = None,
-                 name: Optional[str] = None,
-                 ):
-        self._on_complete_ = on_complete
-        self._name = name
-        self._next_promise: Optional[_Promise] = None
+    __slots__ = 'result', 'serialized_exception', 'exception_str'
 
-        self._state = self.INITIALIZED
-        self._exception: Optional[Exception] = None
+    def set_exception(self, e: Optional[Exception]) -> None:
+        if e is None:
+            self.serialized_exception = None
+            self.exception_str = ''
+            return
 
-        # Value of this _Promise. may be an intermediate result.
-        self._value = value
-
-        # _Promise is not a continuation monad, as `_result` is of type
-        # T instead of (T -> r) -> r. Therefore we need to store the first promise here.
-        self._first_promise: '_Promise' = _first_promise or self
-
-    @property
-    def _exception(self) -> Optional[Exception]:
-        return getattr(self, '_exception_', None)
-
-    @_exception.setter
-    def _exception(self, e: Exception) -> None:
-        self._exception_ = e
+        self.exception_str = f'{type(e)}: {str(e)}'
         try:
-            self._serialized_exception_ = pickle.dumps(e) if e is not None else None
+            self.serialized_exception = pickle.dumps(e)
         except pickle.PicklingError:
             logger.error(f"failed to pickle {e}")
             if isinstance(e, Exception):
@@ -214,365 +201,7 @@ class _Promise(object):
             else:
                 e = Exception(str(e))
             # degenerate to a plain Exception
-            self._serialized_exception_ = pickle.dumps(e)
-
-    @property
-    def _serialized_exception(self) -> Optional[bytes]:
-        return getattr(self, '_serialized_exception_', None)
-
-    @property
-    def _on_complete(self) -> Optional[Callable]:
-        # https://github.com/python/mypy/issues/4125
-        return self._on_complete_
-
-    @_on_complete.setter
-    def _on_complete(self, val: Optional[Callable]) -> None:
-        self._on_complete_ = val
-
-    def __repr__(self) -> str:
-        name = self._name or getattr(self._on_complete, '__name__',
-                                     '??') if self._on_complete else 'None'
-        val = repr(self._value) if self._value is not self.NO_RESULT else 'NA'
-        return '{}(_s={}, val={}, _on_c={}, id={}, name={}, pr={}, _next={})'.format(
-            self.__class__, self._state, val, self._on_complete, id(self), name, getattr(
-                next, '_progress_reference', 'NA'), repr(self._next_promise)
-        )
-
-    def pretty_print_1(self) -> str:
-        if self._name:
-            name = self._name
-        elif self._on_complete is None:
-            name = 'lambda x: x'
-        elif hasattr(self._on_complete, '__name__'):
-            name = getattr(self._on_complete, '__name__')
-        else:
-            name = self._on_complete.__class__.__name__
-        val = repr(self._value) if self._value not in (self.NO_RESULT, self.ASYNC_RESULT) else '...'
-        prefix = {
-            self.INITIALIZED: '      ',
-            self.RUNNING:     '   >>>',  # noqa: E241
-            self.FINISHED:    '(done)',  # noqa: E241
-        }[self._state]
-        return '{} {}({}),'.format(prefix, name, val)
-
-    def then(self: Any, on_complete: Callable) -> Any:
-        """
-        Call ``on_complete`` as soon as this promise is finalized.
-        """
-        assert self._state in (self.INITIALIZED, self.RUNNING)
-
-        if self._next_promise is not None:
-            return self._next_promise.then(on_complete)
-
-        if self._on_complete is not None:
-            self._set_next_promise(self.__class__(
-                _first_promise=self._first_promise,
-                on_complete=on_complete
-            ))
-            return self._next_promise
-
-        else:
-            self._on_complete = on_complete
-            self._set_next_promise(self.__class__(_first_promise=self._first_promise))
-            return self._next_promise
-
-    def _set_next_promise(self, next: '_Promise') -> None:
-        assert self is not next
-        assert self._state in (self.INITIALIZED, self.RUNNING)
-
-        self._next_promise = next
-        assert self._next_promise is not None
-        for p in iter(self._next_promise):
-            p._first_promise = self._first_promise
-
-    def _finalize(self, value: Optional[T] = NO_RESULT) -> None:
-        """
-        Sets this promise to complete.
-
-        Orchestrators may choose to use this helper function.
-
-        :param value: new value.
-        """
-        if self._state not in (self.INITIALIZED, self.RUNNING):
-            raise ValueError('finalize: {} already finished. {}'.format(repr(self), value))
-
-        self._state = self.RUNNING
-
-        if value is not self.NO_RESULT:
-            self._value = value
-        assert self._value is not self.NO_RESULT, repr(self)
-
-        if self._on_complete:
-            try:
-                next_result = self._on_complete(self._value)
-            except Exception as e:
-                self.fail(e)
-                return
-        else:
-            next_result = self._value
-
-        if isinstance(next_result, _Promise):
-            # hack: _Promise is not a continuation monad.
-            next_result = next_result._first_promise  # type: ignore
-            assert next_result not in self, repr(self._first_promise) + repr(next_result)
-            assert self not in next_result
-            next_result._append_promise(self._next_promise)
-            self._set_next_promise(next_result)
-            assert self._next_promise
-            if self._next_promise._value is self.NO_RESULT:
-                self._next_promise._value = self._value
-            self.propagate_to_next()
-        elif next_result is not self.ASYNC_RESULT:
-            # simple map. simply forward
-            if self._next_promise:
-                self._next_promise._value = next_result
-            else:
-                # Hack: next_result is of type U, _value is of type T
-                self._value = next_result  # type: ignore
-            self.propagate_to_next()
-        else:
-            # asynchronous promise
-            pass
-
-    def propagate_to_next(self) -> None:
-        self._state = self.FINISHED
-        logger.debug('finalized {}'.format(repr(self)))
-        if self._next_promise:
-            self._next_promise._finalize()
-
-    def fail(self, e: Exception) -> None:
-        """
-        Sets the whole completion to be faild with this exception and end the
-        evaluation.
-        """
-        if self._state == self.FINISHED:
-            raise ValueError(
-                'Invalid State: called fail, but Completion is already finished: {}'.format(str(e)))
-        assert self._state in (self.INITIALIZED, self.RUNNING)
-        logger.exception('_Promise failed')
-        self._exception = e
-        self._value = f'_exception: {e}'
-        if self._next_promise:
-            self._next_promise.fail(e)
-        self._state = self.FINISHED
-
-    def __contains__(self, item: '_Promise') -> bool:
-        return any(item is p for p in iter(self._first_promise))
-
-    def __iter__(self) -> Iterator['_Promise']:
-        yield self
-        elem = self._next_promise
-        while elem is not None:
-            yield elem
-            elem = elem._next_promise
-
-    def _append_promise(self, other: Optional['_Promise']) -> None:
-        if other is not None:
-            assert self not in other
-            assert other not in self
-            self._last_promise()._set_next_promise(other)
-
-    def _last_promise(self) -> '_Promise':
-        return list(iter(self))[-1]
-
-
-class ProgressReference(object):
-    def __init__(self,
-                 message: str,
-                 mgr: Any,
-                 completion: Optional[Callable[[], 'Completion']] = None
-                 ):
-        """
-        ProgressReference can be used within Completions::
-
-            +---------------+      +---------------------------------+
-            |               | then |                                 |
-            | My Completion | +--> | on_complete=ProgressReference() |
-            |               |      |                                 |
-            +---------------+      +---------------------------------+
-
-        See :func:`Completion.with_progress` for an easy way to create
-        a progress reference
-
-        """
-        super(ProgressReference, self).__init__()
-        self.progress_id = str(uuid.uuid4())
-        self.message = message
-        self.mgr = mgr
-
-        #: The completion can already have a result, before the write
-        #: operation is effective. progress == 1 means, the services are
-        #: created / removed.
-        self.completion: Optional[Callable[[], Completion]] = completion
-
-        #: if a orchestrator module can provide a more detailed
-        #: progress information, it needs to also call ``progress.update()``.
-        self.progress = 0.0
-
-        self._completion_has_result = False
-        self.mgr.all_progress_references.append(self)
-
-    def __str__(self) -> str:
-        """
-        ``__str__()`` is used for determining the message for progress events.
-        """
-        return self.message or super(ProgressReference, self).__str__()
-
-    def __call__(self, arg: T) -> T:
-        self._completion_has_result = True
-        self.progress = 1.0
-        return arg
-
-    @property
-    def progress(self) -> float:
-        return self._progress
-
-    @progress.setter
-    def progress(self, progress: float) -> None:
-        assert progress <= 1.0
-        self._progress = progress
-        try:
-            if self.effective:
-                self.mgr.remote("progress", "complete", self.progress_id)
-                self.mgr.all_progress_references = [
-                    p for p in self.mgr.all_progress_references if p is not self]
-            else:
-                self.mgr.remote("progress", "update", self.progress_id, self.message,
-                                progress,
-                                [("origin", "orchestrator")])
-        except ImportError:
-            # If the progress module is disabled that's fine,
-            # they just won't see the output.
-            pass
-
-    @property
-    def effective(self) -> bool:
-        return self.progress == 1 and self._completion_has_result
-
-    def update(self) -> None:
-        def progress_run(progress: float) -> None:
-            self.progress = progress
-        if self.completion:
-            c = self.completion().then(progress_run)
-            self.mgr.process([c._first_promise])
-        else:
-            self.progress = 1
-
-    def fail(self) -> None:
-        self._completion_has_result = True
-        self.progress = 1
-
-
-class Completion(_Promise, Generic[T]):
-    """
-    Combines multiple promises into one overall operation.
-
-    Completions are composable by being able to
-    call one completion from another completion. I.e. making them re-usable
-    using Promises E.g.::
-
-        >>> #doctest: +SKIP
-        ... return Orchestrator().get_hosts().then(self._create_osd)
-
-    where ``get_hosts`` returns a Completion of list of hosts and
-    ``_create_osd`` takes a list of hosts.
-
-    The concept behind this is to store the computation steps
-    explicit and then explicitly evaluate the chain:
-
-        >>> #doctest: +SKIP
-        ... p = Completion(on_complete=lambda x: x*2).then(on_complete=lambda x: str(x))
-        ... p.finalize(2)
-        ... assert p.result = "4"
-
-    or graphically::
-
-        +---------------+      +-----------------+
-        |               | then |                 |
-        | lambda x: x*x | +--> | lambda x: str(x)|
-        |               |      |                 |
-        +---------------+      +-----------------+
-
-    """
-
-    def __init__(self,
-                 _first_promise: Optional["Completion"] = None,
-                 value: Any = _Promise.NO_RESULT,
-                 on_complete: Optional[Callable] = None,
-                 name: Optional[str] = None,
-                 ) -> None:
-        super(Completion, self).__init__(_first_promise, value, on_complete, name)
-
-    @property
-    def _progress_reference(self) -> Optional[ProgressReference]:
-        if hasattr(self._on_complete, 'progress_id'):
-            return self._on_complete  # type: ignore
-        return None
-
-    @property
-    def progress_reference(self) -> Optional[ProgressReference]:
-        """
-        ProgressReference. Marks this completion
-        as a write completeion.
-        """
-
-        references = [c._progress_reference for c in iter(  # type: ignore
-            self) if c._progress_reference is not None]  # type: ignore
-        if references:
-            assert len(references) == 1
-            return references[0]
-        return None
-
-    @classmethod
-    def with_progress(cls: Any,
-                      message: str,
-                      mgr: Any,
-                      _first_promise: Optional["Completion"] = None,
-                      value: Any = _Promise.NO_RESULT,
-                      on_complete: Optional[Callable] = None,
-                      calc_percent: Optional[Callable[[], Any]] = None
-                      ) -> Any:
-
-        c = cls(
-            _first_promise=_first_promise,
-            value=value,
-            on_complete=on_complete
-        ).add_progress(message, mgr, calc_percent)
-
-        return c._first_promise
-
-    def add_progress(self,
-                     message: str,
-                     mgr: Any,
-                     calc_percent: Optional[Callable[[], Any]] = None
-                     ) -> Any:
-        return self.then(
-            on_complete=ProgressReference(
-                message=message,
-                mgr=mgr,
-                completion=calc_percent
-            )
-        )
-
-    def fail(self, e: Exception) -> None:
-        super(Completion, self).fail(e)
-        if self._progress_reference:
-            self._progress_reference.fail()
-
-    def finalize(self, result: Union[None, object, T] = _Promise.NO_RESULT) -> None:
-        if self._first_promise._state == self.INITIALIZED:
-            self._first_promise._finalize(result)
-
-    @property
-    def result(self) -> T:
-        """
-        The result of the operation that we were waited
-        for.  Only valid after calling Orchestrator.process() on this
-        completion.
-        """
-        last = self._last_promise()
-        assert last._state == _Promise.FINISHED
-        return cast(T, last._value)
+            self.serialized_exception = pickle.dumps(e)
 
     def result_str(self) -> str:
         """Force a string."""
@@ -582,88 +211,19 @@ class Completion(_Promise, Generic[T]):
             return '\n'.join(str(x) for x in self.result)
         return str(self.result)
 
-    @property
-    def exception(self) -> Optional[Exception]:
-        return self._last_promise()._exception
 
-    @property
-    def serialized_exception(self) -> Optional[bytes]:
-        return self._last_promise()._serialized_exception
-
-    @property
-    def has_result(self) -> bool:
-        """
-        Has the operation already a result?
-
-        For Write operations, it can already have a
-        result, if the orchestrator's configuration is
-        persistently written. Typically this would
-        indicate that an update had been written to
-        a manifest, but that the update had not
-        necessarily been pushed out to the cluster.
-
-        :return:
-        """
-        return self._last_promise()._state == _Promise.FINISHED
-
-    @property
-    def is_errored(self) -> bool:
-        """
-        Has the completion failed. Default implementation looks for
-        self.exception. Can be overwritten.
-        """
-        return self.exception is not None
-
-    @property
-    def needs_result(self) -> bool:
-        """
-        Could the external operation be deemed as complete,
-        or should we wait?
-        We must wait for a read operation only if it is not complete.
-        """
-        return not self.is_errored and not self.has_result
-
-    @property
-    def is_finished(self) -> bool:
-        """
-        Could the external operation be deemed as complete,
-        or should we wait?
-        We must wait for a read operation only if it is not complete.
-        """
-        return self.is_errored or (self.has_result)
-
-    def pretty_print(self) -> str:
-
-        reprs = '\n'.join(p.pretty_print_1() for p in iter(self._first_promise))
-        return """<{}>[\n{}\n]""".format(self.__class__.__name__, reprs)
-
-
-def pretty_print(completions: Sequence[Completion]) -> str:
-    return ', '.join(c.pretty_print() for c in completions)
-
-
-def raise_if_exception(c: Completion) -> None:
+def raise_if_exception(c: OrchResult[T]) -> T:
     """
-    :raises OrchestratorError: Some user error or a config error.
-    :raises Exception: Some internal error
+    Due to different sub-interpreters, this MUST not be in the `OrchResult` class.
     """
     if c.serialized_exception is not None:
         try:
             e = pickle.loads(c.serialized_exception)
         except (KeyError, AttributeError):
-            raise Exception('{}: {}'.format(type(c.exception), c.exception))
+            raise Exception(c.exception_str)
         raise e
-
-
-class TrivialReadCompletion(Completion[T]):
-    """
-    This is the trivial completion simply wrapping a result.
-    """
-
-    def __init__(self, result: T):
-        super(TrivialReadCompletion, self).__init__()
-        if result:
-            self.finalize(result)
+    assert c.result is not None, 'OrchResult should either have an exception or a result'
+    return c.result
 
 
 def _hide_in_features(f: FuncT) -> FuncT:
@@ -733,21 +293,6 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     @_hide_in_features
-    def process(self, completions: List[Completion]) -> None:
-        """
-        Given a list of Completion instances, process any which are
-        incomplete.
-
-        Callers should inspect the detail of each completion to identify
-        partial completion/progress information, and present that information
-        to the user.
-
-        This method should not block, as this would make it slow to query
-        a status, while other long running operations are in progress.
-        """
-        raise NotImplementedError()
-
-    @_hide_in_features
     def get_feature_set(self) -> Dict[str, dict]:
         """Describes which methods this orchestrator implements
 
@@ -790,7 +335,7 @@ class Orchestrator(object):
     def resume(self) -> None:
         raise NotImplementedError()
 
-    def add_host(self, host_spec: HostSpec) -> Completion[str]:
+    def add_host(self, host_spec: HostSpec) -> OrchResult[str]:
         """
         Add a host to the orchestrator inventory.
 
@@ -798,7 +343,7 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def remove_host(self, host: str) -> Completion[str]:
+    def remove_host(self, host: str) -> OrchResult[str]:
         """
         Remove a host from the orchestrator inventory.
 
@@ -806,7 +351,7 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def update_host_addr(self, host: str, addr: str) -> Completion[str]:
+    def update_host_addr(self, host: str, addr: str) -> OrchResult[str]:
         """
         Update a host's address
 
@@ -815,7 +360,7 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def get_hosts(self) -> Completion[List[HostSpec]]:
+    def get_hosts(self) -> OrchResult[List[HostSpec]]:
         """
         Report the hosts in the cluster.
 
@@ -823,19 +368,19 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def add_host_label(self, host: str, label: str) -> Completion[str]:
+    def add_host_label(self, host: str, label: str) -> OrchResult[str]:
         """
         Add a host label
         """
         raise NotImplementedError()
 
-    def remove_host_label(self, host: str, label: str) -> Completion[str]:
+    def remove_host_label(self, host: str, label: str) -> OrchResult[str]:
         """
         Remove a host label
         """
         raise NotImplementedError()
 
-    def host_ok_to_stop(self, hostname: str) -> Completion:
+    def host_ok_to_stop(self, hostname: str) -> OrchResult:
         """
         Check if the specified host can be safely stopped without reducing availability
 
@@ -843,19 +388,19 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def enter_host_maintenance(self, hostname: str, force: bool = False) -> Completion:
+    def enter_host_maintenance(self, hostname: str, force: bool = False) -> OrchResult:
         """
         Place a host in maintenance, stopping daemons and disabling it's systemd target
         """
         raise NotImplementedError()
 
-    def exit_host_maintenance(self, hostname: str) -> Completion:
+    def exit_host_maintenance(self, hostname: str) -> OrchResult:
         """
         Return a host from maintenance, restarting the clusters systemd target
         """
         raise NotImplementedError()
 
-    def get_inventory(self, host_filter: Optional['InventoryFilter'] = None, refresh: bool = False) -> Completion[List['InventoryHost']]:
+    def get_inventory(self, host_filter: Optional['InventoryFilter'] = None, refresh: bool = False) -> OrchResult[List['InventoryHost']]:
         """
         Returns something that was created by `ceph-volume inventory`.
 
@@ -863,7 +408,7 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def describe_service(self, service_type: Optional[str] = None, service_name: Optional[str] = None, refresh: bool = False) -> Completion[List['ServiceDescription']]:
+    def describe_service(self, service_type: Optional[str] = None, service_name: Optional[str] = None, refresh: bool = False) -> OrchResult[List['ServiceDescription']]:
         """
         Describe a service (of any kind) that is already configured in
         the orchestrator.  For example, when viewing an OSD in the dashboard
@@ -877,7 +422,7 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def list_daemons(self, service_name: Optional[str] = None, daemon_type: Optional[str] = None, daemon_id: Optional[str] = None, host: Optional[str] = None, refresh: bool = False) -> Completion[List['DaemonDescription']]:
+    def list_daemons(self, service_name: Optional[str] = None, daemon_type: Optional[str] = None, daemon_id: Optional[str] = None, host: Optional[str] = None, refresh: bool = False) -> OrchResult[List['DaemonDescription']]:
         """
         Describe a daemon (of any kind) that is already configured in
         the orchestrator.
@@ -886,11 +431,12 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def apply(self, specs: Sequence["GenericSpec"]) -> Completion[List[str]]:
+    @handle_orch_error
+    def apply(self, specs: Sequence["GenericSpec"]) -> List[str]:
         """
         Applies any spec
         """
-        fns: Dict[str, Callable] = {
+        fns: Dict[str, Callable[..., OrchResult[str]]] = {
             'alertmanager': self.apply_alertmanager,
             'crash': self.apply_crash,
             'grafana': self.apply_grafana,
@@ -900,7 +446,7 @@ class Orchestrator(object):
             'mon': self.apply_mon,
             'nfs': self.apply_nfs,
             'node-exporter': self.apply_node_exporter,
-            'osd': lambda dg: self.apply_drivegroups([dg]),
+            'osd': lambda dg: self.apply_drivegroups([dg]),  # type: ignore
             'prometheus': self.apply_prometheus,
             'rbd-mirror': self.apply_rbd_mirror,
             'rgw': self.apply_rgw,
@@ -909,29 +455,20 @@ class Orchestrator(object):
             'cephadm-exporter': self.apply_cephadm_exporter,
         }
 
-        def merge(ls: Union[List[T], T], r: Union[List[T], T]) -> List[T]:
-            if isinstance(ls, list):
-                return ls + [r]  # type: ignore
-            return [ls, r]  # type: ignore
+        def merge(l: OrchResult[List[str]], r: OrchResult[str]) -> OrchResult[List[str]]:  # noqa: E741
+            l_res = raise_if_exception(l)
+            r_res = raise_if_exception(r)
+            l_res.append(r_res)
+            return OrchResult(l_res)
+        return raise_if_exception(reduce(merge, [fns[spec.service_type](spec) for spec in specs], OrchResult([])))
 
-        spec, *specs = specs
-
-        fn = cast(Callable[["GenericSpec"], Completion], fns[spec.service_type])
-        completion = fn(spec)
-        for s in specs:
-            def next(ls: list) -> Any:
-                fn = cast(Callable[["GenericSpec"], Completion], fns[spec.service_type])
-                return fn(s).then(lambda r: merge(ls, r))
-            completion = completion.then(next)
-        return completion
-
-    def plan(self, spec: Sequence["GenericSpec"]) -> Completion[List]:
+    def plan(self, spec: Sequence["GenericSpec"]) -> OrchResult[List]:
         """
         Plan (Dry-run, Preview) a List of Specs.
         """
         raise NotImplementedError()
 
-    def remove_daemons(self, names: List[str]) -> Completion[List[str]]:
+    def remove_daemons(self, names: List[str]) -> OrchResult[List[str]]:
         """
         Remove specific daemon(s).
 
@@ -939,7 +476,7 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def remove_service(self, service_name: str) -> Completion[str]:
+    def remove_service(self, service_name: str) -> OrchResult[str]:
         """
         Remove a service (a collection of daemons).
 
@@ -947,7 +484,7 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def service_action(self, action: str, service_name: str) -> Completion[List[str]]:
+    def service_action(self, action: str, service_name: str) -> OrchResult[List[str]]:
         """
         Perform an action (start/stop/reload) on a service (i.e., all daemons
         providing the logical service).
@@ -955,24 +492,24 @@ class Orchestrator(object):
         :param action: one of "start", "stop", "restart", "redeploy", "reconfig"
         :param service_name: service_type + '.' + service_id
                             (e.g. "mon", "mgr", "mds.mycephfs", "rgw.realm.zone", ...)
-        :rtype: Completion
+        :rtype: OrchResult
         """
         # assert action in ["start", "stop", "reload, "restart", "redeploy"]
         raise NotImplementedError()
 
-    def daemon_action(self, action: str, daemon_name: str, image: Optional[str] = None) -> Completion[str]:
+    def daemon_action(self, action: str, daemon_name: str, image: Optional[str] = None) -> OrchResult[str]:
         """
         Perform an action (start/stop/reload) on a daemon.
 
         :param action: one of "start", "stop", "restart", "redeploy", "reconfig"
         :param daemon_name: name of daemon
         :param image: Container image when redeploying that daemon
-        :rtype: Completion
+        :rtype: OrchResult
         """
         # assert action in ["start", "stop", "reload, "restart", "redeploy"]
         raise NotImplementedError()
 
-    def create_osds(self, drive_group: DriveGroupSpec) -> Completion[str]:
+    def create_osds(self, drive_group: DriveGroupSpec) -> OrchResult[str]:
         """
         Create one or more OSDs within a single Drive Group.
 
@@ -983,7 +520,7 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def apply_drivegroups(self, specs: List[DriveGroupSpec]) -> Completion[List[str]]:
+    def apply_drivegroups(self, specs: List[DriveGroupSpec]) -> OrchResult[List[str]]:
         """ Update OSD cluster """
         raise NotImplementedError()
 
@@ -997,13 +534,13 @@ class Orchestrator(object):
     def preview_osdspecs(self,
                          osdspec_name: Optional[str] = 'osd',
                          osdspecs: Optional[List[DriveGroupSpec]] = None
-                         ) -> Completion[str]:
+                         ) -> OrchResult[str]:
         """ Get a preview for OSD deployments """
         raise NotImplementedError()
 
     def remove_osds(self, osd_ids: List[str],
                     replace: bool = False,
-                    force: bool = False) -> Completion[str]:
+                    force: bool = False) -> OrchResult[str]:
         """
         :param osd_ids: list of OSD IDs
         :param replace: marks the OSD as being destroyed. See :ref:`orchestrator-osd-replace`
@@ -1013,19 +550,19 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def stop_remove_osds(self, osd_ids: List[str]) -> Completion:
+    def stop_remove_osds(self, osd_ids: List[str]) -> OrchResult:
         """
         TODO
         """
         raise NotImplementedError()
 
-    def remove_osds_status(self) -> Completion:
+    def remove_osds_status(self) -> OrchResult:
         """
         Returns a status of the ongoing OSD removal operations.
         """
         raise NotImplementedError()
 
-    def blink_device_light(self, ident_fault: str, on: bool, locations: List['DeviceLightLoc']) -> Completion[List[str]]:
+    def blink_device_light(self, ident_fault: str, on: bool, locations: List['DeviceLightLoc']) -> OrchResult[List[str]]:
         """
         Instructs the orchestrator to enable or disable either the ident or the fault LED.
 
@@ -1035,134 +572,134 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def zap_device(self, host: str, path: str) -> Completion[str]:
+    def zap_device(self, host: str, path: str) -> OrchResult[str]:
         """Zap/Erase a device (DESTROYS DATA)"""
         raise NotImplementedError()
 
-    def add_mon(self, spec: ServiceSpec) -> Completion[List[str]]:
+    def add_mon(self, spec: ServiceSpec) -> OrchResult[List[str]]:
         """Create mon daemon(s)"""
         raise NotImplementedError()
 
-    def apply_mon(self, spec: ServiceSpec) -> Completion[str]:
+    def apply_mon(self, spec: ServiceSpec) -> OrchResult[str]:
         """Update mon cluster"""
         raise NotImplementedError()
 
-    def add_mgr(self, spec: ServiceSpec) -> Completion[List[str]]:
+    def add_mgr(self, spec: ServiceSpec) -> OrchResult[List[str]]:
         """Create mgr daemon(s)"""
         raise NotImplementedError()
 
-    def apply_mgr(self, spec: ServiceSpec) -> Completion[str]:
+    def apply_mgr(self, spec: ServiceSpec) -> OrchResult[str]:
         """Update mgr cluster"""
         raise NotImplementedError()
 
-    def add_mds(self, spec: ServiceSpec) -> Completion[List[str]]:
+    def add_mds(self, spec: ServiceSpec) -> OrchResult[List[str]]:
         """Create MDS daemon(s)"""
         raise NotImplementedError()
 
-    def apply_mds(self, spec: ServiceSpec) -> Completion[str]:
+    def apply_mds(self, spec: ServiceSpec) -> OrchResult[str]:
         """Update MDS cluster"""
         raise NotImplementedError()
 
-    def add_rgw(self, spec: RGWSpec) -> Completion[List[str]]:
+    def add_rgw(self, spec: RGWSpec) -> OrchResult[List[str]]:
         """Create RGW daemon(s)"""
         raise NotImplementedError()
 
-    def apply_rgw(self, spec: RGWSpec) -> Completion[str]:
+    def apply_rgw(self, spec: RGWSpec) -> OrchResult[str]:
         """Update RGW cluster"""
         raise NotImplementedError()
 
-    def apply_ha_rgw(self, spec: HA_RGWSpec) -> Completion[str]:
+    def apply_ha_rgw(self, spec: HA_RGWSpec) -> OrchResult[str]:
         """Update ha-rgw daemons"""
         raise NotImplementedError()
 
-    def add_rbd_mirror(self, spec: ServiceSpec) -> Completion[List[str]]:
+    def add_rbd_mirror(self, spec: ServiceSpec) -> OrchResult[List[str]]:
         """Create rbd-mirror daemon(s)"""
         raise NotImplementedError()
 
-    def apply_rbd_mirror(self, spec: ServiceSpec) -> Completion[str]:
+    def apply_rbd_mirror(self, spec: ServiceSpec) -> OrchResult[str]:
         """Update rbd-mirror cluster"""
         raise NotImplementedError()
 
-    def add_nfs(self, spec: NFSServiceSpec) -> Completion[List[str]]:
+    def add_nfs(self, spec: NFSServiceSpec) -> OrchResult[List[str]]:
         """Create NFS daemon(s)"""
         raise NotImplementedError()
 
-    def apply_nfs(self, spec: NFSServiceSpec) -> Completion[str]:
+    def apply_nfs(self, spec: NFSServiceSpec) -> OrchResult[str]:
         """Update NFS cluster"""
         raise NotImplementedError()
 
-    def add_iscsi(self, spec: IscsiServiceSpec) -> Completion[List[str]]:
+    def add_iscsi(self, spec: IscsiServiceSpec) -> OrchResult[List[str]]:
         """Create iscsi daemon(s)"""
         raise NotImplementedError()
 
-    def apply_iscsi(self, spec: IscsiServiceSpec) -> Completion[str]:
+    def apply_iscsi(self, spec: IscsiServiceSpec) -> OrchResult[str]:
         """Update iscsi cluster"""
         raise NotImplementedError()
 
-    def add_prometheus(self, spec: ServiceSpec) -> Completion[List[str]]:
+    def add_prometheus(self, spec: ServiceSpec) -> OrchResult[List[str]]:
         """Create new prometheus daemon"""
         raise NotImplementedError()
 
-    def apply_prometheus(self, spec: ServiceSpec) -> Completion[str]:
+    def apply_prometheus(self, spec: ServiceSpec) -> OrchResult[str]:
         """Update prometheus cluster"""
         raise NotImplementedError()
 
-    def add_node_exporter(self, spec: ServiceSpec) -> Completion[List[str]]:
+    def add_node_exporter(self, spec: ServiceSpec) -> OrchResult[List[str]]:
         """Create a new Node-Exporter service"""
         raise NotImplementedError()
 
-    def apply_node_exporter(self, spec: ServiceSpec) -> Completion[str]:
+    def apply_node_exporter(self, spec: ServiceSpec) -> OrchResult[str]:
         """Update existing a Node-Exporter daemon(s)"""
         raise NotImplementedError()
 
-    def add_crash(self, spec: ServiceSpec) -> Completion[List[str]]:
+    def add_crash(self, spec: ServiceSpec) -> OrchResult[List[str]]:
         """Create a new crash service"""
         raise NotImplementedError()
 
-    def apply_crash(self, spec: ServiceSpec) -> Completion[str]:
+    def apply_crash(self, spec: ServiceSpec) -> OrchResult[str]:
         """Update existing a crash daemon(s)"""
         raise NotImplementedError()
 
-    def add_grafana(self, spec: ServiceSpec) -> Completion[List[str]]:
+    def add_grafana(self, spec: ServiceSpec) -> OrchResult[List[str]]:
         """Create a new grafana service"""
         raise NotImplementedError()
 
-    def apply_grafana(self, spec: ServiceSpec) -> Completion[str]:
+    def apply_grafana(self, spec: ServiceSpec) -> OrchResult[str]:
         """Update existing a grafana service"""
         raise NotImplementedError()
 
-    def add_alertmanager(self, spec: ServiceSpec) -> Completion[List[str]]:
+    def add_alertmanager(self, spec: ServiceSpec) -> OrchResult[List[str]]:
         """Create a new AlertManager service"""
         raise NotImplementedError()
 
-    def apply_alertmanager(self, spec: ServiceSpec) -> Completion[str]:
+    def apply_alertmanager(self, spec: ServiceSpec) -> OrchResult[str]:
         """Update an existing AlertManager daemon(s)"""
         raise NotImplementedError()
 
-    def add_cephadm_exporter(self, spec: ServiceSpec) -> Completion[List[str]]:
+    def add_cephadm_exporter(self, spec: ServiceSpec) -> OrchResult[List[str]]:
         """Create a new cephadm exporter daemon"""
         raise NotImplementedError()
 
-    def apply_cephadm_exporter(self, spec: ServiceSpec) -> Completion[str]:
+    def apply_cephadm_exporter(self, spec: ServiceSpec) -> OrchResult[str]:
         """Update an existing cephadm exporter daemon"""
         raise NotImplementedError()
 
-    def upgrade_check(self, image: Optional[str], version: Optional[str]) -> Completion[str]:
+    def upgrade_check(self, image: Optional[str], version: Optional[str]) -> OrchResult[str]:
         raise NotImplementedError()
 
-    def upgrade_start(self, image: Optional[str], version: Optional[str]) -> Completion[str]:
+    def upgrade_start(self, image: Optional[str], version: Optional[str]) -> OrchResult[str]:
         raise NotImplementedError()
 
-    def upgrade_pause(self) -> Completion[str]:
+    def upgrade_pause(self) -> OrchResult[str]:
         raise NotImplementedError()
 
-    def upgrade_resume(self) -> Completion[str]:
+    def upgrade_resume(self) -> OrchResult[str]:
         raise NotImplementedError()
 
-    def upgrade_stop(self) -> Completion[str]:
+    def upgrade_stop(self) -> OrchResult[str]:
         raise NotImplementedError()
 
-    def upgrade_status(self) -> Completion['UpgradeStatusSpec']:
+    def upgrade_status(self) -> OrchResult['UpgradeStatusSpec']:
         """
         If an upgrade is currently underway, report on where
         we are in the process, or if some error has occurred.
@@ -1172,7 +709,7 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     @_hide_in_features
-    def upgrade_available(self) -> Completion:
+    def upgrade_available(self) -> OrchResult:
         """
         Report on what versions are available to upgrade to
 
@@ -1778,7 +1315,6 @@ class OrchestratorClientMixin(Orchestrator):
     >>> class MyModule(OrchestratorClientMixin):
     ...    def func(self):
     ...        completion = self.add_host('somehost')  # calls `_oremote()`
-    ...        self._orchestrator_wait([completion])
     ...        self.log.debug(completion.result)
 
     .. note:: Orchestrator implementations should not inherit from `OrchestratorClientMixin`.
@@ -1835,24 +1371,3 @@ class OrchestratorClientMixin(Orchestrator):
             if meth not in f_set or not f_set[meth]['available']:
                 raise NotImplementedError(f'{o} does not implement {meth}') from e
             raise
-
-    def _orchestrator_wait(self, completions: List[Completion]) -> None:
-        """
-        Wait for completions to complete (reads) or
-        become persistent (writes).
-
-        Waits for writes to be *persistent* but not *effective*.
-
-        :param completions: List of Completions
-        :raises NoOrchestrator:
-        :raises RuntimeError: something went wrong while calling the process method.
-        :raises ImportError: no `orchestrator` module or backend not found.
-        """
-        while any(not c.has_result for c in completions):
-            self.process(completions)
-            self.__get_mgr().log.info("Operations pending: %s",
-                                      sum(1 for c in completions if not c.has_result))
-            if any(c.needs_result for c in completions):
-                time.sleep(1)
-            else:
-                break

--- a/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator/tests/test_orchestrator.py
@@ -11,9 +11,7 @@ from ceph.utils import datetime_now
 from mgr_module import HandleCommandResult
 
 from test_orchestrator import TestOrchestrator as _TestOrchestrator
-from tests import mock
 
-from orchestrator import raise_if_exception, Completion, ProgressReference
 from orchestrator import InventoryHost, DaemonDescription, ServiceDescription, DaemonDescriptionStatus
 from orchestrator import OrchestratorValidationError
 from orchestrator.module import to_format, Format, OrchestratorCli, preview_table_osd
@@ -72,178 +70,6 @@ def test_daemon_description():
     assert dd.status.value == DaemonDescriptionStatus.error.value
 
 
-def test_raise():
-    c = Completion()
-    c._exception = ZeroDivisionError()
-    with pytest.raises(ZeroDivisionError):
-        raise_if_exception(c)
-
-
-def test_promise():
-    p = Completion(value=3)
-    p.finalize()
-    assert p.result == 3
-
-
-def test_promise_then():
-    p = Completion(value=3).then(lambda three: three + 1)
-    p.finalize()
-    assert p.result == 4
-
-
-def test_promise_mondatic_then():
-    p = Completion(value=3)
-    p.then(lambda three: Completion(value=three + 1))
-    p.finalize()
-    assert p.result == 4
-
-
-def some_complex_completion():
-    c = Completion(value=3).then(
-        lambda three: Completion(value=three + 1).then(
-            lambda four: four + 1))
-    return c
-
-
-def test_promise_mondatic_then_combined():
-    p = some_complex_completion()
-    p.finalize()
-    assert p.result == 5
-
-
-def test_promise_flat():
-    p = Completion()
-    p.then(lambda r1: Completion(value=r1 + ' there').then(
-        lambda r11: r11 + '!'))
-    p.finalize('hello')
-    assert p.result == 'hello there!'
-
-
-def test_side_effect():
-    foo = {'x': 1}
-
-    def run(x):
-        foo['x'] = x
-
-    foo['x'] = 1
-    Completion(value=3).then(run).finalize()
-    assert foo['x'] == 3
-
-
-def test_progress():
-    c = some_complex_completion()
-    mgr = mock.MagicMock()
-    mgr.process = lambda cs: [c.finalize(None) for c in cs]
-
-    progress_val = 0.75
-    c._last_promise().then(
-        on_complete=ProgressReference(message='hello world',
-                                      mgr=mgr,
-                                      completion=lambda: Completion(
-                                          on_complete=lambda _: progress_val))
-    )
-    mgr.remote.assert_called_with('progress', 'update', c.progress_reference.progress_id, 'hello world', 0.0, [
-                                  ('origin', 'orchestrator')])
-
-    c.finalize()
-    mgr.remote.assert_called_with('progress', 'complete', c.progress_reference.progress_id)
-
-    c.progress_reference.update()
-    mgr.remote.assert_called_with('progress', 'update', c.progress_reference.progress_id,
-                                  'hello world', progress_val, [('origin', 'orchestrator')])
-    assert not c.progress_reference.effective
-
-    progress_val = 1
-    c.progress_reference.update()
-    assert c.progress_reference.effective
-    mgr.remote.assert_called_with('progress', 'complete', c.progress_reference.progress_id)
-
-
-def test_with_progress():
-    mgr = mock.MagicMock()
-    mgr.process = lambda cs: [c.finalize(None) for c in cs]
-
-    def execute(y):
-        return str(y)
-
-    def run(x):
-        def two(_):
-            return execute(x * 2)
-
-        return Completion.with_progress(
-            message='message',
-            on_complete=two,
-            mgr=mgr
-
-        )
-    c = Completion(on_complete=lambda x: x * 10).then(run)._first_promise
-    c.finalize(2)
-    assert c.result == '40'
-    c.progress_reference.update()
-    assert c.progress_reference.effective
-
-
-def test_exception():
-
-    def run(x):
-        raise KeyError(x)
-
-    c = Completion(value=3).then(run)
-    c.finalize()
-    with pytest.raises(KeyError):
-        raise_if_exception(c)
-
-
-def test_fail():
-    c = Completion().then(lambda _: 3)
-    c._first_promise.fail(KeyError())
-    assert isinstance(c.exception, KeyError)
-
-    with pytest.raises(ValueError,
-                       match='Invalid State: called fail, but Completion is already finished: {}'.format(
-                           str(ZeroDivisionError()))):
-        c._first_promise.fail(ZeroDivisionError())
-
-
-def test_pretty_print():
-    mgr = mock.MagicMock()
-    mgr.process = lambda cs: [c.finalize(None) for c in cs]
-
-    def add_one(x):
-        return x + 1
-
-    c = Completion(value=1, on_complete=add_one).then(
-        str
-    ).add_progress('message', mgr)
-
-    assert c.pretty_print() == """<Completion>[
-       add_one(1),
-       str(...),
-       ProgressReference(...),
-]"""
-    c.finalize()
-    assert c.pretty_print() == """<Completion>[
-(done) add_one(1),
-(done) str(2),
-(done) ProgressReference('2'),
-]"""
-
-    p = some_complex_completion()
-    assert p.pretty_print() == """<Completion>[
-       <lambda>(3),
-       lambda x: x(...),
-]"""
-    p.finalize()
-    assert p.pretty_print() == """<Completion>[
-(done) <lambda>(3),
-(done) <lambda>(4),
-(done) lambda x: x(5),
-(done) lambda x: x(5),
-]"""
-
-    assert p.result == 5
-
-
 def test_apply():
     to = _TestOrchestrator('', 0, 0)
     completion = to.apply([
@@ -251,8 +77,8 @@ def test_apply():
         ServiceSpec(service_type='nfs'),
         ServiceSpec(service_type='nfs'),
     ])
-    completion.finalize(42)
-    assert completion.result == [None, None, None]
+    res = '<NFSServiceSpec for service_name=nfs>'
+    assert completion.result == [res, res, res]
 
 
 def test_yaml():

--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -440,12 +440,10 @@ class Module(MgrModule):
     def remote_from_orchestrator_cli_self_test(self, what):
         import orchestrator
         if what == 'OrchestratorError':
-            c = orchestrator.TrivialReadCompletion(result=None)
-            c.fail(orchestrator.OrchestratorError('hello, world'))
+            c = orchestrator.OrchResult(result=None, exception=orchestrator.OrchestratorError('hello, world'))
             return c
         elif what == "ZeroDivisionError":
-            c = orchestrator.TrivialReadCompletion(result=None)
-            c.fail(ZeroDivisionError('hello, world'))
+            c = orchestrator.OrchResult(result=None, exception=ZeroDivisionError('hello, world'))
             return c
         assert False, repr(what)
 

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -20,41 +20,7 @@ from mgr_module import CLICommand, HandleCommandResult
 from mgr_module import MgrModule
 
 import orchestrator
-
-
-class TestCompletion(orchestrator.Completion):
-    def evaluate(self):
-        self.finalize(None)
-
-
-def deferred_read(f):
-    # type: (Callable) -> Callable[..., TestCompletion]
-    """
-    Decorator to make methods return
-    a completion object that executes themselves.
-    """
-
-    @functools.wraps(f)
-    def wrapper(*args, **kwargs):
-        return TestCompletion(on_complete=lambda _: f(*args, **kwargs))
-
-    return wrapper
-
-
-def deferred_write(message):
-    def inner(f):
-        # type: (Callable) -> Callable[..., TestCompletion]
-
-        @functools.wraps(f)
-        def wrapper(self, *args, **kwargs):
-            return TestCompletion.with_progress(
-                message=message,
-                mgr=self,
-                on_complete=lambda _: f(self, *args, **kwargs),
-            )
-
-        return wrapper
-    return inner
+from orchestrator import handle_orch_error, raise_if_exception
 
 
 class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
@@ -66,13 +32,6 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
 
     The implementation is similar to the Rook orchestrator, but simpler.
     """
-
-    def process(self, completions: List[TestCompletion]) -> None:  # type: ignore
-        if completions:
-            self.log.info("process: completions={0}".format(orchestrator.pretty_print(completions)))
-
-            for p in completions:
-                p.evaluate()
 
     @CLICommand('test_orchestrator load_data', perm='w')
     def _load_data(self, inbuf):
@@ -98,7 +57,6 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         self._initialized = threading.Event()
         self._shutdown = threading.Event()
         self._init_data({})
-        self.all_progress_references = list()  # type: List[orchestrator.ProgressReference]
 
     def shutdown(self):
         self._shutdown.set()
@@ -108,14 +66,6 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         self._initialized.set()
 
         while not self._shutdown.is_set():
-            # XXX hack (or is it?) to kick all completions periodically,
-            # in case we had a caller that wait()'ed on them long enough
-            # to get persistence but not long enough to get completion
-
-            self.all_progress_references = [p for p in self.all_progress_references if not p.effective]
-            for p in self.all_progress_references:
-                p.update()
-
             self._shutdown.wait(5)
 
     def _init_data(self, data=None):
@@ -126,7 +76,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         self._daemons = [orchestrator.DaemonDescription.from_json(daemon)
                           for daemon in data.get('daemons', [])]
 
-    @deferred_read
+    @handle_orch_error
     def get_inventory(self, host_filter=None, refresh=False):
         """
         There is no guarantee which devices are returned by get_inventory.
@@ -190,7 +140,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
             daemons.append(daemon)
         return daemons
 
-    @deferred_read
+    @handle_orch_error
     def describe_service(self, service_type=None, service_name=None, refresh=False):
         if self._services:
             # Dummy data
@@ -218,7 +168,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         return list(filter(_filter_func, services))
 
-    @deferred_read
+    @handle_orch_error
     def list_daemons(self, service_name=None, daemon_type=None, daemon_id=None, host=None, refresh=False):
         """
         There is no guarantee which daemons are returned by describe_service, except that
@@ -246,8 +196,9 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
     def preview_drivegroups(self, drive_group_name=None, dg_specs=None):
         return [{}]
 
+    @handle_orch_error
     def create_osds(self, drive_group):
-        # type: (DriveGroupSpec) -> TestCompletion
+        # type: (DriveGroupSpec) -> str
         """ Creates OSDs from a drive group specification.
 
         $: ceph orch osd create -i <dg.file>
@@ -255,105 +206,98 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         The drivegroup file must only contain one spec at a time.
         """
 
-        def run(all_hosts):
-            # type: (List[orchestrator.HostSpec]) -> None
-            drive_group.validate()
+        drive_group.validate()
+        all_hosts = raise_if_exception(self.get_hosts())
 
-            def get_hosts_func(label=None, as_hostspec=False):
-                if as_hostspec:
-                    return all_hosts
-                return [h.hostname for h in all_hosts]
 
-            if not drive_group.placement.filter_matching_hosts(get_hosts_func):
-                raise orchestrator.OrchestratorValidationError('failed to match')
+        def get_hosts_func(label=None, as_hostspec=False):
+            if as_hostspec:
+                return all_hosts
+            return [h.hostname for h in all_hosts]
 
-        return self.get_hosts().then(run).then(
-            on_complete=orchestrator.ProgressReference(
-                message='create_osds',
-                mgr=self,
-            )
-        )
+        if not drive_group.placement.filter_matching_hosts(get_hosts_func):
+            raise orchestrator.OrchestratorValidationError('failed to match')
+        return ''
 
+    @handle_orch_error
     def apply_drivegroups(self, specs):
-        # type: (List[DriveGroupSpec]) -> TestCompletion
+        # type: (List[DriveGroupSpec]) -> List[str]
         drive_group = specs[0]
 
-        def run(all_hosts):
-            # type: (List[orchestrator.HostSpec]) -> None
-            drive_group.validate()
+        all_hosts = raise_if_exception(self.get_hosts())
 
-            def get_hosts_func(label=None, as_hostspec=False):
-                if as_hostspec:
-                    return all_hosts
-                return [h.hostname for h in all_hosts]
+        drive_group.validate()
 
-            if not drive_group.placement.filter_matching_hosts(get_hosts_func):
-                raise orchestrator.OrchestratorValidationError('failed to match')
-        return self.get_hosts().then(run).then(
-            on_complete=orchestrator.ProgressReference(
-                message='apply_drivesgroups',
-                mgr=self,
-            )
-        )
+        def get_hosts_func(label=None, as_hostspec=False):
+            if as_hostspec:
+                return all_hosts
+            return [h.hostname for h in all_hosts]
 
-    @deferred_write("remove_daemons")
+        if not drive_group.placement.filter_matching_hosts(get_hosts_func):
+            raise orchestrator.OrchestratorValidationError('failed to match')
+        return []
+
+    @handle_orch_error
     def remove_daemons(self, names):
         assert isinstance(names, list)
+        return 'done'
 
-    @deferred_write("remove_service")
+    @handle_orch_error
     def remove_service(self, service_name):
         assert isinstance(service_name, str)
+        return 'done'
 
-    @deferred_write("blink_device_light")
+    @handle_orch_error
     def blink_device_light(self, ident_fault, on, locations):
         assert ident_fault in ("ident", "fault")
         assert len(locations)
         return ''
 
-    @deferred_write("service_action")
+    @handle_orch_error
     def service_action(self, action, service_name):
-        pass
+        return 'done'
 
-    @deferred_write("daemon_action")
+    @handle_orch_error
     def daemon_action(self, action, daemon_name, image=None):
-        pass
+        return 'done'
 
-    @deferred_write("Adding NFS service")
+    @handle_orch_error
     def add_nfs(self, spec):
-        # type: (NFSServiceSpec) -> None
+        # type: (NFSServiceSpec) -> List[str]
         assert isinstance(spec.pool, str)
+        return [spec.one_line_str()]
 
-    @deferred_write("apply_nfs")
+    @handle_orch_error
     def apply_nfs(self, spec):
-        pass
+        return spec.one_line_str()
 
-    @deferred_write("add_iscsi")
+    @handle_orch_error
     def add_iscsi(self, spec):
-        # type: (IscsiServiceSpec) -> None
-        pass
+        # type: (IscsiServiceSpec) -> List[str]
+        return [spec.one_line_str()]
 
-    @deferred_write("apply_iscsi")
+    @handle_orch_error
     def apply_iscsi(self, spec):
-        # type: (IscsiServiceSpec) -> None
-        pass
+        # type: (IscsiServiceSpec) -> str
+        return spec.one_line_str()
 
-    @deferred_write("add_mds")
+    @handle_orch_error
     def add_mds(self, spec):
-        pass
+        return 'done'
 
-    @deferred_write("add_rgw")
+    @handle_orch_error
     def add_rgw(self, spec):
-        pass
+        return 'done'
 
-    @deferred_read
+    @handle_orch_error
     def get_hosts(self):
         if self._inventory:
             return [orchestrator.HostSpec(i.name, i.addr, i.labels) for i in self._inventory]
         return [orchestrator.HostSpec('localhost')]
 
-    @deferred_write("add_host")
+    @handle_orch_error
     def add_host(self, spec):
-        # type: (orchestrator.HostSpec) -> None
+        # type: (orchestrator.HostSpec) -> str
         host = spec.hostname
         if host == 'raise_validation_error':
             raise orchestrator.OrchestratorValidationError("MON count must be either 1, 3 or 5")
@@ -368,22 +312,27 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         if host == 'raise_import_error':
             raise ImportError("test_orchestrator not enabled")
         assert isinstance(host, str)
+        return ''
 
-    @deferred_write("remove_host")
+    @handle_orch_error
     def remove_host(self, host):
         assert isinstance(host, str)
+        return 'done'
 
-    @deferred_write("apply_mgr")
+    @handle_orch_error
     def apply_mgr(self, spec):
-        # type: (ServiceSpec) -> None
+        # type: (ServiceSpec) -> str
 
         assert not spec.placement.hosts or len(spec.placement.hosts) == spec.placement.count
         assert all([isinstance(h, str) for h in spec.placement.hosts])
+        return spec.one_line_str()
 
-    @deferred_write("apply_mon")
+    @handle_orch_error
     def apply_mon(self, spec):
-        # type: (ServiceSpec) -> None
+        # type: (ServiceSpec) -> str
 
         assert not spec.placement.hosts or len(spec.placement.hosts) == spec.placement.count
         assert all([isinstance(h[0], str) for h in spec.placement.hosts])
         assert all([isinstance(h[1], str) or h[1] is None for h in spec.placement.hosts])
+        return spec.one_line_str()
+

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -205,37 +205,21 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         The drivegroup file must only contain one spec at a time.
         """
+        return self._create_osds(drive_group)
+
+    def _create_osds(self, drive_group):
+        # type: (DriveGroupSpec) -> str
 
         drive_group.validate()
         all_hosts = raise_if_exception(self.get_hosts())
-
-
-        def get_hosts_func(label=None, as_hostspec=False):
-            if as_hostspec:
-                return all_hosts
-            return [h.hostname for h in all_hosts]
-
-        if not drive_group.placement.filter_matching_hosts(get_hosts_func):
+        if not drive_group.placement.filter_matching_hostspecs(all_hosts):
             raise orchestrator.OrchestratorValidationError('failed to match')
         return ''
 
     @handle_orch_error
     def apply_drivegroups(self, specs):
         # type: (List[DriveGroupSpec]) -> List[str]
-        drive_group = specs[0]
-
-        all_hosts = raise_if_exception(self.get_hosts())
-
-        drive_group.validate()
-
-        def get_hosts_func(label=None, as_hostspec=False):
-            if as_hostspec:
-                return all_hosts
-            return [h.hostname for h in all_hosts]
-
-        if not drive_group.placement.filter_matching_hosts(get_hosts_func):
-            raise orchestrator.OrchestratorValidationError('failed to match')
-        return []
+        return [self._create_osds(dg) for dg in specs]
 
     @handle_orch_error
     def remove_daemons(self, names):
@@ -335,4 +319,3 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         assert all([isinstance(h[0], str) for h in spec.placement.hosts])
         assert all([isinstance(h[1], str) or h[1] is None for h in spec.placement.hosts])
         return spec.one_line_str()
-

--- a/src/pybind/mgr/tests/__init__.py
+++ b/src/pybind/mgr/tests/__init__.py
@@ -73,7 +73,10 @@ if 'UNITTEST' in os.environ:
             except FileNotFoundError:
                 val = None
             mo = [o for o in self.MODULE_OPTIONS if o['name'] == key]
-            if len(mo) == 1:
+            if len(mo) >= 1:  # >= 1, cause self.MODULE_OPTIONS. otherwise it
+                #               fails when importing multiple modules.
+                if 'default' in mo and val is None:
+                    val = mo[0]['default']
                 if val is not None:
                     cls = {
                         'str': str,

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -42,6 +42,7 @@ commands =
         mgr_util.py \
         tests/ \
         cephadm/ \
+        mds_autoscaler/ \
         orchestrator/ \
         insights/ \
         pg_autoscaler/ \

--- a/src/pybind/mgr/volumes/fs/fs_util.py
+++ b/src/pybind/mgr/volumes/fs/fs_util.py
@@ -41,7 +41,6 @@ def create_mds(mgr, fs_name, placement):
                                     placement=PlacementSpec.from_string(placement))
     try:
         completion = mgr.apply_mds(spec)
-        mgr._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
     except (ImportError, orchestrator.OrchestratorError):
         return 0, "", "Volume created successfully (no MDS daemons created)"

--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -27,7 +27,6 @@ def available_clusters(mgr):
     '''
     # TODO check cephadm cluster list with rados pool conf objects
     completion = mgr.describe_service(service_type='nfs')
-    mgr._orchestrator_wait([completion])
     orchestrator.raise_if_exception(completion)
     return [cluster.spec.service_id for cluster in completion.result
             if cluster.spec.service_id]
@@ -662,7 +661,6 @@ class NFSCluster:
                               pool=self.pool_name, namespace=self.pool_ns,
                               placement=PlacementSpec.from_string(placement))
         completion = self.mgr.apply_nfs(spec)
-        self.mgr._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
 
     def create_empty_rados_obj(self):
@@ -678,7 +676,6 @@ class NFSCluster:
     def _restart_nfs_service(self):
         completion = self.mgr.service_action(action='restart',
                                              service_name='nfs.'+self.cluster_id)
-        self.mgr._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
 
     @cluster_setter
@@ -725,7 +722,6 @@ class NFSCluster:
             if cluster_id in cluster_list:
                 self.mgr.fs_export.delete_all_exports(cluster_id)
                 completion = self.mgr.remove_service('nfs.' + self.cluster_id)
-                self.mgr._orchestrator_wait([completion])
                 orchestrator.raise_if_exception(completion)
                 self.delete_config_obj()
                 return 0, "NFS Cluster Deleted Successfully", ""
@@ -744,7 +740,6 @@ class NFSCluster:
     def _show_nfs_cluster_info(self, cluster_id):
         self._set_cluster_id(cluster_id)
         completion = self.mgr.list_daemons(daemon_type='nfs')
-        self.mgr._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
         host_ip = []
         # Here completion.result is a list DaemonDescription objects

--- a/src/pybind/mgr/volumes/fs/operations/volume.py
+++ b/src/pybind/mgr/volumes/fs/operations/volume.py
@@ -87,7 +87,6 @@ def delete_volume(mgr, volname, metadata_pool, data_pools):
     # Tear down MDS daemons
     try:
         completion = mgr.remove_service('mds.' + volname)
-        mgr._orchestrator_wait([completion])
         orchestrator.raise_if_exception(completion)
     except (ImportError, orchestrator.OrchestratorError):
         log.warning("OrchestratorError, not tearing down MDS daemons")


### PR DESCRIPTION
Only Rook's `create_osd` function used the old interface. Everything else was redundant by now. 
 
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
