### PR TITLE
pacific: mon/ConfigMonitor: make config changes via KVMonitor's pending set

### DIFF
--- a/src/mon/ConfigMonitor.h
+++ b/src/mon/ConfigMonitor.h
@@ -20,6 +20,8 @@ class ConfigMonitor : public PaxosService
 
   std::map<std::string,ceph::buffer::list> current;
 
+  void encode_pending_to_kvmon();
+
 public:
   ConfigMonitor(Monitor &m, Paxos &p, const std::string& service_name);
 

--- a/src/mon/KVMonitor.h
+++ b/src/mon/KVMonitor.h
@@ -55,4 +55,15 @@ public:
   void check_all_subs();
 
   bool maybe_send_update(Subscription *sub);
+
+
+  // used by other services to adjust kv content; note that callers MUST ensure that
+  // propose_pending() is called and a commit is forced to provide atomicity and
+  // proper subscriber notifications.
+  void enqueue_set(const std::string& key, bufferlist &v) {
+    pending[key] = v;
+  }
+  void enqueue_rm(const std::string& key) {
+    pending[key] = boost::none;
+  }
 };


### PR DESCRIPTION
backport #39723

We need to ensure that changes we make to the kv store (config/...)
are proposed via KVMonitor so that they are properly versioned there
and shared with subscribers (notably, the mgr).

Fixes: bb7ebc41532aeb23cff2241ab07b3f01c2f57ddd
Signed-off-by: Sage Weil <sage@newdream.net>
(cherry picked from commit dab72abd0ae8a3038f73dbe0983b2eaef3937ef6)