### PR TITLE
mgr/cephadm: When device size contains the decimal, it can not match size exactly

### DIFF
--- a/src/python-common/ceph/deployment/drive_selection/matchers.py
+++ b/src/python-common/ceph/deployment/drive_selection/matchers.py
@@ -286,7 +286,7 @@ class SizeMatcher(Matcher):
         :return: A Tuple with normalized output (10, 'GB')
         :rtype: tuple
         """
-        return re.findall(r"\d+", data)[0], cls._parse_suffix(data)
+        return re.findall(r"\d+\.?\d*", data)[0], cls._parse_suffix(data)
 
     def _parse_filter(self) -> None:
         """ Identifies which type of 'size' filter is applied
@@ -322,7 +322,7 @@ class SizeMatcher(Matcher):
         if high:
             self.high = self._get_k_v(high.group())
 
-        exact = re.match(r"^\d+[A-Z]{1,2}$", self.value)
+        exact = re.match(r"^\d+\.?\d*[A-Z]{1,2}$", self.value)
         if exact:
             self.exact = self._get_k_v(exact.group())
 


### PR DESCRIPTION
mgr/cephadm: When device size contains the decimal, it can not match size exactly

for example, osd.yaml:
service_type: osd
service_name: test
placement:
  host_pattern: '*'
spec:
  data_devices:
    size: 3.6TB

Signed-off-by: jianglong01 <jianglong01@qianxin.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
