### PR TITLE
 cephadm: ignore UnicodeDecodeError when reading sysctl 

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -6386,7 +6386,7 @@ class HostFacts():
 ##################################
 
 def command_gather_facts(ctx: CephadmContext):
-    """gather_facts is intended to provide host releated metadata to the caller"""
+    """gather_facts is intended to provide host related metadata to the caller"""
     host = HostFacts(ctx)
     print(host.dump())
 

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -1334,12 +1334,16 @@ def call(ctx: CephadmContext,
     async def tee(reader: asyncio.StreamReader) -> str:
         collected = StringIO()
         async for line in reader:
-            message = line.decode('utf-8')
-            collected.write(message)
-            if verbosity == CallVerbosity.VERBOSE:
-                logger.info(prefix + message.rstrip())
-            elif verbosity != CallVerbosity.SILENT:
-                logger.debug(prefix + message.rstrip())
+            try:
+                message = line.decode('utf-8')
+            except UnicodeDecodeError as e:
+                logger.info('failed to decode line: {}'.format(line))
+            else:
+                collected.write(message)
+                if verbosity == CallVerbosity.VERBOSE:
+                    logger.info(prefix + message.rstrip())
+                elif verbosity != CallVerbosity.SILENT:
+                    logger.debug(prefix + message.rstrip())
         return collected.getvalue()
 
     async def run_with_timeout() -> Tuple[str, str, int]:


### PR DESCRIPTION
For some unknown reason, on my machine the `sunrpc.transports` value is
broken and returns giberish. While this definitely shouldn't happen, it
is still possible to prevent `cephadm` from stopping to work. Restart
fixed the issue for me.

```
user@home ~ » sudo sysctl -a | rg sunrpc.transports
sysctl: reading key "kernel.spl.hostid"
sunrpc.transports = sb#R�
user@home ~ » sudo sysctl -a | rg sunrpc.transports
sysctl: reading key "kernel.spl.hostid"
sunrpc.transports = £»M�
user@home ~ » sudo sysctl -a | rg sunrpc.transports
sysctl: reading key "kernel.spl.hostid"
sunrpc.transports = ¨>�
user@home ~ » sudo sysctl -a | rg sunrpc.transports
sysctl: reading key "kernel.spl.hostid"
sunrpc.transports = �í�
user@home ~ » sudo sysctl -a | rg sunrpc.transports
sysctl: reading key "kernel.spl.hostid"
sunrpc.transports = V¡�
user@home ~ » sudo sysctl -a | rg sunrpc.transports
sysctl: reading key "kernel.spl.hostid"
sunrpc.transports = ëCõ�
user@home ~ » sudo sysctl -a | rg sunrpc.transports
sysctl: reading key "kernel.spl.hostid"
sunrpc.transports = #^ÿ~
user@home ~ »
```

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
