### PR TITLE
ceph.spec: update gcc to version 10 on Centos

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -151,11 +151,8 @@ BuildRequires:	gperf
 BuildRequires:  cmake > 3.5
 BuildRequires:	cryptsetup
 BuildRequires:	fuse-devel
-%if 0%{with seastar}
-BuildRequires:	gcc-toolset-9-gcc-c++ >= 9.2.1-2.3
-%else
-BuildRequires:	gcc-c++
-%endif
+BuildRequires:	gcc-toolset-10-gcc
+BuildRequires:	gcc-toolset-10-systemtap
 BuildRequires:	gdbm
 %if 0%{with tcmalloc}
 # libprofiler did not build on ppc64le until 2.7.90


### PR DESCRIPTION
we are seeing https://bugzilla.redhat.com/show_bug.cgi?id=1929043
which was introduced to fix
https://bugzilla.redhat.com/show_bug.cgi?id=1853900
which should be fixed in the latest gcc release

fixes: https://tracker.ceph.com/issues/49303

Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>

** I used this to bypass shaman failure and thought of getting a review, understand crimson might/might not be available to use gcc 10, will close, if reviewers does not find it reliable right now.
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
