### PR TITLE
tools/cephfs-mirror: fix a dangling pointer

### DIFF
--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -913,7 +913,8 @@ int PeerReplayer::synchronize(const std::string &dir_path, uint64_t snap_id,
     return r;
   }
 
-  snap_metadata snap_meta[] = {{PRIMARY_SNAP_ID_KEY.c_str(), stringify(snap_id).c_str()}};
+  auto snap_id_str{stringify(snap_id)};
+  snap_metadata snap_meta[] = {{PRIMARY_SNAP_ID_KEY.c_str(), snap_id_str.c_str()}};
   r = ceph_mksnap(m_remote_mount, dir_path.c_str(), snap_name.c_str(), 0755,
                   snap_meta, 1);
   if (r < 0) {


### PR DESCRIPTION
stringify(snap_id) is ephemeral:

Compiler warning:
```
tools/cephfs_mirror/PeerReplayer.cc:916:62: warning: object backing the pointer will be destroyed at the end of the
 full-expression [-Wdangling-gsl]
  snap_metadata snap_meta[] = {{PRIMARY_SNAP_ID_KEY.c_str(), stringify(snap_id).c_str()}};

```

Fixes: https://tracker.ceph.com/issues/49419
Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
