### PR TITLE
tools/kvstore-tool: implement 'histogram' command

### DIFF
--- a/doc/man/8/ceph-kvstore-tool.rst
+++ b/doc/man/8/ceph-kvstore-tool.rst
@@ -85,6 +85,9 @@ which are as follows:
     Format and information content may vary between releases. For RocksDB information includes
     compactions stats, performance counters, memory usage and internal RocksDB stats. 
 
+:command:`histogram`
+    Presents key-value sizes distribution statistics from the underlying KV database.
+
 Availability
 ============
 

--- a/src/kv/CMakeLists.txt
+++ b/src/kv/CMakeLists.txt
@@ -2,6 +2,7 @@ set(kv_srcs
   KeyValueDB.cc
   MemDB.cc
   RocksDBStore.cc
+  KeyValueHistogram.cc
   rocksdb_cache/ShardedCache.cc
   rocksdb_cache/BinnedLRUCache.cc)
 

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -264,6 +264,8 @@ public:
 
 private:
   // This class filters a WholeSpaceIterator by a prefix.
+  // Performs as a dummy wrapper over WholeSpaceIterator
+  // if prefix is empty
   class PrefixIteratorImpl : public IteratorImpl {
     const std::string prefix;
     WholeSpaceIterator generic_iter;
@@ -273,10 +275,14 @@ private:
     ~PrefixIteratorImpl() override { }
 
     int seek_to_first() override {
-      return generic_iter->seek_to_first(prefix);
+      return prefix.empty() ?
+	generic_iter->seek_to_first() :
+	generic_iter->seek_to_first(prefix);
     }
     int seek_to_last() override {
-      return generic_iter->seek_to_last(prefix);
+      return prefix.empty() ?
+	generic_iter->seek_to_last() :
+	generic_iter->seek_to_last(prefix);
     }
     int upper_bound(const std::string &after) override {
       return generic_iter->upper_bound(prefix, after);
@@ -287,7 +293,11 @@ private:
     bool valid() override {
       if (!generic_iter->valid())
 	return false;
-      return generic_iter->raw_key_is_prefixed(prefix);
+      if (prefix.empty())
+        return true;
+      return prefix.empty() ?
+	      true :
+	      generic_iter->raw_key_is_prefixed(prefix);
     }
     int next() override {
       return generic_iter->next();

--- a/src/kv/KeyValueHistogram.cc
+++ b/src/kv/KeyValueHistogram.cc
@@ -1,0 +1,78 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "include/stringify.h"
+#include "KeyValueHistogram.h"
+using std::map;
+using std::string;
+using ceph::Formatter;
+
+#define KEY_SLAB 32
+#define VALUE_SLAB 64
+
+int KeyValueHistogram::get_key_slab(size_t sz)
+{
+  return (sz / KEY_SLAB);
+}
+
+string KeyValueHistogram::get_key_slab_to_range(int slab)
+{
+  int lower_bound = slab * KEY_SLAB;
+  int upper_bound = (slab + 1) * KEY_SLAB;
+  string ret = "[" + stringify(lower_bound) + "," + stringify(upper_bound) + ")";
+  return ret;
+}
+
+int KeyValueHistogram::get_value_slab(size_t sz)
+{
+  return (sz / VALUE_SLAB);
+}
+
+string KeyValueHistogram::get_value_slab_to_range(int slab)
+{
+  int lower_bound = slab * VALUE_SLAB;
+  int upper_bound = (slab + 1) * VALUE_SLAB;
+  string ret = "[" + stringify(lower_bound) + "," + stringify(upper_bound) + ")";
+  return ret;
+}
+
+void KeyValueHistogram::update_hist_entry(map<string, map<int, struct key_dist> >& key_hist,
+  const string& prefix, size_t key_size, size_t value_size)
+{
+  uint32_t key_slab = get_key_slab(key_size);
+  uint32_t value_slab = get_value_slab(value_size);
+  key_hist[prefix][key_slab].count++;
+  key_hist[prefix][key_slab].max_len =
+    std::max<size_t>(key_size, key_hist[prefix][key_slab].max_len);
+  key_hist[prefix][key_slab].val_map[value_slab].count++;
+  key_hist[prefix][key_slab].val_map[value_slab].max_len =
+    std::max<size_t>(value_size,
+      key_hist[prefix][key_slab].val_map[value_slab].max_len);
+}
+
+void KeyValueHistogram::dump(Formatter* f)
+{
+  f->open_object_section("rocksdb_value_distribution");
+  for (auto i : value_hist) {
+    f->dump_unsigned(get_value_slab_to_range(i.first).data(), i.second);
+  }
+  f->close_section();
+
+  f->open_object_section("rocksdb_key_value_histogram");
+  for (auto i : key_hist) {
+    f->dump_string("prefix", i.first);
+    f->open_object_section("key_hist");
+    for (auto k : i.second) {
+      f->dump_unsigned(get_key_slab_to_range(k.first).data(), k.second.count);
+      f->dump_unsigned("max_len", k.second.max_len);
+      f->open_object_section("value_hist");
+      for (auto j : k.second.val_map) {
+        f->dump_unsigned(get_value_slab_to_range(j.first).data(), j.second.count);
+        f->dump_unsigned("max_len", j.second.max_len);
+      }
+      f->close_section();
+    }
+    f->close_section();
+  }
+  f->close_section();
+}

--- a/src/kv/KeyValueHistogram.h
+++ b/src/kv/KeyValueHistogram.h
@@ -1,0 +1,38 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#ifndef KeyValueHistogram_H
+#define KeyValueHistogram_H
+
+#include <map>
+#include <string>
+#include "common/Formatter.h"
+
+/**
+ *
+ * Key Value DB Histogram generator
+ *
+ */
+struct KeyValueHistogram {
+  struct value_dist {
+    uint64_t count;
+    uint32_t max_len;
+  };
+
+  struct key_dist {
+    uint64_t count;
+    uint32_t max_len;
+    std::map<int, struct value_dist> val_map; ///< slab id to count, max length of value and key
+  };
+
+  std::map<std::string, std::map<int, struct key_dist> > key_hist;
+  std::map<int, uint64_t> value_hist;
+  int get_key_slab(size_t sz);
+  std::string get_key_slab_to_range(int slab);
+  int get_value_slab(size_t sz);
+  std::string get_value_slab_to_range(int slab);
+  void update_hist_entry(std::map<std::string, std::map<int, struct key_dist> >& key_hist,
+    const std::string& prefix, size_t key_size, size_t value_size);
+  void dump(ceph::Formatter* f);
+};
+
+#endif

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1997,29 +1997,6 @@ public:
     }
   };
 
-  struct DBHistogram {
-    struct value_dist {
-      uint64_t count;
-      uint32_t max_len;
-    };
-
-    struct key_dist {
-      uint64_t count;
-      uint32_t max_len;
-      std::map<int, struct value_dist> val_map; ///< slab id to count, max length of value and key
-    };
-
-    std::map<std::string, std::map<int, struct key_dist> > key_hist;
-    std::map<int, uint64_t> value_hist;
-    int get_key_slab(size_t sz);
-    std::string get_key_slab_to_range(int slab);
-    int get_value_slab(size_t sz);
-    std::string get_value_slab_to_range(int slab);
-    void update_hist_entry(std::map<std::string, std::map<int, struct key_dist> > &key_hist,
-			  const std::string &prefix, size_t key_size, size_t value_size);
-    void dump(ceph::Formatter *f);
-  };
-
   struct BigDeferredWriteContext {
     uint64_t off = 0;     // original logical offset
     uint32_t b_off = 0;   // blob relative offset

--- a/src/test/cli/ceph-kvstore-tool/help.t
+++ b/src/test/cli/ceph-kvstore-tool/help.t
@@ -19,4 +19,5 @@
     compact-range <prefix> <start> <end>
     destructive-repair  (use only as last resort! may corrupt healthy data)
     stats
+    histogram [prefix]
   

--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -48,6 +48,7 @@ void usage(const char *pname)
     << "  compact-range <prefix> <start> <end>\n"
     << "  destructive-repair  (use only as last resort! may corrupt healthy data)\n"
     << "  stats\n"
+    << "  histogram [prefix]\n"
     << std::endl;
 }
 
@@ -347,6 +348,11 @@ int main(int argc, const char *argv[])
     st.compact_range(prefix, start, end);
   } else if (cmd == "stats") {
     st.print_stats();
+  } else if (cmd == "histogram") {
+    string prefix;
+    if (argc > 4)
+      prefix = url_unescape(argv[4]);
+    st.build_size_histogram(prefix);
   } else {
     std::cerr << "Unrecognized command: " << cmd << std::endl;
     return 1;

--- a/src/tools/kvstore_tool.h
+++ b/src/tools/kvstore_tool.h
@@ -77,4 +77,5 @@ public:
   int destructive_repair();
 
   int print_stats() const;
+  int build_size_histogram(const string& prefix) const;
 };


### PR DESCRIPTION
This command shows information on key/value counts and lengths for KV  DB.

Signed-off-by: Igor Fedotov <ifedotov@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
