### PR TITLE
octopus: mgr/rbd_support: mirror snapshot schedule should skip non-primary images

### DIFF
--- a/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
+++ b/src/pybind/mgr/rbd_support/mirror_snapshot_schedule.py
@@ -216,9 +216,10 @@ class CreateSnapshotRequests:
                 pool_id, namespace, image_id, comp.get_return_value()))
 
         if comp.get_return_value() < 0:
-            self.log.error(
-                "error when opening {}/{}/{}: {}".format(
-                    pool_id, namespace, image_id, comp.get_return_value()))
+            if comp.get_return_value() != -errno.ENOENT:
+                self.log.error(
+                    "error when opening {}/{}/{}: {}".format(
+                        pool_id, namespace, image_id, comp.get_return_value()))
             self.finish(image_spec)
             return
 
@@ -249,9 +250,10 @@ class CreateSnapshotRequests:
                 pool_id, namespace, image_id, comp.get_return_value(), mode))
 
         if comp.get_return_value() < 0:
-            self.log.error(
-                "error when getting mirror mode for {}/{}/{}: {}".format(
-                    pool_id, namespace, image_id, comp.get_return_value()))
+            if comp.get_return_value() != -errno.ENOENT:
+                self.log.error(
+                    "error when getting mirror mode for {}/{}/{}: {}".format(
+                        pool_id, namespace, image_id, comp.get_return_value()))
             self.close_image(image_spec, image)
             return
 
@@ -290,9 +292,18 @@ class CreateSnapshotRequests:
                 pool_id, namespace, image_id, comp.get_return_value(), info))
 
         if comp.get_return_value() < 0:
-            self.log.error(
-                "error when getting mirror info for {}/{}/{}: {}".format(
-                    pool_id, namespace, image_id, comp.get_return_value()))
+            if comp.get_return_value() != -errno.ENOENT:
+                self.log.error(
+                    "error when getting mirror info for {}/{}/{}: {}".format(
+                        pool_id, namespace, image_id, comp.get_return_value()))
+            self.close_image(image_spec, image)
+            return
+
+        if not info['primary']:
+            self.log.debug(
+                "CreateSnapshotRequests.handle_get_mirror_info: {}/{}/{}: {}".format(
+                    pool_id, namespace, image_id,
+                    "is not primary"))
             self.close_image(image_spec, image)
             return
 
@@ -324,7 +335,8 @@ class CreateSnapshotRequests:
             "CreateSnapshotRequests.handle_create_snapshot for {}/{}/{}: r={}, snap_id={}".format(
                 pool_id, namespace, image_id, comp.get_return_value(), snap_id))
 
-        if comp.get_return_value() < 0:
+        if comp.get_return_value() < 0 and \
+           comp.get_return_value() != -errno.ENOENT:
             self.log.error(
                 "error when creating snapshot for {}/{}/{}: {}".format(
                     pool_id, namespace, image_id, comp.get_return_value()))
@@ -529,7 +541,9 @@ class MirrorSnapshotScheduleHandler:
                     [(x['id'], x['name']) for x in filter(
                         lambda x: x['id'] in mirror_images,
                         rbd.RBD().list2(ioctx))])
-                for image_id in mirror_images:
+                for image_id, info in mirror_images.items():
+                    if not info['primary']:
+                        continue
                     image_name = image_names.get(image_id)
                     if not image_name:
                         continue


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49335

---

backport of https://github.com/ceph/ceph/pull/39522
parent tracker: https://tracker.ceph.com/issues/49284

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh