### PR TITLE
test/librbd: resolve compile error on centos

### DIFF
--- a/src/test/librbd/migration/test_mock_HttpClient.cc
+++ b/src/test/librbd/migration/test_mock_HttpClient.cc
@@ -175,7 +175,7 @@ public:
         boost::asio::ssl::context::no_sslv2 |
         boost::asio::ssl::context::single_dh_use);
     ctx.use_certificate_chain(
-        boost::asio::buffer(CERT.data(), CERT.size()));
+        boost::asio::buffer(CERTIFICATE.data(), CERTIFICATE.size()));
     ctx.use_private_key(
         boost::asio::buffer(KEY.data(), KEY.size()),
         boost::asio::ssl::context::file_format::pem);
@@ -184,7 +184,7 @@ public:
   }
 
   // dummy self-signed cert for localhost
-  const std::string CERT =
+  const std::string CERTIFICATE =
       "-----BEGIN CERTIFICATE-----\n"
       "MIIDXzCCAkegAwIBAgIUYH6rAaq66LC6yJ3XK1WEMIfmY4cwDQYJKoZIhvcNAQEL\n"
       "BQAwPzELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAlZBMQ8wDQYDVQQHDAZNY0xlYW4x\n"


### PR DESCRIPTION
test/librbd: resolve compile error on centos

resolve compile error: expected unqualified-id before ‘=’ token

Signed-off-by: YuanXin <yuanxin@didiglobal.com>
Signed-off-by: mychoxin <mychoxin@gmail.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
