### PR TITLE
pacific: librbd: correct incremental deep-copy object-map inconsistencies

### DIFF
--- a/qa/suites/rbd/mirror-thrash/workloads/rbd-mirror-journal-stress-workunit.yaml
+++ b/qa/suites/rbd/mirror-thrash/workloads/rbd-mirror-journal-stress-workunit.yaml
@@ -1,0 +1,15 @@
+meta:
+- desc: run the rbd_mirror_stress.sh workunit to test the rbd-mirror daemon
+tasks:
+- workunit:
+    clients:
+      cluster1.client.mirror: [rbd/rbd_mirror_stress.sh]
+    env:
+      # override workunit setting of CEPH_ARGS='--cluster'
+      CEPH_ARGS: ''
+      RBD_MIRROR_INSTANCES: '4'
+      RBD_MIRROR_USE_EXISTING_CLUSTER: '1'
+      RBD_MIRROR_USE_RBD_MIRROR: '1'
+      MIRROR_POOL_MODE: 'pool'
+      MIRROR_IMAGE_MODE: 'journal'
+    timeout: 6h

--- a/qa/suites/rbd/mirror-thrash/workloads/rbd-mirror-snapshot-stress-workunit-exclusive-lock.yaml
+++ b/qa/suites/rbd/mirror-thrash/workloads/rbd-mirror-snapshot-stress-workunit-exclusive-lock.yaml
@@ -7,6 +7,9 @@ tasks:
     env:
       # override workunit setting of CEPH_ARGS='--cluster'
       CEPH_ARGS: ''
+      MIRROR_POOL_MODE: 'image'
+      MIRROR_IMAGE_MODE: 'snapshot'
+      RBD_IMAGE_FEATURES: 'layering,exclusive-lock'
       RBD_MIRROR_INSTANCES: '4'
       RBD_MIRROR_USE_EXISTING_CLUSTER: '1'
       RBD_MIRROR_USE_RBD_MIRROR: '1'

--- a/qa/suites/rbd/mirror-thrash/workloads/rbd-mirror-snapshot-stress-workunit-fast-diff.yaml
+++ b/qa/suites/rbd/mirror-thrash/workloads/rbd-mirror-snapshot-stress-workunit-fast-diff.yaml
@@ -1,0 +1,16 @@
+meta:
+- desc: run the rbd_mirror_stress.sh workunit to test the rbd-mirror daemon
+tasks:
+- workunit:
+    clients:
+      cluster1.client.mirror: [rbd/rbd_mirror_stress.sh]
+    env:
+      # override workunit setting of CEPH_ARGS='--cluster'
+      CEPH_ARGS: ''
+      MIRROR_POOL_MODE: 'image'
+      MIRROR_IMAGE_MODE: 'snapshot'
+      RBD_IMAGE_FEATURES: 'layering,exclusive-lock,object-map,fast-diff'
+      RBD_MIRROR_INSTANCES: '4'
+      RBD_MIRROR_USE_EXISTING_CLUSTER: '1'
+      RBD_MIRROR_USE_RBD_MIRROR: '1'
+    timeout: 6h

--- a/qa/suites/rbd/mirror-thrash/workloads/rbd-mirror-snapshot-stress-workunit-minimum.yaml
+++ b/qa/suites/rbd/mirror-thrash/workloads/rbd-mirror-snapshot-stress-workunit-minimum.yaml
@@ -1,0 +1,16 @@
+meta:
+- desc: run the rbd_mirror_stress.sh workunit to test the rbd-mirror daemon
+tasks:
+- workunit:
+    clients:
+      cluster1.client.mirror: [rbd/rbd_mirror_stress.sh]
+    env:
+      # override workunit setting of CEPH_ARGS='--cluster'
+      CEPH_ARGS: ''
+      MIRROR_POOL_MODE: 'image'
+      MIRROR_IMAGE_MODE: 'snapshot'
+      RBD_IMAGE_FEATURES: 'layering'
+      RBD_MIRROR_INSTANCES: '4'
+      RBD_MIRROR_USE_EXISTING_CLUSTER: '1'
+      RBD_MIRROR_USE_RBD_MIRROR: '1'
+    timeout: 6h

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -542,6 +542,9 @@ status()
                     echo "image ${image} journal status"
                     rbd --cluster ${cluster} -p ${image_pool} --namespace "${image_ns}" journal status --image ${image}
                     echo
+                    echo "image ${image} snapshots"
+                    rbd --cluster ${cluster} -p ${image_pool} --namespace "${image_ns}" snap ls --all ${image}
+                    echo
                 done
 
                 echo "${cluster} ${image_pool} ${image_ns} rbd_mirroring omap vals"
@@ -902,7 +905,9 @@ create_image_and_enable_mirror()
     fi
 
     create_image ${cluster} ${pool} ${image} $@
-    enable_mirror ${cluster} ${pool} ${image} ${mode}
+    if [ "${MIRROR_POOL_MODE}" = "image" ] || [ "$pool" = "${PARENT_POOL}" ]; then
+        enable_mirror ${cluster} ${pool} ${image} ${mode}
+    fi
 }
 
 enable_journaling()

--- a/qa/workunits/rbd/rbd_mirror_stress.sh
+++ b/qa/workunits/rbd/rbd_mirror_stress.sh
@@ -90,9 +90,10 @@ start_mirrors ${CLUSTER2}
 
 testlog "TEST: add image and test replay after client crashes"
 image=test
-create_image ${CLUSTER2} ${POOL} ${image} '512M'
+create_image_and_enable_mirror ${CLUSTER2} ${POOL} ${image} ${MIRROR_IMAGE_MODE} '512M'
 wait_for_image_replay_started ${CLUSTER1} ${POOL} ${image}
 
+clean_snap_name=
 for i in `seq 1 10`
 do
   stress_write_image ${CLUSTER2} ${POOL} ${image}
@@ -104,12 +105,35 @@ do
   wait_for_image_replay_started ${CLUSTER1} ${POOL} ${image}
   wait_for_replay_complete ${CLUSTER1} ${CLUSTER2} ${POOL} ${image}
   wait_for_snap_present ${CLUSTER1} ${POOL} ${image} ${snap_name}
+
+  if [ -n "${clean_snap_name}" ]; then
+      compare_image_snaps ${POOL} ${image} ${clean_snap_name}
+  fi
+  compare_image_snaps ${POOL} ${image} ${snap_name}
+
+  clean_snap_name="snap${i}-clean"
+  create_snap ${CLUSTER2} ${POOL} ${image} ${clean_snap_name}
+done
+
+wait_for_image_replay_started ${CLUSTER1} ${POOL} ${image}
+wait_for_replay_complete ${CLUSTER1} ${CLUSTER2} ${POOL} ${image}
+wait_for_snap_present ${CLUSTER1} ${POOL} ${image} ${clean_snap_name}
+
+for i in `seq 1 10`
+do
+  snap_name="snap${i}"
+  compare_image_snaps ${POOL} ${image} ${snap_name}
+
+  snap_name="snap${i}-clean"
   compare_image_snaps ${POOL} ${image} ${snap_name}
 done
 
 for i in `seq 1 10`
 do
   snap_name="snap${i}"
+  remove_snapshot ${CLUSTER2} ${POOL} ${image} ${snap_name}
+
+  snap_name="snap${i}-clean"
   remove_snapshot ${CLUSTER2} ${POOL} ${image} ${snap_name}
 done
 
@@ -121,7 +145,7 @@ snap_name="snap"
 for i in `seq 1 ${IMAGE_COUNT}`
 do
   image="image_${i}"
-  create_image ${CLUSTER2} ${POOL} ${image} '128M'
+  create_image_and_enable_mirror ${CLUSTER2} ${POOL} ${image} ${MIRROR_IMAGE_MODE} '128M'
   if [ -n "${RBD_MIRROR_REDUCE_WRITES}" ]; then
     write_image ${CLUSTER2} ${POOL} ${image} 100
   else

--- a/qa/workunits/rbd/rbd_mirror_stress.sh
+++ b/qa/workunits/rbd/rbd_mirror_stress.sh
@@ -31,6 +31,7 @@ compare_image_snaps()
     local pool=$1
     local image=$2
     local snap_name=$3
+    local ret=0
 
     local rmt_export=${TEMPDIR}/${CLUSTER2}-${pool}-${image}.export
     local loc_export=${TEMPDIR}/${CLUSTER1}-${pool}-${image}.export
@@ -38,8 +39,13 @@ compare_image_snaps()
     rm -f ${rmt_export} ${loc_export}
     rbd --cluster ${CLUSTER2} -p ${pool} export ${image}@${snap_name} ${rmt_export}
     rbd --cluster ${CLUSTER1} -p ${pool} export ${image}@${snap_name} ${loc_export}
-    cmp ${rmt_export} ${loc_export}
+    if ! cmp ${rmt_export} ${loc_export}
+    then
+        show_diff ${rmt_export} ${loc_export}
+        ret=1
+    fi
     rm -f ${rmt_export} ${loc_export}
+    return ${ret}
 }
 
 wait_for_pool_images()

--- a/src/librbd/api/DiffIterate.cc
+++ b/src/librbd/api/DiffIterate.cc
@@ -30,12 +30,6 @@ namespace api {
 
 namespace {
 
-enum ObjectDiffState {
-  OBJECT_DIFF_STATE_NONE    = 0,
-  OBJECT_DIFF_STATE_UPDATED = 1,
-  OBJECT_DIFF_STATE_HOLE    = 2
-};
-
 struct DiffContext {
   DiffIterate<>::Callback callback;
   void *callback_arg;
@@ -282,7 +276,8 @@ int DiffIterate<I>::execute() {
         ldout(cct, 20) << "object " << object << dendl;
 
         const uint64_t object_no = extents.front().objectno;
-        if (object_diff_state[object_no] == OBJECT_DIFF_STATE_NONE &&
+        uint8_t diff_state = object_diff_state[object_no];
+        if (diff_state == object_map::DIFF_STATE_HOLE &&
             from_snap_id == 0 && !diff_context.parent_diff.empty()) {
           // no data in child object -- report parent diff instead
           for (auto& oe : extents) {
@@ -300,9 +295,9 @@ int DiffIterate<I>::execute() {
               }
             }
           }
-        } else if (object_diff_state[object_no] != OBJECT_DIFF_STATE_NONE) {
-          bool updated = (object_diff_state[object_no] ==
-                            OBJECT_DIFF_STATE_UPDATED);
+        } else if (diff_state == object_map::DIFF_STATE_HOLE_UPDATED ||
+                   diff_state == object_map::DIFF_STATE_DATA_UPDATED) {
+          bool updated = (diff_state == object_map::DIFF_STATE_DATA_UPDATED);
           for (auto& oe : extents) {
             r = m_callback(off + oe.offset, oe.length, updated, m_callback_arg);
             if (r < 0) {

--- a/src/librbd/api/DiffIterate.cc
+++ b/src/librbd/api/DiffIterate.cc
@@ -122,8 +122,9 @@ private:
         auto state = snapshot_extent.get_val().state;
 
         // ignore DNE object (and parent)
-        if (key == io::WriteReadSnapIds{0, 0} &&
-            state != io::SPARSE_EXTENT_STATE_DATA) {
+        if ((state == io::SPARSE_EXTENT_STATE_DNE) ||
+            (key == io::INITIAL_WRITE_READ_SNAP_IDS &&
+             state == io::SPARSE_EXTENT_STATE_ZEROED)) {
           continue;
         }
 

--- a/src/librbd/deep_copy/ImageCopyRequest.cc
+++ b/src/librbd/deep_copy/ImageCopyRequest.cc
@@ -177,21 +177,28 @@ int ImageCopyRequest<I>::send_next_object_copy() {
 
   uint64_t ono = m_object_no++;
 
+  uint8_t object_diff_state = object_map::DIFF_STATE_HOLE;
   if (m_object_diff_state.size() > 0) {
     std::set<uint64_t> src_objects;
     map_src_objects(ono, &src_objects);
 
-    bool skip = true;
     for (auto src_ono : src_objects) {
-      if (src_ono >= m_object_diff_state.size() ||
-          m_object_diff_state[src_ono] != object_map::DIFF_STATE_HOLE) {
-        skip = false;
-        break;
+      if (src_ono >= m_object_diff_state.size()) {
+        object_diff_state = object_map::DIFF_STATE_DATA_UPDATED;
+      } else {
+        auto state = m_object_diff_state[src_ono];
+        if ((state == object_map::DIFF_STATE_HOLE_UPDATED &&
+             object_diff_state != object_map::DIFF_STATE_DATA_UPDATED) ||
+            (state == object_map::DIFF_STATE_DATA &&
+             object_diff_state == object_map::DIFF_STATE_HOLE) ||
+            (state == object_map::DIFF_STATE_DATA_UPDATED)) {
+          object_diff_state = state;
+        }
       }
     }
 
-    if (skip) {
-      ldout(m_cct, 20) << "skipping clean object " << ono << dendl;
+    if (object_diff_state == object_map::DIFF_STATE_HOLE) {
+      ldout(m_cct, 20) << "skipping non-existent object " << ono << dendl;
       return 1;
     }
   }
@@ -202,6 +209,10 @@ int ImageCopyRequest<I>::send_next_object_copy() {
   uint32_t flags = 0;
   if (m_flatten) {
     flags |= OBJECT_COPY_REQUEST_FLAG_FLATTEN;
+  }
+  if (object_diff_state == object_map::DIFF_STATE_DATA) {
+    // no source objects have been updated and at least one has clean data
+    flags |= OBJECT_COPY_REQUEST_FLAG_EXISTS_CLEAN;
   }
 
   Context *ctx = new LambdaContext(

--- a/src/librbd/deep_copy/ImageCopyRequest.cc
+++ b/src/librbd/deep_copy/ImageCopyRequest.cc
@@ -184,7 +184,7 @@ int ImageCopyRequest<I>::send_next_object_copy() {
     bool skip = true;
     for (auto src_ono : src_objects) {
       if (src_ono >= m_object_diff_state.size() ||
-          m_object_diff_state[src_ono] != object_map::DIFF_STATE_NONE) {
+          m_object_diff_state[src_ono] != object_map::DIFF_STATE_HOLE) {
         skip = false;
         break;
       }

--- a/src/librbd/deep_copy/ObjectCopyRequest.cc
+++ b/src/librbd/deep_copy/ObjectCopyRequest.cc
@@ -29,6 +29,7 @@ namespace deep_copy {
 using librbd::util::create_async_context_callback;
 using librbd::util::create_context_callback;
 using librbd::util::create_rados_callback;
+using librbd::util::get_image_ctx;
 
 template <typename I>
 ObjectCopyRequest<I>::ObjectCopyRequest(I *src_image_ctx,
@@ -50,14 +51,17 @@ ObjectCopyRequest<I>::ObjectCopyRequest(I *src_image_ctx,
   ceph_assert(!m_snap_map.empty());
 
   m_src_async_op = new io::AsyncOperation();
-  m_src_async_op->start_op(*util::get_image_ctx(m_src_image_ctx));
+  m_src_async_op->start_op(*get_image_ctx(m_src_image_ctx));
 
   m_src_io_ctx.dup(m_src_image_ctx->data_ctx);
   m_dst_io_ctx.dup(m_dst_image_ctx->data_ctx);
 
   m_dst_oid = m_dst_image_ctx->get_object_name(dst_object_number);
 
-  ldout(m_cct, 20) << "dst_oid=" << m_dst_oid << dendl;
+  ldout(m_cct, 20) << "dst_oid=" << m_dst_oid << ", "
+                   << "src_snap_id_start=" << m_src_snap_id_start << ", "
+                   << "dst_snap_id_start=" << m_dst_snap_id_start << ", "
+                   << "snap_map=" << m_snap_map << dendl;
 }
 
 template <typename I>
@@ -77,7 +81,7 @@ void ObjectCopyRequest<I>::send_list_snaps() {
   snap_ids.reserve(1 + m_snap_map.size());
   snap_ids.push_back(m_src_snap_id_start);
   for (auto& [src_snap_id, _] : m_snap_map) {
-    if (src_snap_id != snap_ids.front()) {
+    if (m_src_snap_id_start < src_snap_id) {
       snap_ids.push_back(src_snap_id);
     }
   }
@@ -90,7 +94,7 @@ void ObjectCopyRequest<I>::send_list_snaps() {
     *m_src_image_ctx, create_context_callback<
       ObjectCopyRequest, &ObjectCopyRequest<I>::handle_list_snaps>(this));
   auto aio_comp = io::AioCompletion::create_and_start(
-    ctx, util::get_image_ctx(m_src_image_ctx), io::AIO_TYPE_GENERIC);
+    ctx, get_image_ctx(m_src_image_ctx), io::AIO_TYPE_GENERIC);
   auto req = io::ImageDispatchSpec::create_list_snaps(
     *m_src_image_ctx, io::IMAGE_DISPATCH_LAYER_NONE, aio_comp,
     io::Extents{m_image_extents}, std::move(snap_ids), list_snaps_flags,
@@ -122,12 +126,6 @@ void ObjectCopyRequest<I>::send_read() {
     // all snapshots have been read
     merge_write_ops();
     compute_zero_ops();
-
-    if (m_snapshot_sparse_bufferlist.empty()) {
-      // nothing to copy
-      finish(-ENOENT);
-      return;
-    }
 
     send_update_object_map();
     return;
@@ -163,7 +161,7 @@ void ObjectCopyRequest<I>::send_read() {
   auto ctx = create_context_callback<
     ObjectCopyRequest<I>, &ObjectCopyRequest<I>::handle_read>(this);
   auto aio_comp = io::AioCompletion::create_and_start(
-    ctx, util::get_image_ctx(m_src_image_ctx), io::AIO_TYPE_READ);
+    ctx, get_image_ctx(m_src_image_ctx), io::AIO_TYPE_READ);
 
   auto req = io::ImageDispatchSpec::create_read(
     *m_src_image_ctx, io::IMAGE_DISPATCH_LAYER_INTERNAL_START, aio_comp,
@@ -274,6 +272,14 @@ void ObjectCopyRequest<I>::handle_update_object_map(int r) {
 
 template <typename I>
 void ObjectCopyRequest<I>::process_copyup() {
+  if (m_snapshot_sparse_bufferlist.empty()) {
+    // no data to copy or truncate/zero. only the copyup state machine cares
+    // about whether the object exists or not, and it always copies from
+    // snap id 0.
+    finish(m_src_snap_id_start > 0 ? 0 : -ENOENT);
+    return;
+  }
+
   ldout(m_cct, 20) << dendl;
 
   // let dispatch layers have a chance to process the data but
@@ -654,13 +660,20 @@ void ObjectCopyRequest<I>::compute_zero_ops() {
     }
   }
 
-  bool fast_diff = m_dst_image_ctx->test_features(RBD_FEATURE_FAST_DIFF);
-  uint64_t prev_end_size = 0;
-
   // ensure we have a zeroed interval for each snapshot
   for (auto& [src_snap_seq, _] : m_snap_map) {
-    m_dst_zero_interval[src_snap_seq];
+    if (m_src_snap_id_start < src_snap_seq) {
+      m_dst_zero_interval[src_snap_seq];
+    }
   }
+
+  // exists if copying from an arbitrary snapshot w/o any deltas in the
+  // start snapshot slot (i.e. DNE)
+  bool object_exists = (
+      m_src_snap_id_start > 0 &&
+      m_snapshot_delta.count({m_src_snap_id_start, m_src_snap_id_start}) == 0);
+  bool fast_diff = m_dst_image_ctx->test_features(RBD_FEATURE_FAST_DIFF);
+  uint64_t prev_end_size = 0;
 
   // compute zero ops from the zeroed intervals
   for (auto &it : m_dst_zero_interval) {
@@ -679,11 +692,12 @@ void ObjectCopyRequest<I>::compute_zero_ops() {
 
     auto dst_may_exist_it = m_dst_object_may_exist.find(dst_snap_seq);
     ceph_assert(dst_may_exist_it != m_dst_object_may_exist.end());
-    if (!dst_may_exist_it->second && prev_end_size > 0) {
+    if (!dst_may_exist_it->second && object_exists) {
       ldout(m_cct, 5) << "object DNE for snap_id: " << dst_snap_seq << dendl;
       m_snapshot_sparse_bufferlist[src_snap_seq].insert(
         0, m_dst_image_ctx->layout.object_size,
         {io::SPARSE_EXTENT_STATE_ZEROED, m_dst_image_ctx->layout.object_size});
+      object_exists = false;
       prev_end_size = 0;
       continue;
     }
@@ -707,21 +721,16 @@ void ObjectCopyRequest<I>::compute_zero_ops() {
         if (overlap == 0) {
           ldout(m_cct, 20) << "no parent overlap" << dendl;
           hide_parent = false;
-        } else if (src_snap_seq == m_dst_zero_interval.begin()->first) {
-          for (auto e : image_extents) {
-            prev_end_size += e.second;
-          }
-          ceph_assert(prev_end_size <= m_dst_image_ctx->layout.object_size);
         }
       }
     }
 
-    uint64_t end_size = prev_end_size;
-
     // update end_size if there are writes into higher offsets
+    uint64_t end_size = prev_end_size;
     auto iter = m_snapshot_sparse_bufferlist.find(src_snap_seq);
     if (iter != m_snapshot_sparse_bufferlist.end()) {
       for (auto &sparse_bufferlist : iter->second) {
+        object_exists = true;
         end_size = std::max(
           end_size, sparse_bufferlist.get_off() + sparse_bufferlist.get_len());
       }
@@ -752,6 +761,8 @@ void ObjectCopyRequest<I>::compute_zero_ops() {
               object_extent.offset, length,
               {io::SPARSE_EXTENT_STATE_ZEROED, length});
           }
+
+          object_exists = (object_extent.offset > 0 || hide_parent);
           end_size = std::min(end_size, object_extent.offset);
         } else {
           // zero interval inside the object
@@ -761,19 +772,24 @@ void ObjectCopyRequest<I>::compute_zero_ops() {
           m_snapshot_sparse_bufferlist[src_snap_seq].insert(
             object_extent.offset, object_extent.length,
             {io::SPARSE_EXTENT_STATE_ZEROED, object_extent.length});
+          object_exists = true;
         }
       }
     }
 
-    ldout(m_cct, 20) << "src_snap_seq=" << src_snap_seq << ", "
-                     << "end_size=" << end_size << dendl;
-    if (end_size > 0 || hide_parent) {
-      m_dst_object_state[src_snap_seq] = OBJECT_EXISTS;
-      if (fast_diff && end_size == prev_end_size &&
-          m_snapshot_sparse_bufferlist.count(src_snap_seq) == 0) {
-        m_dst_object_state[src_snap_seq] = OBJECT_EXISTS_CLEAN;
+    uint8_t dst_object_map_state = OBJECT_NONEXISTENT;
+    if (object_exists) {
+      dst_object_map_state = OBJECT_EXISTS;
+      if (fast_diff && m_snapshot_sparse_bufferlist.count(src_snap_seq) == 0) {
+        dst_object_map_state = OBJECT_EXISTS_CLEAN;
       }
+      m_dst_object_state[src_snap_seq] = dst_object_map_state;
     }
+
+    ldout(m_cct, 20) << "dst_snap_seq=" << dst_snap_seq << ", "
+                     << "end_size=" << end_size << ", "
+                     << "dst_object_map_state="
+                     << static_cast<uint32_t>(dst_object_map_state) << dendl;
     prev_end_size = end_size;
   }
 }

--- a/src/librbd/deep_copy/Types.h
+++ b/src/librbd/deep_copy/Types.h
@@ -12,8 +12,9 @@ namespace librbd {
 namespace deep_copy {
 
 enum {
-  OBJECT_COPY_REQUEST_FLAG_FLATTEN   = 1U << 0,
-  OBJECT_COPY_REQUEST_FLAG_MIGRATION = 1U << 1,
+  OBJECT_COPY_REQUEST_FLAG_FLATTEN      = 1U << 0,
+  OBJECT_COPY_REQUEST_FLAG_MIGRATION    = 1U << 1,
+  OBJECT_COPY_REQUEST_FLAG_EXISTS_CLEAN = 1U << 2,
 };
 
 typedef std::vector<librados::snap_t> SnapIds;

--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -484,8 +484,7 @@ private:
   void list_from_parent();
   void handle_list_from_parent(int r);
 
-  void zero_initial_extent(const interval_set<uint64_t>& written_extents,
-                           bool dne);
+  void zero_initial_extent(bool dne);
 };
 
 } // namespace io

--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -484,7 +484,7 @@ private:
   void list_from_parent();
   void handle_list_from_parent(int r);
 
-  void zero_initial_extent(bool dne);
+  void zero_extent(uint64_t snap_id, bool dne);
 };
 
 } // namespace io

--- a/src/librbd/object_map/DiffRequest.cc
+++ b/src/librbd/object_map/DiffRequest.cc
@@ -175,58 +175,67 @@ void DiffRequest<I>::handle_load_object_map(int r) {
     m_object_map.resize(num_objs);
   }
 
-  if (m_object_diff_state->size() < num_objs) {
+  size_t prev_object_diff_state_size = m_object_diff_state->size();
+  if (prev_object_diff_state_size < num_objs) {
     // the diff state should be the largest of all snapshots in the set
     m_object_diff_state->resize(num_objs);
   }
   if (m_object_map.size() < m_object_diff_state->size()) {
     // the image was shrunk so expanding the object map will flag end objects
     // as non-existent and they will be compared against the previous object
-    // map
+    // diff state
     m_object_map.resize(m_object_diff_state->size());
   }
 
-  uint64_t overlap = std::min(m_object_map.size(), m_prev_object_map.size());
+  uint64_t overlap = std::min(m_object_map.size(), prev_object_diff_state_size);
   auto it = m_object_map.begin();
   auto overlap_end_it = it + overlap;
-  auto pre_it = m_prev_object_map.begin();
   auto diff_it = m_object_diff_state->begin();
   uint64_t i = 0;
-  for (; it != overlap_end_it; ++it, ++pre_it, ++diff_it, ++i) {
-    ldout(cct, 20) << "object state: " << i << " "
-                   << static_cast<uint32_t>(*pre_it)
-                   << "->" << static_cast<uint32_t>(*it) << dendl;
-    if (*it == OBJECT_NONEXISTENT) {
-      if (*pre_it != OBJECT_NONEXISTENT) {
-        *diff_it = DIFF_STATE_HOLE;
-      }
-    } else if (*it == OBJECT_EXISTS ||
-               (*pre_it != *it &&
-                !(*pre_it == OBJECT_EXISTS &&
-                  *it == OBJECT_EXISTS_CLEAN))) {
-      *diff_it = DIFF_STATE_UPDATED;
+  for (; it != overlap_end_it; ++it, ++diff_it, ++i) {
+    uint8_t object_map_state = *it;
+    uint8_t prev_object_diff_state = *diff_it;
+    if (object_map_state == OBJECT_EXISTS ||
+        object_map_state == OBJECT_PENDING ||
+        (object_map_state == OBJECT_EXISTS_CLEAN &&
+         prev_object_diff_state != DIFF_STATE_DATA &&
+         prev_object_diff_state != DIFF_STATE_DATA_UPDATED)) {
+      *diff_it = DIFF_STATE_DATA_UPDATED;
+    } else if (object_map_state == OBJECT_NONEXISTENT &&
+               prev_object_diff_state != DIFF_STATE_HOLE &&
+               prev_object_diff_state != DIFF_STATE_HOLE_UPDATED) {
+      *diff_it = DIFF_STATE_HOLE_UPDATED;
     }
+
+    ldout(cct, 20) << "object state: " << i << " "
+                   << static_cast<uint32_t>(prev_object_diff_state)
+                   << "->" << static_cast<uint32_t>(*diff_it) << " ("
+                   << static_cast<uint32_t>(object_map_state) << ")"
+                   << dendl;
   }
   ldout(cct, 20) << "computed overlap diffs" << dendl;
 
   bool diff_from_start = (m_snap_id_start == 0);
   auto end_it = m_object_map.end();
-  if (m_object_map.size() > m_prev_object_map.size() &&
-      (diff_from_start || m_prev_object_map_valid)) {
+  if (m_object_map.size() > prev_object_diff_state_size) {
     for (; it != end_it; ++it,++diff_it, ++i) {
-      ldout(cct, 20) << "object state: " << i << " "
-                     << "->" << static_cast<uint32_t>(*it) << dendl;
-      if (*it == OBJECT_NONEXISTENT) {
-        *diff_it = DIFF_STATE_NONE;
+      uint8_t object_map_state = *it;
+      if (object_map_state == OBJECT_NONEXISTENT) {
+        *diff_it = DIFF_STATE_HOLE;
+      } else if (diff_from_start || object_map_state != OBJECT_EXISTS_CLEAN) {
+        *diff_it = DIFF_STATE_DATA_UPDATED;
       } else {
-        *diff_it = DIFF_STATE_UPDATED;
+        *diff_it = DIFF_STATE_DATA;
       }
+
+      ldout(cct, 20) << "object state: " << i << " "
+                     << "->" << static_cast<uint32_t>(*diff_it) << " ("
+                     << static_cast<uint32_t>(*it) << ")" << dendl;
     }
   }
   ldout(cct, 20) << "computed resize diffs" << dendl;
 
-  m_prev_object_map = m_object_map;
-  m_prev_object_map_valid = true;
+  m_object_diff_state_valid = true;
 
   std::shared_lock image_locker{m_image_ctx->image_lock};
   load_object_map(&image_locker);

--- a/src/librbd/object_map/DiffRequest.h
+++ b/src/librbd/object_map/DiffRequest.h
@@ -68,8 +68,7 @@ private:
   uint64_t m_current_size = 0;
 
   BitVector<2> m_object_map;
-  BitVector<2> m_prev_object_map;
-  bool m_prev_object_map_valid = false;
+  bool m_object_diff_state_valid = false;
 
   bufferlist m_out_bl;
 

--- a/src/librbd/object_map/Types.h
+++ b/src/librbd/object_map/Types.h
@@ -8,9 +8,10 @@ namespace librbd {
 namespace object_map {
 
 enum DiffState {
-  DIFF_STATE_NONE    = 0,
-  DIFF_STATE_UPDATED = 1,
-  DIFF_STATE_HOLE    = 2
+  DIFF_STATE_HOLE         = 0, /* unchanged hole */
+  DIFF_STATE_DATA         = 1, /* unchanged data */
+  DIFF_STATE_HOLE_UPDATED = 2, /* new hole */
+  DIFF_STATE_DATA_UPDATED = 3  /* new data */
 };
 
 } // namespace object_map

--- a/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
@@ -231,7 +231,7 @@ public:
       librados::snap_t src_snap_id_start,
       librados::snap_t src_snap_id_end,
       librados::snap_t dst_snap_id_start,
-      Context *on_finish) {
+      uint32_t flags, Context *on_finish) {
     SnapMap snap_map;
     util::compute_snap_map(mock_dst_image_ctx.cct, src_snap_id_start,
                            src_snap_id_end, m_dst_snap_ids, m_snap_seqs,
@@ -240,7 +240,7 @@ public:
     expect_get_object_name(mock_dst_image_ctx);
     return new MockObjectCopyRequest(&mock_src_image_ctx, &mock_dst_image_ctx,
                                      src_snap_id_start, dst_snap_id_start,
-                                     snap_map, 0, 0, nullptr, on_finish);
+                                     snap_map, 0, flags, nullptr, on_finish);
   }
 
   void expect_read(librbd::MockTestImageCtx& mock_image_ctx,
@@ -516,7 +516,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, DNE) {
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
                                                   mock_dst_image_ctx, 0,
-                                                  CEPH_NOSNAP, 0, &ctx);
+                                                  CEPH_NOSNAP, 0, 0, &ctx);
 
   InSequence seq;
   expect_list_snaps(mock_src_image_ctx, -ENOENT);
@@ -547,7 +547,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Write) {
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
                                                   mock_dst_image_ctx, 0,
-                                                  CEPH_NOSNAP, 0, &ctx);
+                                                  CEPH_NOSNAP, 0, 0, &ctx);
 
   librados::MockTestMemIoCtxImpl &mock_dst_io_ctx(get_mock_io_ctx(
     request->get_dst_io_ctx()));
@@ -589,7 +589,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, ReadError) {
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
                                                   mock_dst_image_ctx, 0,
-                                                  CEPH_NOSNAP, 0, &ctx);
+                                                  CEPH_NOSNAP, 0, 0, &ctx);
 
   InSequence seq;
   expect_list_snaps(mock_src_image_ctx, 0);
@@ -622,7 +622,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteError) {
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
                                                   mock_dst_image_ctx, 0,
-                                                  CEPH_NOSNAP, 0, &ctx);
+                                                  CEPH_NOSNAP, 0, 0, &ctx);
 
   librados::MockTestMemIoCtxImpl &mock_dst_io_ctx(get_mock_io_ctx(
     request->get_dst_io_ctx()));
@@ -676,7 +676,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteSnaps) {
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
                                                   mock_dst_image_ctx, 0,
-                                                  CEPH_NOSNAP, 0, &ctx);
+                                                  CEPH_NOSNAP, 0, 0, &ctx);
 
   librados::MockTestMemIoCtxImpl &mock_dst_io_ctx(get_mock_io_ctx(
     request->get_dst_io_ctx()));
@@ -740,7 +740,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Trim) {
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
                                                   mock_dst_image_ctx, 0,
-                                                  CEPH_NOSNAP, 0, &ctx);
+                                                  CEPH_NOSNAP, 0, 0, &ctx);
 
   librados::MockTestMemIoCtxImpl &mock_dst_io_ctx(get_mock_io_ctx(
     request->get_dst_io_ctx()));
@@ -794,7 +794,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Remove) {
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
                                                   mock_dst_image_ctx, 0,
-                                                  CEPH_NOSNAP, 0, &ctx);
+                                                  CEPH_NOSNAP, 0, 0, &ctx);
 
   librados::MockTestMemIoCtxImpl &mock_dst_io_ctx(get_mock_io_ctx(
     request->get_dst_io_ctx()));
@@ -847,7 +847,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, ObjectMapUpdateError) {
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
                                                   mock_dst_image_ctx, 0,
-                                                  CEPH_NOSNAP, 0, &ctx);
+                                                  CEPH_NOSNAP, 0, 0, &ctx);
 
   InSequence seq;
   expect_list_snaps(mock_src_image_ctx, 0);
@@ -882,7 +882,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, PrepareCopyupError) {
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
                                                   mock_dst_image_ctx, 0,
-                                                  CEPH_NOSNAP, 0, &ctx);
+                                                  CEPH_NOSNAP, 0, 0, &ctx);
 
   InSequence seq;
   expect_list_snaps(mock_src_image_ctx, 0);
@@ -957,7 +957,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteSnapsStart) {
                                                   src_snap_id_start,
                                                   CEPH_NOSNAP,
                                                   dst_snap_id_start,
-                                                  &ctx);
+                                                  0, &ctx);
 
   librados::MockTestMemIoCtxImpl &mock_dst_io_ctx(get_mock_io_ctx(
     request->get_dst_io_ctx()));
@@ -1014,7 +1014,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Incremental) {
 
   C_SaferCond ctx1;
   auto request1 = create_request(mock_src_image_ctx, mock_dst_image_ctx,
-                                 0, m_src_snap_ids[0], 0, &ctx1);
+                                 0, m_src_snap_ids[0], 0, 0, &ctx1);
 
   expect_list_snaps(mock_src_image_ctx, 0);
 
@@ -1041,7 +1041,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Incremental) {
   C_SaferCond ctx2;
   auto request2 = create_request(mock_src_image_ctx, mock_dst_image_ctx,
                                  m_src_snap_ids[0], m_src_snap_ids[2],
-                                 m_dst_snap_ids[0], &ctx2);
+                                 m_dst_snap_ids[0], 0, &ctx2);
 
   expect_list_snaps(mock_src_image_ctx, 0);
   expect_start_op(mock_exclusive_lock);
@@ -1058,6 +1058,45 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Incremental) {
   request2->send();
   ASSERT_EQ(0, ctx2.wait());
   ASSERT_EQ(0, compare_objects());
+}
+
+TEST_F(TestMockDeepCopyObjectCopyRequest, SkipSnapList) {
+  librbd::MockTestImageCtx mock_src_image_ctx(*m_src_image_ctx);
+  librbd::MockTestImageCtx mock_dst_image_ctx(*m_dst_image_ctx);
+
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  prepare_exclusive_lock(mock_dst_image_ctx, mock_exclusive_lock);
+
+  librbd::MockObjectMap mock_object_map;
+  mock_dst_image_ctx.object_map = &mock_object_map;
+
+  expect_op_work_queue(mock_src_image_ctx);
+  expect_test_features(mock_dst_image_ctx);
+  expect_get_object_count(mock_dst_image_ctx);
+
+  ASSERT_EQ(0, create_snap("snap1"));
+  mock_dst_image_ctx.snaps = m_dst_image_ctx->snaps;
+
+  InSequence seq;
+
+  // clean (no-updates) snapshots
+  ASSERT_EQ(0, create_snap("snap2"));
+  mock_dst_image_ctx.snaps = m_dst_image_ctx->snaps;
+
+  C_SaferCond ctx;
+  auto request = create_request(mock_src_image_ctx, mock_dst_image_ctx,
+                                m_src_snap_ids[0], m_src_snap_ids[1],
+                                m_dst_snap_ids[0],
+                                OBJECT_COPY_REQUEST_FLAG_EXISTS_CLEAN, &ctx);
+
+  expect_start_op(mock_exclusive_lock);
+  expect_update_object_map(mock_dst_image_ctx, mock_object_map,
+                           m_dst_snap_ids[1],
+                           is_fast_diff(mock_dst_image_ctx) ?
+                             OBJECT_EXISTS_CLEAN : OBJECT_EXISTS, 0);
+
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
 }
 
 } // namespace deep_copy

--- a/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
@@ -14,6 +14,7 @@
 #include "librbd/api/Image.h"
 #include "librbd/api/Io.h"
 #include "librbd/deep_copy/ObjectCopyRequest.h"
+#include "librbd/deep_copy/Utils.h"
 #include "librbd/io/ReadResult.h"
 #include "librbd/io/Utils.h"
 #include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
@@ -148,6 +149,7 @@ public:
   asio::ContextWQ *m_work_queue;
 
   SnapMap m_snap_map;
+  SnapSeqs m_snap_seqs;
   std::vector<librados::snap_t> m_src_snap_ids;
   std::vector<librados::snap_t> m_dst_snap_ids;
 
@@ -227,12 +229,18 @@ public:
       librbd::MockTestImageCtx &mock_src_image_ctx,
       librbd::MockTestImageCtx &mock_dst_image_ctx,
       librados::snap_t src_snap_id_start,
+      librados::snap_t src_snap_id_end,
       librados::snap_t dst_snap_id_start,
       Context *on_finish) {
+    SnapMap snap_map;
+    util::compute_snap_map(mock_dst_image_ctx.cct, src_snap_id_start,
+                           src_snap_id_end, m_dst_snap_ids, m_snap_seqs,
+                           &snap_map);
+
     expect_get_object_name(mock_dst_image_ctx);
     return new MockObjectCopyRequest(&mock_src_image_ctx, &mock_dst_image_ctx,
                                      src_snap_id_start, dst_snap_id_start,
-                                     m_snap_map, 0, 0, nullptr, on_finish);
+                                     snap_map, 0, 0, nullptr, on_finish);
   }
 
   void expect_read(librbd::MockTestImageCtx& mock_image_ctx,
@@ -374,6 +382,7 @@ public:
                             m_snap_map.rbegin()->second.end());
     }
     m_snap_map[src_snap_id] = dst_snap_ids;
+    m_snap_seqs[src_snap_id] = dst_snap_id;
     m_src_snap_ids.push_back(src_snap_id);
     m_dst_snap_ids.push_back(dst_snap_id);
 
@@ -506,8 +515,8 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, DNE) {
 
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
-                                                  mock_dst_image_ctx, 0, 0,
-                                                  &ctx);
+                                                  mock_dst_image_ctx, 0,
+                                                  CEPH_NOSNAP, 0, &ctx);
 
   InSequence seq;
   expect_list_snaps(mock_src_image_ctx, -ENOENT);
@@ -537,8 +546,8 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Write) {
 
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
-                                                  mock_dst_image_ctx, 0, 0,
-                                                  &ctx);
+                                                  mock_dst_image_ctx, 0,
+                                                  CEPH_NOSNAP, 0, &ctx);
 
   librados::MockTestMemIoCtxImpl &mock_dst_io_ctx(get_mock_io_ctx(
     request->get_dst_io_ctx()));
@@ -579,8 +588,8 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, ReadError) {
 
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
-                                                  mock_dst_image_ctx, 0, 0,
-                                                  &ctx);
+                                                  mock_dst_image_ctx, 0,
+                                                  CEPH_NOSNAP, 0, &ctx);
 
   InSequence seq;
   expect_list_snaps(mock_src_image_ctx, 0);
@@ -612,8 +621,8 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteError) {
 
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
-                                                  mock_dst_image_ctx, 0, 0,
-                                                  &ctx);
+                                                  mock_dst_image_ctx, 0,
+                                                  CEPH_NOSNAP, 0, &ctx);
 
   librados::MockTestMemIoCtxImpl &mock_dst_io_ctx(get_mock_io_ctx(
     request->get_dst_io_ctx()));
@@ -666,8 +675,8 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteSnaps) {
 
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
-                                                  mock_dst_image_ctx, 0, 0,
-                                                  &ctx);
+                                                  mock_dst_image_ctx, 0,
+                                                  CEPH_NOSNAP, 0, &ctx);
 
   librados::MockTestMemIoCtxImpl &mock_dst_io_ctx(get_mock_io_ctx(
     request->get_dst_io_ctx()));
@@ -730,8 +739,8 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Trim) {
 
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
-                                                  mock_dst_image_ctx, 0, 0,
-                                                  &ctx);
+                                                  mock_dst_image_ctx, 0,
+                                                  CEPH_NOSNAP, 0, &ctx);
 
   librados::MockTestMemIoCtxImpl &mock_dst_io_ctx(get_mock_io_ctx(
     request->get_dst_io_ctx()));
@@ -784,8 +793,8 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, Remove) {
 
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
-                                                  mock_dst_image_ctx, 0, 0,
-                                                  &ctx);
+                                                  mock_dst_image_ctx, 0,
+                                                  CEPH_NOSNAP, 0, &ctx);
 
   librados::MockTestMemIoCtxImpl &mock_dst_io_ctx(get_mock_io_ctx(
     request->get_dst_io_ctx()));
@@ -837,8 +846,8 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, ObjectMapUpdateError) {
 
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
-                                                  mock_dst_image_ctx, 0, 0,
-                                                  &ctx);
+                                                  mock_dst_image_ctx, 0,
+                                                  CEPH_NOSNAP, 0, &ctx);
 
   InSequence seq;
   expect_list_snaps(mock_src_image_ctx, 0);
@@ -872,8 +881,8 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, PrepareCopyupError) {
 
   C_SaferCond ctx;
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
-                                                  mock_dst_image_ctx, 0, 0,
-                                                  &ctx);
+                                                  mock_dst_image_ctx, 0,
+                                                  CEPH_NOSNAP, 0, &ctx);
 
   InSequence seq;
   expect_list_snaps(mock_src_image_ctx, 0);
@@ -924,8 +933,10 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteSnapsStart) {
   interval_set<uint64_t> four;
   scribble(m_src_image_ctx, 10, 102400, &four);
 
-  // src end's dst snap seqs should point to HEAD revision
-  m_snap_map[m_src_image_ctx->snaps[0]][0] = CEPH_NOSNAP;
+  // map should begin after src start and src end's dst snap seqs should
+  // point to HEAD revision
+  m_snap_seqs.rbegin()->second = CEPH_NOSNAP;
+  m_dst_snap_ids.pop_back();
 
   librbd::MockTestImageCtx mock_src_image_ctx(*m_src_image_ctx);
   librbd::MockTestImageCtx mock_dst_image_ctx(*m_dst_image_ctx);
@@ -944,6 +955,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteSnapsStart) {
   MockObjectCopyRequest *request = create_request(mock_src_image_ctx,
                                                   mock_dst_image_ctx,
                                                   src_snap_id_start,
+                                                  CEPH_NOSNAP,
                                                   dst_snap_id_start,
                                                   &ctx);
 
@@ -975,6 +987,76 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, WriteSnapsStart) {
 
   request->send();
   ASSERT_EQ(0, ctx.wait());
+  ASSERT_EQ(0, compare_objects());
+}
+
+TEST_F(TestMockDeepCopyObjectCopyRequest, Incremental) {
+  librbd::MockTestImageCtx mock_src_image_ctx(*m_src_image_ctx);
+  librbd::MockTestImageCtx mock_dst_image_ctx(*m_dst_image_ctx);
+
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  prepare_exclusive_lock(mock_dst_image_ctx, mock_exclusive_lock);
+
+  librbd::MockObjectMap mock_object_map;
+  mock_dst_image_ctx.object_map = &mock_object_map;
+
+  expect_op_work_queue(mock_src_image_ctx);
+  expect_test_features(mock_dst_image_ctx);
+  expect_get_object_count(mock_dst_image_ctx);
+
+  // scribble some data
+  interval_set<uint64_t> one;
+  scribble(m_src_image_ctx, 10, 102400, &one);
+  ASSERT_EQ(0, create_snap("snap1"));
+  mock_dst_image_ctx.snaps = m_dst_image_ctx->snaps;
+
+  InSequence seq;
+
+  C_SaferCond ctx1;
+  auto request1 = create_request(mock_src_image_ctx, mock_dst_image_ctx,
+                                 0, m_src_snap_ids[0], 0, &ctx1);
+
+  expect_list_snaps(mock_src_image_ctx, 0);
+
+  expect_read(mock_src_image_ctx, m_src_snap_ids[0], 0, one.range_end(), 0);
+
+  expect_start_op(mock_exclusive_lock);
+  expect_update_object_map(mock_dst_image_ctx, mock_object_map,
+                           m_dst_snap_ids[0], OBJECT_EXISTS, 0);
+
+  librados::MockTestMemIoCtxImpl &mock_dst_io_ctx(get_mock_io_ctx(
+    request1->get_dst_io_ctx()));
+  expect_prepare_copyup(mock_dst_image_ctx);
+  expect_start_op(mock_exclusive_lock);
+  expect_write(mock_dst_io_ctx, 0, one.range_end(), {0, {}}, 0);
+
+  request1->send();
+  ASSERT_EQ(0, ctx1.wait());
+
+  // clean (no-updates) snapshots
+  ASSERT_EQ(0, create_snap("snap2"));
+  ASSERT_EQ(0, create_snap("snap3"));
+  mock_dst_image_ctx.snaps = m_dst_image_ctx->snaps;
+
+  C_SaferCond ctx2;
+  auto request2 = create_request(mock_src_image_ctx, mock_dst_image_ctx,
+                                 m_src_snap_ids[0], m_src_snap_ids[2],
+                                 m_dst_snap_ids[0], &ctx2);
+
+  expect_list_snaps(mock_src_image_ctx, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_update_object_map(mock_dst_image_ctx, mock_object_map,
+                           m_dst_snap_ids[1],
+                           is_fast_diff(mock_dst_image_ctx) ?
+                             OBJECT_EXISTS_CLEAN : OBJECT_EXISTS, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_update_object_map(mock_dst_image_ctx, mock_object_map,
+                           m_dst_snap_ids[2],
+                           is_fast_diff(mock_dst_image_ctx) ?
+                             OBJECT_EXISTS_CLEAN : OBJECT_EXISTS, 0);
+
+  request2->send();
+  ASSERT_EQ(0, ctx2.wait());
   ASSERT_EQ(0, compare_objects());
 }
 

--- a/src/test/librbd/object_map/test_mock_DiffRequest.cc
+++ b/src/test/librbd/object_map/test_mock_DiffRequest.cc
@@ -186,9 +186,9 @@ TEST_F(TestMockObjectMapDiffRequest, FullDelta) {
 
   BitVector<2> expected_diff_state;
   expected_diff_state.resize(object_count);
-  expected_diff_state[1] = DIFF_STATE_UPDATED;
-  expected_diff_state[2] = DIFF_STATE_UPDATED;
-  expected_diff_state[3] = DIFF_STATE_HOLE;
+  expected_diff_state[1] = DIFF_STATE_DATA_UPDATED;
+  expected_diff_state[2] = DIFF_STATE_DATA_UPDATED;
+  expected_diff_state[3] = DIFF_STATE_HOLE_UPDATED;
   ASSERT_EQ(expected_diff_state, m_object_diff_state);
 }
 
@@ -233,8 +233,9 @@ TEST_F(TestMockObjectMapDiffRequest, IntermediateDelta) {
 
   BitVector<2> expected_diff_state;
   expected_diff_state.resize(object_count);
-  expected_diff_state[2] = DIFF_STATE_UPDATED;
-  expected_diff_state[3] = DIFF_STATE_UPDATED;
+  expected_diff_state[1] = DIFF_STATE_DATA;
+  expected_diff_state[2] = DIFF_STATE_DATA_UPDATED;
+  expected_diff_state[3] = DIFF_STATE_DATA_UPDATED;
   ASSERT_EQ(expected_diff_state, m_object_diff_state);
 }
 
@@ -279,7 +280,9 @@ TEST_F(TestMockObjectMapDiffRequest, EndDelta) {
 
   BitVector<2> expected_diff_state;
   expected_diff_state.resize(object_count);
-  expected_diff_state[3] = DIFF_STATE_HOLE;
+  expected_diff_state[1] = DIFF_STATE_DATA;
+  expected_diff_state[2] = DIFF_STATE_DATA_UPDATED;
+  expected_diff_state[3] = DIFF_STATE_HOLE_UPDATED;
   ASSERT_EQ(expected_diff_state, m_object_diff_state);
 }
 
@@ -370,7 +373,7 @@ TEST_F(TestMockObjectMapDiffRequest, IntermediateSnapDNE) {
 
   BitVector<2> expected_diff_state;
   expected_diff_state.resize(object_count);
-  expected_diff_state[1] = DIFF_STATE_UPDATED;
+  expected_diff_state[1] = DIFF_STATE_DATA_UPDATED;
   ASSERT_EQ(expected_diff_state, m_object_diff_state);
 }
 
@@ -430,7 +433,7 @@ TEST_F(TestMockObjectMapDiffRequest, LoadIntermediateObjectMapDNE) {
 
   BitVector<2> expected_diff_state;
   expected_diff_state.resize(object_count);
-  expected_diff_state[1] = DIFF_STATE_UPDATED;
+  expected_diff_state[1] = DIFF_STATE_DATA_UPDATED;
   ASSERT_EQ(expected_diff_state, m_object_diff_state);
 }
 

--- a/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.cc
+++ b/src/tools/rbd_mirror/image_replayer/snapshot/Replayer.cc
@@ -431,17 +431,19 @@ void Replayer<I>::scan_local_mirror_snapshots(
           prune_snap_ids.insert(local_snap_id);
         }
       } else {
-        // start snap will be last complete mirror snapshot or initial
-        // image revision
-        m_local_snap_id_end = local_snap_id;
-
         if (mirror_ns->last_copied_object_number == 0) {
           // snapshot might be missing image state, object-map, etc, so just
           // delete and re-create it if we haven't started copying data
-          // objects
+          // objects. Also only prune this snapshot since we will need the
+          // previous mirror snapshot for syncing.
+          prune_snap_ids.clear();
           prune_snap_ids.insert(local_snap_id);
           break;
         }
+
+        // start snap will be last complete mirror snapshot or initial
+        // image revision
+        m_local_snap_id_end = local_snap_id;
       }
     } else if (mirror_ns->is_primary()) {
       if (mirror_ns->complete) {


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
