### PR TITLE
crimson/mon: resend mon command when connected and cleanups

### DIFF
--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -513,10 +513,10 @@ void Client::ms_handle_reset(crimson::net::ConnectionRef conn, bool /* is_replac
       logger().warn("active conn reset {}", conn->get_peer_addr());
       active_con.reset();
       return reopen_session(-1).then([this] {
-	if (active_con) {
-	  send_pendings();
-	}
-	return seastar::now();
+        if (active_con) {
+          on_session_opened();
+        }
+        return seastar::now();
       });
     } else {
       return seastar::now();
@@ -757,7 +757,7 @@ seastar::future<> Client::handle_monmap(crimson::net::ConnectionRef conn,
     logger().warn("mon.{} went away", cur_mon);
     return reopen_session(-1).then([this] {
       if (active_con) {
-        send_pendings();
+        on_session_opened();
       }
       return seastar::now();
     });
@@ -878,7 +878,7 @@ seastar::future<> Client::authenticate()
 {
   return reopen_session(-1).then([this] {
     if (active_con) {
-      send_pendings();
+      on_session_opened();
     }
     return seastar::now();
   });
@@ -1019,7 +1019,7 @@ seastar::future<> Client::send_message(MessageRef m)
   }
 }
 
-void Client::send_pendings()
+void Client::on_session_opened()
 {
   for (auto& m : pending_messages) {
     (void) active_con->get_conn()->send(m.msg);

--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -1011,13 +1011,12 @@ Client::run_command(const std::vector<std::string>& cmd,
 seastar::future<> Client::send_message(MessageRef m)
 {
   if (active_con) {
-    if (!pending_messages.empty()) {
-      send_pendings();
-    }
+    assert(pending_messages.empty());
     return active_con->get_conn()->send(m);
+  } else {
+    auto& delayed = pending_messages.emplace_back(m);
+    return delayed.pr.get_future();
   }
-  auto& delayed = pending_messages.emplace_back(m);
-  return delayed.pr.get_future();
 }
 
 void Client::send_pendings()

--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -993,14 +993,14 @@ void Client::_finish_auth(const entity_addr_t& peer)
 }
 
 Client::command_result_t
-Client::run_command(const std::vector<std::string>& cmd,
-                    const bufferlist& bl)
+Client::run_command(std::string&& cmd,
+                    bufferlist&& bl)
 {
   auto m = make_message<MMonCommand>(monmap.fsid);
   auto tid = ++last_mon_command_id;
   m->set_tid(tid);
-  m->cmd = cmd;
-  m->set_data(bl);
+  m->cmd = {std::move(cmd)};
+  m->set_data(std::move(bl));
   auto& req = mon_commands[tid];
   return send_message(m).then([&req] {
     return req.get_future();

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -35,6 +35,7 @@ class MAuthReply;
 struct MMonMap;
 struct MMonSubscribeAck;
 struct MMonGetVersionReply;
+struct MMonCommand;
 struct MMonCommandAck;
 struct MLogAck;
 struct MConfig;
@@ -67,7 +68,12 @@ class Client : public crimson::net::Dispatcher,
   ceph_tid_t last_mon_command_id = 0;
   using command_result_t =
     seastar::future<std::tuple<std::int32_t, string, ceph::bufferlist>>;
-  std::map<ceph_tid_t, typename command_result_t::promise_type> mon_commands;
+  struct mon_command_t {
+    ceph::ref_t<MMonCommand> req;
+    typename command_result_t::promise_type result;
+    mon_command_t(ceph::ref_t<MMonCommand> req);
+  };
+  std::map<ceph_tid_t, mon_command_t> mon_commands;
 
   MonSub sub;
 

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -171,7 +171,7 @@ private:
   // @param rank, rank of the monitor to be connected, if it is less than 0,
   //              try to connect to all monitors in monmap, until one of them
   //              is connected.
-  // @return true if a connection is established to a monitor
+  // @return true if a connection to monitor is established
   seastar::future<bool> reopen_session(int rank);
   std::vector<unsigned> get_random_mons(unsigned n) const;
   seastar::future<> _add_conn(unsigned rank, uint64_t global_id);

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -82,8 +82,8 @@ public:
     return monmap.fsid;
   }
   get_version_t get_version(const std::string& map);
-  command_result_t run_command(const std::vector<std::string>& cmd,
-			       const bufferlist& bl);
+  command_result_t run_command(std::string&& cmd,
+                               bufferlist&& bl);
   seastar::future<> send_message(MessageRef);
   bool sub_want(const std::string& what, version_t start, unsigned flags);
   void sub_got(const std::string& what, version_t have);

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
@@ -73,7 +74,7 @@ class Client : public crimson::net::Dispatcher,
     typename command_result_t::promise_type result;
     mon_command_t(ceph::ref_t<MMonCommand> req);
   };
-  std::map<ceph_tid_t, mon_command_t> mon_commands;
+  std::vector<mon_command_t> mon_commands;
 
   MonSub sub;
 

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -168,7 +168,11 @@ private:
   seastar::future<> authenticate();
 
   bool is_hunting() const;
-  seastar::future<> reopen_session(int rank);
+  // @param rank, rank of the monitor to be connected, if it is less than 0,
+  //              try to connect to all monitors in monmap, until one of them
+  //              is connected.
+  // @return true if a connection is established to a monitor
+  seastar::future<bool> reopen_session(int rank);
   std::vector<unsigned> get_random_mons(unsigned n) const;
   seastar::future<> _add_conn(unsigned rank, uint64_t global_id);
   void _finish_auth(const entity_addr_t& peer);

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -155,7 +155,7 @@ private:
   seastar::future<> handle_log_ack(Ref<MLogAck> m);
   seastar::future<> handle_config(Ref<MConfig> m);
 
-  void send_pendings();
+  void on_session_opened();
 private:
   seastar::future<> load_keyring();
   seastar::future<> authenticate();

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -155,7 +155,7 @@ private:
   seastar::future<> handle_log_ack(Ref<MLogAck> m);
   seastar::future<> handle_config(Ref<MConfig> m);
 
-  void on_session_opened();
+  seastar::future<> on_session_opened();
 private:
   seastar::future<> load_keyring();
   seastar::future<> authenticate();

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -404,7 +404,7 @@ seastar::future<> OSD::_add_me_to_crush()
       "weight": {:.4f},
       "args": [{}]
     }})", whoami, weight, loc);
-    return monc->run_command({cmd}, {});
+    return monc->run_command(std::move(cmd), {});
   }).then([](auto&& command_result) {
     [[maybe_unused]] auto [code, message, out] = std::move(command_result);
     if (code) {


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
