### PR TITLE
octopus: ceph-volume: pass --filter-for-batch from drive-group subcommand

### DIFF
--- a/src/ceph-volume/ceph_volume/drive_group/main.py
+++ b/src/ceph-volume/ceph_volume/drive_group/main.py
@@ -90,7 +90,7 @@ class Deploy(object):
     def get_dg_spec(self, dg):
         dg_spec = DriveGroupSpec._from_json_impl(dg)
         dg_spec.validate()
-        i = Inventory([])
+        i = Inventory(['--filter-for-batch'])
         i.main()
         inventory = i.get_report()
         devices = [Device.from_json(i) for i in inventory]


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49332

---

backport of https://github.com/ceph/ceph/pull/38610
parent tracker: https://tracker.ceph.com/issues/48631

this backport was staged using ceph-backport.sh version 15.1.1.389
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh