### PR TITLE
mgr/cephadm: remove spec from CephadmDaemonDeploySpec

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -27,7 +27,7 @@ from ceph.deployment.service_spec import \
     HostPlacementSpec
 from ceph.utils import str_to_datetime, datetime_to_str, datetime_now
 from cephadm.serve import CephadmServe
-from cephadm.services.cephadmservice import CephadmDaemonSpec
+from cephadm.services.cephadmservice import CephadmDaemonDeploySpec
 
 from mgr_module import MgrModule, HandleCommandResult, Option
 from mgr_util import create_self_signed_cert
@@ -1593,10 +1593,16 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         ]
 
     def _daemon_action(self, daemon_type: str, daemon_id: str, host: str, action: str, image: Optional[str] = None) -> str:
-        daemon_spec: CephadmDaemonSpec = CephadmDaemonSpec(
+        dd = DaemonDescription(
+            hostname=host,
+            daemon_type=daemon_type,
+            daemon_id=daemon_id
+        )
+        daemon_spec: CephadmDaemonDeploySpec = CephadmDaemonDeploySpec(
             host=host,
             daemon_id=daemon_id,
             daemon_type=daemon_type,
+            service_name=dd.service_name(),
         )
 
         self._daemon_action_set_image(action, image, daemon_type, daemon_id)
@@ -1895,7 +1901,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
     def _add_daemon(self,
                     daemon_type: str,
                     spec: ServiceSpec,
-                    create_func: Callable[..., CephadmDaemonSpec]) -> List[str]:
+                    create_func: Callable[..., CephadmDaemonDeploySpec]) -> List[str]:
         """
         Add (and place) a daemon. Require explicit host placement.  Do not
         schedule, and do not apply the related scheduling limitations.
@@ -1920,7 +1926,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                         daemons: List[DaemonDescription],
                         hosts: List[HostPlacementSpec],
                         count: int,
-                        create_func: Callable[..., CephadmDaemonSpec]) -> List[str]:
+                        create_func: Callable[..., CephadmDaemonDeploySpec]) -> List[str]:
         if count > len(hosts):
             raise OrchestratorError('too few hosts: want %d, have %s' % (
                 count, hosts))
@@ -1928,7 +1934,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         did_config = False
         service_type = daemon_type_to_service(daemon_type)
 
-        args = []  # type: List[CephadmDaemonSpec]
+        args = []  # type: List[CephadmDaemonDeploySpec]
         for host, network, name in hosts:
             daemon_id = self.get_unique_name(daemon_type, host, daemons,
                                              prefix=spec.service_id,
@@ -1952,7 +1958,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             )
             daemons.append(sd)
 
-        @forall_hosts
+        @ forall_hosts
         def create_func_map(*args: Any) -> str:
             daemon_spec = create_func(*args)
             return CephadmServe(self)._create_daemon(daemon_spec)

--- a/src/pybind/mgr/cephadm/services/container.py
+++ b/src/pybind/mgr/cephadm/services/container.py
@@ -1,11 +1,9 @@
 import logging
-from typing import List, Any, Tuple, Dict
+from typing import List, Any, Tuple, Dict, cast
 
 from ceph.deployment.service_spec import CustomContainerSpec
 
-from orchestrator import OrchestratorError
-
-from .cephadmservice import CephadmService, CephadmDaemonSpec
+from .cephadmservice import CephadmService, CephadmDaemonDeploySpec
 
 logger = logging.getLogger(__name__)
 
@@ -13,25 +11,17 @@ logger = logging.getLogger(__name__)
 class CustomContainerService(CephadmService):
     TYPE = 'container'
 
-    def prepare_create(self, daemon_spec: CephadmDaemonSpec[CustomContainerSpec]) \
-            -> CephadmDaemonSpec:
+    def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) \
+            -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type
-        if daemon_spec.spec is None:
-            # Exit here immediately because the required service
-            # spec to create a daemon is not provided. This is only
-            # provided when a service is applied via 'orch apply'
-            # command.
-            msg = "Required service specification not provided"
-            raise OrchestratorError(msg)
         daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
         return daemon_spec
 
-    def generate_config(self, daemon_spec: CephadmDaemonSpec[CustomContainerSpec]) \
+    def generate_config(self, daemon_spec: CephadmDaemonDeploySpec) \
             -> Tuple[Dict[str, Any], List[str]]:
         assert self.TYPE == daemon_spec.daemon_type
-        assert daemon_spec.spec
         deps: List[str] = []
-        spec: CustomContainerSpec = daemon_spec.spec
+        spec = cast(CustomContainerSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
         config: Dict[str, Any] = spec.config_json()
         logger.debug(
             'Generated configuration for \'%s\' service: config-json=%s, dependencies=%s' %

--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -17,7 +17,7 @@ from ceph.utils import datetime_now
 from orchestrator import OrchestratorError
 from mgr_module import MonCommandFailed
 
-from cephadm.services.cephadmservice import CephadmDaemonSpec, CephService
+from cephadm.services.cephadmservice import CephadmDaemonDeploySpec, CephService
 
 if TYPE_CHECKING:
     from cephadm.module import CephadmOrchestrator
@@ -121,7 +121,8 @@ class OSDService(CephService):
                     continue
 
                 created.append(osd_id)
-                daemon_spec: CephadmDaemonSpec = CephadmDaemonSpec(
+                daemon_spec: CephadmDaemonDeploySpec = CephadmDaemonDeploySpec(
+                    service_name=drive_group.service_name(),
                     daemon_id=osd_id,
                     host=host,
                     daemon_type='osd',

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -3,7 +3,7 @@ import pytest
 from unittest.mock import MagicMock, call
 
 from cephadm.services.cephadmservice import MonService, MgrService, MdsService, RgwService, \
-    RbdMirrorService, CrashService, CephadmExporter, CephadmDaemonSpec
+    RbdMirrorService, CrashService, CephadmExporter, CephadmDaemonDeploySpec
 from cephadm.services.iscsi import IscsiService
 from cephadm.services.nfs import NFSService
 from cephadm.services.osd import OSDService
@@ -92,7 +92,11 @@ class TestCephadmService:
         iscsi_spec.spec.daemon_type = "iscsi"
         iscsi_spec.spec.ssl_cert = ''
 
-        iscsi_daemon_spec = CephadmDaemonSpec(host='host', daemon_id='a', spec=iscsi_spec)
+        mgr.spec_store = MagicMock()
+        mgr.spec_store.__getitem__.return_value = iscsi_spec
+
+        iscsi_daemon_spec = CephadmDaemonDeploySpec(
+            host='host', daemon_id='a', service_name=iscsi_spec.service_name())
 
         iscsi_service.prepare_create(iscsi_daemon_spec)
 


### PR DESCRIPTION
This removes a bunch of untested code that broke in previous PRs already

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
