### PR TITLE
qa/suites/rados/singletone: whitelist MON_DOWN when injecting msgr errors

### DIFF
--- a/qa/suites/rados/singleton/msgr-failures/few.yaml
+++ b/qa/suites/rados/singleton/msgr-failures/few.yaml
@@ -6,3 +6,4 @@ overrides:
         mon client directed command retry: 5
     log-ignorelist:
       - \(OSD_SLOW_PING_TIME
+      - \(MON_DOWN\)

--- a/qa/suites/rados/singleton/msgr-failures/many.yaml
+++ b/qa/suites/rados/singleton/msgr-failures/many.yaml
@@ -10,3 +10,4 @@ overrides:
         debug monc: 10
     log-ignorelist:
       - \(OSD_SLOW_PING_TIME
+      - \(MON_DOWN\)


### PR DESCRIPTION
add a 'none.yaml' facet which doesn't whitelist so we hopefully capture
other causes of MON_DOWN.

This fixes at least one source of https://tracker.ceph.com/issues/45441

Fixes: https://tracker.ceph.com/issues/45441
Signed-off-by: Sage Weil <sage@newdream.net>