### PR TITLE
qa: update featureful_client suite to use octopus instead of nautilus

### DIFF
--- a/qa/suites/fs/upgrade/featureful_client/old_client/tasks/0-octopus.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/tasks/0-octopus.yaml
@@ -1,9 +1,9 @@
 meta:
 - desc: |
-   install ceph/nautilus latest
+   install ceph/octopus latest
 tasks:
 - install:
-    branch: nautilus
+    branch: octopus
     exclude_packages:
       - librados3
       - ceph-mgr-dashboard
@@ -12,7 +12,7 @@ tasks:
       - ceph-mgr-cephadm
       - cephadm
     extra_packages: ['librados2']
-- print: "**** done installing nautilus"
+- print: "**** done installing octopus"
 - ceph:
     log-ignorelist:
       - overall HEALTH_
@@ -34,5 +34,5 @@ tasks:
         ms bind msgr2: false
 - exec:
     osd.0:
-      - ceph osd set-require-min-compat-client nautilus
+      - ceph osd set-require-min-compat-client octopus
 - print: "**** done ceph"

--- a/qa/suites/fs/upgrade/featureful_client/old_client/tasks/1-client.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/tasks/1-client.yaml
@@ -1,6 +1,6 @@
 tasks:
 - ceph-fuse:
-- print: "**** done nautilus client"
+- print: "**** done octopus client"
 - workunit:
     clients:
       all:

--- a/qa/suites/fs/upgrade/featureful_client/old_client/tasks/2-upgrade.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/tasks/2-upgrade.yaml
@@ -43,6 +43,6 @@ tasks:
     - ceph versions
     - ceph osd require-osd-release octopus
     - for f in `ceph osd pool ls` ; do ceph osd pool set $f pg_autoscale_mode off ; done
-    #- ceph osd set-require-min-compat-client nautilus
+    #- ceph osd set-require-min-compat-client octopus
 - ceph.healthy:
 - print: "**** done ceph.restart"

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/0-octopus.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/0-octopus.yaml
@@ -1,9 +1,9 @@
 meta:
 - desc: |
-   install ceph/nautilus latest
+   install ceph/octopus latest
 tasks:
 - install:
-    branch: nautilus
+    branch: octopus
     exclude_packages:
       - librados3
       - ceph-mgr-dashboard
@@ -12,7 +12,7 @@ tasks:
       - ceph-mgr-cephadm
       - cephadm
     extra_packages: ['librados2']
-- print: "**** done installing nautilus"
+- print: "**** done installing octopus"
 - ceph:
     log-ignorelist:
       - overall HEALTH_
@@ -34,5 +34,5 @@ tasks:
         ms bind msgr2: false
 - exec:
     osd.0:
-      - ceph osd set-require-min-compat-client nautilus
+      - ceph osd set-require-min-compat-client octopus
 - print: "**** done ceph"

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/1-client.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/1-client.yaml
@@ -3,7 +3,7 @@ overrides:
   nuke-on-error: false
 tasks:
 - ceph-fuse:
-- print: "**** done nautilus client"
+- print: "**** done octopus client"
 #- workunit:
 #    clients:
 #      all:

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/2-upgrade.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/2-upgrade.yaml
@@ -43,6 +43,6 @@ tasks:
     - ceph osd dump -f json-pretty
     - ceph osd require-osd-release octopus
     - for f in `ceph osd pool ls` ; do ceph osd pool set $f pg_autoscale_mode off ; done
-    #- ceph osd set-require-min-compat-client nautilus
+    #- ceph osd set-require-min-compat-client octopus
 - ceph.healthy:
 - print: "**** done ceph.restart"


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/49458
Signed-off-by: Sidharth Anupkrishnan <sanupkri@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
