### PR TITLE
crimson/osd: fetch configuration from monitors conditionally.

### DIFF
--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -173,7 +173,8 @@ int main(int argc, char* argv[])
     ("mkkey", "generate a new secret key. "
               "This is normally used in combination with --mkfs")
     ("mkfs", "create a [new] data directory")
-    ("debug", "enable debug output on all loggers");
+    ("debug", "enable debug output on all loggers")
+    ("no-mon-config", "do not retrieve configuration from monitors on boot");
 
   auto [ceph_args, app_args] = partition_args(app, argv, argv + argc);
   if (ceph_argparse_need_usage(ceph_args) &&
@@ -242,7 +243,9 @@ int main(int argc, char* argv[])
             seastar::engine().exit(1);
           }).get();
         }
-        fetch_config().get();
+        if (config.count("no-mon-config") == 0) {
+          fetch_config().get();
+        }
         if (config.count("mkfs")) {
           osd.invoke_on(
 	    0,


### PR DESCRIPTION
Before this change we were always attempting to fetch the config from monitors, even if `--no-mon-config` had been passed (and maybe even there was no monitor yet). This was the reason for failures at teuthology like:
http://pulpito.front.sepia.ceph.com/rzarzynski-2021-02-15_21:09:02-rados-master-distro-basic-smithi/5885250

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
