### PR TITLE
mgr/zabbix: add desc to commands

### DIFF
--- a/src/pybind/mgr/zabbix/module.py
+++ b/src/pybind/mgr/zabbix/module.py
@@ -87,30 +87,6 @@ class Module(MgrModule):
             default=100)
     ]
 
-    COMMANDS = [
-        {
-            "cmd": "zabbix config-set name=key,type=CephString "
-                   "name=value,type=CephString",
-            "desc": "Set a configuration value",
-            "perm": "rw"
-        },
-        {
-            "cmd": "zabbix config-show",
-            "desc": "Show current configuration",
-            "perm": "r"
-        },
-        {
-            "cmd": "zabbix send",
-            "desc": "Force sending data to Zabbix",
-            "perm": "rw"
-        },
-        {
-            "cmd": "zabbix discovery",
-            "desc": "Discovering Zabbix data",
-            "perm": "r"
-        },
-    ]
-
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(Module, self).__init__(*args, **kwargs)
         self.event = Event()
@@ -405,10 +381,16 @@ class Module(MgrModule):
 
     @CLIReadCommand('zabbix config-show')
     def config_show(self) -> Tuple[int, str, str]:
+        """
+        Show current configuration
+        """
         return 0, json.dumps(self.config, indent=4, sort_keys=True), ''
 
     @CLIWriteCommand('zabbix config-set')
     def config_set(self, key: str, value: str) -> Tuple[int, str, str]:
+        """
+        Set a configuration value
+        """
         if not value:
             return -errno.EINVAL, '', 'Value should not be empty or None'
 
@@ -423,6 +405,9 @@ class Module(MgrModule):
 
     @CLIReadCommand('zabbix send')
     def do_send(self) -> Tuple[int, str, str]:
+        """
+        Force sending data to Zabbix
+        """
         data = self.get_data()
         if self.send(data):
             return 0, 'Sending data to Zabbix', ''
@@ -431,6 +416,9 @@ class Module(MgrModule):
 
     @CLIReadCommand('zabbix discovery')
     def do_discovery(self) -> Tuple[int, str, str]:
+        """
+        Discovering Zabbix data
+        """
         if self.discovery():
             return 0, 'Sending discovery data to Zabbix', ''
 


### PR DESCRIPTION
it was an oversight in 43802146b070e2d5dddc59b32fba549f14afa375 which
failed to migrate the desc as docstrings.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
