### PR TITLE
rpm: set build parallelism from memory on SUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1201,8 +1201,6 @@ done
 %endif
 
 %if 0%{?suse_version}
-# the following setting fixed an OOM condition we once encountered in the OBS
-RPM_OPT_FLAGS="$RPM_OPT_FLAGS --param ggc-min-expand=20 --param ggc-min-heapsize=32768"
 %limit_build -m 2600
 %endif
 

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -293,6 +293,7 @@ BuildRequires:	systemd-rpm-macros
 %{?systemd_requires}
 PreReq:		%fillup_prereq
 BuildRequires:	fdupes
+BuildRequires:  memory-constraints
 BuildRequires:	net-tools
 BuildRequires:	libbz2-devel
 BuildRequires:	mozilla-nss-devel
@@ -1202,6 +1203,7 @@ done
 %if 0%{?suse_version}
 # the following setting fixed an OOM condition we once encountered in the OBS
 RPM_OPT_FLAGS="$RPM_OPT_FLAGS --param ggc-min-expand=20 --param ggc-min-heapsize=32768"
+%limit_build -m 2600
 %endif
 
 export CPPFLAGS="$java_inc"
@@ -1284,7 +1286,11 @@ cmake .. \
 %if 0%{with rbd_ssd_cache}
     -DWITH_RBD_SSD_CACHE:BOOL=ON \
 %endif
+%if 0%{?suse_version}
+    -DBOOST_J:STRING=%{jobs} \
+%else
     -DBOOST_J:STRING=%{_smp_build_ncpus} \
+%endif
     -DWITH_GRAFANA:BOOL=ON
 
 %if %{with cmake_verbose_logging}


### PR DESCRIPTION
43b441f9a3bc907c17d52385251001ffcd5d3ff9 removed a bunch of code which the SUSE
builds were relying on to avoid OOM. This commit brings back that code in
a much-streamlined form: the SUSE-specific %limit_build macro.

This also has the advantage of not breaking the build on older RPMs which only
know about %_smp_mflags, and not the newer %_smp_build_ncpus etc. macros.

Fixes: 43b441f9a3bc907c17d52385251001ffcd5d3ff9
Fixes: https://tracker.ceph.com/issues/49556