### PR TITLE
octopus: qa/tasks/vstart_runner: do not teardown test_path if "create-cluster-only"

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -1268,7 +1268,10 @@ class LocalContext(object):
                     self.daemons.daemons[prefixed_type][svc_id] = LocalDaemon(svc_type, svc_id)
 
     def __del__(self):
-        shutil.rmtree(self.teuthology_config['test_path'])
+        test_path = self.teuthology_config['test_path']
+        # opt_create_cluster_only does not create the test path
+        if test_path:
+            shutil.rmtree(test_path)
 
 def teardown_cluster():
     log.info('\ntearing down the cluster...')


### PR DESCRIPTION
backport of #35352

otherwise we could be removing a "None" directory when tearing down the cluster,
and have following failure:

Exception ignored in: <bound method LocalContext.__del__ of <__main__.LocalContext object at 0x7f99fd4a6cc0>>
Traceback (most recent call last):
  File "../qa/tasks/vstart_runner.py", line 1189, in __del__
    shutil.rmtree(self.teuthology_config['test_path'])
  File "/tmp/tmp.mmM2ugspuR/venv/lib/python3.6/shutil.py", line 477, in rmtree
    onerror(os.lstat, path, sys.exc_info())
  File "/tmp/tmp.mmM2ugspuR/venv/lib/python3.6/shutil.py", line 475, in rmtree
    orig_st = os.lstat(path)
TypeError: lstat: path should be string, bytes or os.PathLike, not NoneType

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 954e9a6fa67cce8e3eb8105ee858340b60b84b15)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
