### PR TITLE
octopus: qa/suites/upgrade: s/whitelist/ignorelist for octopus specific tests

### DIFF
--- a/qa/suites/rados/thrash-old-clients/1-install/jewel-v1only.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/jewel-v1only.yaml
@@ -1,7 +1,7 @@
 overrides:
   ceph:
     mon_bind_msgr2: false
-    log-whitelist:
+    log-ignorelist:
       - \(MON_DOWN\)
     conf:
       global:

--- a/qa/suites/rados/thrash-old-clients/1-install/jewel.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/jewel.yaml
@@ -1,7 +1,7 @@
 overrides:
   ceph:
     mon_bind_msgr2: false
-    log-whitelist:
+    log-ignorelist:
       - \(MON_DOWN\)
     conf:
       global:

--- a/qa/suites/upgrade-clients/client-upgrade-octopus-pacific/octopus-client-x/rbd/0-cluster/start.yaml
+++ b/qa/suites/upgrade-clients/client-upgrade-octopus-pacific/octopus-client-x/rbd/0-cluster/start.yaml
@@ -16,6 +16,6 @@ roles:
 - - client.1
 overrides:
   ceph:
-    #log-whitelist:
+    #log-ignorelist:
       #- failed to encode map
     fs: xfs

--- a/qa/suites/upgrade/mimic-x-singleton/1-install/mimic.yaml
+++ b/qa/suites/upgrade/mimic-x-singleton/1-install/mimic.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - \(MON_DOWN\)
       - \(MGR_DOWN\)
       - slow request

--- a/qa/suites/upgrade/mimic-x-singleton/3-thrash/default.yaml
+++ b/qa/suites/upgrade/mimic-x-singleton/3-thrash/default.yaml
@@ -4,7 +4,7 @@ meta:
    small chance to increase the number of pgs
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - objects unfound and apparently lost
     - log bound mismatch

--- a/qa/suites/upgrade/mimic-x-singleton/6-finish-upgrade.yaml
+++ b/qa/suites/upgrade/mimic-x-singleton/6-finish-upgrade.yaml
@@ -4,7 +4,7 @@ meta:
     restartin remaining osds
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(FS_DEGRADED\)
       - \(MDS_

--- a/qa/suites/upgrade/mimic-x/parallel/0-cluster/start.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/0-cluster/start.yaml
@@ -29,7 +29,7 @@ overrides:
   ceph:
     mon_bind_msgr2: false
     mon_bind_addrvec: false
-    log-whitelist:
+    log-ignorelist:
     - scrub mismatch
     - ScrubResult
     - wrongly marked

--- a/qa/suites/upgrade/mimic-x/parallel/1-ceph-install/mimic.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/1-ceph-install/mimic.yaml
@@ -16,7 +16,7 @@ tasks:
     extra_packages: ['librados2']
 - print: "**** done installing mimic"
 - ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(FS_
       - \(MDS_

--- a/qa/suites/upgrade/mimic-x/parallel/6-final-workload/rados_mon_thrash.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/6-final-workload/rados_mon_thrash.yaml
@@ -3,7 +3,7 @@ meta:
    librados C and C++ api tests
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - reached quota
       - \(REQUEST_SLOW\)
 tasks:

--- a/qa/suites/upgrade/mimic-x/stress-split-erasure-code/3-thrash/default.yaml
+++ b/qa/suites/upgrade/mimic-x/stress-split-erasure-code/3-thrash/default.yaml
@@ -4,7 +4,7 @@ meta:
    small chance to increase the number of pgs
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - wrongly marked me down
     - objects unfound and apparently lost

--- a/qa/suites/upgrade/mimic-x/stress-split/0-cluster/start.yaml
+++ b/qa/suites/upgrade/mimic-x/stress-split/0-cluster/start.yaml
@@ -11,7 +11,7 @@ overrides:
     mon_bind_msgr2: false
     mon_bind_addrvec: false
     fs: xfs
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(MON_DOWN\)
       - \(MGR_DOWN\)

--- a/qa/suites/upgrade/mimic-x/stress-split/3-thrash/default.yaml
+++ b/qa/suites/upgrade/mimic-x/stress-split/3-thrash/default.yaml
@@ -4,7 +4,7 @@ meta:
    small chance to increase the number of pgs
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - wrongly marked me down
     - objects unfound and apparently lost

--- a/qa/suites/upgrade/octopus-p2p/octopus-p2p-parallel/point-to-point-upgrade.yaml
+++ b/qa/suites/upgrade/octopus-p2p/octopus-p2p-parallel/point-to-point-upgrade.yaml
@@ -11,7 +11,7 @@ meta:
    run workload and upgrade-sequence in parallel
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - reached quota
     - scrub
     - osd_map_max_advance

--- a/qa/suites/upgrade/octopus-p2p/octopus-p2p-stress-split/0-cluster/start.yaml
+++ b/qa/suites/upgrade/octopus-p2p/octopus-p2p-stress-split/0-cluster/start.yaml
@@ -6,7 +6,7 @@ meta:
 overrides:
   ceph:
     fs: xfs
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(MON_DOWN\)
       - \(MGR_DOWN\)

--- a/qa/suites/upgrade/octopus-p2p/octopus-p2p-stress-split/3-thrash/default.yaml
+++ b/qa/suites/upgrade/octopus-p2p/octopus-p2p-stress-split/3-thrash/default.yaml
@@ -4,7 +4,7 @@ meta:
    small chance to increase the number of pgs
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
     - but it is still running
     - wrongly marked me down
     - objects unfound and apparently lost

--- a/qa/suites/upgrade/octopus-p2p/octopus-p2p-stress-split/thrashosds-health.yaml
+++ b/qa/suites/upgrade/octopus-p2p/octopus-p2p-stress-split/thrashosds-health.yaml
@@ -1,6 +1,6 @@
 overrides:
   ceph:
-    log-whitelist:
+    log-ignorelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)
       - \(OSD_


### PR DESCRIPTION
some upgrade tests are only present for octopus and not for master and
hence we missed updating the ignorelist terminology for those cases.

Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
