### PR TITLE
octopus: common/mempool: Improve mempool shard selection

### DIFF
--- a/src/include/mempool.h
+++ b/src/include/mempool.h
@@ -254,11 +254,16 @@ public:
 
   void adjust_count(ssize_t items, ssize_t bytes);
 
-  shard_t* pick_a_shard() {
+  static size_t pick_a_shard_int() {
     // Dirt cheap, see:
-    //   http://fossies.org/dox/glibc-2.24/pthread__self_8c_source.html
+    //   https://fossies.org/dox/glibc-2.32/pthread__self_8c_source.html
     size_t me = (size_t)pthread_self();
     size_t i = (me >> 3) & ((1 << num_shard_bits) - 1);
+    return i;
+  }
+
+  shard_t* pick_a_shard() {
+    size_t i = pick_a_shard_int();
     return &shard[i];
   }
 

--- a/src/include/mempool.h
+++ b/src/include/mempool.h
@@ -258,7 +258,7 @@ public:
     // Dirt cheap, see:
     //   https://fossies.org/dox/glibc-2.32/pthread__self_8c_source.html
     size_t me = (size_t)pthread_self();
-    size_t i = (me >> 3) & ((1 << num_shard_bits) - 1);
+    size_t i = (me >> 12) & ((1 << num_shard_bits) - 1);
     return i;
   }
 

--- a/src/include/mempool.h
+++ b/src/include/mempool.h
@@ -258,7 +258,7 @@ public:
     // Dirt cheap, see:
     //   https://fossies.org/dox/glibc-2.32/pthread__self_8c_source.html
     size_t me = (size_t)pthread_self();
-    size_t i = (me >> 12) & ((1 << num_shard_bits) - 1);
+    size_t i = (me >> CEPH_PAGE_SHIFT) & ((1 << num_shard_bits) - 1);
     return i;
   }
 

--- a/src/test/test_mempool.cc
+++ b/src/test/test_mempool.cc
@@ -402,6 +402,33 @@ TEST(mempool, btree_map_test)
   ASSERT_EQ(0, mempool::osd::allocated_bytes());
 }
 
+TEST(mempool, check_shard_select)
+{
+  const size_t samples = 100;
+  std::atomic_int shards[mempool::num_shards] = {0};
+  std::vector<std::thread> workers;
+  for (size_t i = 0; i < samples; i++) {
+    workers.push_back(
+      std::thread([&](){
+          size_t i = mempool::pool_t::pick_a_shard_int();
+          shards[i]++;
+        }));
+  }
+  for (auto& t:workers) {
+    t.join();
+  }
+  workers.clear();
+
+  double EX = (double)samples / (double)mempool::num_shards;
+  double VarX = 0;
+  for (size_t i = 0; i < mempool::num_shards; i++) {
+    VarX += (EX - shards[i]) * (EX - shards[i]);
+  }
+  //random gives VarX below 200
+  //when half slots are 0, we get ~300
+  //when all samples go into one slot, we get ~9000
+  EXPECT_LT(VarX, 200);
+}
 
 
 int main(int argc, char **argv)

--- a/src/test/test_mempool.cc
+++ b/src/test/test_mempool.cc
@@ -22,6 +22,7 @@
 #include "gtest/gtest.h"
 #include "include/btree_map.h"
 #include "include/mempool.h"
+#include <thread>
 
 void check_usage(mempool::pool_index_t ix)
 {
@@ -404,7 +405,7 @@ TEST(mempool, btree_map_test)
 
 TEST(mempool, check_shard_select)
 {
-  const size_t samples = 100;
+  const size_t samples = mempool::num_shards * 100;
   std::atomic_int shards[mempool::num_shards] = {0};
   std::vector<std::thread> workers;
   for (size_t i = 0; i < samples; i++) {
@@ -419,15 +420,16 @@ TEST(mempool, check_shard_select)
   }
   workers.clear();
 
-  double EX = (double)samples / (double)mempool::num_shards;
-  double VarX = 0;
+  size_t missed = 0;
   for (size_t i = 0; i < mempool::num_shards; i++) {
-    VarX += (EX - shards[i]) * (EX - shards[i]);
+    if (shards[i] == 0) {
+      missed++;
+    }
   }
-  //random gives VarX below 200
-  //when half slots are 0, we get ~300
-  //when all samples go into one slot, we get ~9000
-  EXPECT_LT(VarX, 200);
+
+  // If more than half of the shards did not get anything,
+  // the distribution is bad enough to deserve a failure.
+  EXPECT_LT(missed, mempool::num_shards / 2);
 }
 
 


### PR DESCRIPTION
backport tracker: 

* https://tracker.ceph.com/issues/49053 
* https://tracker.ceph.com/issues/49993

---

backport of https://github.com/ceph/ceph/pull/39057
parent tracker: https://tracker.ceph.com/issues/49052

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh