### PR TITLE
mgr/cephadm: fix 'auth get-or-create' call

### DIFF
--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -147,11 +147,13 @@ class CephadmService(metaclass=ABCMeta):
             'caps': caps,
         })
         if err:
-            ret, out, err = self.mgr.check_mon_command({
+            ret, out, err = self.mgr.mon_command({
                 'prefix': 'auth caps',
                 'entity': entity,
                 'caps': caps,
             })
+            if err:
+                self.mgr.log.warning(f"Unable to update caps for {entity}")
         return keyring
 
     def _inventory_get_addr(self, hostname: str) -> str:

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -144,12 +144,14 @@ class CephadmService(metaclass=ABCMeta):
         ret, keyring, err = self.mgr.check_mon_command({
             'prefix': 'auth get-or-create',
             'entity': entity,
-        })
-        ret, out, err = self.mgr.check_mon_command({
-            'prefix': 'auth caps',
-            'entity': entity,
             'caps': caps,
         })
+        if err:
+            ret, out, err = self.mgr.check_mon_command({
+                'prefix': 'auth caps',
+                'entity': entity,
+                'caps': caps,
+            })
         return keyring
 
     def _inventory_get_addr(self, hostname: str) -> str:

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -107,7 +107,8 @@ class TestCephadmService:
                          'osd', 'allow rwx']
 
         expected_call = call({'prefix': 'auth get-or-create',
-                              'entity': 'client.iscsi.a'})
+                              'entity': 'client.iscsi.a',
+                              'caps': expected_caps})
         expected_call2 = call({'prefix': 'auth caps',
                                'entity': 'client.iscsi.a',
                                'caps': expected_caps})

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -19,7 +19,9 @@ class FakeMgr:
     def __init__(self):
         self.config = ''
         self.check_mon_command = MagicMock(side_effect=self._check_mon_command)
+        self.mon_command = MagicMock(side_effect=self._check_mon_command)
         self.template = MagicMock()
+        self.log = MagicMock()
 
     def _check_mon_command(self, cmd_dict, inbuf=None):
         prefix = cmd_dict.get('prefix')
@@ -114,7 +116,7 @@ class TestCephadmService:
                                'caps': expected_caps})
 
         assert expected_call in mgr.check_mon_command.mock_calls
-        assert expected_call2 in mgr.check_mon_command.mock_calls
+        assert expected_call2 in mgr.mon_command.mock_calls
 
     def test_get_auth_entity(self):
         mgr = FakeMgr()


### PR DESCRIPTION
If get-or-create caps doesn't work, we do 'auth caps' to update caps,
but this can also fail if the mons are running 15.2.0 (the 'mgr' profile
was updated to allow 'auth caps' in 15.2.1, see 467a27a66edb61d0d698ac596c645b67145395e6).

Signed-off-by: Sage Weil <sage@newdream.net>