### PR TITLE
pacific: qa: remove passed_validation check for test_damage

### DIFF
--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -13,9 +13,6 @@ from teuthology.misc import sudo_write_file
 from teuthology.orchestra import run
 from teuthology.orchestra.run import CommandFailedError
 
-from teuthology.contextutil import safe_while
-
-
 log = logging.getLogger(__name__)
 
 def for_teuthology(f):
@@ -381,13 +378,11 @@ class CephFSTestCase(CephTestCase):
         except contextutil.MaxWhileTries as e:
             raise RuntimeError("rank {0} failed to reach desired subtree state".format(rank)) from e
 
-    def _wait_until_scrub_complete(self, path="/", recursive=True):
+    def _wait_until_scrub_complete(self, path="/", recursive=True, timeout=100):
         out_json = self.fs.rank_tell(["scrub", "start", path] + ["recursive"] if recursive else [])
-        with safe_while(sleep=10, tries=10) as proceed:
-            while proceed():
-                out_json = self.fs.rank_tell(["scrub", "status"])
-                if out_json['status'] == "no active scrubs running":
-                    break;
+        if not self.fs.wait_until_scrub_complete(tag=out_json["scrub_tag"],
+                                                 sleep=10, timeout=timeout):
+            log.info("timed out waiting for scrub to complete")
 
     def _wait_distributed_subtrees(self, count, status=None, rank=None, path=None):
         try:

--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -379,7 +379,7 @@ class CephFSTestCase(CephTestCase):
             raise RuntimeError("rank {0} failed to reach desired subtree state".format(rank)) from e
 
     def _wait_until_scrub_complete(self, path="/", recursive=True, timeout=100):
-        out_json = self.fs.rank_tell(["scrub", "start", path] + ["recursive"] if recursive else [])
+        out_json = self.fs.run_scrub(["start", path] + ["recursive"] if recursive else [])
         if not self.fs.wait_until_scrub_complete(tag=out_json["scrub_tag"],
                                                  sleep=10, timeout=timeout):
             log.info("timed out waiting for scrub to complete")

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -1583,7 +1583,8 @@ class Filesystem(MDSCluster):
     def get_scrub_status(self, rank=0):
         return self.run_scrub(["status"], rank)
 
-    def wait_until_scrub_complete(self, result=None, tag=None, rank=0, sleep=30, timeout=300):
+    def wait_until_scrub_complete(self, result=None, tag=None, rank=0, sleep=30,
+                                  timeout=300, reverse=False):
         # time out after "timeout" seconds and assume as done
         if result is None:
             result = "no active scrubs running"
@@ -1591,9 +1592,14 @@ class Filesystem(MDSCluster):
             while proceed():
                 out_json = self.rank_tell(["scrub", "status"], rank=rank)
                 assert out_json is not None
-                if result in out_json['status']:
-                    log.info("all active scrubs completed")
-                    return True
+                if not reverse:
+                    if result in out_json['status']:
+                        log.info("all active scrubs completed")
+                        return True
+                else:
+                    if result not in out_json['status']:
+                        log.info("all active scrubs completed")
+                        return True
 
                 if tag is not None:
                     status = out_json['scrubs'][tag]

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -18,6 +18,7 @@ from teuthology.exceptions import CommandFailedError
 from teuthology import misc
 from teuthology.nuke import clear_firewall
 from teuthology.parallel import parallel
+from teuthology import contextutil
 from tasks.ceph_manager import write_conf
 from tasks import ceph_manager
 
@@ -1575,3 +1576,26 @@ class Filesystem(MDSCluster):
         assert(new_max_mds < oldmax)
         self.set_max_mds(new_max_mds)
         return self.wait_for_daemons()
+
+    def wait_until_scrub_complete(self, result=None, tag=None, rank=0, sleep=30, timeout=300):
+        # time out after "timeout" seconds and assume as done
+        if result is None:
+            result = "no active scrubs running"
+        with contextutil.safe_while(sleep=sleep, tries=timeout//sleep) as proceed:
+            while proceed():
+                out_json = self.rank_tell(["scrub", "status"], rank=rank)
+                assert out_json is not None
+                if result in out_json['status']:
+                    log.info("all active scrubs completed")
+                    return True
+
+                if tag is not None:
+                    status = out_json['scrubs'][tag]
+                    if status is not None:
+                        log.info(f"scrub status for tag:{tag} - {status}")
+                    else:
+                        log.info(f"scrub has completed for tag:{tag}")
+                        return True
+
+        # timed out waiting for scrub to complete
+        return False

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -1577,8 +1577,11 @@ class Filesystem(MDSCluster):
         self.set_max_mds(new_max_mds)
         return self.wait_for_daemons()
 
+    def run_scrub(self, cmd, rank=0):
+        return self.rank_tell(["scrub"] + cmd, rank)
+
     def get_scrub_status(self, rank=0):
-        return self.rank_tell(["scrub", "status"], rank)
+        return self.run_scrub(["status"], rank)
 
     def wait_until_scrub_complete(self, result=None, tag=None, rank=0, sleep=30, timeout=300):
         # time out after "timeout" seconds and assume as done

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -1577,6 +1577,9 @@ class Filesystem(MDSCluster):
         self.set_max_mds(new_max_mds)
         return self.wait_for_daemons()
 
+    def get_scrub_status(self, rank=0):
+        return self.rank_tell(["scrub", "status"], rank)
+
     def wait_until_scrub_complete(self, result=None, tag=None, rank=0, sleep=30, timeout=300):
         # time out after "timeout" seconds and assume as done
         if result is None:

--- a/qa/tasks/cephfs/test_damage.py
+++ b/qa/tasks/cephfs/test_damage.py
@@ -451,7 +451,7 @@ class TestDamage(CephFSTestCase):
         self.mount_a.umount_wait()
 
         # Now repair the stats
-        scrub_json = self.fs.rank_tell(["scrub", "start", "/subdir", "repair"])
+        scrub_json = self.fs.run_scrub(["start", "/subdir", "repair"])
         log.info(json.dumps(scrub_json, indent=2))
 
         self.assertNotEqual(scrub_json, None)

--- a/qa/tasks/cephfs/test_damage.py
+++ b/qa/tasks/cephfs/test_damage.py
@@ -454,9 +454,9 @@ class TestDamage(CephFSTestCase):
         scrub_json = self.fs.rank_tell(["scrub", "start", "/subdir", "repair"])
         log.info(json.dumps(scrub_json, indent=2))
 
-        self.assertEqual(scrub_json["passed_validation"], False)
-        self.assertEqual(scrub_json["raw_stats"]["checked"], True)
-        self.assertEqual(scrub_json["raw_stats"]["passed"], False)
+        self.assertNotEqual(scrub_json, None)
+        self.assertEqual(scrub_json["return_code"], 0)
+        self.assertEqual(self.fs.wait_until_scrub_complete(tag=scrub_json["scrub_tag"]), True)
 
         # Check that the file count is now correct
         self.mount_a.mount_wait()

--- a/qa/tasks/cephfs/test_data_scan.py
+++ b/qa/tasks/cephfs/test_data_scan.py
@@ -509,7 +509,7 @@ class TestDataScan(CephFSTestCase):
 
         # run scrub to update and make sure rstat.rbytes info in subdir inode and dirfrag
         # are matched
-        out_json = self.fs.rank_tell(["scrub", "start", "/subdir", "repair", "recursive"])
+        out_json = self.fs.run_scrub(["start", "/subdir", "repair", "recursive"])
         self.assertNotEqual(out_json, None)
         self.assertEqual(out_json["return_code"], 0)
         self.assertEqual(self.fs.wait_until_scrub_complete(tag=out_json["scrub_tag"]), True)

--- a/qa/tasks/cephfs/test_data_scan.py
+++ b/qa/tasks/cephfs/test_data_scan.py
@@ -511,6 +511,8 @@ class TestDataScan(CephFSTestCase):
         # are matched
         out_json = self.fs.rank_tell(["scrub", "start", "/subdir", "repair", "recursive"])
         self.assertNotEqual(out_json, None)
+        self.assertEqual(out_json["return_code"], 0)
+        self.assertEqual(self.fs.wait_until_scrub_complete(tag=out_json["scrub_tag"]), True)
 
         # Remove the whole 'sudbdir' directory
         self.mount_a.run_shell(["rm", "-rf", "subdir/"])

--- a/qa/tasks/cephfs/test_forward_scrub.py
+++ b/qa/tasks/cephfs/test_forward_scrub.py
@@ -236,6 +236,8 @@ class TestForwardScrub(CephFSTestCase):
         with self.assert_cluster_log("inode table repaired", invert_match=True):
             out_json = self.fs.rank_tell(["scrub", "start", "/", "repair", "recursive"])
             self.assertNotEqual(out_json, None)
+            self.assertEqual(out_json["return_code"], 0)
+            self.assertEqual(self.fs.wait_until_scrub_complete(tag=out_json["scrub_tag"]), True)
 
         self.mds_cluster.mds_stop()
         self.mds_cluster.mds_fail()
@@ -259,6 +261,8 @@ class TestForwardScrub(CephFSTestCase):
         with self.assert_cluster_log("inode table repaired"):
             out_json = self.fs.rank_tell(["scrub", "start", "/", "repair", "recursive"])
             self.assertNotEqual(out_json, None)
+            self.assertEqual(out_json["return_code"], 0)
+            self.assertEqual(self.fs.wait_until_scrub_complete(tag=out_json["scrub_tag"]), True)
 
         self.mds_cluster.mds_stop()
         table_text = self.fs.table_tool(["0", "show", "inode"])
@@ -290,6 +294,9 @@ class TestForwardScrub(CephFSTestCase):
         with self.assert_cluster_log("bad backtrace on inode"):
             out_json = self.fs.rank_tell(["scrub", "start", "/", "repair", "recursive"])
             self.assertNotEqual(out_json, None)
+            self.assertEqual(out_json["return_code"], 0)
+            self.assertEqual(self.fs.wait_until_scrub_complete(tag=out_json["scrub_tag"]), True)
+
         self.fs.mds_asok(["flush", "journal"])
         backtrace = self.fs.read_backtrace(file_ino)
         self.assertEqual(['alpha', 'parent_a'],

--- a/qa/tasks/cephfs/test_forward_scrub.py
+++ b/qa/tasks/cephfs/test_forward_scrub.py
@@ -234,7 +234,7 @@ class TestForwardScrub(CephFSTestCase):
         self.mount_a.umount_wait()
 
         with self.assert_cluster_log("inode table repaired", invert_match=True):
-            out_json = self.fs.rank_tell(["scrub", "start", "/", "repair", "recursive"])
+            out_json = self.fs.run_scrub(["start", "/", "repair", "recursive"])
             self.assertNotEqual(out_json, None)
             self.assertEqual(out_json["return_code"], 0)
             self.assertEqual(self.fs.wait_until_scrub_complete(tag=out_json["scrub_tag"]), True)
@@ -259,7 +259,7 @@ class TestForwardScrub(CephFSTestCase):
         self.fs.wait_for_daemons()
 
         with self.assert_cluster_log("inode table repaired"):
-            out_json = self.fs.rank_tell(["scrub", "start", "/", "repair", "recursive"])
+            out_json = self.fs.run_scrub(["start", "/", "repair", "recursive"])
             self.assertNotEqual(out_json, None)
             self.assertEqual(out_json["return_code"], 0)
             self.assertEqual(self.fs.wait_until_scrub_complete(tag=out_json["scrub_tag"]), True)
@@ -292,7 +292,7 @@ class TestForwardScrub(CephFSTestCase):
                                   "oh i'm sorry did i overwrite your xattr?")
 
         with self.assert_cluster_log("bad backtrace on inode"):
-            out_json = self.fs.rank_tell(["scrub", "start", "/", "repair", "recursive"])
+            out_json = self.fs.run_scrub(["start", "/", "repair", "recursive"])
             self.assertNotEqual(out_json, None)
             self.assertEqual(out_json["return_code"], 0)
             self.assertEqual(self.fs.wait_until_scrub_complete(tag=out_json["scrub_tag"]), True)

--- a/qa/tasks/cephfs/test_multimds_misc.py
+++ b/qa/tasks/cephfs/test_multimds_misc.py
@@ -86,7 +86,7 @@ class TestScrub2(CephFSTestCase):
             file_obj_name = "{0:x}.00000000".format(ino)
             self.fs.rados(["rmxattr", file_obj_name, "parent"])
 
-        out_json = self.fs.rank_tell(["scrub", "start", "/d1/d2/d3", "recursive", "force"], 0)
+        out_json = self.fs.run_scrub(["start", "/d1/d2/d3", "recursive", "force"], 0)
         self.assertNotEqual(out_json, None)
         self.assertEqual(out_json["return_code"], 0)
         self.assertEqual(self.fs.wait_until_scrub_complete(tag=out_json["scrub_tag"]), True)
@@ -129,10 +129,10 @@ class TestScrub2(CephFSTestCase):
             file_obj_name = "{0:x}.00000000".format(ino)
             self.fs.rados(["rmxattr", file_obj_name, "parent"])
 
-        out_json = self.fs.rank_tell(["scrub", "start", "/d1/d2/d3", "recursive", "force"], 0)
+        out_json = self.fs.run_scrub(["start", "/d1/d2/d3", "recursive", "force"], 0)
         self.assertNotEqual(out_json, None)
         
-        res = self.fs.rank_tell(["scrub", "abort"])
+        res = self.fs.run_scrub(["abort"])
         self.assertEqual(res['return_code'], 0)
 
         # Abort and verify in both mdss. We also check the status in rank 0 mds because
@@ -154,10 +154,10 @@ class TestScrub2(CephFSTestCase):
             file_obj_name = "{0:x}.00000000".format(ino)
             self.fs.rados(["rmxattr", file_obj_name, "parent"])
 
-        out_json = self.fs.rank_tell(["scrub", "start", "/d1/d2/d3", "recursive", "force"], 0)
+        out_json = self.fs.run_scrub(["start", "/d1/d2/d3", "recursive", "force"], 0)
         self.assertNotEqual(out_json, None)
 
-        res = self.fs.rank_tell(["scrub", "pause"])
+        res = self.fs.run_scrub(["pause"])
         self.assertEqual(res['return_code'], 0)
 
         self.wait_until_true(lambda: "PAUSED" in self.fs.get_scrub_status(1)['status']
@@ -168,7 +168,7 @@ class TestScrub2(CephFSTestCase):
         self.assertTrue(checked)
 
         # resume and verify
-        res = self.fs.rank_tell(["scrub", "resume"])
+        res = self.fs.run_scrub(["resume"])
         self.assertEqual(res['return_code'], 0)
         
         self.wait_until_true(lambda: not("PAUSED" in self.fs.get_scrub_status(1)['status'])
@@ -187,10 +187,10 @@ class TestScrub2(CephFSTestCase):
             file_obj_name = "{0:x}.00000000".format(ino)
             self.fs.rados(["rmxattr", file_obj_name, "parent"])
 
-        out_json = self.fs.rank_tell(["scrub", "start", "/d1/d2/d3", "recursive", "force"], 0)
+        out_json = self.fs.run_scrub(["start", "/d1/d2/d3", "recursive", "force"], 0)
         self.assertNotEqual(out_json, None)
 
-        res = self.fs.rank_tell(["scrub", "pause"])
+        res = self.fs.run_scrub(["pause"])
         self.assertEqual(res['return_code'], 0)
 
         self.wait_until_true(lambda: "PAUSED" in self.fs.get_scrub_status(1)['status']
@@ -200,7 +200,7 @@ class TestScrub2(CephFSTestCase):
         checked = self._check_task_status("paused")
         self.assertTrue(checked)
 
-        res = self.fs.rank_tell(["scrub", "abort"])
+        res = self.fs.run_scrub(["abort"])
         self.assertEqual(res['return_code'], 0)
 
         self.wait_until_true(lambda: "PAUSED" in self.fs.get_scrub_status(1)['status']
@@ -215,7 +215,7 @@ class TestScrub2(CephFSTestCase):
         self.assertTrue(checked)
 
         # resume and verify
-        res = self.fs.rank_tell(["scrub", "resume"])
+        res = self.fs.run_scrub(["resume"])
         self.assertEqual(res['return_code'], 0)
 
         self.wait_until_true(lambda: not("PAUSED" in self.fs.get_scrub_status(1)['status'])

--- a/qa/tasks/cephfs/test_multimds_misc.py
+++ b/qa/tasks/cephfs/test_multimds_misc.py
@@ -10,9 +10,6 @@ class TestScrub2(CephFSTestCase):
     MDSS_REQUIRED = 3
     CLIENTS_REQUIRED = 1
 
-    def _get_scrub_status(self, rank=0):
-        return self.fs.rank_tell(["scrub", "status"], rank)
-
     def _check_task_status_na(self, timo=120):
         """ check absence of scrub status in ceph status """
         with safe_while(sleep=1, tries=120, action='wait for task status') as proceed:
@@ -140,9 +137,9 @@ class TestScrub2(CephFSTestCase):
 
         # Abort and verify in both mdss. We also check the status in rank 0 mds because
         # it is supposed to gather the scrub status from other mdss.
-        self.wait_until_true(lambda: "no active" in self._get_scrub_status(1)['status']
-                and "no active" in self._get_scrub_status(2)['status']
-                and "no active" in self._get_scrub_status(0)['status'], 30)
+        self.wait_until_true(lambda: "no active" in self.fs.get_scrub_status(1)['status']
+                and "no active" in self.fs.get_scrub_status(2)['status']
+                and "no active" in self.fs.get_scrub_status(0)['status'], 30)
 
         # sleep enough to fetch updated task status
         checked = self._check_task_status_na()
@@ -163,9 +160,9 @@ class TestScrub2(CephFSTestCase):
         res = self.fs.rank_tell(["scrub", "pause"])
         self.assertEqual(res['return_code'], 0)
 
-        self.wait_until_true(lambda: "PAUSED" in self._get_scrub_status(1)['status']
-                and "PAUSED" in self._get_scrub_status(2)['status']
-                and "PAUSED" in self._get_scrub_status(0)['status'], 30)
+        self.wait_until_true(lambda: "PAUSED" in self.fs.get_scrub_status(1)['status']
+                and "PAUSED" in self.fs.get_scrub_status(2)['status']
+                and "PAUSED" in self.fs.get_scrub_status(0)['status'], 30)
 
         checked = self._check_task_status("paused")
         self.assertTrue(checked)
@@ -174,9 +171,9 @@ class TestScrub2(CephFSTestCase):
         res = self.fs.rank_tell(["scrub", "resume"])
         self.assertEqual(res['return_code'], 0)
         
-        self.wait_until_true(lambda: not("PAUSED" in self._get_scrub_status(1)['status'])
-                and not("PAUSED" in self._get_scrub_status(2)['status'])
-                and not("PAUSED" in self._get_scrub_status(0)['status']), 30)
+        self.wait_until_true(lambda: not("PAUSED" in self.fs.get_scrub_status(1)['status'])
+                and not("PAUSED" in self.fs.get_scrub_status(2)['status'])
+                and not("PAUSED" in self.fs.get_scrub_status(0)['status']), 30)
 
         checked = self._check_task_status_na()
         self.assertTrue(checked)
@@ -196,9 +193,9 @@ class TestScrub2(CephFSTestCase):
         res = self.fs.rank_tell(["scrub", "pause"])
         self.assertEqual(res['return_code'], 0)
 
-        self.wait_until_true(lambda: "PAUSED" in self._get_scrub_status(1)['status']
-                and "PAUSED" in self._get_scrub_status(2)['status']
-                and "PAUSED" in self._get_scrub_status(0)['status'], 30)
+        self.wait_until_true(lambda: "PAUSED" in self.fs.get_scrub_status(1)['status']
+                and "PAUSED" in self.fs.get_scrub_status(2)['status']
+                and "PAUSED" in self.fs.get_scrub_status(0)['status'], 30)
 
         checked = self._check_task_status("paused")
         self.assertTrue(checked)
@@ -206,12 +203,12 @@ class TestScrub2(CephFSTestCase):
         res = self.fs.rank_tell(["scrub", "abort"])
         self.assertEqual(res['return_code'], 0)
 
-        self.wait_until_true(lambda: "PAUSED" in self._get_scrub_status(1)['status']
-                and "0 inodes" in self._get_scrub_status(1)['status']
-                and "PAUSED" in self._get_scrub_status(2)['status']
-                and "0 inodes" in self._get_scrub_status(2)['status']
-                and "PAUSED" in self._get_scrub_status(0)['status']
-                and "0 inodes" in self._get_scrub_status(0)['status'], 30)
+        self.wait_until_true(lambda: "PAUSED" in self.fs.get_scrub_status(1)['status']
+                and "0 inodes" in self.fs.get_scrub_status(1)['status']
+                and "PAUSED" in self.fs.get_scrub_status(2)['status']
+                and "0 inodes" in self.fs.get_scrub_status(2)['status']
+                and "PAUSED" in self.fs.get_scrub_status(0)['status']
+                and "0 inodes" in self.fs.get_scrub_status(0)['status'], 30)
 
         # scrub status should still be paused...
         checked = self._check_task_status("paused")
@@ -221,9 +218,9 @@ class TestScrub2(CephFSTestCase):
         res = self.fs.rank_tell(["scrub", "resume"])
         self.assertEqual(res['return_code'], 0)
 
-        self.wait_until_true(lambda: not("PAUSED" in self._get_scrub_status(1)['status'])
-                and not("PAUSED" in self._get_scrub_status(2)['status'])
-                and not("PAUSED" in self._get_scrub_status(0)['status']), 30)
+        self.wait_until_true(lambda: not("PAUSED" in self.fs.get_scrub_status(1)['status'])
+                and not("PAUSED" in self.fs.get_scrub_status(2)['status'])
+                and not("PAUSED" in self.fs.get_scrub_status(0)['status']), 30)
 
         checked = self._check_task_status_na()
         self.assertTrue(checked)

--- a/qa/tasks/cephfs/test_scrub.py
+++ b/qa/tasks/cephfs/test_scrub.py
@@ -104,7 +104,7 @@ class DupInodeWorkload(Workload):
         self._filesystem.wait_for_daemons()
 
     def validate(self):
-        out_json = self._filesystem.rank_tell(["scrub", "start", "/", "recursive", "repair"])
+        out_json = self._filesystem.run_scrub(["start", "/", "recursive", "repair"])
         self.assertNotEqual(out_json, None)
         self.assertEqual(out_json["return_code"], 0)
         self.assertEqual(self._filesystem.wait_until_scrub_complete(tag=out_json["scrub_tag"]), True)
@@ -135,7 +135,7 @@ class TestScrub(CephFSTestCase):
         # Apply any data damage the workload wants
         workload.damage()
 
-        out_json = self.fs.rank_tell(["scrub", "start", "/", "recursive", "repair"])
+        out_json = self.fs.run_scrub(["start", "/", "recursive", "repair"])
         self.assertNotEqual(out_json, None)
         self.assertEqual(out_json["return_code"], 0)
         self.assertEqual(self.fs.wait_until_scrub_complete(tag=out_json["scrub_tag"]), True)

--- a/qa/tasks/cephfs/test_scrub.py
+++ b/qa/tasks/cephfs/test_scrub.py
@@ -106,6 +106,8 @@ class DupInodeWorkload(Workload):
     def validate(self):
         out_json = self._filesystem.rank_tell(["scrub", "start", "/", "recursive", "repair"])
         self.assertNotEqual(out_json, None)
+        self.assertEqual(out_json["return_code"], 0)
+        self.assertEqual(self._filesystem.wait_until_scrub_complete(tag=out_json["scrub_tag"]), True)
         self.assertTrue(self._filesystem.are_daemons_healthy())
         return self._errors
 
@@ -135,6 +137,8 @@ class TestScrub(CephFSTestCase):
 
         out_json = self.fs.rank_tell(["scrub", "start", "/", "recursive", "repair"])
         self.assertNotEqual(out_json, None)
+        self.assertEqual(out_json["return_code"], 0)
+        self.assertEqual(self.fs.wait_until_scrub_complete(tag=out_json["scrub_tag"]), True)
 
         # See that the files are present and correct
         errors = workload.validate()
@@ -162,7 +166,7 @@ class TestScrub(CephFSTestCase):
         That scrubbing new files does not lead to errors
         """
         workload.create_files(1000)
-        self._wait_until_scrub_complete()
+        self.fs.wait_until_scrub_complete()
         self.assertEqual(self._get_damage_count(), 0)
 
     def test_scrub_backtrace_for_new_files(self):

--- a/qa/tasks/cephfs/test_scrub_checks.py
+++ b/qa/tasks/cephfs/test_scrub_checks.py
@@ -29,8 +29,6 @@ class TestScrubControls(CephFSTestCase):
     def _resume_scrub(self, expected):
         res = self.fs.rank_tell(["scrub", "resume"])
         self.assertEqual(res['return_code'], expected)
-    def _get_scrub_status(self):
-        return self.fs.rank_tell(["scrub", "status"])
     def _check_task_status(self, expected_status, timo=120):
         """ check scrub status for current active mds in ceph status """
         with safe_while(sleep=1, tries=120, action='wait for task status') as proceed:
@@ -98,7 +96,7 @@ done
 
         # pause and verify
         self._pause_scrub(0)
-        out_json = self._get_scrub_status()
+        out_json = self.fs.get_scrub_status()
         self.assertTrue("PAUSED" in out_json['status'])
 
         checked = self._check_task_status("paused")
@@ -106,7 +104,7 @@ done
 
         # resume and verify
         self._resume_scrub(0)
-        out_json = self._get_scrub_status()
+        out_json = self.fs.get_scrub_status()
         self.assertFalse("PAUSED" in out_json['status'])
 
         checked = self._check_task_status_na()
@@ -123,7 +121,7 @@ done
 
         # pause and verify
         self._pause_scrub(0)
-        out_json = self._get_scrub_status()
+        out_json = self.fs.get_scrub_status()
         self.assertTrue("PAUSED" in out_json['status'])
 
         checked = self._check_task_status("paused")
@@ -131,7 +129,7 @@ done
 
         # abort and verify
         self._abort_scrub(0)
-        out_json = self._get_scrub_status()
+        out_json = self.fs.get_scrub_status()
         self.assertTrue("PAUSED" in out_json['status'])
         self.assertTrue("0 inodes" in out_json['status'])
 
@@ -141,7 +139,7 @@ done
 
         # resume and verify
         self._resume_scrub(0)
-        out_json = self._get_scrub_status()
+        out_json = self.fs.get_scrub_status()
         self.assertTrue("no active" in out_json['status'])
 
         checked = self._check_task_status_na()
@@ -161,7 +159,7 @@ done
 
         # pause and verify
         self._pause_scrub(0)
-        out_json = self._get_scrub_status()
+        out_json = self.fs.get_scrub_status()
         self.assertTrue("PAUSED" in out_json['status'])
 
         checked = self._check_task_status("paused")
@@ -281,9 +279,6 @@ class TestScrubChecks(CephFSTestCase):
         ino = self.mount_a.path_to_ino(new_file)
         rados_obj_name = "{ino:x}.00000000".format(ino=ino)
         command = "scrub start {file}".format(file=test_new_file)
-
-        def _get_scrub_status():
-            return self.fs.rank_tell(["scrub", "status"], mds_rank)
 
         def _check_and_clear_damage(ino, dtype):
             all_damage = self.fs.rank_tell(["damage", "ls"], mds_rank)

--- a/qa/tasks/cephfs/test_scrub_checks.py
+++ b/qa/tasks/cephfs/test_scrub_checks.py
@@ -21,13 +21,13 @@ class TestScrubControls(CephFSTestCase):
     CLIENTS_REQUIRED = 1
 
     def _abort_scrub(self, expected):
-        res = self.fs.rank_tell(["scrub", "abort"])
+        res = self.fs.run_scrub(["abort"])
         self.assertEqual(res['return_code'], expected)
     def _pause_scrub(self, expected):
-        res = self.fs.rank_tell(["scrub", "pause"])
+        res = self.fs.run_scrub(["pause"])
         self.assertEqual(res['return_code'], expected)
     def _resume_scrub(self, expected):
-        res = self.fs.rank_tell(["scrub", "resume"])
+        res = self.fs.run_scrub(["resume"])
         self.assertEqual(res['return_code'], expected)
     def _check_task_status(self, expected_status, timo=120):
         """ check scrub status for current active mds in ceph status """
@@ -70,7 +70,7 @@ done
 
         self.create_scrub_data(test_dir)
 
-        out_json = self.fs.rank_tell(["scrub", "start", abs_test_path, "recursive"])
+        out_json = self.fs.run_scrub(["start", abs_test_path, "recursive"])
         self.assertNotEqual(out_json, None)
 
         # abort and verify
@@ -91,7 +91,7 @@ done
 
         self.create_scrub_data(test_dir)
 
-        out_json = self.fs.rank_tell(["scrub", "start", abs_test_path, "recursive"])
+        out_json = self.fs.run_scrub(["start", abs_test_path, "recursive"])
         self.assertNotEqual(out_json, None)
 
         # pause and verify
@@ -116,7 +116,7 @@ done
 
         self.create_scrub_data(test_dir)
 
-        out_json = self.fs.rank_tell(["scrub", "start", abs_test_path, "recursive"])
+        out_json = self.fs.run_scrub(["start", abs_test_path, "recursive"])
         self.assertNotEqual(out_json, None)
 
         # pause and verify
@@ -154,7 +154,7 @@ done
 
         self.create_scrub_data(test_dir)
 
-        out_json = self.fs.rank_tell(["scrub", "start", abs_test_path, "recursive"])
+        out_json = self.fs.run_scrub(["start", abs_test_path, "recursive"])
         self.assertNotEqual(out_json, None)
 
         # pause and verify

--- a/qa/tasks/cephfs/test_scrub_checks.py
+++ b/qa/tasks/cephfs/test_scrub_checks.py
@@ -77,7 +77,7 @@ done
 
         # abort and verify
         self._abort_scrub(0)
-        self.wait_until_true(lambda: "no active" in self._get_scrub_status()['status'], 30)
+        self.fs.wait_until_scrub_complete(sleep=5, timeout=30)
 
         # sleep enough to fetch updated task status
         checked = self._check_task_status_na()
@@ -298,7 +298,7 @@ class TestScrubChecks(CephFSTestCase):
         self.assertFalse(_check_and_clear_damage(ino, "backtrace"));
         self.fs.rados(["rmxattr", rados_obj_name, "parent"], pool=self.fs.get_data_pool_name())
         self.tell_command(mds_rank, command, success_validator)
-        self.wait_until_true(lambda: "no active" in _get_scrub_status()['status'], 30)
+        self.fs.wait_until_scrub_complete(sleep=5, timeout=30)
         self.assertTrue(_check_and_clear_damage(ino, "backtrace"));
 
         command = "flush_path /"

--- a/qa/tasks/cephfs_upgrade_snap.py
+++ b/qa/tasks/cephfs_upgrade_snap.py
@@ -24,14 +24,14 @@ def task(ctx, config):
     mds_map = fs.get_mds_map()
     assert(mds_map['max_mds'] == 1)
 
-    json = fs.rank_tell(["scrub", "start", "/", "force", "recursive", "repair"])
+    json = fs.run_scrub(["start", "/", "force", "recursive", "repair"])
     if not json or json['return_code'] == 0:
         assert(fs.wait_until_scrub_complete(tag=json["scrub_tag"]) == True)
         log.info("scrub / completed")
     else:
         log.info("scrub / failed: {}".format(json))
 
-    json = fs.rank_tell(["scrub", "start", "~mdsdir", "force", "recursive", "repair"])
+    json = fs.run_scrub(["start", "~mdsdir", "force", "recursive", "repair"])
     if not json or json['return_code'] == 0:
         assert(fs.wait_until_scrub_complete(tag=json["scrub_tag"]) == True)
         log.info("scrub ~mdsdir completed")

--- a/qa/tasks/cephfs_upgrade_snap.py
+++ b/qa/tasks/cephfs_upgrade_snap.py
@@ -26,12 +26,14 @@ def task(ctx, config):
 
     json = fs.rank_tell(["scrub", "start", "/", "force", "recursive", "repair"])
     if not json or json['return_code'] == 0:
+        assert(fs.wait_until_scrub_complete(tag=json["scrub_tag"]) == True)
         log.info("scrub / completed")
     else:
         log.info("scrub / failed: {}".format(json))
 
     json = fs.rank_tell(["scrub", "start", "~mdsdir", "force", "recursive", "repair"])
     if not json or json['return_code'] == 0:
+        assert(fs.wait_until_scrub_complete(tag=json["scrub_tag"]) == True)
         log.info("scrub ~mdsdir completed")
     else:
         log.info("scrub / failed: {}".format(json))

--- a/qa/tasks/fwd_scrub.py
+++ b/qa/tasks/fwd_scrub.py
@@ -62,7 +62,7 @@ class ForwardScrubber(Thrasher, Greenlet):
     def _scrub(self, path="/", recursive=True):
         self.logger.info(f"scrubbing fs: {self.fs.name}")
         recopt = ["recursive", "force"] if recursive else ["force"]
-        out_json = self.fs.rank_tell(["scrub", "start", path] + recopt)
+        out_json = self.fs.run_scrub(["start", path] + recopt)
         assert out_json is not None
 
         tag = out_json['scrub_tag']

--- a/qa/tasks/fwd_scrub.py
+++ b/qa/tasks/fwd_scrub.py
@@ -8,8 +8,6 @@ from gevent import sleep, GreenletExit
 from gevent.greenlet import Greenlet
 from gevent.event import Event
 from teuthology import misc as teuthology
-from teuthology import contextutil
-from teuthology.orchestra.run import CommandFailedError
 
 from tasks import ceph_manager
 from tasks.cephfs.filesystem import MDSCluster, Filesystem
@@ -73,29 +71,8 @@ class ForwardScrubber(Thrasher, Greenlet):
         assert out_json['return_code'] == 0
         assert out_json['mode'] == 'asynchronous'
 
-        return self._wait_until_scrub_complete(tag)
-
-    def _wait_until_scrub_complete(self, tag):
-        # time out after scrub_timeout seconds and assume as done
-        with contextutil.safe_while(sleep=30, tries=self.scrub_timeout//30) as proceed:
-            while proceed():
-                try:
-                    out_json = self.fs.rank_tell(["scrub", "status"])
-                    assert out_json is not None
-                    if out_json['status'] == "no active scrubs running":
-                        self.logger.info("all active scrubs completed")
-                        return
-
-                    status = out_json['scrubs'][tag]
-                    if status is not None:
-                        self.logger.info(f"scrub status for tag:{tag} - {status}")
-                    else:
-                        self.logger.info(f"scrub has completed for tag:{tag}")
-                        return
-                except CommandFailedError as e:
-                    self.logger.exception(f"exception while getting scrub status: {e}")
-                    self.logger.info("retrying scrub status command in a while")
-                    pass
+        return self.fs.wait_until_scrub_complete(tag=tag, sleep=30,
+                                                 timeout=self.scrub_timeout)
 
 def stop_all_fwd_scrubbers(thrashers):
     for thrasher in thrashers:

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -12741,20 +12741,15 @@ public:
     tag(tag), formatter(f), on_finish(fin), header(nullptr) {}
 
   void finish(int r) override {
+    formatter->open_object_section("results");
+    formatter->dump_int("return_code", r);
     if (r == 0) {
-      // since recursive scrub is asynchronous, dump minimal output
-      // to not upset cli tools.
-      formatter->open_object_section("results");
-      formatter->dump_int("return_code", 0);
       formatter->dump_string("scrub_tag", tag);
       formatter->dump_string("mode", "asynchronous");
-      formatter->close_section(); // results
-    } else { // we failed the lookup or something; dump ourselves
-      formatter->open_object_section("results");
-      formatter->dump_int("return_code", r);
-      formatter->close_section(); // results
-      r = 0; // already dumped in formatter
     }
+    formatter->close_section();
+
+    r = 0;
     if (on_finish)
       on_finish->complete(r);
   }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49609

backport of #38684
parent tracker: https://tracker.ceph.com/issues/48559

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
