### PR TITLE
octopus: cephadm: Delete the unnecessary error line in open_ports

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2381,7 +2381,6 @@ class Firewalld(object):
             else:
                 logger.debug('firewalld port %s is enabled in current zone' % tcp_port)
 
-            out, err, ret = call([self.cmd, '--permanent', '--query-port', tcp_port], verbose_on_failure=False)
     def apply_rules(self):
         # type: () -> None
         if not self.available:


### PR DESCRIPTION
In #39020, d9fbd7e is cherry picked from 70722a2. there is no bug in 70722a2,
but there is a bug in d9fbd7e. It seems that the unnecessary error line was added during cherry picking.
So error only occurs in octopus branch.
This commit directly fixes issue in octopus branch instead of cherry picking
since cherry picking from 70722a2 has already been applied to octopus branch.

This commit deletes the unnecessary error line added in d9fbd7e.
In d9fbd7e, the parameter verbose_on_failure was removed in call.
However, the unnecessary line that uses verbose_on_failure was
added in open_ports and so error occurs.

Fixes: https://tracker.ceph.com/issues/49467
Signed-off-by: Donggyu Park <donggyu_park@tmax.co.kr>


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
