### PR TITLE
mgr/dashboard: E2E Failure: should edit a pools placement group

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/pools/pools.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/pools/pools.po.ts
@@ -40,10 +40,19 @@ export class PoolPageHelper extends PageHelper {
 
     cy.get('input[name=pgNum]').clear().type(`${new_pg}`);
     cy.get('cd-submit-button').click();
-    const str = `${new_pg} active+clean`;
     this.getTableRow(name);
     if (wait) {
-      this.getTableRow(name).contains(str);
+      this.getTableRow(name)
+        .get('.datatable-body-cell')
+        .eq(4)
+        .text()
+        .should((pgStatus) => {
+          expect(
+            pgStatus
+              .split(',')
+              .reduce((acc, curr) => (acc += curr ? parseInt(curr.trim().split(' ')[0], 10) : 0), 0)
+          ).to.equal(new_pg);
+        });
     }
   }
 


### PR DESCRIPTION
This PR fixes the e2e failure for pools page while editing placement group, by relaxing the matching.

Fixes: https://tracker.ceph.com/issues/49331
Signed-off-by: Avan Thakkar <athakkar@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
