### PR TITLE
rgw: add assignment of compressor_message

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -6136,7 +6136,7 @@ void RGWCompleteMultipart::execute()
         if (!compressed)
           cs_info.compression_type = obj_part.cs_info.compression_type;
         cs_info.orig_size += obj_part.cs_info.orig_size;
-        cs_info.compressor_message = obj_part.cs_info.compressor_message;
+        cs_info.compressor_message = obj_part.cs_info.compressor_message; 
         compressed = true;
       }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -6136,6 +6136,7 @@ void RGWCompleteMultipart::execute()
         if (!compressed)
           cs_info.compression_type = obj_part.cs_info.compression_type;
         cs_info.orig_size += obj_part.cs_info.orig_size;
+        cs_info.compressor_message = obj_part.cs_info.compressor_message;
         compressed = true;
       }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -6136,7 +6136,7 @@ void RGWCompleteMultipart::execute()
         if (!compressed)
           cs_info.compression_type = obj_part.cs_info.compression_type;
         cs_info.orig_size += obj_part.cs_info.orig_size;
-        cs_info.compressor_message = obj_part.cs_info.compressor_message; 
+        cs_info.compressor_message = obj_part.cs_info.compressor_message;
         compressed = true;
       }
 


### PR DESCRIPTION
Last patch of compressor_message has a bug released. This patch is to fix the bug of file decompression, when the file is larger than 15M.
I see the last patch of compressor_message is merged in v16.1.0. As this patch is based on the last one, so it should be merged after the last patch.

Last patch addr:https://github.com/ceph/ceph/pull/34263

Fixes:https://tracker.ceph.com/issues/49692
Signed-off-by: zhouyunkai <498549175@qq.com>

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
