### PR TITLE
doc/dev: rewrite t8y "re-running tests"

### DIFF
--- a/doc/dev/developer_guide/testing_integration_tests/tests-integration-testing-teuthology-workflow.rst
+++ b/doc/dev/developer_guide/testing_integration_tests/tests-integration-testing-teuthology-workflow.rst
@@ -238,10 +238,13 @@ example, for the above test ID, the link is - http://pulpito.front.sepia.ceph.co
 
 Re-running Tests
 ----------------
-You can pass ``--rerun`` option, with test ID as an argument to it, to
-``teuthology-suite`` command. Generally, this is useful in cases where teuthology test
-batch has some failed/dead jobs that we might want to retrigger. We can trigger
-jobs based on their status using::
+
+The ``teuthology-suite`` command has a ``--rerun`` option, which allows you to
+re-run tests. This is handy when your test has failed or is dead. The
+``--rerun`` option takes the name of a teuthology run as an argument, as you
+can see in the example below:
+
+.. prompt:: bash $ 
 
    teuthology-suite -v \
     -m smithi \
@@ -251,8 +254,8 @@ jobs based on their status using::
     -R fail,dead,queued,running \
     -e $CEPH_QA_MAIL
 
-The meaning of the rest the options is already covered in `Triggering Tests`_
-section.
+The meaning and function of the other options is covered in the table in the
+`Triggering Tests`_ section.
 
 Naming the ceph-ci branch
 -------------------------


### PR DESCRIPTION
This PR rewrites the "re-running tests" section
so that its elegance and readability are improved.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
