### PR TITLE
[WIP] cephfs-mirror: support file system peer additions with remote monitor host

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -35,18 +35,22 @@ using ceph::bufferlist;
 using ceph::Formatter;
 
 void ClusterInfo::encode(ceph::buffer::list &bl) const {
-  ENCODE_START(1, 1, bl);
+  ENCODE_START(2, 1, bl);
   encode(client_name, bl);
   encode(cluster_name, bl);
   encode(fs_name, bl);
+  encode(mon_host, bl);
   ENCODE_FINISH(bl);
 }
 
 void ClusterInfo::decode(ceph::buffer::list::const_iterator &iter) {
-  DECODE_START(1, iter);
+  DECODE_START(2, iter);
   decode(client_name, iter);
   decode(cluster_name, iter);
   decode(fs_name, iter);
+  if (struct_v >= 2) {
+    decode(mon_host, iter);
+  }
   DECODE_FINISH(iter);
 }
 
@@ -54,11 +58,18 @@ void ClusterInfo::dump(ceph::Formatter *f) const {
   f->dump_string("client_name", client_name);
   f->dump_string("cluster_name", cluster_name);
   f->dump_string("fs_name", fs_name);
+  if (!mon_host.empty()) {
+    f->dump_string("mon_host", mon_host);
+  }
 }
 
 void ClusterInfo::print(std::ostream& out) const {
   out << "[client_name=" << client_name << ", cluster_name=" << cluster_name
-      << ", fs_name=" << fs_name << "]" << std::endl;
+      << ", fs_name=" << fs_name;
+  if (!mon_host.empty()) {
+    out << ", mon_host=" << mon_host;
+  }
+  out << std::endl;
 }
 
 void Peer::encode(ceph::buffer::list &bl) const {

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -44,15 +44,24 @@ struct ClusterInfo {
       cluster_name(cluster_name),
       fs_name(fs_name) {
   }
+  ClusterInfo(std::string_view client_name, std::string_view cluster_name,
+              std::string_view fs_name, std::string_view mon_host)
+    : client_name(client_name),
+      cluster_name(cluster_name),
+      fs_name(fs_name),
+      mon_host(mon_host) {
+  }
 
   std::string client_name;
   std::string cluster_name;
   std::string fs_name;
+  std::string mon_host;
 
   bool operator==(const ClusterInfo &cluster_info) const {
     return client_name == cluster_info.client_name &&
            cluster_name == cluster_info.cluster_name &&
-           fs_name == cluster_info.fs_name;
+           fs_name == cluster_info.fs_name &&
+           mon_host == cluster_info.mon_host;
   }
 
   void dump(ceph::Formatter *f) const;
@@ -64,7 +73,11 @@ struct ClusterInfo {
 
 inline std::ostream& operator<<(std::ostream& out, const ClusterInfo &cluster_info) {
   out << "{client_name=" << cluster_info.client_name << ", cluster_name="
-      << cluster_info.cluster_name << ", fs_name=" << cluster_info.fs_name << "}";
+      << cluster_info.cluster_name << ", fs_name=" << cluster_info.fs_name;
+  if (!cluster_info.mon_host.empty()) {
+    out << ", mon_host=" << cluster_info.mon_host;
+  }
+  out << "}";
   return out;
 }
 
@@ -142,6 +155,13 @@ struct MirrorInfo {
                 std::string_view cluster_name,
                 std::string_view fs_name) {
     peers.emplace(Peer(uuid, ClusterInfo(client_name, cluster_name, fs_name)));
+  }
+  void peer_add(std::string_view uuid,
+                std::string_view client_name,
+                std::string_view cluster_name,
+                std::string_view fs_name,
+                std::string_view mon_host) {
+    peers.emplace(Peer(uuid, ClusterInfo(client_name, cluster_name, fs_name, mon_host)));
   }
   void peer_remove(std::string_view uuid) {
     peers.erase(uuid);

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -1134,8 +1134,10 @@ public:
                 const cmdmap_t &cmdmap, std::stringstream &ss) {
     string remote_spec;
     string remote_fs_name;
+    string remote_mon_host;
     cmd_getval(cmdmap, "remote_cluster_spec", remote_spec);
     cmd_getval(cmdmap, "remote_fs_name", remote_fs_name);
+    cmd_getval(cmdmap, "remote_mon_host", remote_mon_host);
 
     // verify (and extract) remote cluster specification
     auto remote_conf = extract_remote_cluster_conf(remote_spec);
@@ -1153,9 +1155,9 @@ public:
     uuid_d uuid_gen;
     uuid_gen.generate_random();
 
-    auto f = [uuid_gen, remote_conf, remote_fs_name](auto &&fs) {
+    auto f = [uuid_gen, remote_conf, remote_fs_name, remote_mon_host](auto &&fs) {
                fs->mirror_info.peer_add(stringify(uuid_gen), (*remote_conf).first,
-                                        (*remote_conf).second, remote_fs_name);
+                                        (*remote_conf).second, remote_fs_name, remote_mon_host);
              };
     fsmap.modify_filesystem(fs->fscid, std::move(f));
     return true;

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -438,7 +438,8 @@ COMMAND("fs mirror disable "
 COMMAND("fs mirror peer_add "
 	"name=fs_name,type=CephString "
 	"name=remote_cluster_spec,type=CephString "
-	"name=remote_fs_name,type=CephString",
+	"name=remote_fs_name,type=CephString "
+	"name=remote_mon_host,type=CephString,req=false",
 	"add a mirror peer for a ceph filesystem", "mds", "rw")
 COMMAND("fs mirror peer_remove "
 	"name=fs_name,type=CephString "

--- a/src/pybind/mgr/mirroring/fs/utils.py
+++ b/src/pybind/mgr/mirroring/fs/utils.py
@@ -15,11 +15,14 @@ DIRECTORY_MAP_PREFIX = "dir_map_"
 
 log = logging.getLogger(__name__)
 
-def connect_to_cluster(client_name, cluster_name, desc=''):
+def connect_to_cluster(client_name, cluster_name, mon_host, desc=''):
     try:
-        log.debug(f'connecting to {desc} cluster: {client_name}/{cluster_name}')
-        r_rados = rados.Rados(rados_id=client_name, clustername=cluster_name)
-        r_rados.conf_read_file()
+        log.debug(f'connecting to {desc} cluster: {client_name}/{cluster_name} mon_host: {mon_host}')
+        if not mon_host:
+            r_rados = rados.Rados(rados_id=client_name, clustername=cluster_name)
+            r_rados.conf_read_file()
+        else:
+            r_rados = rados.Rados(rados_id=client_name, conf={'mon_host':mon_host})
         r_rados.connect()
         log.debug(f'connected to {desc} cluster')
         return r_rados
@@ -38,9 +41,9 @@ def disconnect_from_cluster(cluster_name, cluster):
     except Exception as e:
         log.error(f'error disconnecting: {e}')
 
-def connect_to_filesystem(client_name, cluster_name, fs_name, desc):
+def connect_to_filesystem(client_name, cluster_name, fs_name, mon_host, desc):
     try:
-        cluster = connect_to_cluster(client_name, cluster_name, desc)
+        cluster = connect_to_cluster(client_name, cluster_name, mon_host, desc)
         log.debug(f'connecting to {desc} filesystem: {fs_name}')
         fs = cephfs.LibCephFS(rados_inst=cluster)
         log.debug('CephFS initializing...')

--- a/src/pybind/mgr/mirroring/module.py
+++ b/src/pybind/mgr/mirroring/module.py
@@ -30,10 +30,11 @@ class Module(MgrModule):
     def snapshot_mirorr_peer_add(self,
                                  fs_name: str,
                                  remote_cluster_spec: str,
-                                 remote_fs_name: Optional[str] = None):
+                                 remote_fs_name: Optional[str] = None,
+                                 remote_mon_host: Optional[str] = None):
         """Add a remote filesystem peer"""
         return self.fs_snapshot_mirror.peer_add(fs_name, remote_cluster_spec,
-                                                remote_fs_name)
+                                                remote_fs_name, remote_mon_host)
 
     @CLIWriteCommand('fs snapshot mirror peer_remove')
     def snapshot_mirror_peer_remove(self,

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -140,9 +140,10 @@ int PeerReplayer::init() {
 
   auto &remote_client = m_peer.remote.client_name;
   auto &remote_cluster = m_peer.remote.cluster_name;
+  auto &remote_mon_host = m_peer.remote.mon_host;
   auto remote_filesystem = Filesystem{0, m_peer.remote.fs_name};
 
-  int r = connect(remote_client, remote_cluster, &m_remote_cluster);
+  int r = connect(remote_client, remote_cluster, &m_remote_cluster, remote_mon_host);
   if (r < 0) {
     derr << ": error connecting to remote cluster: " << cpp_strerror(r)
          << dendl;

--- a/src/tools/cephfs_mirror/Utils.cc
+++ b/src/tools/cephfs_mirror/Utils.cc
@@ -18,9 +18,9 @@ namespace cephfs {
 namespace mirror {
 
 int connect(std::string_view client_name, std::string_view cluster_name,
-            RadosRef *cluster) {
+            RadosRef *cluster, std::string_view mon_host) {
   dout(20) << ": connecting to cluster=" << cluster_name << ", client=" << client_name
-           << dendl;
+           << ", mon_host=" << mon_host << dendl;
 
   CephInitParameters iparams(CEPH_ENTITY_TYPE_CLIENT);
   if (client_name.empty() || !iparams.name.from_str(client_name)) {
@@ -33,7 +33,7 @@ int connect(std::string_view client_name, std::string_view cluster_name,
   cct->_conf->cluster = cluster_name;
 
   int r = cct->_conf.parse_config_files(nullptr, nullptr, 0);
-  if (r < 0) {
+  if (r < 0 && r != -ENOENT) {
     derr << ": could not read ceph conf: " << ": " << cpp_strerror(r) << dendl;
     return r;
   }
@@ -48,6 +48,15 @@ int connect(std::string_view client_name, std::string_view cluster_name,
     return r;
   }
   cct->_conf.parse_env(cct->get_module_type());
+
+  if (!mon_host.empty()) {
+    r = cct->_conf.set_val("mon_host", std::string(mon_host));
+    if (r < 0) {
+      derr << "failed to set mon_host config: " << cpp_strerror(r) << dendl;
+      cct->put();
+      return r;
+    }
+  }
 
   cluster->reset(new librados::Rados());
 

--- a/src/tools/cephfs_mirror/Utils.h
+++ b/src/tools/cephfs_mirror/Utils.h
@@ -10,7 +10,7 @@ namespace cephfs {
 namespace mirror {
 
 int connect(std::string_view client_name, std::string_view cluster_name,
-            RadosRef *cluster);
+            RadosRef *cluster, std::string_view mon_host={});
 
 int mount(RadosRef cluster, const Filesystem &filesystem, bool cross_check_fscid,
           MountRef *mount);


### PR DESCRIPTION
Peer cluster monitor host is tracked in FSMap::ClusterInfo. Mirror daemons can connect to the peer cluster without the need for the peer cluster configuration file to be present in the primary site. librados searches for keyring in default locations. 

pybing/mirroring needs to connect to the remote cluster when adding a peer. This is to set a special xattr (on root) to "mark" the remote filesystem as a peer. This is done so that a "peered" filesystem cannot be added as a peer again from another cluster. However, librados python binding does not seem to search for keyrings in default locations as mentioned in https://docs.ceph.com/en/latest/rados/api/python/#connect-to-the-cluster thereby failing the connect (see changes in src/pybind/mgr/mirroring/fs/utils.py in this PR). Specifying the path to keyring file (or accepting it from the user) does not look clean too.

@batrick @liewegas @mchangir ^^

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
