### PR TITLE
common: s/prctl/pthread_getname_np/ for better portability

### DIFF
--- a/src/common/code_environment.cc
+++ b/src/common/code_environment.cc
@@ -18,8 +18,8 @@
 
 #include "acconfig.h"
 
-#ifdef HAVE_SYS_PRCTL_H
-#include <sys/prctl.h>
+#ifdef HAVE_PTHREAD_GETNAME_NP
+#include <pthread.h>
 #endif
 
 #include <string.h>
@@ -46,19 +46,18 @@ std::ostream &operator<<(std::ostream &oss, const enum code_environment_t e)
   return oss;
 }
 
-#if defined(HAVE_SYS_PRCTL_H) && defined(PR_GET_NAME) /* Since 2.6.11 */
+#if defined(HAVE_PTHREAD_GETNAME_NP) && !defined(_WIN32)
 
 int get_process_name(char *buf, int len)
 {
   if (len <= 16) {
-    /* The man page discourages using this prctl with a buffer shorter
-     * than 16 bytes. With a 16-byte buffer, it might not be
-     * null-terminated. */
+    // The man page discourages using pthread_getname_np() with a buffer shorter
+    // than 16 bytes. With a 16-byte buffer, it might not be null-terminated.
     return -ENAMETOOLONG;
   }
   // FIPS zeroization audit 20191115: this memset is not security related.
   memset(buf, 0, len);
-  return prctl(PR_GET_NAME, buf);
+  return pthread_getname_np(pthread_self(), buf, len);
 }
 
 #elif defined(HAVE_GETPROGNAME)


### PR DESCRIPTION
prctl() is linux specific, let's use pthread_getname_np for thread names.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
