### PR TITLE
mon: load our config from rocksdb on startup

### DIFF
--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1250,6 +1250,7 @@ void RocksDBStore::close()
     must_close_default_cf = false;
   }
   default_cf = nullptr;
+  db->Close();
   delete db;
   db = nullptr;
 }

--- a/src/mon/ConfigMonitor.h
+++ b/src/mon/ConfigMonitor.h
@@ -55,4 +55,7 @@ public:
   void check_sub(MonSession *s);
   void check_sub(Subscription *sub);
   void check_all_subs();
+
+  static void bootstrap_mon_config(MonitorDBStore *store,
+				   const OSDMap& osdmap);
 };


### PR DESCRIPTION
Among other things, this means that things like log_to_file=true in the mon config database will apply to mons during startup.  I noticed this while debugging a cephadm teuthology run and noticed that there were no 'ceph version' lines for the mon restarts like I was expecting.. because the log_to_file=true option is non-default (with cephadm) and stored in the mon config database.  Currently the options don't get applied until the ConfigMonitor update_from_paxos() method runs later in the mon startup process (before we try to join a quorum, at least, but after a bunch of other important startup work has been done).

This only partially implements loading the mon config: it doesn't extract the latest OSDMap and apply config keys related to crush location, mostly because this is complicated and tedious when OSDMonitor doesn't store a full map for every epoch and the mon machinery isn't all started up.