### PR TITLE
mgr/dashboard: report mgr fsid 

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cluster_configuration.py
+++ b/src/pybind/mgr/dashboard/controllers/cluster_configuration.py
@@ -39,6 +39,9 @@ class ClusterConfiguration(RESTController):
         :return: list of config options extended by their current values
         """
         config_dump = CephService.send_command('mon', 'config dump')
+        mgr_config = mgr.get('config')
+        config_dump.append({'name': 'fsid', 'section': 'mgr', 'value': mgr_config['fsid']})
+
         for config_dump_entry in config_dump:
             for i, elem in enumerate(options):
                 if config_dump_entry['name'] == elem['name']:

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/configuration.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/configuration.e2e-spec.ts
@@ -51,7 +51,7 @@ describe('Configuration page', () => {
 
     it('should show only modified configurations', () => {
       configuration.filterTable('Modified', 'yes');
-      configuration.getTableCount('found').should('eq', 1);
+      configuration.getTableCount('found').should('eq', 2);
     });
 
     it('should hide all modified configurations', () => {


### PR DESCRIPTION
Add mgr fsid from the ceph mgr API.

![image](https://user-images.githubusercontent.com/37327689/107814643-89c4af80-6d72-11eb-9748-0fce90691601.png)

Fixes: https://tracker.ceph.com/issues/49283
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
