### PR TITLE
cephadm: introduce flake8

### DIFF
--- a/src/cephadm/CMakeLists.txt
+++ b/src/cephadm/CMakeLists.txt
@@ -1,4 +1,4 @@
 if(WITH_TESTS)
   include(AddCephTest)
-  add_tox_test(cephadm TOX_ENVS py3 mypy)
+  add_tox_test(cephadm TOX_ENVS py3 mypy flake8)
 endif()

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -176,9 +176,9 @@ logging_config = {
         },
     },
     'handlers': {
-        'console':{
-            'level':'INFO',
-            'class':'logging.StreamHandler',
+        'console': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
         },
         'log_file': {
             'level': 'DEBUG',
@@ -665,7 +665,7 @@ class HAproxy(object):
     @staticmethod
     def get_container_mounts(data_dir: str) -> Dict[str, str]:
         mounts = dict()
-        mounts[os.path.join(data_dir,'haproxy')] = '/var/lib/haproxy'
+        mounts[os.path.join(data_dir, 'haproxy')] = '/var/lib/haproxy'
         return mounts
 
 ##################################
@@ -753,7 +753,7 @@ class Keepalived(object):
     @staticmethod
     def get_container_mounts(data_dir: str) -> Dict[str, str]:
         mounts = dict()
-        mounts[os.path.join(data_dir,'keepalived.conf')] = '/etc/keepalived/keepalived.conf'
+        mounts[os.path.join(data_dir, 'keepalived.conf')] = '/etc/keepalived/keepalived.conf'
         return mounts
 
 ##################################
@@ -3201,7 +3201,7 @@ def get_image_info_from_inspect(out, image):
 
 
 ##################################
-def check_subnet(subnets:str) -> Tuple[int, List[int], str]:
+def check_subnet(subnets: str) -> Tuple[int, List[int], str]:
     """Determine whether the given string is a valid subnet
 
     :param subnets: subnet string, a single definition or comma separated list of CIDR subnets
@@ -4612,9 +4612,9 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                             if not version or '.' not in version:
                                 version = seen_versions.get(image_id, None)
                             if daemon_type == NFSGanesha.daemon_type:
-                                version = NFSGanesha.get_version(ctx,container_id)
+                                version = NFSGanesha.get_version(ctx, container_id)
                             if daemon_type == CephIscsi.daemon_type:
-                                version = CephIscsi.get_version(ctx,container_id)
+                                version = CephIscsi.get_version(ctx, container_id)
                             elif not version:
                                 if daemon_type in Ceph.daemons:
                                     out, err, code = call(ctx,
@@ -5856,7 +5856,7 @@ def get_ipv6_address(ifname):
         field = iface_setting.split()
         if field[-1] == ifname:
             ipv6_raw = field[0]
-            ipv6_fmtd = ":".join([ipv6_raw[_p:_p + 4] for _p in range(0, len(field[0]),4)])
+            ipv6_fmtd = ":".join([ipv6_raw[_p:_p + 4] for _p in range(0, len(field[0]), 4)])
             # apply naming rules using ipaddress module
             ipv6 = ipaddress.ip_address(ipv6_fmtd)
             return "{}/{}".format(str(ipv6), int('0x{}'.format(field[2]), 16))
@@ -6355,7 +6355,7 @@ class HostFacts():
         out, _, _ = call_throws(self.ctx, ['sysctl', '-a'], verbosity=CallVerbosity.SILENT)
         if out:
             param_list = out.split('\n')
-            param_dict = {param.split(" = ")[0]:param.split(" = ")[-1] for param in param_list}
+            param_dict = {param.split(" = ")[0]: param.split(" = ")[-1] for param in param_list}
 
             # return only desired parameters
             if 'net.ipv4.ip_nonlocal_bind' in param_dict:
@@ -6569,14 +6569,14 @@ td,th {{
                 data = json.dumps(self.server.cephadm_cache.health)
 
             self.send_response(status_code)
-            self.send_header('Content-type','application/json')
+            self.send_header('Content-type', 'application/json')
             self.end_headers()
             self.wfile.write(data.encode('utf-8'))
         else:
             # Invalid GET URL
             bad_request_msg = "Valid URLs are: {}".format(', '.join(CephadmDaemonHandler.valid_routes))
             self.send_response(404, message=bad_request_msg)  # reason
-            self.send_header('Content-type','application/json')
+            self.send_header('Content-type', 'application/json')
             self.end_headers()
             self.wfile.write(json.dumps({"message": bad_request_msg}).encode('utf-8'))
     

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4640,10 +4640,10 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                                 elif daemon_type in ['prometheus',
                                                      'alertmanager',
                                                      'node-exporter']:
-                                    cmd = daemon_type.replace('-', '_')
+                                    daemon_type = daemon_type.replace('-', '_')
                                     out, err, code = call(ctx,
                                                           [container_path, 'exec', container_id,
-                                                           cmd, '--version'])
+                                                           daemon_type, '--version'])
                                     if not code and \
                                        err.startswith('%s, version ' % cmd):
                                         version = err.split(' ')[2]

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2481,11 +2481,12 @@ def deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid,
             ctx,
             image=ctx.image,
             entrypoint='/usr/bin/ceph-mon',
-            args=['--mkfs',
-                  '-i', str(daemon_id),
-                  '--fsid', fsid,
-                  '-c', '/tmp/config',
-                  '--keyring', '/tmp/keyring',
+            args=[
+                '--mkfs',
+                '-i', str(daemon_id),
+                '--fsid', fsid,
+                '-c', '/tmp/config',
+                '--keyring', '/tmp/keyring',
             ] + get_daemon_args(ctx, fsid, 'mon', daemon_id),
             volume_mounts={
                 log_dir: '/var/log/ceph:z',
@@ -2862,7 +2863,8 @@ def install_base_units(ctx, fsid):
     # cluster unit
     existed = os.path.exists(ctx.unit_dir + '/ceph-%s.target' % fsid)
     with open(ctx.unit_dir + '/ceph-%s.target.new' % fsid, 'w') as f:
-        f.write('[Unit]\n'
+        f.write(
+                '[Unit]\n'
                 'Description=Ceph cluster {fsid}\n'
                 'PartOf=ceph.target\n'
                 'Before=ceph.target\n'
@@ -3413,11 +3415,12 @@ def create_initial_monmap(
         ctx,
         image=ctx.image,
         entrypoint='/usr/bin/monmaptool',
-        args=['--create',
-              '--clobber',
-              '--fsid', fsid,
-              '--addv', mon_id, mon_addr,
-              '/tmp/monmap'
+        args=[
+            '--create',
+            '--clobber',
+            '--fsid', fsid,
+            '--addv', mon_id, mon_addr,
+            '/tmp/monmap'
         ],
         volume_mounts={
             monmap.name: '/tmp/monmap:z',
@@ -3445,12 +3448,13 @@ def prepare_create_mon(
         ctx,
         image=ctx.image,
         entrypoint='/usr/bin/ceph-mon',
-        args=['--mkfs',
-              '-i', mon_id,
-              '--fsid', fsid,
-              '-c', '/dev/null',
-              '--monmap', '/tmp/monmap',
-              '--keyring', '/tmp/keyring',
+        args=[
+            '--mkfs',
+            '-i', mon_id,
+            '--fsid', fsid,
+            '-c', '/dev/null',
+            '--monmap', '/tmp/monmap',
+            '--keyring', '/tmp/keyring',
         ] + get_daemon_args(ctx, fsid, 'mon', mon_id),
         volume_mounts={
             log_dir: '/var/log/ceph:z',
@@ -3819,9 +3823,7 @@ def command_bootstrap(ctx):
     (uid, gid) = extract_uid_gid(ctx)
 
     # create some initial keys
-    (mon_key, mgr_key, admin_key,
-     bootstrap_keyring, admin_keyring
-    ) = \
+    (mon_key, mgr_key, admin_key, bootstrap_keyring, admin_keyring) = \
         create_initial_keys(ctx, uid, gid, mgr_id)
 
     monmap = create_initial_monmap(ctx, uid, gid, fsid, mon_id, addr_arg)
@@ -6371,7 +6373,8 @@ class HostFacts():
     def dump(self):
         # type: () -> str
         """Return the attributes of this HostFacts object as json"""
-        data = {k: getattr(self, k) for k in dir(self)
+        data = {
+                k: getattr(self, k) for k in dir(self)
                 if not k.startswith('_') and
                 isinstance(getattr(self, k),
                            (float, int, str, list, dict, tuple))
@@ -6997,9 +7000,10 @@ WantedBy=ceph-{fsid}.target
         with open(os.path.join(self.daemon_path, 'unit.run'), "w") as f:
             f.write(self.unit_run)
 
-        with open(os.path.join(self.ctx.unit_dir,
-                              f"{self.unit_name}.new"),
-                  "w"
+        with open(
+                os.path.join(self.ctx.unit_dir,
+                f"{self.unit_name}.new"),
+                "w"
         ) as f:
             f.write(self.unit_file)
             os.rename(

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -6699,10 +6699,10 @@ class CephadmDaemon():
         logger.exception(exc)
         self.cephadm_cache.update_task(
             thread_type,
-                {
-                    "scrape_errors": errors,
-                    "data": None,
-                }
+            {
+                "scrape_errors": errors,
+                "data": None,
+            }
         )
 
     def _scrape_host_facts(self, refresh_interval=10):
@@ -7309,7 +7309,7 @@ def _get_parser():
               "Support multiple mounts. "
               "ie: `--mount /foo /bar:/bar`. "
               "When no destination is passed, default is /mnt"),
-              nargs='+')
+        nargs='+')
     parser_shell.add_argument(
         '--env', '-e',
         action='append',

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4016,7 +4016,7 @@ def registry_login(ctx: CephadmContext, url, username, password):
         out, _, _ = call_throws(ctx, cmd)
         if 'podman' in container_path:
             os.chmod('/etc/ceph/podman-auth.json', 0o600)
-    except:
+    except Exception:
         raise Error("Failed to login to custom registry @ %s as %s with given password" % (ctx.registry_url, ctx.registry_username))
 
 ##################################

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3281,7 +3281,7 @@ def prepare_mon_addresses(
                 logger.warning('Using msgr2 protocol for unrecognized port %d' %
                                port)
                 addr_arg = '[v2:%s]' % ctx.mon_ip
-            base_ip = ctx.mon_ip[0:-(len(str(port)))-1]
+            base_ip = ctx.mon_ip[0:-(len(str(port))) - 1]
             check_ip_port(ctx, base_ip, port)
         else:
             base_ip = ctx.mon_ip
@@ -3302,7 +3302,7 @@ def prepare_mon_addresses(
             port = int(hasport[0])
             # strip off v1: or v2: prefix
             addr = re.sub(r'^\w+:', '', addr)
-            base_ip = addr[0:-(len(str(port)))-1]
+            base_ip = addr[0:-(len(str(port))) - 1]
             check_ip_port(ctx, base_ip, port)
     else:
         raise Error('must specify --mon-ip or --mon-addrv')
@@ -3592,7 +3592,7 @@ def prepare_ssh(
             with open(auth_keys_file, 'r') as f:
                 f.seek(0, os.SEEK_END)
                 if f.tell() > 0:
-                    f.seek(f.tell()-1, os.SEEK_SET) # go to last char
+                    f.seek(f.tell() - 1, os.SEEK_SET) # go to last char
                     if f.read() != '\n':
                         add_newline = True
 
@@ -5856,7 +5856,7 @@ def get_ipv6_address(ifname):
         field = iface_setting.split()
         if field[-1] == ifname:
             ipv6_raw = field[0]
-            ipv6_fmtd = ":".join([ipv6_raw[_p:_p+4] for _p in range(0, len(field[0]),4)])
+            ipv6_fmtd = ":".join([ipv6_raw[_p:_p + 4] for _p in range(0, len(field[0]),4)])
             # apply naming rules using ipaddress module
             ipv6 = ipaddress.ip_address(ipv6_fmtd)
             return "{}/{}".format(str(ipv6), int('0x{}'.format(field[2]), 16))

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1111,7 +1111,7 @@ class FileLock(object):
             self._lock_counter = max(0, self._lock_counter - 1)
 
             raise
-        return _Acquire_ReturnProxy(lock = self)
+        return _Acquire_ReturnProxy(lock=self)
 
     def release(self, force=False):
         """
@@ -6937,7 +6937,7 @@ class CephadmDaemon():
         
         return """set -e 
 {py3} {bin_path} exporter --fsid {fsid} --id {daemon_id} --port {port} &""".format(
-            py3 = shutil.which('python3'),
+            py3=shutil.which('python3'),
             bin_path=self.binary_path,
             fsid=self.fsid,
             daemon_id=self.daemon_id,
@@ -7435,7 +7435,7 @@ def _get_parser():
     parser_bootstrap.add_argument(
         '--ssl-dashboard-port',
         type=int,
-        default = 8443,
+        default=8443,
         help='Port number used to connect with dashboard using SSL')
     parser_bootstrap.add_argument(
         '--dashboard-key',

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -361,8 +361,8 @@ class NFSGanesha(object):
         # type: (CephadmContext, str) -> Optional[str]
         version = None
         out, err, code = call(ctx,
-            [ctx.container_path, 'exec', container_id,
-             NFSGanesha.entrypoint, '-v'])
+                              [ctx.container_path, 'exec', container_id,
+                               NFSGanesha.entrypoint, '-v'])
         if code == 0:
             match = re.search(r'NFS-Ganesha Release\s*=\s*[V]*([\d.]+)', out)
             if match:
@@ -522,8 +522,8 @@ class CephIscsi(object):
         # type: (CephadmContext, str) -> Optional[str]
         version = None
         out, err, code = call(ctx,
-            [ctx.container_path, 'exec', container_id,
-             '/usr/bin/python3', '-c', "import pkg_resources; print(pkg_resources.require('ceph_iscsi')[0].version)"])
+                              [ctx.container_path, 'exec', container_id,
+                               '/usr/bin/python3', '-c', "import pkg_resources; print(pkg_resources.require('ceph_iscsi')[0].version)"])
         if code == 0:
             version = out.strip()
         return version
@@ -1383,7 +1383,7 @@ def call_throws(
 def call_timeout(ctx, command, timeout):
     # type: (CephadmContext, List[str], int) -> int
     logger.debug('Running command (timeout=%s): %s'
-            % (timeout, ' '.join(command)))
+                 % (timeout, ' '.join(command)))
 
     def raise_timeout(command, timeout):
         # type: (List[str], int) -> NoReturn
@@ -1417,10 +1417,10 @@ def is_available(ctx, what, func):
             break
         elif num > retry:
             raise Error('%s not available after %s tries'
-                    % (what, retry))
+                        % (what, retry))
 
         logger.info('%s not available, waiting (%s/%s)...'
-                % (what, num, retry))
+                    % (what, num, retry))
 
         num += 1
         time.sleep(2)
@@ -1692,10 +1692,10 @@ def get_last_local_ceph_image(ctx: CephadmContext, container_path: str):
     :return: The most recent local ceph image (already pulled)
     """
     out, _, _ = call_throws(ctx,
-        [container_path, 'images',
-         '--filter', 'label=ceph=True',
-         '--filter', 'dangling=false',
-         '--format', '{{.Repository}}@{{.Digest}}'])
+                            [container_path, 'images',
+                             '--filter', 'label=ceph=True',
+                             '--filter', 'dangling=false',
+                             '--format', '{{.Repository}}@{{.Digest}}'])
     return _filter_last_local_ceph_image(out)
 
 
@@ -1771,7 +1771,7 @@ def make_log_dir(ctx, fsid, uid=None, gid=None):
 def make_var_run(ctx, fsid, uid, gid):
     # type: (CephadmContext, str, int, int) -> None
     call_throws(ctx, ['install', '-d', '-m0770', '-o', str(uid), '-g', str(gid),
-                 '/var/run/ceph/%s' % fsid])
+                      '/var/run/ceph/%s' % fsid])
 
 
 def copy_tree(ctx, src, dst, uid=None, gid=None):
@@ -2273,8 +2273,8 @@ def get_container_mounts(ctx, fsid, daemon_type, daemon_id,
                 mounts[ceph_folder + '/monitoring/prometheus/alerts'] = '/etc/prometheus/ceph'
             else:
                 logger.error('{}{}{}'.format(termcolor.red,
-                'Ceph shared source folder does not exist.',
-                termcolor.end))
+                                             'Ceph shared source folder does not exist.',
+                                             termcolor.end))
     except AttributeError:
         pass
 
@@ -2548,9 +2548,9 @@ def deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid,
         # ceph daemons do not need a restart; others (presumably) do to pick
         # up the new config
         call_throws(ctx, ['systemctl', 'reset-failed',
-                     get_unit_name(fsid, daemon_type, daemon_id)])
+                          get_unit_name(fsid, daemon_type, daemon_id)])
         call_throws(ctx, ['systemctl', 'restart',
-                     get_unit_name(fsid, daemon_type, daemon_id)])
+                          get_unit_name(fsid, daemon_type, daemon_id)])
 
 def _write_container_cmd_to_bash(ctx, file_obj, container, comment=None, background=False):
     # type: (CephadmContext, IO[str], CephContainer, Optional[str], Optional[bool]) -> None
@@ -2688,7 +2688,7 @@ def deploy_daemon_units(
             f.write(c.image + '\n')
             os.fchmod(f.fileno(), 0o600)
             os.rename(data_dir + '/unit.image.new',
-                    data_dir + '/unit.image')
+                      data_dir + '/unit.image')
 
     # systemd
     install_base_units(ctx, fsid)
@@ -2780,7 +2780,7 @@ class Firewalld(object):
                 out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--add-port', tcp_port])
                 if ret:
                     raise RuntimeError('unable to add port %s to current zone: %s' %
-                                    (tcp_port, err))
+                                       (tcp_port, err))
             else:
                 logger.debug('firewalld port %s is enabled in current zone' % tcp_port)
 
@@ -2801,7 +2801,7 @@ class Firewalld(object):
                 out, err, ret = call(self.ctx, [self.cmd, '--permanent', '--remove-port', tcp_port])
                 if ret:
                     raise RuntimeError('unable to remove port %s from current zone: %s' %
-                                    (tcp_port, err))
+                                       (tcp_port, err))
                 else:
                     logger.info(f"Port {tcp_port} disabled")
             else:
@@ -2907,9 +2907,9 @@ def get_unit_file(ctx, fsid):
     extra_args = ''
     if 'podman' in ctx.container_path:
         extra_args = ('ExecStartPre=-/bin/rm -f /%t/%n-pid /%t/%n-cid\n'
-            'ExecStopPost=-/bin/rm -f /%t/%n-pid /%t/%n-cid\n'
-            'Type=forking\n'
-            'PIDFile=/%t/%n-pid\n')
+                      'ExecStopPost=-/bin/rm -f /%t/%n-pid /%t/%n-cid\n'
+                      'Type=forking\n'
+                      'PIDFile=/%t/%n-pid\n')
 
     u = """# generated by cephadm
 [Unit]
@@ -3826,7 +3826,7 @@ def command_bootstrap(ctx):
     monmap = create_initial_monmap(ctx, uid, gid, fsid, mon_id, addr_arg)
     (mon_dir, log_dir) = \
         prepare_create_mon(ctx, uid, gid, fsid, mon_id,
-                   bootstrap_keyring.name, monmap.name)
+                           bootstrap_keyring.name, monmap.name)
 
     with open(mon_dir + '/config', 'w') as f:
         os.fchown(f.fileno(), uid, gid)
@@ -4532,8 +4532,8 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                         continue
                     (cluster, daemon_id) = j.split('-', 1)
                     fsid = get_legacy_daemon_fsid(ctx,
-                            cluster, daemon_type, daemon_id,
-                            legacy_dir=legacy_dir)
+                                                  cluster, daemon_type, daemon_id,
+                                                  legacy_dir=legacy_dir)
                     legacy_unit_name = 'ceph-%s@%s' % (daemon_type, daemon_id)
                     val: Dict[str, Any] = {
                         'style': 'legacy',
@@ -4581,13 +4581,12 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                         version = None
                         start_stamp = None
 
-                        out, err, code = call(ctx,
-                            [
-                                container_path, 'inspect',
-                                '--format', '{{.Id}},{{.Config.Image}},{{.Image}},{{.Created}},{{index .Config.Labels "io.ceph.version"}}',
-                                'ceph-%s-%s' % (fsid, j)
-                            ],
-                            verbosity=CallVerbosity.DEBUG)
+                        cmd = [
+                            container_path, 'inspect',
+                            '--format', '{{.Id}},{{.Config.Image}},{{.Image}},{{.Created}},{{index .Config.Labels "io.ceph.version"}}',
+                            'ceph-%s-%s' % (fsid, j)
+                        ]
+                        out, err, code = call(ctx, cmd, verbosity=CallVerbosity.DEBUG)
                         if not code:
                             (container_id, image_name, image_id, start,
                              version) = out.strip().split(',')
@@ -4619,16 +4618,16 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                             elif not version:
                                 if daemon_type in Ceph.daemons:
                                     out, err, code = call(ctx,
-                                        [container_path, 'exec', container_id,
-                                         'ceph', '-v'])
+                                                          [container_path, 'exec', container_id,
+                                                           'ceph', '-v'])
                                     if not code and \
                                        out.startswith('ceph version '):
                                         version = out.split(' ')[2]
                                         seen_versions[image_id] = version
                                 elif daemon_type == 'grafana':
                                     out, err, code = call(ctx,
-                                        [container_path, 'exec', container_id,
-                                         'grafana-server', '-v'])
+                                                          [container_path, 'exec', container_id,
+                                                           'grafana-server', '-v'])
                                     if not code and \
                                        out.startswith('Version '):
                                         version = out.split(' ')[1]
@@ -4638,24 +4637,24 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                                                      'node-exporter']:
                                     cmd = daemon_type.replace('-', '_')
                                     out, err, code = call(ctx,
-                                        [container_path, 'exec', container_id,
-                                         cmd, '--version'])
+                                                          [container_path, 'exec', container_id,
+                                                           cmd, '--version'])
                                     if not code and \
                                        err.startswith('%s, version ' % cmd):
                                         version = err.split(' ')[2]
                                         seen_versions[image_id] = version
                                 elif daemon_type == 'haproxy':
                                     out, err, code = call(ctx,
-                                        [container_path, 'exec', container_id,
-                                         'haproxy', '-v'])
+                                                          [container_path, 'exec', container_id,
+                                                           'haproxy', '-v'])
                                     if not code and \
                                        out.startswith('HA-Proxy version '):
                                         version = out.split(' ')[2]
                                         seen_versions[image_id] = version
                                 elif daemon_type == 'keepalived':
                                     out, err, code = call(ctx,
-                                        [container_path, 'exec', container_id,
-                                         'keepalived', '--version'])
+                                                          [container_path, 'exec', container_id,
+                                                           'keepalived', '--version'])
                                     if not code and \
                                        err.startswith('Keepalived '):
                                         version = err.split(' ')[1]
@@ -4923,13 +4922,13 @@ def command_adopt_ceph(ctx, daemon_type, daemon_id, fsid):
             os.rename(simple_fn, new_fn)
             logger.info('Disabling host unit ceph-volume@ simple unit...')
             call(ctx, ['systemctl', 'disable',
-                  'ceph-volume@simple-%s-%s.service' % (daemon_id, osd_fsid)])
+                       'ceph-volume@simple-%s-%s.service' % (daemon_id, osd_fsid)])
         else:
             # assume this is an 'lvm' c-v for now, but don't error
             # out if it's not.
             logger.info('Disabling host unit ceph-volume@ lvm unit...')
             call(ctx, ['systemctl', 'disable',
-                  'ceph-volume@lvm-%s-%s.service' % (daemon_id, osd_fsid)])
+                       'ceph-volume@lvm-%s-%s.service' % (daemon_id, osd_fsid)])
 
     # config
     config_src = '/etc/ceph/%s.conf' % (ctx.cluster)
@@ -5087,9 +5086,9 @@ def _adjust_grafana_ini(filename):
                     server_section=True
                 if server_section:
                     line = re.sub(r'^cert_file.*',
-                            'cert_file = /etc/grafana/certs/cert_file', line)
+                                  'cert_file = /etc/grafana/certs/cert_file', line)
                     line = re.sub(r'^cert_key.*',
-                            'cert_key = /etc/grafana/certs/cert_key', line)
+                                  'cert_key = /etc/grafana/certs/cert_key', line)
                 grafana_ini.write(line)
         os.rename("{}.new".format(filename), filename)
     except OSError as err:
@@ -5188,7 +5187,7 @@ def command_rm_cluster(ctx):
     call_throws(ctx, ['rm', '-f', ctx.unit_dir +
                       '/ceph-%s.target' % ctx.fsid])
     call_throws(ctx, ['rm', '-rf',
-                  ctx.unit_dir + '/ceph-%s.target.wants' % ctx.fsid])
+                      ctx.unit_dir + '/ceph-%s.target.wants' % ctx.fsid])
     # rm data
     call_throws(ctx, ['rm', '-rf', ctx.data_dir + '/' + ctx.fsid])
     # rm logs
@@ -5778,7 +5777,7 @@ def create_packager(ctx: CephadmContext,
     if distro in YumDnf.DISTRO_NAMES:
         return YumDnf(ctx, stable=stable, version=version,
                       branch=branch, commit=commit,
-                   distro=distro, distro_version=distro_version)
+                      distro=distro, distro_version=distro_version)
     elif distro in Apt.DISTRO_NAMES:
         return Apt(ctx, stable=stable, version=version,
                    branch=branch, commit=commit,
@@ -6996,7 +6995,7 @@ WantedBy=ceph-{fsid}.target
 
         with open(
                 os.path.join(self.ctx.unit_dir,
-                f"{self.unit_name}.new"),
+                             f"{self.unit_name}.new"),
                 "w"
         ) as f:
             f.write(self.unit_file)
@@ -7006,9 +7005,9 @@ WantedBy=ceph-{fsid}.target
         
         call_throws(self.ctx, ['systemctl', 'daemon-reload'])
         call(self.ctx, ['systemctl', 'stop', self.unit_name],
-            verbosity=CallVerbosity.DEBUG)
+             verbosity=CallVerbosity.DEBUG)
         call(self.ctx, ['systemctl', 'reset-failed', self.unit_name],
-            verbosity=CallVerbosity.DEBUG)
+             verbosity=CallVerbosity.DEBUG)
         call_throws(self.ctx, ['systemctl', 'enable', '--now', self.unit_name])
 
     @classmethod
@@ -7083,18 +7082,16 @@ def command_maintenance(ctx: CephadmContext):
         logger.info("Requested to place host into maintenance")
         if systemd_target_state(target):
             _out, _err, code = call(ctx,
-                ['systemctl', 'disable', target],
-                verbosity=CallVerbosity.DEBUG
-            )
+                                    ['systemctl', 'disable', target],
+                                    verbosity=CallVerbosity.DEBUG)
             if code:
                 logger.error(f"Failed to disable the {target} target")
                 return "failed - to disable the target"
             else:
                 # stopping a target waits by default
                 _out, _err, code = call(ctx,
-                    ['systemctl', 'stop', target],
-                    verbosity=CallVerbosity.DEBUG
-                )
+                                        ['systemctl', 'stop', target],
+                                        verbosity=CallVerbosity.DEBUG)
                 if code:
                     logger.error(f"Failed to stop the {target} target")
                     return "failed - to disable the target"
@@ -7109,18 +7106,16 @@ def command_maintenance(ctx: CephadmContext):
         # exit maintenance request
         if not systemd_target_state(target):
             _out, _err, code = call(ctx,
-                ['systemctl', 'enable', target],
-                verbosity=CallVerbosity.DEBUG
-            )
+                                    ['systemctl', 'enable', target],
+                                    verbosity=CallVerbosity.DEBUG)
             if code:
                 logger.error(f"Failed to enable the {target} target")
                 return "failed - unable to enable the target"
             else:
                 # starting a target waits by default
                 _out, _err, code = call(ctx,
-                    ['systemctl', 'start', target],
-                    verbosity=CallVerbosity.DEBUG
-                )
+                                        ['systemctl', 'start', target],
+                                        verbosity=CallVerbosity.DEBUG)
                 if code:
                     logger.error(f"Failed to start the {target} target")
                     return "failed - unable to start the target"

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1,50 +1,5 @@
 #!/usr/bin/python3
 
-# Default container images -----------------------------------------------------
-DEFAULT_IMAGE = 'docker.io/ceph/daemon-base:latest-master-devel'
-DEFAULT_IMAGE_IS_MASTER = True
-DEFAULT_PROMETHEUS_IMAGE = "docker.io/prom/prometheus:v2.18.1"
-DEFAULT_NODE_EXPORTER_IMAGE = "docker.io/prom/node-exporter:v0.18.1"
-DEFAULT_GRAFANA_IMAGE = "docker.io/ceph/ceph-grafana:6.7.4"
-DEFAULT_ALERT_MANAGER_IMAGE = "docker.io/prom/alertmanager:v0.20.0"
-# ------------------------------------------------------------------------------
-
-LATEST_STABLE_RELEASE = 'pacific'
-DATA_DIR = '/var/lib/ceph'
-LOG_DIR = '/var/log/ceph'
-LOCK_DIR = '/run/cephadm'
-LOGROTATE_DIR = '/etc/logrotate.d'
-UNIT_DIR = '/etc/systemd/system'
-LOG_DIR_MODE = 0o770
-DATA_DIR_MODE = 0o700
-CONTAINER_PREFERENCE = ['podman', 'docker']  # prefer podman to docker
-MIN_PODMAN_VERSION = (2, 0, 2)
-CUSTOM_PS1 = r'[ceph: \u@\h \W]\$ '
-DEFAULT_TIMEOUT = None  # in seconds
-DEFAULT_RETRY = 15
-SHELL_DEFAULT_CONF = '/etc/ceph/ceph.conf'
-SHELL_DEFAULT_KEYRING = '/etc/ceph/ceph.client.admin.keyring'
-
-"""
-You can invoke cephadm in two ways:
-
-1. The normal way, at the command line.
-
-2. By piping the script to the python3 binary.  In this latter case, you should
-   prepend one or more lines to the beginning of the script.
-
-   For arguments,
-
-       injected_argv = [...]
-
-   e.g.,
-
-       injected_argv = ['ls']
-
-   For reading stdin from the '--config-json -' argument,
-
-       injected_stdin = '...'
-"""
 import asyncio
 import asyncio.subprocess
 import argparse
@@ -77,7 +32,6 @@ from contextlib import redirect_stdout
 import ssl
 from enum import Enum
 
-
 from typing import Dict, List, Tuple, Optional, Union, Any, NoReturn, Callable, IO
 
 import re
@@ -91,12 +45,56 @@ from threading import Thread, RLock
 from urllib.error import HTTPError
 from urllib.request import urlopen
 
-cached_stdin = None
 
+# Default container images -----------------------------------------------------
+DEFAULT_IMAGE = 'docker.io/ceph/daemon-base:latest-master-devel'
+DEFAULT_IMAGE_IS_MASTER = True
+DEFAULT_PROMETHEUS_IMAGE = "docker.io/prom/prometheus:v2.18.1"
+DEFAULT_NODE_EXPORTER_IMAGE = "docker.io/prom/node-exporter:v0.18.1"
+DEFAULT_GRAFANA_IMAGE = "docker.io/ceph/ceph-grafana:6.7.4"
+DEFAULT_ALERT_MANAGER_IMAGE = "docker.io/prom/alertmanager:v0.20.0"
+# ------------------------------------------------------------------------------
+
+LATEST_STABLE_RELEASE = 'pacific'
+DATA_DIR = '/var/lib/ceph'
+LOG_DIR = '/var/log/ceph'
+LOCK_DIR = '/run/cephadm'
+LOGROTATE_DIR = '/etc/logrotate.d'
+UNIT_DIR = '/etc/systemd/system'
+LOG_DIR_MODE = 0o770
+DATA_DIR_MODE = 0o700
+CONTAINER_PREFERENCE = ['podman', 'docker']  # prefer podman to docker
+MIN_PODMAN_VERSION = (2, 0, 2)
+CUSTOM_PS1 = r'[ceph: \u@\h \W]\$ '
+DEFAULT_TIMEOUT = None  # in seconds
+DEFAULT_RETRY = 15
+SHELL_DEFAULT_CONF = '/etc/ceph/ceph.conf'
+SHELL_DEFAULT_KEYRING = '/etc/ceph/ceph.client.admin.keyring'
 DATEFMT = '%Y-%m-%dT%H:%M:%S.%fZ'
 
-
 logger: logging.Logger = None  # type: ignore
+
+"""
+You can invoke cephadm in two ways:
+
+1. The normal way, at the command line.
+
+2. By piping the script to the python3 binary.  In this latter case, you should
+   prepend one or more lines to the beginning of the script.
+
+   For arguments,
+
+       injected_argv = [...]
+
+   e.g.,
+
+       injected_argv = ['ls']
+
+   For reading stdin from the '--config-json -' argument,
+
+       injected_stdin = '...'
+"""
+cached_stdin = None
 
 ##################################
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -952,6 +952,7 @@ def port_in_use(ctx, port_num):
     # type: (CephadmContext, int) -> bool
     """Detect whether a port is in use on the local machine - IPv4 and IPv6"""
     logger.info('Verifying port %d ...' % port_num)
+
     def _port_in_use(af: socket.AddressFamily, address: str) -> bool:
         try:
             s = socket.socket(af, socket.SOCK_STREAM)
@@ -3889,8 +3890,10 @@ def command_bootstrap(ctx):
             out = cli(['mgr', 'dump'])
         j = json.loads(out)
         epoch = j['epoch']
+
         # wait for mgr to have it
         logger.info('Waiting for the mgr to restart...')
+
         def mgr_has_latest_epoch():
             # type: () -> bool
             try:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -435,7 +435,7 @@ class NFSGanesha(object):
         entrypoint = '/usr/bin/ganesha-rados-grace'
 
         assert self.pool
-        args=['--pool', self.pool]
+        args = ['--pool', self.pool]
         if self.namespace:
             args += ['--ns', self.namespace]
         if self.userid:
@@ -2559,10 +2559,10 @@ def _write_container_cmd_to_bash(ctx, file_obj, container, comment=None, backgro
         # unit file, makes it easier to read and grok.
         file_obj.write('# ' + comment + '\n')
     # Sometimes, adding `--rm` to a run_cmd doesn't work. Let's remove the container manually
-    file_obj.write('! '+ ' '.join(container.rm_cmd()) + ' 2> /dev/null\n')
+    file_obj.write('! ' + ' '.join(container.rm_cmd()) + ' 2> /dev/null\n')
     # Sometimes, `podman rm` doesn't find the container. Then you'll have to add `--storage`
     if 'podman' in ctx.container_path:
-        file_obj.write('! '+ ' '.join(container.rm_cmd(storage=True)) + ' 2> /dev/null\n')
+        file_obj.write('! ' + ' '.join(container.rm_cmd(storage=True)) + ' 2> /dev/null\n')
 
     # container run command
     file_obj.write(' '.join(container.run_cmd()) + (' &' if background else '') + '\n')
@@ -2677,7 +2677,7 @@ def deploy_daemon_units(
             # make sure we also stop the tcmu container
             ceph_iscsi = CephIscsi.init(ctx, fsid, daemon_id)
             tcmu_container = ceph_iscsi.get_tcmu_runner_container()
-            f.write('! '+ ' '.join(tcmu_container.stop_cmd()) + '\n')
+            f.write('! ' + ' '.join(tcmu_container.stop_cmd()) + '\n')
             f.write(' '.join(CephIscsi.configfs_mount_umount(data_dir, mount=False)) + '\n')
         os.fchmod(f.fileno(), 0o600)
         os.rename(data_dir + '/unit.poststop.new',
@@ -3497,7 +3497,7 @@ def wait_for_mon(
     # wait for the service to become available
     def is_mon_available():
         # type: () -> bool
-        timeout=ctx.timeout if ctx.timeout else 60 # seconds
+        timeout = ctx.timeout if ctx.timeout else 60 # seconds
         out, err, ret = call(ctx, c.run_cmd(),
                              desc=c.entrypoint,
                              timeout=timeout)
@@ -3524,7 +3524,7 @@ def create_mgr(
     logger.info('Waiting for mgr to start...')
     def is_mgr_available():
         # type: () -> bool
-        timeout=ctx.timeout if ctx.timeout else 60 # seconds
+        timeout = ctx.timeout if ctx.timeout else 60 # seconds
         try:
             out = clifunc(['status', '-f', 'json-pretty'], timeout=timeout)
             j = json.loads(out)
@@ -4161,7 +4161,7 @@ def command_deploy(ctx):
         config_js = get_parm(ctx.config_json)  # type: Dict[str, str]
         if not daemon_ports:
             logger.info("cephadm-exporter will use default port ({})".format(CephadmDaemon.default_port))
-            daemon_ports =[CephadmDaemon.default_port]
+            daemon_ports = [CephadmDaemon.default_port]
            
         CephadmDaemon.validate_config(config_js)
         
@@ -5078,12 +5078,12 @@ def _adjust_grafana_ini(filename):
         with open(filename, "r") as grafana_ini:
             lines = grafana_ini.readlines()
         with open("{}.new".format(filename), "w") as grafana_ini:
-            server_section=False
+            server_section = False
             for line in lines:
                 if line.startswith('['):
-                    server_section=False
+                    server_section = False
                 if line.startswith('[server]'):
-                    server_section=True
+                    server_section = True
                 if server_section:
                     line = re.sub(r'^cert_file.*',
                                   'cert_file = /etc/grafana/certs/cert_file', line)
@@ -6308,7 +6308,7 @@ class HostFacts():
                         summary = {}  # type: Dict[str, int]
                         for line in profiles.split('\n'):
                             item, mode = line.split(' ')
-                            mode= mode.strip('()')
+                            mode = mode.strip('()')
                             if mode in summary:
                                 summary[mode] += 1
                             else:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1211,7 +1211,7 @@ if sys.version_info < (3, 8):
             self._threads = {}
 
         def is_active(self):
-                return True
+            return True
 
         def close(self):
             self._join_threads()
@@ -3152,7 +3152,7 @@ def _pull_image(ctx, image):
 
     cmd = [ctx.container_path, 'pull', image]
     if 'podman' in ctx.container_path and os.path.exists('/etc/ceph/podman-auth.json'):
-            cmd.append('--authfile=/etc/ceph/podman-auth.json')
+        cmd.append('--authfile=/etc/ceph/podman-auth.json')
     cmd_str = ' '.join(cmd)
 
     for sleep_secs in [1, 4, 25]:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -96,7 +96,7 @@ cached_stdin = None
 DATEFMT = '%Y-%m-%dT%H:%M:%S.%fZ'
 
 
-logger: logging.Logger = None # type: ignore
+logger: logging.Logger = None  # type: ignore
 
 ##################################
 
@@ -891,7 +891,7 @@ def dict_get(d: Dict, key: str, default: Any = None, require: bool = False) -> A
     """
     if require and key not in d.keys():
         raise Error('{} missing from dict'.format(key))
-    return d.get(key, default) # type: ignore
+    return d.get(key, default)  # type: ignore
 
 ##################################
 
@@ -1789,7 +1789,7 @@ def copy_tree(ctx, src, dst, uid=None, gid=None):
 
         logger.debug('copy directory \'%s\' -> \'%s\'' % (src_dir, dst_dir))
         shutil.rmtree(dst_dir, ignore_errors=True)
-        shutil.copytree(src_dir, dst_dir) # dirs_exist_ok needs python 3.8
+        shutil.copytree(src_dir, dst_dir)  # dirs_exist_ok needs python 3.8
 
         for dirpath, dirnames, filenames in os.walk(dst_dir):
             logger.debug('chown %s:%s \'%s\'' % (uid, gid, dirpath))
@@ -3194,7 +3194,7 @@ def get_image_info_from_inspect(out, image):
         raise Error('inspect {}: empty result'.format(image))
     r = {
         'image_id': normalize_container_id(image_id)
-    } # type: Dict[str, Union[str,List[str]]]
+    }  # type: Dict[str, Union[str,List[str]]]
     if digests:
         r['repo_digests'] = digests[1:-1].split(' ')
     return r
@@ -3349,7 +3349,7 @@ def create_initial_keys(
     ctx: CephadmContext,
     uid: int, gid: int,
     mgr_id: str
-) -> Tuple[str, str, str, Any, Any]: # type: ignore
+) -> Tuple[str, str, str, Any, Any]:  # type: ignore
 
     _image = ctx.image
 
@@ -3497,7 +3497,7 @@ def wait_for_mon(
     # wait for the service to become available
     def is_mon_available():
         # type: () -> bool
-        timeout = ctx.timeout if ctx.timeout else 60 # seconds
+        timeout = ctx.timeout if ctx.timeout else 60  # seconds
         out, err, ret = call(ctx, c.run_cmd(),
                              desc=c.entrypoint,
                              timeout=timeout)
@@ -3524,7 +3524,7 @@ def create_mgr(
     logger.info('Waiting for mgr to start...')
     def is_mgr_available():
         # type: () -> bool
-        timeout = ctx.timeout if ctx.timeout else 60 # seconds
+        timeout = ctx.timeout if ctx.timeout else 60  # seconds
         try:
             out = clifunc(['status', '-f', 'json-pretty'], timeout=timeout)
             j = json.loads(out)
@@ -3592,12 +3592,12 @@ def prepare_ssh(
             with open(auth_keys_file, 'r') as f:
                 f.seek(0, os.SEEK_END)
                 if f.tell() > 0:
-                    f.seek(f.tell() - 1, os.SEEK_SET) # go to last char
+                    f.seek(f.tell() - 1, os.SEEK_SET)  # go to last char
                     if f.read() != '\n':
                         add_newline = True
 
         with open(auth_keys_file, 'a') as f:
-            os.fchown(f.fileno(), ssh_uid, ssh_gid) # just in case we created it
+            os.fchown(f.fileno(), ssh_uid, ssh_gid)  # just in case we created it
             os.fchmod(f.fileno(), 0o600)  # just in case we created it
             if add_newline:
                 f.write('\n')
@@ -4058,7 +4058,7 @@ def command_deploy(ctx):
         logger.info('%s daemon %s ...' % ('Deploy', ctx.name))
 
     # Get and check ports explicitly required to be opened
-    daemon_ports = [] # type: List[int]
+    daemon_ports = []  # type: List[int]
 
     # only check port in use if not reconfig or redeploy since service
     # we are redeploying/reconfiguring will already be using the port
@@ -4086,7 +4086,7 @@ def command_deploy(ctx):
             daemon_ports.extend(Monitoring.port_map[daemon_type])
 
         # make sure provided config-json is sufficient
-        config = get_parm(ctx.config_json) # type: ignore
+        config = get_parm(ctx.config_json)  # type: ignore
         required_files = Monitoring.components[daemon_type].get('config-json-files', list())
         required_args = Monitoring.components[daemon_type].get('config-json-args', list())
         if required_files:
@@ -4212,7 +4212,7 @@ def command_shell(ctx):
     if not ctx.keyring and os.path.exists(SHELL_DEFAULT_KEYRING):
         ctx.keyring = SHELL_DEFAULT_KEYRING
 
-    container_args = [] # type: List[str]
+    container_args = []  # type: List[str]
     mounts = get_container_mounts(ctx, ctx.fsid, daemon_type, daemon_id,
                                   no_config=True if ctx.config else False)
     binds = get_container_binds(ctx, ctx.fsid, daemon_type, daemon_id)
@@ -4274,7 +4274,7 @@ def command_enter(ctx):
     if not ctx.fsid:
         raise Error('must pass --fsid to specify cluster')
     (daemon_type, daemon_id) = ctx.name.split('.', 1)
-    container_args = [] # type: List[str]
+    container_args = []  # type: List[str]
     if ctx.command:
         command = ctx.command
     else:
@@ -4307,7 +4307,7 @@ def command_ceph_volume(ctx):
         l = FileLock(ctx, ctx.fsid)
         l.acquire()
 
-    (uid, gid) = (0, 0) # ceph-volume runs as root
+    (uid, gid) = (0, 0)  # ceph-volume runs as root
     mounts = get_container_mounts(ctx, ctx.fsid, 'osd', None)
 
     tmp_config = None
@@ -4377,7 +4377,7 @@ def command_logs(ctx):
     # call this directly, without our wrapper, so that we get an unmolested
     # stdout with logger prefixing.
     logger.debug("Running command: %s" % ' '.join(cmd))
-    subprocess.call(cmd) # type: ignore
+    subprocess.call(cmd)  # type: ignore
 
 ##################################
 
@@ -4667,7 +4667,7 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                                 else:
                                     logger.warning('version for unknown daemon type %s' % daemon_type)
                         else:
-                            vfile = os.path.join(data_dir, fsid, j, 'unit.image') # type: ignore
+                            vfile = os.path.join(data_dir, fsid, j, 'unit.image')  # type: ignore
                             try:
                                 with open(vfile, 'r') as f:
                                     image_name = f.read().strip() or None
@@ -4675,7 +4675,7 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                                 pass
 
                         # unit.meta?
-                        mfile = os.path.join(data_dir, fsid, j, 'unit.meta') # type: ignore
+                        mfile = os.path.join(data_dir, fsid, j, 'unit.meta')  # type: ignore
                         try:
                             with open(mfile, 'r') as f:
                                 meta = json.loads(f.read())
@@ -5217,9 +5217,9 @@ def check_time_sync(ctx, enabler=None):
     # type: (CephadmContext, Optional[Packager]) -> bool
     units = [
         'chrony.service',  # 18.04 (at least)
-        'chronyd.service', # el / opensuse
+        'chronyd.service',  # el / opensuse
         'systemd-timesyncd.service',
-        'ntpd.service', # el7 (at least)
+        'ntpd.service',  # el7 (at least)
         'ntp.service',  # 18.04 (at least)
         'ntpsec.service',  # 20.04 (at least) / buster
     ]
@@ -6314,7 +6314,7 @@ class HostFacts():
                             else:
                                 summary[mode] = 0
                         summary_str = ",".join(["{} {}".format(v, k) for k, v in summary.items()])
-                        security = {**security, **summary} # type: ignore
+                        security = {**security, **summary}  # type: ignore
                         security['description'] += "({})".format(summary_str)
 
                     return security
@@ -7776,7 +7776,7 @@ def main():
         av = sys.argv[1:]
 
     ctx = cephadm_init(av)
-    if not ctx: # error, exit
+    if not ctx:  # error, exit
         sys.exit(1)
 
     try:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -271,8 +271,8 @@ class Monitoring(object):
             "cpus": "2",
             "memory": "2GB",
             "args": [
-               "--web.listen-address=:{}".format(port_map['alertmanager'][0]),
-               "--cluster.listen-address=:{}".format(port_map['alertmanager'][1]),
+                "--web.listen-address=:{}".format(port_map['alertmanager'][0]),
+                "--cluster.listen-address=:{}".format(port_map['alertmanager'][1]),
             ],
             "config-json-files": [
                 "alertmanager.yml",

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -304,7 +304,7 @@ class NFSGanesha(object):
     required_files = ['ganesha.conf']
 
     port_map = {
-        "nfs" : 2049,
+        "nfs": 2049,
     }
 
     def __init__(self,
@@ -3638,7 +3638,7 @@ def prepare_dashboard(
 
     # Configure SSL port (cephadm only allows to configure dashboard SSL port)
     # if the user does not want to use SSL he can change this setting once the cluster is up
-    cli(["config", "set",  "mgr", "mgr/dashboard/ssl_server_port" , str(ctx.ssl_dashboard_port)])
+    cli(["config", "set",  "mgr", "mgr/dashboard/ssl_server_port", str(ctx.ssl_dashboard_port)])
 
     # configuring dashboard parameters
     logger.info('Enabling the dashboard module...')

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -6355,7 +6355,7 @@ class HostFacts():
         out, _, _ = call_throws(self.ctx, ['sysctl', '-a'], verbosity=CallVerbosity.SILENT)
         if out:
             param_list = out.split('\n')
-            param_dict = { param.split(" = ")[0]:param.split(" = ")[-1] for param in param_list}
+            param_dict = {param.split(" = ")[0]:param.split(" = ")[-1] for param in param_list}
 
             # return only desired parameters
             if 'net.ipv4.ip_nonlocal_bind' in param_dict:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -147,11 +147,9 @@ class CephadmContext:
 
 
     def __getattr__(self, name: str) -> Any:
-        if "_conf" in self.__dict__ and \
-             hasattr(self._conf, name):
+        if "_conf" in self.__dict__ and hasattr(self._conf, name):
             return getattr(self._conf, name)
-        elif "_args" in self.__dict__ and \
-           hasattr(self._args, name):
+        elif "_args" in self.__dict__ and hasattr(self._args, name):
             return getattr(self._args, name)        
         else:
             return super().__getattribute__(name)
@@ -1371,12 +1369,12 @@ def call(ctx: CephadmContext,
 
 
 def call_throws(
-         ctx: CephadmContext,
-         command: List[str],
-         desc: Optional[str] = None,
-         verbosity: CallVerbosity = CallVerbosity.VERBOSE_ON_FAILURE,
-         timeout: Optional[int] = DEFAULT_TIMEOUT,
-         **kwargs) -> Tuple[str, str, int]:
+        ctx: CephadmContext,
+        command: List[str],
+        desc: Optional[str] = None,
+        verbosity: CallVerbosity = CallVerbosity.VERBOSE_ON_FAILURE,
+        timeout: Optional[int] = DEFAULT_TIMEOUT,
+        **kwargs) -> Tuple[str, str, int]:
     out, err, ret = call(ctx, command, desc, verbosity, timeout, **kwargs)
     if ret:
         raise RuntimeError('Failed command: %s' % ' '.join(command))
@@ -2864,14 +2862,14 @@ def install_base_units(ctx, fsid):
     existed = os.path.exists(ctx.unit_dir + '/ceph-%s.target' % fsid)
     with open(ctx.unit_dir + '/ceph-%s.target.new' % fsid, 'w') as f:
         f.write(
-                '[Unit]\n'
-                'Description=Ceph cluster {fsid}\n'
-                'PartOf=ceph.target\n'
-                'Before=ceph.target\n'
-                '\n'
-                '[Install]\n'
-                'WantedBy=multi-user.target ceph.target\n'.format(
-                    fsid=fsid)
+            '[Unit]\n'
+            'Description=Ceph cluster {fsid}\n'
+            'PartOf=ceph.target\n'
+            'Before=ceph.target\n'
+            '\n'
+            '[Install]\n'
+            'WantedBy=multi-user.target ceph.target\n'.format(
+                fsid=fsid)
         )
         os.rename(ctx.unit_dir + '/ceph-%s.target.new' % fsid,
                   ctx.unit_dir + '/ceph-%s.target' % fsid)
@@ -3043,9 +3041,10 @@ class CephContainer:
         binds = sum([['--mount', '{}'.format(','.join(bind))]
                      for bind in self.bind_mounts], [])
 
-        return cmd_args + self.container_args + envs + vols + binds + [
-                   self.image,
-               ] + self.args  # type: ignore
+        return \
+            cmd_args + self.container_args + \
+            envs + vols + binds + \
+            [self.image] + self.args  # type: ignore
 
     def shell_cmd(self, cmd: List[str]) -> List[str]:
         cmd_args: List[str] = [
@@ -3114,9 +3113,8 @@ class CephContainer:
 
     def run(self, timeout=DEFAULT_TIMEOUT):
         # type: (Optional[int]) -> str
-        out, _, _ = call_throws(
-                self.ctx,
-                self.run_cmd(), desc=self.entrypoint, timeout=timeout)
+        out, _, _ = call_throws(self.ctx, self.run_cmd(),
+                                desc=self.entrypoint, timeout=timeout)
         return out
 
 ##################################
@@ -4534,8 +4532,7 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                     if '-' not in j:
                         continue
                     (cluster, daemon_id) = j.split('-', 1)
-                    fsid = get_legacy_daemon_fsid(
-                            ctx,
+                    fsid = get_legacy_daemon_fsid(ctx,
                             cluster, daemon_type, daemon_id,
                             legacy_dir=legacy_dir)
                     legacy_unit_name = 'ceph-%s@%s' % (daemon_type, daemon_id)
@@ -5829,12 +5826,12 @@ def get_ipv4_address(ifname):
     # type: (str) -> str
     def _extract(sock, offset):
         return socket.inet_ntop(
-                socket.AF_INET,
-                fcntl.ioctl(
-                    sock.fileno(),
-                    offset,
-                    struct.pack('256s', bytes(ifname[:15], 'utf-8'))
-                )[20:24])
+            socket.AF_INET,
+            fcntl.ioctl(
+                sock.fileno(),
+                offset,
+                struct.pack('256s', bytes(ifname[:15], 'utf-8'))
+            )[20:24])
 
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
@@ -6175,8 +6172,7 @@ class HostFacts():
                     iftype = 'physical'
                     driver_path = os.path.join(dev_link, 'driver')
                     if os.path.exists(driver_path):
-                        driver = os.path.basename(
-                                    os.path.realpath(driver_path))
+                        driver = os.path.basename(os.path.realpath(driver_path))
                     else:
                         driver = 'Unknown'
 
@@ -6374,10 +6370,10 @@ class HostFacts():
         # type: () -> str
         """Return the attributes of this HostFacts object as json"""
         data = {
-                k: getattr(self, k) for k in dir(self)
-                if not k.startswith('_') and
-                isinstance(getattr(self, k),
-                           (float, int, str, list, dict, tuple))
+            k: getattr(self, k) for k in dir(self)
+            if not k.startswith('_') and
+            isinstance(getattr(self, k),
+                       (float, int, str, list, dict, tuple))
         }
         return json.dumps(data, indent=2, sort_keys=True)
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2225,7 +2225,7 @@ def get_container_mounts(ctx, fsid, daemon_type, daemon_id,
 
     if daemon_type in Ceph.daemons:
         if fsid:
-            run_path = os.path.join('/var/run/ceph', fsid);
+            run_path = os.path.join('/var/run/ceph', fsid)
             if os.path.exists(run_path):
                 mounts[run_path] = '/var/run/ceph:z'
             log_dir = get_log_dir(fsid, ctx.log_dir)
@@ -4751,7 +4751,7 @@ def command_adopt(ctx):
 
     # call correct adoption
     if daemon_type in Ceph.daemons:
-        command_adopt_ceph(ctx, daemon_type, daemon_id, fsid);
+        command_adopt_ceph(ctx, daemon_type, daemon_id, fsid)
     elif daemon_type == 'prometheus':
         command_adopt_prometheus(ctx, daemon_id, fsid)
     elif daemon_type == 'grafana':

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2623,7 +2623,7 @@ def deploy_daemon_units(
             # add nfs to the rados grace db
             nfs_ganesha = NFSGanesha.init(ctx, fsid, daemon_id)
             prestart = nfs_ganesha.get_rados_grace_container('add')
-            _write_container_cmd_to_bash(ctx, f, prestart,  'add daemon to rados grace')
+            _write_container_cmd_to_bash(ctx, f, prestart, 'add daemon to rados grace')
         elif daemon_type == CephIscsi.daemon_type:
             f.write(' '.join(CephIscsi.configfs_mount_umount(data_dir, mount=True)) + '\n')
             ceph_iscsi = CephIscsi.init(ctx, fsid, daemon_id)
@@ -3638,7 +3638,7 @@ def prepare_dashboard(
 
     # Configure SSL port (cephadm only allows to configure dashboard SSL port)
     # if the user does not want to use SSL he can change this setting once the cluster is up
-    cli(["config", "set",  "mgr", "mgr/dashboard/ssl_server_port", str(ctx.ssl_dashboard_port)])
+    cli(["config", "set", "mgr", "mgr/dashboard/ssl_server_port", str(ctx.ssl_dashboard_port)])
 
     # configuring dashboard parameters
     logger.info('Enabling the dashboard module...')

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -142,7 +142,7 @@ class CephadmContext:
         if "_conf" in self.__dict__ and hasattr(self._conf, name):
             return getattr(self._conf, name)
         elif "_args" in self.__dict__ and hasattr(self._args, name):
-            return getattr(self._args, name)        
+            return getattr(self._args, name)
         else:
             return super().__getattribute__(name)
 
@@ -1622,7 +1622,7 @@ def infer_config(func):
                         name = daemon['name']
                         break
             if name:
-                config = '/var/lib/ceph/{}/{}/config'.format(ctx.fsid, 
+                config = '/var/lib/ceph/{}/{}/config'.format(ctx.fsid,
                                                              name)
         if config:
             logger.info('Inferring config %s' % config)
@@ -2521,7 +2521,7 @@ def deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid,
                 deploy_daemon_units(ctx, fsid, uid, gid, daemon_type, daemon_id,
                                     c, osd_fsid=osd_fsid)
             else:
-                raise RuntimeError("attempting to deploy a daemon without a container image") 
+                raise RuntimeError("attempting to deploy a daemon without a container image")
 
     if not os.path.exists(data_dir + '/unit.created'):
         with open(data_dir + '/unit.created', 'w') as f:
@@ -3210,7 +3210,7 @@ def check_subnet(subnets: str) -> Tuple[int, List[int], str]:
     """
 
     rc = 0
-    versions = set() 
+    versions = set()
     errors = []
     subnet_list = subnets.split(',')
     for subnet in subnet_list:
@@ -3331,7 +3331,7 @@ def prepare_mon_addresses(
 def prepare_cluster_network(ctx: CephadmContext) -> Tuple[str, bool]:
     cluster_network = ""
     ipv6_cluster_network = False
-    # the cluster network may not exist on this node, so all we can do is 
+    # the cluster network may not exist on this node, so all we can do is
     # validate that the address given is valid ipv4 or ipv6 subnet
     if ctx.cluster_network:
         rc, versions, err_msg = check_subnet(ctx.cluster_network)
@@ -5775,7 +5775,7 @@ class Zypper(Packager):
         self.install(['podman'])
 
 
-def create_packager(ctx: CephadmContext, 
+def create_packager(ctx: CephadmContext,
                     stable=None, version=None, branch=None, commit=None):
     distro, distro_version, distro_codename = get_distro()
     if distro in YumDnf.DISTRO_NAMES:
@@ -6418,7 +6418,7 @@ class CephadmCache:
         self.host = {}
         self.lock = RLock()
     
-    @property 
+    @property
     def health(self):
         return {
             "started_epoch_secs": self.started_epoch_secs,
@@ -6533,7 +6533,7 @@ td,th {{
         """Handle *all* GET requests"""
 
         if self.path == '/':
-            # provide a html response if someone hits the root url, to document the 
+            # provide a html response if someone hits the root url, to document the
             # available api endpoints
             return self._fetch_root()
         elif self.path in CephadmDaemonHandler.valid_routes:
@@ -6563,7 +6563,7 @@ td,th {{
                 if tasks['daemons'] == 'inactive':
                     status_code = 204
             elif u == 'disks':
-                data = json.dumps(self.server.cephadm_cache.disks)    
+                data = json.dumps(self.server.cephadm_cache.disks)
                 if tasks['disks'] == 'inactive':
                     status_code = 204
             elif u == 'host':
@@ -6611,7 +6611,7 @@ class CephadmDaemon():
     def __init__(self, ctx: CephadmContext, fsid, daemon_id=None, port=None):
         self.ctx = ctx
         self.fsid = fsid
-        self.daemon_id = daemon_id 
+        self.daemon_id = daemon_id
         if not port:
             self.port = CephadmDaemon.default_port
         else:
@@ -6746,7 +6746,7 @@ class CephadmDaemon():
                             "scrape_timestamp": s_time,
                             "scrape_duration_secs": elapsed,
                             "scrape_errors": errors,
-                            "data": data,                    
+                            "data": data,
                         }
                     )
                     logger.debug(f"completed host-facts scrape - {elapsed}s")
@@ -6756,7 +6756,7 @@ class CephadmDaemon():
         logger.info("host-facts thread stopped")
 
     def _scrape_ceph_volume(self, refresh_interval=15):
-        # we're invoking the ceph_volume command, so we need to set the args that it 
+        # we're invoking the ceph_volume command, so we need to set the args that it
         # expects to use
         self.ctx.command = "inventory --format=json".split()
         self.ctx.fsid = self.fsid
@@ -6784,7 +6784,7 @@ class CephadmDaemon():
                 else:
                     elapsed = time.time() - s_time
 
-                    # if the call to ceph-volume returns junk with the 
+                    # if the call to ceph-volume returns junk with the
                     # json, it won't parse
                     stdout = stream.getvalue()
 
@@ -6805,7 +6805,7 @@ class CephadmDaemon():
                             "scrape_timestamp": s_time,
                             "scrape_duration_secs": elapsed,
                             "scrape_errors": errors,
-                            "data": data, 
+                            "data": data,
                         }
                     )
                     
@@ -6875,7 +6875,7 @@ class CephadmDaemon():
     def reload(self, *args):
         """reload -HUP received
         
-        This is a placeholder function only, and serves to provide the hook that could 
+        This is a placeholder function only, and serves to provide the hook that could
         be exploited later if the exporter evolves to incorporate a config file
         """
         logger.info("Reload request received - ignoring, no action needed")
@@ -6942,7 +6942,7 @@ class CephadmDaemon():
     @property
     def unit_run(self):
         
-        return """set -e 
+        return """set -e
 {py3} {bin_path} exporter --fsid {fsid} --id {daemon_id} --port {port} &""".format(
             py3=shutil.which('python3'),
             bin_path=self.binary_path,
@@ -6991,7 +6991,7 @@ WantedBy=ceph-{fsid}.target
                 f.write(config[filename])
 
         # When __file__ is <stdin> we're being invoked over remoto via the orchestrator, so
-        # we pick up the file from where the orchestrator placed it - otherwise we'll 
+        # we pick up the file from where the orchestrator placed it - otherwise we'll
         # copy it to the binary location for this cluster
         if not __file__ == '<stdin>':
             shutil.copy(__file__,
@@ -7713,7 +7713,7 @@ def _get_parser():
         help='cluster FSID')
     parser_maintenance.add_argument(
         "maintenance_action",
-        type=str, 
+        type=str,
         choices=['enter', 'exit'],
         help="Maintenance action - enter maintenance, or exit maintenance")
     parser_maintenance.set_defaults(func=command_maintenance)

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -333,8 +333,7 @@ class NFSGanesha(object):
     @classmethod
     def init(cls, ctx, fsid, daemon_id):
         # type: (CephadmContext, str, Union[int, str]) -> NFSGanesha
-        return cls(ctx, fsid, daemon_id, get_parm(ctx.config_json),
-                                                  ctx.image)
+        return cls(ctx, fsid, daemon_id, get_parm(ctx.config_json), ctx.image)
 
     def get_container_mounts(self, data_dir):
         # type: (str) -> Dict[str, str]
@@ -346,7 +345,7 @@ class NFSGanesha(object):
             cluster = self.rgw.get('cluster', 'ceph')
             rgw_user = self.rgw.get('user', 'admin')
             mounts[os.path.join(data_dir, 'keyring.rgw')] = \
-                    '/var/lib/ceph/radosgw/%s-%s/keyring:z' % (cluster, rgw_user)
+                '/var/lib/ceph/radosgw/%s-%s/keyring:z' % (cluster, rgw_user)
         return mounts
 
     @staticmethod
@@ -3340,8 +3339,8 @@ def prepare_cluster_network(ctx: CephadmContext) -> Tuple[str, bool]:
         ipv6_cluster_network = True if 6 in versions else False
     else:
         logger.info("- internal network (--cluster-network) has not "
-                       "been provided, OSD replication will default to "
-                       "the public_network")
+                    "been provided, OSD replication will default to "
+                    "the public_network")
 
     return cluster_network, ipv6_cluster_network
 
@@ -3392,8 +3391,8 @@ def create_initial_keys(
                % (mon_key, admin_key, mgr_id, mgr_key))
 
     admin_keyring = write_tmp('[client.admin]\n'
-                                  '\tkey = ' + admin_key + '\n',
-                                       uid, gid)
+                              '\tkey = ' + admin_key + '\n',
+                              uid, gid)
 
     # tmp keyring file
     bootstrap_keyring = write_tmp(keyring, uid, gid)
@@ -3773,7 +3772,7 @@ def command_bootstrap(ctx):
         ctx.output_config = os.path.join(ctx.output_dir, 'ceph.conf')
     if not ctx.output_keyring:
         ctx.output_keyring = os.path.join(ctx.output_dir,
-                                           'ceph.client.admin.keyring')
+                                          'ceph.client.admin.keyring')
     if not ctx.output_pub_ssh_key:
         ctx.output_pub_ssh_key = os.path.join(ctx.output_dir, 'ceph.pub')
 
@@ -3783,7 +3782,7 @@ def command_bootstrap(ctx):
         if not ctx.allow_overwrite:
             if os.path.exists(f):
                 raise Error('%s already exists; delete or pass '
-                              '--allow-overwrite to overwrite' % f)
+                            '--allow-overwrite to overwrite' % f)
         dirname = os.path.dirname(f)
         if dirname and not os.path.exists(dirname):
             fname = os.path.basename(f)
@@ -3985,18 +3984,18 @@ def command_registry_login(ctx: CephadmContext):
             registry_login(ctx, ctx.registry_url, ctx.registry_username, ctx.registry_password)
         else:
             raise Error("json provided for custom registry login did not include all necessary fields. "
-                            "Please setup json file as\n"
-                            "{\n"
-                              " \"url\": \"REGISTRY_URL\",\n"
-                              " \"username\": \"REGISTRY_USERNAME\",\n"
-                              " \"password\": \"REGISTRY_PASSWORD\"\n"
-                            "}\n")
+                        "Please setup json file as\n"
+                        "{\n"
+                        " \"url\": \"REGISTRY_URL\",\n"
+                        " \"username\": \"REGISTRY_USERNAME\",\n"
+                        " \"password\": \"REGISTRY_PASSWORD\"\n"
+                        "}\n")
     elif ctx.registry_url and ctx.registry_username and ctx.registry_password:
         registry_login(ctx, ctx.registry_url, ctx.registry_username, ctx.registry_password)
     else:
         raise Error("Invalid custom registry arguments received. To login to a custom registry include "
-                        "--registry-url, --registry-username and --registry-password "
-                        "options or --registry-json option")
+                    "--registry-url, --registry-username and --registry-password "
+                    "options or --registry-json option")
     return 0
 
 def registry_login(ctx: CephadmContext, url, username, password):
@@ -4941,7 +4940,7 @@ def command_adopt_ceph(ctx, daemon_type, daemon_id, fsid):
     # logs
     logger.info('Moving logs...')
     log_dir_src = ('/var/log/ceph/%s-%s.%s.log*' %
-                    (ctx.cluster, daemon_type, daemon_id))
+                   (ctx.cluster, daemon_type, daemon_id))
     log_dir_src = os.path.abspath(ctx.legacy_dir + log_dir_src)
     log_dir_dst = make_log_dir(ctx, fsid, uid=uid, gid=gid)
     move_files(ctx, glob(log_dir_src),
@@ -4966,7 +4965,7 @@ def command_adopt_prometheus(ctx, daemon_id, fsid):
     _stop_and_disable(ctx, 'prometheus')
 
     data_dir_dst = make_data_dir(ctx, fsid, daemon_type, daemon_id,
-                                     uid=uid, gid=gid)
+                                 uid=uid, gid=gid)
 
     # config
     config_src = '/etc/prometheus/prometheus.yml'
@@ -4996,7 +4995,7 @@ def command_adopt_grafana(ctx, daemon_id, fsid):
     _stop_and_disable(ctx, 'grafana-server')
 
     data_dir_dst = make_data_dir(ctx, fsid, daemon_type, daemon_id,
-                                     uid=uid, gid=gid)
+                                 uid=uid, gid=gid)
 
     # config
     config_src = '/etc/grafana/grafana.ini'
@@ -5050,7 +5049,7 @@ def command_adopt_alertmanager(ctx, daemon_id, fsid):
     _stop_and_disable(ctx, 'prometheus-alertmanager')
 
     data_dir_dst = make_data_dir(ctx, fsid, daemon_type, daemon_id,
-                                     uid=uid, gid=gid)
+                                 uid=uid, gid=gid)
 
     # config
     config_src = '/etc/prometheus/alertmanager.yml'
@@ -5120,7 +5119,7 @@ def command_rm_daemon(ctx):
 
     if daemon_type in ['mon', 'osd'] and not ctx.force:
         raise Error('must pass --force to proceed: '
-                      'this command may destroy precious data!')
+                    'this command may destroy precious data!')
 
     call(ctx, ['systemctl', 'stop', unit_name],
          verbosity=CallVerbosity.DEBUG)
@@ -5151,7 +5150,7 @@ def command_rm_cluster(ctx):
     # type: (CephadmContext) -> None
     if not ctx.force:
         raise Error('must pass --force to proceed: '
-                      'this command may destroy precious data!')
+                    'this command may destroy precious data!')
 
     l = FileLock(ctx, ctx.fsid)
     l.acquire()
@@ -5179,16 +5178,15 @@ def command_rm_cluster(ctx):
         call(ctx, ['systemctl', 'disable', unit_name],
              verbosity=CallVerbosity.DEBUG)
 
-    slice_name = 'system-%s.slice' % (('ceph-%s' % ctx.fsid).replace('-',
-                                                                      '\\x2d'))
+    slice_name = 'system-%s.slice' % (('ceph-%s' % ctx.fsid).replace('-', '\\x2d'))
     call(ctx, ['systemctl', 'stop', slice_name],
          verbosity=CallVerbosity.DEBUG)
 
     # rm units
     call_throws(ctx, ['rm', '-f', ctx.unit_dir +
-                             '/ceph-%s@.service' % ctx.fsid])
+                      '/ceph-%s@.service' % ctx.fsid])
     call_throws(ctx, ['rm', '-f', ctx.unit_dir +
-                             '/ceph-%s.target' % ctx.fsid])
+                      '/ceph-%s.target' % ctx.fsid])
     call_throws(ctx, ['rm', '-rf',
                   ctx.unit_dir + '/ceph-%s.target.wants' % ctx.fsid])
     # rm data
@@ -5196,7 +5194,7 @@ def command_rm_cluster(ctx):
     # rm logs
     call_throws(ctx, ['rm', '-rf', ctx.log_dir + '/' + ctx.fsid])
     call_throws(ctx, ['rm', '-rf', ctx.log_dir +
-                             '/*.wants/ceph-%s@*' % ctx.fsid])
+                      '/*.wants/ceph-%s@*' % ctx.fsid])
     # rm logrotate config
     call_throws(ctx, ['rm', '-f', ctx.logrotate_dir + '/ceph-%s' % ctx.fsid])
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3225,7 +3225,7 @@ def check_subnet(subnets: str) -> Tuple[int, List[int], str]:
         except ValueError as e:
             rc = 1
             errors.append(f"{subnet} invalid: {str(e)}")
-    
+
     return rc, list(versions), ", ".join(errors)
 
 
@@ -3324,7 +3324,7 @@ def prepare_mon_addresses(
         if not mon_network:
             raise Error('Failed to infer CIDR network for mon ip %s; pass '
                         '--skip-mon-network to configure it later' % base_ip)
-    
+
     return (addr_arg, ipv6, mon_network)
 
 
@@ -3749,7 +3749,7 @@ def finish_bootstrap_config(
     if mon_network:
         logger.info(f"Setting mon public_network to {mon_network}")
         cli(['config', 'set', 'mon', 'public_network', mon_network])
-    
+
     if cluster_network:
         logger.info(f"Setting cluster_network to {cluster_network}")
         cli(['config', 'set', 'global', 'cluster_network', cluster_network])
@@ -4166,12 +4166,12 @@ def command_deploy(ctx):
         if not daemon_ports:
             logger.info("cephadm-exporter will use default port ({})".format(CephadmDaemon.default_port))
             daemon_ports = [CephadmDaemon.default_port]
-           
+
         CephadmDaemon.validate_config(config_js)
-        
+
         deploy_daemon(ctx, ctx.fsid, daemon_type, daemon_id, None,
                       uid, gid, ports=daemon_ports)
-    
+
     else:
         raise Error('daemon type {} not implemented in command_deploy function'
                     .format(daemon_type))
@@ -6340,7 +6340,7 @@ class HostFacts():
 
         if ret:
             return ret
-        
+
         return {
             "type": "None",
             "description": "Linux Security Module framework is not available"
@@ -6417,7 +6417,7 @@ class CephadmCache:
         self.daemons = {}
         self.host = {}
         self.lock = RLock()
-    
+
     @property
     def health(self):
         return {
@@ -6474,7 +6474,7 @@ class CephadmDaemonHandler(BaseHTTPRequestHandler):
         @classmethod
         def authorize(cls, f):
             """Implement a basic token check.
-            
+
             The token is installed at deployment time and must be provided to
             ensure we only respond to callers who know our token i.e. mgr
             """
@@ -6485,7 +6485,7 @@ class CephadmDaemonHandler(BaseHTTPRequestHandler):
                     return
                 f(self, *args, **kwargs)
             return wrapper
-    
+
     def _help_page(self):
         return """<!DOCTYPE html>
 <html>
@@ -6586,7 +6586,7 @@ td,th {{
             self.send_header('Content-type', 'application/json')
             self.end_headers()
             self.wfile.write(json.dumps({"message": bad_request_msg}).encode('utf-8'))
-    
+
     def log_message(self, format, *args):
         rqst = " ".join(str(a) for a in args)
         logger.info(f"client:{self.address_string()} [{self.log_date_time_string()}] {rqst}")
@@ -6630,7 +6630,7 @@ class CephadmDaemon():
 
         if not config or not all([k_name in config for k_name in CephadmDaemon.config_requirements]):
             raise Error(f"config must contain the following fields : {reqs}")
-        
+
         if not all([isinstance(config[k_name], str) for k_name in CephadmDaemon.config_requirements]):
             errors.append(f"the following fields must be strings: {reqs}")
 
@@ -6652,7 +6652,7 @@ class CephadmDaemon():
                     raise ValueError
             except (TypeError, ValueError):
                 errors.append("port must be an integer > 1024")
-        
+
         if errors:
             raise Error("Parameter errors : {}".format(", ".join(errors)))
 
@@ -6717,7 +6717,7 @@ class CephadmDaemon():
         exception_encountered = False
 
         while True:
-            
+
             if self.stop or exception_encountered:
                 break
 
@@ -6750,7 +6750,7 @@ class CephadmDaemon():
                         }
                     )
                     logger.debug(f"completed host-facts scrape - {elapsed}s")
-            
+
             time.sleep(CephadmDaemon.loop_delay)
             ctr += CephadmDaemon.loop_delay
         logger.info("host-facts thread stopped")
@@ -6808,11 +6808,11 @@ class CephadmDaemon():
                             "data": data,
                         }
                     )
-                    
+
                     logger.debug(f"completed ceph-volume scrape - {elapsed}s")
             time.sleep(CephadmDaemon.loop_delay)
             ctr += CephadmDaemon.loop_delay
-        
+
         logger.info("ceph-volume thread stopped")
 
     def _scrape_list_daemons(self, refresh_interval=20):
@@ -6821,13 +6821,13 @@ class CephadmDaemon():
         while True:
             if self.stop or exception_encountered:
                 break
-            
+
             if ctr >= refresh_interval:
                 ctr = 0
                 logger.debug("executing list-daemons scrape")
                 errors = []
                 s_time = time.time()
-                
+
                 try:
                     # list daemons should ideally be invoked with a fsid
                     data = list_daemons(self.ctx)
@@ -6850,7 +6850,7 @@ class CephadmDaemon():
                         }
                     )
                     logger.debug(f"completed list-daemons scrape - {elapsed}s")
-            
+
             time.sleep(CephadmDaemon.loop_delay)
             ctr += CephadmDaemon.loop_delay
         logger.info("list-daemons thread stopped")
@@ -6874,7 +6874,7 @@ class CephadmDaemon():
 
     def reload(self, *args):
         """reload -HUP received
-        
+
         This is a placeholder function only, and serves to provide the hook that could
         be exploited later if the exporter evolves to incorporate a config file
         """
@@ -6901,7 +6901,7 @@ class CephadmDaemon():
 
         host_facts = self._create_thread(self._scrape_host_facts, 'host', 5)
         self.workers.append(host_facts)
-        
+
         daemons = self._create_thread(self._scrape_list_daemons, 'daemons', 20)
         self.workers.append(daemons)
 
@@ -6918,7 +6918,7 @@ class CephadmDaemon():
         self.http_server.token = self.token
         server_thread = self._create_thread(self.http_server.serve_forever, 'http_server')
         logger.info(f"https server listening on {self.http_server.server_address[0]}:{self.http_server.server_port}")
-        
+
         ctr = 0
         while server_thread.is_alive():
             if self.stop:
@@ -6938,10 +6938,10 @@ class CephadmDaemon():
             ctr += CephadmDaemon.loop_delay
 
         logger.info("Main http server thread stopped")
-    
+
     @property
     def unit_run(self):
-        
+
         return """set -e
 {py3} {bin_path} exporter --fsid {fsid} --id {daemon_id} --port {port} &""".format(
             py3=shutil.which('python3'),
@@ -7009,7 +7009,7 @@ WantedBy=ceph-{fsid}.target
             os.rename(
                 os.path.join(self.ctx.unit_dir, f"{self.unit_name}.new"),
                 os.path.join(self.ctx.unit_dir, self.unit_name))
-        
+
         call_throws(self.ctx, ['systemctl', 'daemon-reload'])
         call(self.ctx, ['systemctl', 'stop', self.unit_name],
              verbosity=CallVerbosity.DEBUG)
@@ -7061,7 +7061,7 @@ def command_exporter(ctx: CephadmContext):
 
     if ctx.fsid not in os.listdir(ctx.data_dir):
         raise Error(f"cluster fsid '{ctx.fsid}' not found in '{ctx.data_dir}'")
-            
+
     exporter.run()
 
 ##################################
@@ -7084,7 +7084,7 @@ def command_maintenance(ctx: CephadmContext):
         raise Error('must pass --fsid to specify cluster')
 
     target = f"ceph-{ctx.fsid}.target"
-    
+
     if ctx.maintenance_action.lower() == 'enter':
         logger.info("Requested to place host into maintenance")
         if systemd_target_state(target):

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4387,9 +4387,10 @@ def list_networks(ctx):
 
     ## sadly, 18.04's iproute2 4.15.0-2ubun doesn't support the -j flag,
     ## so we'll need to use a regex to parse 'ip' command output.
-    #out, _, _ = call_throws(['ip', '-j', 'route', 'ls'])
-    #j = json.loads(out)
-    #for x in j:
+    ##
+    # out, _, _ = call_throws(['ip', '-j', 'route', 'ls'])
+    # j = json.loads(out)
+    # for x in j:
 
     res = _list_ipv4_networks(ctx)
     res.update(_list_ipv6_networks(ctx))

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -7805,5 +7805,6 @@ def main():
         r = 0
     sys.exit(r)
 
+
 if __name__ == "__main__":
     main()

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2944,10 +2944,10 @@ StartLimitBurst=5
 [Install]
 WantedBy=ceph-{fsid}.target
 """.format(
-    container_path=ctx.container_path,
-    fsid=fsid,
-    data_dir=ctx.data_dir,
-    extra_args=extra_args)
+        container_path=ctx.container_path,
+        fsid=fsid,
+        data_dir=ctx.data_dir,
+        extra_args=extra_args)
 
     return u
 
@@ -4851,7 +4851,7 @@ def command_adopt_ceph(ctx, daemon_type, daemon_id, fsid):
     if not os.path.exists(data_dir_src):
         raise Error("{}.{} data directory '{}' does not exist.  "
                     "Incorrect ID specified, or daemon alrady adopted?".format(
-                    daemon_type, daemon_id, data_dir_src))
+                        daemon_type, daemon_id, data_dir_src))
 
     osd_fsid = None
     if daemon_type == 'osd':
@@ -6969,10 +6969,8 @@ RestartSec=10s
 
 [Install]
 WantedBy=ceph-{fsid}.target
-""".format(
-        fsid=self.fsid,
-        daemon_path=self.daemon_path
-)
+""".format(fsid=self.fsid,
+           daemon_path=self.daemon_path)
 
     def deploy_daemon_unit(self, config=None):
         """deploy a specific unit file for cephadm

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -100,6 +100,7 @@ logger: logging.Logger = None  # type: ignore
 
 ##################################
 
+
 class BaseConfig:
 
     def __init__(self):
@@ -194,6 +195,7 @@ logging_config = {
     }
 }
 
+
 class termcolor:
     yellow = '\033[93m'
     red = '\033[31m'
@@ -279,6 +281,8 @@ class Monitoring(object):
     }  # type: ignore
 
 ##################################
+
+
 def populate_files(config_dir, config_files, uid, gid):
     # type: (str, Dict, int, int) -> None
     """create config files for different services"""
@@ -290,6 +294,7 @@ def populate_files(config_dir, config_files, uid, gid):
             os.fchown(f.fileno(), uid, gid)
             os.fchmod(f.fileno(), 0o600)
             f.write(config_content)
+
 
 class NFSGanesha(object):
     """Defines a NFS-Ganesha container"""
@@ -587,6 +592,7 @@ class CephIscsi(object):
         return tcmu_container
 
 ##################################
+
 
 class HAproxy(object):
     """Defines an HAproxy container"""
@@ -926,6 +932,7 @@ def get_supported_daemons():
 
 ##################################
 
+
 class PortOccupiedError(Error):
     pass
 
@@ -983,6 +990,7 @@ def check_ip_port(ctx, ip, port):
         attempt_bind(ctx, s, ip, port)
 
 ##################################
+
 
 # this is an abbreviated version of
 # https://github.com/benediktschmitt/py-filelock/blob/master/filelock.py
@@ -1301,6 +1309,7 @@ except ImportError:
             finally:
                 asyncio.set_event_loop(None)
                 loop.close()
+
 
 def call(ctx: CephadmContext,
          command: List[str],
@@ -2549,6 +2558,7 @@ def deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid,
         call_throws(ctx, ['systemctl', 'restart',
                           get_unit_name(fsid, daemon_type, daemon_id)])
 
+
 def _write_container_cmd_to_bash(ctx, file_obj, container, comment=None, background=False):
     # type: (CephadmContext, IO[str], CephContainer, Optional[str], Optional[bool]) -> None
     if comment:
@@ -2828,6 +2838,7 @@ def update_firewalld(ctx, daemon_type):
 
     firewall.open_ports(fw_ports)
     firewall.apply_rules()
+
 
 def install_base_units(ctx, fsid):
     # type: (CephadmContext, str) -> None
@@ -3163,6 +3174,7 @@ def _pull_image(ctx, image):
         time.sleep(sleep_secs)
 
     raise RuntimeError('Failed command: %s: maximum retries reached' % cmd_str)
+
 ##################################
 
 
@@ -3196,8 +3208,9 @@ def get_image_info_from_inspect(out, image):
         r['repo_digests'] = digests[1:-1].split(' ')
     return r
 
-
 ##################################
+
+
 def check_subnet(subnets: str) -> Tuple[int, List[int], str]:
     """Determine whether the given string is a valid subnet
 
@@ -3223,6 +3236,7 @@ def check_subnet(subnets: str) -> Tuple[int, List[int], str]:
             errors.append(f"{subnet} invalid: {str(e)}")
     
     return rc, list(versions), ", ".join(errors)
+
 
 def unwrap_ipv6(address):
     # type: (str) -> str
@@ -3971,6 +3985,7 @@ def command_bootstrap(ctx):
 
 ##################################
 
+
 def command_registry_login(ctx: CephadmContext):
     if ctx.registry_json:
         logger.info("Pulling custom registry login info from %s." % ctx.registry_json)
@@ -3995,6 +4010,7 @@ def command_registry_login(ctx: CephadmContext):
                     "--registry-url, --registry-username and --registry-password "
                     "options or --registry-json option")
     return 0
+
 
 def registry_login(ctx: CephadmContext, url, username, password):
     logger.info("Logging into custom registry.")
@@ -4714,8 +4730,8 @@ def get_daemon_description(ctx, fsid, name, detail=False, legacy_dir=None):
         return d
     raise Error('Daemon not found: {}. See `cephadm ls`'.format(name))
 
-
 ##################################
+
 
 @default_image
 def command_adopt(ctx):
@@ -5105,8 +5121,8 @@ def _stop_and_disable(ctx, unit_name):
         logger.info('Disabling old systemd unit %s...' % unit_name)
         call_throws(ctx, ['systemctl', 'disable', unit_name])
 
-
 ##################################
+
 
 def command_rm_daemon(ctx):
     # type: (CephadmContext) -> None
@@ -5209,8 +5225,8 @@ def command_rm_cluster(ctx):
                 if os.path.exists(files[n]):
                     os.remove(files[n])
 
-
 ##################################
+
 
 def check_time_sync(ctx, enabler=None):
     # type: (CephadmContext, Optional[Packager]) -> bool
@@ -5818,6 +5834,7 @@ def command_install(ctx: CephadmContext):
 
 ##################################
 
+
 def get_ipv4_address(ifname):
     # type: (str) -> str
     def _extract(sock, offset):
@@ -5911,8 +5928,9 @@ def read_file(path_list, file_name=''):
                     return content
     return "Unknown"
 
-
 ##################################
+
+
 class HostFacts():
     _dmi_path_list = ['/sys/class/dmi/id']
     _nic_path_list = ['/sys/class/net']
@@ -6375,13 +6393,14 @@ class HostFacts():
 
 ##################################
 
+
 def command_gather_facts(ctx: CephadmContext):
     """gather_facts is intended to provide host releated metadata to the caller"""
     host = HostFacts(ctx)
     print(host.dump())
 
-
 ##################################
+
 
 def command_verify_prereqs(ctx: CephadmContext):
     if ctx.service_type == 'haproxy' or ctx.service_type == 'keepalived':
@@ -6450,6 +6469,7 @@ class CephadmHTTPServer(ThreadingMixIn, HTTPServer):
     daemon_threads = True
     cephadm_cache: CephadmCache
     token: str
+
 
 class CephadmDaemonHandler(BaseHTTPRequestHandler):
     server: CephadmHTTPServer
@@ -7055,9 +7075,9 @@ def command_exporter(ctx: CephadmContext):
         raise Error(f"cluster fsid '{ctx.fsid}' not found in '{ctx.data_dir}'")
             
     exporter.run()
-        
 
 ##################################
+
 
 def systemd_target_state(target_name: str, subsystem: str = 'ceph') -> bool:
     # TODO: UNITTEST
@@ -7121,8 +7141,8 @@ def command_maintenance(ctx: CephadmContext):
                 else:
                     return f"success - systemd target {target} enabled and started"
 
-
 ##################################
+
 
 def _get_parser():
     # type: () -> argparse.ArgumentParser

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -163,9 +163,6 @@ class CephadmContext:
             super().__setattr__(name, value)
 
 
-##################################  
-
-
 # Log and console output config
 logging_config = {
     'version': 1,
@@ -1845,7 +1842,7 @@ def move_files(ctx, src, dst, uid=None, gid=None):
             os.chown(dst_file, uid, gid)
 
 
-## copied from distutils ##
+# copied from distutils
 def find_executable(executable, path=None):
     """Tries to find 'executable' in the directories listed in 'path'.
     A string listing directories separated by 'os.pathsep'; defaults to
@@ -4385,9 +4382,9 @@ def command_logs(ctx):
 def list_networks(ctx):
     # type: (CephadmContext) -> Dict[str,List[str]]
 
-    ## sadly, 18.04's iproute2 4.15.0-2ubun doesn't support the -j flag,
-    ## so we'll need to use a regex to parse 'ip' command output.
-    ##
+    # sadly, 18.04's iproute2 4.15.0-2ubun doesn't support the -j flag,
+    # so we'll need to use a regex to parse 'ip' command output.
+    #
     # out, _, _ = call_throws(['ip', '-j', 'route', 'ls'])
     # j = json.loads(out)
     # for x in j:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -6069,8 +6069,7 @@ class HostFacts():
                 "wwid": disk_wwid,
                 "dev_name": dev,
                 "disk_size_bytes": disk_size_bytes,
-                }
-            )
+            })
         return disk_list
 
     @property

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -5188,9 +5188,9 @@ def command_rm_cluster(ctx):
          verbosity=CallVerbosity.DEBUG)
 
     # rm units
-    call_throws(ctx, ['rm', '-f', ctx.unit_dir +
+    call_throws(ctx, ['rm', '-f', ctx.unit_dir +  # noqa: W504
                       '/ceph-%s@.service' % ctx.fsid])
-    call_throws(ctx, ['rm', '-f', ctx.unit_dir +
+    call_throws(ctx, ['rm', '-f', ctx.unit_dir +  # noqa: W504
                       '/ceph-%s.target' % ctx.fsid])
     call_throws(ctx, ['rm', '-rf',
                       ctx.unit_dir + '/ceph-%s.target.wants' % ctx.fsid])
@@ -5198,7 +5198,7 @@ def command_rm_cluster(ctx):
     call_throws(ctx, ['rm', '-rf', ctx.data_dir + '/' + ctx.fsid])
     # rm logs
     call_throws(ctx, ['rm', '-rf', ctx.log_dir + '/' + ctx.fsid])
-    call_throws(ctx, ['rm', '-rf', ctx.log_dir +
+    call_throws(ctx, ['rm', '-rf', ctx.log_dir +  # noqa: W504
                       '/*.wants/ceph-%s@*' % ctx.fsid])
     # rm logrotate config
     call_throws(ctx, ['rm', '-f', ctx.logrotate_dir + '/ceph-%s' % ctx.fsid])
@@ -6373,9 +6373,8 @@ class HostFacts():
         """Return the attributes of this HostFacts object as json"""
         data = {
             k: getattr(self, k) for k in dir(self)
-            if not k.startswith('_') and
-            isinstance(getattr(self, k),
-                       (float, int, str, list, dict, tuple))
+            if not k.startswith('_')
+            and isinstance(getattr(self, k), (float, int, str, list, dict, tuple))
         }
         return json.dumps(data, indent=2, sort_keys=True)
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3811,8 +3811,8 @@ def command_bootstrap(ctx):
     mgr_id = ctx.mgr_id or generate_service_id()
     logger.info('Cluster fsid: %s' % fsid)
 
-    l = FileLock(ctx, fsid)
-    l.acquire()
+    lock = FileLock(ctx, fsid)
+    lock.acquire()
 
     (addr_arg, ipv6, mon_network) = prepare_mon_addresses(ctx)
     cluster_network, ipv6_cluster_network = prepare_cluster_network(ctx)
@@ -4043,8 +4043,8 @@ def command_deploy(ctx):
     # type: (CephadmContext) -> None
     daemon_type, daemon_id = ctx.name.split('.', 1)
 
-    l = FileLock(ctx, ctx.fsid)
-    l.acquire()
+    lock = FileLock(ctx, ctx.fsid)
+    lock.acquire()
 
     if daemon_type not in get_supported_daemons():
         raise Error('daemon type %s not recognized' % daemon_type)
@@ -4310,8 +4310,8 @@ def command_ceph_volume(ctx):
     if ctx.fsid:
         make_log_dir(ctx, ctx.fsid)
 
-        l = FileLock(ctx, ctx.fsid)
-        l.acquire()
+        lock = FileLock(ctx, ctx.fsid)
+        lock.acquire()
 
     (uid, gid) = (0, 0)  # ceph-volume runs as root
     mounts = get_container_mounts(ctx, ctx.fsid, 'osd', None)
@@ -4746,8 +4746,8 @@ def command_adopt(ctx):
                                   legacy_dir=ctx.legacy_dir)
     if not fsid:
         raise Error('could not detect legacy fsid; set fsid in ceph.conf')
-    l = FileLock(ctx, fsid)
-    l.acquire()
+    lock = FileLock(ctx, fsid)
+    lock.acquire()
 
     # call correct adoption
     if daemon_type in Ceph.daemons:
@@ -5118,8 +5118,9 @@ def _stop_and_disable(ctx, unit_name):
 
 def command_rm_daemon(ctx):
     # type: (CephadmContext) -> None
-    l = FileLock(ctx, ctx.fsid)
-    l.acquire()
+    lock = FileLock(ctx, ctx.fsid)
+    lock.acquire()
+
     (daemon_type, daemon_id) = ctx.name.split('.', 1)
     unit_name = get_unit_name_by_daemon_name(ctx, ctx.fsid, ctx.name)
 
@@ -5158,8 +5159,8 @@ def command_rm_cluster(ctx):
         raise Error('must pass --force to proceed: '
                     'this command may destroy precious data!')
 
-    l = FileLock(ctx, ctx.fsid)
-    l.acquire()
+    lock = FileLock(ctx, ctx.fsid)
+    lock.acquire()
 
     # stop + disable individual daemon units
     for d in list_daemons(ctx, detail=False):
@@ -5954,7 +5955,7 @@ class HostFacts():
         cpu_set = set()
 
         for line in output:
-            field = [l.strip() for l in line.split(':')]
+            field = [f.strip() for f in line.split(':')]
             if "model name" in line:
                 self.cpu_model = field[1]
             if "physical id" in line:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1391,7 +1391,7 @@ def call_timeout(ctx, command, timeout):
 
     try:
         return subprocess.call(command, timeout=timeout)
-    except subprocess.TimeoutExpired as e:
+    except subprocess.TimeoutExpired:
         raise_timeout(command, timeout)
 
 ##################################
@@ -2472,7 +2472,7 @@ def deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid,
         create_daemon_dirs(ctx, fsid, daemon_type, daemon_id, uid, gid)
         mon_dir = get_data_dir(fsid, ctx.data_dir, 'mon', daemon_id)
         log_dir = get_log_dir(fsid, ctx.log_dir)
-        out = CephContainer(
+        CephContainer(
             ctx,
             image=ctx.image,
             entrypoint='/usr/bin/ceph-mon',
@@ -3579,7 +3579,7 @@ def prepare_ssh(
         logger.info('Adding key to %s@localhost\'s authorized_keys...' % ctx.ssh_user)
         try:
             s_pwd = pwd.getpwnam(ctx.ssh_user)
-        except KeyError as e:
+        except KeyError:
             raise Error('Cannot find uid/gid for ssh-user: %s' % (ctx.ssh_user))
         ssh_uid = s_pwd.pw_uid
         ssh_gid = s_pwd.pw_gid
@@ -3882,7 +3882,7 @@ def command_bootstrap(ctx):
         # necessary
         try:
             out = cli(['mgr', 'stat'])
-        except Exception as e:
+        except Exception:
             out = cli(['mgr', 'dump'])
         j = json.loads(out)
         epoch = j['epoch']
@@ -5274,8 +5274,6 @@ def command_check_host(ctx: CephadmContext) -> None:
 
 
 def command_prepare_host(ctx: CephadmContext) -> None:
-    container_path = ctx.container_path
-
     logger.info('Verifying podman|docker is present...')
     pkg = None
     try:
@@ -5500,7 +5498,7 @@ class Apt(Packager):
         logger.info('Attempting podman install...')
         try:
             self.install(['podman'])
-        except Error as e:
+        except Error:
             logger.info('Podman did not work.  Falling back to docker...')
             self.install(['docker.io'])
 
@@ -5804,7 +5802,7 @@ def command_add_repo(ctx: CephadmContext):
     if ctx.version:
         try:
             (x, y, z) = ctx.version.split('.')
-        except Exception as e:
+        except Exception:
             raise Error('version must be in the form x.y.z (e.g., 15.2.0)')
 
     pkg = create_packager(ctx, stable=ctx.release,

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -9,12 +9,10 @@ import ipaddress
 import json
 import logging
 from logging.config import dictConfig
-from operator import truediv
 import os
 import platform
 import pwd
 import random
-import select
 import shutil
 import socket
 import string

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -129,23 +129,18 @@ class BaseConfig:
 class CephadmContext:
 
     def __init__(self):
-
         self.__dict__["_args"] = None
         self.__dict__["_conf"] = BaseConfig()
-
 
     def set_args(self, args: argparse.Namespace) -> None:
         self._conf.set_from_args(args)
         self._args = args
 
-
     def has_function(self) -> bool:
         return "func" in self._args
 
-
     def __contains__(self, name: str) -> bool:
         return hasattr(self, name)
-
 
     def __getattr__(self, name: str) -> Any:
         if "_conf" in self.__dict__ and hasattr(self._conf, name):
@@ -2718,7 +2713,6 @@ def deploy_daemon_units(
         call_throws(ctx, ['systemctl', 'start', unit_name])
 
 
-
 class Firewalld(object):
     def __init__(self, ctx):
         # type: (CephadmContext) -> None
@@ -3767,7 +3761,6 @@ def finish_bootstrap_config(
         logger.info('Enabling IPv6 (ms_bind_ipv6) binding')
         cli(['config', 'set', 'global', 'ms_bind_ipv6', 'true'])
 
-
     with open(ctx.output_config, 'w') as f:
         f.write(config)
     logger.info('Wrote config to %s' % ctx.output_config)
@@ -3804,7 +3797,6 @@ def command_bootstrap(ctx):
                 os.makedirs(dirname, 0o755)
             except PermissionError:
                 raise Error(f"Unable to create {dirname} due to permissions failure. Retry with root, or sudo or preallocate the directory.")
-
 
     if not ctx.skip_prepare_host:
         command_prepare_host(ctx)
@@ -3943,7 +3935,6 @@ def command_bootstrap(ctx):
         # deploy the service (commented out until the cephadm changes are in the ceph container build)
         logger.info('Deploying cephadm exporter service with default placement...')
         cli(['orch', 'apply', 'cephadm-exporter'])
-
 
     if not ctx.skip_dashboard:
         prepare_dashboard(ctx, uid, gid, cli, wait_for_mgr_restart)
@@ -6216,7 +6207,6 @@ class HostFacts():
             if self.interfaces[iface]["iftype"] == 'physical':
                 phys_devs.append(iface)
         return len(phys_devs)
-
 
     def _get_mem_data(self, field_name):
         # type: (str) -> int

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3519,6 +3519,7 @@ def create_mgr(
 
     # wait for the service to become available
     logger.info('Waiting for mgr to start...')
+
     def is_mgr_available():
         # type: () -> bool
         timeout = ctx.timeout if ctx.timeout else 60  # seconds

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -6,7 +6,6 @@ skipsdist=true
 max-line-length = 100
 ignore =
     E501,
-    W291,
     W293,
     W503,
     W504,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -6,7 +6,6 @@ skipsdist=true
 max-line-length = 100
 ignore =
     E501,
-    F841,
     W291,
     W293,
     W503,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -6,7 +6,6 @@ skipsdist=true
 max-line-length = 100
 ignore =
     E501,
-    E722,
     E741,
     F401,
     F841,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E302,
     E303,
     E305,
     E306,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E303,
     E305,
     E306,
     E402,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E251,
     E261,
     E265,
     E266,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E131,
     E201,
     E203,
     E225,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E226,
     E231,
     E241,
     E251,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -7,7 +7,6 @@ max-line-length = 100
 ignore =
     E501,
     W503,
-    W504,
 exclude =
     .tox,
     .vagrant,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -6,7 +6,6 @@ skipsdist=true
 max-line-length = 100
 ignore =
     E501,
-    E741,
     F401,
     F841,
     W291,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,8 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E261,
-    E265,
     E266,
     E301,
     E302,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E201,
     E203,
     E225,
     E226,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E241,
     E251,
     E261,
     E265,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E122,
     E123,
     E124,
     E126,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E124,
     E126,
     E127,
     E128,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E126,
     E127,
     E128,
     E131,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E128,
     E131,
     E201,
     E203,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E305,
     E306,
     E402,
     E501,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -1,6 +1,53 @@
 [tox]
-envlist = py3, mypy
+envlist = py3, mypy, flake8
 skipsdist=true
+
+[flake8]
+max-line-length = 100
+ignore =
+    E117,
+    E121,
+    E122,
+    E123,
+    E124,
+    E126,
+    E127,
+    E128,
+    E131,
+    E201,
+    E203,
+    E225,
+    E226,
+    E231,
+    E241,
+    E251,
+    E261,
+    E265,
+    E266,
+    E301,
+    E302,
+    E303,
+    E305,
+    E306,
+    E402,
+    E501,
+    E703,
+    E722,
+    E741,
+    F401,
+    F841,
+    W291,
+    W293,
+    W503,
+    W504,
+exclude =
+    .tox,
+    .vagrant,
+    __pycache__,
+    *.pyc,
+    templates,
+    .eggs
+statistics = True
 
 [testenv]
 skip_install=true
@@ -13,3 +60,10 @@ commands=pytest {posargs}
 basepython = python3
 deps = mypy==0.790
 commands = mypy --config-file ../mypy.ini {posargs:cephadm}
+
+[testenv:flake8]
+basepython = python3
+deps =
+    flake8
+commands =
+    flake8 --config=tox.ini {posargs:cephadm}

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -6,7 +6,6 @@ skipsdist=true
 max-line-length = 100
 ignore =
     E501,
-    E703,
     E722,
     E741,
     F401,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E402,
     E501,
     E703,
     E722,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E127,
     E128,
     E131,
     E201,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E203,
     E225,
     E226,
     E231,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E266,
     E301,
     E302,
     E303,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -6,7 +6,6 @@ skipsdist=true
 max-line-length = 100
 ignore =
     E501,
-    W293,
     W503,
     W504,
 exclude =

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E301,
     E302,
     E303,
     E305,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -6,7 +6,6 @@ skipsdist=true
 max-line-length = 100
 ignore =
     E501,
-    F401,
     F841,
     W291,
     W293,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E121,
     E122,
     E123,
     E124,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E231,
     E241,
     E251,
     E261,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E225,
     E226,
     E231,
     E241,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E123,
     E124,
     E126,
     E127,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E117,
     E121,
     E122,
     E123,

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -5,7 +5,6 @@ skipsdist=true
 [flake8]
 max-line-length = 100
 ignore =
-    E306,
     E402,
     E501,
     E703,


### PR DESCRIPTION
Adds flake8 as a linter for bin/cephadm

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
