### PR TITLE
use mclock_scheduler as the default scheduler

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -12,6 +12,8 @@
 * RGW: `radosgw-admin realm delete` is now renamed to `radosgw-admin realm rm`. This
   is consistent with the help message.
 
+* OSD: Ceph now uses mclock_scheduler as its default osd_op_queue to provide QoS.
+
 >=16.0.0
 --------
 * mgr/nfs: ``nfs`` module is moved out of volumes plugin. Prior using the

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -642,6 +642,7 @@ function run_osd() {
     ceph_args+=" --osd-scrub-load-threshold=2000"
     ceph_args+=" --osd-data=$osd_data"
     ceph_args+=" --osd-journal=${osd_data}/journal"
+    ceph_args+=" --osd-op-queue=wpq"
     ceph_args+=" --chdir="
     ceph_args+=$EXTRA_OPTS
     ceph_args+=" --run-dir=$dir"
@@ -697,6 +698,7 @@ function run_osd_filestore() {
     ceph_args+=" --osd-scrub-load-threshold=2000"
     ceph_args+=" --osd-data=$osd_data"
     ceph_args+=" --osd-journal=${osd_data}/journal"
+    ceph_args+=" --osd-op-queue=wpq"
     ceph_args+=" --chdir="
     ceph_args+=$EXTRA_OPTS
     ceph_args+=" --run-dir=$dir"

--- a/qa/suites/rados/mgr/tasks/progress.yaml
+++ b/qa/suites/rados/mgr/tasks/progress.yaml
@@ -1,4 +1,8 @@
-
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd mclock profile: high_recovery_ops
 tasks:
   - install:
   - ceph:

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4450,19 +4450,18 @@ options:
   type: str
   level: advanced
   desc: which operation priority queue algorithm to use
-  long_desc: which operation priority queue algorithm to use; mclock_scheduler is
-    currently experimental
+  long_desc: which operation priority queue algorithm to use
   fmt_desc: This sets the type of queue to be used for prioritizing ops
     within each OSD. Both queues feature a strict sub-queue which is
     dequeued before the normal queue. The normal queue is different
     between implementations. The WeightedPriorityQueue (``wpq``)
     dequeues operations in relation to their priorities to prevent
     starvation of any queue. WPQ should help in cases where a few OSDs
-    are more overloaded than others. The new mClockQueue
+    are more overloaded than others. The mClockQueue
     (``mclock_scheduler``) prioritizes operations based on which class
     they belong to (recovery, scrub, snaptrim, client op, osd subop).
     See `QoS Based on mClock`_. Requires a restart.
-  default: wpq
+  default: mclock_scheduler
   see_also:
   - osd_op_queue_cut_off
   enum_values:


### PR DESCRIPTION
The aim is to default to mclock_scheduler in quincy, so start early and
get more testing.

Signed-off-by: Neha Ojha <nojha@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
