### PR TITLE
rgw/notification: set correct type to "post" and "copy" notifications

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5073,7 +5073,7 @@ void RGWCopyObj::execute(optional_yield y)
 
   // make reservation for notification if needed
   std::unique_ptr<rgw::sal::Notification> res = store->get_notification(s->object.get(),
-						s, rgw::notify::ObjectCreatedPost);
+						s, rgw::notify::ObjectCreatedCopy);
   op_ret = res->publish_reserve();
   if (op_ret < 0) {
     return;
@@ -5762,7 +5762,7 @@ void RGWInitMultipart::execute(optional_yield y)
 
   // make reservation for notification if needed
   std::unique_ptr<rgw::sal::Notification> res = store->get_notification(s->object.get(),
-				s, rgw::notify::ObjectCreatedCompleteMultipartUpload);
+				s, rgw::notify::ObjectCreatedPost);
   op_ret = res->publish_reserve();
   if (op_ret < 0) {
     return;


### PR DESCRIPTION
~added 2 commits to the PR so that tests would pass, however, they address completely different issues.~

@dang could you please help review this commit: 00789848391c0a46d4cdca126f08c69fbe76a508
~@tschoonj could you please help review this commit: bc6e38ffff8c5f7cd002fc55ae661d210cd7e671~
~@TRYTOBE8TME this PR include merging the changes between these 2 PR:~
~* https://github.com/ceph/ceph/pull/39139~
~* https://github.com/ceph/ceph/pull/39392~
---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
