### PR TITLE
cmake: Fix build with ninja

### DIFF
--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -167,6 +167,21 @@ function(do_build_boost version)
       URL_HASH SHA256=${boost_sha256}
       DOWNLOAD_NO_PROGRESS 1)
   endif()
+
+  foreach(c ${Boost_BUILD_COMPONENTS})
+    string(TOUPPER ${c} upper_c)
+    if(c MATCHES "^python")
+      set(c "python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}")
+    endif()
+    if(Boost_USE_STATIC_LIBS)
+      set(Boost_${upper_c}_LIBRARY_OUT
+        ${boost_root_dir}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}boost_${c}${CMAKE_STATIC_LIBRARY_SUFFIX})
+    else()
+      set(Boost_${upper_c}_LIBRARY_OUT
+        ${boost_root_dir}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}boost_${c}${CMAKE_SHARED_LIBRARY_SUFFIX})
+    endif()
+    list(APPEND Boost_LIBRARIES_OUT ${Boost_${upper_c}_LIBRARY_OUT})
+  endforeach()
   # build all components in a single shot
   include(ExternalProject)
   ExternalProject_Add(Boost
@@ -175,7 +190,9 @@ function(do_build_boost version)
     BUILD_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ${build_command}
     BUILD_IN_SOURCE 1
     INSTALL_COMMAND ${install_command}
-    PREFIX "${boost_root_dir}")
+    PREFIX "${boost_root_dir}"
+    BUILD_BYPRODUCTS ${Boost_LIBRARIES_OUT}
+    )
 endfunction()
 
 set(Boost_context_DEPENDENCIES thread chrono system date_time)


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

This fixes the outputs of BuildBoost being unknown which causes more
careful build tools (ninja) to complain about missing boost libraries.

This is my first take, and while it works maybe more restructuring of the cmake
is required as it duplicates the `Boost_LIBRARIES_OUT` construction which
may be undesirable. I'm happy to make any changes.

Signed-off-by: Kurt Kartaltepe <kkartaltepe@gmail.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
