### PR TITLE
os/bluestore: Set new compression blob size to 64K

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5446,7 +5446,7 @@ options:
     state) media
   fmt_desc: Default value of ``bluestore compression min blob size``
     for non-rotational (solid state) media.
-  default: 8_K
+  default: 64_K
   see_also:
   - bluestore_compression_min_blob_size
   flags:


### PR DESCRIPTION
Based on compression test results (no detailed methodology report yet, data pre-processed in:
https://docs.google.com/spreadsheets/d/1zIlu1aZFodgmZOJm7VboJBbteoERVtJtx8AY1KzKmQE )
I would like to propose change of compression blob size to 64K.

Graphs show evolution of cluster. X-axis is 8 steps of testing. 
Test is 4-64k random read/write that spans 600MB dataset of 150k objects each 4MB.

It shows significant reduction in space used:
![used_space](https://user-images.githubusercontent.com/13020832/109153684-81567680-776d-11eb-948c-e95735ee9ba3.png)

And still has reasonable impact on performance:
![write_iops](https://user-images.githubusercontent.com/13020832/109154333-6fc19e80-776e-11eb-9cd5-19fc377c0e8c.png)
![read_iops](https://user-images.githubusercontent.com/13020832/109154336-7223f880-776e-11eb-8d4b-a32f3c69cfac.png)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
