### PR TITLE
qa/suites/rados/cephadm: Add 20.04 podman:testing

### DIFF
--- a/qa/distros/all/ubuntu_20.04_podman_testing.yaml
+++ b/qa/distros/all/ubuntu_20.04_podman_testing.yaml
@@ -1,0 +1,12 @@
+os_type: ubuntu
+os_version: "20.04"
+
+# feel free to remove this test, if Kubic project is no longer maintained.
+tasks:
+- exec:
+    all:
+    - curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/testing/xUbuntu_20.04/Release.key | sudo apt-key add -
+    - echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/testing/xUbuntu_20.04/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:testing.list
+    - sudo apt update
+    - sudo apt -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install podman
+    - echo -e "[[registry]]\nlocation = 'docker.io'\n\n[[registry.mirror]]\nlocation='docker-mirror.front.sepia.ceph.com:5000'\n" | sudo tee /etc/containers/registries.conf

--- a/qa/suites/rados/cephadm/smoke/distro/ubuntu_20.04_podman_testing.yaml
+++ b/qa/suites/rados/cephadm/smoke/distro/ubuntu_20.04_podman_testing.yaml
@@ -1,0 +1,1 @@
+.qa/distros/all/ubuntu_20.04_podman_testing.yaml

--- a/qa/suites/rados/cephadm/with-work/distro/ubuntu_20.04_podman_testing.yaml
+++ b/qa/suites/rados/cephadm/with-work/distro/ubuntu_20.04_podman_testing.yaml
@@ -1,0 +1,1 @@
+.qa/distros/all/ubuntu_20.04_podman_testing.yaml

--- a/qa/suites/rados/cephadm/workunits/distro/ubuntu_20.04_podman_testing.yaml
+++ b/qa/suites/rados/cephadm/workunits/distro/ubuntu_20.04_podman_testing.yaml
@@ -1,0 +1,1 @@
+.qa/distros/all/ubuntu_20.04_podman_testing.yaml


### PR DESCRIPTION
make sure next podman versions aren't breaking cephadm

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

Not sure we should actually merge this PR. But I'd like to know. We had too many breakages originating from podman in the last months. 


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
