### PR TITLE
pacific: mgr/dashboard: Fix missing root path of each session for CephFS

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -303,10 +303,12 @@ class CephFS(RESTController):
                 client['type'] = "userspace"
                 client['version'] = client['client_metadata']['ceph_version']
                 client['hostname'] = client['client_metadata']['hostname']
+                client['root'] = client['client_metadata']['root']
             elif "kernel_version" in client['client_metadata']:  # pragma: no cover - no complexity
                 client['type'] = "kernel"
                 client['version'] = client['client_metadata']['kernel_version']
                 client['hostname'] = client['client_metadata']['hostname']
+                client['root'] = client['client_metadata']['root']
             else:  # pragma: no cover - no complexity there
                 client['type'] = "unknown"
                 client['version'] = ""


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49085

---

backport of https://github.com/ceph/ceph/pull/36518
parent tracker: https://tracker.ceph.com/issues/48062

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh