### PR TITLE
crimson/onode-staged-tree: fix tree_cursor_t::Cursor to be aware of extent duplication

### DIFF
--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h
@@ -70,8 +70,10 @@ struct FLTreeOnode : Onode, Value {
     auto p = prepare_mutate_payload<
       onode_layout_t,
       Recorder>(t);
-    p.second->record_delta(
-      p.first);
+    if (p.second) {
+      p.second->record_delta(
+        p.first);
+    }
     status = status_t::STABLE;
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
@@ -160,4 +160,12 @@ inline std::ostream& operator<<(std::ostream& os, const tree_stats_t& stats) {
   return os;
 }
 
+template <typename PtrType>
+void reset_ptr(PtrType& ptr, const char* origin_base, const char* new_base) {
+  assert((const char*)ptr > origin_base);
+  assert((const char*)ptr - origin_base < NODE_BLOCK_SIZE);
+  ptr = reinterpret_cast<PtrType>(
+      (const char*)ptr - origin_base + new_base);
+}
+
 }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -205,9 +205,9 @@ class tree_cursor_t final
     node_version_t version;
 
     // cached key value info
-    std::optional<key_view_t> key_view; // maybe still point to the read_only extent
+    const char* p_node_base = nullptr;
+    std::optional<key_view_t> key_view;
     const value_header_t* p_value_header = nullptr;
-    node_offset_t offset_value_header;
 
     // cached data-structures to update value payload
     std::optional<NodeExtentMutable> value_payload_mut;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -47,6 +47,19 @@ namespace crimson::os::seastore::onode {
 class LeafNode;
 class InternalNode;
 
+using layout_version_t = uint32_t;
+struct node_version_t {
+  layout_version_t layout;
+  bool is_duplicate;
+
+  bool operator==(const node_version_t& rhs) const {
+    return (layout == rhs.layout && is_duplicate == rhs.is_duplicate);
+  }
+  bool operator!=(const node_version_t& rhs) const {
+    return !(*this == rhs);
+  }
+};
+
 /**
  * tree_cursor_t
  *
@@ -57,7 +70,6 @@ class InternalNode;
  *
  * Exposes public interfaces for Btree::Cursor.
  */
-using layout_version_t = uint32_t;
 class tree_cursor_t final
   : public boost::intrusive_ref_counter<
            tree_cursor_t, boost::thread_unsafe_counter> {
@@ -90,8 +102,8 @@ class tree_cursor_t final
 
   /// Returns the key view in tree if it is not an end cursor.
   const key_view_t& get_key_view(value_magic_t magic) const {
-    maybe_update_cache(magic);
-    return cache.get_key_view();
+    assert(!is_end());
+    return cache.get_key_view(magic, position);
   }
 
   /// Returns the next tree_cursor_t in tree, can be end if there's no next.
@@ -106,15 +118,15 @@ class tree_cursor_t final
 
   /// Get the latest value_header_t pointer for read.
   const value_header_t* read_value_header(value_magic_t magic) const {
-    maybe_update_cache(magic);
-    return cache.get_p_value_header();
+    assert(!is_end());
+    return cache.get_p_value_header(magic, position);
   }
 
   /// Prepare the node extent to be mutable and recorded.
   std::pair<NodeExtentMutable&, ValueDeltaRecorder*>
   prepare_mutate_value_payload(context_t c) {
-    maybe_update_cache(c.vb.get_header_magic());
-    return cache.prepare_mutate_value_payload(c);
+    assert(!is_end());
+    return cache.prepare_mutate_value_payload(c, position);
   }
 
   /// Extends the size of value payload.
@@ -134,8 +146,8 @@ class tree_cursor_t final
   Ref<LeafNode> get_leaf_node() const { return ref_leaf_node; }
   template <bool VALIDATE>
   void update_track(Ref<LeafNode>, const search_position_t&);
-  void update_cache(LeafNode&, const key_view_t&, const value_header_t*) const;
-  void maybe_update_cache(value_magic_t magic) const;
+  void update_cache_same_node(const key_view_t&,
+                              const value_header_t*) const;
 
   static Ref<tree_cursor_t> create(Ref<LeafNode> node, const search_position_t& pos) {
     return new tree_cursor_t(node, pos);
@@ -162,40 +174,44 @@ class tree_cursor_t final
   /** Cache
    *
    * Cached memory pointers or views which may be outdated due to
-   * asynchronous leaf node updates.
+   * extent copy-on-write or asynchronous leaf node updates.
    */
   class Cache {
    public:
-    Cache();
-    bool is_latest() const;
-    void invalidate() { valid = false; }
-    void update(LeafNode&, const key_view_t&, const value_header_t*);
-    void validate_is_latest(const LeafNode&, const search_position_t&) const;
-
-    const key_view_t& get_key_view() const {
-      assert(is_latest());
-      assert(key_view.has_value());
+    Cache(Ref<LeafNode>&);
+    void validate_is_latest(const search_position_t&) const;
+    void invalidate() { needs_update_all = true; }
+    void update_all(const node_version_t&, const key_view_t&, const value_header_t*);
+    const key_view_t& get_key_view(
+        value_magic_t magic, const search_position_t& pos) {
+      make_latest(magic, pos);
       return *key_view;
     }
-    const value_header_t* get_p_value_header() const {
-      assert(is_latest());
-      assert(p_value_header);
+    const value_header_t* get_p_value_header(
+        value_magic_t magic, const search_position_t& pos) {
+      make_latest(magic, pos);
       return p_value_header;
     }
     std::pair<NodeExtentMutable&, ValueDeltaRecorder*>
-    prepare_mutate_value_payload(context_t);
+    prepare_mutate_value_payload(context_t, const search_position_t&);
 
    private:
-    LeafNode* p_leaf_node = nullptr;
-    std::optional<key_view_t> key_view;
-    const value_header_t* p_value_header = nullptr;
+    void maybe_duplicate(const node_version_t&);
+    void make_latest(value_magic_t, const search_position_t&);
 
-    // to update value payload
+    // metadata about how cache is valid
+    Ref<LeafNode>& ref_leaf_node;
+    bool needs_update_all = true;
+    node_version_t version;
+
+    // cached key value info
+    std::optional<key_view_t> key_view; // maybe still point to the read_only extent
+    const value_header_t* p_value_header = nullptr;
+    node_offset_t offset_value_header;
+
+    // cached data-structures to update value payload
     std::optional<NodeExtentMutable> value_payload_mut;
     ValueDeltaRecorder* p_value_recorder = nullptr;
-
-    layout_version_t version;
-    bool valid = false;
   };
   mutable Cache cache;
 
@@ -486,7 +502,8 @@ class LeafNode final : public Node {
   LeafNode& operator=(LeafNode&&) = delete;
 
   bool is_level_tail() const;
-  layout_version_t get_layout_version() const { return layout_version; }
+  node_version_t get_version() const;
+  const char* read() const;
   std::tuple<key_view_t, const value_header_t*> get_kv(const search_position_t&) const;
   node_future<Ref<tree_cursor_t>> get_next_cursor(context_t, const search_position_t&);
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
@@ -294,6 +294,12 @@ class NodeExtentAccessorT {
 
   const node_stage_t& read() const { return node_stage; }
   laddr_t get_laddr() const { return extent->get_laddr(); }
+  bool is_duplicate() const {
+    // we cannot rely on whether the extent state is MUTATION_PENDING because
+    // we may access the extent (internally) after it becomes DIRTY after
+    // transaction submission.
+    return recorder != nullptr;
+  }
 
   // must be called before any mutate attempes.
   // for the safety of mixed read and mutate, call before read.

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
@@ -70,6 +70,8 @@ class NodeImpl {
   virtual node_type_t node_type() const = 0;
   virtual field_type_t field_type() const = 0;
   virtual laddr_t laddr() const = 0;
+  virtual const char* read() const = 0;
+  virtual bool is_duplicate() const = 0;
   virtual void prepare_mutate(context_t) = 0;
   virtual bool is_level_tail() const = 0;
   virtual bool is_empty() const = 0;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -89,6 +89,8 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
   node_type_t node_type() const override { return NODE_TYPE; }
   field_type_t field_type() const override { return FIELD_TYPE; }
   laddr_t laddr() const override { return extent.get_laddr(); }
+  const char* read() const override { return extent.read().p_start(); }
+  bool is_duplicate() const override { return extent.is_duplicate(); }
   void prepare_mutate(context_t c) override { return extent.prepare_mutate(c); }
   bool is_level_tail() const override { return extent.read().is_level_tail(); }
   bool is_empty() const override { return extent.read().keys() == 0; }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
@@ -73,6 +73,13 @@ struct value_header_t {
   value_magic_t magic;
   value_size_t payload_size;
 
+  bool operator==(const value_header_t& rhs) const {
+    return (magic == rhs.magic && payload_size == rhs.payload_size);
+  }
+  bool operator!=(const value_header_t& rhs) const {
+    return !(*this == rhs);
+  }
+
   value_size_t allocation_size() const {
     return payload_size + sizeof(value_header_t);
   }

--- a/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
+++ b/src/test/crimson/seastore/onode_tree/test_fltree_onode_manager.cc
@@ -1,16 +1,14 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
 // vim: ts=8 sw=2 smarttab
 
-#include <string>
-#include <iostream>
-#include <sstream>
+#include <boost/range/combine.hpp>
 
 #include "test/crimson/gtest_seastar.h"
 
 #include "test/crimson/seastore/transaction_manager_test_state.h"
 
-#include "crimson/os/futurized_collection.h"
 #include "crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h"
+#include "crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h"
 
 using namespace crimson;
 using namespace crimson::os;
@@ -25,19 +23,41 @@ namespace {
   }
 }
 
-ghobject_t make_oid(unsigned i) {
-  stringstream ss;
-  ss << "object_" << i;
-  auto ret = ghobject_t(
-    hobject_t(
-      sobject_t(ss.str(), CEPH_NOSNAP)));
-  ret.hobj.nspace = "asdf";
-  return ret;
-}
+struct onode_item_t {
+  uint32_t size;
+  uint64_t id;
+  uint32_t cnt_modify = 0;
 
-struct fltree_onode_manager_test_t :
-  public seastar_test_suite_t,
-  TMTestState {
+  void initialize(Transaction& t, Onode& value) const {
+    auto& layout = value.get_mutable_layout(t);
+    layout.size = size;
+    layout.omap_root.update(omap_root_t(id, cnt_modify));
+    validate(value);
+  }
+
+  void validate(Onode& value) const {
+    auto& layout = value.get_layout();
+    ceph_assert(laddr_t(layout.size) == laddr_t{size});
+    ceph_assert(layout.omap_root.get().addr == id);
+    ceph_assert(layout.omap_root.get().depth == cnt_modify);
+  }
+
+  void modify(Transaction& t, Onode& value) {
+    validate(value);
+    ++cnt_modify;
+    initialize(t, value);
+  }
+
+  static onode_item_t create(std::size_t size, std::size_t id) {
+    ceph_assert(size <= std::numeric_limits<uint32_t>::max());
+    return {(uint32_t)size, id};
+  }
+};
+
+struct fltree_onode_manager_test_t
+    : public seastar_test_suite_t, TMTestState {
+  using iterator_t = typename KVPool<onode_item_t>::iterator_t;
+
   FLTreeOnodeManagerRef manager;
 
   seastar::future<> set_up_fut() final {
@@ -63,73 +83,143 @@ struct fltree_onode_manager_test_t :
     return TMTestState::_mkfs(
     ).then([this] {
       return seastar::do_with(
-	tm->create_transaction(),
-	[this](auto &t) {
-	  return manager->mkfs(*t
-	  ).safe_then([this, &t] {
-	    return tm->submit_transaction(std::move(t));
-	  }).handle_error(
-	    crimson::ct_error::assert_all{
-	      "Invalid error in _mkfs"
-	    }
-	  );
-	});
+        tm->create_transaction(),
+        [this](auto &t) {
+          return manager->mkfs(*t
+          ).safe_then([this, &t] {
+            return tm->submit_transaction(std::move(t));
+          }).handle_error(
+            crimson::ct_error::assert_all{
+              "Invalid error in _mkfs"
+            }
+          );
+        });
+    });
+  }
+
+  template <typename F>
+  void with_transaction(F&& f) {
+    auto t = tm->create_transaction();
+    std::invoke(f, *t);
+    tm->submit_transaction(std::move(t)).unsafe_get0();
+  }
+
+  template <typename F>
+  void with_onode_write(iterator_t& it, F&& f) {
+    with_transaction([this, &it, f=std::move(f)] (auto& t) {
+      auto p_kv = *it;
+      auto onode = manager->get_or_create_onode(
+          t, p_kv->key).unsafe_get0();
+      std::invoke(f, t, *onode, p_kv->value);
+      manager->write_dirty(t, {onode}).unsafe_get0();
+    });
+  }
+
+  void validate_onode(iterator_t& it) {
+    with_transaction([this, &it] (auto& t) {
+      auto p_kv = *it;
+      auto onode = manager->get_onode(
+          t, p_kv->key).unsafe_get0();
+      p_kv->value.validate(*onode);
+    });
+  }
+
+  template <typename F>
+  void with_onodes_process(
+      iterator_t& start, iterator_t& end, F&& f) {
+    std::vector<ghobject_t> oids;
+    std::vector<onode_item_t*> items;
+    auto it = start;
+    while(it != end) {
+      auto p_kv = *it;
+      oids.emplace_back(p_kv->key);
+      items.emplace_back(&p_kv->value);
+      ++it;
+    }
+    with_transaction([this, &oids, &items, f=std::move(f)] (auto& t) mutable {
+      std::invoke(f, t, oids, items);
     });
   }
 
   template <typename F>
   void with_onodes_write(
-    std::vector<ghobject_t> oids,
-    F &&f) {
-    auto t = tm->create_transaction();
-    auto onodes = manager->get_or_create_onodes(
-      *t,
-      oids).unsafe_get0();
-    std::invoke(f, *t, onodes);
-    manager->write_dirty(
-      *t,
-      onodes
-    ).unsafe_get0();
-    tm->submit_transaction(std::move(t)).unsafe_get0();
+      iterator_t& start, iterator_t& end, F&& f) {
+    with_onodes_process(start, end,
+        [this, f=std::move(f)] (auto& t, auto& oids, auto& items) {
+      auto onodes = manager->get_or_create_onodes(
+          t, oids).unsafe_get0();
+      for (auto tup : boost::combine(onodes, items)) {
+        OnodeRef onode;
+        onode_item_t* p_item;
+        boost::tie(onode, p_item) = tup;
+        std::invoke(f, t, *onode, *p_item);
+      }
+      manager->write_dirty(t, onodes).unsafe_get0();
+    });
   }
 
-  template <typename F>
-  void with_onodes_write_range(
-    unsigned start,
-    unsigned end,
-    unsigned stride,
-    F &&f) {
-    std::vector<ghobject_t> oids;
-    for (unsigned i = start; i < end; i += stride) {
-      oids.emplace_back(make_oid(i));
-    }
-    with_onodes_write(std::move(oids), std::forward<F>(f));
-  }
-
-  template <typename F>
-  void with_onode_write(unsigned i, F &&f) {
-    with_onodes_write_range(
-      i,
-      i + 1,
-      1, [this, f=std::forward<F>(f)](auto &t, auto &onodes) {
-	assert(onodes.size() == 1);
-	std::invoke(f, t, *onodes[0]);
-      });
+  void validate_onodes(
+      iterator_t& start, iterator_t& end) {
+    with_onodes_process(start, end,
+        [this] (auto& t, auto& oids, auto& items) {
+      for (auto tup : boost::combine(oids, items)) {
+        ghobject_t oid;
+        onode_item_t* p_item;
+        boost::tie(oid, p_item) = tup;
+        auto onode = manager->get_onode(t, oid).unsafe_get0();
+        p_item->validate(*onode);
+      }
+    });
   }
 
   fltree_onode_manager_test_t() {}
 };
 
-TEST_F(fltree_onode_manager_test_t, touch)
+TEST_F(fltree_onode_manager_test_t, 1_single)
 {
   run_async([this] {
-    with_onode_write(0, [](auto &t, auto &onode) {
-      onode.get_mutable_layout(t);
+    auto pool = KVPool<onode_item_t>::create_range({0, 1}, {128, 256});
+    auto iter = pool.begin();
+    with_onode_write(iter, [](auto& t, auto& onode, auto& item) {
+      item.initialize(t, onode);
     });
-    /* Disabled pending fix
-    with_onode_write(0, [](auto &t, auto &onode) {
-      onode.get_mutable_layout(t);
+    validate_onode(iter);
+
+    with_onode_write(iter, [](auto& t, auto& onode, auto& item) {
+      item.modify(t, onode);
     });
-    */
+    validate_onode(iter);
+  });
+}
+
+TEST_F(fltree_onode_manager_test_t, 2_synthetic)
+{
+  run_async([this] {
+    auto pool = KVPool<onode_item_t>::create_range(
+        {0, 100}, {32, 64, 128, 256, 512});
+    auto start = pool.begin();
+    auto end = pool.end();
+    with_onodes_write(start, end,
+        [](auto& t, auto& onode, auto& item) {
+      item.initialize(t, onode);
+    });
+    validate_onodes(start, end);
+
+    auto rd_start = pool.random_begin();
+    auto rd_end = rd_start + 50;
+    with_onodes_write(rd_start, rd_end,
+        [](auto& t, auto& onode, auto& item) {
+      item.modify(t, onode);
+    });
+    validate_onodes(start, end);
+
+    pool.shuffle();
+    rd_start = pool.random_begin();
+    rd_end = rd_start + 50;
+    with_onodes_write(rd_start, rd_end,
+        [](auto& t, auto& onode, auto& item) {
+      item.modify(t, onode);
+    });
+    validate_onodes(start, end);
   });
 }

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -1203,9 +1203,10 @@ TEST_F(d_seastore_tm_test_t, 6_random_insert_leaf_node)
   run_async([this] {
     constexpr bool TEST_SEASTORE = true;
     constexpr bool TRACK_CURSORS = true;
-    KVPool<test_item_t> kvs{{8, 11, 64, 256, 301, 320},
-                            {8, 16, 128, 512, 576, 640},
-                            {0, 32}, {0, 10}, {0, 4}};
+    auto kvs = KVPool<test_item_t>::create_raw_range(
+        {8, 11, 64, 256, 301, 320},
+        {8, 16, 128, 512, 576, 640},
+        {0, 32}, {0, 10}, {0, 4});
     auto tree = std::make_unique<TreeBuilder<TRACK_CURSORS, test_item_t>>(kvs,
         (TEST_SEASTORE ? NodeExtentManager::create_seastore(*tm)
                        : NodeExtentManager::create_dummy(IS_DUMMY_SYNC)));

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -712,6 +712,10 @@ class DummyChildPool {
    protected:
     node_type_t node_type() const override { return node_type_t::LEAF; }
     field_type_t field_type() const override { return field_type_t::N0; }
+    const char* read() const override {
+      ceph_abort("impossible path"); }
+    bool is_duplicate() const override {
+      ceph_abort("impossible path"); }
     level_t level() const override { return 0u; }
     void prepare_mutate(context_t) override {
       ceph_abort("impossible path"); }

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -169,6 +169,8 @@ TEST_F(a_basic_test_t, 2_node_sizes)
   });
 }
 
+using TestBtree = Btree<TestValue>;
+
 struct b_dummy_tree_test_t : public seastar_test_suite_t {
   NodeExtentManagerURef moved_nm;
   TransactionRef ref_t;
@@ -206,23 +208,21 @@ TEST_F(b_dummy_tree_test_t, 3_random_insert_leaf_node)
     ASSERT_TRUE(tree.last(t).unsafe_get0().is_end());
 
     std::vector<std::tuple<ghobject_t,
-                           value_item_t,
+                           test_item_t,
                            TestBtree::Cursor>> insert_history;
     auto f_validate_insert_new = [this, &insert_history] (
-        const ghobject_t& key, const value_item_t& value) {
+        const ghobject_t& key, const test_item_t& value) {
       auto [cursor, success] = tree.insert(
-          t, key, value.get_config()).unsafe_get0();
-      ceph_assert(success);
-      ceph_assert(cursor.get_ghobj() == key);
-      Values::initialize_cursor(t, cursor, value);
+          t, key, {value.get_payload_size()}).unsafe_get0();
+      initialize_cursor_from_item(t, key, value, cursor, success);
       insert_history.emplace_back(key, value, cursor);
       auto cursor_ = tree.find(t, key).unsafe_get0();
       ceph_assert(cursor_ != tree.end());
       ceph_assert(cursor_.value() == cursor.value());
-      Values::validate_cursor(cursor_, key, value);
+      validate_cursor_from_item(key, value, cursor_);
       return cursor.value();
     };
-    auto values = Values(15);
+    auto values = Values<test_item_t>(15);
 
     // insert key1, value1 at STAGE_LEFT
     auto key1 = make_ghobj(3, 3, 3, "ns3", "oid3", 3, 3);
@@ -242,9 +242,9 @@ TEST_F(b_dummy_tree_test_t, 3_random_insert_leaf_node)
     {
       auto value1_dup = values.pick();
       auto [cursor1_dup, ret1_dup] = tree.insert(
-          t, key1, value1_dup.get_config()).unsafe_get0();
+          t, key1, {value1_dup.get_payload_size()}).unsafe_get0();
       ASSERT_FALSE(ret1_dup);
-      Values::validate_cursor(cursor1_dup, key1, value1);
+      validate_cursor_from_item(key1, value1, cursor1_dup);
     }
 
     // insert key2, value2 to key1's left at STAGE_LEFT
@@ -300,7 +300,7 @@ TEST_F(b_dummy_tree_test_t, 3_random_insert_leaf_node)
     f_validate_insert_new(key11, value11);
 
     // insert key, value randomly until a perfect 3-ary tree is formed
-    std::vector<std::pair<ghobject_t, value_item_t>> kvs{
+    std::vector<std::pair<ghobject_t, test_item_t>> kvs{
       {make_ghobj(2, 2, 2, "ns2", "oid2", 2, 2), values.pick()},
       {make_ghobj(2, 2, 2, "ns2", "oid2", 4, 4), values.pick()},
       {make_ghobj(2, 2, 2, "ns3", "oid3", 4, 4), values.pick()},
@@ -330,21 +330,21 @@ TEST_F(b_dummy_tree_test_t, 3_random_insert_leaf_node)
       // validate values in tree keep intact
       auto cursor = tree.find(t, k).unsafe_get0();
       EXPECT_NE(cursor, tree.end());
-      Values::validate_cursor(cursor, k, v);
+      validate_cursor_from_item(k, v, cursor);
       // validate values in cursors keep intact
-      Values::validate_cursor(c, k, v);
+      validate_cursor_from_item(k, v, c);
     }
     {
       auto cursor = tree.lower_bound(t, key_s).unsafe_get0();
-      Values::validate_cursor(cursor, smallest_key, smallest_value);
+      validate_cursor_from_item(smallest_key, smallest_value, cursor);
     }
     {
       auto cursor = tree.begin(t).unsafe_get0();
-      Values::validate_cursor(cursor, smallest_key, smallest_value);
+      validate_cursor_from_item(smallest_key, smallest_value, cursor);
     }
     {
       auto cursor = tree.last(t).unsafe_get0();
-      Values::validate_cursor(cursor, largest_key, largest_value);
+      validate_cursor_from_item(largest_key, largest_value, cursor);
     }
 
     // validate range query
@@ -360,7 +360,7 @@ TEST_F(b_dummy_tree_test_t, 3_random_insert_leaf_node)
       auto cursor = tree.begin(t).unsafe_get0();
       for (auto& [k, v] : kvs) {
         ASSERT_FALSE(cursor.is_end());
-        Values::validate_cursor(cursor, k, v);
+        validate_cursor_from_item(k, v, cursor);
         cursor = cursor.get_next(t).unsafe_get0();
       }
       ASSERT_TRUE(cursor.is_end());
@@ -432,7 +432,7 @@ class TestTree {
   }
 
   seastar::future<> build_tree(
-      const std::vector<ghobject_t>& keys, const std::vector<value_item_t>& values) {
+      const std::vector<ghobject_t>& keys, const std::vector<test_item_t>& values) {
     return seastar::async([this, keys, values] {
       tree.mkfs(t).unsafe_get0();
       //logger().info("\n---------------------------------------------"
@@ -453,7 +453,7 @@ class TestTree {
     });
   }
 
-  seastar::future<> split(const ghobject_t& key, const value_item_t& value,
+  seastar::future<> split(const ghobject_t& key, const test_item_t& value,
                           const split_expectation_t& expected) {
     return seastar::async([this, key, value, expected] {
       TestBtree tree_clone(NodeExtentManager::create_dummy(IS_DUMMY_SYNC));
@@ -463,10 +463,8 @@ class TestTree {
 
       logger().info("insert {}:", key_hobj_t(key));
       auto [cursor, success] = tree_clone.insert(
-          t_clone, key, value.get_config()).unsafe_get0();
-      ASSERT_TRUE(success);
-      ASSERT_EQ(cursor.get_ghobj(), key);
-      Values::initialize_cursor(t_clone, cursor, value);
+          t_clone, key, {value.get_payload_size()}).unsafe_get0();
+      initialize_cursor_from_item(t, key, value, cursor, success);
 
       std::ostringstream oss;
       tree_clone.dump(t_clone, oss);
@@ -476,27 +474,25 @@ class TestTree {
       for (auto& [k, v, c] : insert_history) {
         auto result = tree_clone.find(t_clone, k).unsafe_get0();
         EXPECT_NE(result, tree_clone.end());
-        Values::validate_cursor(result, k, v);
+        validate_cursor_from_item(k, v, result);
       }
       auto result = tree_clone.find(t_clone, key).unsafe_get0();
       EXPECT_NE(result, tree_clone.end());
-      Values::validate_cursor(result, key, value);
+      validate_cursor_from_item(key, value, result);
       EXPECT_TRUE(last_split.match(expected));
     });
   }
 
-  value_item_t create_value(size_t size) {
+  test_item_t create_value(size_t size) {
     return values.create(size);
   }
 
  private:
-  seastar::future<> insert_tree(const ghobject_t& key, const value_item_t& value) {
+  seastar::future<> insert_tree(const ghobject_t& key, const test_item_t& value) {
     return seastar::async([this, &key, &value] {
       auto [cursor, success] = tree.insert(
-          t, key, value.get_config()).unsafe_get0();
-      ASSERT_TRUE(success);
-      ASSERT_EQ(cursor.get_ghobj(), key);
-      Values::initialize_cursor(t, cursor, value);
+          t, key, {value.get_payload_size()}).unsafe_get0();
+      initialize_cursor_from_item(t, key, value, cursor, success);
       insert_history.emplace_back(key, value, cursor);
     });
   }
@@ -507,9 +503,9 @@ class TestTree {
   ValueBuilderImpl<TestValue> vb;
   context_t c;
   TestBtree tree;
-  Values values;
+  Values<test_item_t> values;
   std::vector<std::tuple<
-    ghobject_t, value_item_t, TestBtree::Cursor>> insert_history;
+    ghobject_t, test_item_t, TestBtree::Cursor>> insert_history;
 };
 
 struct c_dummy_test_t : public seastar_test_suite_t {};
@@ -661,7 +657,7 @@ TEST_F(c_dummy_test_t, 4_split_leaf_node)
       std::vector<ghobject_t> keys = {
         make_ghobj(2, 2, 2, "ns3", "oid3", 3, 3),
         make_ghobj(3, 3, 3, "ns3", "oid3", 3, 3)};
-      std::vector<value_item_t> values = {
+      std::vector<test_item_t> values = {
         test.create_value(1360),
         test.create_value(1632)};
       test.build_tree(keys, values).get0();
@@ -1207,10 +1203,10 @@ TEST_F(d_seastore_tm_test_t, 6_random_insert_leaf_node)
   run_async([this] {
     constexpr bool TEST_SEASTORE = true;
     constexpr bool TRACK_CURSORS = true;
-    KVPool kvs{{8, 11, 64, 256, 301, 320},
-               {8, 16, 128, 512, 576, 640},
-               {0, 32}, {0, 10}, {0, 4}};
-    auto tree = std::make_unique<TreeBuilder<TRACK_CURSORS>>(kvs,
+    KVPool<test_item_t> kvs{{8, 11, 64, 256, 301, 320},
+                            {8, 16, 128, 512, 576, 640},
+                            {0, 32}, {0, 10}, {0, 4}};
+    auto tree = std::make_unique<TreeBuilder<TRACK_CURSORS, test_item_t>>(kvs,
         (TEST_SEASTORE ? NodeExtentManager::create_seastore(*tm)
                        : NodeExtentManager::create_dummy(IS_DUMMY_SYNC)));
     {

--- a/src/tools/crimson/perf_staged_fltree.cc
+++ b/src/tools/crimson/perf_staged_fltree.cc
@@ -9,6 +9,8 @@
 #include "crimson/common/log.h"
 #include "crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h"
 #include "crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h"
+
+#include "test/crimson/seastore/onode_tree/test_value.h"
 #include "test/crimson/seastore/transaction_manager_test_state.h"
 
 using namespace crimson::os::seastore::onode;
@@ -23,10 +25,10 @@ class PerfTree : public TMTestState {
  public:
   PerfTree(bool is_dummy) : is_dummy{is_dummy} {}
 
-  seastar::future<> run(KVPool& kvs) {
+  seastar::future<> run(KVPool<test_item_t>& kvs) {
     return tm_setup().then([this, &kvs] {
       return seastar::async([this, &kvs] {
-        auto tree = std::make_unique<TreeBuilder<TRACK>>(kvs,
+        auto tree = std::make_unique<TreeBuilder<TRACK, test_item_t>>(kvs,
             (is_dummy ? NodeExtentManager::create_dummy(true)
                       : NodeExtentManager::create_seastore(*tm)));
         {
@@ -84,10 +86,10 @@ seastar::future<> run(const bpo::variables_map& config) {
     auto range0 = config["range0"].as<std::vector<unsigned>>();
     ceph_assert(range0.size() == 2);
 
-    KVPool kvs{str_sizes, onode_sizes,
-               {range2[0], range2[1]},
-               {range1[0], range1[1]},
-               {range0[0], range0[1]}};
+    KVPool<test_item_t> kvs{str_sizes, onode_sizes,
+                            {range2[0], range2[1]},
+                            {range1[0], range1[1]},
+                            {range0[0], range0[1]}};
     PerfTree<TRACK> perf{is_dummy};
     perf.run(kvs).get0();
   });

--- a/src/tools/crimson/perf_staged_fltree.cc
+++ b/src/tools/crimson/perf_staged_fltree.cc
@@ -86,10 +86,11 @@ seastar::future<> run(const bpo::variables_map& config) {
     auto range0 = config["range0"].as<std::vector<unsigned>>();
     ceph_assert(range0.size() == 2);
 
-    KVPool<test_item_t> kvs{str_sizes, onode_sizes,
-                            {range2[0], range2[1]},
-                            {range1[0], range1[1]},
-                            {range0[0], range0[1]}};
+    auto kvs = KVPool<test_item_t>::create_raw_range(
+        str_sizes, onode_sizes,
+        {range2[0], range2[1]},
+        {range1[0], range1[1]},
+        {range0[0], range0[1]});
     PerfTree<TRACK> perf{is_dummy};
     perf.run(kvs).get0();
   });


### PR DESCRIPTION
Previously, tree_cursor_t::Cache is not aware of the COWed extent, and still point to the read-only version of value header.
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
