### PR TITLE
bluestore: use string_view and bump rocksdb to v6.15.5

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -3493,6 +3493,10 @@ int BlueFS::unlock_file(FileLock *fl)
 
 int BlueFS::readdir(std::string_view dirname, vector<string> *ls)
 {
+  // dirname may contain a trailing /
+  if (!dirname.empty() && dirname.back() == '/') {
+    dirname.remove_suffix(1);
+  }
   std::lock_guard l(lock);
   dout(10) << __func__ << " " << dirname << dendl;
   if (dirname.empty()) {

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -153,7 +153,7 @@ public:
   struct Dir : public RefCountedObject {
     MEMPOOL_CLASS_HELPERS();
 
-    mempool::bluefs::map<std::string,FileRef> file_map;
+    mempool::bluefs::map<std::string, FileRef, std::less<>> file_map;
 
   private:
     FRIEND_MAKE_REF(Dir);
@@ -309,8 +309,8 @@ private:
   };
 
   // cache
-  mempool::bluefs::map<std::string, DirRef> dir_map;              ///< dirname -> Dir
-  mempool::bluefs::unordered_map<uint64_t,FileRef> file_map; ///< ino -> File
+  mempool::bluefs::map<std::string, DirRef, std::less<>> dir_map;          ///< dirname -> Dir
+  mempool::bluefs::unordered_map<uint64_t, FileRef> file_map; ///< ino -> File
 
   // map of dirty files, files of same dirty_seq are grouped into list.
   std::map<uint64_t, dirty_file_list_t> dirty_files;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -63,7 +63,7 @@ public:
   virtual ~BlueFSVolumeSelector() {
   }
   virtual void* get_hint_for_log() const = 0;
-  virtual void* get_hint_by_dir(const std::string& dirname) const = 0;
+  virtual void* get_hint_by_dir(std::string_view dirname) const = 0;
 
   virtual void add_usage(void* file_hint, const bluefs_fnode_t& fnode) = 0;
   virtual void sub_usage(void* file_hint, const bluefs_fnode_t& fnode) = 0;
@@ -506,14 +506,14 @@ public:
   int get_block_extents(unsigned id, interval_set<uint64_t> *extents);
 
   int open_for_write(
-    const std::string& dir,
-    const std::string& file,
+    std::string_view dir,
+    std::string_view file,
     FileWriter **h,
     bool overwrite);
 
   int open_for_read(
-    const std::string& dir,
-    const std::string& file,
+    std::string_view dir,
+    std::string_view file,
     FileReader **h,
     bool random = false);
 
@@ -522,21 +522,21 @@ public:
     _close_writer(h);
   }
 
-  int rename(const std::string& old_dir, const std::string& old_file,
-	     const std::string& new_dir, const std::string& new_file);
+  int rename(std::string_view old_dir, std::string_view old_file,
+	     std::string_view new_dir, std::string_view new_file);
 
-  int readdir(const std::string& dirname, std::vector<std::string> *ls);
+  int readdir(std::string_view dirname, std::vector<std::string> *ls);
 
-  int unlink(const std::string& dirname, const std::string& filename);
-  int mkdir(const std::string& dirname);
-  int rmdir(const std::string& dirname);
+  int unlink(std::string_view dirname, std::string_view filename);
+  int mkdir(std::string_view dirname);
+  int rmdir(std::string_view dirname);
   bool wal_is_rotational();
 
-  bool dir_exists(const std::string& dirname);
-  int stat(const std::string& dirname, const std::string& filename,
+  bool dir_exists(std::string_view dirname);
+  int stat(std::string_view dirname, std::string_view filename,
 	   uint64_t *size, utime_t *mtime);
 
-  int lock_file(const std::string& dirname, const std::string& filename, FileLock **p);
+  int lock_file(std::string_view dirname, std::string_view filename, FileLock **p);
   int unlock_file(FileLock *l);
 
   void compact_log();
@@ -662,7 +662,7 @@ public:
     : wal_total(_wal_total), db_total(_db_total), slow_total(_slow_total) {}
 
   void* get_hint_for_log() const override;
-  void* get_hint_by_dir(const std::string& dirname) const override;
+  void* get_hint_by_dir(std::string_view dirname) const override;
 
   void add_usage(void* hint, const bluefs_fnode_t& fnode) override {
     // do nothing

--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -30,13 +30,17 @@ rocksdb::Status err_to_status(int r)
   }
 }
 
-void split(const std::string &fn, std::string *dir, std::string *file)
+std::pair<std::string_view, std::string_view>
+split(const std::string &fn)
 {
   size_t slash = fn.rfind('/');
-  *file = fn.substr(slash + 1);
-  while (slash && fn[slash-1] == '/')
+  assert(slash != fn.npos);
+  size_t file_begin = slash + 1;
+  while (slash && fn[slash - 1] == '/')
     --slash;
-  *dir = fn.substr(0, slash);
+  return {string_view(fn.data(), slash),
+          string_view(fn.data() + file_begin,
+	              fn.size() - file_begin)};
 }
 
 }
@@ -353,8 +357,7 @@ rocksdb::Status BlueRocksEnv::NewSequentialFile(
 {
   if (fname[0] == '/')
     return target()->NewSequentialFile(fname, result, options);
-  std::string dir, file;
-  split(fname, &dir, &file);
+  auto [dir, file] = split(fname);
   BlueFS::FileReader *h;
   int r = fs->open_for_read(dir, file, &h, false);
   if (r < 0)
@@ -368,8 +371,7 @@ rocksdb::Status BlueRocksEnv::NewRandomAccessFile(
   std::unique_ptr<rocksdb::RandomAccessFile>* result,
   const rocksdb::EnvOptions& options)
 {
-  std::string dir, file;
-  split(fname, &dir, &file);
+  auto [dir, file] = split(fname);
   BlueFS::FileReader *h;
   int r = fs->open_for_read(dir, file, &h, true);
   if (r < 0)
@@ -383,8 +385,7 @@ rocksdb::Status BlueRocksEnv::NewWritableFile(
   std::unique_ptr<rocksdb::WritableFile>* result,
   const rocksdb::EnvOptions& options)
 {
-  std::string dir, file;
-  split(fname, &dir, &file);
+  auto [dir, file] = split(fname);
   BlueFS::FileWriter *h;
   int r = fs->open_for_write(dir, file, &h, false);
   if (r < 0)
@@ -399,10 +400,8 @@ rocksdb::Status BlueRocksEnv::ReuseWritableFile(
   std::unique_ptr<rocksdb::WritableFile>* result,
   const rocksdb::EnvOptions& options)
 {
-  std::string old_dir, old_file;
-  split(old_fname, &old_dir, &old_file);
-  std::string new_dir, new_file;
-  split(new_fname, &new_dir, &new_file);
+  auto [old_dir, old_file] = split(old_fname);
+  auto [new_dir, new_file] = split(new_fname);
 
   int r = fs->rename(old_dir, old_file, new_dir, new_file);
   if (r < 0)
@@ -430,8 +429,7 @@ rocksdb::Status BlueRocksEnv::FileExists(const std::string& fname)
 {
   if (fname[0] == '/')
     return target()->FileExists(fname);
-  std::string dir, file;
-  split(fname, &dir, &file);
+  auto [dir, file] = split(fname);
   if (fs->stat(dir, file, NULL, NULL) == 0)
     return rocksdb::Status::OK();
   return err_to_status(-ENOENT);
@@ -450,8 +448,7 @@ rocksdb::Status BlueRocksEnv::GetChildren(
 
 rocksdb::Status BlueRocksEnv::DeleteFile(const std::string& fname)
 {
-  std::string dir, file;
-  split(fname, &dir, &file);
+  auto [dir, file] = split(fname);
   int r = fs->unlink(dir, file);
   if (r < 0)
     return err_to_status(r);
@@ -486,8 +483,7 @@ rocksdb::Status BlueRocksEnv::GetFileSize(
   const std::string& fname,
   uint64_t* file_size)
 {
-  std::string dir, file;
-  split(fname, &dir, &file);
+  auto [dir, file] = split(fname);
   int r = fs->stat(dir, file, file_size, NULL);
   if (r < 0)
     return err_to_status(r);
@@ -497,8 +493,7 @@ rocksdb::Status BlueRocksEnv::GetFileSize(
 rocksdb::Status BlueRocksEnv::GetFileModificationTime(const std::string& fname,
 						      uint64_t* file_mtime)
 {
-  std::string dir, file;
-  split(fname, &dir, &file);
+  auto [dir, file] = split(fname);
   utime_t mtime;
   int r = fs->stat(dir, file, NULL, &mtime);
   if (r < 0)
@@ -511,10 +506,8 @@ rocksdb::Status BlueRocksEnv::RenameFile(
   const std::string& src,
   const std::string& target)
 {
-  std::string old_dir, old_file;
-  split(src, &old_dir, &old_file);
-  std::string new_dir, new_file;
-  split(target, &new_dir, &new_file);
+  auto [old_dir, old_file] = split(src);
+  auto [new_dir, new_file] = split(target);
 
   int r = fs->rename(old_dir, old_file, new_dir, new_file);
   if (r < 0)
@@ -537,8 +530,7 @@ rocksdb::Status BlueRocksEnv::AreFilesSame(
     if (fs->dir_exists(path)) {
       continue;
     }
-    std::string dir, file;
-    split(path, &dir, &file);
+    auto [dir, file] = split(path);
     int r = fs->stat(dir, file, nullptr, nullptr);
     if (!r) {
       continue;
@@ -556,8 +548,7 @@ rocksdb::Status BlueRocksEnv::LockFile(
   const std::string& fname,
   rocksdb::FileLock** lock)
 {
-  std::string dir, file;
-  split(fname, &dir, &file);
+  auto [dir, file] = split(fname);
   BlueFS::FileLock *l = NULL;
   int r = fs->lock_file(dir, file, &l);
   if (r < 0)

--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -7,6 +7,8 @@
 #include "kv/RocksDBStore.h"
 #include "string.h"
 
+namespace {
+
 rocksdb::Status err_to_status(int r)
 {
   switch (r) {
@@ -26,6 +28,17 @@ rocksdb::Status err_to_status(int r)
     ceph_abort_msg("unrecognized error code");
     return rocksdb::Status::NotSupported(rocksdb::Status::kNone);
   }
+}
+
+void split(const std::string &fn, std::string *dir, std::string *file)
+{
+  size_t slash = fn.rfind('/');
+  *file = fn.substr(slash + 1);
+  while (slash && fn[slash-1] == '/')
+    --slash;
+  *dir = fn.substr(0, slash);
+}
+
 }
 
 // A file abstraction for reading sequentially through a file

--- a/src/os/bluestore/BlueRocksEnv.h
+++ b/src/os/bluestore/BlueRocksEnv.h
@@ -16,14 +16,6 @@
 class BlueFS;
 
 class BlueRocksEnv : public rocksdb::EnvWrapper {
-  void split(const std::string &fn, std::string *dir, std::string *file) {
-    size_t slash = fn.rfind('/');
-    *file = fn.substr(slash + 1);
-    while (slash && fn[slash-1] == '/')
-      --slash;
-    *dir = fn.substr(0, slash);
-  }
-
 public:
   // Create a brand new sequentially-readable file with the specified name.
   // On success, stores a pointer to the new file in *result and returns OK.

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -16264,7 +16264,7 @@ void RocksDBBlueFSVolumeSelector::get_paths(const std::string& base, paths& res)
   res.emplace_back(base + ".slow", l_totals[LEVEL_SLOW - LEVEL_FIRST]);
 }
 
-void* RocksDBBlueFSVolumeSelector::get_hint_by_dir(const string& dirname) const {
+void* RocksDBBlueFSVolumeSelector::get_hint_by_dir(std::string_view dirname) const {
   uint8_t res = LEVEL_DB;
   if (dirname.length() > 5) {
     // the "db.slow" and "db.wal" directory names are hard-coded at

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -3762,7 +3762,7 @@ public:
   void* get_hint_for_log() const override {
     return  reinterpret_cast<void*>(LEVEL_LOG);
   }
-  void* get_hint_by_dir(const std::string& dirname) const override;
+  void* get_hint_by_dir(std::string_view dirname) const override;
 
   void add_usage(void* hint, const bluefs_fnode_t& fnode) override {
     if (hint == nullptr)

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -214,24 +214,24 @@ struct bluefs_transaction_t {
     using ceph::encode;
     encode((__u8)OP_INIT, op_bl);
   }
-  void op_dir_create(const std::string& dir) {
+  void op_dir_create(std::string_view dir) {
     using ceph::encode;
     encode((__u8)OP_DIR_CREATE, op_bl);
     encode(dir, op_bl);
   }
-  void op_dir_remove(const std::string& dir) {
+  void op_dir_remove(std::string_view dir) {
     using ceph::encode;
     encode((__u8)OP_DIR_REMOVE, op_bl);
     encode(dir, op_bl);
   }
-  void op_dir_link(const std::string& dir, const std::string& file, uint64_t ino) {
+  void op_dir_link(std::string_view dir, std::string_view file, uint64_t ino) {
     using ceph::encode;
     encode((__u8)OP_DIR_LINK, op_bl);
     encode(dir, op_bl);
     encode(file, op_bl);
     encode(ino, op_bl);
   }
-  void op_dir_unlink(const std::string& dir, const std::string& file) {
+  void op_dir_unlink(std::string_view dir, std::string_view file) {
     using ceph::encode;
     encode((__u8)OP_DIR_UNLINK, op_bl);
     encode(dir, op_bl);


### PR DESCRIPTION
to pick up a bunch of cleanups which silence warnings like range-based
loop using `auto` instead of `auto &`.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
