### PR TITLE
pacific: mgr/dashboard: fix PUT - /api/host/{hostname} while adding labels 

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/host.py
+++ b/src/pybind/mgr/dashboard/controllers/host.py
@@ -375,6 +375,12 @@ class Host(RESTController):
 
     @raise_if_no_orchestrator([OrchFeature.HOST_LABEL_ADD, OrchFeature.HOST_LABEL_REMOVE])
     @handle_orchestrator_error('host')
+    @EndpointDoc('',
+                 parameters={
+                     'hostname': (str, 'Hostname'),
+                     'labels': ([str], 'Host Labels'),
+                 },
+                 responses={200: None, 204: None})
     def set(self, hostname: str, labels: List[str]):
         """
         Update the specified host.
@@ -384,6 +390,12 @@ class Host(RESTController):
         """
         orch = OrchClient.instance()
         host = get_host(hostname)
+        # only allow List[str] type for labels
+        if not isinstance(labels, list):
+            raise DashboardException(
+                msg='Expected list of labels. Please check API documentation.',
+                http_status_code=400,
+                component='orchestrator')
         current_labels = set(host['labels'])
         # Remove labels.
         remove_labels = list(current_labels.difference(set(labels)))

--- a/src/pybind/mgr/dashboard/openapi.yaml
+++ b/src/pybind/mgr/dashboard/openapi.yaml
@@ -3334,7 +3334,8 @@ paths:
         \ name of the host to be processed.\n        :param labels: List of labels.\n\
         \        "
       parameters:
-      - in: path
+      - description: Hostname
+        in: path
         name: hostname
         required: true
         schema:
@@ -3345,7 +3346,10 @@ paths:
             schema:
               properties:
                 labels:
-                  type: string
+                  description: Host Labels
+                  items:
+                    type: string
+                  type: array
               required:
               - labels
               type: object
@@ -3353,7 +3357,9 @@ paths:
         '200':
           content:
             application/vnd.ceph.api.v1.0+json:
-              type: object
+              schema:
+                properties: {}
+                type: object
           description: Resource updated.
         '202':
           content:

--- a/src/pybind/mgr/dashboard/tests/test_host.py
+++ b/src/pybind/mgr/dashboard/tests/test_host.py
@@ -136,6 +136,10 @@ class HostControllerTest(ControllerTestCase):
             fake_client.hosts.remove_label.assert_called_once_with('node0', 'aaa')
             fake_client.hosts.add_label.assert_called_once_with('node0', 'ccc')
 
+            # return 400 if type other than List[str]
+            self._put('{}/node0'.format(self.URL_HOST), {'labels': 'ddd'})
+            self.assertStatus(400)
+
     @mock.patch('dashboard.controllers.host.time')
     def test_identify_device(self, mock_time):
         url = '{}/host-0/identify_device'.format(self.URL_HOST)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49652

---

backport of https://github.com/ceph/ceph/pull/39476
parent tracker: https://tracker.ceph.com/issues/49292

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh