### PR TITLE
nautilus: mgr/dashboard: customize CherryPy Server Header

### DIFF
--- a/qa/tasks/mgr/dashboard/test_requests.py
+++ b/qa/tasks/mgr/dashboard/test_requests.py
@@ -21,3 +21,9 @@ class RequestsTest(DashboardTestCase):
         self.assertHeaders({
             'Content-Type': 'application/json',
         })
+
+    def test_server(self):
+        self._get('/api/summary')
+        self.assertHeaders({
+            'server': 'Ceph-Dashboard'
+        })

--- a/src/pybind/mgr/dashboard/services/auth.py
+++ b/src/pybind/mgr/dashboard/services/auth.py
@@ -14,6 +14,10 @@ import jwt
 from .access_control import LocalAuthenticator, UserDoesNotExist
 from .. import mgr, logger
 
+cherrypy.config.update({
+    'response.headers.server': 'Ceph-Dashboard'
+    })
+
 
 class JwtManager(object):
     JWT_TOKEN_BLACKLIST_KEY = "jwt_token_black_list"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49248

---

backport of https://github.com/ceph/ceph/pull/34656
parent tracker: https://tracker.ceph.com/issues/44935

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh