### PR TITLE
doc/RBD:fixes for ceph-immutable-object-cache daemon enable command

### DIFF
--- a/doc/rbd/rbd-persistent-read-only-cache.rst
+++ b/doc/rbd/rbd-persistent-read-only-cache.rst
@@ -128,7 +128,7 @@ command, user name, monitor caps, and OSD caps::
 The ``ceph-immutable-object-cache`` daemon can be managed by ``systemd`` by specifying the user
 ID as the daemon instance::
 
-  systemctl enable ceph-immutable-object-cache@immutable-object-cache.{unique id}
+  systemctl enable ceph-immutable-object-cache@ceph-immutable-object-cache.{unique id}
 
 The ``ceph-immutable-object-cache`` can also be run in foreground by ``ceph-immutable-object-cache`` command::
 


### PR DESCRIPTION
Document for rbd-persistent-read-only-cache shows how to manage
ceph-immutable-object-cache daemon using systemd.
command example needs fixing.It should be
systemctl enable ceph-immutable-object-cache@ceph-immutable-object-cache.{unique id}

Fixes: https://tracker.ceph.com/issues/49849
Signed-off-by: Rachanaben Patel <racpatel@redhat.com>
