### PR TITLE
doc/dev: t5logy: rewrite "suites inventory"

### DIFF
--- a/doc/dev/developer_guide/testing_integration_tests/tests-integration-testing-teuthology-intro.rst
+++ b/doc/dev/developer_guide/testing_integration_tests/tests-integration-testing-teuthology-intro.rst
@@ -96,50 +96,55 @@ Suites Inventory
 The ``suites`` directory of the `ceph/qa sub-directory`_ contains all the
 integration tests for all the Ceph components.
 
-`ceph-deploy <https://github.com/ceph/ceph/tree/master/qa/suites/ceph-deploy>`_
-  install a Ceph cluster with ``ceph-deploy`` (`ceph-deploy man page`_)
+.. list-table:: **Suites**
 
-`dummy <https://github.com/ceph/ceph/tree/master/qa/suites/dummy>`_
-  get a machine, do nothing and return success (commonly used to
-  verify that the integration testing infrastructure works as expected)
+  * - **Component**
+    - **Function**
 
-`fs <https://github.com/ceph/ceph/tree/master/qa/suites/fs>`_
-  test CephFS mounted using FUSE
+  * - `ceph-deploy <https://github.com/ceph/ceph/tree/master/qa/suites/ceph-deploy>`_
+    - install a Ceph cluster with ``ceph-deploy`` (`ceph-deploy man page`_)
 
-`kcephfs <https://github.com/ceph/ceph/tree/master/qa/suites/kcephfs>`_
-  test CephFS mounted using kernel
+  * - `dummy <https://github.com/ceph/ceph/tree/master/qa/suites/dummy>`_
+    - get a machine, do nothing and return success (commonly used to verify
+      that the integration testing infrastructure works as expected)
 
-`krbd <https://github.com/ceph/ceph/tree/master/qa/suites/krbd>`_
-  test the RBD kernel module
+  * - `fs <https://github.com/ceph/ceph/tree/master/qa/suites/fs>`_
+    - test CephFS mounted using FUSE
 
-`multimds <https://github.com/ceph/ceph/tree/master/qa/suites/multimds>`_
-  test CephFS with multiple MDSs
+  * - `kcephfs <https://github.com/ceph/ceph/tree/master/qa/suites/kcephfs>`_
+    - test CephFS mounted using kernel
 
-`powercycle <https://github.com/ceph/ceph/tree/master/qa/suites/powercycle>`_
-  verify the Ceph cluster behaves when machines are powered off
-  and on again
+  * - `krbd <https://github.com/ceph/ceph/tree/master/qa/suites/krbd>`_
+    - test the RBD kernel module
 
-`rados <https://github.com/ceph/ceph/tree/master/qa/suites/rados>`_
-  run Ceph clusters including OSDs and MONs, under various conditions of
-  stress
+  * - `multimds <https://github.com/ceph/ceph/tree/master/qa/suites/multimds>`_
+    - test CephFS with multiple MDSs
 
-`rbd <https://github.com/ceph/ceph/tree/master/qa/suites/rbd>`_
-  run RBD tests using actual Ceph clusters, with and without qemu
+  * - `powercycle <https://github.com/ceph/ceph/tree/master/qa/suites/powercycle>`_
+    - verify the Ceph cluster behaves when machines are powered off and on
+      again
 
-`rgw <https://github.com/ceph/ceph/tree/master/qa/suites/rgw>`_
-  run RGW tests using actual Ceph clusters
+  * - `rados <https://github.com/ceph/ceph/tree/master/qa/suites/rados>`_
+    - run Ceph clusters including OSDs and MONs, under various conditions of
+      stress
 
-`smoke <https://github.com/ceph/ceph/tree/master/qa/suites/smoke>`_
-  run tests that exercise the Ceph API with an actual Ceph cluster
+  * - `rbd <https://github.com/ceph/ceph/tree/master/qa/suites/rbd>`_
+    - run RBD tests using actual Ceph clusters, with and without qemu
 
-`teuthology <https://github.com/ceph/ceph/tree/master/qa/suites/teuthology>`_
-  verify that teuthology can run integration tests, with and without OpenStack
+  * - `rgw <https://github.com/ceph/ceph/tree/master/qa/suites/rgw>`_
+    - run RGW tests using actual Ceph clusters
 
-`upgrade <https://github.com/ceph/ceph/tree/master/qa/suites/upgrade>`_
-  for various versions of Ceph, verify that upgrades can happen
-  without disrupting an ongoing workload
+  * - `smoke <https://github.com/ceph/ceph/tree/master/qa/suites/smoke>`_
+    - run tests that exercise the Ceph API with an actual Ceph cluster
 
-`ceph-deploy man page`_
+  * - `teuthology <https://github.com/ceph/ceph/tree/master/qa/suites/teuthology>`_ 
+    - verify that teuthology can run integration tests, with and without OpenStack
+
+  * - `upgrade <https://github.com/ceph/ceph/tree/master/qa/suites/upgrade>`_
+    - for various versions of Ceph, verify that upgrades can happen without disrupting an ongoing workload
+
+  * - `ceph-deploy man page`_
+    - Exactly what it says on the tin.
 
 teuthology-describe
 -------------------


### PR DESCRIPTION
This really just re-organizes this information into
a table. I think tables are easier to read than what
was here before.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
