### PR TITLE
mgr/dashboard: fix tooltip for Provisioned/Total Provisioned fields

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.html
@@ -64,7 +64,7 @@
                 <span *ngIf="selection.features_name?.indexOf('fast-diff') === -1">
                   <span class="form-text text-muted"
                         [ngbTooltip]="usageNotAvailableTooltipTpl"
-                        placement="right"
+                        placement="top"
                         i18n>N/A</span>
                 </span>
                 <span *ngIf="selection.features_name?.indexOf('fast-diff') !== -1">
@@ -79,7 +79,7 @@
                 <span *ngIf="selection.features_name?.indexOf('fast-diff') === -1">
                   <span class="form-text text-muted"
                         [ngbTooltip]="usageNotAvailableTooltipTpl"
-                        placement="right"
+                        placement="top"
                         i18n>N/A</span>
                 </span>
                 <span *ngIf="selection.features_name?.indexOf('fast-diff') !== -1">


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/46619
Signed-off-by: Avan Thakkar <athakkar@redhat.com>

Before:
![Screenshot from 2021-02-17 00-17-17](https://user-images.githubusercontent.com/23611106/108108636-e13a8680-70b6-11eb-9361-b1ad896c9942.png)

After:
![Screenshot from 2021-02-16 23-57-45](https://user-images.githubusercontent.com/23611106/108108831-252d8b80-70b7-11eb-895f-def856f3b722.png)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
