### PR TITLE
pacific: vstart: fix ganesha cluster id and rados url errors

### DIFF
--- a/src/pybind/mgr/test_orchestrator/dummy_data.json
+++ b/src/pybind/mgr/test_orchestrator/dummy_data.json
@@ -327,8 +327,8 @@
           }
         ]
       },
-      "service_id": "ganesha-vstart",
-      "service_name": "nfs.ganesha-vstart",
+      "service_id": "vstart",
+      "service_name": "nfs.vstart",
       "service_type": "nfs",
       "pool": "nfs-ganesha",
       "namespace": "vstart",
@@ -434,7 +434,7 @@
       "container_image_id": "36114e38494190b0c9d4b088c12e6e4086e8017b96b4d5fc14eb5406bd51b55b",
       "container_image_name": "quay.io/ceph-ci/ceph:master",
       "created": "2020-04-16T05:44:41.551646",
-      "daemon_id": "ganesha-vstart.osd0",
+      "daemon_id": "vstart.osd0",
       "daemon_type": "nfs",
       "hostname": "osd0",
       "last_refresh": "2020-04-16T06:51:43.182937",

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1126,7 +1126,7 @@ start_ganesha() {
     cluster_id="vstart"
     GANESHA_PORT=$(($CEPH_PORT + 4000))
     local ganesha=0
-    test_user="ganesha-$cluster_id"
+    test_user="$cluster_id"
     pool_name="nfs-ganesha"
     namespace=$cluster_id
     url="rados://$pool_name/$namespace/conf-nfs.$test_user"
@@ -1169,8 +1169,6 @@ start_ganesha() {
            Minor_Versions = 1, 2;
         }
 
-        %url $url
-
         RADOS_KV {
            pool = $pool_name;
            namespace = $namespace;
@@ -1180,8 +1178,10 @@ start_ganesha() {
 
         RADOS_URLS {
 	   Userid = $test_user;
-	   watch_url = \"$url\";
-        }" > "$ganesha_dir/ganesha-$name.conf"
+	   watch_url = '$url';
+        }
+
+	%url $url" > "$ganesha_dir/ganesha-$name.conf"
 	wconf <<EOF
 [ganesha.$name]
         host = $HOSTNAME


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49412

---

backport of https://github.com/ceph/ceph/pull/39249
parent tracker: https://tracker.ceph.com/issues/49122

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh