### PR TITLE
mon/PGMap: include the per-pool usage breakdown in pg dump

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1621,6 +1621,16 @@ void PGMap::dump_osd_stats(ceph::Formatter *f, bool with_net) const
     f->close_section();
   }
   f->close_section();
+
+  f->open_array_section("pool_statfs");
+  for (auto& p : pool_statfs) {
+    f->open_object_section("item");
+    f->dump_int("poolid", p.first.first);
+    f->dump_int("osd", p.first.second);
+    p.second.dump(f);
+    f->close_section();
+  }
+  f->close_section();
 }
 
 void PGMap::dump_osd_ping_times(ceph::Formatter *f) const


### PR DESCRIPTION
We started accounting for this ages ago, but we don't expose it anywhere.

Signed-off-by: Sage Weil <sage@newdream.net>