### PR TITLE
README.md: correct notes on `-j` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,13 @@ be up to 5x slower with some workloads. Please pass
 "-DCMAKE_BUILD_TYPE=RelWithDebInfo" to do_cmake.sh to create a non-debug
 release.)
 
-(Note: `ninja` alone will use only one CPU thread, this could take a while. use
-the `-j` option to use more threads. Something like `ninja -j$(nproc)` would be
-a good start.
+(Note: the number of jobs used by `ninja` is derived from the the number of
+CPU cores of the building host if unspecified. Use the `-j` option to limit
+the job number if the build jobs are running out of memory. On average, each
+job takes around 2.5GiB memory.
 
 This assumes you make your build dir a subdirectory of the ceph.git
-checkout. If you put it elsewhere, just point `CEPH_GIT_DIR`to the correct
+checkout. If you put it elsewhere, just point `CEPH_GIT_DIR` to the correct
 path to the checkout. Any additional CMake args can be specified setting ARGS
 before invoking do_cmake. See [cmake options](#cmake-options)
 for more details. Eg.


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
