### PR TITLE
cephadm: make /sys/fs/selinux empty

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2233,6 +2233,8 @@ def get_container_mounts(ctx, fsid, daemon_type, daemon_id,
         mounts['/run/udev'] = '/run/udev'
     if daemon_type == 'osd':
         mounts['/sys'] = '/sys'  # for numa.cc, pick_address, cgroups, ...
+        # selinux-policy in the container may not match the host.
+        mounts['/usr/share/empty'] = '/sys/fs/selinux:ro'
         mounts['/run/lvm'] = '/run/lvm'
         mounts['/run/lock/lvm'] = '/run/lock/lvm'
 


### PR DESCRIPTION
When the following conditions are true:

  1) A host has `selinux-policy-targeted`,
  2) We mount the host's `/sys` into a privileged container,
  3) The container has `SELINUXTYPE=targeted` in `/etc/selinux/config`,
  4) The container does not have an `selinux-policy-targeted` package,

then SELinux-enabled applications like restorecon or DNF do not work inside the container.

Resolve this by making `/sys/fs/selinux` an empty directory.

https://tracker.ceph.com/issues/49239

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>