### PR TITLE
qa/suites/rados/cephadm: add ubuntu 18.04 + podman to test matrix again

### DIFF
--- a/qa/distros/all/ubuntu_18.04_podman.yaml
+++ b/qa/distros/all/ubuntu_18.04_podman.yaml
@@ -8,5 +8,5 @@ tasks:
     - curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/Release.key | sudo apt-key add -
     - echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
     - sudo apt update
-    - sudo apt -y install podman
+    - sudo apt -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install podman
     - echo -e "[[registry]]\nlocation = 'docker.io'\n\n[[registry.mirror]]\nlocation='docker-mirror.front.sepia.ceph.com:5000'\n" | sudo tee /etc/containers/registries.conf

--- a/qa/suites/rados/cephadm/smoke/distro/ubuntu_18.04_podman.yaml
+++ b/qa/suites/rados/cephadm/smoke/distro/ubuntu_18.04_podman.yaml
@@ -1,0 +1,1 @@
+.qa/distros/all/ubuntu_18.04_podman.yaml

--- a/qa/suites/rados/cephadm/with-work/distro/ubuntu_18.04_podman.yaml
+++ b/qa/suites/rados/cephadm/with-work/distro/ubuntu_18.04_podman.yaml
@@ -1,0 +1,1 @@
+.qa/distros/all/ubuntu_18.04_podman.yaml

--- a/qa/suites/rados/cephadm/workunits/distro/ubuntu_18.04_podman.yaml
+++ b/qa/suites/rados/cephadm/workunits/distro/ubuntu_18.04_podman.yaml
@@ -1,0 +1,1 @@
+.qa/distros/all/ubuntu_18.04_podman.yaml


### PR DESCRIPTION
Podman 3 was released and it fixed a few bugs. (in addition to creating regressions again)

reverts #39087
see also #39420 

**Blocked by https://tracker.ceph.com/issues/49293**
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
