### PR TITLE
qa: wait for daemons to come up via cephadm

### DIFF
--- a/qa/suites/fs/cephadm/multivolume/0-start.yaml
+++ b/qa/suites/fs/cephadm/multivolume/0-start.yaml
@@ -35,5 +35,5 @@ tasks:
     host.a:
       - ceph fs volume create foo
       - ceph fs volume create bar
-- sleep:
-    interval: 60
+- fs.ready:
+    timeout: 300

--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -195,7 +195,6 @@ class CephFSTestCase(CephTestCase):
             self.recovery_fs.set_data_pool_name(self.fs.get_data_pool_name())
             self.recovery_fs.create()
             self.recovery_fs.getinfo(refresh=True)
-            self.recovery_fs.mds_restart()
             self.recovery_fs.wait_for_daemons()
 
         # Load an config settings of interest

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -1050,21 +1050,6 @@ class Filesystem(MDSCluster):
 
             status = self.status()
 
-    def get_lone_mds_id(self):
-        """
-        Get a single MDS ID: the only one if there is only one
-        configured, else the only one currently holding a rank,
-        else raise an error.
-        """
-        if len(self.mds_ids) != 1:
-            alive = self.get_rank_names()
-            if len(alive) == 1:
-                return alive[0]
-            else:
-                raise ValueError("Explicit MDS argument required when multiple MDSs in use")
-        else:
-            return self.mds_ids[0]
-
     def put_metadata_object_raw(self, object_id, infile):
         """
         Save an object to the metadata pool
@@ -1127,13 +1112,13 @@ class Filesystem(MDSCluster):
 
     def mds_asok(self, command, mds_id=None, timeout=None):
         if mds_id is None:
-            mds_id = self.get_lone_mds_id()
+            return self.rank_asok(command, timeout=timeout)
 
         return self.json_asok(command, 'mds', mds_id, timeout=timeout)
 
     def mds_tell(self, command, mds_id=None):
         if mds_id is None:
-            mds_id = self.get_lone_mds_id()
+            return self.rank_tell(command)
 
         return json.loads(self.mon_manager.raw_cluster_cmd("tell", f"mds.{mds_id}", *command))
 

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -575,6 +575,9 @@ class Filesystem(MDSCluster):
         assert(mds_map['max_mds'] == max_mds)
         assert(mds_map['in'] == list(range(0, max_mds)))
 
+    def reset(self):
+        self.mon_manager.raw_cluster_cmd("fs", "reset", str(self.name), '--yes-i-really-mean-it')
+
     def fail(self):
         self.mon_manager.raw_cluster_cmd("fs", "fail", str(self.name))
 

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -917,7 +917,7 @@ class Filesystem(MDSCluster):
                 for mds_id, mds_status in mds_map['info'].items():
                     if mds_status['state'] == 'up:active':
                         try:
-                            daemon_status = self.mds_asok(["status"], mds_id=mds_status['name'])
+                            daemon_status = self.mds_tell(["status"], mds_id=mds_status['name'])
                         except CommandFailedError as cfe:
                             if cfe.exitstatus == errno.EINVAL:
                                 # Old version, can't do this check
@@ -1130,6 +1130,12 @@ class Filesystem(MDSCluster):
             mds_id = self.get_lone_mds_id()
 
         return self.json_asok(command, 'mds', mds_id, timeout=timeout)
+
+    def mds_tell(self, command, mds_id=None):
+        if mds_id is None:
+            mds_id = self.get_lone_mds_id()
+
+        return json.loads(self.mon_manager.raw_cluster_cmd("tell", f"mds.{mds_id}", *command))
 
     def rank_asok(self, command, rank=0, status=None, timeout=None):
         info = self.get_rank(rank=rank, status=status)

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -893,15 +893,7 @@ class Filesystem(MDSCluster):
             mds.check_status()
 
         active_count = 0
-        try:
-            mds_map = self.get_mds_map(status=status)
-        except CommandFailedError as cfe:
-            # Old version, fall back to non-multi-fs commands
-            if cfe.exitstatus == errno.EINVAL:
-                mds_map = json.loads(
-                        self.mon_manager.raw_cluster_cmd('mds', 'dump', '--format=json'))
-            else:
-                raise
+        mds_map = self.get_mds_map(status=status)
 
         log.debug("are_daemons_healthy: mds map: {0}".format(mds_map))
 

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -448,7 +448,7 @@ class TestMirroringCommands(CephFSTestCase):
         self.assertTrue(uuid_peer_b is not None)
         # reset filesystem
         self.fs.fail()
-        self.fs.mon_manager.raw_cluster_cmd("fs", "reset", self.fs.name, "--yes-i-really-mean-it")
+        self.fs.reset()
         self.fs.wait_for_daemons()
         self._verify_mirroring(self.fs.name, "disabled")
 

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -301,11 +301,6 @@ class TestConfigCommands(CephFSTestCase):
         out = self.mount_a.admin_socket(['config', 'get', test_key])
         self.assertEqual(out[test_key], test_val)
 
-        self.mount_a.write_n_mb("file.bin", 1);
-
-        # Implicitly asserting that things don't have lockdep error in shutdown
-        self.mount_a.umount_wait(require_clean=True)
-        self.fs.mds_stop()
 
     def test_mds_config_asok(self):
         test_key = "mds_max_purge_ops"
@@ -313,10 +308,6 @@ class TestConfigCommands(CephFSTestCase):
         self.fs.mds_asok(['config', 'set', test_key, test_val])
         out = self.fs.mds_asok(['config', 'get', test_key])
         self.assertEqual(out[test_key], test_val)
-
-        # Implicitly asserting that things don't have lockdep error in shutdown
-        self.mount_a.umount_wait(require_clean=True)
-        self.fs.mds_stop()
 
     def test_mds_config_tell(self):
         test_key = "mds_max_purge_ops"
@@ -329,10 +320,6 @@ class TestConfigCommands(CephFSTestCase):
         # Read it back with asok because there is no `tell` equivalent
         out = self.fs.mds_asok(['config', 'get', test_key])
         self.assertEqual(out[test_key], test_val)
-
-        # Implicitly asserting that things don't have lockdep error in shutdown
-        self.mount_a.umount_wait(require_clean=True)
-        self.fs.mds_stop()
 
 
 class TestMirroringCommands(CephFSTestCase):

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -313,12 +313,10 @@ class TestConfigCommands(CephFSTestCase):
         test_key = "mds_max_purge_ops"
         test_val = "123"
 
-        mds_id = self.fs.get_lone_mds_id()
-        self.fs.mon_manager.raw_cluster_cmd("tell", "mds.{0}".format(mds_id), "injectargs",
-                                            "--{0}={1}".format(test_key, test_val))
+        self.fs.rank_tell(['injectargs', "--{0}={1}".format(test_key, test_val)])
 
         # Read it back with asok because there is no `tell` equivalent
-        out = self.fs.mds_asok(['config', 'get', test_key])
+        out = self.fs.rank_tell(['config', 'get', test_key])
         self.assertEqual(out[test_key], test_val)
 
 

--- a/qa/tasks/cephfs/test_auto_repair.py
+++ b/qa/tasks/cephfs/test_auto_repair.py
@@ -36,8 +36,7 @@ class TestMDSAutoRepair(CephFSTestCase):
 
         # Restart the MDS to drop the metadata cache (because we expired the journal,
         # nothing gets replayed into cache on restart)
-        self.fs.mds_stop()
-        self.fs.mds_fail_restart()
+        self.fs.rank_fail()
         self.fs.wait_for_daemons()
 
         # remove testdir1's backtrace

--- a/qa/tasks/cephfs/test_auto_repair.py
+++ b/qa/tasks/cephfs/test_auto_repair.py
@@ -40,7 +40,7 @@ class TestMDSAutoRepair(CephFSTestCase):
         self.fs.wait_for_daemons()
 
         # remove testdir1's backtrace
-        self.fs.rados(["rmxattr", dir_objname, "parent"])
+        self.fs.radosm(["rmxattr", dir_objname, "parent"])
 
         # readdir (fetch dirfrag) should fix testdir1's backtrace
         self.mount_a.mount_wait()
@@ -50,7 +50,7 @@ class TestMDSAutoRepair(CephFSTestCase):
         self.fs.mds_asok(['flush', 'journal'])
 
         # check if backtrace exists
-        self.fs.rados(["getxattr", dir_objname, "parent"])
+        self.fs.radosm(["getxattr", dir_objname, "parent"])
 
     def test_mds_readonly(self):
         """

--- a/qa/tasks/cephfs/test_cap_flush.py
+++ b/qa/tasks/cephfs/test_cap_flush.py
@@ -49,8 +49,7 @@ class TestCapFlush(CephFSTestCase):
         time.sleep(10)
 
         # Restart mds. Client will re-send the unsafe request and cap flush
-        self.fs.mds_stop()
-        self.fs.mds_fail_restart()
+        self.fs.rank_fail()
         self.fs.wait_for_daemons()
 
         mode = self.mount_a.run_shell(['stat', '-c' '%a', file_path]).stdout.getvalue().strip()

--- a/qa/tasks/cephfs/test_client_recovery.py
+++ b/qa/tasks/cephfs/test_client_recovery.py
@@ -135,13 +135,12 @@ class TestClientRecovery(CephFSTestCase):
         # =================
         # Check that if I stop an MDS and a client goes away, the MDS waits
         # for the reconnect period
-        self.fs.mds_stop()
-        self.fs.mds_fail()
+        self.fs.fail()
 
         mount_a_client_id = self.mount_a.get_global_id()
         self.mount_a.umount_wait(force=True)
 
-        self.fs.mds_restart()
+        self.fs.set_joinable()
 
         self.fs.wait_for_state('up:reconnect', reject='up:active', timeout=MDS_RESTART_GRACE)
         # Check that the MDS locally reports its state correctly
@@ -178,8 +177,7 @@ class TestClientRecovery(CephFSTestCase):
         # =========================
         mount_a_client_id = self.mount_a.get_global_id()
 
-        self.fs.mds_stop()
-        self.fs.mds_fail()
+        self.fs.fail()
 
         # The mount goes away while the MDS is offline
         self.mount_a.kill()
@@ -187,7 +185,7 @@ class TestClientRecovery(CephFSTestCase):
         # wait for it to die
         time.sleep(5)
 
-        self.fs.mds_restart()
+        self.fs.set_joinable()
 
         # Enter reconnect phase
         self.fs.wait_for_state('up:reconnect', reject='up:active', timeout=MDS_RESTART_GRACE)
@@ -468,13 +466,12 @@ class TestClientRecovery(CephFSTestCase):
         )
 
         # Immediately kill the MDS and then client A
-        self.fs.mds_stop()
-        self.fs.mds_fail()
+        self.fs.fail()
         self.mount_a.kill()
         self.mount_a.kill_cleanup()
 
         # Restart the MDS.  Wait for it to come up, it'll have to time out in clientreplay
-        self.fs.mds_restart()
+        self.fs.set_joinable()
         log.info("Waiting for reconnect...")
         self.fs.wait_for_state("up:reconnect")
         log.info("Waiting for active...")

--- a/qa/tasks/cephfs/test_data_scan.py
+++ b/qa/tasks/cephfs/test_data_scan.py
@@ -341,8 +341,7 @@ class TestDataScan(CephFSTestCase):
 
         # Reset the MDS map in case multiple ranks were in play: recovery procedure
         # only understands how to rebuild metadata under rank 0
-        self.fs.mon_manager.raw_cluster_cmd('fs', 'reset', self.fs.name,
-                '--yes-i-really-mean-it')
+        self.fs.reset()
 
         self.fs.mds_restart()
 

--- a/qa/tasks/cephfs/test_data_scan.py
+++ b/qa/tasks/cephfs/test_data_scan.py
@@ -9,7 +9,7 @@ import os
 import time
 import traceback
 
-from io import BytesIO
+from io import BytesIO, StringIO
 from collections import namedtuple, defaultdict
 from textwrap import dedent
 
@@ -62,9 +62,8 @@ class Workload(object):
         default just wipe everything in the metadata pool
         """
         # Delete every object in the metadata pool
-        objects = self._filesystem.rados(["ls"]).split("\n")
-        for o in objects:
-            self._filesystem.rados(["rm", o])
+        pool = self._filesystem.get_metadata_pool_name()
+        self._filesystem.rados(["purge", pool, '--yes-i-really-really-mean-it'])
 
     def flush(self):
         """
@@ -342,7 +341,7 @@ class TestDataScan(CephFSTestCase):
         # only understands how to rebuild metadata under rank 0
         self.fs.reset()
 
-        self.fs.set_joinable()
+        self.fs.set_joinable() # redundant with reset
 
         def get_state(mds_id):
             info = self.mds_cluster.get_mds_info(mds_id)
@@ -414,9 +413,9 @@ class TestDataScan(CephFSTestCase):
         self._rebuild_metadata(StripedStashedLayout(self.fs, self.mount_a))
 
     def _dirfrag_keys(self, object_id):
-        keys_str = self.fs.rados(["listomapkeys", object_id])
+        keys_str = self.fs.radosmo(["listomapkeys", object_id], stdout=StringIO())
         if keys_str:
-            return keys_str.split("\n")
+            return keys_str.strip().split("\n")
         else:
             return []
 
@@ -466,7 +465,7 @@ class TestDataScan(CephFSTestCase):
         victim_key = keys[7]  # arbitrary choice
         log.info("victim_key={0}".format(victim_key))
         victim_dentry = victim_key.split("_head")[0]
-        self.fs.rados(["rmomapkey", frag_obj_id, victim_key])
+        self.fs.radosm(["rmomapkey", frag_obj_id, victim_key])
 
         # Start filesystem back up, observe that the file appears to be gone in an `ls`
         self.fs.set_joinable()
@@ -575,15 +574,14 @@ class TestDataScan(CephFSTestCase):
         # introduce duplicated primary link
         file1_key = "file1_head"
         self.assertIn(file1_key, dirfrag1_keys)
-        file1_omap_data = self.fs.rados(["getomapval", dirfrag1_oid, file1_key, '-'],
-                                        stdout_data=BytesIO())
-        self.fs.rados(["setomapval", dirfrag2_oid, file1_key], stdin_data=file1_omap_data)
+        file1_omap_data = self.fs.radosmo(["getomapval", dirfrag1_oid, file1_key, '-'])
+        self.fs.radosm(["setomapval", dirfrag2_oid, file1_key], stdin=BytesIO(file1_omap_data))
         self.assertIn(file1_key, self._dirfrag_keys(dirfrag2_oid))
 
         # remove a remote link, make inode link count incorrect
         link1_key = 'link1_head'
         self.assertIn(link1_key, dirfrag1_keys)
-        self.fs.rados(["rmomapkey", dirfrag1_oid, link1_key])
+        self.fs.radosm(["rmomapkey", dirfrag1_oid, link1_key])
 
         # increase good primary link's version
         self.mount_a.run_shell(["touch", "testdir1/file1"])
@@ -639,8 +637,8 @@ class TestDataScan(CephFSTestCase):
         self.fs.mds_asok(["flush", "journal"], mds1_id)
         self.fs.fail()
 
-        self.fs.rados(["rm", "mds0_inotable"])
-        self.fs.rados(["rm", "mds1_inotable"])
+        self.fs.radosm(["rm", "mds0_inotable"])
+        self.fs.radosm(["rm", "mds1_inotable"])
 
         self.fs.data_scan(["scan_links", "--filesystem", self.fs.name])
 
@@ -676,7 +674,7 @@ class TestDataScan(CephFSTestCase):
         for item in old_snaptable['snapserver']['snaps']:
             del item['stamp']
 
-        self.fs.rados(["rm", "mds_snaptable"])
+        self.fs.radosm(["rm", "mds_snaptable"])
         self.fs.data_scan(["scan_links", "--filesystem", self.fs.name])
 
         new_snaptable = json.loads(self.fs.table_tool([self.fs.name + ":0", "show", "snap"]))

--- a/qa/tasks/cephfs/test_fragment.py
+++ b/qa/tasks/cephfs/test_fragment.py
@@ -1,4 +1,4 @@
-
+from io import StringIO
 
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 from teuthology.orchestra import run
@@ -223,9 +223,9 @@ class TestFragmentation(CephFSTestCase):
         )
         # Check that the metadata pool objects for all the myriad
         # child fragments are gone
-        metadata_objs = self.fs.rados(["ls"])
+        metadata_objs = self.fs.radosmo(["ls"], stdout=StringIO()).strip()
         frag_objs = []
-        for o in metadata_objs:
+        for o in metadata_objs.split("\n"):
             if o.startswith("{0:x}.".format(dir_inode_no)):
                 frag_objs.append(o)
         self.assertListEqual(frag_objs, [])

--- a/qa/tasks/cephfs/test_mantle.py
+++ b/qa/tasks/cephfs/test_mantle.py
@@ -1,3 +1,5 @@
+from io import StringIO
+
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
 import json
 import logging
@@ -21,7 +23,7 @@ class TestMantle(CephFSTestCase):
 
     def push_balancer(self, obj, lua_code, expect):
         self.fs.mon_manager.raw_cluster_cmd_result('fs', 'set', self.fs.name, 'balancer', obj)
-        self.fs.rados(["put", obj, "-"], stdin_data=lua_code)
+        self.fs.radosm(["put", obj, "-"], stdin=StringIO(lua_code))
         with self.assert_cluster_log(failure + obj + " " + expect):
             log.info("run a " + obj + " balancer that expects=" + expect)
 
@@ -58,7 +60,7 @@ class TestMantle(CephFSTestCase):
         self.start_mantle()
         lua_code = "BAL_LOG(0, \"test\")\nreturn {3, 4}"
         self.fs.mon_manager.raw_cluster_cmd_result('fs', 'set', self.fs.name, 'balancer', "valid.lua")
-        self.fs.rados(["put", "valid.lua", "-"], stdin_data=lua_code)
+        self.fs.radosm(["put", "valid.lua", "-"], stdin=StringIO(lua_code))
         with self.assert_cluster_log(success + "valid.lua"):
             log.info("run a valid.lua balancer")
 

--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -70,8 +70,7 @@ class TestMisc(CephFSTestCase):
 
         data_pool_name = self.fs.get_data_pool_name()
 
-        self.fs.mds_stop()
-        self.fs.mds_fail()
+        self.fs.fail()
 
         self.fs.mon_manager.raw_cluster_cmd('fs', 'rm', self.fs.name,
                                             '--yes-i-really-mean-it')
@@ -109,9 +108,10 @@ class TestMisc(CephFSTestCase):
                                             self.fs.metadata_pool_name,
                                             data_pool_name, "--force")
 
+        self.fs.mon_manager.raw_cluster_cmd('fs', 'fail', self.fs.name)
+
         self.fs.mon_manager.raw_cluster_cmd('fs', 'rm', self.fs.name,
                                             '--yes-i-really-mean-it')
-
 
         self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'delete',
                                             self.fs.metadata_pool_name,

--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -205,14 +205,11 @@ class TestCacheDrop(CephFSTestCase):
 
     def _run_drop_cache_cmd(self, timeout=None):
         result = None
-        mds_id = self.fs.get_lone_mds_id()
+        args = ["cache", "drop"]
         if timeout is not None:
-            result = self.fs.mon_manager.raw_cluster_cmd("tell", "mds.{0}".format(mds_id),
-                                                    "cache", "drop", str(timeout))
-        else:
-            result = self.fs.mon_manager.raw_cluster_cmd("tell", "mds.{0}".format(mds_id),
-                                                    "cache", "drop")
-        return json.loads(result)
+            args.append(str(timeout))
+        result = self.fs.rank_tell(args)
+        return result
 
     def _setup(self, max_caps=20, threshold=400):
         # create some files

--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -1,3 +1,4 @@
+from io import StringIO
 
 from tasks.cephfs.fuse_mount import FuseMount
 from tasks.cephfs.cephfs_test_case import CephFSTestCase
@@ -83,9 +84,8 @@ class TestMisc(CephFSTestCase):
                                             self.fs.metadata_pool_name,
                                             self.fs.pgs_per_fs_pool.__str__())
 
-        dummyfile = '/etc/fstab'
-
-        self.fs.put_metadata_object_raw("key", dummyfile)
+        # insert a garbage object
+        self.fs.radosm(["put", "foo", "-"], stdin=StringIO("bar"))
 
         def get_pool_df(fs, name):
             try:

--- a/qa/tasks/cephfs/test_multimds_misc.py
+++ b/qa/tasks/cephfs/test_multimds_misc.py
@@ -84,7 +84,7 @@ class TestScrub2(CephFSTestCase):
 
         def assertTagged(ino):
             file_obj_name = "{0:x}.00000000".format(ino)
-            self.fs.rados(["getxattr", file_obj_name, "scrub_tag"])
+            self.fs.radosm(["getxattr", file_obj_name, "scrub_tag"])
 
         for ino in inos:
             assertTagged(ino)
@@ -95,7 +95,7 @@ class TestScrub2(CephFSTestCase):
 
         for ino in inos:
             file_obj_name = "{0:x}.00000000".format(ino)
-            self.fs.rados(["rmxattr", file_obj_name, "parent"])
+            self.fs.radosm(["rmxattr", file_obj_name, "parent"])
 
         out_json = self.fs.run_scrub(["start", "/d1/d2/d3", "recursive", "force"], 0)
         self.assertNotEqual(out_json, None)
@@ -138,7 +138,7 @@ class TestScrub2(CephFSTestCase):
 
         for ino in inos:
             file_obj_name = "{0:x}.00000000".format(ino)
-            self.fs.rados(["rmxattr", file_obj_name, "parent"])
+            self.fs.radosm(["rmxattr", file_obj_name, "parent"])
 
         out_json = self.fs.run_scrub(["start", "/d1/d2/d3", "recursive", "force"], 0)
         self.assertNotEqual(out_json, None)
@@ -161,7 +161,7 @@ class TestScrub2(CephFSTestCase):
 
         for ino in inos:
             file_obj_name = "{0:x}.00000000".format(ino)
-            self.fs.rados(["rmxattr", file_obj_name, "parent"])
+            self.fs.radosm(["rmxattr", file_obj_name, "parent"])
 
         out_json = self.fs.run_scrub(["start", "/d1/d2/d3", "recursive", "force"], 0)
         self.assertNotEqual(out_json, None)
@@ -190,7 +190,7 @@ class TestScrub2(CephFSTestCase):
 
         for ino in inos:
             file_obj_name = "{0:x}.00000000".format(ino)
-            self.fs.rados(["rmxattr", file_obj_name, "parent"])
+            self.fs.radosm(["rmxattr", file_obj_name, "parent"])
 
         out_json = self.fs.run_scrub(["start", "/d1/d2/d3", "recursive", "force"], 0)
         self.assertNotEqual(out_json, None)

--- a/qa/tasks/cephfs/test_openfiletable.py
+++ b/qa/tasks/cephfs/test_openfiletable.py
@@ -42,7 +42,7 @@ class OpenFileTable(CephFSTestCase):
         mds0_openfiles.1 to hold the extra keys.
         """
 
-        self.fs.rados(["stat", "mds0_openfiles.1"])
+        self.fs.radosm(["stat", "mds0_openfiles.1"])
 
         # Now close the file
         self.mount_a.kill_background(p)

--- a/qa/tasks/cephfs/test_recovery_pool.py
+++ b/qa/tasks/cephfs/test_recovery_pool.py
@@ -121,8 +121,8 @@ class TestRecoveryPool(CephFSTestCase):
         self.recovery_fs.table_tool([recovery_fs + ":0", "reset", "inode"])
 
         # Stop the MDS
-        self.fs.mds_stop()
-        self.fs.mds_fail()
+        self.fs.mds_stop() # otherwise MDS will join once the fs is reset
+        self.fs.fail()
 
         # After recovery, we need the MDS to not be strict about stats (in production these options
         # are off by default, but in QA we need to explicitly disable them)
@@ -146,7 +146,6 @@ class TestRecoveryPool(CephFSTestCase):
                 # Normal reset should fail when no objects are present, we'll use --force instead
                 self.fs.journal_tool(["journal", "reset"], 0)
 
-        self.fs.mds_stop()
         self.fs.data_scan(['scan_extents', '--alternate-pool',
                            recovery_pool, '--filesystem', self.fs.name,
                            self.fs.get_data_pool_name()])
@@ -174,6 +173,7 @@ class TestRecoveryPool(CephFSTestCase):
 
         # Start the MDS
         self.fs.mds_restart()
+        self.fs.set_joinable()
         self.recovery_fs.mds_restart()
         self.fs.wait_for_daemons()
         self.recovery_fs.wait_for_daemons()

--- a/qa/tasks/cephfs/test_recovery_pool.py
+++ b/qa/tasks/cephfs/test_recovery_pool.py
@@ -134,8 +134,7 @@ class TestRecoveryPool(CephFSTestCase):
 
         # Reset the MDS map in case multiple ranks were in play: recovery procedure
         # only understands how to rebuild metadata under rank 0
-        self.fs.mon_manager.raw_cluster_cmd('fs', 'reset', self.fs.name,
-                '--yes-i-really-mean-it')
+        self.fs.reset()
 
         self.fs.table_tool([self.fs.name + ":0", "reset", "session"])
         self.fs.table_tool([self.fs.name + ":0", "reset", "snap"])

--- a/qa/tasks/cephfs/test_recovery_pool.py
+++ b/qa/tasks/cephfs/test_recovery_pool.py
@@ -56,10 +56,9 @@ class OverlayWorkload(object):
         Damage the filesystem pools in ways that will be interesting to recover from.  By
         default just wipe everything in the metadata pool
         """
-        # Delete every object in the metadata pool
-        objects = self._orig_fs.rados(["ls"]).split("\n")
-        for o in objects:
-            self._orig_fs.rados(["rm", o])
+
+        pool = self._orig_fs.get_metadata_pool_name()
+        self._orig_fs.rados(["purge", pool, '--yes-i-really-really-mean-it'])
 
     def flush(self):
         """

--- a/qa/tasks/cephfs/test_scrub_checks.py
+++ b/qa/tasks/cephfs/test_scrub_checks.py
@@ -314,8 +314,7 @@ class TestScrubChecks(CephFSTestCase):
         self.fs.mds_stop()
 
         # remove the dentry from dirfrag, cause incorrect fragstat/rstat
-        self.fs.rados(["rmomapkey", dir_objname, "file_head"],
-                      pool=self.fs.get_metadata_pool_name())
+        self.fs.radosm(["rmomapkey", dir_objname, "file_head"])
 
         self.fs.mds_fail_restart()
         self.fs.wait_for_daemons()

--- a/qa/tasks/cephfs/test_strays.py
+++ b/qa/tasks/cephfs/test_strays.py
@@ -913,7 +913,7 @@ ln dir_1/original dir_2/linkto
 
         self.mds_cluster.mds_stop()
         self.mds_cluster.mds_fail()
-        self.fs.rados(["rm", "500.00000000"])
+        self.fs.radosm(["rm", "500.00000000"])
         self.mds_cluster.mds_restart()
         self.fs.wait_for_daemons()
 

--- a/qa/tasks/repair_test.py
+++ b/qa/tasks/repair_test.py
@@ -4,8 +4,6 @@ Test pool repairing after objects are damaged.
 import logging
 import time
 
-from teuthology import misc as teuthology
-
 log = logging.getLogger(__name__)
 
 
@@ -123,20 +121,16 @@ def repair_test_2(ctx, manager, config, chooser):
     with manager.pool(pool, 1):
         log.info("starting repair test type 2")
         victim_osd = chooser(manager, pool, 0)
-        first_mon = teuthology.get_first_mon(ctx, config)
-        (mon,) = ctx.cluster.only(first_mon).remotes.keys()
 
         # create object
         log.info("doing put and setomapval")
         manager.do_put(pool, 'file1', '/etc/hosts')
-        manager.do_rados(mon, ['-p', pool, 'setomapval', 'file1',
-                                   'key', 'val'])
+        manager.do_rados(['setomapval', 'file1', 'key', 'val'], pool=pool)
         manager.do_put(pool, 'file2', '/etc/hosts')
         manager.do_put(pool, 'file3', '/etc/hosts')
         manager.do_put(pool, 'file4', '/etc/hosts')
         manager.do_put(pool, 'file5', '/etc/hosts')
-        manager.do_rados(mon, ['-p', pool, 'setomapval', 'file5',
-                                   'key', 'val'])
+        manager.do_rados(['setomapval', 'file5', 'key', 'val'], pool=pool)
         manager.do_put(pool, 'file6', '/etc/hosts')
 
         # corrupt object

--- a/qa/tasks/scrub_test.py
+++ b/qa/tasks/scrub_test.py
@@ -285,8 +285,7 @@ def test_list_inconsistent_obj(ctx, manager, osd_remote, pg, acting, osd_id,
     pool = 'rbd'
     omap_key = 'key'
     omap_val = 'val'
-    manager.do_rados(mon, ['-p', pool, 'setomapval', obj_name,
-                           omap_key, omap_val])
+    manager.do_rados(['setomapval', obj_name, omap_key, omap_val], pool=pool)
     # Update missing digests, requires "osd deep scrub update digest min age: 0"
     pgnum = get_pgnum(pg)
     manager.do_pg_scrub(pool, pgnum, 'deep-scrub')
@@ -370,8 +369,7 @@ def task(ctx, config):
     manager.wait_for_clean()
 
     # write some data
-    p = manager.do_rados(mon, ['-p', 'rbd', 'bench', '--no-cleanup', '1',
-                               'write', '-b', '4096'])
+    p = manager.do_rados(['bench', '--no-cleanup', '1', 'write', '-b', '4096'], pool='rbd')
     log.info('err is %d' % p.exitstatus)
 
     # wait for some PG to have data that we can mess with
@@ -379,9 +377,9 @@ def task(ctx, config):
     osd = acting[0]
 
     osd_remote, obj_path, obj_name = find_victim_object(ctx, pg, osd)
-    manager.do_rados(mon, ['-p', 'rbd', 'setomapval', obj_name, 'key', 'val'])
+    manager.do_rados(['setomapval', obj_name, 'key', 'val'], pool='rbd')
     log.info('err is %d' % p.exitstatus)
-    manager.do_rados(mon, ['-p', 'rbd', 'setomapheader', obj_name, 'hdr'])
+    manager.do_rados(['setomapheader', obj_name, 'hdr'], pool='rbd')
     log.info('err is %d' % p.exitstatus)
 
     # Update missing digests, requires "osd deep scrub update digest min age: 0"

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -836,7 +836,7 @@ class LocalCephManager(CephManager):
 
 class LocalCephCluster(CephCluster):
     def __init__(self, ctx):
-        # Deliberately skip calling parent constructor
+        # Deliberately skip calling CephCluster constructor
         self._ctx = ctx
         self.mon_manager = LocalCephManager()
         self._conf = defaultdict(dict)
@@ -907,9 +907,19 @@ class LocalCephCluster(CephCluster):
 
 class LocalMDSCluster(LocalCephCluster, MDSCluster):
     def __init__(self, ctx):
-        super(LocalMDSCluster, self).__init__(ctx)
-        self.mds_ids = ctx.daemons.daemons['ceph.mds'].keys()
-        self.mds_daemons = dict([(id_, LocalDaemon("mds", id_)) for id_ in self.mds_ids])
+        LocalCephCluster.__init__(self, ctx)
+        # Deliberately skip calling MDSCluster constructor
+        self._mds_ids = ctx.daemons.daemons['ceph.mds'].keys()
+        log.debug("Discovered MDS IDs: {0}".format(self._mds_ids))
+        self._mds_daemons = dict([(id_, LocalDaemon("mds", id_)) for id_ in self.mds_ids])
+
+    @property
+    def mds_ids(self):
+        return self._mds_ids
+
+    @property
+    def mds_daemons(self):
+        return self._mds_daemons
 
     def clear_firewall(self):
         # FIXME: unimplemented
@@ -934,10 +944,10 @@ class LocalMgrCluster(LocalCephCluster, MgrCluster):
         self.mgr_daemons = dict([(id_, LocalDaemon("mgr", id_)) for id_ in self.mgr_ids])
 
 
-class LocalFilesystem(Filesystem, LocalMDSCluster):
+class LocalFilesystem(LocalMDSCluster, Filesystem):
     def __init__(self, ctx, fs_config={}, fscid=None, name=None, create=False):
-        # Deliberately skip calling parent constructor
-        self._ctx = ctx
+        # Deliberately skip calling Filesystem constructor
+        LocalMDSCluster.__init__(self, ctx)
 
         self.id = None
         self.name = name
@@ -948,23 +958,7 @@ class LocalFilesystem(Filesystem, LocalMDSCluster):
         self.fs_config = fs_config
         self.ec_profile = fs_config.get('ec_profile')
 
-        # Hack: cheeky inspection of ceph.conf to see what MDSs exist
-        self.mds_ids = set()
-        for line in open("ceph.conf").readlines():
-            match = re.match("^\[mds\.(.+)\]$", line)
-            if match:
-                self.mds_ids.add(match.group(1))
-
-        if not self.mds_ids:
-            raise RuntimeError("No MDSs found in ceph.conf!")
-
-        self.mds_ids = list(self.mds_ids)
-
-        log.debug("Discovered MDS IDs: {0}".format(self.mds_ids))
-
         self.mon_manager = LocalCephManager()
-
-        self.mds_daemons = dict([(id_, LocalDaemon("mds", id_)) for id_ in self.mds_ids])
 
         self.client_remote = LocalRemote()
 


### PR DESCRIPTION
Rather than waiting for a set amount of time.

Fixes: https://tracker.ceph.com/issues/49684
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
