### PR TITLE
doc/cephadm: Disable automatic deployment of daemons

### DIFF
--- a/doc/cephadm/operations.rst
+++ b/doc/cephadm/operations.rst
@@ -355,3 +355,65 @@ the following command on the host:
 .. code-block:: bash
 
   cephadm rm-daemon --fsid CLUSTER_ID --name SERVICE_NAME
+
+
+.. _cephadm-spec-unmanaged:
+
+Disable automatic deployment of daemons
+=======================================
+
+Cephadm supports disabling the automated deployment and removal of daemons per service. In
+this case, the CLI supports two commands that are dedicated to this mode. 
+
+To disable the automatic management of dameons, apply
+the :ref:`orchestrator-cli-service-spec` with ``unmanaged=True``. 
+
+``mgr.yaml``:
+
+.. code-block:: yaml
+
+  service_type: mgr
+  unmanaged: true
+  placement:
+    label: mgr
+
+.. code-block:: bash
+
+  ceph orch apply -i mgr.yaml
+
+.. note::
+
+  cephadm will no longer deploy any new daemons, if the placement
+  specification matches additional hosts.
+
+To manually deploy a daemon on a host, please execute:
+
+.. code-block:: bash
+
+  ceph orch daemon add <daemon-type>  --placement=<placement spec>
+
+For example 
+
+.. code-block:: bash
+
+  ceph orch daemon add mgr --placement=my_host
+
+To manually remove a daemon, please run:
+
+.. code-block:: bash
+
+  ceph orch daemon rm <daemon name>... [--force]
+
+For example 
+
+.. code-block:: bash
+
+  ceph orch daemon rm mgr.my_host.xyzxyz
+
+.. note:: 
+
+  For managed services (``unmanaged=False``), cephadm will automatically
+  deploy a new daemon a few seconds later.
+    
+* See :ref:`orchestrator-cli-create-osds` for special handling of unmanaged OSDs. 
+* See also :ref:`cephadm-pause`

--- a/doc/cephadm/troubleshooting.rst
+++ b/doc/cephadm/troubleshooting.rst
@@ -8,6 +8,8 @@ a specific service no longer runs properly.
 As cephadm deploys daemons as containers, troubleshooting daemons is slightly
 different. Here are a few tools and commands to help investigating issues.
 
+.. _cephadm-pause:
+
 Pausing or disabling cephadm
 ----------------------------
 
@@ -26,6 +28,9 @@ completely with::
 This will disable all of the ``ceph orch ...`` CLI commands but the previously
 deployed daemon containers will still continue to exist and start as they
 did before.
+
+Please refer to :ref:`cephadm-spec-unmanaged` for disabling individual
+services.
 
 
 Per-service and per-daemon events

--- a/doc/mgr/orchestrator.rst
+++ b/doc/mgr/orchestrator.rst
@@ -198,6 +198,8 @@ If you want to avoid this behavior (disable automatic creation of OSD on availab
 
     ceph orch apply osd --all-available-devices --unmanaged=true
 
+* For cephadm, see also :ref:`cephadm-spec-unmanaged`.
+
 Remove an OSD
 -------------
 ::
@@ -703,7 +705,7 @@ where the properties of a service specification are:
     If set to ``true``, the orchestrator will not deploy nor
     remove any daemon associated with this service. Placement and all other
     properties will be ignored. This is useful, if this service should not
-    be managed temporarily.
+    be managed temporarily. For cephadm, See :ref:`cephadm-spec-unmanaged`
 
 Each service type can have additional service specific properties.
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/45767
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
