### PR TITLE
cephadm: fix escaping/quoting of stderr-prefix arg for ceph daemons

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -59,6 +59,7 @@ import os
 import platform
 import pwd
 import random
+import shlex
 import shutil
 import socket
 import string
@@ -2068,7 +2069,7 @@ def get_daemon_args(ctx, fsid, daemon_type, daemon_id):
             '--setgroup', 'ceph',
             '--default-log-to-file=false',
             '--default-log-to-stderr=true',
-            '--default-log-stderr-prefix="debug "',
+            '--default-log-stderr-prefix=debug ',
         ]
         if daemon_type == 'mon':
             r += [
@@ -2592,10 +2593,15 @@ def _write_container_cmd_to_bash(ctx, file_obj, container, comment=None, backgro
     file_obj.write('! '+ ' '.join(container.rm_cmd()) + ' 2> /dev/null\n')
     # Sometimes, `podman rm` doesn't find the container. Then you'll have to add `--storage`
     if 'podman' in ctx.container_path:
-        file_obj.write('! '+ ' '.join(container.rm_cmd(storage=True)) + ' 2> /dev/null\n')
+        file_obj.write(
+            '! '
+            + ' '.join([shlex.quote(a) for a in container.rm_cmd(storage=True)])
+            + ' 2> /dev/null\n')
 
     # container run command
-    file_obj.write(' '.join(container.run_cmd()) + (' &' if background else '') + '\n')
+    file_obj.write(
+        ' '.join([shlex.quote(a) for a in container.run_cmd()])
+        + (' &' if background else '') + '\n')
 
 
 def deploy_daemon_units(


### PR DESCRIPTION
cephadm: fix escaping/quoting of stderr-prefix arg for ceph daemons