### PR TITLE
octopus: mgr/dashboard: add ssl verify option for prometheus and alert manager

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -719,6 +719,19 @@ in order to manage silences.
   should not disturb each other through annoying duplicated notifications
   popping up.
 
+If you are using a self-signed certificate in your Prometheus or your
+Alertmanager setup, you should disable certificate verification in the
+dashboard to avoid refused connections, e.g. caused by certificates signed by
+unknown CA or not matching the host name.
+
+- For Prometheus::
+
+  $ ceph dashboard set-prometheus-api-ssl-verify False
+
+- For Alertmanager::
+
+  $ ceph dashboard set-alertmanager-api-ssl-verify False
+
 .. _dashboard-user-role-management:
 
 User and Role Management

--- a/src/pybind/mgr/dashboard/controllers/prometheus.py
+++ b/src/pybind/mgr/dashboard/controllers/prometheus.py
@@ -29,20 +29,23 @@ class PrometheusRESTController(RESTController):
     def prometheus_proxy(self, method, path, params=None, payload=None):
         # type (str, str, dict, dict)
         return self._proxy(self._get_api_url(Settings.PROMETHEUS_API_HOST),
-                           method, path, 'Prometheus', params, payload)
+                           method, path, 'Prometheus', params, payload,
+                           verify=Settings.PROMETHEUS_API_SSL_VERIFY)
 
     def alert_proxy(self, method, path, params=None, payload=None):
         # type (str, str, dict, dict)
         return self._proxy(self._get_api_url(Settings.ALERTMANAGER_API_HOST),
-                           method, path, 'Alertmanager', params, payload)
+                           method, path, 'Alertmanager', params, payload,
+                           verify=Settings.ALERTMANAGER_API_SSL_VERIFY)
 
     def _get_api_url(self, host):
         return host.rstrip('/') + '/api/v1'
 
-    def _proxy(self, base_url, method, path, api_name, params=None, payload=None):
-        # type (str, str, str, str, dict, dict)
+    def _proxy(self, base_url, method, path, api_name, params=None, payload=None, verify=True):
+        # type (str, str, str, str, dict, dict, bool)
         try:
-            response = requests.request(method, base_url + path, params=params, json=payload)
+            response = requests.request(method, base_url + path, params=params,
+                                        json=payload, verify=verify)
         except Exception:
             raise DashboardException(
                 "Could not reach {}'s API on {}".format(api_name, base_url),

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -51,7 +51,9 @@ class Options(object):
 
     # Prometheus settings
     PROMETHEUS_API_HOST = ('', str)
+    PROMETHEUS_API_SSL_VERIFY = (True, bool)
     ALERTMANAGER_API_HOST = ('', str)
+    ALERTMANAGER_API_SSL_VERIFY = (True, bool)
 
     # iSCSI management settings
     ISCSI_API_SSL_VERIFICATION = (True, bool)

--- a/src/pybind/mgr/dashboard/tests/test_prometheus.py
+++ b/src/pybind/mgr/dashboard/tests/test_prometheus.py
@@ -32,37 +32,39 @@ class PrometheusControllerTest(ControllerTestCase):
         with patch('requests.request') as mock_request:
             self._get('/api/prometheus/rules')
             mock_request.assert_called_with('GET', self.prometheus_host_api + '/rules',
-                                            json=None, params={})
+                                            json=None, params={}, verify=True)
 
     def test_list(self):
         with patch('requests.request') as mock_request:
             self._get('/api/prometheus')
             mock_request.assert_called_with('GET', self.alert_host_api + '/alerts',
-                                            json=None, params={})
+                                            json=None, params={}, verify=True)
 
     def test_get_silences(self):
         with patch('requests.request') as mock_request:
             self._get('/api/prometheus/silences')
             mock_request.assert_called_with('GET', self.alert_host_api + '/silences',
-                                            json=None, params={})
+                                            json=None, params={}, verify=True)
 
     def test_add_silence(self):
         with patch('requests.request') as mock_request:
             self._post('/api/prometheus/silence', {'id': 'new-silence'})
             mock_request.assert_called_with('POST', self.alert_host_api + '/silences',
-                                            params=None, json={'id': 'new-silence'})
+                                            params=None, json={'id': 'new-silence'},
+                                            verify=True)
 
     def test_update_silence(self):
         with patch('requests.request') as mock_request:
             self._post('/api/prometheus/silence', {'id': 'update-silence'})
             mock_request.assert_called_with('POST', self.alert_host_api + '/silences',
-                                            params=None, json={'id': 'update-silence'})
+                                            params=None, json={'id': 'update-silence'},
+                                            verify=True)
 
     def test_expire_silence(self):
         with patch('requests.request') as mock_request:
             self._delete('/api/prometheus/silence/0')
             mock_request.assert_called_with('DELETE', self.alert_host_api + '/silence/0',
-                                            json=None, params=None)
+                                            json=None, params=None, verify=True)
 
     def test_silences_empty_delete(self):
         with patch('requests.request') as mock_request:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48190

---

backport of https://github.com/ceph/ceph/pull/37641
parent tracker: https://tracker.ceph.com/issues/47863

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh