### PR TITLE
cmake: support COMPONENTS param in Findpmem.cmake

### DIFF
--- a/cmake/modules/Buildpmem.cmake
+++ b/cmake/modules/Buildpmem.cmake
@@ -44,6 +44,5 @@ function(build_pmem)
   set_target_properties(pmem::pmemobj PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES ${PMDK_INCLUDE}
     IMPORTED_LOCATION "${PMDK_LIB}/libpmemobj.a"
-    INTERFACE_LINK_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
-
+    INTERFACE_LINK_LIBRARIES "pmem::pmem;${CMAKE_THREAD_LIBS_INIT}")
 endfunction()

--- a/cmake/modules/Findpmem.cmake
+++ b/cmake/modules/Findpmem.cmake
@@ -1,45 +1,47 @@
 # - Find pmem
 #
-# PMEM_INCLUDE_DIR - Where to find libpmem.h
-# PMEM_LIBRARIES - List of libraries when using pmdk.
+# pmem_INCLUDE_DIRS - Where to find libpmem headers
+# pmem_LIBRARIES - List of libraries when using libpmem.
 # pmem_FOUND - True if pmem found.
-# PMEMOBJ_INCLUDE_DIR - Where to find libpmemobj.h
-# PMEMOBJ_LIBRARIES - List of libraries when using pmdk obj.
-# pmemobj_FOUND - True if pmemobj found.
 
-find_path(PMEM_INCLUDE_DIR libpmem.h)
-find_library(PMEM_LIBRARIES pmem)
+foreach(component pmem ${pmem_FIND_COMPONENTS})
+  if(component STREQUAL pmem)
+    find_path(pmem_${component}_INCLUDE_DIR libpmem.h)
+    find_library(pmem_${component}_LIBRARY pmem)
+  elseif(component STREQUAL pmemobj)
+    find_path(pmem_${component}_INCLUDE_DIR libpmemobj.h)
+    find_library(pmem_${component}_LIBRARY pmemobj)
+  else()
+    message(FATAL_ERROR "unknown libpmem component: ${component}")
+  endif()
+  mark_as_advanced(
+    pmem_${component}_INCLUDE_DIR
+    pmem_${component}_LIBRARY)
+  list(APPEND pmem_INCLUDE_DIRS "pmem_${component}_INCLUDE_DIR")
+  list(APPEND pmem_LIBRARIES "pmem_${component}_LIBRARY")
+endforeach()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(pmem
-  DEFAULT_MSG PMEM_LIBRARIES PMEM_INCLUDE_DIR)
+  DEFAULT_MSG pmem_INCLUDE_DIRS pmem_LIBRARIES)
 
 mark_as_advanced(
-  PMEM_INCLUDE_DIR
-  PMEM_LIBRARIES)
+  pmem_INCLUDE_DIRS
+  pmem_LIBRARIES)
 
-if(pmem_FOUND AND NOT TARGET pmem::pmem)
-  add_library(pmem::pmem UNKNOWN IMPORTED)
-  set_target_properties(pmem::pmem PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${PMEM_INCLUDE_DIR}"
-    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-    IMPORTED_LOCATION "${PMEM_LIBRARIES}")
-endif()
-
-find_path(PMEMOBJ_INCLUDE_DIR libpmemobj.h)
-find_library(PMEMOBJ_LIBRARIES pmemobj)
-
-find_package_handle_standard_args(pmemobj
-  DEFAULT_MSG PMEMOBJ_LIBRARIES PMEMOBJ_INCLUDE_DIR)
-
-mark_as_advanced(
-  PMEMOBJ_INCLUDE_DIR
-  PMEMOBJ_LIBRARIES)
-
-if(pmemobj_FOUND AND NOT TARGET pmem::pmemobj)
-  add_library(pmem::pmemobj UNKNOWN IMPORTED)
-  set_target_properties(pmem::pmemobj PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${PMEMOBJ_INCLUDE_DIR}"
-    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-    IMPORTED_LOCATION "${PMEMOBJ_LIBRARIES}")
+if(pmem_FOUND)
+  foreach(component pmem ${pmem_FIND_COMPONENTS})
+    if(NOT TARGET pmem::${component})
+      add_library(pmem::${component} UNKNOWN IMPORTED)
+      set_target_properties(pmem::${component} PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${pmem_${component}_INCLUDE_DIR}"
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+        IMPORTED_LOCATION "${pmem_${component}_LIBRARY}")
+      # all pmem libraries calls into pmem::pmem
+      if(NOT component STREQUAL pmem)
+        set_target_properties(pmem::${component} PROPERTIES
+          INTERFACE_LINK_LIBRARIES pmem::pmem)
+      endif()
+    endif()
+  endforeach()
 endif()

--- a/src/blk/CMakeLists.txt
+++ b/src/blk/CMakeLists.txt
@@ -40,9 +40,8 @@ if(WITH_ZBD)
   target_link_libraries(blk PRIVATE ${ZBD_LIBRARIES})
 endif()
 
-if(WITH_BLUESTORE_PMEM OR WITH_RBD_RWL)
+if(WITH_BLUESTORE_PMEM)
   target_link_libraries(blk
-    PUBLIC pmem::pmemobj
     PRIVATE pmem::pmem)
 endif()
 

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(rbd_types STATIC
 
 if (WITH_RBD_RWL)
   target_link_libraries(rbd_types
-    PRIVATE pmem::pmemobj)
+    PUBLIC pmem::pmemobj)
 endif()
 
 set(librbd_internal_srcs


### PR DESCRIPTION
add two components: pmem and pmemobj to this package. so we can find
them and link against them in a more intuitive way.

before this change the COMPONENTS parameter passed to

find_package(pmem ...)

is dropped on the floor and ignored.

after this change, it is checked and taken into consideration.

also, in this change, the exposed variables are renamed from

PMEM_* to pmem_*

to be consistent with the package name. it's encouraged to be consistent
with the package name when it comes to the INCLUDE_DIR and LIBRARIES
variable names.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
