### PR TITLE
pybind/ceph_argparse: do not print flag name before CephChoices in he…

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -830,10 +830,8 @@ class argdesc(object):
         """
         if self.t == CephBool:
             chunk = "--{0}".format(self.name.replace("_", "-"))
-        elif self.t == CephPrefix:
+        elif self.t == CephPrefix or self.t == CephChoices:
             chunk = str(self.instance)
-        elif self.t == CephChoices:
-            chunk = f'--{self.name} {{{str(self.instance)}}}'
         elif self.t == CephOsdName:
             # it just so happens all CephOsdName commands are named 'id' anyway,
             # so <id|osd.id> is perfect.


### PR DESCRIPTION
…lp descs

This reverts commit 332abcd25059c3ed07ca5df54110a83e07f28f86.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
