### PR TITLE
cephadm: allow redeploy of daemons in error state if container running

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1972,6 +1972,13 @@ def check_units(ctx, units, enabler=None):
     return False
 
 
+def is_container_running(ctx: CephadmContext, name: str) -> bool:
+    out, err, ret = call_throws(ctx, [
+        ctx.container_path, 'ps',
+        '--format', '{{.Names}}'])
+    return name in out
+
+
 def get_legacy_config_fsid(cluster, legacy_dir=None):
     # type: (str, Optional[str]) -> Optional[str]
     config_file = '/etc/ceph/%s.conf' % cluster
@@ -3970,8 +3977,9 @@ def command_deploy(ctx):
 
     redeploy = False
     unit_name = get_unit_name(ctx.fsid, daemon_type, daemon_id)
+    container_name = 'ceph-%s-%s.%s' % (ctx.fsid, daemon_type, daemon_id)
     (_, state, _) = check_unit(ctx, unit_name)
-    if state == 'running':
+    if state == 'running' or is_container_running(ctx, container_name):
         redeploy = True
 
     if ctx.reconfig:


### PR DESCRIPTION
Signed-off-by: Adam King <adking@redhat.com>

Right now any daemon that is in an error state, has its container running and has ports to check cannot be redeployed as the binary will still consider it an initial deployment and check the ports which will be in use by the container. In situations like 
those described here https://tracker.ceph.com/issues/49013 where the error state is caused by a non-updated unit.run file a redeploy could fix the daemon. However, the redeploy would be blocked due to the ports being in use and the user would be required to manually go stop the services or fix the unit.run files. With this change, a situation like this could be fixed by simply redeploying the daemons using orchestrator commands instead.

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
