### PR TITLE
mgr/cephadm: Provide an integrated configuration validation feature

### DIFF
--- a/doc/cephadm/operations.rst
+++ b/doc/cephadm/operations.rst
@@ -106,9 +106,18 @@ that it does not fill up the root file system.
 
 Health checks
 =============
+The cephadm module provides additional healthchecks to supplement the default healthchecks
+provided by the Cluster. These additional healthchecks fall into two categories;
+
+- **cephadm operations**: Healthchecks in this category are always executed when the cephadm module is active.
+- **cluster configuration**: These healthchecks are *optional*, and focus on the configuration of the hosts in
+  the cluster
+
+CEPHADM Operations
+------------------
 
 CEPHADM_PAUSED
---------------
+^^^^^^^^^^^^^^
 
 Cephadm background work has been paused with ``ceph orch pause``.  Cephadm
 continues to perform passive monitoring activities (like checking
@@ -122,7 +131,7 @@ Resume cephadm work with::
 .. _cephadm-stray-host:
 
 CEPHADM_STRAY_HOST
-------------------
+^^^^^^^^^^^^^^^^^^
 
 One or more hosts have running Ceph daemons but are not registered as
 hosts managed by *cephadm*.  This means that those services cannot
@@ -148,7 +157,7 @@ See :ref:`cephadm-fqdn` for more information about host names and
 domain names.
 
 CEPHADM_STRAY_DAEMON
---------------------
+^^^^^^^^^^^^^^^^^^^^
 
 One or more Ceph daemons are running but not are not managed by
 *cephadm*.  This may be because they were deployed using a different
@@ -166,7 +175,7 @@ This warning can be disabled entirely with::
   ceph config set mgr mgr/cephadm/warn_on_stray_daemons false
 
 CEPHADM_HOST_CHECK_FAILED
--------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 One or more hosts have failed the basic cephadm host check, which verifies
 that (1) the host is reachable and cephadm can be executed there, and (2)
@@ -186,10 +195,114 @@ You can disable this health warning with::
 
   ceph config set mgr mgr/cephadm/warn_on_failed_host_check false
 
+Cluster Configuration Checks
+----------------------------
+Cephadm periodically scans each of the hosts in the cluster, to understand the state
+of the OS, disks, NICs etc. These facts can then be analysed for consistency across the hosts
+in the cluster to identify any configuration anomalies.
+
+The configuration checks are an **optional** feature, enabled by the following command
+::
+
+  ceph config set mgr mgr/cephadm/config_checks_enabled true
+
+The configuration checks are triggered after each host scan (1m). The cephadm log entries will
+show the current state and outcome of the configuration checks as follows;
+
+Disabled state (config_checks_enabled false)
+::
+
+  ALL cephadm checks are disabled, use 'ceph config set mgr mgr/cephadm/config_checks_enabled true' to enable
+
+Enabled state (config_checks_enabled true)
+::
+
+  CEPHADM 8/8 checks enabled and executed (0 bypassed, 0 disabled). No issues detected
+
+The configuration checks themselves are managed through several cephadm sub-commands.
+
+To determine whether the configuration checks are enabled, you can use the following command
+::
+
+  ceph cephadm config-check status
+
+This command will return the status of the configuration checker as either "Enabled" or "Disabled".
+
+
+Listing all the configuration checks and their current state
+::
+
+  ceph cephadm config-check ls
+
+  e.g.
+    NAME             HEALTHCHECK                      STATUS   DESCRIPTION
+  kernel_security  CEPHADM_CHECK_KERNEL_LSM         enabled  checks SELINUX/Apparmor profiles are consistent across cluster hosts
+  os_subscription  CEPHADM_CHECK_SUBSCRIPTION       enabled  checks subscription states are consistent for all cluster hosts
+  public_network   CEPHADM_CHECK_PUBLIC_MEMBERSHIP  enabled  check that all hosts have a NIC on the Ceph public_netork
+  osd_mtu_size     CEPHADM_CHECK_MTU                enabled  check that OSD hosts share a common MTU setting
+  osd_linkspeed    CEPHADM_CHECK_LINKSPEED          enabled  check that OSD hosts share a common linkspeed
+  network_missing  CEPHADM_CHECK_NETWORK_MISSING    enabled  checks that the cluster/public networks defined exist on the Ceph hosts
+  ceph_release     CEPHADM_CHECK_CEPH_RELEASE       enabled  check for Ceph version consistency - ceph daemons should be on the same release (unless upgrade is active)
+  kernel_version   CEPHADM_CHECK_KERNEL_VERSION     enabled  checks that the MAJ.MIN of the kernel on Ceph hosts is consistent
+
+The name of each configuration check, can then be used to enable or disable a specific check.
+::
+
+  ceph cephadm config-check disable <name>
+
+  eg.
+  ceph cephadm config-check disable kernel_security
+
+CEPHADM_CHECK_KERNEL_LSM
+^^^^^^^^^^^^^^^^^^^^^^^^
+Each host within the cluster is expected to operate within the same Linux Security Module (LSM) state. For example,
+if the majority of the hosts are running with SELINUX in enforcing mode, any host not running in this mode
+would be flagged as an anomaly and a healtcheck (WARNING) state raised.
+
+CEPHADM_CHECK_SUBSCRIPTION
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+This check relates to the status of vendor subscription. This check is only performed for hosts using RHEL, but helps
+to confirm that all your hosts are covered by an active subscription so patches and updates
+are available.
+
+CEPHADM_CHECK_PUBLIC_MEMBERSHIP
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+All members of the cluster should have NICs configured on at least one of the public network subnets. Hosts
+that are not on the public network will rely on routing which may affect performance
+
+CEPHADM_CHECK_MTU
+^^^^^^^^^^^^^^^^^
+The MTU of the NICs on OSDs can be a key factor in consistent performance. This check examines hosts
+that are running OSD services to ensure that the MTU is configured consistently within the cluster. This is
+determined by establishing the MTU setting that the majority of hosts are using, with any anomalies being
+resulting in a Ceph healthcheck.
+
+CEPHADM_CHECK_LINKSPEED
+^^^^^^^^^^^^^^^^^^^^^^^
+Similar to the MTU check, linkspeed consistency is also a factor in consistent cluster performance.
+This check determines the linkspeed shared by the majority of "OSD hosts", resulting in a healthcheck for
+any hosts that are set at a lower linkspeed rate.
+
+CEPHADM_CHECK_NETWORK_MISSING
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The public_network and cluster_network settings support subnet definitions for IPv4 and IPv6. If these
+settings are not found on any host in the cluster a healthcheck is raised.
+
+CEPHADM_CHECK_CEPH_RELEASE
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+Under normal operations, the ceph cluster should be running daemons under the same ceph release (i.e. all
+pacific). This check looks at the active release for each daemon, and reports any anomalies as a
+healthcheck. *This check is bypassed if an upgrade process is active within the cluster.*
+
+CEPHADM_CHECK_KERNEL_VERSION
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The OS kernel version (maj.min) is checked for consistency across the hosts. Once again, the
+majority of the hosts is used as the basis of identifying anomalies.
+
 /etc/ceph/ceph.conf
 ===================
 
-Cephadm distributes a minimized ``ceph.conf`` that only contains 
+Cephadm distributes a minimized ``ceph.conf`` that only contains
 a minimal set of information to connect to the Ceph cluster.
 
 To update the configuration settings, instead of manually editing
@@ -197,7 +310,7 @@ the ``ceph.conf`` file, use the config database instead::
 
   ceph config set ...
 
-See :ref:`ceph-conf-database` for details. 
+See :ref:`ceph-conf-database` for details.
 
 By default, cephadm does not deploy that minimized ``ceph.conf`` across the
 cluster. To enable the management of ``/etc/ceph/ceph.conf`` files on all
@@ -205,7 +318,7 @@ hosts, please enable this by running::
 
   ceph config set mgr mgr/cephadm/manage_etc_ceph_ceph_conf true
 
-To set up an initial configuration before bootstrapping 
+To set up an initial configuration before bootstrapping
 the cluster, create an initial ``ceph.conf`` file. For example::
 
   cat <<EOF > /etc/ceph/ceph.conf

--- a/src/pybind/mgr/cephadm/configchecks.py
+++ b/src/pybind/mgr/cephadm/configchecks.py
@@ -242,6 +242,13 @@ class CephadmConfigChecks:
                 else:
                     self.log.debug("config_checks match module definition")
 
+    def lookup_check(self, key_value: str, key_name: str = 'name') -> Optional[CephadmCheckDefinition]:
+
+        for c in self.health_checks:
+            if getattr(c, key_name) == key_value:
+                return c
+        return None
+
     @property
     def defined_checks(self) -> int:
         return len(self.health_checks)

--- a/src/pybind/mgr/cephadm/configchecks.py
+++ b/src/pybind/mgr/cephadm/configchecks.py
@@ -339,16 +339,14 @@ class CephadmConfigChecks:
         """Build a map of service -> service metadata"""
         service_map: Dict[str, Optional[Dict[str, str]]] = {}
 
-        # If we have the mgr bindings in place, we can create a map
-        if hasattr(self.mgr, '_ceph_get_server'):
-            for server in self.mgr.list_servers():
-                for service in server.get('services', []):
-                    service_map.update(
-                        {
-                            f"{service['type']}.{service['id']}":
-                            self.mgr.get_metadata(service['type'], service['id'])
-                        }
-                    )
+        for server in self.mgr.list_servers():
+            for service in server.get('services', []):
+                service_map.update(
+                    {
+                        f"{service['type']}.{service['id']}":
+                        self.mgr.get_metadata(service['type'], service['id'])
+                    }
+                )
         return service_map
 
     def _check_kernel_lsm(self) -> None:

--- a/src/pybind/mgr/cephadm/configchecks.py
+++ b/src/pybind/mgr/cephadm/configchecks.py
@@ -2,6 +2,8 @@ import json
 import ipaddress
 import logging
 
+from mgr_module import ServiceInfoT
+
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast, Tuple, Callable
 
 if TYPE_CHECKING:
@@ -347,13 +349,14 @@ class CephadmConfigChecks:
         service_map: Dict[str, Optional[Dict[str, str]]] = {}
 
         for server in self.mgr.list_servers():
-            for service in server.get('services', []):
-                service_map.update(
-                    {
-                        f"{service['type']}.{service['id']}":
-                        self.mgr.get_metadata(service['type'], service['id'])
-                    }
-                )
+            for service in cast(List[ServiceInfoT], server.get('services', [])):
+                if service:
+                    service_map.update(
+                        {
+                            f"{service['type']}.{service['id']}":
+                            self.mgr.get_metadata(service['type'], service['id'])
+                        }
+                    )
         return service_map
 
     def _check_kernel_lsm(self) -> None:

--- a/src/pybind/mgr/cephadm/configchecks.py
+++ b/src/pybind/mgr/cephadm/configchecks.py
@@ -198,7 +198,7 @@ class CephadmConfigChecks:
             "no": [],
             "unknown": [],
         }
-        self.host_to_role: Dict[str, List[Optional[str]]] = {}
+        self.host_to_role: Dict[str, List[str]] = {}
         self.kernel_to_hosts: Dict[str, List[str]] = {}
 
         self.public_network_list: List[str] = []

--- a/src/pybind/mgr/cephadm/configchecks.py
+++ b/src/pybind/mgr/cephadm/configchecks.py
@@ -1,0 +1,250 @@
+# import ssl
+import json
+# import sys
+# import tempfile
+# import time
+# import socket
+import ipaddress
+import logging
+# import inspect
+# from threading import Event
+# from urllib.request import Request, urlopen
+
+from typing import Any, Dict, List, Set
+
+logger = logging.getLogger(__name__)
+
+
+class Hosts:
+    def __init__(self):
+        self.map = {}
+
+    def add_host(self, hostname: str, hostData: Dict[str, Any]) -> None:
+        return None
+
+    def hosts_with_role(self, role: str) -> List[str]:
+        return []
+
+
+class HostData:
+    def __init__(self, json_data: Dict[str, Any]):
+        data = json_data.get('data', None)
+        assert data
+        self.valid = True if data and len(data.keys()) > 1 else False
+        if self.valid:
+            data = json_data['data']
+            for k in data:
+                setattr(self, k, data[k])
+
+
+class CephHost:
+    def __init__(self, json_data: Dict[str, Any]):
+        self.os = HostData(json_data.get('host', {}))
+        daemon_section = json_data.get('daemons', {})
+        self.daemons = daemon_section['data'] if 'data' in daemon_section else []
+
+
+class SubnetLookup:
+    def __init__(self, subnet, hostname, mtu, speed):
+        self.subnet = subnet
+        self.mtu_map = {
+            mtu: [hostname]
+        }
+        self.speed_map = {
+            speed: [hostname]
+        }
+
+    @property
+    def host_list(self) -> List[str]:
+        return self.mtu_map[next(iter(self.mtu_map))]
+
+    def update(self, hostname, mtu, speed) -> None:
+        if mtu in self.mtu_map and hostname not in self.mtu_map[mtu]:
+            self.mtu_map[mtu].append(hostname)
+        else:
+            self.mtu_map[mtu] = [hostname]
+
+        if speed in self.speed_map and hostname not in self.speed_map[speed]:
+            self.speed_map[speed].append(hostname)
+        else:
+            self.speed_map[speed] = [hostname]
+
+    def __repr__(self) -> Dict[str, Any]:
+        return json.dumps({
+            "subnet": self.subnet,
+            "mtu_map": self.mtu_map,
+            "speed_map": self.speed_map
+        })
+
+
+class CephadmConfigChecks:
+    def __init__(self, mgr):
+        self.mgr = mgr
+        self.log = logger
+        self.healthchecks = {
+            "CEPHADM_CHECK_OS": [],
+            "CEPHADM_CHECK_SUBSCRIPTION": [],
+            "CEPHADM_CHECK_KERNEL_LSM": [],
+            "CEPHADM_CHECK_MTU": [],
+            "CEPHADM_CHECK_LINKSPEED": [],
+            "CEPHADM_CHECK_PUBLIC_MEMBERSHIP": [],
+            "CEPHADM_CHECK_DAEMON_DISABLED": [],
+        }
+        self.subnet_lookup = {}  # subnet CIDR -> SubnetLookup Object
+
+        self.public_network_list = None
+        self.cluster_network_list = None
+        ret, out, _err = self.mgr.mon_command({
+            'prefix': 'config dump',
+            'format': 'json'
+        })
+        assert ret == 0
+        js = json.loads(out)
+        for item in js:
+            if item['name'] == "cluster_network":
+                self.cluster_network_list = item['value'].strip().split(',')
+            if item['name'] == "public_network":
+                self.public_network_list = item['value'].strip().split(',')
+
+        self.log.error(f"public networks {self.public_network_list}")
+        self.log.error(f"cluster networks {self.cluster_network_list}")
+
+    def _update_subnet_lookups(self, hostname: str, devname: str, nic: Dict[str, Any]) -> None:
+        if nic['ipv4_address']:
+            try:
+                iface = ipaddress.IPv4Interface(nic['ipv4_address'])
+                subnet = str(iface.network)
+            except ipaddress.AddressValueError as e:
+                self.log.error(f"Invalid network on {hostname}, interface {devname} : {str(e)}")
+                return
+
+            if subnet:
+                mtu = nic.get('mtu', None)
+                speed = nic.get('speed', None)
+                if not mtu or not speed:
+                    return
+
+                this_subnet = self.subnet_lookup.get(subnet, None)
+                if this_subnet:
+                    this_subnet.update(hostname, mtu, speed)
+                else:
+                    self.subnet_lookup[subnet] = SubnetLookup(subnet, hostname, mtu, speed)
+
+        if nic['ipv6_address']:
+            pass
+
+    def role_from_name(self, name: str) -> str:
+        return name.split('.')[0]
+
+    def hosts_with_role(self, role_name: str) -> List[str]:
+        host_list = []
+        for hostname in self.mgr.cache.facts:
+            host = CephHost(self.mgr.cache.facts[hostname])
+            for d in host.daemons:
+                if self.role_from_name(d['name']) == role_name:
+                    host_list.append(hostname)
+        return host_list
+
+    def host_roles(self, hostname: str) -> List[str]:
+        role_list = []
+        host = CephHost(self.mgr.cache.facts[hostname])
+        for d in host.daemons:
+            role_list.append(self.role_from_name(d['name']))
+        return role_list
+
+    def run_checks(self) -> None:
+
+        # os_to_host = {}  # TODO needs better support in gather-facts
+        lsm_to_host = {}
+        subscribed: Dict[str, List[str]] = {
+            "Yes": [],
+            "No": [],
+        }
+        host_to_role = {}
+        disabled_daemons = {}
+        osd_hosts = set()
+
+        # build lookup "maps"
+        for hostname in self.mgr.cache.facts:
+            self.log.error(json.dumps(self.mgr.cache.facts[hostname]))
+        #     host = CephHost(self.mgr.cache.facts[hostname])
+        #     # self.log.error(f"object contains {list(host.os.__dict__.keys())}")
+        #     # self.log.error(f"sec {host.os.kernel_security['description']}")
+        #     lsm_to_host[host.os.kernel_security['description']] = hostname
+        #     # self.log.error(f"{host.os.subscribed}")
+        #     subscribed[host.os.subscribed].append(hostname)
+
+        #     interfaces = host.os.interfaces
+        #     for name in interfaces:
+        #         if name in ['lo']:
+        #             continue
+        #         self._update_subnet_lookups(hostname, name, interfaces[name])
+
+        #     roles: Set[str] = set()
+        #     # for d in host.daemons:
+        #     #     roles.add(self.role_from_name(d['name'])
+        #     #     if not d['enabled']:
+        #     #         unit_name=d['systemd_unit']
+        #     #         disabled_daemons[unit_name]=hostname
+
+        #     host_to_role[hostname] = list(roles)
+
+        # osd_hosts = self.hosts_with_role('osd')
+
+        # # checks
+        # if len(lsm_to_host.keys()) > 1:
+        #     # selinux security policy issue - CEPHADM_CHECK_KERNEL_LSM
+        #     pass
+        # if len(subscribed['Yes']) > 0 and len(subscribed['No']) > 0:
+        #     # inconsistent subscription states - CEPHADM_CHECK_SUBSCRIPTION
+        #     pass
+
+        # # all hosts must have NIC on the public network
+        # all_hosts = set(self.mgr.cache.facts.keys())
+        # for c_net in self.public_network_list:
+        #     subnet_data = self.subnet_lookup.get(c_net, None)
+        #     if subnet_data:
+        #         hosts_in_subnet = set(subnet_data.host_list)
+        #         errors = all_hosts.difference(hosts_in_subnet)
+        #         if errors:
+        #             # CEPHADM_CHECK_PUBLIC_MEMBERSHIP
+        #             self.log.error(f"subnet check for {c_net} found {len(errors)} host(s) missing")
+
+        # # all hosts with the osd role must share a common mtu and speed
+        # osd_network_list = self.cluster_network_list or self.public_network_list
+        # for osd_net in osd_network_list:
+        #     subnet_data = self.subnet_lookup.get(osd_net, None)
+        #     if subnet_data:
+
+        #         # FIXME this feels overly complex
+        #         # what do I want to show as the error?
+        #         for mtu, host_list in subnet_data.mtu_map.items():
+        #             mtu_hosts = set(host_list)
+        #             errors = osd_hosts.difference(mtu_hosts)
+        #             if errors:
+        #                 self.log.error(f"MTU problem {mtu}: {errors}")
+        #                 # CEPHADM_CHECK_MTU
+        #                 pass
+        #         for speed, host_list in subnet_data.speed_map.items():
+        #             speed_hosts = set(host_list)
+        #             errors = osd_hosts.difference(speed_hosts)
+        #             if errors:
+        #                 self.log.error(f"Linkspeed problem {speed} : {errors}")
+        #                 # CEPHADM_CHECK_LINKSPEED
+        #                 pass
+
+        #     else:
+        #         self.log.warning(
+        #             f"Network {osd_net} has been defined, but is not present on any host")
+
+        # # All daemons should be in an enabled state
+        # if disabled_daemons:
+        #     self.log.error("disabled daemons found")
+        #     # CEPHADM_CHECK_DAEMON_DISABLED
+        #     pass
+
+        # self.log.error(f"lsm status {json.dumps(lsm_to_host)}")
+        # self.log.error(f"subscription states : {json.dumps(subscribed)}")
+
+        # self.log.error(f"mtu data : {str(self.subnet_lookup)}")
+        # self.log.error(f"roles : {json.dumps(host_to_role)}")

--- a/src/pybind/mgr/cephadm/configchecks.py
+++ b/src/pybind/mgr/cephadm/configchecks.py
@@ -511,6 +511,9 @@ class CephadmConfigChecks:
                     speed_copy = subnet_data.speed_map.copy()
                     del speed_copy[speed_ptr]
                     for bad_speed in speed_copy:
+                        if bad_speed > speed_ptr:
+                            # skip speed is better than most...it can stay!
+                            continue
                         for h in speed_copy[bad_speed]:
                             host = HostFacts()
                             host.load_facts(self.mgr.cache.facts[h])

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1151,6 +1151,16 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         err, msg = self._update_config_check(check_name, 'disabled')
         if err:
             return HandleCommandResult(retval=err, stderr=f"Failed to disable check '{check_name}': {msg}")
+        else:
+            # drop any outstanding raised healthcheck for this check
+            config_check = self.config_checker.lookup_check(check_name)
+            if config_check:
+                if config_check.healthcheck_name in self.health_checks:
+                    self.health_checks.pop(config_check.healthcheck_name, None)
+                    self.set_health_checks(self.health_checks)
+            else:
+                self.log.error(
+                    f"Unable to resolve a check name ({check_name}) to a healthcheck definition?")
 
         return HandleCommandResult(stdout="ok")
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -315,6 +315,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             default=True,
             desc='Automatically convert image tags to image digest. Make sure all daemons use the same image',
         ),
+        Option(
+            'config_checks_enabled',
+            type='bool',
+            default=False,
+            desc='Enable or disable the cephadm configuration analysis',
+        ),
     ]
 
     def __init__(self, *args: Any, **kwargs: Any):

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -53,6 +53,7 @@ class CephadmServe:
     def __init__(self, mgr: "CephadmOrchestrator"):
         self.mgr: "CephadmOrchestrator" = mgr
         self.log = logger
+        self.config_checker = CephadmConfigChecks(self.mgr)
 
     def serve(self) -> None:
         """
@@ -62,6 +63,8 @@ class CephadmServe:
         of cephadm. This loop will then attempt to apply this new state.
         """
         self.log.debug("serve starting")
+        self.config_checker.load_network_config()
+
         while self.mgr.run:
 
             try:
@@ -182,8 +185,7 @@ class CephadmServe:
 
         refresh(self.mgr.cache.get_hosts())
 
-        checker = CephadmConfigChecks(self.mgr)
-        checker.run_checks()
+        self.config_checker.run_checks()
 
         health_changed = False
         for k in [

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -53,7 +53,6 @@ class CephadmServe:
     def __init__(self, mgr: "CephadmOrchestrator"):
         self.mgr: "CephadmOrchestrator" = mgr
         self.log = logger
-        self.config_checker = CephadmConfigChecks(self.mgr)
 
     def serve(self) -> None:
         """
@@ -63,7 +62,7 @@ class CephadmServe:
         of cephadm. This loop will then attempt to apply this new state.
         """
         self.log.debug("serve starting")
-        self.config_checker.load_network_config()
+        self.mgr.config_checker.load_network_config()
 
         while self.mgr.run:
 
@@ -185,7 +184,7 @@ class CephadmServe:
 
         refresh(self.mgr.cache.get_hosts())
 
-        self.config_checker.run_checks()
+        self.mgr.config_checker.run_checks()
 
         health_changed = False
         for k in [

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -182,6 +182,9 @@ class CephadmServe:
 
         refresh(self.mgr.cache.get_hosts())
 
+        checker = CephadmConfigChecks(self.mgr)
+        checker.run_checks()
+
         health_changed = False
         for k in [
                 'CEPHADM_HOST_CHECK_FAILED',

--- a/src/pybind/mgr/cephadm/tests/test_configchecks.py
+++ b/src/pybind/mgr/cephadm/tests/test_configchecks.py
@@ -310,6 +310,13 @@ class TestConfigCheck:
         assert out
         assert len(out) == len(checker.health_checks)
 
+    def test_lookup_check(self, mgr):
+        checker = CephadmConfigChecks(mgr)
+        check = checker.lookup_check('osd_mtu_size')
+        logger.debug(json.dumps(check.to_json()))
+        assert check
+        assert check.healthcheck_name == "CEPHADM_CHECK_MTU"
+
     def test_old_checks_removed(self, mgr):
         mgr.datastore.update({
             "config_checks": '{"bogus_one": "enabled", "bogus_two": "enabled", '

--- a/src/pybind/mgr/cephadm/tests/test_configchecks.py
+++ b/src/pybind/mgr/cephadm/tests/test_configchecks.py
@@ -1,0 +1,602 @@
+import copy
+import json
+import logging
+import ipaddress
+import pytest
+import uuid
+
+from time import time as now
+
+from ..configchecks import CephadmConfigChecks
+from ..inventory import HostCache
+from ..upgrade import CephadmUpgrade, UpgradeState
+from orchestrator import DaemonDescription
+
+from typing import List, Dict, Any, Optional
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+host_sample = {
+    "arch": "x86_64",
+    "bios_date": "04/01/2014",
+    "bios_version": "F2",
+    "cpu_cores": 16,
+    "cpu_count": 2,
+    "cpu_load": {
+            "15min": 0.0,
+            "1min": 0.01,
+            "5min": 0.01
+    },
+    "cpu_model": "Intel® Xeon® Processor E5-2698 v3",
+    "cpu_threads": 64,
+    "flash_capacity": "4.0TB",
+    "flash_capacity_bytes": 4000797868032,
+    "flash_count": 2,
+    "flash_list": [
+        {
+            "description": "ATA CT2000MX500SSD1 (2.0TB)",
+            "dev_name": "sda",
+            "disk_size_bytes": 2000398934016,
+            "model": "CT2000MX500SSD1",
+            "rev": "023",
+            "vendor": "ATA",
+            "wwid": "t10.ATA     CT2000MX500SSD1                         193023156DE0"
+        },
+        {
+            "description": "ATA CT2000MX500SSD1 (2.0TB)",
+            "dev_name": "sdb",
+            "disk_size_bytes": 2000398934016,
+            "model": "CT2000MX500SSD1",
+            "rev": "023",
+            "vendor": "ATA",
+            "wwid": "t10.ATA     CT2000MX500SSD1                         193023156DE0"
+        },
+    ],
+    "hdd_capacity": "16.0TB",
+    "hdd_capacity_bytes": 16003148120064,
+    "hdd_count": 4,
+    "hdd_list": [
+        {
+                    "description": "ST4000VN008-2DR1 (4.0TB)",
+                    "dev_name": "sdc",
+                    "disk_size_bytes": 4000787030016,
+                    "model": "ST4000VN008-2DR1",
+                    "rev": "SC60",
+                    "vendor": "ATA",
+                    "wwid": "t10.ATA     ST4000VN008-2DR1                                  Z340EPBJ"
+        },
+        {
+            "description": "ST4000VN008-2DR1 (4.0TB)",
+            "dev_name": "sdd",
+            "disk_size_bytes": 4000787030016,
+            "model": "ST4000VN008-2DR1",
+            "rev": "SC60",
+            "vendor": "ATA",
+            "wwid": "t10.ATA     ST4000VN008-2DR1                                  Z340EPBJ"
+        },
+        {
+            "description": "ST4000VN008-2DR1 (4.0TB)",
+            "dev_name": "sde",
+            "disk_size_bytes": 4000787030016,
+            "model": "ST4000VN008-2DR1",
+            "rev": "SC60",
+            "vendor": "ATA",
+            "wwid": "t10.ATA     ST4000VN008-2DR1                                  Z340EPBJ"
+        },
+        {
+            "description": "ST4000VN008-2DR1 (4.0TB)",
+            "dev_name": "sdf",
+            "disk_size_bytes": 4000787030016,
+            "model": "ST4000VN008-2DR1",
+            "rev": "SC60",
+            "vendor": "ATA",
+            "wwid": "t10.ATA     ST4000VN008-2DR1                                  Z340EPBJ"
+        },
+    ],
+    "hostname": "dummy",
+    "interfaces": {
+        "eth0": {
+                "driver": "e1000e",
+                "iftype": "physical",
+                "ipv4_address": "10.7.17.1/24",
+                "ipv6_address": "fe80::215:17ff:feab:50e2/64",
+                "lower_devs_list": [],
+                "mtu": 9000,
+                "nic_type": "ethernet",
+                "operstate": "up",
+                "speed": 1000,
+                "upper_devs_list": [],
+        },
+        "eth1": {
+            "driver": "e1000e",
+            "iftype": "physical",
+            "ipv4_address": "10.7.18.1/24",
+            "ipv6_address": "fe80::215:17ff:feab:50e2/64",
+            "lower_devs_list": [],
+            "mtu": 9000,
+            "nic_type": "ethernet",
+            "operstate": "up",
+            "speed": 1000,
+            "upper_devs_list": [],
+        },
+        "eth2": {
+            "driver": "r8169",
+            "iftype": "physical",
+            "ipv4_address": "10.7.19.1/24",
+            "ipv6_address": "fe80::76d4:35ff:fe58:9a79/64",
+            "lower_devs_list": [],
+            "mtu": 1500,
+            "nic_type": "ethernet",
+            "operstate": "up",
+            "speed": 1000,
+            "upper_devs_list": []
+        },
+    },
+    "kernel": "4.18.0-240.10.1.el8_3.x86_64",
+    "kernel_parameters": {
+        "net.ipv4.ip_nonlocal_bind": "0",
+    },
+    "kernel_security": {
+        "SELINUX": "enforcing",
+        "SELINUXTYPE": "targeted",
+        "description": "SELinux: Enabled(enforcing, targeted)",
+        "type": "SELinux"
+    },
+    "memory_available_kb": 19489212,
+    "memory_free_kb": 245164,
+    "memory_total_kb": 32900916,
+    "model": "StorageHeavy",
+    "nic_count": 3,
+    "operating_system": "Red Hat Enterprise Linux 8.3 (Ootpa)",
+    "subscribed": "Yes",
+    "system_uptime": 777600.0,
+    "timestamp": now(),
+    "vendor": "Ceph Servers Inc",
+}
+
+
+def role_list(n: int) -> List[str]:
+    if n == 1:
+        return ['mon', 'mgr', 'osd']
+    if n in [2, 3]:
+        return ['mon', 'mds', 'osd']
+
+    return ['osd']
+
+
+def generate_testdata(count: int = 10, public_network: str = '10.7.17.0/24', cluster_network: str = '10.7.18.0/24'):
+    # public network = eth0, cluster_network = eth1
+    assert count > 3
+    assert public_network
+    num_disks = host_sample['hdd_count']
+    hosts = {}
+    daemons = {}
+    daemon_to_host = {}
+    osd_num = 0
+    public_netmask = public_network.split('/')[1]
+    cluster_ip_list = []
+    cluster_netmask = ''
+
+    public_ip_list = [str(i) for i in list(ipaddress.ip_network(public_network).hosts())]
+    if cluster_network:
+        cluster_ip_list = [str(i) for i in list(ipaddress.ip_network(cluster_network).hosts())]
+        cluster_netmask = cluster_network.split('/')[1]
+
+    for n in range(1, count + 1, 1):
+
+        new_host = copy.deepcopy(host_sample)
+        hostname = f"node-{n}.ceph.com"
+
+        new_host['hostname'] = hostname
+        new_host['interfaces']['eth0']['ipv4_address'] = f"{public_ip_list.pop(0)}/{public_netmask}"
+        if cluster_ip_list:
+            new_host['interfaces']['eth1']['ipv4_address'] = f"{cluster_ip_list.pop(0)}/{cluster_netmask}"
+        else:
+            new_host['interfaces']['eth1']['ipv4_address'] = ''
+
+        hosts[hostname] = new_host
+        daemons[hostname] = {}
+        for r in role_list(n):
+            name = ''
+            if r == 'osd':
+                for n in range(num_disks):
+                    osd = DaemonDescription(
+                        hostname=hostname, daemon_type='osd', daemon_id=osd_num)
+                    name = f"osd.{osd_num}"
+                    daemons[hostname][name] = osd
+                    daemon_to_host[name] = hostname
+                    osd_num += 1
+            else:
+                name = f"{r}.{hostname}"
+                daemons[hostname][name] = DaemonDescription(
+                    hostname=hostname, daemon_type=r, daemon_id=hostname)
+                daemon_to_host[name] = hostname
+
+    logger.debug(f"daemon to host lookup - {json.dumps(daemon_to_host)}")
+    return hosts, daemons, daemon_to_host
+
+
+@pytest.fixture()
+def mgr():
+    """Provide a fake ceph mgr object preloaded with a configuration"""
+    mgr = FakeMgr()
+    mgr.cache.facts, mgr.cache.daemons, mgr.daemon_to_host = \
+        generate_testdata(public_network='10.9.64.0/24', cluster_network='')
+    mgr.module_option.update({
+        "config_checks_enabled": 'true',
+    })
+    yield mgr
+
+
+class FakeMgr:
+
+    def __init__(self):
+        self.datastore = {}
+        self.module_option = {}
+        self.health_checks = {}
+        self.default_version = 'quincy'
+        self.version_overrides = {}
+        self.daemon_to_host = {}
+
+        self.cache = HostCache(self)
+        self.upgrade = CephadmUpgrade(self)
+
+    def set_health_checks(self, checks: dict):
+        return
+
+    def get_module_option(self, keyname: str) -> Optional[str]:
+        return self.module_option.get(keyname, None)
+
+    def set_module_option(self, keyname: str, value: str) -> None:
+        return None
+
+    def get_store(self, keyname: str, default=None) -> Optional[str]:
+        return self.datastore.get(keyname, None)
+
+    def set_store(self, keyname: str, value: str) -> None:
+        return None
+
+    def _ceph_get_server(self) -> None:
+        pass
+
+    def get_metadata(self, daemon_type: str, daemon_id: str) -> Dict[str, Any]:
+        key = f"{daemon_type}.{daemon_id}"
+        if key in self.version_overrides:
+            logger.debug(f"override applied for {key}")
+            version_str = self.version_overrides[key]
+        else:
+            version_str = self.default_version
+
+        return {"ceph_release": version_str, "hostname": self.daemon_to_host[key]}
+
+    def list_servers(self) -> List[Dict[str, List[Dict[str, str]]]]:
+        num_disks = host_sample['hdd_count']
+        osd_num = 0
+        service_map = []
+
+        for hostname in self.cache.facts:
+
+            host_num = int(hostname.split('.')[0].split('-')[1])
+            svc_list = []
+            for r in role_list(host_num):
+                if r == 'osd':
+                    for _n in range(num_disks):
+                        svc_list.append({
+                            "type": "osd",
+                            "id": osd_num,
+                        })
+                        osd_num += 1
+                else:
+                    svc_list.append({
+                        "type": r,
+                        "id": hostname,
+                    })
+
+            service_map.append({"services": svc_list})
+        logger.debug(f"services map - {json.dumps(service_map)}")
+        return service_map
+
+    def use_repo_digest(self) -> None:
+        return None
+
+
+class TestConfigCheck:
+
+    def test_no_issues(self, mgr):
+        checker = CephadmConfigChecks(mgr)
+        checker.cluster_network_list = []
+        checker.public_network_list = ['10.9.64.0/24']
+        checker.run_checks()
+
+        assert not mgr.health_checks
+
+    def test_missing_networks(self, mgr):
+
+        checker = CephadmConfigChecks(mgr)
+        checker.cluster_network_list = []
+        checker.public_network_list = ['10.9.66.0/24']
+        checker.run_checks()
+
+        logger.info(json.dumps(mgr.health_checks))
+        logger.info(checker.subnet_lookup)
+        assert len(mgr.health_checks) == 1
+        assert 'CEPHADM_CHECK_NETWORK_MISSING' in mgr.health_checks
+        assert mgr.health_checks['CEPHADM_CHECK_NETWORK_MISSING']['detail'][0] == \
+            "10.9.66.0/24 not found on any host in the cluster"
+
+    def test_bad_mtu_single(self, mgr):
+
+        bad_node = mgr.cache.facts['node-1.ceph.com']
+        bad_node['interfaces']['eth0']['mtu'] = 1500
+
+        checker = CephadmConfigChecks(mgr)
+        checker.cluster_network_list = []
+        checker.public_network_list = ['10.9.64.0/24']
+
+        checker.run_checks()
+        logger.info(json.dumps(mgr.health_checks))
+        logger.info(checker.subnet_lookup)
+        assert "CEPHADM_CHECK_MTU" in mgr.health_checks and len(mgr.health_checks) == 1
+        assert mgr.health_checks['CEPHADM_CHECK_MTU']['detail'][0] == \
+            'host node-1.ceph.com(eth0) is using MTU 1500 on 10.9.64.0/24, NICs on other hosts use 9000'
+
+    def test_bad_mtu_multiple(self, mgr):
+
+        for n in [1, 5]:
+            bad_node = mgr.cache.facts[f'node-{n}.ceph.com']
+            bad_node['interfaces']['eth0']['mtu'] = 1500
+
+        checker = CephadmConfigChecks(mgr)
+        checker.cluster_network_list = []
+        checker.public_network_list = ['10.9.64.0/24']
+
+        checker.run_checks()
+        logger.info(json.dumps(mgr.health_checks))
+        logger.info(checker.subnet_lookup)
+        assert "CEPHADM_CHECK_MTU" in mgr.health_checks and len(mgr.health_checks) == 1
+        assert mgr.health_checks['CEPHADM_CHECK_MTU']['count'] == 2
+
+    def test_bad_linkspeed_single(self, mgr):
+
+        bad_node = mgr.cache.facts['node-1.ceph.com']
+        bad_node['interfaces']['eth0']['speed'] = 100
+
+        checker = CephadmConfigChecks(mgr)
+        checker.cluster_network_list = []
+        checker.public_network_list = ['10.9.64.0/24']
+
+        checker.run_checks()
+        logger.info(json.dumps(mgr.health_checks))
+        logger.info(checker.subnet_lookup)
+        assert mgr.health_checks
+        assert "CEPHADM_CHECK_LINKSPEED" in mgr.health_checks and len(mgr.health_checks) == 1
+        assert mgr.health_checks['CEPHADM_CHECK_LINKSPEED']['detail'][0] == \
+            'host node-1.ceph.com(eth0) has linkspeed of 100 on 10.9.64.0/24, NICs on other hosts use 1000'
+
+    def test_release_mismatch_single(self, mgr):
+
+        mgr.version_overrides = {
+            "osd.1": "pacific",
+        }
+
+        checker = CephadmConfigChecks(mgr)
+        checker.cluster_network_list = []
+        checker.public_network_list = ['10.9.64.0/24']
+
+        checker.run_checks()
+        logger.info(json.dumps(mgr.health_checks))
+        assert mgr.health_checks
+        assert "CEPHADM_CHECK_CEPH_RELEASE" in mgr.health_checks and len(mgr.health_checks) == 1
+        assert mgr.health_checks['CEPHADM_CHECK_CEPH_RELEASE']['detail'][0] == \
+            'osd.1 is running pacific (majority of cluster is using quincy)'
+
+    def test_release_mismatch_multi(self, mgr):
+
+        mgr.version_overrides = {
+            "osd.1": "pacific",
+            "osd.5": "octopus",
+        }
+
+        checker = CephadmConfigChecks(mgr)
+        checker.cluster_network_list = []
+        checker.public_network_list = ['10.9.64.0/24']
+
+        checker.run_checks()
+        logger.info(json.dumps(mgr.health_checks))
+        assert mgr.health_checks
+        assert "CEPHADM_CHECK_CEPH_RELEASE" in mgr.health_checks and len(mgr.health_checks) == 1
+        assert len(mgr.health_checks['CEPHADM_CHECK_CEPH_RELEASE']['detail']) == 2
+
+    def test_kernel_mismatch(self, mgr):
+
+        bad_host = mgr.cache.facts['node-1.ceph.com']
+        bad_host['kernel'] = "5.10.18.0-241.10.1.el8.x86_64"
+
+        checker = CephadmConfigChecks(mgr)
+        checker.cluster_network_list = []
+        checker.public_network_list = ['10.9.64.0/24']
+
+        checker.run_checks()
+        logger.info(json.dumps(mgr.health_checks))
+        assert len(mgr.health_checks) == 1
+        assert 'CEPHADM_CHECK_KERNEL_VERSION' in mgr.health_checks
+        assert mgr.health_checks['CEPHADM_CHECK_KERNEL_VERSION']['detail'][0] == \
+            "host node-1.ceph.com running kernel 5.10, majority of hosts(9) running 4.18"
+        assert mgr.health_checks['CEPHADM_CHECK_KERNEL_VERSION']['count'] == 1
+
+    def test_inconsistent_subscription(self, mgr):
+
+        bad_host = mgr.cache.facts['node-5.ceph.com']
+        bad_host['subscribed'] = "no"
+
+        checker = CephadmConfigChecks(mgr)
+        checker.cluster_network_list = []
+        checker.public_network_list = ['10.9.64.0/24']
+
+        checker.run_checks()
+        logger.info(json.dumps(mgr.health_checks))
+        assert len(mgr.health_checks) == 1
+        assert "CEPHADM_CHECK_SUBSCRIPTION" in mgr.health_checks
+        assert mgr.health_checks['CEPHADM_CHECK_SUBSCRIPTION']['detail'][0] == \
+            "node-5.ceph.com does not have an active subscription"
+
+    def test_kernel_security_inconsistent(self, mgr):
+
+        bad_node = mgr.cache.facts['node-3.ceph.com']
+        bad_node['kernel_security'] = {
+            "SELINUX": "permissive",
+            "SELINUXTYPE": "targeted",
+            "description": "SELinux: Enabled(permissive, targeted)",
+            "type": "SELinux"
+        }
+        checker = CephadmConfigChecks(mgr)
+        checker.cluster_network_list = []
+        checker.public_network_list = ['10.9.64.0/24']
+
+        checker.run_checks()
+        logger.info(json.dumps(mgr.health_checks))
+        assert len(mgr.health_checks) == 1
+        assert 'CEPHADM_CHECK_KERNEL_LSM' in mgr.health_checks
+        assert mgr.health_checks['CEPHADM_CHECK_KERNEL_LSM']['detail'][0] == \
+            "node-3.ceph.com has inconsistent KSM settings compared to the majority of hosts(9) in the cluster"
+
+    def test_release_and_bad_mtu(self, mgr):
+
+        mgr.version_overrides = {
+            "osd.1": "pacific",
+        }
+        bad_node = mgr.cache.facts['node-1.ceph.com']
+        bad_node['interfaces']['eth0']['mtu'] = 1500
+
+        checker = CephadmConfigChecks(mgr)
+        checker.cluster_network_list = []
+        checker.public_network_list = ['10.9.64.0/24']
+
+        checker.run_checks()
+        logger.info(json.dumps(mgr.health_checks))
+        logger.info(checker.subnet_lookup)
+        assert mgr.health_checks
+        assert len(mgr.health_checks) == 2
+        assert "CEPHADM_CHECK_CEPH_RELEASE" in mgr.health_checks and \
+            "CEPHADM_CHECK_MTU" in mgr.health_checks
+
+    def test_release_mtu_LSM(self, mgr):
+
+        mgr.version_overrides = {
+            "osd.1": "pacific",
+        }
+        bad_node1 = mgr.cache.facts['node-1.ceph.com']
+        bad_node1['interfaces']['eth0']['mtu'] = 1500
+        bad_node2 = mgr.cache.facts['node-3.ceph.com']
+        bad_node2['kernel_security'] = {
+            "SELINUX": "permissive",
+            "SELINUXTYPE": "targeted",
+            "description": "SELinux: Enabled(permissive, targeted)",
+            "type": "SELinux"
+        }
+        checker = CephadmConfigChecks(mgr)
+        checker.cluster_network_list = []
+        checker.public_network_list = ['10.9.64.0/24']
+
+        checker.run_checks()
+        logger.info(json.dumps(mgr.health_checks))
+        logger.info(checker.subnet_lookup)
+        assert mgr.health_checks
+        assert len(mgr.health_checks) == 3
+        assert \
+            "CEPHADM_CHECK_CEPH_RELEASE" in mgr.health_checks and \
+            "CEPHADM_CHECK_MTU" in mgr.health_checks and \
+            "CEPHADM_CHECK_KERNEL_LSM" in mgr.health_checks
+
+    def test_release_mtu_LSM_subscription(self, mgr):
+
+        mgr.version_overrides = {
+            "osd.1": "pacific",
+        }
+        bad_node1 = mgr.cache.facts['node-1.ceph.com']
+        bad_node1['interfaces']['eth0']['mtu'] = 1500
+        bad_node1['subscribed'] = "no"
+        bad_node2 = mgr.cache.facts['node-3.ceph.com']
+        bad_node2['kernel_security'] = {
+            "SELINUX": "permissive",
+            "SELINUXTYPE": "targeted",
+            "description": "SELinux: Enabled(permissive, targeted)",
+            "type": "SELinux"
+        }
+        checker = CephadmConfigChecks(mgr)
+        checker.cluster_network_list = []
+        checker.public_network_list = ['10.9.64.0/24']
+
+        checker.run_checks()
+        logger.info(json.dumps(mgr.health_checks))
+        logger.info(checker.subnet_lookup)
+        assert mgr.health_checks
+        assert len(mgr.health_checks) == 4
+        assert \
+            "CEPHADM_CHECK_CEPH_RELEASE" in mgr.health_checks and \
+            "CEPHADM_CHECK_MTU" in mgr.health_checks and \
+            "CEPHADM_CHECK_KERNEL_LSM" in mgr.health_checks and \
+            "CEPHADM_CHECK_SUBSCRIPTION" in mgr.health_checks
+
+    def test_skip_release_during_upgrade(self, mgr):
+        mgr.upgrade.upgrade_state = UpgradeState.from_json({
+            'target_name': 'wah',
+            'progress_id': str(uuid.uuid4()),
+            'target_id': 'wah',
+            'error': '',
+            'paused': False,
+        })
+        checker = CephadmConfigChecks(mgr)
+        checker.cluster_network_list = []
+        checker.public_network_list = ['10.9.64.0/24']
+
+        checker.run_checks()
+        logger.info(f"{checker.skipped_checks_count} skipped check(s): {checker.skipped_checks}")
+        assert checker.skipped_checks_count == 1
+        assert 'ceph_release' in checker.skipped_checks
+
+    def test_skip_when_disabled(self, mgr):
+        mgr.module_option.update({
+            "config_checks_enabled": "false"
+        })
+        checker = CephadmConfigChecks(mgr)
+        checker.cluster_network_list = []
+        checker.public_network_list = ['10.9.64.0/24']
+
+        checker.run_checks()
+        logger.info(checker.active_checks)
+        logger.info(checker.defined_checks)
+        assert checker.active_checks_count == 0
+
+    def test_skip_mtu_checks(self, mgr):
+        mgr.datastore.update({
+            'config_checks': '{"osd_mtu_size": "disabled"}'
+        })
+
+        checker = CephadmConfigChecks(mgr)
+        checker.cluster_network_list = []
+        checker.public_network_list = ['10.9.64.0/24']
+
+        checker.run_checks()
+        logger.info(checker.active_checks)
+        logger.info(checker.defined_checks)
+        assert 'osd_mtu_size' not in checker.active_checks
+        assert checker.defined_checks == 8 and checker.active_checks_count == 7
+
+    def test_skip_mtu_lsm_checks(self, mgr):
+        mgr.datastore.update({
+            'config_checks': '{"osd_mtu_size": "disabled", "kernel_security": "disabled"}'
+        })
+
+        checker = CephadmConfigChecks(mgr)
+        checker.cluster_network_list = []
+        checker.public_network_list = ['10.9.64.0/24']
+
+        checker.run_checks()
+        logger.info(checker.active_checks)
+        logger.info(checker.defined_checks)
+        assert 'osd_mtu_size' not in checker.active_checks and \
+            'kernel_security' not in checker.active_checks
+        assert checker.defined_checks == 8 and checker.active_checks_count == 6
+        assert not mgr.health_checks

--- a/src/pybind/mgr/cephadm/tests/test_configchecks.py
+++ b/src/pybind/mgr/cephadm/tests/test_configchecks.py
@@ -343,6 +343,19 @@ class TestConfigCheck:
 
         assert not mgr.health_checks
 
+    def test_no_public_network(self, mgr):
+        bad_node = mgr.cache.facts['node-1.ceph.com']
+        bad_node['interfaces']['eth0']['ipv4_address'] = "192.168.1.20/24"
+        checker = CephadmConfigChecks(mgr)
+        checker.cluster_network_list = []
+        checker.public_network_list = ['10.9.64.0/24']
+        checker.run_checks()
+        logger.debug(mgr.health_checks)
+        assert len(mgr.health_checks) == 1
+        assert 'CEPHADM_CHECK_PUBLIC_MEMBERSHIP' in mgr.health_checks
+        assert mgr.health_checks['CEPHADM_CHECK_PUBLIC_MEMBERSHIP']['detail'][0] == \
+            'node-1.ceph.com does not have an interface on any public network'
+
     def test_missing_networks(self, mgr):
 
         checker = CephadmConfigChecks(mgr)

--- a/src/pybind/mgr/cephadm/tests/test_configchecks.py
+++ b/src/pybind/mgr/cephadm/tests/test_configchecks.py
@@ -419,6 +419,20 @@ class TestConfigCheck:
         assert mgr.health_checks['CEPHADM_CHECK_LINKSPEED']['detail'][0] == \
             'host node-1.ceph.com(eth0) has linkspeed of 100 on 10.9.64.0/24, NICs on other hosts use 1000'
 
+    def test_super_linkspeed_single(self, mgr):
+
+        bad_node = mgr.cache.facts['node-1.ceph.com']
+        bad_node['interfaces']['eth0']['speed'] = 10000
+
+        checker = CephadmConfigChecks(mgr)
+        checker.cluster_network_list = []
+        checker.public_network_list = ['10.9.64.0/24']
+
+        checker.run_checks()
+        logger.info(json.dumps(mgr.health_checks))
+        logger.info(checker.subnet_lookup)
+        assert not mgr.health_checks
+
     def test_release_mismatch_single(self, mgr):
 
         mgr.version_overrides = {


### PR DESCRIPTION
This PR provides a new feature to cephadm, enabling it to actively look for configuration anomalies within the configuration of the clusters hosts and daemons. This initial implementation provides 8 checks that are executed during each 'reconcile' with any issues resulting in ceph health checks. Each check can be independently disabled via new commands that have been added:
<pre>
ceph cephadm config-check status
ceph cephadm config-check ls
ceph cephadm config-check enable &lt;check_name&gt;
ceph cephadm config-check disable &lt;check_name&gt;
</pre>
Signed-off-by: Paul Cuzner <pcuzner@redhat.com>
