### PR TITLE
crimson/osd: do not pass lvalue of the lambda to seastar::futurize_invoke

### DIFF
--- a/src/crimson/osd/osd_operation_sequencer.h
+++ b/src/crimson/osd/osd_operation_sequencer.h
@@ -59,8 +59,8 @@ public:
         return last_unblocked == prev_op;
       });
     }
-    return have_green_light.then([this_op, do_op=std::move(do_op), this] {
-      auto result = seastar::futurize_invoke(do_op);
+    return have_green_light.then([this_op, do_op=std::move(do_op), this]() mutable {
+      auto result = seastar::futurize_invoke(std::move(do_op));
       // unblock the next one
       last_unblocked = this_op;
       unblocked.broadcast();


### PR DESCRIPTION


Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
