### PR TITLE
octopus: mgr/dashboard: delete EOF when reading passwords from file

### DIFF
--- a/src/pybind/mgr/dashboard/tests/test_access_control.py
+++ b/src/pybind/mgr/dashboard/tests/test_access_control.py
@@ -585,6 +585,18 @@ class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
                                       'admin@user.com')
         self.assertGreaterEqual(user['lastUpdate'], user_orig['lastUpdate'])
 
+    def test_sanitize_password(self):
+        self.test_create_user()
+        password = 'myPass\\n\\r\\n'
+        with open('/tmp/test_sanitize_password.txt', 'w+') as pwd_file:
+            # Add new line separators (like some text editors when a file is saved).
+            pwd_file.write('{}{}'.format(password, '\n\r\n\n'))
+            pwd_file.seek(0)
+            user = self.exec_cmd('ac-user-set-password', username='admin',
+                                 inbuf=pwd_file.read(), force_password=True)
+            pass_hash = password_hash(password, user['password'])
+            self.assertEqual(user['password'], pass_hash)
+
     def test_set_user_password_nonexistent_user(self):
         with self.assertRaises(CmdException) as ctx:
             self.exec_cmd('ac-user-set-password', username='admin',

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -343,8 +343,10 @@ def CLICheckNonemptyFileInput(func):
     def check(*args, **kwargs):
         if not 'inbuf' in kwargs:
             return -errno.EINVAL, '', ERROR_MSG_NO_INPUT_FILE
-        if not kwargs['inbuf'] or (isinstance(kwargs['inbuf'], str)
-                                   and not kwargs['inbuf'].strip('\n')):
+        if isinstance(kwargs['inbuf'], str):
+            # Delete new line separator at EOF (it may have been added by a text editor).
+            kwargs['inbuf'] = kwargs['inbuf'].rstrip('\r\n').rstrip('\n')
+        if not kwargs['inbuf']:
             return -errno.EINVAL, '', ERROR_MSG_EMPTY_INPUT_FILE
         return func(*args, **kwargs)
     return check


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49272

---

backport of https://github.com/ceph/ceph/pull/39362
parent tracker: https://tracker.ceph.com/issues/49216

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh