### PR TITLE
mgr/cephadm: less noise about refreshing hosts

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -163,7 +163,7 @@ class CephadmServe:
                     failures.append(r)
 
             if self.mgr.cache.host_needs_facts_refresh(host):
-                self.log.info(('Refreshing %s facts' % host))
+                self.log.debug(('Refreshing %s facts' % host))
                 r = self._refresh_facts(host)
                 if r:
                     failures.append(r)


### PR DESCRIPTION
These happen every ~10 minutes and will obscure any real messages of
interest.

Signed-off-by: Sage Weil <sage@newdream.net>