### PR TITLE
cmake: build static libs if they are internal ones

### DIFF
--- a/src/blk/CMakeLists.txt
+++ b/src/blk/CMakeLists.txt
@@ -25,7 +25,7 @@ if(WITH_ZBD)
     zoned/HMSMRDevice.cc)
 endif()
 
-add_library(blk ${libblk_srcs})
+add_library(blk STATIC ${libblk_srcs})
 target_include_directories(blk PRIVATE "./")
 
 if(HAVE_LIBAIO)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -213,7 +213,7 @@ elseif(HAVE_ARMV8_CRC)
     crc32c_aarch64.c)
 endif(HAVE_INTEL)
 
-add_library(crc32 ${crc32_srcs})
+add_library(crc32 STATIC ${crc32_srcs})
 if(HAVE_ARMV8_CRC)
   set_target_properties(crc32 PROPERTIES
     COMPILE_FLAGS "${CMAKE_C_FLAGS} ${ARMV8_CRC_COMPILE_FLAGS}")


### PR DESCRIPTION
there are chances that user or build script set `BUILD_SHARED_LIBS`,
so these convenience libraries (using the autotools' terminology)
are built and linked by never get installed.

Fixes: https://tracker.ceph.com/issues/38611
Fixes: https://tracker.ceph.com/issues/49080
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
