### PR TITLE
nautilus: rados/upgrade/nautilus-x-singleton fails due to cluster [WRN] evicting unresponsive client

### DIFF
--- a/qa/suites/upgrade/mimic-x/parallel/1-ceph-install/mimic.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/1-ceph-install/mimic.yaml
@@ -30,6 +30,7 @@ tasks:
       - Monitor daemon marked osd
       - Behind on trimming
       - Manager daemon
+      - evicting unresponsive client
     conf:
       global:
         mon warn on pool no app: false

--- a/qa/suites/upgrade/nautilus-p2p/nautilus-p2p-parallel/point-to-point-upgrade.yaml
+++ b/qa/suites/upgrade/nautilus-p2p/nautilus-p2p-parallel/point-to-point-upgrade.yaml
@@ -12,6 +12,7 @@ meta:
 overrides:
   ceph:
     log-whitelist:
+    - evicting unresponsive client
     - reached quota
     - scrub
     - osd_map_max_advance

--- a/qa/suites/upgrade/nautilus-p2p/nautilus-p2p-stress-split/0-cluster/start.yaml
+++ b/qa/suites/upgrade/nautilus-p2p/nautilus-p2p-stress-split/0-cluster/start.yaml
@@ -7,6 +7,7 @@ overrides:
   ceph:
     fs: xfs
     log-whitelist:
+      - evicting unresponsive client
       - overall HEALTH_
       - \(MON_DOWN\)
       - \(MGR_DOWN\)

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -390,6 +390,7 @@ void MgrStandby::handle_mgr_map(MMgrMap* mmap)
   // this MgrMap is changing its set of enabled modules
   bool need_respawn = py_module_registry.handle_mgr_map(map);
   if (need_respawn) {
+    dout(1) << "respawning because set of enabled modules changed!" << dendl;
     respawn();
   }
 


### PR DESCRIPTION
https://tracker.ceph.com/issues/48286