### PR TITLE
qa: krbd_blkroset.t: update for separate hw and user read-only flags

### DIFF
--- a/qa/rbd/krbd_blkroset.t
+++ b/qa/rbd/krbd_blkroset.t
@@ -146,9 +146,7 @@ R/O, unpartitioned:
   $ blockdev --setrw $DEV
   .*BLKROSET: Permission denied (re)
   [1]
-  $ sudo blockdev --setrw $DEV
-  .*BLKROSET: Read-only file system (re)
-  [1]
+  $ sudo blockdev --setrw $DEV  # succeeds but effectively ignored
   $ blockdev --getro $DEV
   1
   $ dd if=/dev/urandom of=$DEV bs=1k seek=1 count=1 status=none
@@ -182,15 +180,11 @@ R/O, partitioned:
   $ blockdev --setrw ${DEV}p1
   .*BLKROSET: Permission denied (re)
   [1]
-  $ sudo blockdev --setrw ${DEV}p1
-  .*BLKROSET: Read-only file system (re)
-  [1]
+  $ sudo blockdev --setrw ${DEV}p1  # succeeds but effectively ignored
   $ blockdev --setrw ${DEV}p2
   .*BLKROSET: Permission denied (re)
   [1]
-  $ sudo blockdev --setrw ${DEV}p2
-  .*BLKROSET: Read-only file system (re)
-  [1]
+  $ sudo blockdev --setrw ${DEV}p2  # succeeds but effectively ignored
   $ blockdev --getro ${DEV}p1
   1
   $ blockdev --getro ${DEV}p2
@@ -227,9 +221,7 @@ Unpartitioned:
   $ blockdev --setrw $DEV
   .*BLKROSET: Permission denied (re)
   [1]
-  $ sudo blockdev --setrw $DEV
-  .*BLKROSET: Read-only file system (re)
-  [1]
+  $ sudo blockdev --setrw $DEV  # succeeds but effectively ignored
   $ blockdev --getro $DEV
   1
   $ dd if=/dev/urandom of=$DEV bs=1k seek=1 count=1 status=none
@@ -263,15 +255,11 @@ Partitioned:
   $ blockdev --setrw ${DEV}p1
   .*BLKROSET: Permission denied (re)
   [1]
-  $ sudo blockdev --setrw ${DEV}p1
-  .*BLKROSET: Read-only file system (re)
-  [1]
+  $ sudo blockdev --setrw ${DEV}p1  # succeeds but effectively ignored
   $ blockdev --setrw ${DEV}p2
   .*BLKROSET: Permission denied (re)
   [1]
-  $ sudo blockdev --setrw ${DEV}p2
-  .*BLKROSET: Read-only file system (re)
-  [1]
+  $ sudo blockdev --setrw ${DEV}p2  # succeeds but effectively ignored
   $ blockdev --getro ${DEV}p1
   1
   $ blockdev --getro ${DEV}p2


### PR DESCRIPTION
Since kernel 5.12, hardware read-only state and user read-only
policy (BLKROGET/SET ioctls) are tracked separately in the block
layer.  As the purpose of our ->set_read_only() method was exactly
that, it was removed.

As a side effect, BLKROSET no longer returns EROFS on an attempt
to make a read-only mapping read-write with "blockdev --setrw".
The policy gets updated, but the device remains read-only as before
because the hardware (== mapping) state is controlled by the driver.

Fixes: https://tracker.ceph.com/issues/49858
Signed-off-by: Ilya Dryomov <idryomov@gmail.com>