### PR TITLE
octopus: os/bluestore/BlueFS: use iterator_impl::copy instead of bufferlist::c_str() to avoid bufferlist rebuild

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1946,8 +1946,9 @@ int64_t BlueFS::_read_random(
 	      << dendl;
 
       if (out) {
-	// NOTE: h->bl is normally a contiguous buffer so c_str() is free.
-	memcpy(out, buf->bl.c_str() + off - buf->bl_off, r);
+	auto p = buf->bl.begin();
+	p.seek(off - buf->bl_off);
+	p.copy(r, out);
 	out += r;
       }
 
@@ -2059,8 +2060,9 @@ int64_t BlueFS::_read(
       outbl->claim_append(t);
     }
     if (out) {
-      // NOTE: h->bl is normally a contiguous buffer so c_str() is free.
-      memcpy(out, buf->bl.c_str() + off - buf->bl_off, r);
+      auto p = buf->bl.begin();
+      p.seek(off - buf->bl_off);
+      p.copy(r, out);
       out += r;
     }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49386

---

backport of https://github.com/ceph/ceph/pull/39406
parent tracker: https://tracker.ceph.com/issues/49383

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh