### PR TITLE
mgr/cephadm: redeploy daemons deployed using old image after upgrade

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1757,6 +1757,11 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
     def daemon_is_self(self, daemon_type: str, daemon_id: str) -> bool:
         return daemon_type == 'mgr' and daemon_id == self.get_mgr_id()
 
+    def get_active_mgr_digests(self) -> List[str]:
+        digests = self.mgr_service.get_active_daemon(
+            self.cache.get_daemons_by_type('mgr')).container_image_digests
+        return digests if digests else []
+
     def _schedule_daemon_action(self, daemon_name: str, action: str) -> str:
         dd = self.cache.get_daemon(daemon_name)
         assert dd.daemon_type is not None

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -279,6 +279,7 @@ class CephadmServe:
             sd.memory_request = d.get('memory_request')
             sd.memory_limit = d.get('memory_limit')
             sd._service_name = d.get('service_name')
+            sd.deployed_by = d.get('deployed_by')
             sd.version = d.get('version')
             sd.ports = d.get('ports')
             sd.ip = d.get('ip')
@@ -880,6 +881,7 @@ class CephadmServe:
                             'service_name': daemon_spec.service_name,
                             'ports': daemon_spec.ports,
                             'ip': daemon_spec.ip,
+                            'deployed_by': self.mgr.get_active_mgr_digests(),
                         }),
                         '--config-json', '-',
                     ] + daemon_spec.extra_args,

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -289,7 +289,7 @@ class TestCephadm(object):
                 _run_cephadm.assert_called_with(
                     'test', 'mon.test', 'deploy', [
                         '--name', 'mon.test',
-                        '--meta-json', '{"service_name": "mon", "ports": [], "ip": null}',
+                        '--meta-json', '{"service_name": "mon", "ports": [], "ip": null, "deployed_by": []}',
                         '--config-json', '-',
                         '--reconfig',
                     ],

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -83,6 +83,7 @@ def test_upgrade_run(use_repo_digest, cephadm_module: CephadmOrchestrator):
                             container_id='container_id',
                             container_image_id='image_id',
                             container_image_digests=['to_image@repo_digest'],
+                            deployed_by=['to_image@repo_digest'],
                             version='version',
                             state='running',
                         )

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -23,7 +23,8 @@ class CephadmNoImage(Enum):
 # NOTE: order important here as these are used for upgrade order
 CEPH_TYPES = ['mgr', 'mon', 'crash', 'osd', 'mds', 'rgw', 'rbd-mirror', 'cephfs-mirror']
 GATEWAY_TYPES = ['iscsi', 'nfs']
-CEPH_UPGRADE_ORDER = CEPH_TYPES + GATEWAY_TYPES
+MONITORING_STACK_TYPES = ['node-exporter', 'prometheus', 'alertmanager', 'grafana']
+CEPH_UPGRADE_ORDER = CEPH_TYPES + GATEWAY_TYPES + MONITORING_STACK_TYPES
 
 
 # Used for _run_cephadm used for check-host etc that don't require an --image parameter

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -848,7 +848,7 @@ class DaemonDescription(object):
 
         self.ports: Optional[List[int]] = ports
         self.ip: Optional[str] = ip
-        
+
         self.deployed_by = deployed_by
 
         self.is_active = is_active

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -793,6 +793,7 @@ class DaemonDescription(object):
                  service_name: Optional[str] = None,
                  ports: Optional[List[int]] = None,
                  ip: Optional[str] = None,
+                 deployed_by: Optional[List[str]] = None,
                  ) -> None:
 
         # Host is at the same granularity as InventoryHost
@@ -847,6 +848,8 @@ class DaemonDescription(object):
 
         self.ports: Optional[List[int]] = ports
         self.ip: Optional[str] = ip
+        
+        self.deployed_by = deployed_by
 
         self.is_active = is_active
 


### PR DESCRIPTION
daemons not upgraded during the upgrade call and mgr daemons that could
have been upgraded by a mgr running the old pre-upgrade image need to be
redeployed after the rest of the upgrade is complete in case something
important has changed in the deployment between the old image and new
image

Fixes: https://tracker.ceph.com/issues/49013

Signed-off-by: Adam King <adking@redhat.com>

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
