### PR TITLE
[RFC, DNM] run-tox-tests.sh

### DIFF
--- a/run-tox-tests.sh
+++ b/run-tox-tests.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -ex
+
+tox_version="$(tox --version | cut -d' ' -f1)"
+
+oldest_tox="$(cat <<EOF | sort -V | head -n 1
+2.9.0
+$tox_version
+EOF
+)"
+
+echo $oldest_tox
+
+if [ ! "$oldest_tox" == "2.9.0" ] ; then
+  rm -rf tox-venv
+  python3 -m venv tox-venv
+  . ./tox-venv/bin/activate
+  pip install tox
+fi
+
+status=0
+
+run_tox_1(){
+    echo $1
+    out="$(tox -c $1)"
+    status=$?
+    if [ $status != 0 ] ; then
+      echo "$out"
+    fi
+    return $status
+}
+
+export -f run_tox_1
+
+tests="
+src/python-common/tox.ini
+src/cephadm/tox.ini
+src/pybind/mgr/tox.ini
+qa/tox.ini
+src/pybind/mgr/dashboard/tox.ini
+"
+
+echo "$tests" | xargs -P 0 -n 1 -I {} bash -c 'run_tox_1 "$@"' _ {}
+


### PR DESCRIPTION
Not all tox tests need compiled ceph binaries and libraries.
run-tox-tests.sh is more or less run-make-check.sh without
compiling ceph and thus providing a shortcut for PRs that
only modify python files.

**TODOs**

- [ ] Does it make sense to use bash here? 
- [ ] I'm avoiding `src/tools/setup-virtualenv.sh`. This might be problematic. 
- [ ] This adds new complexity to the deployment, as it does not replace make check
- [ ] Is it worth it at all?

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
