### PR TITLE
mgr/dashboard: always pass algorithm to jwt.decode

### DIFF
--- a/qa/tasks/mgr/dashboard/test_auth.py
+++ b/qa/tasks/mgr/dashboard/test_auth.py
@@ -20,7 +20,7 @@ class AuthTest(DashboardTestCase):
         self.reset_session()
 
     def _validate_jwt_token(self, token, username, permissions):
-        payload = jwt.decode(token, verify=False)
+        payload = jwt.decode(token, verify=False, algorithms='HS256')
         self.assertIn('username', payload)
         self.assertEqual(payload['username'], username)
 

--- a/src/pybind/mgr/dashboard/services/auth.py
+++ b/src/pybind/mgr/dashboard/services/auth.py
@@ -123,7 +123,7 @@ class JwtManager(object):
 
     @classmethod
     def blocklist_token(cls, token):
-        token = jwt.decode(token, verify=False)
+        token = jwt.decode(token, verify=False, algorithms=cls.JWT_ALGORITHM)
         blocklist_json = mgr.get_store(cls.JWT_TOKEN_BLOCKLIST_KEY)
         if not blocklist_json:
             blocklist_json = "{}"


### PR DESCRIPTION
See https://github.com/jpadilla/pyjwt/issues/594

Signed-off-by: Sage Weil <sage@newdream.net>