### PR TITLE
test/osd: Use get_data() to simplify calls

### DIFF
--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -1929,17 +1929,17 @@ TEST_F(OSDMapTest, BUG_48884)
     JSONParser parser2;
     parser2.parse(bucket.c_str(), static_cast<int>(bucket.size()));
     auto* obj = parser2.find_obj("name");
-    if (obj->get_data_val().str.compare("localrack") == 0) {
+    if (obj->get_data().compare("localrack") == 0) {
       obj = parser2.find_obj("kb");
-      ASSERT_EQ(obj->get_data_val().str, "3904");
+      ASSERT_EQ(obj->get_data(), "3904");
       obj = parser2.find_obj("kb_used");
-      ASSERT_EQ(obj->get_data_val().str, "3512");
+      ASSERT_EQ(obj->get_data(), "3512");
       obj = parser2.find_obj("kb_used_omap");
-      ASSERT_EQ(obj->get_data_val().str, "384");
+      ASSERT_EQ(obj->get_data(), "384");
       obj = parser2.find_obj("kb_used_meta");
-      ASSERT_EQ(obj->get_data_val().str, "384");
+      ASSERT_EQ(obj->get_data(), "384");
       obj = parser2.find_obj("kb_avail");
-      ASSERT_EQ(obj->get_data_val().str, "384");
+      ASSERT_EQ(obj->get_data(), "384");
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
