### PR TITLE
nautilus: mgr/dashboard: fix MTU Mismatch alert

### DIFF
--- a/monitoring/prometheus/alerts/ceph_default_alerts.yml
+++ b/monitoring/prometheus/alerts/ceph_default_alerts.yml
@@ -201,7 +201,7 @@ groups:
             rate of the past 48 hours.
 
       - alert: MTU Mismatch
-        expr: node_network_mtu_bytes{device!="lo"} != on(device) group_left() (quantile(0.5, node_network_mtu_bytes{device!="lo"}) by (device))
+        expr: node_network_mtu_bytes{device!="lo"} != on() group_left() (quantile(0.5, node_network_mtu_bytes{device!="lo"}))
         labels:
           severity: warning
           type: ceph_default


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49323

---

backport of https://github.com/ceph/ceph/pull/39462
parent tracker: https://tracker.ceph.com/issues/49291

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh