### PR TITLE
librbd: permit disabling QCOW migration format support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,10 @@ CMAKE_DEPENDENT_OPTION(WITH_SYSTEM_LIBURING "Require and build with system libur
 CMAKE_DEPENDENT_OPTION(WITH_BLUESTORE_PMEM "Enable PMDK libraries" OFF
   "WITH_BLUESTORE" OFF)
 
+CMAKE_DEPENDENT_OPTION(WITH_RBD_MIGRATION_FORMAT_QCOW_V1
+  "Enable librbd QCOW v1 migration format support" ON
+  "WITH_RBD" OFF)
+
 CMAKE_DEPENDENT_OPTION(WITH_RBD_RWL "Enable librbd persistent write back cache" OFF
   "WITH_RBD" OFF)
 

--- a/qa/workunits/rbd/cli_migration.sh
+++ b/qa/workunits/rbd/cli_migration.sh
@@ -162,8 +162,17 @@ test_import_qcow_format() {
 EOF
     cat ${TEMPDIR}/spec.json
 
+    set +e
     rbd migration prepare --import-only \
         --source-spec-path ${TEMPDIR}/spec.json ${dest_image}
+    local error_code=$?
+    set -e
+
+    if [ $error_code -eq 95 ]; then
+        echo "skipping QCOW test (librbd support disabled)"
+        return 0
+    fi
+    test $error_code -eq 0
 
     compare_images "${base_image}" "${dest_image}"
 

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -360,6 +360,9 @@
 /* Define if unit tests are built. */
 #cmakedefine UNIT_TESTS_BUILT
 
+/* Define if RBD QCOW migration format is enabled */
+#cmakedefine WITH_RBD_MIGRATION_FORMAT_QCOW_V1
+
 /* Define if RWL is enabled */
 #cmakedefine WITH_RBD_RWL
 

--- a/src/librbd/migration/QCOWFormat.cc
+++ b/src/librbd/migration/QCOWFormat.cc
@@ -901,7 +901,12 @@ void QCOWFormat<I>::handle_probe(int r, Context* on_finish) {
 
   m_bl.clear();
   if (header_probe.version == 1) {
+#ifdef WITH_RBD_MIGRATION_FORMAT_QCOW_V1
     read_v1_header(on_finish);
+#else // WITH_RBD_MIGRATION_FORMAT_QCOW_V1
+    lderr(cct) << "QCOW is not supported" << dendl;
+    on_finish->complete(-ENOTSUP);
+#endif // WITH_RBD_MIGRATION_FORMAT_QCOW_V1
     return;
   } else if (header_probe.version >= 2 && header_probe.version <= 3) {
     read_v2_header(on_finish);
@@ -913,6 +918,8 @@ void QCOWFormat<I>::handle_probe(int r, Context* on_finish) {
     return;
   }
 }
+
+#ifdef WITH_RBD_MIGRATION_FORMAT_QCOW_V1
 
 template <typename I>
 void QCOWFormat<I>::read_v1_header(Context* on_finish) {
@@ -1013,6 +1020,8 @@ void QCOWFormat<I>::handle_read_v1_header(int r, Context* on_finish) {
 
   read_l1_table(on_finish);
 }
+
+#endif // WITH_RBD_MIGRATION_FORMAT_QCOW_V1
 
 template <typename I>
 void QCOWFormat<I>::read_v2_header(Context* on_finish) {

--- a/src/librbd/migration/QCOWFormat.h
+++ b/src/librbd/migration/QCOWFormat.h
@@ -8,6 +8,7 @@
 #include "librbd/Types.h"
 #include "librbd/migration/FormatInterface.h"
 #include "librbd/migration/QCOW.h"
+#include "acconfig.h"
 #include "json_spirit/json_spirit.h"
 #include <boost/asio/io_context_strand.hpp>
 #include <boost/iostreams/filter/zlib.hpp>
@@ -175,8 +176,10 @@ private:
   void probe(Context* on_finish);
   void handle_probe(int r, Context* on_finish);
 
+#ifdef WITH_RBD_MIGRATION_FORMAT_QCOW_V1
   void read_v1_header(Context* on_finish);
   void handle_read_v1_header(int r, Context* on_finish);
+#endif // WITH_RBD_MIGRATION_FORMAT_QCOW_V1
 
   void read_v2_header(Context* on_finish);
   void handle_read_v2_header(int r, Context* on_finish);


### PR DESCRIPTION
Downstream Red Hat products do not support the older QCOW format. This
will allow the support for the legacy QCOW format to be disabled for the
new RBD import-only migration support.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
