### PR TITLE
qa/tasks/cephadm: fix compressing logs

### DIFF
--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -232,8 +232,8 @@ def ceph_log(ctx, config):
             log.info('Compressing logs...')
             ctx.cluster.sh(
                 'sudo find /var/log/ceph -name *.log -print0 | '
-                'sudo xargs -0 --no-run-if-empty -- gzip --',
-                wait=False)
+                'sudo xargs -0 --no-run-if-empty -- gzip --'
+            )
 
             log.info('Archiving logs...')
             path = os.path.join(ctx.archive, 'remote')


### PR DESCRIPTION
We need to wait for logs to compress before copying them.

Fixes: 6d7ba1180e66df2d6dee3a01fe3e12cafaa6fe8c
Signed-off-by: Sage Weil <sage@newdream.net>