### PR TITLE
qa: use normal build for valgrind

### DIFF
--- a/qa/suites/fs/verify/validater/valgrind.yaml
+++ b/qa/suites/fs/verify/validater/valgrind.yaml
@@ -4,7 +4,6 @@
 overrides:
   install:
     ceph:
-      flavor: notcmalloc
       debuginfo: true
   ceph:
     # Valgrind makes everything slow, so ignore slow requests and extend heartbeat grace

--- a/qa/suites/rados/valgrind-leaks/1-start.yaml
+++ b/qa/suites/rados/valgrind-leaks/1-start.yaml
@@ -6,7 +6,6 @@ openstack:
 overrides:
   install:
     ceph:
-      flavor: notcmalloc
       debuginfo: true
   ceph:
     log-ignorelist:

--- a/qa/suites/rados/verify/validater/valgrind.yaml
+++ b/qa/suites/rados/verify/validater/valgrind.yaml
@@ -4,7 +4,6 @@ os_type: centos
 overrides:
   install:
     ceph:
-      flavor: notcmalloc
       debuginfo: true
   ceph:
     conf:

--- a/qa/suites/rbd/valgrind/validator/memcheck.yaml
+++ b/qa/suites/rbd/valgrind/validator/memcheck.yaml
@@ -4,7 +4,6 @@ os_type: centos
 overrides:
   install:
     ceph:
-      flavor: notcmalloc
       debuginfo: true
   rbd_fsx:
     valgrind: ["--tool=memcheck"]

--- a/qa/suites/rgw/multisite/valgrind.yaml
+++ b/qa/suites/rgw/multisite/valgrind.yaml
@@ -6,7 +6,6 @@ os_type: ubuntu
 overrides:
   install:
     ceph:
-#      flavor: notcmalloc
   ceph:
     conf:
       global:

--- a/qa/suites/rgw/sts/tasks/0-install.yaml
+++ b/qa/suites/rgw/sts/tasks/0-install.yaml
@@ -3,7 +3,6 @@ os_type: centos
 
 tasks:
 - install:
-#    flavor: notcmalloc
 - ceph:
 - openssl_keys:
 - rgw:

--- a/qa/suites/rgw/verify/validater/valgrind.yaml
+++ b/qa/suites/rgw/verify/validater/valgrind.yaml
@@ -5,7 +5,6 @@ os_version: "8.0"
 overrides:
   install:
     ceph:
-      flavor: notcmalloc
       #debuginfo: true
   rgw:
     client.0:

--- a/qa/suites/rgw/website/overrides.yaml
+++ b/qa/suites/rgw/website/overrides.yaml
@@ -4,7 +4,6 @@
 
 overrides:
   install:
-#    flavor: notcmalloc
   ceph:
     conf:
       global:

--- a/qa/valgrind.supp
+++ b/qa/valgrind.supp
@@ -1,3 +1,11 @@
+
+{
+   <allthefrees, so we can behave with tcmalloc>
+   Memcheck:Free
+   fun:free
+   ...
+}
+
 {
    older boost mersenne twister uses uninitialized memory for randomness
    Memcheck:Cond


### PR DESCRIPTION
With some extra valgrind args we can use the tcmalloc-linked binaries!  The tradeoff is we have to whitelist any memcheck errors with free(), since tcmalloc causes the delete vs delete[] error due to some internal optimizations (see https://github.com/gperftools/gperftools/issues/792).

Depends on https://github.com/ceph/teuthology/pull/1618