### PR TITLE
msg/async: initialize worker in RDMAStack::create_worker() and drop Stack::num_workers 

### DIFF
--- a/doc/rados/configuration/ms-ref.rst
+++ b/doc/rados/configuration/ms-ref.rst
@@ -83,14 +83,3 @@ Async messenger options
 :Type: 64-bit Unsigned Integer
 :Required: No
 :Default: ``3``
-
-
-``ms_async_max_op_threads``
-
-:Description: Maximum number of worker threads used by each Async Messenger instance. 
-              Set to lower values when your machine has limited CPU count, and increase 
-              when your CPUs are underutilized (i. e. one or more of CPUs are
-              constantly on 100% load during I/O operations).
-:Type: 64-bit Unsigned Integer
-:Required: No
-:Default: ``5``

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -142,7 +142,6 @@ OPTION(ms_blackhole_client, OPT_BOOL)
 OPTION(ms_dump_on_send, OPT_BOOL)           // hexdump msg to log on send
 OPTION(ms_dump_corrupt_message_level, OPT_INT)  // debug level to hexdump undecodeable messages at
 OPTION(ms_async_op_threads, OPT_U64)            // number of worker processing threads for async messenger created on init
-OPTION(ms_async_max_op_threads, OPT_U64)        // max number of worker processing threads for async messenger
 OPTION(ms_async_rdma_device_name, OPT_STR)
 OPTION(ms_async_rdma_enable_hugepage, OPT_BOOL)
 OPTION(ms_async_rdma_buffer_size, OPT_INT)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1149,11 +1149,6 @@ std::vector<Option> get_global_options() {
     .set_min_max(1, 24)
     .set_description("Threadpool size for AsyncMessenger (ms_type=async)"),
 
-    Option("ms_async_max_op_threads", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(5)
-    .set_description("Maximum threadpool size of AsyncMessenger")
-    .add_see_also("ms_async_op_threads"),
-
     Option("ms_async_rdma_device_name", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("")
     .set_description(""),

--- a/src/msg/async/PosixStack.h
+++ b/src/msg/async/PosixStack.h
@@ -48,8 +48,7 @@ class PosixNetworkStack : public NetworkStack {
   explicit PosixNetworkStack(CephContext *c);
 
   void spawn_worker(unsigned i, std::function<void ()> &&func) override {
-    threads.resize(i+1);
-    threads[i] = std::thread(func);
+    threads.emplace_back(std::move(func));
   }
   void join_worker(unsigned i) override {
     ceph_assert(threads.size() > i && threads[i].joinable());

--- a/src/msg/async/PosixStack.h
+++ b/src/msg/async/PosixStack.h
@@ -47,7 +47,7 @@ class PosixNetworkStack : public NetworkStack {
  public:
   explicit PosixNetworkStack(CephContext *c);
 
-  void spawn_worker(unsigned i, std::function<void ()> &&func) override {
+  void spawn_worker(std::function<void ()> &&func) override {
     threads.emplace_back(std::move(func));
   }
   void join_worker(unsigned i) override {

--- a/src/msg/async/Stack.cc
+++ b/src/msg/async/Stack.cc
@@ -34,9 +34,8 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "stack "
 
-std::function<void ()> NetworkStack::add_thread(unsigned worker_id)
+std::function<void ()> NetworkStack::add_thread(Worker* w)
 {
-  Worker *w = workers[worker_id];
   return [this, w]() {
       char tp_name[16];
       sprintf(tp_name, "msgr-worker-%u", w->id);
@@ -122,10 +121,10 @@ void NetworkStack::start()
   }
 
   for (unsigned i = 0; i < num_workers; ++i) {
-    if (workers[i]->is_init())
+    Worker* worker = workers[i];
+    if (worker->is_init())
       continue;
-    std::function<void ()> thread = add_thread(i);
-    spawn_worker(i, std::move(thread));
+    spawn_worker(add_thread(worker));
   }
   started = true;
   lk.unlock();

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -297,7 +297,7 @@ class NetworkStack {
   ceph::spinlock pool_spin;
   bool started = false;
 
-  std::function<void ()> add_thread(unsigned i);
+  std::function<void ()> add_thread(Worker* w);
 
   virtual Worker* create_worker(CephContext *c, unsigned i) = 0;
 

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -334,7 +334,7 @@ class NetworkStack {
   }
   void drain();
   unsigned get_num_worker() const {
-    return num_workers;
+    return workers.size();
   }
 
   // direct is used in tests only

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -338,7 +338,7 @@ class NetworkStack {
   }
 
   // direct is used in tests only
-  virtual void spawn_worker(unsigned i, std::function<void ()> &&) = 0;
+  virtual void spawn_worker(std::function<void ()> &&) = 0;
   virtual void join_worker(unsigned i) = 0;
 
   virtual bool is_ready() { return true; };

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -293,7 +293,6 @@ class Worker {
 };
 
 class NetworkStack {
-  unsigned num_workers = 0;
   ceph::spinlock pool_spin;
   bool started = false;
 

--- a/src/msg/async/dpdk/DPDKStack.cc
+++ b/src/msg/async/dpdk/DPDKStack.cc
@@ -242,7 +242,7 @@ int DPDKWorker::connect(const entity_addr_t &addr, const SocketOptions &opts, Co
   return r;
 }
 
-void DPDKStack::spawn_worker(unsigned i, std::function<void ()> &&func)
+void DPDKStack::spawn_worker(std::function<void ()> &&func)
 {
   // create a extra master thread
   //

--- a/src/msg/async/dpdk/DPDKStack.h
+++ b/src/msg/async/dpdk/DPDKStack.h
@@ -258,7 +258,7 @@ class DPDKStack : public NetworkStack {
   {}
   virtual bool support_local_listen_table() const override { return true; }
 
-  virtual void spawn_worker(unsigned i, std::function<void ()> &&func) override;
+  virtual void spawn_worker(std::function<void ()> &&func) override;
   virtual void join_worker(unsigned i) override;
 };
 

--- a/src/msg/async/dpdk/DPDKStack.h
+++ b/src/msg/async/dpdk/DPDKStack.h
@@ -254,9 +254,8 @@ class DPDKStack : public NetworkStack {
   }
 
  public:
-  explicit DPDKStack(CephContext *cct): NetworkStack(cct) {
-    funcs.resize(cct->_conf->ms_async_max_op_threads);
-  }
+  explicit DPDKStack(CephContext *cct): NetworkStack(cct)
+  {}
   virtual bool support_local_listen_table() const override { return true; }
 
   virtual void spawn_worker(unsigned i, std::function<void ()> &&func) override;

--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -800,7 +800,7 @@ Worker* RDMAStack::create_worker(CephContext *c, unsigned worker_id)
   return w;
 }
 
-void RDMAStack::spawn_worker(unsigned i, std::function<void ()> &&func)
+void RDMAStack::spawn_worker(std::function<void ()> &&func)
 {
   threads.emplace_back(std::move(func));
 }

--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -799,6 +799,11 @@ RDMAStack::~RDMAStack()
   }
 }
 
+Worker* RDMAStack::create_worker(CephContext *c, unsigned worker_id)
+{
+  return new RDMAWorker(c, worker_id);
+}
+
 void RDMAStack::spawn_worker(unsigned i, std::function<void ()> &&func)
 {
   threads.resize(i+1);

--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -802,8 +802,7 @@ Worker* RDMAStack::create_worker(CephContext *c, unsigned worker_id)
 
 void RDMAStack::spawn_worker(unsigned i, std::function<void ()> &&func)
 {
-  threads.resize(i+1);
-  threads[i] = std::thread(func);
+  threads.emplace_back(std::move(func));
 }
 
 void RDMAStack::join_worker(unsigned i)

--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -782,13 +782,6 @@ RDMAStack::RDMAStack(CephContext *cct)
     rdma_dispatcher(std::make_shared<RDMADispatcher>(cct, ib))
 {
   ldout(cct, 20) << __func__ << " constructing RDMAStack..." << dendl;
-
-  unsigned num = get_num_worker();
-  for (unsigned i = 0; i < num; ++i) {
-    RDMAWorker* w = dynamic_cast<RDMAWorker*>(get_worker(i));
-    w->set_dispatcher(rdma_dispatcher);
-    w->set_ib(ib);
-  }
   ldout(cct, 20) << " creating RDMAStack:" << this << " with dispatcher:" << rdma_dispatcher.get() << dendl;
 }
 
@@ -801,7 +794,10 @@ RDMAStack::~RDMAStack()
 
 Worker* RDMAStack::create_worker(CephContext *c, unsigned worker_id)
 {
-  return new RDMAWorker(c, worker_id);
+  auto w = new RDMAWorker(c, worker_id);
+  w->set_dispatcher(rdma_dispatcher);
+  w->set_ib(ib);
+  return w;
 }
 
 void RDMAStack::spawn_worker(unsigned i, std::function<void ()> &&func)

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -326,9 +326,7 @@ class RDMAStack : public NetworkStack {
 
   std::atomic<bool> fork_finished = {false};
 
-  virtual Worker* create_worker(CephContext *c, unsigned worker_id) override {
-    return new RDMAWorker(c, worker_id);
-  }
+  virtual Worker* create_worker(CephContext *c, unsigned worker_id) override;
 
  public:
   explicit RDMAStack(CephContext *cct);

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -333,7 +333,7 @@ class RDMAStack : public NetworkStack {
   virtual ~RDMAStack();
   virtual bool nonblock_connect_need_writable_event() const override { return false; }
 
-  virtual void spawn_worker(unsigned i, std::function<void ()> &&func) override;
+  virtual void spawn_worker(std::function<void ()> &&func) override;
   virtual void join_worker(unsigned i) override;
   virtual bool is_ready() override { return fork_finished.load(); };
   virtual void ready() override { fork_finished = true; };


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
