### PR TITLE
pacific: doc: fix broken links multimds and kcephfs

### DIFF
--- a/doc/dev/developer_guide/tests-integration-tests.rst
+++ b/doc/dev/developer_guide/tests-integration-tests.rst
@@ -103,16 +103,10 @@ all the integration tests, for all the Ceph components.
   verify the :ref:`testing-integration-tests` infrastructure works as expected)
 
 `fs <https://github.com/ceph/ceph/tree/master/qa/suites/fs>`_
-  test CephFS mounted using FUSE
-
-`kcephfs <https://github.com/ceph/ceph/tree/master/qa/suites/kcephfs>`_
-  test CephFS mounted using kernel
+  test CephFS mounted using kernel and FUSE clients, also with multiple MDSs.
 
 `krbd <https://github.com/ceph/ceph/tree/master/qa/suites/krbd>`_
   test the RBD kernel module
-
-`multimds <https://github.com/ceph/ceph/tree/master/qa/suites/multimds>`_
-  test CephFS with multiple MDSs
 
 `powercycle <https://github.com/ceph/ceph/tree/master/qa/suites/powercycle>`_
   verify the Ceph cluster behaves when machines are powered off


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49423

---

backport of https://github.com/ceph/ceph/pull/39618
parent tracker: https://tracker.ceph.com/issues/49372

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh