### PR TITLE
luminous: ceph-kvstore-tool: use unique_ptr<> manage the lifecycle of bluestore…

### DIFF
--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -36,53 +36,54 @@ using namespace std;
 
 class StoreTool
 {
-  boost::scoped_ptr<BlueStore> bluestore;
-
-  // TODO: make KeyValueDB enable_shared_from_this
-  // bluestore will hold *db* also, use unique_ptr/shared_ptr will
-  // double free. 
-  KeyValueDB* db;
+#ifdef HAVE_LIBAIO
+  struct Deleter {
+    BlueStore *bluestore;
+    Deleter(BlueStore *store = nullptr)
+    : bluestore(store)
+    {}
+    void operator()(KeyValueDB *db) {
+      if (bluestore) {
+	bluestore->umount();
+	delete bluestore;
+      } else {
+	delete db;
+      }
+    }
+  };
+  std::unique_ptr<KeyValueDB, Deleter> db;
+#else
+  std::unique_ptr<KeyValueDB> db;
+#endif
 
   string store_path;
 
   public:
   StoreTool(string type, const string &path, bool need_open_db=true) : store_path(path) {
-    KeyValueDB *db_ptr;
     if (type == "bluestore-kv") {
 #ifdef HAVE_LIBAIO
       // note: we'll leak this!  the only user is ceph-kvstore-tool and
       // we don't care.
-      bluestore.reset(new BlueStore(g_ceph_context, path));
+      auto bluestore = new BlueStore(g_ceph_context, path);
+      KeyValueDB *db_ptr;
       int r = bluestore->start_kv_only(&db_ptr, need_open_db);
       if (r < 0) {
 	exit(1);
       }
+      db = decltype(db){db_ptr, Deleter(bluestore)};
 #else
       cerr << "bluestore not compiled in" << std::endl;
       exit(1);
 #endif
     } else {
-      db_ptr = KeyValueDB::create(g_ceph_context, type, path);
-      if (need_open_db) {
-        int r = db_ptr->open(std::cerr);
-        if (r < 0) {
-	  cerr << "failed to open type " << type << " path " << path << ": "
-	       << cpp_strerror(r) << std::endl;
-	  exit(1);
-	}
-	db = db_ptr;
+      auto db_ptr = KeyValueDB::create(g_ceph_context, type, path);
+      int r = db_ptr->open(std::cerr);
+      if (r < 0) {
+	cerr << "failed to open type " << type << " path " << path << ": "
+	     << cpp_strerror(r) << std::endl;
+	exit(1);
       }
-    }
-  }
-
-  ~StoreTool() {
-    if (bluestore) {
-      bluestore->umount();   
-    }
-    else {
-      if (db) {
-        delete db;
-      }
+      db.reset(db_ptr);
     }
   }
 


### PR DESCRIPTION
… and db

ceph-kvstore-tool segfaults while running against bluestore-kv without this patch.

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 8dc100d3f334cc90f6ef879a33eea34807c0184f)

 Conflicts:
	src/tools/ceph_kvstore_tool.cc


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
