### PR TITLE
nautilus: mgr/dashboard: set security headers

### DIFF
--- a/qa/tasks/mgr/dashboard/test_requests.py
+++ b/qa/tasks/mgr/dashboard/test_requests.py
@@ -25,5 +25,8 @@ class RequestsTest(DashboardTestCase):
     def test_server(self):
         self._get('/api/summary')
         self.assertHeaders({
-            'server': 'Ceph-Dashboard'
+            'server': 'Ceph-Dashboard',
+            'Content-Security-Policy': "frame-ancestors 'self';",
+            'X-Content-Type-Options': 'nosniff',
+            'Strict-Transport-Security': 'max-age=63072000; includeSubDomains; preload'
         })

--- a/qa/tasks/mgr/test_prometheus.py
+++ b/qa/tasks/mgr/test_prometheus.py
@@ -48,6 +48,7 @@ class TestPrometheus(MgrTestCase):
         r = requests.get(original_uri + "metrics", allow_redirects=False)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.headers["content-type"], "text/plain;charset=utf-8")
+        self.assertEqual(r.headers["server"], "Ceph-Prometheus")
 
     def test_urls(self):
         self._assign_ports("prometheus", "server_port")

--- a/src/pybind/mgr/dashboard/services/auth.py
+++ b/src/pybind/mgr/dashboard/services/auth.py
@@ -15,8 +15,11 @@ from .access_control import LocalAuthenticator, UserDoesNotExist
 from .. import mgr, logger
 
 cherrypy.config.update({
-    'response.headers.server': 'Ceph-Dashboard'
-    })
+    'response.headers.server': 'Ceph-Dashboard',
+    'response.headers.content-security-policy': "frame-ancestors 'self';",
+    'response.headers.x-content-type-options': 'nosniff',
+    'response.headers.strict-transport-security': 'max-age=63072000; includeSubDomains; preload'
+})
 
 
 class JwtManager(object):

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -48,6 +48,9 @@ os._exit = os_exit_noop
 # it's a dict, the writer doesn't need to declare 'global' for access
 
 _global_instance = None  # type: Optional[Module]
+cherrypy.config.update({
+    'response.headers.server': 'Ceph-Prometheus'
+})
 
 
 def health_status_to_number(status):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49420

---

backport of https://github.com/ceph/ceph/pull/39405
parent tracker: https://tracker.ceph.com/issues/49243

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh