### PR TITLE
rbd: use portable zero-ing memory function

### DIFF
--- a/src/librbd/crypto/luks/LoadRequest.cc
+++ b/src/librbd/crypto/luks/LoadRequest.cc
@@ -212,7 +212,7 @@ void LoadRequest<I>::read_volume_key() {
 
 template <typename I>
 void LoadRequest<I>::finish(int r) {
-  explicit_bzero(&m_passphrase[0], m_passphrase.size());
+  ceph_memzero_s(&m_passphrase[0], m_passphrase.size(), m_passphrase.size());
   m_on_finish->complete(r);
   delete this;
 }

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -1660,7 +1660,7 @@ static int do_map(int argc, const char *argv[], Config *cfg, bool reconnect)
     std::string passphrase((std::istreambuf_iterator<char>(file)),
                            (std::istreambuf_iterator<char>()));
     auto sg = make_scope_guard([&] {
-      explicit_bzero(&passphrase[0], passphrase.size()); });
+      ceph_memzero_s(&passphrase[0], passphrase.size(), passphrase.size()); });
     file.close();
     if (!passphrase.empty() && passphrase[passphrase.length() - 1] == '\n') {
       passphrase.erase(passphrase.length() - 1);


### PR DESCRIPTION

rbd: use portable zero-ing memory function ceph_memzero_s
Signed-off-by: YuanXin yuanxin@didiglobal.com
Signed-off-by: mychoxin mychoxin@gmail.com

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
