### PR TITLE
nautilus: mgr/dashboard: report mgr fsid 

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cluster_configuration.py
+++ b/src/pybind/mgr/dashboard/controllers/cluster_configuration.py
@@ -20,6 +20,9 @@ class ClusterConfiguration(RESTController):
         :return: list of config options extended by their current values
         """
         config_dump = CephService.send_command('mon', 'config dump')
+        mgr_config = mgr.get('config')
+        config_dump.append({'name': 'fsid', 'section': 'mgr', 'value': mgr_config['fsid']})
+
         for config_dump_entry in config_dump:
             for i, elem in enumerate(options):
                 if config_dump_entry['name'] == elem['name']:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49600

---

backport of https://github.com/ceph/ceph/pull/39452
parent tracker: https://tracker.ceph.com/issues/49283

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh