### PR TITLE
nautilus: qa/tasks/mgr/test_progress: fix wait_until_equal

### DIFF
--- a/qa/tasks/mgr/test_progress.py
+++ b/qa/tasks/mgr/test_progress.py
@@ -166,8 +166,7 @@ class TestProgress(MgrTestCase):
 
         # Wait for a progress event to pop up
         self.wait_until_equal(lambda: self._osd_in_out_events_count('out'), 1,
-                              timeout=self.EVENT_CREATION_PERIOD*2,
-                              period=1)
+                              timeout=self.EVENT_CREATION_PERIOD*2)
         ev = self._get_osd_in_out_events('out')[0]
         log.info(json.dumps(ev, indent=1))
         self.assertIn("Rebalancing after osd.0 marked out", ev['message'])
@@ -182,13 +181,12 @@ class TestProgress(MgrTestCase):
         
         # First Event should complete promptly
         self.wait_until_true(lambda: self._is_complete(initial_event['id']),
-                             timeout=self.EVENT_CREATION_PERIOD)
+                             timeout=self.RECOVERY_PERIOD)
 
         try:
             # Wait for progress event marked in to pop up
             self.wait_until_equal(lambda: self._osd_in_out_events_count('in'), 1,
-                                  timeout=self.EVENT_CREATION_PERIOD*2,
-                                  period=1)
+                                  timeout=self.EVENT_CREATION_PERIOD*2)
         except RuntimeError as ex:
             if not "Timed out after" in str(ex):
                 raise ex
@@ -261,7 +259,7 @@ class TestProgress(MgrTestCase):
 
         # Event should complete promptly
         self.wait_until_true(lambda: self._is_complete(ev['id']),
-                             timeout=self.EVENT_CREATION_PERIOD)
+                             timeout=self.RECOVERY_PERIOD)
         self.assertTrue(self._is_quiet())
 
     def test_osd_came_back(self):
@@ -365,8 +363,8 @@ class TestProgress(MgrTestCase):
                 'osd', 'out', '0')
 
         # Wait for a progress event to pop up
-        self.wait_until_equal(lambda: len(self._all_events()), 1,
-                              timeout=self.EVENT_CREATION_PERIOD*2)
+        self.wait_until_equal(lambda: self._osd_in_out_events_count('out'), 1,
+                              timeout=self.RECOVERY_PERIOD)
 
         ev = self._all_events()[0]
 

--- a/qa/tasks/mgr/test_progress.py
+++ b/qa/tasks/mgr/test_progress.py
@@ -183,7 +183,7 @@ class TestProgress(MgrTestCase):
         # First Event should complete promptly
         self.wait_until_true(lambda: self._is_complete(initial_event['id']),
                              timeout=self.EVENT_CREATION_PERIOD)
-       
+
         try:
             # Wait for progress event marked in to pop up
             self.wait_until_equal(lambda: self._osd_in_out_events_count('in'), 1,
@@ -274,10 +274,11 @@ class TestProgress(MgrTestCase):
         ev1 = self._simulate_failure()
 
         ev2 = self._simulate_back_in([0], ev1)
-        
-        # Wait for progress event to ultimately complete
-        self.wait_until_true(lambda: self._is_complete(ev2['id']),
-                             timeout=self.RECOVERY_PERIOD)
+
+        if ev2 is not None:
+            # Wait for progress event to ultimately complete
+            self.wait_until_true(lambda: self._is_complete(ev2['id']),
+                                 timeout=self.RECOVERY_PERIOD)
 
         self.assertTrue(self._is_quiet())
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/50006

---

Nautilus ceph_test_case doesn't have period arg
so remove that in wait_until_equal. Also, increase
time to wait for complete events by using RECOVERY_PERIOD
instead of EVENT_CREATION_PERIOD

Also, Nautilus is missing the commit: 
b03537949abd8d453aa06c1580a4578868904bd1
This is a fix to this issue:
https://tracker.ceph.com/issues/40618

backporting the relevant commits from Octopus PRs:
#39360
backporting relevant commits from master PRs:
#30095

Fixes: https://tracker.ceph.com/issues/48824

Signed-off-by: Kamoltat ksirivad@redhat.com
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
