### PR TITLE
os/bluestore: strip trailing slash for directory listings

### DIFF
--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -429,7 +429,10 @@ rocksdb::Status BlueRocksEnv::GetChildren(
   std::vector<std::string>* result)
 {
   result->clear();
-  int r = fs->readdir(dir, result);
+  // dir may contain trailing /
+  std::string dir_only, empty;
+  split(dir, &dir_only, &empty);
+  int r = fs->readdir(dir_only, result);
   if (r < 0)
     return rocksdb::Status::NotFound(dir, strerror(ENOENT));//    return err_to_status(r);
   return rocksdb::Status::OK();


### PR DESCRIPTION
Calls to `BlueRocksEnv::GetChildren` may contain a trailing `/` in the
queried directory, which is stripped away with this patch.
    
If it's not stripped, the directory entry is not found in BlueFS:
```
10 bluefs readdir db/
20 bluefs readdir dir db/ not found
 3 rocksdb: [db/db_impl/db_impl_open.cc:1785] Persisting Option File error: OK
```
Fixes: https://tracker.ceph.com/issues/49815
Signed-off-by: Jonas Jelten <jj@sft.lol>


## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
