### PR TITLE
pacific: cephadm: use image id, not name, when inspecting for RepoDigests

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4645,7 +4645,7 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                                 out, err, code = call(
                                     ctx,
                                     [
-                                        container_path, 'image', 'inspect', image_name,
+                                        container_path, 'image', 'inspect', image_id,
                                         '--format', '{{.RepoDigests}}',
                                     ],
                                     verbosity=CallVerbosity.DEBUG)


### PR DESCRIPTION
backport for #40045

The name is ambiguous, but the image_id is not!  This fixes problems
during upgrade where upgrade thinks the container is upgraded (due to
an incorrect digest) when in fact it is not.

Fixes: 0826c45e0cb5d60fcf8cd71cd14edd34a6997cd4

Signed-off-by: Sage Weil <sage@newdream.net>
(cherry picked from commit f6e802a0d865f64c5e408bdef8e6c3153b1e9842)