### PR TITLE
pacific: rgw multisite: fix RGWCoroutine error handling

### DIFF
--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -1010,6 +1010,7 @@ bool RGWCoroutine::drain_children(int num_cr_left,
           int r = (*cb)(stack_id, ret);
           if (r < 0) {
             drain_status.ret = r;
+            drain_status.should_exit = true;
             num_cr_left = 0; /* need to drain all */
           }
         }

--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -973,7 +973,9 @@ bool RGWCoroutine::drain_children(int num_cr_left,
       yield wait_for_child();
       int ret;
       uint64_t stack_id;
-      while (collect(&ret, skip_stack, &stack_id)) {
+      bool again = false;
+      do {
+        again = collect(&ret, skip_stack, &stack_id);
         if (ret < 0) {
             ldout(cct, 10) << "collect() returned ret=" << ret << dendl;
             /* we should have reported this error */
@@ -982,7 +984,7 @@ bool RGWCoroutine::drain_children(int num_cr_left,
         if (cb) {
           (*cb)(stack_id, ret);
         }
-      }
+      } while (again);
     }
     done = true;
   }
@@ -1000,7 +1002,9 @@ bool RGWCoroutine::drain_children(int num_cr_left,
       yield wait_for_child();
       int ret;
       uint64_t stack_id;
-      while (collect(&ret, nullptr, &stack_id)) {
+      bool again = false;
+      do {
+        again = collect(&ret, nullptr, &stack_id);
         if (ret < 0) {
           ldout(cct, 10) << "collect() returned ret=" << ret << dendl;
           /* we should have reported this error */
@@ -1014,7 +1018,7 @@ bool RGWCoroutine::drain_children(int num_cr_left,
             num_cr_left = 0; /* need to drain all */
           }
         }
-      }
+      } while (again);
     }
     done = true;
   }

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1226,8 +1226,6 @@ class RGWRunBucketSourcesSyncCR : public RGWCoroutine {
   RGWRESTConn *conn{nullptr};
   rgw_zone_id last_zone;
 
-  int ret{0};
-
   int source_num_shards{0};
   int target_num_shards{0};
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49172

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
