### PR TITLE
qa/suites/rados/cephadm/upgrade: deploy a legacy r.z-style rgw

### DIFF
--- a/qa/suites/rados/cephadm/upgrade/3-start-upgrade.yaml
+++ b/qa/suites/rados/cephadm/upgrade/3-start-upgrade.yaml
@@ -2,4 +2,10 @@ tasks:
 - cephadm.shell:
     env: [sha1]
     mon.a:
+      - radosgw-admin realm create --rgw-realm=r --default
+      - radosgw-admin zonegroup create --rgw-zonegroup=default --master --default
+      - radosgw-admin zone create --rgw-zonegroup=default --rgw-zone=z --master --default
+      - radosgw-admin period update --rgw-realm=r --commit
+      - ceph orch apply rgw r z --placement=2 --port=8000
+      - sleep 120
       - ceph orch upgrade start --image quay.ceph.io/ceph-ci/ceph:$sha1


### PR DESCRIPTION
https://pulpito.ceph.com/sage-2021-03-10_21:13:00-rados:cephadm:upgrade-wip-sage-testing-2021-03-09-1434-distro-basic-gibba/