### PR TITLE
octopus: ceph-volume: Update batch.py

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -102,7 +102,7 @@ def get_physical_fast_allocs(devices, type_, fast_slots_per_device, new_osds, ar
     requested_slots = getattr(args, '{}_slots'.format(type_))
     if not requested_slots or requested_slots < fast_slots_per_device:
         if requested_slots:
-            mlogger.info('{}_slots argument is to small, ignoring'.format(type_))
+            mlogger.info('{}_slots argument is too small, ignoring'.format(type_))
         requested_slots = fast_slots_per_device
 
     requested_size = getattr(args, '{}_size'.format(type_), 0)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49289

---

backport of https://github.com/ceph/ceph/pull/38562
parent tracker: https://tracker.ceph.com/issues/48648

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh