### PR TITLE
rgw: allow rgw_data_notify_interval_msec=0 to disable notifications

### DIFF
--- a/qa/suites/rgw/multisite/notify.yaml
+++ b/qa/suites/rgw/multisite/notify.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      client.0: # disable notifications on one zone per cluster
+        rgw data notify interval msec: 0

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -2801,9 +2801,13 @@ options:
   type: int
   level: advanced
   desc: data changes notification interval to followers
+  long_desc: In multisite, radosgw will occasionally broadcast new entries in its
+    data changes log to peer zones, so they can prioritize sync of some
+    of the most recent changes. Can be disabled with 0.
   default: 200
   services:
   - rgw
+  with_legacy: true
 - name: rgw_torrent_origin
   type: str
   level: advanced
@@ -2822,7 +2826,7 @@ options:
   type: bool
   level: basic
   desc: Enable dynamic resharding
-  long_desc: If true, RGW will dynamicall increase the number of shards in buckets
+  long_desc: If true, RGW will dynamically increase the number of shards in buckets
     that have a high number of objects per shard.
   default: true
   services:

--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -990,6 +990,10 @@ void RGWDataChangesLog::renew_stop()
 
 void RGWDataChangesLog::mark_modified(int shard_id, const rgw_bucket_shard& bs)
 {
+  if (!cct->_conf->rgw_data_notify_interval_msec) {
+    return;
+  }
+
   auto key = bs.get_key();
   {
     std::shared_lock rl{modified_lock}; // read lock to check for existence

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1311,8 +1311,10 @@ int RGWRados::init_complete(const DoutPrefixProvider *dpp)
       sync_log_trimmer->start();
     }
   }
-  data_notifier = new RGWDataNotifier(this);
-  data_notifier->start();
+  if (cct->_conf->rgw_data_notify_interval_msec) {
+    data_notifier = new RGWDataNotifier(this);
+    data_notifier->start();
+  }
 
   binfo_cache = new RGWChainedCacheImpl<bucket_info_entry>;
   binfo_cache->init(svc.cache);


### PR DESCRIPTION
the data changes log for multisite will occasionally broadcast recent changes to other zones, which they can use to prioritize sync of some of the most recent changes. they'll eventually see all changes as they replay the data changes log, though, so notifications aren't required for successful sync. the ability to turn them off is useful for testing

Fixes: https://tracker.ceph.com/issues/49723

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
