### PR TITLE
pacific: cmake: build static libs if they are internal ones

### DIFF
--- a/src/blk/CMakeLists.txt
+++ b/src/blk/CMakeLists.txt
@@ -25,7 +25,7 @@ if(WITH_ZBD)
     zoned/HMSMRDevice.cc)
 endif()
 
-add_library(blk ${libblk_srcs})
+add_library(blk STATIC ${libblk_srcs})
 target_include_directories(blk PRIVATE "./")
 
 if(HAVE_LIBAIO)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -213,7 +213,7 @@ elseif(HAVE_ARMV8_CRC)
     crc32c_aarch64.c)
 endif(HAVE_INTEL)
 
-add_library(crc32 ${crc32_srcs})
+add_library(crc32 STATIC ${crc32_srcs})
 if(HAVE_ARMV8_CRC)
   set_target_properties(crc32 PROPERTIES
     COMPILE_FLAGS "${CMAKE_C_FLAGS} ${ARMV8_CRC_COMPILE_FLAGS}")


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49377

---

backport of https://github.com/ceph/ceph/pull/39566
parent tracker: https://tracker.ceph.com/issues/38611

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh