### PR TITLE
mgr/diskprediction_local: wrap line longer than 100 chars

### DIFF
--- a/src/pybind/mgr/diskprediction_local/module.py
+++ b/src/pybind/mgr/diskprediction_local/module.py
@@ -13,7 +13,7 @@ from mgr_module import CommandResult, MgrModule, Option
 #  from .predictor import get_diskfailurepredictor_path
 #
 # in a command thread.  See https://tracker.ceph.com/issues/42764
-import scipy # noqa: ignore=F401
+import scipy  # noqa: ignore=F401
 from .predictor import DevSmartT, Predictor, get_diskfailurepredictor_path
 
 
@@ -130,7 +130,8 @@ class Module(MgrModule):
         health_data: Dict[str, Dict[str, Any]] = {}
         predict_datas: List[DevSmartT] = []
         try:
-            r, outb, outs = self.remote('devicehealth', 'show_device_metrics', devid=devid, sample='')
+            r, outb, outs = self.remote(
+                'devicehealth', 'show_device_metrics', devid=devid, sample='')
             if r != 0:
                 self.log.error('failed to get device %s health', devid)
                 health_data = {}
@@ -145,7 +146,8 @@ class Module(MgrModule):
             self.log.error('invalid value received for MODULE_OPTIONS.predictor_model')
             return predicted_result
         try:
-            obj_predictor.initialize("{}/models/{}".format(get_diskfailurepredictor_path(), self.predictor_model))
+            obj_predictor.initialize(
+                "{}/models/{}".format(get_diskfailurepredictor_path(), self.predictor_model))
         except Exception as e:
             self.log.error('Error initializing predictor: %s', e)
             return predicted_result

--- a/src/pybind/mgr/diskprediction_local/predictor.py
+++ b/src/pybind/mgr/diskprediction_local/predictor.py
@@ -167,13 +167,14 @@ class RHDiskFailurePredictor(Predictor):
         roll_window_size = 6
 
         # rolling means generator
+        dataset_size = disk_days_attrs.shape[0] - roll_window_size + 1
         gen = (disk_days_attrs[i: i + roll_window_size, ...].mean(axis=0)
-               for i in range(0, disk_days_attrs.shape[0] - roll_window_size + 1))
+               for i in range(dataset_size))
         means = np.vstack(gen)
 
         # rolling stds generator
         gen = (disk_days_attrs[i: i + roll_window_size, ...].std(axis=0, ddof=1)
-               for i in range(0, disk_days_attrs.shape[0] - roll_window_size + 1))
+               for i in range(dataset_size))
         stds = np.vstack(gen)
 
         # coefficient of variation
@@ -182,8 +183,7 @@ class RHDiskFailurePredictor(Predictor):
         featurized = np.hstack((means,
                                 stds,
                                 cvs,
-                                disk_days_sa['user_capacity'][: disk_days_attrs.shape[0] - roll_window_size + 1].reshape(-1, 1)
-                                ))
+                                disk_days_sa['user_capacity'][: dataset_size].reshape(-1, 1)))
 
         # scale features
         scaler_path = os.path.join(self.model_dirpath, manufacturer + "_scaler.pkl")


### PR DESCRIPTION
to appease flake8 and autopep8

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
