### PR TITLE
osd: remove a ceph_assert() from a legitimate path

### DIFF
--- a/src/osd/pg_scrubber.cc
+++ b/src/osd/pg_scrubber.cc
@@ -807,7 +807,6 @@ void PgScrubber::on_init()
 
 void PgScrubber::on_replica_init()
 {
-  ceph_assert(!m_active);
   m_active = true;
 }
 


### PR DESCRIPTION
on_replica_init() might be legitimately called twice,
if the replica was waiting for updates to complete
before servicing the request.

Fixes: https://tracker.ceph.com/issues/49867
