### PR TITLE
pacific: osd: Don't clear m_planned_scrub until scrub finishes successfully

### DIFF
--- a/src/osd/pg_scrubber.cc
+++ b/src/osd/pg_scrubber.cc
@@ -1141,7 +1141,6 @@ void PgScrubber::set_op_parameters(requested_scrub_t& request)
   // the publishing here seems to be required for tests synchronization
   m_pg->publish_stats_to_osd();
   m_flags.deep_scrub_on_error = request.deep_scrub_on_error;
-  request = requested_scrub_t{};
 }
 
 void PgScrubber::scrub_compare_maps()
@@ -1489,6 +1488,8 @@ void PgScrubber::scrub_finish()
 	   << " deep_scrub_on_error: " << m_flags.deep_scrub_on_error << dendl;
 
   ceph_assert(m_pg->is_locked());
+
+  m_pg->m_planned_scrub = requested_scrub_t{};
 
   // if the repair request comes from auto-repair and large number of errors,
   // we would like to cancel auto-repair


### PR DESCRIPTION
backport #39535

Fixes: https://tracker.ceph.com/issues/48984

Signed-off-by: David Zafman <dzafman@redhat.com>
(cherry picked from commit 0b63c850a251f75bcb7436efefe4f24480c4ed7e)