### PR TITLE
nautilus: rgw: beast frontend uses 512k mprotected coroutine stacks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,3 +58,6 @@
 [submodule "src/c-ares"]
 	path = src/c-ares
 	url = https://github.com/ceph/c-ares.git
+[submodule "src/spawn"]
+	path = src/spawn
+	url = https://github.com/ceph/spawn.git

--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -230,6 +230,7 @@ macro(build_boost version)
         INTERFACE_LINK_LIBRARIES "${dependencies}")
       unset(dependencies)
     endif()
+    set(Boost_${c}_FOUND "TRUE")
   endforeach()
 
   # for header-only libraries

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -692,6 +692,12 @@ if(WITH_RBD)
   add_subdirectory(rbd_replay)
 endif(WITH_RBD)
 
+if(WITH_BOOST_CONTEXT)
+  set(SPAWN_BUILD_TESTS OFF CACHE INTERNAL "disable building of spawn unit tests")
+  set(SPAWN_INSTALL OFF CACHE INTERNAL "disable installation of spawn headers")
+  add_subdirectory(spawn)
+endif()
+
 # RadosGW
 if(WITH_KVS)
   add_subdirectory(key_value_store)

--- a/src/cls/CMakeLists.txt
+++ b/src/cls/CMakeLists.txt
@@ -86,6 +86,10 @@ if (WITH_RADOSGW)
     otp/cls_otp_types.cc
     )
   add_library(cls_otp_client STATIC ${cls_otp_client_srcs})
+  if (WITH_BOOST_CONTEXT)
+    target_include_directories(cls_otp_client PRIVATE
+      $<TARGET_PROPERTY:spawn,INTERFACE_INCLUDE_DIRECTORIES>)
+  endif()
 endif (WITH_RADOSGW)
 
 # cls_refcount

--- a/src/common/async/yield_context.h
+++ b/src/common/async/yield_context.h
@@ -22,31 +22,28 @@
 
 #ifndef HAVE_BOOST_CONTEXT
 
-// hide the dependencies on boost::context and boost::coroutines
-namespace boost::asio {
+// hide the dependency on boost::context
+namespace spawn {
 struct yield_context;
 }
 
 #else // HAVE_BOOST_CONTEXT
-#ifndef BOOST_COROUTINES_NO_DEPRECATION_WARNING
-#define BOOST_COROUTINES_NO_DEPRECATION_WARNING
-#endif
-#include <boost/asio/spawn.hpp>
+#include <spawn/spawn.hpp>
 
 #endif // HAVE_BOOST_CONTEXT
 
 
-/// optional-like wrapper for a boost::asio::yield_context and its associated
+/// optional-like wrapper for a spawn::yield_context and its associated
 /// boost::asio::io_context. operations that take an optional_yield argument
 /// will, when passed a non-empty yield context, suspend this coroutine instead
 /// of the blocking the thread of execution
 class optional_yield {
   boost::asio::io_context *c = nullptr;
-  boost::asio::yield_context *y = nullptr;
+  spawn::yield_context *y = nullptr;
  public:
   /// construct with a valid io and yield_context
   explicit optional_yield(boost::asio::io_context& c,
-                          boost::asio::yield_context& y) noexcept
+                          spawn::yield_context& y) noexcept
     : c(&c), y(&y) {}
 
   /// type tag to construct an empty object
@@ -60,7 +57,7 @@ class optional_yield {
   boost::asio::io_context& get_io_context() const noexcept { return *c; }
 
   /// return a reference to the yield_context. only valid if non-empty
-  boost::asio::yield_context& get_yield_context() const noexcept { return *y; }
+  spawn::yield_context& get_yield_context() const noexcept { return *y; }
 };
 
 // type tag object to construct an empty optional_yield

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -151,6 +151,10 @@ add_library(rgw_common OBJECT ${librgw_common_srcs})
 target_include_directories(rgw_common SYSTEM PUBLIC "services")
 target_include_directories(rgw_common PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src")
 
+if(WITH_BOOST_CONTEXT)
+  target_link_libraries(rgw_common PUBLIC spawn)
+endif()
+
 if(WITH_LTTNG)
   # rgw/rgw_op.cc includes "tracing/rgw_op.h"
   # rgw/rgw_rados.cc includes "tracing/rgw_rados.h"
@@ -219,7 +223,7 @@ if(WITH_CURL_OPENSSL)
 endif()
 
 if(WITH_BOOST_CONTEXT)
-  target_link_libraries(rgw_a PRIVATE spawn)
+  target_link_libraries(rgw_a PUBLIC spawn)
 endif()
 
 set(rgw_libs rgw_a)
@@ -257,6 +261,9 @@ target_link_libraries(radosgw_a PRIVATE ${rgw_libs})
 if(WITH_RADOSGW_BEAST_FRONTEND AND WITH_RADOSGW_BEAST_OPENSSL)
   # used by rgw_asio_frontend.cc
   target_link_libraries(radosgw_a PRIVATE OpenSSL::SSL)
+endif()
+if(WITH_BOOST_CONTEXT)
+  target_link_libraries(radosgw_a PUBLIC spawn)
 endif()
 
 add_executable(radosgw rgw_main.cc)
@@ -379,9 +386,6 @@ if(WITH_RADOSGW_AMQP_ENDPOINT)
 endif()
 if(WITH_RADOSGW_KAFKA_ENDPOINT)
   target_link_libraries(rgw_admin_user PRIVATE RDKafka::RDKafka)
-endif()
-if(WITH_BOOST_CONTEXT)
-  target_link_libraries(rgw_admin_user PRIVATE Boost::coroutine Boost::context)
 endif()
 
 if(WITH_TESTS)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -152,7 +152,8 @@ target_include_directories(rgw_common SYSTEM PUBLIC "services")
 target_include_directories(rgw_common PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src")
 
 if(WITH_BOOST_CONTEXT)
-  target_link_libraries(rgw_common PUBLIC spawn)
+  target_include_directories(rgw_common PRIVATE
+    $<TARGET_PROPERTY:spawn,INTERFACE_INCLUDE_DIRECTORIES>)
 endif()
 
 if(WITH_LTTNG)
@@ -386,6 +387,9 @@ if(WITH_RADOSGW_AMQP_ENDPOINT)
 endif()
 if(WITH_RADOSGW_KAFKA_ENDPOINT)
   target_link_libraries(rgw_admin_user PRIVATE RDKafka::RDKafka)
+endif()
+if(WITH_BOOST_CONTEXT)
+  target_link_libraries(rgw_admin_user PRIVATE spawn)
 endif()
 
 if(WITH_TESTS)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -219,7 +219,7 @@ if(WITH_CURL_OPENSSL)
 endif()
 
 if(WITH_BOOST_CONTEXT)
-  target_link_libraries(rgw_a PRIVATE Boost::coroutine Boost::context)
+  target_link_libraries(rgw_a PRIVATE spawn)
 endif()
 
 set(rgw_libs rgw_a)

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -8,6 +8,7 @@
 #include <boost/asio.hpp>
 #include <boost/intrusive/list.hpp>
 
+#include <boost/context/protected_fixedsize_stack.hpp>
 #include <spawn/spawn.hpp>
 
 #include "common/async/shared_mutex.h"
@@ -34,6 +35,11 @@ namespace ssl = boost::asio::ssl;
 #endif
 
 using parse_buffer = boost::beast::flat_static_buffer<65536>;
+
+// use mmap/mprotect to allocate 512k coroutine stacks
+auto make_stack_allocator() {
+  return boost::context::protected_fixedsize_stack{512*1024};
+}
 
 template <typename Stream>
 class StreamIO : public rgw::asio::ClientIO {
@@ -670,7 +676,7 @@ void AsioFrontend::accept(Listener& l, boost::system::error_code ec)
           stream.async_shutdown(yield[ec]);
         }
         s.shutdown(tcp::socket::shutdown_both, ec);
-      });
+      }, make_stack_allocator());
   } else {
 #else
   {
@@ -684,7 +690,7 @@ void AsioFrontend::accept(Listener& l, boost::system::error_code ec)
         handle_connection(context, env, s, *buffer, false, pause_mutex,
                           scheduler.get(), ec, yield);
         s.shutdown(tcp::socket::shutdown_both, ec);
-      });
+      }, make_stack_allocator());
   }
 }
 

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -6,11 +6,9 @@
 #include <vector>
 
 #include <boost/asio.hpp>
-#define BOOST_COROUTINES_NO_DEPRECATION_WARNING
-#include <boost/range/begin.hpp>
-#include <boost/range/end.hpp>
-#include <boost/asio/spawn.hpp>
 #include <boost/intrusive/list.hpp>
+
+#include <spawn/spawn.hpp>
 
 #include "common/async/shared_mutex.h"
 #include "common/errno.h"
@@ -123,7 +121,7 @@ void handle_connection(boost::asio::io_context& context,
                        SharedMutex& pause_mutex,
                        rgw::dmclock::Scheduler *scheduler,
                        boost::system::error_code& ec,
-                       boost::asio::yield_context yield)
+                       spawn::yield_context yield)
 {
   // limit header to 4k, since we read it all into a single flat_buffer
   static constexpr size_t header_limit = 4096;
@@ -649,8 +647,8 @@ void AsioFrontend::accept(Listener& l, boost::system::error_code ec)
   // spawn a coroutine to handle the connection
 #ifdef WITH_RADOSGW_BEAST_OPENSSL
   if (l.use_ssl) {
-    boost::asio::spawn(context,
-      [this, s=std::move(socket)] (boost::asio::yield_context yield) mutable {
+    spawn::spawn(context,
+      [this, s=std::move(socket)] (spawn::yield_context yield) mutable {
         Connection conn{s};
         auto c = connections.add(conn);
         // wrap the socket in an ssl stream
@@ -677,8 +675,8 @@ void AsioFrontend::accept(Listener& l, boost::system::error_code ec)
 #else
   {
 #endif // WITH_RADOSGW_BEAST_OPENSSL
-    boost::asio::spawn(context,
-      [this, s=std::move(socket)] (boost::asio::yield_context yield) mutable {
+    spawn::spawn(context,
+      [this, s=std::move(socket)] (spawn::yield_context yield) mutable {
         Connection conn{s};
         auto c = connections.add(conn);
         auto buffer = std::make_unique<parse_buffer>();

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -301,6 +301,10 @@ target_link_libraries(ceph_test_librgw_file_nfsns
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
   )
+if(WITH_BOOST_CONTEXT)
+  target_link_libraries(ceph_test_librgw_file_nfsns spawn)
+endif()
+
 
 # ceph_test_librgw_file_aw (nfs write transaction [atomic write] tests)
 add_executable(ceph_test_librgw_file_aw
@@ -325,6 +329,9 @@ target_link_libraries(ceph_test_librgw_file_marker
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
   )
+if(WITH_BOOST_CONTEXT)
+  target_link_libraries(ceph_test_librgw_file_marker spawn)
+endif()
 
 # ceph_test_rgw_token
 add_executable(ceph_test_rgw_token

--- a/src/test/librados/CMakeLists.txt
+++ b/src/test/librados/CMakeLists.txt
@@ -133,6 +133,9 @@ add_executable(ceph_test_rados_api_tier_pp
   $<TARGET_OBJECTS:unit-main>)
 target_link_libraries(ceph_test_rados_api_tier_pp
   librados global ${UNITTEST_LIBS} Boost::system radostest-cxx)
+if(WITH_BOOST_CONTEXT)
+  target_link_libraries(ceph_test_rados_api_tier_pp spawn)
+endif()
 
 add_executable(ceph_test_rados_api_snapshots
   snapshots.cc)

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -40,9 +40,9 @@ add_executable(unittest_rgw_reshard_wait test_rgw_reshard_wait.cc)
 add_ceph_unittest(unittest_rgw_reshard_wait)
 target_link_libraries(unittest_rgw_reshard_wait ${rgw_libs})
 
-set(test_rgw_a_src
-  test_rgw_common.cc)
+set(test_rgw_a_src test_rgw_common.cc)
 add_library(test_rgw_a STATIC ${test_rgw_a_src})
+target_link_libraries(test_rgw_a ${rgw_libs})
 
 # ceph_test_rgw_manifest
 set(test_rgw_manifest_srcs test_rgw_manifest.cc)
@@ -50,7 +50,6 @@ add_executable(ceph_test_rgw_manifest
   ${test_rgw_manifest_srcs}
   )
 target_link_libraries(ceph_test_rgw_manifest
-  ${rgw_libs}
   test_rgw_a
   cls_rgw_client
   cls_lock_client
@@ -73,7 +72,6 @@ add_executable(ceph_test_rgw_obj
   ${test_rgw_obj_srcs}
   )
 target_link_libraries(ceph_test_rgw_obj
-  ${rgw_libs}
   test_rgw_a
   cls_rgw_client
   cls_lock_client

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -150,6 +150,8 @@ target_link_libraries(unittest_rgw_dmclock_scheduler radosgw_a dmclock)
 if(WITH_BOOST_CONTEXT)
   target_compile_definitions(unittest_rgw_dmclock_scheduler PRIVATE BOOST_COROUTINES_NO_DEPRECATION_WARNING)
   target_link_libraries(unittest_rgw_dmclock_scheduler Boost::coroutine Boost::context)
+  target_include_directories(unittest_rgw_dmclock_scheduler PRIVATE
+    $<TARGET_PROPERTY:spawn,INTERFACE_INCLUDE_DIRECTORIES>)
 endif()
 
 if(WITH_RADOSGW_AMQP_ENDPOINT)

--- a/src/test/rgw/test_rgw_reshard_wait.cc
+++ b/src/test/rgw/test_rgw_reshard_wait.cc
@@ -13,7 +13,9 @@
  */
 
 #include "rgw/rgw_reshard.h"
+#ifdef HAVE_BOOST_CONTEXT
 #include <spawn/spawn.hpp>
+#endif
 
 #include <gtest/gtest.h>
 

--- a/src/test/rgw/test_rgw_reshard_wait.cc
+++ b/src/test/rgw/test_rgw_reshard_wait.cc
@@ -13,6 +13,7 @@
  */
 
 #include "rgw/rgw_reshard.h"
+#include <spawn/spawn.hpp>
 
 #include <gtest/gtest.h>
 
@@ -64,7 +65,7 @@ TEST(ReshardWait, wait_yield)
   RGWReshardWait waiter(wait_duration);
 
   boost::asio::io_context context;
-  boost::asio::spawn(context, [&] (boost::asio::yield_context yield) {
+  spawn::spawn(context, [&] (spawn::yield_context yield) {
       EXPECT_EQ(0, waiter.wait(optional_yield{context, yield}));
     });
 
@@ -89,8 +90,8 @@ TEST(ReshardWait, stop_yield)
   RGWReshardWait short_waiter(short_duration);
 
   boost::asio::io_context context;
-  boost::asio::spawn(context,
-    [&] (boost::asio::yield_context yield) {
+  spawn::spawn(context,
+    [&] (spawn::yield_context yield) {
       EXPECT_EQ(-ECANCELED, long_waiter.wait(optional_yield{context, yield}));
     });
 
@@ -133,13 +134,13 @@ TEST(ReshardWait, stop_multiple)
   // spawn 4 coroutines
   boost::asio::io_context context;
   {
-    auto async_waiter = [&] (boost::asio::yield_context yield) {
+    auto async_waiter = [&] (spawn::yield_context yield) {
         EXPECT_EQ(-ECANCELED, long_waiter.wait(optional_yield{context, yield}));
       };
-    boost::asio::spawn(context, async_waiter);
-    boost::asio::spawn(context, async_waiter);
-    boost::asio::spawn(context, async_waiter);
-    boost::asio::spawn(context, async_waiter);
+    spawn::spawn(context, async_waiter);
+    spawn::spawn(context, async_waiter);
+    spawn::spawn(context, async_waiter);
+    spawn::spawn(context, async_waiter);
   }
 
   const auto start = Clock::now();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/43921

---

backport of https://github.com/ceph/ceph/pull/31580
parent tracker: https://tracker.ceph.com/issues/43739

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh