### PR TITLE
nautilus: mgr/dashboard: Fix missing root path of each session for CephFS

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -269,10 +269,12 @@ class CephFS(RESTController):
                 client['type'] = "userspace"
                 client['version'] = client['client_metadata']['ceph_version']
                 client['hostname'] = client['client_metadata']['hostname']
+                client['root'] = client['client_metadata']['root']
             elif "kernel_version" in client['client_metadata']:
                 client['type'] = "kernel"
                 client['version'] = client['client_metadata']['kernel_version']
                 client['hostname'] = client['client_metadata']['hostname']
+                client['root'] = client['client_metadata']['root']
             else:
                 client['type'] = "unknown"
                 client['version'] = ""


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49084

---

backport of https://github.com/ceph/ceph/pull/36518
parent tracker: https://tracker.ceph.com/issues/48062

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh