### PR TITLE
mgr/dashboard: Device health status is not getting listed under hosts section

### DIFF
--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -225,12 +225,20 @@ class CephService(object):
 
             for daemon in daemons:
                 svc_type, svc_id = daemon.split('.')
-                try:
-                    dev_smart_data = CephService.send_command(
-                        svc_type, 'smart', svc_id, devid=device['devid'])
-                except SendCommandError:
-                    # Try to retrieve SMART data from another daemon.
-                    continue
+                if 'osd' in svc_type:
+                    try:
+                        dev_smart_data = CephService.send_command(
+                            svc_type, 'smart', svc_id, devid=device['devid'])
+                    except SendCommandError:
+                        # Try to retrieve SMART data from another daemon.
+                        continue
+                else:
+                    try:
+                        dev_smart_data = CephService.send_command(
+                            svc_type, 'device get-health-metrics', svc_id, devid=device['devid'])
+                    except SendCommandError:
+                        # Try to retrieve SMART data from another daemon.
+                        continue
                 for dev_id, dev_data in dev_smart_data.items():
                     if 'error' in dev_data:
                         logger.warning(


### PR DESCRIPTION
Device health is shown as failed to retrieve data under Hosts > Device Health section. This PR intends to fix this issue.

Fixes: https://tracker.ceph.com/issues/49354
Signed-off-by: Aashish Sharma <aasharma@redhat.com>



<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
