### PR TITLE
pacific: rpm: use PMDK system libraries on SUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -41,6 +41,9 @@
 %bcond_without lttng
 %bcond_without libradosstriper
 %bcond_without ocf
+%bcond_without rbd_rwl_cache
+%bcond_without rbd_ssd_cache
+%global _system_pmdk 0
 %global _remote_tarball_prefix https://download.ceph.com/tarballs/
 %endif
 %if 0%{?suse_version}
@@ -50,8 +53,14 @@
 %bcond_with libradosstriper
 %ifarch x86_64 aarch64 ppc64le
 %bcond_without lttng
+%global _system_pmdk 1
+%bcond_without rbd_rwl_cache
+%bcond_without rbd_ssd_cache
 %else
 %bcond_with lttng
+%global _system_pmdk 0
+%bcond_with rbd_rwl_cache
+%bcond_with rbd_ssd_cache
 %endif
 %bcond_with ocf
 %bcond_with selinux
@@ -62,8 +71,6 @@
 %endif
 %bcond_with seastar
 %bcond_with jaeger
-%bcond_without rbd_rwl_cache
-%bcond_without rbd_ssd_cache
 %if 0%{?fedora} || 0%{?suse_version} >= 1500
 # distros that ship cmd2 and/or colorama
 %bcond_without cephfs_shell
@@ -283,6 +290,10 @@ BuildRequires:  rdma-core-devel
 BuildRequires:	liblz4-devel >= 1.7
 # for prometheus-alerts
 BuildRequires:  golang-github-prometheus-prometheus
+%if 0%{?_system_pmdk}
+BuildRequires:  libpmem-devel
+BuildRequires:  libpmemobj-devel
+%endif
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 Requires:	systemd
@@ -1278,6 +1289,9 @@ ${CMAKE} .. \
 %endif
 %if 0%{with rbd_ssd_cache}
     -DWITH_RBD_SSD_CACHE=ON \
+%endif
+%if 0%{?_system_pmdk}
+    -DWITH_SYSTEM_PMDK:BOOL=ON \
 %endif
     -DBOOST_J=$CEPH_SMP_NCPUS \
     -DWITH_GRAFANA=ON

--- a/cmake/modules/Buildpmem.cmake
+++ b/cmake/modules/Buildpmem.cmake
@@ -44,6 +44,5 @@ function(build_pmem)
   set_target_properties(pmem::pmemobj PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES ${PMDK_INCLUDE}
     IMPORTED_LOCATION "${PMDK_LIB}/libpmemobj.a"
-    INTERFACE_LINK_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
-
+    INTERFACE_LINK_LIBRARIES "pmem::pmem;${CMAKE_THREAD_LIBS_INIT}")
 endfunction()

--- a/cmake/modules/Findpmem.cmake
+++ b/cmake/modules/Findpmem.cmake
@@ -1,45 +1,47 @@
 # - Find pmem
 #
-# PMEM_INCLUDE_DIR - Where to find libpmem.h
-# PMEM_LIBRARIES - List of libraries when using pmdk.
+# pmem_INCLUDE_DIRS - Where to find libpmem headers
+# pmem_LIBRARIES - List of libraries when using libpmem.
 # pmem_FOUND - True if pmem found.
-# PMEMOBJ_INCLUDE_DIR - Where to find libpmemobj.h
-# PMEMOBJ_LIBRARIES - List of libraries when using pmdk obj.
-# pmemobj_FOUND - True if pmemobj found.
 
-find_path(PMEM_INCLUDE_DIR libpmem.h)
-find_library(PMEM_LIBRARIES pmem)
+foreach(component pmem ${pmem_FIND_COMPONENTS})
+  if(component STREQUAL pmem)
+    find_path(pmem_${component}_INCLUDE_DIR libpmem.h)
+    find_library(pmem_${component}_LIBRARY pmem)
+  elseif(component STREQUAL pmemobj)
+    find_path(pmem_${component}_INCLUDE_DIR libpmemobj.h)
+    find_library(pmem_${component}_LIBRARY pmemobj)
+  else()
+    message(FATAL_ERROR "unknown libpmem component: ${component}")
+  endif()
+  mark_as_advanced(
+    pmem_${component}_INCLUDE_DIR
+    pmem_${component}_LIBRARY)
+  list(APPEND pmem_INCLUDE_DIRS "pmem_${component}_INCLUDE_DIR")
+  list(APPEND pmem_LIBRARIES "pmem_${component}_LIBRARY")
+endforeach()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(pmem
-  DEFAULT_MSG PMEM_LIBRARIES PMEM_INCLUDE_DIR)
+  DEFAULT_MSG pmem_INCLUDE_DIRS pmem_LIBRARIES)
 
 mark_as_advanced(
-  PMEM_INCLUDE_DIR
-  PMEM_LIBRARIES)
+  pmem_INCLUDE_DIRS
+  pmem_LIBRARIES)
 
-if(pmem_FOUND AND NOT TARGET pmem::pmem)
-  add_library(pmem::pmem UNKNOWN IMPORTED)
-  set_target_properties(pmem::pmem PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${PMEM_INCLUDE_DIR}"
-    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-    IMPORTED_LOCATION "${PMEM_LIBRARIES}")
-endif()
-
-find_path(PMEMOBJ_INCLUDE_DIR libpmemobj.h)
-find_library(PMEMOBJ_LIBRARIES pmemobj)
-
-find_package_handle_standard_args(pmemobj
-  DEFAULT_MSG PMEMOBJ_LIBRARIES PMEMOBJ_INCLUDE_DIR)
-
-mark_as_advanced(
-  PMEMOBJ_INCLUDE_DIR
-  PMEMOBJ_LIBRARIES)
-
-if(pmemobj_FOUND AND NOT TARGET pmem::pmemobj)
-  add_library(pmem::pmemobj UNKNOWN IMPORTED)
-  set_target_properties(pmem::pmemobj PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${PMEMOBJ_INCLUDE_DIR}"
-    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-    IMPORTED_LOCATION "${PMEMOBJ_LIBRARIES}")
+if(pmem_FOUND)
+  foreach(component pmem ${pmem_FIND_COMPONENTS})
+    if(NOT TARGET pmem::${component})
+      add_library(pmem::${component} UNKNOWN IMPORTED)
+      set_target_properties(pmem::${component} PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${pmem_${component}_INCLUDE_DIR}"
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+        IMPORTED_LOCATION "${pmem_${component}_LIBRARY}")
+      # all pmem libraries calls into pmem::pmem
+      if(NOT component STREQUAL pmem)
+        set_target_properties(pmem::${component} PROPERTIES
+          INTERFACE_LINK_LIBRARIES pmem::pmem)
+      endif()
+    endif()
+  endforeach()
 endif()

--- a/src/blk/CMakeLists.txt
+++ b/src/blk/CMakeLists.txt
@@ -40,9 +40,8 @@ if(WITH_ZBD)
   target_link_libraries(blk PRIVATE ${ZBD_LIBRARIES})
 endif()
 
-if(WITH_BLUESTORE_PMEM OR WITH_RBD_RWL)
+if(WITH_BLUESTORE_PMEM)
   target_link_libraries(blk
-    PUBLIC pmem::pmemobj
     PRIVATE pmem::pmem)
 endif()
 

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(rbd_types STATIC
 
 if (WITH_RBD_RWL)
   target_link_libraries(rbd_types
-    PRIVATE pmem::pmemobj)
+    PUBLIC pmem::pmemobj)
 endif()
 
 set(librbd_internal_srcs


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49593

---

backport of

* https://github.com/ceph/ceph/pull/39755
* https://github.com/ceph/ceph/pull/39846

parent tracker: https://tracker.ceph.com/issues/49550

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh