### PR TITLE
[RFC] [DNM] [WIP] os/bluestore: yet another fix for onode's pinning

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1063,7 +1063,7 @@ public:
   struct Onode {
     MEMPOOL_CLASS_HELPERS();
 
-    std::atomic_int nref;  ///< reference count
+    std::atomic<uint32_t> nref;  ///< reference count
     Collection *c;
     ghobject_t oid;
 
@@ -1077,7 +1077,6 @@ public:
     bool cached;              ///< Onode is logically in the cache
                               /// (it can be pinned and hence physically out
                               /// of it at the moment though)
-    std::atomic_bool pinned;  ///< Onode is pinned
                               /// (or should be pinned when cached)
     ExtentMap extent_map;
 
@@ -1097,7 +1096,6 @@ public:
 	key(k),
 	exists(false),
         cached(false),
-        pinned(false),
 	extent_map(this) {
     }
     Onode(Collection* c, const ghobject_t& o,
@@ -1108,7 +1106,6 @@ public:
       key(k),
       exists(false),
       cached(false),
-      pinned(false),
       extent_map(this) {
     }
     Onode(Collection* c, const ghobject_t& o,
@@ -1119,7 +1116,6 @@ public:
       key(k),
       exists(false),
       cached(false),
-      pinned(false),
       extent_map(this) {
     }
 
@@ -1135,15 +1131,18 @@ public:
     void get();
     void put();
 
+    inline bool pinned() const {
+      return !!(nref & 0x80000000);
+    }
     inline bool put_cache() {
       ceph_assert(!cached);
       cached = true;
-      return !pinned;
+      return !pinned();
     }
     inline bool pop_cache() {
       ceph_assert(cached);
       cached = false;
-      return !pinned;
+      return !pinned();
     }
 
     const std::string& get_omap_prefix();


### PR DESCRIPTION
Actually this PR is a proposal for discussion. This implements Onode's put/get in a way I presume they should look like,
General overview is as follows:
Aside from regular reference counting put/get methods implement
Onode pinning via using nref's high bit to mark onode being pinned.
The mismatch between this bit state and reference counting means pinning/unpinning is in progress.

Besides these methods are obliged to meet the following requirements:
1. get/put op shouldn't proceed before previous pinning/unpinning op is in progress. Achieved via using atomic's compare_exchange_* methods.
2. onode removal shouldn't occur while unpinning is still in progress (special case of 1.?)
3. avoid lock acquisition if pin/unpin isn't required. Not sure that removing the requirement would
  make life easier.

This still has a deadlock issue caused by a messy use of OnodeCacheShard's lock.
Onode's get/put might be called  both under th lock and out of it.
Consider OnodeSpace::add() vs. ~TransContext 

Which in turn indicates more general issue - we can't use cache shard's lock inside put/get methods without an outside refactoring. Presumably we should split OnodeSpace and OnodeCacheShard locking. And enforce(prohibit) no onode refcount increment under OnodeCacheShard lock. 
The latter doesn't look simple enough though since OnodeSpace and OnodeCacheShard are are pretty tied and call each other. Well, perhaps updating LruOnodeCacheShard::_trim_to would be enough to untie them but still not sure I'm comfortable with the approach.

Another question is whether we need all these pinning stuff? IIUC the intention of pinning is just to be able to bypass pinned (nref>1) onodes during cache trimming.
Wouldn't this approach similar to https://github.com/ceph/ceph/pull/39720 be enough?
I.e. bypass pinned entries during the trim and track some hint to avoid their enumeration on each call?


Signed-off-by: Igor Fedotov <ifedotov@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
