### PR TITLE
cmake: do not build debug_mutex or lockdep for Release build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,7 +320,8 @@ if(WITH_LZ4)
   set(HAVE_LZ4 ${LZ4_FOUND})
 endif(WITH_LZ4)
 
-option(WITH_CEPH_DEBUG_MUTEX "Use debug ceph::mutex with lockdep" OFF)
+CMAKE_DEPENDENT_OPTION(WITH_CEPH_DEBUG_MUTEX "Use debug ceph::mutex with lockdep" ON
+  "CMAKE_BUILD_TYPE STREQUAL Debug" OFF)
 
 #if allocator is set on command line make sure it matches below strings
 set(ALLOCATOR "" CACHE STRING

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,7 +113,7 @@ if(NOT CMAKE_BUILD_TYPE)
       STRING "Default BUILD_TYPE is Debug, other options are: RelWithDebInfo, Release, and MinSizeRel." FORCE)
 endif()
 
-if(WITH_CEPH_DEBUG_MUTEX OR CMAKE_BUILD_TYPE STREQUAL Debug)
+if(WITH_CEPH_DEBUG_MUTEX)
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-DCEPH_DEBUG_MUTEX>)
 endif()
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -77,7 +77,6 @@ set(common_srcs
   lockdep.cc
   mempool.cc
   mime.c
-  mutex_debug.cc
   numa.cc
   openssl_opts_handler.cc
   options.cc
@@ -90,7 +89,6 @@ set(common_srcs
   reverse.c
   run_cmd.cc
   scrub_types.cc
-  shared_mutex_debug.cc
   signal.cc
   snap_types.cc
   str_list.cc
@@ -102,6 +100,12 @@ set(common_srcs
   utf8.c
   util.cc
   version.cc)
+
+if(WITH_CEPH_DEBUG_MUTEX)
+  list(APPEND common_srcs
+    mutex_debug.cc
+    shared_mutex_debug.cc)
+endif()
 
 if(WIN32)
   if(MINGW)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -74,7 +74,6 @@ set(common_srcs
   hostname.cc
   ipaddr.cc
   iso_8601.cc
-  lockdep.cc
   mempool.cc
   mime.c
   numa.cc
@@ -103,6 +102,7 @@ set(common_srcs
 
 if(WITH_CEPH_DEBUG_MUTEX)
   list(APPEND common_srcs
+    lockdep.cc
     mutex_debug.cc
     shared_mutex_debug.cc)
 endif()

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -352,9 +352,9 @@ private:
   std::set<std::string> _experimental_features;
 
   ceph::PluginRegistry* _plugin_registry;
-
+#ifdef CEPH_DEBUG_MUTEX
   md_config_obs_t *_lockdep_obs;
-
+#endif
 public:
   TOPNSPC::crush::CrushLocation crush_location;
 private:

--- a/src/common/lockdep.h
+++ b/src/common/lockdep.h
@@ -16,6 +16,9 @@
 #define CEPH_LOCKDEP_H
 
 #include "include/common_fwd.h"
+
+#ifdef CEPH_DEBUG_MUTEX
+
 extern bool g_lockdep;
 
 extern void lockdep_register_ceph_context(CephContext *cct);
@@ -30,4 +33,17 @@ extern int lockdep_will_lock(const char *n, int id, bool force_backtrace=false,
 extern int lockdep_locked(const char *n, int id, bool force_backtrace=false);
 extern int lockdep_will_unlock(const char *n, int id);
 extern int lockdep_dump_locks();
+
+#else
+
+static constexpr bool g_lockdep = false;
+#define lockdep_register(...) 0
+#define lockdep_unregister(...)
+#define lockdep_will_lock(...) 0
+#define lockdep_locked(...) 0
+#define lockdep_will_unlock(...) 0
+
+#endif	// CEPH_DEBUG_MUTEX
+
+
 #endif

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -15,7 +15,6 @@ set(crimson_alien_common_srcs
   ${PROJECT_SOURCE_DIR}/src/common/Finisher.cc
   ${PROJECT_SOURCE_DIR}/src/common/HeartbeatMap.cc
   ${PROJECT_SOURCE_DIR}/src/common/PluginRegistry.cc
-  ${PROJECT_SOURCE_DIR}/src/common/lockdep.cc
   ${PROJECT_SOURCE_DIR}/src/common/perf_counters.cc
   ${PROJECT_SOURCE_DIR}/src/common/perf_counters_collection.cc
   ${PROJECT_SOURCE_DIR}/src/common/RefCountedObj.cc
@@ -31,6 +30,7 @@ set(crimson_alien_common_srcs
   $<TARGET_OBJECTS:common_prioritycache_obj>)
 if(WITH_CEPH_DEBUG_MUTEX)
   list(APPEND crimson_alien_common_srcs
+    ${PROJECT_SOURCE_DIR}/src/common/lockdep.cc
     ${PROJECT_SOURCE_DIR}/src/common/mutex_debug.cc
     ${PROJECT_SOURCE_DIR}/src/common/shared_mutex_debug.cc)
 endif()

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -5,7 +5,7 @@ set_target_properties(alien::cflags PROPERTIES
   INTERFACE_COMPILE_DEFINITIONS "WITH_SEASTAR;WITH_ALIEN"
   INTERFACE_INCLUDE_DIRECTORIES $<TARGET_PROPERTY:Seastar::seastar,INTERFACE_INCLUDE_DIRECTORIES>)
 
-add_library(crimson-alien-common STATIC
+set(crimson_alien_common_srcs
   ${PROJECT_SOURCE_DIR}/src/common/admin_socket.cc
   ${PROJECT_SOURCE_DIR}/src/common/blkdev.cc
   ${PROJECT_SOURCE_DIR}/src/common/ceph_context.cc
@@ -31,6 +31,9 @@ add_library(crimson-alien-common STATIC
   ${PROJECT_SOURCE_DIR}/src/global/global_context.cc
   $<TARGET_OBJECTS:compressor_objs>
   $<TARGET_OBJECTS:common_prioritycache_obj>)
+add_library(crimson-alien-common STATIC
+  ${crimson_alien_common_srcs})
+
 target_link_libraries(crimson-alien-common
   crimson-common
   alien::cflags)

--- a/src/crimson/os/alienstore/CMakeLists.txt
+++ b/src/crimson/os/alienstore/CMakeLists.txt
@@ -16,11 +16,9 @@ set(crimson_alien_common_srcs
   ${PROJECT_SOURCE_DIR}/src/common/HeartbeatMap.cc
   ${PROJECT_SOURCE_DIR}/src/common/PluginRegistry.cc
   ${PROJECT_SOURCE_DIR}/src/common/lockdep.cc
-  ${PROJECT_SOURCE_DIR}/src/common/mutex_debug.cc
   ${PROJECT_SOURCE_DIR}/src/common/perf_counters.cc
   ${PROJECT_SOURCE_DIR}/src/common/perf_counters_collection.cc
   ${PROJECT_SOURCE_DIR}/src/common/RefCountedObj.cc
-  ${PROJECT_SOURCE_DIR}/src/common/shared_mutex_debug.cc
   ${PROJECT_SOURCE_DIR}/src/common/SubProcess.cc
   ${PROJECT_SOURCE_DIR}/src/common/Throttle.cc
   ${PROJECT_SOURCE_DIR}/src/common/Timer.cc
@@ -31,6 +29,11 @@ set(crimson_alien_common_srcs
   ${PROJECT_SOURCE_DIR}/src/global/global_context.cc
   $<TARGET_OBJECTS:compressor_objs>
   $<TARGET_OBJECTS:common_prioritycache_obj>)
+if(WITH_CEPH_DEBUG_MUTEX)
+  list(APPEND crimson_alien_common_srcs
+    ${PROJECT_SOURCE_DIR}/src/common/mutex_debug.cc
+    ${PROJECT_SOURCE_DIR}/src/common/shared_mutex_debug.cc)
+endif()
 add_library(crimson-alien-common STATIC
   ${crimson_alien_common_srcs})
 

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -260,12 +260,12 @@ add_executable(unittest_weighted_priority_queue
 target_link_libraries(unittest_weighted_priority_queue ceph-common)
 add_ceph_unittest(unittest_weighted_priority_queue)
 
-# unittest_mutex_debug
-add_executable(unittest_mutex_debug
-  test_mutex_debug.cc
-  )
-add_ceph_unittest(unittest_mutex_debug)
-target_link_libraries(unittest_mutex_debug ceph-common)
+if(WITH_CEPH_DEBUG_MUTEX)
+  add_executable(unittest_mutex_debug
+    test_mutex_debug.cc)
+  add_ceph_unittest(unittest_mutex_debug)
+  target_link_libraries(unittest_mutex_debug ceph-common)
+endif()
 
 # unittest_shunique_lock
 add_executable(unittest_shunique_lock

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -25,10 +25,12 @@ if(HAVE_BLKID AND LINUX)
 endif()
 
 # unittest_lockdep
-add_executable(unittest_lockdep
-  test_lockdep.cc)
-add_ceph_unittest(unittest_lockdep)
-target_link_libraries(unittest_lockdep ceph-common)
+if(WITH_CEPH_DEBUG_MUTEX)
+  add_executable(unittest_lockdep
+    test_lockdep.cc)
+  add_ceph_unittest(unittest_lockdep)
+  target_link_libraries(unittest_lockdep ceph-common)
+endif()
 
 # unittest_counter
 add_executable(unittest_counter


### PR DESCRIPTION
this change is a follow-up of #39905. it intends to reduce the

- compile time by not compiling debug mutex and lockdeps related stuff, and
- runtime memory footprint by removing unused lockdeps related global variables.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
