### PR TITLE
doc/rados: avoid including cephadm into the toctree

### DIFF
--- a/doc/rados/index.rst
+++ b/doc/rados/index.rst
@@ -23,14 +23,12 @@ and write data to the Ceph Storage Cluster.
 
       Ceph Storage Clusters have a few required settings, but most configuration
       settings have default values. A typical deployment uses a deployment tool
-      to define a cluster and bootstrap a monitor. See `Deployment`_ for details
-      on ``cephadm.``
+      to define a cluster and bootstrap a monitor. See :ref:`cephadm` for details.
 
       .. toctree::
          :maxdepth: 2
 
          Configuration <configuration/index>
-         Deployment <../cephadm/index>
 
    .. container:: column
 


### PR DESCRIPTION
Otherwise cephadm will be also included in the doc/rados toctree

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

## Old toctree:

![image](https://user-images.githubusercontent.com/2574405/108399100-101d3d80-721a-11eb-9b96-cc7281cfbe0b.png)



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
