### PR TITLE
mgr/cephadm: Purge OSD service even with active daemons

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -735,7 +735,7 @@ class CephadmServe:
         for service_name, spec in list(existing_services):
             if service_name not in self.mgr.spec_store.spec_deleted:
                 continue
-            if self.mgr.cache.get_daemons_by_service(service_name):
+            if not service_name.startswith('osd.') and self.mgr.cache.get_daemons_by_service(service_name):
                 continue
             if spec.service_type in ['mon', 'mgr']:
                 continue
@@ -785,7 +785,7 @@ class CephadmServe:
     def _create_daemon(self,
                        daemon_spec: CephadmDaemonDeploySpec,
                        reconfig: bool = False,
-                       osd_uuid_map: Optional[Dict[str, Any]] = None,
+                       osd_uuid_map: Optional[Dict[str, str]] = None,
                        ) -> str:
 
         with set_exception_subject('service', orchestrator.DaemonDescription(

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -80,7 +80,8 @@ class CephadmDaemonDeploySpec:
             daemon_id=self.daemon_id,
             hostname=self.host,
             status=status,
-            status_desc=status_desc
+            status_desc=status_desc,
+            service_name=self.service_name,
         )
 
 

--- a/src/pybind/mgr/cephadm/tests/fixtures.py
+++ b/src/pybind/mgr/cephadm/tests/fixtures.py
@@ -91,6 +91,8 @@ def assert_rm_service(cephadm: CephadmOrchestrator, srv_name):
     CephadmServe(cephadm)._purge_deleted_services()
     if not unmanaged:  # cause then we're not deleting daemons
         assert srv_name not in cephadm.spec_store, f'{cephadm.spec_store[srv_name]!r}'
+        if not srv_name.startswith('osd'):
+            assert not cephadm.cache.get_daemons_by_service(srv_name)
 
 
 @contextmanager

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -124,6 +124,7 @@ def handle_orch_error(f: Callable[..., T]) -> Callable[..., 'OrchResult[T]']:
         try:
             return OrchResult(f(*args, **kwargs))
         except Exception as e:
+            logger.exception(f'Orchestrator API call {f.__name__} failed')
             return OrchResult(None, exception=e)
 
     return cast(Callable[..., OrchResult[T]], wrapper)

--- a/src/pybind/mgr/tox.ini
+++ b/src/pybind/mgr/tox.ini
@@ -38,7 +38,7 @@ deps =
     cython
     -rrequirements.txt
 commands =
-    pytest --doctest-modules {posargs: \
+    pytest -vv --log-level INFO --doctest-modules {posargs: \
         mgr_util.py \
         tests/ \
         cephadm/ \


### PR DESCRIPTION
Otherwise OSD services would be stuck in "deleting" as we're not acutally
removing OSD daemons when removing the OSD spec.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
