### PR TITLE
nautilus: mgr/telemetry: check if 'ident' channel is active

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -366,6 +366,8 @@ class Module(MgrModule):
             r.append('crash')
         if self.channel_device:
             r.append('device')
+        if self.channel_ident:
+            r.append('ident')
         return r
 
     def gather_device_report(self):


### PR DESCRIPTION
NOTE: Backport omits eb3b27c8da741ff7b325eb7ac8bd85dd10b97994 which was also omitted from the pacific backport PR https://github.com/ceph/ceph/pull/39727

backport tracker: https://tracker.ceph.com/issues/49637

---

backport of https://github.com/ceph/ceph/pull/39538
parent tracker: https://tracker.ceph.com/issues/49349

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh