### PR TITLE
crimson/osd: tune the default for crimson_alien_op_num_threads.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5579,7 +5579,7 @@ std::vector<Option> get_global_options() {
     .set_description("The maximum number concurrent IO operations, 0 for unlimited"),
 
     Option("crimson_alien_op_num_threads", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(16)
+    .set_default(6)
     .set_flag(Option::FLAG_STARTUP)
     .set_description("The number of threads for serving alienized ObjectStore"),
 


### PR DESCRIPTION
This commit tries to optimize the default size of AlienStore's thread pool. Recent testing has shown the intial value, which
is `16`, is far from being optimal while the optimum is close to `4`:

  https://gist.github.com/rzarzynski/c851212f4b0baef4097a6087533ba17b

Further testing by Mark Nelson suggests that the sweet spot is closer to `8` taking into account 4 KB writes with lower queue depths:

  https://docs.google.com/spreadsheets/d/1IR9ysWRkaGdX5e9w_YV8kfeeglR2pEY3V9hovY0ECV8/edit#gid=1884533182

As a kind of compromise, `6` is proposed in this commit.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
