### PR TITLE
cephadm: version command hide traceback when login is needed

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3077,9 +3077,11 @@ class CephContainer:
 @infer_image
 def command_version(ctx):
     # type: (CephadmContext) -> int
-    out = CephContainer(ctx, ctx.image, 'ceph', ['--version']).run()
-    print(out.strip())
-    return 0
+    c = CephContainer(ctx, ctx.image, 'ceph', ['--version'])
+    out, err, ret = call(ctx, c.run_cmd(), desc=c.entrypoint)
+    if not ret:
+        print(out.strip())
+    return ret
 
 ##################################
 


### PR DESCRIPTION
if image comes from a authenticated registry and login has not been done yet the traceback should be hidden and only show the error message

traceback shown before
![image](https://user-images.githubusercontent.com/22037319/108435166-e6164c00-7216-11eb-8af4-61c82be04be6.png)

after no traceback
![image](https://user-images.githubusercontent.com/22037319/108435185-f4fcfe80-7216-11eb-87aa-a422864220da.png)

Fixes: https://tracker.ceph.com/issues/49366
Signed-off-by: Daniel Pivonka <dpivonka@redhat.com>