### PR TITLE
octopus: mgr/dashboard: fix tooltip for Provisioned/Total Provisioned fields

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.html
@@ -58,7 +58,7 @@
             <span *ngIf="selection.features_name?.indexOf('fast-diff') === -1">
               <span class="form-text text-muted"
                     [tooltip]="usageNotAvailableTooltipTpl"
-                    placement="right"
+                    placement="top"
                     i18n>N/A</span>
             </span>
             <span *ngIf="selection.features_name?.indexOf('fast-diff') !== -1">
@@ -73,7 +73,7 @@
             <span *ngIf="selection.features_name?.indexOf('fast-diff') === -1">
               <span class="form-text text-muted"
                     [tooltip]="usageNotAvailableTooltipTpl"
-                    placement="right"
+                    placement="top"
                     i18n>N/A</span>
             </span>
             <span *ngIf="selection.features_name?.indexOf('fast-diff') !== -1">


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49388

---

backport of https://github.com/ceph/ceph/pull/39501
parent tracker: https://tracker.ceph.com/issues/46619

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh