### PR TITLE
doc/dev: t7gy s/Priority/N/

### DIFF
--- a/doc/dev/developer_guide/testing_integration_tests/tests-integration-testing-teuthology-intro.rst
+++ b/doc/dev/developer_guide/testing_integration_tests/tests-integration-testing-teuthology-intro.rst
@@ -63,23 +63,23 @@ Select your job's priority (the value of ``N``) in accordance with the following
 
    * - Priority
      - Explanation
-   * - **Priority < 10**
+   * - **N < 10**
      - Use this if the sky is falling and some group of tests must be run ASAP.
-   * - **10 <= Priority < 50**
+   * - **10 <= N < 50**
      - Use this if your tests are urgent and blocking other important
        development.
-   * - **50 <= Priority < 75**
+   * - **50 <= N < 75**
      - Use this if you are testing a particular feature/fix and running fewer
        than about 25 jobs. This range is also used for urgent release testing.
-   * - **75 <= Priority < 100**
+   * - **75 <= N < 100**
      - Tech Leads regularly schedule integration tests with this priority to
        verify pull requests against master.
-   * - **100 <= Priority < 150**
+   * - **100 <= N < 150**
      - This priority is used for QE validation of point releases.
-   * - **150 <= Priority < 200**
+   * - **150 <= N < 200**
      - Use this priority for 100 jobs or fewer that test a particular feature
        or fix.  Results are available in about 24 hours.
-   * - **200 <= Priority < 1000**
+   * - **200 <= N < 1000**
      - Use this priority for large test runs.  Results are available in about a
        week.
 


### PR DESCRIPTION
"N" just looks better in this table than does
"Priority". I've been thinking about this all
day, and I just decided to make this change.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
