### PR TITLE
lockdep: fix follows/follows_bt resize() size

### DIFF
--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -41,9 +41,8 @@ static constexpr size_t MAX_LOCKS = 128 * 1024;   // increase me as needed
 static std::bitset<MAX_LOCKS> free_ids; // bit set = free
 static ceph::unordered_map<pthread_t, std::map<int,ceph::BackTrace*> > held;
 static constexpr size_t NR_LOCKS = 4096; // the initial number of locks
-static constexpr size_t MAX_FOLLOWERS = 4096;
-static std::vector<std::bitset<MAX_FOLLOWERS>> follows(NR_LOCKS); // follows[a][b] means b taken after a
-static std::vector<std::array<ceph::BackTrace *, MAX_FOLLOWERS>> follows_bt(NR_LOCKS);
+static std::vector<std::bitset<MAX_LOCKS>> follows(NR_LOCKS); // follows[a][b] means b taken after a
+static std::vector<std::map<int,ceph::BackTrace *>> follows_bt(NR_LOCKS);
 // upper bound of lock id
 unsigned current_maxid;
 int last_freed_id = -1;

--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -172,8 +172,8 @@ static int _lockdep_register(const char *name)
     if (current_maxid <= (unsigned)id) {
       current_maxid = (unsigned)id + 1;
       if (current_maxid == follows.size()) {
-        follows.resize(current_maxid);
-        follows_bt.resize(current_maxid);
+        follows.resize(current_maxid + 1);
+        follows_bt.resize(current_maxid + 1);
       }
     }
     lock_ids[name] = id;


### PR DESCRIPTION
When lock number > 4096, it will cause crash like:

```
980038  ceph version 17.0.0-1852-g7d8ba51fbd0 (7d8ba51fbd0258713432a7a0950d258fb9d833b2) quincy (dev)
980039  1: ./bin/ceph-fuse(+0x64c8a6) [0x563b97a4c8a6]
980040  2: /lib64/libpthread.so.0(+0x12dc0) [0x147c2574bdc0]
980041  3: gsignal()
980042  4: abort()
980043  5: (operator new(unsigned long, void*)+0) [0x147c2784b790]
980044  6: (std::vector<std::bitset<4096ul>, std::allocator<std::bitset<4096ul> > >::operator[](unsigned long)+0x4f) [0x147c27ab0ee7       ]
980045  7: (lockdep_will_lock(char const*, int, bool, bool)+0x58f) [0x147c27aae843]
980046  8: (ceph::mutex_debug_detail::mutex_debugging_base::_will_lock(bool)+0x4a) [0x147c27abdb48]
980047  9: (ceph::mutex_debug_detail::mutex_debug_impl<false>::lock(bool)+0x38) [0x563b978962e0]
980048  10: (std::scoped_lock<ceph::mutex_debug_detail::mutex_debug_impl<false> >::scoped_lock(ceph::mutex_debug_detail::mutex_debug_impl<       false>&)+0x2f) [0x563b9789440f]
980049  11: (Client::add_update_cap(Inode*, MetaSession*, unsigned long, unsigned int, unsigned int, unsigned int, unsigned int, inodeno_t       , int, UserPerm const&)+0xd0) [0x563b978e35ba]
980050  12: (Client::add_update_inode(InodeStat*, utime_t, MetaSession*, UserPerm const&)+0x11c2) [0x563b978c0fb0]
980051  13: (Client::insert_trace(MetaRequest*, MetaSession*)+0x1014) [0x563b978c55c4]
980052  14: (Client::handle_client_reply(boost::intrusive_ptr<MClientReply const> const&)+0xb3c) [0x563b978d22c2]
980053  15: (Client::ms_dispatch2(boost::intrusive_ptr<Message> const&)+0x4e0) [0x563b978d3f8c]
980054  16: (Messenger::ms_deliver_dispatch(boost::intrusive_ptr<Message> const&)+0xe9) [0x147c27bb1add]
980055  17: (DispatchQueue::entry()+0x61d) [0x147c27bb04c9]
980056  18: (DispatchQueue::DispatchThread::entry()+0x1c) [0x147c27d35ad6]
980057  19: (Thread::entry_wrapper()+0x83) [0x147c279675a7]
980058  20: (Thread::_entry_func(void*)+0x18) [0x147c2796751a]
980059  21: /lib64/libpthread.so.0(+0x82de) [0x147c257412de]
980060  22: clone()
```


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
