### PR TITLE
rgw: add option to uniquely register in servicemap

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7381,6 +7381,13 @@ std::vector<Option> get_rgw_options() {
     .set_default("")
 #endif
     .set_description("Directory where luarocks install packages from allowlist"),
+
+  Option("rgw_register_with_unique_name", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("Register in service map with unique name")
+    .set_long_description(
+        "If true, RGW will register in the service map with a unique identifier."
+        "The suffix unique identifier is the RADOS client session ID.")
   });
 }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1137,6 +1137,12 @@ int RGWRados::register_to_service_map(const string& daemon_type, const map<strin
     name = name.substr(4);
   }
   int ret = rados.service_daemon_register(daemon_type, name, metadata);
+  auto unique_name = cct->_conf.get_val<bool>("rgw_register_with_unique_name");
+  if (unique_name) {
+    std::string instance_id = stringify(rados.get_instance_id());
+    std::string rgw_service_map_name = name + "." + instance_id;
+    ret = rados.service_daemon_register(daemon_type, rgw_service_map_name, metadata);
+  }
   if (ret < 0) {
     ldout(cct, 0) << "ERROR: service_daemon_register() returned ret=" << ret << ": " << cpp_strerror(-ret) << dendl;
     return ret;


### PR DESCRIPTION
If rgw_register_with_unique_name is set to True, the rgw process will
register in the service map with a uniq identifier. The uniq identifier
is the RADOS client session ID appended to the name of the gateway.

This will give us better visibility when
query the Ceph status and also will also us to run multiple rgws with
the same cephX user AND to be displayed individually. Previously, using a
single cephX user to run multiple gateways was possible but the Ceph
status would display a single rgw.
Also, in the same situation it will allow us to gather metrics and
export them through the ceph-mgr Prometheus exporter.

Fixes: https://tracker.ceph.com/issues/49227
Signed-off-by: Sébastien Han <seb@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
