### PR TITLE
doc/cephadm: rewrite "preparation" in adoption.rst

### DIFF
--- a/doc/cephadm/adoption.rst
+++ b/doc/cephadm/adoption.rst
@@ -15,37 +15,40 @@ Limitations
 Preparation
 -----------
 
-#. Get the ``cephadm`` command line tool on each host in the existing
-   cluster.  See :ref:`get-cephadm`.
+#. Make sure that the ``cephadm`` command line tool is available on each host
+   in the existing cluster.  See :ref:`get-cephadm` to learn how.
 
-#. Prepare each host for use by ``cephadm``:
+#. Prepare each host for use by ``cephadm`` by running this command:
 
    .. prompt:: bash #
 
       cephadm prepare-host
 
-#. Determine which Ceph version you will use.  You can use any Octopus (15.2.z)
-   release or later.  For example, ``docker.io/ceph/ceph:v15.2.0``.  The default
-   will be the latest stable release, but if you are upgrading from an earlier
-   release at the same time be sure to refer to the upgrade notes for any
-   special steps to take while upgrading.
+#. Choose a version of Ceph to use for the conversion. This procedure will work
+   with any release of Ceph that is Octopus (15.2.z) or later, inclusive.  The
+   latest stable release of Ceph is the default. You might be upgrading from an
+   earlier Ceph release at the same time that you're performing this
+   conversion; if you are upgrading from an earlier release, make sure to
+   follow any upgrade-releated instructions for that release.
 
-   The image is passed to cephadm with:
+   Pass the image to cephadm with the following command:
 
    .. prompt:: bash #
 
       cephadm --image $IMAGE <rest of command goes here>
 
-#. Cephadm can provide a list of all Ceph daemons on the current host:
+   The conversion begins.
+
+#. Confirm that the conversion is underway by running ``cephadm ls`` and
+   making sure that the style of the daemons is changed:
 
    .. prompt:: bash #
 
       cephadm ls
 
-   Before starting, you should see that all existing daemons have a
-   style of ``legacy`` in the resulting output.  As the adoption
-   process progresses, adopted daemons will appear as style
-   ``cephadm:v1``.
+   Before starting the converstion process, ``cephadm ls`` shows all existing
+   daemons to have a style of ``legacy``. As the adoption process progresses,
+   adopted daemons will appear with a style of ``cephadm:v1``.
 
 
 Adoption process


### PR DESCRIPTION
This rewrites the "Adoption" section of
preparation.rst in the Cephadm manual.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
