### PR TITLE
qa/rgw: put PG_AVAILABILITY ignorelist override in its own file

### DIFF
--- a/qa/suites/rgw/crypt/1-ceph-install/install.yaml
+++ b/qa/suites/rgw/crypt/1-ceph-install/install.yaml
@@ -1,7 +1,5 @@
 overrides:
   ceph:
-    log-ignorelist:
-    - \(PG_AVAILABILITY\)
     wait-for-scrub: false
 
 tasks:

--- a/qa/suites/rgw/crypt/ignore-pg-availability.yaml
+++ b/qa/suites/rgw/crypt/ignore-pg-availability.yaml
@@ -1,0 +1,1 @@
+../ignore-pg-availability.yaml

--- a/qa/suites/rgw/ignore-pg-availability.yaml
+++ b/qa/suites/rgw/ignore-pg-availability.yaml
@@ -1,0 +1,5 @@
+# https://tracker.ceph.com/issues/45802
+overrides:
+  ceph:
+    log-ignorelist:
+    - \(PG_AVAILABILITY\)

--- a/qa/suites/rgw/multifs/ignore-pg-availability.yaml
+++ b/qa/suites/rgw/multifs/ignore-pg-availability.yaml
@@ -1,0 +1,1 @@
+../ignore-pg-availability.yaml

--- a/qa/suites/rgw/multisite/ignore-pg-availability.yaml
+++ b/qa/suites/rgw/multisite/ignore-pg-availability.yaml
@@ -1,0 +1,1 @@
+../ignore-pg-availability.yaml

--- a/qa/suites/rgw/multisite/overrides.yaml
+++ b/qa/suites/rgw/multisite/overrides.yaml
@@ -1,7 +1,5 @@
 overrides:
   ceph:
-    log-ignorelist:
-    - \(PG_AVAILABILITY\)
     wait-for-scrub: false
     conf:
       client:

--- a/qa/suites/rgw/sts/ignore-pg-availability.yaml
+++ b/qa/suites/rgw/sts/ignore-pg-availability.yaml
@@ -1,0 +1,1 @@
+../ignore-pg-availability.yaml

--- a/qa/suites/rgw/verify/ignore-pg-availability.yaml
+++ b/qa/suites/rgw/verify/ignore-pg-availability.yaml
@@ -1,0 +1,1 @@
+../ignore-pg-availability.yaml

--- a/qa/suites/rgw/verify/tasks/cls.yaml
+++ b/qa/suites/rgw/verify/tasks/cls.yaml
@@ -1,7 +1,3 @@
-overrides:
-  ceph:
-    log-ignorelist:
-    - \(PG_AVAILABILITY\)
 tasks:
 - workunit:
     clients:


### PR DESCRIPTION
now covers the sts and multifs subsuites

re: https://tracker.ceph.com/issues/45802

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
