### PR TITLE
doc: fixes for cephadm documentation

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -11,6 +11,7 @@ then deploying the needed services.
 Requirements
 ============
 
+- Python 3
 - Systemd
 - Podman or Docker for running containers
 - Time synchronization (such as chrony or NTP)
@@ -44,8 +45,9 @@ curl-based installation
   standalone script. 
   
   .. prompt:: bash #
+     :substitutions:
 
-   curl --silent --remote-name --location https://github.com/ceph/ceph/raw/octopus/src/cephadm/cephadm
+     curl --silent --remote-name --location https://github.com/ceph/ceph/raw/|stable-release|/src/cephadm/cephadm
 
   Make the ``cephadm`` script executable:
 
@@ -65,9 +67,10 @@ curl-based installation
   run the following commands:
 
   .. prompt:: bash #
+     :substitutions:
 
-    ./cephadm add-repo --release octopus
-    ./cephadm install
+     ./cephadm add-repo --release |stable-release|
+     ./cephadm install
 
   Confirm that ``cephadm`` is now in your PATH by running ``which``:
 
@@ -236,9 +239,10 @@ command.  There are several ways to do this:
   CephFS file systems), etc.:
 
   .. prompt:: bash #
+     :substitutions:
 
-    cephadm add-repo --release octopus
-    cephadm install ceph-common
+     cephadm add-repo --release |stable-release|
+     cephadm install ceph-common
 
 Confirm that the ``ceph`` command is accessible with:
 


### PR DESCRIPTION
Be sure to note that python 3 is a prerequisite. Minimal centos 8
installs don't have it, for instance.

Also, we probably don't want to hardcode an octopus URL into the
suggested curl command. Change it to fetch from "|stable-release|", though
possibly, we ought to add a 'latest' tag or something to point to the
latest released version.

Fixes: https://tracker.ceph.com/issues/49806
Signed-off-by: Jeff Layton <jlayton@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
