### PR TITLE
python-common: Verify data_devices is not None

### DIFF
--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -284,6 +284,9 @@ class DriveGroupSpec(ServiceSpec):
                 self.placement.host_pattern is not None:
             raise DriveGroupValidationError('host_pattern must be of type string')
 
+        if self.data_devices is None:
+            raise DriveGroupValidationError("`data_devices` element is required.")
+
         specs = [self.data_devices, self.db_devices, self.wal_devices, self.journal_devices]
         for s in filter(None, specs):
             s.validate()

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -489,6 +489,10 @@ class ServiceSpec(object):
         :param json_spec: A valid dict with ServiceSpec
         """
 
+        if not isinstance(json_spec, dict):
+            raise ServiceSpecValidationError(
+                f'Service Spec is not an (JSON or YAML) object. got "{str(json_spec)}"')
+
         c = json_spec.copy()
 
         # kludge to make `from_json` compatible to `Orchestrator.describe_service`

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -30,22 +30,24 @@ def test_DriveGroup(test_input):
     assert all([isinstance(x, Device) for x in dg.data_devices.paths])
     assert dg.data_devices.paths[0].path == '/dev/sda'
 
-@pytest.mark.parametrize("test_input",
+@pytest.mark.parametrize("match,test_input",
 [
     (
-        {}
+        "Failed to validate Drive Group: OSD spec needs a `placement` key.",
+        '{}'
     ),
     (
-        yaml.safe_load("""
+        'Failed to validate Drive Group: DeviceSelection cannot be empty', """
 service_type: osd
 service_id: mydg
 placement:
   host_pattern: '*'
 data_devices:
   limit: 1
-"""),
-
-        yaml.safe_load("""
+"""
+    ),
+    (
+        'Failed to validate Drive Group: filter_logic must be either <AND> or <OR>', """
 service_type: osd
 service_id: mydg
 placement:
@@ -53,13 +55,24 @@ placement:
 data_devices:
   all: True
 filter_logic: XOR
-""")
-    )
+"""
+    ),
+    (
+        'Failed to validate Drive Group: `data_devices` element is required.', """
+service_type: osd
+service_id: mydg
+placement:
+  host_pattern: '*'
+spec:
+  db_devices:
+    model: model
+"""
+    ),
 ])
-def test_DriveGroup_fail(test_input):
-    with pytest.raises(ServiceSpecValidationError):
-        DriveGroupSpec.from_json(test_input)
-
+def test_DriveGroup_fail(match, test_input):
+    with pytest.raises(ServiceSpecValidationError, match=match):
+        osd_spec = DriveGroupSpec.from_json(yaml.safe_load(test_input))
+        osd_spec.validate()
 
 
 def test_drivegroup_pattern():

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -1,4 +1,6 @@
 # flake8: noqa
+import re
+
 import pytest
 import yaml
 
@@ -32,6 +34,10 @@ def test_DriveGroup(test_input):
 
 @pytest.mark.parametrize("match,test_input",
 [
+    (
+        re.escape('Service Spec is not an (JSON or YAML) object. got "None"'),
+        ''
+    ),
     (
         "Failed to validate Drive Group: OSD spec needs a `placement` key.",
         '{}'


### PR DESCRIPTION
Add validation to verify that `data_devices` is not None

Fixes: https://tracker.ceph.com/issues/49191
Fixes: https://tracker.ceph.com/issues/48325
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
