### PR TITLE
rgw: remove a pessimizing move

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -961,7 +961,7 @@ namespace rgw {
   static inline std::string prefix_xattr_keystr(const rgw_xattrstr& key) {
     std::string keystr;
     keystr.reserve(sizeof(RGW_ATTR_META_PREFIX) + key.len);
-    keystr += {RGW_ATTR_META_PREFIX};
+    keystr += (RGW_ATTR_META_PREFIX);
     keystr += string{key.val, key.len};
     return keystr;
   }
@@ -1845,7 +1845,7 @@ namespace rgw {
                       &state->dest_placement,
                       state->bucket_owner.get_id(),
                       *static_cast<RGWObjectCtx *>(state->obj_ctx),
-                      std::move(state->object->clone()), olh_epoch, state->req_id,
+                      state->object->clone(), olh_epoch, state->req_id,
 		      this, state->yield);
 
     op_ret = processor->prepare(state->yield);


### PR DESCRIPTION

("rgw_file.cc:1848:23: warning: moving a temporary
object prevents copy elision)".
Also - fix a Clang warning re 'braces around scalar initializer'

Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
