### PR TITLE
mon: fix INCOMPAT_QUINCY ondisk compatset feature bit

### DIFF
--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -1077,7 +1077,7 @@ public:
 #define CEPH_MON_FEATURE_INCOMPAT_NAUTILUS CompatSet::Feature(11, "nautilus ondisk layout")
 #define CEPH_MON_FEATURE_INCOMPAT_OCTOPUS CompatSet::Feature(12, "octopus ondisk layout")
 #define CEPH_MON_FEATURE_INCOMPAT_PACIFIC CompatSet::Feature(13, "pacific ondisk layout")
-#define CEPH_MON_FEATURE_INCOMPAT_QUINCY CompatSet::Feature(13, "quincy ondisk layout")
+#define CEPH_MON_FEATURE_INCOMPAT_QUINCY CompatSet::Feature(14, "quincy ondisk layout")
 // make sure you add your feature to Monitor::get_supported_features
 
 


### PR DESCRIPTION
This was overlapping with pacific.

Signed-off-by: Sage Weil <sage@newdream.net>