### PR TITLE
mgr: add --max <n> to 'osd ok-to-stop' command

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -992,11 +992,16 @@ data should remain readable and writeable, although data redundancy
 may be reduced as some PGs may end up in a degraded (but active)
 state.  It will return a success code if it is okay to stop the
 OSD(s), or an error code and informative message if it is not or if no
-conclusion can be drawn at the current time.
+conclusion can be drawn at the current time.  When ``--max <num>`` is
+provided, up to <num> OSDs IDs will return (including the provided
+OSDs) that can all be stopped simultaneously.  This allows larger sets
+of stoppable OSDs to be generated easily by providing a single
+starting OSD and a max.  Additional OSDs are drawn from adjacent locations
+in the CRUSH hierarchy.
 
 Usage::
 
-  ceph osd ok-to-stop <id> [<ids>...]
+  ceph osd ok-to-stop <id> [<ids>...] [--max <num>]
 
 Subcommand ``pause`` pauses osd.
 

--- a/qa/standalone/misc/ok-to-stop.sh
+++ b/qa/standalone/misc/ok-to-stop.sh
@@ -264,6 +264,8 @@ function TEST_0_osd() {
     ceph osd ok-to-stop 3 || return 1
     ! ceph osd ok-to-stop 0 1 || return 1
     ! ceph osd ok-to-stop 2 3 || return 1
+    ceph osd ok-to-stop 0 --max 2 | grep '[0]' || return 1
+    ceph osd ok-to-stop 1 --max 2 | grep '[1]' || return 1
 
     # with min_size 2 we can stop 1 osds
     ceph osd pool set ec min_size 2 || return 1
@@ -273,6 +275,11 @@ function TEST_0_osd() {
     ceph osd ok-to-stop 2 3 || return 1
     ! ceph osd ok-to-stop 0 1 2 || return 1
     ! ceph osd ok-to-stop 1 2 3 || return 1
+
+    ceph osd ok-to-stop 0 --max 2 | grep '[0,1]' || return 1
+    ceph osd ok-to-stop 0 --max 20 | grep '[0,1]' || return 1
+    ceph osd ok-to-stop 2 --max 2 | grep '[2,3]' || return 1
+    ceph osd ok-to-stop 2 --max 20 | grep '[2,3]' || return 1
 
     # we should get the same result with one of the osds already down
     kill_daemons $dir TERM osd.0 || return 1

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -1250,18 +1250,6 @@ def main():
                               errno.errorcode.get(ret, 'Unknown'), outs),
                           file=sys.stderr)
 
-        if ret < 0:
-            ret = -ret
-            errstr = errno.errorcode.get(ret, 'Unknown')
-            print('Error {0}: {1}'.format(errstr, outs), file=sys.stderr)
-            if len(targets) > 1:
-                final_ret = ret
-            else:
-                return ret
-
-        if outs:
-            print(prefix + outs, file=sys.stderr)
-
         sys.stdout.flush()
 
         if parsed_args.output_file:
@@ -1287,12 +1275,23 @@ def main():
                 except IOError as e:
                     if e.errno != errno.EPIPE:
                         raise e
+        final_e = None
         try:
             sys.stdout.flush()
         except IOError as e:
             if e.errno != errno.EPIPE:
-                raise e
+                final_e = e
 
+        if ret < 0:
+            ret = -ret
+            errstr = errno.errorcode.get(ret, 'Unknown')
+            print('Error {0}: {1}'.format(errstr, outs), file=sys.stderr)
+            final_ret = ret
+        elif outs:
+            print(prefix + outs, file=sys.stderr)
+
+        if final_e:
+            raise final_e
 
     # Block until command completion (currently scrub and deep_scrub only)
     if block:

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1643,20 +1643,21 @@ bool DaemonServer::_handle_command(
 	    continue;
 	  }
 	  touched_pgs++;
-	  if (!(q.second.state & PG_STATE_ACTIVE) ||
-	      (q.second.state & PG_STATE_DEGRADED)) {
-	    ++dangerous_pgs;
-	    continue;
-	  }
+
 	  const pg_pool_t *pi = osdmap.get_pg_pool(q.first.pool());
 	  if (!pi) {
 	    ++dangerous_pgs; // pool is creating or deleting
-	  } else {
-	    if (pg_acting.size() < pi->min_size) {
-	      ++dangerous_pgs;
-	    }
+            continue;
 	  }
-	}
+
+	  if (!(q.second.state & PG_STATE_ACTIVE)) {
+	    ++dangerous_pgs;
+	    continue;
+	  }
+          if (pg_acting.size() < pi->min_size) {
+            ++dangerous_pgs;
+          }
+        }
       });
     if (r) {
       cmdctx->reply(r, ss);

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -868,6 +868,129 @@ void DaemonServer::log_access_denied(
         "#client-authentication";
 }
 
+int DaemonServer::_check_offlines_pgs(
+  const set<int>& osds,
+  const OSDMap& osdmap,
+  const PGMap& pgmap,
+  int *out_touched_pgs)
+{
+  int touched_pgs = 0;
+  int dangerous_pgs = 0;
+  for (const auto& q : pgmap.pg_stat) {
+    set<int32_t> pg_acting;  // net acting sets (with no missing if degraded)
+    bool found = false;
+    if (q.second.state & PG_STATE_DEGRADED) {
+      for (auto& anm : q.second.avail_no_missing) {
+	if (osds.count(anm.osd)) {
+	  found = true;
+	  continue;
+	}
+	if (anm.osd != CRUSH_ITEM_NONE) {
+	  pg_acting.insert(anm.osd);
+	}
+      }
+    } else {
+      for (auto& a : q.second.acting) {
+	if (osds.count(a)) {
+	  found = true;
+	  continue;
+	}
+	if (a != CRUSH_ITEM_NONE) {
+	  pg_acting.insert(a);
+	}
+      }
+    }
+    if (!found) {
+      continue;
+    }
+    touched_pgs++;
+    const pg_pool_t *pi = osdmap.get_pg_pool(q.first.pool());
+    if (!pi) {
+      ++dangerous_pgs; // pool is creating or deleting
+      continue;
+    }
+    if (!(q.second.state & PG_STATE_ACTIVE)) {
+      ++dangerous_pgs;
+      continue;
+    }
+    if (pg_acting.size() < pi->min_size) {
+      ++dangerous_pgs;
+    }
+  }
+  dout(20) << osds << " -> " << dangerous_pgs << "/" << touched_pgs
+	   << " dangerous/touched" << dendl;
+  *out_touched_pgs = touched_pgs;
+  return dangerous_pgs;
+}
+
+int DaemonServer::_maximize_ok_to_stop_set(
+  const set<int>& orig_osds,
+  unsigned max,
+  const OSDMap& osdmap,
+  const PGMap& pgmap,
+  int *out_touched_pgs,
+  set<int> *out_osds)
+{
+  dout(20) << "orig_osds " << orig_osds << " max " << max << dendl;
+  *out_osds = orig_osds;
+  int r = _check_offlines_pgs(orig_osds, osdmap, pgmap, out_touched_pgs);
+  if (r > 0) {
+    return r;
+  }
+  if (orig_osds.size() == max) {
+    // already at max
+    return 0;
+  }
+
+  // semi-arbitrarily start with the first osd in the set
+  set<int> osds = orig_osds;
+  int parent = *osds.begin();
+  set<int> children;
+
+  while (true) {
+    // identify the next parent
+    r = osdmap.crush->get_immediate_parent_id(parent, &parent);
+    if (r < 0) {
+      return 0;  // just go with what we have so far!
+    }
+
+    // get candidate additions that are beneath this point in the tree
+    children.clear();
+    r = osdmap.crush->get_all_children(parent, &children);
+    if (r < 0) {
+      return 0;  // just go with what we have so far!
+    }
+    dout(20) << "  parent " << parent << " children " << children << dendl;
+
+    // try adding in more osds
+    int failed = 0;  // how many children we failed to add to our set
+    for (auto o : children) {
+      if (o >= 0 && osdmap.is_up(o) && osds.count(o) == 0) {
+	osds.insert(o);
+	int touched;
+	r = _check_offlines_pgs(osds, osdmap, pgmap, &touched);
+	if (r > 0) {
+	  osds.erase(o);
+	  ++failed;
+	  continue;
+	}
+	*out_osds = osds;
+	*out_touched_pgs = touched;
+	if (osds.size() == max) {
+	  dout(20) << " hit max" << dendl;
+	  return 0;  // yay, we hit the max
+	}
+      }
+    }
+
+    if (failed) {
+      // we hit some failures; go with what we have
+      dout(20) << " hit some peer failures" << dendl;
+      return 0;
+    }
+  }
+}
+
 bool DaemonServer::_handle_command(
   std::shared_ptr<CommandContext>& cmdctx)
 {
@@ -1594,6 +1717,11 @@ bool DaemonServer::_handle_command(
     vector<string> ids;
     cmd_getval(cmdctx->cmdmap, "ids", ids);
     set<int> osds;
+    int64_t max = 1;
+    cmd_getval(cmdctx->cmdmap, "max", max);
+    if (max < (int)osds.size()) {
+      max = osds.size();
+    }
     int r;
     cluster_state.with_osdmap([&](const OSDMap& osdmap) {
 	r = osdmap.parse_osd_id_list(ids, &osds, &ss);
@@ -1606,6 +1734,7 @@ bool DaemonServer::_handle_command(
       cmdctx->reply(r, ss);
       return true;
     }
+    set<int> out_osds;
     int touched_pgs = 0;
     int dangerous_pgs = 0;
     cluster_state.with_osdmap_and_pgmap([&](const OSDMap& osdmap, const PGMap& pg_map) {
@@ -1615,51 +1744,11 @@ bool DaemonServer::_handle_command(
 	  r = -EAGAIN;
 	  return;
 	}
-	for (const auto& q : pg_map.pg_stat) {
-          set<int32_t> pg_acting;  // net acting sets (with no missing if degraded)
-	  bool found = false;
-	  if (q.second.state & PG_STATE_DEGRADED) {
-	    for (auto& anm : q.second.avail_no_missing) {
-	      if (osds.count(anm.osd)) {
-		found = true;
-		continue;
-	      }
-	      if (anm.osd != CRUSH_ITEM_NONE) {
-		pg_acting.insert(anm.osd);
-	      }
-	    }
-	  } else {
-	    for (auto& a : q.second.acting) {
-	      if (osds.count(a)) {
-		found = true;
-		continue;
-	      }
-	      if (a != CRUSH_ITEM_NONE) {
-		pg_acting.insert(a);
-	      }
-	    }
-	  }
-	  if (!found) {
-	    continue;
-	  }
-	  touched_pgs++;
-
-	  const pg_pool_t *pi = osdmap.get_pg_pool(q.first.pool());
-	  if (!pi) {
-	    ++dangerous_pgs; // pool is creating or deleting
-            continue;
-	  }
-
-	  if (!(q.second.state & PG_STATE_ACTIVE)) {
-	    ++dangerous_pgs;
-	    continue;
-	  }
-          if (pg_acting.size() < pi->min_size) {
-            ++dangerous_pgs;
-          }
-        }
+	dangerous_pgs = _maximize_ok_to_stop_set(
+	  osds, max, osdmap, pg_map,
+	  &touched_pgs, &out_osds);
       });
-    if (r) {
+    if (r < 0) {
       cmdctx->reply(r, ss);
       return true;
     }
@@ -1669,11 +1758,21 @@ bool DaemonServer::_handle_command(
       cmdctx->reply(-EBUSY, ss);
       return true;
     }
-    ss << "OSD(s) " << osds << " are ok to stop without reducing"
+    ss << "These OSD(s) are ok to stop without reducing"
        << " availability or risking data, provided there are no other concurrent failures"
        << " or interventions." << std::endl;
     ss << touched_pgs << " PGs are likely to be"
        << " degraded (but remain available) as a result.";
+    if (!f) {
+      f.reset(Formatter::create("json"));
+    }
+    f->open_array_section("osds");
+    for (auto o : out_osds) {
+      f->dump_int("osd", o);
+    }
+    f->close_section();
+    f->flush(cmdctx->odata);
+    cmdctx->odata.append("\n");
     cmdctx->reply(0, ss);
     return true;
   } else if (prefix == "pg force-recovery" ||

--- a/src/mgr/DaemonServer.h
+++ b/src/mgr/DaemonServer.h
@@ -99,6 +99,19 @@ private:
 
   void _prune_pending_service_map();
 
+  int _check_offlines_pgs(
+    const set<int>& osds,
+    const OSDMap& osdmap,
+    const PGMap& pgmap,
+    int *out_touched_pgs);
+  int _maximize_ok_to_stop_set(
+    const set<int>& orig_osds,
+    unsigned max,
+    const OSDMap& osdmap,
+    const PGMap& pgmap,
+    int *out_touched_pgs,
+    set<int> *out_osds);
+
   utime_t started_at;
   std::atomic<bool> pgmap_ready;
   std::set<int32_t> reported_osds;

--- a/src/mgr/DaemonServer.h
+++ b/src/mgr/DaemonServer.h
@@ -45,6 +45,69 @@ class CommandContext;
 struct OSDPerfMetricQuery;
 struct MDSPerfMetricQuery;
 
+
+struct offline_pg_report {
+  set<int> osds;
+  set<pg_t> ok, not_ok;
+  set<pg_t> ok_become_degraded, ok_become_more_degraded;             // ok
+  set<pg_t> bad_no_pool, bad_already_inactive, bad_become_inactive;  // not ok
+
+  bool ok_to_stop() const {
+    return not_ok.empty();
+  }
+
+  void dump(Formatter *f) const {
+    f->dump_bool("ok_to_stop", ok_to_stop());
+    f->open_array_section("osds");
+    for (auto o : osds) {
+      f->dump_int("osd", o);
+    }
+    f->close_section();
+    f->dump_unsigned("num_ok_pgs", ok.size());
+    f->dump_unsigned("num_not_ok_pgs", not_ok.size());
+
+    // bad news
+    if (!bad_no_pool.empty()) {
+      f->open_array_section("bad_no_pool_pgs");
+      for (auto pg : bad_no_pool) {
+	f->dump_stream("pg") << pg;
+      }
+      f->close_section();
+    }
+    if (!bad_already_inactive.empty()) {
+      f->open_array_section("bad_already_inactive");
+      for (auto pg : bad_already_inactive) {
+	f->dump_stream("pg") << pg;
+      }
+      f->close_section();
+    }
+    if (!bad_become_inactive.empty()) {
+      f->open_array_section("bad_become_inactive");
+      for (auto pg : bad_become_inactive) {
+	f->dump_stream("pg") << pg;
+      }
+      f->close_section();
+    }
+
+    // informative
+    if (!ok_become_degraded.empty()) {
+      f->open_array_section("ok_become_degraded");
+      for (auto pg : ok_become_degraded) {
+	f->dump_stream("pg") << pg;
+      }
+      f->close_section();
+    }
+    if (!ok_become_more_degraded.empty()) {
+      f->open_array_section("ok_become_more_degraded");
+      for (auto pg : ok_become_more_degraded) {
+	f->dump_stream("pg") << pg;
+      }
+      f->close_section();
+    }
+  }
+};
+
+
 /**
  * Server used in ceph-mgr to communicate with Ceph daemons like
  * MDSs and OSDs.
@@ -99,18 +162,17 @@ private:
 
   void _prune_pending_service_map();
 
-  int _check_offlines_pgs(
+  void _check_offlines_pgs(
     const set<int>& osds,
     const OSDMap& osdmap,
     const PGMap& pgmap,
-    int *out_touched_pgs);
-  int _maximize_ok_to_stop_set(
+    offline_pg_report *report);
+  void _maximize_ok_to_stop_set(
     const set<int>& orig_osds,
     unsigned max,
     const OSDMap& osdmap,
     const PGMap& pgmap,
-    int *out_touched_pgs,
-    set<int> *out_osds);
+    offline_pg_report *report);
 
   utime_t started_at;
   std::atomic<bool> pgmap_ready;

--- a/src/mgr/MgrCommands.h
+++ b/src/mgr/MgrCommands.h
@@ -157,7 +157,8 @@ COMMAND("osd purge " \
 COMMAND("osd safe-to-destroy name=ids,type=CephString,n=N",
 	"check whether osd(s) can be safely destroyed without reducing data durability",
 	"osd", "r")
-COMMAND("osd ok-to-stop name=ids,type=CephString,n=N",
+COMMAND("osd ok-to-stop name=ids,type=CephString,n=N "\
+	"name=max,type=CephInt,req=false",
 	"check whether osd(s) can be safely stopped without reducing immediate"\
 	" data availability", "osd", "r")
 

--- a/src/test/osd/safe-to-destroy.sh
+++ b/src/test/osd/safe-to-destroy.sh
@@ -82,7 +82,7 @@ function TEST_ok_to_stop() {
     ceph osd ok-to-stop 1
     ceph osd ok-to-stop 2
     ceph osd ok-to-stop 3
-    expect_failure $dir degraded ceph osd ok-to-stop 0 1
+    expect_failure $dir bad_become_inactive ceph osd ok-to-stop 0 1
 
     ceph osd pool set foo min_size 1
     sleep 1
@@ -92,8 +92,8 @@ function TEST_ok_to_stop() {
     ceph osd ok-to-stop 1 2
     ceph osd ok-to-stop 2 3
     ceph osd ok-to-stop 3 4
-    expect_failure $dir degraded ceph osd ok-to-stop 0 1 2
-    expect_failure $dir degraded ceph osd ok-to-stop 0 1 2 3
+    expect_failure $dir bad_become_inactive ceph osd ok-to-stop 0 1 2
+    expect_failure $dir bad_become_inactive ceph osd ok-to-stop 0 1 2 3
 }
 
 main safe-to-destroy "$@"


### PR DESCRIPTION
Given and initial (set of) osd(s), if provide up to N OSDs that can be stopped together without making PGs become unavailable.  This can be used to quickly identify large(r) batches of OSDs that can be stopped together to (for example) upgrade.

Adjust the command output to dump structured JSON so that we can include
- which osd(s) are safe to stop together (since it might include more than what was provided on the command line)
- which pgs would become degraded or become more degraded
- on failure, which pgs would become inactive, are already inactive, or are creating/deleting

Note that this required some CLI changes:
- ceph command now prints stdout (the json output) when the exit code is non-zero

For example, a successful return:
```
$ bin/ceph osd ok-to-stop 5 --max 20

{"ok_to_stop":true,"osds":[0,1,5],"num_ok_pgs":163,"num_not_ok_pgs":0,"ok_become_degraded":["1.0","1.1","1.2","1.3","1.4","1.8","1.9","1.a","1.b","1.c","1.e","1.f","1.10","1.12","1.14","1.15","1.17","1.18","1.19","1.1a","1.1b","1.1c","1.1d","1.1f","1.20","1.21","1.22","1.23","1.27","1.28","1.29","1.2a","1.2c","1.2d","1.2e","1.2f","1.30","1.31","1.32","1.36","1.37","1.39","1.3b","1.3c","1.3d","1.3e","1.3f","1.40","1.41","1.42","1.44","1.45","1.46","1.47","1.48","1.49","1.4a","1.4b","1.4e","1.50","1.52","1.54","1.57","1.59","1.5a","1.5e","1.60","1.62","1.63","1.67","1.69","1.6e","1.6f","1.70","1.71","1.72","1.73","1.75","1.76","1.79","1.7a","1.7c","1.82","1.83","1.84","1.86","1.87","1.88","1.8a","1.8b","1.8c","1.8e","1.8f","1.90","1.91","1.95","1.97","1.98","1.99","1.9a","1.9b","1.9e","1.9f","1.a0","1.a2","1.a3","1.a4","1.a5","1.a6","1.a7","1.a8","1.ae","1.af","1.b0","1.b3","1.b4","1.b6","1.b7","1.b8","1.b9","1.bb","1.bc","1.bd","1.be","1.c1","1.c5","1.c6","1.c7","1.c8","1.ca","1.ce","1.cf","1.d0","1.d4","1.d5","1.d7","1.d8","1.d9","1.db","1.e0","1.e1","1.e3","1.e5","1.e6","1.e7","1.e8","1.e9","1.ea","1.eb","1.ec","1.ef","1.f1","1.f2","1.f3","1.f5","1.f6","1.f8","1.fa","1.fb","1.fc","1.fd","1.fe","1.ff"]}
```
and a failed command:
```
$ bin/ceph osd ok-to-stop 5 6 7 8 --max 20

{"ok_to_stop":false,"osds":[5,6,7,8],"num_ok_pgs":176,"num_not_ok_pgs":9,"bad_become_inactive":["1.10","1.16","1.21","1.27","1.3e","1.5f","1.a7","1.c1","1.e9"],"ok_become_degraded":["1.0","1.1","1.2","1.4","1.5","1.6","1.7","1.8","1.9","1.a","1.d","1.11","1.12","1.13","1.15","1.18","1.1a","1.1e","1.20","1.22","1.23","1.24","1.26","1.28","1.29","1.2a","1.2c","1.2d","1.2f","1.31","1.32","1.33","1.35","1.36","1.37","1.38","1.3a","1.3c","1.3d","1.3f","1.40","1.41","1.42","1.43","1.44","1.45","1.46","1.47","1.48","1.49","1.4b","1.4c","1.4e","1.4f","1.51","1.52","1.53","1.54","1.55","1.57","1.59","1.5b","1.5c","1.5d","1.63","1.65","1.68","1.69","1.6a","1.6c","1.6d","1.6e","1.6f","1.70","1.71","1.73","1.74","1.75","1.79","1.7a","1.7b","1.7d","1.80","1.82","1.83","1.84","1.85","1.88","1.8b","1.8c","1.8d","1.8e","1.8f","1.90","1.92","1.93","1.94","1.96","1.99","1.9a","1.9b","1.9c","1.9d","1.a0","1.a1","1.a4","1.a5","1.a6","1.a9","1.aa","1.ab","1.ac","1.ae","1.af","1.b2","1.b3","1.b4","1.b5","1.b6","1.b7","1.b8","1.b9","1.bb","1.bc","1.bd","1.be","1.bf","1.c0","1.c3","1.c4","1.c5","1.c6","1.c7","1.c8","1.ca","1.cc","1.cd","1.ce","1.d0","1.d2","1.d3","1.d4","1.d6","1.d7","1.d8","1.d9","1.da","1.db","1.dc","1.dd","1.de","1.df","1.e0","1.e1","1.e2","1.e5","1.e6","1.e8","1.ea","1.ec","1.ee","1.ef","1.f0","1.f1","1.f3","1.f5","1.f6","1.f7","1.f8","1.f9","1.fa","1.fb","1.fc","1.fd","1.fe","1.ff"]}
Error EBUSY: unsafe to stop osd(s)
unsafe to stop osd(s)
```
