### PR TITLE
ceph.spec.in: Enable tcmalloc and lttng on IBM Power and Z

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -24,7 +24,7 @@
 %bcond_with zbd
 %bcond_with cmake_verbose_logging
 %bcond_without ceph_test_package
-%ifarch s390 s390x
+%ifarch s390
 %bcond_with tcmalloc
 %else
 %bcond_without tcmalloc
@@ -48,7 +48,7 @@
 %bcond_with cephfs_java
 %bcond_with kafka_endpoint
 %bcond_with libradosstriper
-%ifarch x86_64 aarch64 ppc64le
+%ifarch x86_64 aarch64 ppc64le s390x
 %bcond_without lttng
 %else
 %bcond_with lttng

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -158,7 +158,11 @@ BuildRequires:	gcc-c++
 %endif
 BuildRequires:	gdbm
 %if 0%{with tcmalloc}
-%if 0%{?fedora} || 0%{?rhel}
+# libprofiler did not build on ppc64le until 2.7.90
+%if 0%{?fedora} || 0%{?rhel} >= 8
+BuildRequires:	gperftools-devel >= 2.7.90
+%endif
+%if 0%{?rhel} && 0%{?rhel} < 8
 BuildRequires:	gperftools-devel >= 2.6.1
 %endif
 %if 0%{?suse_version}
@@ -403,7 +407,7 @@ Requires:      python%{python3_pkgversion}-setuptools
 Requires:      util-linux
 Requires:      xfsprogs
 Requires:      which
-%if 0%{?fedora} || 0%{?rhel}
+%if 0%{?rhel} && 0%{?rhel} < 8
 # The following is necessary due to tracker 36508 and can be removed once the
 # associated upstream bugs are resolved.
 %if 0%{with tcmalloc}


### PR DESCRIPTION
Issues have been reported by IBM due to missing tcmalloc functionality 
on both Power and Z.  These commits fix that, but depend on an EPEL8 
update currently in testing:

https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2021-dd6932436d
