### PR TITLE
osdc: switch to use lru_get_next_expire()

### DIFF
--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -1338,7 +1338,7 @@ void ObjectCacher::trim()
   }
 
   while (ob_lru.lru_get_size() > max_objects) {
-    Object *ob = static_cast<Object*>(ob_lru.lru_expire());
+    Object *ob = static_cast<Object*>(ob_lru.lru_get_next_expire());
     if (!ob)
       break;
 


### PR DESCRIPTION
In the lru_expire() it will remove the object and later in the
close_object() when it try to remove it again, we will hit crash:

/data/ceph/src/include/lru.h: 97: FAILED ceph_assert(list == &top || list == &bottom || list == &pintail)

ceph version 17.0.0-1853-g56debe83936 (56debe83936e9d9c29d05923b7820363dc21bcda) quincy (dev)
1: (ceph::__ceph_assert_fail(char const*, char const*, int, char const*)+0x1aa) [0x14781529fe78]
2: /data/ceph/build/lib/libceph-common.so.2(+0x16d00fa) [0x1478152a00fa]
3: (LRU::lru_remove(LRUObject*)+0x70) [0x56192d2920b4]
4: (ObjectCacher::close_object(ObjectCacher::Object*)+0x185) [0x56192d457b51]
5: (ObjectCacher::trim()+0x70a) [0x56192d45cfb0]

Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
