### PR TITLE
osd: clean obc locking and repop creation as a sidequest of crimson's InternalClientRequest

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -4145,7 +4145,7 @@ void PrimaryLogPG::execute_ctx(OpContext *ctx)
   // issue replica writes
   ceph_tid_t rep_tid = osd->get_tid();
 
-  RepGather *repop = new_repop(ctx, obc, rep_tid);
+  RepGather *repop = new_repop(ctx, rep_tid);
 
   issue_repop(repop, ctx);
   eval_repop(repop);
@@ -11019,7 +11019,7 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
 }
 
 PrimaryLogPG::RepGather *PrimaryLogPG::new_repop(
-  OpContext *ctx, ObjectContextRef obc,
+  OpContext *ctx,
   ceph_tid_t rep_tid)
 {
   if (ctx->op)
@@ -11097,7 +11097,7 @@ PrimaryLogPG::OpContextUPtr PrimaryLogPG::simple_opc_create(ObjectContextRef obc
 
 void PrimaryLogPG::simple_opc_submit(OpContextUPtr ctx)
 {
-  RepGather *repop = new_repop(ctx.get(), ctx->obc, ctx->reqid.tid);
+  RepGather *repop = new_repop(ctx.get(), ctx->reqid.tid);
   dout(20) << __func__ << " " << repop << dendl;
   issue_repop(repop, ctx.get());
   eval_repop(repop);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1611,6 +1611,52 @@ int PrimaryLogPG::do_scrub_ls(const MOSDOp *m, OSDOp *osd_op)
 }
 
 /**
+ * Grabs locks for OpContext, should be cleaned up in close_op_ctx
+ *
+ * @param ctx [in,out] ctx to get locks for
+ * @return true on success, false if we are queued
+ */
+bool PrimaryLogPG::get_rw_locks(bool write_ordered, OpContext *ctx)
+{
+  /* If head_obc, !obc->obs->exists and we will always take the
+   * snapdir lock *before* the head lock.  Since all callers will do
+   * this (read or write) if we get the first we will be guaranteed
+   * to get the second.
+   */
+  if (write_ordered && ctx->op->may_read()) {
+    ctx->lock_type = RWState::RWEXCL;
+  } else if (write_ordered) {
+    ctx->lock_type = RWState::RWWRITE;
+  } else {
+    ceph_assert(ctx->op->may_read());
+    ctx->lock_type = RWState::RWREAD;
+  }
+
+  if (ctx->head_obc) {
+    ceph_assert(!ctx->obc->obs.exists);
+    if (!ctx->lock_manager.get_lock_type(
+          ctx->lock_type,
+          ctx->head_obc->obs.oi.soid,
+          ctx->head_obc,
+          ctx->op)) {
+      ctx->lock_type = RWState::RWNONE;
+      return false;
+    }
+  }
+  if (ctx->lock_manager.get_lock_type(
+        ctx->lock_type,
+        ctx->obc->obs.oi.soid,
+        ctx->obc,
+        ctx->op)) {
+    return true;
+  } else {
+    ceph_assert(!ctx->head_obc);
+    ctx->lock_type = RWState::RWNONE;
+    return false;
+  }
+}
+
+/**
  * Releases locks
  *
  * @param manager [in] manager with locks to release

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -868,44 +868,7 @@ protected:
    * @param ctx [in,out] ctx to get locks for
    * @return true on success, false if we are queued
    */
-  bool get_rw_locks(bool write_ordered, OpContext *ctx) {
-    /* If head_obc, !obc->obs->exists and we will always take the
-     * snapdir lock *before* the head lock.  Since all callers will do
-     * this (read or write) if we get the first we will be guaranteed
-     * to get the second.
-     */
-    if (write_ordered && ctx->op->may_read()) {
-      ctx->lock_type = RWState::RWEXCL;
-    } else if (write_ordered) {
-      ctx->lock_type = RWState::RWWRITE;
-    } else {
-      ceph_assert(ctx->op->may_read());
-      ctx->lock_type = RWState::RWREAD;
-    }
-
-    if (ctx->head_obc) {
-      ceph_assert(!ctx->obc->obs.exists);
-      if (!ctx->lock_manager.get_lock_type(
-	    ctx->lock_type,
-	    ctx->head_obc->obs.oi.soid,
-	    ctx->head_obc,
-	    ctx->op)) {
-	ctx->lock_type = RWState::RWNONE;
-	return false;
-      }
-    }
-    if (ctx->lock_manager.get_lock_type(
-	  ctx->lock_type,
-	  ctx->obc->obs.oi.soid,
-	  ctx->obc,
-	  ctx->op)) {
-      return true;
-    } else {
-      ceph_assert(!ctx->head_obc);
-      ctx->lock_type = RWState::RWNONE;
-      return false;
-    }
-  }
+  bool get_rw_locks(bool write_ordered, OpContext *ctx);
 
   /**
    * Cleans up OpContext

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -933,7 +933,6 @@ protected:
   void issue_repop(RepGather *repop, OpContext *ctx);
   RepGather *new_repop(
     OpContext *ctx,
-    ObjectContextRef obc,
     ceph_tid_t rep_tid);
   boost::intrusive_ptr<RepGather> new_repop(
     eversion_t version,


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
