### PR TITLE
librbd: use on-disk image name when storing mirror snapshot state

### DIFF
--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -671,30 +671,17 @@ int Operations<I>::rename(const char *dstname) {
     return -EEXIST;
   }
 
-  if (m_image_ctx.test_features(RBD_FEATURE_JOURNALING)) {
-    uint64_t request_id = util::reserve_async_request_id();
-    r = invoke_async_request(OPERATION_RENAME,
-                             exclusive_lock::OPERATION_REQUEST_TYPE_GENERAL,
-                             true,
-                             boost::bind(&Operations<I>::execute_rename, this,
-                                         dstname, _1),
-                             boost::bind(&ImageWatcher<I>::notify_rename,
-                                         m_image_ctx.image_watcher, request_id,
-                                         dstname, _1));
-    if (r < 0 && r != -EEXIST) {
-      return r;
-    }
-  } else {
-    C_SaferCond cond_ctx;
-    {
-      std::shared_lock owner_lock{m_image_ctx.owner_lock};
-      execute_rename(dstname, &cond_ctx);
-    }
-
-    r = cond_ctx.wait();
-    if (r < 0) {
-      return r;
-    }
+  uint64_t request_id = util::reserve_async_request_id();
+  r = invoke_async_request(OPERATION_RENAME,
+                           exclusive_lock::OPERATION_REQUEST_TYPE_GENERAL,
+                           true,
+                           boost::bind(&Operations<I>::execute_rename, this,
+                                       dstname, _1),
+                           boost::bind(&ImageWatcher<I>::notify_rename,
+                                       m_image_ctx.image_watcher, request_id,
+                                       dstname, _1));
+  if (r < 0 && r != -EEXIST) {
+    return r;
   }
 
   m_image_ctx.set_image_name(dstname);

--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -715,19 +715,19 @@ void Operations<I>::execute_rename(const std::string &dest_name,
     return;
   }
 
-  m_image_ctx.image_lock.lock_shared();
-  if (m_image_ctx.name == dest_name) {
-    m_image_ctx.image_lock.unlock_shared();
-    on_finish->complete(-EEXIST);
-    return;
-  }
-  m_image_ctx.image_lock.unlock_shared();
-
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 5) << this << " " << __func__ << ": dest_name=" << dest_name
                 << dendl;
 
   if (m_image_ctx.old_format) {
+    m_image_ctx.image_lock.lock_shared();
+    if (m_image_ctx.name == dest_name) {
+      m_image_ctx.image_lock.unlock_shared();
+      on_finish->complete(-EEXIST);
+      return;
+    }
+    m_image_ctx.image_lock.unlock_shared();
+
     // unregister watch before and register back after rename
     on_finish = new C_NotifyUpdate<I>(m_image_ctx, on_finish);
     on_finish = new LambdaContext([this, on_finish](int r) {

--- a/src/librbd/mirror/snapshot/SetImageStateRequest.h
+++ b/src/librbd/mirror/snapshot/SetImageStateRequest.h
@@ -40,6 +40,9 @@ private:
    * <start>
    *    |
    *    v
+   * GET_NAME
+   *    |
+   *    v
    * GET_SNAP_LIMIT
    *    |
    *    v
@@ -65,6 +68,9 @@ private:
 
   bufferlist m_bl;
   bufferlist m_state_bl;
+
+  void get_name();
+  void handle_get_name(int r);
 
   void get_snap_limit();
   void handle_get_snap_limit(int r);

--- a/src/librbd/operation/RenameRequest.h
+++ b/src/librbd/operation/RenameRequest.h
@@ -27,6 +27,9 @@ public:
    * <start>
    *    |
    *    v
+   * STATE_READ_DIRECTORY
+   *    |
+   *    v
    * STATE_READ_SOURCE_HEADER
    *    |
    *    v
@@ -45,6 +48,7 @@ public:
    *
    */
   enum State {
+    STATE_READ_DIRECTORY,
     STATE_READ_SOURCE_HEADER,
     STATE_WRITE_DEST_HEADER,
     STATE_UPDATE_DIRECTORY,
@@ -69,10 +73,12 @@ private:
   std::string m_source_oid;
   std::string m_dest_oid;
 
-  State m_state = STATE_READ_SOURCE_HEADER;
+  State m_state = STATE_READ_DIRECTORY;
 
+  bufferlist m_source_name_bl;
   bufferlist m_header_bl;
 
+  void send_read_directory();
   void send_read_source_header();
   void send_write_destination_header();
   void send_update_directory();

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -5068,14 +5068,22 @@ TEST_F(TestLibRBD, RenameViaLockOwner)
   librbd::Image image1;
   ASSERT_EQ(0, rbd.open(ioctx, image1, name.c_str(), NULL));
 
+  bool lock_owner;
+  ASSERT_EQ(0, image1.is_exclusive_lock_owner(&lock_owner));
+  ASSERT_FALSE(lock_owner);
+
+  std::string new_name = get_temp_image_name();
+  ASSERT_EQ(0, rbd.rename(ioctx, name.c_str(), new_name.c_str()));
+  ASSERT_EQ(0, image1.is_exclusive_lock_owner(&lock_owner));
+  ASSERT_FALSE(lock_owner);
+
   bufferlist bl;
   ASSERT_EQ(0, image1.write(0, 0, bl));
-
-  bool lock_owner;
   ASSERT_EQ(0, image1.is_exclusive_lock_owner(&lock_owner));
   ASSERT_TRUE(lock_owner);
 
-  std::string new_name = get_temp_image_name();
+  name = new_name;
+  new_name = get_temp_image_name();
   ASSERT_EQ(0, rbd.rename(ioctx, name.c_str(), new_name.c_str()));
   ASSERT_EQ(0, image1.is_exclusive_lock_owner(&lock_owner));
   ASSERT_TRUE(lock_owner);

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -5054,7 +5054,7 @@ TEST_F(TestLibRBD, RebuildObjectMapViaLockOwner)
 
 TEST_F(TestLibRBD, RenameViaLockOwner)
 {
-  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
   ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/49115
Signed-off-by: Mykola Golub <mgolub@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
