### PR TITLE
rpm: openSUSE Tumbleweed has lua54 now

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -89,7 +89,7 @@
 # SLE does not support luarocks
 %bcond_with lua_packages
 %else
-%global luarocks_package_name lua53-luarocks
+%global luarocks_package_name lua54-luarocks
 %bcond_without lua_packages
 %endif
 %else


### PR DESCRIPTION
Until someone figures out an easier way, we are stuck with the minor Lua version
in the package names.

Signed-off-by: Nathan Cutler <ncutler@suse.com>
