### PR TITLE
mgr/cephadm: use existing cephx key it if varies

### DIFF
--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -512,13 +512,12 @@ class MgrService(CephService):
         mgr_id, _ = daemon_spec.daemon_id, daemon_spec.host
 
         # get mgr. key
-        ret, keyring, err = self.mgr.check_mon_command({
-            'prefix': 'auth get-or-create',
-            'entity': self.get_auth_entity(mgr_id),
-            'caps': ['mon', 'profile mgr',
-                     'osd', 'allow *',
-                     'mds', 'allow *'],
-        })
+        keyring = self.mgr._get_or_create_key(
+            self.get_auth_entity(mgr_id),
+            ['mon', 'profile mgr',
+             'osd', 'allow *',
+             'mds', 'allow *'],
+        )
 
         # Retrieve ports used by manager modules
         # In the case of the dashboard port and with several manager daemons
@@ -620,14 +619,12 @@ class MdsService(CephService):
         mds_id, _ = daemon_spec.daemon_id, daemon_spec.host
 
         # get mgr. key
-        ret, keyring, err = self.mgr.check_mon_command({
-            'prefix': 'auth get-or-create',
-            'entity': self.get_auth_entity(mds_id),
-            'caps': ['mon', 'profile mds',
-                     'osd', 'allow rw tag cephfs *=*',
-                     'mds', 'allow'],
-        })
-        daemon_spec.keyring = keyring
+        daemon_spec.keyring = self.mgr._get_or_create_key(
+            self.get_auth_entity(mds_id),
+            ['mon', 'profile mds',
+             'osd', 'allow rw tag cephfs *=*',
+             'mds', 'allow'],
+        )
 
         daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
 
@@ -733,14 +730,12 @@ class RgwService(CephService):
         return daemon_spec
 
     def get_keyring(self, rgw_id: str) -> str:
-        ret, keyring, err = self.mgr.check_mon_command({
-            'prefix': 'auth get-or-create',
-            'entity': self.get_auth_entity(rgw_id),
-            'caps': ['mon', 'allow *',
-                     'mgr', 'allow rw',
-                     'osd', 'allow rwx tag rgw *=*'],
-        })
-        return keyring
+        return self.mgr._get_or_create_key(
+            self.get_auth_entity(rgw_id),
+            ['mon', 'allow *',
+             'mgr', 'allow rw',
+             'osd', 'allow rwx tag rgw *=*'],
+        )
 
     def create_realm_zonegroup_zone(self, spec: RGWSpec, rgw_id: str) -> None:
         if utils.get_cluster_health(self.mgr) != 'HEALTH_OK':
@@ -913,14 +908,11 @@ class RbdMirrorService(CephService):
         assert self.TYPE == daemon_spec.daemon_type
         daemon_id, _ = daemon_spec.daemon_id, daemon_spec.host
 
-        ret, keyring, err = self.mgr.check_mon_command({
-            'prefix': 'auth get-or-create',
-            'entity': self.get_auth_entity(daemon_id),
-            'caps': ['mon', 'profile rbd-mirror',
-                     'osd', 'profile rbd'],
-        })
-
-        daemon_spec.keyring = keyring
+        daemon_spec.keyring = self.mgr._get_or_create_key(
+            self.get_auth_entity(daemon_id),
+            ['mon', 'profile rbd-mirror',
+             'osd', 'profile rbd'],
+        )
 
         daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
 
@@ -947,14 +939,11 @@ class CrashService(CephService):
         assert self.TYPE == daemon_spec.daemon_type
         daemon_id, host = daemon_spec.daemon_id, daemon_spec.host
 
-        ret, keyring, err = self.mgr.check_mon_command({
-            'prefix': 'auth get-or-create',
-            'entity': self.get_auth_entity(daemon_id, host=host),
-            'caps': ['mon', 'profile crash',
-                     'mgr', 'profile crash'],
-        })
-
-        daemon_spec.keyring = keyring
+        daemon_spec.keyring = self.mgr._get_or_create_key(
+            self.get_auth_entity(daemon_id, host=host),
+            ['mon', 'profile crash',
+             'mgr', 'profile crash'],
+        )
 
         daemon_spec.final_config, daemon_spec.deps = self.generate_config(daemon_spec)
 

--- a/src/pybind/mgr/cephadm/services/iscsi.py
+++ b/src/pybind/mgr/cephadm/services/iscsi.py
@@ -27,15 +27,14 @@ class IscsiService(CephService):
         spec = cast(IscsiServiceSpec, self.mgr.spec_store[daemon_spec.service_name].spec)
         igw_id = daemon_spec.daemon_id
 
-        ret, keyring, err = self.mgr.check_mon_command({
-            'prefix': 'auth get-or-create',
-            'entity': self.get_auth_entity(igw_id),
-            'caps': ['mon', 'profile rbd, '
-                            'allow command "osd blocklist", '
-                            'allow command "config-key get" with "key" prefix "iscsi/"',
-                     'mgr', 'allow command "service status"',
-                     'osd', 'allow rwx'],
-        })
+        keyring = self.mgr._get_or_create_key(
+            self.get_auth_entity(igw_id),
+            ['mon', 'profile rbd, '
+             'allow command "osd blocklist", '
+             'allow command "config-key get" with "key" prefix "iscsi/"',
+             'mgr', 'allow command "service status"',
+             'osd', 'allow rwx'],
+        )
 
         if spec.ssl_cert:
             if isinstance(spec.ssl_cert, list):

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -118,28 +118,22 @@ class NFSService(CephService):
             osd_caps = '%s namespace=%s' % (osd_caps, spec.namespace)
 
         logger.info('Create keyring: %s' % entity)
-        ret, keyring, err = self.mgr.check_mon_command({
-            'prefix': 'auth get-or-create',
-            'entity': entity,
-            'caps': ['mon', 'allow r',
-                     'osd', osd_caps],
-        })
-
-        return keyring
+        return self.mgr._get_or_create_key(
+            entity,
+            ['mon', 'allow r',
+             'osd', osd_caps],
+        )
 
     def create_rgw_keyring(self, daemon_spec: CephadmDaemonDeploySpec) -> str:
         daemon_id = daemon_spec.daemon_id
         entity: AuthEntity = self.get_auth_entity(f'{daemon_id}-rgw')
 
         logger.info('Create keyring: %s' % entity)
-        ret, keyring, err = self.mgr.check_mon_command({
-            'prefix': 'auth get-or-create',
-            'entity': entity,
-            'caps': ['mon', 'allow r',
-                     'osd', 'allow rwx tag rgw *=*'],
-        })
-
-        return keyring
+        return self.mgr._get_or_create_key(
+            entity,
+            ['mon', 'allow r',
+             'osd', 'allow rwx tag rgw *=*'],
+        )
 
     def remove_rgw_keyring(self, daemon: DaemonDescription) -> None:
         assert daemon.daemon_id is not None

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -18,6 +18,7 @@ class FakeMgr:
     def __init__(self):
         self.config = ''
         self.check_mon_command = MagicMock(side_effect=self._check_mon_command)
+        self._get_or_create_key = MagicMock()
         self.template = MagicMock()
 
     def _check_mon_command(self, cmd_dict, inbuf=None):
@@ -105,11 +106,9 @@ class TestCephadmService:
                          'mgr', 'allow command "service status"',
                          'osd', 'allow rwx']
 
-        expected_call = call({'prefix': 'auth get-or-create',
-                              'entity': 'client.iscsi.a',
-                              'caps': expected_caps})
+        expected_call = call('client.iscsi.a', expected_caps)
 
-        assert expected_call in mgr.check_mon_command.mock_calls
+        assert expected_call in mgr._get_or_create_key.mock_calls
 
     def test_get_auth_entity(self):
         mgr = FakeMgr()


### PR DESCRIPTION
If the cephx key in the mon differs from what we provide to
'auth get-or-create', then we get back an error.  In that case, just
fetch the cephx key the mon already has for that entity and use it.

Fixes: https://tracker.ceph.com/issues/49680
Signed-off-by: Sage Weil <sage@newdream.net>