### PR TITLE
nautilus: mgr/volumes: don't require typing

### DIFF
--- a/src/pybind/mgr/volumes/fs/operations/access.py
+++ b/src/pybind/mgr/volumes/fs/operations/access.py
@@ -1,6 +1,9 @@
 import errno
 import json
-from typing import List
+try:
+    from typing import List
+except ImportError:
+    pass # For typing only
 
 def prepare_updated_caps_list(existing_caps, mds_cap_str, osd_cap_str, authorize=True):
     caps_list = [] # type: List[str]

--- a/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v1.py
+++ b/src/pybind/mgr/volumes/fs/operations/versions/subvolume_v1.py
@@ -6,7 +6,10 @@ import errno
 import logging
 import json
 from datetime import datetime
-from typing import List, Dict
+try:
+    from typing import List, Dict
+except ImportError:
+    pass # For typing only
 
 import cephfs
 


### PR DESCRIPTION
This isn't available for python2 on centos 7. This is only needed
for nautilus because that's the last release using python 2 and centos 7.

Fixes: https://tracker.ceph.com/issues/49762
Signed-off-by: Josh Durgin <jdurgin@redhat.com>