### PR TITLE
nautilus: mgr/prometheus: Add SLOW_OPS healthcheck as a metric

### DIFF
--- a/monitoring/prometheus/alerts/ceph_default_alerts.yml
+++ b/monitoring/prometheus/alerts/ceph_default_alerts.yml
@@ -236,3 +236,15 @@ groups:
           description: >
             Pool {{ $labels.name }} will be full in less than 5 days
             assuming the average fill-up rate of the past 48 hours.
+
+  - name: healthchecks
+    rules:
+      - alert: Slow OSD Ops
+        expr: ceph_healthcheck_slow_ops > 0
+        for: 30s
+        labels:
+          severity: warning
+          type: ceph_default
+        annotations:
+          description: >
+            {{ $value }} OSD requests are taking too long to process (osd_op_complaint_time exceeded)

--- a/src/mgr/DaemonHealthMetricCollector.cc
+++ b/src/mgr/DaemonHealthMetricCollector.cc
@@ -55,6 +55,8 @@ class SlowOps final : public DaemonHealthMetricCollector {
       return;
     }
     static const char* fmt = "%1% slow ops, oldest one blocked for %2% sec, %3%";
+    // Note this message format is used in mgr/prometheus, so any change in format
+    // requires a corresponding change in the mgr/prometheus module.
     ostringstream ss;
     if (daemons.size() > 1) {
       if (daemons.size() > 10) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49540

---

backport of https://github.com/ceph/ceph/pull/37590
parent tracker: https://tracker.ceph.com/issues/47756

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh