### PR TITLE
mon/KVMonitor: fix 'osd new' cross-service commit

### DIFF
--- a/src/mon/KVMonitor.cc
+++ b/src/mon/KVMonitor.cc
@@ -376,7 +376,7 @@ void KVMonitor::do_osd_destroy(int32_t id, uuid_d& uuid)
     pending[iter->key()] = boost::none;
   }
 
-  paxos.trigger_propose();
+  propose_pending();
 }
 
 int KVMonitor::validate_osd_new(
@@ -417,6 +417,8 @@ void KVMonitor::do_osd_new(
   dmcrypt_key_value.append(dmcrypt_key);
 
   pending[dmcrypt_key_prefix] = dmcrypt_key_value;
+
+  propose_pending();
 }
 
 


### PR DESCRIPTION
When we converted ConfigKeyService to KVMonitor, we didn't correctly
change this to propose_pending(), which mean that the kv change wasn't
captured in the paxos transaction.

Fixes: bb7ebc41532aeb23cff2241ab07b3f01c2f57ddd

Need to make sure this is backported to pacific as part of #39595 


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>