### PR TITLE
pybind/ceph_argparse: print --format flag name in help descs

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -830,8 +830,13 @@ class argdesc(object):
         """
         if self.t == CephBool:
             chunk = "--{0}".format(self.name.replace("_", "-"))
-        elif self.t == CephPrefix or self.t == CephChoices:
+        elif self.t == CephPrefix:
             chunk = str(self.instance)
+        elif self.t == CephChoices:
+            if self.name == 'format':
+                chunk = f'--{self.name} {{{str(self.instance)}}}'
+            else:
+                chunk = str(self.instance)
         elif self.t == CephOsdName:
             # it just so happens all CephOsdName commands are named 'id' anyway,
             # so <id|osd.id> is perfect.


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/49757

Signed-off-by: Adam King <adking@redhat.com>

Replacement for: https://github.com/ceph/ceph/pull/40041

Treating format flag as special and printing it differently than other CephChoices parameters

Full 'ceph -h' output with this change: https://pastebin.com/raw/tMjQ3RqS

new orch ls desc: `orch ls [<service_type>] [<service_name>] [--export] [--format {plain|json|json-pretty|yaml}] [--refresh]`
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
