### PR TITLE
octopus: rgw: fix sts get_session_token duration check failed

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -166,6 +166,9 @@ static inline void get_v2_qs_map(const req_info& info,
     if (k.find("x-amz-meta-") == /* offset */ 0) {
       rgw_add_amz_meta_header(qs_map, k, elt.second);
     }
+    if (k == "x-amz-security-token") {
+      qs_map[k] = elt.second;
+    }
   }
 }
 

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -412,8 +412,9 @@ int RGWSTSGetSessionToken::get_params()
     }
 
     if (duration_in_secs < STS::GetSessionTokenRequest::getMinDuration() ||
-            duration_in_secs > s->cct->_conf->rgw_sts_max_session_duration)
+            duration_in_secs > s->cct->_conf->rgw_sts_max_session_duration) {
       return -EINVAL;
+    }
   }
 
   return 0;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49361

---

backport of https://github.com/ceph/ceph/pull/38917
parent tracker: https://tracker.ceph.com/issues/48883

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh