### PR TITLE
octopus: blk/kernel: fix io_uring got (4) Interrupted system call

### DIFF
--- a/src/os/bluestore/io_uring.cc
+++ b/src/os/bluestore/io_uring.cc
@@ -198,7 +198,7 @@ get_cqe:
 
   if (events == 0) {
     struct epoll_event ev;
-    int ret = epoll_wait(d->epoll_fd, &ev, 1, timeout_ms);
+    int ret = TEMP_FAILURE_RETRY(epoll_wait(d->epoll_fd, &ev, 1, timeout_ms));
     if (ret < 0)
       events = -errno;
     else if (ret > 0)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49039

---

backport of https://github.com/ceph/ceph/pull/38901
parent tracker: https://tracker.ceph.com/issues/47661

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh