### PR TITLE
test: pass peer_uuid when invoking `fs snapshot mirror peer_add`

### DIFF
--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from io import StringIO
 from os.path import join as os_path_join
 
@@ -346,7 +347,8 @@ class TestMirroringCommands(CephFSTestCase):
         self.fs.mon_manager.raw_cluster_cmd("fs", "mirror", "disable", fs_name)
 
     def _add_peer(self, fs_name, peer_spec, remote_fs_name):
-        self.fs.mon_manager.raw_cluster_cmd("fs", "mirror", "peer_add", fs_name, peer_spec, remote_fs_name)
+        peer_uuid = str(uuid.uuid4())
+        self.fs.mon_manager.raw_cluster_cmd("fs", "mirror", "peer_add", fs_name, peer_uuid, peer_spec, remote_fs_name)
 
     def _remove_peer(self, fs_name, peer_uuid):
         self.fs.mon_manager.raw_cluster_cmd("fs", "mirror", "peer_remove", fs_name, peer_uuid)
@@ -366,12 +368,12 @@ class TestMirroringCommands(CephFSTestCase):
         fs_map = status.get_fsmap_byname(fs_name)
         mirror_info = fs_map.get('mirror_info', None)
         self.assertTrue(mirror_info is not None)
-        for uuid, remote in mirror_info['peers'].items():
+        for peer_uuid, remote in mirror_info['peers'].items():
             client_name = remote['remote']['client_name']
             cluster_name = remote['remote']['cluster_name']
             spec = f'{client_name}@{cluster_name}'
             if spec == peer_spec:
-                return uuid
+                return peer_uuid
         return None
 
     def test_mirroring_command(self):

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -1150,6 +1150,11 @@ public:
       ss << "peer already exists";
       return true;
     }
+    if (fs->mirror_info.has_peer((*remote_conf).first, (*remote_conf).second,
+                                 remote_fs_name)) {
+      ss << "peer already exists";
+      return true;
+    }
 
     auto f = [peer_uuid, remote_conf, remote_fs_name](auto &&fs) {
                fs->mirror_info.peer_add(peer_uuid, (*remote_conf).first,


### PR DESCRIPTION
Also, add a check in `peer_add` monitor interface baed on remote cluster spec and filesystem name to check an existing file system peer.

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
