### PR TITLE
doc/cephadm: break mon section into sections

### DIFF
--- a/doc/cephadm/mon.rst
+++ b/doc/cephadm/mon.rst
@@ -4,8 +4,8 @@ MON Service
 
 .. _deploy_additional_monitors:
 
-Deploying additional monitors (beyond the default three)
-========================================================
+Deploying additional monitors 
+-----------------------------
 
 A typical Ceph cluster has three or five monitor daemons that are spread
 across different hosts.  We recommend deploying five monitors if there are
@@ -29,7 +29,7 @@ manual administration of the ceph monitor daemons is not necessary.
 needed, as new hosts are added to the cluster. 
 
 Designating a Particular Subnet for Monitors
-============================================
+--------------------------------------------
 
 To designate a particular IP subnet for use by ceph monitor daemons, use a
 command of the following form, including the subnet's address in `CIDR`_
@@ -49,18 +49,18 @@ Cephadm deploys new monitor daemons only on hosts that have IP addresses in
 the designated subnet.
 
 Changing the number of monitors from the default
-================================================
+------------------------------------------------
 
-* If you want to adjust the default of 5 monitors, run this command:
+If you want to adjust the default of 5 monitors, run this command:
 
   .. prompt:: bash #
 
      ceph orch apply mon *<number-of-monitors>*
 
 Deploying monitors only to specific hosts
-=========================================
+-----------------------------------------
 
-* To deploy monitors on a specific set of hosts, run this command:
+To deploy monitors on a specific set of hosts, run this command:
 
   .. prompt:: bash #
 
@@ -69,11 +69,10 @@ Deploying monitors only to specific hosts
   Be sure to include the first (bootstrap) host in this list.
 
 Using Host Labels
-=================
+-----------------
 
-* You can control which hosts the monitors run on by making use of
-  host labels.  To set the ``mon`` label to the appropriate
-  hosts, run this command:
+You can control which hosts the monitors run on by making use of host labels.
+To set the ``mon`` label to the appropriate hosts, run this command:
   
   .. prompt:: bash #
 
@@ -109,12 +108,14 @@ Using Host Labels
 
     ceph orch apply mon label:mon
 
-Deploying Monitors Manually 
-===========================
+See also :ref:`host labels <orchestrator-host-labels>`.
 
-* You can explicitly specify the IP address or CIDR network for each monitor
-  and control where it is placed.  To disable automated monitor deployment, run
-  this command:
+Deploying Monitors on a Particular Network 
+------------------------------------------
+
+You can explicitly specify the IP address or CIDR network for each monitor and
+control where each monitor is placed.  To disable automated monitor deployment,
+run this command:
 
   .. prompt:: bash #
 


### PR DESCRIPTION
This PR breaks the "Deploy Additional Monitors" section
of the cephadm documentation into several subsections
whose titles spotlight the matter under discussion in
those respective subsections.

inb4: Another PR is on deck that rewrites the sentences
in this chapter of the cephadm documentation. I'd like
to get this chapter broken up into these subsections before
I rewrite those sentences. So I'm hoping for no grammatical
mission creep on this one. The grammar and clarity updates
are coming.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
