### PR TITLE
doc/dev: adding upstream repo name

### DIFF
--- a/doc/dev/developer_guide/basic-workflow.rst
+++ b/doc/dev/developer_guide/basic-workflow.rst
@@ -122,10 +122,9 @@ Add the upstream repo as a "remote" and fetch it:
    git remote add ceph https://github.com/ceph/ceph.git
    git fetch ceph
 
-Fetching is a process that downloads all objects (commits, branches) that have
-been added since the last sync. These commands download all the branches from
-``ceph/ceph.git`` to the local git repo as ``remotes/ceph/$BRANCH_NAME`` and
-can be referenced as ``ceph/$BRANCH_NAME`` in local git commands.
+These commands fetch all the branches and commits from ``ceph/ceph.git`` to the
+local git repo as ``remotes/ceph/$BRANCH_NAME`` and can be referenced as
+``ceph/$BRANCH_NAME`` in local git commands.
 
 
 Resetting Local Master to Upstream Master


### PR DESCRIPTION
This commit makes one sentence slightly less
ambiguous by designating the location from
which the "ceph fetch" command fetches objects.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
