### PR TITLE
mds/client: create cephfs errno aliases

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -354,7 +354,7 @@ public:
 
   /**
    * Returns the length of the buffer that got filled in, or -errno.
-   * If it returns -ERANGE you just need to increase the size of the
+   * If it returns -CEPHFS_ERANGE you just need to increase the size of the
    * buffer and try again.
    */
   int _getdents(dir_result_t *dirp, char *buf, int buflen, bool ful);  // get a bunch of dentries at once
@@ -1441,7 +1441,7 @@ private:
   ino_t last_used_faked_ino;
   ino_t last_used_faked_root;
 
-  int local_osd = -ENXIO;
+  int local_osd = -CEPHFS_ENXIO;
   epoch_t local_osd_epoch = 0;
 
   // mds requests

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -696,13 +696,13 @@ int Inode::set_deleg(Fh *fh, unsigned type, ceph_deleg_cb_t cb, void *priv)
    * allow it, with an unusual error to make it clear.
    */
   if (!client->get_deleg_timeout())
-    return -ETIME;
+    return -CEPHFS_ETIME;
 
   // Just say no if we have any recalled delegs still outstanding
   if (has_recalled_deleg()) {
     lsubdout(client->cct, client, 10) << __func__ <<
 	  ": has_recalled_deleg" << dendl;
-    return -EAGAIN;
+    return -CEPHFS_EAGAIN;
   }
 
   // check vs. currently open files on this inode
@@ -711,17 +711,17 @@ int Inode::set_deleg(Fh *fh, unsigned type, ceph_deleg_cb_t cb, void *priv)
     if (open_count_for_write()) {
       lsubdout(client->cct, client, 10) << __func__ <<
 	    ": open for write" << dendl;
-      return -EAGAIN;
+      return -CEPHFS_EAGAIN;
     }
     break;
   case CEPH_DELEGATION_WR:
     if (open_count() > 1) {
       lsubdout(client->cct, client, 10) << __func__ << ": open" << dendl;
-      return -EAGAIN;
+      return -CEPHFS_EAGAIN;
     }
     break;
   default:
-    return -EINVAL;
+    return -CEPHFS_EINVAL;
   }
 
   /*
@@ -742,7 +742,7 @@ int Inode::set_deleg(Fh *fh, unsigned type, ceph_deleg_cb_t cb, void *priv)
   if (!caps_issued_mask(need)) {
     lsubdout(client->cct, client, 10) << __func__ << ": cap mismatch, have="
       << ccap_string(caps_issued()) << " need=" << ccap_string(need) << dendl;
-    return -EAGAIN;
+    return -CEPHFS_EAGAIN;
   }
 
   for (list<Delegation>::iterator d = delegations.begin();

--- a/src/client/hypertable/CephBroker.cc
+++ b/src/client/hypertable/CephBroker.cc
@@ -152,7 +152,7 @@ void CephBroker::create(ResponseCallbackOpen *cb, const char *fname, uint32_t fl
   String directory = abspath.substr(0, abspath.rfind('/'));
   int r;
   HT_INFOF("Calling mkdirs on %s", directory.c_str());
-  if((r=ceph_mkdirs(cmount, directory.c_str(), 0644)) < 0 && r!=-EEXIST) {
+  if((r=ceph_mkdirs(cmount, directory.c_str(), 0644)) < 0 && r!=-CEPHFS_EEXIST) {
     HT_ERRORF("create failed on mkdirs: dname='%s' - %d", directory.c_str(), -r);
     report_error(cb, -r);
     return;
@@ -360,7 +360,7 @@ void CephBroker::mkdirs(ResponseCallback *cb, const char *dname) {
 
   make_abs_path(dname, absdir);
   int r;
-  if((r=ceph_mkdirs(cmount, absdir.c_str(), 0644)) < 0 && r!=-EEXIST) {
+  if((r=ceph_mkdirs(cmount, absdir.c_str(), 0644)) < 0 && r!=-CEPHFS_EEXIST) {
     HT_ERRORF("mkdirs failed: dname='%s' - %d", absdir.c_str(), -r);
     report_error(cb, -r);
     return;
@@ -459,7 +459,7 @@ void CephBroker::readdir(ResponseCallbackReaddir *cb, const char *dname) {
   int bufpos;
   while (1) {
     r = ceph_getdnames(cmount, dirp, buf, buflen);
-    if (r==-ERANGE) { //expand the buffer
+    if (r==-CEPHFS_ERANGE) { //expand the buffer
       delete [] buf;
       buflen *= 2;
       buf = new char[buflen];

--- a/src/client/posix_acl.cc
+++ b/src/client/posix_acl.cc
@@ -1,5 +1,6 @@
 #include "include/compat.h"
 #include "include/types.h"
+#include "include/fs_types.h"
 #include <sys/stat.h>
 #include "posix_acl.h"
 #include "UserPerm.h"
@@ -75,7 +76,7 @@ int posix_acl_check(const void *xattr, size_t size)
 int posix_acl_equiv_mode(const void *xattr, size_t size, mode_t *mode_p)
 {
   if (posix_acl_check(xattr, size) < 0)
-    return -EINVAL;
+    return -CEPHFS_EINVAL;
 
   int not_equiv = 0;
   mode_t mode = 0;
@@ -104,7 +105,7 @@ int posix_acl_equiv_mode(const void *xattr, size_t size, mode_t *mode_p)
 	not_equiv = 1;
 	break;
       default:
-	return -EINVAL;
+	return -CEPHFS_EINVAL;
     }
     ++entry;
   }
@@ -116,7 +117,7 @@ int posix_acl_equiv_mode(const void *xattr, size_t size, mode_t *mode_p)
 int posix_acl_inherit_mode(bufferptr& acl, mode_t *mode_p)
 {
   if (posix_acl_check(acl.c_str(), acl.length()) <= 0)
-    return -EIO;
+    return -CEPHFS_EIO;
 
   acl_ea_entry *group_entry = NULL, *mask_entry = NULL;
   mode_t mode = *mode_p;
@@ -151,7 +152,7 @@ int posix_acl_inherit_mode(bufferptr& acl, mode_t *mode_p)
 	not_equiv = 1;
 	break;
       default:
-	return -EIO;
+	return -CEPHFS_EIO;
 
     }
     ++entry;
@@ -164,7 +165,7 @@ int posix_acl_inherit_mode(bufferptr& acl, mode_t *mode_p)
     mask_entry->e_perm = perm;
   } else {
     if (!group_entry)
-      return -EIO;
+      return -CEPHFS_EIO;
     __u16 perm = group_entry->e_perm;
     perm &= (mode >> 3) | ~S_IRWXO;
     mode &= (perm << 3) | ~S_IRWXG;
@@ -178,7 +179,7 @@ int posix_acl_inherit_mode(bufferptr& acl, mode_t *mode_p)
 int posix_acl_access_chmod(bufferptr& acl, mode_t mode)
 {
   if (posix_acl_check(acl.c_str(), acl.length()) <= 0)
-    return -EIO;
+    return -CEPHFS_EIO;
 
   acl_ea_entry *group_entry = NULL, *mask_entry = NULL;
 
@@ -210,7 +211,7 @@ int posix_acl_access_chmod(bufferptr& acl, mode_t mode)
     mask_entry->e_perm = (mode & S_IRWXG) >> 3;
   } else {
     if (!group_entry)
-      return -EIO;
+      return -CEPHFS_EIO;
     group_entry->e_perm = (mode & S_IRWXG) >> 3;
   }
   return 0;
@@ -220,7 +221,7 @@ int posix_acl_permits(const bufferptr& acl, uid_t i_uid, gid_t i_gid,
 			 const UserPerm& perms, unsigned want)
 {
   if (posix_acl_check(acl.c_str(), acl.length()) < 0)
-    return -EIO;
+    return -CEPHFS_EIO;
 
   const acl_ea_header *header = reinterpret_cast<const acl_ea_header*>(acl.c_str());
   const acl_ea_entry *entry = header->a_entries;
@@ -257,16 +258,16 @@ int posix_acl_permits(const bufferptr& acl, uid_t i_uid, gid_t i_gid,
 	break;
       case ACL_OTHER:
 	if (group_found)
-	  return -EACCES;
+	  return -CEPHFS_EACCES;
 	else
 	  goto check_perm;
 	break;
       default:
-	return -EIO;
+	return -CEPHFS_EIO;
     }
     ++entry;
   }
-  return -EIO;
+  return -CEPHFS_EIO;
 
 check_mask:
   next_entry = entry + 1;
@@ -276,12 +277,12 @@ check_mask:
       __u16 mask = next_entry->e_perm;
       if ((perm & mask & want) == want)
 	return 0;
-      return -EACCES;
+      return -CEPHFS_EACCES;
     }
     ++next_entry;
   }
 check_perm:
   if ((perm & want) == want)
     return 0;
-  return -EACCES;
+  return -CEPHFS_EACCES;
 }

--- a/src/include/fs_types.h
+++ b/src/include/fs_types.h
@@ -6,6 +6,47 @@
 #include "types.h"
 class JSONObj;
 
+#define CEPHFS_EBLOCKLISTED    108
+#define CEPHFS_EPERM           1
+#define CEPHFS_ESTALE          116
+#define CEPHFS_ENOSPC          28
+#define CEPHFS_ETIMEDOUT       110
+#define CEPHFS_EIO             5
+#define CEPHFS_ENOTCONN        107
+#define CEPHFS_EEXIST          17
+#define CEPHFS_EINTR           4
+#define CEPHFS_EINVAL          22
+#define CEPHFS_EBADF           9
+#define CEPHFS_EROFS           30
+#define CEPHFS_EAGAIN          11
+#define CEPHFS_EACCES          13
+#define CEPHFS_ELOOP           40
+#define CEPHFS_EISDIR          21
+#define CEPHFS_ENOENT          2
+#define CEPHFS_ENOTDIR         20
+#define CEPHFS_ENAMETOOLONG    36
+#define CEPHFS_EBUSY           16
+#define CEPHFS_EDQUOT          122
+#define CEPHFS_EFBIG           27
+#define CEPHFS_ERANGE          34
+#define CEPHFS_ENXIO           6
+#define CEPHFS_ECANCELED       125
+#define CEPHFS_ENODATA         61
+#define CEPHFS_EOPNOTSUPP      95
+#define CEPHFS_EXDEV           18
+#define CEPHFS_ENOMEM          12
+#define CEPHFS_ENOTRECOVERABLE 131
+#define CEPHFS_ENOSYS          38
+#define CEPHFS_EWOULDBLOCK     CEPHFS_EAGAIN
+#define CEPHFS_ENOTEMPTY       39
+#define CEPHFS_EDEADLK         35
+#define CEPHFS_EDEADLOCK       CEPHFS_EDEADLK
+#define CEPHFS_EDOM            33
+#define CEPHFS_EMLINK          31
+#define CEPHFS_ETIME           62
+#define CEPHFS_EOLDSNAPC       85
+
+
 // --------------------------------------
 // ino
 

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1648,7 +1648,7 @@ public:
     CDirIOContext(d), fin(f), ret1(0), ret2(0), ret3(0) { }
   void finish(int r) override {
     // check the correctness of backtrace
-    if (r >= 0 && ret3 != -ECANCELED)
+    if (r >= 0 && ret3 != -CEPHFS_ECANCELED)
       dir->inode->verify_diri_backtrace(btbl, ret3);
     if (r >= 0) r = ret1;
     if (r >= 0) r = ret2;
@@ -1691,7 +1691,7 @@ void CDir::_omap_fetch(MDSContext *c, const std::set<dentry_key_t>& keys)
     rd.getxattr("parent", &fin->btbl, &fin->ret3);
     rd.set_last_op_flags(CEPH_OSD_OP_FLAG_FAILOK);
   } else {
-    fin->ret3 = -ECANCELED;
+    fin->ret3 = -CEPHFS_ECANCELED;
   }
 
   mdcache->mds->objecter->read(oid, oloc, rd, CEPH_NOSNAP, NULL, 0,
@@ -1939,7 +1939,7 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
   dout(10) << "_fetched header " << hdrbl.length() << " bytes "
 	   << omap.size() << " keys for " << *this << dendl;
 
-  ceph_assert(r == 0 || r == -ENOENT || r == -ENODATA);
+  ceph_assert(r == 0 || r == -CEPHFS_ENOENT || r == -CEPHFS_ENODATA);
   ceph_assert(is_auth());
   ceph_assert(!is_frozen());
 
@@ -2030,7 +2030,7 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
                                << err.what() << "(" << get_path() << ")";
 
       // Remember that this dentry is damaged.  Subsequent operations
-      // that try to act directly on it will get their EIOs, but this
+      // that try to act directly on it will get their CEPHFS_EIOs, but this
       // dirfrag as a whole will continue to look okay (minus the
       // mysteriously-missing dentry)
       go_bad_dentry(last, dname);
@@ -2121,7 +2121,7 @@ void CDir::go_bad(bool complete)
 
   state_clear(STATE_FETCHING);
   auth_unpin(this);
-  finish_waiting(WAIT_COMPLETE, -EIO);
+  finish_waiting(WAIT_COMPLETE, -CEPHFS_EIO);
 }
 
 // -----------------------
@@ -2549,7 +2549,7 @@ void CDir::_committed(int r, version_t v)
 {
   if (r < 0) {
     // the directory could be partly purged during MDS failover
-    if (r == -ENOENT && committed_version == 0 &&
+    if (r == -CEPHFS_ENOENT && committed_version == 0 &&
 	!inode->is_base() && get_parent_dir()->inode->is_stray()) {
       r = 0;
       if (inode->snaprealm)

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -716,7 +716,7 @@ int FSMap::parse_filesystem(
         return 0;
       }
     }
-    return -ENOENT;
+    return -CEPHFS_ENOENT;
   } else {
     *result = get_filesystem(fscid);
     return 0;
@@ -1091,7 +1091,7 @@ int FSMap::parse_role(
     if (r >= 0) {
       ss << "Invalid file system";
     }
-    return -ENOENT;
+    return -CEPHFS_ENOENT;
   }
 
   return r;
@@ -1108,14 +1108,14 @@ int FSMap::parse_role(
   if (colon_pos == std::string::npos) {
     if (legacy_client_fscid == FS_CLUSTER_ID_NONE) {
       ss << "No filesystem selected";
-      return -ENOENT;
+      return -CEPHFS_ENOENT;
     }
     fs = get_filesystem(legacy_client_fscid);
     rank_pos = 0;
   } else {
     if (parse_filesystem(role_str.substr(0, colon_pos), &fs) < 0) {
       ss << "Invalid filesystem";
-      return -ENOENT;
+      return -CEPHFS_ENOENT;
     }
     rank_pos = colon_pos+1;
   }
@@ -1126,14 +1126,14 @@ int FSMap::parse_role(
   long rank_i = strict_strtol(rank_str.c_str(), 10, &err);
   if (rank_i < 0 || !err.empty()) {
     ss << "Invalid rank '" << rank_str << "'";
-    return -EINVAL;
+    return -CEPHFS_EINVAL;
   } else {
     rank = rank_i;
   }
 
   if (fs->mds_map.in.count(rank) == 0) {
     ss << "Rank '" << rank << "' not found";
-    return -ENOENT;
+    return -CEPHFS_ENOENT;
   }
 
   *role = {fs->fscid, rank};

--- a/src/mds/JournalPointer.cc
+++ b/src/mds/JournalPointer.cc
@@ -61,7 +61,7 @@ int JournalPointer::load(Objecter *objecter)
     try {
       decode(q);
     } catch (const buffer::error &e) {
-      return -EINVAL;
+      return -CEPHFS_EINVAL;
     }
   } else {
     dout(1) << "Journal pointer '" << object_id << "' read failed: " << cpp_strerror(r) << dendl;

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -383,8 +383,8 @@ int MDBalancer::localize_balancer()
   /* success: store the balancer in memory and set the version. */
   if (!r) {
     if (ret_t == std::cv_status::timeout) {
-      mds->objecter->op_cancel(tid, -ECANCELED);
-      return -ETIMEDOUT;
+      mds->objecter->op_cancel(tid, -CEPHFS_ECANCELED);
+      return -CEPHFS_ETIMEDOUT;
     }
     bal_code.assign(lua_src.to_str());
     bal_version.assign(oid.name);
@@ -874,7 +874,7 @@ int MDBalancer::mantle_prep_rebalance()
 
   /* mantle doesn't know about cluster size, so check target len here */
   if ((int) state.targets.size() != cluster_size)
-    return -EINVAL;
+    return -CEPHFS_EINVAL;
   else if (ret)
     return ret;
 

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -97,7 +97,7 @@ class C_MDL_WriteError : public MDSIOContextBase {
     MDSRank *mds = get_mds();
     // assume journal is reliable, so don't choose action based on
     // g_conf()->mds_action_on_write_error.
-    if (r == -EBLOCKLISTED) {
+    if (r == -CEPHFS_EBLOCKLISTED) {
       derr << "we have been blocklisted (fenced), respawning..." << dendl;
       mds->respawn();
     } else {
@@ -749,7 +749,7 @@ int MDLog::trim_all()
     if (pending_events.count(ls->seq)) {
       dout(5) << __func__ << ": segment " << ls->seq << " has pending events" << dendl;
       submit_mutex.unlock();
-      return -EAGAIN;
+      return -CEPHFS_EAGAIN;
     }
 
     if (expiring_segments.count(ls)) {
@@ -968,13 +968,13 @@ void MDLog::_recovery_thread(MDSContext *completion)
   // front = default ino and back = null
   JournalPointer jp(mds->get_nodeid(), mds->mdsmap->get_metadata_pool());
   const int read_result = jp.load(mds->objecter);
-  if (read_result == -ENOENT) {
+  if (read_result == -CEPHFS_ENOENT) {
     inodeno_t const default_log_ino = MDS_INO_LOG_OFFSET + mds->get_nodeid();
     jp.front = default_log_ino;
     int write_result = jp.save(mds->objecter);
     // Nothing graceful we can do for this
     ceph_assert(write_result >= 0);
-  } else if (read_result == -EBLOCKLISTED) {
+  } else if (read_result == -CEPHFS_EBLOCKLISTED) {
     derr << "Blocklisted during JournalPointer read!  Respawning..." << dendl;
     mds->respawn();
     ceph_abort(); // Should be unreachable because respawn calls execv
@@ -996,7 +996,7 @@ void MDLog::_recovery_thread(MDSContext *completion)
       if (mds->is_daemon_stopping()) {
         return;
       }
-      completion->complete(-EAGAIN);
+      completion->complete(-CEPHFS_EAGAIN);
       return;
     }
     dout(1) << "Erasing journal " << jp.back << dendl;
@@ -1009,7 +1009,7 @@ void MDLog::_recovery_thread(MDSContext *completion)
     C_SaferCond recover_wait;
     back.recover(&recover_wait);
     int recovery_result = recover_wait.wait();
-    if (recovery_result == -EBLOCKLISTED) {
+    if (recovery_result == -CEPHFS_EBLOCKLISTED) {
       derr << "Blocklisted during journal recovery!  Respawning..." << dendl;
       mds->respawn();
       ceph_abort(); // Should be unreachable because respawn calls execv
@@ -1028,7 +1028,7 @@ void MDLog::_recovery_thread(MDSContext *completion)
 
     // If we are successful, or find no data, we can update the JournalPointer to
     // reflect that the back journal is gone.
-    if (erase_result != 0 && erase_result != -ENOENT) {
+    if (erase_result != 0 && erase_result != -CEPHFS_ENOENT) {
       derr << "Failed to erase journal " << jp.back << ": " << cpp_strerror(erase_result) << dendl;
     } else {
       dout(1) << "Successfully erased journal, updating journal pointer" << dendl;
@@ -1057,7 +1057,7 @@ void MDLog::_recovery_thread(MDSContext *completion)
   int recovery_result = recover_wait.wait();
   dout(4) << "Journal " << jp.front << " recovered." << dendl;
 
-  if (recovery_result == -EBLOCKLISTED) {
+  if (recovery_result == -CEPHFS_EBLOCKLISTED) {
     derr << "Blocklisted during journal recovery!  Respawning..." << dendl;
     mds->respawn();
     ceph_abort(); // Should be unreachable because respawn calls execv
@@ -1079,7 +1079,7 @@ void MDLog::_recovery_thread(MDSContext *completion)
         delete front_journal;
         return;
       }
-      completion->complete(-EINVAL);
+      completion->complete(-CEPHFS_EINVAL);
     }
   } else if (mds->is_standby_replay() || front_journal->get_stream_format() >= g_conf()->mds_journal_format) {
     /* The journal is of configured format, or we are in standbyreplay and will
@@ -1321,21 +1321,21 @@ void MDLog::_replay_thread()
     if (journaler->get_error()) {
       r = journaler->get_error();
       dout(0) << "_replay journaler got error " << r << ", aborting" << dendl;
-      if (r == -ENOENT) {
+      if (r == -CEPHFS_ENOENT) {
         if (mds->is_standby_replay()) {
           // journal has been trimmed by somebody else
-          r = -EAGAIN;
+          r = -CEPHFS_EAGAIN;
         } else {
           mds->clog->error() << "missing journal object";
           mds->damaged_unlocked();
           ceph_abort();  // Should be unreachable because damaged() calls respawn()
         }
-      } else if (r == -EINVAL) {
+      } else if (r == -CEPHFS_EINVAL) {
         if (journaler->get_read_pos() < journaler->get_expire_pos()) {
           // this should only happen if you're following somebody else
           if(journaler->is_readonly()) {
-            dout(0) << "expire_pos is higher than read_pos, returning EAGAIN" << dendl;
-            r = -EAGAIN;
+            dout(0) << "expire_pos is higher than read_pos, returning CEPHFS_EAGAIN" << dendl;
+            r = -CEPHFS_EAGAIN;
           } else {
             mds->clog->error() << "invalid journaler offsets";
             mds->damaged_unlocked();
@@ -1351,8 +1351,8 @@ void MDLog::_replay_thread()
           journaler->reread_head(&reread_fin);
           int err = reread_fin.wait();
           if (err) {
-            if (err == -ENOENT && mds->is_standby_replay()) {
-              r = -EAGAIN;
+            if (err == -CEPHFS_ENOENT && mds->is_standby_replay()) {
+              r = -CEPHFS_EAGAIN;
               dout(1) << "Journal header went away while in standby replay, journal rewritten?"
                       << dendl;
               break;
@@ -1368,8 +1368,8 @@ void MDLog::_replay_thread()
           }
 	  standby_trim_segments();
           if (journaler->get_read_pos() < journaler->get_expire_pos()) {
-            dout(0) << "expire_pos is higher than read_pos, returning EAGAIN" << dendl;
-            r = -EAGAIN;
+            dout(0) << "expire_pos is higher than read_pos, returning CEPHFS_EAGAIN" << dendl;
+            r = -CEPHFS_EAGAIN;
           }
         }
       }

--- a/src/mds/MDSContext.cc
+++ b/src/mds/MDSContext.cc
@@ -107,7 +107,7 @@ void MDSIOContextBase::complete(int r) {
     return;
   }
 
-  if (r == -EBLOCKLISTED) {
+  if (r == -CEPHFS_EBLOCKLISTED) {
     derr << "MDSIOContextBase: blocklisted!  Restarting..." << dendl;
     mds->respawn();
   } else {

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -137,7 +137,7 @@ void MDSDaemon::asok_command(
   dout(1) << "asok_command: " << command << " " << cmdmap
 	  << " (starting...)" << dendl;
 
-  int r = -ENOSYS;
+  int r = -CEPHFS_ENOSYS;
   bufferlist outbl;
   CachedStackStringStream css;
   auto& ss = *css;
@@ -169,7 +169,7 @@ void MDSDaemon::asok_command(
   } else if (command == "heap") {
     if (!ceph_using_tcmalloc()) {
       ss << "not using tcmalloc";
-      r = -EOPNOTSUPP;
+      r = -CEPHFS_EOPNOTSUPP;
     } else {
       string heapcmd;
       cmd_getval(cmdmap, "heapcmd", heapcmd);
@@ -197,7 +197,7 @@ void MDSDaemon::asok_command(
 	return;
       } catch (const TOPNSPC::common::bad_cmd_get& e) {
 	ss << e.what();
-	r = -EINVAL;
+	r = -CEPHFS_EINVAL;
       }
     }
   }
@@ -469,7 +469,7 @@ int MDSDaemon::init()
   // to run on Windows.
   derr << "The Ceph MDS does not support running on Windows at the moment."
        << dendl;
-  return -ENOSYS;
+  return -CEPHFS_ENOSYS;
 #endif // _WIN32
 
   dout(10) << "Dumping misc struct sizes:" << dendl;
@@ -539,7 +539,7 @@ int MDSDaemon::init()
          << "maximum retry time reached." << dendl;
     std::lock_guard locker{mds_lock};
     suicide();
-    return -ETIMEDOUT;
+    return -CEPHFS_ETIMEDOUT;
   }
 
   mds_lock.lock();
@@ -633,12 +633,12 @@ void MDSDaemon::handle_command(const cref_t<MCommand> &m)
       << *m->get_connection()->peer_addrs << dendl;
 
     ss << "permission denied";
-    r = -EACCES;
+    r = -CEPHFS_EACCES;
   } else if (m->cmd.empty()) {
-    r = -EINVAL;
+    r = -CEPHFS_EINVAL;
     ss << "no command given";
   } else if (!TOPNSPC::common::cmdmap_from_json(m->cmd, &cmdmap, ss)) {
-    r = -EINVAL;
+    r = -CEPHFS_EINVAL;
   } else {
     cct->get_admin_socket()->queue_tell_command(m);
     return;

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -322,7 +322,7 @@ public:
   int remove_data_pool(int64_t poolid) {
     std::vector<int64_t>::iterator p = std::find(data_pools.begin(), data_pools.end(), poolid);
     if (p == data_pools.end())
-      return -ENOENT;
+      return -CEPHFS_ENOENT;
     data_pools.erase(p);
     return 0;
   }

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -62,7 +62,7 @@ public:
 
     if (mdcache->is_readonly()) {
       dout(5) << __func__ << ": read-only FS" << dendl;
-      complete(-EROFS);
+      complete(-CEPHFS_EROFS);
       return;
     }
 
@@ -265,7 +265,7 @@ public:
   }
 
 private:
-  // context which completes itself (with -ETIMEDOUT) after a specified
+  // context which completes itself (with -CEPHFS_ETIMEDOUT) after a specified
   // timeout or when explicitly completed, whichever comes first. Note
   // that the context does not detroy itself after completion -- it
   // needs to be explicitly freed.
@@ -287,7 +287,7 @@ private:
 
       timer_task = new LambdaContext([this](int) {
           timer_task = nullptr;
-          complete(-ETIMEDOUT);
+          complete(-CEPHFS_ETIMEDOUT);
         });
       mds->timer.add_event_after(timeout, timer_task);
     }
@@ -354,7 +354,7 @@ private:
       } else if (recall_timeout > 0 && duration > recall_timeout) {
         gather.set_finisher(new C_MDSInternalNoop);
         gather.activate();
-        return handle_recall_client_state(-ETIMEDOUT);
+        return handle_recall_client_state(-CEPHFS_ETIMEDOUT);
       } else {
         uint64_t remaining = (recall_timeout == 0 ? 0 : recall_timeout-duration);
         C_ContextTimeout *ctx = new C_ContextTimeout(
@@ -947,7 +947,7 @@ void MDSRank::damaged_unlocked()
 
 void MDSRank::handle_write_error(int err)
 {
-  if (err == -EBLOCKLISTED) {
+  if (err == -CEPHFS_EBLOCKLISTED) {
     derr << "we have been blocklisted (fenced), respawning..." << dendl;
     respawn();
     return;
@@ -1560,17 +1560,17 @@ void MDSRank::boot_start(BootStep step, int r)
 {
   // Handle errors from previous step
   if (r < 0) {
-    if (is_standby_replay() && (r == -EAGAIN)) {
-      dout(0) << "boot_start encountered an error EAGAIN"
+    if (is_standby_replay() && (r == -CEPHFS_EAGAIN)) {
+      dout(0) << "boot_start encountered an error CEPHFS_EAGAIN"
               << ", respawning since we fell behind journal" << dendl;
       respawn();
-    } else if (r == -EINVAL || r == -ENOENT) {
+    } else if (r == -CEPHFS_EINVAL || r == -CEPHFS_ENOENT) {
       // Invalid or absent data, indicates damaged on-disk structures
       clog->error() << "Error loading MDS rank " << whoami << ": "
         << cpp_strerror(r);
       damaged();
       ceph_assert(r == 0);  // Unreachable, damaged() calls respawn()
-    } else if (r == -EROFS) {
+    } else if (r == -CEPHFS_EROFS) {
       dout(0) << "boot error forcing transition to read-only; MDS will try to continue" << dendl;
     } else {
       // Completely unexpected error, give up and die
@@ -2547,7 +2547,7 @@ void MDSRankDispatcher::handle_asok_command(
 
     if (!got_val) {
       *css << "no target epoch given";
-      r = -EINVAL;
+      r = -CEPHFS_EINVAL;
       goto out;
     }
     {
@@ -2580,7 +2580,7 @@ void MDSRankDispatcher::handle_asok_command(
     SessionFilter filter;
     r = filter.parse(filter_args, css.get());
     if (r != 0) {
-      r = -EINVAL;
+      r = -CEPHFS_EINVAL;
       goto out;
     }
     evict_clients(filter, on_finish);
@@ -2589,7 +2589,7 @@ void MDSRankDispatcher::handle_asok_command(
     std::string client_id;
     if (!cmd_getval(cmdmap, "client_id", client_id)) {
       *css << "Invalid client_id specified";
-      r = -ENOENT;
+      r = -CEPHFS_ENOENT;
       goto out;
     }
     std::lock_guard l(mds_lock);
@@ -2597,7 +2597,7 @@ void MDSRankDispatcher::handle_asok_command(
         g_conf()->mds_session_blocklist_on_evict, *css);
     if (!evicted) {
       dout(15) << css->strv() << dendl;
-      r = -ENOENT;
+      r = -CEPHFS_ENOENT;
     }
   } else if (command == "session config" ||
 	     command == "client config") {
@@ -2615,7 +2615,7 @@ void MDSRankDispatcher::handle_asok_command(
 	     command == "scrub_start") {
     if (whoami != 0) {
       *css << "Not rank 0";
-      r = -EXDEV;
+      r = -CEPHFS_EXDEV;
       goto out;
     }
 
@@ -2641,7 +2641,7 @@ void MDSRankDispatcher::handle_asok_command(
   } else if (command == "scrub abort") {
     if (whoami != 0) {
       *css << "Not rank 0";
-      r = -EXDEV;
+      r = -CEPHFS_EXDEV;
       goto out;
     }
 
@@ -2663,7 +2663,7 @@ void MDSRankDispatcher::handle_asok_command(
   } else if (command == "scrub pause") {
     if (whoami != 0) {
       *css << "Not rank 0";
-      r = -EXDEV;
+      r = -CEPHFS_EXDEV;
       goto out;
     }
 
@@ -2685,7 +2685,7 @@ void MDSRankDispatcher::handle_asok_command(
   } else if (command == "scrub resume") {
     if (whoami != 0) {
       *css << "Not rank 0";
-      r = -EXDEV;
+      r = -CEPHFS_EXDEV;
       goto out;
     }
     command_scrub_resume(f);
@@ -2694,7 +2694,7 @@ void MDSRankDispatcher::handle_asok_command(
   } else if (command == "tag path") {
     if (whoami != 0) {
       *css << "Not rank 0";
-      r = -EXDEV;
+      r = -CEPHFS_EXDEV;
       goto out;
     }
     string path;
@@ -2714,13 +2714,13 @@ void MDSRankDispatcher::handle_asok_command(
     string path;
     if(!cmd_getval(cmdmap, "path", path)) {
       *css << "malformed path";
-      r = -EINVAL;
+      r = -CEPHFS_EINVAL;
       goto out;
     }
     int64_t rank;
     if(!cmd_getval(cmdmap, "rank", rank)) {
       *css << "malformed rank";
-      r = -EINVAL;
+      r = -CEPHFS_EINVAL;
       goto out;
     }
     command_export_dir(f, path, (mds_rank_t)rank);
@@ -2763,7 +2763,7 @@ void MDSRankDispatcher::handle_asok_command(
       if (mdsmap->get_tableserver() == whoami) {
 	snapserver->dump(f);
       } else {
-	r = -EXDEV;
+	r = -CEPHFS_EXDEV;
 	*css << "Not snapserver";
       }
     } else {
@@ -2789,12 +2789,12 @@ void MDSRankDispatcher::handle_asok_command(
     std::lock_guard l(mds_lock);
     damage_entry_id_t id = 0;
     if (!cmd_getval(cmdmap, "damage_id", (int64_t&)id)) {
-      r = -EINVAL;
+      r = -CEPHFS_EINVAL;
       goto out;
     }
     damage_table.erase(id);
   } else {
-    r = -ENOSYS;
+    r = -CEPHFS_ENOSYS;
   }
 out:
   on_finish(r, css->str(), outbl);
@@ -2811,7 +2811,7 @@ void MDSRankDispatcher::evict_clients(
 {
   bufferlist outbl;
   if (is_any_replay()) {
-    on_finish(-EAGAIN, "MDS is replaying log", outbl);
+    on_finish(-CEPHFS_EAGAIN, "MDS is replaying log", outbl);
     return;
   }
 
@@ -3009,18 +3009,18 @@ int MDSRank::_command_export_dir(
 
   if (target == whoami || !mdsmap->is_up(target) || !mdsmap->is_in(target)) {
     derr << "bad MDS target " << target << dendl;
-    return -ENOENT;
+    return -CEPHFS_ENOENT;
   }
 
   CInode *in = mdcache->cache_traverse(fp);
   if (!in) {
     derr << "Bath path '" << path << "'" << dendl;
-    return -ENOENT;
+    return -CEPHFS_ENOENT;
   }
   CDir *dir = in->get_dirfrag(frag_t());
   if (!dir || !(dir->is_auth())) {
     derr << "bad export_dir path dirfrag frag_t() or dir not auth" << dendl;
-    return -EINVAL;
+    return -CEPHFS_EINVAL;
   }
 
   mdcache->migrator->export_dir(dir, target);
@@ -3461,7 +3461,7 @@ int MDSRank::config_client(int64_t session_id, bool remove,
   Session *session = sessionmap.get_session(entity_name_t(CEPH_ENTITY_TYPE_CLIENT, session_id));
   if (!session) {
     ss << "session " << session_id << " not in sessionmap!";
-    return -ENOENT;
+    return -CEPHFS_ENOENT;
   }
 
   if (option == "timeout") {
@@ -3469,7 +3469,7 @@ int MDSRank::config_client(int64_t session_id, bool remove,
       auto it = session->info.client_metadata.find("timeout");
       if (it == session->info.client_metadata.end()) {
 	ss << "Nonexistent config: " << option;
-	return -ENODATA;
+	return -CEPHFS_ENODATA;
       }
       session->info.client_metadata.erase(it);
     } else {
@@ -3477,14 +3477,14 @@ int MDSRank::config_client(int64_t session_id, bool remove,
       strtoul(value.c_str(), &end, 0);
       if (*end) {
 	ss << "Invalid config for timeout: " << value;
-	return -EINVAL;
+	return -CEPHFS_EINVAL;
       }
       session->info.client_metadata[option] = value;
     }
     //sessionmap._mark_dirty(session, true);
   } else {
     ss << "Invalid config option: " << option;
-    return -EINVAL;
+    return -CEPHFS_EINVAL;
   }
 
   return 0;

--- a/src/mds/MDSTable.cc
+++ b/src/mds/MDSTable.cc
@@ -168,7 +168,7 @@ void MDSTable::load_2(int r, bufferlist& bl, Context *onfinish)
 {
   ceph_assert(is_opening());
   state = STATE_ACTIVE;
-  if (r == -EBLOCKLISTED) {
+  if (r == -CEPHFS_EBLOCKLISTED) {
     mds->respawn();
     return;
   }

--- a/src/mds/Mantle.cc
+++ b/src/mds/Mantle.cc
@@ -53,7 +53,7 @@ int Mantle::balance(std::string_view script,
   if (luaL_loadstring(L, script.data())) {
     mantle_dout(0) << "WARNING: mantle could not load balancer: "
             << lua_tostring(L, -1) << mantle_dendl;
-    return -EINVAL;
+    return -CEPHFS_EINVAL;
   }
 
   /* tell the balancer which mds is making the decision */
@@ -84,20 +84,20 @@ int Mantle::balance(std::string_view script,
   if (lua_pcall(L, 0, 1, 0) != LUA_OK) {
     mantle_dout(0) << "WARNING: mantle could not execute script: "
             << lua_tostring(L, -1) << mantle_dendl;
-    return -EINVAL;
+    return -CEPHFS_EINVAL;
   }
 
   /* parse response by iterating over Lua stack */
   if (lua_istable(L, -1) == 0) {
     mantle_dout(0) << "WARNING: mantle script returned a malformed response" << mantle_dendl;
-    return -EINVAL;
+    return -CEPHFS_EINVAL;
   }
 
   /* fill in return value */
   for (lua_pushnil(L); lua_next(L, -2); lua_pop(L, 1)) {
     if (!lua_isinteger(L, -2) || !lua_isnumber(L, -1)) {
       mantle_dout(0) << "WARNING: mantle script returned a malformed response" << mantle_dendl;
-      return -EINVAL;
+      return -CEPHFS_EINVAL;
     }
     mds_rank_t rank(lua_tointeger(L, -2));
     my_targets[rank] = lua_tonumber(L, -1);

--- a/src/mds/OpenFileTable.cc
+++ b/src/mds/OpenFileTable.cc
@@ -745,7 +745,7 @@ void OpenFileTable::_load_finish(int op_r, int header_r, int values_r,
 				 std::map<std::string, bufferlist> &values)
 {
   using ceph::decode;
-  int err = -EINVAL;
+  int err = -CEPHFS_EINVAL;
 
   auto decode_func = [this](unsigned idx, inodeno_t ino, bufferlist &bl) {
     auto p = bl.cbegin();

--- a/src/mds/RecoveryQueue.cc
+++ b/src/mds/RecoveryQueue.cc
@@ -188,7 +188,7 @@ void RecoveryQueue::_recovered(CInode *in, int r, uint64_t size, utime_t mtime)
 
   if (r != 0) {
     dout(0) << "recovery error! " << r << dendl;
-    if (r == -EBLOCKLISTED) {
+    if (r == -CEPHFS_EBLOCKLISTED) {
       mds->respawn();
       return;
     } else {

--- a/src/mds/ScrubStack.h
+++ b/src/mds/ScrubStack.h
@@ -54,7 +54,7 @@ public:
    * caller should provide a context which is completed after all
    * in-progress scrub operations are completed and pending inodes
    * are removed from the scrub stack (with the context callbacks for
-   * inodes completed with -ECANCELED).
+   * inodes completed with -CEPHFS_ECANCELED).
    * @param on_finish Context callback to invoke after abort
    */
   void scrub_abort(Context *on_finish);
@@ -72,8 +72,8 @@ public:
   /**
    * Resume a paused scrub. Unlike abort or pause, this is instantaneous.
    * Pending pause operations are cancelled (context callbacks are
-   * invoked with -ECANCELED).
-   * @returns 0 (success) if resumed, -EINVAL if an abort is in-progress.
+   * invoked with -CEPHFS_ECANCELED).
+   * @returns 0 (success) if resumed, -CEPHFS_EINVAL if an abort is in-progress.
    */
   bool scrub_resume();
 
@@ -242,7 +242,7 @@ private:
 
   /**
    * Abort pending scrubs for inodes waiting in the inode stack.
-   * Completion context is complete with -ECANCELED.
+   * Completion context is complete with -CEPHFS_ECANCELED.
    */
   void abort_pending_scrubs();
 

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -436,7 +436,7 @@ private:
   MDLog *mdlog;
   PerfCounters *logger = nullptr;
 
-  // OSDMap full status, used to generate ENOSPC on some operations
+  // OSDMap full status, used to generate CEPHFS_ENOSPC on some operations
   bool is_full = false;
 
   // State for while in reconnect

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -1011,14 +1011,14 @@ int Session::check_access(CInode *in, unsigned mask,
       inode->layout.pool_ns.length() &&
       !connection->has_feature(CEPH_FEATURE_FS_FILE_LAYOUT_V2)) {
     dout(10) << __func__ << " client doesn't support FS_FILE_LAYOUT_V2" << dendl;
-    return -EIO;
+    return -CEPHFS_EIO;
   }
 
   if (!auth_caps.is_capable(path, inode->uid, inode->gid, inode->mode,
 			    caller_uid, caller_gid, caller_gid_list, mask,
 			    new_uid, new_gid,
 			    info.inst.addr)) {
-    return -EACCES;
+    return -CEPHFS_EACCES;
   }
   return 0;
 }
@@ -1123,7 +1123,7 @@ int SessionFilter::parse(
       id = strict_strtoll(s.c_str(), 10, &err);
       if (!err.empty()) {
 	*ss << "Invalid filter '" << s << "'";
-	return -EINVAL;
+	return -CEPHFS_EINVAL;
       }
       return 0;
     }
@@ -1153,13 +1153,13 @@ int SessionFilter::parse(
       id = strict_strtoll(v.c_str(), 10, &err);
       if (!err.empty()) {
         *ss << err;
-        return -EINVAL;
+        return -CEPHFS_EINVAL;
       }
     } else if (k == "reconnecting") {
 
       /**
        * Strict boolean parser.  Allow true/false/0/1.
-       * Anything else is -EINVAL.
+       * Anything else is -CEPHFS_EINVAL.
        */
       auto is_true = [](std::string_view bstr, bool *out) -> bool
       {
@@ -1172,7 +1172,7 @@ int SessionFilter::parse(
           *out = false;
           return 0;
         } else {
-          return -EINVAL;
+          return -CEPHFS_EINVAL;
         }
       };
 
@@ -1182,11 +1182,11 @@ int SessionFilter::parse(
         set_reconnecting(bval);
       } else {
         *ss << "Invalid boolean value '" << v << "'";
-        return -EINVAL;
+        return -CEPHFS_EINVAL;
       }
     } else {
       *ss << "Invalid filter key '" << k << "'";
-      return -EINVAL;
+      return -CEPHFS_EINVAL;
     }
   }
 

--- a/src/mds/SnapClient.cc
+++ b/src/mds/SnapClient.cc
@@ -280,7 +280,7 @@ int SnapClient::dump_cache(Formatter *f) const
 {
   if (!is_synced()) {
     dout(5) << "dump_cache: not synced" << dendl;
-    return -EINVAL;
+    return -CEPHFS_EINVAL;
   }
 
   map<snapid_t, const SnapInfo*> snaps;

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -77,7 +77,7 @@ public:
   C_IO_PurgeStrayPurged(StrayManager *sm_, CDentry *d, bool oh) : 
     StrayManagerIOContext(sm_), dn(d), only_head(oh) { }
   void finish(int r) override {
-    ceph_assert(r == 0 || r == -ENOENT);
+    ceph_assert(r == 0 || r == -CEPHFS_ENOENT);
     sm->_purge_stray_purged(dn, only_head);
   }
   void print(ostream& out) const override {
@@ -475,7 +475,7 @@ bool StrayManager::_eval_stray(CDentry *dn)
 	if (in->state_test(CInode::STATE_MISSINGOBJS)) {
 	  mds->clog->error() << "previous attempt at committing dirfrag of ino "
 			     << in->ino() << " has failed, missing object";
-	  mds->handle_write_error(-ENOENT);
+	  mds->handle_write_error(-CEPHFS_ENOENT);
 	}
 	return false;  // not until some snaps are deleted.
       }


### PR DESCRIPTION
Replace system errno macros with cephfs aliases

Fixes: https://tracker.ceph.com/issues/48802
Signed-off-by: Milind Changire <mchangir@redhat.com>



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>