### PR TITLE
mgr/dashboard: warn password expiration in User Management

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.html
@@ -20,3 +20,27 @@
     {{ role }}{{ !isLast ? ", " : "" }}
   </span>
 </ng-template>
+
+<ng-template #warningTpl
+             let-column="column"
+             let-value="value"
+             let-row="row">
+  <div [class.border-danger]="row.remainingDays < this.expirationDangerAlert"
+       [class.border-warning]="row.remainingDays < this.expirationWarningAlert && row.remainingDays >= this.expirationDangerAlert"
+       class="border-margin">
+    <div class="warning-content"> {{ value }} </div>
+  </div>
+</ng-template>
+
+<ng-template #durationTpl
+             let-column="column"
+             let-value="value"
+             let-row="row">
+  <i *ngIf="row.remainingDays < this.expirationWarningAlert"
+     i18n-title
+     title="User's password is about to expire"
+     [class.icon-danger-color]="row.remainingDays < this.expirationDangerAlert"
+     [class.icon-warning-color]="row.remainingDays < this.expirationWarningAlert && row.remainingDays >= this.expirationDangerAlert"
+     class="{{ icons.warning }}"></i>
+  <span title="{{ value | cdDate }}">{{ row.remainingTimeWithoutSeconds / 1000 | duration }}</span>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.scss
@@ -1,0 +1,16 @@
+@use './src/styles/vendor/variables' as vv;
+
+.border-margin {
+  border-left: 3px solid transparent;
+  height: calc(100% + 10px);
+  margin-bottom: -5px;
+  margin-left: -5px;
+  margin-top: -5px;
+}
+
+.warning-content {
+  height: 100%;
+  padding-bottom: 5px;
+  padding-left: 5px;
+  padding-top: 5px;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.spec.ts
@@ -79,4 +79,19 @@ describe('UserListComponent', () => {
       }
     });
   });
+  it('should calculate remaining days', () => {
+    const day = 60 * 60 * 24 * 1000;
+    let today = Date.now();
+    expect(component.getRemainingDays(today + day * 2 + 1000)).toBe(2);
+    today = Date.now();
+    expect(component.getRemainingDays(today + day * 2 - 1000)).toBe(1);
+    today = Date.now();
+    expect(component.getRemainingDays(today + day + 1000)).toBe(1);
+    today = Date.now();
+    expect(component.getRemainingDays(today + 1)).toBe(0);
+    today = Date.now();
+    expect(component.getRemainingDays(today - (day + 1))).toBe(0);
+    expect(component.getRemainingDays(null)).toBe(undefined);
+    expect(component.getRemainingDays(undefined)).toBe(undefined);
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/duration.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/duration.pipe.spec.ts
@@ -8,7 +8,7 @@ describe('DurationPipe', () => {
   });
 
   it('transforms seconds into a human readable duration', () => {
-    expect(pipe.transform(0)).toBe('1 second');
+    expect(pipe.transform(0)).toBe('');
     expect(pipe.transform(6)).toBe('6 seconds');
     expect(pipe.transform(60)).toBe('1 minute');
     expect(pipe.transform(600)).toBe('10 minutes');

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/duration.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/duration.pipe.ts
@@ -13,6 +13,9 @@ export class DurationPipe implements PipeTransform {
    * @return {string}         The phrase describing the the amount of time
    */
   transform(seconds: number): string {
+    if (seconds === null || seconds <= 0) {
+      return '';
+    }
     const levels = [
       [`${Math.floor(seconds / 31536000)}`, 'years'],
       [`${Math.floor((seconds % 31536000) / 86400)}`, 'days'],

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/pipes.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/pipes.module.ts
@@ -111,6 +111,7 @@ import { UpperFirstPipe } from './upper-first.pipe';
     MillisecondsPipe,
     NotAvailablePipe,
     UpperFirstPipe,
+    DurationPipe,
     MapPipe,
     TruncatePipe
   ]

--- a/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_basics.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/ceph-custom/_basics.scss
@@ -74,6 +74,18 @@ option {
   white-space: pre;
 }
 
+.icon-danger-color {
+  color: vv.$danger;
+}
+
+.icon-warning-color {
+  color: vv.$warning;
+}
+
+.border-warning {
+  border-left: 4px solid vv.$warning;
+}
+
 .border-danger {
   border-left: 4px solid vv.$danger;
 }


### PR DESCRIPTION
This PR adds support to warn about user's incoming password expiration on the User Management settings tab. 

Me and @waadkh7 discussed that an easy way to visualize that an user's password is about to expire is adding a small icon next to the username because is at the left which is faster for the eye to see. We've also changed the Expiration date to days remaining(the column name is too long, we should change it). 

In the following images you'll see how it looks and also there is hover interactions on the icons and the days remaining. 

The icon color is `$danger` for `<= USER_PWD_EXPIRATION_WARNING_2` and `$warning` for `<= USER_PWD_EXPIRATION_WARNING_1`


![image](https://user-images.githubusercontent.com/30913090/111957699-a4fea980-8aec-11eb-8143-2ba00d8114c3.png)

Fixes: https://tracker.ceph.com/issues/43058
Signed-off-by: Pere Díaz Bou <pere-altea@hotmail.com>

## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
