### PR TITLE
pacific: rgw: fix valgrind errors when protected_fixedsize_stack is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,6 +350,13 @@ else(ALLOCATOR)
   endif(gperftools_FOUND)
 endif(ALLOCATOR)
 
+if(${ALLOCATOR} STREQUAL "libc" AND WITH_SYSTEM_BOOST)
+  # valgrind can only work with libc allocator
+  # if system boost is not used, valgrind use should
+  #   be indicated via the WITH_BOOST_VALGRIND parameter
+  add_definitions(-DBOOST_USE_VALGRIND)
+endif()
+
 # Mingw generates incorrect entry points when using "-pie".
 if(WIN32 OR (HAVE_LIBTCMALLOC AND WITH_STATIC_LIBSTDCXX))
   set(EXE_LINKER_USE_PIE FALSE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,13 +350,6 @@ else(ALLOCATOR)
   endif(gperftools_FOUND)
 endif(ALLOCATOR)
 
-if(${ALLOCATOR} STREQUAL "libc" AND WITH_SYSTEM_BOOST)
-  # valgrind can only work with libc allocator
-  # if system boost is not used, valgrind use should
-  #   be indicated via the WITH_BOOST_VALGRIND parameter
-  add_definitions(-DBOOST_USE_VALGRIND)
-endif()
-
 # Mingw generates incorrect entry points when using "-pie".
 if(WIN32 OR (HAVE_LIBTCMALLOC AND WITH_STATIC_LIBSTDCXX))
   set(EXE_LINKER_USE_PIE FALSE)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -178,6 +178,8 @@ target_include_directories(rgw_common PRIVATE "${LUA_INCLUDE_DIR}")
 
 target_include_directories(rgw_common PRIVATE
   $<TARGET_PROPERTY:spawn,INTERFACE_INCLUDE_DIRECTORIES>)
+target_compile_definitions(rgw_common PRIVATE
+  $<TARGET_PROPERTY:spawn,INTERFACE_COMPILE_DEFINITIONS>)
 
 if(WITH_LTTNG)
   # rgw/rgw_op.cc includes "tracing/rgw_op.h"

--- a/src/test/cls_fifo/CMakeLists.txt
+++ b/src/test/cls_fifo/CMakeLists.txt
@@ -1,8 +1,6 @@
 add_executable(ceph_test_cls_fifo
   test_cls_fifo.cc
   )
-target_include_directories(ceph_test_cls_fifo PRIVATE
-  $<TARGET_PROPERTY:spawn,INTERFACE_INCLUDE_DIRECTORIES>)
 target_link_libraries(ceph_test_cls_fifo
   neorados_cls_fifo
   libneorados
@@ -21,8 +19,6 @@ install(TARGETS
 add_executable(ceph_bench_cls_fifo
   bench_cls_fifo.cc
   )
-target_include_directories(ceph_bench_cls_fifo PRIVATE
-  $<TARGET_PROPERTY:spawn,INTERFACE_INCLUDE_DIRECTORIES>)
 target_link_libraries(ceph_bench_cls_fifo
   neorados_cls_fifo
   libneorados

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -20,8 +20,6 @@ if(NOT WIN32)
   set(neorados_srcs
       neorados.cc)
   add_executable(neorados ${neorados_srcs})
-  target_include_directories(neorados PRIVATE
-    $<TARGET_PROPERTY:spawn,INTERFACE_INCLUDE_DIRECTORIES>)
   target_link_libraries(neorados libneorados spawn ${CMAKE_DL_LIBS})
   #install(TARGETS neorados DESTINATION bin)
 endif()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49060

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
