### PR TITLE
vstart_runner: remove duplicate methods from LocalCephManager

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -1014,53 +1014,6 @@ class LocalCephManager(CephManager):
                   "{0}.{1}".format(daemon_type, daemon_id)] + command,
             check_status=check_status, timeout=timeout, stdout=stdout)
 
-    def get_mon_socks(self):
-        """
-        Get monitor sockets.
-
-        :return socks: tuple of strings; strings are individual sockets.
-        """
-        from json import loads
-
-        output = loads(self.raw_cluster_cmd('--format=json', 'mon', 'dump'))
-        socks = []
-        for mon in output['mons']:
-            for addrvec_mem in mon['public_addrs']['addrvec']:
-                socks.append(addrvec_mem['addr'])
-        return tuple(socks)
-
-    def get_msgrv1_mon_socks(self):
-        """
-        Get monitor sockets that use msgrv2 to operate.
-
-        :return socks: tuple of strings; strings are individual sockets.
-        """
-        from json import loads
-
-        output = loads(self.raw_cluster_cmd('--format=json', 'mon', 'dump'))
-        socks = []
-        for mon in output['mons']:
-            for addrvec_mem in mon['public_addrs']['addrvec']:
-                if addrvec_mem['type'] == 'v1':
-                    socks.append(addrvec_mem['addr'])
-        return tuple(socks)
-
-    def get_msgrv2_mon_socks(self):
-        """
-        Get monitor sockets that use msgrv2 to operate.
-
-        :return socks: tuple of strings; strings are individual sockets.
-        """
-        from json import loads
-
-        output = loads(self.raw_cluster_cmd('--format=json', 'mon', 'dump'))
-        socks = []
-        for mon in output['mons']:
-            for addrvec_mem in mon['public_addrs']['addrvec']:
-                if addrvec_mem['type'] == 'v2':
-                    socks.append(addrvec_mem['addr'])
-        return tuple(socks)
-
 
 class LocalCephCluster(CephCluster):
     def __init__(self, ctx):


### PR DESCRIPTION
LocalCephManager already inherits these methods from CephManager.






<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>