### PR TITLE
pacific: pybind/mgr/balancer/module.py: assign weight-sets to all buckets before balancing

### DIFF
--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -1229,8 +1229,13 @@ class Module(MgrModule):
                                 'change balancer mode and retry might help'
 
     def get_compat_weight_set_weights(self, ms):
-        if not CRUSHMap.have_default_choose_args(ms.crush_dump):
+        have_choose_args = CRUSHMap.have_default_choose_args(ms.crush_dump)
+        if have_choose_args:
+            # get number of buckets in choose_args
+            choose_args_len = len(CRUSHMap.get_default_choose_args(ms.crush_dump))
+        if not have_choose_args or choose_args_len != len(ms.crush_dump['buckets']):
             # enable compat weight-set first
+            self.log.debug('no choose_args or all buckets do not have weight-sets')
             self.log.debug('ceph osd crush weight-set create-compat')
             result = CommandResult('')
             self.send_command(result, 'mon', '', json.dumps({


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49760

---

backport of https://github.com/ceph/ceph/pull/40007
parent tracker: https://tracker.ceph.com/issues/49576

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh