### PR TITLE
octopus: qa/suites/rados/dashboard: whitelist TELEMETRY_CHANGED

### DIFF
--- a/qa/suites/rados/dashboard/tasks/dashboard.yaml
+++ b/qa/suites/rados/dashboard/tasks/dashboard.yaml
@@ -23,6 +23,7 @@ tasks:
         - \(POOL_APP_NOT_ENABLED\)
         - \(OSDMAP_FLAGS\)
         - \(OSD_FLAGS\)
+        - \(TELEMETRY_CHANGED\)
         - pauserd,pausewr flag\(s\) set
         - Monitor daemon marked osd\.[[:digit:]]+ down, but it is still running
         - evicting unresponsive client .+


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49397

---

backport of https://github.com/ceph/ceph/pull/39283
parent tracker: https://tracker.ceph.com/issues/48990

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh