### PR TITLE
octopus: crush/CrushWrapper: update shadow trees on update_item()

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1615,6 +1615,12 @@ int CrushWrapper::adjust_subtree_weight(CephContext *cct, int id, int weight,
       }
     }
   }
+  int ret = rebuild_roots_with_classes(cct);
+  if (ret < 0) {
+    ldout(cct, 0) << __func__ << " unable to rebuild roots with classes: "
+		  << cpp_strerror(ret) << dendl;
+    return ret;
+  }
   return changed;
 }
 

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1426,6 +1426,12 @@ int CrushWrapper::update_item(
 		    << ((float)old_iweight/(float)0x10000) << " -> " << weight
 		    << dendl;
       adjust_item_weight_in_loc(cct, item, iweight, loc);
+      ret = rebuild_roots_with_classes(cct);
+      if (ret < 0) {
+	ldout(cct, 0) << __func__ << " unable to rebuild roots with classes: "
+		      << cpp_strerror(ret) << dendl;
+	return ret;
+      }
       ret = 1;
     }
     if (get_item_name(item) != name) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49530

---

backport of https://github.com/ceph/ceph/pull/39629
parent tracker: https://tracker.ceph.com/issues/48065

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh