### PR TITLE
mgr/cephadm: fix 'auth caps' fallback

### DIFF
--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -144,7 +144,7 @@ class CephadmService(metaclass=ABCMeta):
         return DaemonDescription()
 
     def get_keyring_with_caps(self, entity: AuthEntity, caps: List[str]) -> str:
-        ret, keyring, err = self.mgr.check_mon_command({
+        ret, keyring, err = self.mgr.mon_command({
             'prefix': 'auth get-or-create',
             'entity': entity,
             'caps': caps,

--- a/src/pybind/mgr/cephadm/tests/test_services.py
+++ b/src/pybind/mgr/cephadm/tests/test_services.py
@@ -115,7 +115,7 @@ class TestCephadmService:
                                'entity': 'client.iscsi.a',
                                'caps': expected_caps})
 
-        assert expected_call in mgr.check_mon_command.mock_calls
+        assert expected_call in mgr.mon_command.mock_calls
         assert expected_call2 in mgr.mon_command.mock_calls
 
     def test_get_auth_entity(self):


### PR DESCRIPTION
The first get-or-create attempt also needs to tolerate failure.

Fixes: 8ceea1961f818dc2d07edf9c256ebe5150b6b133

Signed-off-by: Sage Weil <sage@newdream.net>