### PR TITLE
cephadm: Allow mounting <empty> folder in all OSs

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2234,7 +2234,11 @@ def get_container_mounts(ctx, fsid, daemon_type, daemon_id,
     if daemon_type == 'osd':
         mounts['/sys'] = '/sys'  # for numa.cc, pick_address, cgroups, ...
         # selinux-policy in the container may not match the host.
-        mounts['/usr/share/empty'] = '/sys/fs/selinux:ro'
+        if HostFacts(ctx).selinux_enabled:
+            selinux_folder = '/var/lib/ceph/%s/selinux' % fsid
+            if not os.path.exists(selinux_folder):
+                os.makedirs(selinux_folder, mode=0o755)
+                mounts[selinux_folder] = '/sys/fs/selinux:ro'
         mounts['/run/lvm'] = '/run/lvm'
         mounts['/run/lock/lvm'] = '/run/lock/lvm'
 
@@ -6150,9 +6154,9 @@ class HostFacts():
 
     @property
     def kernel_security(self):
-        # type: () -> Optional[Dict[str, str]]
+        # type: () -> Dict[str, str]
         """Determine the security features enabled in the kernel - SELinux, AppArmor"""
-        def _fetch_selinux() -> Optional[Dict[str, str]]:
+        def _fetch_selinux() -> Dict[str, str]:
             """Read the selinux config file to determine state"""
             security = {}
             for selinux_path in HostFacts._selinux_path_list:
@@ -6169,9 +6173,9 @@ class HostFacts():
                     else:
                         security['description'] = "SELinux: Enabled({}, {})".format(security['SELINUX'], security['SELINUXTYPE'])
                     return security
-            return None
+            return {}
 
-        def _fetch_apparmor() -> Optional[Dict[str, str]]:
+        def _fetch_apparmor() -> Dict[str, str]:
             """Read the apparmor profiles directly, returning an overview of AppArmor status"""
             security = {}
             for apparmor_path in HostFacts._apparmor_path_list:
@@ -6196,9 +6200,9 @@ class HostFacts():
                         security['description'] += "({})".format(summary_str)
 
                     return security
-            return None
+            return {}
 
-        ret = None
+        ret = {}
         if os.path.exists('/sys/kernel/security/lsm'):
             lsm = read_file(['/sys/kernel/security/lsm']).strip()
             if 'selinux' in lsm:
@@ -6211,13 +6215,18 @@ class HostFacts():
                     "description": "Linux Security Module framework is active, but is not using SELinux or AppArmor"
                 }
 
-        if ret is not None:
+        if ret:
             return ret
         
         return {
             "type": "None",
             "description": "Linux Security Module framework is not available"
         }
+
+    @property
+    def selinux_enabled(self):
+        return (self.kernel_security["type"] == "SELinux") and \
+               (self.kernel_security["description"] != "SELinux: Disabled")
 
     @property
     def kernel_parameters(self):
@@ -7684,4 +7693,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
There are OSs without </usr/share/empty> folder

Maybe we can close https://github.com/ceph/ceph/pull/39418 in favor of this one.

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
