### PR TITLE
mgr/cephadm: based sleep interval on configured intervals/timeouts

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -97,7 +97,15 @@ class CephadmServe:
         self.log.debug("serve exit")
 
     def _serve_sleep(self) -> None:
-        sleep_interval = 600
+        sleep_interval = max(
+            30,
+            min(
+                self.mgr.host_check_interval,
+                self.mgr.facts_cache_timeout,
+                self.mgr.daemon_cache_timeout,
+                self.mgr.device_cache_timeout,
+            )
+        )
         self.log.debug('Sleeping for %d seconds', sleep_interval)
         ret = self.mgr.event.wait(sleep_interval)
         self.mgr.event.clear()


### PR DESCRIPTION
Set a semi-arbitrary floor of 15 seconds.

Signed-off-by: Sage Weil <sage@newdream.net>