### PR TITLE
mgr/cephadm: It need to remove osd daemon after ceph orch rm osd.

### DIFF
--- a/src/pybind/mgr/cephadm/services/osd.py
+++ b/src/pybind/mgr/cephadm/services/osd.py
@@ -678,8 +678,8 @@ class OSDRemovalQueue(object):
                 if not osd.purge():
                     raise orchestrator.OrchestratorError(f"Could not purge OSD <{osd.osd_id}>")
 
-            if not osd.exists:
-                continue
+            #if not osd.exists:
+            #    continue
             assert osd.fullname is not None
             assert osd.hostname is not None
             CephadmServe(self.mgr)._remove_daemon(osd.fullname, osd.hostname)


### PR DESCRIPTION
Scene:
host1: osd.1 osd.2 osd.3
host2: osd.4 osd.5 osd.6

We exec 'ceph orch rm osd 3' and 'ceph orch rm osd 6'.
Then exec 'ceph orch device zap host2 /dev/sdd'.
After /dev/sdd launch, it will contain two osd.3 in this cluster.

Signed-off-by: JL <ahongloumeng@163.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
