### PR TITLE
rgw/notifications: get/delete of specific notification

### DIFF
--- a/doc/radosgw/s3/bucketops.rst
+++ b/doc/radosgw/s3/bucketops.rst
@@ -607,7 +607,7 @@ Parameters
 +------------------------+-----------+----------------------------------------------------------------------------------------+
 | Name                   | Type      | Description                                                                            |
 +========================+===========+========================================================================================+
-| ``notification-id``    | String    | Name of the notification. If not provided, all notifications on the bucket are deleted |
+| ``notification``       | String    | Name of the notification. If not provided, all notifications on the bucket are deleted |
 +------------------------+-----------+----------------------------------------------------------------------------------------+
 
 HTTP Response
@@ -638,7 +638,7 @@ Parameters
 +------------------------+-----------+----------------------------------------------------------------------------------------+
 | Name                   | Type      | Description                                                                            |
 +========================+===========+========================================================================================+
-| ``notification-id``    | String    | Name of the notification. If not provided, all notifications on the bucket are listed  |
+| ``notification``       | String    | Name of the notification. If not provided, all notifications on the bucket are listed  |
 +------------------------+-----------+----------------------------------------------------------------------------------------+
 
 Response Entities

--- a/examples/boto3/README.md
+++ b/examples/boto3/README.md
@@ -94,6 +94,21 @@ Expected output:
 }
 ```
 
+- Get configuration of all notification of a bucket:
+```
+aws --endpoint-url http://localhost:8000 s3api get-bucket-notification-configuration --bucket=mybucket --notification=""
+```
+
+- Delete a specific notification from a bucket:
+```
+aws --endpoint-url http://localhost:8000 s3api delete-bucket-notification-configuration --bucket=mybucket --notification=notif1
+```
+
+- Delete all notifications from a bucket:
+```
+aws --endpoint-url http://localhost:8000 s3api delete-bucket-notification-configuration --bucket=mybucket --notification=""
+```
+
 # Developers
 Anyone developing an extension to the S3 API supported by AWS, please modify ``service-2.sdk-extras.json`` (all extensions should go into the same file), so that boto3 could be used to test the new API. 
 In addition, python files with code samples should be added to this directory demonstrating use of the new API.

--- a/examples/boto3/delete_notification.py
+++ b/examples/boto3/delete_notification.py
@@ -13,7 +13,7 @@ elif len(sys.argv) == 2:
     bucketname = sys.argv[1]
     notification_name = ""
 else:
-    print('Usage: ' + sys.argv[0] + ' <bucket> [notification]')
+    print('Usage: ' + sys.argv[0] + ' <bucket> <notification>')
     sys.exit(1)
 
 # endpoint and keys from vstart
@@ -29,8 +29,5 @@ client = boto3.client('s3',
 # deleting a specific notification congifuration from a bucket (when NotificationId is provided) or 
 # deleting all notification configurations on a bucket (without deleting the bucket itself) are extension to AWS S3 API
 
-if notification_name == "":
-    print(client.delete_bucket_notification_configuration(Bucket=bucketname))
-else:
-    print(client.delete_bucket_notification_configuration(Bucket=bucketname,
+print(client.delete_bucket_notification_configuration(Bucket=bucketname,
                                                           Notification=notification_name))

--- a/examples/boto3/service-2.sdk-extras.json
+++ b/examples/boto3/service-2.sdk-extras.json
@@ -6,12 +6,23 @@
             "name":"DeleteBucketNotificationConfiguration",
             "http":{
                 "method":"DELETE",
-                "requestUri":"/{Bucket}?notification",
+                "requestUri":"/{Bucket}?notification={Notification}",
                 "responseCode":204
             },
             "input":{"shape":"DeleteBucketNotificationConfigurationRequest"},
             "documentationUrl":"https://docs.ceph.com/docs/master/radosgw/s3/bucketops/#delete-notification",
             "documentation":"<p>Deletes the notification configuration from the bucket.</p>"
+        },
+        "GetBucketNotificationConfiguration":{
+            "name":"GetBucketNotificationConfiguration",
+            "http":{
+                "method":"GET",
+                "requestUri":"/{Bucket}?notification={Notification}",
+                "responseCode":200
+            },
+            "input":{"shape":"GetBucketNotificationConfigurationRequest"},
+            "documentationUrl":"https://docs.ceph.com/docs/master/radosgw/s3/bucketops/#get-notification",
+            "documentation":"<p>Get the notification configuration of the bucket.</p>"
         },
         "GetUsageStats":{
             "name":"GetUsageStats",
@@ -79,8 +90,8 @@
                 "Notification":{
                     "shape":"NotificationId",
                     "documentation":"<p>Id of the specific notification on the bucket for which the configuration should be retrieved.</p>",
-                    "location":"querystring",
-                    "locationName":"notification-id"
+                    "location":"uri",
+                    "locationName":"Notification"
                 }
             }
         },
@@ -97,8 +108,8 @@
                 "Notification":{
                     "shape":"NotificationId",
                     "documentation":"<p>Id of the specific notification on the bucket to be deleted.</p>",
-                    "location":"querystring",
-                    "locationName":"notification-id"
+                    "location":"uri",
+                    "locationName":"Notification"
                 }
             }
         },

--- a/src/test/rgw/rgw_multi/zone_ps.py
+++ b/src/test/rgw/rgw_multi/zone_ps.py
@@ -330,30 +330,17 @@ class PSNotificationS3:
         self.conn = conn
         assert bucket_name.strip()
         self.bucket_name = bucket_name
-        self.resource = '/'+bucket_name
         self.topic_conf_list = topic_conf_list
         self.client = boto3.client('s3',
                                    endpoint_url='http://'+conn.host+':'+str(conn.port),
                                    aws_access_key_id=conn.aws_access_key_id,
-                                   aws_secret_access_key=conn.aws_secret_access_key,
-                                   config=Config(signature_version='s3'))
+                                   aws_secret_access_key=conn.aws_secret_access_key)
 
-    def send_request(self, method, parameters=None):
-        """send request to radosgw"""
-        return make_request(self.conn, method, self.resource,
-                            parameters=parameters, sign_parameters=True)
-
-    def get_config(self, notification=None):
+    def get_config(self, notification=''):
         """get notification info"""
-        parameters = None
-        if notification is None:
-            response = self.client.get_bucket_notification_configuration(Bucket=self.bucket_name)
-            status = response['ResponseMetadata']['HTTPStatusCode']
-            return response, status
-        parameters = {'notification': notification}
-        response, status = self.send_request('GET', parameters=parameters)
-        dict_response = xmltodict.parse(response)
-        return dict_response, status
+        response = self.client.get_bucket_notification_configuration(Bucket=self.bucket_name, Notification=notification)
+        status = response['ResponseMetadata']['HTTPStatusCode']
+        return response, status
 
     def set_config(self):
         """set notification"""
@@ -364,11 +351,11 @@ class PSNotificationS3:
         status = response['ResponseMetadata']['HTTPStatusCode']
         return response, status
 
-    def del_config(self, notification=None):
+    def del_config(self, notification=''):
         """delete notification"""
-        parameters = {'notification': notification}
-
-        return self.send_request('DELETE', parameters)
+        response = self.client.delete_bucket_notification_configuration(Bucket=self.bucket_name, Notification=notification)
+        status = response['ResponseMetadata']['HTTPStatusCode']
+        return response, status
 
 
 class PSSubscription:


### PR DESCRIPTION
note this is a fix to the tool and documentation not the code
(specific delete/get already supported in he code)

Fixes: https://tracker.ceph.com/issues/48369

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

## testing
* copy the new `service-2.sdk-extras.json` file into `~/.aws/models/s3/2006-03-01/`. if this directory does not exist already, create it first
* run a ceph cluster using vstart
* create a topic:
```
aws --endpoint-url http://localhost:8000 sns create-topic --name fishtopic --attributes='{"push-endpoint": "amqp://127.0.0.1:5672", "amqp-exchange": "ex1", "amqp-ack-level": "broker"}'
```
* create a bucket:
```
aws --endpoint-url http://localhost:8000 s3 mb s3://fish
```
* create 2 notifications:
```
aws --region=default --endpoint-url http://localhost:8000 s3api put-bucket-notification-configuration --bucket fish --notification-configuration='{"TopicConfigurations": [{"Id": "creation-notif", "TopicArn": "arn:aws:sns:default::fishtopic", "Events": ["s3:ObjectCreated:*"]}]}'

aws --region=default --endpoint-url http://localhost:8000 s3api put-bucket-notification-configuration --bucket fish --notification-configuration='{"TopicConfigurations": [{"Id": "deletion-notif", "TopicArn": "arn:aws:sns:default::fishtopic", "Events": ["s3:ObjectRemoved:*"]}]}'
```
* fetch **one** of the notifications using CLI:
```
aws --region=default --endpoint-url http://localhost:8000 s3api get-bucket-notification-configuration --bucket fish --notification "creation-notif"
```
* fetch all notifications using CLI:
```
aws --region=default --endpoint-url http://localhost:8000 s3api get-bucket-notification-configuration --bucket fish --notification ""
```
* delete **one** of the notifications using CLI (fetch all notifications to make sure only one is deleted):
```
aws --region=default --endpoint-url http://localhost:8000 s3api delete-bucket-notification-configuration --bucket fish --notification "creation-notif"
```
* delete all notifications using CLI  (fetch all notifications to make sure all are deleted):
```
aws --region=default --endpoint-url http://localhost:8000 s3api delete-bucket-notification-configuration --bucket fish --notification ""
```
* you can repeat the entire test (no need to create the topic and bucket again) with the `get_notification.py` and `delete_notification.py` boto3 scripts

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
