### PR TITLE
octopus: qa/suites/rados/singletone: whitelist MON_DOWN when injecting msgr errors

### DIFF
--- a/qa/suites/rados/singleton/msgr-failures/few.yaml
+++ b/qa/suites/rados/singleton/msgr-failures/few.yaml
@@ -6,3 +6,4 @@ overrides:
         mon client directed command retry: 5
     log-ignorelist:
       - \(OSD_SLOW_PING_TIME
+      - \(MON_DOWN\)

--- a/qa/suites/rados/singleton/msgr-failures/many.yaml
+++ b/qa/suites/rados/singleton/msgr-failures/many.yaml
@@ -10,3 +10,4 @@ overrides:
         debug monc: 10
     log-ignorelist:
       - \(OSD_SLOW_PING_TIME
+      - \(MON_DOWN\)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49402

---

backport of https://github.com/ceph/ceph/pull/39586
parent tracker: https://tracker.ceph.com/issues/45441

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh