### PR TITLE
pacific: qa: slow metadata ops during scrubbing

### DIFF
--- a/qa/suites/fs/workload/scrub/yes.yaml
+++ b/qa/suites/fs/workload/scrub/yes.yaml
@@ -1,3 +1,9 @@
+overrides:
+  ceph:
+    log-ignorelist:
+      - slow metadata IO
+      - SLOW_OPS
+      - slow request
 tasks:
 - fwd_scrub:
     scrub_timeout: 900


### PR DESCRIPTION
https://tracker.ceph.com/issues/49630