### PR TITLE
qa/suites/rbd: make osds generate less logs for qemu_xfstests

### DIFF
--- a/qa/suites/rbd/encryption/workloads/qemu_xfstests_luks1.yaml
+++ b/qa/suites/rbd/encryption/workloads/qemu_xfstests_luks1.yaml
@@ -2,6 +2,22 @@ overrides:
   install:
     ceph:
       extra_packages: [rbd-nbd]
+  ceph:
+    conf:
+      osd:
+        debug bluefs: "1/5"
+        debug bluestore: "1/5"
+        debug filestore: "1/3"
+        debug journal: "0/5"
+        debug rocksdb: "4/5"
+  ceph-deploy:
+    conf:
+      osd:
+        debug bluefs: "1/5"
+        debug bluestore: "1/5"
+        debug filestore: "1/3"
+        debug journal: "0/5"
+        debug rocksdb: "4/5"
 tasks:
 - qemu:
     all:

--- a/qa/suites/rbd/encryption/workloads/qemu_xfstests_luks2.yaml
+++ b/qa/suites/rbd/encryption/workloads/qemu_xfstests_luks2.yaml
@@ -2,6 +2,22 @@ overrides:
   install:
     ceph:
       extra_packages: [rbd-nbd]
+  ceph:
+    conf:
+      osd:
+        debug bluefs: "1/5"
+        debug bluestore: "1/5"
+        debug filestore: "1/3"
+        debug journal: "0/5"
+        debug rocksdb: "4/5"
+  ceph-deploy:
+    conf:
+      osd:
+        debug bluefs: "1/5"
+        debug bluestore: "1/5"
+        debug filestore: "1/3"
+        debug journal: "0/5"
+        debug rocksdb: "4/5"
 tasks:
 - qemu:
     all:

--- a/qa/suites/rbd/migration/7-io-workloads/qemu_xfstests.yaml
+++ b/qa/suites/rbd/migration/7-io-workloads/qemu_xfstests.yaml
@@ -1,3 +1,20 @@
+overrides:
+  ceph:
+    conf:
+      osd:
+        debug bluefs: "1/5"
+        debug bluestore: "1/5"
+        debug filestore: "1/3"
+        debug journal: "0/5"
+        debug rocksdb: "4/5"
+  ceph-deploy:
+    conf:
+      osd:
+        debug bluefs: "1/5"
+        debug bluestore: "1/5"
+        debug filestore: "1/3"
+        debug journal: "0/5"
+        debug rocksdb: "4/5"
 io_workload:
   sequential:
     - qemu:

--- a/qa/suites/rbd/qemu/workloads/qemu_xfstests.yaml
+++ b/qa/suites/rbd/qemu/workloads/qemu_xfstests.yaml
@@ -1,3 +1,20 @@
+overrides:
+  ceph:
+    conf:
+      osd:
+        debug bluefs: "1/5"
+        debug bluestore: "1/5"
+        debug filestore: "1/3"
+        debug journal: "0/5"
+        debug rocksdb: "4/5"
+  ceph-deploy:
+    conf:
+      osd:
+        debug bluefs: "1/5"
+        debug bluestore: "1/5"
+        debug filestore: "1/3"
+        debug journal: "0/5"
+        debug rocksdb: "4/5"
 tasks:
 - qemu:
     all:


### PR DESCRIPTION
Archiving and transferring the osd logs after qemu xfstests
required more than 3 hours on smithi.

Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
