### PR TITLE
doc/cephadm: add prompts to adoption.rst

### DIFF
--- a/doc/cephadm/adoption.rst
+++ b/doc/cephadm/adoption.rst
@@ -18,9 +18,11 @@ Preparation
 #. Get the ``cephadm`` command line tool on each host in the existing
    cluster.  See :ref:`get-cephadm`.
 
-#. Prepare each host for use by ``cephadm``::
+#. Prepare each host for use by ``cephadm``:
 
-     # cephadm prepare-host
+   .. prompt:: bash #
+
+      cephadm prepare-host
 
 #. Determine which Ceph version you will use.  You can use any Octopus (15.2.z)
    release or later.  For example, ``docker.io/ceph/ceph:v15.2.0``.  The default
@@ -28,13 +30,17 @@ Preparation
    release at the same time be sure to refer to the upgrade notes for any
    special steps to take while upgrading.
 
-   The image is passed to cephadm with::
+   The image is passed to cephadm with:
 
-     # cephadm --image $IMAGE <rest of command goes here>
+   .. prompt:: bash #
 
-#. Cephadm can provide a list of all Ceph daemons on the current host::
+      cephadm --image $IMAGE <rest of command goes here>
 
-     # cephadm ls
+#. Cephadm can provide a list of all Ceph daemons on the current host:
+
+   .. prompt:: bash #
+
+      cephadm ls
 
    Before starting, you should see that all existing daemons have a
    style of ``legacy`` in the resulting output.  As the adoption
@@ -46,40 +52,54 @@ Adoption process
 ----------------
 
 #. Ensure the ceph configuration is migrated to use the cluster config database.
-   If the ``/etc/ceph/ceph.conf`` is identical on each host, then on one host::
+   If the ``/etc/ceph/ceph.conf`` is identical on each host, then on one host:
 
-     # ceph config assimilate-conf -i /etc/ceph/ceph.conf
+   .. prompt:: bash #
+
+      ceph config assimilate-conf -i /etc/ceph/ceph.conf
 
    If there are config variations on each host, you may need to repeat
    this command on each host.  You can view the cluster's
-   configuration to confirm that it is complete with::
+   configuration to confirm that it is complete with:
 
-     # ceph config dump
+   .. prompt:: bash #
 
-#. Adopt each monitor::
+      ceph config dump
 
-     # cephadm adopt --style legacy --name mon.<hostname>
+#. Adopt each monitor:
+
+   .. prompt:: bash #
+
+      cephadm adopt --style legacy --name mon.<hostname>
 
    Each legacy monitor should stop, quickly restart as a cephadm
    container, and rejoin the quorum.
 
-#. Adopt each manager::
+#. Adopt each manager:
 
-     # cephadm adopt --style legacy --name mgr.<hostname>
+   .. prompt:: bash #
 
-#. Enable cephadm::
+      cephadm adopt --style legacy --name mgr.<hostname>
 
-     # ceph mgr module enable cephadm
-     # ceph orch set backend cephadm
+#. Enable cephadm:
 
-#. Generate an SSH key::
+   .. prompt:: bash #
 
-     # ceph cephadm generate-key
-     # ceph cephadm get-pub-key > ~/ceph.pub
+      ceph mgr module enable cephadm
+      ceph orch set backend cephadm
 
-#. Install the cluster SSH key on each host in the cluster::
+#. Generate an SSH key:
 
-     # ssh-copy-id -f -i ~/ceph.pub root@<host>
+   .. prompt:: bash #
+
+      ceph cephadm generate-key
+      ceph cephadm get-pub-key > ~/ceph.pub
+
+#. Install the cluster SSH key on each host in the cluster:
+
+   .. prompt:: bash #
+
+      ssh-copy-id -f -i ~/ceph.pub root@<host>
 
    .. note::
      It is also possible to import an existing ssh key. See
@@ -87,62 +107,88 @@ Adoption process
      document for instructions describing how to import existing
      ssh keys.
 
-#. Tell cephadm which hosts to manage::
+#. Tell cephadm which hosts to manage:
 
-     # ceph orch host add <hostname> [ip-address]
+   .. prompt:: bash #
+
+      ceph orch host add <hostname> [ip-address]
 
    This will perform a ``cephadm check-host`` on each host before
    adding it to ensure it is working.  The IP address argument is only
    required if DNS does not allow you to connect to each host by its
    short name.
 
-#. Verify that the adopted monitor and manager daemons are visible::
+#. Verify that the adopted monitor and manager daemons are visible:
 
-     # ceph orch ps
+   .. prompt:: bash #
 
-#. Adopt all OSDs in the cluster::
+      ceph orch ps
 
-     # cephadm adopt --style legacy --name <name>
+#. Adopt all OSDs in the cluster:
 
-   For example::
+   .. prompt:: bash #
 
-     # cephadm adopt --style legacy --name osd.1
-     # cephadm adopt --style legacy --name osd.2
+      cephadm adopt --style legacy --name <name>
+
+   For example:
+
+   .. prompt:: bash #
+
+      cephadm adopt --style legacy --name osd.1
+      cephadm adopt --style legacy --name osd.2
 
 #. Redeploy MDS daemons by telling cephadm how many daemons to run for
    each file system.  You can list file systems by name with ``ceph fs
-   ls``.  Run the following command on the master nodes::
+   ls``.  Run the following command on the master nodes:
 
-     # ceph orch apply mds <fs-name> [--placement=<placement>]
+   .. prompt:: bash #
 
-   For example, in a cluster with a single file system called `foo`::
+      ceph orch apply mds <fs-name> [--placement=<placement>]
 
-     # ceph fs ls
-     name: foo, metadata pool: foo_metadata, data pools: [foo_data ]
-     # ceph orch apply mds foo 2
+   For example, in a cluster with a single file system called `foo`:
 
-   Wait for the new MDS daemons to start with::
+   .. prompt:: bash #
 
-     # ceph orch ps --daemon-type mds
+      ceph fs ls
 
-   Finally, stop and remove the legacy MDS daemons::
+   .. code-block:: bash
 
-     # systemctl stop ceph-mds.target
-     # rm -rf /var/lib/ceph/mds/ceph-*
+      name: foo, metadata pool: foo_metadata, data pools: [foo_data ]
+
+   .. prompt:: bash #
+
+      ceph orch apply mds foo 2
+
+   Wait for the new MDS daemons to start with:
+
+   .. prompt:: bash #
+
+      ceph orch ps --daemon-type mds
+
+   Finally, stop and remove the legacy MDS daemons:
+
+   .. prompt:: bash #
+
+      systemctl stop ceph-mds.target
+      rm -rf /var/lib/ceph/mds/ceph-*
 
 #. Redeploy RGW daemons.  Cephadm manages RGW daemons by zone.  For each
-   zone, deploy new RGW daemons with cephadm::
+   zone, deploy new RGW daemons with cephadm:
 
-     # ceph orch apply rgw <realm> <zone> [--subcluster=<subcluster>] [--port=<port>] [--ssl] [--placement=<placement>]
+   .. prompt:: bash #
+
+      ceph orch apply rgw <realm> <zone> [--subcluster=<subcluster>] [--port=<port>] [--ssl] [--placement=<placement>]
 
    where *<placement>* can be a simple daemon count, or a list of
    specific hosts (see :ref:`orchestrator-cli-placement-spec`).
 
    Once the daemons have started and you have confirmed they are functioning,
-   stop and remove the old legacy daemons::
+   stop and remove the old legacy daemons:
 
-     # systemctl stop ceph-rgw.target
-     # rm -rf /var/lib/ceph/radosgw/ceph-*
+   .. prompt:: bash #
+
+      systemctl stop ceph-rgw.target
+      rm -rf /var/lib/ceph/radosgw/ceph-*
 
    For adopting single-site systems without a realm, see also
    :ref:`rgw-multisite-migrate-from-single-site`.


### PR DESCRIPTION
This PR formats the bash prompts and the bash
output so that it appears in the correct (easily
copy-and-pasteable) format. This PR will be
followed by a grammar-improving PR, but this
PR is just a formatting PR.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
