### PR TITLE
msg,mon,mgr,osd,common: log when DispatchQueue throttle limit is reached

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -34,6 +34,8 @@
 * RGW: For `radosgw-admin account rm`, the `--purge-data` option previously applied only
   to buckets and objects, but now deletes account users, roles, groups, and oidc-providers
   too instead of failing with ENOTEMPTY.
+* CephFS: Dispatch Queue Throttling produces a cluster warning every 30s by default and
+  updates the 'ceph status' with a health warning.
 * RADOS: When objects are read during deep scrubs, the data is read in strides,
   and the scrubbing process is delayed between each read in order to avoid monopolizing
   the I/O capacity of the OSD.

--- a/doc/rados/configuration/network-config-ref.rst
+++ b/doc/rados/configuration/network-config-ref.rst
@@ -341,6 +341,7 @@ General Settings
 .. confval:: ms_max_backoff
 .. confval:: ms_die_on_bad_msg
 .. confval:: ms_dispatch_throttle_bytes
+.. confval:: ms_dispatch_throttle_log_interval
 .. confval:: ms_inject_socket_failures
 
 

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -1049,6 +1049,29 @@ this may be done for specific OSDs or a given mask, for example:
    ceph config set class:ssd bluestore_slow_ops_warn_lifetime 300
    ceph config set class:ssd bluestore_slow_ops_warn_threshold 5
 
+DISPATCH_QUEUE_THROTTLE
+_______________________
+
+Messenger reached Dispatch Queue throttle limit. Hitting the Dispatch Queue
+throttle limit would prevent fast dispatch of critical messages. This warning
+will be reported in ``ceph health detail``. The warning state is cleared when
+the condition clears.
+
+:confval:`ms_dispatch_throttle_bytes` represents the total size of messages
+waiting to be dispatched. This configuration limit messages that are read off
+the network but still being processed.
+
+:confval:`ms_dispatch_throttle_log_interval` is the interval in seconds to
+show the cluster warning and health warning. Setting it to 0 disables the
+cluster warning and health warning.
+
+To change the default values, run a command of the following form:
+
+.. prompt:: bash $
+
+   ceph config set global ms_dispatch_throttle_bytes 50
+   ceph config set global ms_dispatch_throttle_log_interval 5
+
 Device Health
 -------------
 

--- a/qa/suites/fs/multiclient/tasks/cephfs_misc_tests.yaml
+++ b/qa/suites/fs/multiclient/tasks/cephfs_misc_tests.yaml
@@ -13,3 +13,4 @@ overrides:
       - responding to mclientcaps
       - RECENT_CRASH
       - MON_DOWN
+      - DISPATCH_QUEUE_THROTTLE

--- a/qa/suites/fs/thrash/multifs/tasks/1-thrash/mds.yaml
+++ b/qa/suites/fs/thrash/multifs/tasks/1-thrash/mds.yaml
@@ -5,3 +5,4 @@ overrides:
   ceph:
     log-ignorelist:
       - Replacing daemon mds
+      - DISPATCH_QUEUE_THROTTLE

--- a/qa/suites/fs/thrash/multifs/tasks/1-thrash/mon.yaml
+++ b/qa/suites/fs/thrash/multifs/tasks/1-thrash/mon.yaml
@@ -3,6 +3,7 @@ overrides:
     log-ignorelist:
       - overall HEALTH_
       - \(MON_DOWN\)
+      - DISPATCH_QUEUE_THROTTLE
 tasks:
 - mon_thrash:
     check_mds_failover: True

--- a/qa/suites/fs/thrash/workloads/tasks/1-thrash/mds.yaml
+++ b/qa/suites/fs/thrash/workloads/tasks/1-thrash/mds.yaml
@@ -5,3 +5,4 @@ overrides:
   ceph:
     log-ignorelist:
       - Replacing daemon mds
+      - DISPATCH_QUEUE_THROTTLE

--- a/qa/suites/fs/thrash/workloads/tasks/1-thrash/mon.yaml
+++ b/qa/suites/fs/thrash/workloads/tasks/1-thrash/mon.yaml
@@ -3,6 +3,7 @@ overrides:
     log-ignorelist:
       - overall HEALTH_
       - \(MON_DOWN\)
+      - DISPATCH_QUEUE_THROTTLE
 tasks:
 - mon_thrash:
     check_mds_failover: True

--- a/qa/suites/fs/thrash/workloads/tasks/1-thrash/osd.yaml
+++ b/qa/suites/fs/thrash/workloads/tasks/1-thrash/osd.yaml
@@ -5,5 +5,6 @@ overrides:
       - objects unfound and apparently lost
       - MDS_SLOW_METADATA_IO
       - MDS_TRIM
+      - DISPATCH_QUEUE_THROTTLE
 tasks:
 - thrashosds:

--- a/qa/suites/rados/singleton-nomsgr/all/dispatch-queue-throttle-warnings.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/dispatch-queue-throttle-warnings.yaml
@@ -1,0 +1,18 @@
+roles:
+- [mon.a, mgr.x, osd.0, client.0]
+tasks:
+- install:
+- ceph:
+    pre-mgr-commands:
+      - sudo ceph config set mgr mgr_pool false --force
+    conf:
+      osd:
+# we may land on ext4
+        osd max object name len: 400
+        osd max object namespace len: 64
+    log-ignorelist:
+      - DISPATCH_QUEUE_THROTTLE
+- workunit:
+    clients:
+      all:
+        - rados/test_dispatch_queue_throttle_warnings.sh

--- a/qa/workunits/rados/test_dispatch_queue_throttle_warnings.sh
+++ b/qa/workunits/rados/test_dispatch_queue_throttle_warnings.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -uex
+
+# number of osds = 1
+crushtool -o crushmap --build --num_osds 1 host straw 2 rack straw 2 row straw 2 root straw 0
+ceph osd setcrushmap -i crushmap
+ceph osd tree
+ceph tell osd.* injectargs --osd_max_markdown_count 1024 --osd_max_markdown_period 1
+ceph osd set noout
+
+wait_for_healthy() {
+  while ceph health detail | grep "DISPATCH_QUEUE_THROTTLE"
+  do
+    sleep 1
+  done
+}
+
+test_dispatch_queue_throttle() {
+    ceph config set global ms_dispatch_throttle_bytes 10
+    ceph config set global ms_dispatch_throttle_log_interval 1
+    ceph health detail
+    ceph health | grep "Dispatch Queue Throttling"
+    ceph health detail | grep "DISPATCH_QUEUE_THROTTLE"
+    ceph config set global ms_dispatch_throttle_bytes 104857600 # default: 100_M
+    ceph config set global ms_dispatch_throttle_log_interval 30
+    wait_for_healthy
+}
+
+test_dispatch_queue_throttle
+
+exit 0

--- a/src/common/Throttle.cc
+++ b/src/common/Throttle.cc
@@ -197,6 +197,7 @@ bool Throttle::get_or_fail(int64_t c)
     std::lock_guard l(lock);
     if (_should_wait(c) || !conds.empty()) {
       ldout(cct, 10) << "get_or_fail " << c << " failed" << dendl;
+      failed++;
       result = false;
     } else {
       ldout(cct, 10) << "get_or_fail " << c << " success (" << count.load()
@@ -256,6 +257,7 @@ void Throttle::reset()
   if (!conds.empty())
     conds.front().notify_one();
   count = 0;
+  failed = 0;
   if (logger) {
     logger->set(l_throttle_val, 0);
   }

--- a/src/common/Throttle.h
+++ b/src/common/Throttle.h
@@ -33,7 +33,7 @@ class Throttle final : public ThrottleInterface {
   CephContext *cct;
   const std::string name;
   PerfCountersRef logger;
-  std::atomic<int64_t> count = { 0 }, max = { 0 };
+  std::atomic<int64_t> count = { 0 }, max = { 0 }, failed = { 0 };
   std::mutex lock;
   std::list<std::condition_variable> conds;
   const bool use_perf;
@@ -116,6 +116,15 @@ public:
    * @returns number of requests being hold after this
    */
   int64_t put(int64_t c = 1) override;
+
+  /**
+   * gets the number of (current) slot request failures.
+   * @returns the number of slot request failures
+   */
+  int64_t get_failed() const {
+    return failed.load();
+  }
+
    /**
    * reset the zero to the stock
    */

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -1192,6 +1192,14 @@ options:
   fmt_desc: Throttles total size of messages waiting to be dispatched.
   default: 100_M
   with_legacy: true
+- name: ms_dispatch_throttle_log_interval
+  type: secs
+  level: advanced
+  desc: Interval in seconds to show the cluster warning and health warning (in ceph status)
+        when the dispatch throttle limit is exceeded. Setting it to 0 disables the
+        cluster warning and health warning.
+  default: 30
+  min: 0
 - name: ms_bind_ipv4
   type: bool
   level: advanced

--- a/src/mgr/DaemonHealthMetric.cc
+++ b/src/mgr/DaemonHealthMetric.cc
@@ -18,6 +18,7 @@ std::list<DaemonHealthMetric> DaemonHealthMetric::generate_test_instances() {
   std::list<DaemonHealthMetric> o;
   o.push_back(DaemonHealthMetric(daemon_metric::SLOW_OPS, 1));
   o.push_back(DaemonHealthMetric(daemon_metric::PENDING_CREATING_PGS, 1, 2));
+  o.push_back(DaemonHealthMetric(daemon_metric::DISPATCH_QUEUE_THROTTLE, 1));
   return o;
 }
 

--- a/src/mgr/DaemonHealthMetric.h
+++ b/src/mgr/DaemonHealthMetric.h
@@ -14,6 +14,7 @@ namespace ceph { class Formatter; }
 enum class daemon_metric : uint8_t {
   SLOW_OPS,
   PENDING_CREATING_PGS,
+  DISPATCH_QUEUE_THROTTLE,
   NONE,
 };
 
@@ -21,6 +22,7 @@ static inline const char *daemon_metric_name(daemon_metric t) {
   switch (t) {
   case daemon_metric::SLOW_OPS: return "SLOW_OPS";
   case daemon_metric::PENDING_CREATING_PGS: return "PENDING_CREATING_PGS";
+  case daemon_metric::DISPATCH_QUEUE_THROTTLE: return "DISPATCH_QUEUE_THROTTLE";
   case daemon_metric::NONE: return "NONE";
   default: return "???";
   }

--- a/src/mgr/DaemonHealthMetricCollector.cc
+++ b/src/mgr/DaemonHealthMetricCollector.cc
@@ -93,6 +93,33 @@ class PendingPGs final : public DaemonHealthMetricCollector {
   vector<DaemonKey> osds;
 };
 
+class DispatchQueueThrottle final : public DaemonHealthMetricCollector {
+  bool _is_relevant(daemon_metric type) const override {
+    return type == daemon_metric::DISPATCH_QUEUE_THROTTLE;
+  }
+  health_check_t& _get_check(health_check_map_t& cm) const override {
+    return cm.get_or_add("DISPATCH_QUEUE_THROTTLE", HEALTH_WARN, "", 1);
+  }
+  bool _update(const DaemonKey& daemon,
+               const DaemonHealthMetric& metric) override {
+    auto failed_count = metric.get_n();
+    value.n = failed_count;
+    if (failed_count) {
+      daemons.push_back(daemon);
+      return true;
+    } else {
+      return false;
+    }
+  }
+  void _summarize(health_check_t& check) const override {
+    if (daemons.empty()) {
+      return;
+    }
+    check.summary = fmt::format("Dispatch Queue Throttling, {} messages throttled.", value.n);
+  }
+  vector<DaemonKey> daemons;
+};
+
 } // anonymous namespace
 
 unique_ptr<DaemonHealthMetricCollector>
@@ -103,6 +130,8 @@ DaemonHealthMetricCollector::create(daemon_metric m)
     return std::make_unique<SlowOps>();
   case daemon_metric::PENDING_CREATING_PGS:
     return std::make_unique<PendingPGs>();
+  case daemon_metric::DISPATCH_QUEUE_THROTTLE:
+    return std::make_unique<DispatchQueueThrottle>();
   default:
     return {};
   }

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -83,10 +83,13 @@ MonClient::MonClient(CephContext *cct_, boost::asio::io_context& service) :
     cct_->_conf.get_val<double>("mon_client_hunt_interval_min_multiple")),
   last_mon_command_tid(0),
   version_req_id(0)
-{}
+{
+  cct->_conf.add_observer(this);
+}
 
 MonClient::~MonClient()
 {
+  cct->_conf.remove_observer(this);
 }
 
 int MonClient::build_initial_monmap()
@@ -908,6 +911,34 @@ bool MonClient::ms_handle_reset(Connection *con)
       return true;
     }
   }
+}
+
+bool MonClient::ms_handle_throttle(ms_throttle_t ttype, const ThrottleInfo& tinfo) {
+  switch (ttype) {
+  case ms_throttle_t::MESSAGE:
+    break; // TODO
+  case ms_throttle_t::BYTES:
+    break; // TODO
+  case ms_throttle_t::DISPATCH_QUEUE:
+    {
+      //cluster log a warning that Dispatch Queue Throttle Limit hit
+      if (!log_client) {
+        return false; //cannot handle if the daemon didn't setup a log_client for me
+      }
+      LogChannelRef clog = log_client->create_channel(CLOG_CHANNEL_CLUSTER);
+      clog->warn() << "Throttler Limit has been hit. "
+                   << "Some message processing may be significantly delayed. "
+                   << "Additional info: " << tinfo.takenslots << "/"
+                   << tinfo.maxslots << " bytes used, "
+                   << tinfo.failedrequests << " messages throttled.";
+    }
+    break;
+  case ms_throttle_t::NONE:
+    break;
+  default:
+    return false;
+  }
+  return true;
 }
 
 bool MonClient::_opened() const
@@ -1805,6 +1836,30 @@ int MonClient::handle_auth_request(
   // discard old challenge
   auth_meta->authorizer_challenge.reset();
   return -EACCES;
+}
+
+std::vector<std::string> MonClient::get_tracked_keys() const noexcept {
+  return {
+    "ms_dispatch_throttle_bytes"s,
+    "ms_dispatch_throttle_log_interval"s
+  };
+}
+
+void MonClient::handle_conf_change(const ConfigProxy& conf,
+                                      const std::set <std::string> &changed) {
+  ldout(cct, 10) << __func__ << " " << changed << dendl;
+  if (changed.count("ms_dispatch_throttle_bytes")) {
+    if (messenger) {
+      messenger->dispatch_throttle_bytes =
+        cct->_conf.get_val<Option::size_t>("ms_dispatch_throttle_bytes");
+    }
+  }
+  if (changed.count("ms_dispatch_throttle_log_interval")) {
+    if (messenger) {
+      messenger->dispatch_throttle_log_interval =
+        cct->_conf.get_val<std::chrono::seconds>("ms_dispatch_throttle_log_interval");
+    }
+  }
 }
 
 AuthAuthorizer* MonClient::build_authorizer(int service_id) const {

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -279,9 +279,10 @@ inline boost::system::error_condition make_error_condition(monc_errc e) noexcept
 const boost::system::error_category& monc_category() noexcept;
 
 class MonClient : public Dispatcher,
-		  public AuthClient,
-		  public AuthServer, /* for mgr, osd, mds */
-		  public AdminSocketHook {
+                  public AuthClient,
+                  public AuthServer, /* for mgr, osd, mds */
+                  public AdminSocketHook,
+                  public md_config_obs_t {
   static constexpr auto dout_subsys = ceph_subsys_monc;
 public:
   // Error, Newest, Oldest
@@ -322,6 +323,7 @@ private:
   bool ms_handle_reset(Connection *con) override;
   void ms_handle_remote_reset(Connection *con) override {}
   bool ms_handle_refused(Connection *con) override { return false; }
+  bool ms_handle_throttle(ms_throttle_t ttype, const ThrottleInfo& tinfo) override;
 
   void handle_monmap(MMonMap *m);
   void handle_config(MConfig *m);
@@ -422,7 +424,10 @@ public:
     uint32_t auth_method,
     const ceph::buffer::list& bl,
     ceph::buffer::list *reply) override;
-
+  // md_config_obs_t (config observer)
+  std::vector<std::string> get_tracked_keys() const noexcept override;
+  void handle_conf_change(const ConfigProxy& conf,
+                          const std::set <std::string> &changed) override;
   void set_entity_name(EntityName name) { entity_name = name; }
   void set_handle_authentication_dispatcher(Dispatcher *d) {
     handle_authentication_dispatcher = d;

--- a/src/msg/DispatchQueue.h
+++ b/src/msg/DispatchQueue.h
@@ -213,6 +213,11 @@ class DispatchQueue {
   uint64_t get_id() {
     return next_id++;
   }
+
+  Messenger* get_messenger() const {
+    return msgr;
+  }
+
   void start();
   void entry();
   void wait();

--- a/src/msg/Dispatcher.h
+++ b/src/msg/Dispatcher.h
@@ -22,6 +22,7 @@
 #include "include/ceph_assert.h"
 #include "include/common_fwd.h"
 #include "msg/MessageRef.h"
+#include "msg/msg_types.h"
 
 #include <variant>
 
@@ -32,6 +33,12 @@ class KeyStore;
 
 class Dispatcher {
 public:
+  typedef struct {
+    uint64_t takenslots;
+    uint64_t maxslots;
+    uint64_t failedrequests;
+  } ThrottleInfo;
+
   /* Ordering of dispatch for a list of Dispatchers. */
   using priority_t = uint32_t;
   static constexpr priority_t PRIORITY_HIGH = std::numeric_limits<priority_t>::max() / 4;
@@ -242,6 +249,16 @@ public:
    * return false for failure (failure to parse caps, for instance)
    */
   [[nodiscard]] virtual bool ms_handle_fast_authentication(Connection *con) {
+    return false;
+  }
+
+  /**
+   * handle throttle limit hit and cluster log it.
+   *
+   * return true if handled
+   * return false if not handled
+   */
+  virtual bool ms_handle_throttle(ms_throttle_t ttype, const ThrottleInfo& tinfo) {
     return false;
   }
 

--- a/src/msg/Messenger.cc
+++ b/src/msg/Messenger.cc
@@ -58,6 +58,8 @@ Messenger::Messenger(CephContext *cct_, entity_name_t w)
 {
   auth_registry.refresh_config();
   comp_registry.refresh_config();
+  dispatch_throttle_bytes.store(cct->_conf.get_val<Option::size_t>("ms_dispatch_throttle_bytes"));
+  dispatch_throttle_log_interval.store(cct->_conf.get_val<std::chrono::seconds>("ms_dispatch_throttle_log_interval"));
 }
 
 void Messenger::set_endpoint_addr(const entity_addr_t& a,

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -140,6 +140,8 @@ protected:
 public:
   AuthClient *auth_client = 0;
   AuthServer *auth_server = 0;
+  std::atomic<uint64_t> dispatch_throttle_bytes;
+  std::atomic<std::chrono::seconds> dispatch_throttle_log_interval;
 
 #ifdef UNIT_TESTS_BUILT
   Interceptor *interceptor = nullptr;
@@ -856,6 +858,18 @@ public:
 
   void set_require_authorizer(bool b) {
     require_authorizer = b;
+  }
+  /**
+   * Notify each Dispatcher that the Throttle Limit has been hit. Call
+   * this function whenever the connections are getting throttled.
+   *
+   * @param ttype Throttle type
+   * @param tinfo Throttle info
+   */
+  void ms_deliver_throttle(ms_throttle_t ttype, const Dispatcher::ThrottleInfo& tinfo) {
+    for ([[maybe_unused]] const auto& [priority, dispatcher] : dispatchers) {
+      dispatcher->ms_handle_throttle(ttype, tinfo);
+    }
   }
 
   /**

--- a/src/msg/async/Protocol.h
+++ b/src/msg/async/Protocol.h
@@ -106,6 +106,8 @@ protected:
   AsyncConnection *connection;
   AsyncMessenger *messenger;
   CephContext *cct;
+  ceph::coarse_mono_time throttle_prev_log {ceph::coarse_mono_clock::zero()};
+  const std::chrono::seconds THROTTLE_DELIVER_INTERVAL {std::chrono::seconds(120)};
 public:
   std::shared_ptr<AuthConnectionMeta> auth_meta;
 

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -742,6 +742,10 @@ CtPtr ProtocolV1::throttle_dispatch_queue() {
   ldout(cct, 20) << __func__ << dendl;
 
   if (cur_msg_size) {
+    Messenger* msgr = connection->dispatch_queue->get_messenger();
+    //update max if it's changed in the conf. Expecting qa tests would change ms_dispatch_throttle_bytes.
+    connection->dispatch_queue->dispatch_throttler.reset_max(msgr->dispatch_throttle_bytes.load());
+
     if (!connection->dispatch_queue->dispatch_throttler.get_or_fail(
             cur_msg_size)) {
       ldout(cct, 1)
@@ -750,6 +754,20 @@ CtPtr ProtocolV1::throttle_dispatch_queue() {
           << connection->dispatch_queue->dispatch_throttler.get_current() << "/"
           << connection->dispatch_queue->dispatch_throttler.get_max()
           << " failed, just wait." << dendl;
+      ceph::coarse_mono_time throttle_now = ceph::coarse_mono_clock::now();
+      std::chrono::seconds configured_interval = msgr->dispatch_throttle_log_interval.load();
+      if (configured_interval.count()) {
+        if (std::chrono::duration_cast<std::chrono::seconds>(throttle_now - throttle_prev_log) >=
+            configured_interval) {
+          //Cluster logging that throttling is occurring.
+          Dispatcher::ThrottleInfo tinfo;
+          tinfo.takenslots = connection->dispatch_queue->dispatch_throttler.get_current();
+          tinfo.maxslots = connection->dispatch_queue->dispatch_throttler.get_max();
+          tinfo.failedrequests = connection->dispatch_queue->dispatch_throttler.get_failed();
+          msgr->ms_deliver_throttle(ms_throttle_t::DISPATCH_QUEUE, tinfo);
+          throttle_prev_log = throttle_now;
+        }
+      }
       // following thread pool deal with th full message queue isn't a
       // short time, so we can wait a ms.
       if (connection->register_time_events.empty()) {
@@ -758,6 +776,15 @@ CtPtr ProtocolV1::throttle_dispatch_queue() {
                                                   connection->wakeup_handler));
       }
       return nullptr;
+    }
+    else {
+      //Don't deliver ms_throttle_t::NONE forever. Limit it for THROTTLE_DELIVER_INTERVAL seconds
+      //since the last ms_throttle_t::DISPATCH_QUEUE delivery.
+      if (std::chrono::duration_cast<std::chrono::seconds>
+          (ceph::coarse_mono_clock::now() - throttle_prev_log) <= THROTTLE_DELIVER_INTERVAL) {
+        Dispatcher::ThrottleInfo tinfo = {0, 0, 0};
+        msgr->ms_deliver_throttle(ms_throttle_t::NONE, tinfo);
+      }
     }
   }
 

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -828,4 +828,11 @@ inline std::ostream& operator<<(std::ostream& out, const ceph_entity_inst &i)
   return out << n;
 }
 
+enum class ms_throttle_t {
+    MESSAGE,
+    BYTES,
+    DISPATCH_QUEUE,
+    NONE
+};
+
 #endif

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6853,6 +6853,41 @@ bool OSD::ms_handle_refused(Connection *con)
   return true;
 }
 
+bool OSD::ms_handle_throttle(ms_throttle_t ttype, const ThrottleInfo& tinfo) {
+  switch (ttype) {
+  case ms_throttle_t::MESSAGE:
+    break; // TODO
+  case ms_throttle_t::BYTES:
+    break; // TODO
+  case ms_throttle_t::DISPATCH_QUEUE:
+    {
+      //save the latest throttled time, save the number of messages throttled.
+      std::lock_guard l(dispatch_queue_throttle_lock);
+      last_throttled.store(ceph::coarse_mono_clock::now());
+      messages_throttled.store(tinfo.failedrequests);
+    }
+    break;
+  case ms_throttle_t::NONE:
+    {
+      //No Throttling
+      std::lock_guard l(dispatch_queue_throttle_lock);
+      if (last_throttled.load() != ceph::coarse_mono_clock::zero()) {
+        //Don't be hurry to reset last_throttled. Give get_health_metrics()
+        //THROTTLE_STATUS_INTERVAL seconds to read and display the previous status.
+        if (std::chrono::duration_cast<std::chrono::seconds>
+            (ceph::coarse_mono_clock::now() - last_throttled) >= THROTTLE_STATUS_INTERVAL) {
+          last_throttled.store(ceph::coarse_mono_clock::zero());
+          messages_throttled.store(0);
+        }
+      }
+    }
+    break;
+  default:
+    return false;
+  }
+  return true;
+}
+
 struct CB_OSD_GetVersion {
   OSD *osd;
   explicit CB_OSD_GetVersion(OSD *o) : osd(o) {}
@@ -8044,6 +8079,16 @@ vector<DaemonHealthMetric> OSD::get_health_metrics()
       }
     }
     metrics.emplace_back(daemon_metric::PENDING_CREATING_PGS, n_primaries);
+  }
+  {
+    std::lock_guard l(dispatch_queue_throttle_lock);
+    if (messages_throttled.load() > 0) {
+      stringstream ss;
+      ss << "Dispatch Queue Throttling, " << messages_throttled.load() << " messages throttled.";
+      lgeneric_subdout(cct,osd,1) << ss.str() << dendl;
+      clog->warn() << ss.str();
+      metrics.emplace_back(daemon_metric::DISPATCH_QUEUE_THROTTLE, messages_throttled.load());
+    }
   }
   return metrics;
 }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/46226



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>