### PR TITLE
mgr/prometheus: fix typo in get_collect_time_metrics

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1132,11 +1132,11 @@ class Module(MgrModule):
         sum_metric = self.metrics.get('prometheus_collect_duration_seconds_sum')
         count_metric = self.metrics.get('prometheus_collect_duration_seconds_count')
         if sum_metric is None:
-            sum_metrics = MetricCounter(
+            sum_metric = MetricCounter(
                 'prometheus_collect_duration_seconds_sum',
                 'The sum of seconds took to collect all metrics of this exporter',
                 ('method',))
-            self.metrics['prometheus_collect_duration_seconds_sum'] = sum_metrics
+            self.metrics['prometheus_collect_duration_seconds_sum'] = sum_metric
         if count_metric is None:
             count_metric = MetricCounter(
                 'prometheus_collect_duration_seconds_count',


### PR DESCRIPTION
This causes a failure the first time through this function, but
subsequent calls succeed, making it a bit hard to notice.

Fixes: 58fd057e2c8799fa000b9937aa992e13cbbd485f

Fixes: https://tracker.ceph.com/issues/49846
Signed-off-by: Sage Weil <sage@newdream.net>