### PR TITLE
nautilus: mgr/dashboard: fix dashboard instance ssl certificate functionality 

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -152,7 +152,7 @@ class CherryPyConfig(object):
 
         if use_ssl:
             # SSL initialization
-            cert = self.get_store("crt")
+            cert = self.get_localized_store("crt")
             if cert is not None:
                 self.cert_tmp = tempfile.NamedTemporaryFile()
                 self.cert_tmp.write(cert.encode('utf-8'))
@@ -161,7 +161,7 @@ class CherryPyConfig(object):
             else:
                 cert_fname = self.get_localized_module_option('crt_file')
 
-            pkey = self.get_store("key")
+            pkey = self.get_localized_store("key")
             if pkey is not None:
                 self.pkey_tmp = tempfile.NamedTemporaryFile()
                 self.pkey_tmp.write(pkey.encode('utf-8'))

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -556,6 +556,14 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule):
         """
         return self._ceph_get_store(key)
 
+    def get_localized_store(self, key, default=None):
+        r = self._ceph_get_store(_get_localized_key(self.get_mgr_id(), key))
+        if r is None:
+            r = self._ceph_get_store(key)
+            if r is None:
+                r = default
+        return r
+
     def get_active_uri(self):
         return self._ceph_get_active_uri()
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49704

---

backport of https://github.com/ceph/ceph/pull/39503
parent tracker: https://tracker.ceph.com/issues/46542

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh