### PR TITLE
common: enable log to journald

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -25,6 +25,7 @@ set(common_srcs
   Graylog.cc
   HTMLFormatter.cc
   HeartbeatMap.cc
+  Journald.cc
   LogClient.cc
   LogEntry.cc
   ostream_temp.cc

--- a/src/common/Journald.cc
+++ b/src/common/Journald.cc
@@ -1,0 +1,255 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "Journald.h"
+
+#include <endian.h>
+#include <fcntl.h>
+#include <memory>
+#include <string>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <sys/un.h>
+#include <syslog.h>
+#include <unistd.h>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+#include "include/ceph_assert.h"
+#include "common/LogEntry.h"
+#include "log/Entry.h"
+#include "log/SubsystemMap.h"
+
+
+namespace ceph::logging {
+
+namespace {
+const struct sockaddr_un sockaddr = {
+  AF_UNIX,
+  "/run/systemd/journal/socket",
+};
+
+ssize_t sendmsg_fd(int transport_fd, int fd)
+{
+  constexpr size_t control_len = CMSG_LEN(sizeof(int));
+  char control[control_len];
+  struct msghdr mh = {
+    (struct sockaddr*)&sockaddr, // msg_name
+    sizeof(sockaddr),            // msg_namelen
+    nullptr,                     // msg_iov
+    0,                           // msg_iovlen
+    &control,                    // msg_control
+    control_len,                 // msg_controllen
+  };
+  ceph_assert(transport_fd >= 0);
+
+  struct cmsghdr *cmsg = CMSG_FIRSTHDR(&mh);
+  cmsg->cmsg_level = SOL_SOCKET;
+  cmsg->cmsg_type = SCM_RIGHTS;
+  cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+  *reinterpret_cast<int *>(CMSG_DATA(cmsg)) = fd;
+
+  return sendmsg(transport_fd, &mh, MSG_NOSIGNAL);
+}
+
+char map_prio(short ceph_prio)
+{
+  if (ceph_prio < 0)
+    return LOG_ERR;
+  if (ceph_prio == 0)
+    return LOG_WARNING;
+  if (ceph_prio < 5)
+    return LOG_NOTICE;
+  if (ceph_prio < 10)
+    return LOG_INFO;
+  return LOG_DEBUG;
+}
+}
+
+namespace detail {
+class EntryEncoderBase {
+ public:
+  EntryEncoderBase():
+    m_msg_vec {
+      {}, {}, { (char *)"\n", 1 },
+    } 
+  {
+  }
+
+  constexpr struct iovec *iovec() { return this->m_msg_vec; }
+  constexpr std::size_t iovec_len()
+  {
+    return sizeof(m_msg_vec) / sizeof(m_msg_vec[0]);
+  }
+
+ protected:
+  fmt::memory_buffer meta_buf;
+  struct iovec m_msg_vec[3];
+};
+
+class EntryEncoder : public EntryEncoderBase {
+ public:
+  void encode(const Entry& e, const SubsystemMap *s)
+  {
+    meta_buf.clear();
+    fmt::format_to(meta_buf,
+      R"(PRIORITY={:d}
+CEPH_SUBSYS={}
+TIMESTAMP={}
+CEPH_PRIO={}
+THREAD={:016x}
+MESSAGE
+)",
+      map_prio(e.m_prio),
+      s->get_name(e.m_subsys),
+      e.m_stamp.time_since_epoch().count().count,
+      e.m_prio,
+      e.m_thread);
+
+    uint64_t msg_len = htole64(e.size());
+    meta_buf.resize(meta_buf.size() + sizeof(msg_len));
+    *(reinterpret_cast<uint64_t*>(meta_buf.end()) - 1) = htole64(e.size());
+
+    m_msg_vec[0].iov_base = meta_buf.data();
+    m_msg_vec[0].iov_len = meta_buf.size();
+
+    m_msg_vec[1].iov_base = (void *)e.strv().data();
+    m_msg_vec[1].iov_len = e.size();
+  }
+};
+
+enum class JournaldClient::MemFileMode {
+  MEMFD_CREATE,
+  OPEN_TMPFILE,
+  OPEN_UNLINK,  
+};
+
+constexpr const char *mem_file_dir = "/dev/shm";
+
+void JournaldClient::detect_mem_file_mode()
+{
+  int memfd = memfd_create("ceph-journald", MFD_ALLOW_SEALING | MFD_CLOEXEC);
+  if (memfd >= 0) {
+    mem_file_mode = MemFileMode::MEMFD_CREATE;
+    close(memfd);
+    return;
+  }
+  memfd = open(mem_file_dir, O_TMPFILE | O_EXCL | O_CLOEXEC, S_IRUSR | S_IWUSR);
+  if (memfd >= 0) {
+    mem_file_mode = MemFileMode::OPEN_TMPFILE;
+    close(memfd);
+    return;
+  }
+  mem_file_mode = MemFileMode::OPEN_UNLINK;
+}
+
+int JournaldClient::open_mem_file()
+{
+  switch (mem_file_mode) {
+  case MemFileMode::MEMFD_CREATE:
+    return memfd_create("ceph-journald", MFD_ALLOW_SEALING | MFD_CLOEXEC);
+  case MemFileMode::OPEN_TMPFILE:
+    return open(mem_file_dir, O_TMPFILE | O_EXCL | O_CLOEXEC, S_IRUSR | S_IWUSR);
+  case MemFileMode::OPEN_UNLINK:
+    char mem_file_template[] = "/dev/shm/ceph-journald-XXXXXX";
+    int fd = mkostemp(mem_file_template, O_CLOEXEC);
+    unlink(mem_file_template);
+    return fd;
+  }
+  ceph_abort("Unexpected mem_file_mode");
+}
+
+JournaldClient::JournaldClient() :
+  m_msghdr({
+    (struct sockaddr*)&sockaddr, // msg_name
+    sizeof(sockaddr),            // msg_namelen
+  })
+{
+  fd = socket(AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0);
+  ceph_assertf(fd > 0, "socket creation failed: %s", strerror(errno));
+
+  int sendbuf = 2 * 1024 * 1024;
+  setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &sendbuf, sizeof(sendbuf));
+
+  detect_mem_file_mode();
+}
+
+JournaldClient::~JournaldClient()
+{
+  close(fd);
+}
+
+int JournaldClient::send()
+{
+  int ret = sendmsg(fd, &m_msghdr, MSG_NOSIGNAL);
+  if (ret >= 0)
+    return 0;
+
+  /* Fail silently if the journal is not available */
+  if (errno == ENOENT)
+    return -1;
+
+  if (errno != EMSGSIZE && errno != ENOBUFS) {
+    std::cerr << "Failed to send log to journald: " << strerror(errno) << std::endl;
+    return -1;
+  }
+  /* Message doesn't fit... Let's dump the data in a memfd and
+   * just pass a file descriptor of it to the other side.
+   */
+  int buffer_fd = open_mem_file();
+  if (buffer_fd < 0) {
+    std::cerr << "Failed to open buffer_fd while sending log to journald: " << strerror(errno) << std::endl;
+    return -1;
+  }
+
+  ret = writev(buffer_fd, m_msghdr.msg_iov, m_msghdr.msg_iovlen);
+  if (ret < 0) {
+    std::cerr << "Failed to write to buffer_fd while sending log to journald: " << strerror(errno) << std::endl;
+    goto err_close_buffer_fd;
+  }
+
+  if (mem_file_mode == MemFileMode::MEMFD_CREATE) {
+    ret = fcntl(buffer_fd, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_WRITE | F_SEAL_SEAL);
+    if (ret) {
+      std::cerr << "Failed to seal buffer_fd while sending log to journald: " << strerror(errno) << std::endl;
+      goto err_close_buffer_fd;
+    }
+  }
+  
+  ret = sendmsg_fd(fd, buffer_fd);
+  if (ret < 0) {
+    /* Fail silently if the journal is not available */
+    if (errno == ENOENT)
+      goto err_close_buffer_fd;
+
+    std::cerr << "Failed to send fd while sending log to journald: " << strerror(errno) << std::endl;
+    goto err_close_buffer_fd;
+  }
+  close(buffer_fd);
+  return 0;
+
+err_close_buffer_fd:
+  close(buffer_fd);
+  return -1;
+}
+
+} // namespace ceph::logging::detail
+
+JournaldLogger::JournaldLogger(const SubsystemMap *s) :
+  m_entry_encoder(make_unique<detail::EntryEncoder>()),
+  m_subs(s)
+{
+  client.m_msghdr.msg_iov = m_entry_encoder->iovec();
+  client.m_msghdr.msg_iovlen = m_entry_encoder->iovec_len();
+}
+
+JournaldLogger::~JournaldLogger() = default;
+
+int JournaldLogger::log_entry(const Entry& e)
+{
+  m_entry_encoder->encode(e, m_subs);
+  return client.send();
+}
+
+}

--- a/src/common/Journald.h
+++ b/src/common/Journald.h
@@ -1,0 +1,65 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_COMMON_JOURNALD_H
+#define CEPH_COMMON_JOURNALD_H
+
+#include <memory>
+#include <sys/types.h>
+#include <sys/socket.h>
+
+namespace ceph {
+
+namespace logging {
+
+namespace detail {
+class EntryEncoder;
+
+class JournaldClient {
+ public:
+  JournaldClient();
+  ~JournaldClient();
+  int send();
+  struct msghdr m_msghdr;
+ private:
+  int fd;
+
+  enum class MemFileMode;
+  MemFileMode mem_file_mode;
+
+  void detect_mem_file_mode();
+  int open_mem_file();
+};
+}
+
+class Entry;
+class SubsystemMap;
+
+/**
+ * Logger to send local logs to journald
+ * 
+ * local logs means @code dout(0) << ... @endcode and similars
+ */
+class JournaldLogger {
+ public:
+  JournaldLogger(const SubsystemMap *s);
+  ~JournaldLogger();
+
+  /**
+   * @returns 0 if log entry is successfully sent, -1 otherwise.
+   */
+  int log_entry(const Entry &e);
+
+ private:
+  detail::JournaldClient client;
+
+  std::unique_ptr<detail::EntryEncoder> m_entry_encoder;
+
+  const SubsystemMap * m_subs;
+};
+
+
+}
+}
+
+#endif

--- a/src/common/Journald.h
+++ b/src/common/Journald.h
@@ -8,12 +8,15 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
+struct LogEntry;
+
 namespace ceph {
 
 namespace logging {
 
 namespace detail {
 class EntryEncoder;
+class LogEntryEncoder;
 
 class JournaldClient {
  public:
@@ -39,6 +42,8 @@ class SubsystemMap;
  * Logger to send local logs to journald
  * 
  * local logs means @code dout(0) << ... @endcode and similars
+ * 
+ * @see JournaldClusterLogger
  */
 class JournaldLogger {
  public:
@@ -58,6 +63,26 @@ class JournaldLogger {
   const SubsystemMap * m_subs;
 };
 
+/**
+ * Logger to send cluster log recieved by MON to journald
+ * 
+ * @see JournaldLogger
+ */
+class JournaldClusterLogger {
+ public:
+  JournaldClusterLogger();
+  ~JournaldClusterLogger();
+
+  /**
+   * @returns 0 if log entry is successfully sent, -1 otherwise.
+   */
+  int log_log_entry(const LogEntry &le);
+
+ private:
+  detail::JournaldClient client;
+
+  std::unique_ptr<detail::LogEntryEncoder> m_log_entry_encoder;
+};
 
 }
 }

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -287,6 +287,8 @@ public:
       "err_to_graylog",
       "log_graylog_host",
       "log_graylog_port",
+      "log_to_journald",
+      "err_to_journald",
       "log_coarse_timestamps",
       "fsid",
       "host",
@@ -348,6 +350,18 @@ public:
 
     if (log->graylog() && (changed.count("log_graylog_host") || changed.count("log_graylog_port"))) {
       log->graylog()->set_destination(conf->log_graylog_host, conf->log_graylog_port);
+    }
+
+    // journald
+    if (changed.count("log_to_journald") || changed.count("err_to_journald")) {
+      int l = conf.get_val<bool>("log_to_journald") ? 99 : (conf.get_val<bool>("err_to_journald") ? -1 : -2);
+      log->set_journald_level(l, l);
+
+      if (l > -2) {
+        log->start_journald_logger();
+      } else {
+        log->stop_journald_logger();
+      }
     }
 
     if (changed.find("log_coarse_timestamps") != changed.end()) {

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -665,6 +665,16 @@ std::vector<Option> get_global_options() {
     .set_description("port number for the remote graylog server")
     .add_see_also("log_graylog_host"),
 
+    Option("log_to_journald", Option::TYPE_BOOL, Option::LEVEL_BASIC)
+    .set_default(false)
+    .set_description("send log lines to journald")
+    .add_see_also("err_to_journald"),
+
+    Option("err_to_journald", Option::TYPE_BOOL, Option::LEVEL_BASIC)
+    .set_default(false)
+    .set_description("send critical error log lines to journald")
+    .add_see_also("log_to_journald"),
+
     Option("log_coarse_timestamps", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description("timestamp log entries from coarse system clock "

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -793,6 +793,12 @@ std::vector<Option> get_global_options() {
     .set_description("Graylog port for cluster log messages")
     .add_see_also("mon_cluster_log_to_graylog"),
 
+    Option("mon_cluster_log_to_journald", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("false")
+    .set_flag(Option::FLAG_RUNTIME)
+    .add_service("mon")
+    .set_description("Make monitor send cluster log to journald"),
+
     Option("enable_experimental_unrecoverable_data_corrupting_features", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_flag(Option::FLAG_RUNTIME)
     .set_default("")

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(crimson-common STATIC
   ${PROJECT_SOURCE_DIR}/src/common/HTMLFormatter.cc
   ${PROJECT_SOURCE_DIR}/src/common/Formatter.cc
   ${PROJECT_SOURCE_DIR}/src/common/Graylog.cc
+  ${PROJECT_SOURCE_DIR}/src/common/Journald.cc
   ${PROJECT_SOURCE_DIR}/src/common/ostream_temp.cc
   ${PROJECT_SOURCE_DIR}/src/common/LogEntry.cc
   ${PROJECT_SOURCE_DIR}/src/common/TextTable.cc

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -22,6 +22,7 @@ namespace ceph {
 namespace logging {
 
 class Graylog;
+class JournaldLogger;
 class SubsystemMap;
 
 class Log : private Thread
@@ -58,10 +59,12 @@ class Log : private Thread
   int m_syslog_log = -2, m_syslog_crash = -2;
   int m_stderr_log = -1, m_stderr_crash = -1;
   int m_graylog_log = -3, m_graylog_crash = -3;
+  int m_journald_log = -3, m_journald_crash = -3;
 
   std::string m_log_stderr_prefix;
 
   std::shared_ptr<Graylog> m_graylog;
+  std::unique_ptr<JournaldLogger> m_journald;
 
   std::vector<char> m_log_buf;
 
@@ -106,6 +109,11 @@ public:
 
   void start_graylog();
   void stop_graylog();
+
+  void set_journald_level(int log, int crash);
+
+  void start_journald_logger();
+  void stop_journald_logger();
 
   std::shared_ptr<Graylog> graylog() { return m_graylog; }
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -152,6 +152,11 @@ if(NOT WIN32)
   target_link_libraries(ceph_bench_log rt)
 endif()
 
+add_executable(ceph_bench_journald_logger
+  bench_journald_logger.cc
+  )
+target_link_libraries(ceph_bench_journald_logger ceph-common)
+
 # ceph_test_mutate
 add_executable(ceph_test_mutate
   test_mutate.cc

--- a/src/test/bench_journald_logger.cc
+++ b/src/test/bench_journald_logger.cc
@@ -1,0 +1,20 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "common/Journald.h"
+#include "log/Entry.h"
+#include "log/SubsystemMap.h"
+
+using namespace ceph::logging;
+
+int main()
+{
+  SubsystemMap subs;
+  JournaldLogger journald(&subs);
+
+  for (int i = 0; i < 100000; i++) {
+    MutableEntry entry(0, 0);
+    entry.get_ostream() << "This is log message " << i << ", which is a little bit looooooooo********ooooooooog and may contains multiple\nlines.";
+    journald.log_entry(entry);
+  }
+}

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -358,3 +358,7 @@ target_link_libraries(unittest_blocked_completion Boost::system GTest::GTest)
 
 add_executable(unittest_allocate_unique test_allocate_unique.cc)
 add_ceph_unittest(unittest_allocate_unique)
+
+add_executable(unittest_journald_logger test_journald_logger.cc)
+target_link_libraries(unittest_journald_logger ceph-common)
+add_ceph_unittest(unittest_journald_logger)

--- a/src/test/common/test_journald_logger.cc
+++ b/src/test/common/test_journald_logger.cc
@@ -1,0 +1,41 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <cerrno>
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+
+#include "common/Journald.h"
+#include "log/Entry.h"
+#include "log/SubsystemMap.h"
+
+using namespace ceph::logging;
+
+class JournaldLoggerTest : public ::testing::Test {
+ protected:
+  SubsystemMap subs;
+  JournaldLogger journald = {&subs};
+  MutableEntry entry = {0, 0};
+
+  void SetUp() override {
+    struct stat buffer;
+    if (stat("/run/systemd/journal/socket", &buffer) < 0) {
+      if (errno == ENOENT) {
+        GTEST_SKIP() << "No journald socket present.";
+      }
+      FAIL() << "Unexpected stat error: " << strerror(errno);
+    }
+  }
+};
+
+TEST_F(JournaldLoggerTest, Log)
+{
+  entry.get_ostream() << "This is a testing regular log message.";
+  EXPECT_EQ(journald.log_entry(entry), 0);
+}
+
+TEST_F(JournaldLoggerTest, VeryLongLog)
+{
+  entry.get_ostream() << std::string(16 * 1024 * 1024, 'a');
+  EXPECT_EQ(journald.log_entry(entry), 0);
+}


### PR DESCRIPTION
Enable ceph daemons to directly send logs to journald via unix domain socket.

While sending logs, metadata like priority, thread, timestamp is sent as structured data. And can be queried by journalctl.

Note that I don't use libsystemd because I want the implementation to be as efficient as possible.

We can work around the issue stated in #39547 if we let daemon talk to journald directly

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

I have used `vstart.sh` to verify that this works on my PC. Since this depends on external service `journald`, could you comment on whether I need to write tests? If so, how?

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
