### PR TITLE
mgr/dashboard: fix PUT - /api/host/{hostname} while adding labels

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/host.py
+++ b/src/pybind/mgr/dashboard/controllers/host.py
@@ -375,6 +375,12 @@ class Host(RESTController):
 
     @raise_if_no_orchestrator([OrchFeature.HOST_LABEL_ADD, OrchFeature.HOST_LABEL_REMOVE])
     @handle_orchestrator_error('host')
+    @EndpointDoc('',
+                 parameters={
+                     'hostname': (str, 'Hostname'),
+                     'labels': ([str], 'Host Labels'),
+                 },
+                 responses={200: None, 204: None})
     def set(self, hostname: str, labels: List[str]):
         """
         Update the specified host.
@@ -384,6 +390,12 @@ class Host(RESTController):
         """
         orch = OrchClient.instance()
         host = get_host(hostname)
+        # only allow List[str] type for labels
+        if not isinstance(labels, list):
+            raise DashboardException(
+                msg='Expected list of labels. Please check API documentation.',
+                http_status_code=400,
+                component='orchestrator')
         current_labels = set(host['labels'])
         # Remove labels.
         remove_labels = list(current_labels.difference(set(labels)))

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -3334,7 +3334,8 @@ paths:
         \ name of the host to be processed.\n        :param labels: List of labels.\n\
         \        "
       parameters:
-      - in: path
+      - description: Hostname
+        in: path
         name: hostname
         required: true
         schema:
@@ -3345,7 +3346,10 @@ paths:
             schema:
               properties:
                 labels:
-                  type: string
+                  description: Host Labels
+                  items:
+                    type: string
+                  type: array
               required:
               - labels
               type: object
@@ -3353,7 +3357,9 @@ paths:
         '200':
           content:
             application/vnd.ceph.api.v1.0+json:
-              type: object
+              schema:
+                properties: {}
+                type: object
           description: Resource updated.
         '202':
           content:

--- a/src/pybind/mgr/dashboard/tests/test_host.py
+++ b/src/pybind/mgr/dashboard/tests/test_host.py
@@ -136,6 +136,10 @@ class HostControllerTest(ControllerTestCase):
             fake_client.hosts.remove_label.assert_called_once_with('node0', 'aaa')
             fake_client.hosts.add_label.assert_called_once_with('node0', 'ccc')
 
+            # return 400 if type other than List[str]
+            self._put('{}/node0'.format(self.URL_HOST), {'labels': 'ddd'})
+            self.assertStatus(400)
+
     @mock.patch('dashboard.controllers.host.time')
     def test_identify_device(self, mock_time):
         url = '{}/host-0/identify_device'.format(self.URL_HOST)


### PR DESCRIPTION
This PR fixes PUT - /api/host/{hostname} for adding labels if
a single string is provided as input.

Fixes: https://tracker.ceph.com/issues/49292
Signed-off-by: Avan Thakkar <athakkar@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
