### PR TITLE
crimson: multiple fixes for connection failure handling in MonClient

### DIFF
--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -569,6 +569,7 @@ void Client::ms_handle_reset(crimson::net::ConnectionRef conn, bool /* is_replac
     if (found != pending_conns.end()) {
       logger().warn("pending conn reset by {}", conn->get_peer_addr());
       (*found)->close();
+      pending_conns.erase(found);
       return seastar::now();
     } else if (active_con && active_con->is_my_peer(conn->get_peer_addr())) {
       logger().warn("active conn reset {}", conn->get_peer_addr());

--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -513,7 +513,9 @@ void Client::tick()
                                        active_con->renew_tickets(),
                                        active_con->renew_rotating_keyring()).then_unpack([] {});
     } else {
-      return seastar::now();
+      assert(is_hunting());
+      logger().info("{} continuing the hunt", __func__);
+      return authenticate();
     }
   });
 }
@@ -1032,8 +1034,8 @@ seastar::future<> Client::reopen_session(int rank)
     });
   }).then([this] {
     if (!active_con) {
-      return seastar::make_exception_future(
-	  crimson::common::system_shutdown_exception());
+      logger().warn("cannot establish the active_con with any mon");
+      return seastar::now();
     }
     return active_con->renew_rotating_keyring();
   });


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
