### PR TITLE
pacific: mgr/telemetry: check if 'ident' channel is active; identify dashboard telemetry test

### DIFF
--- a/qa/tasks/mgr/dashboard/test_telemetry.py
+++ b/qa/tasks/mgr/dashboard/test_telemetry.py
@@ -11,6 +11,15 @@ class TelemetryTest(DashboardTestCase):
         data = cls._get('/api/mgr/module/telemetry')
         cls.pre_enabled_status = data['enabled']
 
+        # identify ourselves so we can filter these reports out on the server side
+        cls._put(
+            '/api/settings',
+            {
+                'mgr/telemetry/channel_ident': True,
+                'mgr/telemetry/organization': 'ceph-qa',
+            }
+        )
+
     @classmethod
     def tearDownClass(cls):
         if cls.pre_enabled_status:

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -367,6 +367,8 @@ class Module(MgrModule):
             r.append('crash')
         if self.channel_device:
             r.append('device')
+        if self.channel_ident:
+            r.append('ident')
         return r
 
     def gather_device_report(self):


### PR DESCRIPTION
backports of #39429 and #39538