### PR TITLE
qa: don't expect "file exists" error for "mkdir -p"

### DIFF
--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -62,7 +62,7 @@ class FuseMount(CephFSMount):
         log.info("Client client.%s config is %s" % (self.client_id,
                                                     self.client_config))
 
-        self._create_mntpt(cwd=self.test_dir)
+        self._create_mntpt()
 
         retval = self._run_mount_cmd(mntopts, check_status)
         if retval:

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -176,16 +176,12 @@ class CephFSMount(object):
         log.info('Ready to start {}...'.format(type(self).__name__))
 
     def _create_mntpt(self):
-        stderr = StringIO()
+        self.client_remote.run(args=f'mkdir -p -v {self.hostfs_mntpt}',
+                               timeout=60)
         # Use 0000 mode to prevent undesired modifications to the mountpoint on
         # the local file system.
-        script = f'mkdir -m 0000 -p -v {self.hostfs_mntpt}'.split()
-        try:
-            self.client_remote.run(args=script, timeout=(15*60),
-                                   stderr=stderr)
-        except CommandFailedError:
-            if 'file exists' not in stderr.getvalue().lower():
-                raise
+        self.client_remote.run(args=f'chmod 0000 {self.hostfs_mntpt}',
+                               timeout=60)
 
     @property
     def _nsenter_args(self):

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -175,7 +175,7 @@ class CephFSMount(object):
         self.fs.wait_for_daemons()
         log.info('Ready to start {}...'.format(type(self).__name__))
 
-    def _create_mntpt(self, cwd=None):
+    def _create_mntpt(self):
         stderr = StringIO()
         # Use 0000 mode to prevent undesired modifications to the mountpoint on
         # the local file system.

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -707,12 +707,11 @@ class LocalFuseMount(LocalCephFSMount, FuseMount):
         self._mount_cmd_cwd, self._mount_cmd_logger, \
             self._mount_cmd_stdin = None, None, None
 
-    def _create_mntpt(self, cwd=None):
+    def _create_mntpt(self):
         stderr = StringIO()
         script = f'mkdir -p -v {self.hostfs_mntpt}'.split()
         try:
-            self.client_remote.run(args=script, cwd=self.test_dir,
-                                   stderr=stderr)
+            self.client_remote.run(args=script, stderr=stderr)
         except CommandFailedError:
             if 'file exists' not in stderr.getvalue().lower():
                 raise

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -707,14 +707,11 @@ class LocalFuseMount(LocalCephFSMount, FuseMount):
         self._mount_cmd_cwd, self._mount_cmd_logger, \
             self._mount_cmd_stdin = None, None, None
 
+    # XXX: CephFSMount._create_mntpt() sets mountpoint's permission mode to
+    # 0000 which doesn't work for vstart_runner since superuser privileges are
+    # not used for mounting Ceph FS with FUSE.
     def _create_mntpt(self):
-        stderr = StringIO()
-        script = f'mkdir -p -v {self.hostfs_mntpt}'.split()
-        try:
-            self.client_remote.run(args=script, stderr=stderr)
-        except CommandFailedError:
-            if 'file exists' not in stderr.getvalue().lower():
-                raise
+        self.client_remote.run(args=f'mkdir -p -v {self.hostfs_mntpt}')
 
     def _run_mount_cmd(self, mntopts, check_status):
         super(type(self), self)._run_mount_cmd(mntopts, check_status)


### PR DESCRIPTION
"mkdir -p" doesn't raise any error when directory to be created already
exists. Also, use chmod command instead of mkdir command to set
permission mode on directory since mkdir command would have no effect
on directory's permission mode if directory already exists.




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>