### PR TITLE
common/TrackedOp: add op priority for TrackedOp

### DIFF
--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -478,6 +478,7 @@ void TrackedOp::dump(utime_t now, Formatter *f) const
   if (!state)
     return;
   f->dump_string("description", get_desc());
+  f->dump_unsigned("priority", get_priority());
   f->dump_stream("initiated_at") << get_initiated();
   f->dump_float("age", now - get_initiated());
   f->dump_float("duration", get_duration());

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -93,6 +93,11 @@ void OpRequest::_dump_op_descriptor_unlocked(ostream& stream) const
   get_req()->print(stream);
 }
 
+void OpRequest::_dump_op_priority(unsigned& priority) const
+{
+  priority = get_req()->get_priority();
+}
+
 void OpRequest::_unregistered() {
   request->clear_data();
   request->clear_payload();

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -80,6 +80,7 @@ protected:
   void _dump_op_descriptor_unlocked(std::ostream& stream) const override;
   void _unregistered() override;
   bool filter_out(const std::set<std::string>& filters) override;
+  void _dump_op_priority(unsigned& priority) const override;
 
 public:
   ~OpRequest() override {


### PR DESCRIPTION
https://tracker.ceph.com/issues/49789

Signed-off-by: Yite Gu <yite.gu@easystack.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
