### PR TITLE
tools/rados: assign to optional<> without deref'ing it

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -2723,7 +2723,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     }
     string attr_name(nargs[obj_name ? 1 : 2]);
     if (!obj_name) {
-      *obj_name = nargs[1];
+      obj_name = nargs[1];
     }
     bufferlist bl;
     ret = detail::getxattr(io_ctx, *obj_name, attr_name, bl, use_striper);
@@ -2744,7 +2744,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
 
     string attr_name(nargs[obj_name ? 1 : 2]);
     if (!obj_name) {
-      *obj_name = nargs[1];
+      obj_name = nargs[1];
     }
     ret = detail::rmxattr(io_ctx, *obj_name, attr_name, use_striper);
 


### PR DESCRIPTION
this change addresses a regression introduced by
d333b35aa10bf03a8bc047994d5cf3fed019b49a

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
