### PR TITLE
qa: use tcmalloc with valgrind in fs:valgrind

### DIFF
--- a/qa/suites/fs/valgrind/debug.yaml
+++ b/qa/suites/fs/valgrind/debug.yaml
@@ -1,0 +1,4 @@
+overrides:
+  install:
+    ceph:
+      debuginfo: true

--- a/qa/suites/fs/valgrind/notcmalloc.yaml
+++ b/qa/suites/fs/valgrind/notcmalloc.yaml
@@ -1,8 +1,0 @@
-meta:
-- desc: use notcmalloc version for valgrind
-
-overrides:
-  install:
-    ceph:
-      flavor: notcmalloc
-      debuginfo: true


### PR DESCRIPTION
We're not doing notcmalloc builds anymore now that we can use tcmalloc with Valgrind.