### PR TITLE
crimson/osd: drop pending ops when pg interval changes

### DIFF
--- a/src/crimson/osd/osd_connection_priv.h
+++ b/src/crimson/osd/osd_connection_priv.h
@@ -12,7 +12,7 @@
 namespace crimson::osd {
 
 struct OSDConnectionPriv : public crimson::net::Connection::user_private_t {
-  OperationRepeatSequencer<ClientRequest> opSequencer;
+  OperationRepeatSequencer<ClientRequest> op_sequencer;
   ClientRequest::ConnectionPipeline client_request_conn_pipeline;
   RemotePeeringEvent::ConnectionPipeline peering_request_conn_pipeline;
   RepRequest::ConnectionPipeline replicated_request_conn_pipeline;

--- a/src/crimson/osd/osd_operation_sequencer.h
+++ b/src/crimson/osd/osd_operation_sequencer.h
@@ -61,9 +61,13 @@ public:
     });
   }
 
-  void finish_op(OpRef& op, const spg_t& pgid) {
+  void finish_op(OpRef& op, const spg_t& pgid, bool interrutped) {
     assert(op->pos);
-    pg_ops.at(pgid).erase(*(op->pos));
+    auto curr_op_pos = *(op->pos);
+    if (interrutped) {
+      curr_op_pos->second.set_value();
+    }
+    pg_ops.at(pgid).erase(curr_op_pos);
   }
 private:
   std::map<spg_t, std::map<OpRef, seastar::promise<>, OperationComparator<T>>> pg_ops;

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -23,7 +23,7 @@ namespace crimson::osd {
 
 ClientRequest::ClientRequest(
   OSD &osd, crimson::net::ConnectionRef conn, Ref<MOSDOp> &&m)
-  : osd(osd), conn(conn), m(m), ors(get_osd_priv(conn.get()).opSequencer)
+  : osd(osd), conn(conn), m(m), ors(get_osd_priv(conn.get()).op_sequencer)
 {}
 
 ClientRequest::~ClientRequest()


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
