### PR TITLE
mgr/dashboard: Warn the user when creating/editing pools without application tags

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -184,9 +184,13 @@
                               [selectionLimit]="4"
                               (selection)="appSelection()">
             </cd-select-badges>
+            <i *ngIf="data.applications.selected <= 0"
+               i18n-title
+               title="Pools should be associated with an application tag"
+               class="{{icons.warning}} icon-warning-color">
+            </i>
           </div>
         </div>
-
         <!-- CRUSH -->
         <div *ngIf="isErasure || isReplicated">
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.scss
@@ -1,0 +1,3 @@
+.icon-warning-color {
+  margin-left: 3px;
+}


### PR DESCRIPTION
Signed-off-by: Waad Alkhoury <walkhour@redhat.com>


This PR to warn the users who are willing to create/edit a pool that they might rush into errors if they don't select a tag in the pool applications tags section.

A warning icon next to the application tag section will show up if there is no tag selected that can be easily noticed and recommend user to select a tag on hover.

The following image will show how the icon looks like:

![WarningIcon-1](https://user-images.githubusercontent.com/56444536/111443852-1532b700-870a-11eb-849e-f3802812716a.png)

![WarningIcon-2](https://user-images.githubusercontent.com/56444536/111443863-195ed480-870a-11eb-9b7e-051b27918dd4.png)

Hovering over the icon

Fixes: https://tracker.ceph.com/issues/40676
Signed-off-by: Waad Alkhoury walkhour@redhat.com

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
