### PR TITLE
octopus: qa/suites/krbd: address recent issues caused by newer kernels

### DIFF
--- a/qa/suites/krbd/singleton/tasks/rbd_xfstests.yaml
+++ b/qa/suites/krbd/singleton/tasks/rbd_xfstests.yaml
@@ -25,6 +25,7 @@ tasks:
         - generic/045
         - generic/046
         - generic/223
+        - ext4/002  # removed upstream
         - ext4/304
         - generic/388
         - generic/405

--- a/qa/suites/krbd/singleton/tasks/rbd_xfstests.yaml
+++ b/qa/suites/krbd/singleton/tasks/rbd_xfstests.yaml
@@ -15,7 +15,7 @@ tasks:
         test_image: 'test_image-0'
         test_size: 5120  # MB
         scratch_image: 'scratch_image-0'
-        scratch_size: 5120  # MB
+        scratch_size: 15360  # MB
         fs_type: ext4
         tests: '-g auto -g blockdev -x clone'
         exclude:

--- a/qa/tasks/rbd.py
+++ b/qa/tasks/rbd.py
@@ -476,8 +476,7 @@ def xfstests(ctx, config):
                 exclude:
                 - generic/42
                 randomize: true
-                xfstests_branch: master
-                xfstests_url: 'https://raw.github.com/ceph/branch/master/qa'
+                xfstests_url: 'https://raw.github.com/ceph/ceph-ci/wip-55555/qa'
     """
     if config is None:
         config = { 'all': None }


### PR DESCRIPTION
Backport of #39781.  Commit https://github.com/ceph/ceph/commit/88f1087f9c56a9a6bee42ae465b2e88a66869951 is omitted because all releases use the same version of the script -- the task pulls it from master.