### PR TITLE
common/mempool: only fail tests if sharding is very bad

### DIFF
--- a/src/include/mempool.h
+++ b/src/include/mempool.h
@@ -259,7 +259,7 @@ public:
     // Dirt cheap, see:
     //   https://fossies.org/dox/glibc-2.32/pthread__self_8c_source.html
     size_t me = (size_t)pthread_self();
-    size_t i = (me >> 12) & ((1 << num_shard_bits) - 1);
+    size_t i = (me >> CEPH_PAGE_SHIFT) & ((1 << num_shard_bits) - 1);
     return i;
   }
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/49781
Signed-off-by: singuliere <singuliere@autistici.org>

## Checklist
- [X] References tracker ticket
- [ ] Updates documentation if necessary
- [X] Includes tests for new functionality or reproducer for bug
