### PR TITLE
rpm: disable parallel compression on SUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -109,9 +109,11 @@
 
 # disable dwz which compresses the debuginfo
 %global _find_debuginfo_dwz_opts %{nil}
+%if ! 0%{?suse_version}
 # use multi-threaded xz compression: xz level 7 using ncpus threads
 %global _source_payload w7T%{_smp_build_ncpus}.xzdio
 %global _binary_payload w7T%{_smp_build_ncpus}.xzdio
+%endif
 
 %define smp_limit_mem_per_job() %( \
   kb_per_job=%1 \


### PR DESCRIPTION
This code causes the Ceph build in OBS to fail due to OOM, because the typical
setting of %_smp_build_ncpus in the OBS is 16, but available memory is
insufficient to sustain such a high degree of parallelism for the in-memory
compression operation.

Fixes: b50fc9e61c39e6f9544b67cb5cd49c67bf6dd02e
Fixes: https://tracker.ceph.com/issues/49583
Signed-off-by: Nathan Cutler <ncutler@suse.com>
