### PR TITLE
octopus: mgr/dashboard: report mgr fsid

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cluster_configuration.py
+++ b/src/pybind/mgr/dashboard/controllers/cluster_configuration.py
@@ -20,6 +20,9 @@ class ClusterConfiguration(RESTController):
         :return: list of config options extended by their current values
         """
         config_dump = CephService.send_command('mon', 'config dump')
+        mgr_config = mgr.get('config')
+        config_dump.append({'name': 'fsid', 'section': 'mgr', 'value': mgr_config['fsid']})
+
         for config_dump_entry in config_dump:
             for i, elem in enumerate(options):
                 if config_dump_entry['name'] == elem['name']:

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/configuration.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/configuration.e2e-spec.ts
@@ -52,7 +52,7 @@ describe('Configuration page', () => {
 
     it('should show only modified configurations', () => {
       configuration.filterTable('Modified', 'yes');
-      configuration.getTableFoundCount().should('eq', 1);
+      configuration.getTableFoundCount().should('eq', 2);
     });
 
     it('should hide all modified configurations', () => {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49599

---

backport of https://github.com/ceph/ceph/pull/39452
parent tracker: https://tracker.ceph.com/issues/49283

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh