### PR TITLE
mgr/rook: Add timezone info

### DIFF
--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -1,4 +1,3 @@
-import datetime
 import threading
 import functools
 import os
@@ -6,6 +5,7 @@ import json
 
 from ceph.deployment import inventory
 from ceph.deployment.service_spec import ServiceSpec, NFSServiceSpec, RGWSpec, PlacementSpec
+from ceph.utils import datetime_now
 
 from typing import List, Dict, Optional, Callable, Any, TypeVar, Tuple
 
@@ -263,7 +263,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
                          service_type: Optional[str] = None,
                          service_name: Optional[str] = None,
                          refresh: bool = False) -> List[orchestrator.ServiceDescription]:
-        now = datetime.datetime.utcnow()
+        now = datetime_now()
 
         # CephCluster
         cl = self.rook_cluster.rook_api_get(

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -22,6 +22,7 @@ from urllib3.exceptions import ProtocolError
 
 from ceph.deployment.drive_group import DriveGroupSpec
 from ceph.deployment.service_spec import ServiceSpec, NFSServiceSpec, RGWSpec
+from ceph.utils import datetime_now
 from mgr_util import merge_dicts
 
 from typing import Optional, TypeVar, List, Callable, Any, cast, Generic, \
@@ -325,7 +326,7 @@ class RookCluster(object):
                     return False
             return True
 
-        refreshed = datetime.datetime.utcnow()
+        refreshed = datetime_now()
         pods = [i for i in self.rook_pods.items if predicate(i)]
 
         pods_summary = []
@@ -356,13 +357,13 @@ class RookCluster(object):
                 'created': None,
             }
 
-            # note: we want UTC but no tzinfo
+            # note: we want UTC
             if d['metadata'].get('creation_timestamp', None):
                 s['created'] = d['metadata']['creation_timestamp'].astimezone(
-                    tz=datetime.timezone.utc).replace(tzinfo=None)
+                    tz=datetime.timezone.utc)
             if d['status'].get('start_time', None):
                 s['started'] = d['status']['start_time'].astimezone(
-                    tz=datetime.timezone.utc).replace(tzinfo=None)
+                    tz=datetime.timezone.utc)
 
             pods_summary.append(s)
 


### PR DESCRIPTION
Recently time zone info was added[1] to various properties like created,
started and others in cephadm and changes were made to orchestrator module too.
Let's add timezone info to rook as well, which will fix the type error.

[1] https://github.com/ceph/ceph/pull/37920

Fixes: https://tracker.ceph.com/issues/49126
Signed-off-by: Varsha Rao <varao@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---
-->
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
