### PR TITLE
crush/CrushWrapper: update shadow trees on update_item()

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1427,6 +1427,12 @@ int CrushWrapper::update_item(
 		    << ((float)old_iweight/(float)0x10000) << " -> " << weight
 		    << dendl;
       adjust_item_weight_in_loc(cct, item, iweight, loc);
+      ret = rebuild_roots_with_classes(cct);
+      if (ret < 0) {
+	ldout(cct, 0) << __func__ << " unable to rebuild roots with classes: "
+		      << cpp_strerror(ret) << dendl;
+	return ret;
+      }
       ret = 1;
     }
     if (get_item_name(item) != name) {

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1616,6 +1616,12 @@ int CrushWrapper::adjust_subtree_weight(CephContext *cct, int id, int weight,
       }
     }
   }
+  int ret = rebuild_roots_with_classes(cct);
+  if (ret < 0) {
+    ldout(cct, 0) << __func__ << " unable to rebuild roots with classes: "
+		  << cpp_strerror(ret) << dendl;
+    return ret;
+  }
   return changed;
 }
 


### PR DESCRIPTION
insert_item() already does this, but update_item did not.

Fixes: https://tracker.ceph.com/issues/48065
Signed-off-by: Sage Weil <sage@newdream.net>