### PR TITLE
qa: test nowsync option in kernel client workflows

### DIFF
--- a/qa/suites/fs/workload/wsync/no.yaml
+++ b/qa/suites/fs/workload/wsync/no.yaml
@@ -1,0 +1,3 @@
+overrides:
+  kclient:
+    mntopts: ["nowsync"]

--- a/qa/suites/fs/workload/wsync/yes.yaml
+++ b/qa/suites/fs/workload/wsync/yes.yaml
@@ -1,0 +1,3 @@
+overrides:
+  kclient:
+    mntopts: ["wsync"]

--- a/qa/tasks/ceph_fuse.py
+++ b/qa/tasks/ceph_fuse.py
@@ -108,9 +108,7 @@ def task(ctx, config):
         if client_config is None:
             client_config = {}
         # top level overrides
-        for k, v in top_overrides.items():
-            if v is not None:
-                client_config[k] = v
+        misc.deep_merge(client_config, top_overrides)
         # mount specific overrides
         client_config_overrides = overrides.get(entity)
         misc.deep_merge(client_config, client_config_overrides)

--- a/qa/tasks/kclient.py
+++ b/qa/tasks/kclient.py
@@ -84,9 +84,7 @@ def task(ctx, config):
         if client_config is None:
             client_config = {}
         # top level overrides
-        for k, v in top_overrides.items():
-            if v is not None:
-                client_config[k] = v
+        deep_merge(client_config, top_overrides)
         # mount specific overrides
         client_config_overrides = overrides.get(entity)
         deep_merge(client_config, client_config_overrides)


### PR DESCRIPTION
This might be incomplete if mounts fail because `nowsync` is unrecognized.