### PR TITLE
rbd: fix mingw 5.0.3 compatibility issue

### DIFF
--- a/src/tools/rbd_wnbd/rbd_wnbd.cc
+++ b/src/tools/rbd_wnbd/rbd_wnbd.cc
@@ -402,8 +402,7 @@ int map_device_using_suprocess(std::string arguments, int timeout_ms)
   status = WaitForMultipleObjects(2, wait_events, FALSE, timeout_ms);
   switch(status) {
     case WAIT_OBJECT_0:
-      if (!GetOverlappedResultEx(pipe_handle, &connect_o,
-                                 &bytes_read, timeout_ms, TRUE)) {
+      if (!GetOverlappedResult(pipe_handle, &connect_o, &bytes_read, TRUE)) {
         err = GetLastError();
         derr << "Couln't establish a connection with the child process. "
              << "Error: " << win32_strerror(err) << dendl;
@@ -440,8 +439,7 @@ int map_device_using_suprocess(std::string arguments, int timeout_ms)
   status = WaitForMultipleObjects(2, wait_events, FALSE, timeout_ms);
   switch(status) {
     case WAIT_OBJECT_0:
-      if (!GetOverlappedResultEx(pipe_handle, &read_o,
-                                 &bytes_read, timeout_ms, TRUE)) {
+      if (!GetOverlappedResult(pipe_handle, &read_o, &bytes_read, TRUE)) {
         err = GetLastError();
         derr << "Receiving child process reply failed with: "
              << win32_strerror(err) << dendl;


### PR DESCRIPTION
GetOverlappedResultEx isn't avaialable when using mingw 5.0.3
(default on Ubuntu Bionic).

Since we don't really need the extra parameters, we'll switch
to GetOverlappedResult.

We're doing this mostly for testing purposes as the mingw 5.0.3
runtime is known to be broken.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>