### PR TITLE
mgr/dashboard: fix MTU Mismatch alert

### DIFF
--- a/monitoring/prometheus/alerts/ceph_default_alerts.yml
+++ b/monitoring/prometheus/alerts/ceph_default_alerts.yml
@@ -215,7 +215,7 @@ groups:
             rate of the past 48 hours.
 
       - alert: MTU Mismatch
-        expr: node_network_mtu_bytes{device!="lo"} != on(device) group_left() (quantile(0.5, node_network_mtu_bytes{device!="lo"}) by (device))
+        expr: node_network_mtu_bytes{device!="lo"} != on() group_left() (quantile(0.5, node_network_mtu_bytes{device!="lo"}))
         labels:
           severity: warning
           type: ceph_default


### PR DESCRIPTION
This PR intends to fix the expression used for MTU Mismatch alert in prometheus

Fixes: https://tracker.ceph.com/issues/49291
Signed-off-by: Aashish Sharma <aasharma@redhat.com>

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
