### PR TITLE
octopus: librbd: don't log error if get mirror status fails due to mirroring disabled

### DIFF
--- a/src/librbd/mirror/GetStatusRequest.cc
+++ b/src/librbd/mirror/GetStatusRequest.cc
@@ -50,8 +50,10 @@ void GetStatusRequest<I>::handle_get_info(int r) {
   ldout(cct, 20) << "r=" << r << dendl;
 
   if (r < 0) {
-    lderr(cct) << "failed to retrieve mirroring state: " << cpp_strerror(r)
-               << dendl;
+    if (r != -ENOENT) {
+      lderr(cct) << "failed to retrieve mirroring state: " << cpp_strerror(r)
+                 << dendl;
+    }
     finish(r);
     return;
   } else if (m_mirror_image->state != cls::rbd::MIRROR_IMAGE_STATE_ENABLED) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49263

---

backport of https://github.com/ceph/ceph/pull/39409
parent tracker: https://tracker.ceph.com/issues/49245

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh