### PR TITLE
cmake: do not pass -fpermissive when compiling C code

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,7 +64,7 @@ endif()
 if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
   if(MINGW)
     # The MINGW headers are missing some "const" qualifiers.
-    add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-fpermissive>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fpermissive>)
   else()
     string(APPEND CMAKE_EXE_LINKER_FLAGS " -rdynamic")
   endif()


### PR DESCRIPTION
silences warnings like

[2/768] /usr/bin/x86_64-w64-mingw32-gcc-posix -DBOOST_ASIO_DISABLE_THREAD_KEYWORD_EXTENSION -DHAVE_CONFIG_H -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2 -D_POSIX=1 -D_POSIX_=1 -D_POSIX_C_SOURCE=1
-D_POSIX_THREADS=1 -D_REENTRANT -D_THREAD_SAFE -D_WIN32_WINNT=0x0A00 -D__CEPH__ -D__STDC_FORMAT_MACROS -Isrc/include -I../src -I../src/include/win32 -isystem ../build.deps/mingw/boost/include -isystem
include -isystem ../src/xxHash -isystem ../src/rapidjson/include -isystem ../src/fmt/include -O3 -DNDEBUG   -include winsock_wrapper.h -include win32_errno.h -U_FORTIFY_SOURCE -Wall
-fno-strict-aliasing -fsigned-char -Wtype-limits -Wignored-qualifiers -Wpointer-arith -Werror=format-security -Winit-self -Wno-unknown-pragmas -fpermissive -fdiagnostics-color=auto -std=gnu99 -MD -MT
src/CMakeFiles/common-objs.dir/xxHash/xxhash.c.obj -MF src/CMakeFiles/common-objs.dir/xxHash/xxhash.c.obj.d -o src/CMakeFiles/common-objs.dir/xxHash/xxhash.c.obj   -c ../src/xxHash/xxhash.c
cc1: warning: command line option '-fpermissive' is valid for C++/ObjC++ but not for C

see also
https://gcc.gnu.org/onlinedocs/gcc-4.0.4/gcc/C_002b_002b-Dialect-Options.html

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
