### PR TITLE
doc/dev: add t8y debug section names

### DIFF
--- a/doc/dev/developer_guide/testing_integration_tests/tests-integration-testing-teuthology-debugging-tips.rst
+++ b/doc/dev/developer_guide/testing_integration_tests/tests-integration-testing-teuthology-debugging-tips.rst
@@ -6,6 +6,9 @@ Analyzing and Debugging A Teuthology Job
 To learn more about how to schedule an integration test, refer to `Scheduling
 Test Run`_.
 
+Viewing Test Results
+--------------------
+
 When a teuthology run has been completed successfully, use `pulpito`_ dasboard
 to view the results::
 
@@ -26,6 +29,9 @@ and access `teuthology archives`_, like this for example:
 .. note:: This requires you to have access to the Sepia lab. To learn how to
           request access to the Speia lab, see: 
           https://ceph.github.io/sepia/adding_users/
+
+Identifying Failed Jobs
+-----------------------
 
 On pulpito, jobs in red specify either a failed job or a dead job.
 A job is combination of daemons and configurations that are formed using


### PR DESCRIPTION
This commit adds two section headings to the
Debugging section of the Teuthology Guide:

  1. Viewing Test Results
  2. Identifying Failed Jobs

The text as it stood before seemed to call out for
this explicit sectioning of material, so I've answered
that call.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
