### PR TITLE
cephfs-mirror: fix possible incorrect symbolic link synchronization

### DIFF
--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -1306,8 +1306,10 @@ class CephFSMount(object):
             "available": int(avail)
         }
 
-    def dir_checksum(self, path=None):
+    def dir_checksum(self, path=None, follow_symlinks=False):
         cmd = ["find"]
+        if follow_symlinks:
+            cmd.append("-L")
         if path:
             cmd.append(path)
         cmd.extend(["-type", "f", "-exec", "md5sum", "{}", "+"])

--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -681,6 +681,7 @@ int PeerReplayer::remote_file_op(const std::string &dir_path,
       return r;
     }
 
+    target[stx.stx_size] = '\0';
     r = ceph_symlink(m_remote_mount, target, remote_path.c_str());
     if (r < 0 && r != EEXIST) {
       derr << ": failed to symlink remote path=" << remote_path << " to target=" << target


### PR DESCRIPTION
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
