### PR TITLE
mgr/cephadm: simplify handling for rgw

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -268,3 +268,12 @@
 * ``ceph pg #.# list_unfound`` output has been enhanced to provide
   might_have_unfound information which indicates which OSDs may
   contain the unfound objects.
+
+* The ``ceph orch apply rgw`` syntax and behavior have changed.  RGW
+  services can now be arbitrarily named (it is no longer forced to be
+  `realm.zone`).  The ``--rgw-realm=...`` and ``--rgw-zone=...``
+  arguments are now optional, which means that if they are omitted, a
+  vanilla single-cluster RGW will be deployed.  When the realm and
+  zone are provided, the user is now responsible for setting up the
+  multisite configuration beforehand--cephadm no longer attempts to
+  create missing realms or zones.

--- a/doc/cephadm/adoption.rst
+++ b/doc/cephadm/adoption.rst
@@ -181,10 +181,11 @@ Adoption process
 
    .. prompt:: bash #
 
-      ceph orch apply rgw <realm> <zone> [--subcluster=<subcluster>] [--port=<port>] [--ssl] [--placement=<placement>]
+      ceph orch apply rgw <svc_id> [--rgw-realm=<realm>] [--rgw-zone=<zone>] [--port=<port>] [--ssl] [--placement=<placement>]
 
    where *<placement>* can be a simple daemon count, or a list of
-   specific hosts (see :ref:`orchestrator-cli-placement-spec`).
+   specific hosts (see :ref:`orchestrator-cli-placement-spec`), and the
+   zone and realm arguments are needed only for a multisite setup.
 
    After the daemons have started and you have confirmed that they are
    functioning, stop and remove the old, legacy daemons:
@@ -193,9 +194,6 @@ Adoption process
 
       systemctl stop ceph-rgw.target
       rm -rf /var/lib/ceph/radosgw/ceph-*
-
-   To learn more about adopting single-site systems without a realm, see
-   :ref:`rgw-multisite-migrate-from-single-site`.
 
 #. Check the output of the command ``ceph health detail`` for cephadm warnings
    about stray cluster daemons or hosts that are not yet managed by cephadm.

--- a/doc/cephadm/rgw.rst
+++ b/doc/cephadm/rgw.rst
@@ -8,32 +8,41 @@ Deploy RGWs
 ===========
 
 Cephadm deploys radosgw as a collection of daemons that manage a
-particular *realm* and *zone*.  (For more information about realms and
-zones, see :ref:`multisite`.)
+single-cluster deployment or a particular *realm* and *zone* in a
+multisite deployment.  (For more information about realms and zones,
+see :ref:`multisite`.)
 
 Note that with cephadm, radosgw daemons are configured via the monitor
 configuration database instead of via a `ceph.conf` or the command line.  If
 that configuration isn't already in place (usually in the
-``client.rgw.<realmname>.<zonename>`` section), then the radosgw
+``client.rgw.<something>`` section), then the radosgw
 daemons will start up with default settings (e.g., binding to port
 80).
 
-To deploy a set of radosgw daemons for a particular realm and zone, run the
-following command:
+To deploy a set of radosgw daemons, with an arbitrary service name
+*name*, run the following command:
 
 .. prompt:: bash #
 
-  ceph orch apply rgw *<realm-name>* *<zone-name>* --placement="*<num-daemons>* [*<host1>* ...]"
+  ceph orch apply rgw *<name>* [--rgw-realm=*<realm-name>*] [--rgw-zone=*<zone-name>*] --placement="*<num-daemons>* [*<host1>* ...]"
 
-For example, to deploy 2 rgw daemons serving the *myorg* realm and the *us-east-1* zone on *myhost1* and *myhost2*:
+For example, to deploy 2 RGW daemons (the default) for a single-cluster RGW deployment
+under the arbitrary service id *foo*:
 
 .. prompt:: bash #
 
-   ceph orch apply rgw myorg us-east-1 --placement="2 myhost1 myhost2"
+   ceph orch apply rgw foo
 
-Cephadm will wait for a healthy cluster and automatically create the supplied realm and zone if they do not exist before deploying the rgw daemon(s)
+To deploy RGWs serving the multisite *myorg* realm and the *us-east-1* zone on
+*myhost1* and *myhost2*:
 
-Alternatively, the realm, zonegroup, and zone can be manually created using ``radosgw-admin`` commands:
+.. prompt:: bash #
+
+   ceph orch apply rgw east --rgw-realm=myorg --rgw-zone=us-east-1 --placement="2 myhost1 myhost2"
+
+Note that in a multisite situation, cephadm only deploys the daemons.  It does not create
+or update the realm or zone configurations.  To create a new realm and zone, you need to do
+something like:
 
 .. prompt:: bash #
 
@@ -52,7 +61,7 @@ Alternatively, the realm, zonegroup, and zone can be manually created using ``ra
   radosgw-admin period update --rgw-realm=<realm-name> --commit
 
 See :ref:`orchestrator-cli-placement-spec` for details of the placement
-specification.
+specification.  See :ref:`multisite` for more information of setting up multisite RGW.
 
 
 .. _orchestrator-haproxy-service-spec:

--- a/doc/mgr/orchestrator.rst
+++ b/doc/mgr/orchestrator.rst
@@ -103,7 +103,7 @@ The ``name`` parameter is an identifier of the group of instances:
 Creating/growing/shrinking/removing services::
 
     ceph orch apply mds <fs_name> [--placement=<placement>] [--dry-run]
-    ceph orch apply rgw <realm> <zone> [--subcluster=<subcluster>] [--port=<port>] [--ssl] [--placement=<placement>] [--dry-run]
+    ceph orch apply rgw <name> [--rgw-realm=<realm>] [--rgw-zone=<zone>] [--port=<port>] [--ssl] [--placement=<placement>] [--dry-run]
     ceph orch apply nfs <name> <pool> [--namespace=<namespace>] [--placement=<placement>] [--dry-run]
     ceph orch rm <service_name> [--force]
 
@@ -157,7 +157,7 @@ This is an overview of the current implementation status of the orchestrators.
  apply nfs                           ✔      ✔
  apply osd                           ✔      ✔
  apply rbd-mirror                    ✔      ✔
- apply rgw                           ⚪      ✔
+ apply rgw                           ✔      ✔
  apply container                     ⚪      ✔
  host add                            ⚪      ✔
  host ls                             ✔      ✔

--- a/qa/suites/rados/cephadm/smoke/fixed-2.yaml
+++ b/qa/suites/rados/cephadm/smoke/fixed-2.yaml
@@ -7,7 +7,7 @@ roles:
   - osd.2
   - osd.3
   - client.0
-  - ceph.rgw.realm.zone.a
+  - ceph.rgw.foo.a
   - node-exporter.a
   - alertmanager.a
 - - mon.b

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -732,30 +732,15 @@ def ceph_rgw(ctx, config):
                     if teuthology.is_type('rgw', cluster_name)(r)]:
             c_, _, id_ = teuthology.split_role(role)
             log.info('Adding %s on %s' % (role, remote.shortname))
-            realmzone = '.'.join(id_.split('.')[0:2])
-            if realmzone not in nodes:
-                nodes[realmzone] = []
-            nodes[realmzone].append(remote.shortname + '=' + id_)
+            svc = '.'.join(id_.split('.')[0:2])
+            if svc not in nodes:
+                nodes[svc] = []
+            nodes[svc].append(remote.shortname + '=' + id_)
             daemons[role] = (remote, id_)
 
-    for realmzone in nodes.keys():
-        (realm, zone) = realmzone.split('.', 1)
-
-        # TODO: those should be moved to mgr/cephadm
-        _shell(ctx, cluster_name, remote,
-               ['radosgw-admin', 'realm', 'create', '--rgw-realm', realm, '--default']
-        )
-        _shell(ctx, cluster_name, remote,
-               ['radosgw-admin', 'zonegroup', 'create', '--rgw-zonegroup=default', '--master', '--default']
-        )
-        _shell(ctx, cluster_name, remote,
-               ['radosgw-admin', 'zone', 'create', '--rgw-zonegroup=default', '--rgw-zone', zone,  '--master', '--default']
-        )
-
-    for realmzone, nodes in nodes.items():
-        (realm, zone) = realmzone.split('.', 1)
+    for svc, nodes in nodes.items():
         _shell(ctx, cluster_name, remote, [
-            'ceph', 'orch', 'apply', 'rgw', realm, zone,
+            'ceph', 'orch', 'apply', 'rgw', svc,
              '--placement',
              str(len(nodes)) + ';' + ';'.join(nodes)]
         )

--- a/src/cephadm/vstart-smoke.sh
+++ b/src/cephadm/vstart-smoke.sh
@@ -64,7 +64,7 @@ bin/ceph orch apply grafana 1
 
 while ! bin/ceph dashboard get-grafana-api-url | grep $host ; do sleep 1 ; done
 
-bin/ceph orch apply rgw myrealm myzone 1
+bin/ceph orch apply rgw foo --placement=1
 
 bin/ceph orch ps
 bin/ceph orch ls

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -2,7 +2,6 @@ import errno
 import json
 import re
 import logging
-import subprocess
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, List, Callable, TypeVar, \
     Optional, Dict, Any, Tuple, NewType
@@ -662,9 +661,6 @@ class RgwService(CephService):
     def config(self, spec: RGWSpec, rgw_id: str) -> None:  # type: ignore
         assert self.TYPE == spec.service_type
 
-        # create realm, zonegroup, and zone if needed
-        self.create_realm_zonegroup_zone(spec, rgw_id)
-
         # ensure rgw_realm and rgw_zone is set for these daemons
         ret, out, err = self.mgr.check_mon_command({
             'prefix': 'config set',
@@ -741,134 +737,6 @@ class RgwService(CephService):
                      'osd', 'allow rwx tag rgw *=*'],
         })
         return keyring
-
-    def create_realm_zonegroup_zone(self, spec: RGWSpec, rgw_id: str) -> None:
-        if utils.get_cluster_health(self.mgr) != 'HEALTH_OK':
-            raise OrchestratorError('Health not ok, will try again when health ok')
-
-        # get keyring needed to run rados commands and strip out just the keyring
-        keyring = self.get_keyring(rgw_id).split('key = ', 1)[1].rstrip()
-
-        # We can call radosgw-admin within the container, cause cephadm gives the MGR the required keyring permissions
-
-        def get_realms() -> List[str]:
-            cmd = ['radosgw-admin',
-                   '--key=%s' % keyring,
-                   '--user', 'rgw.%s' % rgw_id,
-                   'realm', 'list',
-                   '--format=json']
-            result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            out = result.stdout
-            if not out:
-                return []
-            try:
-                j = json.loads(out)
-                return j.get('realms', [])
-            except Exception:
-                raise OrchestratorError('failed to parse realm info')
-
-        def create_realm() -> None:
-            cmd = ['radosgw-admin',
-                   '--key=%s' % keyring,
-                   '--user', 'rgw.%s' % rgw_id,
-                   'realm', 'create',
-                   '--rgw-realm=%s' % spec.rgw_realm,
-                   '--default']
-            result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            if result.returncode:
-                err = 'failed to create RGW realm "%s": %r' % (spec.rgw_realm, result.stderr)
-                raise OrchestratorError(err)
-            self.mgr.log.info('created realm: %s' % spec.rgw_realm)
-
-        def get_zonegroups() -> List[str]:
-            cmd = ['radosgw-admin',
-                   '--key=%s' % keyring,
-                   '--user', 'rgw.%s' % rgw_id,
-                   'zonegroup', 'list',
-                   '--format=json']
-            result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            out = result.stdout
-            if not out:
-                return []
-            try:
-                j = json.loads(out)
-                return j.get('zonegroups', [])
-            except Exception:
-                raise OrchestratorError('failed to parse zonegroup info')
-
-        def create_zonegroup() -> None:
-            cmd = ['radosgw-admin',
-                   '--key=%s' % keyring,
-                   '--user', 'rgw.%s' % rgw_id,
-                   'zonegroup', 'create',
-                   '--rgw-zonegroup=default',
-                   '--master', '--default']
-            result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            if result.returncode:
-                err = 'failed to create RGW zonegroup "%s": %r' % ('default', result.stderr)
-                raise OrchestratorError(err)
-            self.mgr.log.info('created zonegroup: default')
-
-        def create_zonegroup_if_required() -> None:
-            zonegroups = get_zonegroups()
-            if 'default' not in zonegroups:
-                create_zonegroup()
-
-        def get_zones() -> List[str]:
-            cmd = ['radosgw-admin',
-                   '--key=%s' % keyring,
-                   '--user', 'rgw.%s' % rgw_id,
-                   'zone', 'list',
-                   '--format=json']
-            result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            out = result.stdout
-            if not out:
-                return []
-            try:
-                j = json.loads(out)
-                return j.get('zones', [])
-            except Exception:
-                raise OrchestratorError('failed to parse zone info')
-
-        def create_zone() -> None:
-            cmd = ['radosgw-admin',
-                   '--key=%s' % keyring,
-                   '--user', 'rgw.%s' % rgw_id,
-                   'zone', 'create',
-                   '--rgw-zonegroup=default',
-                   '--rgw-zone=%s' % spec.rgw_zone,
-                   '--master', '--default']
-            result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            if result.returncode:
-                err = 'failed to create RGW zone "%s": %r' % (spec.rgw_zone, result.stderr)
-                raise OrchestratorError(err)
-            self.mgr.log.info('created zone: %s' % spec.rgw_zone)
-
-        changes = False
-        realms = get_realms()
-        if spec.rgw_realm not in realms:
-            create_realm()
-            changes = True
-
-        zones = get_zones()
-        if spec.rgw_zone not in zones:
-            create_zonegroup_if_required()
-            create_zone()
-            changes = True
-
-        # update period if changes were made
-        if changes:
-            cmd = ['radosgw-admin',
-                   '--key=%s' % keyring,
-                   '--user', 'rgw.%s' % rgw_id,
-                   'period', 'update',
-                   '--rgw-realm=%s' % spec.rgw_realm,
-                   '--commit']
-            result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            if result.returncode:
-                err = 'failed to update RGW period: %r' % (result.stderr)
-                raise OrchestratorError(err)
-            self.mgr.log.info('updated period')
 
     def ok_to_stop(
             self,

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -661,19 +661,22 @@ class RgwService(CephService):
     def config(self, spec: RGWSpec, rgw_id: str) -> None:  # type: ignore
         assert self.TYPE == spec.service_type
 
-        # ensure rgw_realm and rgw_zone is set for these daemons
-        ret, out, err = self.mgr.check_mon_command({
-            'prefix': 'config set',
-            'who': f"{utils.name_to_config_section('rgw')}.{spec.service_id}",
-            'name': 'rgw_zone',
-            'value': spec.rgw_zone,
-        })
-        ret, out, err = self.mgr.check_mon_command({
-            'prefix': 'config set',
-            'who': f"{utils.name_to_config_section('rgw')}.{spec.rgw_realm}",
-            'name': 'rgw_realm',
-            'value': spec.rgw_realm,
-        })
+        # set rgw_realm and rgw_zone, if present
+        if spec.rgw_realm:
+            ret, out, err = self.mgr.check_mon_command({
+                'prefix': 'config set',
+                'who': f"{utils.name_to_config_section('rgw')}.{spec.service_id}",
+                'name': 'rgw_realm',
+                'value': spec.rgw_realm,
+            })
+        if spec.rgw_zone:
+            ret, out, err = self.mgr.check_mon_command({
+                'prefix': 'config set',
+                'who': f"{utils.name_to_config_section('rgw')}.{spec.service_id}",
+                'name': 'rgw_zone',
+                'value': spec.rgw_zone,
+            })
+
         ret, out, err = self.mgr.check_mon_command({
             'prefix': 'config set',
             'who': f"{utils.name_to_config_section('rgw')}.{spec.service_id}",

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -702,6 +702,7 @@ class TestCephadm(object):
             (ServiceSpec('alertmanager'), CephadmOrchestrator.add_alertmanager),
             (ServiceSpec('rbd-mirror'), CephadmOrchestrator.add_rbd_mirror),
             (ServiceSpec('mds', service_id='fsname'), CephadmOrchestrator.add_mds),
+            (RGWSpec(rgw_realm='realm', rgw_zone='zone'), CephadmOrchestrator.add_rgw),
             (RGWSpec(service_id="foo"), CephadmOrchestrator.add_rgw),
             (ServiceSpec('cephadm-exporter'), CephadmOrchestrator.add_cephadm_exporter),
         ]

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -101,7 +101,6 @@ class TestCephadm(object):
         assert wait(cephadm_module, cephadm_module.get_hosts()) == []
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
-    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __, ___: None)
     def test_service_ls(self, cephadm_module):
         with with_host(cephadm_module, 'test'):
             c = cephadm_module.list_daemons(refresh=True)
@@ -185,7 +184,6 @@ class TestCephadm(object):
             assert wait(cephadm_module, c)[0].name() == 'rgw.myrgw.foobar'
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
-    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __, ___: None)
     def test_daemon_action(self, cephadm_module: CephadmOrchestrator):
         cephadm_module.service_cache_timeout = 10
         with with_host(cephadm_module, 'test'):
@@ -211,7 +209,6 @@ class TestCephadm(object):
                 CephadmServe(cephadm_module)._check_daemons()
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
-    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __, ___: None)
     def test_daemon_action_fail(self, cephadm_module: CephadmOrchestrator):
         cephadm_module.service_cache_timeout = 10
         with with_host(cephadm_module, 'test'):
@@ -660,7 +657,6 @@ class TestCephadm(object):
             assert out == []
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
-    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __, ___: None)
     def test_rgw_update(self, cephadm_module):
         with with_host(cephadm_module, 'host1'):
             with with_host(cephadm_module, 'host2'):
@@ -716,7 +712,6 @@ class TestCephadm(object):
     )
     @mock.patch("cephadm.serve.CephadmServe._deploy_cephadm_binary", _deploy_cephadm_binary('test'))
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
-    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __, ___: None)
     def test_daemon_add(self, spec: ServiceSpec, meth, cephadm_module):
         unmanaged_spec = ServiceSpec.from_json(spec.to_json())
         unmanaged_spec.unmanaged = True
@@ -901,7 +896,6 @@ class TestCephadm(object):
     )
     @mock.patch("cephadm.serve.CephadmServe._deploy_cephadm_binary", _deploy_cephadm_binary('test'))
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
-    @mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __, ___: None)
     def test_apply_save(self, spec: ServiceSpec, meth, cephadm_module: CephadmOrchestrator):
         with with_host(cephadm_module, 'test'):
             with with_service(cephadm_module, spec, meth, 'test'):

--- a/src/pybind/mgr/cephadm/tests/test_migration.py
+++ b/src/pybind/mgr/cephadm/tests/test_migration.py
@@ -10,7 +10,6 @@ from tests import mock
 
 
 @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('[]'))
-@mock.patch("cephadm.services.cephadmservice.RgwService.create_realm_zonegroup_zone", lambda _, __, ___: None)
 def test_migrate_scheduler(cephadm_module: CephadmOrchestrator):
     with with_host(cephadm_module, 'host1', refresh_hosts=False):
         with with_host(cephadm_module, 'host2', refresh_hosts=False):

--- a/src/pybind/mgr/cephadm/tests/test_spec.py
+++ b/src/pybind/mgr/cephadm/tests/test_spec.py
@@ -72,8 +72,7 @@ from orchestrator import DaemonDescription, OrchestratorError
   "service_type": "rgw",
   "service_id": "default-rgw-realm.eu-central-1.1",
   "rgw_realm": "default-rgw-realm",
-  "rgw_zone": "eu-central-1",
-  "subcluster": "1"
+  "rgw_zone": "eu-central-1"
 },
 {
   "service_type": "osd",
@@ -296,40 +295,38 @@ def test_dd_octopus(dd_json):
     # https://tracker.ceph.com/issues/44934
     (
         RGWSpec(
+            service_id="foo",
             rgw_realm="default-rgw-realm",
             rgw_zone="eu-central-1",
-            subcluster='1',
         ),
         DaemonDescription(
             daemon_type='rgw',
-            daemon_id="default-rgw-realm.eu-central-1.1.ceph-001.ytywjo",
+            daemon_id="foo.ceph-001.ytywjo",
             hostname="ceph-001",
         ),
         True
     ),
     (
-        # no subcluster
+        # no realm
         RGWSpec(
-            rgw_realm="default-rgw-realm",
+            service_id="foo.bar",
             rgw_zone="eu-central-1",
         ),
         DaemonDescription(
             daemon_type='rgw',
-            daemon_id="default-rgw-realm.eu-central-1.ceph-001.ytywjo",
+            daemon_id="foo.bar.ceph-001.ytywjo",
             hostname="ceph-001",
         ),
         True
     ),
     (
-        # with tld
+        # no realm or zone
         RGWSpec(
-            rgw_realm="default-rgw-realm",
-            rgw_zone="eu-central-1",
-            subcluster='1',
+            service_id="bar",
         ),
         DaemonDescription(
             daemon_type='rgw',
-            daemon_id="default-rgw-realm.eu-central-1.1.host.domain.tld.ytywjo",
+            daemon_id="bar.host.domain.tld.ytywjo",
             hostname="host.domain.tld",
         ),
         True
@@ -337,8 +334,7 @@ def test_dd_octopus(dd_json):
     (
         # explicit naming
         RGWSpec(
-            rgw_realm="realm",
-            rgw_zone="zone",
+            service_id="realm.zone",
         ),
         DaemonDescription(
             daemon_type='rgw',
@@ -351,9 +347,20 @@ def test_dd_octopus(dd_json):
         # without host
         RGWSpec(
             service_type='rgw',
-            rgw_realm="default-rgw-realm",
-            rgw_zone="eu-central-1",
-            subcluster='1',
+            service_id="foo",
+        ),
+        DaemonDescription(
+            daemon_type='rgw',
+            daemon_id="foo.hostname.ytywjo",
+            hostname=None,
+        ),
+        False
+    ),
+    (
+        # without host (2)
+        RGWSpec(
+            service_type='rgw',
+            service_id="default-rgw-realm.eu-central-1.1",
         ),
         DaemonDescription(
             daemon_type='rgw',
@@ -363,16 +370,14 @@ def test_dd_octopus(dd_json):
         False
     ),
     (
-        # zone contains hostname
-        # https://tracker.ceph.com/issues/45294
+        # service_id contains hostname
+        # (sort of) https://tracker.ceph.com/issues/45294
         RGWSpec(
-            rgw_realm="default.rgw.realm",
-            rgw_zone="ceph.001",
-            subcluster='1',
+            service_id="default.rgw.realm.ceph.001",
         ),
         DaemonDescription(
             daemon_type='rgw',
-            daemon_id="default.rgw.realm.ceph.001.1.ceph.001.ytywjo",
+            daemon_id="default.rgw.realm.ceph.001.ceph.001.ytywjo",
             hostname="ceph.001",
         ),
         True

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -906,9 +906,7 @@ Usage:
 
     @_cli_write_command('orch daemon add rgw')
     def _rgw_add(self,
-                 realm_name: str,
-                 zone_name: str,
-                 subcluster: Optional[str] = None,
+                 svc_id: str,
                  port: Optional[int] = None,
                  ssl: bool = False,
                  placement: Optional[str] = None,
@@ -918,9 +916,7 @@ Usage:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
         spec = RGWSpec(
-            rgw_realm=realm_name,
-            rgw_zone=zone_name,
-            subcluster=subcluster,
+            service_id=svc_id,
             rgw_frontend_port=port,
             ssl=ssl,
             placement=PlacementSpec.from_string(placement),
@@ -1096,9 +1092,9 @@ Usage:
 
     @_cli_write_command('orch apply rgw')
     def _apply_rgw(self,
-                   realm_name: str,
-                   zone_name: str,
-                   subcluster: Optional[str] = None,
+                   svc_id: str,
+                   realm_name: Optional[str] = None,
+                   zone_name: Optional[str] = None,
                    port: Optional[int] = None,
                    ssl: bool = False,
                    placement: Optional[str] = None,
@@ -1111,9 +1107,9 @@ Usage:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
         spec = RGWSpec(
+            service_id=svc_id,
             rgw_realm=realm_name,
             rgw_zone=zone_name,
-            subcluster=subcluster,
             rgw_frontend_port=port,
             ssl=ssl,
             placement=PlacementSpec.from_string(placement),

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -426,15 +426,19 @@ class RookCluster(object):
             _update_fs, _create_fs)
 
     def apply_objectstore(self, spec: RGWSpec) -> str:
-
-        # FIXME: service_id is $realm.$zone, but rook uses realm
-        # $crname and zone $crname.  The '.'  will confuse kubernetes.
-        # For now, assert that realm==zone.
         assert spec.service_id is not None
-        (realm, zone) = spec.service_id.split('.', 1)
-        assert realm == zone
-        assert spec.subcluster is None
-        name = realm
+
+        name = spec.service_id
+
+        if '.' in spec.service_id:
+            # rook does not like . in the name.  this is could
+            # there because it is a legacy rgw spec that was named
+            # like $realm.$zone, except that I doubt there were any
+            # users of this code.  Instead, focus on future users and
+            # translate . to - (fingers crossed!) instead.
+            name = spec.service_id.replace('.', '-')
+
+        # FIXME: pass realm and/or zone through to the CR
 
         def _create_zone() -> cos.CephObjectStore:
             port = None

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -664,6 +664,7 @@ class RGWSpec(ServiceSpec):
                  ssl: bool = False,
                  preview_only: bool = False,
                  config: Optional[Dict[str, str]] = None,
+                 subcluster: Optional[str] = None,  # legacy, only for from_json on upgrade
                  ):
         assert service_type == 'rgw', service_type
         super(RGWSpec, self).__init__(

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -657,7 +657,6 @@ class RGWSpec(ServiceSpec):
                  placement: Optional[PlacementSpec] = None,
                  rgw_realm: Optional[str] = None,
                  rgw_zone: Optional[str] = None,
-                 subcluster: Optional[str] = None,
                  rgw_frontend_port: Optional[int] = None,
                  rgw_frontend_ssl_certificate: Optional[List[str]] = None,
                  rgw_frontend_ssl_key: Optional[List[str]] = None,
@@ -667,18 +666,6 @@ class RGWSpec(ServiceSpec):
                  config: Optional[Dict[str, str]] = None,
                  ):
         assert service_type == 'rgw', service_type
-        if service_id:
-            a = service_id.split('.', 2)
-            rgw_realm = a[0]
-            if len(a) > 1:
-                rgw_zone = a[1]
-            if len(a) > 2:
-                subcluster = a[2]
-        else:
-            if subcluster:
-                service_id = '%s.%s.%s' % (rgw_realm, rgw_zone, subcluster)
-            else:
-                service_id = '%s.%s' % (rgw_realm, rgw_zone)
         super(RGWSpec, self).__init__(
             'rgw', service_id=service_id,
             placement=placement, unmanaged=unmanaged,
@@ -686,7 +673,6 @@ class RGWSpec(ServiceSpec):
 
         self.rgw_realm = rgw_realm
         self.rgw_zone = rgw_zone
-        self.subcluster = subcluster
         self.rgw_frontend_port = rgw_frontend_port
         self.rgw_frontend_ssl_certificate = rgw_frontend_ssl_certificate
         self.rgw_frontend_ssl_key = rgw_frontend_ssl_key
@@ -709,16 +695,6 @@ class RGWSpec(ServiceSpec):
         else:
             ports.append(f"port={self.get_port()}")
         return f'beast {" ".join(ports)}'
-
-    def validate(self) -> None:
-        super(RGWSpec, self).validate()
-
-        if not self.rgw_realm:
-            raise ServiceSpecValidationError(
-                'Cannot add RGW: No realm specified')
-        if not self.rgw_zone:
-            raise ServiceSpecValidationError(
-                'Cannot add RGW: No zone specified')
 
 
 yaml.add_representer(RGWSpec, ServiceSpec.yaml_representer)

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -667,6 +667,11 @@ class RGWSpec(ServiceSpec):
                  subcluster: Optional[str] = None,  # legacy, only for from_json on upgrade
                  ):
         assert service_type == 'rgw', service_type
+
+        # for backward compatibility with octopus spec files,
+        if not service_id and (rgw_realm and rgw_zone):
+            service_id = rgw_realm + '.' + rgw_zone
+
         super(RGWSpec, self).__init__(
             'rgw', service_id=service_id,
             placement=placement, unmanaged=unmanaged,

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -161,7 +161,6 @@ placement:
 spec:
   rgw_realm: default-rgw-realm
   rgw_zone: eu-central-1
-  subcluster: '1'
 ---
 service_type: osd
 service_id: osd_spec_default
@@ -236,9 +235,10 @@ spec:
                              ),
                              (
                                      ServiceSpec(
-                                         service_type='rgw'
+                                         service_type='rgw',
+                                         service_id='foo',
                                      ),
-                                     RGWSpec(),
+                                     RGWSpec(service_id='foo'),
                                      True
                              ),
                          ])


### PR DESCRIPTION
- radosgw-admin fiddling with zone/realm config is out of scope
- remove naming constraints
- keep the --rgw-zone= and --rgw-realm= arguments, but make them optional.  if omitted, we'll get the simple non-multisite rgw behavior with autocreated pools etc.
- update rook to match

Existing octopus deployments will continue to work: they follow the old naming convention, and we're just allowing new specs to deviate from that convention.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>