### PR TITLE
rgw: rgw::sal::RGWBucket initializes creation_time

### DIFF
--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -311,7 +311,7 @@ class RGWBucket {
   protected:
     RGWBucketEnt ent;
     RGWBucketInfo info;
-    RGWUser* owner;
+    RGWUser* owner = nullptr;
     RGWAttrs attrs;
     obj_version bucket_version;
     ceph::real_time mtime;
@@ -337,21 +337,32 @@ class RGWBucket {
       rgw_obj_key next_marker;
     };
 
-    RGWBucket() : ent(), info(), owner(nullptr), attrs(), bucket_version() {}
+    RGWBucket() = default;
     RGWBucket(RGWUser* _u) :
-      ent(), info(), owner(_u), attrs(), bucket_version() { }
-    RGWBucket(const rgw_bucket& _b) :
-      ent(), info(), owner(nullptr), attrs(), bucket_version() { ent.bucket = _b; info.bucket = _b; }
-    RGWBucket(const RGWBucketEnt& _e) :
-      ent(_e), info(), owner(nullptr), attrs(), bucket_version() { info.bucket = ent.bucket; info.placement_rule = ent.placement_rule; }
-    RGWBucket(const RGWBucketInfo& _i) :
-      ent(), info(_i), owner(nullptr), attrs(), bucket_version() {ent.bucket = info.bucket; ent.placement_rule = info.placement_rule; }
+      owner(_u) { }
+    RGWBucket(const rgw_bucket& _b) { ent.bucket = _b; info.bucket = _b; }
+    RGWBucket(const RGWBucketEnt& _e) : ent(_e) {
+      info.bucket = ent.bucket;
+      info.placement_rule = ent.placement_rule;
+      info.creation_time = ent.creation_time;
+    }
+    RGWBucket(const RGWBucketInfo& _i) : info(_i) {
+      ent.bucket = info.bucket;
+      ent.placement_rule = info.placement_rule;
+      ent.creation_time = info.creation_time;
+    }
     RGWBucket(const rgw_bucket& _b, RGWUser* _u) :
-      ent(), info(), owner(_u), attrs(), bucket_version() { ent.bucket = _b; info.bucket = _b; }
-    RGWBucket(const RGWBucketEnt& _e, RGWUser* _u) :
-      ent(_e), info(), owner(_u), attrs(), bucket_version() { info.bucket = ent.bucket; info.placement_rule = ent.placement_rule; }
-    RGWBucket(const RGWBucketInfo& _i, RGWUser* _u) :
-      ent(), info(_i), owner(_u), attrs(), bucket_version() { ent.bucket = info.bucket;  ent.placement_rule = info.placement_rule;}
+      owner(_u) { ent.bucket = _b; info.bucket = _b; }
+    RGWBucket(const RGWBucketEnt& _e, RGWUser* _u) : ent(_e), owner(_u) {
+      info.bucket = ent.bucket;
+      info.placement_rule = ent.placement_rule;
+      info.creation_time = ent.creation_time;
+    }
+    RGWBucket(const RGWBucketInfo& _i, RGWUser* _u) : info(_i), owner(_u) {
+      ent.bucket = info.bucket;
+      ent.placement_rule = info.placement_rule;
+      ent.creation_time = info.creation_time;
+    }
     virtual ~RGWBucket() = default;
 
     virtual std::unique_ptr<RGWObject> get_object(const rgw_obj_key& key) = 0;


### PR DESCRIPTION
rgw::sal::RGWUser::list_buckets() uses the RGWBucketEnt constructor. RGWBucketEnt::creation_time is initialized, but get_creation_time() returns the uninitialized info.creation_time

Fixes: https://tracker.ceph.com/issues/49741

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
