### PR TITLE
 crimson/osd: fix the serialization of notify_reply_t. 

### DIFF
--- a/src/crimson/osd/watch.cc
+++ b/src/crimson/osd/watch.cc
@@ -114,6 +114,14 @@ bool notify_reply_t::operator<(const notify_reply_t& rhs) const
   return lhsp < rhsp;
 }
 
+std::ostream &operator<<(std::ostream &out, const notify_reply_t &rhs)
+{
+  out << "notify_reply_t{watcher_gid=" << rhs.watcher_gid
+      << ", watcher_cookie=" << rhs.watcher_cookie
+      << ", bl=" << rhs.bl << "}";
+  return out;
+}
+
 seastar::future<> Notify::remove_watcher(WatchRef watch)
 {
   if (discarded || complete) {
@@ -143,6 +151,7 @@ seastar::future<> Notify::maybe_send_completion()
 {
   logger().info("{} -- {} in progress watchers", __func__, watchers.size());
   if (watchers.empty()) {
+    logger().debug("{} sending notify replies: {}", __func__, notify_replies);
     // prepare reply
     ceph::bufferlist bl;
     encode(notify_replies, bl);

--- a/src/crimson/osd/watch.h
+++ b/src/crimson/osd/watch.h
@@ -107,6 +107,7 @@ struct notify_reply_t {
     DENC_FINISH(p);
   }
 };
+std::ostream &operator<<(std::ostream &out, const notify_reply_t &rhs);
 
 class Notify {
   std::set<WatchRef> watchers;

--- a/src/crimson/osd/watch.h
+++ b/src/crimson/osd/watch.h
@@ -100,11 +100,10 @@ struct notify_reply_t {
 
   bool operator<(const notify_reply_t& rhs) const;
   DENC(notify_reply_t, v, p) {
-    DENC_START(1, 1, p);
+    // there is no versioning / preamble
     denc(v.watcher_gid, p);
     denc(v.watcher_cookie, p);
     denc(v.bl, p);
-    DENC_FINISH(p);
   }
 };
 std::ostream &operator<<(std::ostream &out, const notify_reply_t &rhs);


### PR DESCRIPTION
The `LibRadosWatchNotify.WatchNotify2` was expecting data in the very raw form:

```cpp
  std::map<std::pair<uint64_t,uint64_t>, bufferlist> reply_map;
  std::set<std::pair<uint64_t,uint64_t> > missed_map;
  auto reply_p = reply.cbegin();
  decode(reply_map, reply_p);
  decode(missed_map, reply_p);
```

while the serialization of `notify_reply_t` was appending extra preamable with versioning data.

This was the root cause of the following problem:
```
2021-03-04T15:40:03.001 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: Running main() from gmock_main.cc
2021-03-04T15:40:03.001 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: [==========] Running 11 tests from 2 test suites.
2021-03-04T15:40:03.002 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: [----------] Global test environment set-up.
2021-03-04T15:40:03.002 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: [----------] 10 tests from LibRadosWatchNotify
2021-03-04T15:40:03.002 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: [ RUN      ] LibRadosWatchNotify.WatchNotify
2021-03-04T15:40:03.002 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: watch_notify_test_cb
2021-03-04T15:40:03.003 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: [       OK ] LibRadosWatchNotify.WatchNotify (744 ms)
2021-03-04T15:40:03.003 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: [ RUN      ] LibRadosWatchNotify.Watch2Delete
2021-03-04T15:40:03.003 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: waiting up to 300 for disconnect notification ...
2021-03-04T15:40:03.003 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: watch_notify2_test_errcb cookie 94023196839536 err -107
2021-03-04T15:40:03.004 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: [       OK ] LibRadosWatchNotify.Watch2Delete (3123 ms)
2021-03-04T15:40:03.004 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: [ RUN      ] LibRadosWatchNotify.AioWatchDelete
2021-03-04T15:40:03.004 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: waiting up to 300 for disconnect notification ...
2021-03-04T15:40:03.004 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: watch_notify2_test_errcb cookie 94023196851488 err -107
2021-03-04T15:40:03.005 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: [       OK ] LibRadosWatchNotify.AioWatchDelete (5086 ms)
2021-03-04T15:40:03.005 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: [ RUN      ] LibRadosWatchNotify.WatchNotify2
2021-03-04T15:40:03.005 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: watch_notify2_test_cb from 4394 notify_id 120259084288 cookie 94023196869248
2021-03-04T15:40:03.005 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: unknown file: Failure
2021-03-04T15:40:03.006 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: C++ exception with description "End of buffer" thrown in the test body.
```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
