### PR TITLE
mgr/cephadm: SpecStore: use d-under accessor methods

### DIFF
--- a/src/pybind/mgr/cephadm/services/ha_rgw.py
+++ b/src/pybind/mgr/cephadm/services/ha_rgw.py
@@ -23,9 +23,9 @@ class HA_RGWService(CephService):
         # spec should be in spec store
         if not daemon_spec.spec:
             service_name: str = "ha-rgw." + daemon_spec.daemon_id.split('.')[0]
-            if service_name in self.mgr.spec_store.specs:
+            if service_name in self.mgr.spec_store:
                 daemon_spec.spec = cast(
-                    HA_RGWSpec, self.mgr.spec_store.specs.get(service_name))
+                    HA_RGWSpec, self.mgr.spec_store[service_name].spec)
         assert daemon_spec.spec
 
         if daemon_spec.daemon_type == 'haproxy':

--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -30,9 +30,9 @@ class IscsiService(CephService):
         # spec should be in spec store
         if not daemon_spec.spec:
             service_name: str = "iscsi." + daemon_spec.daemon_id.split('.')[0]
-            if service_name in self.mgr.spec_store.specs:
+            if service_name in self.mgr.spec_store:
                 daemon_spec.spec = cast(
-                    IscsiServiceSpec, self.mgr.spec_store.specs.get(service_name))
+                    IscsiServiceSpec, self.mgr.spec_store[service_name].spec)
         assert daemon_spec.spec
 
         spec = daemon_spec.spec

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -101,9 +101,9 @@ class AlertmanagerService(CephadmService):
         # spec should be in spec store
         if not daemon_spec.spec:
             service_name: str = "alertmanager"
-            if service_name in self.mgr.spec_store.specs:
+            if service_name in self.mgr.spec_store:
                 daemon_spec.spec = cast(
-                    AlertManagerSpec, self.mgr.spec_store.specs.get(service_name))
+                    AlertManagerSpec, self.mgr.spec_store[service_name].spec)
         assert daemon_spec.spec
         daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
         return daemon_spec

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -30,9 +30,9 @@ class NFSService(CephService):
         # spec should be in spec store
         if not daemon_spec.spec:
             service_name: str = "nfs." + daemon_spec.daemon_id.split('.')[0]
-            if service_name in self.mgr.spec_store.specs:
+            if service_name in self.mgr.spec_store:
                 daemon_spec.spec = cast(
-                    NFSServiceSpec, self.mgr.spec_store.specs.get(service_name))
+                    NFSServiceSpec, self.mgr.spec_store[service_name].spec)
         assert daemon_spec.spec
 
         daemon_id = daemon_spec.daemon_id


### PR DESCRIPTION
This fixes a conflict between:

* 1fcdad17685a8884135a2cda0cdfe3525e325474
* 2c7f899124207d0d4866e16d9eb5609777ea22e8

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
