### PR TITLE
client: make Inode to inherit from RefCountedObject

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1057,7 +1057,7 @@ protected:
 
   std::map<snapid_t, int> ll_snap_ref;
 
-  Inode*                 root = nullptr;
+  InodeRef               root = nullptr;
   map<Inode*, InodeRef>  root_parents;
   Inode*                 root_ancestor = nullptr;
   LRU                    lru;    // lru list of Dentry's in our local metadata cache.

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -214,8 +214,7 @@ int Inode::caps_issued(int *implemented) const
 {
   int c = snap_caps;
   int i = 0;
-  for (const auto &pair : caps) {
-    const Cap &cap = pair.second;
+  for (const auto &[mds, cap] : caps) {
     if (cap_is_valid(cap)) {
       c |= cap.issued;
       i |= cap.implemented;
@@ -305,22 +304,18 @@ bool Inode::caps_issued_mask(unsigned mask, bool allow_impl)
 int Inode::caps_used()
 {
   int w = 0;
-  for (map<int,int>::iterator p = cap_refs.begin();
-       p != cap_refs.end();
-       ++p)
-    if (p->second)
-      w |= p->first;
+  for (const auto &[cap, cnt] : cap_refs)
+    if (cnt)
+      w |= cap;
   return w;
 }
 
 int Inode::caps_file_wanted()
 {
   int want = 0;
-  for (map<int,int>::iterator p = open_by_mode.begin();
-       p != open_by_mode.end();
-       ++p)
-    if (p->second)
-      want |= ceph_caps_for_mode(p->first);
+  for (const auto &[mode, cnt] : open_by_mode)
+    if (cnt)
+      want |= ceph_caps_for_mode(mode);
   return want;
 }
 

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -78,32 +78,29 @@ struct CapSnap {
   //snapid_t follows;  // map key
   InodeRef in;
   SnapContext context;
-  int issued, dirty;
+  int issued = 0, dirty = 0;
 
-  uint64_t size;
+  uint64_t size = 0;
   utime_t ctime, btime, mtime, atime;
-  version_t time_warp_seq;
-  uint64_t change_attr;
-  uint32_t   mode;
-  uid_t      uid;
-  gid_t      gid;
+  version_t time_warp_seq = 0;
+  uint64_t change_attr = 0;
+  uint32_t   mode = 0;
+  uid_t      uid = 0;
+  gid_t      gid = 0;
   map<string,bufferptr> xattrs;
-  version_t xattr_version;
+  version_t xattr_version = 0;
 
   bufferlist inline_data;
-  version_t inline_version;
+  version_t inline_version = 0;
 
-  bool writing, dirty_data;
-  uint64_t flush_tid;
+  bool writing = false, dirty_data = false;
+  uint64_t flush_tid = 0;
 
-  int64_t cap_dirtier_uid;
-  int64_t cap_dirtier_gid;
+  int64_t cap_dirtier_uid = -1;
+  int64_t cap_dirtier_gid = -1;
 
   explicit CapSnap(Inode *i)
-    : in(i), issued(0), dirty(0), size(0), time_warp_seq(0), change_attr(0),
-      mode(0), uid(0), gid(0), xattr_version(0), inline_version(0),
-      writing(false), dirty_data(false), flush_tid(0), cap_dirtier_uid(-1),
-      cap_dirtier_gid(-1)
+    : in(i)
   {}
 
   void dump(Formatter *f) const;
@@ -123,47 +120,47 @@ struct Inode {
   // -- the actual inode --
   inodeno_t ino; // ORDER DEPENDENCY: oset
   snapid_t  snapid;
-  ino_t faked_ino;
+  ino_t faked_ino = 0;
 
-  uint32_t   rdev;    // if special file
+  uint32_t   rdev = 0;    // if special file
 
   // affected by any inode change...
   utime_t    ctime;   // inode change time
   utime_t    btime;   // birth time
 
   // perm (namespace permissions)
-  uint32_t   mode;
-  uid_t      uid;
-  gid_t      gid;
+  uint32_t   mode = 0;
+  uid_t      uid = 0;
+  gid_t      gid = 0;
 
   // nlink
-  int32_t    nlink;
+  int32_t    nlink = 0;
 
   // file (data access)
-  ceph_dir_layout dir_layout;
+  ceph_dir_layout dir_layout{};
   file_layout_t layout;
-  uint64_t   size;        // on directory, # dentries
-  uint32_t   truncate_seq;
-  uint64_t   truncate_size;
+  uint64_t   size = 0;        // on directory, # dentries
+  uint32_t   truncate_seq = 1;
+  uint64_t   truncate_size = -1;
   utime_t    mtime;   // file data modify time.
   utime_t    atime;   // file data access time.
-  uint32_t   time_warp_seq;  // count of (potential) mtime/atime timewarps (i.e., utimes())
-  uint64_t   change_attr;
+  uint32_t   time_warp_seq = 0;  // count of (potential) mtime/atime timewarps (i.e., utimes())
+  uint64_t   change_attr = 0;
 
-  uint64_t max_size;  // max size we can write to
+  uint64_t max_size = 0;  // max size we can write to
 
   // dirfrag, recursive accountin
   frag_info_t dirstat;
   nest_info_t rstat;
 
   // special stuff
-  version_t version;           // auth only
-  version_t xattr_version;
+  version_t version = 0;           // auth only
+  version_t xattr_version = 0;
   utime_t   snap_btime;        // snapshot creation (birth) time
   std::map<std::string, std::string> snap_metadata;
 
   // inline data
-  version_t  inline_version;
+  version_t  inline_version = 0;
   bufferlist inline_data;
 
   bool fscrypt = false; // fscrypt enabled ?
@@ -185,7 +182,7 @@ struct Inode {
     return ceph_str_hash(which, dn.data(), dn.length());
   }
 
-  unsigned flags;
+  unsigned flags = 0;
 
   quota_info_t quota;
 
@@ -195,24 +192,29 @@ struct Inode {
   }
 
   // about the dir (if this is one!)
-  Dir       *dir;     // if i'm a dir.
+  Dir       *dir = 0;     // if i'm a dir.
   fragtree_t dirfragtree;
-  uint64_t dir_release_count, dir_ordered_count;
-  bool dir_hashed, dir_replicated;
+  uint64_t dir_release_count = 1;
+  uint64_t dir_ordered_count = 1;
+  bool dir_hashed = false;
+  bool dir_replicated = false;
 
   // per-mds caps
   std::map<mds_rank_t, Cap> caps;            // mds -> Cap
-  Cap *auth_cap;
-  int64_t cap_dirtier_uid;
-  int64_t cap_dirtier_gid;
-  unsigned dirty_caps, flushing_caps;
+  Cap *auth_cap = 0;
+  int64_t cap_dirtier_uid = -1;
+  int64_t cap_dirtier_gid = -1;
+  unsigned dirty_caps = 0;
+  unsigned flushing_caps = 0;
   std::map<ceph_tid_t, int> flushing_cap_tids;
-  int shared_gen, cache_gen;
-  int snap_caps, snap_cap_refs;
+  int shared_gen = 0;
+  int cache_gen = 0;
+  int snap_caps = 0;
+  int snap_cap_refs = 0;
   utime_t hold_caps_until;
   xlist<Inode*>::item delay_cap_item, dirty_cap_item, flushing_cap_item;
 
-  SnapRealm *snaprealm;
+  SnapRealm *snaprealm = 0;
   xlist<Inode*>::item snaprealm_item;
   InodeRef snapdir_parent;  // only if we are a snapdir inode
   map<snapid_t,CapSnap> cap_snaps;   // pending flush to mds
@@ -223,10 +225,12 @@ struct Inode {
 
   ObjectCacher::ObjectSet oset; // ORDER DEPENDENCY: ino
 
-  uint64_t     reported_size, wanted_max_size, requested_max_size;
+  uint64_t reported_size = 0;
+  uint64_t wanted_max_size = 0;
+  uint64_t requested_max_size = 0;
 
-  int       _ref;      // ref count. 1 for each dentry, fh that links to me.
-  uint64_t  ll_ref;   // separate ref count for ll client
+  int       _ref = 0;      // ref count. 1 for each dentry, fh that links to me.
+  uint64_t  ll_ref = 0;   // separate ref count for ll client
   xlist<Dentry *> dentries; // if i'm linked to a dentry.
   string    symlink;  // symlink content, if it's a symlink
   map<string,bufferptr> xattrs;
@@ -277,27 +281,13 @@ struct Inode {
 
   std::set<Fh*> fhs;
 
-  mds_rank_t dir_pin;
+  mds_rank_t dir_pin = MDS_RANK_NONE;
 
+  Inode() = delete;
   Inode(Client *c, vinodeno_t vino, file_layout_t *newlayout)
-    : client(c), ino(vino.ino), snapid(vino.snapid), faked_ino(0),
-      rdev(0), mode(0), uid(0), gid(0), nlink(0),
-      size(0), truncate_seq(1), truncate_size(-1),
-      time_warp_seq(0), change_attr(0), max_size(0), version(0),
-      xattr_version(0), inline_version(0), flags(0),
-      dir(0), dir_release_count(1), dir_ordered_count(1),
-      dir_hashed(false), dir_replicated(false), auth_cap(NULL),
-      cap_dirtier_uid(-1), cap_dirtier_gid(-1),
-      dirty_caps(0), flushing_caps(0), shared_gen(0), cache_gen(0),
-      snap_caps(0), snap_cap_refs(0),
-      delay_cap_item(this), dirty_cap_item(this), flushing_cap_item(this),
-      snaprealm(0), snaprealm_item(this),
-      oset((void *)this, newlayout->pool_id, this->ino),
-      reported_size(0), wanted_max_size(0), requested_max_size(0),
-      _ref(0), ll_ref(0), dir_pin(MDS_RANK_NONE)
-  {
-    memset(&dir_layout, 0, sizeof(dir_layout));
-  }
+    : client(c), ino(vino.ino), snapid(vino.snapid), delay_cap_item(this),
+      dirty_cap_item(this), flushing_cap_item(this), snaprealm_item(this),
+      oset((void *)this, newlayout->pool_id, this->ino) {}
   ~Inode();
 
   vinodeno_t vino() const { return vinodeno_t(ino, snapid); }


### PR DESCRIPTION
The intrusive ptr in Client.cc may make the _ref not consistent if
outside the client_lock.

Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
