### PR TITLE
pacific: common: Fix assertion when disabling and re-enabling clog_to_monitors

### DIFF
--- a/src/common/LogClient.cc
+++ b/src/common/LogClient.cc
@@ -133,6 +133,10 @@ LogClient::LogClient(CephContext *cct, Messenger *m, MonMap *mm,
 {
 }
 
+void LogChannel::set_log_to_monitors(bool v) {
+  log_to_monitors = v;
+}
+
 void LogChannel::update_config(map<string,string> &log_to_monitors,
 			       map<string,string> &log_to_syslog,
 			       map<string,string> &log_channels,

--- a/src/common/LogClient.cc
+++ b/src/common/LogClient.cc
@@ -133,8 +133,12 @@ LogClient::LogClient(CephContext *cct, Messenger *m, MonMap *mm,
 {
 }
 
-void LogChannel::set_log_to_monitors(bool v) {
-  log_to_monitors = v;
+void LogChannel::set_log_to_monitors(bool v)
+{
+  if (log_to_monitors != v) {
+    parent->reset();
+    log_to_monitors = v;
+  }
 }
 
 void LogChannel::update_config(map<string,string> &log_to_monitors,
@@ -330,6 +334,15 @@ version_t LogClient::queue(LogEntry &entry)
   }
 
   return entry.seq;
+}
+
+void LogClient::reset()
+{
+  std::lock_guard l(log_lock);
+  if (log_queue.size()) {
+    log_queue.clear();
+  }
+  last_log_sent = last_log;
 }
 
 uint64_t LogClient::get_next_seq()

--- a/src/common/LogClient.h
+++ b/src/common/LogClient.h
@@ -232,6 +232,7 @@ public:
   const EntityName& get_myname();
   entity_name_t get_myrank();
   version_t queue(LogEntry &entry);
+  void reset();
 
 private:
   ceph::ref_t<Message> _get_mon_log_message();

--- a/src/common/LogClient.h
+++ b/src/common/LogClient.h
@@ -117,9 +117,7 @@ public:
     do_log(CLOG_SEC, s);
   }
 
-  void set_log_to_monitors(bool v) {
-    log_to_monitors = v;
-  }
+  void set_log_to_monitors(bool v);
   void set_log_to_syslog(bool v) {
     log_to_syslog = v;
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49642

backport of #38997
parent tracker: https://tracker.ceph.com/issues/48946

Tested on centos8