### PR TITLE
doc/ceph-fuse: add some options to man page

### DIFF
--- a/doc/man/8/ceph-fuse.rst
+++ b/doc/man/8/ceph-fuse.rst
@@ -36,10 +36,6 @@ Any options not recognized by ceph-fuse will be passed on to libfuse.
 
    Mount options.
 
-.. option:: -d
-
-   Run in foreground, send all log output to stderr and enable FUSE debugging (-o debug).
-
 .. option:: -c ceph.conf, --conf=ceph.conf
 
    Use *ceph.conf* configuration file instead of the default
@@ -53,6 +49,12 @@ Any options not recognized by ceph-fuse will be passed on to libfuse.
 
    Pass the name of CephX user whose secret key is be to used for mounting.
 
+.. option:: --id <client-id>
+
+   Pass the name of CephX user whose secret key is be to used for mounting.
+   ``--id`` takes just the ID of the client in contrast to ``-n``. For
+   example, ``--id 0`` for using ``client.0``.
+
 .. option:: -k <path-to-keyring>
 
    Provide path to keyring; useful when it's absent in standard locations.
@@ -65,9 +67,19 @@ Any options not recognized by ceph-fuse will be passed on to libfuse.
 
    Foreground: do not daemonize after startup (run in foreground). Do not generate a pid file.
 
+.. option:: -d
+
+   Run in foreground, send all log output to stderr and enable FUSE debugging
+   (-o debug).
+
 .. option:: -s
 
    Disable multi-threaded operation.
+
+.. option:: --client_fs
+
+   Pass the name of Ceph FS to be mounted. Not passing this option mounts the
+   default Ceph FS on the Ceph cluster.
 
 Availability
 ============


### PR DESCRIPTION
Add description for options --id and --client_fs to the ceph-fuse manual
and move description for -d closer to -f since both options are similar.




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>