### PR TITLE
pacific: osd: Refinements to mclock built-in profiles implementation.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3043,22 +3043,40 @@ std::vector<Option> get_global_options() {
     .set_description("mclock anticipation timeout in seconds")
     .set_long_description("the amount of time that mclock waits until the unused resource is forfeited"),
 
-    Option("osd_mclock_cost_per_io_msec", Option::TYPE_UINT, Option::LEVEL_DEV)
-    .set_default(0)
-    .set_description("Cost per IO in milliseconds to consider per OSD (overrides _ssd and _hdd if non-zero)")
-    .set_long_description("This option specifies the cost factor to consider in msec per OSD. This is considered by the mclock_scheduler to set an additional cost factor in QoS calculations. Only considered for osd_op_queue = mclock_scheduler")
+    Option("osd_mclock_cost_per_io_usec", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    .set_default(0.0)
+    .set_description("Cost per IO in microseconds to consider per OSD (overrides _ssd and _hdd if non-zero)")
+    .set_long_description("This option specifies the cost factor to consider in usec per OSD. This is considered by the mclock scheduler to set an additional cost factor in QoS calculations. Only considered for osd_op_queue = mclock_scheduler")
     .set_flag(Option::FLAG_RUNTIME),
 
-    Option("osd_mclock_cost_per_io_msec_hdd", Option::TYPE_UINT, Option::LEVEL_DEV)
-    .set_default(0)
-    .set_description("Cost per IO in milliseconds to consider per OSD (for rotational media)")
-    .set_long_description("This option specifies the cost factor to consider in msec per OSD for rotational device type. This is considered by the mclock_scheduler to set an additional cost factor in QoS calculations. Only considered for osd_op_queue = mclock_scheduler")
+    Option("osd_mclock_cost_per_io_usec_hdd", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    .set_default(25000.0)
+    .set_description("Cost per IO in microseconds to consider per OSD (for rotational media)")
+    .set_long_description("This option specifies the cost factor to consider in usec per OSD for rotational device type. This is considered by the mclock_scheduler to set an additional cost factor in QoS calculations. Only considered for osd_op_queue = mclock_scheduler")
     .set_flag(Option::FLAG_RUNTIME),
 
-    Option("osd_mclock_cost_per_io_msec_ssd", Option::TYPE_UINT, Option::LEVEL_DEV)
-    .set_default(0)
-    .set_description("Cost per IO in milliseconds to consider per OSD (for solid state media)")
-    .set_long_description("This option specifies the cost factor to consider in msec per OSD for solid state device type. This is considered by the mclock_scheduler to set an additional cost factor in QoS calculations. Only considered for osd_op_queue = mclock_scheduler")
+    Option("osd_mclock_cost_per_io_usec_ssd", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    .set_default(50.0)
+    .set_description("Cost per IO in microseconds to consider per OSD (for solid state media)")
+    .set_long_description("This option specifies the cost factor to consider in usec per OSD for solid state device type. This is considered by the mclock_scheduler to set an additional cost factor in QoS calculations. Only considered for osd_op_queue = mclock_scheduler")
+    .set_flag(Option::FLAG_RUNTIME),
+
+    Option("osd_mclock_cost_per_byte_usec", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    .set_default(0.0)
+    .set_description("Cost per byte in microseconds to consider per OSD (overrides _ssd and _hdd if non-zero)")
+    .set_long_description("This option specifies the cost per byte to consider in microseconds per OSD. This is considered by the mclock scheduler to set an additional cost factor in QoS calculations. Only considered for osd_op_queue = mclock_scheduler")
+    .set_flag(Option::FLAG_RUNTIME),
+
+    Option("osd_mclock_cost_per_byte_usec_hdd", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    .set_default(5.2)
+    .set_description("Cost per byte in microseconds to consider per OSD (for rotational media)")
+    .set_long_description("This option specifies the cost per byte to consider in microseconds per OSD for rotational device type. This is considered by the mclock_scheduler to set an additional cost factor in QoS calculations. Only considered for osd_op_queue = mclock_scheduler")
+    .set_flag(Option::FLAG_RUNTIME),
+
+    Option("osd_mclock_cost_per_byte_usec_ssd", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    .set_default(0.011)
+    .set_description("Cost per byte in microseconds to consider per OSD (for solid state media)")
+    .set_long_description("This option specifies the cost per byte to consider in microseconds per OSD for solid state device type. This is considered by the mclock_scheduler to set an additional cost factor in QoS calculations. Only considered for osd_op_queue = mclock_scheduler")
     .set_flag(Option::FLAG_RUNTIME),
 
     Option("osd_mclock_max_capacity_iops", Option::TYPE_FLOAT, Option::LEVEL_BASIC)
@@ -3068,7 +3086,7 @@ std::vector<Option> get_global_options() {
     .set_flag(Option::FLAG_RUNTIME),
 
     Option("osd_mclock_max_capacity_iops_hdd", Option::TYPE_FLOAT, Option::LEVEL_BASIC)
-    .set_default(10000.0)
+    .set_default(315.0)
     .set_description("Max IOPs capacity (at 4KiB block size) to consider per OSD (for rotational media)")
     .set_long_description("This option specifies the max OSD capacity in iops per OSD. Helps in QoS calculations when enabling a dmclock profile. Only considered for osd_op_queue = mclock_scheduler")
     .set_flag(Option::FLAG_RUNTIME),

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3080,7 +3080,7 @@ std::vector<Option> get_global_options() {
     .set_flag(Option::FLAG_RUNTIME),
 
     Option("osd_mclock_profile", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("balanced")
+    .set_default("high_client_ops")
     .set_enum_allowed( { "balanced", "high_recovery_ops", "high_client_ops", "custom" } )
     .set_description("Which mclock profile to use")
     .set_long_description("This option specifies the mclock profile to enable - one among the set of built-in profiles or a custom profile. Only considered for osd_op_queue = mclock_scheduler")

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9947,6 +9947,15 @@ void OSD::handle_conf_change(const ConfigProxy& conf,
   std::lock_guard l{osd_lock};
 
   if (changed.count("osd_max_backfills") ||
+      changed.count("osd_delete_sleep") ||
+      changed.count("osd_delete_sleep_hdd") ||
+      changed.count("osd_delete_sleep_ssd") ||
+      changed.count("osd_delete_sleep_hybrid") ||
+      changed.count("osd_snap_trim_sleep") ||
+      changed.count("osd_snap_trim_sleep_hdd") ||
+      changed.count("osd_snap_trim_sleep_ssd") ||
+      changed.count("osd_snap_trim_sleep_hybrid") ||
+      changed.count("osd_scrub_sleep") ||
       changed.count("osd_recovery_sleep") ||
       changed.count("osd_recovery_sleep_hdd") ||
       changed.count("osd_recovery_sleep_ssd") ||
@@ -9978,6 +9987,21 @@ void OSD::handle_conf_change(const ConfigProxy& conf,
       cct->_conf.set_val("osd_recovery_sleep_hdd", std::to_string(0));
       cct->_conf.set_val("osd_recovery_sleep_ssd", std::to_string(0));
       cct->_conf.set_val("osd_recovery_sleep_hybrid", std::to_string(0));
+
+      // Disable delete sleep
+      cct->_conf.set_val("osd_delete_sleep", std::to_string(0));
+      cct->_conf.set_val("osd_delete_sleep_hdd", std::to_string(0));
+      cct->_conf.set_val("osd_delete_sleep_ssd", std::to_string(0));
+      cct->_conf.set_val("osd_delete_sleep_hybrid", std::to_string(0));
+
+      // Disable snap trim sleep
+      cct->_conf.set_val("osd_snap_trim_sleep", std::to_string(0));
+      cct->_conf.set_val("osd_snap_trim_sleep_hdd", std::to_string(0));
+      cct->_conf.set_val("osd_snap_trim_sleep_ssd", std::to_string(0));
+      cct->_conf.set_val("osd_snap_trim_sleep_hybrid", std::to_string(0));
+
+      // Disable scrub sleep
+      cct->_conf.set_val("osd_scrub_sleep", std::to_string(0));
     } else {
       service.local_reserver.set_max(cct->_conf->osd_max_backfills);
       service.remote_reserver.set_max(cct->_conf->osd_max_backfills);

--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -47,6 +47,7 @@ mClockScheduler::mClockScheduler(CephContext *cct,
   ceph_assert(num_shards > 0);
   set_max_osd_capacity();
   set_osd_mclock_cost_per_io();
+  set_osd_mclock_cost_per_byte();
   set_mclock_profile();
   enable_mclock_profile_settings();
   client_registry.update_from_config(cct->_conf);
@@ -460,9 +461,12 @@ const char** mClockScheduler::get_tracked_conf_keys() const
     "osd_mclock_scheduler_background_best_effort_res",
     "osd_mclock_scheduler_background_best_effort_wgt",
     "osd_mclock_scheduler_background_best_effort_lim",
-    "osd_mclock_cost_per_io_msec",
-    "osd_mclock_cost_per_io_msec_hdd",
-    "osd_mclock_cost_per_io_msec_ssd",
+    "osd_mclock_cost_per_io_usec",
+    "osd_mclock_cost_per_io_usec_hdd",
+    "osd_mclock_cost_per_io_usec_ssd",
+    "osd_mclock_cost_per_byte_usec",
+    "osd_mclock_cost_per_byte_usec_hdd",
+    "osd_mclock_cost_per_byte_usec_ssd",
     "osd_mclock_max_capacity_iops",
     "osd_mclock_max_capacity_iops_hdd",
     "osd_mclock_max_capacity_iops_ssd",
@@ -476,10 +480,15 @@ void mClockScheduler::handle_conf_change(
   const ConfigProxy& conf,
   const std::set<std::string> &changed)
 {
-  if (changed.count("osd_mclock_cost_per_io_msec") ||
-      changed.count("osd_mclock_cost_per_io_msec_hdd") ||
-      changed.count("osd_mclock_cost_per_io_msec_ssd")) {
+  if (changed.count("osd_mclock_cost_per_io_usec") ||
+      changed.count("osd_mclock_cost_per_io_usec_hdd") ||
+      changed.count("osd_mclock_cost_per_io_usec_ssd")) {
     set_osd_mclock_cost_per_io();
+  }
+  if (changed.count("osd_mclock_cost_per_byte_usec") ||
+      changed.count("osd_mclock_cost_per_byte_usec_hdd") ||
+      changed.count("osd_mclock_cost_per_byte_usec_ssd")) {
+    set_osd_mclock_cost_per_byte();
   }
   if (changed.count("osd_mclock_max_capacity_iops") ||
       changed.count("osd_mclock_max_capacity_iops_hdd") ||

--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -386,6 +386,21 @@ void mClockScheduler::set_global_recovery_options()
   cct->_conf.set_val("osd_recovery_sleep_ssd", std::to_string(0));
   cct->_conf.set_val("osd_recovery_sleep_hybrid", std::to_string(0));
 
+  // Disable delete sleep
+  cct->_conf.set_val("osd_delete_sleep", std::to_string(0));
+  cct->_conf.set_val("osd_delete_sleep_hdd", std::to_string(0));
+  cct->_conf.set_val("osd_delete_sleep_ssd", std::to_string(0));
+  cct->_conf.set_val("osd_delete_sleep_hybrid", std::to_string(0));
+
+  // Disable snap trim sleep
+  cct->_conf.set_val("osd_snap_trim_sleep", std::to_string(0));
+  cct->_conf.set_val("osd_snap_trim_sleep_hdd", std::to_string(0));
+  cct->_conf.set_val("osd_snap_trim_sleep_ssd", std::to_string(0));
+  cct->_conf.set_val("osd_snap_trim_sleep_hybrid", std::to_string(0));
+
+  // Disable scrub sleep
+  cct->_conf.set_val("osd_scrub_sleep", std::to_string(0));
+
   // Apply the changes
   cct->_conf.apply_changes(nullptr);
 }

--- a/src/osd/scheduler/mClockScheduler.cc
+++ b/src/osd/scheduler/mClockScheduler.cc
@@ -110,31 +110,62 @@ void mClockScheduler::set_max_osd_capacity()
         cct->_conf.get_val<double>("osd_mclock_max_capacity_iops_ssd");
     }
   }
-  // Set max osd bandwidth across all shards (at 4KiB blocksize)
-  max_osd_bandwidth = max_osd_capacity * 4 * 1024;
   // Set per op-shard iops limit
   max_osd_capacity /= num_shards;
+  dout(1) << __func__ << " #op shards: " << num_shards
+          << " max osd capacity(iops) per shard: " << max_osd_capacity << dendl;
 }
 
 void mClockScheduler::set_osd_mclock_cost_per_io()
 {
-  if (cct->_conf.get_val<uint64_t>("osd_mclock_cost_per_io_msec")) {
-    osd_mclock_cost_per_io_msec =
-      cct->_conf.get_val<uint64_t>("osd_mclock_cost_per_io_msec");
+  std::chrono::seconds sec(1);
+  if (cct->_conf.get_val<double>("osd_mclock_cost_per_io_usec")) {
+    osd_mclock_cost_per_io =
+      cct->_conf.get_val<double>("osd_mclock_cost_per_io_usec");
   } else {
     if (is_rotational) {
-      osd_mclock_cost_per_io_msec =
-        cct->_conf.get_val<uint64_t>("osd_mclock_cost_per_io_msec_hdd");
+      osd_mclock_cost_per_io =
+        cct->_conf.get_val<double>("osd_mclock_cost_per_io_usec_hdd");
+      // For HDDs, convert value to seconds
+      osd_mclock_cost_per_io /= std::chrono::microseconds(sec).count();
     } else {
-      osd_mclock_cost_per_io_msec =
-        cct->_conf.get_val<uint64_t>("osd_mclock_cost_per_io_msec_ssd");
+      // For SSDs, convert value to milliseconds
+      osd_mclock_cost_per_io =
+        cct->_conf.get_val<double>("osd_mclock_cost_per_io_usec_ssd");
+      osd_mclock_cost_per_io /= std::chrono::milliseconds(sec).count();
     }
   }
+  dout(1) << __func__ << " osd_mclock_cost_per_io: "
+          << std::fixed << osd_mclock_cost_per_io << dendl;
+}
+
+void mClockScheduler::set_osd_mclock_cost_per_byte()
+{
+  std::chrono::seconds sec(1);
+  if (cct->_conf.get_val<double>("osd_mclock_cost_per_byte_usec")) {
+    osd_mclock_cost_per_byte =
+      cct->_conf.get_val<double>("osd_mclock_cost_per_byte_usec");
+  } else {
+    if (is_rotational) {
+      osd_mclock_cost_per_byte =
+        cct->_conf.get_val<double>("osd_mclock_cost_per_byte_usec_hdd");
+      // For HDDs, convert value to seconds
+      osd_mclock_cost_per_byte /= std::chrono::microseconds(sec).count();
+    } else {
+      osd_mclock_cost_per_byte =
+        cct->_conf.get_val<double>("osd_mclock_cost_per_byte_usec_ssd");
+      // For SSDs, convert value to milliseconds
+      osd_mclock_cost_per_byte /= std::chrono::milliseconds(sec).count();
+    }
+  }
+  dout(1) << __func__ << " osd_mclock_cost_per_byte: "
+          << std::fixed << osd_mclock_cost_per_byte << dendl;
 }
 
 void mClockScheduler::set_mclock_profile()
 {
   mclock_profile = cct->_conf.get_val<std::string>("osd_mclock_profile");
+  dout(1) << __func__ << " mclock profile: " << mclock_profile << dendl;
 }
 
 std::string mClockScheduler::get_mclock_profile()
@@ -358,19 +389,11 @@ void mClockScheduler::set_global_recovery_options()
   cct->_conf.apply_changes(nullptr);
 }
 
-int mClockScheduler::calc_scaled_cost(int cost)
+int mClockScheduler::calc_scaled_cost(int item_cost)
 {
-  // Calculate scaled cost in msecs based on item cost
-  int scaled_cost = std::floor((cost / max_osd_bandwidth) * 1000);
-
-  // Scale the cost down by an additional cost factor if specified
-  // to account for different device characteristics (hdd, ssd).
-  // This option can be used to further tune the performance further
-  // if necessary (disabled by default).
-  if (osd_mclock_cost_per_io_msec > 0) {
-    scaled_cost *= osd_mclock_cost_per_io_msec / 1000.0;
-  }
-
+  // Calculate total scaled cost in secs
+  int scaled_cost =
+    std::round(osd_mclock_cost_per_io + (osd_mclock_cost_per_byte * item_cost));
   return std::max(scaled_cost, 1);
 }
 

--- a/src/osd/scheduler/mClockScheduler.h
+++ b/src/osd/scheduler/mClockScheduler.h
@@ -67,8 +67,8 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
   const uint32_t num_shards;
   bool is_rotational;
   double max_osd_capacity;
-  double max_osd_bandwidth;
-  uint64_t osd_mclock_cost_per_io_msec;
+  double osd_mclock_cost_per_io;
+  double osd_mclock_cost_per_byte;
   std::string mclock_profile = "high_client_ops";
   struct ClientAllocs {
     uint64_t res;
@@ -144,6 +144,9 @@ public:
 
   // Set the cost per io for the osd
   void set_osd_mclock_cost_per_io();
+
+  // Set the cost per byte for the osd
+  void set_osd_mclock_cost_per_byte();
 
   // Set the mclock profile type to enable
   void set_mclock_profile();

--- a/src/osd/scheduler/mClockScheduler.h
+++ b/src/osd/scheduler/mClockScheduler.h
@@ -69,8 +69,32 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
   bool is_rotational;
   double max_osd_capacity;
   uint64_t osd_mclock_cost_per_io_msec;
-  std::string mclock_profile = "balanced";
-  std::map<op_scheduler_class, double> client_allocs;
+  std::string mclock_profile = "high_client_ops";
+  struct ClientAllocs {
+    uint64_t res;
+    uint64_t wgt;
+    uint64_t lim;
+
+    ClientAllocs(uint64_t _res, uint64_t _wgt, uint64_t _lim) {
+      update(_res, _wgt, _lim);
+    }
+
+    inline void update(uint64_t _res, uint64_t _wgt, uint64_t _lim) {
+      res = _res;
+      wgt = _wgt;
+      lim = _lim;
+    }
+  };
+  std::array<
+    ClientAllocs,
+    static_cast<size_t>(op_scheduler_class::client) + 1
+  > client_allocs = {
+    // Placeholder, get replaced with configured values
+    ClientAllocs(1, 1, 1), // background_recovery
+    ClientAllocs(1, 1, 1), // background_best_effort
+    ClientAllocs(1, 1, 1), // immediate (not used)
+    ClientAllocs(1, 1, 1)  // client
+  };
   std::map<op_type_t, int> client_cost_infos;
   std::map<op_type_t, int> client_scaled_cost_infos;
   class ClientRegistry {
@@ -115,6 +139,7 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
 
 public:
   mClockScheduler(CephContext *cct, uint32_t num_shards, bool is_rotational);
+  ~mClockScheduler() override;
 
   // Set the max osd capacity in iops
   void set_max_osd_capacity();
@@ -122,26 +147,26 @@ public:
   // Set the cost per io for the osd
   void set_osd_mclock_cost_per_io();
 
-  // Set the mclock related config params based on the profile
-  void enable_mclock_profile();
+  // Set the mclock profile type to enable
+  void set_mclock_profile();
 
   // Get the active mclock profile
   std::string get_mclock_profile();
 
-  // Set client capacity allocations based on profile
-  void set_client_allocations();
+  // Set "balanced" profile allocations
+  void set_balanced_profile_allocations();
 
-  // Get client allocation
-  double get_client_allocation(op_type_t op_type);
+  // Set "high_recovery_ops" profile allocations
+  void set_high_recovery_ops_profile_allocations();
 
-  // Set "balanced" profile parameters
-  void set_balanced_profile_config();
+  // Set "high_client_ops" profile allocations
+  void set_high_client_ops_profile_allocations();
 
-  // Set "high_recovery_ops" profile parameters
-  void set_high_recovery_ops_profile_config();
+  // Set the mclock related config params based on the profile
+  void enable_mclock_profile_settings();
 
-  // Set "high_client_ops" profile parameters
-  void set_high_client_ops_profile_config();
+  // Set mclock config parameter based on allocations
+  void set_profile_config();
 
   // Set recovery specific Ceph settings for profiles
   void set_global_recovery_options();

--- a/src/osd/scheduler/mClockScheduler.h
+++ b/src/osd/scheduler/mClockScheduler.h
@@ -38,7 +38,6 @@ constexpr uint64_t default_max = 999999;
 
 using client_id_t = uint64_t;
 using profile_id_t = uint64_t;
-using op_type_t = OpSchedulerItem::OpQueueable::op_type_t;
 
 struct client_profile_id_t {
   client_id_t client_id;
@@ -68,6 +67,7 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
   const uint32_t num_shards;
   bool is_rotational;
   double max_osd_capacity;
+  double max_osd_bandwidth;
   uint64_t osd_mclock_cost_per_io_msec;
   std::string mclock_profile = "high_client_ops";
   struct ClientAllocs {
@@ -95,8 +95,6 @@ class mClockScheduler : public OpScheduler, md_config_obs_t {
     ClientAllocs(1, 1, 1), // immediate (not used)
     ClientAllocs(1, 1, 1)  // client
   };
-  std::map<op_type_t, int> client_cost_infos;
-  std::map<op_type_t, int> client_scaled_cost_infos;
   class ClientRegistry {
     std::array<
       crimson::dmclock::ClientInfo,
@@ -172,10 +170,7 @@ public:
   void set_global_recovery_options();
 
   // Calculate scale cost per item
-  int calc_scaled_cost(op_type_t op_type, int cost);
-
-  // Update mclock client cost info
-  bool maybe_update_client_cost_info(op_type_t op_type, int new_cost);
+  int calc_scaled_cost(int cost);
 
   // Enqueue op in the back of the regular queue
   void enqueue(OpSchedulerItem &&item) final;

--- a/src/test/osd/TestMClockScheduler.cc
+++ b/src/test/osd/TestMClockScheduler.cc
@@ -93,7 +93,7 @@ TEST_F(mClockSchedulerTest, TestEmpty) {
 
   for (unsigned i = 100; i < 105; i+=2) {
     q.enqueue(create_item(i, client1, op_scheduler_class::client));
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    std::this_thread::sleep_for(std::chrono::microseconds(1));
   }
 
   ASSERT_FALSE(q.empty());
@@ -126,7 +126,7 @@ TEST_F(mClockSchedulerTest, TestSingleClientOrderedEnqueueDequeue) {
 
   for (unsigned i = 100; i < 105; ++i) {
     q.enqueue(create_item(i, client1, op_scheduler_class::client));
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    std::this_thread::sleep_for(std::chrono::microseconds(1));
   }
 
   auto r = get_item(q.dequeue());
@@ -150,6 +150,7 @@ TEST_F(mClockSchedulerTest, TestMultiClientOrderedEnqueueDequeue) {
   for (unsigned i = 0; i < NUM; ++i) {
     for (auto &&c: {client1, client2, client3}) {
       q.enqueue(create_item(i, c));
+      std::this_thread::sleep_for(std::chrono::microseconds(1));
     }
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49699

---

backport of https://github.com/ceph/ceph/pull/39140 and https://github.com/ceph/ceph/pull/39858
parent tracker: https://tracker.ceph.com/issues/49698

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh