### PR TITLE
osd/Watch: use vector<> instead of list<>

### DIFF
--- a/src/osd/Watch.cc
+++ b/src/osd/Watch.cc
@@ -193,10 +193,11 @@ void Notify::maybe_complete_notify()
     // prepare reply
     bufferlist bl;
     encode(notify_replies, bl);
-    list<pair<uint64_t,uint64_t> > missed;
-    for (auto p = watchers.begin(); p != watchers.end(); ++p) {
-      missed.push_back(make_pair((*p)->get_watcher_gid(),
-				 (*p)->get_cookie()));
+    vector<pair<uint64_t,uint64_t>> missed;
+    missed.reserve(watchers.size());
+    for (auto& watcher : watchers) {
+      missed.emplace_back(watcher->get_watcher_gid(),
+                          watcher->get_cookie());
     }
     encode(missed, bl);
 


### PR DESCRIPTION
there is no need to use a list<> here. and this change does not
change the encoding schema here. also, as a fact, the user of the
watch-notify feature is decoding the bufferlist like:

 std::map<std::pair<uint64_t,uint64_t>, bufferlist> reply_map;
 std::set<std::pair<uint64_t,uint64_t> > missed_map;
 decode(reply_map, reply_p);
 decode(missed_map, reply_p);

so, in this change, change list<> to vector<> for both smaller memory
footprint and for better readability.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
