### PR TITLE
[RFC, DNM] cephadm: add json structured log output

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -18,6 +18,7 @@ DEFAULT_TIMEOUT = None  # in seconds
 DEFAULT_RETRY = 15
 SHELL_DEFAULT_CONF = '/etc/ceph/ceph.conf'
 SHELL_DEFAULT_KEYRING = '/etc/ceph/ceph.client.admin.keyring'
+DEFAULT_LOG_FORMAT='plain'
 
 """
 You can invoke cephadm in two ways:
@@ -107,6 +108,7 @@ class BaseConfig:
         self.timeout: Optional[int] = DEFAULT_TIMEOUT
         self.retry: int = DEFAULT_RETRY
         self.env: List[str] = []
+        self.formatter: str = DEFAULT_LOG_FORMAT
 
         self.container_init: bool = CONTAINER_INIT
         self.container_path: str = ""
@@ -7053,6 +7055,10 @@ def _get_parser():
         action='store_true',
         default=not CONTAINER_INIT,
         help='Do not run podman/docker with `--init`')
+    parser.add_argument(
+        '--formatter', '-f',
+        default=DEFAULT_LOG_FORMAT,
+        help='TODO:')
 
     subparsers = parser.add_subparsers(help='sub-command')
 
@@ -7633,6 +7639,20 @@ def cephadm_init(args: List[str]) -> Optional[CephadmContext]:
         os.makedirs(LOG_DIR)
     dictConfig(logging_config)
     logger = logging.getLogger()
+
+    if ctx.formatter == 'json':
+        try:
+            from pythonjsonlogger import jsonlogger
+        except ModuleNotFoundError as e:
+            sys.stderr.write('ERROR: %s\n' % e)
+            sys.stderr.write('ERROR: Maybe try `pip install python-json-logger`?\n')
+            sys.exit(1)
+
+        logHandler = logging.StreamHandler()
+        formatter = jsonlogger.JsonFormatter()
+        for handler in logger.handlers:
+            if handler.name == "console":
+                handler.setFormatter(formatter)
 
     if ctx.verbose:
         for handler in logger.handlers:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -7674,7 +7674,7 @@ def main():
     except Error as e:
         if ctx.verbose:
             raise
-        sys.stderr.write('ERROR: %s\n' % e)
+        logger.error('ERROR: %s' % e)
         sys.exit(1)
     if not r:
         r = 0


### PR DESCRIPTION
adds json structured log output

Output on the console will look similar to the following:
```
$ ~/cephadm --format json bootstrap 
{"message": "\u001b[93mThis is a development version of cephadm.\u001b[0m"}
{"message": "\u001b[93mFor information regarding the latest stable release:\u001b[0m"}
{"message": "\u001b[93m    https://docs.ceph.com/docs/pacific/cephadm/install\u001b[0m"}
{"message": "Verifying podman|docker is present..."}
{"message": "Verifying lvm2 is present..."}
{"message": "Verifying time synchronization is in place..."}
{"message": "Unit chronyd.service is enabled and running"}
{"message": "Repeating the final host check..."}
{"message": "podman|docker (/usr/bin/podman) is present"}
{"message": "systemctl is present"}
{"message": "lvcreate is present"}
{"message": "Unit chronyd.service is enabled and running"}
{"message": "Host looks OK"}
{"message": "Cluster fsid: 71785ff0-6a69-11eb-8c17-8cdcd44b8f38"}
{"message": "ERROR: must specify --mon-ip or --mon-addrv\n"}
```

Does not affect the formatting of the log file: `/var/log/ceph/cephadm.log`

Downside is this uses a [library](https://github.com/madzak/python-json-logger) outside the python stdlib:
```
pip install python-json-logger
```

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
