### PR TITLE
qa/suites/rados/cephadm: add back centos+rhel with kubic podman

### DIFF
--- a/qa/suites/rados/cephadm/smoke/distro/centos_8.2_kubic_stable.yaml
+++ b/qa/suites/rados/cephadm/smoke/distro/centos_8.2_kubic_stable.yaml
@@ -1,0 +1,1 @@
+.qa/distros/podman/centos_8.2_kubic_stable.yaml

--- a/qa/suites/rados/cephadm/smoke/distro/rhel_8.3_kubic_stable.yaml
+++ b/qa/suites/rados/cephadm/smoke/distro/rhel_8.3_kubic_stable.yaml
@@ -1,0 +1,1 @@
+.qa/distros/podman/rhel_8.3_kubic_stable.yaml

--- a/qa/suites/rados/cephadm/workunits/0-distro/centos_8.2_kubic_stable.yaml
+++ b/qa/suites/rados/cephadm/workunits/0-distro/centos_8.2_kubic_stable.yaml
@@ -1,0 +1,1 @@
+.qa/distros/podman/centos_8.2_kubic_stable.yaml


### PR DESCRIPTION
TODO
- [x] wait for https://github.com/ceph/teuthology/pull/1628 to merge