### PR TITLE
vstart_runner: define path to ceph binary and use it

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -158,6 +158,8 @@ else:
     BIN_PREFIX = "./"
     SRC_PREFIX = "./"
 
+CEPH_CMD = os.path.join(BIN_PREFIX, 'ceph')
+
 
 def rm_nonascii_chars(var):
     var = var.replace(b'\xe2\x80\x98', b'\'')
@@ -970,7 +972,7 @@ class LocalCephManager(CephManager):
                               This can be 'cluster', 'audit', ...
         :type watch_channel: str
         """
-        args = [os.path.join(BIN_PREFIX, "ceph"), "-w"]
+        args = [CEPH_CMD, "-w"]
         if watch_channel is not None:
             args.append("--watch-channel")
             args.append(watch_channel)
@@ -984,7 +986,7 @@ class LocalCephManager(CephManager):
 
         Accepts arguments same as teuthology.orchestra.remote.run().
         """
-        kwargs['args'] = [os.path.join(BIN_PREFIX,'ceph')]+list(kwargs['args'])
+        kwargs['args'] = [CEPH_CMD] + list(kwargs['args'])
         return self.controller.run(**kwargs)
 
     def raw_cluster_cmd(self, *args, **kwargs):
@@ -1009,10 +1011,9 @@ class LocalCephManager(CephManager):
         if stdout is None:
             stdout = StringIO()
 
-        return self.controller.run(
-            args=[os.path.join(BIN_PREFIX, "ceph"), "daemon",
-                  "{0}.{1}".format(daemon_type, daemon_id)] + command,
-            check_status=check_status, timeout=timeout, stdout=stdout)
+        args=[CEPH_CMD, "daemon", f'{daemon_type}', f'{daemon_id}'] + command
+        return self.controller.run(args=args, check_status=check_status,
+                                   timeout=timeout, stdout=stdout)
 
     def get_mon_socks(self):
         """
@@ -1646,7 +1647,7 @@ def exec_test():
         client_name = "client.{0}".format(client_id)
 
         if client_name not in open("./keyring").read():
-            p = remote.run(args=[os.path.join(BIN_PREFIX, "ceph"), "auth", "get-or-create", client_name,
+            p = remote.run(args=[CEPH_CMD, "auth", "get-or-create", client_name,
                                  "osd", "allow rw",
                                  "mds", "allow",
                                  "mon", "allow r"], stdout=StringIO())
@@ -1680,7 +1681,7 @@ def exec_test():
 
     # For the benefit of polling tests like test_full -- in teuthology land we set this
     # in a .yaml, here it's just a hardcoded thing for the developer's pleasure.
-    remote.run(args=[os.path.join(BIN_PREFIX, "ceph"), "tell", "osd.*", "injectargs", "--osd-mon-report-interval", "5"])
+    remote.run(args=[CEPH_CMD, "tell", "osd.*", "injectargs", "--osd-mon-report-interval", "5"])
     ceph_cluster.set_ceph_conf("osd", "osd_mon_report_interval", "5")
 
     # Vstart defaults to two segments, which very easily gets a "behind on trimming" health warning


### PR DESCRIPTION
... instead of joining path to <ceph-repo-root>/build/bin/ directory to
'ceph' everytime.




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>