### PR TITLE
 pacific: librados, tests: allow to list objects with the NUL character in names

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -222,7 +222,7 @@ typedef void *rados_ioctx_t;
  *
  * An iterator for listing the objects in a pool.
  * Used with rados_nobjects_list_open(),
- * rados_nobjects_list_next(), and
+ * rados_nobjects_list_next(), rados_nobjects_list_next2(), and
  * rados_nobjects_list_close().
  */
 typedef void *rados_list_ctx_t;
@@ -1136,6 +1136,32 @@ CEPH_RADOS_API int rados_nobjects_list_next(rados_list_ctx_t ctx,
                                             const char **entry,
 	                                    const char **key,
                                             const char **nspace);
+
+/**
+ * Get the next object name, locator and their sizes in the pool
+ *
+ * The sizes allow to list objects with \0 (the NUL character)
+ * in .e.g *entry. Is is unusual see such object names but a bug
+ * in a client has risen the need to handle them as well.
+ * *entry and *key are valid until next call to rados_nobjects_list_*
+ *
+ * @param ctx iterator marking where you are in the listing
+ * @param entry where to store the name of the entry
+ * @param key where to store the object locator (set to NULL to ignore)
+ * @param nspace where to store the object namespace (set to NULL to ignore)
+ * @param entry_size where to store the size of name of the entry
+ * @param key_size where to store the size of object locator (set to NULL to ignore)
+ * @param nspace_size where to store the size of object namespace (set to NULL to ignore)
+ * @returns 0 on success, negative error code on failure
+ * @returns -ENOENT when there are no more objects to list
+ */
+CEPH_RADOS_API int rados_nobjects_list_next2(rados_list_ctx_t ctx,
+                                             const char **entry,
+                                             const char **key,
+                                             const char **nspace,
+                                             size_t *entry_size,
+                                             size_t *key_size,
+                                             size_t *nspace_size);
 
 /**
  * Close the object listing handle.

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -2410,6 +2410,22 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_nobjects_list_next)(
   const char **nspace)
 {
   tracepoint(librados, rados_nobjects_list_next_enter, listctx);
+  uint32_t retval = rados_nobjects_list_next2(listctx, entry, key, nspace, NULL, NULL, NULL);
+  tracepoint(librados, rados_nobjects_list_next_exit, 0, *entry, key, nspace);
+  return retval;
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_nobjects_list_next);
+
+extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_nobjects_list_next2)(
+  rados_list_ctx_t listctx,
+  const char **entry,
+  const char **key,
+  const char **nspace,
+  size_t *entry_size,
+  size_t *key_size,
+  size_t *nspace_size)
+{
+  tracepoint(librados, rados_nobjects_list_next2_enter, listctx);
   librados::ObjListCtx *lh = (librados::ObjListCtx *)listctx;
   Objecter::NListContext *h = lh->nlc;
 
@@ -2421,11 +2437,11 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_nobjects_list_next)(
   if (h->list.empty()) {
     int ret = lh->ctx->nlist(lh->nlc, RADOS_LIST_MAX_ENTRIES);
     if (ret < 0) {
-      tracepoint(librados, rados_nobjects_list_next_exit, ret, NULL, NULL, NULL);
+      tracepoint(librados, rados_nobjects_list_next2_exit, ret, NULL, NULL, NULL, NULL, NULL, NULL);
       return ret;
     }
     if (h->list.empty()) {
-      tracepoint(librados, rados_nobjects_list_next_exit, -ENOENT, NULL, NULL, NULL);
+      tracepoint(librados, rados_nobjects_list_next2_exit, -ENOENT, NULL, NULL, NULL, NULL, NULL, NULL);
       return -ENOENT;
     }
   }
@@ -2440,10 +2456,19 @@ extern "C" int LIBRADOS_C_API_DEFAULT_F(rados_nobjects_list_next)(
   }
   if (nspace)
     *nspace = h->list.front().nspace.c_str();
-  tracepoint(librados, rados_nobjects_list_next_exit, 0, *entry, key, nspace);
+
+  if (entry_size)
+    *entry_size = h->list.front().oid.size();
+  if (key_size)
+    *key_size = h->list.front().locator.size();
+  if (nspace_size)
+    *nspace_size = h->list.front().nspace.size();
+
+  tracepoint(librados, rados_nobjects_list_next2_exit, 0, entry, key, nspace,
+             entry_size, key_size, nspace_size);
   return 0;
 }
-LIBRADOS_C_API_BASE_DEFAULT(rados_nobjects_list_next);
+LIBRADOS_C_API_BASE_DEFAULT(rados_nobjects_list_next2);
 
 
 /*

--- a/src/tools/scratchtool.c
+++ b/src/tools/scratchtool.c
@@ -291,8 +291,8 @@ static int testrados(void)
 	r = rados_nobjects_list_open(io_ctx, &h);
 	printf("rados_nobjects_list_open = %d, h = %p\n", r, h);
 	const char *poolname;
-	while (rados_nobjects_list_next(h, &poolname, NULL, NULL) == 0)
-		printf("rados_nobjects_list_next got object '%s'\n", poolname);
+	while (rados_nobjects_list_next2(h, &poolname, NULL, NULL, NULL, NULL, NULL) == 0)
+		printf("rados_nobjects_list_next2 got object '%s'\n", poolname);
 	rados_nobjects_list_close(h);
 
 	/* stat */

--- a/src/tracing/librados.tp
+++ b/src/tracing/librados.tp
@@ -1884,6 +1884,32 @@ TRACEPOINT_EVENT(librados, rados_nobjects_list_next_exit,
     )
 )
 
+TRACEPOINT_EVENT(librados, rados_nobjects_list_next2_enter,
+    TP_ARGS(
+        rados_list_ctx_t, listctx),
+    TP_FIELDS(
+        ctf_integer_hex(rados_list_ctx_t, listctx, listctx)
+    )
+)
+
+TRACEPOINT_EVENT(librados, rados_nobjects_list_next2_exit,
+    TP_ARGS(
+        int, retval,
+        const char* const*, entry,
+        const char* const*, key,
+        const char* const*, nspace,
+        const size_t*, entry_size,
+        const size_t*, key_size,
+        const size_t*, nspace_size),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+        ceph_ctf_sequencep(char, entry, entry, size_t, entry_size)
+        ceph_ctf_sequencep(char, key, key, size_t, key_size)
+        ceph_ctf_sequencep(char, nspace, nspace, size_t, nspace_size)
+    )
+)
+
+
 TRACEPOINT_EVENT(librados, rados_objects_list_open_enter,
     TP_ARGS(
         rados_ioctx_t, ioctx),


### PR DESCRIPTION
This is backport of PR #39322. The nautilus' counterpart is #39324.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
