### PR TITLE
doc: fix broken links multimds and kcephfs

### DIFF
--- a/doc/dev/developer_guide/testing_integration_tests/tests-integration-testing-teuthology-intro.rst
+++ b/doc/dev/developer_guide/testing_integration_tests/tests-integration-testing-teuthology-intro.rst
@@ -109,16 +109,10 @@ integration tests for all the Ceph components.
       that the integration testing infrastructure works as expected)
 
   * - `fs <https://github.com/ceph/ceph/tree/master/qa/suites/fs>`_
-    - test CephFS mounted using FUSE
-
-  * - `kcephfs <https://github.com/ceph/ceph/tree/master/qa/suites/kcephfs>`_
-    - test CephFS mounted using kernel
+    - test CephFS mounted using kernel and FUSE clients, also with multiple MDSs.
 
   * - `krbd <https://github.com/ceph/ceph/tree/master/qa/suites/krbd>`_
     - test the RBD kernel module
-
-  * - `multimds <https://github.com/ceph/ceph/tree/master/qa/suites/multimds>`_
-    - test CephFS with multiple MDSs
 
   * - `powercycle <https://github.com/ceph/ceph/tree/master/qa/suites/powercycle>`_
     - verify the Ceph cluster behaves when machines are powered off and on


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/49372



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>