### PR TITLE
mgr/orch: Fix flake8 error

### DIFF
--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -572,7 +572,8 @@ class CephadmUpgrade:
                 osd_min_name = osdmap.get("require_osd_release", "argonaut")
                 osd_min = ceph_release_to_major(osd_min_name)
                 if osd_min < int(target_major):
-                    logger.info(f'Upgrade: Setting require_osd_release to {target_major} {target_major_name}')
+                    logger.info(
+                        f'Upgrade: Setting require_osd_release to {target_major} {target_major_name}')
                     ret, _, err = self.mgr.check_mon_command({
                         'prefix': 'osd require-osd-release',
                         'release': target_major_name,

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -726,7 +726,7 @@ class Orchestrator(object):
                 ...     OrchestratorClientMixin().get_hosts()
 
         :return: boolean representing whether the module is available/usable
-        :return: string describing any error 
+        :return: string describing any error
         :return: dict containing any module specific information
         """
         raise NotImplementedError()


### PR DESCRIPTION
#39153 was merged a few seconds ago, but in the meantime another PR got merged that introduced a flake8 error.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
