### PR TITLE
pacific: mgr/rbd_support: bail out if snapshot mirroring is not enabled

### DIFF
--- a/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
+++ b/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
@@ -263,6 +263,7 @@ class CreateSnapshotRequests:
                     pool_id, namespace, image_id,
                     "snapshot mirroring is not enabled"))
             self.close_image(image_spec, image)
+            return
 
         self.get_mirror_info(image_spec, image)
 

--- a/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
+++ b/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
@@ -262,7 +262,7 @@ class CreateSnapshotRequests:
                 "CreateSnapshotRequests.handle_get_mirror_mode: {}/{}/{}: {}".format(
                     pool_id, namespace, image_id,
                     "snapshot mirroring is not enabled"))
-            self.close_image(image_spec)
+            self.close_image(image_spec, image)
 
         self.get_mirror_info(image_spec, image)
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48971

-- 

backport 2 commits from #39371