### PR TITLE
[DNM: NEEDS REBASE] nautilus: osd: Try other PGs when reservation failures occur

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -4,3 +4,6 @@
 * $pid expansion in config paths like `admin_socket` will now properly expand
   to the daemon pid for commands like `ceph-mds` or `ceph-osd`. Previously only
   `ceph-fuse`/`rbd-nbd` expanded `$pid` with the actual daemon pid.
+
+* Scubs are more aggressive in trying to find more simultaneous possible PGs within osd_max_scrubs limitation.
+  It is possible that increasing osd_scrub_sleep may be necessary to maintain client responsiveness.

--- a/qa/standalone/scrub/osd-scrub-test.sh
+++ b/qa/standalone/scrub/osd-scrub-test.sh
@@ -311,6 +311,128 @@ function TEST_deep_scrub_abort() {
     _scrub_abort $dir deep_scrub
 }
 
+function TEST_scrub_parallelism() {
+    local dir=$1
+    local poolname=test
+    local OSDS=8
+    local PGS=64
+    local objects=$(expr $PGS \* 15)
+    local size=2
+    local osd_max_scrubs_per_osd=2
+    local maxscrubs=$(expr $OSDS / $size \* $osd_max_scrubs_per_osd)
+
+    TESTDATA="testdata.$$"
+
+    setup $dir || return 1
+    run_mon $dir a --osd_pool_default_size=$size || return 1
+    run_mgr $dir x || return 1
+    for osd in $(seq 0 $(expr $OSDS - 1))
+    do
+      run_osd $dir $osd --osd_pool_default_pg_autoscale_mode=off \
+	      --osd_deep_scrub_randomize_ratio=0.0 \
+	      --osd_max_scrubs=$osd_max_scrubs_per_osd \
+	      --osd_scrub_chunk_max=5 \
+	      --osd_scrub_sleep=7.0 \
+	      --osd_scrub_interval_randomize_ratio=0  || return 1
+    done
+
+    # Create a pool
+    create_pool $poolname $PGS $PGS
+    wait_for_clean || return 1
+    poolid=$(ceph osd dump | grep "^pool.*[']${poolname}[']" | awk '{ print $2 }')
+
+    ceph pg dump pgs
+
+    dd if=/dev/urandom of=$TESTDATA bs=1032 count=1
+    for i in `seq 1 $objects`
+    do
+        rados -p $poolname put obj${i} $TESTDATA
+    done
+    rm -f $TESTDATA
+
+    ceph pg dump pgs
+
+    ceph osd set noscrub
+    sleep 3
+    for i in $(seq 0 $(expr $PGS - 1))
+    do
+      ceph pg scrub $poolid.$(printf '%x' $i) || return 1
+    done
+    ceph osd unset noscrub
+
+    # Wait for scrubbing to start
+    set -o pipefail
+    found="no"
+    for i in $(seq 0 200)
+    do
+      flush_pg_stats
+      if ceph pg dump pgs | grep -q "scrubbing"
+      then
+        found="yes"
+        #ceph pg dump pgs
+        break
+      fi
+    done
+    set +o pipefail
+
+    if test $found = "no";
+    then
+      echo "Scrubbing never started"
+      return 1
+    fi
+
+    local zero_count=0
+    local found_count=0
+    local threshold="$(expr $maxscrubs - 1)"
+    set -o pipefail
+    while(true)
+    do
+      sleep 1
+      scrubs=$(ceph pg dump pgs | grep scrubbing | wc -l)
+      # Occasionally we still see scrubs that have finished with new scrubs starting
+      # so more scrubs appear to be running then is possible.
+      # Also, count 1 less than maximum possible scrubs
+      if test $scrubs -ge $threshold
+      then
+        found_count=$(expr $found_count + 1)
+        continue
+      fi
+      if test $scrubs = "0"
+      then
+        zero_count=$(expr $zero_count + 1)
+        if test $zero_count = "10"
+        then
+          break
+        fi
+      else
+        zero_count=0
+      fi
+    done
+    set +o pipefail
+
+    echo found $found_count max scrubs
+
+    ERRORS=0
+    if test $found_count -lt "20"
+    then
+	    echo "Only detected near to or at maximum scrubs $found_count time(s)"
+      ERRORS=$(expr $ERRORS + 1)
+    fi
+
+    grep "reserve failed" $dir/osd.*.log
+    if ! grep -q "reserve failed" $dir/osd.*.log
+    then
+      ERRORS=$(expr $ERRORS + 1)
+    fi
+
+    if test $ERRORS -gt 0
+    then
+      return 1
+    fi
+
+    teardown $dir || return 1
+}
+
 main osd-scrub-test "$@"
 
 # Local Variables:

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7979,6 +7979,14 @@ void OSD::sched_scrub()
       PGRef pg = _lookup_lock_pg(scrub.pgid);
       if (!pg)
 	continue;
+
+      // If this one couldn't reserve, skip for now
+      if (pg->get_reserve_failed()) {
+	pg->unlock();
+	dout(20) << __func__ << " pg  " << scrub.pgid << " reserve failed, skipped" << dendl;
+        continue;
+      }
+
       // This has already started, so go on to the next scrub job
       if (pg->scrubber.active) {
 	pg->unlock();
@@ -7996,8 +8004,8 @@ void OSD::sched_scrub()
       // If it is reserving, let it resolve before going to the next scrub job
       if (pg->scrubber.local_reserved && !pg->scrubber.active) {
 	pg->unlock();
-	dout(30) << __func__ << ": reserve in progress pgid " << scrub.pgid << dendl;
-	break;
+	dout(10) << __func__ << ": reserve in progress pgid " << scrub.pgid << dendl;
+	goto out;
       }
       dout(10) << "sched_scrub scrubbing " << scrub.pgid << " at " << scrub.sched_time
 	       << (pg->get_must_scrub() ? ", explicitly requested" :
@@ -8005,11 +8013,35 @@ void OSD::sched_scrub()
 	       << dendl;
       if (pg->sched_scrub()) {
 	pg->unlock();
-	break;
+        dout(10) << __func__ << " scheduled a scrub!" << " (~" << scrub.pgid << "~)" << dendl;
+	goto out;
       }
+      // If this is set now we must have had a local reserve failure, so can't scrub anything right now
+      if (pg->get_reserve_failed()) {
+	pg->unlock();
+	dout(20) << __func__ << " pg  " << scrub.pgid << " local reserve failed, nothing to be done now" << dendl;
+        goto out;
+      }
+
       pg->unlock();
     } while (service.next_scrub_stamp(scrub, &scrub));
+
+    // Clear reserve_failed from all pending PGs, so we try again
+    if (service.first_scrub_stamp(&scrub)) {
+      do {
+        if (scrub.sched_time > now)
+	  break;
+        PGRef pg = _lookup_lock_pg(scrub.pgid);
+	// If we can't lock, it's ok we can get it next time
+        if (!pg)
+	  continue;
+        pg->clear_reserve_failed();
+        pg->unlock();
+      } while (service.next_scrub_stamp(scrub, &scrub));
+    }
   }
+
+out:
   dout(20) << "sched_scrub done" << dendl;
 }
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1138,6 +1138,7 @@ PG::Scrubber::Scrubber()
    auto_repair(false),
    check_repair(false),
    deep_scrub_on_error(false),
+   reserve_failed(false),
    num_digest_updates_pending(0),
    state(INACTIVE),
    deep(false)
@@ -4511,6 +4512,7 @@ bool PG::sched_scrub()
       scrub_reserve_replicas();
     } else {
       dout(20) << __func__ << ": failed to reserve locally" << dendl;
+      set_reserve_failed();
       return false;
     }
   }
@@ -4520,6 +4522,7 @@ bool PG::sched_scrub()
       dout(20) << __func__ << ": failed, a peer declined" << dendl;
       clear_scrub_reserved();
       scrub_unreserve_replicas();
+      set_reserve_failed();
       return false;
     } else if (scrubber.reserved_peers.size() == actingset.size()) {
       dout(20) << __func__ << ": success, reserved self and replicas" << dendl;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5187,8 +5187,7 @@ void PG::replica_scrub(
 void PG::scrub(epoch_t queued, ThreadPool::TPHandle &handle)
 {
   if (cct->_conf->osd_scrub_sleep > 0 &&
-      (scrubber.state == PG::Scrubber::NEW_CHUNK ||
-       scrubber.state == PG::Scrubber::INACTIVE) &&
+      scrubber.state == PG::Scrubber::NEW_CHUNK &&
        scrubber.needs_sleep) {
     ceph_assert(!scrubber.sleeping);
     dout(20) << __func__ << " state is INACTIVE|NEW_CHUNK, sleeping" << dendl;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1129,7 +1129,7 @@ void PG::clear_primary_state()
 }
 
 PG::Scrubber::Scrubber()
- : local_reserved(false), remote_reserved(false), reserve_failed(false),
+ : local_reserved(false), remote_reserved(false), reserve_reject(false),
    epoch_start(0),
    active(false),
    shallow_errors(0), deep_errors(0), fixed(0),
@@ -4516,7 +4516,7 @@ bool PG::sched_scrub()
   }
 
   if (scrubber.local_reserved) {
-    if (scrubber.reserve_failed) {
+    if (scrubber.reserve_reject) {
       dout(20) << __func__ << ": failed, a peer declined" << dendl;
       clear_scrub_reserved();
       scrub_unreserve_replicas();
@@ -4721,7 +4721,7 @@ void PG::handle_scrub_reserve_reject(OpRequestRef op, pg_shard_t from)
   } else {
     /* One decline stops this pg from being scheduled for scrubbing. */
     dout(10) << " osd." << from << " scrub reserve = fail" << dendl;
-    scrubber.reserve_failed = true;
+    scrubber.reserve_reject = true;
     sched_scrub();
   }
 }
@@ -4784,7 +4784,7 @@ void PG::schedule_recovery_retry(float delay)
 void PG::clear_scrub_reserved()
 {
   scrubber.reserved_peers.clear();
-  scrubber.reserve_failed = false;
+  scrubber.reserve_reject = false;
 
   if (scrubber.local_reserved) {
     scrubber.local_reserved = false;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1690,7 +1690,7 @@ public:
 
     // metadata
     set<pg_shard_t> reserved_peers;
-    bool local_reserved, remote_reserved, reserve_failed;
+    bool local_reserved, remote_reserved, reserve_reject;
     epoch_t epoch_start;
 
     // common to both scrubs

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -256,6 +256,12 @@ struct PGPool {
  */
 
 class PG : public DoutPrefixProvider {
+
+public:
+  bool get_reserve_failed() const { return scrubber.reserve_failed; }
+  void set_reserve_failed() { scrubber.reserve_failed = true; }
+  void clear_reserve_failed() { scrubber.reserve_failed = false; }
+
 public:
   // -- members --
   const spg_t pg_id;
@@ -1731,6 +1737,9 @@ public:
     // this flag indicates that if a regular scrub detects errors <= osd_scrub_auto_repair_num_errors,
     // we should deep scrub in order to auto repair
     bool deep_scrub_on_error;
+    // This PG could not get all the scrub reservations
+    bool reserve_failed;
+
 
     // Maps from objects with errors to missing/inconsistent peers
     map<hobject_t, set<pg_shard_t>> missing;
@@ -1848,6 +1857,7 @@ public:
       auto_repair = false;
       check_repair = false;
       deep_scrub_on_error = false;
+      reserve_failed = false;
 
       state = PG::Scrubber::INACTIVE;
       start = hobject_t();


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
