### PR TITLE
mgr/devicehealth: silence flake8 warnings

### DIFF
--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -25,7 +25,7 @@ HEALTH_MESSAGES = {
 MAX_SAMPLES = 500
 
 
-def get_ata_wear_level(data: Dict[Any,Any]) -> Optional[float]:
+def get_ata_wear_level(data: Dict[Any, Any]) -> Optional[float]:
     """
     Extract wear level (as float) from smartctl -x --json output for SATA SSD
     """
@@ -38,7 +38,7 @@ def get_ata_wear_level(data: Dict[Any,Any]) -> Optional[float]:
     return None
 
 
-def get_nvme_wear_level(data: Dict[Any,Any]) -> Optional[float]:
+def get_nvme_wear_level(data: Dict[Any, Any]) -> Optional[float]:
     """
     Extract wear level (as float) from smartctl -x --json output for NVME SSD
     """


### PR DESCRIPTION
turns out 4840507cfcdd5182003671994d0bc9604d072e3e was racing with
99805d9cff87f7fe264bbadc235cb8cc311fd460. so we failed to identify this
before merging the former.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
