### PR TITLE
ceph.spec: switch over to ninja-build

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -22,6 +22,7 @@
 #################################################################################
 %bcond_with make_check
 %bcond_with cmake_verbose_logging
+%bcond_without ninja
 %bcond_without ceph_test_package
 %ifarch s390
 %bcond_with tcmalloc
@@ -408,6 +409,9 @@ BuildRequires:  gcc-toolset-%{gts_version}-libasan-devel
 # distro-conditional dependencies
 #################################################################################
 %if 0%{?suse_version}
+%if 0%{with ninja}
+BuildRequires:  ninja
+%endif
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:	systemd-rpm-macros
 %{?systemd_requires}
@@ -436,6 +440,9 @@ BuildRequires:	jsonnet
 %if 0%{?fedora} || 0%{?rhel} || 0%{?openEuler}
 Requires:	systemd
 BuildRequires:  boost-random
+%if 0%{with ninja}
+BuildRequires:	ninja-build
+%endif
 BuildRequires:	nss-devel
 BuildRequires:	keyutils-libs-devel
 BuildRequires:  libatomic
@@ -1423,6 +1430,7 @@ env | sort
 mkdir -p %{_vpath_builddir}
 pushd %{_vpath_builddir}
 cmake .. \
+    -GNinja \
 %if 0%{?suse_version} == 1500
     -DCMAKE_C_COMPILER=gcc-11 \
     -DCMAKE_CXX_COMPILER=g++-11 \
@@ -1539,10 +1547,18 @@ cat ./CMakeFiles/CMakeOutput.log
 cat ./CMakeFiles/CMakeError.log
 %endif
 
+%if 0%{with ninja}
+%if 0%{?suse_version}
+ninja %{_smp_mflags}
+%else
+%ninja_build
+%endif
+%else
 %if 0%{?suse_version}
 make %{_smp_mflags}
 %else
 %make_build
+%endif
 %endif
 
 popd
@@ -1559,7 +1575,11 @@ popd
 %install
 
 pushd %{_vpath_builddir}
+%if 0%{with ninja}
+%ninja_install
+%else
 %make_install
+%endif
 # we have dropped sysvinit bits
 rm -f %{buildroot}/%{_sysconfdir}/init.d/ceph
 popd


### PR DESCRIPTION
for faster configure and build

the reason why we don't use cmake+ninja for building debian packages is
that the cmake+ninja support was added in debhelper v11.2.1. see
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=895044

without which, we'd have to override override_dh_auto_build to use "ninja"
instead of "make", and specify the builddir explicitly everywhere.

it'd be better to wait until we ditch the bionic builds and do this to
save the efforts.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
