### PR TITLE
cephadm: `cephadm ls` broken for SUSE downstream alertmanager container

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -281,6 +281,35 @@ class Monitoring(object):
         },
     }  # type: ignore
 
+    @staticmethod
+    def get_version(ctx, container_id, daemon_type):
+        # type: (CephadmContext, str, str) -> str
+        """
+        :param: daemon_type Either "prometheus", "alertmanager" or "node-exporter"
+        """
+        assert daemon_type in ('prometheus', 'alertmanager', 'node-exporter')
+        cmd = daemon_type.replace('-', '_')
+        code = -1
+        err = ''
+        version = ''
+        if daemon_type == 'alertmanager':
+            for cmd in ['alertmanager', 'prometheus-alertmanager']:
+                _, err, code = call(ctx, [
+                        ctx.container_path, 'exec', container_id, cmd,
+                        '--version'
+                    ], verbosity=CallVerbosity.SILENT)
+                if code == 0:
+                    break
+            cmd = 'alertmanager'  # reset cmd for version extraction
+        else:
+            _, err, code = call(ctx, [
+                ctx.container_path, 'exec', container_id, cmd, '--version'
+            ])
+        if code == 0 and \
+            err.startswith('%s, version ' % cmd):
+            version = err.split(' ')[2]
+        return version
+
 ##################################
 def populate_files(config_dir, config_files, uid, gid):
     # type: (str, Dict, int, int) -> None
@@ -4562,24 +4591,8 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                                 elif daemon_type in ['prometheus',
                                                      'alertmanager',
                                                      'node-exporter']:
-                                    cmd = daemon_type.replace('-', '_')
-                                    if daemon_type == 'alertmanager':
-                                        for cmd in ['alertmanager', 'prometheus-alertmanager']:
-                                            out, err, code = call(ctx, [
-                                                    container_path, 'exec', container_id, cmd,
-                                                    '--version'
-                                                ], verbosity=CallVerbosity.SILENT)
-                                            if code == 0:
-                                                break
-                                        cmd = 'alertmanager'  # reset cmd for version extraction
-                                    else:
-                                        out, err, code = call(ctx, [
-                                            container_path, 'exec', container_id, cmd, '--version'
-                                        ])
-                                    if not code and \
-                                       err.startswith('%s, version ' % cmd):
-                                        version = err.split(' ')[2]
-                                        seen_versions[image_id] = version
+                                    version = Monitoring.get_version(ctx, container_id, daemon_type)
+                                    seen_versions[image_id] = version
                                 elif daemon_type == 'haproxy':
                                     out, err, code = call(ctx,
                                         [container_path, 'exec', container_id,

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4563,9 +4563,19 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                                                      'alertmanager',
                                                      'node-exporter']:
                                     cmd = daemon_type.replace('-', '_')
-                                    out, err, code = call(ctx,
-                                        [container_path, 'exec', container_id,
-                                         cmd, '--version'])
+                                    if daemon_type == 'alertmanager':
+                                        for cmd in ['alertmanager', 'prometheus-alertmanager']:
+                                            out, err, code = call(ctx, [
+                                                    container_path, 'exec', container_id, cmd,
+                                                    '--version'
+                                                ], verbosity=CallVerbosity.SILENT)
+                                            if code == 0:
+                                                break
+                                        cmd = 'alertmanager'  # reset cmd for version extraction
+                                    else:
+                                        out, err, code = call(ctx, [
+                                            container_path, 'exec', container_id, cmd, '--version'
+                                        ])
                                     if not code and \
                                        err.startswith('%s, version ' % cmd):
                                         version = err.split(' ')[2]

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -54,12 +54,10 @@ import ipaddress
 import json
 import logging
 from logging.config import dictConfig
-from operator import truediv
 import os
 import platform
 import pwd
 import random
-import select
 import shutil
 import socket
 import string

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -807,3 +807,39 @@ class TestMaintenance:
     def test_parser_BAD(self):
         with pytest.raises(SystemExit):
             cd._parse_args(['host-maintenance', 'wah'])
+
+
+class TestMonitoring(object):
+    @mock.patch('cephadm.call')
+    def test_get_version_alertmanager(self, _call):
+        ctx = mock.Mock()
+        daemon_type = 'alertmanager'
+
+        # binary `prometheus`
+        _call.return_value = '', '{}, version 0.16.1'.format(daemon_type), 0
+        version = cd.Monitoring.get_version(ctx, 'container_id', daemon_type)
+        assert version == '0.16.1'
+
+        # binary `prometheus-alertmanager`
+        _call.side_effect = (
+            ('', '', 1),
+            ('', '{}, version 0.16.1'.format(daemon_type), 0),
+        )
+        version = cd.Monitoring.get_version(ctx, 'container_id', daemon_type)
+        assert version == '0.16.1'
+
+    @mock.patch('cephadm.call')
+    def test_get_version_prometheus(self, _call):
+        ctx = mock.Mock()
+        daemon_type = 'prometheus'
+        _call.return_value = '', '{}, version 0.16.1'.format(daemon_type), 0
+        version = cd.Monitoring.get_version(ctx, 'container_id', daemon_type)
+        assert version == '0.16.1'
+
+    @mock.patch('cephadm.call')
+    def test_get_version_node_exporter(self, _call):
+        ctx = mock.Mock()
+        daemon_type = 'node-exporter'
+        _call.return_value = '', '{}, version 0.16.1'.format(daemon_type.replace('-', '_')), 0
+        version = cd.Monitoring.get_version(ctx, 'container_id', daemon_type)
+        assert version == '0.16.1'


### PR DESCRIPTION
Fixes an error with `cephadm ls` when SUSE's downstream alertmanager is used. The difference here is that the executable is named `prometheus-alertmanager` instead of `alertmanager` as in the Prometheus upstream image.
```
#==[ Command ]======================================#
# /usr/sbin/cephadm ls
Non-zero exit code 127 from /usr/bin/podman exec 81581144900c6b7f5a1da7124bd0debb26cd455349f162729b4ea3e9f7fc4f86 alertmanager --version
/usr/bin/podman:stderr Error: exec failed: container_linux.go:349: starting container process caused "exec: \"alertmanager\": executable file not found in $PATH": OCI runtime command not found error
[
...
    {
        "style": "cephadm:v1",
        "name": "alertmanager.ses-5-admin",
        "fsid": "33ec5433-261d-3dad-b75a-cd21d35a0946",
        "systemd_unit": "ceph-33ec5433-261d-3dad-b75a-cd21d35a0946@alertmanager.ses-5-admin",
        "enabled": true,
        "state": "running",
        "container_id": "81581144900c6b7f5a1da7124bd0debb26cd455349f162729b4ea3e9f7fc4f86",
        "container_image_name": "foo.bar.de:5000/registry.suse.com/caasp/v4.5/prometheus-alertmanager:0.16.2",
        "container_image_id": "4683615b36cb2f4fb8580ae7ebbe0cdf42db25ae79c7ca3f48f5096706c25679",
        "version": null,
        "started": "2021-02-23T17:25:13.927267",
        "created": "2021-01-20T17:02:49.987979",
        "deployed": "2021-01-22T15:49:37.746184",
        "configured": "2021-01-22T15:49:38.822172" 
    },
...
]
```

Fixes: https://tracker.ceph.com/issues/49506

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
