### PR TITLE
test/lazy-omap-stats: Various enhancements

### DIFF
--- a/src/test/lazy-omap-stats/CMakeLists.txt
+++ b/src/test/lazy-omap-stats/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(ceph_test_lazy_omap_stats
   main.cc
   lazy_omap_stats_test.cc)
 target_link_libraries(ceph_test_lazy_omap_stats
-  librados Boost::system ${UNITTEST_LIBS})
+  librados Boost::system ceph-common ${UNITTEST_LIBS})
 install(TARGETS
   ceph_test_lazy_omap_stats
   DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/lazy-omap-stats/lazy_omap_stats_test.h
+++ b/src/test/lazy-omap-stats/lazy_omap_stats_test.h
@@ -39,9 +39,15 @@ class LazyOmapStatsTest
     unsigned keys = 2000;
     unsigned how_many = 50;
     std::string pool_name = "lazy_omap_test_pool";
+    std::string pool_id;
     unsigned total_bytes = 0;
     unsigned total_keys = 0;
   } conf;
+
+  typedef enum {
+    TARGET_MON,
+    TARGET_MGR
+  } CommandTarget;
 
   LazyOmapStatsTest(LazyOmapStatsTest&) = delete;
   void operator=(LazyOmapStatsTest) = delete;
@@ -51,7 +57,7 @@ class LazyOmapStatsTest
   const std::string get_name() const;
   void create_payload();
   void write_many(const unsigned how_many);
-  void scrub() const;
+  void scrub();
   const int find_matches(std::string& output, std::regex& reg) const;
   void check_one();
   const int find_index(std::string& haystack, std::regex& needle,
@@ -61,7 +67,6 @@ class LazyOmapStatsTest
   void check_column(const int index, const std::string& table,
                     const std::string& type, bool header = true) const;
   index_t get_indexes(std::regex& reg, std::string& output) const;
-  const std::string get_pool_id(std::string& pool);
   void check_pg_dump();
   void check_pg_dump_summary();
   void check_pg_dump_pgs();
@@ -69,7 +74,10 @@ class LazyOmapStatsTest
   void check_pg_ls();
   const std::string get_output(
       const std::string command = R"({"prefix": "pg dump"})",
-      const bool silent = false);
+      const bool silent = false,
+      const CommandTarget target = CommandTarget::TARGET_MGR);
+  void get_pool_id(const std::string& pool);
+  std::map<std::string, std::string> get_scrub_stamps();
   void wait_for_active_clean();
 
  public:


### PR DESCRIPTION
Primarily removal of boost::process call to blocking deep scrub cli
command.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
