### PR TITLE
src,qa: Upgrade to mypy 0.901

### DIFF
--- a/qa/tasks/mgr/dashboard/helper.py
+++ b/qa/tasks/mgr/dashboard/helper.py
@@ -593,7 +593,7 @@ class JLeaf(namedtuple('JLeaf', ['typ', 'none'])):
 
 JList = namedtuple('JList', ['elem_typ'])
 
-JTuple = namedtuple('JList', ['elem_typs'])
+JTuple = namedtuple('JTuple', ['elem_typs'])
 
 JUnion = namedtuple('JUnion', ['elem_typs'])
 

--- a/qa/tox.ini
+++ b/qa/tox.ini
@@ -10,7 +10,7 @@ commands=flake8 --select=F,E9 --exclude=venv,.tox
 
 [testenv:mypy]
 basepython = python3
-deps = mypy==0.790
+deps = mypy==0.812
 commands = mypy {posargs:.}
 
 [testenv:import-tasks]

--- a/qa/tox.ini
+++ b/qa/tox.ini
@@ -10,7 +10,15 @@ commands=flake8 --select=F,E9 --exclude=venv,.tox
 
 [testenv:mypy]
 basepython = python3
-deps = mypy==0.812
+deps =
+  mypy==0.901
+  types-boto
+  types-requests
+  types-jwt
+  types-paramiko
+  types-PyYAML
+  types-cryptography
+  types-python-dateutil
 commands = mypy {posargs:.}
 
 [testenv:import-tasks]

--- a/qa/workunits/mon/test_mon_config_key.py
+++ b/qa/workunits/mon/test_mon_config_key.py
@@ -20,6 +20,7 @@ import string
 import subprocess
 import sys
 import time
+from typing import List, Dict
 
 #
 # Accepted Environment variables:
@@ -64,9 +65,9 @@ OPS = {
     'dump': ['existing', 'enoent'],
 }
 
-CONFIG_PUT = []  # list: keys
-CONFIG_DEL = []  # list: keys
-CONFIG_EXISTING = {}  # map: key -> size
+CONFIG_PUT: List[str] = []  # list: keys
+CONFIG_DEL: List[str] = []  # list: keys
+CONFIG_EXISTING: Dict[str, int] = {}  # map: key -> size
 
 
 def run_cmd(cmd, expects=0):

--- a/qa/workunits/rest/test_mgr_rest_api.py
+++ b/qa/workunits/rest/test_mgr_rest_api.py
@@ -89,6 +89,7 @@ for method, endpoint, args in screenplay:
         headers=headers,
         verify=False,
         auth=auth)
+    assert request is not None
     print(request.text)
     if request.status_code != 200 or 'error' in request.json():
         print('ERROR: %s request for URL "%s" failed' % (method, url))

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -41,7 +41,7 @@ commands=pytest {posargs}
 
 [testenv:mypy]
 basepython = python3
-deps = mypy==0.790
+deps = mypy==0.812
 commands = mypy --config-file ../mypy.ini {posargs:cephadm}
 
 [testenv:fix]

--- a/src/cephadm/tox.ini
+++ b/src/cephadm/tox.ini
@@ -41,7 +41,7 @@ commands=pytest {posargs}
 
 [testenv:mypy]
 basepython = python3
-deps = mypy==0.812
+deps = mypy==0.901
 commands = mypy --config-file ../mypy.ini {posargs:cephadm}
 
 [testenv:fix]

--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -6,6 +6,7 @@
 import json
 import re
 from copy import deepcopy
+from typing import Any, Dict, List, no_type_check
 
 import cherrypy
 import rados
@@ -25,11 +26,6 @@ from ..tools import TaskManager, str_to_bool
 from . import ApiController, BaseController, ControllerDoc, Endpoint, \
     EndpointDoc, ReadPermission, RESTController, Task, UiApiController, \
     UpdatePermission
-
-try:
-    from typing import Any, Dict, List, no_type_check
-except ImportError:
-    no_type_check = object()  # Just for type checking
 
 ISCSI_SCHEMA = {
     'user': (str, 'username'),

--- a/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
@@ -4,6 +4,7 @@ import json
 import logging
 import re
 from functools import partial
+from typing import no_type_check
 
 import cherrypy
 import rbd
@@ -17,12 +18,6 @@ from ..tools import ViewCache
 from . import ApiController, BaseController, ControllerDoc, Endpoint, \
     EndpointDoc, ReadPermission, RESTController, Task, UpdatePermission, \
     allow_empty_body
-
-try:
-    from typing import no_type_check
-except ImportError:
-    no_type_check = object()  # Just for type checking
-
 
 logger = logging.getLogger('controllers.rbd_mirror')
 

--- a/src/pybind/mgr/dashboard/plugins/debug.py
+++ b/src/pybind/mgr/dashboard/plugins/debug.py
@@ -3,15 +3,11 @@
 
 import json
 from enum import Enum
+from typing import no_type_check
 
 from . import PLUGIN_MANAGER as PM
 from . import interfaces as I  # noqa: E741,N812
 from .plugin import SimplePlugin as SP
-
-try:
-    from typing import no_type_check
-except ImportError:
-    no_type_check = object()  # Just for type checking
 
 
 class Actions(Enum):

--- a/src/pybind/mgr/dashboard/plugins/feature_toggles.py
+++ b/src/pybind/mgr/dashboard/plugins/feature_toggles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from enum import Enum
-from typing import List, Optional
+from typing import List, Optional, Set, no_type_check
 
 import cherrypy
 from mgr_module import CLICommand, Option
@@ -16,11 +16,6 @@ from ..controllers.rgw import Rgw, RgwBucket, RgwDaemon, RgwUser
 from . import PLUGIN_MANAGER as PM
 from . import interfaces as I  # noqa: E741,N812
 from .ttl_cache import ttl_cache
-
-try:
-    from typing import Set, no_type_check
-except ImportError:
-    no_type_check = object()  # Just for type checking
 
 
 class Features(Enum):

--- a/src/pybind/mgr/dashboard/plugins/plugin.py
+++ b/src/pybind/mgr/dashboard/plugins/plugin.py
@@ -1,12 +1,9 @@
+from typing import no_type_check
+
 from mgr_module import Command, Option
 
 from . import PLUGIN_MANAGER as PM
 from . import interfaces as I  # noqa: E741,N812
-
-try:
-    from typing import no_type_check
-except ImportError:
-    no_type_check = object()  # Just for type checking
 
 
 class SimplePlugin(I.CanMgr, I.HasOptions, I.HasCommands):

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -592,7 +592,8 @@ class RookCluster(object):
                         if block_devices:
                             if not hasattr(current_node, 'devices'):
                                 current_node.devices = ccl.DevicesList()
-                            new_devices = list(set(block_devices) - set([d.name for d in current_node.devices]))
+                            current_device_names = set(d.name for d in current_node.devices)
+                            new_devices = [bd for bd in block_devices if bd.path not in current_device_names]
                             current_node.devices.extend(
                                 ccl.DevicesItem(name=n.path) for n in new_devices
                             )

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -58,7 +58,7 @@ basepython = python3
 deps =
     cython
     -rrequirements.txt
-    mypy==0.790
+    mypy==0.812
 commands =
     mypy --config-file=../../mypy.ini \
            -m alerts \

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -58,7 +58,12 @@ basepython = python3
 deps =
     cython
     -rrequirements.txt
-    mypy==0.812
+    mypy==0.901
+    types-backports
+    types-python-dateutil
+    types-requests
+    types-PyYAML
+    types-jwt
 commands =
     mypy --config-file=../../mypy.ini \
            -m alerts \

--- a/src/python-common/requirements.txt
+++ b/src/python-common/requirements.txt
@@ -1,6 +1,6 @@
 pytest >=2.1.3,<5; python_version < '3.5'
 mock; python_version < '3.3'
-mypy==0.790; python_version >= '3'
+mypy==0.812; python_version >= '3'
 pytest-mypy; python_version >= '3'
 pytest >= 2.1.3; python_version >= '3'
 pyyaml

--- a/src/python-common/requirements.txt
+++ b/src/python-common/requirements.txt
@@ -1,7 +1,8 @@
 pytest >=2.1.3,<5; python_version < '3.5'
 mock; python_version < '3.3'
-mypy==0.812; python_version >= '3'
+mypy==0.901; python_version >= '3'
 pytest-mypy; python_version >= '3'
 pytest >= 2.1.3; python_version >= '3'
 pyyaml
 typing-extensions; python_version < '3.8'
+types-PyYAML


### PR DESCRIPTION
Fixed:

* rook/rook_cluster.py:591: error: List comprehension has incompatible type List[Union[str, Any]]; expected List[Optional[Device]]
* dashboard/plugins/feature_toggles.py:104: error: List comprehension has incompatible type List[str]; expected List[Features]

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
