### PR TITLE
octopus: osd: Try other PGs when reservation failures occur

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -28,3 +28,6 @@
   ``--mon-host-override <ip>`` command-line switch. This generally should only
   be used for debugging and only affects initial communication with Ceph's
   monitor cluster.
+
+* Scubs are more aggressive in trying to find more simultaneous possible PGs within osd_max_scrubs limitation.
+  It is possible that increasing osd_scrub_sleep may be necessary to maintain client responsiveness.

--- a/qa/standalone/scrub/osd-scrub-test.sh
+++ b/qa/standalone/scrub/osd-scrub-test.sh
@@ -391,6 +391,128 @@ function TEST_scrub_permit_time() {
     teardown $dir || return 1
 }
 
+function TEST_scrub_parallelism() {
+    local dir=$1
+    local poolname=test
+    local OSDS=8
+    local PGS=64
+    local objects=$(expr $PGS \* 15)
+    local size=2
+    local osd_max_scrubs_per_osd=2
+    local maxscrubs=$(expr $OSDS / $size \* $osd_max_scrubs_per_osd)
+
+    TESTDATA="testdata.$$"
+
+    setup $dir || return 1
+    run_mon $dir a --osd_pool_default_size=$size || return 1
+    run_mgr $dir x || return 1
+    for osd in $(seq 0 $(expr $OSDS - 1))
+    do
+      run_osd $dir $osd --osd_pool_default_pg_autoscale_mode=off \
+	      --osd_deep_scrub_randomize_ratio=0.0 \
+	      --osd_max_scrubs=$osd_max_scrubs_per_osd \
+	      --osd_scrub_chunk_max=5 \
+	      --osd_scrub_sleep=7.0 \
+	      --osd_scrub_interval_randomize_ratio=0  || return 1
+    done
+
+    # Create a pool
+    create_pool $poolname $PGS $PGS
+    wait_for_clean || return 1
+    poolid=$(ceph osd dump | grep "^pool.*[']${poolname}[']" | awk '{ print $2 }')
+
+    ceph pg dump pgs
+
+    dd if=/dev/urandom of=$TESTDATA bs=1032 count=1
+    for i in `seq 1 $objects`
+    do
+        rados -p $poolname put obj${i} $TESTDATA
+    done
+    rm -f $TESTDATA
+
+    ceph pg dump pgs
+
+    ceph osd set noscrub
+    sleep 3
+    for i in $(seq 0 $(expr $PGS - 1))
+    do
+      ceph tell $poolid.$(printf '%x' $i) scrub || return 1
+    done
+    ceph osd unset noscrub
+
+    # Wait for scrubbing to start
+    set -o pipefail
+    found="no"
+    for i in $(seq 0 200)
+    do
+      flush_pg_stats
+      if ceph pg dump pgs | grep -q "scrubbing"
+      then
+        found="yes"
+        #ceph pg dump pgs
+        break
+      fi
+    done
+    set +o pipefail
+
+    if test $found = "no";
+    then
+      echo "Scrubbing never started"
+      return 1
+    fi
+
+    local zero_count=0
+    local found_count=0
+    local threshold="$(expr $maxscrubs - 1)"
+    set -o pipefail
+    while(true)
+    do
+      sleep 1
+      scrubs=$(ceph pg dump pgs | grep scrubbing | wc -l)
+      # Occasionally we still see scrubs that have finished with new scrubs starting
+      # so more scrubs appear to be running then is possible.
+      # Also, count 1 less than maximum possible scrubs
+      if test $scrubs -ge $threshold
+      then
+        found_count=$(expr $found_count + 1)
+        continue
+      fi
+      if test $scrubs = "0"
+      then
+        zero_count=$(expr $zero_count + 1)
+        if test $zero_count = "10"
+        then
+          break
+        fi
+      else
+        zero_count=0
+      fi
+    done
+    set +o pipefail
+
+    echo found $found_count max scrubs
+
+    ERRORS=0
+    if test $found_count -lt "20"
+    then
+	    echo "Only detected near to or at maximum scrubs $found_count time(s)"
+      ERRORS=$(expr $ERRORS + 1)
+    fi
+
+    grep "reserve failed" $dir/osd.*.log
+    if ! grep -q "reserve failed" $dir/osd.*.log
+    then
+      ERRORS=$(expr $ERRORS + 1)
+    fi
+
+    if test $ERRORS -gt 0
+    then
+      return 1
+    fi
+
+    teardown $dir || return 1
+}
+
 main osd-scrub-test "$@"
 
 # Local Variables:

--- a/qa/standalone/scrub/osd-scrub-test.sh
+++ b/qa/standalone/scrub/osd-scrub-test.sh
@@ -344,6 +344,53 @@ function TEST_deep_scrub_abort() {
     _scrub_abort $dir deep_scrub
 }
 
+function TEST_scrub_permit_time() {
+    local dir=$1
+    local poolname=test
+    local OSDS=3
+    local objects=15
+
+    TESTDATA="testdata.$$"
+
+    setup $dir || return 1
+    run_mon $dir a --osd_pool_default_size=3 || return 1
+    run_mgr $dir x || return 1
+    local scrub_begin_hour=$(date -d '2 hour ago' +"%H" | sed 's/^0//')
+    local scrub_end_hour=$(date -d '1 hour ago' +"%H" | sed 's/^0//')
+    for osd in $(seq 0 $(expr $OSDS - 1))
+    do
+      run_osd $dir $osd --bluestore_cache_autotune=false \
+	                --osd_deep_scrub_randomize_ratio=0.0 \
+	                --osd_scrub_interval_randomize_ratio=0 \
+                        --osd_scrub_begin_hour=$scrub_begin_hour \
+                        --osd_scrub_end_hour=$scrub_end_hour || return 1
+    done
+
+    # Create a pool with a single pg
+    create_pool $poolname 1 1
+    wait_for_clean || return 1
+
+    # Trigger a scrub on a PG
+    local pgid=$(get_pg $poolname SOMETHING)
+    local primary=$(get_primary $poolname SOMETHING)
+    local last_scrub=$(get_last_scrub_stamp $pgid)
+    # If we don't specify an amount of time to subtract from
+    # current time to set last_scrub_stamp, it sets the deadline
+    # back by osd_max_interval which would cause the time permit checking
+    # to be skipped.  Set back 1 day, the default scrub_min_interval.
+    ceph tell $pgid scrub $(( 24 * 60 * 60 )) || return 1
+
+    # Scrub should not run
+    for ((i=0; i < 30; i++)); do
+        if test "$(get_last_scrub_stamp $pgid)" '>' "$last_scrub" ; then
+            return 1
+        fi
+        sleep 1
+    done
+
+    teardown $dir || return 1
+}
+
 main osd-scrub-test "$@"
 
 # Local Variables:

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -365,6 +365,7 @@ PG::Scrubber::Scrubber()
    auto_repair(false),
    check_repair(false),
    deep_scrub_on_error(false),
+   reserve_failed(false),
    num_digest_updates_pending(0),
    state(INACTIVE),
    deep(false)
@@ -1465,6 +1466,7 @@ bool PG::sched_scrub()
       scrub_reserve_replicas();
     } else {
       dout(20) << __func__ << ": failed to reserve locally" << dendl;
+      set_reserve_failed();
       return false;
     }
   }
@@ -1474,6 +1476,7 @@ bool PG::sched_scrub()
       dout(20) << __func__ << ": failed, a peer declined" << dendl;
       clear_scrub_reserved();
       scrub_unreserve_replicas();
+      set_reserve_failed();
       return false;
     } else if (scrubber.reserved_peers.size() == get_actingset().size()) {
       dout(20) << __func__ << ": success, reserved self and replicas" << dendl;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2486,8 +2486,7 @@ void PG::scrub(epoch_t queued, ThreadPool::TPHandle &handle)
   OSDService *osds = osd;
   double scrub_sleep = osds->osd->scrub_sleep_time(scrubber.must_scrub);
   if (scrub_sleep > 0 &&
-      (scrubber.state == PG::Scrubber::NEW_CHUNK ||
-       scrubber.state == PG::Scrubber::INACTIVE) &&
+      scrubber.state == PG::Scrubber::NEW_CHUNK &&
        scrubber.needs_sleep) {
     ceph_assert(!scrubber.sleeping);
     dout(20) << __func__ << " state is INACTIVE|NEW_CHUNK, sleeping" << dendl;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -356,7 +356,7 @@ void PG::clear_primary_state()
 }
 
 PG::Scrubber::Scrubber()
- : local_reserved(false), remote_reserved(false), reserve_failed(false),
+ : local_reserved(false), remote_reserved(false), reserve_reject(false),
    epoch_start(0),
    active(false),
    shallow_errors(0), deep_errors(0), fixed(0),
@@ -1470,7 +1470,7 @@ bool PG::sched_scrub()
   }
 
   if (scrubber.local_reserved) {
-    if (scrubber.reserve_failed) {
+    if (scrubber.reserve_reject) {
       dout(20) << __func__ << ": failed, a peer declined" << dendl;
       clear_scrub_reserved();
       scrub_unreserve_replicas();
@@ -1979,7 +1979,7 @@ void PG::handle_scrub_reserve_reject(OpRequestRef op, pg_shard_t from)
   } else {
     /* One decline stops this pg from being scheduled for scrubbing. */
     dout(10) << " osd." << from << " scrub reserve = fail" << dendl;
-    scrubber.reserve_failed = true;
+    scrubber.reserve_reject = true;
     sched_scrub();
   }
 }
@@ -2084,7 +2084,7 @@ void PG::unreserve_recovery_space() {
 void PG::clear_scrub_reserved()
 {
   scrubber.reserved_peers.clear();
-  scrubber.reserve_failed = false;
+  scrubber.reserve_reject = false;
 
   if (scrubber.local_reserved) {
     scrubber.local_reserved = false;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -176,6 +176,10 @@ public:
   const pg_shard_t pg_whoami;
   const spg_t pg_id;
 
+  bool get_reserve_failed() const { return scrubber.reserve_failed; }
+  void set_reserve_failed() { scrubber.reserve_failed = true; }
+  void clear_reserve_failed() { scrubber.reserve_failed = false; }
+
 public:
   // -- members --
   const coll_t coll;
@@ -1144,6 +1148,9 @@ public:
     // this flag indicates that if a regular scrub detects errors <= osd_scrub_auto_repair_num_errors,
     // we should deep scrub in order to auto repair
     bool deep_scrub_on_error;
+    // This PG could not get all the scrub reservations
+    bool reserve_failed;
+
 
     // Maps from objects with errors to missing/inconsistent peers
     map<hobject_t, set<pg_shard_t>> missing;
@@ -1261,6 +1268,7 @@ public:
       auto_repair = false;
       check_repair = false;
       deep_scrub_on_error = false;
+      reserve_failed = false;
 
       state = PG::Scrubber::INACTIVE;
       start = hobject_t();

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1103,7 +1103,7 @@ public:
 
     // metadata
     set<pg_shard_t> reserved_peers;
-    bool local_reserved, remote_reserved, reserve_failed;
+    bool local_reserved, remote_reserved, reserve_reject;
     epoch_t epoch_start;
 
     // common to both scrubs


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
