### PR TITLE
octopus: librbd: explicitly disable readahead for writearound cache

### DIFF
--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -776,8 +776,6 @@ public:
     ASSIGN_OPTION(non_blocking_aio, bool);
     ASSIGN_OPTION(cache, bool);
     ASSIGN_OPTION(sparse_read_threshold_bytes, Option::size_t);
-    ASSIGN_OPTION(readahead_max_bytes, Option::size_t);
-    ASSIGN_OPTION(readahead_disable_after_bytes, Option::size_t);
     ASSIGN_OPTION(clone_copy_on_read, bool);
     ASSIGN_OPTION(enable_alloc_hint, bool);
     ASSIGN_OPTION(mirroring_replay_delay, uint64_t);
@@ -786,6 +784,12 @@ public:
     ASSIGN_OPTION(skip_partial_discard, bool);
     ASSIGN_OPTION(discard_granularity_bytes, uint64_t);
     ASSIGN_OPTION(blkin_trace_all, bool);
+
+    auto cache_policy = config.get_val<std::string>("rbd_cache_policy");
+    if (cache_policy == "writethrough" || cache_policy == "writeback") {
+      ASSIGN_OPTION(readahead_max_bytes, Option::size_t);
+      ASSIGN_OPTION(readahead_disable_after_bytes, Option::size_t);
+    }
 
 #undef ASSIGN_OPTION
 

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -203,8 +203,8 @@ namespace librbd {
     bool non_blocking_aio;
     bool cache;
     uint64_t sparse_read_threshold_bytes;
-    uint64_t readahead_max_bytes;
-    uint64_t readahead_disable_after_bytes;
+    uint64_t readahead_max_bytes = 0;
+    uint64_t readahead_disable_after_bytes = 0;
     bool clone_copy_on_read;
     bool enable_alloc_hint;
     uint32_t alloc_hint_flags = 0U;

--- a/src/librbd/image/OpenRequest.cc
+++ b/src/librbd/image/OpenRequest.cc
@@ -582,6 +582,8 @@ Context *OpenRequest<I>::send_init_cache(int *result) {
     auto cache = cache::WriteAroundObjectDispatch<I>::create(
       m_image_ctx, max_dirty, writethrough_until_flush);
     cache->init();
+
+    m_image_ctx->readahead.set_max_readahead_size(0);
   } else if (cache_policy == "writethrough" || cache_policy == "writeback") {
     if (cache_policy == "writethrough") {
       max_dirty = 0;


### PR DESCRIPTION
https://tracker.ceph.com/issues/48674