### PR TITLE
qa/suites/rados/cephadm/upgrade: change starting version by distro

### DIFF
--- a/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-centos_8.yaml
+++ b/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-centos_8.yaml
@@ -1,0 +1,13 @@
+tasks:
+- cephadm:
+    image: docker.io/ceph/ceph:v15.2.5
+    cephadm_branch: v15.2.5
+    cephadm_git_url: https://github.com/ceph/ceph
+    # avoid --cap-add=PTRACE + --privileged for older cephadm versions
+    allow_ptrace: false
+os_type: centos
+os_version: "8.2"
+overrides:
+  selinux:
+    whitelist:
+      - scontext=system_u:system_r:logrotate_t:s0

--- a/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-ubuntu_20.04.yaml
+++ b/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-ubuntu_20.04.yaml
@@ -5,3 +5,5 @@ tasks:
     cephadm_git_url: https://github.com/ceph/ceph
     # avoid --cap-add=PTRACE + --privileged for older cephadm versions
     allow_ptrace: false
+os_type: ubuntu
+os_version: "20.04"

--- a/qa/suites/rados/cephadm/upgrade/distro$
+++ b/qa/suites/rados/cephadm/upgrade/distro$
@@ -1,1 +1,0 @@
-../smoke/distro


### PR DESCRIPTION
centos/rhel have podman 2, which does not like conflicting --cap-add and
--privileged arguments.  cephadm versions prior to 15.2.5 use both args,
however, which means the rhel/centos upgrade test has to start at 15.2.5
to work at all on those distros (with the updated podman).

Fixes: https://tracker.ceph.com/issues/48142