### PR TITLE
ceph.spec.in: remove trailing whitespace

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -425,7 +425,7 @@ Requires:       python%{python3_pkgversion}
 Recommends:     podman >= 2.0.2
 %endif
 %description -n cephadm
-Utility to bootstrap a Ceph cluster and manage Ceph daemons deployed 
+Utility to bootstrap a Ceph cluster and manage Ceph daemons deployed
 with systemd and podman.
 
 %package -n ceph-common


### PR DESCRIPTION
RPM's `parseSpec()` Python method internally strips this whitespace character.

Tools that process this spec file with `parseSpec()` and evaluate `RPMTAG_DESCRIPTION` cannot match this exact `%description` string as written here.

Strip the trailing whitespace so that the `RPMTAG_DESCRIPTION` header matches what we've written in the spec.