### PR TITLE
rpm: re-disable SUSE lttng build on z390x

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -48,7 +48,7 @@
 %bcond_with cephfs_java
 %bcond_with kafka_endpoint
 %bcond_with libradosstriper
-%ifarch x86_64 aarch64 ppc64le s390x
+%ifarch x86_64 aarch64 ppc64le
 %bcond_without lttng
 %else
 %bcond_with lttng


### PR DESCRIPTION
This partially reverts 2b1e646f7aade3135a98c505111ac7ebef5e93a6 which
mistakenly changed a line inside an "%if 0%{?suse_version}" conditional.

Fixes: 2b1e646f7aade3135a98c505111ac7ebef5e93a6
Signed-off-by: Nathan Cutler <ncutler@suse.com>
