### PR TITLE
crimson/monc: consider v1 addresses when connecting to a monitor.

### DIFF
--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -133,6 +133,7 @@ Connection::Connection(const AuthRegistry& auth_registry,
 
 seastar::future<> Connection::handle_auth_reply(Ref<MAuthReply> m)
 {
+  logger().info("{}", __func__);
   reply.set_value(m);
   reply = {};
   return seastar::now();
@@ -436,6 +437,7 @@ int Connection::handle_auth_bad_method(uint32_t old_auth_method,
 
 void Connection::close()
 {
+  logger().info("{}", __func__);
   reply.set_value(Ref<MAuthReply>(nullptr));
   reply = {};
   if (auth_done) {


### PR DESCRIPTION
This should tackle https://pulpito.ceph.com/nhm-2021-02-01_16:12:18-rados-master-distro-basic-smithi/5846557/.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
