### PR TITLE
crimson/onode-staged-tree: fix Cursor operator==()

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -143,6 +143,8 @@ CachedExtentRef Cache::alloc_new_extent_by_type(
     return alloc_new_extent<lba_manager::btree::LBALeafNode>(t, length);
   case extent_types_t::ONODE_BLOCK:
     return alloc_new_extent<OnodeBlock>(t, length);
+  case extent_types_t::ONODE_BLOCK_STAGED:
+    return alloc_new_extent<onode::SeastoreNodeExtent>(t, length);
   case extent_types_t::EXTMAP_INNER:
     return alloc_new_extent<extentmap_manager::ExtMapInnerNode>(t, length);
   case extent_types_t::EXTMAP_LEAF:
@@ -499,8 +501,6 @@ Cache::get_root_ret Cache::get_root(Transaction &t)
   }
 }
 
-using StagedOnodeBlock = crimson::os::seastore::onode::SeastoreNodeExtent;
-
 Cache::get_extent_ertr::future<CachedExtentRef> Cache::get_extent_by_type(
   extent_types_t type,
   paddr_t offset,
@@ -553,7 +553,7 @@ Cache::get_extent_ertr::future<CachedExtentRef> Cache::get_extent_by_type(
 	return CachedExtentRef(extent.detach(), false /* add_ref */);
       });
     case extent_types_t::ONODE_BLOCK_STAGED:
-      return get_extent<StagedOnodeBlock>(offset, length
+      return get_extent<onode::SeastoreNodeExtent>(offset, length
       ).safe_then([](auto extent) {
 	return CachedExtentRef(extent.detach(), false /* add_ref */);
       });

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
@@ -93,8 +93,8 @@ class Btree {
     bool operator>=(const Cursor& o) const { return (int)compare_to(o) >= 0; }
     bool operator<(const Cursor& o) const { return (int)compare_to(o) < 0; }
     bool operator<=(const Cursor& o) const { return (int)compare_to(o) <= 0; }
-    bool operator==(const Cursor& o) const { return (int)compare_to(o) != 0; }
-    bool operator!=(const Cursor& o) const { return (int)compare_to(o) == 0; }
+    bool operator==(const Cursor& o) const { return (int)compare_to(o) == 0; }
+    bool operator!=(const Cursor& o) const { return (int)compare_to(o) != 0; }
 
     btree_future<Cursor> get_next(Transaction& t) {
       assert(!is_end());

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
@@ -285,8 +285,9 @@ class TreeBuilder {
 #ifndef NDEBUG
         auto [key, value] = kv_iter.get_kv();
         Values::validate_cursor(cursor, key, value);
-        return tree->lower_bound(t, key
+        return tree->find(t, key
         ).safe_then([this, cursor](auto cursor_) mutable {
+          assert(!cursor_.is_end());
           auto [key, value] = kv_iter.get_kv();
           ceph_assert(cursor_.get_ghobj() == key);
           ceph_assert(cursor_.value() == cursor.value());
@@ -315,7 +316,7 @@ class TreeBuilder {
             assert(c_iter != cursors->end());
             auto [k, v] = kv_iter.get_kv();
             // validate values in tree keep intact
-            return tree->lower_bound(t, k).safe_then([this, &c_iter](auto cursor) {
+            return tree->find(t, k).safe_then([this, &c_iter](auto cursor) {
               auto [k, v] = kv_iter.get_kv();
               Values::validate_cursor(cursor, k, v);
               // validate values in cursors keep intact
@@ -349,7 +350,7 @@ class TreeBuilder {
       auto iter = kvs.begin();
       while (!iter.is_end()) {
         auto [k, v] = iter.get_kv();
-        auto cursor = tree->lower_bound(t, k).unsafe_get0();
+        auto cursor = tree->find(t, k).unsafe_get0();
         Values::validate_cursor(cursor, k, v);
         ++iter;
       }

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -216,7 +216,8 @@ TEST_F(b_dummy_tree_test_t, 3_random_insert_leaf_node)
       ceph_assert(cursor.get_ghobj() == key);
       Values::initialize_cursor(t, cursor, value);
       insert_history.emplace_back(key, value, cursor);
-      auto cursor_ = tree.lower_bound(t, key).unsafe_get0();
+      auto cursor_ = tree.find(t, key).unsafe_get0();
+      ceph_assert(cursor_ != tree.end());
       ceph_assert(cursor_.value() == cursor.value());
       Values::validate_cursor(cursor_, key, value);
       return cursor.value();
@@ -327,7 +328,8 @@ TEST_F(b_dummy_tree_test_t, 3_random_insert_leaf_node)
 
     for (auto& [k, v, c] : insert_history) {
       // validate values in tree keep intact
-      auto cursor = tree.lower_bound(t, k).unsafe_get0();
+      auto cursor = tree.find(t, k).unsafe_get0();
+      EXPECT_NE(cursor, tree.end());
       Values::validate_cursor(cursor, k, v);
       // validate values in cursors keep intact
       Values::validate_cursor(c, k, v);
@@ -472,10 +474,12 @@ class TestTree {
       EXPECT_EQ(tree_clone.height(t_clone).unsafe_get0(), 2);
 
       for (auto& [k, v, c] : insert_history) {
-        auto result = tree_clone.lower_bound(t_clone, k).unsafe_get0();
+        auto result = tree_clone.find(t_clone, k).unsafe_get0();
+        EXPECT_NE(result, tree_clone.end());
         Values::validate_cursor(result, k, v);
       }
-      auto result = tree_clone.lower_bound(t_clone, key).unsafe_get0();
+      auto result = tree_clone.find(t_clone, key).unsafe_get0();
+      EXPECT_NE(result, tree_clone.end());
       Values::validate_cursor(result, key, value);
       EXPECT_TRUE(last_split.match(expected));
     });


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
