### PR TITLE
pacific: nautilus: qa: "Assertion `cb_done' failed."

### DIFF
--- a/src/test/fs/test_ino_release_cb.cc
+++ b/src/test/fs/test_ino_release_cb.cc
@@ -6,7 +6,7 @@
 #define MAX_CEPH_FILES	1000
 #define DIRNAME		"ino_release_cb"
 
-static volatile bool cb_done = false;
+static std::atomic<bool> cb_done = false;
 
 static void cb(void *hdl, vinodeno_t vino)
 {


### PR DESCRIPTION
https://tracker.ceph.com/issues/49474