### PR TITLE
crimson/osd: make client_requests idempotent

### DIFF
--- a/src/crimson/osd/ec_backend.h
+++ b/src/crimson/osd/ec_backend.h
@@ -35,4 +35,8 @@ private:
 		      std::vector<pg_log_entry_t>&& log_entries) final;
   CollectionRef coll;
   crimson::os::FuturizedStore* store;
+  seastar::future<> request_committed(const osd_reqid_t& reqid,
+				       const eversion_t& version) final {
+    return seastar::now();
+  }
 };

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -624,6 +624,7 @@ public:
 	return &it->second;
     }
   }
+  seastar::future<std::tuple<bool, int>> already_complete(const osd_reqid_t& reqid);
   int get_recovery_op_priority() const {
     int64_t pri = 0;
     get_pool().info.opts.get(pool_opts_t::RECOVERY_OP_PRIORITY, &pri);

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -30,6 +30,7 @@ namespace ceph::os {
 
 namespace crimson::osd {
   class ShardServices;
+  class PG;
 }
 
 class PGBackend
@@ -207,6 +208,9 @@ protected:
   crimson::os::FuturizedStore* store;
   bool stopping = false;
   std::optional<peering_info_t> peering;
+  virtual seastar::future<> request_committed(
+    const osd_reqid_t& reqid,
+    const eversion_t& at_version) = 0;
 public:
   struct loaded_object_md_t {
     ObjectState os;
@@ -232,4 +236,5 @@ private:
 		      epoch_t min_epoch, epoch_t max_epoch,
 		      std::vector<pg_log_entry_t>&& log_entries) = 0;
   friend class ReplicatedRecoveryBackend;
+  friend class ::crimson::osd::PG;
 };


### PR DESCRIPTION
When redoing client requests, they might have already taken effect
on the underlying disk. This commit deals with that situation by
making those requests immediately reply to clients if they are already
done

Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
