### PR TITLE
nautilus: mgr/dashboard: fix issues related with PyJWT versions >=2.0.0 

### DIFF
--- a/qa/tasks/mgr/dashboard/test_auth.py
+++ b/qa/tasks/mgr/dashboard/test_auth.py
@@ -20,7 +20,7 @@ class AuthTest(DashboardTestCase):
         self.reset_session()
 
     def _validate_jwt_token(self, token, username, permissions):
-        payload = jwt.decode(token, verify=False)
+        payload = jwt.decode(token, options={'verify_signature': False})
         self.assertIn('username', payload)
         self.assertEqual(payload['username'], username)
 

--- a/src/pybind/mgr/dashboard/constraints.txt
+++ b/src/pybind/mgr/dashboard/constraints.txt
@@ -1,7 +1,7 @@
 CherryPy==13.1.0
 enum34==1.1.6
 more-itertools==4.1.0
-PyJWT==1.6.4
+PyJWT==2.0.1
 bcrypt==3.1.4
 python3-saml==1.4.1
 requests==2.20.0

--- a/src/pybind/mgr/dashboard/controllers/auth.py
+++ b/src/pybind/mgr/dashboard/controllers/auth.py
@@ -29,7 +29,10 @@ class Auth(RESTController):
             url_prefix = 'https' if mgr.get_localized_module_option('ssl') else 'http'
             logger.debug('Login successful')
             token = JwtManager.gen_token(username)
-            token = token.decode('utf-8')
+
+            # For backward-compatibility: PyJWT versions < 2.0.0 return bytes.
+            token = token.decode('utf-8') if isinstance(token, bytes) else token
+
             set_cookies(url_prefix, token)
             return {
                 'token': token,

--- a/src/pybind/mgr/dashboard/requirements.txt
+++ b/src/pybind/mgr/dashboard/requirements.txt
@@ -18,7 +18,7 @@ portend==2.2
 py==1.5.2
 pycodestyle==2.4.0
 pycparser==2.18
-PyJWT==1.6.4
+PyJWT
 pyopenssl
 pytest==3.3.2
 pytest-cov==2.5.1

--- a/src/pybind/mgr/dashboard/services/auth.py
+++ b/src/pybind/mgr/dashboard/services/auth.py
@@ -97,7 +97,7 @@ class JwtManager(object):
 
     @classmethod
     def blacklist_token(cls, token):
-        token = jwt.decode(token, verify=False)
+        token = cls.decode_token(token)
         blacklist_json = mgr.get_store(cls.JWT_TOKEN_BLACKLIST_KEY)
         if not blacklist_json:
             blacklist_json = "{}"

--- a/src/pybind/mgr/dashboard/tests/test_auth.py
+++ b/src/pybind/mgr/dashboard/tests/test_auth.py
@@ -1,0 +1,20 @@
+import unittest
+
+from .. import mgr
+from ..services.auth import JwtManager
+
+
+class JwtManagerTest(unittest.TestCase):
+
+    def test_generate_token_and_decode(self):
+        mgr.get_module_option.return_value = JwtManager.JWT_TOKEN_TTL
+        mgr.get_store.return_value = 'jwt_secret'
+
+        token = JwtManager.gen_token('my-username')
+        self.assertIsInstance(token, str)
+        self.assertTrue(token)
+
+        decoded_token = JwtManager.decode_token(token)
+        self.assertIsInstance(decoded_token, dict)
+        self.assertEqual(decoded_token['iss'], 'ceph-dashboard')
+        self.assertEqual(decoded_token['username'], 'my-username')


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49596

---

backport of https://github.com/ceph/ceph/pull/39801
parent tracker: https://tracker.ceph.com/issues/49574

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh