### PR TITLE
qa/suites/krbd: address recent issues caused by newer kernels

### DIFF
--- a/qa/run_xfstests.sh
+++ b/qa/run_xfstests.sh
@@ -280,7 +280,7 @@ XFSTESTS_DIR="/var/lib/xfstests"  # hardcoded into dbench binary
 TEST_DIR="/mnt/test_dir"
 SCRATCH_MNT="/mnt/scratch_mnt"
 MKFS_OPTIONS=""
-EXT_MOUNT_OPTIONS="-o block_validity"
+EXT_MOUNT_OPTIONS="-o block_validity,dioread_nolock"
 
 trap cleanup EXIT ERR HUP INT QUIT
 setup

--- a/qa/suites/krbd/singleton/tasks/rbd_xfstests.yaml
+++ b/qa/suites/krbd/singleton/tasks/rbd_xfstests.yaml
@@ -25,6 +25,7 @@ tasks:
         - generic/045
         - generic/046
         - generic/223
+        - ext4/002  # removed upstream
         - ext4/304
         - generic/388
         - generic/405

--- a/qa/suites/krbd/singleton/tasks/rbd_xfstests.yaml
+++ b/qa/suites/krbd/singleton/tasks/rbd_xfstests.yaml
@@ -15,7 +15,7 @@ tasks:
         test_image: 'test_image-0'
         test_size: 5120  # MB
         scratch_image: 'scratch_image-0'
-        scratch_size: 5120  # MB
+        scratch_size: 15360  # MB
         fs_type: ext4
         tests: '-g auto -g blockdev -x clone'
         exclude:

--- a/qa/tasks/rbd.py
+++ b/qa/tasks/rbd.py
@@ -534,8 +534,7 @@ def xfstests(ctx, config):
                 exclude:
                 - generic/42
                 randomize: true
-                xfstests_branch: master
-                xfstests_url: 'https://raw.github.com/ceph/branch/master/qa'
+                xfstests_url: 'https://raw.github.com/ceph/ceph-ci/wip-55555/qa'
     """
     if config is None:
         config = { 'all': None }


### PR DESCRIPTION
A new http://download.ceph.com/qa/xfstests.tar.gz has been uploaded.