### PR TITLE
crimson/osd: implement timeout for notify propagation.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3463,7 +3463,7 @@ std::vector<Option> get_global_options() {
 
     Option("osd_default_notify_timeout", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(30)
-    .set_description(""),
+    .set_description("default number of seconds after which notify propagation times out. used if a client has not specified other value"),
 
     Option("osd_kill_backfill_at", Option::TYPE_INT, Option::LEVEL_DEV)
     .set_default(0)

--- a/src/crimson/osd/watch.h
+++ b/src/crimson/osd/watch.h
@@ -89,6 +89,7 @@ public:
   uint64_t get_cookie() const {
     return winfo.cookie;
   }
+  void cancel_notify(const uint64_t notify_id);
 };
 
 using WatchRef = seastar::shared_ptr<Watch>;
@@ -116,12 +117,21 @@ class Notify {
   uint64_t user_version;
   bool complete = false;
   bool discarded = false;
+  seastar::timer<seastar::lowres_clock> timeout_timer{
+    [this] { do_timeout(); }
+  };
 
   /// (gid,cookie) -> reply_bl for everyone who acked the notify
   std::multiset<notify_reply_t> notify_replies;
 
   uint64_t get_id() const { return ninfo.notify_id; }
-  seastar::future<> maybe_send_completion();
+
+  /// Sends notify completion if watchers.empty() or timeout
+  seastar::future<> maybe_send_completion(
+    std::set<WatchRef> timedout_watchers = {});
+
+  /// Called on Notify timeout
+  void do_timeout();
 
   template <class WatchIteratorT>
   Notify(WatchIteratorT begin,
@@ -166,6 +176,9 @@ Notify::Notify(WatchIteratorT begin,
     conn(std::move(conn)),
     client_gid(client_gid),
     user_version(user_version) {
+  if (ninfo.timeout) {
+    timeout_timer.arm(std::chrono::seconds{ninfo.timeout});
+  }
 }
 
 template <class WatchIteratorT, class... Args>

--- a/src/crimson/osd/watch.h
+++ b/src/crimson/osd/watch.h
@@ -115,8 +115,8 @@ class Notify {
   crimson::net::ConnectionRef conn;
   uint64_t client_gid;
   uint64_t user_version;
-  bool complete = false;
-  bool discarded = false;
+  bool complete{false};
+  bool discarded{false};
   seastar::timer<seastar::lowres_clock> timeout_timer{
     [this] { do_timeout(); }
   };


### PR DESCRIPTION
This missed feature was the root cause of the following failure at Sepia:

```
2021-03-04T15:40:03.013 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: [ RUN      ] LibRadosWatchNotify.WatchNotify2Timeout
2021-03-04T15:40:03.013 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: watch_notify2_test_cb from 4394 notify_id 120259084288 cookie 94023196911472
2021-03-04T15:40:03.013 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: /home/jenkins-build/build/workspace/ceph-dev-new-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/17.0.0-1471-g8bd81c29/rpm/el8/BUILD/ceph-17.0.0-1471-g8bd81c29/src/test/librados/watch_notify.cc:425: Failure
2021-03-04T15:40:03.014 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: Expected equality of these values:
2021-03-04T15:40:03.015 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify:   -110
2021-03-04T15:40:03.015 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify:   rados_notify2(ioctx, notify_oid, "notify", 6, 1000, &reply_buf, &reply_buf_len)
2021-03-04T15:40:03.015 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify:     Which is: 0
2021-03-04T15:40:03.016 INFO:tasks.workunit.client.0.smithi058.stdout:         api_watch_notify: [  FAILED  ] LibRadosWatchNotify.WatchNotify2Timeout (3020 ms)
```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
