### PR TITLE
mgr/cephadm: prevent traceback when invalid osd id passed to 'orch osd rm stop'

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2286,7 +2286,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             try:
                 self.to_remove_osds.rm(OSD(osd_id=int(osd_id),
                                            remove_util=self.to_remove_osds.rm_util))
-            except (NotFoundError, KeyError):
+            except (NotFoundError, KeyError, ValueError):
                 return f'Unable to find OSD in the queue: {osd_id}'
 
         # trigger the serve loop to halt the removal


### PR DESCRIPTION
orch osd rm expects a str that can be converted to an int passed to it
if the user passed something that cant be converted it shows a traceback
catching the ValueError prevents this traceback.

Fixes: https://tracker.ceph.com/issues/49659
Signed-off-by: Daniel Pivonka <dpivonka@redhat.com>