### PR TITLE
qa/ceph_manager: accepts commands as str too

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1345,6 +1345,9 @@ class CephManager:
 
         Accepts arguments same as that of teuthology.orchestra.run.run()
         """
+        if isinstance(kwargs['args'], str):
+            kwargs['args'] = shlex.split(kwargs['args'])
+
         if self.cephadm:
             return shell(self.ctx, self.cluster, self.controller,
                          args=['ceph'] + list(kwargs['args']),

--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -137,7 +137,7 @@ class CephFSTestCase(CephTestCase):
         # In case anything is in the OSD blocklist list, clear it out.  This is to avoid
         # the OSD map changing in the background (due to blocklist expiry) while tests run.
         try:
-            self.mds_cluster.mon_manager.raw_cluster_cmd("osd", "blocklist", "clear")
+            self.mds_cluster.mon_manager.run_cluster_cmd(args="osd blocklist clear")
         except CommandFailedError:
             # Fallback for older Ceph cluster
             blocklist = json.loads(self.mds_cluster.mon_manager.raw_cluster_cmd("osd",

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -47,6 +47,7 @@ from IPy import IP
 import unittest
 import platform
 import logging
+import shlex
 
 from unittest import suite, loader
 
@@ -982,6 +983,8 @@ class LocalCephManager(CephManager):
 
         Accepts arguments same as teuthology.orchestra.remote.run().
         """
+        if isinstance(kwargs['args'], str):
+            kwargs['args'] = shlex.split(kwargs['args'])
         kwargs['args'] = [CEPH_CMD] + list(kwargs['args'])
         return self.controller.run(**kwargs)
 


### PR DESCRIPTION
Modify `CephManager.run_cluster_cmd()` to accept command arguments as
string as well since typing commands as strings is much lesser effort
than typing as list. This brings the interface a step closter to
`teuthology.orchestra.remote.run()`'s interface since it too can accept
commands arguments as string.

The change in `cephfs_test_case.py` is just to allow testing this PR
locally and on teuthology.

Signed-off-by: Rishabh Dave <ridave@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>