### PR TITLE
crimson/net: throw read_eof if short read

### DIFF
--- a/src/crimson/net/Socket.cc
+++ b/src/crimson/net/Socket.cc
@@ -92,8 +92,8 @@ Socket::read_exactly(size_t bytes) {
     if (bytes == 0) {
       return seastar::make_ready_future<seastar::temporary_buffer<char>>();
     }
-    return in.read_exactly(bytes).then([](auto buf) {
-      if (buf.empty()) {
+    return in.read_exactly(bytes).then([bytes](auto buf) {
+      if (buf.size() < bytes) {
         throw std::system_error(make_error_code(error::read_eof));
       }
       return seastar::make_ready_future<tmp_buf>(std::move(buf));


### PR DESCRIPTION
as per the implementation and the document of input_stream::read_exactly():

/// stream and returns them. If the end of stream is reached before n
/// bytes were read, fewer than n bytes will be returned - so despite
/// the method's name, the caller must not assume the returned buffer
/// will always contain exactly n bytes.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
