### PR TITLE
pybind/rados: remove rados_nobjects_list_next() from .pxi

### DIFF
--- a/src/pybind/rados/c_rados.pxd
+++ b/src/pybind/rados/c_rados.pxd
@@ -190,7 +190,6 @@ cdef extern from "rados/librados.h" nogil:
     void rados_getxattrs_end(rados_xattrs_iter_t iter)
 
     int rados_nobjects_list_open(rados_ioctx_t io, rados_list_ctx_t *ctx)
-    int rados_nobjects_list_next(rados_list_ctx_t ctx, const char **entry, const char **key, const char **nspace)
     int rados_nobjects_list_next2(rados_list_ctx_t ctx,
                                   const char **entry,
                                   const char **key,

--- a/src/pybind/rados/mock_rados.pxi
+++ b/src/pybind/rados/mock_rados.pxi
@@ -265,8 +265,6 @@ cdef nogil:
 
     int rados_nobjects_list_open(rados_ioctx_t io, rados_list_ctx_t *ctx):
         pass
-    int rados_nobjects_list_next(rados_list_ctx_t ctx, const char **entry, const char **key, const char **nspace):
-        pass
     int rados_nobjects_list_next2(rados_list_ctx_t ctx, const char **entry, const char **key, const char **nspace,
 				  size_t *entry_size, size_t *key_size, size_t *nspace_size):
         pass


### PR DESCRIPTION
this is a follow-up of da5d4c813ffdd391da54dcf5022763616bab4b21

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
