### PR TITLE
doc/mgr/crash: explain needed crash upload permissions

### DIFF
--- a/doc/mgr/crash.rst
+++ b/doc/mgr/crash.rst
@@ -3,19 +3,39 @@ Crash Module
 The crash module collects information about daemon crashdumps and stores
 it in the Ceph cluster for later analysis.
 
-Daemon crashdumps are dumped in /var/lib/ceph/crash by default; this can
-be configured with the option 'crash dir'.  Crash directories are named by
-time and date and a randomly-generated UUID, and contain a metadata file
-'meta' and a recent log file, with a "crash_id" that is the same.
-This module allows the metadata about those dumps to be persisted in
-the monitors' storage.
-
 Enabling
 --------
 
 The *crash* module is enabled with::
 
   ceph mgr module enable crash
+
+The *crash* upload key is generated with::
+
+  ceph auth get-or-create client.crash mon 'profile crash' mgr 'profile crash'
+
+On each node, you should store this key in
+``/etc/ceph/ceph.client.crash.keyring``.
+
+
+Automated collection
+--------------------
+
+Daemon crashdumps are dumped in ``/var/lib/ceph/crash`` by default; this can
+be configured with the option 'crash dir'.  Crash directories are named by
+time and date and a randomly-generated UUID, and contain a metadata file
+'meta' and a recent log file, with a "crash_id" that is the same.
+
+These crashes can be automatically submitted and persisted in the monitors'
+storage by using ``ceph-crash.service``.
+It watches the crashdump directory and uploads them with ``ceph crash post``.
+
+``ceph-crash`` tries some authentication names: ``client.crash.$hostname``,
+``client.crash`` and ``client.admin``.
+In order to successfully upload with ``ceph crash post``, these need
+the suitable permissions: ``mon profile crash`` and ``mgr profile crash``
+and a keyring needs to be in ``/etc/ceph``.
+
 
 Commands
 --------

--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -308,11 +308,11 @@ The following entries describe valid capability profiles:
               you're doing as the security ramifications are substantial and
               pervasive.
 
-``profile crash`` (Monitor only)
+``profile crash`` (Monitor and MGR)
 
 :Description: Gives a user read-only access to monitors, used in conjunction
-              with the manager ``crash`` module when collecting daemon crash
-              dumps for later analysis.
+              with the manager ``crash`` module to upload daemon crash
+              dumps into monitor storage for later analysis.
 
 Pool
 ----


### PR DESCRIPTION
The documentation to set up `ceph-crash` was unclear what permissions are needed.


## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>