### PR TITLE
win32*.sh: use the right target when building the tests

### DIFF
--- a/win32_build.sh
+++ b/win32_build.sh
@@ -185,7 +185,7 @@ if [[ -z $SKIP_BUILD ]]; then
     # TODO: do we actually need the ceph compression libs?
     ninja_targets+=" compressor ceph_lz4 ceph_snappy ceph_zlib ceph_zstd"
     if [[ -z $SKIP_TESTS ]]; then
-      ninja_targets+=" test ceph_radosacl ceph_scratchtool"
+      ninja_targets+=" tests ceph_radosacl ceph_scratchtool"
     fi
 
     ninja -v $ninja_targets 2>&1 | tee "${BUILD_DIR}/build.log"


### PR DESCRIPTION
win32*.sh: use the right target when building the tests

We switched from make to ninja but we're using the wrong target
when building the tests.

"ninja test" tries to actually run the tests. We'll have to use
"ninja tests" when targeting Windows.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>