### PR TITLE
rgw: Dpp Addition for remaining log messages in create_bucket

### DIFF
--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -135,7 +135,7 @@ namespace rgw {
     }
   }
 
-  void RGWLibProcess::handle_request(RGWRequest* r)
+  void RGWLibProcess::handle_request(const DoutPrefixProvider *dpp, RGWRequest* r)
   {
     /*
      * invariant: valid requests are derived from RGWLibRequst
@@ -320,7 +320,7 @@ namespace rgw {
 
       ldpp_dout(s, 2) << "executing" << dendl;
       op->pre_exec();
-      op->execute(null_yield);
+      op->execute(s, null_yield);
       op->complete();
 
     } catch (const ceph::crypto::DigestException& e) {

--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -77,7 +77,7 @@ get_canon_amz_hdr(const meta_map_t& meta_map)
  * ?get the canonical representation of the object's location
  */
 static std::string
-get_canon_resource(const char* const request_uri,
+get_canon_resource(const DoutPrefixProvider *dpp, const char* const request_uri,
                    const std::map<std::string, std::string>& sub_resources)
 {
   std::string dest;
@@ -107,7 +107,7 @@ get_canon_resource(const char* const request_uri,
     }
   }
 
-  dout(10) << "get_canon_resource(): dest=" << dest << dendl;
+  ldpp_dout(dpp, 10) << "get_canon_resource(): dest=" << dest << dendl;
   return dest;
 }
 
@@ -116,6 +116,7 @@ get_canon_resource(const char* const request_uri,
  * compute a request's signature
  */
 void rgw_create_s3_canonical_header(
+  const DoutPrefixProvider *dpp,
   const char* const method,
   const char* const content_md5,
   const char* const content_type,
@@ -150,7 +151,7 @@ void rgw_create_s3_canonical_header(
 
   dest.append(get_canon_amz_hdr(meta_map));
   dest.append(get_canon_amz_hdr(qs_map));
-  dest.append(get_canon_resource(request_uri, sub_resources));
+  dest.append(get_canon_resource(dpp, request_uri, sub_resources));
 
   dest_str = dest;
 }
@@ -174,7 +175,8 @@ static inline void get_v2_qs_map(const req_info& info,
  * get the header authentication  information required to
  * compute a request's signature
  */
-bool rgw_create_s3_canonical_header(const req_info& info,
+bool rgw_create_s3_canonical_header(const DoutPrefixProvider *dpp,
+                                    const req_info& info,
                                     utime_t* const header_time,
                                     std::string& dest,
                                     const bool qsr)
@@ -235,7 +237,7 @@ bool rgw_create_s3_canonical_header(const req_info& info,
     request_uri = info.effective_uri;
   }
 
-  rgw_create_s3_canonical_header(info.method, content_md5, content_type,
+  rgw_create_s3_canonical_header(dpp, info.method, content_md5, content_type,
                                  date.c_str(), meta_map, qs_map,
 				 request_uri.c_str(), sub_resources, dest);
   return true;

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -419,6 +419,7 @@ public:
 } /* namespace rgw */
 
 void rgw_create_s3_canonical_header(
+  const DoutPrefixProvider *dpp,
   const char *method,
   const char *content_md5,
   const char *content_type,
@@ -428,16 +429,17 @@ void rgw_create_s3_canonical_header(
   const char *request_uri,
   const std::map<std::string, std::string>& sub_resources,
   std::string& dest_str);
-bool rgw_create_s3_canonical_header(const req_info& info,
+bool rgw_create_s3_canonical_header(const DoutPrefixProvider *dpp,
+                                    const req_info& info,
                                     utime_t *header_time,       /* out */
                                     std::string& dest,          /* out */
                                     bool qsr);
 static inline std::tuple<bool, std::string, utime_t>
-rgw_create_s3_canonical_header(const req_info& info, const bool qsr) {
+rgw_create_s3_canonical_header(const DoutPrefixProvider *dpp, const req_info& info, const bool qsr) {
   std::string dest;
   utime_t header_time;
 
-  const bool ok = rgw_create_s3_canonical_header(info, &header_time, dest, qsr);
+  const bool ok = rgw_create_s3_canonical_header(dpp, info, &header_time, dest, qsr);
   return std::make_tuple(ok, dest, header_time);
 }
 

--- a/src/rgw/rgw_coroutine.h
+++ b/src/rgw/rgw_coroutine.h
@@ -272,14 +272,14 @@ protected:
     return status;
   }
 
-  virtual int operate_wrapper() {
-    return operate();
+  virtual int operate_wrapper(const DoutPrefixProvider *dpp) {
+    return operate(dpp);
   }
 public:
   RGWCoroutine(CephContext *_cct) : status(_cct), _yield_ret(false), cct(_cct), stack(NULL), retcode(0), state(RGWCoroutine_Run) {}
   ~RGWCoroutine() override;
 
-  virtual int operate() = 0;
+  virtual int operate(const DoutPrefixProvider *dpp) = 0;
 
   bool is_done() { return (state == RGWCoroutine_Done || state == RGWCoroutine_Error); }
   bool is_error() { return (state == RGWCoroutine_Error); }
@@ -474,7 +474,7 @@ public:
     return id;
   }
 
-  int operate(RGWCoroutinesEnv *env);
+  int operate(const DoutPrefixProvider *dpp, RGWCoroutinesEnv *env);
 
   bool is_done() {
     return done_flag;
@@ -663,8 +663,8 @@ public:
     }
   }
 
-  int run(list<RGWCoroutinesStack *>& ops);
-  int run(RGWCoroutine *op);
+  int run(const DoutPrefixProvider *dpp, list<RGWCoroutinesStack *>& ops);
+  int run(const DoutPrefixProvider *dpp, RGWCoroutine *op);
   void stop() {
     bool expected = false;
     if (going_down.compare_exchange_strong(expected, true)) {
@@ -715,10 +715,10 @@ RGWAioCompletionNotifier *RGWCoroutinesStack::create_completion_notifier(T value
 class RGWSimpleCoroutine : public RGWCoroutine {
   bool called_cleanup;
 
-  int operate() override;
+  int operate(const DoutPrefixProvider *dpp) override;
 
   int state_init();
-  int state_send_request();
+  int state_send_request(const DoutPrefixProvider *dpp);
   int state_request_complete();
   int state_all_complete();
 
@@ -729,7 +729,7 @@ public:
   ~RGWSimpleCoroutine() override;
 
   virtual int init() { return 0; }
-  virtual int send_request() = 0;
+  virtual int send_request(const DoutPrefixProvider *dpp) = 0;
   virtual int request_complete() = 0;
   virtual int finish() { return 0; }
   virtual void request_cleanup() {}

--- a/src/rgw/rgw_cr_rest.cc
+++ b/src/rgw/rgw_cr_rest.cc
@@ -87,7 +87,7 @@ RGWStreamReadHTTPResourceCRF::~RGWStreamReadHTTPResourceCRF()
   }
 }
 
-int RGWStreamReadHTTPResourceCRF::init()
+int RGWStreamReadHTTPResourceCRF::init(const DoutPrefixProvider *dpp)
 {
   env->stack->init_new_io(req);
 
@@ -191,7 +191,7 @@ RGWStreamWriteHTTPResourceCRF::~RGWStreamWriteHTTPResourceCRF()
   }
 }
 
-void RGWStreamWriteHTTPResourceCRF::send_ready(const rgw_rest_obj& rest_obj)
+void RGWStreamWriteHTTPResourceCRF::send_ready(const DoutPrefixProvider *dpp, const rgw_rest_obj& rest_obj)
 {
   req->set_send_length(rest_obj.content_len);
   for (auto h : rest_obj.attrs) {
@@ -264,10 +264,10 @@ RGWStreamSpliceCR::RGWStreamSpliceCR(CephContext *_cct, RGWHTTPManager *_mgr,
                                                                in_crf(_in_crf), out_crf(_out_crf) {}
 RGWStreamSpliceCR::~RGWStreamSpliceCR() { }
 
-int RGWStreamSpliceCR::operate() {
+int RGWStreamSpliceCR::operate(const DoutPrefixProvider *dpp) {
   reenter(this) {
     {
-      int ret = in_crf->init();
+      int ret = in_crf->init(dpp);
       if (ret < 0) {
         return set_cr_error(ret);
       }
@@ -303,7 +303,7 @@ int RGWStreamSpliceCR::operate() {
         if (ret < 0) {
           return set_cr_error(ret);
         }
-        out_crf->send_ready(in_crf->get_rest_obj());
+        out_crf->send_ready(dpp, in_crf->get_rest_obj());
         ret = out_crf->send();
         if (ret < 0) {
           return set_cr_error(ret);

--- a/src/rgw/rgw_cr_tools.cc
+++ b/src/rgw/rgw_cr_tools.cc
@@ -16,7 +16,7 @@
 #define dout_subsys ceph_subsys_rgw
 
 template<>
-int RGWUserCreateCR::Request::_send_request()
+int RGWUserCreateCR::Request::_send_request(const DoutPrefixProvider *dpp)
 {
   CephContext *cct = store->ctx();
 
@@ -91,20 +91,20 @@ int RGWUserCreateCR::Request::_send_request()
 }
 
 template<>
-int RGWGetUserInfoCR::Request::_send_request()
+int RGWGetUserInfoCR::Request::_send_request(const DoutPrefixProvider *dpp)
 {
   return store->ctl()->user->get_info_by_uid(dpp, params.user, result.get(), null_yield);
 }
 
 template<>
-int RGWGetBucketInfoCR::Request::_send_request()
+int RGWGetBucketInfoCR::Request::_send_request(const DoutPrefixProvider *dpp)
 {
   return store->getRados()->get_bucket_info(store->svc(), params.tenant, params.bucket_name,
                                 result->bucket_info, &result->mtime, null_yield, dpp, &result->attrs);
 }
 
 template<>
-int RGWBucketCreateLocalCR::Request::_send_request()
+int RGWBucketCreateLocalCR::Request::_send_request(const DoutPrefixProvider *dpp)
 {
   CephContext *cct = store->ctx();
   auto& zone_svc = store->svc()->zone;
@@ -229,7 +229,7 @@ int RGWBucketCreateLocalCR::Request::_send_request()
 }
 
 template<>
-int RGWObjectSimplePutCR::Request::_send_request()
+int RGWObjectSimplePutCR::Request::_send_request(const DoutPrefixProvider *dpp)
 {
   RGWDataAccess::ObjectRef obj;
 
@@ -254,7 +254,7 @@ int RGWObjectSimplePutCR::Request::_send_request()
 }
 
 template<>
-int RGWBucketLifecycleConfigCR::Request::_send_request()
+int RGWBucketLifecycleConfigCR::Request::_send_request(const DoutPrefixProvider *dpp)
 {
   CephContext *cct = store->ctx();
 
@@ -276,7 +276,7 @@ int RGWBucketLifecycleConfigCR::Request::_send_request()
 }
 
 template<>
-int RGWBucketGetSyncPolicyHandlerCR::Request::_send_request()
+int RGWBucketGetSyncPolicyHandlerCR::Request::_send_request(const DoutPrefixProvider *dpp)
 {
   CephContext *cct = store->ctx();
 

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -2300,8 +2300,8 @@ public:
     return 0;
   }
 
-  void execute(optional_yield y) override {
-    RGWGetObj::execute(y);
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override {
+    RGWGetObj::execute(dpp, y);
     _size = get_state()->obj_size;
   }
 

--- a/src/rgw/rgw_lib_frontend.h
+++ b/src/rgw/rgw_lib_frontend.h
@@ -66,7 +66,7 @@ namespace rgw {
     } /* enqueue_req */
 
     /* "regular" requests */
-    void handle_request(RGWRequest* req) override; // async handler, deletes req
+    void handle_request(const DoutPrefixProvider *dpp, RGWRequest* req) override; // async handler, deletes req
     int process_request(RGWLibRequest* req);
     int process_request(RGWLibRequest* req, RGWLibIO* io);
     void set_access_key(RGWAccessKey& key) { access_key = key; }

--- a/src/rgw/rgw_loadgen.cc
+++ b/src/rgw/rgw_loadgen.cc
@@ -16,7 +16,7 @@ void RGWLoadGenRequestEnv::set_date(utime_t& tm)
   date_str = rgw_to_asctime(tm);
 }
 
-int RGWLoadGenRequestEnv::sign(RGWAccessKey& access_key)
+int RGWLoadGenRequestEnv::sign(const DoutPrefixProvider *dpp, RGWAccessKey& access_key)
 {
   meta_map_t meta_map;
   map<string, string> sub_resources;
@@ -24,7 +24,8 @@ int RGWLoadGenRequestEnv::sign(RGWAccessKey& access_key)
   string canonical_header;
   string digest;
 
-  rgw_create_s3_canonical_header(request_method.c_str(),
+  rgw_create_s3_canonical_header(dpp,
+                                 request_method.c_str(),
                                  nullptr, /* const char *content_md5 */
                                  content_type.c_str(),
                                  date_str.c_str(),

--- a/src/rgw/rgw_loadgen.h
+++ b/src/rgw/rgw_loadgen.h
@@ -27,7 +27,7 @@ struct RGWLoadGenRequestEnv {
   }
 
   void set_date(utime_t& tm);
-  int sign(RGWAccessKey& access_key);
+  int sign(const DoutPrefixProvider *dpp, RGWAccessKey& access_key);
 };
 
 /* XXX does RGWLoadGenIO actually want to perform stream/HTTP I/O,

--- a/src/rgw/rgw_loadgen_process.cc
+++ b/src/rgw/rgw_loadgen_process.cc
@@ -113,7 +113,7 @@ void RGWLoadGenProcess::gen_request(const string& method,
   req_wq.queue(req);
 } /* RGWLoadGenProcess::gen_request */
 
-void RGWLoadGenProcess::handle_request(RGWRequest* r)
+void RGWLoadGenProcess::handle_request(const DoutPrefixProvider *dpp, RGWRequest* r)
 {
   RGWLoadGenRequest* req = static_cast<RGWLoadGenRequest*>(r);
 
@@ -127,7 +127,7 @@ void RGWLoadGenProcess::handle_request(RGWRequest* r)
   env.request_method = req->method;
   env.uri = req->resource;
   env.set_date(tm);
-  env.sign(access_key);
+  env.sign(dpp, access_key);
 
   RGWLoadGenIO real_client_io(&env);
   RGWRestfulIO client_io(cct, &real_client_io);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -979,7 +979,7 @@ void RGWGetObjTags::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWGetObjTags::execute(optional_yield y)
+void RGWGetObjTags::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   rgw::sal::RGWAttrs attrs;
 
@@ -1022,7 +1022,7 @@ int RGWPutObjTags::verify_permission(optional_yield y)
   return 0;
 }
 
-void RGWPutObjTags::execute(optional_yield y)
+void RGWPutObjTags::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params(y);
   if (op_ret < 0)
@@ -1069,7 +1069,7 @@ int RGWDeleteObjTags::verify_permission(optional_yield y)
   return 0;
 }
 
-void RGWDeleteObjTags::execute(optional_yield y)
+void RGWDeleteObjTags::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   if (rgw::sal::RGWObject::empty(s->object.get()))
     return;
@@ -1092,7 +1092,7 @@ void RGWGetBucketTags::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWGetBucketTags::execute(optional_yield y)
+void RGWGetBucketTags::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   auto iter = s->bucket_attrs.find(RGW_ATTR_TAGS);
   if (iter != s->bucket_attrs.end()) {
@@ -1108,14 +1108,14 @@ int RGWPutBucketTags::verify_permission(optional_yield y) {
   return verify_bucket_owner_or_policy(s, rgw::IAM::s3PutBucketTagging);
 }
 
-void RGWPutBucketTags::execute(optional_yield y)
+void RGWPutBucketTags::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
 
   op_ret = get_params(y);
   if (op_ret < 0) 
     return;
 
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, in_data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(dpp, s->user.get(), nullptr, in_data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
   }
@@ -1138,10 +1138,10 @@ int RGWDeleteBucketTags::verify_permission(optional_yield y)
   return verify_bucket_owner_or_policy(s, rgw::IAM::s3PutBucketTagging);
 }
 
-void RGWDeleteBucketTags::execute(optional_yield y)
+void RGWDeleteBucketTags::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   bufferlist in_data;
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, in_data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(dpp, s->user.get(), nullptr, in_data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -1174,7 +1174,7 @@ void RGWGetBucketReplication::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWGetBucketReplication::execute(optional_yield y)
+void RGWGetBucketReplication::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   send_response_data();
 }
@@ -1183,13 +1183,13 @@ int RGWPutBucketReplication::verify_permission(optional_yield y) {
   return verify_bucket_owner_or_policy(s, rgw::IAM::s3PutReplicationConfiguration);
 }
 
-void RGWPutBucketReplication::execute(optional_yield y) {
+void RGWPutBucketReplication::execute(const DoutPrefixProvider *dpp, optional_yield y) {
 
   op_ret = get_params(y);
   if (op_ret < 0) 
     return;
 
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, in_data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(dpp, s->user.get(), nullptr, in_data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -1224,10 +1224,10 @@ int RGWDeleteBucketReplication::verify_permission(optional_yield y)
   return verify_bucket_owner_or_policy(s, rgw::IAM::s3DeleteReplicationConfiguration);
 }
 
-void RGWDeleteBucketReplication::execute(optional_yield y)
+void RGWDeleteBucketReplication::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   bufferlist in_data;
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, in_data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(dpp, s->user.get(), nullptr, in_data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -2043,7 +2043,7 @@ static inline void rgw_cond_decode_objtags(
   }
 }
 
-void RGWGetObj::execute(optional_yield y)
+void RGWGetObj::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   bufferlist bl;
   gc_invalidate_time = ceph_clock_now();
@@ -2275,7 +2275,7 @@ int RGWGetUsage::verify_permission(optional_yield y)
   return 0;
 }
 
-void RGWListBuckets::execute(optional_yield y)
+void RGWListBuckets::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   bool done;
   bool started = false;
@@ -2365,7 +2365,7 @@ send_end:
   send_response_end();
 }
 
-void RGWGetUsage::execute(optional_yield y)
+void RGWGetUsage::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   uint64_t start_epoch = 0;
   uint64_t end_epoch = (uint64_t)-1;
@@ -2438,7 +2438,7 @@ int RGWStatAccount::verify_permission(optional_yield y)
   return 0;
 }
 
-void RGWStatAccount::execute(optional_yield y)
+void RGWStatAccount::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   string marker;
   rgw::sal::RGWBucketList buckets;
@@ -2504,7 +2504,7 @@ void RGWGetBucketVersioning::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWGetBucketVersioning::execute(optional_yield y)
+void RGWGetBucketVersioning::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   if (! s->bucket_exists) {
     op_ret = -ERR_NO_SUCH_BUCKET;
@@ -2526,7 +2526,7 @@ void RGWSetBucketVersioning::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWSetBucketVersioning::execute(optional_yield y)
+void RGWSetBucketVersioning::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params(y);
   if (op_ret < 0)
@@ -2566,7 +2566,7 @@ void RGWSetBucketVersioning::execute(optional_yield y)
     }
   }
 
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, in_data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(dpp, s->user.get(), nullptr, in_data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -2618,7 +2618,7 @@ void RGWGetBucketWebsite::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWGetBucketWebsite::execute(optional_yield y)
+void RGWGetBucketWebsite::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   if (!s->bucket->get_info().has_website) {
     op_ret = -ERR_NO_SUCH_WEBSITE_CONFIGURATION;
@@ -2635,14 +2635,14 @@ void RGWSetBucketWebsite::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWSetBucketWebsite::execute(optional_yield y)
+void RGWSetBucketWebsite::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params(y);
 
   if (op_ret < 0)
     return;
 
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, in_data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(dpp, s->user.get(), nullptr, in_data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << " forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -2672,11 +2672,11 @@ void RGWDeleteBucketWebsite::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWDeleteBucketWebsite::execute(optional_yield y)
+void RGWDeleteBucketWebsite::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   bufferlist in_data;
 
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, in_data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(dpp, s->user.get(), nullptr, in_data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "NOTICE: forward_to_master failed on bucket=" << s->bucket->get_name()
       << "returned err=" << op_ret << dendl;
@@ -2710,7 +2710,7 @@ void RGWStatBucket::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWStatBucket::execute(optional_yield y)
+void RGWStatBucket::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   if (!s->bucket_exists) {
     op_ret = -ERR_NO_SUCH_BUCKET;
@@ -2765,7 +2765,7 @@ void RGWListBucket::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWListBucket::execute(optional_yield y)
+void RGWListBucket::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   if (!s->bucket_exists) {
     op_ret = -ERR_NO_SUCH_BUCKET;
@@ -3034,7 +3034,7 @@ static void filter_out_website(std::map<std::string, ceph::bufferlist>& add_attr
 }
 
 
-void RGWCreateBucket::execute(optional_yield y)
+void RGWCreateBucket::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   buffer::list aclbl;
   buffer::list corsbl;
@@ -3265,7 +3265,7 @@ void RGWDeleteBucket::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWDeleteBucket::execute(optional_yield y)
+void RGWDeleteBucket::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   if (s->bucket_name.empty()) {
     op_ret = -EINVAL;
@@ -3308,7 +3308,7 @@ void RGWDeleteBucket::execute(optional_yield y)
   }
 
   bufferlist in_data;
-  op_ret = store->forward_request_to_master(s->user.get(), &ot.read_version, in_data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(dpp, s->user.get(), &ot.read_version, in_data, nullptr, s->info, y);
   if (op_ret < 0) {
     if (op_ret == -ENOENT) {
       /* adjust error, we want to return with NoSuchBucket and not
@@ -3693,7 +3693,7 @@ static CompressorRef get_compressor_plugin(const req_state *s,
   return Compressor::create(s->cct, alg);
 }
 
-void RGWPutObj::execute(optional_yield y)
+void RGWPutObj::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   char supplied_md5_bin[CEPH_CRYPTO_MD5_DIGESTSIZE + 1];
   char supplied_md5[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
@@ -4078,7 +4078,7 @@ void RGWPostObj::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWPostObj::execute(optional_yield y)
+void RGWPostObj::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   boost::optional<RGWPutObj_Compress> compressor;
   CompressorRef plugin;
@@ -4405,7 +4405,7 @@ int RGWPutMetadataAccount::verify_permission(optional_yield y)
   return 0;
 }
 
-void RGWPutMetadataAccount::execute(optional_yield y)
+void RGWPutMetadataAccount::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   /* Params have been extracted earlier. See init_processing(). */
   RGWUserInfo new_uinfo;
@@ -4451,7 +4451,7 @@ void RGWPutMetadataBucket::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWPutMetadataBucket::execute(optional_yield y)
+void RGWPutMetadataBucket::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params(y);
   if (op_ret < 0) {
@@ -4541,7 +4541,7 @@ void RGWPutMetadataObject::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWPutMetadataObject::execute(optional_yield y)
+void RGWPutMetadataObject::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   rgw_obj target_obj;
   rgw::sal::RGWAttrs attrs, rmattrs;
@@ -4701,7 +4701,7 @@ void RGWDeleteObj::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWDeleteObj::execute(optional_yield y)
+void RGWDeleteObj::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   if (!s->bucket_exists) {
     op_ret = -ERR_NO_SUCH_BUCKET;
@@ -5071,7 +5071,7 @@ void RGWCopyObj::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWCopyObj::execute(optional_yield y)
+void RGWCopyObj::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   if (init_common() < 0)
     return;
@@ -5198,7 +5198,7 @@ void RGWGetACLs::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWGetACLs::execute(optional_yield y)
+void RGWGetACLs::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   stringstream ss;
   RGWAccessControlPolicy* const acl = \
@@ -5281,7 +5281,7 @@ void RGWDeleteLC::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWPutACLs::execute(optional_yield y)
+void RGWPutACLs::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   bufferlist bl;
 
@@ -5369,7 +5369,7 @@ void RGWPutACLs::execute(optional_yield y)
     if (s->canned_acl.empty()) {
       in_data.append(data);
     }
-    op_ret = store->forward_request_to_master(s->user.get(), nullptr, in_data, nullptr, s->info, y);
+    op_ret = store->forward_request_to_master(dpp, s->user.get(), nullptr, in_data, nullptr, s->info, y);
     if (op_ret < 0) {
       ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
       return;
@@ -5417,7 +5417,7 @@ void RGWPutACLs::execute(optional_yield y)
   }
 }
 
-void RGWPutLC::execute(optional_yield y)
+void RGWPutLC::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   bufferlist bl;
   
@@ -5496,7 +5496,7 @@ void RGWPutLC::execute(optional_yield y)
     ldpp_dout(this, 15) << "New LifecycleConfiguration:" << ss.str() << dendl;
   }
 
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(dpp, s->user.get(), nullptr, data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -5509,10 +5509,10 @@ void RGWPutLC::execute(optional_yield y)
   return;
 }
 
-void RGWDeleteLC::execute(optional_yield y)
+void RGWDeleteLC::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   bufferlist data;
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(dpp, s->user.get(), nullptr, data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -5530,7 +5530,7 @@ int RGWGetCORS::verify_permission(optional_yield y)
   return verify_bucket_owner_or_policy(s, rgw::IAM::s3GetBucketCORS);
 }
 
-void RGWGetCORS::execute(optional_yield y)
+void RGWGetCORS::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = read_bucket_cors();
   if (op_ret < 0)
@@ -5548,7 +5548,7 @@ int RGWPutCORS::verify_permission(optional_yield y)
   return verify_bucket_owner_or_policy(s, rgw::IAM::s3PutBucketCORS);
 }
 
-void RGWPutCORS::execute(optional_yield y)
+void RGWPutCORS::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   rgw_raw_obj obj;
 
@@ -5556,7 +5556,7 @@ void RGWPutCORS::execute(optional_yield y)
   if (op_ret < 0)
     return;
 
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, in_data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(dpp, s->user.get(), nullptr, in_data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -5575,10 +5575,10 @@ int RGWDeleteCORS::verify_permission(optional_yield y)
   return verify_bucket_owner_or_policy(s, rgw::IAM::s3PutBucketCORS);
 }
 
-void RGWDeleteCORS::execute(optional_yield y)
+void RGWDeleteCORS::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   bufferlist data;
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(dpp, s->user.get(), nullptr, data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -5628,7 +5628,7 @@ int RGWOptionsCORS::validate_cors_request(RGWCORSConfiguration *cc) {
   return 0;
 }
 
-void RGWOptionsCORS::execute(optional_yield y)
+void RGWOptionsCORS::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = read_bucket_cors();
   if (op_ret < 0)
@@ -5670,7 +5670,7 @@ void RGWGetRequestPayment::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWGetRequestPayment::execute(optional_yield y)
+void RGWGetRequestPayment::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   requester_pays = s->bucket->get_info().requester_pays;
 }
@@ -5685,10 +5685,10 @@ void RGWSetRequestPayment::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWSetRequestPayment::execute(optional_yield y)
+void RGWSetRequestPayment::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
 
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, in_data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(dpp, s->user.get(), nullptr, in_data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -5747,7 +5747,7 @@ void RGWInitMultipart::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWInitMultipart::execute(optional_yield y)
+void RGWInitMultipart::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   bufferlist aclbl;
   rgw::sal::RGWAttrs attrs;
@@ -5864,7 +5864,7 @@ void RGWCompleteMultipart::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWCompleteMultipart::execute(optional_yield y)
+void RGWCompleteMultipart::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   RGWMultiCompleteUpload *parts;
   map<int, string>::iterator iter;
@@ -6195,7 +6195,7 @@ void RGWAbortMultipart::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWAbortMultipart::execute(optional_yield y)
+void RGWAbortMultipart::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = -EINVAL;
   string upload_id;
@@ -6231,7 +6231,7 @@ void RGWListMultipart::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWListMultipart::execute(optional_yield y)
+void RGWListMultipart::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   string meta_oid;
   RGWMPObj mp;
@@ -6266,7 +6266,7 @@ void RGWListBucketMultiparts::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWListBucketMultiparts::execute(optional_yield y)
+void RGWListBucketMultiparts::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   vector<rgw_bucket_dir_entry> objs;
   string marker_meta;
@@ -6309,7 +6309,7 @@ void RGWListBucketMultiparts::execute(optional_yield y)
   }
 }
 
-void RGWGetHealthCheck::execute(optional_yield y)
+void RGWGetHealthCheck::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   if (!g_conf()->rgw_healthcheck_disabling_path.empty() &&
       (::access(g_conf()->rgw_healthcheck_disabling_path.c_str(), F_OK) == 0)) {
@@ -6382,7 +6382,7 @@ void RGWDeleteMultiObj::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWDeleteMultiObj::execute(optional_yield y)
+void RGWDeleteMultiObj::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   RGWMultiDelDelete *multi_delete;
   vector<rgw_obj_key>::iterator iter;
@@ -6676,7 +6676,7 @@ void RGWBulkDelete::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWBulkDelete::execute(optional_yield y)
+void RGWBulkDelete::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   deleter = std::unique_ptr<Deleter>(new Deleter(this, store, s));
 
@@ -7114,7 +7114,7 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
   return op_ret;
 }
 
-void RGWBulkUploadOp::execute(optional_yield y)
+void RGWBulkUploadOp::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   ceph::bufferlist buffer(64 * 1024);
 
@@ -7258,7 +7258,7 @@ void RGWGetAttrs::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWGetAttrs::execute(optional_yield y)
+void RGWGetAttrs::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params();
   if (op_ret < 0)
@@ -7314,7 +7314,7 @@ void RGWRMAttrs::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWRMAttrs::execute(optional_yield y)
+void RGWRMAttrs::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params();
   if (op_ret < 0)
@@ -7351,7 +7351,7 @@ void RGWSetAttrs::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWSetAttrs::execute(optional_yield y)
+void RGWSetAttrs::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params(y);
   if (op_ret < 0)
@@ -7376,7 +7376,7 @@ void RGWGetObjLayout::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWGetObjLayout::execute(optional_yield y)
+void RGWGetObjLayout::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   /* Make sure bucket is correct */
   s->object->set_bucket(s->bucket.get());
@@ -7409,7 +7409,7 @@ void RGWConfigBucketMetaSearch::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWConfigBucketMetaSearch::execute(optional_yield y)
+void RGWConfigBucketMetaSearch::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params(y);
   if (op_ret < 0) {
@@ -7456,7 +7456,7 @@ void RGWDelBucketMetaSearch::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWDelBucketMetaSearch::execute(optional_yield y)
+void RGWDelBucketMetaSearch::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   s->bucket->get_info().mdsearch_config.clear();
 
@@ -7574,14 +7574,14 @@ int RGWPutBucketPolicy::get_params(optional_yield y)
   return op_ret;
 }
 
-void RGWPutBucketPolicy::execute(optional_yield y)
+void RGWPutBucketPolicy::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params(y);
   if (op_ret < 0) {
     return;
   }
 
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(dpp, s->user.get(), nullptr, data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 20) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -7628,7 +7628,7 @@ int RGWGetBucketPolicy::verify_permission(optional_yield y)
   return 0;
 }
 
-void RGWGetBucketPolicy::execute(optional_yield y)
+void RGWGetBucketPolicy::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   rgw::sal::RGWAttrs attrs(s->bucket_attrs);
   auto aiter = attrs.find(RGW_ATTR_IAM_POLICY);
@@ -7669,7 +7669,7 @@ int RGWDeleteBucketPolicy::verify_permission(optional_yield y)
   return 0;
 }
 
-void RGWDeleteBucketPolicy::execute(optional_yield y)
+void RGWDeleteBucketPolicy::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = retry_raced_bucket_write(this, s->bucket.get(), [this] {
       rgw::sal::RGWAttrs attrs(s->bucket_attrs);
@@ -7689,7 +7689,7 @@ int RGWPutBucketObjectLock::verify_permission(optional_yield y)
   return verify_bucket_owner_or_policy(s, rgw::IAM::s3PutBucketObjectLockConfiguration);
 }
 
-void RGWPutBucketObjectLock::execute(optional_yield y)
+void RGWPutBucketObjectLock::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   if (!s->bucket->get_info().obj_lock_enabled()) {
     ldpp_dout(this, 0) << "ERROR: object Lock configuration cannot be enabled on existing buckets" << dendl;
@@ -7725,7 +7725,7 @@ void RGWPutBucketObjectLock::execute(optional_yield y)
     return;
   }
 
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(dpp, s->user.get(), nullptr, data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldout(s->cct, 20) << __func__ << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -7749,7 +7749,7 @@ int RGWGetBucketObjectLock::verify_permission(optional_yield y)
   return verify_bucket_owner_or_policy(s, rgw::IAM::s3GetBucketObjectLockConfiguration);
 }
 
-void RGWGetBucketObjectLock::execute(optional_yield y)
+void RGWGetBucketObjectLock::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   if (!s->bucket->get_info().obj_lock_enabled()) {
     op_ret = -ERR_NO_SUCH_OBJECT_LOCK_CONFIGURATION;
@@ -7777,7 +7777,7 @@ void RGWPutObjRetention::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWPutObjRetention::execute(optional_yield y)
+void RGWPutObjRetention::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   if (!s->bucket->get_info().obj_lock_enabled()) {
     ldpp_dout(this, 0) << "ERROR: object retention can't be set if bucket object lock not configured" << dendl;
@@ -7856,7 +7856,7 @@ void RGWGetObjRetention::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWGetObjRetention::execute(optional_yield y)
+void RGWGetObjRetention::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   if (!s->bucket->get_info().obj_lock_enabled()) {
     ldpp_dout(this, 0) << "ERROR: bucket object lock not configured" << dendl;
@@ -7900,7 +7900,7 @@ void RGWPutObjLegalHold::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWPutObjLegalHold::execute(optional_yield y) {
+void RGWPutObjLegalHold::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   if (!s->bucket->get_info().obj_lock_enabled()) {
     ldpp_dout(this, 0) << "ERROR: object legal hold can't be set if bucket object lock not configured" << dendl;
     op_ret = -ERR_INVALID_REQUEST;
@@ -7950,7 +7950,7 @@ void RGWGetObjLegalHold::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWGetObjLegalHold::execute(optional_yield y)
+void RGWGetObjLegalHold::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   if (!s->bucket->get_info().obj_lock_enabled()) {
     ldpp_dout(this, 0) << "ERROR: bucket object lock not configured" << dendl;
@@ -7981,7 +7981,7 @@ void RGWGetObjLegalHold::execute(optional_yield y)
   return;
 }
 
-void RGWGetClusterStat::execute(optional_yield y)
+void RGWGetClusterStat::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = store->cluster_stat(stats_op);
 }
@@ -7996,7 +7996,7 @@ int RGWGetBucketPolicyStatus::verify_permission(optional_yield y)
   return 0;
 }
 
-void RGWGetBucketPolicyStatus::execute(optional_yield y)
+void RGWGetBucketPolicyStatus::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   isPublic = (s->iam_policy && rgw::IAM::is_public(*s->iam_policy)) || s->bucket_acl->is_public();
 }
@@ -8017,7 +8017,7 @@ int RGWPutBucketPublicAccessBlock::get_params(optional_yield y)
   return op_ret;
 }
 
-void RGWPutBucketPublicAccessBlock::execute(optional_yield y)
+void RGWPutBucketPublicAccessBlock::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   RGWXMLDecoder::XMLParser parser;
   if (!parser.init()) {
@@ -8044,7 +8044,7 @@ void RGWPutBucketPublicAccessBlock::execute(optional_yield y)
     return;
   }
 
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(dpp, s->user.get(), nullptr, data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -8069,7 +8069,7 @@ int RGWGetBucketPublicAccessBlock::verify_permission(optional_yield y)
   return 0;
 }
 
-void RGWGetBucketPublicAccessBlock::execute(optional_yield y)
+void RGWGetBucketPublicAccessBlock::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   auto attrs = s->bucket_attrs;
   if (auto aiter = attrs.find(RGW_ATTR_PUBLIC_ACCESS);
@@ -8109,7 +8109,7 @@ int RGWDeleteBucketPublicAccessBlock::verify_permission(optional_yield y)
   return 0;
 }
 
-void RGWDeleteBucketPublicAccessBlock::execute(optional_yield y)
+void RGWDeleteBucketPublicAccessBlock::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = retry_raced_bucket_write(this, s->bucket.get(), [this] {
       rgw::sal::RGWAttrs attrs(s->bucket_attrs);

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -191,7 +191,7 @@ public:
   virtual int verify_permission(optional_yield y) = 0;
   virtual int verify_op_mask();
   virtual void pre_exec() {}
-  virtual void execute(optional_yield y) = 0;
+  virtual void execute(const DoutPrefixProvider *dpp, optional_yield y) = 0;
   virtual void send_response() {}
   virtual void complete() {
     send_response();
@@ -340,7 +340,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int parse_range();
   int read_user_manifest_part(
     rgw::sal::RGWBucket* bucket,
@@ -391,7 +391,7 @@ class RGWGetObjTags : public RGWOp {
   bool has_tags{false};
  public:
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void pre_exec() override;
 
   virtual void send_response_data(bufferlist& bl) = 0;
@@ -406,7 +406,7 @@ class RGWPutObjTags : public RGWOp {
   bufferlist tags_bl;
  public:
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual void send_response() override = 0;
   virtual int get_params(optional_yield y) = 0;
@@ -420,7 +420,7 @@ class RGWDeleteObjTags: public RGWOp {
  public:
   void pre_exec() override;
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "delete_obj_tags"; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_DELETE; }
@@ -433,7 +433,7 @@ protected:
   bool has_tags{false};
 public:
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void pre_exec() override;
 
   virtual void send_response_data(bufferlist& bl) = 0;
@@ -448,7 +448,7 @@ protected:
   bufferlist in_data;
 public:
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual void send_response() override = 0;
   virtual int get_params(optional_yield y) = 0;
@@ -461,7 +461,7 @@ class RGWDeleteBucketTags : public RGWOp {
 public:
   void pre_exec() override;
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "delete_bucket_tags"; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_DELETE; }
@@ -473,7 +473,7 @@ struct rgw_sync_policy_group;
 class RGWGetBucketReplication : public RGWOp {
 public:
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void pre_exec() override;
 
   virtual void send_response_data() = 0;
@@ -488,7 +488,7 @@ protected:
   std::vector<rgw_sync_policy_group> sync_policy_groups;
 public:
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual void send_response() override = 0;
   virtual int get_params(optional_yield y) = 0;
@@ -503,7 +503,7 @@ protected:
 public:
   void pre_exec() override;
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "delete_bucket_replication"; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_DELETE; }
@@ -574,7 +574,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual int get_data(std::list<acct_path_t>& items,
                        bool * is_truncated) = 0;
@@ -651,7 +651,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "bulk_upload"; }
 
@@ -758,7 +758,7 @@ public:
   }
 
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual int get_params(optional_yield y) = 0;
   virtual void handle_listing_chunk(rgw::sal::RGWBucketList&& buckets) {
@@ -799,7 +799,7 @@ public:
   }
 
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual int get_params(optional_yield y) = 0;
   void send_response() override {}
@@ -819,7 +819,7 @@ public:
   RGWStatAccount() = default;
 
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   void send_response() override = 0;
   const char* name() const override { return "stat_account"; }
@@ -855,7 +855,7 @@ public:
 		    allow_unordered(false), shard_id(-1) {}
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   void init(rgw::sal::RGWRadosStore *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
@@ -872,7 +872,7 @@ class RGWGetBucketLogging : public RGWOp {
 public:
   RGWGetBucketLogging() {}
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield) override { }
+  void execute(const DoutPrefixProvider *dpp, optional_yield) override { }
 
   void send_response() override = 0;
   const char* name() const override { return "get_bucket_logging"; }
@@ -885,7 +885,7 @@ public:
   RGWGetBucketLocation() {}
   ~RGWGetBucketLocation() override {}
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield) override { }
+  void execute(const DoutPrefixProvider *dpp, optional_yield) override { }
 
   void send_response() override = 0;
   const char* name() const override { return "get_bucket_location"; }
@@ -903,7 +903,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   void send_response() override = 0;
   const char* name() const override { return "get_bucket_versioning"; }
@@ -929,7 +929,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual int get_params(optional_yield y) { return 0; }
 
@@ -945,7 +945,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   void send_response() override = 0;
   const char* name() const override { return "get_bucket_website"; }
@@ -962,7 +962,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual int get_params(optional_yield y) { return 0; }
 
@@ -978,7 +978,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   void send_response() override = 0;
   const char* name() const override { return "delete_bucket_website"; }
@@ -993,7 +993,7 @@ protected:
 public:
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   void send_response() override = 0;
   const char* name() const override { return "stat_bucket"; }
@@ -1029,7 +1029,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void init(rgw::sal::RGWRadosStore *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
@@ -1052,7 +1052,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   void send_response() override = 0;
   const char* name() const override { return "delete_bucket"; }
@@ -1196,7 +1196,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   /* this is for cases when copying data from other object */
   virtual int get_decrypt_filter(std::unique_ptr<RGWGetObj_Filter>* filter,
@@ -1262,7 +1262,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual int get_encrypt_filter(std::unique_ptr<rgw::putobj::DataProcessor> *filter,
                                  rgw::putobj::DataProcessor *cb) {
@@ -1303,7 +1303,7 @@ public:
   int init_processing(optional_yield y) override;
   int verify_permission(optional_yield y) override;
   void pre_exec() override { }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
@@ -1342,7 +1342,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
@@ -1368,7 +1368,7 @@ public:
   }
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
@@ -1401,7 +1401,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int handle_slo_manifest(bufferlist& bl, optional_yield y);
 
   virtual int get_params(optional_yield y) { return 0; }
@@ -1489,7 +1489,7 @@ public:
   }
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void progress_cb(off_t ofs);
 
   virtual int check_storage_class(const rgw_placement_rule& src_placement) {
@@ -1515,7 +1515,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   void send_response() override = 0;
   const char* name() const override { return "get_acls"; }
@@ -1534,7 +1534,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual int get_policy_from_state(rgw::sal::RGWRadosStore *store, struct req_state *s, stringstream& ss) { return 0; }
   virtual int get_params(optional_yield y) = 0;
@@ -1553,7 +1553,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield) override = 0;
+  void execute(const DoutPrefixProvider *dpp, optional_yield) override = 0;
 
   void send_response() override = 0;
   const char* name() const override { return "get_lifecycle"; }
@@ -1584,7 +1584,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
 //  virtual int get_policy_from_state(RGWRados *store, struct req_state *s, stringstream& ss) { return 0; }
   virtual int get_params(optional_yield y) = 0;
@@ -1599,7 +1599,7 @@ public:
   RGWDeleteLC() = default;
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   void send_response() override = 0;
   const char* name() const override { return "delete_lifecycle"; }
@@ -1614,7 +1614,7 @@ public:
   RGWGetCORS() {}
 
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   void send_response() override = 0;
   const char* name() const override { return "get_cors"; }
@@ -1632,7 +1632,7 @@ public:
   ~RGWPutCORS() override {}
 
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
@@ -1648,7 +1648,7 @@ public:
   RGWDeleteCORS() {}
 
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   void send_response() override = 0;
   const char* name() const override { return "delete_cors"; }
@@ -1668,7 +1668,7 @@ public:
 
   int verify_permission(optional_yield y) override {return 0;}
   int validate_cors_request(RGWCORSConfiguration *cc);
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void get_response_params(string& allowed_hdrs, string& exp_hdrs, unsigned *max_age);
   void send_response() override = 0;
   const char* name() const override { return "options_cors"; }
@@ -1685,7 +1685,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   void send_response() override = 0;
   const char* name() const override { return "get_request_payment"; }
@@ -1702,7 +1702,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual int get_params(optional_yield y) { return 0; }
 
@@ -1727,7 +1727,7 @@ public:
   }
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
@@ -1751,7 +1751,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void complete() override;
 
   virtual int get_params(optional_yield y) = 0;
@@ -1767,7 +1767,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   void send_response() override = 0;
   const char* name() const override { return "abort_multipart"; }
@@ -1797,7 +1797,7 @@ public:
   }
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
@@ -1845,7 +1845,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
@@ -1864,7 +1864,7 @@ public:
     return 0;
   }
 
-  void execute(optional_yield) override {
+  void execute(const DoutPrefixProvider *dpp, optional_yield) override {
     op_ret = 0;
   }
 
@@ -1889,7 +1889,7 @@ public:
     return 0;
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "get_health_check"; }
 
@@ -1923,7 +1923,7 @@ public:
   }
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual int get_params(optional_yield y) = 0;
   virtual void send_status() = 0;
@@ -2152,7 +2152,7 @@ public:
 
   int verify_permission(optional_yield y);
   void pre_exec();
-  void execute(optional_yield y);
+  void execute(const DoutPrefixProvider *dpp, optional_yield y);
 
   virtual int get_params() = 0;
   virtual void send_response() = 0;
@@ -2175,7 +2175,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
@@ -2200,7 +2200,7 @@ public:
 
   int verify_permission(optional_yield y);
   void pre_exec();
-  void execute(optional_yield y);
+  void execute(const DoutPrefixProvider *dpp, optional_yield y);
 
   virtual int get_params() = 0;
   virtual void send_response() = 0;
@@ -2225,7 +2225,7 @@ public:
     return check_caps(s->user->get_info().caps);
   }
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "get_obj_layout"; }
   virtual RGWOpType get_type() override { return RGW_OP_GET_OBJ_LAYOUT; }
@@ -2243,7 +2243,7 @@ public:
   uint32_t op_mask() override {
     return RGW_OP_TYPE_WRITE;
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int get_params(optional_yield y);
   const char* name() const override { return "put_bucket_policy"; }
   RGWOpType get_type() override {
@@ -2260,7 +2260,7 @@ public:
   uint32_t op_mask() override {
     return RGW_OP_TYPE_READ;
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   const char* name() const override { return "get_bucket_policy"; }
   RGWOpType get_type() override {
     return RGW_OP_GET_BUCKET_POLICY;
@@ -2275,7 +2275,7 @@ public:
   uint32_t op_mask() override {
     return RGW_OP_TYPE_WRITE;
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int get_params(optional_yield y);
   const char* name() const override { return "delete_bucket_policy"; }
   RGWOpType get_type() override {
@@ -2293,7 +2293,7 @@ public:
   ~RGWPutBucketObjectLock() {}
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   virtual void send_response() override = 0;
   virtual int get_params(optional_yield y) = 0;
   const char* name() const override { return "put_bucket_object_lock"; }
@@ -2305,7 +2305,7 @@ class RGWGetBucketObjectLock : public RGWOp {
 public:
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   virtual void send_response() override = 0;
   const char* name() const override {return "get_bucket_object_lock"; }
   RGWOpType get_type() override { return RGW_OP_GET_BUCKET_OBJ_LOCK; }
@@ -2322,7 +2322,7 @@ public:
   RGWPutObjRetention():bypass_perm(true), bypass_governance_mode(false) {}
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   virtual void send_response() override = 0;
   virtual int get_params(optional_yield y) = 0;
   const char* name() const override { return "put_obj_retention"; }
@@ -2336,7 +2336,7 @@ protected:
 public:
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   virtual void send_response() override = 0;
   const char* name() const override {return "get_obj_retention"; }
   RGWOpType get_type() override { return RGW_OP_GET_OBJ_RETENTION; }
@@ -2350,7 +2350,7 @@ protected:
 public:
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   virtual void send_response() override = 0;
   virtual int get_params(optional_yield y) = 0;
   const char* name() const override { return "put_obj_legal_hold"; }
@@ -2364,7 +2364,7 @@ protected:
 public:
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   virtual void send_response() override = 0;
   const char* name() const override {return "get_obj_legal_hold"; }
   RGWOpType get_type() override { return RGW_OP_GET_OBJ_LEGAL_HOLD; }
@@ -2380,7 +2380,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   virtual int get_params(optional_yield y) = 0;
   const char* name() const override { return "config_bucket_meta_search"; }
@@ -2394,7 +2394,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield) override {}
+  void execute(const DoutPrefixProvider *dpp, optional_yield) override {}
 
   const char* name() const override { return "get_bucket_meta_search"; }
   virtual RGWOpType get_type() override { return RGW_OP_GET_BUCKET_META_SEARCH; }
@@ -2407,7 +2407,7 @@ public:
 
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "delete_bucket_meta_search"; }
   virtual RGWOpType delete_type() { return RGW_OP_DEL_BUCKET_META_SEARCH; }
@@ -2426,7 +2426,7 @@ public:
   int verify_permission(optional_yield) override {return 0;}
   virtual void send_response() override = 0;
   virtual int get_params(optional_yield y) = 0;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   const char* name() const override { return "get_cluster_stat"; }
   dmc::client_id dmclock_client() override { return dmc::client_id::admin; }
 };
@@ -2439,7 +2439,7 @@ public:
   const char* name() const override { return "get_bucket_policy_status"; }
   virtual RGWOpType get_type() override { return RGW_OP_GET_BUCKET_POLICY_STATUS; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   dmc::client_id dmclock_client() override { return dmc::client_id::metadata; }
 };
 
@@ -2453,7 +2453,7 @@ public:
   virtual RGWOpType get_type() override { return RGW_OP_PUT_BUCKET_PUBLIC_ACCESS_BLOCK; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   int get_params(optional_yield y);
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   dmc::client_id dmclock_client() override { return dmc::client_id::metadata; }
 };
 
@@ -2466,7 +2466,7 @@ public:
   virtual RGWOpType get_type() override { return RGW_OP_GET_BUCKET_PUBLIC_ACCESS_BLOCK; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
   int get_params(optional_yield y);
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   dmc::client_id dmclock_client() override { return dmc::client_id::metadata; }
 };
 
@@ -2479,7 +2479,7 @@ public:
   virtual RGWOpType get_type() override { return RGW_OP_DELETE_BUCKET_PUBLIC_ACCESS_BLOCK; }
   virtual uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
   int get_params(optional_yield y);
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void send_response() override;
   dmc::client_id dmclock_client() override { return dmc::client_id::metadata; }
 };

--- a/src/rgw/rgw_period_puller.cc
+++ b/src/rgw/rgw_period_puller.cc
@@ -24,7 +24,7 @@ RGWPeriodPuller::RGWPeriodPuller(RGWSI_Zone *zone_svc, RGWSI_SysObj *sysobj_svc)
 namespace {
 
 // pull the given period over the connection
-int pull_period(RGWRESTConn* conn, const std::string& period_id,
+int pull_period(const DoutPrefixProvider *dpp, RGWRESTConn* conn, const std::string& period_id,
                 const std::string& realm_id, RGWPeriod& period,
 		optional_yield y)
 {
@@ -40,7 +40,7 @@ int pull_period(RGWRESTConn* conn, const std::string& period_id,
 
   bufferlist data;
 #define MAX_REST_RESPONSE (128 * 1024)
-  int r = conn->forward(user, info, nullptr, MAX_REST_RESPONSE, nullptr, &data, y);
+  int r = conn->forward(dpp, user, info, nullptr, MAX_REST_RESPONSE, nullptr, &data, y);
   if (r < 0) {
     return r;
   }
@@ -81,7 +81,7 @@ int RGWPeriodPuller::pull(const std::string& period_id, RGWPeriod& period,
     ldout(cct, 14) << "pulling period " << period_id
         << " from master" << dendl;
     // request the period from the master zone
-    r = pull_period(svc.zone->get_master_conn(), period_id,
+    r = pull_period(dpp, svc.zone->get_master_conn(), period_id,
                     svc.zone->get_realm().get_id(), period, y);
     if (r < 0) {
       lderr(cct) << "failed to pull period " << period_id << dendl;

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -82,7 +82,7 @@ RGWRequest* RGWProcess::RGWWQ::_dequeue() {
 
 void RGWProcess::RGWWQ::_process(RGWRequest *req, ThreadPool::TPHandle &) {
   perfcounter->inc(l_rgw_qactive);
-  process->handle_request(req);
+  process->handle_request(this, req);
   process->req_throttle.put(1);
   perfcounter->inc(l_rgw_qactive, -1);
 }
@@ -164,7 +164,7 @@ int rgw_process_authenticated(RGWHandler_REST * const handler,
   op->pre_exec();
 
   ldpp_dout(op, 2) << "executing" << dendl;
-  op->execute(y);
+  op->execute(op, y);
 
   ldpp_dout(op, 2) << "completing" << dendl;
   op->complete();

--- a/src/rgw/rgw_pubsub_push.cc
+++ b/src/rgw/rgw_pubsub_push.cc
@@ -73,7 +73,7 @@ private:
     }
 
     // send message to endpoint
-    int send_request() override {
+    int send_request(const DoutPrefixProvider *dpp) override {
       init_new_io(this);
       const auto rc = sync_env->http_manager->add_request(this);
       if (rc < 0) {
@@ -232,7 +232,7 @@ private:
       topic(_topic), conn(_conn), message(_message) {}
 
     // send message to endpoint, without waiting for reply
-    int operate() override {
+    int operate(const DoutPrefixProvider *dpp) override {
       reenter(this) {
         const auto rc = amqp::publish(conn, topic, message);
         if (rc < 0) {
@@ -262,7 +262,7 @@ private:
       topic(_topic), conn(_conn), message(_message) {}
 
     // send message to endpoint, waiting for reply
-    int operate() override {
+    int operate(const DoutPrefixProvider *dpp) override {
       reenter(this) {
         yield {
           init_new_io(this);
@@ -504,7 +504,7 @@ private:
       topic(_topic), conn(_conn), message(_message) {}
 
     // send message to endpoint, without waiting for reply
-    int operate() override {
+    int operate(const DoutPrefixProvider *dpp) override {
       reenter(this) {
         const auto rc = kafka::publish(conn, topic, message);
         if (rc < 0) {
@@ -534,7 +534,7 @@ private:
       topic(_topic), conn(_conn), message(_message) {}
 
     // send message to endpoint, waiting for reply
-    int operate() override {
+    int operate(const DoutPrefixProvider *dpp) override {
       reenter(this) {
         yield {
           init_new_io(this);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1095,7 +1095,8 @@ public:
 
   int rewrite_obj(RGWBucketInfo& dest_bucket_info, rgw::sal::RGWObject* obj, const DoutPrefixProvider *dpp, optional_yield y);
 
-  int stat_remote_obj(RGWObjectCtx& obj_ctx,
+  int stat_remote_obj(const DoutPrefixProvider *dpp,
+               RGWObjectCtx& obj_ctx,
                const rgw_user& user_id,
                req_info *info,
                const rgw_zone_id& source_zone,

--- a/src/rgw/rgw_rest_bucket.cc
+++ b/src/rgw/rgw_rest_bucket.cc
@@ -23,12 +23,12 @@ public:
     return caps.check_cap("buckets", RGW_CAP_READ);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "get_bucket_info"; }
 };
 
-void RGWOp_Bucket_Info::execute(optional_yield y)
+void RGWOp_Bucket_Info::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   RGWBucketAdminOpState op_state;
 
@@ -60,12 +60,12 @@ public:
     return caps.check_cap("buckets", RGW_CAP_READ);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "get_policy"; }
 };
 
-void RGWOp_Get_Policy::execute(optional_yield y)
+void RGWOp_Get_Policy::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   RGWBucketAdminOpState op_state;
 
@@ -90,12 +90,12 @@ public:
     return caps.check_cap("buckets", RGW_CAP_WRITE);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "check_bucket_index"; }
 };
 
-void RGWOp_Check_Bucket_Index::execute(optional_yield y)
+void RGWOp_Check_Bucket_Index::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   std::string bucket;
 
@@ -124,12 +124,12 @@ public:
     return caps.check_cap("buckets", RGW_CAP_WRITE);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "link_bucket"; }
 };
 
-void RGWOp_Bucket_Link::execute(optional_yield y)
+void RGWOp_Bucket_Link::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   std::string uid_str;
   std::string bucket;
@@ -150,7 +150,7 @@ void RGWOp_Bucket_Link::execute(optional_yield y)
   op_state.set_new_bucket_name(new_bucket_name);
 
   bufferlist data;
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(s, s->user.get(), nullptr, data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -167,12 +167,12 @@ public:
     return caps.check_cap("buckets", RGW_CAP_WRITE);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "unlink_bucket"; }
 };
 
-void RGWOp_Bucket_Unlink::execute(optional_yield y)
+void RGWOp_Bucket_Unlink::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   std::string uid_str;
   std::string bucket;
@@ -188,7 +188,7 @@ void RGWOp_Bucket_Unlink::execute(optional_yield y)
   op_state.set_bucket_name(bucket);
 
   bufferlist data;
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(s, s->user.get(), nullptr, data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -205,12 +205,12 @@ public:
     return caps.check_cap("buckets", RGW_CAP_WRITE);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "remove_bucket"; }
 };
 
-void RGWOp_Bucket_Remove::execute(optional_yield y)
+void RGWOp_Bucket_Remove::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   std::string bucket_name;
   bool delete_children;
@@ -237,14 +237,14 @@ public:
     return caps.check_cap("buckets", RGW_CAP_WRITE);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "set_bucket_quota"; }
 };
 
 #define QUOTA_INPUT_MAX_LEN 1024
 
-void RGWOp_Set_Bucket_Quota::execute(optional_yield y)
+void RGWOp_Set_Bucket_Quota::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   bool uid_arg_existed = false;
   std::string uid_str;
@@ -314,12 +314,12 @@ public:
     return caps.check_cap("buckets", RGW_CAP_WRITE);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "sync_bucket"; }
 };
 
-void RGWOp_Sync_Bucket::execute(optional_yield y)
+void RGWOp_Sync_Bucket::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   std::string bucket;
   std::string tenant;
@@ -346,12 +346,12 @@ public:
     return caps.check_cap("buckets", RGW_CAP_WRITE);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "remove_object"; }
 };
 
-void RGWOp_Object_Remove::execute(optional_yield y)
+void RGWOp_Object_Remove::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   std::string bucket;
   std::string object;

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -116,7 +116,7 @@ static void get_gmt_date_str(string& date_str)
   date_str = buffer;
 }
 
-int RGWRESTSimpleRequest::execute(RGWAccessKey& key, const char *_method, const char *resource, optional_yield y)
+int RGWRESTSimpleRequest::execute(const DoutPrefixProvider *dpp, RGWAccessKey& key, const char *_method, const char *resource, optional_yield y)
 {
   method = _method;
   string new_url = url;
@@ -139,7 +139,7 @@ int RGWRESTSimpleRequest::execute(RGWAccessKey& key, const char *_method, const 
   meta_map_t meta_map;
   map<string, string> sub_resources;
 
-  rgw_create_s3_canonical_header(method.c_str(), NULL, NULL, date_str.c_str(),
+  rgw_create_s3_canonical_header(dpp, method.c_str(), NULL, NULL, date_str.c_str(),
 				 meta_map, meta_map, url.c_str(), sub_resources,
 				 canonical_header);
 
@@ -233,7 +233,7 @@ void RGWHTTPSimpleRequest::get_out_headers(map<string, string> *pheaders)
   out_headers.clear();
 }
 
-static int sign_request(CephContext *cct, RGWAccessKey& key, RGWEnv& env, req_info& info)
+static int sign_request(const DoutPrefixProvider *dpp, CephContext *cct, RGWAccessKey& key, RGWEnv& env, req_info& info)
 {
   /* don't sign if no key is provided */
   if (key.key.empty()) {
@@ -247,7 +247,7 @@ static int sign_request(CephContext *cct, RGWAccessKey& key, RGWEnv& env, req_in
   }
 
   string canonical_header;
-  if (!rgw_create_s3_canonical_header(info, NULL, canonical_header, false)) {
+  if (!rgw_create_s3_canonical_header(dpp, info, NULL, canonical_header, false)) {
     ldout(cct, 0) << "failed to create canonical s3 header" << dendl;
     return -EINVAL;
   }
@@ -269,7 +269,7 @@ static int sign_request(CephContext *cct, RGWAccessKey& key, RGWEnv& env, req_in
   return 0;
 }
 
-int RGWRESTSimpleRequest::forward_request(RGWAccessKey& key, req_info& info, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y)
+int RGWRESTSimpleRequest::forward_request(const DoutPrefixProvider *dpp, RGWAccessKey& key, req_info& info, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y)
 {
 
   string date_str;
@@ -293,7 +293,7 @@ int RGWRESTSimpleRequest::forward_request(RGWAccessKey& key, req_info& info, siz
   if (content_md5) {
     new_env.set("HTTP_CONTENT_MD5", content_md5);
   }
-  int ret = sign_request(cct, key, new_env, new_info);
+  int ret = sign_request(dpp, cct, key, new_env, new_info);
   if (ret < 0) {
     ldout(cct, 0) << "ERROR: failed to sign request" << dendl;
     return ret;
@@ -557,9 +557,9 @@ void RGWRESTGenerateHTTPHeaders::set_policy(RGWAccessControlPolicy& policy)
   add_grants_headers(grants_by_type, *new_env, new_info->x_meta_map);
 }
 
-int RGWRESTGenerateHTTPHeaders::sign(RGWAccessKey& key)
+int RGWRESTGenerateHTTPHeaders::sign(const DoutPrefixProvider *dpp, RGWAccessKey& key)
 {
-  int ret = sign_request(cct, key, *new_env, *new_info);
+  int ret = sign_request(dpp, cct, key, *new_env, *new_info);
   if (ret < 0) {
     ldout(cct, 0) << "ERROR: failed to sign request" << dendl;
     return ret;
@@ -593,25 +593,25 @@ void RGWRESTStreamS3PutObj::send_init(rgw::sal::RGWObject* obj)
   url = headers_gen.get_url();
 }
 
-int RGWRESTStreamS3PutObj::send_ready(RGWAccessKey& key, map<string, bufferlist>& rgw_attrs, bool send)
+int RGWRESTStreamS3PutObj::send_ready(const DoutPrefixProvider *dpp, RGWAccessKey& key, map<string, bufferlist>& rgw_attrs, bool send)
 {
   headers_gen.set_obj_attrs(rgw_attrs);
 
-  return send_ready(key, send);
+  return send_ready(dpp, key, send);
 }
 
-int RGWRESTStreamS3PutObj::send_ready(RGWAccessKey& key, const map<string, string>& http_attrs,
+int RGWRESTStreamS3PutObj::send_ready(const DoutPrefixProvider *dpp, RGWAccessKey& key, const map<string, string>& http_attrs,
                                       RGWAccessControlPolicy& policy, bool send)
 {
   headers_gen.set_http_attrs(http_attrs);
   headers_gen.set_policy(policy);
 
-  return send_ready(key, send);
+  return send_ready(dpp, key, send);
 }
 
-int RGWRESTStreamS3PutObj::send_ready(RGWAccessKey& key, bool send)
+int RGWRESTStreamS3PutObj::send_ready(const DoutPrefixProvider *dpp, RGWAccessKey& key, bool send)
 {
-  headers_gen.sign(key);
+  headers_gen.sign(dpp, key);
 
   for (const auto& kv: new_env.get_map()) {
     headers.emplace_back(kv);
@@ -628,10 +628,10 @@ int RGWRESTStreamS3PutObj::send_ready(RGWAccessKey& key, bool send)
   return 0;
 }
 
-int RGWRESTStreamS3PutObj::put_obj_init(RGWAccessKey& key, rgw::sal::RGWObject* obj, uint64_t obj_size, map<string, bufferlist>& attrs, bool send)
+int RGWRESTStreamS3PutObj::put_obj_init(const DoutPrefixProvider *dpp, RGWAccessKey& key, rgw::sal::RGWObject* obj, uint64_t obj_size, map<string, bufferlist>& attrs, bool send)
 {
   send_init(obj);
-  return send_ready(key, attrs, send);
+  return send_ready(dpp, key, attrs, send);
 }
 
 void set_str_from_headers(map<string, string>& out_headers, const string& header_name, string& str)
@@ -683,33 +683,33 @@ static void send_prepare_convert(const rgw_obj& obj, string *resource)
   *resource = urlsafe_bucket + "/" + urlsafe_object;
 }
 
-int RGWRESTStreamRWRequest::send_request(RGWAccessKey& key, map<string, string>& extra_headers, const rgw_obj& obj, RGWHTTPManager *mgr)
+int RGWRESTStreamRWRequest::send_request(const DoutPrefixProvider *dpp, RGWAccessKey& key, map<string, string>& extra_headers, const rgw_obj& obj, RGWHTTPManager *mgr)
 {
   string resource;
   send_prepare_convert(obj, &resource);
 
-  return send_request(&key, extra_headers, resource, mgr);
+  return send_request(dpp, &key, extra_headers, resource, mgr);
 }
 
-int RGWRESTStreamRWRequest::send_prepare(RGWAccessKey& key, map<string, string>& extra_headers, const rgw_obj& obj)
+int RGWRESTStreamRWRequest::send_prepare(const DoutPrefixProvider *dpp, RGWAccessKey& key, map<string, string>& extra_headers, const rgw_obj& obj)
 {
   string resource;
   send_prepare_convert(obj, &resource);
 
-  return do_send_prepare(&key, extra_headers, resource);
+  return do_send_prepare(dpp, &key, extra_headers, resource);
 }
 
-int RGWRESTStreamRWRequest::send_prepare(RGWAccessKey *key, map<string, string>& extra_headers, const string& resource,
+int RGWRESTStreamRWRequest::send_prepare(const DoutPrefixProvider *dpp, RGWAccessKey *key, map<string, string>& extra_headers, const string& resource,
                                            bufferlist *send_data)
 {
   string new_resource;
   //do not encode slash
   url_encode(resource, new_resource, false);
 
-  return do_send_prepare(key, extra_headers, new_resource, send_data);
+  return do_send_prepare(dpp, key, extra_headers, new_resource, send_data);
 }
 
-int RGWRESTStreamRWRequest::do_send_prepare(RGWAccessKey *key, map<string, string>& extra_headers, const string& resource,
+int RGWRESTStreamRWRequest::do_send_prepare(const DoutPrefixProvider *dpp, RGWAccessKey *key, map<string, string>& extra_headers, const string& resource,
                                          bufferlist *send_data)
 {
   string new_url = url;
@@ -757,7 +757,7 @@ int RGWRESTStreamRWRequest::do_send_prepare(RGWAccessKey *key, map<string, strin
     new_info.init_meta_info(nullptr);
 #endif
 
-    int ret = headers_gen.sign(*key);
+    int ret = headers_gen.sign(dpp, *key);
     if (ret < 0) {
       ldout(cct, 0) << "ERROR: failed to sign request" << dendl;
       return ret;
@@ -781,10 +781,10 @@ int RGWRESTStreamRWRequest::do_send_prepare(RGWAccessKey *key, map<string, strin
   return 0;
 }
 
-int RGWRESTStreamRWRequest::send_request(RGWAccessKey *key, map<string, string>& extra_headers, const string& resource,
+int RGWRESTStreamRWRequest::send_request(const DoutPrefixProvider *dpp, RGWAccessKey *key, map<string, string>& extra_headers, const string& resource,
                                          RGWHTTPManager *mgr, bufferlist *send_data)
 {
-  int ret = send_prepare(key, extra_headers, resource, send_data);
+  int ret = send_prepare(dpp, key, extra_headers, resource, send_data);
   if (ret < 0) {
     return ret;
   }

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -63,8 +63,8 @@ public:
   RGWRESTSimpleRequest(CephContext *_cct, const string& _method, const string& _url,
                        param_vec_t *_headers, param_vec_t *_params) : RGWHTTPSimpleRequest(_cct, _method, _url, _headers, _params) {}
 
-  int execute(RGWAccessKey& key, const char *method, const char *resource, optional_yield y);
-  int forward_request(RGWAccessKey& key, req_info& info, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y);
+  int execute(const DoutPrefixProvider *dpp, RGWAccessKey& key, const char *method, const char *resource, optional_yield y);
+  int forward_request(const DoutPrefixProvider *dpp, RGWAccessKey& key, req_info& info, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y);
 };
 
 class RGWWriteDrainCB {
@@ -89,7 +89,7 @@ public:
   int set_obj_attrs(map<string, bufferlist>& rgw_attrs);
   void set_http_attrs(const map<string, string>& http_attrs);
   void set_policy(RGWAccessControlPolicy& policy);
-  int sign(RGWAccessKey& key);
+  int sign(const DoutPrefixProvider *dpp, RGWAccessKey& key);
 
   const string& get_url() { return url; }
 };
@@ -169,12 +169,12 @@ public:
   }
   virtual ~RGWRESTStreamRWRequest() override {}
 
-  int send_prepare(RGWAccessKey *key, map<string, string>& extra_headers, const string& resource, bufferlist *send_data = nullptr /* optional input data */);
-  int send_prepare(RGWAccessKey& key, map<string, string>& extra_headers, const rgw_obj& obj);
+  int send_prepare(const DoutPrefixProvider *dpp, RGWAccessKey *key, map<string, string>& extra_headers, const string& resource, bufferlist *send_data = nullptr /* optional input data */);
+  int send_prepare(const DoutPrefixProvider *dpp, RGWAccessKey& key, map<string, string>& extra_headers, const rgw_obj& obj);
   int send(RGWHTTPManager *mgr);
 
-  int send_request(RGWAccessKey& key, map<string, string>& extra_headers, const rgw_obj& obj, RGWHTTPManager *mgr);
-  int send_request(RGWAccessKey *key, map<string, string>& extra_headers, const string& resource, RGWHTTPManager *mgr, bufferlist *send_data = nullptr /* optional input data */);
+  int send_request(const DoutPrefixProvider *dpp, RGWAccessKey& key, map<string, string>& extra_headers, const rgw_obj& obj, RGWHTTPManager *mgr);
+  int send_request(const DoutPrefixProvider *dpp, RGWAccessKey *key, map<string, string>& extra_headers, const string& resource, RGWHTTPManager *mgr, bufferlist *send_data = nullptr /* optional input data */);
 
   int complete_request(optional_yield y,
                        string *etag = nullptr,
@@ -186,7 +186,7 @@ public:
   void add_params(param_vec_t *params);
 
 private:
-  int do_send_prepare(RGWAccessKey *key, map<string, string>& extra_headers, const string& resource, bufferlist *send_data = nullptr /* optional input data */);
+  int do_send_prepare(const DoutPrefixProvider *dpp, RGWAccessKey *key, map<string, string>& extra_headers, const string& resource, bufferlist *send_data = nullptr /* optional input data */);
 };
 
 class RGWRESTStreamReadRequest : public RGWRESTStreamRWRequest {
@@ -213,12 +213,12 @@ public:
   ~RGWRESTStreamS3PutObj() override;
 
   void send_init(rgw::sal::RGWObject* obj);
-  int send_ready(RGWAccessKey& key, map<string, bufferlist>& rgw_attrs, bool send);
-  int send_ready(RGWAccessKey& key, const map<string, string>& http_attrs,
+  int send_ready(const DoutPrefixProvider *dpp, RGWAccessKey& key, map<string, bufferlist>& rgw_attrs, bool send);
+  int send_ready(const DoutPrefixProvider *dpp, RGWAccessKey& key, const map<string, string>& http_attrs,
                  RGWAccessControlPolicy& policy, bool send);
-  int send_ready(RGWAccessKey& key, bool send);
+  int send_ready(const DoutPrefixProvider *dpp, RGWAccessKey& key, bool send);
 
-  int put_obj_init(RGWAccessKey& key, rgw::sal::RGWObject* obj, uint64_t obj_size, map<string, bufferlist>& attrs, bool send);
+  int put_obj_init(const DoutPrefixProvider *dpp, RGWAccessKey& key, rgw::sal::RGWObject* obj, uint64_t obj_size, map<string, bufferlist>& attrs, bool send);
 
   RGWGetDataCB *get_out_cb() { return out_cb; }
 };

--- a/src/rgw/rgw_rest_config.cc
+++ b/src/rgw/rgw_rest_config.cc
@@ -30,8 +30,8 @@
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
-void RGWOp_ZoneGroupMap_Get::execute(optional_yield y) {
-  op_ret = zonegroup_map.read(g_ceph_context, store->svc()->sysobj, y);
+void RGWOp_ZoneGroupMap_Get::execute(const DoutPrefixProvider *dpp, optional_yield y) {
+  op_ret = zonegroup_map.read(this, g_ceph_context, store->svc()->sysobj, y);
   if (op_ret < 0) {
     dout(5) << "failed to read zone_group map" << dendl;
   }

--- a/src/rgw/rgw_rest_config.h
+++ b/src/rgw/rgw_rest_config.h
@@ -32,7 +32,7 @@ public:
   int verify_permission(optional_yield) override {
     return check_caps(s->user->get_caps());
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void send_response() override;
   const char* name() const override {
     if (old_format) {
@@ -54,7 +54,7 @@ public:
   int verify_permission(optional_yield) override {
     return check_caps(s->user->get_caps());
   }
-  void execute(optional_yield) override {} /* store already has the info we need, just need to send response */
+  void execute(const DoutPrefixProvider *dpp, optional_yield) override {} /* store already has the info we need, just need to send response */
   void send_response() override ;
   const char* name() const override {
     return "get_zone_config";

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -86,7 +86,7 @@ void RGWRESTConn::populate_params(param_vec_t& params, const rgw_user *uid, cons
   populate_zonegroup(params, zonegroup);
 }
 
-int RGWRESTConn::forward(const rgw_user& uid, req_info& info, obj_version *objv, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y)
+int RGWRESTConn::forward(const DoutPrefixProvider *dpp, const rgw_user& uid, req_info& info, obj_version *objv, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y)
 {
   string url;
   int ret = get_url(url);
@@ -101,7 +101,7 @@ int RGWRESTConn::forward(const rgw_user& uid, req_info& info, obj_version *objv,
     params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "ver", buf));
   }
   RGWRESTSimpleRequest req(cct, info.method, url, NULL, &params);
-  return req.forward_request(key, info, max_response, inbl, outbl, y);
+  return req.forward_request(dpp, key, info, max_response, inbl, outbl, y);
 }
 
 class StreamObjData : public RGWGetDataCB {
@@ -131,7 +131,8 @@ int RGWRESTConn::put_obj_send_init(rgw::sal::RGWObject* obj, const rgw_http_para
   return 0;
 }
 
-int RGWRESTConn::put_obj_async(const rgw_user& uid, rgw::sal::RGWObject* obj, uint64_t obj_size,
+int RGWRESTConn::put_obj_async(const DoutPrefixProvider *dpp,
+                               const rgw_user& uid, rgw::sal::RGWObject* obj, uint64_t obj_size,
                                map<string, bufferlist>& attrs, bool send,
                                RGWRESTStreamS3PutObj **req)
 {
@@ -143,7 +144,7 @@ int RGWRESTConn::put_obj_async(const rgw_user& uid, rgw::sal::RGWObject* obj, ui
   param_vec_t params;
   populate_params(params, &uid, self_zone_group);
   RGWRESTStreamS3PutObj *wr = new RGWRESTStreamS3PutObj(cct, "PUT", url, NULL, &params, host_style);
-  ret = wr->put_obj_init(key, obj, obj_size, attrs, send);
+  ret = wr->put_obj_init(dpp, key, obj, obj_size, attrs, send);
   if (ret < 0) {
     delete wr;
     return ret;
@@ -185,7 +186,7 @@ static void set_header(T val, map<string, string>& headers, const string& header
 }
 
 
-int RGWRESTConn::get_obj(const rgw_user& uid, req_info *info /* optional */, const rgw::sal::RGWObject* obj,
+int RGWRESTConn::get_obj(const DoutPrefixProvider *dpp, const rgw_user& uid, req_info *info /* optional */, const rgw::sal::RGWObject* obj,
                          const real_time *mod_ptr, const real_time *unmod_ptr,
                          uint32_t mod_zone_id, uint64_t mod_pg_ver,
                          bool prepend_metadata, bool get_op, bool rgwx_stat,
@@ -203,10 +204,10 @@ int RGWRESTConn::get_obj(const rgw_user& uid, req_info *info /* optional */, con
   params.sync_manifest = sync_manifest;
   params.skip_decrypt = skip_decrypt;
   params.cb = cb;
-  return get_obj(obj, params, send, req);
+  return get_obj(dpp, obj, params, send, req);
 }
 
-int RGWRESTConn::get_obj(const rgw::sal::RGWObject* obj, const get_obj_params& in_params, bool send, RGWRESTStreamRWRequest **req)
+int RGWRESTConn::get_obj(const DoutPrefixProvider *dpp, const rgw::sal::RGWObject* obj, const get_obj_params& in_params, bool send, RGWRESTStreamRWRequest **req)
 {
   string url;
   int ret = get_url(url);
@@ -269,7 +270,7 @@ int RGWRESTConn::get_obj(const rgw::sal::RGWObject* obj, const get_obj_params& i
     set_header(buf, extra_headers, "RANGE");
   }
 
-  int r = (*req)->send_prepare(key, extra_headers, obj->get_obj());
+  int r = (*req)->send_prepare(dpp, key, extra_headers, obj->get_obj());
   if (r < 0) {
     goto done_err;
   }
@@ -303,7 +304,8 @@ int RGWRESTConn::complete_request(RGWRESTStreamRWRequest *req,
   return ret;
 }
 
-int RGWRESTConn::get_resource(const string& resource,
+int RGWRESTConn::get_resource(const DoutPrefixProvider *dpp,
+                     const string& resource,
 		     param_vec_t *extra_params,
 		     map<string, string> *extra_headers,
 		     bufferlist& bl,
@@ -333,7 +335,7 @@ int RGWRESTConn::get_resource(const string& resource,
     headers.insert(extra_headers->begin(), extra_headers->end());
   }
 
-  ret = req.send_request(&key, headers, resource, mgr, send_data);
+  ret = req.send_request(dpp, &key, headers, resource, mgr, send_data);
   if (ret < 0) {
     ldout(cct, 5) << __func__ << ": send_request() resource=" << resource << " returned ret=" << ret << dendl;
     return ret;
@@ -376,9 +378,9 @@ void RGWRESTReadResource::init_common(param_vec_t *extra_headers)
   req.set_params(&params);
 }
 
-int RGWRESTReadResource::read(optional_yield y)
+int RGWRESTReadResource::read(const DoutPrefixProvider *dpp, optional_yield y)
 {
-  int ret = req.send_request(&conn->get_key(), headers, resource, mgr);
+  int ret = req.send_request(dpp, &conn->get_key(), headers, resource, mgr);
   if (ret < 0) {
     ldout(cct, 5) << __func__ << ": send_request() resource=" << resource << " returned ret=" << ret << dendl;
     return ret;
@@ -387,9 +389,9 @@ int RGWRESTReadResource::read(optional_yield y)
   return req.complete_request(y);
 }
 
-int RGWRESTReadResource::aio_read()
+int RGWRESTReadResource::aio_read(const DoutPrefixProvider *dpp)
 {
-  int ret = req.send_request(&conn->get_key(), headers, resource, mgr);
+  int ret = req.send_request(dpp, &conn->get_key(), headers, resource, mgr);
   if (ret < 0) {
     ldout(cct, 5) << __func__ << ": send_request() resource=" << resource << " returned ret=" << ret << dendl;
     return ret;
@@ -434,12 +436,12 @@ void RGWRESTSendResource::init_common(param_vec_t *extra_headers)
   req.set_params(&params);
 }
 
-int RGWRESTSendResource::send(bufferlist& outbl, optional_yield y)
+int RGWRESTSendResource::send(const DoutPrefixProvider *dpp, bufferlist& outbl, optional_yield y)
 {
   req.set_send_length(outbl.length());
   req.set_outbl(outbl);
 
-  int ret = req.send_request(&conn->get_key(), headers, resource, mgr);
+  int ret = req.send_request(dpp, &conn->get_key(), headers, resource, mgr);
   if (ret < 0) {
     ldout(cct, 5) << __func__ << ": send_request() resource=" << resource << " returned ret=" << ret << dendl;
     return ret;
@@ -448,12 +450,12 @@ int RGWRESTSendResource::send(bufferlist& outbl, optional_yield y)
   return req.complete_request(y);
 }
 
-int RGWRESTSendResource::aio_send(bufferlist& outbl)
+int RGWRESTSendResource::aio_send(const DoutPrefixProvider *dpp, bufferlist& outbl)
 {
   req.set_send_length(outbl.length());
   req.set_outbl(outbl);
 
-  int ret = req.send_request(&conn->get_key(), headers, resource, mgr);
+  int ret = req.send_request(dpp, &conn->get_key(), headers, resource, mgr);
   if (ret < 0) {
     ldout(cct, 5) << __func__ << ": send_request() resource=" << resource << " returned ret=" << ret << dendl;
     return ret;

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -108,12 +108,12 @@ public:
   virtual void populate_params(param_vec_t& params, const rgw_user *uid, const string& zonegroup);
 
   /* sync request */
-  int forward(const rgw_user& uid, req_info& info, obj_version *objv, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y);
+  int forward(const DoutPrefixProvider *dpp, const rgw_user& uid, req_info& info, obj_version *objv, size_t max_response, bufferlist *inbl, bufferlist *outbl, optional_yield y);
 
 
   /* async requests */
   int put_obj_send_init(rgw::sal::RGWObject* obj, const rgw_http_param_pair *extra_params, RGWRESTStreamS3PutObj **req);
-  int put_obj_async(const rgw_user& uid, rgw::sal::RGWObject* obj, uint64_t obj_size,
+  int put_obj_async(const DoutPrefixProvider *dpp, const rgw_user& uid, rgw::sal::RGWObject* obj, uint64_t obj_size,
                     map<string, bufferlist>& attrs, bool send, RGWRESTStreamS3PutObj **req);
   int complete_request(RGWRESTStreamS3PutObj *req, string& etag,
                        ceph::real_time *mtime, optional_yield y);
@@ -143,9 +143,9 @@ public:
     uint64_t range_end{0};
   };
 
-  int get_obj(const rgw::sal::RGWObject* obj, const get_obj_params& params, bool send, RGWRESTStreamRWRequest **req);
+  int get_obj(const DoutPrefixProvider *dpp, const rgw::sal::RGWObject* obj, const get_obj_params& params, bool send, RGWRESTStreamRWRequest **req);
 
-  int get_obj(const rgw_user& uid, req_info *info /* optional */, const rgw::sal::RGWObject* obj,
+  int get_obj(const DoutPrefixProvider *dpp, const rgw_user& uid, req_info *info /* optional */, const rgw::sal::RGWObject* obj,
               const ceph::real_time *mod_ptr, const ceph::real_time *unmod_ptr,
               uint32_t mod_zone_id, uint64_t mod_pg_ver,
               bool prepend_metadata, bool get_op, bool rgwx_stat, bool sync_manifest,
@@ -158,7 +158,8 @@ public:
                        map<string, string> *pheaders,
                        optional_yield y);
 
-  int get_resource(const string& resource,
+  int get_resource(const DoutPrefixProvider *dpp,
+                   const string& resource,
 		   param_vec_t *extra_params,
                    map<string, string>* extra_headers,
                    bufferlist& bl,
@@ -167,13 +168,13 @@ public:
                    optional_yield y);
 
   template <class T>
-  int get_json_resource(const string& resource, param_vec_t *params,
+  int get_json_resource(const DoutPrefixProvider *dpp, const string& resource, param_vec_t *params,
                         bufferlist *in_data, optional_yield y, T& t);
   template <class T>
-  int get_json_resource(const string& resource, param_vec_t *params,
+  int get_json_resource(const DoutPrefixProvider *dpp, const string& resource, param_vec_t *params,
                         optional_yield y, T& t);
   template <class T>
-  int get_json_resource(const string& resource, const rgw_http_param_pair *pp,
+  int get_json_resource(const DoutPrefixProvider *dpp, const string& resource, const rgw_http_param_pair *pp,
                         optional_yield y, T& t);
 
 private:
@@ -211,11 +212,11 @@ public:
 
 
 template<class T>
-int RGWRESTConn::get_json_resource(const string& resource, param_vec_t *params,
+int RGWRESTConn::get_json_resource(const DoutPrefixProvider *dpp, const string& resource, param_vec_t *params,
                                    bufferlist *in_data, optional_yield y, T& t)
 {
   bufferlist bl;
-  int ret = get_resource(resource, params, nullptr, bl, in_data, nullptr, y);
+  int ret = get_resource(dpp, resource, params, nullptr, bl, in_data, nullptr, y);
   if (ret < 0) {
     return ret;
   }
@@ -229,18 +230,18 @@ int RGWRESTConn::get_json_resource(const string& resource, param_vec_t *params,
 }
 
 template<class T>
-int RGWRESTConn::get_json_resource(const string& resource, param_vec_t *params,
+int RGWRESTConn::get_json_resource(const DoutPrefixProvider *dpp, const string& resource, param_vec_t *params,
                                    optional_yield y, T& t)
 {
-  return get_json_resource(resource, params, nullptr, y, t);
+  return get_json_resource(dpp, resource, params, nullptr, y, t);
 }
 
 template<class T>
-int RGWRESTConn::get_json_resource(const string& resource, const rgw_http_param_pair *pp,
+int RGWRESTConn::get_json_resource(const DoutPrefixProvider *dpp, const string& resource, const rgw_http_param_pair *pp,
                                    optional_yield y, T& t)
 {
   param_vec_t params = make_param_list(pp);
-  return get_json_resource(resource, &params, y, t);
+  return get_json_resource(dpp, resource, &params, y, t);
 }
 
 class RGWStreamIntoBufferlist : public RGWHTTPStreamRWRequest::ReceiveCB {
@@ -296,9 +297,9 @@ public:
   template <class T>
   int decode_resource(T *dest);
 
-  int read(optional_yield y);
+  int read(const DoutPrefixProvider *dpp, optional_yield y);
 
-  int aio_read();
+  int aio_read(const DoutPrefixProvider *dpp);
 
   string to_str() {
     return req.to_str();
@@ -325,7 +326,7 @@ public:
   int wait(T *dest, optional_yield y);
 
   template <class T>
-  int fetch(T *dest, optional_yield y);
+  int fetch(const DoutPrefixProvider *dpp, T *dest, optional_yield y);
 };
 
 
@@ -344,9 +345,9 @@ int RGWRESTReadResource::decode_resource(T *dest)
 }
 
 template <class T>
-int RGWRESTReadResource::fetch(T *dest, optional_yield y)
+int RGWRESTReadResource::fetch(const DoutPrefixProvider *dpp, T *dest, optional_yield y)
 {
-  int ret = read(y);
+  int ret = read(dpp, y);
   if (ret < 0) {
     return ret;
   }
@@ -417,9 +418,9 @@ public:
     return req.get_io_user_info();
   }
 
-  int send(bufferlist& bl, optional_yield y);
+  int send(const DoutPrefixProvider *dpp, bufferlist& bl, optional_yield y);
 
-  int aio_send(bufferlist& bl);
+  int aio_send(const DoutPrefixProvider *dpp, bufferlist& bl);
 
   string to_str() {
     return req.to_str();

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -37,7 +37,7 @@
 #define LOG_CLASS_LIST_MAX_ENTRIES (1000)
 #define dout_subsys ceph_subsys_rgw
 
-void RGWOp_MDLog_List::execute(optional_yield y) {
+void RGWOp_MDLog_List::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   string   period = s->info.args.get("period");
   string   shard = s->info.args.get("id");
   string   max_entries_str = s->info.args.get("max-entries");
@@ -117,7 +117,7 @@ void RGWOp_MDLog_List::send_response() {
   flusher.flush();
 }
 
-void RGWOp_MDLog_Info::execute(optional_yield y) {
+void RGWOp_MDLog_Info::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   num_objects = s->cct->_conf->rgw_md_log_max_shards;
   period = store->svc()->mdlog->read_oldest_log_period(y, s);
   op_ret = period.get_error();
@@ -138,7 +138,7 @@ void RGWOp_MDLog_Info::send_response() {
   flusher.flush();
 }
 
-void RGWOp_MDLog_ShardInfo::execute(optional_yield y) {
+void RGWOp_MDLog_ShardInfo::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   string period = s->info.args.get("period");
   string shard = s->info.args.get("id");
   string err;
@@ -174,7 +174,7 @@ void RGWOp_MDLog_ShardInfo::send_response() {
   flusher.flush();
 }
 
-void RGWOp_MDLog_Delete::execute(optional_yield y) {
+void RGWOp_MDLog_Delete::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   string   marker = s->info.args.get("marker"),
            period = s->info.args.get("period"),
            shard = s->info.args.get("id"),
@@ -231,7 +231,7 @@ void RGWOp_MDLog_Delete::execute(optional_yield y) {
   op_ret = meta_log.trim(shard_id, {}, {}, {}, marker);
 }
 
-void RGWOp_MDLog_Lock::execute(optional_yield y) {
+void RGWOp_MDLog_Lock::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   string period, shard_id_str, duration_str, locker_id, zone_id;
   unsigned shard_id;
 
@@ -280,7 +280,7 @@ void RGWOp_MDLog_Lock::execute(optional_yield y) {
     op_ret = -ERR_LOCKED;
 }
 
-void RGWOp_MDLog_Unlock::execute(optional_yield y) {
+void RGWOp_MDLog_Unlock::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   string period, shard_id_str, locker_id, zone_id;
   unsigned shard_id;
 
@@ -317,7 +317,7 @@ void RGWOp_MDLog_Unlock::execute(optional_yield y) {
   op_ret = meta_log.unlock(shard_id, zone_id, locker_id);
 }
 
-void RGWOp_MDLog_Notify::execute(optional_yield y) {
+void RGWOp_MDLog_Notify::execute(const DoutPrefixProvider *dpp, optional_yield y) {
 #define LARGE_ENOUGH_BUF (128 * 1024)
 
   int r = 0;
@@ -359,7 +359,7 @@ void RGWOp_MDLog_Notify::execute(optional_yield y) {
   op_ret = 0;
 }
 
-void RGWOp_BILog_List::execute(optional_yield y) {
+void RGWOp_BILog_List::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   string tenant_name = s->info.args.get("tenant"),
          bucket_name = s->info.args.get("bucket"),
          marker = s->info.args.get("marker"),
@@ -455,7 +455,7 @@ void RGWOp_BILog_List::send_response_end() {
   flusher.flush();
 }
       
-void RGWOp_BILog_Info::execute(optional_yield y) {
+void RGWOp_BILog_Info::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   string tenant_name = s->info.args.get("tenant"),
          bucket_name = s->info.args.get("bucket"),
          bucket_instance = s->info.args.get("bucket-instance");
@@ -514,7 +514,7 @@ void RGWOp_BILog_Info::send_response() {
   flusher.flush();
 }
 
-void RGWOp_BILog_Delete::execute(optional_yield y) {
+void RGWOp_BILog_Delete::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   string tenant_name = s->info.args.get("tenant"),
          bucket_name = s->info.args.get("bucket"),
          start_marker = s->info.args.get("start-marker"),
@@ -559,7 +559,7 @@ void RGWOp_BILog_Delete::execute(optional_yield y) {
   return;
 }
 
-void RGWOp_DATALog_List::execute(optional_yield y) {
+void RGWOp_DATALog_List::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   string   shard = s->info.args.get("id");
 
   string   max_entries_str = s->info.args.get("max-entries"),
@@ -630,7 +630,7 @@ void RGWOp_DATALog_List::send_response() {
 }
 
 
-void RGWOp_DATALog_Info::execute(optional_yield y) {
+void RGWOp_DATALog_Info::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   num_objects = s->cct->_conf->rgw_data_log_num_shards;
   op_ret = 0;
 }
@@ -646,7 +646,7 @@ void RGWOp_DATALog_Info::send_response() {
   flusher.flush();
 }
 
-void RGWOp_DATALog_ShardInfo::execute(optional_yield y) {
+void RGWOp_DATALog_ShardInfo::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   string shard = s->info.args.get("id");
   string err;
 
@@ -669,7 +669,7 @@ void RGWOp_DATALog_ShardInfo::send_response() {
   flusher.flush();
 }
 
-void RGWOp_DATALog_Notify::execute(optional_yield y) {
+void RGWOp_DATALog_Notify::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   string  source_zone = s->info.args.get("source-zone");
 #define LARGE_ENOUGH_BUF (128 * 1024)
 
@@ -716,7 +716,7 @@ void RGWOp_DATALog_Notify::execute(optional_yield y) {
   op_ret = 0;
 }
 
-void RGWOp_DATALog_Delete::execute(optional_yield y) {
+void RGWOp_DATALog_Delete::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   string   marker = s->info.args.get("marker"),
            shard = s->info.args.get("id"),
            err;
@@ -768,12 +768,12 @@ public:
   int verify_permission(optional_yield) override {
     return check_caps(s->user->get_caps());
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void send_response() override;
   const char* name() const override { return "get_metadata_log_status"; }
 };
 
-void RGWOp_MDLog_Status::execute(optional_yield y)
+void RGWOp_MDLog_Status::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   auto sync = store->getRados()->get_meta_sync_manager();
   if (sync == nullptr) {
@@ -781,7 +781,7 @@ void RGWOp_MDLog_Status::execute(optional_yield y)
     op_ret = -ENOENT;
     return;
   }
-  op_ret = sync->read_sync_status(&status);
+  op_ret = sync->read_sync_status(dpp, &status);
 }
 
 void RGWOp_MDLog_Status::send_response()
@@ -806,12 +806,12 @@ public:
   int verify_permission(optional_yield y) override {
     return check_caps(s->user->get_caps());
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void send_response() override;
   const char* name() const override { return "get_bucket_index_log_status"; }
 };
 
-void RGWOp_BILog_Status::execute(optional_yield y)
+void RGWOp_BILog_Status::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   const auto options = s->info.args.get("options");
   bool merge = (options == "merge");
@@ -973,12 +973,12 @@ public:
   int verify_permission(optional_yield y) override {
     return check_caps(s->user->get_caps());
   }
-  void execute(optional_yield y) override ;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override ;
   void send_response() override;
   const char* name() const override { return "get_data_changes_log_status"; }
 };
 
-void RGWOp_DATALog_Status::execute(optional_yield y)
+void RGWOp_DATALog_Status::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   const auto source_zone = s->info.args.get("source-zone");
   auto sync = store->getRados()->get_data_sync_manager(source_zone);
@@ -987,7 +987,7 @@ void RGWOp_DATALog_Status::execute(optional_yield y)
     op_ret = -ENOENT;
     return;
   }
-  op_ret = sync->read_sync_status(&status);
+  op_ret = sync->read_sync_status(dpp, &status);
 }
 
 void RGWOp_DATALog_Status::send_response()

--- a/src/rgw/rgw_rest_log.h
+++ b/src/rgw/rgw_rest_log.h
@@ -36,7 +36,7 @@ public:
   void send_response() override;
   virtual void send_response(list<rgw_bi_log_entry>& entries, string& marker);
   virtual void send_response_end();
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   const char* name() const override {
     return "list_bucket_index_log";
   }
@@ -58,7 +58,7 @@ public:
     return check_caps(s->user->get_caps());
   }
   void send_response() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   const char* name() const override {
     return "bucket_index_log_info";
   }
@@ -72,7 +72,7 @@ public:
   int check_caps(const RGWUserCaps& caps) override {
     return caps.check_cap("bilog", RGW_CAP_WRITE);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   const char* name() const override {
     return "trim_bucket_index_log";
   }
@@ -92,7 +92,7 @@ public:
   int verify_permission(optional_yield y) override {
     return check_caps(s->user->get_caps());
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void send_response() override;
   const char* name() const override {
     return "list_metadata_log";
@@ -112,7 +112,7 @@ public:
   int verify_permission(optional_yield y) override {
     return check_caps(s->user->get_caps());
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void send_response() override;
   const char* name() const override {
     return "get_metadata_log_info";
@@ -131,7 +131,7 @@ public:
   int verify_permission(optional_yield y) override {
     return check_caps(s->user->get_caps());
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void send_response() override;
   const char* name() const override {
     return "get_metadata_log_shard_info";
@@ -146,7 +146,7 @@ public:
   int check_caps(const RGWUserCaps& caps) override {
     return caps.check_cap("mdlog", RGW_CAP_WRITE);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   const char* name() const override {
     return "lock_mdlog_object";
   }
@@ -160,7 +160,7 @@ public:
   int check_caps(const RGWUserCaps& caps) override {
     return caps.check_cap("mdlog", RGW_CAP_WRITE);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   const char* name() const override {
     return "unlock_mdlog_object";
   }
@@ -174,7 +174,7 @@ public:
   int check_caps(const RGWUserCaps& caps) override {
     return caps.check_cap("mdlog", RGW_CAP_WRITE);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   const char* name() const override {
     return "mdlog_notify";
   }
@@ -188,7 +188,7 @@ public:
   int check_caps(const RGWUserCaps& caps) override {
     return caps.check_cap("mdlog", RGW_CAP_WRITE);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   const char* name() const override {
     return "trim_metadata_log";
   }
@@ -209,7 +209,7 @@ public:
   int verify_permission(optional_yield y) override {
     return check_caps(s->user->get_caps());
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void send_response() override;
   const char* name() const override {
     return "list_data_changes_log";
@@ -228,7 +228,7 @@ public:
   int verify_permission(optional_yield y) override {
     return check_caps(s->user->get_caps());
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void send_response() override;
   const char* name() const override {
     return "get_data_changes_log_info";
@@ -247,7 +247,7 @@ public:
   int verify_permission(optional_yield y) override {
     return check_caps(s->user->get_caps());
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void send_response() override;
   const char* name() const override {
     return "get_data_changes_log_shard_info";
@@ -262,7 +262,7 @@ public:
   int check_caps(const RGWUserCaps& caps) override {
     return caps.check_cap("datalog", RGW_CAP_WRITE);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   const char* name() const override {
     return "datalog_notify";
   }
@@ -276,7 +276,7 @@ public:
   int check_caps(const RGWUserCaps& caps) override {
     return caps.check_cap("datalog", RGW_CAP_WRITE);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   const char* name() const override {
     return "trim_data_changes_log";
   }

--- a/src/rgw/rgw_rest_metadata.cc
+++ b/src/rgw/rgw_rest_metadata.cc
@@ -49,7 +49,7 @@ static inline void frame_metadata_key(req_state *s, string& out) {
   }
 }
 
-void RGWOp_Metadata_Get::execute(optional_yield y) {
+void RGWOp_Metadata_Get::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   string metadata_key;
 
   frame_metadata_key(s, metadata_key);
@@ -66,16 +66,16 @@ void RGWOp_Metadata_Get::execute(optional_yield y) {
   op_ret = 0;
 }
 
-void RGWOp_Metadata_Get_Myself::execute(optional_yield y) {
+void RGWOp_Metadata_Get_Myself::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   string owner_id;
 
   owner_id = s->owner.get_id().to_str();
   s->info.args.append("key", owner_id);
 
-  return RGWOp_Metadata_Get::execute(y);
+  return RGWOp_Metadata_Get::execute(dpp, y);
 }
 
-void RGWOp_Metadata_List::execute(optional_yield y) {
+void RGWOp_Metadata_List::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   string marker;
   ldout(s->cct, 16) << __func__
 		    << " raw marker " << s->info.args.get("marker")
@@ -234,7 +234,7 @@ static bool string_to_sync_type(const string& sync_string,
   return true;
 }
 
-void RGWOp_Metadata_Put::execute(optional_yield y) {
+void RGWOp_Metadata_Put::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   bufferlist bl;
   string metadata_key;
 
@@ -290,7 +290,7 @@ void RGWOp_Metadata_Put::send_response() {
   end_header(s);
 }
 
-void RGWOp_Metadata_Delete::execute(optional_yield y) {
+void RGWOp_Metadata_Delete::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   string metadata_key;
 
   frame_metadata_key(s, metadata_key);

--- a/src/rgw/rgw_rest_metadata.h
+++ b/src/rgw/rgw_rest_metadata.h
@@ -26,7 +26,7 @@ public:
   int check_caps(const RGWUserCaps& caps) override {
     return caps.check_cap("metadata", RGW_CAP_READ);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   const char* name() const override { return "list_metadata"; }
 };
 
@@ -38,7 +38,7 @@ public:
   int check_caps(const RGWUserCaps& caps) override {
     return caps.check_cap("metadata", RGW_CAP_READ);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   const char* name() const override { return "get_metadata"; }
 };
 
@@ -47,7 +47,7 @@ public:
   RGWOp_Metadata_Get_Myself() {}
   ~RGWOp_Metadata_Get_Myself() override {}
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 };
 
 class RGWOp_Metadata_Put : public RGWRESTOp {
@@ -61,7 +61,7 @@ public:
   int check_caps(const RGWUserCaps& caps) override {
     return caps.check_cap("metadata", RGW_CAP_WRITE);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void send_response() override;
   const char* name() const override { return "set_metadata"; }
   RGWOpType get_type() override { return RGW_OP_ADMIN_SET_METADATA; }
@@ -75,7 +75,7 @@ public:
   int check_caps(const RGWUserCaps& caps) override {
     return caps.check_cap("metadata", RGW_CAP_WRITE);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   const char* name() const override { return "remove_metadata"; }
 };
 

--- a/src/rgw/rgw_rest_oidc_provider.cc
+++ b/src/rgw/rgw_rest_oidc_provider.cc
@@ -114,7 +114,7 @@ int RGWCreateOIDCProvider::get_params()
   return 0;
 }
 
-void RGWCreateOIDCProvider::execute(optional_yield y)
+void RGWCreateOIDCProvider::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params();
   if (op_ret < 0) {
@@ -138,7 +138,7 @@ void RGWCreateOIDCProvider::execute(optional_yield y)
 
 }
 
-void RGWDeleteOIDCProvider::execute(optional_yield y)
+void RGWDeleteOIDCProvider::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   RGWOIDCProvider provider(s->cct, store->getRados()->pctl, provider_arn, s->user->get_tenant());
   op_ret = provider.delete_obj(y);
@@ -156,7 +156,7 @@ void RGWDeleteOIDCProvider::execute(optional_yield y)
   }
 }
 
-void RGWGetOIDCProvider::execute(optional_yield y)
+void RGWGetOIDCProvider::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   RGWOIDCProvider provider(s->cct, store->getRados()->pctl, provider_arn, s->user->get_tenant());
   op_ret = provider.get(s);
@@ -197,7 +197,7 @@ int RGWListOIDCProviders::verify_permission(optional_yield y)
   return 0;
 }
 
-void RGWListOIDCProviders::execute(optional_yield y)
+void RGWListOIDCProviders::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   vector<RGWOIDCProvider> result;
   op_ret = RGWOIDCProvider::get_providers(s, store->getRados(), s->user->get_tenant(), result);

--- a/src/rgw/rgw_rest_oidc_provider.h
+++ b/src/rgw/rgw_rest_oidc_provider.h
@@ -34,7 +34,7 @@ class RGWCreateOIDCProvider : public RGWRestOIDCProviderWrite {
 public:
   RGWCreateOIDCProvider() = default;
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int get_params();
   const char* name() const override { return "create_oidc_provider"; }
   RGWOpType get_type() override { return RGW_OP_CREATE_OIDC_PROVIDER; }
@@ -44,7 +44,7 @@ public:
 class RGWDeleteOIDCProvider : public RGWRestOIDCProviderWrite {
 public:
   RGWDeleteOIDCProvider() = default;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   const char* name() const override { return "delete_oidc_provider"; }
   RGWOpType get_type() override { return RGW_OP_DELETE_OIDC_PROVIDER; }
   uint64_t get_op() override { return rgw::IAM::iamDeleteOIDCProvider; }
@@ -53,7 +53,7 @@ public:
 class RGWGetOIDCProvider : public RGWRestOIDCProviderRead {
 public:
   RGWGetOIDCProvider() = default;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   const char* name() const override { return "get_oidc_provider"; }
   RGWOpType get_type() override { return RGW_OP_GET_OIDC_PROVIDER; }
   uint64_t get_op() override { return rgw::IAM::iamGetOIDCProvider; }
@@ -63,7 +63,7 @@ class RGWListOIDCProviders : public RGWRestOIDCProviderRead {
 public:
   RGWListOIDCProviders() = default;
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int get_params();
   const char* name() const override { return "list_oidc_providers"; }
   RGWOpType get_type() override { return RGW_OP_LIST_OIDC_PROVIDERS; }

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -483,10 +483,10 @@ class RGWPSCreateNotif_ObjStore_S3 : public RGWPSCreateNotifOp {
 
 public:
   const char* name() const override { return "pubsub_notification_create_s3"; }
-  void execute(optional_yield) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield) override;
 };
 
-void RGWPSCreateNotif_ObjStore_S3::execute(optional_yield y) {
+void RGWPSCreateNotif_ObjStore_S3::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   op_ret = get_params_from_body();
   if (op_ret < 0) {
     return;
@@ -625,11 +625,11 @@ private:
   }
 
 public:
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   const char* name() const override { return "pubsub_notification_delete_s3"; }
 };
 
-void RGWPSDeleteNotif_ObjStore_S3::execute(optional_yield y) {
+void RGWPSDeleteNotif_ObjStore_S3::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   op_ret = get_params();
   if (op_ret < 0) {
     return;
@@ -716,7 +716,7 @@ private:
   }
 
 public:
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void send_response() override {
     if (op_ret) {
       set_req_state_err(s, op_ret);
@@ -733,7 +733,7 @@ public:
   const char* name() const override { return "pubsub_notifications_get_s3"; }
 };
 
-void RGWPSListNotifs_ObjStore_S3::execute(optional_yield y) {
+void RGWPSListNotifs_ObjStore_S3::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   ps.emplace(store, s->owner.get_id().tenant);
   auto b = ps->get_bucket(bucket_info.bucket);
   ceph_assert(b);

--- a/src/rgw/rgw_rest_pubsub_common.cc
+++ b/src/rgw/rgw_rest_pubsub_common.cc
@@ -47,7 +47,7 @@ bool topics_has_endpoint_secret(const rgw_pubsub_topics& topics) {
     return false;
 }
 
-void RGWPSCreateTopicOp::execute(optional_yield y) {
+void RGWPSCreateTopicOp::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   op_ret = get_params();
   if (op_ret < 0) {
     return;
@@ -62,7 +62,7 @@ void RGWPSCreateTopicOp::execute(optional_yield y) {
   ldout(s->cct, 20) << "successfully created topic '" << topic_name << "'" << dendl;
 }
 
-void RGWPSListTopicsOp::execute(optional_yield y) {
+void RGWPSListTopicsOp::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   ps.emplace(store, s->owner.get_id().tenant);
   op_ret = ps->get_topics(&result);
   // if there are no topics it is not considered an error
@@ -79,7 +79,7 @@ void RGWPSListTopicsOp::execute(optional_yield y) {
   ldout(s->cct, 20) << "successfully got topics" << dendl;
 }
 
-void RGWPSGetTopicOp::execute(optional_yield y) {
+void RGWPSGetTopicOp::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   op_ret = get_params();
   if (op_ret < 0) {
     return;
@@ -98,7 +98,7 @@ void RGWPSGetTopicOp::execute(optional_yield y) {
   ldout(s->cct, 1) << "successfully got topic '" << topic_name << "'" << dendl;
 }
 
-void RGWPSDeleteTopicOp::execute(optional_yield y) {
+void RGWPSDeleteTopicOp::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   op_ret = get_params();
   if (op_ret < 0) {
     return;
@@ -112,7 +112,7 @@ void RGWPSDeleteTopicOp::execute(optional_yield y) {
   ldout(s->cct, 1) << "successfully removed topic '" << topic_name << "'" << dendl;
 }
 
-void RGWPSCreateSubOp::execute(optional_yield y) {
+void RGWPSCreateSubOp::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   op_ret = get_params();
   if (op_ret < 0) {
     return;
@@ -127,7 +127,7 @@ void RGWPSCreateSubOp::execute(optional_yield y) {
   ldout(s->cct, 20) << "successfully created subscription '" << sub_name << "'" << dendl;
 }
 
-void RGWPSGetSubOp::execute(optional_yield y) {
+void RGWPSGetSubOp::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   op_ret = get_params();
   if (op_ret < 0) {
     return;
@@ -147,7 +147,7 @@ void RGWPSGetSubOp::execute(optional_yield y) {
   ldout(s->cct, 20) << "successfully got subscription '" << sub_name << "'" << dendl;
 }
 
-void RGWPSDeleteSubOp::execute(optional_yield y) {
+void RGWPSDeleteSubOp::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   op_ret = get_params();
   if (op_ret < 0) {
     return;
@@ -162,7 +162,7 @@ void RGWPSDeleteSubOp::execute(optional_yield y) {
   ldout(s->cct, 20) << "successfully removed subscription '" << sub_name << "'" << dendl;
 }
 
-void RGWPSAckSubEventOp::execute(optional_yield y) {
+void RGWPSAckSubEventOp::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   op_ret = get_params();
   if (op_ret < 0) {
     return;
@@ -177,7 +177,7 @@ void RGWPSAckSubEventOp::execute(optional_yield y) {
   ldpp_dout(this, 20) << "successfully acked event on subscription '" << sub_name << "'" << dendl;
 }
 
-void RGWPSPullSubEventsOp::execute(optional_yield y) {
+void RGWPSPullSubEventsOp::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   op_ret = get_params();
   if (op_ret < 0) {
     return;

--- a/src/rgw/rgw_rest_pubsub_common.h
+++ b/src/rgw/rgw_rest_pubsub_common.h
@@ -29,7 +29,7 @@ public:
   void pre_exec() override {
     rgw_bucket_object_pre_exec(s);
   }
-  void execute(optional_yield) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield) override;
 
   const char* name() const override { return "pubsub_topic_create"; }
   RGWOpType get_type() override { return RGW_OP_PUBSUB_TOPIC_CREATE; }
@@ -49,7 +49,7 @@ public:
   void pre_exec() override {
     rgw_bucket_object_pre_exec(s);
   }
-  void execute(optional_yield) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield) override;
 
   const char* name() const override { return "pubsub_topics_list"; }
   RGWOpType get_type() override { return RGW_OP_PUBSUB_TOPICS_LIST; }
@@ -72,7 +72,7 @@ public:
   void pre_exec() override {
     rgw_bucket_object_pre_exec(s);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "pubsub_topic_get"; }
   RGWOpType get_type() override { return RGW_OP_PUBSUB_TOPIC_GET; }
@@ -94,7 +94,7 @@ public:
   void pre_exec() override {
     rgw_bucket_object_pre_exec(s);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "pubsub_topic_delete"; }
   RGWOpType get_type() override { return RGW_OP_PUBSUB_TOPIC_DELETE; }
@@ -118,7 +118,7 @@ public:
   void pre_exec() override {
     rgw_bucket_object_pre_exec(s);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "pubsub_subscription_create"; }
   RGWOpType get_type() override { return RGW_OP_PUBSUB_SUB_CREATE; }
@@ -141,7 +141,7 @@ public:
   void pre_exec() override {
     rgw_bucket_object_pre_exec(s);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "pubsub_subscription_get"; }
   RGWOpType get_type() override { return RGW_OP_PUBSUB_SUB_GET; }
@@ -164,7 +164,7 @@ public:
   void pre_exec() override {
     rgw_bucket_object_pre_exec(s);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "pubsub_subscription_delete"; }
   RGWOpType get_type() override { return RGW_OP_PUBSUB_SUB_DELETE; }
@@ -189,7 +189,7 @@ public:
   void pre_exec() override {
     rgw_bucket_object_pre_exec(s);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "pubsub_subscription_ack"; }
   RGWOpType get_type() override { return RGW_OP_PUBSUB_SUB_ACK; }
@@ -218,7 +218,7 @@ public:
   void pre_exec() override {
     rgw_bucket_object_pre_exec(s);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "pubsub_subscription_pull"; }
   RGWOpType get_type() override { return RGW_OP_PUBSUB_SUB_PULL; }

--- a/src/rgw/rgw_rest_realm.cc
+++ b/src/rgw/rgw_rest_realm.cc
@@ -51,7 +51,7 @@ void RGWOp_Period_Base::send_response()
 // GET /admin/realm/period
 class RGWOp_Period_Get : public RGWOp_Period_Base {
  public:
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int check_caps(const RGWUserCaps& caps) override {
     return caps.check_cap("zone", RGW_CAP_READ);
   }
@@ -61,7 +61,7 @@ class RGWOp_Period_Get : public RGWOp_Period_Base {
   const char* name() const override { return "get_period"; }
 };
 
-void RGWOp_Period_Get::execute(optional_yield y)
+void RGWOp_Period_Get::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   string realm_id, realm_name, period_id;
   epoch_t epoch = 0;
@@ -81,7 +81,7 @@ void RGWOp_Period_Get::execute(optional_yield y)
 // POST /admin/realm/period
 class RGWOp_Period_Post : public RGWOp_Period_Base {
  public:
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int check_caps(const RGWUserCaps& caps) override {
     return caps.check_cap("zone", RGW_CAP_WRITE);
   }
@@ -91,7 +91,7 @@ class RGWOp_Period_Post : public RGWOp_Period_Base {
   const char* name() const override { return "post_period"; }
 };
 
-void RGWOp_Period_Post::execute(optional_yield y)
+void RGWOp_Period_Post::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   auto cct = store->ctx();
 
@@ -266,12 +266,12 @@ public:
   int verify_permission(optional_yield) override {
     return check_caps(s->user->get_caps());
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void send_response() override;
   const char* name() const override { return "get_realm"; }
 };
 
-void RGWOp_Realm_Get::execute(optional_yield y)
+void RGWOp_Realm_Get::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   string id;
   RESTArgs::get_string(s, "id", id, &id);
@@ -312,12 +312,12 @@ public:
   int verify_permission(optional_yield) override {
     return check_caps(s->user->get_caps());
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void send_response() override;
   const char* name() const override { return "list_realms"; }
 };
 
-void RGWOp_Realm_List::execute(optional_yield y)
+void RGWOp_Realm_List::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   {
     // read default realm

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -124,7 +124,7 @@ int RGWCreateRole::get_params()
   return 0;
 }
 
-void RGWCreateRole::execute(optional_yield y)
+void RGWCreateRole::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params();
   if (op_ret < 0) {
@@ -164,7 +164,7 @@ int RGWDeleteRole::get_params()
   return 0;
 }
 
-void RGWDeleteRole::execute(optional_yield y)
+void RGWDeleteRole::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params();
   if (op_ret < 0) {
@@ -223,7 +223,7 @@ int RGWGetRole::get_params()
   return 0;
 }
 
-void RGWGetRole::execute(optional_yield y)
+void RGWGetRole::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params();
   if (op_ret < 0) {
@@ -271,7 +271,7 @@ int RGWModifyRole::get_params()
   return 0;
 }
 
-void RGWModifyRole::execute(optional_yield y)
+void RGWModifyRole::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params();
   if (op_ret < 0) {
@@ -315,7 +315,7 @@ int RGWListRoles::get_params()
   return 0;
 }
 
-void RGWListRoles::execute(optional_yield y)
+void RGWListRoles::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params();
   if (op_ret < 0) {
@@ -363,7 +363,7 @@ int RGWPutRolePolicy::get_params()
   return 0;
 }
 
-void RGWPutRolePolicy::execute(optional_yield y)
+void RGWPutRolePolicy::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params();
   if (op_ret < 0) {
@@ -394,7 +394,7 @@ int RGWGetRolePolicy::get_params()
   return 0;
 }
 
-void RGWGetRolePolicy::execute(optional_yield y)
+void RGWGetRolePolicy::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params();
   if (op_ret < 0) {
@@ -432,7 +432,7 @@ int RGWListRolePolicies::get_params()
   return 0;
 }
 
-void RGWListRolePolicies::execute(optional_yield y)
+void RGWListRolePolicies::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params();
   if (op_ret < 0) {
@@ -466,7 +466,7 @@ int RGWDeleteRolePolicy::get_params()
   return 0;
 }
 
-void RGWDeleteRolePolicy::execute(optional_yield y)
+void RGWDeleteRolePolicy::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params();
   if (op_ret < 0) {

--- a/src/rgw/rgw_rest_role.h
+++ b/src/rgw/rgw_rest_role.h
@@ -40,7 +40,7 @@ class RGWCreateRole : public RGWRoleWrite {
 public:
   RGWCreateRole() = default;
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int get_params();
   const char* name() const override { return "create_role"; }
   RGWOpType get_type() override { return RGW_OP_CREATE_ROLE; }
@@ -50,7 +50,7 @@ public:
 class RGWDeleteRole : public RGWRoleWrite {
 public:
   RGWDeleteRole() = default;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int get_params();
   const char* name() const override { return "delete_role"; }
   RGWOpType get_type() override { return RGW_OP_DELETE_ROLE; }
@@ -62,7 +62,7 @@ class RGWGetRole : public RGWRoleRead {
 public:
   RGWGetRole() = default;
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int get_params();
   const char* name() const override { return "get_role"; }
   RGWOpType get_type() override { return RGW_OP_GET_ROLE; }
@@ -72,7 +72,7 @@ public:
 class RGWModifyRole : public RGWRoleWrite {
 public:
   RGWModifyRole() = default;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int get_params();
   const char* name() const override { return "modify_role"; }
   RGWOpType get_type() override { return RGW_OP_MODIFY_ROLE; }
@@ -83,7 +83,7 @@ class RGWListRoles : public RGWRoleRead {
 public:
   RGWListRoles() = default;
   int verify_permission(optional_yield y) override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int get_params();
   const char* name() const override { return "list_roles"; }
   RGWOpType get_type() override { return RGW_OP_LIST_ROLES; }
@@ -93,7 +93,7 @@ public:
 class RGWPutRolePolicy : public RGWRoleWrite {
 public:
   RGWPutRolePolicy() = default;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int get_params();
   const char* name() const override { return "put_role_policy"; }
   RGWOpType get_type() override { return RGW_OP_PUT_ROLE_POLICY; }
@@ -103,7 +103,7 @@ public:
 class RGWGetRolePolicy : public RGWRoleRead {
 public:
   RGWGetRolePolicy() = default;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int get_params();
   const char* name() const override { return "get_role_policy"; }
   RGWOpType get_type() override { return RGW_OP_GET_ROLE_POLICY; }
@@ -113,7 +113,7 @@ public:
 class RGWListRolePolicies : public RGWRoleRead {
 public:
   RGWListRolePolicies() = default;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int get_params();
   const char* name() const override { return "list_role_policies"; }
   RGWOpType get_type() override { return RGW_OP_LIST_ROLE_POLICIES; }
@@ -123,7 +123,7 @@ public:
 class RGWDeleteRolePolicy : public RGWRoleWrite {
 public:
   RGWDeleteRolePolicy() = default;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int get_params();
   const char* name() const override { return "delete_role_policy"; }
   RGWOpType get_type() override { return RGW_OP_DELETE_ROLE_POLICY; }

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3377,7 +3377,7 @@ void RGWPutACLs_ObjStore_S3::send_response()
   dump_start(s);
 }
 
-void RGWGetLC_ObjStore_S3::execute(optional_yield y)
+void RGWGetLC_ObjStore_S3::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   config.set_ctx(s->cct);
 
@@ -5010,7 +5010,7 @@ RGWOp* RGWHandler_REST_S3Website::op_head()
   return get_obj_op(false);
 }
 
-int RGWHandler_REST_S3Website::serve_errordoc(int http_ret, const string& errordoc_key, optional_yield y) {
+int RGWHandler_REST_S3Website::serve_errordoc(const DoutPrefixProvider *dpp, int http_ret, const string& errordoc_key, optional_yield y) {
   int ret = 0;
   s->formatter->reset(); /* Try to throw it all away */
 
@@ -5075,7 +5075,7 @@ int RGWHandler_REST_S3Website::serve_errordoc(int http_ret, const string& errord
    *   x-amz-error-message: The specified key does not exist.
    *   x-amz-error-detail-Key: foo
    */
-  getop->execute(y);
+  getop->execute(dpp, y);
   getop->complete();
   return 0;
 }
@@ -5123,7 +5123,7 @@ int RGWHandler_REST_S3Website::error_handler(int err_no,
        On success, it will return zero, and no further content should be sent to the socket
        On failure, we need the double-error handler
      */
-    new_err_no = RGWHandler_REST_S3Website::serve_errordoc(http_error_code, s->bucket->get_info().website_conf.error_doc, y);
+    new_err_no = RGWHandler_REST_S3Website::serve_errordoc(s, http_error_code, s->bucket->get_info().website_conf.error_doc, y);
     if (new_err_no != -1) {
       err_no = new_err_no;
     }
@@ -5500,7 +5500,7 @@ AWSGeneralAbstractor::get_auth_data_v2(const req_state* const s) const
   /* Let's canonize the HTTP headers that are covered by the AWS auth v2. */
   std::string string_to_sign;
   utime_t header_time;
-  if (! rgw_create_s3_canonical_header(s->info, &header_time, string_to_sign,
+  if (! rgw_create_s3_canonical_header(s, s->info, &header_time, string_to_sign,
         qsr)) {
     ldpp_dout(s, 10) << "failed to create the canonized auth header\n"
                    << rgw::crypt_sanitize::auth{s,string_to_sign} << dendl;

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -366,7 +366,7 @@ protected:
 public:
   RGWGetLC_ObjStore_S3() {}
   ~RGWGetLC_ObjStore_S3() override {}
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
  void send_response() override;
 };

--- a/src/rgw/rgw_rest_s3website.h
+++ b/src/rgw/rgw_rest_s3website.h
@@ -35,7 +35,7 @@ protected:
   RGWOp *op_copy() override { return NULL; }
   RGWOp *op_options() override { return NULL; }
 
-  int serve_errordoc(int http_ret, const string &errordoc_key, optional_yield y);
+  int serve_errordoc(const DoutPrefixProvider *dpp, int http_ret, const string &errordoc_key, optional_yield y);
 public:
   using RGWHandler_REST_S3::RGWHandler_REST_S3;
   ~RGWHandler_REST_S3Website() override = default;

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -442,7 +442,7 @@ int RGWSTSGetSessionToken::get_params()
   return 0;
 }
 
-void RGWSTSGetSessionToken::execute(optional_yield y)
+void RGWSTSGetSessionToken::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   if (op_ret = get_params(); op_ret < 0) {
     return;
@@ -495,7 +495,7 @@ int RGWSTSAssumeRoleWithWebIdentity::get_params()
   return 0;
 }
 
-void RGWSTSAssumeRoleWithWebIdentity::execute(optional_yield y)
+void RGWSTSAssumeRoleWithWebIdentity::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   if (op_ret = get_params(); op_ret < 0) {
     return;
@@ -554,7 +554,7 @@ int RGWSTSAssumeRole::get_params()
   return 0;
 }
 
-void RGWSTSAssumeRole::execute(optional_yield y)
+void RGWSTSAssumeRole::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   if (op_ret = get_params(); op_ret < 0) {
     return;

--- a/src/rgw/rgw_rest_sts.h
+++ b/src/rgw/rgw_rest_sts.h
@@ -131,7 +131,7 @@ protected:
   string iss;
 public:
   RGWSTSAssumeRoleWithWebIdentity() = default;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int get_params();
   const char* name() const override { return "assume_role_web_identity"; }
   RGWOpType get_type() override { return RGW_STS_ASSUME_ROLE_WEB_IDENTITY; }
@@ -148,7 +148,7 @@ protected:
   string tokenCode;
 public:
   RGWSTSAssumeRole() = default;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int get_params();
   const char* name() const override { return "assume_role"; }
   RGWOpType get_type() override { return RGW_STS_ASSUME_ROLE; }
@@ -161,7 +161,7 @@ protected:
   string tokenCode;
 public:
   RGWSTSGetSessionToken() = default;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int verify_permission(optional_yield y) override;
   int get_params();
   const char* name() const override { return "get_session_token"; }

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -542,9 +542,9 @@ static void dump_container_metadata(struct req_state *s,
   dump_last_modified(s, s->bucket_mtime);
 }
 
-void RGWStatAccount_ObjStore_SWIFT::execute(optional_yield y)
+void RGWStatAccount_ObjStore_SWIFT::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
-  RGWStatAccount_ObjStore::execute(y);
+  RGWStatAccount_ObjStore::execute(dpp, y);
   op_ret = store->ctl()->user->get_attrs_by_uid(s, s->user->get_id(), &attrs, s->yield);
 }
 
@@ -1834,7 +1834,7 @@ const vector<pair<string, RGWInfo_ObjStore_SWIFT::info>> RGWInfo_ObjStore_SWIFT:
     {"tempauth", {false, RGWInfo_ObjStore_SWIFT::list_tempauth_data}},
 };
 
-void RGWInfo_ObjStore_SWIFT::execute(optional_yield y)
+void RGWInfo_ObjStore_SWIFT::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   bool is_admin_info_enabled = false;
 
@@ -2447,7 +2447,7 @@ RGWOp* RGWSwiftWebsiteHandler::get_ws_redirect_op()
       return 0;
     }
 
-    void execute(optional_yield) override {
+    void execute(const DoutPrefixProvider *dpp, optional_yield) override {
       op_ret = -ERR_PERMANENT_REDIRECT;
       return;
     }

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -84,7 +84,7 @@ public:
   }
   ~RGWStatAccount_ObjStore_SWIFT() override {}
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void send_response() override;
 };
 
@@ -243,7 +243,7 @@ public:
   RGWInfo_ObjStore_SWIFT() {}
   ~RGWInfo_ObjStore_SWIFT() override {}
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void send_response() override;
   static void list_swift_data(Formatter& formatter, const ConfigProxy& config, RGWRados& store);
   static void list_tempauth_data(Formatter& formatter, const ConfigProxy& config, RGWRados& store);

--- a/src/rgw/rgw_rest_usage.cc
+++ b/src/rgw/rgw_rest_usage.cc
@@ -18,12 +18,12 @@ public:
   int check_caps(const RGWUserCaps& caps) override {
     return caps.check_cap("usage", RGW_CAP_READ);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "get_usage"; }
 };
 
-void RGWOp_Usage_Get::execute(optional_yield y) {
+void RGWOp_Usage_Get::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   map<std::string, bool> categories;
 
   string uid_str;
@@ -64,12 +64,12 @@ public:
   int check_caps(const RGWUserCaps& caps) override {
     return caps.check_cap("usage", RGW_CAP_WRITE);
   }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "trim_usage"; }
 };
 
-void RGWOp_Usage_Delete::execute(optional_yield y) {
+void RGWOp_Usage_Delete::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   string uid_str;
   string bucket_name;
   uint64_t start, end;

--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -26,12 +26,12 @@ public:
     return caps.check_cap("users", RGW_CAP_READ);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "list_user"; }
 };
 
-void RGWOp_User_List::execute(optional_yield y)
+void RGWOp_User_List::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   RGWUserAdminOpState op_state;
 
@@ -54,12 +54,12 @@ public:
     return caps.check_cap("users", RGW_CAP_READ);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "get_user_info"; }
 };
 
-void RGWOp_User_Info::execute(optional_yield y)
+void RGWOp_User_Info::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   RGWUserAdminOpState op_state;
 
@@ -101,12 +101,12 @@ public:
     return caps.check_cap("users", RGW_CAP_WRITE);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "create_user"; }
 };
 
-void RGWOp_User_Create::execute(optional_yield y)
+void RGWOp_User_Create::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   std::string uid_str;
   std::string display_name;
@@ -225,7 +225,7 @@ void RGWOp_User_Create::execute(optional_yield y)
   }
 
   bufferlist data;
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(s, s->user.get(), nullptr, data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -242,12 +242,12 @@ public:
     return caps.check_cap("users", RGW_CAP_WRITE);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "modify_user"; }
 };
 
-void RGWOp_User_Modify::execute(optional_yield y)
+void RGWOp_User_Modify::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   std::string uid_str;
   std::string display_name;
@@ -367,7 +367,7 @@ void RGWOp_User_Modify::execute(optional_yield y)
   }
   
   bufferlist data;
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(s, s->user.get(), nullptr, data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -384,12 +384,12 @@ public:
     return caps.check_cap("users", RGW_CAP_WRITE);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "remove_user"; }
 };
 
-void RGWOp_User_Remove::execute(optional_yield y)
+void RGWOp_User_Remove::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   std::string uid_str;
   bool purge_data;
@@ -408,7 +408,7 @@ void RGWOp_User_Remove::execute(optional_yield y)
   op_state.set_purge_data(purge_data);
 
   bufferlist data;
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(s, s->user.get(), nullptr, data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -425,12 +425,12 @@ public:
     return caps.check_cap("users", RGW_CAP_WRITE);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "create_subuser"; }
 };
 
-void RGWOp_Subuser_Create::execute(optional_yield y)
+void RGWOp_Subuser_Create::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   std::string uid_str;
   std::string subuser;
@@ -484,7 +484,7 @@ void RGWOp_Subuser_Create::execute(optional_yield y)
   op_state.set_key_type(key_type);
 
   bufferlist data;
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(s, s->user.get(), nullptr, data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -501,12 +501,12 @@ public:
     return caps.check_cap("users", RGW_CAP_WRITE);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "modify_subuser"; }
 };
 
-void RGWOp_Subuser_Modify::execute(optional_yield y)
+void RGWOp_Subuser_Modify::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   std::string uid_str;
   std::string subuser;
@@ -551,7 +551,7 @@ void RGWOp_Subuser_Modify::execute(optional_yield y)
   op_state.set_key_type(key_type);
 
   bufferlist data;
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(s, s->user.get(), nullptr, data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -568,12 +568,12 @@ public:
     return caps.check_cap("users", RGW_CAP_WRITE);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "remove_subuser"; }
 };
 
-void RGWOp_Subuser_Remove::execute(optional_yield y)
+void RGWOp_Subuser_Remove::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   std::string uid_str;
   std::string subuser;
@@ -594,7 +594,7 @@ void RGWOp_Subuser_Remove::execute(optional_yield y)
     op_state.set_purge_keys();
 
   bufferlist data;
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(s, s->user.get(), nullptr, data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -611,12 +611,12 @@ public:
     return caps.check_cap("users", RGW_CAP_WRITE);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "create_access_key"; }
 };
 
-void RGWOp_Key_Create::execute(optional_yield y)
+void RGWOp_Key_Create::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   std::string uid_str;
   std::string subuser;
@@ -667,12 +667,12 @@ public:
     return caps.check_cap("users", RGW_CAP_WRITE);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "remove_access_key"; }
 };
 
-void RGWOp_Key_Remove::execute(optional_yield y)
+void RGWOp_Key_Remove::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   std::string uid_str;
   std::string subuser;
@@ -714,12 +714,12 @@ public:
     return caps.check_cap("users", RGW_CAP_WRITE);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "add_user_caps"; }
 };
 
-void RGWOp_Caps_Add::execute(optional_yield y)
+void RGWOp_Caps_Add::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   std::string uid_str;
   std::string caps;
@@ -735,7 +735,7 @@ void RGWOp_Caps_Add::execute(optional_yield y)
   op_state.set_caps(caps);
 
   bufferlist data;
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(s, s->user.get(), nullptr, data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -752,12 +752,12 @@ public:
     return caps.check_cap("users", RGW_CAP_WRITE);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "remove_user_caps"; }
 };
 
-void RGWOp_Caps_Remove::execute(optional_yield y)
+void RGWOp_Caps_Remove::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   std::string uid_str;
   std::string caps;
@@ -773,7 +773,7 @@ void RGWOp_Caps_Remove::execute(optional_yield y)
   op_state.set_caps(caps);
 
   bufferlist data;
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(s, s->user.get(), nullptr, data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -809,13 +809,13 @@ public:
     return caps.check_cap("users", RGW_CAP_READ);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "get_quota_info"; }
 };
 
 
-void RGWOp_Quota_Info::execute(optional_yield y)
+void RGWOp_Quota_Info::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   RGWUserAdminOpState op_state;
 
@@ -881,7 +881,7 @@ public:
     return caps.check_cap("users", RGW_CAP_WRITE);
   }
 
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "set_quota_info"; }
 };
@@ -934,7 +934,7 @@ public:
  *
  */
 
-void RGWOp_Quota_Set::execute(optional_yield y)
+void RGWOp_Quota_Set::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   RGWUserAdminOpState op_state;
 

--- a/src/rgw/rgw_rest_user_policy.cc
+++ b/src/rgw/rgw_rest_user_policy.cc
@@ -109,7 +109,7 @@ int RGWPutUserPolicy::get_params()
   return 0;
 }
 
-void RGWPutUserPolicy::execute(optional_yield y)
+void RGWPutUserPolicy::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params();
   if (op_ret < 0) {
@@ -134,7 +134,7 @@ void RGWPutUserPolicy::execute(optional_yield y)
   }
 
   ceph::bufferlist in_data;
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, in_data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(dpp, s->user.get(), nullptr, in_data, nullptr, s->info, y);
   if (op_ret < 0) {
     ldpp_dout(this, 0) << "ERROR: forward_request_to_master returned ret=" << op_ret << dendl;
     return;
@@ -193,7 +193,7 @@ int RGWGetUserPolicy::get_params()
   return 0;
 }
 
-void RGWGetUserPolicy::execute(optional_yield y)
+void RGWGetUserPolicy::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params();
   if (op_ret < 0) {
@@ -257,7 +257,7 @@ int RGWListUserPolicies::get_params()
   return 0;
 }
 
-void RGWListUserPolicies::execute(optional_yield y)
+void RGWListUserPolicies::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params();
   if (op_ret < 0) {
@@ -319,7 +319,7 @@ int RGWDeleteUserPolicy::get_params()
   return 0;
 }
 
-void RGWDeleteUserPolicy::execute(optional_yield y)
+void RGWDeleteUserPolicy::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params();
   if (op_ret < 0) {
@@ -338,7 +338,7 @@ void RGWDeleteUserPolicy::execute(optional_yield y)
   }
 
   ceph::bufferlist in_data;
-  op_ret = store->forward_request_to_master(s->user.get(), nullptr, in_data, nullptr, s->info, y);
+  op_ret = store->forward_request_to_master(dpp, s->user.get(), nullptr, in_data, nullptr, s->info, y);
   if (op_ret < 0) {
     // a policy might've been uploaded to this site when there was no sync
     // req. in earlier releases, proceed deletion

--- a/src/rgw/rgw_rest_user_policy.h
+++ b/src/rgw/rgw_rest_user_policy.h
@@ -35,7 +35,7 @@ public:
 class RGWPutUserPolicy : public RGWUserPolicyWrite {
 public:
   RGWPutUserPolicy() = default;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int get_params();
   const char* name() const override { return "put_user-policy"; }
   uint64_t get_op() override;
@@ -45,7 +45,7 @@ public:
 class RGWGetUserPolicy : public RGWUserPolicyRead {
 public:
   RGWGetUserPolicy() = default;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int get_params();
   const char* name() const override { return "get_user_policy"; }
   uint64_t get_op() override;
@@ -55,7 +55,7 @@ public:
 class RGWListUserPolicies : public RGWUserPolicyRead {
 public:
   RGWListUserPolicies() = default;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int get_params();
   const char* name() const override { return "list_user_policies"; }
   uint64_t get_op() override;
@@ -65,7 +65,7 @@ public:
 class RGWDeleteUserPolicy : public RGWUserPolicyWrite {
 public:
   RGWDeleteUserPolicy() = default;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   int get_params();
   const char* name() const override { return "delete_user_policy"; }
   uint64_t get_op() override;

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -94,7 +94,7 @@ class RGWStore {
 			    optional_yield y) = 0;
     virtual RGWBucketList* list_buckets(void) = 0;
     virtual bool is_meta_master() = 0;
-    virtual int forward_request_to_master(RGWUser* user, obj_version *objv,
+    virtual int forward_request_to_master(const DoutPrefixProvider *dpp, RGWUser* user, obj_version *objv,
 					  bufferlist& in_data, JSONParser *jp, req_info& info,
 					  optional_yield y) = 0;
     virtual int defer_gc(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWBucket* bucket, RGWObject* obj,

--- a/src/rgw/rgw_sal_rados.h
+++ b/src/rgw/rgw_sal_rados.h
@@ -297,7 +297,7 @@ class RGWRadosStore : public RGWStore {
 			    optional_yield y);
     virtual RGWBucketList* list_buckets(void) { return new RGWBucketList(); }
     virtual bool is_meta_master() override;
-    virtual int forward_request_to_master(RGWUser* user, obj_version *objv,
+    virtual int forward_request_to_master(const DoutPrefixProvider *dpp, RGWUser* user, obj_version *objv,
 					  bufferlist& in_data, JSONParser *jp, req_info& info,
 					  optional_yield y) override;
     virtual int defer_gc(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWBucket* bucket, RGWObject* obj,

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -620,7 +620,7 @@ SignedTokenEngine::authenticate(const DoutPrefixProvider* dpp,
 } /* namespace rgw */
 
 
-void RGW_SWIFT_Auth_Get::execute(optional_yield y)
+void RGW_SWIFT_Auth_Get::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   int ret = -EPERM;
 

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -304,7 +304,7 @@ public:
   ~RGW_SWIFT_Auth_Get() override {}
 
   int verify_permission(optional_yield) override { return 0; }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   const char* name() const override { return "swift_auth_get"; }
   dmc::client_id dmclock_client() override { return dmc::client_id::auth; }
 };

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -170,7 +170,7 @@ public:
   virtual RGWCoroutine *alloc_cr() = 0;
   virtual RGWCoroutine *alloc_finisher_cr() { return NULL; }
 
-  int operate() override;
+  int operate(const DoutPrefixProvider *dpp) override;
 };
 
 struct RGWMetaSyncEnv {
@@ -211,7 +211,7 @@ class RGWRemoteMetaLog : public RGWCoroutinesManager {
   RGWMetaSyncEnv sync_env;
 
   void init_sync_env(RGWMetaSyncEnv *env);
-  int store_sync_info(const rgw_meta_sync_info& sync_info);
+  int store_sync_info(const DoutPrefixProvider *dpp, const rgw_meta_sync_info& sync_info);
 
   std::atomic<bool> going_down = { false };
 
@@ -231,12 +231,12 @@ public:
   int init();
   void finish();
 
-  int read_log_info(rgw_mdlog_info *log_info);
-  int read_master_log_shards_info(const string& master_period, map<int, RGWMetadataLogInfo> *shards_info);
-  int read_master_log_shards_next(const string& period, map<int, string> shard_markers, map<int, rgw_mdlog_shard_data> *result);
-  int read_sync_status(rgw_meta_sync_status *sync_status);
-  int init_sync_status();
-  int run_sync(optional_yield y);
+  int read_log_info(const DoutPrefixProvider *dpp, rgw_mdlog_info *log_info);
+  int read_master_log_shards_info(const DoutPrefixProvider *dpp, const string& master_period, map<int, RGWMetadataLogInfo> *shards_info);
+  int read_master_log_shards_next(const DoutPrefixProvider *dpp, const string& period, map<int, string> shard_markers, map<int, rgw_mdlog_shard_data> *result);
+  int read_sync_status(const DoutPrefixProvider *dpp, rgw_meta_sync_status *sync_status);
+  int init_sync_status(const DoutPrefixProvider *dpp);
+  int run_sync(const DoutPrefixProvider *dpp, optional_yield y);
 
   void wakeup(int shard_id);
 
@@ -275,23 +275,23 @@ public:
   RGWMetaSyncStatusManager(rgw::sal::RGWRadosStore *_store, RGWAsyncRadosProcessor *async_rados)
     : store(_store), master_log(this, store, async_rados, this)
   {}
-  int init();
+  int init(const DoutPrefixProvider *dpp);
 
-  int read_sync_status(rgw_meta_sync_status *sync_status) {
-    return master_log.read_sync_status(sync_status);
+  int read_sync_status(const DoutPrefixProvider *dpp, rgw_meta_sync_status *sync_status) {
+    return master_log.read_sync_status(dpp, sync_status);
   }
-  int init_sync_status() { return master_log.init_sync_status(); }
-  int read_log_info(rgw_mdlog_info *log_info) {
-    return master_log.read_log_info(log_info);
+  int init_sync_status(const DoutPrefixProvider *dpp) { return master_log.init_sync_status(dpp); }
+  int read_log_info(const DoutPrefixProvider *dpp, rgw_mdlog_info *log_info) {
+    return master_log.read_log_info(dpp, log_info);
   }
-  int read_master_log_shards_info(const string& master_period, map<int, RGWMetadataLogInfo> *shards_info) {
-    return master_log.read_master_log_shards_info(master_period, shards_info);
+  int read_master_log_shards_info(const DoutPrefixProvider *dpp, const string& master_period, map<int, RGWMetadataLogInfo> *shards_info) {
+    return master_log.read_master_log_shards_info(dpp, master_period, shards_info);
   }
-  int read_master_log_shards_next(const string& period, map<int, string> shard_markers, map<int, rgw_mdlog_shard_data> *result) {
-    return master_log.read_master_log_shards_next(period, shard_markers, result);
+  int read_master_log_shards_next(const DoutPrefixProvider *dpp, const string& period, map<int, string> shard_markers, map<int, rgw_mdlog_shard_data> *result) {
+    return master_log.read_master_log_shards_next(dpp, period, shard_markers, result);
   }
 
-  int run(optional_yield y) { return master_log.run_sync(y); }
+  int run(const DoutPrefixProvider *dpp, optional_yield y) { return master_log.run_sync(dpp, y); }
 
 
   // implements DoutPrefixProvider
@@ -325,7 +325,7 @@ public:
     }
   }
 
-  int operate() override;
+  int operate(const DoutPrefixProvider *dpp) override;
 
   void call_cr(RGWCoroutine *_cr) override {
     if (cr) {
@@ -507,7 +507,7 @@ public:
                            const RGWMDLogStatus& _op_status,
                            RGWMetaSyncShardMarkerTrack *_marker_tracker, const RGWSyncTraceNodeRef& _tn_parent);
 
-  int operate() override;
+  int operate(const DoutPrefixProvider *dpp) override;
 };
 
 class RGWShardCollectCR : public RGWCoroutine {
@@ -523,7 +523,7 @@ public:
                                                              status(0) {}
 
   virtual bool spawn_next() = 0;
-  int operate() override;
+  int operate(const DoutPrefixProvider *dpp) override;
 };
 
 // factory functions for meta sync coroutines needed in mdlog trimming

--- a/src/rgw/rgw_sync_checkpoint.cc
+++ b/src/rgw/rgw_sync_checkpoint.cc
@@ -126,7 +126,8 @@ int bucket_source_sync_checkpoint(const DoutPrefixProvider* dpp,
   return 0;
 }
 
-int source_bilog_markers(RGWSI_Zone* zone_svc,
+int source_bilog_markers(const DoutPrefixProvider *dpp,
+                         RGWSI_Zone* zone_svc,
                          const rgw_sync_bucket_pipe& pipe,
                          BucketIndexShardsManager& remote_markers,
                          optional_yield y)
@@ -139,7 +140,7 @@ int source_bilog_markers(RGWSI_Zone* zone_svc,
     return -EINVAL;
   }
 
-  return rgw_read_remote_bilog_info(conn->second, *pipe.source.bucket,
+  return rgw_read_remote_bilog_info(dpp, conn->second, *pipe.source.bucket,
                                     remote_markers, y);
 }
 
@@ -178,7 +179,7 @@ int rgw_bucket_sync_checkpoint(const DoutPrefixProvider* dpp,
     // fetch remote markers
     spawn::spawn(ioctx, [&] (spawn::yield_context yield) {
       auto y = optional_yield{ioctx, yield};
-      int r = source_bilog_markers(store->svc()->zone, entry.pipe,
+      int r = source_bilog_markers(dpp, store->svc()->zone, entry.pipe,
                                    entry.remote_markers, y);
       if (r < 0) {
         ldpp_dout(dpp, 0) << "failed to fetch remote bilog markers: "

--- a/src/rgw/rgw_sync_error_repo.cc
+++ b/src/rgw/rgw_sync_error_repo.cc
@@ -65,7 +65,7 @@ class RGWErrorRepoWriteCR : public RGWSimpleCoroutine {
       key(key), timestamp(timestamp)
   {}
 
-  int send_request() override {
+  int send_request(const DoutPrefixProvider *dpp) override {
     librados::ObjectWriteOperation op;
     int r = rgw_error_repo_write(op, key, timestamp);
     if (r < 0) {
@@ -108,7 +108,7 @@ class RGWErrorRepoRemoveCR : public RGWSimpleCoroutine {
       key(key), timestamp(timestamp)
   {}
 
-  int send_request() override {
+  int send_request(const DoutPrefixProvider *dpp) override {
     librados::ObjectWriteOperation op;
     int r = rgw_error_repo_remove(op, key, timestamp);
     if (r < 0) {

--- a/src/rgw/rgw_sync_module.cc
+++ b/src/rgw/rgw_sync_module.cc
@@ -39,7 +39,7 @@ RGWCallStatRemoteObjCR::RGWCallStatRemoteObjCR(RGWDataSyncCtx *_sc,
                                                                                                  src_bucket(_src_bucket), key(_key) {
 }
 
-int RGWCallStatRemoteObjCR::operate() {
+int RGWCallStatRemoteObjCR::operate(const DoutPrefixProvider *dpp) {
   reenter(this) {
     yield {
       call(new RGWStatRemoteObjCR(sync_env->async_rados, sync_env->store,

--- a/src/rgw/rgw_sync_module.h
+++ b/src/rgw/rgw_sync_module.h
@@ -190,7 +190,7 @@ public:
 
   ~RGWCallStatRemoteObjCR() override {}
 
-  int operate() override;
+  int operate(const DoutPrefixProvider *dpp) override;
 
   virtual RGWStatRemoteObjCBCR *allocate_callback() {
     return nullptr;

--- a/src/rgw/rgw_sync_module_aws.cc
+++ b/src/rgw/rgw_sync_module_aws.cc
@@ -734,7 +734,7 @@ public:
                                                                                  src_properties(_src_properties) {
   }
 
-  int init() override {
+  int init(const DoutPrefixProvider *dpp) override {
     /* init input connection */
 
 
@@ -753,7 +753,7 @@ public:
     }
 
     RGWRESTStreamRWRequest *in_req;
-    int ret = conn->get_obj(src_obj, req_params, false /* send */, &in_req);
+    int ret = conn->get_obj(dpp, src_obj, req_params, false /* send */, &in_req);
     if (ret < 0) {
       ldout(sc->cct, 0) << "ERROR: " << __func__ << "(): conn->get_obj() returned ret=" << ret << dendl;
       return ret;
@@ -761,7 +761,7 @@ public:
 
     set_req(in_req);
 
-    return RGWStreamReadHTTPResourceCRF::init();
+    return RGWStreamReadHTTPResourceCRF::init(dpp);
   }
 
   int decode_rest_obj(map<string, string>& headers, bufferlist& extra_data) override {
@@ -956,7 +956,7 @@ public:
     }
   }
 
-  void send_ready(const rgw_rest_obj& rest_obj) override {
+  void send_ready(const DoutPrefixProvider *dpp, const rgw_rest_obj& rest_obj) override {
     RGWRESTStreamS3PutObj *r = static_cast<RGWRESTStreamS3PutObj *>(req);
 
     map<string, string> new_attrs;
@@ -968,7 +968,7 @@ public:
 
     RGWAccessControlPolicy policy;
 
-    r->send_ready(target->conn->get_key(), new_attrs, policy, false);
+    r->send_ready(dpp, target->conn->get_key(), new_attrs, policy, false);
   }
 
   void handle_headers(const map<string, string>& headers) {
@@ -1015,7 +1015,7 @@ public:
                                                    dest_obj(_dest_obj),
                                                    src_properties(_src_properties) {}
 
-  int operate() override {
+  int operate(const DoutPrefixProvider *dpp) override {
     reenter(this) {
       /* init input */
       in_crf.reset(new RGWRESTStreamGetCRF(cct, get_env(), this, sc,
@@ -1076,7 +1076,7 @@ public:
                                                    part_info(_part_info),
                                                    petag(_petag) {}
 
-  int operate() override {
+  int operate(const DoutPrefixProvider *dpp) override {
     reenter(this) {
       /* init input */
       in_crf.reset(new RGWRESTStreamGetCRF(cct, get_env(), this, sc,
@@ -1125,7 +1125,7 @@ public:
                                                    dest_obj(_dest_obj),
                                                    upload_id(_upload_id) {}
 
-  int operate() override {
+  int operate(const DoutPrefixProvider *dpp) override {
     reenter(this) {
 
       yield {
@@ -1185,7 +1185,7 @@ public:
                                                    attrs(_attrs),
                                                    upload_id(_upload_id) {}
 
-  int operate() override {
+  int operate(const DoutPrefixProvider *dpp) override {
     reenter(this) {
 
       yield {
@@ -1287,7 +1287,7 @@ public:
                                                    upload_id(_upload_id),
                                                    req_enc(_parts) {}
 
-  int operate() override {
+  int operate(const DoutPrefixProvider *dpp) override {
     reenter(this) {
 
       yield {
@@ -1367,7 +1367,7 @@ public:
                                                             status_obj(_status_obj),
                                                             upload_id(_upload_id) {}
 
-  int operate() override {
+  int operate(const DoutPrefixProvider *dpp) override {
     reenter(this) {
       yield call(new RGWAWSAbortMultipartCR(sc, dest_conn, dest_obj, upload_id));
       if (retcode < 0) {
@@ -1436,7 +1436,7 @@ public:
   }
 
 
-  int operate() override {
+  int operate(const DoutPrefixProvider *dpp) override {
     reenter(this) {
       yield call(new RGWSimpleRadosReadCR<rgw_sync_aws_multipart_upload_info>(sync_env->async_rados, sync_env->svc->sysobj,
                                                                  status_obj, &status, false));
@@ -1593,7 +1593,7 @@ public:
   ~RGWAWSHandleRemoteObjCBCR(){
   }
 
-  int operate() override {
+  int operate(const DoutPrefixProvider *dpp) override {
     reenter(this) {
       ret = decode_attr(attrs, RGW_ATTR_PG_VER, &src_pg_ver, (uint64_t)0);
       if (ret < 0) {
@@ -1736,7 +1736,7 @@ public:
                           AWSSyncInstanceEnv& _instance) : RGWCoroutine(_sc->cct), sc(_sc),
                                                         sync_pipe(_sync_pipe), key(_key),
                                                         mtime(_mtime), instance(_instance) {}
-  int operate() override {
+  int operate(const DoutPrefixProvider *dpp) override {
     reenter(this) {
       ldout(sc->cct, 0) << ": remove remote obj: z=" << sc->source_zone
                               << " b=" <<sync_pipe.info.source_bs.bucket << " k=" << key << " mtime=" << mtime << dendl;

--- a/src/rgw/rgw_sync_module_es.cc
+++ b/src/rgw/rgw_sync_module_es.cc
@@ -647,7 +647,7 @@ public:
                           ElasticConfigRef _conf) : RGWCoroutine(_sc->cct),
                                                     sc(_sc), sync_env(_sc->env),
                                                     conf(_conf) {}
-  int operate() override {
+  int operate(const DoutPrefixProvider *dpp) override {
     reenter(this) {
       ldout(sync_env->cct, 5) << conf->id << ": get elasticsearch info for zone: " << sc->source_zone << dendl;
       yield call(new RGWReadRESTResourceCR<ESInfo> (sync_env->cct,
@@ -678,7 +678,7 @@ public:
                          ElasticConfigRef _conf) : RGWCoroutine(_sc->cct),
                                                    sc(_sc), sync_env(_sc->env),
                                                    conf(_conf) {}
-  int operate() override {
+  int operate(const DoutPrefixProvider *dpp) override {
     reenter(this) {
       ldout(sc->cct, 5) << conf->id << ": put elasticsearch index for zone: " << sc->source_zone << dendl;
 
@@ -752,7 +752,7 @@ public:
                           ElasticConfigRef _conf) : RGWCoroutine(_sc->cct),
                                                     sc(_sc), sync_env(_sc->env),
                                                     conf(_conf) {}
-  int operate() override {
+  int operate(const DoutPrefixProvider *dpp) override {
     reenter(this) {
 
       yield call(new RGWElasticGetESInfoCBCR(sc, conf));
@@ -782,7 +782,7 @@ public:
                           ElasticConfigRef _conf, uint64_t _versioned_epoch) : RGWStatRemoteObjCBCR(_sc, _sync_pipe.info.source_bs.bucket, _key),
                                                                                sync_pipe(_sync_pipe), conf(_conf),
                                                                                versioned_epoch(_versioned_epoch) {}
-  int operate() override {
+  int operate(const DoutPrefixProvider *dpp) override {
     reenter(this) {
       ldout(sync_env->cct, 10) << ": stat of remote obj: z=" << sc->source_zone
                                << " b=" << sync_pipe.info.source_bs.bucket << " k=" << key
@@ -840,7 +840,7 @@ public:
                           ElasticConfigRef _conf) : RGWCoroutine(_sc->cct), sc(_sc), sync_env(_sc->env),
                                                         sync_pipe(_sync_pipe), key(_key),
                                                         mtime(_mtime), conf(_conf) {}
-  int operate() override {
+  int operate(const DoutPrefixProvider *dpp) override {
     reenter(this) {
       ldout(sync_env->cct, 10) << ": remove remote obj: z=" << sc->source_zone
                                << " b=" << sync_pipe.info.source_bs.bucket << " k=" << key << " mtime=" << mtime << dendl;

--- a/src/rgw/rgw_sync_module_es_rest.cc
+++ b/src/rgw/rgw_sync_module_es_rest.cc
@@ -146,7 +146,7 @@ public:
   }
   virtual int get_params() = 0;
   void pre_exec() override;
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 
   const char* name() const override { return "metadata_search"; }
   virtual RGWOpType get_type() override { return RGW_OP_METADATA_SEARCH; }
@@ -158,7 +158,7 @@ void RGWMetadataSearchOp::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
-void RGWMetadataSearchOp::execute(optional_yield y)
+void RGWMetadataSearchOp::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   op_ret = get_params();
   if (op_ret < 0)
@@ -247,7 +247,7 @@ void RGWMetadataSearchOp::execute(optional_yield y)
   }
   ldout(s->cct, 20) << "sending request to elasticsearch, payload=" << string(in.c_str(), in.length()) << dendl;
   auto& extra_headers = es_module->get_request_headers();
-  op_ret = conn->get_resource(resource, &params, &extra_headers,
+  op_ret = conn->get_resource(dpp, resource, &params, &extra_headers,
                               out, &in, nullptr, y);
   if (op_ret < 0) {
     ldout(s->cct, 0) << "ERROR: failed to fetch resource (r=" << resource << ", ret=" << op_ret << ")" << dendl;

--- a/src/rgw/rgw_sync_module_log.cc
+++ b/src/rgw/rgw_sync_module_log.cc
@@ -14,7 +14,7 @@ class RGWLogStatRemoteObjCBCR : public RGWStatRemoteObjCBCR {
 public:
   RGWLogStatRemoteObjCBCR(RGWDataSyncCtx *_sc,
                           rgw_bucket& _src_bucket, rgw_obj_key& _key) : RGWStatRemoteObjCBCR(_sc, _src_bucket, _key) {}
-  int operate() override {
+  int operate(const DoutPrefixProvider *dpp) override {
     ldout(sync_env->cct, 0) << "SYNC_LOG: stat of remote obj: z=" << sc->source_zone
                             << " b=" << src_bucket << " k=" << key << " size=" << size << " mtime=" << mtime
                             << " attrs=" << attrs << dendl;

--- a/src/rgw/rgw_sync_module_pubsub_rest.cc
+++ b/src/rgw/rgw_sync_module_pubsub_rest.cc
@@ -369,10 +369,10 @@ private:
 
 public:
   const char* name() const override { return "pubsub_notification_create"; }
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
 };
 
-void RGWPSCreateNotif_ObjStore::execute(optional_yield y)
+void RGWPSCreateNotif_ObjStore::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   ps.emplace(store, s->owner.get_id().tenant);
 
@@ -401,11 +401,11 @@ private:
   }
 
 public:
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   const char* name() const override { return "pubsub_notification_delete"; }
 };
 
-void RGWPSDeleteNotif_ObjStore::execute(optional_yield y) {
+void RGWPSDeleteNotif_ObjStore::execute(const DoutPrefixProvider *dpp, optional_yield y) {
   op_ret = get_params();
   if (op_ret < 0) {
     return;
@@ -431,7 +431,7 @@ private:
   }
 
 public:
-  void execute(optional_yield y) override;
+  void execute(const DoutPrefixProvider *dpp, optional_yield y) override;
   void send_response() override {
     if (op_ret) {
       set_req_state_err(s, op_ret);
@@ -448,7 +448,7 @@ public:
   const char* name() const override { return "pubsub_notifications_list"; }
 };
 
-void RGWPSListNotifs_ObjStore::execute(optional_yield y)
+void RGWPSListNotifs_ObjStore::execute(const DoutPrefixProvider *dpp, optional_yield y)
 {
   ps.emplace(store, s->owner.get_id().tenant);
   auto b = ps->get_bucket(bucket_info.bucket);

--- a/src/rgw/rgw_sync_trace.cc
+++ b/src/rgw/rgw_sync_trace.cc
@@ -65,10 +65,10 @@ public:
   RGWSyncTraceServiceMapThread(RGWRados *_store, RGWSyncTraceManager *_manager)
     : RGWRadosThread(_store, "sync-trace"), store(_store), manager(_manager) {}
 
-  int process() override;
+  int process(const DoutPrefixProvider *dpp) override;
 };
 
-int RGWSyncTraceServiceMapThread::process()
+int RGWSyncTraceServiceMapThread::process(const DoutPrefixProvider *dpp)
 {
   map<string, string> status;
   status["current_sync"] = manager->get_active_names();

--- a/src/rgw/rgw_trim_bilog.cc
+++ b/src/rgw/rgw_trim_bilog.cc
@@ -446,10 +446,10 @@ class BucketTrimInstanceCR : public RGWCoroutine {
     source_policy = make_shared<rgw_bucket_get_sync_policy_result>();
   }
 
-  int operate() override;
+  int operate(const DoutPrefixProvider *dpp) override;
 };
 
-int BucketTrimInstanceCR::operate()
+int BucketTrimInstanceCR::operate(const DoutPrefixProvider *dpp)
 {
   reenter(this) {
     ldout(cct, 4) << "starting trim on bucket=" << bucket_instance << dendl;
@@ -637,7 +637,7 @@ class AsyncMetadataList : public RGWAsyncRadosRequest {
   const std::string start_marker;
   MetadataListCallback callback;
 
-  int _send_request() override;
+  int _send_request(const DoutPrefixProvider *dpp) override;
  public:
   AsyncMetadataList(CephContext *cct, RGWCoroutine *caller,
                     RGWAioCompletionNotifier *cn, RGWMetadataManager *mgr,
@@ -648,7 +648,7 @@ class AsyncMetadataList : public RGWAsyncRadosRequest {
   {}
 };
 
-int AsyncMetadataList::_send_request()
+int AsyncMetadataList::_send_request(const DoutPrefixProvider *dpp)
 {
   void* handle = nullptr;
   std::list<std::string> keys;
@@ -753,7 +753,7 @@ class MetadataListCR : public RGWSimpleCoroutine {
     request_cleanup();
   }
 
-  int send_request() override {
+  int send_request(const DoutPrefixProvider *dpp) override {
     req = new AsyncMetadataList(cct, this, stack->create_completion_notifier(),
                                 mgr, section, start_marker, callback);
     async_rados->queue(req);
@@ -794,12 +794,12 @@ class BucketTrimCR : public RGWCoroutine {
       observer(observer), obj(obj), counter(config.counter_size), dpp(dpp)
   {}
 
-  int operate() override;
+  int operate(const DoutPrefixProvider *dpp) override;
 };
 
 const std::string BucketTrimCR::section{"bucket.instance"};
 
-int BucketTrimCR::operate()
+int BucketTrimCR::operate(const DoutPrefixProvider *dpp)
 {
   reenter(this) {
     start_time = ceph::mono_clock::now();
@@ -954,10 +954,10 @@ class BucketTrimPollCR : public RGWCoroutine {
       cookie(RGWSimpleRadosLockCR::gen_random_cookie(cct)),
       dpp(dpp) {}
 
-  int operate() override;
+  int operate(const DoutPrefixProvider *dpp) override;
 };
 
-int BucketTrimPollCR::operate()
+int BucketTrimPollCR::operate(const DoutPrefixProvider *dpp)
 {
   reenter(this) {
     for (;;) {

--- a/src/rgw/rgw_trim_datalog.cc
+++ b/src/rgw/rgw_trim_datalog.cc
@@ -41,7 +41,7 @@ class DatalogTrimImplCR : public RGWSimpleCoroutine {
 		      << " marker=" << marker;
   }
 
-  int send_request() override {
+  int send_request(const DoutPrefixProvider *dpp) override {
     set_status() << "sending request";
     cn = stack->create_completion_notifier();
     return store->svc()->datalog_rados->trim_entries(shard, marker,
@@ -116,10 +116,10 @@ class DataLogTrimCR : public RGWCoroutine {
       last_trim(last_trim)
   {}
 
-  int operate() override;
+  int operate(const DoutPrefixProvider *dpp) override;
 };
 
-int DataLogTrimCR::operate()
+int DataLogTrimCR::operate(const DoutPrefixProvider *dpp)
 {
   reenter(this) {
     ldout(cct, 10) << "fetching sync status for zone " << zone_id << dendl;
@@ -207,10 +207,10 @@ class DataLogTrimPollCR : public RGWCoroutine {
       last_trim(num_shards)
   {}
 
-  int operate() override;
+  int operate(const DoutPrefixProvider *dpp) override;
 };
 
-int DataLogTrimPollCR::operate()
+int DataLogTrimPollCR::operate(const DoutPrefixProvider *dpp)
 {
   reenter(this) {
     for (;;) {

--- a/src/rgw/rgw_trim_mdlog.cc
+++ b/src/rgw/rgw_trim_mdlog.cc
@@ -70,10 +70,10 @@ class PurgePeriodLogsCR : public RGWCoroutine {
     svc.mdlog = store->svc()->mdlog;
   }
 
-  int operate() override;
+  int operate(const DoutPrefixProvider *dpp) override;
 };
 
-int PurgePeriodLogsCR::operate()
+int PurgePeriodLogsCR::operate(const DoutPrefixProvider *dpp)
 {
   reenter(this) {
     // read our current oldest log period
@@ -351,10 +351,10 @@ class MetaMasterTrimCR : public RGWCoroutine {
     : RGWCoroutine(env.store->ctx()), env(env)
   {}
 
-  int operate() override;
+  int operate(const DoutPrefixProvider *dpp) override;
 };
 
-int MetaMasterTrimCR::operate()
+int MetaMasterTrimCR::operate(const DoutPrefixProvider *dpp)
 {
   reenter(this) {
     // TODO: detect this and fail before we spawn the trim thread?
@@ -425,10 +425,10 @@ class MetaPeerTrimShardCR : public RGWCoroutine {
       period_id(period_id), shard_id(shard_id), last_trim(last_trim)
   {}
 
-  int operate() override;
+  int operate(const DoutPrefixProvider *dpp) override;
 };
 
-int MetaPeerTrimShardCR::operate()
+int MetaPeerTrimShardCR::operate(const DoutPrefixProvider *dpp)
 {
   reenter(this) {
     // query master's first mdlog entry for this shard
@@ -552,10 +552,10 @@ class MetaPeerTrimCR : public RGWCoroutine {
  public:
   explicit MetaPeerTrimCR(PeerTrimEnv& env) : RGWCoroutine(env.store->ctx()), env(env) {}
 
-  int operate() override;
+  int operate(const DoutPrefixProvider *dpp) override;
 };
 
-int MetaPeerTrimCR::operate()
+int MetaPeerTrimCR::operate(const DoutPrefixProvider *dpp)
 {
   reenter(this) {
     ldout(cct, 10) << "fetching master mdlog info" << dendl;
@@ -617,10 +617,10 @@ class MetaTrimPollCR : public RGWCoroutine {
       cookie(RGWSimpleRadosLockCR::gen_random_cookie(cct))
   {}
 
-  int operate() override;
+  int operate(const DoutPrefixProvider *dpp) override;
 };
 
-int MetaTrimPollCR::operate()
+int MetaTrimPollCR::operate(const DoutPrefixProvider *dpp)
 {
   reenter(this) {
     for (;;) {

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -1070,7 +1070,8 @@ class RGWPeriod
   const std::string get_period_oid_prefix() const;
 
   // gather the metadata sync status for each shard; only for use on master zone
-  int update_sync_status(rgw::sal::RGWRadosStore *store,
+  int update_sync_status(const DoutPrefixProvider *dpp,
+                         rgw::sal::RGWRadosStore *store,
                          const RGWPeriod &current_period,
                          std::ostream& error_stream, bool force_if_stale);
 

--- a/src/rgw/services/svc_mdlog.cc
+++ b/src/rgw/services/svc_mdlog.cc
@@ -127,7 +127,7 @@ class ReadHistoryCR : public RGWCoroutine {
       async_processor(svc.rados->get_async_processor())
   {}
 
-  int operate() {
+  int operate(const DoutPrefixProvider *dpp) {
     reenter(this) {
       yield {
         rgw_raw_obj obj{svc.zone->get_zone_params().log_pool,
@@ -174,7 +174,7 @@ class WriteHistoryCR : public RGWCoroutine {
       async_processor(svc.rados->get_async_processor())
   {}
 
-  int operate() {
+  int operate(const DoutPrefixProvider *dpp) {
     reenter(this) {
       state.oldest_period_id = cursor.get_period().get_id();
       state.oldest_realm_epoch = cursor.get_epoch();
@@ -216,7 +216,7 @@ class TrimHistoryCR : public RGWCoroutine {
     next.next(); // advance past cursor
   }
 
-  int operate() {
+  int operate(const DoutPrefixProvider *dpp) {
     reenter(this) {
       // read an existing history, and write the new history if it's newer
       yield call(new ReadHistoryCR(svc, &existing, objv));


### PR DESCRIPTION
This commit consist of addition of DoutPrefixProvider to the functions which covers log messages of create_bucket.
Also, removed unnecessary DoutPrefixProvider's from classes.

Signed-off-by: Kalpesh Pandya <kapandya@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
