### PR TITLE
nautilus: test/rbd-mirror: fix broken ceph_test_rbd_mirror_random_write

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -1002,10 +1002,18 @@ stress_write_image()
     local image=$3
     local duration=$(awk 'BEGIN {srand(); print int(10 * rand()) + 5}')
 
+    set +e
     timeout ${duration}s ceph_test_rbd_mirror_random_write \
-	--cluster ${cluster} ${pool} ${image} \
-	--debug-rbd=20 --debug-journaler=20 \
-	2> ${TEMPDIR}/rbd-mirror-random-write.log || true
+        --cluster ${cluster} ${pool} ${image} \
+        --debug-rbd=20 --debug-journaler=20 \
+        2> ${TEMPDIR}/rbd-mirror-random-write.log
+    error_code=$?
+    set -e
+
+    if [ $error_code -eq 124 ]; then
+        return 0
+    fi
+    return 1
 }
 
 compare_images()

--- a/src/test/rbd_mirror/random_write.cc
+++ b/src/test/rbd_mirror/random_write.cc
@@ -164,8 +164,8 @@ int main(int argc, const char **argv)
   }
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
-			 CODE_ENVIRONMENT_UTILITY,
-			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+                         CODE_ENVIRONMENT_UTILITY,
+                         CINIT_FLAG_NO_MON_CONFIG);
 
   if (args.size() < 2) {
     usage();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49182

---

backport of https://github.com/ceph/ceph/pull/39241
parent tracker: https://tracker.ceph.com/issues/49117

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh