### PR TITLE
rgw multisite: add bucket log generation to datalog entries

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1061,7 +1061,9 @@ int RGWBucket::sync(RGWBucketAdminOpState& op_state, map<string, bufferlist> *at
   }
 
   for (int i = 0; i < shards_num; ++i, ++shard_id) {
-    r = store->svc()->datalog_rados->add_entry(dpp, bucket_info, shard_id);
+    r = store->svc()->datalog_rados->add_entry(dpp, bucket_info,
+					       bucket_info.layout.logs.back(),
+					       shard_id);
     if (r < 0) {
       set_err_msg(err_msg, "ERROR: failed writing data log:" + cpp_strerror(-r));
       return r;

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1233,8 +1233,7 @@ class RGWRunBucketSourcesSyncCR : public RGWCoroutine {
   int num_shards{0};
   int cur_shard{0};
   bool again = false;
-  std::uint64_t syncing_gen = 0; // TODO: Fill this in from bucket sync status
-  std::optional<uint64_t> entry_gen;
+  std::optional<uint64_t> gen;
 
 public:
   RGWRunBucketSourcesSyncCR(RGWDataSyncCtx *_sc,
@@ -1242,7 +1241,7 @@ public:
                             std::optional<rgw_bucket_shard> _target_bs,
                             std::optional<rgw_bucket_shard> _source_bs,
                             const RGWSyncTraceNodeRef& _tn_parent,
-			    std::optional<uint64_t> entry_gen,
+			    std::optional<uint64_t> gen,
                             ceph::real_time* progress);
 
   int operate() override;
@@ -4578,6 +4577,7 @@ std::ostream& operator<<(std::ostream& out, std::optional<rgw_bucket_shard>& bs)
 static RGWCoroutine* sync_bucket_shard_cr(RGWDataSyncCtx* sc,
                                           boost::intrusive_ptr<const RGWContinuousLeaseCR> lease,
                                           const rgw_bucket_sync_pair_info& sync_pair,
+                                          std::optional<uint64_t> gen,
                                           const RGWSyncTraceNodeRef& tn,
                                           ceph::real_time* progress);
 
@@ -4586,7 +4586,7 @@ RGWRunBucketSourcesSyncCR::RGWRunBucketSourcesSyncCR(RGWDataSyncCtx *_sc,
                                                      std::optional<rgw_bucket_shard> _target_bs,
                                                      std::optional<rgw_bucket_shard> _source_bs,
                                                      const RGWSyncTraceNodeRef& _tn_parent,
-						     std::optional<uint64_t> entry_gen,
+						     std::optional<uint64_t> gen,
                                                      ceph::real_time* progress)
   : RGWCoroutine(_sc->env->cct), sc(_sc), sync_env(_sc->env),
     lease_cr(std::move(lease_cr)), target_bs(_target_bs), source_bs(_source_bs),
@@ -4596,7 +4596,7 @@ RGWRunBucketSourcesSyncCR::RGWRunBucketSourcesSyncCR(RGWDataSyncCtx *_sc,
 	       ":source_bucket=" << source_bucket.value_or(rgw_bucket()) <<
 	       ":source_zone=" << sc->source_zone))),
     progress(progress),
-    entry_gen(entry_gen)
+    gen(gen)
 {
   if (target_bs) {
     target_bucket = target_bs->bucket;
@@ -4627,15 +4627,6 @@ int RGWRunBucketSourcesSyncCR::operate()
         ldpp_dout(sync_env->dpp, 20) << __func__ << "(): sync pipe=" << *siter << dendl;
 
         source_num_shards = siter->source.get_bucket_info().layout.current_index.layout.normal.num_shards;
-	if (entry_gen) {
-	  if (*entry_gen > syncing_gen) {
-	    tn->log(10, "Future generation in datalog entry. Returning error so we'll retry.");
-	    return set_cr_error(-EAGAIN);
-	  } else if (*entry_gen < syncing_gen) {
-	    tn->log(10, "Future generation in datalog entry. Returning error so we'll retry.");
-	    return 0;
-	  }
-	}
 	target_num_shards = siter->target.get_bucket_info().layout.current_index.layout.normal.num_shards;
         if (source_bs) {
           sync_pair.source_bs = *source_bs;
@@ -4673,8 +4664,8 @@ int RGWRunBucketSourcesSyncCR::operate()
 
         cur_progress = (progress ? &shard_progress[prealloc_stack_id()] : nullptr);
 
-        yield_spawn_window(sync_bucket_shard_cr(sc, lease_cr, sync_pair, tn,
-                                                cur_progress),
+        yield_spawn_window(sync_bucket_shard_cr(sc, lease_cr, sync_pair,
+                                                gen, tn, cur_progress),
                            BUCKET_SYNC_SPAWN_WINDOW,
                            [&](uint64_t stack_id, int ret) {
                              handle_complete_stack(stack_id);
@@ -5047,6 +5038,7 @@ class RGWSyncBucketCR : public RGWCoroutine {
   boost::intrusive_ptr<RGWContinuousLeaseCR> bucket_lease_cr;
   rgw_bucket_sync_pair_info sync_pair;
   rgw_bucket_sync_pipe sync_pipe;
+  std::optional<uint64_t> gen;
   ceph::real_time* progress;
 
   const std::string lock_name = "bucket sync";
@@ -5062,10 +5054,12 @@ public:
   RGWSyncBucketCR(RGWDataSyncCtx *_sc,
                   boost::intrusive_ptr<const RGWContinuousLeaseCR> lease_cr,
                   const rgw_bucket_sync_pair_info& _sync_pair,
+                  std::optional<uint64_t> gen,
                   const RGWSyncTraceNodeRef& _tn_parent,
                   ceph::real_time* progress)
     : RGWCoroutine(_sc->cct), sc(_sc), env(_sc->env),
-      data_lease_cr(std::move(lease_cr)), sync_pair(_sync_pair), progress(progress),
+      data_lease_cr(std::move(lease_cr)), sync_pair(_sync_pair),
+      gen(gen), progress(progress),
       lock_duration(cct->_conf->rgw_sync_lease_period),
       status_obj(env->svc->zone->get_zone_params().log_pool,
                  RGWBucketPipeSyncStatusManager::full_status_oid(sc->source_zone,
@@ -5081,10 +5075,12 @@ public:
 static RGWCoroutine* sync_bucket_shard_cr(RGWDataSyncCtx* sc,
                                           boost::intrusive_ptr<const RGWContinuousLeaseCR> lease,
                                           const rgw_bucket_sync_pair_info& sync_pair,
+                                          std::optional<uint64_t> gen,
                                           const RGWSyncTraceNodeRef& tn,
                                           ceph::real_time* progress)
 {
-  return new RGWSyncBucketCR(sc, std::move(lease), sync_pair, tn, progress);
+  return new RGWSyncBucketCR(sc, std::move(lease), sync_pair,
+                             gen, tn, progress);
 }
 
 int RGWSyncBucketCR::operate()
@@ -5197,6 +5193,24 @@ int RGWSyncBucketCR::operate()
           drain_all();
           bucket_lease_cr.reset();
         }
+
+        // if a specific gen was requested, compare that to the sync status
+        if (gen) {
+          const auto current_gen = bucket_status.incremental_gen;
+          if (*gen > current_gen) {
+            retcode = -EAGAIN;
+            tn->log(10, SSTR("requested sync of future generation "
+                             << *gen << " > " << current_gen
+                             << ", returning " << retcode << " for later retry"));
+            return set_cr_error(retcode);
+          } else if (*gen < current_gen) {
+            tn->log(10, SSTR("requested sync of past generation "
+                             << *gen << " < " << current_gen
+                             << ", returning success"));
+            return set_cr_done();
+          }
+        }
+
         yield call(new RGWSyncBucketShardCR(sc, data_lease_cr, sync_pair,
                                             sync_pipe, bucket_status.state,
                                             tn, progress));
@@ -5219,7 +5233,9 @@ RGWCoroutine *RGWRemoteBucketManager::run_sync_cr(int num)
     return nullptr;
   }
 
-  return sync_bucket_shard_cr(&sc, nullptr, sync_pairs[num], sync_env->sync_tracer->root_node, nullptr);
+  constexpr std::optional<uint64_t> gen; // sync current gen
+  return sync_bucket_shard_cr(&sc, nullptr, sync_pairs[num], gen,
+                              sync_env->sync_tracer->root_node, nullptr);
 }
 
 int RGWBucketPipeSyncStatusManager::init()

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1735,7 +1735,7 @@ public:
           if (!marker_tracker->start(log_iter->log_id, 0, log_iter->log_timestamp)) {
             tn->log(0, SSTR("ERROR: cannot start syncing " << log_iter->log_id << ". Duplicate entry?"));
           } else {
-            spawn(sync_single_entry(source_bs, std::nullopt, log_iter->log_id,
+            spawn(sync_single_entry(source_bs, log_iter->entry.gen, log_iter->log_id,
                                     log_iter->log_timestamp, false), false);
           }
 

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -280,7 +280,7 @@ public:
 struct read_remote_data_log_response {
   string marker;
   bool truncated;
-  list<rgw_data_change_log_entry> entries;
+  vector<rgw_data_change_log_entry> entries;
 
   read_remote_data_log_response() : truncated(false) {}
 
@@ -300,7 +300,7 @@ class RGWReadRemoteDataLogShardCR : public RGWCoroutine {
   int shard_id;
   const std::string& marker;
   string *pnext_marker;
-  list<rgw_data_change_log_entry> *entries;
+  vector<rgw_data_change_log_entry> *entries;
   bool *truncated;
 
   read_remote_data_log_response response;
@@ -309,7 +309,7 @@ class RGWReadRemoteDataLogShardCR : public RGWCoroutine {
 public:
   RGWReadRemoteDataLogShardCR(RGWDataSyncCtx *_sc, int _shard_id,
                               const std::string& marker, string *pnext_marker,
-                              list<rgw_data_change_log_entry> *_entries,
+                              vector<rgw_data_change_log_entry> *_entries,
                               bool *_truncated)
     : RGWCoroutine(_sc->cct), sc(_sc), sync_env(_sc->env),
       shard_id(_shard_id), marker(marker), pnext_marker(pnext_marker),
@@ -1415,8 +1415,8 @@ class RGWDataSyncShardCR : public RGWCoroutine {
   std::optional<RGWDataSyncShardMarkerTrack> marker_tracker;
 
   std::string next_marker;
-  list<rgw_data_change_log_entry> log_entries;
-  list<rgw_data_change_log_entry>::iterator log_iter;
+  vector<rgw_data_change_log_entry> log_entries;
+  vector<rgw_data_change_log_entry>::iterator log_iter;
   bool truncated = false;
 
   ceph::mutex inc_lock = ceph::make_mutex("RGWDataSyncShardCR::inc_lock");
@@ -3290,7 +3290,7 @@ class RGWReadPendingBucketShardsCoroutine : public RGWCoroutine {
   int count;
 
   std::string next_marker;
-  list<rgw_data_change_log_entry> log_entries;
+  vector<rgw_data_change_log_entry> log_entries;
   bool truncated;
 
 public:

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1233,6 +1233,8 @@ class RGWRunBucketSourcesSyncCR : public RGWCoroutine {
   int num_shards{0};
   int cur_shard{0};
   bool again = false;
+  std::uint64_t syncing_gen = 0; // TODO: Fill this in from bucket sync status
+  std::optional<uint64_t> entry_gen;
 
 public:
   RGWRunBucketSourcesSyncCR(RGWDataSyncCtx *_sc,
@@ -1240,6 +1242,7 @@ public:
                             std::optional<rgw_bucket_shard> _target_bs,
                             std::optional<rgw_bucket_shard> _source_bs,
                             const RGWSyncTraceNodeRef& _tn_parent,
+			    std::optional<uint64_t> entry_gen,
                             ceph::real_time* progress);
 
   int operate() override;
@@ -1326,7 +1329,9 @@ public:
               << ' ' << *state->obligation << dendl;
           yield call(new RGWRunBucketSourcesSyncCR(sc, lease_cr,
                                                    std::nullopt, /* target_bs */
-                                                   state->key, tn, &progress));
+                                                   state->key, tn,
+                                                   state->obligation->gen,
+						   &progress));
           if (retcode < 0) {
             break;
           }
@@ -4581,12 +4586,17 @@ RGWRunBucketSourcesSyncCR::RGWRunBucketSourcesSyncCR(RGWDataSyncCtx *_sc,
                                                      std::optional<rgw_bucket_shard> _target_bs,
                                                      std::optional<rgw_bucket_shard> _source_bs,
                                                      const RGWSyncTraceNodeRef& _tn_parent,
+						     std::optional<uint64_t> entry_gen,
                                                      ceph::real_time* progress)
   : RGWCoroutine(_sc->env->cct), sc(_sc), sync_env(_sc->env),
     lease_cr(std::move(lease_cr)), target_bs(_target_bs), source_bs(_source_bs),
-    tn(sync_env->sync_tracer->add_node(_tn_parent, "bucket_sync_sources",
-                                       SSTR( "target=" << target_bucket.value_or(rgw_bucket()) << ":source_bucket=" << source_bucket.value_or(rgw_bucket()) << ":source_zone=" << sc->source_zone))),
-    progress(progress)
+    tn(sync_env->sync_tracer->add_node(
+	 _tn_parent, "bucket_sync_sources",
+	 SSTR( "target=" << target_bucket.value_or(rgw_bucket()) <<
+	       ":source_bucket=" << source_bucket.value_or(rgw_bucket()) <<
+	       ":source_zone=" << sc->source_zone))),
+    progress(progress),
+    entry_gen(entry_gen)
 {
   if (target_bs) {
     target_bucket = target_bs->bucket;
@@ -4617,7 +4627,16 @@ int RGWRunBucketSourcesSyncCR::operate()
         ldpp_dout(sync_env->dpp, 20) << __func__ << "(): sync pipe=" << *siter << dendl;
 
         source_num_shards = siter->source.get_bucket_info().layout.current_index.layout.normal.num_shards;
-        target_num_shards = siter->target.get_bucket_info().layout.current_index.layout.normal.num_shards;
+	if (entry_gen) {
+	  if (*entry_gen > syncing_gen) {
+	    tn->log(10, "Future generation in datalog entry. Returning error so we'll retry.");
+	    return set_cr_error(-EAGAIN);
+	  } else if (*entry_gen < syncing_gen) {
+	    tn->log(10, "Future generation in datalog entry. Returning error so we'll retry.");
+	    return 0;
+	  }
+	}
+	target_num_shards = siter->target.get_bucket_info().layout.current_index.layout.normal.num_shards;
         if (source_bs) {
           sync_pair.source_bs = *source_bs;
         } else {

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -611,7 +611,7 @@ void decode_json_obj(BucketSyncState& state, JSONObj *obj);
 struct rgw_bucket_sync_status {
   BucketSyncState state = BucketSyncState::Init;
   rgw_bucket_full_sync_status full;
-  uint64_t incremental_gen;
+  uint64_t incremental_gen = 0;
   std::vector<bool> shards_done_with_gen;
 
   void encode(bufferlist& bl) const {

--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -35,6 +35,7 @@ void rgw_data_change::dump(ceph::Formatter *f) const
   encode_json("key", key, f);
   utime_t ut(timestamp);
   encode_json("timestamp", ut, f);
+  encode_json("gen_id", gen_id, f);
 }
 
 void rgw_data_change::decode_json(JSONObj *obj) {
@@ -49,6 +50,7 @@ void rgw_data_change::decode_json(JSONObj *obj) {
   utime_t ut;
   JSONDecoder::decode_json("timestamp", ut, obj);
   timestamp = ut.to_real_time();
+  JSONDecoder::decode_json("gen_id", gen_id, obj);
 }
 
 void rgw_data_change_log_entry::dump(Formatter *f) const

--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -36,7 +36,7 @@ void rgw_data_change::dump(ceph::Formatter *f) const
   encode_json("key", key, f);
   utime_t ut(timestamp);
   encode_json("timestamp", ut, f);
-  encode_json("gen_id", gen_id, f);
+  encode_json("gen", gen, f);
 }
 
 void rgw_data_change::decode_json(JSONObj *obj) {
@@ -51,7 +51,7 @@ void rgw_data_change::decode_json(JSONObj *obj) {
   utime_t ut;
   JSONDecoder::decode_json("timestamp", ut, obj);
   timestamp = ut.to_real_time();
-  JSONDecoder::decode_json("gen_id", gen_id, obj);
+  JSONDecoder::decode_json("gen", gen, obj);
 }
 
 void rgw_data_change_log_entry::dump(Formatter *f) const
@@ -613,7 +613,7 @@ int RGWDataChangesLog::renew_entries()
   l.unlock();
 
   auto ut = real_clock::now();
-  for (const auto& [bs, gen_id] : entries) {
+  for (const auto& [bs, gen] : entries) {
     auto index = choose_oid(bs);
 
     rgw_data_change change;
@@ -621,7 +621,7 @@ int RGWDataChangesLog::renew_entries()
     change.entity_type = ENTITY_TYPE_BUCKET;
     change.key = bs.get_key();
     change.timestamp = ut;
-    change.gen_id = gen_id;
+    change.gen = gen;
     encode(change, bl);
 
     m[index].first.push_back(bs);
@@ -780,7 +780,7 @@ int RGWDataChangesLog::add_entry(const DoutPrefixProvider *dpp,
     change.entity_type = ENTITY_TYPE_BUCKET;
     change.key = bs.get_key();
     change.timestamp = now;
-    change.gen_id = gen.gen;
+    change.gen = gen.gen;
     encode(change, bl);
 
     ldout(cct, 20) << "RGWDataChangesLog::add_entry() sending update with now=" << now << " cur_expiration=" << expiration << dendl;

--- a/src/rgw/rgw_datalog.h
+++ b/src/rgw/rgw_datalog.h
@@ -50,7 +50,7 @@ struct rgw_data_change {
   DataLogEntityType entity_type;
   std::string key;
   ceph::real_time timestamp;
-  uint64_t gen_id;
+  uint64_t gen = 0;
 
   void encode(ceph::buffer::list& bl) const {
     ENCODE_START(2, 2, bl);
@@ -58,7 +58,7 @@ struct rgw_data_change {
     encode(t, bl);
     encode(key, bl);
     encode(timestamp, bl);
-    encode(gen_id, bl);
+    encode(gen, bl);
     ENCODE_FINISH(bl);
   }
 
@@ -70,9 +70,9 @@ struct rgw_data_change {
      decode(key, bl);
      decode(timestamp, bl);
      if (struct_v < 2)
-       gen_id = 0;
+       gen = 0;
      else
-       decode(gen_id, bl);
+       decode(gen, bl);
      DECODE_FINISH(bl);
   }
 

--- a/src/rgw/rgw_datalog.h
+++ b/src/rgw/rgw_datalog.h
@@ -50,23 +50,29 @@ struct rgw_data_change {
   DataLogEntityType entity_type;
   std::string key;
   ceph::real_time timestamp;
+  uint64_t gen_id;
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 2, bl);
     auto t = std::uint8_t(entity_type);
     encode(t, bl);
     encode(key, bl);
     encode(timestamp, bl);
+    encode(gen_id, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::const_iterator& bl) {
-     DECODE_START(1, bl);
+     DECODE_START(2, bl);
      std::uint8_t t;
      decode(t, bl);
      entity_type = DataLogEntityType(t);
      decode(key, bl);
      decode(timestamp, bl);
+     if (struct_v < 2)
+       gen_id = 0;
+     else
+       decode(gen_id, bl);
      DECODE_FINISH(bl);
   }
 

--- a/src/rgw/rgw_datalog.h
+++ b/src/rgw/rgw_datalog.h
@@ -53,7 +53,9 @@ struct rgw_data_change {
   uint64_t gen = 0;
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(2, 2, bl);
+    // require decoders to recognize v2 when gen>0
+    const uint8_t compat = (gen == 0) ? 1 : 2;
+    ENCODE_START(2, compat, bl);
     auto t = std::uint8_t(entity_type);
     encode(t, bl);
     encode(key, bl);
@@ -69,10 +71,11 @@ struct rgw_data_change {
      entity_type = DataLogEntityType(t);
      decode(key, bl);
      decode(timestamp, bl);
-     if (struct_v < 2)
+     if (struct_v < 2) {
        gen = 0;
-     else
+     } else {
        decode(gen, bl);
+     }
      DECODE_FINISH(bl);
   }
 

--- a/src/rgw/rgw_datalog.h
+++ b/src/rgw/rgw_datalog.h
@@ -199,10 +199,11 @@ class RGWDataChangesLog {
 
   lru_map<rgw_bucket_shard, ChangeStatusPtr> changes;
 
-  bc::flat_set<rgw_bucket_shard> cur_cycle;
+  bc::flat_set<std::pair<rgw_bucket_shard, uint64_t>> cur_cycle;
 
   void _get_change(const rgw_bucket_shard& bs, ChangeStatusPtr& status);
-  void register_renew(const rgw_bucket_shard& bs);
+  void register_renew(const rgw_bucket_shard& bs,
+		      const rgw::bucket_log_layout_generation& gen);
   void update_renewed(const rgw_bucket_shard& bs, ceph::real_time expiration);
 
   ceph::mutex renew_lock = ceph::make_mutex("ChangesRenewThread::lock");
@@ -225,7 +226,8 @@ public:
   int start(const RGWZone* _zone, const RGWZoneParams& zoneparams,
 	    RGWSI_Cls *cls_svc, librados::Rados* lr);
 
-  int add_entry(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info, int shard_id);
+  int add_entry(const DoutPrefixProvider *dpp, const RGWBucketInfo& bucket_info,
+		const rgw::bucket_log_layout_generation& gen, int shard_id);
   int get_log_shard_id(rgw_bucket& bucket, int shard_id);
   int list_entries(int shard, int max_entries,
 		   std::vector<rgw_data_change_log_entry>& entries,

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -859,7 +859,9 @@ int RGWIndexCompletionThread::process()
       /* ignoring error, can't do anything about it */
       continue;
     }
-    r = store->svc.datalog_rados->add_entry(this, bucket_info, bs.shard_id);
+    r = store->svc.datalog_rados->add_entry(this, bucket_info,
+					    bucket_info.layout.logs.back(),
+					    bs.shard_id);
     if (r < 0) {
       lderr(store->ctx()) << "ERROR: failed writing data log" << dendl;
     }
@@ -5038,7 +5040,9 @@ int RGWRados::Object::Delete::delete_obj(optional_yield y, const DoutPrefixProvi
       return r;
     }
 
-    r = store->svc.datalog_rados->add_entry(dpp, target->bucket_info, bs->shard_id);
+    r = store->svc.datalog_rados->add_entry(dpp, target->bucket_info,
+					    target->bucket_info.layout.logs.back(),
+					    bs->shard_id);
     if (r < 0) {
       lderr(store->ctx()) << "ERROR: failed writing data log" << dendl;
       return r;
@@ -6108,7 +6112,9 @@ int RGWRados::Bucket::UpdateIndex::complete(const DoutPrefixProvider *dpp, int64
 
   ret = store->cls_obj_complete_add(*bs, obj, optag, poolid, epoch, ent, category, remove_objs, bilog_flags, zones_trace);
 
-  int r = store->svc.datalog_rados->add_entry(dpp, target->bucket_info, bs->shard_id);
+  int r = store->svc.datalog_rados->add_entry(dpp, target->bucket_info,
+					      target->bucket_info.layout.logs.back(),
+					      bs->shard_id);
   if (r < 0) {
     lderr(store->ctx()) << "ERROR: failed writing data log" << dendl;
   }
@@ -6135,7 +6141,9 @@ int RGWRados::Bucket::UpdateIndex::complete_del(const DoutPrefixProvider *dpp,
 
   ret = store->cls_obj_complete_del(*bs, optag, poolid, epoch, obj, removed_mtime, remove_objs, bilog_flags, zones_trace);
 
-  int r = store->svc.datalog_rados->add_entry(dpp, target->bucket_info, bs->shard_id);
+  int r = store->svc.datalog_rados->add_entry(dpp, target->bucket_info,
+					      target->bucket_info.layout.logs.back(),
+					      bs->shard_id);
   if (r < 0) {
     lderr(store->ctx()) << "ERROR: failed writing data log" << dendl;
   }
@@ -6161,7 +6169,9 @@ int RGWRados::Bucket::UpdateIndex::cancel(const DoutPrefixProvider *dpp)
    * for following the specific bucket shard log. Otherwise they end up staying behind, and users
    * have no way to tell that they're all caught up
    */
-  int r = store->svc.datalog_rados->add_entry(dpp, target->bucket_info, bs->shard_id);
+  int r = store->svc.datalog_rados->add_entry(dpp, target->bucket_info,
+					      target->bucket_info.layout.logs.back(),
+					      bs->shard_id);
   if (r < 0) {
     lderr(store->ctx()) << "ERROR: failed writing data log" << dendl;
   }
@@ -6795,7 +6805,9 @@ int RGWRados::bucket_index_link_olh(const DoutPrefixProvider *dpp, RGWBucketInfo
     return r;
   }
 
-  r = svc.datalog_rados->add_entry(dpp, bucket_info, bs.shard_id);
+  r = svc.datalog_rados->add_entry(dpp, bucket_info,
+				   bucket_info.layout.logs.back(),
+				   bs.shard_id);
   if (r < 0) {
     ldout(cct, 0) << "ERROR: failed writing data log" << dendl;
   }

--- a/src/rgw/services/svc_bi_rados.cc
+++ b/src/rgw/services/svc_bi_rados.cc
@@ -475,7 +475,8 @@ int RGWSI_BucketIndex_RADOS::handle_overwrite(const DoutPrefixProvider *dpp,
     }
 
     for (int i = 0; i < shards_num; ++i, ++shard_id) {
-      ret = svc.datalog_rados->add_entry(dpp, info, shard_id);
+      ret = svc.datalog_rados->add_entry(dpp, info, info.layout.logs.back(),
+					 shard_id);
       if (ret < 0) {
         lderr(cct) << "ERROR: failed writing data log (info.bucket=" << info.bucket << ", shard_id=" << shard_id << ")" << dendl;
         return ret;
@@ -485,4 +486,3 @@ int RGWSI_BucketIndex_RADOS::handle_overwrite(const DoutPrefixProvider *dpp,
 
   return 0;
 }
-


### PR DESCRIPTION
rebased version of https://github.com/ceph/ceph/pull/38561 with additional fixes

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
