### PR TITLE
cmake: moved pmdk to submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -81,3 +81,6 @@
 	path = src/libkmip
 	url = https://github.com/ceph/libkmip
 	branch = ceph-master
+[submodule "src/pmdk"]
+	path = src/pmdk
+	url = https://github.com/ceph/pmdk.git

--- a/cmake/modules/Buildpmem.cmake
+++ b/cmake/modules/Buildpmem.cmake
@@ -3,23 +3,13 @@ function(build_pmem)
   set(PMDK_SRC "${CMAKE_BINARY_DIR}/src/pmdk/src")
   set(PMDK_INCLUDE "${PMDK_SRC}/include")
 
-  # Use debug PMDK libs in debug lib/rbd builds
-  if(CMAKE_BUILD_TYPE STREQUAL Debug)
-    set(PMDK_LIB_DIR "debug")
-  else()
-    set(PMDK_LIB_DIR "nondebug")
-  endif()
-  set(PMDK_LIB "${PMDK_SRC}/${PMDK_LIB_DIR}")
+  set(PMDK_LIB "${PMDK_SRC}/lib")
 
   include(FindMake)
   find_make("MAKE_EXECUTABLE" "make_cmd")
 
   ExternalProject_Add(pmdk_ext
-      GIT_REPOSITORY "https://github.com/ceph/pmdk.git"
-      GIT_TAG "1.7"
-      GIT_SHALLOW TRUE
-      GIT_CONFIG advice.detachedHead=false
-      SOURCE_DIR ${CMAKE_BINARY_DIR}/src/pmdk
+      SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/pmdk
       CONFIGURE_COMMAND ""
       # Explicitly built w/o NDCTL, otherwise if ndtcl is present on the
       # build system tests statically linking to librbd (which uses
@@ -28,7 +18,7 @@ function(build_pmem)
       BUILD_COMMAND ${make_cmd} CC=${CMAKE_C_COMPILER} NDCTL_ENABLE=n
       BUILD_IN_SOURCE 1
       BUILD_BYPRODUCTS "${PMDK_LIB}/libpmem.a" "${PMDK_LIB}/libpmemobj.a"
-      INSTALL_COMMAND "")
+      INSTALL_COMMAND ${make_cmd} install prefix= LIB_PREFIX=lib DESTDIR=${PMDK_SRC} NDCTL_ENABLE=n)
 
   # libpmem
   add_library(pmem::pmem STATIC IMPORTED)


### PR DESCRIPTION
This should address builder issues where internet connectivity
is not available.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
