### PR TITLE
mgr/cephadm: upgrade multiple OSDs in parallel

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1765,7 +1765,7 @@ bool DaemonServer::_handle_command(
     f->flush(cmdctx->odata);
     cmdctx->odata.append("\n");
     if (!out_report.ok_to_stop()) {
-      ss << "unsafe to stop osd(s)";
+      ss << "unsafe to stop osd(s) at this time (" << out_report.not_ok.size() << " PGs are or would become offline)";
       cmdctx->reply(-EBUSY, ss);
     } else {
       cmdctx->reply(0, ss);

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1248,7 +1248,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         okay: bool = True
         for daemon_type, daemon_ids in daemon_map.items():
             r = self.cephadm_services[daemon_type_to_service(
-                daemon_type)].ok_to_stop(daemon_ids, force)
+                daemon_type)].ok_to_stop(daemon_ids, force=force)
             if r.retval:
                 okay = False
                 # collect error notifications so user can see every daemon causing host

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -254,8 +254,8 @@ class CephadmService(metaclass=ABCMeta):
                    force: bool = False,
                    known: Optional[List[str]] = None) -> HandleCommandResult:
         names = [f'{self.TYPE}.{d_id}' for d_id in daemon_ids]
-        out = f'It is presumed safe to stop {names}'
-        err = f'It is NOT safe to stop {names}'
+        out = f'It is presumed safe to stop {",".join(names)}'
+        err = f'It is NOT safe to stop {",".join(names)} at this time'
 
         if self.TYPE not in ['mon', 'osd', 'mds']:
             logger.info(out)

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -222,6 +222,33 @@ class CephadmService(metaclass=ABCMeta):
             except MonCommandFailed as e:
                 logger.warning('Failed to set Dashboard config for %s: %s', service_name, e)
 
+    def ok_to_stop_osd(
+            self,
+            osds: List[str],
+            known: Optional[List[str]] = None,
+            force: bool = False) -> HandleCommandResult:
+        r = HandleCommandResult(*self.mgr.mon_command({
+            'prefix': "osd ok-to-stop",
+            'ids': osds,
+            'max': 16,
+        }))
+        j = None
+        try:
+            j = json.loads(r.stdout)
+        except json.decoder.JSONDecodeError:
+            self.mgr.log.warning("osd ok-to-stop didn't return structured result")
+            raise
+        if r.retval:
+            return r
+        if known is not None and j and j.get('ok_to_stop'):
+            self.mgr.log.debug(f"got {j}")
+            known.extend([f'osd.{x}' for x in j.get('osds', [])])
+        return HandleCommandResult(
+            0,
+            f'{",".join(["osd.%s" % o for o in osds])} {"is" if len(osds) == 1 else "are"} safe to restart',
+            ''
+        )
+
     def ok_to_stop(self,
                    daemon_ids: List[str],
                    force: bool = False,
@@ -233,6 +260,9 @@ class CephadmService(metaclass=ABCMeta):
         if self.TYPE not in ['mon', 'osd', 'mds']:
             logger.info(out)
             return HandleCommandResult(0, out)
+
+        if self.TYPE == 'osd':
+            return self.ok_to_stop_osd(daemon_ids, known, force)
 
         r = HandleCommandResult(*self.mgr.mon_command({
             'prefix': f'{self.TYPE} ok-to-stop',

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -225,7 +225,7 @@ class CephadmService(metaclass=ABCMeta):
     def ok_to_stop_osd(
             self,
             osds: List[str],
-            known: Optional[List[str]] = None,
+            known: Optional[List[str]] = None,  # output argument
             force: bool = False) -> HandleCommandResult:
         r = HandleCommandResult(*self.mgr.mon_command({
             'prefix': "osd ok-to-stop",
@@ -249,10 +249,12 @@ class CephadmService(metaclass=ABCMeta):
             ''
         )
 
-    def ok_to_stop(self,
-                   daemon_ids: List[str],
-                   force: bool = False,
-                   known: Optional[List[str]] = None) -> HandleCommandResult:
+    def ok_to_stop(
+            self,
+            daemon_ids: List[str],
+            force: bool = False,
+            known: Optional[List[str]] = None    # output argument
+    ) -> HandleCommandResult:
         names = [f'{self.TYPE}.{d_id}' for d_id in daemon_ids]
         out = f'It is presumed safe to stop {",".join(names)}'
         err = f'It is NOT safe to stop {",".join(names)} at this time'
@@ -577,10 +579,12 @@ class MgrService(CephService):
         num = len(mgr_map.get('standbys'))
         return bool(num)
 
-    def ok_to_stop(self,
-                   daemon_ids: List[str],
-                   force: bool = False,
-                   known: Optional[List[str]] = None) -> HandleCommandResult:
+    def ok_to_stop(
+            self,
+            daemon_ids: List[str],
+            force: bool = False,
+            known: Optional[List[str]] = None  # output argument
+    ) -> HandleCommandResult:
         # ok to stop if there is more than 1 mgr and not trying to stop the active mgr
 
         warn, warn_message = self._enough_daemons_to_stop(self.TYPE, daemon_ids, 'Mgr', 1, True)
@@ -866,10 +870,12 @@ class RgwService(CephService):
                 raise OrchestratorError(err)
             self.mgr.log.info('updated period')
 
-    def ok_to_stop(self,
-                   daemon_ids: List[str],
-                   force: bool = False,
-                   known: Optional[List[str]] = None) -> HandleCommandResult:
+    def ok_to_stop(
+            self,
+            daemon_ids: List[str],
+            force: bool = False,
+            known: Optional[List[str]] = None  # output argument
+    ) -> HandleCommandResult:
         # if load balancer (ha-rgw) is present block if only 1 daemon up otherwise ok
         # if no load balancer, warn if > 1 daemon, block if only 1 daemon
         def ha_rgw_present() -> bool:
@@ -920,10 +926,12 @@ class RbdMirrorService(CephService):
 
         return daemon_spec
 
-    def ok_to_stop(self,
-                   daemon_ids: List[str],
-                   force: bool = False,
-                   known: Optional[List[str]] = None) -> HandleCommandResult:
+    def ok_to_stop(
+            self,
+            daemon_ids: List[str],
+            force: bool = False,
+            known: Optional[List[str]] = None  # output argument
+    ) -> HandleCommandResult:
         # if only 1 rbd-mirror, alert user (this is not passable with --force)
         warn, warn_message = self._enough_daemons_to_stop(
             self.TYPE, daemon_ids, 'Rbdmirror', 1, True)

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -222,7 +222,10 @@ class CephadmService(metaclass=ABCMeta):
             except MonCommandFailed as e:
                 logger.warning('Failed to set Dashboard config for %s: %s', service_name, e)
 
-    def ok_to_stop(self, daemon_ids: List[str], force: bool = False) -> HandleCommandResult:
+    def ok_to_stop(self,
+                   daemon_ids: List[str],
+                   force: bool = False,
+                   known: Optional[List[str]] = None) -> HandleCommandResult:
         names = [f'{self.TYPE}.{d_id}' for d_id in daemon_ids]
         out = f'It is presumed safe to stop {names}'
         err = f'It is NOT safe to stop {names}'
@@ -544,7 +547,10 @@ class MgrService(CephService):
         num = len(mgr_map.get('standbys'))
         return bool(num)
 
-    def ok_to_stop(self, daemon_ids: List[str], force: bool = False) -> HandleCommandResult:
+    def ok_to_stop(self,
+                   daemon_ids: List[str],
+                   force: bool = False,
+                   known: Optional[List[str]] = None) -> HandleCommandResult:
         # ok to stop if there is more than 1 mgr and not trying to stop the active mgr
 
         warn, warn_message = self._enough_daemons_to_stop(self.TYPE, daemon_ids, 'Mgr', 1, True)
@@ -830,7 +836,10 @@ class RgwService(CephService):
                 raise OrchestratorError(err)
             self.mgr.log.info('updated period')
 
-    def ok_to_stop(self, daemon_ids: List[str], force: bool = False) -> HandleCommandResult:
+    def ok_to_stop(self,
+                   daemon_ids: List[str],
+                   force: bool = False,
+                   known: Optional[List[str]] = None) -> HandleCommandResult:
         # if load balancer (ha-rgw) is present block if only 1 daemon up otherwise ok
         # if no load balancer, warn if > 1 daemon, block if only 1 daemon
         def ha_rgw_present() -> bool:
@@ -881,7 +890,10 @@ class RbdMirrorService(CephService):
 
         return daemon_spec
 
-    def ok_to_stop(self, daemon_ids: List[str], force: bool = False) -> HandleCommandResult:
+    def ok_to_stop(self,
+                   daemon_ids: List[str],
+                   force: bool = False,
+                   known: Optional[List[str]] = None) -> HandleCommandResult:
         # if only 1 rbd-mirror, alert user (this is not passable with --force)
         warn, warn_message = self._enough_daemons_to_stop(
             self.TYPE, daemon_ids, 'Rbdmirror', 1, True)

--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -1,7 +1,7 @@
 import errno
 import json
 import logging
-from typing import List, cast
+from typing import List, cast, Optional
 
 from mgr_module import HandleCommandResult
 from ceph.deployment.service_spec import IscsiServiceSpec
@@ -121,7 +121,10 @@ class IscsiService(CephService):
             get_set_cmd_dicts=get_set_cmd_dicts
         )
 
-    def ok_to_stop(self, daemon_ids: List[str], force: bool = False) -> HandleCommandResult:
+    def ok_to_stop(self,
+                   daemon_ids: List[str],
+                   force: bool = False,
+                   known: Optional[List[str]] = None) -> HandleCommandResult:
         # if only 1 iscsi, alert user (this is not passable with --force)
         warn, warn_message = self._enough_daemons_to_stop(self.TYPE, daemon_ids, 'Iscsi', 1, True)
         if warn:

--- a/src/pybind/mgr/cephadm/services/monitoring.py
+++ b/src/pybind/mgr/cephadm/services/monitoring.py
@@ -1,7 +1,7 @@
 import errno
 import logging
 import os
-from typing import List, Any, Tuple, Dict, cast
+from typing import List, Any, Tuple, Dict, Optional, cast
 
 from mgr_module import HandleCommandResult
 
@@ -84,7 +84,10 @@ class GrafanaService(CephadmService):
             service_url
         )
 
-    def ok_to_stop(self, daemon_ids: List[str], force: bool = False) -> HandleCommandResult:
+    def ok_to_stop(self,
+                   daemon_ids: List[str],
+                   force: bool = False,
+                   known: Optional[List[str]] = None) -> HandleCommandResult:
         warn, warn_message = self._enough_daemons_to_stop(self.TYPE, daemon_ids, 'Grafana', 1)
         if warn and not force:
             return HandleCommandResult(-errno.EBUSY, '', warn_message)
@@ -175,7 +178,10 @@ class AlertmanagerService(CephadmService):
             service_url
         )
 
-    def ok_to_stop(self, daemon_ids: List[str], force: bool = False) -> HandleCommandResult:
+    def ok_to_stop(self,
+                   daemon_ids: List[str],
+                   force: bool = False,
+                   known: Optional[List[str]] = None) -> HandleCommandResult:
         warn, warn_message = self._enough_daemons_to_stop(self.TYPE, daemon_ids, 'Alertmanager', 1)
         if warn and not force:
             return HandleCommandResult(-errno.EBUSY, '', warn_message)
@@ -280,7 +286,10 @@ class PrometheusService(CephadmService):
             service_url
         )
 
-    def ok_to_stop(self, daemon_ids: List[str], force: bool = False) -> HandleCommandResult:
+    def ok_to_stop(self,
+                   daemon_ids: List[str],
+                   force: bool = False,
+                   known: Optional[List[str]] = None) -> HandleCommandResult:
         warn, warn_message = self._enough_daemons_to_stop(self.TYPE, daemon_ids, 'Prometheus', 1)
         if warn and not force:
             return HandleCommandResult(-errno.EBUSY, '', warn_message)
@@ -299,7 +308,10 @@ class NodeExporterService(CephadmService):
         assert self.TYPE == daemon_spec.daemon_type
         return {}, []
 
-    def ok_to_stop(self, daemon_ids: List[str], force: bool = False) -> HandleCommandResult:
+    def ok_to_stop(self,
+                   daemon_ids: List[str],
+                   force: bool = False,
+                   known: Optional[List[str]] = None) -> HandleCommandResult:
         # since node exporter runs on each host and cannot compromise data, no extra checks required
         names = [f'{self.TYPE}.{d_id}' for d_id in daemon_ids]
         out = f'It is presumed safe to stop {names}'

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -1,6 +1,6 @@
 import errno
 import logging
-from typing import Dict, Tuple, Any, List, cast
+from typing import Dict, Tuple, Any, List, cast, Optional
 
 from mgr_module import HandleCommandResult
 
@@ -156,7 +156,10 @@ class NFSService(CephService):
         super().post_remove(daemon)
         self.remove_rgw_keyring(daemon)
 
-    def ok_to_stop(self, daemon_ids: List[str], force: bool = False) -> HandleCommandResult:
+    def ok_to_stop(self,
+                   daemon_ids: List[str],
+                   force: bool = False,
+                   known: Optional[List[str]] = None) -> HandleCommandResult:
         # if only 1 nfs, alert user (this is not passable with --force)
         warn, warn_message = self._enough_daemons_to_stop(self.TYPE, daemon_ids, 'NFS', 1, True)
         if warn:

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -213,7 +213,8 @@ class CephadmUpgrade:
             return True
         return False
 
-    def _wait_for_ok_to_stop(self, s: DaemonDescription) -> bool:
+    def _wait_for_ok_to_stop(self, s: DaemonDescription,
+                             known: Optional[List[str]] = None) -> bool:
         # only wait a little bit; the service might go away for something
         assert s.daemon_type is not None
         assert s.daemon_id is not None

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -213,8 +213,10 @@ class CephadmUpgrade:
             return True
         return False
 
-    def _wait_for_ok_to_stop(self, s: DaemonDescription,
-                             known: Optional[List[str]] = None) -> bool:
+    def _wait_for_ok_to_stop(
+            self, s: DaemonDescription,
+            known: Optional[List[str]] = None,  # NOTE: output argument!
+    ) -> bool:
         # only wait a little bit; the service might go away for something
         assert s.daemon_type is not None
         assert s.daemon_id is not None
@@ -224,6 +226,7 @@ class CephadmUpgrade:
                 return False
 
             # setting force flag to retain old functionality.
+            # note that known is an output argument for ok_to_stop()
             r = self.mgr.cephadm_services[daemon_type_to_service(s.daemon_type)].ok_to_stop([
                 s.daemon_id], known=known, force=True)
 
@@ -472,6 +475,8 @@ class CephadmUpgrade:
                         to_upgrade.append(d)
                     continue
 
+                # NOTE: known_ok_to_stop is an output argument for
+                # _wait_for_ok_to_stop
                 if not self._wait_for_ok_to_stop(d, known_ok_to_stop):
                     return
 

--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -157,6 +157,7 @@ class CephadmUpgrade:
                 self._save_upgrade_state()
                 return 'Resumed upgrade to %s' % self.target_image
             return 'Upgrade to %s in progress' % self.target_image
+        self.mgr.log.info('Upgrade: Started with target %s' % target_name)
         self.upgrade_state = UpgradeState(
             target_name=target_name,
             progress_id=str(uuid.uuid4())
@@ -173,6 +174,7 @@ class CephadmUpgrade:
         if self.upgrade_state.paused:
             return 'Upgrade to %s already paused' % self.target_image
         self.upgrade_state.paused = True
+        self.mgr.log.info('Upgrade: Paused upgrade to %s' % self.target_image)
         self._save_upgrade_state()
         return 'Paused upgrade to %s' % self.target_image
 
@@ -182,6 +184,7 @@ class CephadmUpgrade:
         if not self.upgrade_state.paused:
             return 'Upgrade to %s not paused' % self.target_image
         self.upgrade_state.paused = False
+        self.mgr.log.info('Upgrade: Resumed upgrade to %s' % self.target_image)
         self._save_upgrade_state()
         self.mgr.event.set()
         return 'Resumed upgrade to %s' % self.target_image
@@ -193,6 +196,7 @@ class CephadmUpgrade:
             self.mgr.remote('progress', 'complete',
                             self.upgrade_state.progress_id)
         target_image = self.target_image
+        self.mgr.log.info('Upgrade: Stopped')
         self.upgrade_state = None
         self._save_upgrade_state()
         self._clear_upgrade_health_checks()


### PR DESCRIPTION
Make use of the new ok-to-stop structured output and --max argument to expand the list of OSDs to restart, speeding up upgrades.



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>