### PR TITLE
octopus: mgr/telemetry: check if 'ident' channel is active

### DIFF
--- a/qa/tasks/mgr/dashboard/test_telemetry.py
+++ b/qa/tasks/mgr/dashboard/test_telemetry.py
@@ -11,6 +11,15 @@ class TelemetryTest(DashboardTestCase):
         data = cls._get('/api/mgr/module/telemetry')
         cls.pre_enabled_status = data['enabled']
 
+        # identify ourselves so we can filter these reports out on the server side
+        cls._put(
+            '/api/settings',
+            {
+                'mgr/telemetry/channel_ident': True,
+                'mgr/telemetry/organization': 'ceph-qa',
+            }
+        )
+
     @classmethod
     def tearDownClass(cls):
         if cls.pre_enabled_status:

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -367,6 +367,8 @@ class Module(MgrModule):
             r.append('crash')
         if self.channel_device:
             r.append('device')
+        if self.channel_ident:
+            r.append('ident')
         return r
 
     def gather_device_report(self):


### PR DESCRIPTION
NOTE: Backport omits eb3b27c8da741ff7b325eb7ac8bd85dd10b97994 which was also omitted from the pacific backport PR https://github.com/ceph/ceph/pull/39727

backport tracker: https://tracker.ceph.com/issues/49636

---

backport of

* https://github.com/ceph/ceph/pull/39538
* https://github.com/ceph/ceph/pull/39429

parent tracker: https://tracker.ceph.com/issues/49349

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh