### PR TITLE
Revert "rgw: register daemon in service map with more details"

### DIFF
--- a/qa/suites/rgw/singleton/all/rgw_cephadm.yaml
+++ b/qa/suites/rgw/singleton/all/rgw_cephadm.yaml
@@ -1,0 +1,6 @@
+roles: [mon.a, osd.0, osd.1, osd.2, rgw.z.r.a, rgw.z.r.b]
+tasks:
+- cephadm:
+- exec:
+    mon.a:
+    - sleep 30

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1136,9 +1136,7 @@ int RGWRados::register_to_service_map(const string& daemon_type, const map<strin
   if (name.compare(0, 4, "rgw.") == 0) {
     name = name.substr(4);
   }
-  std::string instance_id = stringify(rados.get_instance_id());
-  std::string rgw_service_map_name = name + "." + instance_id;
-  int ret = rados.service_daemon_register(daemon_type, rgw_service_map_name, metadata);
+  int ret = rados.service_daemon_register(daemon_type, name, metadata);
   if (ret < 0) {
     ldout(cct, 0) << "ERROR: service_daemon_register() returned ret=" << ret << ": " << cpp_strerror(-ret) << dendl;
     return ret;


### PR DESCRIPTION
This reverts commit 46ec2f0ddd81b4b5b4a61633eada998dcd606c9b.

This break cephadm (by triggering CEPHADM_STRAY_DAEMON) because it
assumes that a daemon named rgw.r.z.foo will register as rgw.r.z.foo.
It is not clear to me that there is a way to work around this disparity
that makes much sense.  I think it makes more sense to focus on the
use-case that needs daemons to register under unique names and perhaps
control that behavior via an option or invest in providing daemons with
unique ids.




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>