### PR TITLE
nautilus: mgr/ActivePyModules.cc: always release GIL before attempting to acquire a lock

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -56,6 +56,66 @@ ActivePyModules::ActivePyModules(PyModuleConfig &module_config_,
 
 ActivePyModules::~ActivePyModules() = default;
 
+namespace {
+  // because the Python runtime could relinquish the GIL when performing GC
+  // and re-acquire it afterwards, we should enforce following locking policy:
+  // 1. do not acquire locks when holding the GIL, use a without_gil or
+  //    without_gil_t to guard the code which acquires non-gil locks.
+  // 2. always hold a GIL when calling python functions, for example, when
+  //    constructing a PyFormatter instance.
+  //
+  // a wrapper that provides a convenient RAII-style mechinary for acquiring
+  // and releasing GIL, like the macros of Py_BEGIN_ALLOW_THREADS and
+  // Py_END_ALLOW_THREADS.
+  struct without_gil_t {
+    without_gil_t()
+    {
+      release_gil();
+    }
+    ~without_gil_t()
+    {
+      if (save) {
+        acquire_gil();
+      }
+    }
+  private:
+    void release_gil() {
+      save = PyEval_SaveThread();
+    }
+    void acquire_gil() {
+      assert(save);
+      PyEval_RestoreThread(save);
+      save = nullptr;
+    }
+    PyThreadState *save = nullptr;
+    friend struct with_gil_t;
+  };
+  struct with_gil_t {
+    with_gil_t(without_gil_t& allow_threads)
+      : allow_threads{allow_threads}
+    {
+      allow_threads.acquire_gil();
+    }
+    ~with_gil_t() {
+      allow_threads.release_gil();
+    }
+  private:
+    without_gil_t& allow_threads;
+  };
+  // invoke func with GIL acquired
+  template<typename Func>
+  auto with_gil(without_gil_t& no_gil, Func&& func)
+  {
+    with_gil_t gil{no_gil};
+    return std::invoke(std::forward<Func>(func));
+  }
+  template<typename Func>
+  auto without_gil(Func&& func) {
+    without_gil_t no_gil;
+    return std::invoke(std::forward<Func>(func));
+  }
+}
+
 void ActivePyModules::dump_server(const std::string &hostname,
                       const DaemonStateCollection &dmc,
                       Formatter *f)
@@ -65,15 +125,16 @@ void ActivePyModules::dump_server(const std::string &hostname,
   std::string ceph_version;
 
   for (const auto &[key, state] : dmc) {
-    std::lock_guard l(state->lock);
-    // TODO: pick the highest version, and make sure that
-    // somewhere else (during health reporting?) we are
-    // indicating to the user if we see mixed versions
-    auto ver_iter = state->metadata.find("ceph_version");
-    if (ver_iter != state->metadata.end()) {
-      ceph_version = state->metadata.at("ceph_version");
-    }
-
+    without_gil([&ceph_version, state=state] {
+      std::lock_guard l(state->lock);
+      // TODO: pick the highest version, and make sure that
+      // somewhere else (during health reporting?) we are
+      // indicating to the user if we see mixed versions
+      auto ver_iter = state->metadata.find("ceph_version");
+      if (ver_iter != state->metadata.end()) {
+        ceph_version = state->metadata.at("ceph_version");
+      }
+    });
     f->open_object_section("service");
     f->dump_string("type", key.type);
     f->dump_string("id", key.name);
@@ -84,17 +145,13 @@ void ActivePyModules::dump_server(const std::string &hostname,
   f->dump_string("ceph_version", ceph_version);
 }
 
-
-
 PyObject *ActivePyModules::get_server_python(const std::string &hostname)
 {
-  PyThreadState *tstate = PyEval_SaveThread();
-  std::lock_guard l(lock);
-  PyEval_RestoreThread(tstate);
-  dout(10) << " (" << hostname << ")" << dendl;
-
-  auto dmc = daemon_state.get_by_server(hostname);
-
+  const auto dmc = without_gil([&]{
+    std::lock_guard l(lock);
+    dout(10) << " (" << hostname << ")" << dendl;
+    return daemon_state.get_by_server(hostname);
+  });
   PyFormatter f;
   dump_server(hostname, dmc, &f);
   return f.get();
@@ -103,24 +160,20 @@ PyObject *ActivePyModules::get_server_python(const std::string &hostname)
 
 PyObject *ActivePyModules::list_servers_python()
 {
-  PyFormatter f(false, true);
-  PyThreadState *tstate = PyEval_SaveThread();
   dout(10) << " >" << dendl;
 
-  daemon_state.with_daemons_by_server([this, &f, &tstate]
+  without_gil_t no_gil;
+  return daemon_state.with_daemons_by_server([this, &no_gil]
       (const std::map<std::string, DaemonStateCollection> &all) {
-    PyEval_RestoreThread(tstate);
-
-    for (const auto &i : all) {
-      const auto &hostname = i.first;
-
+    with_gil_t with_gil{no_gil};
+    PyFormatter f(false, true);
+    for (const auto &[hostname, daemon_state] : all) {
       f.open_object_section("server");
-      dump_server(hostname, i.second, &f);
+      dump_server(hostname, daemon_state, &f);
       f.close_section();
     }
+    return f.get();
   });
-
-  return f.get();
 }
 
 PyObject *ActivePyModules::get_metadata_python(
@@ -132,8 +185,9 @@ PyObject *ActivePyModules::get_metadata_python(
     derr << "Requested missing service " << svc_type << "." << svc_id << dendl;
     Py_RETURN_NONE;
   }
-
-  std::lock_guard l(metadata->lock);
+  auto l = without_gil([&] {
+    return std::lock_guard(lock);
+  });
   PyFormatter f;
   f.dump_string("hostname", metadata->hostname);
   for (const auto &i : metadata->metadata) {
@@ -152,8 +206,9 @@ PyObject *ActivePyModules::get_daemon_status_python(
     derr << "Requested missing service " << svc_type << "." << svc_id << dendl;
     Py_RETURN_NONE;
   }
-
-  std::lock_guard l(metadata->lock);
+  auto l = without_gil([&] {
+    return std::lock_guard(lock);
+  });
   PyFormatter f;
   for (const auto &i : metadata->service_status) {
     f.dump_string(i.first.c_str(), i.second);
@@ -168,25 +223,25 @@ PyObject *ActivePyModules::get_python(const std::string &what)
   // Drop the GIL, as most of the following blocks will block on
   // a mutex -- they are all responsible for re-taking the GIL before
   // touching the PyFormatter instance or returning from the function.
-  PyThreadState *tstate = PyEval_SaveThread();
+  without_gil_t no_gil;
 
   if (what == "fs_map") {
-    cluster_state.with_fsmap([&f, &tstate](const FSMap &fsmap) {
-      PyEval_RestoreThread(tstate);
+    return cluster_state.with_fsmap([&](const FSMap &fsmap) {
+      with_gil_t with_gil{no_gil};
       fsmap.dump(&f);
+      return f.get();
     });
-    return f.get();
   } else if (what == "osdmap_crush_map_text") {
     bufferlist rdata;
-    cluster_state.with_osdmap([&rdata, &tstate](const OSDMap &osd_map){
-      PyEval_RestoreThread(tstate);
+    cluster_state.with_osdmap([&](const OSDMap &osd_map){
       osd_map.crush->encode(rdata, CEPH_FEATURES_SUPPORTED_DEFAULT);
     });
     std::string crush_text = rdata.to_str();
-    return PyString_FromString(crush_text.c_str());
+    with_gil_t with_gil{no_gil};
+    return PyUnicode_FromString(crush_text.c_str());
   } else if (what.substr(0, 7) == "osd_map") {
-    cluster_state.with_osdmap([&f, &what, &tstate](const OSDMap &osd_map){
-      PyEval_RestoreThread(tstate);
+    return cluster_state.with_osdmap([&](const OSDMap &osd_map){
+      with_gil_t with_gil{no_gil};
       if (what == "osd_map") {
         osd_map.dump(&f);
       } else if (what == "osd_map_tree") {
@@ -194,10 +249,9 @@ PyObject *ActivePyModules::get_python(const std::string &what)
       } else if (what == "osd_map_crush") {
         osd_map.crush->dump(&f);
       }
+      return f.get();
     });
-    return f.get();
   } else if (what == "modified_config_options") {
-    PyEval_RestoreThread(tstate);
     auto all_daemons = daemon_state.get_all();
     set<string> names;
     for (auto& [key, daemon] : all_daemons) {
@@ -206,6 +260,7 @@ PyObject *ActivePyModules::get_python(const std::string &what)
 	names.insert(name);
       }
     }
+    with_gil_t with_gil{no_gil};
     f.open_array_section("options");
     for (auto& name : names) {
       f.dump_string("name", name);
@@ -213,7 +268,7 @@ PyObject *ActivePyModules::get_python(const std::string &what)
     f.close_section();
     return f.get();
   } else if (what.substr(0, 6) == "config") {
-    PyEval_RestoreThread(tstate);
+    with_gil_t with_gil{no_gil};
     if (what == "config_options") {
       g_conf().config_options(&f);
     } else if (what == "config") {
@@ -221,40 +276,34 @@ PyObject *ActivePyModules::get_python(const std::string &what)
     }
     return f.get();
   } else if (what == "mon_map") {
-    cluster_state.with_monmap(
-      [&f, &tstate](const MonMap &monmap) {
-        PyEval_RestoreThread(tstate);
-        monmap.dump(&f);
-      }
-    );
-    return f.get();
+    return cluster_state.with_monmap([&](const MonMap &monmap) {
+      with_gil_t with_gil{no_gil};
+      monmap.dump(&f);
+      return f.get();
+    });
   } else if (what == "service_map") {
-    cluster_state.with_servicemap(
-      [&f, &tstate](const ServiceMap &service_map) {
-        PyEval_RestoreThread(tstate);
-        service_map.dump(&f);
-      }
-    );
-    return f.get();
+    return cluster_state.with_servicemap([&](const ServiceMap &service_map) {
+      with_gil_t with_gil{no_gil};
+      service_map.dump(&f);
+      return f.get();
+    });
   } else if (what == "osd_metadata") {
     auto dmc = daemon_state.get_by_service("osd");
-    PyEval_RestoreThread(tstate);
-
     for (const auto &[key, state] : dmc) {
       std::lock_guard l(state->lock);
-      f.open_object_section(key.name.c_str());
-      f.dump_string("hostname", state->hostname);
-      for (const auto &[name, val] : state->metadata) {
-        f.dump_string(name.c_str(), val);
-      }
-      f.close_section();
+      with_gil(no_gil, [&f, &name=key.name, state=state] {
+        f.open_object_section(name.c_str());
+        f.dump_string("hostname", state->hostname);
+        for (const auto &[name, val] : state->metadata) {
+          f.dump_string(name.c_str(), val);
+        }
+        f.close_section();
+      });
     }
-    return f.get();
+    return with_gil(no_gil, [&] { return f.get(); });
   } else if (what == "pg_summary") {
-    cluster_state.with_pgmap(
-        [&f, &tstate](const PGMap &pg_map) {
-          PyEval_RestoreThread(tstate);
-
+    return cluster_state.with_pgmap(
+        [&f, &no_gil](const PGMap &pg_map) {
           std::map<std::string, std::map<std::string, uint32_t> > osds;
           std::map<std::string, std::map<std::string, uint32_t> > pools;
           std::map<std::string, uint32_t> all;
@@ -268,6 +317,7 @@ PyObject *ActivePyModules::get_python(const std::string &what)
             }
             all[state]++;
           }
+          with_gil_t with_gil{no_gil};
           f.open_object_section("by_osd");
           for (const auto &i : osds) {
             f.open_object_section(i.first.c_str());
@@ -294,136 +344,129 @@ PyObject *ActivePyModules::get_python(const std::string &what)
           f.open_object_section("pg_stats_sum");
           pg_map.pg_sum.dump(&f);
           f.close_section();
+	  return f.get();
         }
     );
-    return f.get();
   } else if (what == "pg_status") {
-    cluster_state.with_pgmap(
-        [&f, &tstate](const PGMap &pg_map) {
-          PyEval_RestoreThread(tstate);
+    return cluster_state.with_pgmap(
+        [&](const PGMap &pg_map) {
+	  with_gil_t with_gil{no_gil};
 	  pg_map.print_summary(&f, nullptr);
+          return f.get();
         }
     );
-    return f.get();
   } else if (what == "pg_dump") {
-    cluster_state.with_pgmap(
-      [&f, &tstate](const PGMap &pg_map) {
-        PyEval_RestoreThread(tstate);
+    return cluster_state.with_pgmap(
+      [&](const PGMap &pg_map) {
+	with_gil_t with_gil{no_gil};
 	pg_map.dump(&f, false);
+	return f.get();
       }
     );
-    return f.get();
   } else if (what == "devices") {
     daemon_state.with_devices2(
-      [&tstate, &f]() {
-	PyEval_RestoreThread(tstate);
-	f.open_array_section("devices");
+      [&] {
+        with_gil(no_gil, [&] { f.open_array_section("devices"); });
       },
-      [&f] (const DeviceState& dev) {
-	f.dump_object("device", dev);
+      [&](const DeviceState &dev) {
+        with_gil(no_gil, [&] { f.dump_object("device", dev); });
       });
-    f.close_section();
-    return f.get();
+    return with_gil(no_gil, [&] {
+      f.close_section();
+      return f.get();
+    });
   } else if (what.size() > 7 &&
 	     what.substr(0, 7) == "device ") {
     string devid = what.substr(7);
-    if (!daemon_state.with_device(
-	  devid,
-	  [&f, &tstate] (const DeviceState& dev) {
-	    PyEval_RestoreThread(tstate);
-	    f.dump_object("device", dev);
-	  })) {
+    if (!daemon_state.with_device(devid,
+      [&] (const DeviceState& dev) {
+        with_gil_t with_gil{no_gil};
+        f.dump_object("device", dev);
+      })) {
       // device not found
-      PyEval_RestoreThread(tstate);
     }
-    return f.get();
+    return with_gil(no_gil, [&] { return f.get(); });
   } else if (what == "io_rate") {
-    cluster_state.with_pgmap(
-      [&f, &tstate](const PGMap &pg_map) {
-        PyEval_RestoreThread(tstate);
+    return cluster_state.with_pgmap(
+      [&](const PGMap &pg_map) {
+        with_gil_t with_gil{no_gil};
         pg_map.dump_delta(&f);
+	return f.get();
       }
     );
-    return f.get();
   } else if (what == "df") {
-    cluster_state.with_osdmap_and_pgmap(
-      [this, &f, &tstate](
+    return cluster_state.with_osdmap_and_pgmap(
+      [&](
 	const OSDMap& osd_map,
 	const PGMap &pg_map) {
-	PyEval_RestoreThread(tstate);
+        with_gil_t with_gil{no_gil};
         pg_map.dump_cluster_stats(nullptr, &f, true);
         pg_map.dump_pool_stats_full(osd_map, nullptr, &f, true);
+	return f.get();
       });
-    return f.get();
   } else if (what == "pg_stats") {
-    cluster_state.with_pgmap(
-        [&f, &tstate](const PGMap &pg_map) {
-      PyEval_RestoreThread(tstate);
+    return cluster_state.with_pgmap([&](const PGMap &pg_map) {
+      with_gil_t with_gil{no_gil};
       pg_map.dump_pg_stats(&f, false);
+      return f.get();
     });
-    return f.get();
   } else if (what == "pool_stats") {
-    cluster_state.with_pgmap(
-        [&f, &tstate](const PGMap &pg_map) {
-      PyEval_RestoreThread(tstate);
+    return cluster_state.with_pgmap([&](const PGMap &pg_map) {
+      with_gil_t with_gil{no_gil};
       pg_map.dump_pool_stats(&f);
+      return f.get();
     });
-    return f.get();
   } else if (what == "pg_ready") {
-    PyEval_RestoreThread(tstate);
+    with_gil_t with_gil{no_gil};
     server.dump_pg_ready(&f);
     return f.get();
   } else if (what == "osd_stats") {
-    cluster_state.with_pgmap(
-        [&f, &tstate](const PGMap &pg_map) {
-      PyEval_RestoreThread(tstate);
+    return cluster_state.with_pgmap([&](const PGMap &pg_map) {
+      with_gil_t with_gil{no_gil};
       pg_map.dump_osd_stats(&f, false);
+      return f.get();
     });
-    return f.get();
   } else if (what == "osd_ping_times") {
-    cluster_state.with_pgmap(
-        [&f, &tstate](const PGMap &pg_map) {
-      PyEval_RestoreThread(tstate);
+    return cluster_state.with_pgmap([&](const PGMap &pg_map) {
+      with_gil_t with_gil{no_gil};
       pg_map.dump_osd_ping_times(&f);
+      return f.get();
     });
-    return f.get();
   } else if (what == "osd_pool_stats") {
     int64_t poolid = -ENOENT;
-    string pool_name;
-    cluster_state.with_osdmap_and_pgmap([&](const OSDMap& osdmap,
+    return cluster_state.with_osdmap_and_pgmap([&](const OSDMap& osdmap,
 					    const PGMap& pg_map) {
-        PyEval_RestoreThread(tstate);
-        f.open_array_section("pool_stats");
-        for (auto &p : osdmap.get_pools()) {
-          poolid = p.first;
-          pg_map.dump_pool_stats_and_io_rate(poolid, osdmap, &f, nullptr);
-        }
-        f.close_section();
+      with_gil_t with_gil{no_gil};
+      f.open_array_section("pool_stats");
+      for (auto &p : osdmap.get_pools()) {
+        poolid = p.first;
+        pg_map.dump_pool_stats_and_io_rate(poolid, osdmap, &f, nullptr);
+      }
+      f.close_section();
+      return f.get();
     });
-    return f.get();
   } else if (what == "health") {
-    cluster_state.with_health(
-        [&f, &tstate](const ceph::bufferlist &health_json) {
-      PyEval_RestoreThread(tstate);
+    return cluster_state.with_health([&](const ceph::bufferlist &health_json) {
+      with_gil_t with_gil{no_gil};
       f.dump_string("json", health_json.to_str());
+      return f.get();
     });
-    return f.get();
   } else if (what == "mon_status") {
-    cluster_state.with_mon_status(
-        [&f, &tstate](const ceph::bufferlist &mon_status_json) {
-      PyEval_RestoreThread(tstate);
+    return cluster_state.with_mon_status(
+        [&](const ceph::bufferlist &mon_status_json) {
+      with_gil_t with_gil{no_gil};
       f.dump_string("json", mon_status_json.to_str());
+      return f.get();
     });
-    return f.get();
   } else if (what == "mgr_map") {
-    cluster_state.with_mgrmap([&f, &tstate](const MgrMap &mgr_map) {
-      PyEval_RestoreThread(tstate);
+    return cluster_state.with_mgrmap([&](const MgrMap &mgr_map) {
+      with_gil_t with_gil{no_gil};
       mgr_map.dump(&f);
+      return f.get();
     });
-    return f.get();
   } else {
     derr << "Python module requested unknown data '" << what << "'" << dendl;
-    PyEval_RestoreThread(tstate);
+    with_gil_t with_gil{no_gil};
     Py_RETURN_NONE;
   }
 }
@@ -522,9 +565,8 @@ void ActivePyModules::notify_all(const LogEntry &log_entry)
 bool ActivePyModules::get_store(const std::string &module_name,
     const std::string &key, std::string *val) const
 {
-  PyThreadState *tstate = PyEval_SaveThread();
+  without_gil_t no_gil;
   std::lock_guard l(lock);
-  PyEval_RestoreThread(tstate);
 
   const std::string global_key = PyModule::config_prefix
     + module_name + "/" + key;
@@ -577,7 +619,7 @@ PyObject *ActivePyModules::get_typed_config(
   const std::string &key,
   const std::string &prefix) const
 {
-  PyThreadState *tstate = PyEval_SaveThread();
+  without_gil_t no_gil;
   std::string value;
   std::string final_key;
   bool found = false;
@@ -591,7 +633,7 @@ PyObject *ActivePyModules::get_typed_config(
   }
   if (found) {
     PyModuleRef module = py_module_registry.get_module(module_name);
-    PyEval_RestoreThread(tstate);
+    with_gil_t with_gil{no_gil};
     if (!module) {
         derr << "Module '" << module_name << "' is not available" << dendl;
         Py_RETURN_NONE;
@@ -602,37 +644,36 @@ PyObject *ActivePyModules::get_typed_config(
     dout(10) << __func__ << " " << final_key << " found" << dendl;
     return module->get_typed_option_value(key, value);
   }
-  PyEval_RestoreThread(tstate);
   if (prefix.size()) {
     dout(4) << __func__ << " [" << prefix << "/]" << key << " not found "
 	    << dendl;
   } else {
     dout(4) << __func__ << " " << key << " not found " << dendl;
   }
+  with_gil_t with_gil{no_gil};
   Py_RETURN_NONE;
 }
 
 PyObject *ActivePyModules::get_store_prefix(const std::string &module_name,
     const std::string &prefix) const
 {
-  PyThreadState *tstate = PyEval_SaveThread();
+  without_gil_t no_gil;
   std::lock_guard l(lock);
   std::lock_guard lock(module_config.lock);
-  PyEval_RestoreThread(tstate);
 
   const std::string base_prefix = PyModule::config_prefix
                                     + module_name + "/";
   const std::string global_prefix = base_prefix + prefix;
   dout(4) << __func__ << " prefix: " << global_prefix << dendl;
 
-  PyFormatter f;
-  
-  for (auto p = store_cache.lower_bound(global_prefix);
-       p != store_cache.end() && p->first.find(global_prefix) == 0;
-       ++p) {
-    f.dump_string(p->first.c_str() + base_prefix.size(), p->second);
-  }
-  return f.get();
+  return with_gil(no_gil, [&] {
+    PyFormatter f;
+    for (auto p = store_cache.lower_bound(global_prefix);
+         p != store_cache.end() && p->first.find(global_prefix) == 0; ++p) {
+      f.dump_string(p->first.c_str() + base_prefix.size(), p->second);
+    }
+    return f.get();
+  });
 }
 
 void ActivePyModules::set_store(const std::string &module_name,
@@ -703,31 +744,32 @@ PyObject* ActivePyModules::with_perf_counters(
     const std::string &svc_id,
     const std::string &path) const
 {
-  PyThreadState *tstate = PyEval_SaveThread();
-  std::lock_guard l(lock);
-  PyEval_RestoreThread(tstate);
-
   PyFormatter f;
   f.open_array_section(path.c_str());
-
-  auto metadata = daemon_state.get(DaemonKey{svc_name, svc_id});
-  if (metadata) {
-    std::lock_guard l2(metadata->lock);
-    if (metadata->perf_counters.instances.count(path)) {
-      auto counter_instance = metadata->perf_counters.instances.at(path);
-      auto counter_type = metadata->perf_counters.types.at(path);
-      fct(counter_instance, counter_type, f);
-    } else {
-      dout(4) << "Missing counter: '" << path << "' ("
-        << svc_name << "." << svc_id << ")" << dendl;
-      dout(20) << "Paths are:" << dendl;
-      for (const auto &i : metadata->perf_counters.instances) {
-        dout(20) << i.first << dendl;
+  {
+    without_gil_t no_gil;
+    std::lock_guard l(lock);
+    auto metadata = daemon_state.get(DaemonKey{svc_name, svc_id});
+    if (metadata) {
+      std::lock_guard l2(metadata->lock);
+      if (metadata->perf_counters.instances.count(path)) {
+        auto counter_instance = metadata->perf_counters.instances.at(path);
+        auto counter_type = metadata->perf_counters.types.at(path);
+        with_gil(no_gil, [&] {
+          fct(counter_instance, counter_type, f);
+        });
+      } else {
+        dout(4) << "Missing counter: '" << path << "' ("
+		<< svc_name << "." << svc_id << ")" << dendl;
+        dout(20) << "Paths are:" << dendl;
+        for (const auto &i : metadata->perf_counters.instances) {
+          dout(20) << i.first << dendl;
+        }
       }
+    } else {
+      dout(4) << "No daemon state for " << svc_name << "." << svc_id << ")"
+              << dendl;
     }
-  } else {
-    dout(4) << "No daemon state for "
-      << svc_name << "." << svc_id << ")" << dendl;
   }
   f.close_section();
   return f.get();
@@ -793,9 +835,8 @@ PyObject* ActivePyModules::get_perf_schema_python(
     const std::string &svc_type,
     const std::string &svc_id)
 {
-  PyThreadState *tstate = PyEval_SaveThread();
+  without_gil_t no_gil;
   std::lock_guard l(lock);
-  PyEval_RestoreThread(tstate);
 
   DaemonStateCollection daemons;
 
@@ -812,26 +853,29 @@ PyObject* ActivePyModules::get_perf_schema_python(
     }
   }
 
-  PyFormatter f;
+  auto f = with_gil(no_gil, [&] {
+    return PyFormatter();
+  });
   if (!daemons.empty()) {
     for (auto& [key, state] : daemons) {
-      f.open_object_section(ceph::to_string(key).c_str());
-
       std::lock_guard l(state->lock);
-      for (auto ctr_inst_iter : state->perf_counters.instances) {
-        const auto &counter_name = ctr_inst_iter.first;
-	f.open_object_section(counter_name.c_str());
-	auto type = state->perf_counters.types[counter_name];
-	f.dump_string("description", type.description);
-	if (!type.nick.empty()) {
-	  f.dump_string("nick", type.nick);
-	}
-	f.dump_unsigned("type", type.type);
-	f.dump_unsigned("priority", type.priority);
-	f.dump_unsigned("units", type.unit);
-	f.close_section();
-      }
-      f.close_section();
+      with_gil(no_gil, [&, key=ceph::to_string(key), state=state] {
+        f.open_object_section(key.c_str());
+        for (auto ctr_inst_iter : state->perf_counters.instances) {
+          const auto &counter_name = ctr_inst_iter.first;
+          f.open_object_section(counter_name.c_str());
+          auto type = state->perf_counters.types[counter_name];
+          f.dump_string("description", type.description);
+          if (!type.nick.empty()) {
+            f.dump_string("nick", type.nick);
+          }
+          f.dump_unsigned("type", type.type);
+          f.dump_unsigned("priority", type.priority);
+          f.dump_unsigned("units", type.unit);
+          f.close_section();
+        }
+        f.close_section();
+      });
     }
   } else {
     dout(4) << __func__ << ": No daemon state found for "
@@ -842,10 +886,9 @@ PyObject* ActivePyModules::get_perf_schema_python(
 
 PyObject *ActivePyModules::get_context()
 {
-  PyThreadState *tstate = PyEval_SaveThread();
-  std::lock_guard l(lock);
-  PyEval_RestoreThread(tstate);
-
+  auto l = without_gil([&] {
+    return std::lock_guard(lock);
+  });
   // Construct a capsule containing ceph context.
   // Not incrementing/decrementing ref count on the context because
   // it's the global one and it has process lifetime.
@@ -900,16 +943,13 @@ PyObject *construct_with_capsule(
 
 PyObject *ActivePyModules::get_osdmap()
 {
-  OSDMap *newmap = new OSDMap;
-
-  PyThreadState *tstate = PyEval_SaveThread();
-  {
+  auto newmap = without_gil([&] {
+    OSDMap *newmap = new OSDMap;
     cluster_state.with_osdmap([&](const OSDMap& o) {
-        newmap->deepish_copy_from(o);
-      });
-  }
-  PyEval_RestoreThread(tstate);
-
+      newmap->deepish_copy_from(o);
+    });
+    return newmap;
+  });
   return construct_with_capsule("mgr_module", "OSDMap", (void*)newmap);
 }
 

--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -95,6 +95,7 @@ public:
      const std::string &svc_id);
   PyObject *get_context();
   PyObject *get_osdmap();
+  /// @note @c fct is not allowed to acquire locks when holding GIL
   PyObject *with_perf_counters(
       std::function<void(
         PerfCounterInstance& counter_instance,

--- a/src/mgr/CMakeLists.txt
+++ b/src/mgr/CMakeLists.txt
@@ -10,6 +10,7 @@ set(mgr_srcs
   BaseMgrStandbyModule.cc
   ClusterState.cc
   DaemonHealthMetricCollector.cc
+  DaemonKey.cc
   DaemonServer.cc
   DaemonState.cc
   Gil.cc

--- a/src/mgr/ClusterState.h
+++ b/src/mgr/ClusterState.h
@@ -74,24 +74,24 @@ public:
   }
 
   template<typename Callback, typename...Args>
-  void with_servicemap(Callback&& cb, Args&&...args) const
+  auto with_servicemap(Callback&& cb, Args&&...args) const
   {
     std::lock_guard l(lock);
-    std::forward<Callback>(cb)(servicemap, std::forward<Args>(args)...);
+    return std::forward<Callback>(cb)(servicemap, std::forward<Args>(args)...);
   }
 
   template<typename Callback, typename...Args>
-  void with_fsmap(Callback&& cb, Args&&...args) const
+  auto with_fsmap(Callback&& cb, Args&&...args) const
   {
     std::lock_guard l(lock);
-    std::forward<Callback>(cb)(fsmap, std::forward<Args>(args)...);
+    return std::forward<Callback>(cb)(fsmap, std::forward<Args>(args)...);
   }
 
   template<typename Callback, typename...Args>
-  void with_mgrmap(Callback&& cb, Args&&...args) const
+  auto with_mgrmap(Callback&& cb, Args&&...args) const
   {
     std::lock_guard l(lock);
-    std::forward<Callback>(cb)(mgr_map, std::forward<Args>(args)...);
+    return std::forward<Callback>(cb)(mgr_map, std::forward<Args>(args)...);
   }
 
   template<typename Callback, typename...Args>
@@ -111,11 +111,11 @@ public:
   }
 
   template<typename... Args>
-  void with_monmap(Args &&... args) const
+  auto with_monmap(Args &&... args) const
   {
     std::lock_guard l(lock);
     ceph_assert(monc != nullptr);
-    monc->with_monmap(std::forward<Args>(args)...);
+    return monc->with_monmap(std::forward<Args>(args)...);
   }
 
   template<typename... Args>
@@ -138,17 +138,17 @@ public:
   }
 
   template<typename Callback, typename...Args>
-  void with_health(Callback&& cb, Args&&...args) const
+  auto with_health(Callback&& cb, Args&&...args) const
   {
     std::lock_guard l(lock);
-    std::forward<Callback>(cb)(health_json, std::forward<Args>(args)...);
+    return std::forward<Callback>(cb)(health_json, std::forward<Args>(args)...);
   }
 
   template<typename Callback, typename...Args>
-  void with_mon_status(Callback&& cb, Args&&...args) const
+  auto with_mon_status(Callback&& cb, Args&&...args) const
   {
     std::lock_guard l(lock);
-    std::forward<Callback>(cb)(mon_status_json, std::forward<Args>(args)...);
+    return std::forward<Callback>(cb)(mon_status_json, std::forward<Args>(args)...);
   }
 
   void final_init();

--- a/src/mgr/DaemonHealthMetricCollector.cc
+++ b/src/mgr/DaemonHealthMetricCollector.cc
@@ -4,30 +4,6 @@
 #include "include/types.h"
 #include "DaemonHealthMetricCollector.h"
 
-
-
-ostream& operator<<(ostream& os,
-                    const DaemonHealthMetricCollector::DaemonKey& daemon) {
-  return os << daemon.first << "." << daemon.second;
-}
-
-// define operator<<(ostream&, const vector<DaemonKey>&) after
-// ostream& operator<<(ostream&, const DaemonKey&), so that C++'s
-// ADL can use the former instead of using the generic one:
-// operator<<(ostream&, const std::pair<A,B>&)
-ostream& operator<<(
-   ostream& os,
-   const vector<DaemonHealthMetricCollector::DaemonKey>& daemons)
-{
-  os << "[";
-  for (auto d = daemons.begin(); d != daemons.end(); ++d) {
-    if (d != daemons.begin()) os << ",";
-    os << *d;
-  }
-  os << "]";
-  return os;
-}
-
 namespace {
 
 class SlowOps final : public DaemonHealthMetricCollector {

--- a/src/mgr/DaemonHealthMetricCollector.h
+++ b/src/mgr/DaemonHealthMetricCollector.h
@@ -4,11 +4,11 @@
 #include <string>
 
 #include "DaemonHealthMetric.h"
+#include "DaemonKey.h"
 #include "mon/health_check.h"
 
 class DaemonHealthMetricCollector {
 public:
-  using DaemonKey = std::pair<std::string, std::string>;
   static std::unique_ptr<DaemonHealthMetricCollector> create(daemon_metric m);
   void update(const DaemonKey& daemon, const DaemonHealthMetric& metric) {
     if (_is_relevant(metric.get_type())) {

--- a/src/mgr/DaemonKey.cc
+++ b/src/mgr/DaemonKey.cc
@@ -1,0 +1,35 @@
+#include "DaemonKey.h"
+
+std::pair<DaemonKey, bool> DaemonKey::parse(const std::string& s)
+{
+  auto p = s.find('.');
+  if (p == s.npos) {
+    return {{}, false};
+  } else {
+    return {DaemonKey{s.substr(0, p), s.substr(p + 1)}, true};
+  }
+}
+
+bool operator<(const DaemonKey& lhs, const DaemonKey& rhs)
+{
+  if (int cmp = lhs.type.compare(rhs.type); cmp < 0) {
+    return true;
+  } else if (cmp > 0) {
+    return false;
+  } else {
+    return lhs.name < rhs.name;
+  }
+}
+
+std::ostream& operator<<(std::ostream& os, const DaemonKey& key)
+{
+  return os << key.type << '.' << key.name;
+}
+
+namespace ceph {
+std::string to_string(const DaemonKey& key)
+{
+  return key.type + '.' + key.name;
+}
+}
+

--- a/src/mgr/DaemonKey.h
+++ b/src/mgr/DaemonKey.h
@@ -1,0 +1,24 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <ostream>
+#include <string>
+#include <utility>
+
+// Unique reference to a daemon within a cluster
+struct DaemonKey
+{
+  std::string type; // service type, like "osd", "mon"
+  std::string name; // service id / name, like "1", "a"
+  static std::pair<DaemonKey, bool> parse(const std::string& s);
+};
+
+bool operator<(const DaemonKey& lhs, const DaemonKey& rhs);
+std::ostream& operator<<(std::ostream& os, const DaemonKey& key);
+
+namespace ceph {
+  std::string to_string(const DaemonKey& key);
+}
+

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -404,26 +404,13 @@ static DaemonKey key_from_service(
   const std::string& daemon_name)
 {
   if (!service_name.empty()) {
-    return DaemonKey(service_name, daemon_name);
+    return DaemonKey{service_name, daemon_name};
   } else {
-    return DaemonKey(ceph_entity_type_name(peer_type), daemon_name);
+    return DaemonKey{ceph_entity_type_name(peer_type), daemon_name};
   }
 }
 
-static bool key_from_string(
-  const std::string& name,
-  DaemonKey *out)
-{
-  auto p = name.find('.');
-  if (p == std::string::npos) {
-    return false;
-  }
-  out->first = name.substr(0, p);
-  out->second = name.substr(p + 1);
-  return true;
-}
-
-bool DaemonServer::handle_open(MMgrOpen *m)
+bool DaemonServer::handle_open(MMgrOpen* m)
 {
   std::lock_guard l(lock);
 
@@ -542,7 +529,7 @@ bool DaemonServer::handle_close(MMgrClose *m)
 void DaemonServer::update_task_status(DaemonKey key, MMgrReport *m) {
   dout(10) << "got task status from " << key << dendl;
 
-  auto p = pending_service_map.get_daemon(key.first, key.second);
+  auto p = pending_service_map.get_daemon(key.type, key.name);
   if (!map_compare(p.first->task_status, *m->task_status)) {
     p.first->task_status = *m->task_status;
     pending_service_map_dirty = pending_service_map.epoch;
@@ -553,11 +540,11 @@ bool DaemonServer::handle_report(MMgrReport *m)
 {
   DaemonKey key;
   if (!m->service_name.empty()) {
-    key.first = m->service_name;
+    key.type = m->service_name;
   } else {
-    key.first = ceph_entity_type_name(m->get_connection()->get_peer_type());
+    key.type = ceph_entity_type_name(m->get_connection()->get_peer_type());
   }
-  key.second = m->daemon_name;
+  key.name = m->daemon_name;
 
   dout(4) << "from " << m->get_connection() << " " << key << dendl;
 
@@ -589,22 +576,22 @@ bool DaemonServer::handle_report(MMgrReport *m)
               << dendl;
       // issue metadata request in background
       if (!daemon_state.is_updating(key) && 
-          (key.first == "osd" || key.first == "mds" || key.first == "mon")) {
+          (key.type == "osd" || key.type == "mds" || key.type == "mon")) {
 
         std::ostringstream oss;
         auto c = new MetadataUpdate(daemon_state, key);
-        if (key.first == "osd") {
+        if (key.type == "osd") {
           oss << "{\"prefix\": \"osd metadata\", \"id\": "
-              << key.second<< "}";
+              << key.name<< "}";
 
-        } else if (key.first == "mds") {
+        } else if (key.type == "mds") {
           c->set_default("addr", stringify(m->get_source_addr()));
           oss << "{\"prefix\": \"mds metadata\", \"who\": \""
-              << key.second << "\"}";
+              << key.name << "\"}";
  
-        } else if (key.first == "mon") {
+        } else if (key.type == "mon") {
           oss << "{\"prefix\": \"mon metadata\", \"id\": \""
-              << key.second << "\"}";
+              << key.name << "\"}";
         } else {
           ceph_abort();
         }
@@ -678,9 +665,7 @@ bool DaemonServer::handle_report(MMgrReport *m)
 
   // if there are any schema updates, notify the python modules
   if (!m->declare_types.empty() || !m->undeclare_types.empty()) {
-    ostringstream oss;
-    oss << key.first << '.' << key.second;
-    py_modules.notify_all("perf_schema_update", oss.str());
+    py_modules.notify_all("perf_schema_update", ceph::to_string(key));
   }
 
   if (m->get_connection()->peer_is_osd()) {
@@ -969,15 +954,14 @@ bool DaemonServer::_handle_command(
       f.reset(Formatter::create("json-pretty"));
     // only include state from services that are in the persisted service map
     f->open_object_section("service_status");
-    for (auto& p : pending_service_map.services) {
-      if (ServiceMap::is_normal_ceph_entity(p.first)) {
+    for (auto& [type, service] : pending_service_map.services) {
+      if (ServiceMap::is_normal_ceph_entity(type)) {
         continue;
       }
-
-      f->open_object_section(p.first.c_str());
-      for (auto& q : p.second.daemons) {
+      f->open_object_section(type.c_str());
+      for (auto& q : service.daemons) {
 	f->open_object_section(q.first.c_str());
-	DaemonKey key(p.first, q.first);
+	DaemonKey key{type, q.first};
 	ceph_assert(daemon_state.exists(key));
 	auto daemon = daemon_state.get(key);
 	std::lock_guard l(daemon->lock);
@@ -1819,13 +1803,13 @@ bool DaemonServer::_handle_command(
 	     prefix == "config show-with-defaults") {
     string who;
     cmd_getval(g_ceph_context, cmdctx->cmdmap, "who", who);
-    int r = 0;
-    auto dot = who.find('.');
-    DaemonKey key;
-    key.first = who.substr(0, dot);
-    key.second = who.substr(dot + 1);
+    auto [key, valid] = DaemonKey::parse(who);
+    if (!valid) {
+      ss << "invalid daemon name: use <type>.<id>";
+      cmdctx->reply(-EINVAL, ss);
+      return true;
+    }
     DaemonStatePtr daemon = daemon_state.get(key);
-    string name;
     if (!daemon) {
       ss << "no config state for daemon " << who;
       cmdctx->reply(-ENOENT, ss);
@@ -1834,6 +1818,8 @@ bool DaemonServer::_handle_command(
 
     std::lock_guard l(daemon->lock);
 
+    int r = 0;
+    string name;
     if (cmd_getval(g_ceph_context, cmdctx->cmdmap, "key", name)) {
       // handle special options
       if (name == "fsid") {
@@ -2043,8 +2029,7 @@ bool DaemonServer::_handle_command(
   } else if (prefix == "device ls-by-daemon") {
     string who;
     cmd_getval(g_ceph_context, cmdctx->cmdmap, "who", who);
-    DaemonKey k;
-    if (!key_from_string(who, &k)) {
+    if (auto [k, valid] = DaemonKey::parse(who); !valid) {
       ss << who << " is not a valid daemon name";
       r = -EINVAL;
     } else {
@@ -2345,7 +2330,7 @@ void DaemonServer::_prune_pending_service_map()
   while (p != pending_service_map.services.end()) {
     auto q = p->second.daemons.begin();
     while (q != p->second.daemons.end()) {
-      DaemonKey key(p->first, q->first);
+      DaemonKey key{p->first, q->first};
       if (!daemon_state.exists(key)) {
         if (ServiceMap::is_normal_ceph_entity(p->first)) {
           dout(10) << "daemon " << key << " in service map but not in daemon state "
@@ -2451,7 +2436,7 @@ void DaemonServer::send_report()
         if (acc == accumulated.end()) {
           auto collector = DaemonHealthMetricCollector::create(metric.get_type());
           if (!collector) {
-            derr << __func__ << " " << key.first << "." << key.second
+            derr << __func__ << " " << key
 		 << " sent me an unknown health metric: "
 		 << std::hex << static_cast<uint8_t>(metric.get_type())
 		 << std::dec << dendl;
@@ -2798,17 +2783,17 @@ void DaemonServer::got_service_map()
 
   // cull missing daemons, populate new ones
   std::set<std::string> types;
-  for (auto& p : pending_service_map.services) {
-    if (ServiceMap::is_normal_ceph_entity(p.first)) {
+  for (auto& [type, service] : pending_service_map.services) {
+    if (ServiceMap::is_normal_ceph_entity(type)) {
       continue;
     }
 
-    types.insert(p.first);
+    types.insert(type);
 
     std::set<std::string> names;
-    for (auto& q : p.second.daemons) {
+    for (auto& q : service.daemons) {
       names.insert(q.first);
-      DaemonKey key(p.first, q.first);
+      DaemonKey key{type, q.first};
       if (!daemon_state.exists(key)) {
 	auto daemon = std::make_shared<DaemonState>(daemon_state.types);
 	daemon->key = key;
@@ -2818,7 +2803,7 @@ void DaemonServer::got_service_map()
 	dout(10) << "added missing " << key << dendl;
       }
     }
-    daemon_state.cull(p.first, names);
+    daemon_state.cull(type, names);
   }
   daemon_state.cull_services(types);
 }
@@ -2833,11 +2818,11 @@ void DaemonServer::got_mgr_map()
         auto c = new MetadataUpdate(daemon_state, key);
 	// FIXME remove post-nautilus: include 'id' for luminous mons
         oss << "{\"prefix\": \"mgr metadata\", \"who\": \""
-	    << key.second << "\", \"id\": \"" << key.second << "\"}";
+	    << key.name << "\", \"id\": \"" << key.name << "\"}";
         monc->start_mon_command({oss.str()}, {}, &c->outbl, &c->outs, c);
       };
       if (mgrmap.active_name.size()) {
-	DaemonKey key("mgr", mgrmap.active_name);
+	DaemonKey key{"mgr", mgrmap.active_name};
 	have.insert(mgrmap.active_name);
 	if (!daemon_state.exists(key) && !daemon_state.is_updating(key)) {
 	  md_update(key);
@@ -2845,7 +2830,7 @@ void DaemonServer::got_mgr_map()
 	}
       }
       for (auto& i : mgrmap.standbys) {
-        DaemonKey key("mgr", i.second.name);
+        DaemonKey key{"mgr", i.second.name};
 	have.insert(i.second.name);
 	if (!daemon_state.exists(key) && !daemon_state.is_updating(key)) {
 	  md_update(key);

--- a/src/mgr/DaemonState.cc
+++ b/src/mgr/DaemonState.cc
@@ -273,7 +273,7 @@ void DaemonStateIndex::cull_services(const std::set<std::string>& types_exist)
   for (auto it = all.begin(); it != all.end(); ++it) {
     const auto& daemon_key = it->first;
     if (it->second->service_daemon &&
-        types_exist.count(daemon_key.first) == 0) {
+        types_exist.count(daemon_key.type) == 0) {
       victims.insert(daemon_key);
     }
   }

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -27,16 +27,10 @@
 
 // For PerfCounterType
 #include "messages/MMgrReport.h"
+#include "DaemonKey.h"
 
 namespace ceph {
   class Formatter;
-}
-
-// Unique reference to a daemon within a cluster
-typedef std::pair<std::string, std::string> DaemonKey;
-
-static inline std::string to_string(const DaemonKey& dk) {
-  return dk.first + "." + dk.second;
 }
 
 // An instance of a performance counter type, within

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -70,31 +70,27 @@ void MetadataUpdate::finish(int r)
 {
   daemon_state.clear_updating(key);
   if (r == 0) {
-    if (key.first == "mds" || key.first == "osd" || 
-        key.first == "mgr" || key.first == "mon") {
+    if (key.type == "mds" || key.type == "osd" ||
+        key.type == "mgr" || key.type == "mon") {
       json_spirit::mValue json_result;
       bool read_ok = json_spirit::read(
           outbl.to_str(), json_result);
       if (!read_ok) {
-        dout(1) << "mon returned invalid JSON for "
-                << key.first << "." << key.second << dendl;
+        dout(1) << "mon returned invalid JSON for " << key << dendl;
         return;
       }
       if (json_result.type() != json_spirit::obj_type) {
-        dout(1) << "mon returned valid JSON "
-                << key.first << "." << key.second
+        dout(1) << "mon returned valid JSON " << key
 		<< " but not an object: '" << outbl.to_str() << "'" << dendl;
         return;
       }
-      dout(4) << "mon returned valid metadata JSON for "
-              << key.first << "." << key.second << dendl;
+      dout(4) << "mon returned valid metadata JSON for " << key << dendl;
 
       json_spirit::mObject daemon_meta = json_result.get_obj();
 
       // Skip daemon who doesn't have hostname yet
       if (daemon_meta.count("hostname") == 0) {
-        dout(1) << "Skipping incomplete metadata entry for "
-                << key.first << "." << key.second << dendl;
+        dout(1) << "Skipping incomplete metadata entry for " << key << dendl;
         return;
       }
 
@@ -108,15 +104,14 @@ void MetadataUpdate::finish(int r)
       DaemonStatePtr state;
       if (daemon_state.exists(key)) {
         state = daemon_state.get(key);
-	state->hostname = daemon_meta.at("hostname").get_str();
-
-        if (key.first == "mds" || key.first == "mgr" || key.first == "mon") {
+        state->hostname = daemon_meta.at("hostname").get_str();
+        if (key.type == "mds" || key.type == "mgr" || key.type == "mon") {
           daemon_meta.erase("name");
-        } else if (key.first == "osd") {
+        } else if (key.type == "osd") {
           daemon_meta.erase("id");
         }
         daemon_meta.erase("hostname");
-	map<string,string> m;
+        map<string,string> m;
         for (const auto &i : daemon_meta) {
           m[i.first] = i.second.get_str();
 	}
@@ -127,9 +122,9 @@ void MetadataUpdate::finish(int r)
         state->key = key;
         state->hostname = daemon_meta.at("hostname").get_str();
 
-        if (key.first == "mds" || key.first == "mgr" || key.first == "mon") {
+        if (key.type == "mds" || key.type == "mgr" || key.type == "mon") {
           daemon_meta.erase("name");
-        } else if (key.first == "osd") {
+        } else if (key.type == "osd") {
           daemon_meta.erase("id");
         }
         daemon_meta.erase("hostname");
@@ -146,9 +141,8 @@ void MetadataUpdate::finish(int r)
       ceph_abort();
     }
   } else {
-    dout(1) << "mon failed to return metadata for "
-            << key.first << "." << key.second << ": "
-	    << cpp_strerror(r) << dendl;
+    dout(1) << "mon failed to return metadata for " << key
+	    << ": " << cpp_strerror(r) << dendl;
   }
 }
 
@@ -340,8 +334,8 @@ void Mgr::load_all_metadata()
     }
 
     DaemonStatePtr dm = std::make_shared<DaemonState>(daemon_state.types);
-    dm->key = DaemonKey("mds",
-                        daemon_meta.at("name").get_str());
+    dm->key = DaemonKey{"mds",
+                        daemon_meta.at("name").get_str()};
     dm->hostname = daemon_meta.at("hostname").get_str();
 
     daemon_meta.erase("name");
@@ -362,8 +356,8 @@ void Mgr::load_all_metadata()
     }
 
     DaemonStatePtr dm = std::make_shared<DaemonState>(daemon_state.types);
-    dm->key = DaemonKey("mon",
-                        daemon_meta.at("name").get_str());
+    dm->key = DaemonKey{"mon",
+                        daemon_meta.at("name").get_str()};
     dm->hostname = daemon_meta.at("hostname").get_str();
 
     daemon_meta.erase("name");
@@ -387,8 +381,8 @@ void Mgr::load_all_metadata()
     dout(4) << osd_metadata.at("hostname").get_str() << dendl;
 
     DaemonStatePtr dm = std::make_shared<DaemonState>(daemon_state.types);
-    dm->key = DaemonKey("osd",
-                        stringify(osd_metadata.at("id").get_int()));
+    dm->key = DaemonKey{"osd",
+                        stringify(osd_metadata.at("id").get_int())};
     dm->hostname = osd_metadata.at("hostname").get_str();
 
     osd_metadata.erase("id");
@@ -449,12 +443,12 @@ void Mgr::handle_osd_map()
       names_exist.insert(stringify(osd_id));
 
       // Consider whether to update the daemon metadata (new/restarted daemon)
-      const auto k = DaemonKey("osd", stringify(osd_id));
+      bool update_meta = false;
+      const auto k = DaemonKey{"osd", std::to_string(osd_id)};
       if (daemon_state.is_updating(k)) {
         continue;
       }
 
-      bool update_meta = false;
       if (daemon_state.exists(k)) {
         if (osd_map.get_up_from(osd_id) == osd_map.get_epoch()) {
           dout(4) << "Mgr::handle_osd_map: osd." << osd_id
@@ -598,7 +592,7 @@ void Mgr::handle_fs_map(MFSMap* m)
     // Remember which MDS exists so that we can cull any that don't
     names_exist.insert(info.name);
 
-    const auto k = DaemonKey("mds", info.name);
+    const auto k = DaemonKey{"mds", info.name};
     if (daemon_state.is_updating(k)) {
       continue;
     }


### PR DESCRIPTION
For this backport, I cherry-picked the commit 9c652fb305a3e3d1b4a752bac9bd8a85d15c7de9 rather than 0601b31a53a455f0b67c981460d198cb3a97f3de - the direct commit that went into master to fix tracker 39264 - because:

1. former's improvements (RAII-like wrapper around the lock releasing). And that's how the current master's code looks anyway.
2. It'd be easier to make future changes in Nautilus branch if it's closer to the current master rather than diverging somewhere else.

I believe this doesn't violate any backporting requirements. But if 0601b31a53a455f0b67c981460d198cb3a97f3de is preferred, then please let me know, and I'll use that commit for this backport and create a new PR.

----

backport tracker: https://tracker.ceph.com/issues/48713

---

backport of https://github.com/ceph/ceph/pull/38677
parent tracker: https://tracker.ceph.com/issues/39264

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh