### PR TITLE
qa/rgw: reenable valgrind on rgw/multisite suite

### DIFF
--- a/qa/suites/rgw/multisite/valgrind.yaml
+++ b/qa/suites/rgw/multisite/valgrind.yaml
@@ -1,12 +1,19 @@
 # see http://tracker.ceph.com/issues/20360 and http://tracker.ceph.com/issues/18126
-#os_type: centos
-# ubuntu and no valgrind until we migrate test to py3
-os_type: ubuntu
+os_type: centos
 
 overrides:
   install:
     ceph:
-#      flavor: notcmalloc
+      flavor: notcmalloc
+  rgw:
+    c1.client.0:
+      valgrind: [--tool=memcheck, --max-threads=1024] # http://tracker.ceph.com/issues/25214
+    c1.client.1:
+      valgrind: [--tool=memcheck, --max-threads=1024]
+    c2.client.0:
+      valgrind: [--tool=memcheck, --max-threads=1024]
+    c2.client.1:
+      valgrind: [--tool=memcheck, --max-threads=1024]
   ceph:
     conf:
       global:


### PR DESCRIPTION

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
