### PR TITLE
mgr/cephadm: allow RGWSpec networks list to select an IP to bind to

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2082,6 +2082,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         ha = HostAssignment(
             spec=spec,
             hosts=self._hosts_with_daemon_inventory(),
+            networks=self.cache.networks,
             daemons=self.cache.get_daemons_by_service(spec.service_name()),
             allow_colo=self.cephadm_services[spec.service_type].allow_colo(),
         )
@@ -2138,6 +2139,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         HostAssignment(
             spec=spec,
             hosts=self.inventory.all_specs(),  # All hosts, even those without daemon refresh
+            networks=self.cache.networks,
             daemons=self.cache.get_daemons_by_service(spec.service_name()),
             allow_colo=self.cephadm_services[spec.service_type].allow_colo(),
         ).validate()

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -25,10 +25,8 @@ class DaemonPlacement(NamedTuple):
             other.append(f'network={self.network}')
         if self.name:
             other.append(f'name={self.name}')
-        if self.ip:
-            other.append(f'ip={self.ip}')
         if self.port:
-            other.append(f'port={self.port}')
+            other.append(f'{self.ip or "*"}:{self.port}')
         if other:
             res += '(' + ' '.join(other) + ')'
         return res

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -48,10 +48,11 @@ class DaemonPlacement(NamedTuple):
         # fixme: how to match against network?
         if self.name and self.name != dd.daemon_id:
             return False
-        if self.ip and self.ip != dd.ip:
-            return False
-        if self.port and [self.port] != dd.ports:
-            return False
+        if self.port:
+            if [self.port] != dd.ports:
+                return False
+            if self.ip != dd.ip:
+                return False
         return True
 
 

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -1,6 +1,6 @@
 import logging
 import random
-from typing import List, Optional, Callable, TypeVar, Tuple, NamedTuple
+from typing import List, Optional, Callable, TypeVar, Tuple, NamedTuple, Dict
 
 import orchestrator
 from ceph.deployment.service_spec import ServiceSpec
@@ -62,6 +62,7 @@ class HostAssignment(object):
                  spec,  # type: ServiceSpec
                  hosts: List[orchestrator.HostSpec],
                  daemons: List[orchestrator.DaemonDescription],
+                 networks: Dict[str, Dict[str, List[str]]] = {},
                  filter_new_host=None,  # type: Optional[Callable[[str],bool]]
                  allow_colo: bool = False,
                  ):
@@ -71,6 +72,7 @@ class HostAssignment(object):
         self.filter_new_host = filter_new_host
         self.service_name = spec.service_name()
         self.daemons = daemons
+        self.networks = networks
         self.allow_colo = allow_colo
         self.port_start = spec.get_port_start()
 
@@ -202,6 +204,13 @@ class HostAssignment(object):
             existing, to_add))
         return existing_slots + to_add, to_add, to_remove
 
+    def find_ip_on_host(self, hostname: str, subnets: List[str]) -> Optional[str]:
+        for subnet in subnets:
+            ips = self.networks.get(hostname, {}).get(subnet, [])
+            if ips:
+                return sorted(ips)[0]
+        return None
+
     def get_candidates(self) -> List[DaemonPlacement]:
         if self.spec.placement.hosts:
             ls = [
@@ -230,6 +239,20 @@ class HostAssignment(object):
         else:
             raise OrchestratorValidationError(
                 "placement spec is empty: no hosts, no label, no pattern, no count")
+
+        # allocate an IP?
+        if self.spec.networks:
+            orig = ls.copy()
+            ls = []
+            for p in orig:
+                ip = self.find_ip_on_host(p.hostname, self.spec.networks)
+                if ip:
+                    ls.append(DaemonPlacement(hostname=p.hostname, network=p.network,
+                                              name=p.name, port=p.port, ip=ip))
+                else:
+                    logger.debug(
+                        f'Skipping {p.hostname} with no IP in network(s) {self.spec.networks}'
+                    )
 
         if self.filter_new_host:
             old = ls.copy()

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -642,8 +642,6 @@ class CephadmServe:
             daemons_to_remove.pop()
         for d in daemons_to_remove:
             r = True
-            # NOTE: we are passing the 'force' flag here, which means
-            # we can delete a mon instances data.
             assert d.hostname is not None
             self._remove_daemon(d.name(), d.hostname)
 
@@ -919,6 +917,8 @@ class CephadmServe:
 
             self.mgr.cephadm_services[daemon_type_to_service(daemon_type)].pre_remove(daemon)
 
+            # NOTE: we are passing the 'force' flag here, which means
+            # we can delete a mon instances data.
             args = ['--name', name, '--force']
             self.log.info('Removing daemon %s from %s' % (name, host))
             out, err, code = self._run_cephadm(

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -554,6 +554,7 @@ class CephadmServe:
             spec=spec,
             hosts=self.mgr._hosts_with_daemon_inventory(),
             daemons=daemons,
+            networks=self.mgr.cache.networks,
             filter_new_host=matches_network if service_type == 'mon'
             else virtual_ip_allowed if service_type == 'ha-rgw' else None,
             allow_colo=svc.allow_colo(),
@@ -600,7 +601,8 @@ class CephadmServe:
 
                 daemon_spec = svc.make_daemon_spec(
                     slot.hostname, daemon_id, slot.network, spec, daemon_type=daemon_type,
-                    ports=[slot.port] if slot.port else None
+                    ports=[slot.port] if slot.port else None,
+                    ip=slot.ip,
                 )
                 self.log.debug('Placing %s.%s on host %s' % (
                     daemon_type, daemon_id, slot.hostname))

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -124,7 +124,8 @@ class CephadmService(metaclass=ABCMeta):
             network: str,
             spec: ServiceSpecs,
             daemon_type: Optional[str] = None,
-            ports: Optional[List[int]] = None
+            ports: Optional[List[int]] = None,
+            ip: Optional[str] = None,
     ) -> CephadmDaemonDeploySpec:
         return CephadmDaemonDeploySpec(
             host=host,
@@ -133,6 +134,7 @@ class CephadmService(metaclass=ABCMeta):
             network=network,
             daemon_type=daemon_type,
             ports=ports,
+            ip=ip,
         )
 
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -800,6 +800,30 @@ class RgwService(CephService):
                                               'osd', 'allow rwx tag rgw *=*'])
         return keyring
 
+    def purge(self, service_name: str) -> None:
+        self.mgr.check_mon_command({
+            'prefix': 'config rm',
+            'who': utils.name_to_config_section(service_name),
+            'name': 'rgw_realm',
+        })
+        self.mgr.check_mon_command({
+            'prefix': 'config rm',
+            'who': utils.name_to_config_section(service_name),
+            'name': 'rgw_zone',
+        })
+        self.mgr.check_mon_command({
+            'prefix': 'config-key rm',
+            'key': f'rgw/cert/{service_name}',
+        })
+
+    def post_remove(self, daemon: DaemonDescription) -> None:
+        super().post_remove(daemon)
+        self.mgr.check_mon_command({
+            'prefix': 'config rm',
+            'who': utils.name_to_config_section(daemon.name()),
+            'name': 'rgw_frontends',
+        })
+
     def ok_to_stop(
             self,
             daemon_ids: List[str],

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -757,16 +757,28 @@ class RgwService(CephService):
         ftype = spec.rgw_frontend_type or "beast"
         if ftype == 'beast':
             if spec.ssl:
-                args.append(f"ssl_port={port}")
+                if daemon_spec.ip:
+                    args.append(f"ssl_endpoint={daemon_spec.ip}:{port}")
+                else:
+                    args.append(f"ssl_port={port}")
                 args.append(f"ssl_certificate=config://rgw/cert/{spec.service_name()}.crt")
             else:
-                args.append(f"port={port}")
+                if daemon_spec.ip:
+                    args.append(f"endpoint={daemon_spec.ip}:{port}")
+                else:
+                    args.append(f"port={port}")
         elif ftype == 'civetweb':
             if spec.ssl:
-                args.append(f"port={port}s")  # note the 's' suffix on port
+                if daemon_spec.ip:
+                    args.append(f"port={daemon_spec.ip}:{port}s")  # note the 's' suffix on port
+                else:
+                    args.append(f"port={port}s")  # note the 's' suffix on port
                 args.append(f"ssl_certificate=config://rgw/cert/{spec.service_name()}.crt")
             else:
-                args.append(f"port={port}")
+                if daemon_spec.ip:
+                    args.append(f"port={daemon_spec.ip}:{port}")
+                else:
+                    args.append(f"port={port}")
         frontend = f'{ftype} {" ".join(args)}'
 
         ret, out, err = self.mgr.check_mon_command({

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -728,7 +728,7 @@ class RgwService(CephService):
                     % spec.rgw_frontend_ssl_certificate)
             ret, out, err = self.mgr.check_mon_command({
                 'prefix': 'config-key set',
-                'key': f'rgw/cert/{spec.service_name()}.crt',  # NOTE: actually a .pem!
+                'key': f'rgw/cert/{spec.service_name()}',
                 'val': cert_data,
             })
 
@@ -761,7 +761,7 @@ class RgwService(CephService):
                     args.append(f"ssl_endpoint={daemon_spec.ip}:{port}")
                 else:
                     args.append(f"ssl_port={port}")
-                args.append(f"ssl_certificate=config://rgw/cert/{spec.service_name()}.crt")
+                args.append(f"ssl_certificate=config://rgw/cert/{spec.service_name()}")
             else:
                 if daemon_spec.ip:
                     args.append(f"endpoint={daemon_spec.ip}:{port}")
@@ -773,7 +773,7 @@ class RgwService(CephService):
                     args.append(f"port={daemon_spec.ip}:{port}s")  # note the 's' suffix on port
                 else:
                     args.append(f"port={port}s")  # note the 's' suffix on port
-                args.append(f"ssl_certificate=config://rgw/cert/{spec.service_name()}.crt")
+                args.append(f"ssl_certificate=config://rgw/cert/{spec.service_name()}")
             else:
                 if daemon_spec.ip:
                     args.append(f"port={daemon_spec.ip}:{port}")

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -2,7 +2,7 @@
 
 # fmt: off
 
-from typing import NamedTuple, List
+from typing import NamedTuple, List, Dict
 import pytest
 
 from ceph.deployment.hostspec import HostSpec
@@ -727,6 +727,72 @@ def test_node_assignment3(service_type, placement, hosts,
     assert len(hosts) == expected_len
     for h in must_have:
         assert h in [h.hostname for h in hosts]
+
+
+class NodeAssignmentTest4(NamedTuple):
+    spec: ServiceSpec
+    networks: Dict[str, Dict[str, List[str]]]
+    daemons: List[DaemonDescription]
+    expected: List[str]
+    expected_add: List[str]
+    expected_remove: List[DaemonDescription]
+
+
+@pytest.mark.parametrize("spec,networks,daemons,expected,expected_add,expected_remove",
+    [   # noqa: E128
+        NodeAssignmentTest4(
+            ServiceSpec(
+                service_type='rgw',
+                service_id='foo',
+                placement=PlacementSpec(count=6, label='foo'),
+                networks=['10.0.0.0/8'],
+            ),
+            {
+                'host1': {'10.0.0.0/8': ['10.0.0.1']},
+                'host2': {'10.0.0.0/8': ['10.0.0.2']},
+                'host3': {'192.168.0.0/16': ['192.168.0.1']},
+            },
+            [],
+            ['host1(ip=10.0.0.1 port=80)', 'host2(ip=10.0.0.2 port=80)',
+             'host1(ip=10.0.0.1 port=81)', 'host2(ip=10.0.0.2 port=81)',
+             'host1(ip=10.0.0.1 port=82)', 'host2(ip=10.0.0.2 port=82)'],
+            ['host1(ip=10.0.0.1 port=80)', 'host2(ip=10.0.0.2 port=80)',
+             'host1(ip=10.0.0.1 port=81)', 'host2(ip=10.0.0.2 port=81)',
+             'host1(ip=10.0.0.1 port=82)', 'host2(ip=10.0.0.2 port=82)'],
+            []
+        ),
+    ])
+def test_node_assignment4(spec, networks, daemons,
+                          expected, expected_add, expected_remove):
+    all_slots, to_add, to_remove = HostAssignment(
+        spec=spec,
+        hosts=[HostSpec(h, labels=['foo']) for h in networks.keys()],
+        daemons=daemons,
+        allow_colo=True,
+        networks=networks,
+    ).place()
+
+    got = [str(p) for p in all_slots]
+    num_wildcard = 0
+    for i in expected:
+        if i == '*':
+            num_wildcard += 1
+        else:
+            assert i in got
+            got.remove(i)
+    assert num_wildcard == len(got)
+
+    got = [str(p) for p in to_add]
+    num_wildcard = 0
+    for i in expected_add:
+        if i == '*':
+            num_wildcard += 1
+        else:
+            assert i in got
+            got.remove(i)
+    assert num_wildcard == len(got)
+
+    assert sorted([d.name() for d in to_remove]) == sorted(expected_remove)
 
 
 @pytest.mark.parametrize("placement",

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -534,10 +534,10 @@ class NodeAssignmentTest(NamedTuple):
             PlacementSpec(count=6, label='foo'),
             'host1 host2 host3'.split(),
             [],
-            ['host1(port=80)', 'host2(port=80)', 'host3(port=80)',
-             'host1(port=81)', 'host2(port=81)', 'host3(port=81)'],
-            ['host1(port=80)', 'host2(port=80)', 'host3(port=80)',
-             'host1(port=81)', 'host2(port=81)', 'host3(port=81)'],
+            ['host1(*:80)', 'host2(*:80)', 'host3(*:80)',
+             'host1(*:81)', 'host2(*:81)', 'host3(*:81)'],
+            ['host1(*:80)', 'host2(*:80)', 'host3(*:80)',
+             'host1(*:81)', 'host2(*:81)', 'host3(*:81)'],
             []
         ),
         # label + count_per_host + ports (+ xisting)
@@ -550,10 +550,10 @@ class NodeAssignmentTest(NamedTuple):
                 DaemonDescription('rgw', 'b', 'host2', ports=[80]),
                 DaemonDescription('rgw', 'c', 'host1', ports=[82]),
             ],
-            ['host1(port=80)', 'host2(port=80)', 'host3(port=80)',
-             'host1(port=81)', 'host2(port=81)', 'host3(port=81)'],
-            ['host1(port=80)', 'host3(port=80)',
-             'host2(port=81)', 'host3(port=81)'],
+            ['host1(*:80)', 'host2(*:80)', 'host3(*:80)',
+             'host1(*:81)', 'host2(*:81)', 'host3(*:81)'],
+            ['host1(*:80)', 'host3(*:80)',
+             'host2(*:81)', 'host3(*:81)'],
             ['rgw.c']
         ),
         # cephadm.py teuth case
@@ -753,12 +753,12 @@ class NodeAssignmentTest4(NamedTuple):
                 'host3': {'192.168.0.0/16': ['192.168.0.1']},
             },
             [],
-            ['host1(ip=10.0.0.1 port=80)', 'host2(ip=10.0.0.2 port=80)',
-             'host1(ip=10.0.0.1 port=81)', 'host2(ip=10.0.0.2 port=81)',
-             'host1(ip=10.0.0.1 port=82)', 'host2(ip=10.0.0.2 port=82)'],
-            ['host1(ip=10.0.0.1 port=80)', 'host2(ip=10.0.0.2 port=80)',
-             'host1(ip=10.0.0.1 port=81)', 'host2(ip=10.0.0.2 port=81)',
-             'host1(ip=10.0.0.1 port=82)', 'host2(ip=10.0.0.2 port=82)'],
+            ['host1(10.0.0.1:80)', 'host2(10.0.0.2:80)',
+             'host1(10.0.0.1:81)', 'host2(10.0.0.2:81)',
+             'host1(10.0.0.1:82)', 'host2(10.0.0.2:82)'],
+            ['host1(10.0.0.1:80)', 'host2(10.0.0.2:80)',
+             'host1(10.0.0.1:81)', 'host2(10.0.0.2:81)',
+             'host1(10.0.0.1:82)', 'host2(10.0.0.2:82)'],
             []
         ),
     ])

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -3,6 +3,7 @@ import fnmatch
 import re
 from collections import OrderedDict
 from functools import wraps
+from ipaddress import ip_network, ip_address
 from typing import Optional, Dict, Any, List, Union, Callable, Iterable, Type, TypeVar, cast, \
     NamedTuple
 
@@ -115,7 +116,6 @@ class HostPlacementSpec(NamedTuple):
         if not require_network:
             return host_spec
 
-        from ipaddress import ip_network, ip_address
         networks = list()  # type: List[str]
         network = host_spec.network
         # in case we have [v2:1.2.3.4:3000,v1:1.2.3.4:6478]
@@ -474,6 +474,7 @@ class ServiceSpec(object):
                  config: Optional[Dict[str, str]] = None,
                  unmanaged: bool = False,
                  preview_only: bool = False,
+                 networks: Optional[List[str]] = None,
                  ):
         self.placement = PlacementSpec() if placement is None else placement  # type: PlacementSpec
 
@@ -484,6 +485,7 @@ class ServiceSpec(object):
             self.service_id = service_id
         self.unmanaged = unmanaged
         self.preview_only = preview_only
+        self.networks: List[str] = networks or []
 
         self.config: Optional[Dict[str, str]] = None
         if config:
@@ -514,6 +516,7 @@ class ServiceSpec(object):
             service_id: foo
             config:
               some_option: the_value
+            networks: [10.10.0.0/16]
             spec:
               pool: mypool
               namespace: myns
@@ -588,6 +591,8 @@ class ServiceSpec(object):
         ret['placement'] = self.placement.to_json()
         if self.unmanaged:
             ret['unmanaged'] = self.unmanaged
+        if self.networks:
+            ret['networks'] = self.networks
 
         c = {}
         for key, val in sorted(self.__dict__.items(), key=lambda tpl: tpl[0]):
@@ -620,6 +625,13 @@ class ServiceSpec(object):
                     raise ServiceSpecValidationError(
                         f'Cannot set config option {k} in spec: it is managed by cephadm'
                     )
+        for network in self.networks or []:
+            try:
+                ip_network(network)
+            except ValueError as e:
+                raise ServiceSpecValidationError(
+                    f'Cannot parse network {network}: {e}'
+                )
 
     def __repr__(self) -> str:
         return "{}({!r})".format(self.__class__.__name__, self.__dict__)
@@ -650,12 +662,13 @@ class NFSServiceSpec(ServiceSpec):
                  unmanaged: bool = False,
                  preview_only: bool = False,
                  config: Optional[Dict[str, str]] = None,
+                 networks: Optional[List[str]] = None,
                  ):
         assert service_type == 'nfs'
         super(NFSServiceSpec, self).__init__(
             'nfs', service_id=service_id,
             placement=placement, unmanaged=unmanaged, preview_only=preview_only,
-            config=config)
+            config=config, networks=networks)
 
         #: RADOS pool where NFS client recovery data is stored.
         self.pool = pool
@@ -712,6 +725,7 @@ class RGWSpec(ServiceSpec):
                  ssl: bool = False,
                  preview_only: bool = False,
                  config: Optional[Dict[str, str]] = None,
+                 networks: Optional[List[str]] = None,
                  subcluster: Optional[str] = None,  # legacy, only for from_json on upgrade
                  ):
         assert service_type == 'rgw', service_type
@@ -723,7 +737,7 @@ class RGWSpec(ServiceSpec):
         super(RGWSpec, self).__init__(
             'rgw', service_id=service_id,
             placement=placement, unmanaged=unmanaged,
-            preview_only=preview_only, config=config)
+            preview_only=preview_only, config=config, networks=networks)
 
         self.rgw_realm = rgw_realm
         self.rgw_zone = rgw_zone
@@ -763,12 +777,13 @@ class IscsiServiceSpec(ServiceSpec):
                  unmanaged: bool = False,
                  preview_only: bool = False,
                  config: Optional[Dict[str, str]] = None,
+                 networks: Optional[List[str]] = None,
                  ):
         assert service_type == 'iscsi'
         super(IscsiServiceSpec, self).__init__('iscsi', service_id=service_id,
                                                placement=placement, unmanaged=unmanaged,
                                                preview_only=preview_only,
-                                               config=config)
+                                               config=config, networks=networks)
 
         #: RADOS pool where ceph-iscsi config data is stored.
         self.pool = pool
@@ -809,12 +824,13 @@ class AlertManagerSpec(ServiceSpec):
                  preview_only: bool = False,
                  user_data: Optional[Dict[str, Any]] = None,
                  config: Optional[Dict[str, str]] = None,
+                 networks: Optional[List[str]] = None,
                  ):
         assert service_type == 'alertmanager'
         super(AlertManagerSpec, self).__init__(
             'alertmanager', service_id=service_id,
             placement=placement, unmanaged=unmanaged,
-            preview_only=preview_only, config=config)
+            preview_only=preview_only, config=config, networks=networks)
 
         # Custom configuration.
         #
@@ -841,6 +857,7 @@ class HA_RGWSpec(ServiceSpec):
                  service_type: str = 'ha-rgw',
                  service_id: Optional[str] = None,
                  config: Optional[Dict[str, str]] = None,
+                 networks: Optional[List[str]] = None,
                  placement: Optional[PlacementSpec] = None,
                  virtual_ip_interface: Optional[str] = None,
                  virtual_ip_address: Optional[str] = None,
@@ -863,7 +880,8 @@ class HA_RGWSpec(ServiceSpec):
                  ):
         assert service_type == 'ha-rgw'
         super(HA_RGWSpec, self).__init__('ha-rgw', service_id=service_id,
-                                         placement=placement, config=config)
+                                         placement=placement, config=config,
+                                         networks=networks)
 
         self.virtual_ip_interface = virtual_ip_interface
         self.virtual_ip_address = virtual_ip_address
@@ -932,6 +950,7 @@ class CustomContainerSpec(ServiceSpec):
                  service_type: str = 'container',
                  service_id: Optional[str] = None,
                  config: Optional[Dict[str, str]] = None,
+                 networks: Optional[List[str]] = None,
                  placement: Optional[PlacementSpec] = None,
                  unmanaged: bool = False,
                  preview_only: bool = False,
@@ -955,7 +974,8 @@ class CustomContainerSpec(ServiceSpec):
         super(CustomContainerSpec, self).__init__(
             service_type, service_id,
             placement=placement, unmanaged=unmanaged,
-            preview_only=preview_only, config=config)
+            preview_only=preview_only, config=config,
+            networks=networks)
 
         self.image = image
         self.entrypoint = entrypoint

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -200,6 +200,9 @@ service_name: rgw.default-rgw-realm.eu-central-1.1
 placement:
   hosts:
   - ceph-001
+networks:
+- 10.0.0.0/8
+- 192.168.0.0/16
 spec:
   rgw_frontend_type: civetweb
   rgw_realm: default-rgw-realm


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>