### PR TITLE
rgw: clean up some compiler warnings

### DIFF
--- a/src/rgw/rgw_cr_tools.cc
+++ b/src/rgw/rgw_cr_tools.cc
@@ -278,8 +278,6 @@ int RGWBucketLifecycleConfigCR::Request::_send_request()
 template<>
 int RGWBucketGetSyncPolicyHandlerCR::Request::_send_request()
 {
-  CephContext *cct = store->ctx();
-
   int r = store->ctl()->bucket->get_sync_policy_handler(params.zone,
                                                         params.bucket,
                                                         &result->policy_handler,

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4727,10 +4727,11 @@ int RGWRados::set_buckets_enabled(vector<rgw_bucket>& buckets, bool enabled, con
 
   for (iter = buckets.begin(); iter != buckets.end(); ++iter) {
     rgw_bucket& bucket = *iter;
-    if (enabled)
+    if (enabled) {
       ldpp_dout(dpp, 20) << "enabling bucket name=" << bucket.name << dendl;
-    else
+    } else {
       ldpp_dout(dpp, 20) << "disabling bucket name=" << bucket.name << dendl;
+    }
 
     RGWBucketInfo info;
     map<string, bufferlist> attrs;
@@ -5455,10 +5456,11 @@ int RGWRados::get_obj_state_impl(const DoutPrefixProvider *dpp, RGWObjectCtx *rc
       }
     }
   }
-  if (s->obj_tag.length())
+  if (s->obj_tag.length()) {
     ldpp_dout(dpp, 20) << "get_obj_state: setting s->obj_tag to " << s->obj_tag.c_str() << dendl;
-  else
+  } else {
     ldpp_dout(dpp, 20) << "get_obj_state: s->obj_tag was set empty" << dendl;
+  }
 
   /* an object might not be olh yet, but could have olh id tag, so we should set it anyway if
    * it exist, and not only if is_olh() returns true

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -990,7 +990,6 @@ int RGWReshard::process_single_logshard(int logshard_num, const DoutPrefixProvid
   string marker;
   bool truncated = true;
 
-  CephContext *cct = store->ctx();
   constexpr uint32_t max_entries = 1000;
 
   string logshard_oid;


### PR DESCRIPTION
Minimal changes to clean up a few compiler warnings.

These changes are minimal and not expected to be back-ported. Therefore there is no tracker.