### PR TITLE
RGW Zipper - The Great Rename

### DIFF
--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -542,7 +542,7 @@ namespace rgw {
       g_conf()->rgw_nfs_run_sync_thread;
 
     const DoutPrefix dp(cct.get(), dout_subsys, "librgw: ");
-    store = RGWStoreManager::get_storage(&dp, g_ceph_context,
+    store = StoreManager::get_storage(&dp, g_ceph_context,
 					 "rados",
 					 run_gc,
 					 run_lc,
@@ -656,7 +656,7 @@ namespace rgw {
 
     delete olog;
 
-    RGWStoreManager::close_storage(store);
+    StoreManager::close_storage(store);
 
     rgw_tools_cleanup();
     rgw_shutdown_resolver();
@@ -677,10 +677,10 @@ namespace rgw {
     return 0;
   } /* RGWLib::stop() */
 
-  int RGWLibIO::set_uid(rgw::sal::RGWStore *store, const rgw_user& uid)
+  int RGWLibIO::set_uid(rgw::sal::Store *store, const rgw_user& uid)
   {
     const DoutPrefix dp(store->ctx(), dout_subsys, "librgw: ");
-    std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(uid);
+    std::unique_ptr<rgw::sal::User> user = store->get_user(uid);
     /* object exists, but policy is broken */
     int ret = user->load_by_id(&dp, null_yield);
     if (ret < 0) {

--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -677,7 +677,7 @@ namespace rgw {
     return 0;
   } /* RGWLib::stop() */
 
-  int RGWLibIO::set_uid(rgw::sal::Store *store, const rgw_user& uid)
+  int RGWLibIO::set_uid(rgw::sal::Store* store, const rgw_user& uid)
   {
     const DoutPrefix dp(store->ctx(), dout_subsys, "librgw: ");
     std::unique_ptr<rgw::sal::User> user = store->get_user(uid);

--- a/src/rgw/rgw_acl_s3.cc
+++ b/src/rgw/rgw_acl_s3.cc
@@ -291,7 +291,7 @@ static const char *get_acl_header(const RGWEnv *env,
   return env->get(header, NULL);
 }
 
-static int parse_grantee_str(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* store, string& grantee_str,
+static int parse_grantee_str(const DoutPrefixProvider *dpp, rgw::sal::Store* store, string& grantee_str,
         const struct s3_acl_header *perm, ACLGrant& grant)
 {
   string id_type, id_val_quoted;
@@ -305,14 +305,14 @@ static int parse_grantee_str(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* 
   string id_val = rgw_trim_quotes(id_val_quoted);
 
   if (strcasecmp(id_type.c_str(), "emailAddress") == 0) {
-    std::unique_ptr<rgw::sal::RGWUser> user;
+    std::unique_ptr<rgw::sal::User> user;
     ret = store->get_user_by_email(dpp, id_val, null_yield, &user);
     if (ret < 0)
       return ret;
 
     grant.set_canon(user->get_id(), user->get_display_name(), rgw_perm);
   } else if (strcasecmp(id_type.c_str(), "id") == 0) {
-    std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(rgw_user(id_val));
+    std::unique_ptr<rgw::sal::User> user = store->get_user(rgw_user(id_val));
     ret = user->load_by_id(dpp, null_yield);
     if (ret < 0)
       return ret;
@@ -331,7 +331,7 @@ static int parse_grantee_str(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* 
   return 0;
 }
 
-static int parse_acl_header(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* store,
+static int parse_acl_header(const DoutPrefixProvider *dpp, rgw::sal::Store* store,
 			    const RGWEnv *env, const struct s3_acl_header *perm,
 			    std::list<ACLGrant>& _grants)
 {
@@ -453,7 +453,7 @@ static const s3_acl_header acl_header_perms[] = {
 };
 
 int RGWAccessControlPolicy_S3::create_from_headers(const DoutPrefixProvider *dpp,
-						   rgw::sal::RGWStore* store,
+						   rgw::sal::Store* store,
 						   const RGWEnv *env, ACLOwner& _owner)
 {
   std::list<ACLGrant> grants;
@@ -478,7 +478,7 @@ int RGWAccessControlPolicy_S3::create_from_headers(const DoutPrefixProvider *dpp
   can only be called on object that was parsed
  */
 int RGWAccessControlPolicy_S3::rebuild(const DoutPrefixProvider *dpp,
-				       rgw::sal::RGWStore* store, ACLOwner *owner,
+				       rgw::sal::Store* store, ACLOwner *owner,
 				       RGWAccessControlPolicy& dest, std::string &err_msg)
 {
   if (!owner)
@@ -491,7 +491,7 @@ int RGWAccessControlPolicy_S3::rebuild(const DoutPrefixProvider *dpp,
       return -EPERM;
   }
 
-  std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(owner->get_id());
+  std::unique_ptr<rgw::sal::User> user = store->get_user(owner->get_id());
   if (user->load_by_id(dpp, null_yield) < 0) {
     ldout(cct, 10) << "owner info does not exist" << dendl;
     err_msg = "Invalid id";

--- a/src/rgw/rgw_acl_s3.h
+++ b/src/rgw/rgw_acl_s3.h
@@ -14,7 +14,7 @@
 #include "rgw_acl.h"
 
 class RGWUserCtl;
-namespace rgw { namespace sal { class RGWStore; } }
+namespace rgw { namespace sal { class Store; } }
 
 class ACLPermission_S3 : public ACLPermission, public XMLObj
 {
@@ -84,7 +84,7 @@ public:
   bool xml_end(const char *el) override;
 
   void to_xml(ostream& out);
-  int rebuild(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* store, ACLOwner *owner,
+  int rebuild(const DoutPrefixProvider *dpp, rgw::sal::Store* store, ACLOwner *owner,
 	      RGWAccessControlPolicy& dest, std::string &err_msg);
   bool compare_group_name(string& id, ACLGroupTypeEnum group) override;
 
@@ -98,7 +98,7 @@ public:
     int ret = _acl.create_canned(owner, bucket_owner, canned_acl);
     return ret;
   }
-  int create_from_headers(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* store,
+  int create_from_headers(const DoutPrefixProvider *dpp, rgw::sal::Store* store,
 			  const RGWEnv *env, ACLOwner& _owner);
 };
 

--- a/src/rgw/rgw_acl_swift.cc
+++ b/src/rgw/rgw_acl_swift.cc
@@ -114,13 +114,13 @@ static boost::optional<ACLGrant> referrer_to_grant(std::string url_spec,
 
 static ACLGrant user_to_grant(const DoutPrefixProvider *dpp,
 			      CephContext* const cct,
-                              rgw::sal::RGWStore* store,
+                              rgw::sal::Store* store,
                               const std::string& uid,
                               const uint32_t perm)
 {
   RGWUserInfo grant_user;
   ACLGrant grant;
-  std::unique_ptr<rgw::sal::RGWUser> user;
+  std::unique_ptr<rgw::sal::User> user;
 
   user = store->get_user(rgw_user(uid));
   if (user->load_by_id(dpp, null_yield) < 0) {
@@ -135,7 +135,7 @@ static ACLGrant user_to_grant(const DoutPrefixProvider *dpp,
 }
 
 int RGWAccessControlPolicy_SWIFT::add_grants(const DoutPrefixProvider *dpp,
-					     rgw::sal::RGWStore* store,
+					     rgw::sal::Store* store,
                                              const std::vector<std::string>& uids,
                                              const uint32_t perm)
 {
@@ -178,7 +178,7 @@ int RGWAccessControlPolicy_SWIFT::add_grants(const DoutPrefixProvider *dpp,
 
 
 int RGWAccessControlPolicy_SWIFT::create(const DoutPrefixProvider *dpp,
-					 rgw::sal::RGWStore* store,
+					 rgw::sal::Store* store,
                                          const rgw_user& id,
                                          const std::string& name,
                                          const char* read_list,
@@ -303,7 +303,7 @@ void RGWAccessControlPolicy_SWIFT::to_str(string& read, string& write)
 }
 
 void RGWAccessControlPolicy_SWIFTAcct::add_grants(const DoutPrefixProvider *dpp,
-						  rgw::sal::RGWStore* store,
+						  rgw::sal::Store* store,
                                                   const std::vector<std::string>& uids,
                                                   const uint32_t perm)
 {
@@ -314,7 +314,7 @@ void RGWAccessControlPolicy_SWIFTAcct::add_grants(const DoutPrefixProvider *dpp,
       grant.set_group(ACL_GROUP_ALL_USERS, perm);
       acl.add_grant(&grant);
     } else  {
-      std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(rgw_user(uid));
+      std::unique_ptr<rgw::sal::User> user = store->get_user(rgw_user(uid));
 
       if (user->load_by_id(dpp, null_yield) < 0) {
         ldout(cct, 10) << "grant user does not exist:" << uid << dendl;
@@ -330,7 +330,7 @@ void RGWAccessControlPolicy_SWIFTAcct::add_grants(const DoutPrefixProvider *dpp,
 }
 
 bool RGWAccessControlPolicy_SWIFTAcct::create(const DoutPrefixProvider *dpp,
-					      rgw::sal::RGWStore* store,
+					      rgw::sal::Store* store,
                                               const rgw_user& id,
                                               const std::string& name,
                                               const std::string& acl_str)

--- a/src/rgw/rgw_acl_swift.h
+++ b/src/rgw/rgw_acl_swift.h
@@ -17,7 +17,7 @@ class RGWUserCtl;
 
 class RGWAccessControlPolicy_SWIFT : public RGWAccessControlPolicy
 {
-  int add_grants(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* store,
+  int add_grants(const DoutPrefixProvider *dpp, rgw::sal::Store* store,
                  const std::vector<std::string>& uids,
                  uint32_t perm);
 
@@ -28,7 +28,7 @@ public:
   ~RGWAccessControlPolicy_SWIFT() override = default;
 
   int create(const DoutPrefixProvider *dpp,
-	     rgw::sal::RGWStore* store,
+	     rgw::sal::Store* store,
              const rgw_user& id,
              const std::string& name,
              const char* read_list,
@@ -47,11 +47,11 @@ public:
   ~RGWAccessControlPolicy_SWIFTAcct() override {}
 
   void add_grants(const DoutPrefixProvider *dpp,
-		  rgw::sal::RGWStore* store,
+		  rgw::sal::Store* store,
                   const std::vector<std::string>& uids,
                   uint32_t perm);
   bool create(const DoutPrefixProvider *dpp,
-	      rgw::sal::RGWStore* store,
+	      rgw::sal::Store* store,
               const rgw_user& id,
               const std::string& name,
               const std::string& acl_str);

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -74,7 +74,7 @@ extern "C" {
 #define SECRET_KEY_LEN 40
 #define PUBLIC_ID_LEN 20
 
-static rgw::sal::Store *store = NULL;
+static rgw::sal::Store* store = NULL;
 
 static const DoutPrefixProvider* dpp() {
   struct GlobalPrefix : public DoutPrefixProvider {
@@ -1121,9 +1121,9 @@ static void show_reshard_status(
 }
 
 class StoreDestructor {
-  rgw::sal::Store *store;
+  rgw::sal::Store* store;
 public:
-  explicit StoreDestructor(rgw::sal::RadosStore *_s) : store(_s) {}
+  explicit StoreDestructor(rgw::sal::RadosStore* _s) : store(_s) {}
   ~StoreDestructor() {
     StoreManager::close_storage(store);
     rgw_http_client_cleanup();
@@ -1297,7 +1297,7 @@ void set_quota_info(RGWQuotaInfo& quota, OPT opt_cmd, int64_t max_size, int64_t 
   }
 }
 
-int set_bucket_quota(rgw::sal::Store *store, OPT opt_cmd,
+int set_bucket_quota(rgw::sal::Store* store, OPT opt_cmd,
                      const string& tenant_name, const string& bucket_name,
                      int64_t max_size, int64_t max_objects,
                      bool have_max_size, bool have_max_objects)
@@ -1355,7 +1355,7 @@ int set_user_quota(OPT opt_cmd, RGWUser& user, RGWUserAdminOpState& op_state, in
   return 0;
 }
 
-int check_min_obj_stripe_size(rgw::sal::Store *store, rgw::sal::Object* obj, uint64_t min_stripe_size, bool *need_rewrite)
+int check_min_obj_stripe_size(rgw::sal::Store* store, rgw::sal::Object* obj, uint64_t min_stripe_size, bool *need_rewrite)
 {
   RGWObjectCtx obj_ctx(store);
   int ret = obj->get_obj_attrs(&obj_ctx, null_yield, dpp());
@@ -1542,7 +1542,7 @@ int do_check_object_locator(const string& tenant_name, const string& bucket_name
 }
 
 /// search for a matching zone/zonegroup id and return a connection if found
-static boost::optional<RGWRESTConn> get_remote_conn(rgw::sal::RadosStore *store,
+static boost::optional<RGWRESTConn> get_remote_conn(rgw::sal::RadosStore* store,
                                                     const RGWZoneGroup& zonegroup,
                                                     const std::string& remote)
 {
@@ -1562,7 +1562,7 @@ static boost::optional<RGWRESTConn> get_remote_conn(rgw::sal::RadosStore *store,
 }
 
 /// search each zonegroup for a connection
-static boost::optional<RGWRESTConn> get_remote_conn(rgw::sal::RadosStore *store,
+static boost::optional<RGWRESTConn> get_remote_conn(rgw::sal::RadosStore* store,
                                                     const RGWPeriodMap& period_map,
                                                     const std::string& remote)
 {
@@ -2246,7 +2246,7 @@ std::ostream& operator<<(std::ostream& out, const indented& h) {
   return out << std::setw(h.w) << h.header << std::setw(1) << ' ';
 }
 
-static int bucket_source_sync_status(rgw::sal::RadosStore *store, const RGWZone& zone,
+static int bucket_source_sync_status(rgw::sal::RadosStore* store, const RGWZone& zone,
                                      const RGWZone& source, RGWRESTConn *conn,
                                      const RGWBucketInfo& bucket_info,
                                      rgw_sync_bucket_pipe pipe,
@@ -2505,7 +2505,7 @@ static int sync_info(std::optional<rgw_zone_id> opt_target_zone, std::optional<r
   return 0;
 }
 
-static int bucket_sync_info(rgw::sal::RadosStore *store, const RGWBucketInfo& info,
+static int bucket_sync_info(rgw::sal::RadosStore* store, const RGWBucketInfo& info,
                               std::ostream& out)
 {
   const RGWRealm& realm = store->get_zone()->get_realm();
@@ -2544,7 +2544,7 @@ static int bucket_sync_info(rgw::sal::RadosStore *store, const RGWBucketInfo& in
   return 0;
 }
 
-static int bucket_sync_status(rgw::sal::RadosStore *store, const RGWBucketInfo& info,
+static int bucket_sync_status(rgw::sal::RadosStore* store, const RGWBucketInfo& info,
                               const rgw_zone_id& source_zone_id,
 			      std::optional<rgw_bucket>& opt_source_bucket,
                               std::ostream& out)
@@ -2676,7 +2676,7 @@ static int check_pool_support_omap(const rgw_pool& pool)
   return 0;
 }
 
-int check_reshard_bucket_params(rgw::sal::RadosStore *store,
+int check_reshard_bucket_params(rgw::sal::RadosStore* store,
 				const string& bucket_name,
 				const string& tenant,
 				const string& bucket_id,
@@ -2796,7 +2796,7 @@ static int trim_sync_error_log(int shard_id, const string& marker, int delay_ms)
   // unreachable
 }
 
-const string& get_tier_type(rgw::sal::RadosStore *store) {
+const string& get_tier_type(rgw::sal::RadosStore* store) {
   return store->svc()->zone->get_zone().tier_type;
 }
 

--- a/src/rgw/rgw_admin_user.h
+++ b/src/rgw/rgw_admin_user.h
@@ -26,11 +26,11 @@ namespace rgw {
 
   class RGWLibAdmin
   {
-    rgw::sal::RGWStore *store;
+    rgw::sal::Store *store;
     boost::intrusive_ptr<CephContext> cct;
 
   public:
-    rgw::sal::RGWStore* get_store()
+    rgw::sal::Store* get_store()
     {
       return store;
     }

--- a/src/rgw/rgw_admin_user.h
+++ b/src/rgw/rgw_admin_user.h
@@ -26,7 +26,7 @@ namespace rgw {
 
   class RGWLibAdmin
   {
-    rgw::sal::Store *store;
+    rgw::sal::Store* store;
     boost::intrusive_ptr<CephContext> cct;
 
   public:

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -417,7 +417,7 @@ class AsioFrontend {
   void stop();
   void join();
   void pause();
-  void unpause(rgw::sal::RGWStore* store, rgw_auth_registry_ptr_t);
+  void unpause(rgw::sal::Store* store, rgw_auth_registry_ptr_t);
 };
 
 unsigned short parse_port(const char *input, boost::system::error_code& ec)
@@ -1015,7 +1015,7 @@ void AsioFrontend::pause()
   }
 }
 
-void AsioFrontend::unpause(rgw::sal::RGWStore* const store,
+void AsioFrontend::unpause(rgw::sal::Store* const store,
                            rgw_auth_registry_ptr_t auth_registry)
 {
   env.store = store;
@@ -1079,7 +1079,7 @@ void RGWAsioFrontend::pause_for_new_config()
 }
 
 void RGWAsioFrontend::unpause_with_new_config(
-  rgw::sal::RGWStore* const store,
+  rgw::sal::Store* const store,
   rgw_auth_registry_ptr_t auth_registry
 ) {
   impl->unpause(store, std::move(auth_registry));

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -631,7 +631,7 @@ class ExpandMetaVar {
   map<string, string> meta_map;
 
 public:
-  ExpandMetaVar(rgw::sal::Zone *zone_svc) {
+  ExpandMetaVar(rgw::sal::Zone* zone_svc) {
     meta_map["realm"] = zone_svc->get_realm().get_name();
     meta_map["realm_id"] = zone_svc->get_realm().get_id();
     meta_map["zonegroup"] = zone_svc->get_zonegroup().get_name();

--- a/src/rgw/rgw_asio_frontend.h
+++ b/src/rgw/rgw_asio_frontend.h
@@ -22,7 +22,7 @@ public:
   void join() override;
 
   void pause_for_new_config() override;
-  void unpause_with_new_config(rgw::sal::Store *store,
+  void unpause_with_new_config(rgw::sal::Store* store,
                                rgw_auth_registry_ptr_t auth_registry) override;
 };
 

--- a/src/rgw/rgw_asio_frontend.h
+++ b/src/rgw/rgw_asio_frontend.h
@@ -22,7 +22,7 @@ public:
   void join() override;
 
   void pause_for_new_config() override;
-  void unpause_with_new_config(rgw::sal::RGWStore *store,
+  void unpause_with_new_config(rgw::sal::Store *store,
                                rgw_auth_registry_ptr_t auth_registry) override;
 };
 

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -368,7 +368,7 @@ void rgw::auth::WebIdentityApplier::create_account(const DoutPrefixProvider* dpp
                                               const string& display_name,
                                               RGWUserInfo& user_info) const      /* out */
 {
-  std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(acct_user);
+  std::unique_ptr<rgw::sal::User> user = store->get_user(acct_user);
   user->get_info().display_name = display_name;
   user->get_info().type = TYPE_WEB;
   user->get_info().max_buckets =
@@ -392,7 +392,7 @@ void rgw::auth::WebIdentityApplier::load_acct_info(const DoutPrefixProvider* dpp
   federated_user.tenant = role_tenant;
   federated_user.ns = "oidc";
 
-  std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(federated_user);
+  std::unique_ptr<rgw::sal::User> user = store->get_user(federated_user);
 
   //Check in oidc namespace
   if (user->load_by_id(dpp, null_yield) >= 0) {
@@ -591,7 +591,7 @@ void rgw::auth::RemoteApplier::create_account(const DoutPrefixProvider* dpp,
     new_acct_user.tenant = new_acct_user.id;
   }
 
-  std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(new_acct_user);
+  std::unique_ptr<rgw::sal::User> user = store->get_user(new_acct_user);
   user->get_info().display_name = info.acct_name;
   if (info.acct_type) {
     //ldap/keystone for s3 users
@@ -622,7 +622,7 @@ void rgw::auth::RemoteApplier::load_acct_info(const DoutPrefixProvider* dpp, RGW
   auto implicit_value = implicit_tenant_context.get_value();
   bool implicit_tenant = implicit_value.implicit_tenants_for_(implicit_tenant_bit);
   bool split_mode = implicit_value.is_split_mode();
-  std::unique_ptr<rgw::sal::RGWUser> user;
+  std::unique_ptr<rgw::sal::User> user;
 
   /* Normally, empty "tenant" field of acct_user means the authenticated
    * identity has the legacy, global tenant. However, due to inclusion

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -366,7 +366,7 @@ class StrategyRegistry;
 class WebIdentityApplier : public IdentityApplier {
 protected:
   CephContext* const cct;
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
   string role_session;
   string role_tenant;
   rgw::web_idp::WebTokenClaims token_claims;
@@ -379,7 +379,7 @@ protected:
                       RGWUserInfo& user_info) const;     /* out */
 public:
   WebIdentityApplier( CephContext* const cct,
-                      rgw::sal::RGWStore* store,
+                      rgw::sal::Store* store,
                       const string& role_session,
                       const string& role_tenant,
                       const rgw::web_idp::WebTokenClaims& token_claims)
@@ -521,7 +521,7 @@ protected:
   CephContext* const cct;
 
   /* Read-write is intensional here due to RGWUserInfo creation process. */
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
 
   /* Supplemental strategy for extracting permissions from ACLs. Its results
    * will be combined (ORed) with a default strategy that is responsible for
@@ -539,7 +539,7 @@ protected:
 
 public:
   RemoteApplier(CephContext* const cct,
-                rgw::sal::RGWStore* store,
+                rgw::sal::Store* store,
                 acl_strategy_t&& extra_acl_strategy,
                 const AuthInfo& info,
 		rgw::auth::ImplicitTenants& implicit_tenant_context,

--- a/src/rgw/rgw_auth_filters.h
+++ b/src/rgw/rgw_auth_filters.h
@@ -123,7 +123,7 @@ public:
 
 template <typename T>
 class ThirdPartyAccountApplier : public DecoratedApplier<T> {
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
   const rgw_user acct_user_override;
 
 public:
@@ -133,7 +133,7 @@ public:
   static const rgw_user UNKNOWN_ACCT;
 
   template <typename U>
-  ThirdPartyAccountApplier(rgw::sal::RGWStore* store,
+  ThirdPartyAccountApplier(rgw::sal::Store* store,
                            const rgw_user &acct_user_override,
                            U&& decoratee)
     : DecoratedApplier<T>(std::move(decoratee)),
@@ -179,7 +179,7 @@ void ThirdPartyAccountApplier<T>::load_acct_info(const DoutPrefixProvider* dpp, 
   } else {
     /* Compatibility mechanism for multi-tenancy. For more details refer to
      * load_acct_info method of rgw::auth::RemoteApplier. */
-    std::unique_ptr<rgw::sal::RGWUser> user;
+    std::unique_ptr<rgw::sal::User> user;
 
     if (acct_user_override.tenant.empty()) {
       const rgw_user tenanted_uid(acct_user_override.id, acct_user_override.id);
@@ -208,7 +208,7 @@ void ThirdPartyAccountApplier<T>::load_acct_info(const DoutPrefixProvider* dpp, 
 }
 
 template <typename T> static inline
-ThirdPartyAccountApplier<T> add_3rdparty(rgw::sal::RGWStore* store,
+ThirdPartyAccountApplier<T> add_3rdparty(rgw::sal::Store* store,
                                          const rgw_user &acct_user_override,
                                          T&& t) {
   return ThirdPartyAccountApplier<T>(store, acct_user_override,
@@ -219,14 +219,14 @@ ThirdPartyAccountApplier<T> add_3rdparty(rgw::sal::RGWStore* store,
 template <typename T>
 class SysReqApplier : public DecoratedApplier<T> {
   CephContext* const cct;
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
   const RGWHTTPArgs& args;
   mutable boost::tribool is_system;
 
 public:
   template <typename U>
   SysReqApplier(CephContext* const cct,
-		rgw::sal::RGWStore* store,
+		rgw::sal::Store* store,
                 const req_state* const s,
                 U&& decoratee)
     : DecoratedApplier<T>(std::forward<T>(decoratee)),
@@ -262,7 +262,7 @@ void SysReqApplier<T>::load_acct_info(const DoutPrefixProvider* dpp, RGWUserInfo
       /* We aren't writing directly to user_info for consistency and security
        * reasons. rgw_get_user_info_by_uid doesn't trigger the operator=() but
        * calls ::decode instead. */
-      std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(effective_uid);
+      std::unique_ptr<rgw::sal::User> user = store->get_user(effective_uid);
       if (user->load_by_id(dpp, null_yield) < 0) {
         //ldpp_dout(dpp, 0) << "User lookup failed!" << dendl;
         throw -EACCES;
@@ -289,7 +289,7 @@ void SysReqApplier<T>::modify_request_state(const DoutPrefixProvider* dpp, req_s
 
 template <typename T> static inline
 SysReqApplier<T> add_sysreq(CephContext* const cct,
-			    rgw::sal::RGWStore* store,
+			    rgw::sal::Store* store,
                             const req_state* const s,
                             T&& t) {
   return SysReqApplier<T>(cct, store, s, std::forward<T>(t));

--- a/src/rgw/rgw_auth_registry.h
+++ b/src/rgw/rgw_auth_registry.h
@@ -38,7 +38,7 @@ class StrategyRegistry {
 
     s3_main_strategy_t(CephContext* const cct,
 		       ImplicitTenants& implicit_tenant_context,
-		       rgw::sal::RGWStore* store)
+		       rgw::sal::Store* store)
       : s3_main_strategy_plain(cct, implicit_tenant_context, store),
         s3_main_strategy_boto2(cct, implicit_tenant_context, store) {
       add_engine(Strategy::Control::SUFFICIENT, s3_main_strategy_plain);
@@ -61,7 +61,7 @@ class StrategyRegistry {
 public:
   StrategyRegistry(CephContext* const cct,
                    ImplicitTenants& implicit_tenant_context,
-                   rgw::sal::RGWStore* store)
+                   rgw::sal::Store* store)
     : s3_main_strategy(cct, implicit_tenant_context, store),
       s3_post_strategy(cct, implicit_tenant_context, store),
       swift_strategy(cct, implicit_tenant_context, store),
@@ -87,7 +87,7 @@ public:
   static std::shared_ptr<StrategyRegistry>
   create(CephContext* const cct,
          ImplicitTenants& implicit_tenant_context,
-         rgw::sal::RGWStore* store) {
+         rgw::sal::Store* store) {
     return std::make_shared<StrategyRegistry>(cct, implicit_tenant_context, store);
   }
 };

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -35,7 +35,7 @@ class STSAuthStrategy : public rgw::auth::Strategy,
                         public rgw::auth::LocalApplier::Factory,
                         public rgw::auth::RoleApplier::Factory {
   typedef rgw::auth::IdentityApplier::aplptr_t aplptr_t;
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
   rgw::auth::ImplicitTenants& implicit_tenant_context;
 
   STSEngine  sts_engine;
@@ -77,7 +77,7 @@ class STSAuthStrategy : public rgw::auth::Strategy,
 
 public:
   STSAuthStrategy(CephContext* const cct,
-                       rgw::sal::RGWStore* store,
+                       rgw::sal::Store* store,
                        rgw::auth::ImplicitTenants& implicit_tenant_context,
                        AWSEngine::VersionAbstractor* const ver_abstractor)
     : store(store),
@@ -99,7 +99,7 @@ public:
 class ExternalAuthStrategy : public rgw::auth::Strategy,
                              public rgw::auth::RemoteApplier::Factory {
   typedef rgw::auth::IdentityApplier::aplptr_t aplptr_t;
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
   rgw::auth::ImplicitTenants& implicit_tenant_context;
 
   using keystone_config_t = rgw::keystone::CephCtxConfig;
@@ -125,7 +125,7 @@ class ExternalAuthStrategy : public rgw::auth::Strategy,
 
 public:
   ExternalAuthStrategy(CephContext* const cct,
-                       rgw::sal::RGWStore* store,
+                       rgw::sal::Store* store,
                        rgw::auth::ImplicitTenants& implicit_tenant_context,
                        AWSEngine::VersionAbstractor* const ver_abstractor)
     : store(store),
@@ -166,7 +166,7 @@ class AWSAuthStrategy : public rgw::auth::Strategy,
                                 AbstractorT>::value,
                 "AbstractorT must be a subclass of rgw::auth::s3::VersionAbstractor");
 
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
   AbstractorT ver_abstractor;
 
   S3AnonymousEngine anonymous_engine;
@@ -224,7 +224,7 @@ public:
 
   AWSAuthStrategy(CephContext* const cct,
                   rgw::auth::ImplicitTenants& implicit_tenant_context,
-                  rgw::sal::RGWStore* store)
+                  rgw::sal::Store* store)
     : store(store),
       ver_abstractor(cct),
       anonymous_engine(cct,

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -241,12 +241,12 @@ static void dump_mulipart_index_results(list<rgw_obj_index_key>& objs_to_unlink,
   }
 }
 
-void check_bad_user_bucket_mapping(rgw::sal::RGWStore *store, rgw::sal::RGWUser* user,
+void check_bad_user_bucket_mapping(rgw::sal::Store *store, rgw::sal::User* user,
 				   bool fix,
 				   optional_yield y,
                                    const DoutPrefixProvider *dpp)
 {
-  rgw::sal::RGWBucketList user_buckets;
+  rgw::sal::BucketList user_buckets;
   string marker;
 
   CephContext *cct = store->ctx();
@@ -261,7 +261,7 @@ void check_bad_user_bucket_mapping(rgw::sal::RGWStore *store, rgw::sal::RGWUser*
       return;
     }
 
-    map<string, std::unique_ptr<rgw::sal::RGWBucket>>& buckets = user_buckets.get_buckets();
+    map<string, std::unique_ptr<rgw::sal::Bucket>>& buckets = user_buckets.get_buckets();
     for (auto i = buckets.begin();
          i != buckets.end();
          ++i) {
@@ -269,7 +269,7 @@ void check_bad_user_bucket_mapping(rgw::sal::RGWStore *store, rgw::sal::RGWUser*
 
       auto& bucket = i->second;
 
-      std::unique_ptr<rgw::sal::RGWBucket> actual_bucket;
+      std::unique_ptr<rgw::sal::Bucket> actual_bucket;
       int r = store->get_bucket(dpp, user, user->get_tenant(), bucket->get_name(), &actual_bucket, null_yield);
       if (r < 0) {
         ldout(store->ctx(), 0) << "could not get bucket info for bucket=" << bucket << dendl;
@@ -301,7 +301,7 @@ bool rgw_bucket_object_check_filter(const string& oid)
   return rgw_obj_key::oid_to_key_in_ns(oid, &key, ns);
 }
 
-int rgw_remove_object(const DoutPrefixProvider *dpp, rgw::sal::RGWStore *store, rgw::sal::RGWBucket* bucket, rgw_obj_key& key)
+int rgw_remove_object(const DoutPrefixProvider *dpp, rgw::sal::Store *store, rgw::sal::Bucket* bucket, rgw_obj_key& key)
 {
   RGWObjectCtx rctx(store);
 
@@ -309,12 +309,12 @@ int rgw_remove_object(const DoutPrefixProvider *dpp, rgw::sal::RGWStore *store, 
     key.instance = "null";
   }
 
-  std::unique_ptr<rgw::sal::RGWObject> object = bucket->get_object(key);
+  std::unique_ptr<rgw::sal::Object> object = bucket->get_object(key);
 
   return object->delete_object(dpp, &rctx, null_yield);
 }
 
-int rgw_remove_bucket_bypass_gc(rgw::sal::RGWStore *store, rgw::sal::RGWBucket* bucket,
+int rgw_remove_bucket_bypass_gc(rgw::sal::Store *store, rgw::sal::Bucket* bucket,
                                 int concurrent_max, bool keep_index_consistent,
                                 optional_yield y,
                                 const DoutPrefixProvider *dpp)
@@ -342,8 +342,8 @@ int rgw_remove_bucket_bypass_gc(rgw::sal::RGWStore *store, rgw::sal::RGWBucket* 
     return ret;
   }
 
-  rgw::sal::RGWBucket::ListParams params;
-  rgw::sal::RGWBucket::ListResults results;
+  rgw::sal::Bucket::ListParams params;
+  rgw::sal::Bucket::ListResults results;
 
   params.list_versions = true;
   params.allow_unordered = true;
@@ -361,7 +361,7 @@ int rgw_remove_bucket_bypass_gc(rgw::sal::RGWStore *store, rgw::sal::RGWBucket* 
     std::vector<rgw_bucket_dir_entry>::iterator it = results.objs.begin();
     for (; it != results.objs.end(); ++it) {
       RGWObjState *astate = NULL;
-      std::unique_ptr<rgw::sal::RGWObject> obj = bucket->get_object((*it).key);
+      std::unique_ptr<rgw::sal::Object> obj = bucket->get_object((*it).key);
 
       ret = obj->get_obj_state(dpp, &obj_ctx, &astate, y, false);
       if (ret == -ENOENT) {
@@ -376,7 +376,7 @@ int rgw_remove_bucket_bypass_gc(rgw::sal::RGWStore *store, rgw::sal::RGWBucket* 
       if (astate->manifest) {
         RGWObjManifest& manifest = *astate->manifest;
         RGWObjManifest::obj_iterator miter = manifest.obj_begin();
-	std::unique_ptr<rgw::sal::RGWObject> head_obj = bucket->get_object(manifest.get_obj().key);
+	std::unique_ptr<rgw::sal::Object> head_obj = bucket->get_object(manifest.get_obj().key);
         rgw_raw_obj raw_head_obj;
 	head_obj->get_raw_obj(&raw_head_obj);
 
@@ -453,7 +453,7 @@ static void set_err_msg(std::string *sink, std::string msg)
     *sink = msg;
 }
 
-int RGWBucket::init(rgw::sal::RGWStore *_store, RGWBucketAdminOpState& op_state,
+int RGWBucket::init(rgw::sal::Store *_store, RGWBucketAdminOpState& op_state,
                     optional_yield y, const DoutPrefixProvider *dpp, std::string *err_msg)
 {
   if (!_store) {
@@ -486,7 +486,7 @@ int RGWBucket::init(rgw::sal::RGWStore *_store, RGWBucketAdminOpState& op_state,
 
   op_state.set_bucket(bucket->clone());
 
-  if (!rgw::sal::RGWUser::empty(user.get())) {
+  if (!rgw::sal::User::empty(user.get())) {
     r = user->load_by_id(dpp, y);
     if (r < 0) {
       set_err_msg(err_msg, "failed to fetch user info");
@@ -500,7 +500,7 @@ int RGWBucket::init(rgw::sal::RGWStore *_store, RGWBucketAdminOpState& op_state,
   return 0;
 }
 
-bool rgw_find_bucket_by_id(CephContext *cct, rgw::sal::RGWStore* store,
+bool rgw_find_bucket_by_id(CephContext *cct, rgw::sal::Store* store,
                            const string& marker, const string& bucket_id, rgw_bucket* bucket_out)
 {
   void *handle = NULL;
@@ -547,8 +547,8 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state, optional_yield y, const Dou
 
   string bucket_id = op_state.get_bucket_id();
   std::string display_name = op_state.get_user_display_name();
-  std::unique_ptr<rgw::sal::RGWBucket> loc_bucket;
-  std::unique_ptr<rgw::sal::RGWBucket> old_bucket;
+  std::unique_ptr<rgw::sal::Bucket> loc_bucket;
+  std::unique_ptr<rgw::sal::Bucket> old_bucket;
 
   loc_bucket = op_state.get_bucket()->clone();
 
@@ -596,7 +596,7 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state, optional_yield y, const Dou
     return -EIO;
   }
 
-  std::unique_ptr<rgw::sal::RGWUser> owner_user = store->get_user(owner.get_id());
+  std::unique_ptr<rgw::sal::User> owner_user = store->get_user(owner.get_id());
 
   int r = old_bucket->unlink(dpp, owner_user.get(), y, false);
   if (r < 0) {
@@ -767,13 +767,13 @@ int RGWBucket::check_bad_index_multipart(RGWBucketAdminOpState& op_state,
 
   bucket = op_state.get_bucket()->clone();
 
-  rgw::sal::RGWBucket::ListParams params;
+  rgw::sal::Bucket::ListParams params;
 
   params.list_versions = true;
   params.ns = RGW_OBJ_NS_MULTIPART;
 
   do {
-    rgw::sal::RGWBucket::ListResults results;
+    rgw::sal::Bucket::ListResults results;
     int r = bucket->list(dpp, params, listing_max_entries, results, null_yield);
     if (r < 0) {
       set_err_msg(err_msg, "failed to list objects in bucket=" + bucket->get_name() +
@@ -870,13 +870,13 @@ int RGWBucket::check_object_index(const DoutPrefixProvider *dpp,
 
   string prefix;
   string empty_delimiter;
-  rgw::sal::RGWBucket::ListResults results;
+  rgw::sal::Bucket::ListResults results;
   results.is_truncated = true;
 
   Formatter *formatter = flusher.get_formatter();
   formatter->open_object_section("objects");
   while (results.is_truncated) {
-    rgw::sal::RGWBucket::ListParams params;
+    rgw::sal::Bucket::ListParams params;
 
     params.marker = results.next_marker;
     params.prefix = prefix;
@@ -948,13 +948,13 @@ int RGWBucket::sync(RGWBucketAdminOpState& op_state, const DoutPrefixProvider *d
   int shard_id = bucket->get_info().layout.current_index.layout.normal.num_shards? 0 : -1;
 
   if (!sync) {
-    r = static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->bilog_rados->log_stop(bucket->get_info(), -1);
+    r = static_cast<rgw::sal::RadosStore*>(store)->svc()->bilog_rados->log_stop(bucket->get_info(), -1);
     if (r < 0) {
       set_err_msg(err_msg, "ERROR: failed writing stop bilog:" + cpp_strerror(-r));
       return r;
     }
   } else {
-    r = static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->bilog_rados->log_start(bucket->get_info(), -1);
+    r = static_cast<rgw::sal::RadosStore*>(store)->svc()->bilog_rados->log_start(bucket->get_info(), -1);
     if (r < 0) {
       set_err_msg(err_msg, "ERROR: failed writing resync bilog:" + cpp_strerror(-r));
       return r;
@@ -962,7 +962,7 @@ int RGWBucket::sync(RGWBucketAdminOpState& op_state, const DoutPrefixProvider *d
   }
 
   for (int i = 0; i < shards_num; ++i, ++shard_id) {
-    r = static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->datalog_rados->add_entry(dpp, bucket->get_info(), shard_id);
+    r = static_cast<rgw::sal::RadosStore*>(store)->svc()->datalog_rados->add_entry(dpp, bucket->get_info(), shard_id);
     if (r < 0) {
       set_err_msg(err_msg, "ERROR: failed writing data log:" + cpp_strerror(-r));
       return r;
@@ -985,11 +985,11 @@ int RGWBucket::policy_bl_to_stream(bufferlist& bl, ostream& o)
 }
 
 int rgw_object_get_attr(const DoutPrefixProvider *dpp,
-			rgw::sal::RGWStore* store, rgw::sal::RGWObject* obj,
+			rgw::sal::Store* store, rgw::sal::Object* obj,
 			const char* attr_name, bufferlist& out_bl, optional_yield y)
 {
   RGWObjectCtx obj_ctx(store);
-  std::unique_ptr<rgw::sal::RGWObject::ReadOp> rop = obj->get_read_op(&obj_ctx);
+  std::unique_ptr<rgw::sal::Object::ReadOp> rop = obj->get_read_op(&obj_ctx);
 
   return rop->get_attr(dpp, attr_name, out_bl, y);
 }
@@ -1003,7 +1003,7 @@ int RGWBucket::get_policy(RGWBucketAdminOpState& op_state, RGWAccessControlPolic
 
   if (!object_name.empty()) {
     bufferlist bl;
-    std::unique_ptr<rgw::sal::RGWObject> obj = bucket->get_object(rgw_obj_key(object_name));
+    std::unique_ptr<rgw::sal::Object> obj = bucket->get_object(rgw_obj_key(object_name));
 
     ret = rgw_object_get_attr(dpp, store, obj.get(), RGW_ATTR_ACL, bl, y);
     if (ret < 0){
@@ -1031,7 +1031,7 @@ int RGWBucket::get_policy(RGWBucketAdminOpState& op_state, RGWAccessControlPolic
 }
 
 
-int RGWBucketAdminOp::get_policy(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state,
+int RGWBucketAdminOp::get_policy(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
                   RGWAccessControlPolicy& policy, const DoutPrefixProvider *dpp)
 {
   RGWBucket bucket;
@@ -1050,7 +1050,7 @@ int RGWBucketAdminOp::get_policy(rgw::sal::RGWStore *store, RGWBucketAdminOpStat
 /* Wrappers to facilitate RESTful interface */
 
 
-int RGWBucketAdminOp::get_policy(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state,
+int RGWBucketAdminOp::get_policy(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
                   RGWFormatterFlusher& flusher, const DoutPrefixProvider *dpp)
 {
   RGWAccessControlPolicy policy(store->ctx());
@@ -1072,7 +1072,7 @@ int RGWBucketAdminOp::get_policy(rgw::sal::RGWStore *store, RGWBucketAdminOpStat
   return 0;
 }
 
-int RGWBucketAdminOp::dump_s3_policy(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state,
+int RGWBucketAdminOp::dump_s3_policy(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
                   ostream& os, const DoutPrefixProvider *dpp)
 {
   RGWAccessControlPolicy_S3 policy(store->ctx());
@@ -1086,7 +1086,7 @@ int RGWBucketAdminOp::dump_s3_policy(rgw::sal::RGWStore *store, RGWBucketAdminOp
   return 0;
 }
 
-int RGWBucketAdminOp::unlink(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp)
+int RGWBucketAdminOp::unlink(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp)
 {
   RGWBucket bucket;
 
@@ -1097,7 +1097,7 @@ int RGWBucketAdminOp::unlink(rgw::sal::RGWStore *store, RGWBucketAdminOpState& o
   return bucket.unlink(op_state, null_yield, dpp);
 }
 
-int RGWBucketAdminOp::link(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, string *err)
+int RGWBucketAdminOp::link(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, string *err)
 {
   RGWBucket bucket;
   int ret = bucket.init(store, op_state, null_yield, dpp, err);
@@ -1108,7 +1108,7 @@ int RGWBucketAdminOp::link(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_
 
 }
 
-int RGWBucketAdminOp::chown(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state, const string& marker, const DoutPrefixProvider *dpp, string *err)
+int RGWBucketAdminOp::chown(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const string& marker, const DoutPrefixProvider *dpp, string *err)
 {
   RGWBucket bucket;
 
@@ -1124,7 +1124,7 @@ int RGWBucketAdminOp::chown(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op
 
 }
 
-int RGWBucketAdminOp::check_index(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state,
+int RGWBucketAdminOp::check_index(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
                   RGWFormatterFlusher& flusher, optional_yield y, const DoutPrefixProvider *dpp)
 {
   int ret;
@@ -1159,12 +1159,12 @@ int RGWBucketAdminOp::check_index(rgw::sal::RGWStore *store, RGWBucketAdminOpSta
   return 0;
 }
 
-int RGWBucketAdminOp::remove_bucket(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state,
+int RGWBucketAdminOp::remove_bucket(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
 				    optional_yield y, const DoutPrefixProvider *dpp, 
                                     bool bypass_gc, bool keep_index_consistent)
 {
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
-  std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(op_state.get_user_id());
+  std::unique_ptr<rgw::sal::Bucket> bucket;
+  std::unique_ptr<rgw::sal::User> user = store->get_user(op_state.get_user_id());
 
   int ret = store->get_bucket(dpp, user.get(), user->get_tenant(), op_state.get_bucket_name(),
 			      &bucket, y);
@@ -1180,7 +1180,7 @@ int RGWBucketAdminOp::remove_bucket(rgw::sal::RGWStore *store, RGWBucketAdminOpS
   return ret;
 }
 
-int RGWBucketAdminOp::remove_object(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp)
+int RGWBucketAdminOp::remove_object(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp)
 {
   RGWBucket bucket;
 
@@ -1191,7 +1191,7 @@ int RGWBucketAdminOp::remove_object(rgw::sal::RGWStore *store, RGWBucketAdminOpS
   return bucket.remove_object(dpp, op_state);
 }
 
-int RGWBucketAdminOp::sync_bucket(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, string *err_msg)
+int RGWBucketAdminOp::sync_bucket(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, string *err_msg)
 {
   RGWBucket bucket;
   int ret = bucket.init(store, op_state, null_yield, dpp, err_msg);
@@ -1202,13 +1202,13 @@ int RGWBucketAdminOp::sync_bucket(rgw::sal::RGWStore *store, RGWBucketAdminOpSta
   return bucket.sync(op_state, dpp, err_msg);
 }
 
-static int bucket_stats(rgw::sal::RGWStore *store,
+static int bucket_stats(rgw::sal::Store *store,
 			const std::string& tenant_name,
 			const std::string& bucket_name,
 			Formatter *formatter,
                         const DoutPrefixProvider *dpp)
 {
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
   map<RGWObjCategory, RGWStorageStats> stats;
 
   real_time mtime;
@@ -1268,7 +1268,7 @@ static int bucket_stats(rgw::sal::RGWStore *store,
   return 0;
 }
 
-int RGWBucketAdminOp::limit_check(rgw::sal::RGWStore *store,
+int RGWBucketAdminOp::limit_check(rgw::sal::Store *store,
 				  RGWBucketAdminOpState& op_state,
 				  const std::list<std::string>& user_ids,
 				  RGWFormatterFlusher& flusher, optional_yield y,
@@ -1299,16 +1299,16 @@ int RGWBucketAdminOp::limit_check(rgw::sal::RGWStore *store,
     formatter->open_array_section("buckets");
 
     string marker;
-    rgw::sal::RGWBucketList buckets;
+    rgw::sal::BucketList buckets;
     do {
-      std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(rgw_user(user_id));
+      std::unique_ptr<rgw::sal::User> user = store->get_user(rgw_user(user_id));
 
       ret = user->list_buckets(dpp, marker, string(), max_entries, false, buckets, y);
 
       if (ret < 0)
         return ret;
 
-      map<string, std::unique_ptr<rgw::sal::RGWBucket>>& m_buckets = buckets.get_buckets();
+      map<string, std::unique_ptr<rgw::sal::Bucket>>& m_buckets = buckets.get_buckets();
 
       for (const auto& iter : m_buckets) {
 	auto& bucket = iter.second;
@@ -1380,7 +1380,7 @@ int RGWBucketAdminOp::limit_check(rgw::sal::RGWStore *store,
   return ret;
 } /* RGWBucketAdminOp::limit_check */
 
-int RGWBucketAdminOp::info(rgw::sal::RGWStore *store,
+int RGWBucketAdminOp::info(rgw::sal::Store *store,
 			   RGWBucketAdminOpState& op_state,
 			   RGWFormatterFlusher& flusher,
 			   optional_yield y,
@@ -1409,8 +1409,8 @@ int RGWBucketAdminOp::info(rgw::sal::RGWStore *store,
   if (op_state.is_user_op()) {
     formatter->open_array_section("buckets");
 
-    rgw::sal::RGWBucketList buckets;
-    std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(op_state.get_user_id());
+    rgw::sal::BucketList buckets;
+    std::unique_ptr<rgw::sal::User> user = store->get_user(op_state.get_user_id());
     std::string marker;
     const std::string empty_end_marker;
     constexpr bool no_need_stats = false; // set need_stats to false
@@ -1423,7 +1423,7 @@ int RGWBucketAdminOp::info(rgw::sal::RGWStore *store,
       }
 
       const std::string* marker_cursor = nullptr;
-      map<string, std::unique_ptr<rgw::sal::RGWBucket>>& m = buckets.get_buckets();
+      map<string, std::unique_ptr<rgw::sal::Bucket>>& m = buckets.get_buckets();
 
       for (const auto& i : m) {
         const std::string& obj_name = i.first;
@@ -1481,7 +1481,7 @@ int RGWBucketAdminOp::info(rgw::sal::RGWStore *store,
   return 0;
 }
 
-int RGWBucketAdminOp::set_quota(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp)
+int RGWBucketAdminOp::set_quota(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp)
 {
   RGWBucket bucket;
 
@@ -1491,9 +1491,9 @@ int RGWBucketAdminOp::set_quota(rgw::sal::RGWStore *store, RGWBucketAdminOpState
   return bucket.set_quota(op_state, dpp);
 }
 
-static int purge_bucket_instance(rgw::sal::RGWStore *store, const RGWBucketInfo& bucket_info, const DoutPrefixProvider *dpp)
+static int purge_bucket_instance(rgw::sal::Store *store, const RGWBucketInfo& bucket_info, const DoutPrefixProvider *dpp)
 {
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
   int ret = store->get_bucket(nullptr, bucket_info, &bucket);
   if (ret < 0)
     return ret;
@@ -1510,7 +1510,7 @@ inline auto split_tenant(const std::string& bucket_name){
 }
 
 using bucket_instance_ls = std::vector<RGWBucketInfo>;
-void get_stale_instances(rgw::sal::RGWStore *store, const std::string& bucket_name,
+void get_stale_instances(rgw::sal::Store *store, const std::string& bucket_name,
                          const vector<std::string>& lst,
                          bucket_instance_ls& stale_instances,
                          const DoutPrefixProvider *dpp)
@@ -1521,7 +1521,7 @@ void get_stale_instances(rgw::sal::RGWStore *store, const std::string& bucket_na
 // are guaranteed to be stale
   for (const auto& bucket_instance : lst){
     RGWBucketInfo binfo;
-    std::unique_ptr<rgw::sal::RGWBucket> bucket;
+    std::unique_ptr<rgw::sal::Bucket> bucket;
     rgw_bucket rbucket;
     rgw_bucket_parse_bucket_key(store->ctx(), bucket_instance, &rbucket, nullptr);
     int r = store->get_bucket(dpp, nullptr, rbucket, &bucket, null_yield);
@@ -1543,7 +1543,7 @@ void get_stale_instances(rgw::sal::RGWStore *store, const std::string& bucket_na
   // all the instances
   auto [tenant, bname] = split_tenant(bucket_name);
   RGWBucketInfo cur_bucket_info;
-  std::unique_ptr<rgw::sal::RGWBucket> cur_bucket;
+  std::unique_ptr<rgw::sal::Bucket> cur_bucket;
   int r = store->get_bucket(dpp, nullptr, tenant, bname, &cur_bucket, null_yield);
   if (r < 0) {
     if (r == -ENOENT) {
@@ -1581,7 +1581,7 @@ void get_stale_instances(rgw::sal::RGWStore *store, const std::string& bucket_na
   // bucket and walk through these instances to make sure no one else interferes
   // with these
   {
-    RGWBucketReshardLock reshard_lock(static_cast<rgw::sal::RGWRadosStore*>(store), cur_bucket->get_info(), true);
+    RGWBucketReshardLock reshard_lock(static_cast<rgw::sal::RadosStore*>(store), cur_bucket->get_info(), true);
     r = reshard_lock.lock();
     if (r < 0) {
       // most likely bucket is under reshard, return the sureshot stale instances
@@ -1600,12 +1600,12 @@ void get_stale_instances(rgw::sal::RGWStore *store, const std::string& bucket_na
   return;
 }
 
-static int process_stale_instances(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state,
+static int process_stale_instances(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
                                    RGWFormatterFlusher& flusher,
                                    const DoutPrefixProvider *dpp,
                                    std::function<void(const bucket_instance_ls&,
                                                       Formatter *,
-                                                      rgw::sal::RGWStore*)> process_f)
+                                                      rgw::sal::Store*)> process_f)
 {
   std::string marker;
   void *handle;
@@ -1654,14 +1654,14 @@ static int process_stale_instances(rgw::sal::RGWStore *store, RGWBucketAdminOpSt
   return 0;
 }
 
-int RGWBucketAdminOp::list_stale_instances(rgw::sal::RGWStore *store,
+int RGWBucketAdminOp::list_stale_instances(rgw::sal::Store *store,
                                            RGWBucketAdminOpState& op_state,
                                            RGWFormatterFlusher& flusher,
                                            const DoutPrefixProvider *dpp)
 {
   auto process_f = [](const bucket_instance_ls& lst,
                       Formatter *formatter,
-                      rgw::sal::RGWStore*){
+                      rgw::sal::Store*){
                      for (const auto& binfo: lst)
                        formatter->dump_string("key", binfo.bucket.get_key());
                    };
@@ -1669,14 +1669,14 @@ int RGWBucketAdminOp::list_stale_instances(rgw::sal::RGWStore *store,
 }
 
 
-int RGWBucketAdminOp::clear_stale_instances(rgw::sal::RGWStore *store,
+int RGWBucketAdminOp::clear_stale_instances(rgw::sal::Store *store,
                                             RGWBucketAdminOpState& op_state,
                                             RGWFormatterFlusher& flusher,
                                             const DoutPrefixProvider *dpp)
 {
   auto process_f = [dpp](const bucket_instance_ls& lst,
                       Formatter *formatter,
-                      rgw::sal::RGWStore *store){
+                      rgw::sal::Store *store){
                      for (const auto &binfo: lst) {
                        int ret = purge_bucket_instance(store, binfo, dpp);
                        if (ret == 0){
@@ -1693,12 +1693,12 @@ int RGWBucketAdminOp::clear_stale_instances(rgw::sal::RGWStore *store,
   return process_stale_instances(store, op_state, flusher, dpp, process_f);
 }
 
-static int fix_single_bucket_lc(rgw::sal::RGWStore *store,
+static int fix_single_bucket_lc(rgw::sal::Store *store,
                                 const std::string& tenant_name,
                                 const std::string& bucket_name,
                                 const DoutPrefixProvider *dpp)
 {
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
   int ret = store->get_bucket(dpp, nullptr, tenant_name, bucket_name, &bucket, null_yield);
   if (ret < 0) {
     // TODO: Should we handle the case where the bucket could've been removed between
@@ -1721,7 +1721,7 @@ static void format_lc_status(Formatter* formatter,
   formatter->close_section(); // bucket_entry
 }
 
-static void process_single_lc_entry(rgw::sal::RGWStore *store,
+static void process_single_lc_entry(rgw::sal::Store *store,
 				    Formatter *formatter,
                                     const std::string& tenant_name,
                                     const std::string& bucket_name,
@@ -1731,7 +1731,7 @@ static void process_single_lc_entry(rgw::sal::RGWStore *store,
   format_lc_status(formatter, tenant_name, bucket_name, -ret);
 }
 
-int RGWBucketAdminOp::fix_lc_shards(rgw::sal::RGWStore *store,
+int RGWBucketAdminOp::fix_lc_shards(rgw::sal::Store *store,
                                     RGWBucketAdminOpState& op_state,
                                     RGWFormatterFlusher& flusher,
                                     const DoutPrefixProvider *dpp)
@@ -1783,11 +1783,11 @@ int RGWBucketAdminOp::fix_lc_shards(rgw::sal::RGWStore *store,
 }
 
 static bool has_object_expired(const DoutPrefixProvider *dpp,
-			       rgw::sal::RGWStore *store,
-			       rgw::sal::RGWBucket* bucket,
+			       rgw::sal::Store *store,
+			       rgw::sal::Bucket* bucket,
 			       const rgw_obj_key& key, utime_t& delete_at)
 {
-  std::unique_ptr<rgw::sal::RGWObject> obj = bucket->get_object(key);
+  std::unique_ptr<rgw::sal::Object> obj = bucket->get_object(key);
   bufferlist delete_at_bl;
 
   int ret = rgw_object_get_attr(dpp, store, obj.get(), RGW_ATTR_DELETE_AT, delete_at_bl, null_yield);
@@ -1808,8 +1808,8 @@ static bool has_object_expired(const DoutPrefixProvider *dpp,
 }
 
 static int fix_bucket_obj_expiry(const DoutPrefixProvider *dpp,
-				 rgw::sal::RGWStore *store,
-				 rgw::sal::RGWBucket* bucket,
+				 rgw::sal::Store *store,
+				 rgw::sal::Bucket* bucket,
 				 RGWFormatterFlusher& flusher, bool dry_run)
 {
   if (bucket->get_key().bucket_id == bucket->get_key().marker) {
@@ -1824,8 +1824,8 @@ static int fix_bucket_obj_expiry(const DoutPrefixProvider *dpp,
 			       formatter->flush(std::cout);
 			     });
 
-  rgw::sal::RGWBucket::ListParams params;
-  rgw::sal::RGWBucket::ListResults results;
+  rgw::sal::Bucket::ListParams params;
+  rgw::sal::Bucket::ListResults results;
 
   params.list_versions = bucket->versioned();
   params.allow_unordered = true;
@@ -1858,7 +1858,7 @@ static int fix_bucket_obj_expiry(const DoutPrefixProvider *dpp,
   return 0;
 }
 
-int RGWBucketAdminOp::fix_obj_expiry(rgw::sal::RGWStore *store,
+int RGWBucketAdminOp::fix_obj_expiry(rgw::sal::Store *store,
 				     RGWBucketAdminOpState& op_state,
 				     RGWFormatterFlusher& flusher,
                                      const DoutPrefixProvider *dpp, bool dry_run)
@@ -1869,7 +1869,7 @@ int RGWBucketAdminOp::fix_obj_expiry(rgw::sal::RGWStore *store,
     lderr(store->ctx()) << "failed to initialize bucket" << dendl;
     return ret;
   }
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
   ret = store->get_bucket(nullptr, admin_bucket.get_bucket_info(), &bucket);
   if (ret < 0) {
     return ret;
@@ -3052,15 +3052,15 @@ int RGWBucketCtl::set_acl(ACLOwner& owner, rgw_bucket& bucket,
 }
 
 // TODO: remove RGWRados dependency for bucket listing
-int RGWBucketCtl::chown(rgw::sal::RGWStore *store, rgw::sal::RGWBucket* bucket,
+int RGWBucketCtl::chown(rgw::sal::Store *store, rgw::sal::Bucket* bucket,
                         const rgw_user& user_id, const std::string& display_name,
                         const std::string& marker, optional_yield y, const DoutPrefixProvider *dpp)
 {
   RGWObjectCtx obj_ctx(store);
   map<string, bool> common_prefixes;
 
-  rgw::sal::RGWBucket::ListParams params;
-  rgw::sal::RGWBucket::ListResults results;
+  rgw::sal::Bucket::ListParams params;
+  rgw::sal::Bucket::ListResults results;
 
   params.list_versions = true;
   params.allow_unordered = true;
@@ -3083,7 +3083,7 @@ int RGWBucketCtl::chown(rgw::sal::RGWStore *store, rgw::sal::RGWBucket* bucket,
     count += results.objs.size();
 
     for (const auto& obj : results.objs) {
-      std::unique_ptr<rgw::sal::RGWObject> r_obj = bucket->get_object(obj.key);
+      std::unique_ptr<rgw::sal::Object> r_obj = bucket->get_object(obj.key);
 
       ret = r_obj->get_obj_attrs(&obj_ctx, y, dpp);
       if (ret < 0){

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -241,7 +241,7 @@ static void dump_mulipart_index_results(list<rgw_obj_index_key>& objs_to_unlink,
   }
 }
 
-void check_bad_user_bucket_mapping(rgw::sal::Store *store, rgw::sal::User* user,
+void check_bad_user_bucket_mapping(rgw::sal::Store* store, rgw::sal::User* user,
 				   bool fix,
 				   optional_yield y,
                                    const DoutPrefixProvider *dpp)
@@ -301,7 +301,7 @@ bool rgw_bucket_object_check_filter(const string& oid)
   return rgw_obj_key::oid_to_key_in_ns(oid, &key, ns);
 }
 
-int rgw_remove_object(const DoutPrefixProvider *dpp, rgw::sal::Store *store, rgw::sal::Bucket* bucket, rgw_obj_key& key)
+int rgw_remove_object(const DoutPrefixProvider *dpp, rgw::sal::Store* store, rgw::sal::Bucket* bucket, rgw_obj_key& key)
 {
   RGWObjectCtx rctx(store);
 
@@ -314,7 +314,7 @@ int rgw_remove_object(const DoutPrefixProvider *dpp, rgw::sal::Store *store, rgw
   return object->delete_object(dpp, &rctx, null_yield);
 }
 
-int rgw_remove_bucket_bypass_gc(rgw::sal::Store *store, rgw::sal::Bucket* bucket,
+int rgw_remove_bucket_bypass_gc(rgw::sal::Store* store, rgw::sal::Bucket* bucket,
                                 int concurrent_max, bool keep_index_consistent,
                                 optional_yield y,
                                 const DoutPrefixProvider *dpp)
@@ -453,7 +453,7 @@ static void set_err_msg(std::string *sink, std::string msg)
     *sink = msg;
 }
 
-int RGWBucket::init(rgw::sal::Store *_store, RGWBucketAdminOpState& op_state,
+int RGWBucket::init(rgw::sal::Store* _store, RGWBucketAdminOpState& op_state,
                     optional_yield y, const DoutPrefixProvider *dpp, std::string *err_msg)
 {
   if (!_store) {
@@ -1031,7 +1031,7 @@ int RGWBucket::get_policy(RGWBucketAdminOpState& op_state, RGWAccessControlPolic
 }
 
 
-int RGWBucketAdminOp::get_policy(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
+int RGWBucketAdminOp::get_policy(rgw::sal::Store* store, RGWBucketAdminOpState& op_state,
                   RGWAccessControlPolicy& policy, const DoutPrefixProvider *dpp)
 {
   RGWBucket bucket;
@@ -1050,7 +1050,7 @@ int RGWBucketAdminOp::get_policy(rgw::sal::Store *store, RGWBucketAdminOpState& 
 /* Wrappers to facilitate RESTful interface */
 
 
-int RGWBucketAdminOp::get_policy(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
+int RGWBucketAdminOp::get_policy(rgw::sal::Store* store, RGWBucketAdminOpState& op_state,
                   RGWFormatterFlusher& flusher, const DoutPrefixProvider *dpp)
 {
   RGWAccessControlPolicy policy(store->ctx());
@@ -1072,7 +1072,7 @@ int RGWBucketAdminOp::get_policy(rgw::sal::Store *store, RGWBucketAdminOpState& 
   return 0;
 }
 
-int RGWBucketAdminOp::dump_s3_policy(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
+int RGWBucketAdminOp::dump_s3_policy(rgw::sal::Store* store, RGWBucketAdminOpState& op_state,
                   ostream& os, const DoutPrefixProvider *dpp)
 {
   RGWAccessControlPolicy_S3 policy(store->ctx());
@@ -1086,7 +1086,7 @@ int RGWBucketAdminOp::dump_s3_policy(rgw::sal::Store *store, RGWBucketAdminOpSta
   return 0;
 }
 
-int RGWBucketAdminOp::unlink(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp)
+int RGWBucketAdminOp::unlink(rgw::sal::Store* store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp)
 {
   RGWBucket bucket;
 
@@ -1097,7 +1097,7 @@ int RGWBucketAdminOp::unlink(rgw::sal::Store *store, RGWBucketAdminOpState& op_s
   return bucket.unlink(op_state, null_yield, dpp);
 }
 
-int RGWBucketAdminOp::link(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, string *err)
+int RGWBucketAdminOp::link(rgw::sal::Store* store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, string *err)
 {
   RGWBucket bucket;
   int ret = bucket.init(store, op_state, null_yield, dpp, err);
@@ -1108,7 +1108,7 @@ int RGWBucketAdminOp::link(rgw::sal::Store *store, RGWBucketAdminOpState& op_sta
 
 }
 
-int RGWBucketAdminOp::chown(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const string& marker, const DoutPrefixProvider *dpp, string *err)
+int RGWBucketAdminOp::chown(rgw::sal::Store* store, RGWBucketAdminOpState& op_state, const string& marker, const DoutPrefixProvider *dpp, string *err)
 {
   RGWBucket bucket;
 
@@ -1124,7 +1124,7 @@ int RGWBucketAdminOp::chown(rgw::sal::Store *store, RGWBucketAdminOpState& op_st
 
 }
 
-int RGWBucketAdminOp::check_index(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
+int RGWBucketAdminOp::check_index(rgw::sal::Store* store, RGWBucketAdminOpState& op_state,
                   RGWFormatterFlusher& flusher, optional_yield y, const DoutPrefixProvider *dpp)
 {
   int ret;
@@ -1159,7 +1159,7 @@ int RGWBucketAdminOp::check_index(rgw::sal::Store *store, RGWBucketAdminOpState&
   return 0;
 }
 
-int RGWBucketAdminOp::remove_bucket(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
+int RGWBucketAdminOp::remove_bucket(rgw::sal::Store* store, RGWBucketAdminOpState& op_state,
 				    optional_yield y, const DoutPrefixProvider *dpp, 
                                     bool bypass_gc, bool keep_index_consistent)
 {
@@ -1180,7 +1180,7 @@ int RGWBucketAdminOp::remove_bucket(rgw::sal::Store *store, RGWBucketAdminOpStat
   return ret;
 }
 
-int RGWBucketAdminOp::remove_object(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp)
+int RGWBucketAdminOp::remove_object(rgw::sal::Store* store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp)
 {
   RGWBucket bucket;
 
@@ -1191,7 +1191,7 @@ int RGWBucketAdminOp::remove_object(rgw::sal::Store *store, RGWBucketAdminOpStat
   return bucket.remove_object(dpp, op_state);
 }
 
-int RGWBucketAdminOp::sync_bucket(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, string *err_msg)
+int RGWBucketAdminOp::sync_bucket(rgw::sal::Store* store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, string *err_msg)
 {
   RGWBucket bucket;
   int ret = bucket.init(store, op_state, null_yield, dpp, err_msg);
@@ -1202,7 +1202,7 @@ int RGWBucketAdminOp::sync_bucket(rgw::sal::Store *store, RGWBucketAdminOpState&
   return bucket.sync(op_state, dpp, err_msg);
 }
 
-static int bucket_stats(rgw::sal::Store *store,
+static int bucket_stats(rgw::sal::Store* store,
 			const std::string& tenant_name,
 			const std::string& bucket_name,
 			Formatter *formatter,
@@ -1268,7 +1268,7 @@ static int bucket_stats(rgw::sal::Store *store,
   return 0;
 }
 
-int RGWBucketAdminOp::limit_check(rgw::sal::Store *store,
+int RGWBucketAdminOp::limit_check(rgw::sal::Store* store,
 				  RGWBucketAdminOpState& op_state,
 				  const std::list<std::string>& user_ids,
 				  RGWFormatterFlusher& flusher, optional_yield y,
@@ -1380,7 +1380,7 @@ int RGWBucketAdminOp::limit_check(rgw::sal::Store *store,
   return ret;
 } /* RGWBucketAdminOp::limit_check */
 
-int RGWBucketAdminOp::info(rgw::sal::Store *store,
+int RGWBucketAdminOp::info(rgw::sal::Store* store,
 			   RGWBucketAdminOpState& op_state,
 			   RGWFormatterFlusher& flusher,
 			   optional_yield y,
@@ -1481,7 +1481,7 @@ int RGWBucketAdminOp::info(rgw::sal::Store *store,
   return 0;
 }
 
-int RGWBucketAdminOp::set_quota(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp)
+int RGWBucketAdminOp::set_quota(rgw::sal::Store* store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp)
 {
   RGWBucket bucket;
 
@@ -1491,7 +1491,7 @@ int RGWBucketAdminOp::set_quota(rgw::sal::Store *store, RGWBucketAdminOpState& o
   return bucket.set_quota(op_state, dpp);
 }
 
-static int purge_bucket_instance(rgw::sal::Store *store, const RGWBucketInfo& bucket_info, const DoutPrefixProvider *dpp)
+static int purge_bucket_instance(rgw::sal::Store* store, const RGWBucketInfo& bucket_info, const DoutPrefixProvider *dpp)
 {
   std::unique_ptr<rgw::sal::Bucket> bucket;
   int ret = store->get_bucket(nullptr, bucket_info, &bucket);
@@ -1510,7 +1510,7 @@ inline auto split_tenant(const std::string& bucket_name){
 }
 
 using bucket_instance_ls = std::vector<RGWBucketInfo>;
-void get_stale_instances(rgw::sal::Store *store, const std::string& bucket_name,
+void get_stale_instances(rgw::sal::Store* store, const std::string& bucket_name,
                          const vector<std::string>& lst,
                          bucket_instance_ls& stale_instances,
                          const DoutPrefixProvider *dpp)
@@ -1600,7 +1600,7 @@ void get_stale_instances(rgw::sal::Store *store, const std::string& bucket_name,
   return;
 }
 
-static int process_stale_instances(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
+static int process_stale_instances(rgw::sal::Store* store, RGWBucketAdminOpState& op_state,
                                    RGWFormatterFlusher& flusher,
                                    const DoutPrefixProvider *dpp,
                                    std::function<void(const bucket_instance_ls&,
@@ -1654,7 +1654,7 @@ static int process_stale_instances(rgw::sal::Store *store, RGWBucketAdminOpState
   return 0;
 }
 
-int RGWBucketAdminOp::list_stale_instances(rgw::sal::Store *store,
+int RGWBucketAdminOp::list_stale_instances(rgw::sal::Store* store,
                                            RGWBucketAdminOpState& op_state,
                                            RGWFormatterFlusher& flusher,
                                            const DoutPrefixProvider *dpp)
@@ -1669,14 +1669,14 @@ int RGWBucketAdminOp::list_stale_instances(rgw::sal::Store *store,
 }
 
 
-int RGWBucketAdminOp::clear_stale_instances(rgw::sal::Store *store,
+int RGWBucketAdminOp::clear_stale_instances(rgw::sal::Store* store,
                                             RGWBucketAdminOpState& op_state,
                                             RGWFormatterFlusher& flusher,
                                             const DoutPrefixProvider *dpp)
 {
   auto process_f = [dpp](const bucket_instance_ls& lst,
                       Formatter *formatter,
-                      rgw::sal::Store *store){
+                      rgw::sal::Store* store){
                      for (const auto &binfo: lst) {
                        int ret = purge_bucket_instance(store, binfo, dpp);
                        if (ret == 0){
@@ -1693,7 +1693,7 @@ int RGWBucketAdminOp::clear_stale_instances(rgw::sal::Store *store,
   return process_stale_instances(store, op_state, flusher, dpp, process_f);
 }
 
-static int fix_single_bucket_lc(rgw::sal::Store *store,
+static int fix_single_bucket_lc(rgw::sal::Store* store,
                                 const std::string& tenant_name,
                                 const std::string& bucket_name,
                                 const DoutPrefixProvider *dpp)
@@ -1721,7 +1721,7 @@ static void format_lc_status(Formatter* formatter,
   formatter->close_section(); // bucket_entry
 }
 
-static void process_single_lc_entry(rgw::sal::Store *store,
+static void process_single_lc_entry(rgw::sal::Store* store,
 				    Formatter *formatter,
                                     const std::string& tenant_name,
                                     const std::string& bucket_name,
@@ -1731,7 +1731,7 @@ static void process_single_lc_entry(rgw::sal::Store *store,
   format_lc_status(formatter, tenant_name, bucket_name, -ret);
 }
 
-int RGWBucketAdminOp::fix_lc_shards(rgw::sal::Store *store,
+int RGWBucketAdminOp::fix_lc_shards(rgw::sal::Store* store,
                                     RGWBucketAdminOpState& op_state,
                                     RGWFormatterFlusher& flusher,
                                     const DoutPrefixProvider *dpp)
@@ -1783,7 +1783,7 @@ int RGWBucketAdminOp::fix_lc_shards(rgw::sal::Store *store,
 }
 
 static bool has_object_expired(const DoutPrefixProvider *dpp,
-			       rgw::sal::Store *store,
+			       rgw::sal::Store* store,
 			       rgw::sal::Bucket* bucket,
 			       const rgw_obj_key& key, utime_t& delete_at)
 {
@@ -1808,7 +1808,7 @@ static bool has_object_expired(const DoutPrefixProvider *dpp,
 }
 
 static int fix_bucket_obj_expiry(const DoutPrefixProvider *dpp,
-				 rgw::sal::Store *store,
+				 rgw::sal::Store* store,
 				 rgw::sal::Bucket* bucket,
 				 RGWFormatterFlusher& flusher, bool dry_run)
 {
@@ -1858,7 +1858,7 @@ static int fix_bucket_obj_expiry(const DoutPrefixProvider *dpp,
   return 0;
 }
 
-int RGWBucketAdminOp::fix_obj_expiry(rgw::sal::Store *store,
+int RGWBucketAdminOp::fix_obj_expiry(rgw::sal::Store* store,
 				     RGWBucketAdminOpState& op_state,
 				     RGWFormatterFlusher& flusher,
                                      const DoutPrefixProvider *dpp, bool dry_run)
@@ -3052,7 +3052,7 @@ int RGWBucketCtl::set_acl(ACLOwner& owner, rgw_bucket& bucket,
 }
 
 // TODO: remove RGWRados dependency for bucket listing
-int RGWBucketCtl::chown(rgw::sal::Store *store, rgw::sal::Bucket* bucket,
+int RGWBucketCtl::chown(rgw::sal::Store* store, rgw::sal::Bucket* bucket,
                         const rgw_user& user_id, const std::string& display_name,
                         const std::string& marker, optional_yield y, const DoutPrefixProvider *dpp)
 {

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -219,14 +219,14 @@ public:
   static RGWBucketInstanceMetadataHandlerBase *alloc();
 };
 
-extern int rgw_remove_object(const DoutPrefixProvider *dpp, rgw::sal::Store *store, rgw::sal::Bucket* bucket, rgw_obj_key& key);
-extern int rgw_remove_bucket_bypass_gc(rgw::sal::Store *store, rgw::sal::Bucket* bucket, int concurrent_max, optional_yield y);
+extern int rgw_remove_object(const DoutPrefixProvider *dpp, rgw::sal::Store* store, rgw::sal::Bucket* bucket, rgw_obj_key& key);
+extern int rgw_remove_bucket_bypass_gc(rgw::sal::Store* store, rgw::sal::Bucket* bucket, int concurrent_max, optional_yield y);
 
 extern int rgw_object_get_attr(rgw::sal::Store* store, rgw::sal::Object* obj,
 			       const char* attr_name, bufferlist& out_bl,
 			       optional_yield y);
 
-extern void check_bad_user_bucket_mapping(rgw::sal::Store *store, rgw::sal::User* user, bool fix, optional_yield y, const DoutPrefixProvider *dpp);
+extern void check_bad_user_bucket_mapping(rgw::sal::Store* store, rgw::sal::User* user, bool fix, optional_yield y, const DoutPrefixProvider *dpp);
 
 struct RGWBucketAdminOpState {
   rgw_user uid;
@@ -318,7 +318,7 @@ struct RGWBucketAdminOpState {
 class RGWBucket
 {
   RGWUserBuckets buckets;
-  rgw::sal::Store *store;
+  rgw::sal::Store* store;
   RGWAccessHandle handle;
 
   std::unique_ptr<rgw::sal::Bucket> bucket;
@@ -330,7 +330,7 @@ class RGWBucket
 
 public:
   RGWBucket() : store(NULL), handle(NULL), failure(false) {}
-  int init(rgw::sal::Store *storage, RGWBucketAdminOpState& op_state, optional_yield y,
+  int init(rgw::sal::Store* storage, RGWBucketAdminOpState& op_state, optional_yield y,
              const DoutPrefixProvider *dpp, std::string *err_msg = NULL);
 
   int check_bad_index_multipart(RGWBucketAdminOpState& op_state,
@@ -368,42 +368,42 @@ public:
 class RGWBucketAdminOp
 {
 public:
-  static int get_policy(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
+  static int get_policy(rgw::sal::Store* store, RGWBucketAdminOpState& op_state,
                   RGWFormatterFlusher& flusher, const DoutPrefixProvider *dpp);
-  static int get_policy(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
+  static int get_policy(rgw::sal::Store* store, RGWBucketAdminOpState& op_state,
                   RGWAccessControlPolicy& policy, const DoutPrefixProvider *dpp);
-  static int dump_s3_policy(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
+  static int dump_s3_policy(rgw::sal::Store* store, RGWBucketAdminOpState& op_state,
                   ostream& os, const DoutPrefixProvider *dpp);
 
-  static int unlink(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp);
-  static int link(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, string *err_msg = NULL);
-  static int chown(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const string& marker, const DoutPrefixProvider *dpp, string *err_msg = NULL);
+  static int unlink(rgw::sal::Store* store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp);
+  static int link(rgw::sal::Store* store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, string *err_msg = NULL);
+  static int chown(rgw::sal::Store* store, RGWBucketAdminOpState& op_state, const string& marker, const DoutPrefixProvider *dpp, string *err_msg = NULL);
 
-  static int check_index(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
+  static int check_index(rgw::sal::Store* store, RGWBucketAdminOpState& op_state,
                   RGWFormatterFlusher& flusher, optional_yield y, const DoutPrefixProvider *dpp);
 
-  static int remove_bucket(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, optional_yield y,
+  static int remove_bucket(rgw::sal::Store* store, RGWBucketAdminOpState& op_state, optional_yield y,
 			   const DoutPrefixProvider *dpp, bool bypass_gc = false, bool keep_index_consistent = true);
-  static int remove_object(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp);
-  static int info(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, RGWFormatterFlusher& flusher, optional_yield y, const DoutPrefixProvider *dpp);
-  static int limit_check(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
+  static int remove_object(rgw::sal::Store* store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp);
+  static int info(rgw::sal::Store* store, RGWBucketAdminOpState& op_state, RGWFormatterFlusher& flusher, optional_yield y, const DoutPrefixProvider *dpp);
+  static int limit_check(rgw::sal::Store* store, RGWBucketAdminOpState& op_state,
 			 const std::list<std::string>& user_ids,
 			 RGWFormatterFlusher& flusher, optional_yield y,
                          const DoutPrefixProvider *dpp,
 			 bool warnings_only = false);
-  static int set_quota(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp);
+  static int set_quota(rgw::sal::Store* store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp);
 
-  static int list_stale_instances(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
+  static int list_stale_instances(rgw::sal::Store* store, RGWBucketAdminOpState& op_state,
 				  RGWFormatterFlusher& flusher, const DoutPrefixProvider *dpp);
 
-  static int clear_stale_instances(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
+  static int clear_stale_instances(rgw::sal::Store* store, RGWBucketAdminOpState& op_state,
 				   RGWFormatterFlusher& flusher, const DoutPrefixProvider *dpp);
-  static int fix_lc_shards(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
+  static int fix_lc_shards(rgw::sal::Store* store, RGWBucketAdminOpState& op_state,
                            RGWFormatterFlusher& flusher, const DoutPrefixProvider *dpp);
-  static int fix_obj_expiry(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
+  static int fix_obj_expiry(rgw::sal::Store* store, RGWBucketAdminOpState& op_state,
 			    RGWFormatterFlusher& flusher, const DoutPrefixProvider *dpp, bool dry_run = false);
 
-  static int sync_bucket(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, string *err_msg = NULL);
+  static int sync_bucket(rgw::sal::Store* store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, string *err_msg = NULL);
 };
 
 struct rgw_ep_info {
@@ -690,7 +690,7 @@ public:
                     const DoutPrefixProvider *dpp,
                     bool update_entrypoint = true);
 
-  int chown(rgw::sal::Store *store, rgw::sal::Bucket* bucket,
+  int chown(rgw::sal::Store* store, rgw::sal::Bucket* bucket,
             const rgw_user& user_id, const std::string& display_name,
             const std::string& marker, optional_yield y, const DoutPrefixProvider *dpp);
 

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -219,14 +219,14 @@ public:
   static RGWBucketInstanceMetadataHandlerBase *alloc();
 };
 
-extern int rgw_remove_object(const DoutPrefixProvider *dpp, rgw::sal::RGWStore *store, rgw::sal::RGWBucket* bucket, rgw_obj_key& key);
-extern int rgw_remove_bucket_bypass_gc(rgw::sal::RGWStore *store, rgw::sal::RGWBucket* bucket, int concurrent_max, optional_yield y);
+extern int rgw_remove_object(const DoutPrefixProvider *dpp, rgw::sal::Store *store, rgw::sal::Bucket* bucket, rgw_obj_key& key);
+extern int rgw_remove_bucket_bypass_gc(rgw::sal::Store *store, rgw::sal::Bucket* bucket, int concurrent_max, optional_yield y);
 
-extern int rgw_object_get_attr(rgw::sal::RGWStore* store, rgw::sal::RGWObject* obj,
+extern int rgw_object_get_attr(rgw::sal::Store* store, rgw::sal::Object* obj,
 			       const char* attr_name, bufferlist& out_bl,
 			       optional_yield y);
 
-extern void check_bad_user_bucket_mapping(rgw::sal::RGWStore *store, rgw::sal::RGWUser* user, bool fix, optional_yield y, const DoutPrefixProvider *dpp);
+extern void check_bad_user_bucket_mapping(rgw::sal::Store *store, rgw::sal::User* user, bool fix, optional_yield y, const DoutPrefixProvider *dpp);
 
 struct RGWBucketAdminOpState {
   rgw_user uid;
@@ -245,7 +245,7 @@ struct RGWBucketAdminOpState {
   bool sync_bucket;
   int max_aio = 0;
 
-  std::unique_ptr<rgw::sal::RGWBucket>  bucket;
+  std::unique_ptr<rgw::sal::Bucket>  bucket;
 
   RGWQuotaInfo quota;
 
@@ -285,8 +285,8 @@ struct RGWBucketAdminOpState {
   std::string& get_object_name() { return object_name; }
   std::string& get_tenant() { return uid.tenant; }
 
-  rgw::sal::RGWBucket* get_bucket() { return bucket.get(); }
-  void set_bucket(std::unique_ptr<rgw::sal::RGWBucket> _bucket) {
+  rgw::sal::Bucket* get_bucket() { return bucket.get(); }
+  void set_bucket(std::unique_ptr<rgw::sal::Bucket> _bucket) {
     bucket = std::move(_bucket);
     bucket_stored = true;
   }
@@ -318,11 +318,11 @@ struct RGWBucketAdminOpState {
 class RGWBucket
 {
   RGWUserBuckets buckets;
-  rgw::sal::RGWStore *store;
+  rgw::sal::Store *store;
   RGWAccessHandle handle;
 
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
-  std::unique_ptr<rgw::sal::RGWUser> user;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
+  std::unique_ptr<rgw::sal::User> user;
 
   bool failure;
 
@@ -330,7 +330,7 @@ class RGWBucket
 
 public:
   RGWBucket() : store(NULL), handle(NULL), failure(false) {}
-  int init(rgw::sal::RGWStore *storage, RGWBucketAdminOpState& op_state, optional_yield y,
+  int init(rgw::sal::Store *storage, RGWBucketAdminOpState& op_state, optional_yield y,
              const DoutPrefixProvider *dpp, std::string *err_msg = NULL);
 
   int check_bad_index_multipart(RGWBucketAdminOpState& op_state,
@@ -368,42 +368,42 @@ public:
 class RGWBucketAdminOp
 {
 public:
-  static int get_policy(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state,
+  static int get_policy(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
                   RGWFormatterFlusher& flusher, const DoutPrefixProvider *dpp);
-  static int get_policy(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state,
+  static int get_policy(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
                   RGWAccessControlPolicy& policy, const DoutPrefixProvider *dpp);
-  static int dump_s3_policy(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state,
+  static int dump_s3_policy(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
                   ostream& os, const DoutPrefixProvider *dpp);
 
-  static int unlink(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp);
-  static int link(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, string *err_msg = NULL);
-  static int chown(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state, const string& marker, const DoutPrefixProvider *dpp, string *err_msg = NULL);
+  static int unlink(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp);
+  static int link(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, string *err_msg = NULL);
+  static int chown(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const string& marker, const DoutPrefixProvider *dpp, string *err_msg = NULL);
 
-  static int check_index(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state,
+  static int check_index(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
                   RGWFormatterFlusher& flusher, optional_yield y, const DoutPrefixProvider *dpp);
 
-  static int remove_bucket(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state, optional_yield y,
+  static int remove_bucket(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, optional_yield y,
 			   const DoutPrefixProvider *dpp, bool bypass_gc = false, bool keep_index_consistent = true);
-  static int remove_object(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp);
-  static int info(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state, RGWFormatterFlusher& flusher, optional_yield y, const DoutPrefixProvider *dpp);
-  static int limit_check(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state,
+  static int remove_object(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp);
+  static int info(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, RGWFormatterFlusher& flusher, optional_yield y, const DoutPrefixProvider *dpp);
+  static int limit_check(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
 			 const std::list<std::string>& user_ids,
 			 RGWFormatterFlusher& flusher, optional_yield y,
                          const DoutPrefixProvider *dpp,
 			 bool warnings_only = false);
-  static int set_quota(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp);
+  static int set_quota(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp);
 
-  static int list_stale_instances(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state,
+  static int list_stale_instances(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
 				  RGWFormatterFlusher& flusher, const DoutPrefixProvider *dpp);
 
-  static int clear_stale_instances(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state,
+  static int clear_stale_instances(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
 				   RGWFormatterFlusher& flusher, const DoutPrefixProvider *dpp);
-  static int fix_lc_shards(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state,
+  static int fix_lc_shards(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
                            RGWFormatterFlusher& flusher, const DoutPrefixProvider *dpp);
-  static int fix_obj_expiry(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state,
+  static int fix_obj_expiry(rgw::sal::Store *store, RGWBucketAdminOpState& op_state,
 			    RGWFormatterFlusher& flusher, const DoutPrefixProvider *dpp, bool dry_run = false);
 
-  static int sync_bucket(rgw::sal::RGWStore *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, string *err_msg = NULL);
+  static int sync_bucket(rgw::sal::Store *store, RGWBucketAdminOpState& op_state, const DoutPrefixProvider *dpp, string *err_msg = NULL);
 };
 
 struct rgw_ep_info {
@@ -690,7 +690,7 @@ public:
                     const DoutPrefixProvider *dpp,
                     bool update_entrypoint = true);
 
-  int chown(rgw::sal::RGWStore *store, rgw::sal::RGWBucket* bucket,
+  int chown(rgw::sal::Store *store, rgw::sal::Bucket* bucket,
             const rgw_user& user_id, const std::string& display_name,
             const std::string& marker, optional_yield y, const DoutPrefixProvider *dpp);
 
@@ -766,7 +766,7 @@ private:
 
 };
 
-bool rgw_find_bucket_by_id(CephContext *cct, rgw::sal::RGWStore* store, const string& marker,
+bool rgw_find_bucket_by_id(CephContext *cct, rgw::sal::Store* store, const string& marker,
                            const string& bucket_id, rgw_bucket* bucket_out);
 
 #endif

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1496,7 +1496,7 @@ bool verify_object_permission(const DoutPrefixProvider* dpp, struct req_state *s
 }
 
 
-int verify_object_lock(const DoutPrefixProvider* dpp, const rgw::sal::RGWAttrs& attrs, const bool bypass_perm, const bool bypass_governance_mode) {
+int verify_object_lock(const DoutPrefixProvider* dpp, const rgw::sal::Attrs& attrs, const bool bypass_perm, const bool bypass_governance_mode) {
   auto aiter = attrs.find(RGW_ATTR_OBJECT_RETENTION);
   if (aiter != attrs.end()) {
     RGWObjectRetention obj_retention;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -45,10 +45,10 @@ namespace ceph {
 }
 
 namespace rgw::sal {
-  class RGWUser;
-  class RGWBucket;
-  class RGWObject;
-  using RGWAttrs = std::map<std::string, ceph::buffer::list>;
+  class User;
+  class Bucket;
+  class Object;
+  using Attrs = std::map<std::string, ceph::buffer::list>;
 }
 
 using ceph::crypto::MD5;
@@ -1529,11 +1529,11 @@ struct req_state : DoutPrefixProvider {
   string bucket_tenant;
   string bucket_name;
 
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
-  std::unique_ptr<rgw::sal::RGWObject> object;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
+  std::unique_ptr<rgw::sal::Object> object;
   string src_tenant_name;
   string src_bucket_name;
-  std::unique_ptr<rgw::sal::RGWObject> src_object;
+  std::unique_ptr<rgw::sal::Object> src_object;
   ACLOwner bucket_owner;
   ACLOwner owner;
 
@@ -1552,7 +1552,7 @@ struct req_state : DoutPrefixProvider {
 
   bool has_bad_meta{false};
 
-  std::unique_ptr<rgw::sal::RGWUser> user;
+  std::unique_ptr<rgw::sal::User> user;
 
   struct {
     /* TODO(rzarzynski): switch out to the static_ptr for both members. */
@@ -1641,7 +1641,7 @@ struct req_state : DoutPrefixProvider {
   ~req_state();
 
 
-  void set_user(std::unique_ptr<rgw::sal::RGWUser>& u) { user.swap(u); }
+  void set_user(std::unique_ptr<rgw::sal::User>& u) { user.swap(u); }
   bool is_err() const { return err.is_err(); }
 
   // implements DoutPrefixProvider
@@ -2167,7 +2167,7 @@ extern bool verify_object_permission_no_policy(const DoutPrefixProvider* dpp, st
 					       int perm);
 extern int verify_object_lock(
   const DoutPrefixProvider* dpp,
-  const rgw::sal::RGWAttrs& attrs,
+  const rgw::sal::Attrs& attrs,
   const bool bypass_perm,
   const bool bypass_governance_mode);
 

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -187,7 +187,7 @@ RGWAsyncPutSystemObjAttrs::RGWAsyncPutSystemObjAttrs(RGWCoroutine *caller, RGWAi
 }
 
 
-RGWOmapAppend::RGWOmapAppend(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store, const rgw_raw_obj& _obj,
+RGWOmapAppend::RGWOmapAppend(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore* _store, const rgw_raw_obj& _obj,
                              uint64_t _window_size)
                       : RGWConsumerCR<string>(_store->ctx()), async_rados(_async_rados),
                         store(_store), obj(_obj), going_down(false), num_pending_entries(0), window_size(_window_size), total_entries(0)
@@ -212,7 +212,7 @@ int RGWAsyncLockSystemObj::_send_request()
   return l.lock_exclusive(&ref.pool.ioctx(), ref.obj.oid);
 }
 
-RGWAsyncLockSystemObj::RGWAsyncLockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *_store,
+RGWAsyncLockSystemObj::RGWAsyncLockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore* _store,
                       RGWObjVersionTracker *_objv_tracker, const rgw_raw_obj& _obj,
                        const string& _name, const string& _cookie, uint32_t _duration_secs) : RGWAsyncRadosRequest(caller, cn), store(_store),
                                                               obj(_obj),
@@ -238,7 +238,7 @@ int RGWAsyncUnlockSystemObj::_send_request()
   return l.unlock(&ref.pool.ioctx(), ref.obj.oid);
 }
 
-RGWAsyncUnlockSystemObj::RGWAsyncUnlockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *_store,
+RGWAsyncUnlockSystemObj::RGWAsyncUnlockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore* _store,
                                                  RGWObjVersionTracker *_objv_tracker, const rgw_raw_obj& _obj,
                                                  const string& _name, const string& _cookie) : RGWAsyncRadosRequest(caller, cn), store(_store),
   obj(_obj),
@@ -246,7 +246,7 @@ RGWAsyncUnlockSystemObj::RGWAsyncUnlockSystemObj(RGWCoroutine *caller, RGWAioCom
 {
 }
 
-RGWRadosSetOmapKeysCR::RGWRadosSetOmapKeysCR(rgw::sal::RadosStore *_store,
+RGWRadosSetOmapKeysCR::RGWRadosSetOmapKeysCR(rgw::sal::RadosStore* _store,
                       const rgw_raw_obj& _obj,
                       map<string, bufferlist>& _entries) : RGWSimpleCoroutine(_store->ctx()),
                                                 store(_store),
@@ -290,7 +290,7 @@ int RGWRadosSetOmapKeysCR::request_complete()
   return r;
 }
 
-RGWRadosGetOmapKeysCR::RGWRadosGetOmapKeysCR(rgw::sal::RadosStore *_store,
+RGWRadosGetOmapKeysCR::RGWRadosGetOmapKeysCR(rgw::sal::RadosStore* _store,
                       const rgw_raw_obj& _obj,
                       const string& _marker,
                       int _max_entries,
@@ -328,7 +328,7 @@ int RGWRadosGetOmapKeysCR::request_complete()
   return r;
 }
 
-RGWRadosGetOmapValsCR::RGWRadosGetOmapValsCR(rgw::sal::RadosStore *_store,
+RGWRadosGetOmapValsCR::RGWRadosGetOmapValsCR(rgw::sal::RadosStore* _store,
                       const rgw_raw_obj& _obj,
                       const string& _marker,
                       int _max_entries,
@@ -366,7 +366,7 @@ int RGWRadosGetOmapValsCR::request_complete()
   return r;
 }
 
-RGWRadosRemoveOmapKeysCR::RGWRadosRemoveOmapKeysCR(rgw::sal::RadosStore *_store,
+RGWRadosRemoveOmapKeysCR::RGWRadosRemoveOmapKeysCR(rgw::sal::RadosStore* _store,
                       const rgw_raw_obj& _obj,
                       const set<string>& _keys) : RGWSimpleCoroutine(_store->ctx()),
                                                 store(_store),
@@ -401,7 +401,7 @@ int RGWRadosRemoveOmapKeysCR::request_complete()
   return r;
 }
 
-RGWRadosRemoveCR::RGWRadosRemoveCR(rgw::sal::RadosStore *store, const rgw_raw_obj& obj,
+RGWRadosRemoveCR::RGWRadosRemoveCR(rgw::sal::RadosStore* store, const rgw_raw_obj& obj,
                                    RGWObjVersionTracker* objv_tracker)
   : RGWSimpleCoroutine(store->ctx()),
     store(store), obj(obj), objv_tracker(objv_tracker)
@@ -440,7 +440,7 @@ int RGWRadosRemoveCR::request_complete()
   return r;
 }
 
-RGWSimpleRadosLockCR::RGWSimpleRadosLockCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
+RGWSimpleRadosLockCR::RGWSimpleRadosLockCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore* _store,
                       const rgw_raw_obj& _obj,
                       const string& _lock_name,
                       const string& _cookie,
@@ -479,7 +479,7 @@ int RGWSimpleRadosLockCR::request_complete()
   return req->get_ret_status();
 }
 
-RGWSimpleRadosUnlockCR::RGWSimpleRadosUnlockCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
+RGWSimpleRadosUnlockCR::RGWSimpleRadosUnlockCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore* _store,
                       const rgw_raw_obj& _obj,
                       const string& _lock_name,
                       const string& _cookie) : RGWSimpleCoroutine(_store->ctx()),
@@ -595,7 +595,7 @@ int RGWAsyncGetBucketInstanceInfo::_send_request()
   return 0;
 }
 
-RGWRadosBILogTrimCR::RGWRadosBILogTrimCR(rgw::sal::RadosStore *store,
+RGWRadosBILogTrimCR::RGWRadosBILogTrimCR(rgw::sal::RadosStore* store,
                                          const RGWBucketInfo& bucket_info,
                                          int shard_id,
                                          const std::string& start_marker,
@@ -816,7 +816,7 @@ int RGWContinuousLeaseCR::operate()
   return 0;
 }
 
-RGWRadosTimelogAddCR::RGWRadosTimelogAddCR(rgw::sal::RadosStore *_store, const string& _oid,
+RGWRadosTimelogAddCR::RGWRadosTimelogAddCR(rgw::sal::RadosStore* _store, const string& _oid,
                       const cls_log_entry& entry) : RGWSimpleCoroutine(_store->ctx()),
                                                 store(_store),
                                                 oid(_oid), cn(NULL)
@@ -843,7 +843,7 @@ int RGWRadosTimelogAddCR::request_complete()
   return r;
 }
 
-RGWRadosTimelogTrimCR::RGWRadosTimelogTrimCR(rgw::sal::RadosStore *store,
+RGWRadosTimelogTrimCR::RGWRadosTimelogTrimCR(rgw::sal::RadosStore* store,
                                              const std::string& oid,
                                              const real_time& start_time,
                                              const real_time& end_time,
@@ -878,7 +878,7 @@ int RGWRadosTimelogTrimCR::request_complete()
 }
 
 
-RGWSyncLogTrimCR::RGWSyncLogTrimCR(rgw::sal::RadosStore *store, const std::string& oid,
+RGWSyncLogTrimCR::RGWSyncLogTrimCR(rgw::sal::RadosStore* store, const std::string& oid,
                                    const std::string& to_marker,
                                    std::string *last_trim_marker)
   : RGWRadosTimelogTrimCR(store, oid, real_time{}, real_time{},
@@ -909,7 +909,7 @@ int RGWAsyncStatObj::_send_request()
                              nullptr, nullptr, objv_tracker, null_yield);
 }
 
-RGWStatObjCR::RGWStatObjCR(RGWAsyncRadosProcessor *async_rados, rgw::sal::RadosStore *store,
+RGWStatObjCR::RGWStatObjCR(RGWAsyncRadosProcessor *async_rados, rgw::sal::RadosStore* store,
                            const RGWBucketInfo& _bucket_info, const rgw_obj& obj, uint64_t *psize,
                            real_time* pmtime, uint64_t *pepoch,
                            RGWObjVersionTracker *objv_tracker)
@@ -940,7 +940,7 @@ int RGWStatObjCR::request_complete()
   return req->get_ret_status();
 }
 
-RGWRadosNotifyCR::RGWRadosNotifyCR(rgw::sal::RadosStore *store, const rgw_raw_obj& obj,
+RGWRadosNotifyCR::RGWRadosNotifyCR(rgw::sal::RadosStore* store, const rgw_raw_obj& obj,
                                    bufferlist& request, uint64_t timeout_ms,
                                    bufferlist *response)
   : RGWSimpleCoroutine(store->ctx()), store(store), obj(obj),

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -187,7 +187,7 @@ RGWAsyncPutSystemObjAttrs::RGWAsyncPutSystemObjAttrs(RGWCoroutine *caller, RGWAi
 }
 
 
-RGWOmapAppend::RGWOmapAppend(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RGWRadosStore *_store, const rgw_raw_obj& _obj,
+RGWOmapAppend::RGWOmapAppend(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store, const rgw_raw_obj& _obj,
                              uint64_t _window_size)
                       : RGWConsumerCR<string>(_store->ctx()), async_rados(_async_rados),
                         store(_store), obj(_obj), going_down(false), num_pending_entries(0), window_size(_window_size), total_entries(0)
@@ -212,7 +212,7 @@ int RGWAsyncLockSystemObj::_send_request()
   return l.lock_exclusive(&ref.pool.ioctx(), ref.obj.oid);
 }
 
-RGWAsyncLockSystemObj::RGWAsyncLockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RGWRadosStore *_store,
+RGWAsyncLockSystemObj::RGWAsyncLockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *_store,
                       RGWObjVersionTracker *_objv_tracker, const rgw_raw_obj& _obj,
                        const string& _name, const string& _cookie, uint32_t _duration_secs) : RGWAsyncRadosRequest(caller, cn), store(_store),
                                                               obj(_obj),
@@ -238,7 +238,7 @@ int RGWAsyncUnlockSystemObj::_send_request()
   return l.unlock(&ref.pool.ioctx(), ref.obj.oid);
 }
 
-RGWAsyncUnlockSystemObj::RGWAsyncUnlockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RGWRadosStore *_store,
+RGWAsyncUnlockSystemObj::RGWAsyncUnlockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *_store,
                                                  RGWObjVersionTracker *_objv_tracker, const rgw_raw_obj& _obj,
                                                  const string& _name, const string& _cookie) : RGWAsyncRadosRequest(caller, cn), store(_store),
   obj(_obj),
@@ -246,7 +246,7 @@ RGWAsyncUnlockSystemObj::RGWAsyncUnlockSystemObj(RGWCoroutine *caller, RGWAioCom
 {
 }
 
-RGWRadosSetOmapKeysCR::RGWRadosSetOmapKeysCR(rgw::sal::RGWRadosStore *_store,
+RGWRadosSetOmapKeysCR::RGWRadosSetOmapKeysCR(rgw::sal::RadosStore *_store,
                       const rgw_raw_obj& _obj,
                       map<string, bufferlist>& _entries) : RGWSimpleCoroutine(_store->ctx()),
                                                 store(_store),
@@ -290,7 +290,7 @@ int RGWRadosSetOmapKeysCR::request_complete()
   return r;
 }
 
-RGWRadosGetOmapKeysCR::RGWRadosGetOmapKeysCR(rgw::sal::RGWRadosStore *_store,
+RGWRadosGetOmapKeysCR::RGWRadosGetOmapKeysCR(rgw::sal::RadosStore *_store,
                       const rgw_raw_obj& _obj,
                       const string& _marker,
                       int _max_entries,
@@ -328,7 +328,7 @@ int RGWRadosGetOmapKeysCR::request_complete()
   return r;
 }
 
-RGWRadosGetOmapValsCR::RGWRadosGetOmapValsCR(rgw::sal::RGWRadosStore *_store,
+RGWRadosGetOmapValsCR::RGWRadosGetOmapValsCR(rgw::sal::RadosStore *_store,
                       const rgw_raw_obj& _obj,
                       const string& _marker,
                       int _max_entries,
@@ -366,7 +366,7 @@ int RGWRadosGetOmapValsCR::request_complete()
   return r;
 }
 
-RGWRadosRemoveOmapKeysCR::RGWRadosRemoveOmapKeysCR(rgw::sal::RGWRadosStore *_store,
+RGWRadosRemoveOmapKeysCR::RGWRadosRemoveOmapKeysCR(rgw::sal::RadosStore *_store,
                       const rgw_raw_obj& _obj,
                       const set<string>& _keys) : RGWSimpleCoroutine(_store->ctx()),
                                                 store(_store),
@@ -401,7 +401,7 @@ int RGWRadosRemoveOmapKeysCR::request_complete()
   return r;
 }
 
-RGWRadosRemoveCR::RGWRadosRemoveCR(rgw::sal::RGWRadosStore *store, const rgw_raw_obj& obj,
+RGWRadosRemoveCR::RGWRadosRemoveCR(rgw::sal::RadosStore *store, const rgw_raw_obj& obj,
                                    RGWObjVersionTracker* objv_tracker)
   : RGWSimpleCoroutine(store->ctx()),
     store(store), obj(obj), objv_tracker(objv_tracker)
@@ -440,7 +440,7 @@ int RGWRadosRemoveCR::request_complete()
   return r;
 }
 
-RGWSimpleRadosLockCR::RGWSimpleRadosLockCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RGWRadosStore *_store,
+RGWSimpleRadosLockCR::RGWSimpleRadosLockCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
                       const rgw_raw_obj& _obj,
                       const string& _lock_name,
                       const string& _cookie,
@@ -479,7 +479,7 @@ int RGWSimpleRadosLockCR::request_complete()
   return req->get_ret_status();
 }
 
-RGWSimpleRadosUnlockCR::RGWSimpleRadosUnlockCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RGWRadosStore *_store,
+RGWSimpleRadosUnlockCR::RGWSimpleRadosUnlockCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
                       const rgw_raw_obj& _obj,
                       const string& _lock_name,
                       const string& _cookie) : RGWSimpleCoroutine(_store->ctx()),
@@ -595,7 +595,7 @@ int RGWAsyncGetBucketInstanceInfo::_send_request()
   return 0;
 }
 
-RGWRadosBILogTrimCR::RGWRadosBILogTrimCR(rgw::sal::RGWRadosStore *store,
+RGWRadosBILogTrimCR::RGWRadosBILogTrimCR(rgw::sal::RadosStore *store,
                                          const RGWBucketInfo& bucket_info,
                                          int shard_id,
                                          const std::string& start_marker,
@@ -635,12 +635,12 @@ int RGWAsyncFetchRemoteObj::_send_request()
 
   char buf[16];
   snprintf(buf, sizeof(buf), ".%lld", (long long)store->getRados()->instance_id());
-  rgw::sal::RGWAttrs attrs;
+  rgw::sal::Attrs attrs;
 
-  rgw::sal::RGWRadosBucket bucket(store, src_bucket);
-  rgw::sal::RGWRadosObject src_obj(store, key, &bucket);
-  rgw::sal::RGWRadosBucket dest_bucket(store, dest_bucket_info);
-  rgw::sal::RGWRadosObject dest_obj(store, dest_key.value_or(key), &dest_bucket);
+  rgw::sal::RadosBucket bucket(store, src_bucket);
+  rgw::sal::RadosObject src_obj(store, key, &bucket);
+  rgw::sal::RadosBucket dest_bucket(store, dest_bucket_info);
+  rgw::sal::RadosObject dest_obj(store, dest_key.value_or(key), &dest_bucket);
 
   std::optional<uint64_t> bytes_transferred;
   int r = store->getRados()->fetch_remote_obj(obj_ctx,
@@ -697,8 +697,8 @@ int RGWAsyncStatRemoteObj::_send_request()
   char buf[16];
   snprintf(buf, sizeof(buf), ".%lld", (long long)store->getRados()->instance_id());
 
-  rgw::sal::RGWRadosBucket bucket(store, src_bucket);
-  rgw::sal::RGWRadosObject src_obj(store, key, &bucket);
+  rgw::sal::RadosBucket bucket(store, src_bucket);
+  rgw::sal::RadosObject src_obj(store, key, &bucket);
 
   int r = store->getRados()->stat_remote_obj(obj_ctx,
                        rgw_user(user_id),
@@ -816,7 +816,7 @@ int RGWContinuousLeaseCR::operate()
   return 0;
 }
 
-RGWRadosTimelogAddCR::RGWRadosTimelogAddCR(rgw::sal::RGWRadosStore *_store, const string& _oid,
+RGWRadosTimelogAddCR::RGWRadosTimelogAddCR(rgw::sal::RadosStore *_store, const string& _oid,
                       const cls_log_entry& entry) : RGWSimpleCoroutine(_store->ctx()),
                                                 store(_store),
                                                 oid(_oid), cn(NULL)
@@ -843,7 +843,7 @@ int RGWRadosTimelogAddCR::request_complete()
   return r;
 }
 
-RGWRadosTimelogTrimCR::RGWRadosTimelogTrimCR(rgw::sal::RGWRadosStore *store,
+RGWRadosTimelogTrimCR::RGWRadosTimelogTrimCR(rgw::sal::RadosStore *store,
                                              const std::string& oid,
                                              const real_time& start_time,
                                              const real_time& end_time,
@@ -878,7 +878,7 @@ int RGWRadosTimelogTrimCR::request_complete()
 }
 
 
-RGWSyncLogTrimCR::RGWSyncLogTrimCR(rgw::sal::RGWRadosStore *store, const std::string& oid,
+RGWSyncLogTrimCR::RGWSyncLogTrimCR(rgw::sal::RadosStore *store, const std::string& oid,
                                    const std::string& to_marker,
                                    std::string *last_trim_marker)
   : RGWRadosTimelogTrimCR(store, oid, real_time{}, real_time{},
@@ -909,7 +909,7 @@ int RGWAsyncStatObj::_send_request()
                              nullptr, nullptr, objv_tracker, null_yield);
 }
 
-RGWStatObjCR::RGWStatObjCR(RGWAsyncRadosProcessor *async_rados, rgw::sal::RGWRadosStore *store,
+RGWStatObjCR::RGWStatObjCR(RGWAsyncRadosProcessor *async_rados, rgw::sal::RadosStore *store,
                            const RGWBucketInfo& _bucket_info, const rgw_obj& obj, uint64_t *psize,
                            real_time* pmtime, uint64_t *pepoch,
                            RGWObjVersionTracker *objv_tracker)
@@ -940,7 +940,7 @@ int RGWStatObjCR::request_complete()
   return req->get_ret_status();
 }
 
-RGWRadosNotifyCR::RGWRadosNotifyCR(rgw::sal::RGWRadosStore *store, const rgw_raw_obj& obj,
+RGWRadosNotifyCR::RGWRadosNotifyCR(rgw::sal::RadosStore *store, const rgw_raw_obj& obj,
                                    bufferlist& request, uint64_t timeout_ms,
                                    bufferlist *response)
   : RGWSimpleCoroutine(store->ctx()), store(store), obj(obj),

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -111,13 +111,13 @@ public:
 template <class P>
 class RGWSimpleWriteOnlyAsyncCR : public RGWSimpleCoroutine {
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
 
   P params;
   const DoutPrefixProvider *dpp;
 
   class Request : public RGWAsyncRadosRequest {
-    rgw::sal::RadosStore *store;
+    rgw::sal::RadosStore* store;
     P params;
     const DoutPrefixProvider *dpp;
   protected:
@@ -125,7 +125,7 @@ class RGWSimpleWriteOnlyAsyncCR : public RGWSimpleCoroutine {
   public:
     Request(RGWCoroutine *caller,
             RGWAioCompletionNotifier *cn,
-            rgw::sal::RadosStore *store,
+            rgw::sal::RadosStore* store,
             const P& _params,
             const DoutPrefixProvider *dpp) : RGWAsyncRadosRequest(caller, cn),
                                 store(store),
@@ -135,7 +135,7 @@ class RGWSimpleWriteOnlyAsyncCR : public RGWSimpleCoroutine {
 
  public:
   RGWSimpleWriteOnlyAsyncCR(RGWAsyncRadosProcessor *_async_rados,
-			    rgw::sal::RadosStore *_store,
+			    rgw::sal::RadosStore* _store,
 			    const P& _params,
                             const DoutPrefixProvider *_dpp) : RGWSimpleCoroutine(_store->ctx()),
                                                 async_rados(_async_rados),
@@ -172,14 +172,14 @@ class RGWSimpleWriteOnlyAsyncCR : public RGWSimpleCoroutine {
 template <class P, class R>
 class RGWSimpleAsyncCR : public RGWSimpleCoroutine {
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
 
   P params;
   std::shared_ptr<R> result;
   const DoutPrefixProvider *dpp;
 
   class Request : public RGWAsyncRadosRequest {
-    rgw::sal::RadosStore *store;
+    rgw::sal::RadosStore* store;
     P params;
     std::shared_ptr<R> result;
     const DoutPrefixProvider *dpp;
@@ -188,7 +188,7 @@ class RGWSimpleAsyncCR : public RGWSimpleCoroutine {
   public:
     Request(RGWCoroutine *caller,
             RGWAioCompletionNotifier *cn,
-            rgw::sal::RadosStore *_store,
+            rgw::sal::RadosStore* _store,
             const P& _params,
             std::shared_ptr<R>& _result,
             const DoutPrefixProvider *_dpp) : RGWAsyncRadosRequest(caller, cn),
@@ -200,7 +200,7 @@ class RGWSimpleAsyncCR : public RGWSimpleCoroutine {
 
  public:
   RGWSimpleAsyncCR(RGWAsyncRadosProcessor *_async_rados,
-                   rgw::sal::RadosStore *_store,
+                   rgw::sal::RadosStore* _store,
                    const P& _params,
                    std::shared_ptr<R>& _result,
                    const DoutPrefixProvider *_dpp) : RGWSimpleCoroutine(_store->ctx()),
@@ -238,7 +238,7 @@ class RGWSimpleAsyncCR : public RGWSimpleCoroutine {
 
 class RGWGenericAsyncCR : public RGWSimpleCoroutine {
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
 
 
 public:
@@ -353,7 +353,7 @@ public:
 };
 
 class RGWAsyncLockSystemObj : public RGWAsyncRadosRequest {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   rgw_raw_obj obj;
   string lock_name;
   string cookie;
@@ -362,13 +362,13 @@ class RGWAsyncLockSystemObj : public RGWAsyncRadosRequest {
 protected:
   int _send_request() override;
 public:
-  RGWAsyncLockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *_store,
+  RGWAsyncLockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore* _store,
                         RGWObjVersionTracker *_objv_tracker, const rgw_raw_obj& _obj,
 		        const string& _name, const string& _cookie, uint32_t _duration_secs);
 };
 
 class RGWAsyncUnlockSystemObj : public RGWAsyncRadosRequest {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   rgw_raw_obj obj;
   string lock_name;
   string cookie;
@@ -376,7 +376,7 @@ class RGWAsyncUnlockSystemObj : public RGWAsyncRadosRequest {
 protected:
   int _send_request() override;
 public:
-  RGWAsyncUnlockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *_store,
+  RGWAsyncUnlockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore* _store,
                         RGWObjVersionTracker *_objv_tracker, const rgw_raw_obj& _obj,
 		        const string& _name, const string& _cookie);
 };
@@ -584,7 +584,7 @@ public:
 };
 
 class RGWRadosSetOmapKeysCR : public RGWSimpleCoroutine {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   map<string, bufferlist> entries;
 
   rgw_rados_ref ref;
@@ -594,7 +594,7 @@ class RGWRadosSetOmapKeysCR : public RGWSimpleCoroutine {
   boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
 
 public:
-  RGWRadosSetOmapKeysCR(rgw::sal::RadosStore *_store,
+  RGWRadosSetOmapKeysCR(rgw::sal::RadosStore* _store,
 		      const rgw_raw_obj& _obj,
 		      map<string, bufferlist>& _entries);
 
@@ -611,7 +611,7 @@ class RGWRadosGetOmapKeysCR : public RGWSimpleCoroutine {
   };
   using ResultPtr = std::shared_ptr<Result>;
 
-  RGWRadosGetOmapKeysCR(rgw::sal::RadosStore *_store, const rgw_raw_obj& _obj,
+  RGWRadosGetOmapKeysCR(rgw::sal::RadosStore* _store, const rgw_raw_obj& _obj,
                         const string& _marker, int _max_entries,
                         ResultPtr result);
 
@@ -619,7 +619,7 @@ class RGWRadosGetOmapKeysCR : public RGWSimpleCoroutine {
   int request_complete() override;
 
  private:
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   rgw_raw_obj obj;
   string marker;
   int max_entries;
@@ -636,7 +636,7 @@ class RGWRadosGetOmapValsCR : public RGWSimpleCoroutine {
   };
   using ResultPtr = std::shared_ptr<Result>;
 
-  RGWRadosGetOmapValsCR(rgw::sal::RadosStore *_store, const rgw_raw_obj& _obj,
+  RGWRadosGetOmapValsCR(rgw::sal::RadosStore* _store, const rgw_raw_obj& _obj,
                         const string& _marker, int _max_entries,
                         ResultPtr result);
 
@@ -644,7 +644,7 @@ class RGWRadosGetOmapValsCR : public RGWSimpleCoroutine {
   int request_complete() override;
 
  private:
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   rgw_raw_obj obj;
   string marker;
   int max_entries;
@@ -653,7 +653,7 @@ class RGWRadosGetOmapValsCR : public RGWSimpleCoroutine {
 };
 
 class RGWRadosRemoveOmapKeysCR : public RGWSimpleCoroutine {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
 
   rgw_rados_ref ref;
 
@@ -664,7 +664,7 @@ class RGWRadosRemoveOmapKeysCR : public RGWSimpleCoroutine {
   boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
 
 public:
-  RGWRadosRemoveOmapKeysCR(rgw::sal::RadosStore *_store,
+  RGWRadosRemoveOmapKeysCR(rgw::sal::RadosStore* _store,
 		      const rgw_raw_obj& _obj,
 		      const set<string>& _keys);
 
@@ -674,14 +674,14 @@ public:
 };
 
 class RGWRadosRemoveCR : public RGWSimpleCoroutine {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   librados::IoCtx ioctx;
   const rgw_raw_obj obj;
   RGWObjVersionTracker* objv_tracker;
   boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
 
 public:
-  RGWRadosRemoveCR(rgw::sal::RadosStore *store, const rgw_raw_obj& obj,
+  RGWRadosRemoveCR(rgw::sal::RadosStore* store, const rgw_raw_obj& obj,
                    RGWObjVersionTracker* objv_tracker = nullptr);
 
   int send_request() override;
@@ -690,7 +690,7 @@ public:
 
 class RGWSimpleRadosLockCR : public RGWSimpleCoroutine {
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   string lock_name;
   string cookie;
   uint32_t duration;
@@ -700,7 +700,7 @@ class RGWSimpleRadosLockCR : public RGWSimpleCoroutine {
   RGWAsyncLockSystemObj *req;
 
 public:
-  RGWSimpleRadosLockCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
+  RGWSimpleRadosLockCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore* _store,
 		      const rgw_raw_obj& _obj,
                       const string& _lock_name,
 		      const string& _cookie,
@@ -723,7 +723,7 @@ public:
 
 class RGWSimpleRadosUnlockCR : public RGWSimpleCoroutine {
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   string lock_name;
   string cookie;
 
@@ -732,7 +732,7 @@ class RGWSimpleRadosUnlockCR : public RGWSimpleCoroutine {
   RGWAsyncUnlockSystemObj *req;
 
 public:
-  RGWSimpleRadosUnlockCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
+  RGWSimpleRadosUnlockCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore* _store,
 		      const rgw_raw_obj& _obj, 
                       const string& _lock_name,
 		      const string& _cookie);
@@ -749,7 +749,7 @@ public:
 
 class RGWOmapAppend : public RGWConsumerCR<string> {
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
 
   rgw_raw_obj obj;
 
@@ -763,7 +763,7 @@ class RGWOmapAppend : public RGWConsumerCR<string> {
   uint64_t window_size;
   uint64_t total_entries;
 public:
-  RGWOmapAppend(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
+  RGWOmapAppend(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore* _store,
                 const rgw_raw_obj& _obj,
                 uint64_t _window_size = OMAP_APPEND_MAX_ENTRIES_DEFAULT);
   int operate() override;
@@ -782,14 +782,14 @@ public:
 
 class RGWShardedOmapCRManager {
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   RGWCoroutine *op;
 
   int num_shards;
 
   vector<RGWOmapAppend *> shards;
 public:
-  RGWShardedOmapCRManager(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store, RGWCoroutine *_op, int _num_shards, const rgw_pool& pool, const string& oid_prefix)
+  RGWShardedOmapCRManager(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore* _store, RGWCoroutine *_op, int _num_shards, const rgw_pool& pool, const string& oid_prefix)
                       : async_rados(_async_rados),
 		        store(_store), op(_op), num_shards(_num_shards) {
     shards.reserve(num_shards);
@@ -826,7 +826,7 @@ public:
 };
 
 class RGWAsyncGetBucketInstanceInfo : public RGWAsyncRadosRequest {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   rgw_bucket bucket;
   const DoutPrefixProvider *dpp;
 
@@ -834,7 +834,7 @@ protected:
   int _send_request() override;
 public:
   RGWAsyncGetBucketInstanceInfo(RGWCoroutine *caller, RGWAioCompletionNotifier *cn,
-                                rgw::sal::RadosStore *_store, const rgw_bucket& bucket,
+                                rgw::sal::RadosStore* _store, const rgw_bucket& bucket,
                                 const DoutPrefixProvider *dpp)
     : RGWAsyncRadosRequest(caller, cn), store(_store), bucket(bucket), dpp(dpp) {}
 
@@ -844,7 +844,7 @@ public:
 
 class RGWGetBucketInstanceInfoCR : public RGWSimpleCoroutine {
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   rgw_bucket bucket;
   RGWBucketInfo *bucket_info;
   map<string, bufferlist> *pattrs;
@@ -854,7 +854,7 @@ class RGWGetBucketInstanceInfoCR : public RGWSimpleCoroutine {
   
 public:
   // rgw_bucket constructor
-  RGWGetBucketInstanceInfoCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
+  RGWGetBucketInstanceInfoCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore* _store,
                              const rgw_bucket& _bucket, RGWBucketInfo *_bucket_info,
                              map<string, bufferlist> *_pattrs, const DoutPrefixProvider *dpp)
     : RGWSimpleCoroutine(_store->ctx()), async_rados(_async_rados), store(_store),
@@ -891,7 +891,7 @@ class RGWRadosBILogTrimCR : public RGWSimpleCoroutine {
   std::string end_marker;
   boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
  public:
-  RGWRadosBILogTrimCR(rgw::sal::RadosStore *store, const RGWBucketInfo& bucket_info,
+  RGWRadosBILogTrimCR(rgw::sal::RadosStore* store, const RGWBucketInfo& bucket_info,
                       int shard_id, const std::string& start_marker,
                       const std::string& end_marker);
 
@@ -900,7 +900,7 @@ class RGWRadosBILogTrimCR : public RGWSimpleCoroutine {
 };
 
 class RGWAsyncFetchRemoteObj : public RGWAsyncRadosRequest {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   rgw_zone_id source_zone;
 
   std::optional<rgw_user> user_id;
@@ -924,7 +924,7 @@ class RGWAsyncFetchRemoteObj : public RGWAsyncRadosRequest {
 protected:
   int _send_request() override;
 public:
-  RGWAsyncFetchRemoteObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *_store,
+  RGWAsyncFetchRemoteObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore* _store,
                          const rgw_zone_id& _source_zone,
                          std::optional<rgw_user>& _user_id,
                          const rgw_bucket& _src_bucket,
@@ -960,7 +960,7 @@ public:
 class RGWFetchRemoteObjCR : public RGWSimpleCoroutine {
   CephContext *cct;
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   rgw_zone_id source_zone;
 
   std::optional<rgw_user> user_id;
@@ -985,7 +985,7 @@ class RGWFetchRemoteObjCR : public RGWSimpleCoroutine {
   const DoutPrefixProvider *dpp;
 
 public:
-  RGWFetchRemoteObjCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
+  RGWFetchRemoteObjCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore* _store,
                       const rgw_zone_id& _source_zone,
                       std::optional<rgw_user> _user_id,
                       const rgw_bucket& _src_bucket,
@@ -1040,7 +1040,7 @@ public:
 };
 
 class RGWAsyncStatRemoteObj : public RGWAsyncRadosRequest {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   rgw_zone_id source_zone;
 
   rgw_bucket src_bucket;
@@ -1055,7 +1055,7 @@ class RGWAsyncStatRemoteObj : public RGWAsyncRadosRequest {
 protected:
   int _send_request() override;
 public:
-  RGWAsyncStatRemoteObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *_store,
+  RGWAsyncStatRemoteObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore* _store,
                          const rgw_zone_id& _source_zone,
                          rgw_bucket& _src_bucket,
                          const rgw_obj_key& _key,
@@ -1077,7 +1077,7 @@ public:
 class RGWStatRemoteObjCR : public RGWSimpleCoroutine {
   CephContext *cct;
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   rgw_zone_id source_zone;
 
   rgw_bucket src_bucket;
@@ -1092,7 +1092,7 @@ class RGWStatRemoteObjCR : public RGWSimpleCoroutine {
   RGWAsyncStatRemoteObj *req;
 
 public:
-  RGWStatRemoteObjCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
+  RGWStatRemoteObjCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore* _store,
                       const rgw_zone_id& _source_zone,
                       rgw_bucket& _src_bucket,
                       const rgw_obj_key& _key,
@@ -1138,7 +1138,7 @@ public:
 
 class RGWAsyncRemoveObj : public RGWAsyncRadosRequest {
   const DoutPrefixProvider *dpp;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   rgw_zone_id source_zone;
 
   RGWBucketInfo bucket_info;
@@ -1158,7 +1158,7 @@ protected:
   int _send_request() override;
 public:
   RGWAsyncRemoveObj(const DoutPrefixProvider *_dpp, RGWCoroutine *caller, RGWAioCompletionNotifier *cn, 
-                         rgw::sal::RadosStore *_store,
+                         rgw::sal::RadosStore* _store,
                          const rgw_zone_id& _source_zone,
                          RGWBucketInfo& _bucket_info,
                          const rgw_obj_key& _key,
@@ -1193,7 +1193,7 @@ class RGWRemoveObjCR : public RGWSimpleCoroutine {
   const DoutPrefixProvider *dpp;
   CephContext *cct;
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   rgw_zone_id source_zone;
 
   RGWBucketInfo bucket_info;
@@ -1213,7 +1213,7 @@ class RGWRemoveObjCR : public RGWSimpleCoroutine {
   rgw_zone_set *zones_trace;
 
 public:
-  RGWRemoveObjCR(const DoutPrefixProvider *_dpp, RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
+  RGWRemoveObjCR(const DoutPrefixProvider *_dpp, RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore* _store,
                       const rgw_zone_id& _source_zone,
                       RGWBucketInfo& _bucket_info,
                       const rgw_obj_key& _key,
@@ -1270,7 +1270,7 @@ public:
 
 class RGWContinuousLeaseCR : public RGWCoroutine {
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
 
   const rgw_raw_obj obj;
 
@@ -1286,7 +1286,7 @@ class RGWContinuousLeaseCR : public RGWCoroutine {
   bool aborted{false};
 
 public:
-  RGWContinuousLeaseCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
+  RGWContinuousLeaseCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore* _store,
                        const rgw_raw_obj& _obj,
                        const string& _lock_name, int _interval, RGWCoroutine *_caller)
     : RGWCoroutine(_store->ctx()), async_rados(_async_rados), store(_store),
@@ -1316,7 +1316,7 @@ public:
 };
 
 class RGWRadosTimelogAddCR : public RGWSimpleCoroutine {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   list<cls_log_entry> entries;
 
   string oid;
@@ -1324,7 +1324,7 @@ class RGWRadosTimelogAddCR : public RGWSimpleCoroutine {
   boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
 
 public:
-  RGWRadosTimelogAddCR(rgw::sal::RadosStore *_store, const string& _oid,
+  RGWRadosTimelogAddCR(rgw::sal::RadosStore* _store, const string& _oid,
 		        const cls_log_entry& entry);
 
   int send_request() override;
@@ -1332,7 +1332,7 @@ public:
 };
 
 class RGWRadosTimelogTrimCR : public RGWSimpleCoroutine {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
  protected:
   std::string oid;
@@ -1342,7 +1342,7 @@ class RGWRadosTimelogTrimCR : public RGWSimpleCoroutine {
   std::string to_marker;
 
  public:
-  RGWRadosTimelogTrimCR(rgw::sal::RadosStore *store, const std::string& oid,
+  RGWRadosTimelogTrimCR(rgw::sal::RadosStore* store, const std::string& oid,
                         const real_time& start_time, const real_time& end_time,
                         const std::string& from_marker,
                         const std::string& to_marker);
@@ -1358,13 +1358,13 @@ class RGWSyncLogTrimCR : public RGWRadosTimelogTrimCR {
  public:
   static constexpr const char* max_marker = "99999999";
 
-  RGWSyncLogTrimCR(rgw::sal::RadosStore *store, const std::string& oid,
+  RGWSyncLogTrimCR(rgw::sal::RadosStore* store, const std::string& oid,
                    const std::string& to_marker, std::string *last_trim_marker);
   int request_complete() override;
 };
 
 class RGWAsyncStatObj : public RGWAsyncRadosRequest {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   RGWBucketInfo bucket_info;
   rgw_obj obj;
   uint64_t *psize;
@@ -1374,7 +1374,7 @@ class RGWAsyncStatObj : public RGWAsyncRadosRequest {
 protected:
   int _send_request() override;
 public:
-  RGWAsyncStatObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *store,
+  RGWAsyncStatObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore* store,
                   const RGWBucketInfo& _bucket_info, const rgw_obj& obj, uint64_t *psize = nullptr,
                   real_time *pmtime = nullptr, uint64_t *pepoch = nullptr,
                   RGWObjVersionTracker *objv_tracker = nullptr)
@@ -1383,7 +1383,7 @@ public:
 };
 
 class RGWStatObjCR : public RGWSimpleCoroutine {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   RGWAsyncRadosProcessor *async_rados;
   RGWBucketInfo bucket_info;
   rgw_obj obj;
@@ -1393,7 +1393,7 @@ class RGWStatObjCR : public RGWSimpleCoroutine {
   RGWObjVersionTracker *objv_tracker;
   RGWAsyncStatObj *req = nullptr;
  public:
-  RGWStatObjCR(RGWAsyncRadosProcessor *async_rados, rgw::sal::RadosStore *store,
+  RGWStatObjCR(RGWAsyncRadosProcessor *async_rados, rgw::sal::RadosStore* store,
 	  const RGWBucketInfo& _bucket_info, const rgw_obj& obj, uint64_t *psize = nullptr,
 	  real_time* pmtime = nullptr, uint64_t *pepoch = nullptr,
 	  RGWObjVersionTracker *objv_tracker = nullptr);
@@ -1408,7 +1408,7 @@ class RGWStatObjCR : public RGWSimpleCoroutine {
 
 /// coroutine wrapper for IoCtx::aio_notify()
 class RGWRadosNotifyCR : public RGWSimpleCoroutine {
-  rgw::sal::RadosStore *const store;
+  rgw::sal::RadosStore* const store;
   const rgw_raw_obj obj;
   bufferlist request;
   const uint64_t timeout_ms;
@@ -1417,7 +1417,7 @@ class RGWRadosNotifyCR : public RGWSimpleCoroutine {
   boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
 
 public:
-  RGWRadosNotifyCR(rgw::sal::RadosStore *store, const rgw_raw_obj& obj,
+  RGWRadosNotifyCR(rgw::sal::RadosStore* store, const rgw_raw_obj& obj,
                    bufferlist& request, uint64_t timeout_ms,
                    bufferlist *response);
 

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -111,13 +111,13 @@ public:
 template <class P>
 class RGWSimpleWriteOnlyAsyncCR : public RGWSimpleCoroutine {
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
 
   P params;
   const DoutPrefixProvider *dpp;
 
   class Request : public RGWAsyncRadosRequest {
-    rgw::sal::RGWRadosStore *store;
+    rgw::sal::RadosStore *store;
     P params;
     const DoutPrefixProvider *dpp;
   protected:
@@ -125,7 +125,7 @@ class RGWSimpleWriteOnlyAsyncCR : public RGWSimpleCoroutine {
   public:
     Request(RGWCoroutine *caller,
             RGWAioCompletionNotifier *cn,
-            rgw::sal::RGWRadosStore *store,
+            rgw::sal::RadosStore *store,
             const P& _params,
             const DoutPrefixProvider *dpp) : RGWAsyncRadosRequest(caller, cn),
                                 store(store),
@@ -135,7 +135,7 @@ class RGWSimpleWriteOnlyAsyncCR : public RGWSimpleCoroutine {
 
  public:
   RGWSimpleWriteOnlyAsyncCR(RGWAsyncRadosProcessor *_async_rados,
-			    rgw::sal::RGWRadosStore *_store,
+			    rgw::sal::RadosStore *_store,
 			    const P& _params,
                             const DoutPrefixProvider *_dpp) : RGWSimpleCoroutine(_store->ctx()),
                                                 async_rados(_async_rados),
@@ -172,14 +172,14 @@ class RGWSimpleWriteOnlyAsyncCR : public RGWSimpleCoroutine {
 template <class P, class R>
 class RGWSimpleAsyncCR : public RGWSimpleCoroutine {
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
 
   P params;
   std::shared_ptr<R> result;
   const DoutPrefixProvider *dpp;
 
   class Request : public RGWAsyncRadosRequest {
-    rgw::sal::RGWRadosStore *store;
+    rgw::sal::RadosStore *store;
     P params;
     std::shared_ptr<R> result;
     const DoutPrefixProvider *dpp;
@@ -188,7 +188,7 @@ class RGWSimpleAsyncCR : public RGWSimpleCoroutine {
   public:
     Request(RGWCoroutine *caller,
             RGWAioCompletionNotifier *cn,
-            rgw::sal::RGWRadosStore *_store,
+            rgw::sal::RadosStore *_store,
             const P& _params,
             std::shared_ptr<R>& _result,
             const DoutPrefixProvider *_dpp) : RGWAsyncRadosRequest(caller, cn),
@@ -200,7 +200,7 @@ class RGWSimpleAsyncCR : public RGWSimpleCoroutine {
 
  public:
   RGWSimpleAsyncCR(RGWAsyncRadosProcessor *_async_rados,
-                   rgw::sal::RGWRadosStore *_store,
+                   rgw::sal::RadosStore *_store,
                    const P& _params,
                    std::shared_ptr<R>& _result,
                    const DoutPrefixProvider *_dpp) : RGWSimpleCoroutine(_store->ctx()),
@@ -238,7 +238,7 @@ class RGWSimpleAsyncCR : public RGWSimpleCoroutine {
 
 class RGWGenericAsyncCR : public RGWSimpleCoroutine {
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
 
 
 public:
@@ -353,7 +353,7 @@ public:
 };
 
 class RGWAsyncLockSystemObj : public RGWAsyncRadosRequest {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   rgw_raw_obj obj;
   string lock_name;
   string cookie;
@@ -362,13 +362,13 @@ class RGWAsyncLockSystemObj : public RGWAsyncRadosRequest {
 protected:
   int _send_request() override;
 public:
-  RGWAsyncLockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RGWRadosStore *_store,
+  RGWAsyncLockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *_store,
                         RGWObjVersionTracker *_objv_tracker, const rgw_raw_obj& _obj,
 		        const string& _name, const string& _cookie, uint32_t _duration_secs);
 };
 
 class RGWAsyncUnlockSystemObj : public RGWAsyncRadosRequest {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   rgw_raw_obj obj;
   string lock_name;
   string cookie;
@@ -376,7 +376,7 @@ class RGWAsyncUnlockSystemObj : public RGWAsyncRadosRequest {
 protected:
   int _send_request() override;
 public:
-  RGWAsyncUnlockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RGWRadosStore *_store,
+  RGWAsyncUnlockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *_store,
                         RGWObjVersionTracker *_objv_tracker, const rgw_raw_obj& _obj,
 		        const string& _name, const string& _cookie);
 };
@@ -584,7 +584,7 @@ public:
 };
 
 class RGWRadosSetOmapKeysCR : public RGWSimpleCoroutine {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   map<string, bufferlist> entries;
 
   rgw_rados_ref ref;
@@ -594,7 +594,7 @@ class RGWRadosSetOmapKeysCR : public RGWSimpleCoroutine {
   boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
 
 public:
-  RGWRadosSetOmapKeysCR(rgw::sal::RGWRadosStore *_store,
+  RGWRadosSetOmapKeysCR(rgw::sal::RadosStore *_store,
 		      const rgw_raw_obj& _obj,
 		      map<string, bufferlist>& _entries);
 
@@ -611,7 +611,7 @@ class RGWRadosGetOmapKeysCR : public RGWSimpleCoroutine {
   };
   using ResultPtr = std::shared_ptr<Result>;
 
-  RGWRadosGetOmapKeysCR(rgw::sal::RGWRadosStore *_store, const rgw_raw_obj& _obj,
+  RGWRadosGetOmapKeysCR(rgw::sal::RadosStore *_store, const rgw_raw_obj& _obj,
                         const string& _marker, int _max_entries,
                         ResultPtr result);
 
@@ -619,7 +619,7 @@ class RGWRadosGetOmapKeysCR : public RGWSimpleCoroutine {
   int request_complete() override;
 
  private:
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   rgw_raw_obj obj;
   string marker;
   int max_entries;
@@ -636,7 +636,7 @@ class RGWRadosGetOmapValsCR : public RGWSimpleCoroutine {
   };
   using ResultPtr = std::shared_ptr<Result>;
 
-  RGWRadosGetOmapValsCR(rgw::sal::RGWRadosStore *_store, const rgw_raw_obj& _obj,
+  RGWRadosGetOmapValsCR(rgw::sal::RadosStore *_store, const rgw_raw_obj& _obj,
                         const string& _marker, int _max_entries,
                         ResultPtr result);
 
@@ -644,7 +644,7 @@ class RGWRadosGetOmapValsCR : public RGWSimpleCoroutine {
   int request_complete() override;
 
  private:
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   rgw_raw_obj obj;
   string marker;
   int max_entries;
@@ -653,7 +653,7 @@ class RGWRadosGetOmapValsCR : public RGWSimpleCoroutine {
 };
 
 class RGWRadosRemoveOmapKeysCR : public RGWSimpleCoroutine {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
 
   rgw_rados_ref ref;
 
@@ -664,7 +664,7 @@ class RGWRadosRemoveOmapKeysCR : public RGWSimpleCoroutine {
   boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
 
 public:
-  RGWRadosRemoveOmapKeysCR(rgw::sal::RGWRadosStore *_store,
+  RGWRadosRemoveOmapKeysCR(rgw::sal::RadosStore *_store,
 		      const rgw_raw_obj& _obj,
 		      const set<string>& _keys);
 
@@ -674,14 +674,14 @@ public:
 };
 
 class RGWRadosRemoveCR : public RGWSimpleCoroutine {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   librados::IoCtx ioctx;
   const rgw_raw_obj obj;
   RGWObjVersionTracker* objv_tracker;
   boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
 
 public:
-  RGWRadosRemoveCR(rgw::sal::RGWRadosStore *store, const rgw_raw_obj& obj,
+  RGWRadosRemoveCR(rgw::sal::RadosStore *store, const rgw_raw_obj& obj,
                    RGWObjVersionTracker* objv_tracker = nullptr);
 
   int send_request() override;
@@ -690,7 +690,7 @@ public:
 
 class RGWSimpleRadosLockCR : public RGWSimpleCoroutine {
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   string lock_name;
   string cookie;
   uint32_t duration;
@@ -700,7 +700,7 @@ class RGWSimpleRadosLockCR : public RGWSimpleCoroutine {
   RGWAsyncLockSystemObj *req;
 
 public:
-  RGWSimpleRadosLockCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RGWRadosStore *_store,
+  RGWSimpleRadosLockCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
 		      const rgw_raw_obj& _obj,
                       const string& _lock_name,
 		      const string& _cookie,
@@ -723,7 +723,7 @@ public:
 
 class RGWSimpleRadosUnlockCR : public RGWSimpleCoroutine {
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   string lock_name;
   string cookie;
 
@@ -732,7 +732,7 @@ class RGWSimpleRadosUnlockCR : public RGWSimpleCoroutine {
   RGWAsyncUnlockSystemObj *req;
 
 public:
-  RGWSimpleRadosUnlockCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RGWRadosStore *_store,
+  RGWSimpleRadosUnlockCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
 		      const rgw_raw_obj& _obj, 
                       const string& _lock_name,
 		      const string& _cookie);
@@ -749,7 +749,7 @@ public:
 
 class RGWOmapAppend : public RGWConsumerCR<string> {
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
 
   rgw_raw_obj obj;
 
@@ -763,7 +763,7 @@ class RGWOmapAppend : public RGWConsumerCR<string> {
   uint64_t window_size;
   uint64_t total_entries;
 public:
-  RGWOmapAppend(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RGWRadosStore *_store,
+  RGWOmapAppend(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
                 const rgw_raw_obj& _obj,
                 uint64_t _window_size = OMAP_APPEND_MAX_ENTRIES_DEFAULT);
   int operate() override;
@@ -782,14 +782,14 @@ public:
 
 class RGWShardedOmapCRManager {
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   RGWCoroutine *op;
 
   int num_shards;
 
   vector<RGWOmapAppend *> shards;
 public:
-  RGWShardedOmapCRManager(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RGWRadosStore *_store, RGWCoroutine *_op, int _num_shards, const rgw_pool& pool, const string& oid_prefix)
+  RGWShardedOmapCRManager(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store, RGWCoroutine *_op, int _num_shards, const rgw_pool& pool, const string& oid_prefix)
                       : async_rados(_async_rados),
 		        store(_store), op(_op), num_shards(_num_shards) {
     shards.reserve(num_shards);
@@ -826,7 +826,7 @@ public:
 };
 
 class RGWAsyncGetBucketInstanceInfo : public RGWAsyncRadosRequest {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   rgw_bucket bucket;
   const DoutPrefixProvider *dpp;
 
@@ -834,7 +834,7 @@ protected:
   int _send_request() override;
 public:
   RGWAsyncGetBucketInstanceInfo(RGWCoroutine *caller, RGWAioCompletionNotifier *cn,
-                                rgw::sal::RGWRadosStore *_store, const rgw_bucket& bucket,
+                                rgw::sal::RadosStore *_store, const rgw_bucket& bucket,
                                 const DoutPrefixProvider *dpp)
     : RGWAsyncRadosRequest(caller, cn), store(_store), bucket(bucket), dpp(dpp) {}
 
@@ -844,7 +844,7 @@ public:
 
 class RGWGetBucketInstanceInfoCR : public RGWSimpleCoroutine {
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   rgw_bucket bucket;
   RGWBucketInfo *bucket_info;
   map<string, bufferlist> *pattrs;
@@ -854,7 +854,7 @@ class RGWGetBucketInstanceInfoCR : public RGWSimpleCoroutine {
   
 public:
   // rgw_bucket constructor
-  RGWGetBucketInstanceInfoCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RGWRadosStore *_store,
+  RGWGetBucketInstanceInfoCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
                              const rgw_bucket& _bucket, RGWBucketInfo *_bucket_info,
                              map<string, bufferlist> *_pattrs, const DoutPrefixProvider *dpp)
     : RGWSimpleCoroutine(_store->ctx()), async_rados(_async_rados), store(_store),
@@ -891,7 +891,7 @@ class RGWRadosBILogTrimCR : public RGWSimpleCoroutine {
   std::string end_marker;
   boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
  public:
-  RGWRadosBILogTrimCR(rgw::sal::RGWRadosStore *store, const RGWBucketInfo& bucket_info,
+  RGWRadosBILogTrimCR(rgw::sal::RadosStore *store, const RGWBucketInfo& bucket_info,
                       int shard_id, const std::string& start_marker,
                       const std::string& end_marker);
 
@@ -900,7 +900,7 @@ class RGWRadosBILogTrimCR : public RGWSimpleCoroutine {
 };
 
 class RGWAsyncFetchRemoteObj : public RGWAsyncRadosRequest {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   rgw_zone_id source_zone;
 
   std::optional<rgw_user> user_id;
@@ -924,7 +924,7 @@ class RGWAsyncFetchRemoteObj : public RGWAsyncRadosRequest {
 protected:
   int _send_request() override;
 public:
-  RGWAsyncFetchRemoteObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RGWRadosStore *_store,
+  RGWAsyncFetchRemoteObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *_store,
                          const rgw_zone_id& _source_zone,
                          std::optional<rgw_user>& _user_id,
                          const rgw_bucket& _src_bucket,
@@ -960,7 +960,7 @@ public:
 class RGWFetchRemoteObjCR : public RGWSimpleCoroutine {
   CephContext *cct;
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   rgw_zone_id source_zone;
 
   std::optional<rgw_user> user_id;
@@ -985,7 +985,7 @@ class RGWFetchRemoteObjCR : public RGWSimpleCoroutine {
   const DoutPrefixProvider *dpp;
 
 public:
-  RGWFetchRemoteObjCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RGWRadosStore *_store,
+  RGWFetchRemoteObjCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
                       const rgw_zone_id& _source_zone,
                       std::optional<rgw_user> _user_id,
                       const rgw_bucket& _src_bucket,
@@ -1040,7 +1040,7 @@ public:
 };
 
 class RGWAsyncStatRemoteObj : public RGWAsyncRadosRequest {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   rgw_zone_id source_zone;
 
   rgw_bucket src_bucket;
@@ -1055,7 +1055,7 @@ class RGWAsyncStatRemoteObj : public RGWAsyncRadosRequest {
 protected:
   int _send_request() override;
 public:
-  RGWAsyncStatRemoteObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RGWRadosStore *_store,
+  RGWAsyncStatRemoteObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *_store,
                          const rgw_zone_id& _source_zone,
                          rgw_bucket& _src_bucket,
                          const rgw_obj_key& _key,
@@ -1077,7 +1077,7 @@ public:
 class RGWStatRemoteObjCR : public RGWSimpleCoroutine {
   CephContext *cct;
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   rgw_zone_id source_zone;
 
   rgw_bucket src_bucket;
@@ -1092,7 +1092,7 @@ class RGWStatRemoteObjCR : public RGWSimpleCoroutine {
   RGWAsyncStatRemoteObj *req;
 
 public:
-  RGWStatRemoteObjCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RGWRadosStore *_store,
+  RGWStatRemoteObjCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
                       const rgw_zone_id& _source_zone,
                       rgw_bucket& _src_bucket,
                       const rgw_obj_key& _key,
@@ -1138,7 +1138,7 @@ public:
 
 class RGWAsyncRemoveObj : public RGWAsyncRadosRequest {
   const DoutPrefixProvider *dpp;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   rgw_zone_id source_zone;
 
   RGWBucketInfo bucket_info;
@@ -1158,7 +1158,7 @@ protected:
   int _send_request() override;
 public:
   RGWAsyncRemoveObj(const DoutPrefixProvider *_dpp, RGWCoroutine *caller, RGWAioCompletionNotifier *cn, 
-                         rgw::sal::RGWRadosStore *_store,
+                         rgw::sal::RadosStore *_store,
                          const rgw_zone_id& _source_zone,
                          RGWBucketInfo& _bucket_info,
                          const rgw_obj_key& _key,
@@ -1193,7 +1193,7 @@ class RGWRemoveObjCR : public RGWSimpleCoroutine {
   const DoutPrefixProvider *dpp;
   CephContext *cct;
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   rgw_zone_id source_zone;
 
   RGWBucketInfo bucket_info;
@@ -1213,7 +1213,7 @@ class RGWRemoveObjCR : public RGWSimpleCoroutine {
   rgw_zone_set *zones_trace;
 
 public:
-  RGWRemoveObjCR(const DoutPrefixProvider *_dpp, RGWAsyncRadosProcessor *_async_rados, rgw::sal::RGWRadosStore *_store,
+  RGWRemoveObjCR(const DoutPrefixProvider *_dpp, RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
                       const rgw_zone_id& _source_zone,
                       RGWBucketInfo& _bucket_info,
                       const rgw_obj_key& _key,
@@ -1270,7 +1270,7 @@ public:
 
 class RGWContinuousLeaseCR : public RGWCoroutine {
   RGWAsyncRadosProcessor *async_rados;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
 
   const rgw_raw_obj obj;
 
@@ -1286,7 +1286,7 @@ class RGWContinuousLeaseCR : public RGWCoroutine {
   bool aborted{false};
 
 public:
-  RGWContinuousLeaseCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RGWRadosStore *_store,
+  RGWContinuousLeaseCR(RGWAsyncRadosProcessor *_async_rados, rgw::sal::RadosStore *_store,
                        const rgw_raw_obj& _obj,
                        const string& _lock_name, int _interval, RGWCoroutine *_caller)
     : RGWCoroutine(_store->ctx()), async_rados(_async_rados), store(_store),
@@ -1316,7 +1316,7 @@ public:
 };
 
 class RGWRadosTimelogAddCR : public RGWSimpleCoroutine {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   list<cls_log_entry> entries;
 
   string oid;
@@ -1324,7 +1324,7 @@ class RGWRadosTimelogAddCR : public RGWSimpleCoroutine {
   boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
 
 public:
-  RGWRadosTimelogAddCR(rgw::sal::RGWRadosStore *_store, const string& _oid,
+  RGWRadosTimelogAddCR(rgw::sal::RadosStore *_store, const string& _oid,
 		        const cls_log_entry& entry);
 
   int send_request() override;
@@ -1332,7 +1332,7 @@ public:
 };
 
 class RGWRadosTimelogTrimCR : public RGWSimpleCoroutine {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
  protected:
   std::string oid;
@@ -1342,7 +1342,7 @@ class RGWRadosTimelogTrimCR : public RGWSimpleCoroutine {
   std::string to_marker;
 
  public:
-  RGWRadosTimelogTrimCR(rgw::sal::RGWRadosStore *store, const std::string& oid,
+  RGWRadosTimelogTrimCR(rgw::sal::RadosStore *store, const std::string& oid,
                         const real_time& start_time, const real_time& end_time,
                         const std::string& from_marker,
                         const std::string& to_marker);
@@ -1358,13 +1358,13 @@ class RGWSyncLogTrimCR : public RGWRadosTimelogTrimCR {
  public:
   static constexpr const char* max_marker = "99999999";
 
-  RGWSyncLogTrimCR(rgw::sal::RGWRadosStore *store, const std::string& oid,
+  RGWSyncLogTrimCR(rgw::sal::RadosStore *store, const std::string& oid,
                    const std::string& to_marker, std::string *last_trim_marker);
   int request_complete() override;
 };
 
 class RGWAsyncStatObj : public RGWAsyncRadosRequest {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   RGWBucketInfo bucket_info;
   rgw_obj obj;
   uint64_t *psize;
@@ -1374,7 +1374,7 @@ class RGWAsyncStatObj : public RGWAsyncRadosRequest {
 protected:
   int _send_request() override;
 public:
-  RGWAsyncStatObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RGWRadosStore *store,
+  RGWAsyncStatObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *store,
                   const RGWBucketInfo& _bucket_info, const rgw_obj& obj, uint64_t *psize = nullptr,
                   real_time *pmtime = nullptr, uint64_t *pepoch = nullptr,
                   RGWObjVersionTracker *objv_tracker = nullptr)
@@ -1383,7 +1383,7 @@ public:
 };
 
 class RGWStatObjCR : public RGWSimpleCoroutine {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   RGWAsyncRadosProcessor *async_rados;
   RGWBucketInfo bucket_info;
   rgw_obj obj;
@@ -1393,7 +1393,7 @@ class RGWStatObjCR : public RGWSimpleCoroutine {
   RGWObjVersionTracker *objv_tracker;
   RGWAsyncStatObj *req = nullptr;
  public:
-  RGWStatObjCR(RGWAsyncRadosProcessor *async_rados, rgw::sal::RGWRadosStore *store,
+  RGWStatObjCR(RGWAsyncRadosProcessor *async_rados, rgw::sal::RadosStore *store,
 	  const RGWBucketInfo& _bucket_info, const rgw_obj& obj, uint64_t *psize = nullptr,
 	  real_time* pmtime = nullptr, uint64_t *pepoch = nullptr,
 	  RGWObjVersionTracker *objv_tracker = nullptr);
@@ -1408,7 +1408,7 @@ class RGWStatObjCR : public RGWSimpleCoroutine {
 
 /// coroutine wrapper for IoCtx::aio_notify()
 class RGWRadosNotifyCR : public RGWSimpleCoroutine {
-  rgw::sal::RGWRadosStore *const store;
+  rgw::sal::RadosStore *const store;
   const rgw_raw_obj obj;
   bufferlist request;
   const uint64_t timeout_ms;
@@ -1417,7 +1417,7 @@ class RGWRadosNotifyCR : public RGWSimpleCoroutine {
   boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
 
 public:
-  RGWRadosNotifyCR(rgw::sal::RGWRadosStore *store, const rgw_raw_obj& obj,
+  RGWRadosNotifyCR(rgw::sal::RadosStore *store, const rgw_raw_obj& obj,
                    bufferlist& request, uint64_t timeout_ms,
                    bufferlist *response);
 

--- a/src/rgw/rgw_cr_tools.h
+++ b/src/rgw/rgw_cr_tools.h
@@ -41,7 +41,7 @@ struct rgw_get_bucket_info_params {
 };
 
 struct rgw_get_bucket_info_result {
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
 };
 
 using RGWGetBucketInfoCR = RGWSimpleAsyncCR<rgw_get_bucket_info_params, rgw_get_bucket_info_result>;
@@ -66,8 +66,8 @@ using RGWObjectSimplePutCR = RGWSimpleWriteOnlyAsyncCR<rgw_object_simple_put_par
 
 
 struct rgw_bucket_lifecycle_config_params {
-  rgw::sal::RGWBucket* bucket;
-  rgw::sal::RGWAttrs bucket_attrs;
+  rgw::sal::Bucket* bucket;
+  rgw::sal::Attrs bucket_attrs;
   RGWLifecycleConfiguration config;
 };
 

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -467,7 +467,7 @@ class RGWInitDataSyncStatusCoroutine : public RGWCoroutine {
   static constexpr uint32_t lock_duration = 30;
   RGWDataSyncCtx *sc;
   RGWDataSyncEnv *sync_env;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   const rgw_pool& pool;
   const uint32_t num_shards;
 
@@ -589,7 +589,7 @@ public:
 };
 
 RGWRemoteDataLog::RGWRemoteDataLog(const DoutPrefixProvider *dpp,
-                                   rgw::sal::RGWRadosStore *store,
+                                   rgw::sal::RadosStore *store,
                                    RGWAsyncRadosProcessor *async_rados)
   : RGWCoroutinesManager(store->ctx(), store->getRados()->get_cr_registry()),
       dpp(dpp), store(store),
@@ -783,7 +783,7 @@ class RGWListBucketIndexesCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWDataSyncEnv *sync_env;
 
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
 
   rgw_data_sync_status *sync_status;
   int num_shards;
@@ -2967,7 +2967,7 @@ int RGWReadBucketPipeSyncStatusCoroutine::operate()
 class RGWReadRecoveringBucketShardsCoroutine : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWDataSyncEnv *sync_env;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   
   const int shard_id;
   int max_entries;
@@ -3034,7 +3034,7 @@ int RGWReadRecoveringBucketShardsCoroutine::operate()
 class RGWReadPendingBucketShardsCoroutine : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWDataSyncEnv *sync_env;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   
   const int shard_id;
   int max_entries;
@@ -3146,7 +3146,7 @@ RGWCoroutine *RGWRemoteBucketManager::read_sync_status_cr(int num, rgw_bucket_sh
   return new RGWReadBucketPipeSyncStatusCoroutine(&sc, sync_pairs[num], sync_status, nullptr);
 }
 
-RGWBucketPipeSyncStatusManager::RGWBucketPipeSyncStatusManager(rgw::sal::RGWRadosStore *_store,
+RGWBucketPipeSyncStatusManager::RGWBucketPipeSyncStatusManager(rgw::sal::RadosStore *_store,
                                                                std::optional<rgw_zone_id> _source_zone,
                                                                std::optional<rgw_bucket> _source_bucket,
                                                                const rgw_bucket& _dest_bucket) : store(_store),
@@ -4915,7 +4915,7 @@ string RGWBucketPipeSyncStatusManager::status_oid(const rgw_zone_id& source_zone
 
 string RGWBucketPipeSyncStatusManager::obj_status_oid(const rgw_bucket_sync_pipe& sync_pipe,
                                                       const rgw_zone_id& source_zone,
-                                                      const rgw::sal::RGWObject* obj)
+                                                      const rgw::sal::Object* obj)
 {
   string prefix = object_status_oid_prefix + "." + source_zone.id + ":" + obj->get_bucket()->get_key().get_key();
   if (sync_pipe.source_bucket_info.bucket !=
@@ -4953,7 +4953,7 @@ int rgw_read_remote_bilog_info(RGWRESTConn* conn,
 
 class RGWCollectBucketSyncStatusCR : public RGWShardCollectCR {
   static constexpr int max_concurrent_shards = 16;
-  rgw::sal::RGWRadosStore *const store;
+  rgw::sal::RadosStore *const store;
   RGWDataSyncCtx *const sc;
   RGWDataSyncEnv *const env;
   RGWBucketInfo source_bucket_info;
@@ -4969,7 +4969,7 @@ class RGWCollectBucketSyncStatusCR : public RGWShardCollectCR {
   Vector::iterator i, end;
 
  public:
-  RGWCollectBucketSyncStatusCR(rgw::sal::RGWRadosStore *store, RGWDataSyncCtx *sc,
+  RGWCollectBucketSyncStatusCR(rgw::sal::RadosStore *store, RGWDataSyncCtx *sc,
                                const RGWBucketInfo& source_bucket_info,
                                const RGWBucketInfo& dest_bucket_info,
                                Vector *status)
@@ -5008,7 +5008,7 @@ class RGWCollectBucketSyncStatusCR : public RGWShardCollectCR {
 };
 
 int rgw_bucket_sync_status(const DoutPrefixProvider *dpp,
-                           rgw::sal::RGWRadosStore *store,
+                           rgw::sal::RadosStore *store,
                            const rgw_sync_bucket_pipe& pipe,
                            const RGWBucketInfo& dest_bucket_info,
                            const RGWBucketInfo *psource_bucket_info,

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -467,7 +467,7 @@ class RGWInitDataSyncStatusCoroutine : public RGWCoroutine {
   static constexpr uint32_t lock_duration = 30;
   RGWDataSyncCtx *sc;
   RGWDataSyncEnv *sync_env;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   const rgw_pool& pool;
   const uint32_t num_shards;
 
@@ -589,7 +589,7 @@ public:
 };
 
 RGWRemoteDataLog::RGWRemoteDataLog(const DoutPrefixProvider *dpp,
-                                   rgw::sal::RadosStore *store,
+                                   rgw::sal::RadosStore* store,
                                    RGWAsyncRadosProcessor *async_rados)
   : RGWCoroutinesManager(store->ctx(), store->getRados()->get_cr_registry()),
       dpp(dpp), store(store),
@@ -783,7 +783,7 @@ class RGWListBucketIndexesCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWDataSyncEnv *sync_env;
 
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
 
   rgw_data_sync_status *sync_status;
   int num_shards;
@@ -926,7 +926,7 @@ public:
                                                                 sync_marker(_marker),
                                                                 tn(_tn) {}
 
-  RGWCoroutine *store_marker(const string& new_marker, uint64_t index_pos, const real_time& timestamp) override {
+  RGWCoroutine* store_marker(const string& new_marker, uint64_t index_pos, const real_time& timestamp) override {
     sync_marker.marker = new_marker;
     sync_marker.pos = index_pos;
     sync_marker.timestamp = timestamp;
@@ -2967,7 +2967,7 @@ int RGWReadBucketPipeSyncStatusCoroutine::operate()
 class RGWReadRecoveringBucketShardsCoroutine : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWDataSyncEnv *sync_env;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   
   const int shard_id;
   int max_entries;
@@ -3034,7 +3034,7 @@ int RGWReadRecoveringBucketShardsCoroutine::operate()
 class RGWReadPendingBucketShardsCoroutine : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWDataSyncEnv *sync_env;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   
   const int shard_id;
   int max_entries;
@@ -3146,7 +3146,7 @@ RGWCoroutine *RGWRemoteBucketManager::read_sync_status_cr(int num, rgw_bucket_sh
   return new RGWReadBucketPipeSyncStatusCoroutine(&sc, sync_pairs[num], sync_status, nullptr);
 }
 
-RGWBucketPipeSyncStatusManager::RGWBucketPipeSyncStatusManager(rgw::sal::RadosStore *_store,
+RGWBucketPipeSyncStatusManager::RGWBucketPipeSyncStatusManager(rgw::sal::RadosStore* _store,
                                                                std::optional<rgw_zone_id> _source_zone,
                                                                std::optional<rgw_bucket> _source_bucket,
                                                                const rgw_bucket& _dest_bucket) : store(_store),
@@ -3355,7 +3355,7 @@ public:
       sync_marker(_marker), tn(std::move(tn)), objv_tracker(objv_tracker)
   {}
 
-  RGWCoroutine *store_marker(const rgw_obj_key& new_marker, uint64_t index_pos, const real_time& timestamp) override {
+  RGWCoroutine* store_marker(const rgw_obj_key& new_marker, uint64_t index_pos, const real_time& timestamp) override {
     sync_marker.position = new_marker;
     sync_marker.count = index_pos;
 
@@ -3457,7 +3457,7 @@ public:
       stable_timestamp(stable_timestamp)
   {}
 
-  RGWCoroutine *store_marker(const string& new_marker, uint64_t index_pos, const real_time& timestamp) override {
+  RGWCoroutine* store_marker(const string& new_marker, uint64_t index_pos, const real_time& timestamp) override {
     sync_marker.position = new_marker;
     sync_marker.timestamp = timestamp;
 
@@ -4953,7 +4953,7 @@ int rgw_read_remote_bilog_info(RGWRESTConn* conn,
 
 class RGWCollectBucketSyncStatusCR : public RGWShardCollectCR {
   static constexpr int max_concurrent_shards = 16;
-  rgw::sal::RadosStore *const store;
+  rgw::sal::RadosStore* const store;
   RGWDataSyncCtx *const sc;
   RGWDataSyncEnv *const env;
   RGWBucketInfo source_bucket_info;
@@ -4969,7 +4969,7 @@ class RGWCollectBucketSyncStatusCR : public RGWShardCollectCR {
   Vector::iterator i, end;
 
  public:
-  RGWCollectBucketSyncStatusCR(rgw::sal::RadosStore *store, RGWDataSyncCtx *sc,
+  RGWCollectBucketSyncStatusCR(rgw::sal::RadosStore* store, RGWDataSyncCtx *sc,
                                const RGWBucketInfo& source_bucket_info,
                                const RGWBucketInfo& dest_bucket_info,
                                Vector *status)
@@ -5008,7 +5008,7 @@ class RGWCollectBucketSyncStatusCR : public RGWShardCollectCR {
 };
 
 int rgw_bucket_sync_status(const DoutPrefixProvider *dpp,
-                           rgw::sal::RadosStore *store,
+                           rgw::sal::RadosStore* store,
                            const rgw_sync_bucket_pipe& pipe,
                            const RGWBucketInfo& dest_bucket_info,
                            const RGWBucketInfo *psource_bucket_info,

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -298,7 +298,7 @@ class RGWServices;
 struct RGWDataSyncEnv {
   const DoutPrefixProvider *dpp{nullptr};
   CephContext *cct{nullptr};
-  rgw::sal::RGWRadosStore *store{nullptr};
+  rgw::sal::RadosStore *store{nullptr};
   RGWServices *svc{nullptr};
   RGWAsyncRadosProcessor *async_rados{nullptr};
   RGWHTTPManager *http_manager{nullptr};
@@ -309,7 +309,7 @@ struct RGWDataSyncEnv {
 
   RGWDataSyncEnv() {}
 
-  void init(const DoutPrefixProvider *_dpp, CephContext *_cct, rgw::sal::RGWRadosStore *_store, RGWServices *_svc,
+  void init(const DoutPrefixProvider *_dpp, CephContext *_cct, rgw::sal::RadosStore *_store, RGWServices *_svc,
             RGWAsyncRadosProcessor *_async_rados, RGWHTTPManager *_http_manager,
             RGWSyncErrorLogger *_error_logger, RGWSyncTraceManager *_sync_tracer,
             RGWSyncModuleInstanceRef& _sync_module,
@@ -351,7 +351,7 @@ class RGWRados;
 
 class RGWRemoteDataLog : public RGWCoroutinesManager {
   const DoutPrefixProvider *dpp;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   CephContext *cct;
   RGWCoroutinesManagerRegistry *cr_registry;
   RGWAsyncRadosProcessor *async_rados;
@@ -369,7 +369,7 @@ class RGWRemoteDataLog : public RGWCoroutinesManager {
 
 public:
   RGWRemoteDataLog(const DoutPrefixProvider *dpp,
-                   rgw::sal::RGWRadosStore *_store,
+                   rgw::sal::RadosStore *_store,
                    RGWAsyncRadosProcessor *async_rados);
   int init(const rgw_zone_id& _source_zone, RGWRESTConn *_conn, RGWSyncErrorLogger *_error_logger,
            RGWSyncTraceManager *_sync_tracer, RGWSyncModuleInstanceRef& module,
@@ -389,7 +389,7 @@ public:
 };
 
 class RGWDataSyncStatusManager : public DoutPrefixProvider {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
 
   rgw_zone_id source_zone;
   RGWRESTConn *conn;
@@ -407,12 +407,12 @@ class RGWDataSyncStatusManager : public DoutPrefixProvider {
   int num_shards;
 
 public:
-  RGWDataSyncStatusManager(rgw::sal::RGWRadosStore *_store, RGWAsyncRadosProcessor *async_rados,
+  RGWDataSyncStatusManager(rgw::sal::RadosStore *_store, RGWAsyncRadosProcessor *async_rados,
                            const rgw_zone_id& _source_zone, PerfCounters* counters)
     : store(_store), source_zone(_source_zone), conn(NULL), error_logger(NULL),
       sync_module(nullptr), counters(counters),
       source_log(this, store, async_rados), num_shards(0) {}
-  RGWDataSyncStatusManager(rgw::sal::RGWRadosStore *_store, RGWAsyncRadosProcessor *async_rados,
+  RGWDataSyncStatusManager(rgw::sal::RadosStore *_store, RGWAsyncRadosProcessor *async_rados,
                            const rgw_zone_id& _source_zone, PerfCounters* counters,
                            const RGWSyncModuleInstanceRef& _sync_module)
     : store(_store), source_zone(_source_zone), conn(NULL), error_logger(NULL),
@@ -620,7 +620,7 @@ int rgw_read_remote_bilog_info(RGWRESTConn* conn,
                                optional_yield y);
 
 class RGWBucketPipeSyncStatusManager : public DoutPrefixProvider {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
 
   RGWDataSyncEnv sync_env;
 
@@ -648,7 +648,7 @@ class RGWBucketPipeSyncStatusManager : public DoutPrefixProvider {
   int num_shards;
 
 public:
-  RGWBucketPipeSyncStatusManager(rgw::sal::RGWRadosStore *_store,
+  RGWBucketPipeSyncStatusManager(rgw::sal::RadosStore *_store,
                              std::optional<rgw_zone_id> _source_zone,
                              std::optional<rgw_bucket> _source_bucket,
                              const rgw_bucket& dest_bucket);
@@ -661,7 +661,7 @@ public:
 
   static string status_oid(const rgw_zone_id& source_zone, const rgw_bucket_sync_pair_info& bs);
   static string obj_status_oid(const rgw_bucket_sync_pipe& sync_pipe,
-                               const rgw_zone_id& source_zone, const rgw::sal::RGWObject* obj); /* specific source obj sync status,
+                               const rgw_zone_id& source_zone, const rgw::sal::Object* obj); /* specific source obj sync status,
                                                                                        can be used by sync modules */
 
   // implements DoutPrefixProvider
@@ -675,7 +675,7 @@ public:
 
 /// read the sync status of all bucket shards from the given source zone
 int rgw_bucket_sync_status(const DoutPrefixProvider *dpp,
-                           rgw::sal::RGWRadosStore *store,
+                           rgw::sal::RadosStore *store,
                            const rgw_sync_bucket_pipe& pipe,
                            const RGWBucketInfo& dest_bucket_info,
                            const RGWBucketInfo *psource_bucket_info,

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -298,7 +298,7 @@ class RGWServices;
 struct RGWDataSyncEnv {
   const DoutPrefixProvider *dpp{nullptr};
   CephContext *cct{nullptr};
-  rgw::sal::RadosStore *store{nullptr};
+  rgw::sal::RadosStore* store{nullptr};
   RGWServices *svc{nullptr};
   RGWAsyncRadosProcessor *async_rados{nullptr};
   RGWHTTPManager *http_manager{nullptr};
@@ -309,7 +309,7 @@ struct RGWDataSyncEnv {
 
   RGWDataSyncEnv() {}
 
-  void init(const DoutPrefixProvider *_dpp, CephContext *_cct, rgw::sal::RadosStore *_store, RGWServices *_svc,
+  void init(const DoutPrefixProvider *_dpp, CephContext *_cct, rgw::sal::RadosStore* _store, RGWServices *_svc,
             RGWAsyncRadosProcessor *_async_rados, RGWHTTPManager *_http_manager,
             RGWSyncErrorLogger *_error_logger, RGWSyncTraceManager *_sync_tracer,
             RGWSyncModuleInstanceRef& _sync_module,
@@ -351,7 +351,7 @@ class RGWRados;
 
 class RGWRemoteDataLog : public RGWCoroutinesManager {
   const DoutPrefixProvider *dpp;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   CephContext *cct;
   RGWCoroutinesManagerRegistry *cr_registry;
   RGWAsyncRadosProcessor *async_rados;
@@ -369,7 +369,7 @@ class RGWRemoteDataLog : public RGWCoroutinesManager {
 
 public:
   RGWRemoteDataLog(const DoutPrefixProvider *dpp,
-                   rgw::sal::RadosStore *_store,
+                   rgw::sal::RadosStore* _store,
                    RGWAsyncRadosProcessor *async_rados);
   int init(const rgw_zone_id& _source_zone, RGWRESTConn *_conn, RGWSyncErrorLogger *_error_logger,
            RGWSyncTraceManager *_sync_tracer, RGWSyncModuleInstanceRef& module,
@@ -389,7 +389,7 @@ public:
 };
 
 class RGWDataSyncStatusManager : public DoutPrefixProvider {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
 
   rgw_zone_id source_zone;
   RGWRESTConn *conn;
@@ -407,12 +407,12 @@ class RGWDataSyncStatusManager : public DoutPrefixProvider {
   int num_shards;
 
 public:
-  RGWDataSyncStatusManager(rgw::sal::RadosStore *_store, RGWAsyncRadosProcessor *async_rados,
+  RGWDataSyncStatusManager(rgw::sal::RadosStore* _store, RGWAsyncRadosProcessor *async_rados,
                            const rgw_zone_id& _source_zone, PerfCounters* counters)
     : store(_store), source_zone(_source_zone), conn(NULL), error_logger(NULL),
       sync_module(nullptr), counters(counters),
       source_log(this, store, async_rados), num_shards(0) {}
-  RGWDataSyncStatusManager(rgw::sal::RadosStore *_store, RGWAsyncRadosProcessor *async_rados,
+  RGWDataSyncStatusManager(rgw::sal::RadosStore* _store, RGWAsyncRadosProcessor *async_rados,
                            const rgw_zone_id& _source_zone, PerfCounters* counters,
                            const RGWSyncModuleInstanceRef& _sync_module)
     : store(_store), source_zone(_source_zone), conn(NULL), error_logger(NULL),
@@ -620,7 +620,7 @@ int rgw_read_remote_bilog_info(RGWRESTConn* conn,
                                optional_yield y);
 
 class RGWBucketPipeSyncStatusManager : public DoutPrefixProvider {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
 
   RGWDataSyncEnv sync_env;
 
@@ -648,7 +648,7 @@ class RGWBucketPipeSyncStatusManager : public DoutPrefixProvider {
   int num_shards;
 
 public:
-  RGWBucketPipeSyncStatusManager(rgw::sal::RadosStore *_store,
+  RGWBucketPipeSyncStatusManager(rgw::sal::RadosStore* _store,
                              std::optional<rgw_zone_id> _source_zone,
                              std::optional<rgw_bucket> _source_bucket,
                              const rgw_bucket& dest_bucket);
@@ -675,7 +675,7 @@ public:
 
 /// read the sync status of all bucket shards from the given source zone
 int rgw_bucket_sync_status(const DoutPrefixProvider *dpp,
-                           rgw::sal::RadosStore *store,
+                           rgw::sal::RadosStore* store,
                            const rgw_sync_bucket_pipe& pipe,
                            const RGWBucketInfo& dest_bucket_info,
                            const RGWBucketInfo *psource_bucket_info,

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -856,7 +856,7 @@ namespace rgw {
     
     std::string uid; // should match user.user_id, iiuc
 
-    std::unique_ptr<rgw::sal::RGWUser> user;
+    std::unique_ptr<rgw::sal::User> user;
     RGWAccessKey key; // XXXX acc_key
 
     static std::atomic<uint32_t> fs_inst_counter;
@@ -984,7 +984,7 @@ namespace rgw {
       (void) fh_lru.unref(fh, cohort::lru::FLAG_NONE);
     }
 
-    int authorize(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* store) {
+    int authorize(const DoutPrefixProvider *dpp, rgw::sal::Store* store) {
       int ret = store->get_user_by_access_key(dpp, key.id, null_yield, &user);
       if (ret == 0) {
 	RGWAccessKey* k = user->get_info().get_key(key.id);
@@ -1331,7 +1331,7 @@ public:
   uint32_t d_count;
   bool rcb_eof; // caller forced early stop in readdir cycle
 
-  RGWListBucketsRequest(CephContext* _cct, std::unique_ptr<rgw::sal::RGWUser> _user,
+  RGWListBucketsRequest(CephContext* _cct, std::unique_ptr<rgw::sal::User> _user,
 			RGWFileHandle* _rgw_fh, rgw_readdir_cb _rcb,
 			void* _cb_arg, RGWFileHandle::readdir_offset& _offset)
     : RGWLibRequest(_cct, std::move(_user)), rgw_fh(_rgw_fh), offset(_offset),
@@ -1392,7 +1392,7 @@ public:
     sent_data = true;
   }
 
-  void send_response_data(rgw::sal::RGWBucketList& buckets) override {
+  void send_response_data(rgw::sal::BucketList& buckets) override {
     if (!sent_data)
       return;
     auto& m = buckets.get_buckets();
@@ -1461,7 +1461,7 @@ public:
   uint32_t d_count;
   bool rcb_eof; // caller forced early stop in readdir cycle
 
-  RGWReaddirRequest(CephContext* _cct, std::unique_ptr<rgw::sal::RGWUser> _user,
+  RGWReaddirRequest(CephContext* _cct, std::unique_ptr<rgw::sal::User> _user,
 		    RGWFileHandle* _rgw_fh, rgw_readdir_cb _rcb,
 		    void* _cb_arg, RGWFileHandle::readdir_offset& _offset)
     : RGWLibRequest(_cct, std::move(_user)), rgw_fh(_rgw_fh), offset(_offset),
@@ -1785,7 +1785,7 @@ public:
   bool valid;
   bool has_children;
 
-  RGWRMdirCheck (CephContext* _cct, std::unique_ptr<rgw::sal::RGWUser> _user,
+  RGWRMdirCheck (CephContext* _cct, std::unique_ptr<rgw::sal::User> _user,
 		 const RGWFileHandle* _rgw_fh)
     : RGWLibRequest(_cct, std::move(_user)), rgw_fh(_rgw_fh), valid(false),
       has_children(false) {
@@ -1864,7 +1864,7 @@ class RGWCreateBucketRequest : public RGWLibRequest,
 public:
   const std::string& bucket_name;
 
-  RGWCreateBucketRequest(CephContext* _cct, std::unique_ptr<rgw::sal::RGWUser> _user,
+  RGWCreateBucketRequest(CephContext* _cct, std::unique_ptr<rgw::sal::User> _user,
 			std::string& _bname)
     : RGWLibRequest(_cct, std::move(_user)), bucket_name(_bname) {
     op = this;
@@ -1929,7 +1929,7 @@ class RGWDeleteBucketRequest : public RGWLibRequest,
 public:
   const std::string& bucket_name;
 
-  RGWDeleteBucketRequest(CephContext* _cct, std::unique_ptr<rgw::sal::RGWUser> _user,
+  RGWDeleteBucketRequest(CephContext* _cct, std::unique_ptr<rgw::sal::User> _user,
 			std::string& _bname)
     : RGWLibRequest(_cct, std::move(_user)), bucket_name(_bname) {
     op = this;
@@ -1981,7 +1981,7 @@ public:
   buffer::list& bl; /* XXX */
   size_t bytes_written;
 
-  RGWPutObjRequest(CephContext* _cct, std::unique_ptr<rgw::sal::RGWUser> _user,
+  RGWPutObjRequest(CephContext* _cct, std::unique_ptr<rgw::sal::User> _user,
 		  const std::string& _bname, const std::string& _oname,
 		  buffer::list& _bl)
     : RGWLibRequest(_cct, std::move(_user)), bucket_name(_bname), obj_name(_oname),
@@ -2073,7 +2073,7 @@ public:
   size_t read_resid; /* initialize to len, <= sizeof(ulp_buffer) */
   bool do_hexdump = false;
 
-  RGWReadRequest(CephContext* _cct, std::unique_ptr<rgw::sal::RGWUser> _user,
+  RGWReadRequest(CephContext* _cct, std::unique_ptr<rgw::sal::User> _user,
 		 RGWFileHandle* _rgw_fh, uint64_t off, uint64_t len,
 		 void *_ulp_buffer)
     : RGWLibRequest(_cct, std::move(_user)), rgw_fh(_rgw_fh), ulp_buffer(_ulp_buffer),
@@ -2166,7 +2166,7 @@ public:
   const std::string& bucket_name;
   const std::string& obj_name;
 
-  RGWDeleteObjRequest(CephContext* _cct, std::unique_ptr<rgw::sal::RGWUser> _user,
+  RGWDeleteObjRequest(CephContext* _cct, std::unique_ptr<rgw::sal::User> _user,
 		      const std::string& _bname, const std::string& _oname)
     : RGWLibRequest(_cct, std::move(_user)), bucket_name(_bname), obj_name(_oname) {
     op = this;
@@ -2217,7 +2217,7 @@ public:
 
   static constexpr uint32_t FLAG_NONE = 0x000;
 
-  RGWStatObjRequest(CephContext* _cct, std::unique_ptr<rgw::sal::RGWUser> _user,
+  RGWStatObjRequest(CephContext* _cct, std::unique_ptr<rgw::sal::User> _user,
 		    const std::string& _bname, const std::string& _oname,
 		    uint32_t _flags)
     : RGWLibRequest(_cct, std::move(_user)), bucket_name(_bname), obj_name(_oname),
@@ -2310,7 +2310,7 @@ public:
   std::map<std::string, buffer::list> attrs;
   RGWLibFS::BucketStats& bs;
 
-  RGWStatBucketRequest(CephContext* _cct, std::unique_ptr<rgw::sal::RGWUser> _user,
+  RGWStatBucketRequest(CephContext* _cct, std::unique_ptr<rgw::sal::User> _user,
 		       const std::string& _path,
 		       RGWLibFS::BucketStats& _stats)
     : RGWLibRequest(_cct, std::move(_user)), bs(_stats) {
@@ -2385,7 +2385,7 @@ public:
   bool is_dir;
   bool exact_matched;
 
-  RGWStatLeafRequest(CephContext* _cct, std::unique_ptr<rgw::sal::RGWUser> _user,
+  RGWStatLeafRequest(CephContext* _cct, std::unique_ptr<rgw::sal::User> _user,
 		     RGWFileHandle* _rgw_fh, const std::string& _path)
     : RGWLibRequest(_cct, std::move(_user)), rgw_fh(_rgw_fh), path(_path),
       matched(false), is_dir(false), exact_matched(false) {
@@ -2501,8 +2501,8 @@ public:
   size_t bytes_written;
   bool eio;
 
-  RGWWriteRequest(rgw::sal::RGWStore* store,
-		  std::unique_ptr<rgw::sal::RGWUser> _user,
+  RGWWriteRequest(rgw::sal::Store* store,
+		  std::unique_ptr<rgw::sal::User> _user,
 		  RGWFileHandle* _fh, const std::string& _bname,
 		  const std::string& _oname)
     : RGWLibContinuedReq(store->ctx(), std::move(_user)),
@@ -2595,7 +2595,7 @@ public:
   const std::string& src_name;
   const std::string& dst_name;
 
-  RGWCopyObjRequest(CephContext* _cct, std::unique_ptr<rgw::sal::RGWUser> _user,
+  RGWCopyObjRequest(CephContext* _cct, std::unique_ptr<rgw::sal::User> _user,
 		    RGWFileHandle* _src_parent, RGWFileHandle* _dst_parent,
 		    const std::string& _src_name, const std::string& _dst_name)
     : RGWLibRequest(_cct, std::move(_user)), src_parent(_src_parent),
@@ -2682,7 +2682,7 @@ public:
   const std::string& obj_name;
 
   RGWGetAttrsRequest(CephContext* _cct,
-		     std::unique_ptr<rgw::sal::RGWUser> _user,
+		     std::unique_ptr<rgw::sal::User> _user,
 		     const std::string& _bname, const std::string& _oname)
     : RGWLibRequest(_cct, std::move(_user)), RGWGetAttrs(),
       bucket_name(_bname), obj_name(_oname) {
@@ -2737,7 +2737,7 @@ public:
   const std::string& bucket_name;
   const std::string& obj_name;
 
-  RGWSetAttrsRequest(CephContext* _cct, std::unique_ptr<rgw::sal::RGWUser> _user,
+  RGWSetAttrsRequest(CephContext* _cct, std::unique_ptr<rgw::sal::User> _user,
 		     const std::string& _bname, const std::string& _oname)
     : RGWLibRequest(_cct, std::move(_user)), bucket_name(_bname), obj_name(_oname) {
     op = this;
@@ -2793,14 +2793,14 @@ public:
   const std::string& obj_name;
 
   RGWRMAttrsRequest(CephContext* _cct,
-		     std::unique_ptr<rgw::sal::RGWUser> _user,
+		     std::unique_ptr<rgw::sal::User> _user,
 		     const std::string& _bname, const std::string& _oname)
     : RGWLibRequest(_cct, std::move(_user)), RGWRMAttrs(),
       bucket_name(_bname), obj_name(_oname) {
     op = this;
   }
 
-  const rgw::sal::RGWAttrs& get_attrs() {
+  const rgw::sal::Attrs& get_attrs() {
     return attrs;
   }
 
@@ -2848,7 +2848,7 @@ class RGWGetClusterStatReq : public RGWLibRequest,
         public RGWGetClusterStat {
 public:
   struct rados_cluster_stat_t& stats_req;
-  RGWGetClusterStatReq(CephContext* _cct, std::unique_ptr<rgw::sal::RGWUser> _user,
+  RGWGetClusterStatReq(CephContext* _cct, std::unique_ptr<rgw::sal::User> _user,
                        rados_cluster_stat_t& _stats):
   RGWLibRequest(_cct, std::move(_user)), stats_req(_stats){
     op = this;

--- a/src/rgw/rgw_frontend.h
+++ b/src/rgw/rgw_frontend.h
@@ -289,7 +289,7 @@ class RGWFrontendPauser : public RGWRealmReloader::Pauser {
     if (pauser)
       pauser->pause();
   }
-  void resume(rgw::sal::Store *store) override {
+  void resume(rgw::sal::Store* store) override {
     /* Initialize the registry of auth strategies which will coordinate
      * the dynamic reconfiguration. */
     auto auth_registry = \

--- a/src/rgw/rgw_frontend.h
+++ b/src/rgw/rgw_frontend.h
@@ -85,7 +85,7 @@ public:
   virtual void join() = 0;
 
   virtual void pause_for_new_config() = 0;
-  virtual void unpause_with_new_config(rgw::sal::RGWStore* store,
+  virtual void unpause_with_new_config(rgw::sal::Store* store,
                                        rgw_auth_registry_ptr_t auth_registry) = 0;
 };
 
@@ -148,7 +148,7 @@ public:
     env.mutex.get_write();
   }
 
-  void unpause_with_new_config(rgw::sal::RGWStore* const store,
+  void unpause_with_new_config(rgw::sal::Store* const store,
                                rgw_auth_registry_ptr_t auth_registry) override {
     env.store = store;
     env.auth_registry = std::move(auth_registry);
@@ -191,7 +191,7 @@ public:
     pprocess->pause();
   }
 
-  void unpause_with_new_config(rgw::sal::RGWStore* const store,
+  void unpause_with_new_config(rgw::sal::Store* const store,
                                rgw_auth_registry_ptr_t auth_registry) override {
     env.store = store;
     env.auth_registry = auth_registry;
@@ -247,7 +247,7 @@ public:
     }
 
     rgw_user uid(uid_str);
-    std::unique_ptr<rgw::sal::RGWUser> user = env.store->get_user(uid);
+    std::unique_ptr<rgw::sal::User> user = env.store->get_user(uid);
 
     int ret = user->load_by_id(this, null_yield);
     if (ret < 0) {
@@ -289,7 +289,7 @@ class RGWFrontendPauser : public RGWRealmReloader::Pauser {
     if (pauser)
       pauser->pause();
   }
-  void resume(rgw::sal::RGWStore *store) override {
+  void resume(rgw::sal::Store *store) override {
     /* Initialize the registry of auth strategies which will coordinate
      * the dynamic reconfiguration. */
     auto auth_registry = \

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -239,7 +239,7 @@ void *RGWLC::LCWorker::entry() {
   return NULL;
 }
 
-void RGWLC::initialize(CephContext *_cct, rgw::sal::RGWStore *_store) {
+void RGWLC::initialize(CephContext *_cct, rgw::sal::Store *_store) {
   cct = _cct;
   store = _store;
   sal_lc = store->get_lifecycle();
@@ -368,12 +368,12 @@ static bool obj_has_expired(CephContext *cct, ceph::real_time mtime, int days,
   return (timediff >= cmp);
 }
 
-static bool pass_object_lock_check(rgw::sal::RGWStore* store, rgw::sal::RGWObject* obj, RGWObjectCtx& ctx, const DoutPrefixProvider *dpp)
+static bool pass_object_lock_check(rgw::sal::Store* store, rgw::sal::Object* obj, RGWObjectCtx& ctx, const DoutPrefixProvider *dpp)
 {
   if (!obj->get_bucket()->get_info().obj_lock_enabled()) {
     return true;
   }
-  std::unique_ptr<rgw::sal::RGWObject::ReadOp> read_op = obj->get_read_op(&ctx);
+  std::unique_ptr<rgw::sal::Object::ReadOp> read_op = obj->get_read_op(&ctx);
   int ret = read_op->prepare(null_yield, dpp);
   if (ret < 0) {
     if (ret == -ENOENT) {
@@ -416,17 +416,17 @@ static bool pass_object_lock_check(rgw::sal::RGWStore* store, rgw::sal::RGWObjec
 }
 
 class LCObjsLister {
-  rgw::sal::RGWStore *store;
-  rgw::sal::RGWBucket* bucket;
-  rgw::sal::RGWBucket::ListParams list_params;
-  rgw::sal::RGWBucket::ListResults list_results;
+  rgw::sal::Store *store;
+  rgw::sal::Bucket* bucket;
+  rgw::sal::Bucket::ListParams list_params;
+  rgw::sal::Bucket::ListResults list_results;
   string prefix;
   vector<rgw_bucket_dir_entry>::iterator obj_iter;
   rgw_bucket_dir_entry pre_obj;
   int64_t delay_ms;
 
 public:
-  LCObjsLister(rgw::sal::RGWStore *_store, rgw::sal::RGWBucket* _bucket) :
+  LCObjsLister(rgw::sal::Store *_store, rgw::sal::Bucket* _bucket) :
       store(_store), bucket(_bucket) {
     list_params.list_versions = bucket->versioned();
     list_params.allow_unordered = true;
@@ -508,13 +508,13 @@ struct op_env {
   using LCWorker = RGWLC::LCWorker;
 
   lc_op op;
-  rgw::sal::RGWStore *store;
+  rgw::sal::Store *store;
   LCWorker* worker;
-  rgw::sal::RGWBucket* bucket;
+  rgw::sal::Bucket* bucket;
   LCObjsLister& ol;
 
-  op_env(lc_op& _op, rgw::sal::RGWStore *_store, LCWorker* _worker,
-	 rgw::sal::RGWBucket* _bucket, LCObjsLister& _ol)
+  op_env(lc_op& _op, rgw::sal::Store *_store, LCWorker* _worker,
+	 rgw::sal::Bucket* _bucket, LCObjsLister& _ol)
     : op(_op), store(_store), worker(_worker), bucket(_bucket),
       ol(_ol) {}
 }; /* op_env */
@@ -529,12 +529,12 @@ struct lc_op_ctx {
   boost::optional<std::string> next_key_name;
   ceph::real_time effective_mtime;
 
-  rgw::sal::RGWStore *store;
-  rgw::sal::RGWBucket* bucket;
+  rgw::sal::Store *store;
+  rgw::sal::Bucket* bucket;
   lc_op& op; // ok--refers to expanded env.op
   LCObjsLister& ol;
 
-  std::unique_ptr<rgw::sal::RGWObject> obj;
+  std::unique_ptr<rgw::sal::Object> obj;
   RGWObjectCtx rctx;
   const DoutPrefixProvider *dpp;
   WorkQ* wq;
@@ -574,8 +574,8 @@ static int remove_expired_obj(const DoutPrefixProvider *dpp, lc_op_ctx& oc, bool
     obj_key.instance = "null";
   }
 
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
-  std::unique_ptr<rgw::sal::RGWObject> obj;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
+  std::unique_ptr<rgw::sal::Object> obj;
 
   ret = store->get_bucket(nullptr, bucket_info, &bucket);
   if (ret < 0) {
@@ -583,7 +583,7 @@ static int remove_expired_obj(const DoutPrefixProvider *dpp, lc_op_ctx& oc, bool
   }
 
   obj = bucket->get_object(obj_key);
-  std::unique_ptr<rgw::sal::RGWObject::DeleteOp> del_op = obj->get_delete_op(&oc.rctx);
+  std::unique_ptr<rgw::sal::Object::DeleteOp> del_op = obj->get_delete_op(&oc.rctx);
 
   del_op->params.versioning_status = obj->get_bucket()->get_info().versioning_status();
   del_op->params.obj_owner.set_id(rgw_user {meta.owner});
@@ -820,14 +820,14 @@ static inline bool worker_should_stop(time_t stop_at, bool once)
   return !once && stop_at < time(nullptr);
 }
 
-int RGWLC::handle_multipart_expiration(rgw::sal::RGWBucket* target,
+int RGWLC::handle_multipart_expiration(rgw::sal::Bucket* target,
 				       const multimap<string, lc_op>& prefix_map,
 				       LCWorker* worker, time_t stop_at, bool once)
 {
   MultipartMetaFilter mp_filter;
   int ret;
-  rgw::sal::RGWBucket::ListParams params;
-  rgw::sal::RGWBucket::ListResults results;
+  rgw::sal::Bucket::ListParams params;
+  rgw::sal::Bucket::ListResults results;
   auto delay_ms = cct->_conf.get_val<int64_t>("rgw_lc_thread_delay");
   params.list_versions = false;
   /* lifecycle processing does not depend on total order, so can
@@ -913,9 +913,9 @@ int RGWLC::handle_multipart_expiration(rgw::sal::RGWBucket* target,
   return 0;
 }
 
-static int read_obj_tags(const DoutPrefixProvider *dpp, rgw::sal::RGWObject* obj, RGWObjectCtx& ctx, bufferlist& tags_bl)
+static int read_obj_tags(const DoutPrefixProvider *dpp, rgw::sal::Object* obj, RGWObjectCtx& ctx, bufferlist& tags_bl)
 {
-  std::unique_ptr<rgw::sal::RGWObject::ReadOp> rop = obj->get_read_op(&ctx);
+  std::unique_ptr<rgw::sal::Object::ReadOp> rop = obj->get_read_op(&ctx);
 
   return rop->get_attr(dpp, RGW_ATTR_TAGS, tags_bl, null_yield);
 }
@@ -1432,7 +1432,7 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
 			     time_t stop_at, bool once)
 {
   RGWLifecycleConfiguration  config(cct);
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
   string no_ns, list_versions;
   vector<rgw_bucket_dir_entry> objs;
   vector<std::string> result;
@@ -1949,7 +1949,7 @@ static std::string get_lc_shard_name(const rgw_bucket& bucket){
 }
 
 template<typename F>
-static int guard_lc_modify(rgw::sal::RGWStore* store,
+static int guard_lc_modify(rgw::sal::Store* store,
 			   rgw::sal::Lifecycle* sal_lc,
 			   const rgw_bucket& bucket, const string& cookie,
 			   const F& f) {
@@ -1998,11 +1998,11 @@ static int guard_lc_modify(rgw::sal::RGWStore* store,
   return ret;
 }
 
-int RGWLC::set_bucket_config(rgw::sal::RGWBucket* bucket,
-                         const rgw::sal::RGWAttrs& bucket_attrs,
+int RGWLC::set_bucket_config(rgw::sal::Bucket* bucket,
+                         const rgw::sal::Attrs& bucket_attrs,
                          RGWLifecycleConfiguration *config)
 {
-  rgw::sal::RGWAttrs attrs = bucket_attrs;
+  rgw::sal::Attrs attrs = bucket_attrs;
   bufferlist lc_bl;
   config->encode(lc_bl);
 
@@ -2025,10 +2025,10 @@ int RGWLC::set_bucket_config(rgw::sal::RGWBucket* bucket,
   return ret;
 }
 
-int RGWLC::remove_bucket_config(rgw::sal::RGWBucket* bucket,
-                                const rgw::sal::RGWAttrs& bucket_attrs)
+int RGWLC::remove_bucket_config(rgw::sal::Bucket* bucket,
+                                const rgw::sal::Attrs& bucket_attrs)
 {
-  rgw::sal::RGWAttrs attrs = bucket_attrs;
+  rgw::sal::Attrs attrs = bucket_attrs;
   attrs.erase(RGW_ATTR_LC);
   int ret = bucket->set_instance_attrs(this, attrs, null_yield);
 
@@ -2058,9 +2058,9 @@ RGWLC::~RGWLC()
 
 namespace rgw::lc {
 
-int fix_lc_shard_entry(rgw::sal::RGWStore* store,
+int fix_lc_shard_entry(rgw::sal::Store* store,
 		       rgw::sal::Lifecycle* sal_lc,
-		       rgw::sal::RGWBucket* bucket)
+		       rgw::sal::Bucket* bucket)
 {
   if (auto aiter = bucket->get_attrs().find(RGW_ATTR_LC);
       aiter == bucket->get_attrs().end()) {

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -239,7 +239,7 @@ void *RGWLC::LCWorker::entry() {
   return NULL;
 }
 
-void RGWLC::initialize(CephContext *_cct, rgw::sal::Store *_store) {
+void RGWLC::initialize(CephContext *_cct, rgw::sal::Store* _store) {
   cct = _cct;
   store = _store;
   sal_lc = store->get_lifecycle();
@@ -416,7 +416,7 @@ static bool pass_object_lock_check(rgw::sal::Store* store, rgw::sal::Object* obj
 }
 
 class LCObjsLister {
-  rgw::sal::Store *store;
+  rgw::sal::Store* store;
   rgw::sal::Bucket* bucket;
   rgw::sal::Bucket::ListParams list_params;
   rgw::sal::Bucket::ListResults list_results;
@@ -426,7 +426,7 @@ class LCObjsLister {
   int64_t delay_ms;
 
 public:
-  LCObjsLister(rgw::sal::Store *_store, rgw::sal::Bucket* _bucket) :
+  LCObjsLister(rgw::sal::Store* _store, rgw::sal::Bucket* _bucket) :
       store(_store), bucket(_bucket) {
     list_params.list_versions = bucket->versioned();
     list_params.allow_unordered = true;
@@ -508,12 +508,12 @@ struct op_env {
   using LCWorker = RGWLC::LCWorker;
 
   lc_op op;
-  rgw::sal::Store *store;
+  rgw::sal::Store* store;
   LCWorker* worker;
   rgw::sal::Bucket* bucket;
   LCObjsLister& ol;
 
-  op_env(lc_op& _op, rgw::sal::Store *_store, LCWorker* _worker,
+  op_env(lc_op& _op, rgw::sal::Store* _store, LCWorker* _worker,
 	 rgw::sal::Bucket* _bucket, LCObjsLister& _ol)
     : op(_op), store(_store), worker(_worker), bucket(_bucket),
       ol(_ol) {}
@@ -529,7 +529,7 @@ struct lc_op_ctx {
   boost::optional<std::string> next_key_name;
   ceph::real_time effective_mtime;
 
-  rgw::sal::Store *store;
+  rgw::sal::Store* store;
   rgw::sal::Bucket* bucket;
   lc_op& op; // ok--refers to expanded env.op
   LCObjsLister& ol;

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -461,7 +461,7 @@ WRITE_CLASS_ENCODER(RGWLifecycleConfiguration)
 
 class RGWLC : public DoutPrefixProvider {
   CephContext *cct;
-  rgw::sal::Store *store;
+  rgw::sal::Store* store;
   std::unique_ptr<rgw::sal::Lifecycle> sal_lc;
   int max_objs{0};
   string *obj_names{nullptr};
@@ -508,7 +508,7 @@ public:
   RGWLC() : cct(nullptr), store(nullptr) {}
   ~RGWLC();
 
-  void initialize(CephContext *_cct, rgw::sal::Store *_store);
+  void initialize(CephContext *_cct, rgw::sal::Store* _store);
   void finalize();
 
   int process(LCWorker* worker, bool once);
@@ -533,7 +533,7 @@ public:
                            const rgw::sal::Attrs& bucket_attrs);
 
   CephContext *get_cct() const override { return cct; }
-  rgw::sal::Lifecycle *get_lc() const { return sal_lc.get(); }
+  rgw::sal::Lifecycle* get_lc() const { return sal_lc.get(); }
   unsigned get_subsys() const;
   std::ostream& gen_prefix(std::ostream& out) const;
 
@@ -546,7 +546,7 @@ public:
 
 namespace rgw::lc {
 
-int fix_lc_shard_entry(rgw::sal::Store *store,
+int fix_lc_shard_entry(rgw::sal::Store* store,
 		       rgw::sal::Lifecycle* sal_lc,
 		       rgw::sal::Bucket* bucket);
 

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -461,7 +461,7 @@ WRITE_CLASS_ENCODER(RGWLifecycleConfiguration)
 
 class RGWLC : public DoutPrefixProvider {
   CephContext *cct;
-  rgw::sal::RGWStore *store;
+  rgw::sal::Store *store;
   std::unique_ptr<rgw::sal::Lifecycle> sal_lc;
   int max_objs{0};
   string *obj_names{nullptr};
@@ -508,7 +508,7 @@ public:
   RGWLC() : cct(nullptr), store(nullptr) {}
   ~RGWLC();
 
-  void initialize(CephContext *_cct, rgw::sal::RGWStore *_store);
+  void initialize(CephContext *_cct, rgw::sal::Store *_store);
   void finalize();
 
   int process(LCWorker* worker, bool once);
@@ -526,11 +526,11 @@ public:
   bool going_down();
   void start_processor();
   void stop_processor();
-  int set_bucket_config(rgw::sal::RGWBucket* bucket,
-                        const rgw::sal::RGWAttrs& bucket_attrs,
+  int set_bucket_config(rgw::sal::Bucket* bucket,
+                        const rgw::sal::Attrs& bucket_attrs,
                         RGWLifecycleConfiguration *config);
-  int remove_bucket_config(rgw::sal::RGWBucket* bucket,
-                           const rgw::sal::RGWAttrs& bucket_attrs);
+  int remove_bucket_config(rgw::sal::Bucket* bucket,
+                           const rgw::sal::Attrs& bucket_attrs);
 
   CephContext *get_cct() const override { return cct; }
   rgw::sal::Lifecycle *get_lc() const { return sal_lc.get(); }
@@ -539,16 +539,16 @@ public:
 
   private:
 
-  int handle_multipart_expiration(rgw::sal::RGWBucket* target,
+  int handle_multipart_expiration(rgw::sal::Bucket* target,
 				  const multimap<string, lc_op>& prefix_map,
 				  LCWorker* worker, time_t stop_at, bool once);
 };
 
 namespace rgw::lc {
 
-int fix_lc_shard_entry(rgw::sal::RGWStore *store,
+int fix_lc_shard_entry(rgw::sal::Store *store,
 		       rgw::sal::Lifecycle* sal_lc,
-		       rgw::sal::RGWBucket* bucket);
+		       rgw::sal::Bucket* bucket);
 
 std::string s3_expiration_header(
   DoutPrefixProvider* dpp,

--- a/src/rgw/rgw_lib.h
+++ b/src/rgw/rgw_lib.h
@@ -30,7 +30,7 @@ namespace rgw {
     OpsLogSocket* olog;
     rgw::LDAPHelper* ldh{nullptr};
     RGWREST rest; // XXX needed for RGWProcessEnv
-    rgw::sal::RGWStore* store;
+    rgw::sal::Store* store;
     boost::intrusive_ptr<CephContext> cct;
 
   public:
@@ -38,7 +38,7 @@ namespace rgw {
       {}
     ~RGWLib() {}
 
-    rgw::sal::RGWStore* get_store() { return store; }
+    rgw::sal::Store* get_store() { return store; }
 
     RGWLibFrontend* get_fe() { return fe; }
 
@@ -74,7 +74,7 @@ namespace rgw {
       return user_info;
     }
 
-    int set_uid(rgw::sal::RGWStore* store, const rgw_user& uid);
+    int set_uid(rgw::sal::Store* store, const rgw_user& uid);
 
     int write_data(const char *buf, int len);
     int read_data(char *buf, int len);
@@ -121,21 +121,21 @@ namespace rgw {
 
     RGWHandler_Lib() {}
     ~RGWHandler_Lib() override {}
-    static int init_from_header(rgw::sal::RGWStore *store,
+    static int init_from_header(rgw::sal::Store *store,
 				struct req_state *s);
   }; /* RGWHandler_Lib */
 
   class RGWLibRequest : public RGWRequest,
 			public RGWHandler_Lib {
   private:
-    std::unique_ptr<rgw::sal::RGWUser> tuser; // Don't use this.  It's empty except during init.
+    std::unique_ptr<rgw::sal::User> tuser; // Don't use this.  It's empty except during init.
   public:
     CephContext* cct;
 
     /* unambiguiously return req_state */
     inline struct req_state* get_state() { return this->RGWRequest::s; }
 
-    RGWLibRequest(CephContext* _cct, std::unique_ptr<rgw::sal::RGWUser> _user)
+    RGWLibRequest(CephContext* _cct, std::unique_ptr<rgw::sal::User> _user)
       :  RGWRequest(rgwlib.get_store()->get_new_req_id()),
 	 tuser(std::move(_user)), cct(_cct)
       {}
@@ -189,7 +189,7 @@ namespace rgw {
   public:
 
     RGWLibContinuedReq(CephContext* _cct,
-		       std::unique_ptr<rgw::sal::RGWUser> _user)
+		       std::unique_ptr<rgw::sal::User> _user)
       :  RGWLibRequest(_cct, std::move(_user)), io_ctx(),
 	 rstate(_cct, &io_ctx.get_env(), id),
 	 rados_ctx(rgwlib.get_store(), &rstate)
@@ -207,7 +207,7 @@ namespace rgw {
 	    << get_state()->trans_id.c_str() << dendl;
       }
 
-    inline rgw::sal::RGWStore* get_store() { return store; }
+    inline rgw::sal::Store* get_store() { return store; }
     inline RGWLibIO& get_io() { return io_ctx; }
     inline RGWObjectCtx& get_octx() { return rados_ctx; }
 

--- a/src/rgw/rgw_lib.h
+++ b/src/rgw/rgw_lib.h
@@ -121,7 +121,7 @@ namespace rgw {
 
     RGWHandler_Lib() {}
     ~RGWHandler_Lib() override {}
-    static int init_from_header(rgw::sal::Store *store,
+    static int init_from_header(rgw::sal::Store* store,
 				struct req_state *s);
   }; /* RGWHandler_Lib */
 

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -88,7 +88,7 @@ string render_log_object_name(const string& format,
 /* usage logger */
 class UsageLogger {
   CephContext *cct;
-  rgw::sal::Store *store;
+  rgw::sal::Store* store;
   map<rgw_user_bucket, RGWUsageBatch> usage_map;
   ceph::mutex lock = ceph::make_mutex("UsageLogger");
   int32_t num_entries;
@@ -111,7 +111,7 @@ class UsageLogger {
   }
 public:
 
-  UsageLogger(CephContext *_cct, rgw::sal::Store *_store) : cct(_cct), store(_store), num_entries(0), timer(cct, timer_lock) {
+  UsageLogger(CephContext *_cct, rgw::sal::Store* _store) : cct(_cct), store(_store), num_entries(0), timer(cct, timer_lock) {
     timer.init();
     std::lock_guard l{timer_lock};
     set_timer();
@@ -171,7 +171,7 @@ public:
 
 static UsageLogger *usage_logger = NULL;
 
-void rgw_log_usage_init(CephContext *cct, rgw::sal::Store *store)
+void rgw_log_usage_init(CephContext *cct, rgw::sal::Store* store)
 {
   usage_logger = new UsageLogger(cct, store);
 }
@@ -328,7 +328,7 @@ void OpsLogSocket::log(struct rgw_log_entry& entry)
   append_output(bl);
 }
 
-int rgw_log_op(rgw::sal::Store *store, RGWREST* const rest, struct req_state *s,
+int rgw_log_op(rgw::sal::Store* store, RGWREST* const rest, struct req_state *s,
 	       const string& op_name, OpsLogSocket *olog)
 {
   struct rgw_log_entry entry;

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -9,7 +9,7 @@
 #include "common/OutputDataSocket.h"
 
 namespace rgw { namespace sal {
-  class RGWStore;
+  class Store;
 } }
 
 struct rgw_log_entry {
@@ -145,9 +145,9 @@ public:
 
 class RGWREST;
 
-int rgw_log_op(rgw::sal::RGWStore* store, RGWREST* const rest, struct req_state* s,
+int rgw_log_op(rgw::sal::Store* store, RGWREST* const rest, struct req_state* s,
 	       const string& op_name, OpsLogSocket* olog);
-void rgw_log_usage_init(CephContext* cct, rgw::sal::RGWStore* store);
+void rgw_log_usage_init(CephContext* cct, rgw::sal::Store* store);
 void rgw_log_usage_finalize();
 void rgw_format_ops_log_entry(struct rgw_log_entry& entry,
 			      ceph::Formatter *formatter);

--- a/src/rgw/rgw_lua.cc
+++ b/src/rgw/rgw_lua.cc
@@ -63,7 +63,7 @@ std::string script_oid(context ctx, const std::string& tenant) {
 }
 
 
-int read_script(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* store, const std::string& tenant, optional_yield y, context ctx, std::string& script)
+int read_script(const DoutPrefixProvider *dpp, rgw::sal::Store* store, const std::string& tenant, optional_yield y, context ctx, std::string& script)
 {
   RGWObjVersionTracker objv_tracker;
 
@@ -96,7 +96,7 @@ int read_script(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* store, const 
   return 0;
 }
 
-int write_script(rgw::sal::RGWStore* store, const std::string& tenant, optional_yield y, context ctx, const std::string& script)
+int write_script(rgw::sal::Store* store, const std::string& tenant, optional_yield y, context ctx, const std::string& script)
 {
   RGWObjVersionTracker objv_tracker;
 
@@ -121,7 +121,7 @@ int write_script(rgw::sal::RGWStore* store, const std::string& tenant, optional_
   return 0;
 }
 
-int delete_script(rgw::sal::RGWStore* store, const std::string& tenant, optional_yield y, context ctx)
+int delete_script(rgw::sal::Store* store, const std::string& tenant, optional_yield y, context ctx)
 {
   RGWObjVersionTracker objv_tracker;
 
@@ -146,7 +146,7 @@ const std::string PACKAGE_LIST_OBJECT_NAME = "lua_package_allowlist";
 
 namespace bp = boost::process;
 
-int add_package(rgw::sal::RGWStore* store, optional_yield y, const std::string& package_name, bool allow_compilation) {
+int add_package(rgw::sal::Store* store, optional_yield y, const std::string& package_name, bool allow_compilation) {
   // verify that luarocks can load this oackage
   const auto p = bp::search_path("luarocks");
   if (p.empty()) {
@@ -179,7 +179,7 @@ int add_package(rgw::sal::RGWStore* store, optional_yield y, const std::string& 
   std::map<std::string, bufferlist> new_package{{package_name, empty_bl}};
   librados::ObjectWriteOperation op;
   op.omap_set(new_package);
-  ret = rgw_rados_operate(*(static_cast<rgw::sal::RGWRadosStore*>(store)->getRados()->get_lc_pool_ctx()),
+  ret = rgw_rados_operate(*(static_cast<rgw::sal::RadosStore*>(store)->getRados()->get_lc_pool_ctx()),
       PACKAGE_LIST_OBJECT_NAME, &op, y);
 
   if (ret < 0) {
@@ -188,10 +188,10 @@ int add_package(rgw::sal::RGWStore* store, optional_yield y, const std::string& 
   return 0;
 }
 
-int remove_package(rgw::sal::RGWStore* store, optional_yield y, const std::string& package_name) {
+int remove_package(rgw::sal::Store* store, optional_yield y, const std::string& package_name) {
   librados::ObjectWriteOperation op;
   op.omap_rm_keys(std::set<std::string>({package_name}));
-  const auto ret = rgw_rados_operate(*(static_cast<rgw::sal::RGWRadosStore*>(store)->getRados()->get_lc_pool_ctx()),
+  const auto ret = rgw_rados_operate(*(static_cast<rgw::sal::RadosStore*>(store)->getRados()->get_lc_pool_ctx()),
     PACKAGE_LIST_OBJECT_NAME, &op, y);
 
   if (ret < 0) {
@@ -201,7 +201,7 @@ int remove_package(rgw::sal::RGWStore* store, optional_yield y, const std::strin
   return 0;
 }
 
-int list_packages(rgw::sal::RGWStore* store, optional_yield y, packages_t& packages) {
+int list_packages(rgw::sal::Store* store, optional_yield y, packages_t& packages) {
   constexpr auto max_chunk = 1024U;
   std::string start_after;
   bool more = true;
@@ -210,7 +210,7 @@ int list_packages(rgw::sal::RGWStore* store, optional_yield y, packages_t& packa
     librados::ObjectReadOperation op;
     packages_t packages_chunk;
     op.omap_get_keys2(start_after, max_chunk, &packages_chunk, &more, &rval);
-    const auto ret = rgw_rados_operate(*(static_cast<rgw::sal::RGWRadosStore*>(store)->getRados()->get_lc_pool_ctx()),
+    const auto ret = rgw_rados_operate(*(static_cast<rgw::sal::RadosStore*>(store)->getRados()->get_lc_pool_ctx()),
       PACKAGE_LIST_OBJECT_NAME, &op, nullptr, y);
   
     if (ret < 0) {
@@ -223,7 +223,7 @@ int list_packages(rgw::sal::RGWStore* store, optional_yield y, packages_t& packa
   return 0;
 }
 
-int install_packages(rgw::sal::RGWStore* store, optional_yield y, packages_t& failed_packages, std::string& output) {
+int install_packages(rgw::sal::Store* store, optional_yield y, packages_t& failed_packages, std::string& output) {
   // luarocks directory cleanup
   boost::system::error_code ec;
   const auto& luarocks_path = store->get_luarocks_path();

--- a/src/rgw/rgw_lua.h
+++ b/src/rgw/rgw_lua.h
@@ -6,7 +6,7 @@
 class lua_State;
 class rgw_user;
 namespace rgw::sal {
-  class RGWStore;
+  class Store;
 }
 
 namespace rgw::lua {
@@ -26,13 +26,13 @@ context to_context(const std::string& s);
 bool verify(const std::string& script, std::string& err_msg);
 
 // store a lua script in a context
-int write_script(rgw::sal::RGWStore* store, const std::string& tenant, optional_yield y, context ctx, const std::string& script);
+int write_script(rgw::sal::Store* store, const std::string& tenant, optional_yield y, context ctx, const std::string& script);
 
 // read the stored lua script from a context
-int read_script(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* store, const std::string& tenant, optional_yield y, context ctx, std::string& script);
+int read_script(const DoutPrefixProvider *dpp, rgw::sal::Store* store, const std::string& tenant, optional_yield y, context ctx, std::string& script);
 
 // delete the stored lua script from a context
-int delete_script(rgw::sal::RGWStore* store, const std::string& tenant, optional_yield y, context ctx);
+int delete_script(rgw::sal::Store* store, const std::string& tenant, optional_yield y, context ctx);
 
 #ifdef WITH_RADOSGW_LUA_PACKAGES
 #include <set>
@@ -40,17 +40,17 @@ int delete_script(rgw::sal::RGWStore* store, const std::string& tenant, optional
 using packages_t = std::set<std::string>;
 
 // add a lua package to the allowlist
-int add_package(rgw::sal::RGWStore* store, optional_yield y, const std::string& package_name, bool allow_compilation);
+int add_package(rgw::sal::Store* store, optional_yield y, const std::string& package_name, bool allow_compilation);
 
 // remove a lua package from the allowlist
-int remove_package(rgw::sal::RGWStore* store, optional_yield y, const std::string& package_name);
+int remove_package(rgw::sal::Store* store, optional_yield y, const std::string& package_name);
 
 // list lua packages in the allowlist
-int list_packages(rgw::sal::RGWStore* store, optional_yield y, packages_t& packages);
+int list_packages(rgw::sal::Store* store, optional_yield y, packages_t& packages);
 
 // install all packages from the allowlist
 // return the list of packages that failed to install and the output of the install command
-int install_packages(rgw::sal::RGWStore* store, optional_yield y, packages_t& failed_packages, std::string& output);
+int install_packages(rgw::sal::Store* store, optional_yield y, packages_t& failed_packages, std::string& output);
 #endif
 }
 

--- a/src/rgw/rgw_lua_request.cc
+++ b/src/rgw/rgw_lua_request.cc
@@ -24,7 +24,7 @@ constexpr const char* RequestLogAction{"Log"};
 
 int RequestLog(lua_State* L) 
 {
-  const auto store = reinterpret_cast<rgw::sal::RGWRadosStore*>(lua_touserdata(L, lua_upvalueindex(1)));
+  const auto store = reinterpret_cast<rgw::sal::RadosStore*>(lua_touserdata(L, lua_upvalueindex(1)));
   const auto rest = reinterpret_cast<RGWREST*>(lua_touserdata(L, lua_upvalueindex(2)));
   const auto olog = reinterpret_cast<OpsLogSocket*>(lua_touserdata(L, lua_upvalueindex(3)));
   const auto s = reinterpret_cast<req_state*>(lua_touserdata(L, lua_upvalueindex(4)));
@@ -171,7 +171,7 @@ struct BucketMetaTable : public EmptyMetaTable {
   static std::string TableName() {return "Bucket";}
   static std::string Name() {return TableName() + "Meta";}
 
-  using Type = rgw::sal::RGWBucket;
+  using Type = rgw::sal::Bucket;
 
   static int IndexClosure(lua_State* L) {
     const auto bucket = reinterpret_cast<Type*>(lua_touserdata(L, lua_upvalueindex(1)));
@@ -213,7 +213,7 @@ struct ObjectMetaTable : public EmptyMetaTable {
   static const std::string TableName() {return "Object";}
   static std::string Name() {return TableName() + "Meta";}
   
-  using Type = rgw::sal::RGWObject;
+  using Type = rgw::sal::Object;
 
   static int IndexClosure(lua_State* L) {
     const auto obj = reinterpret_cast<const Type*>(lua_touserdata(L, lua_upvalueindex(1)));
@@ -769,7 +769,7 @@ struct RequestMetaTable : public EmptyMetaTable {
 };
 
 int execute(
-    rgw::sal::RGWStore* store,
+    rgw::sal::Store* store,
     RGWREST* rest,
     OpsLogSocket* olog,
     req_state* s, 

--- a/src/rgw/rgw_lua_request.h
+++ b/src/rgw/rgw_lua_request.h
@@ -7,14 +7,14 @@ class req_state;
 class RGWREST;
 class OpsLogSocket;
 namespace rgw::sal {
-  class RGWStore;
+  class Store;
 }
 
 namespace rgw::lua::request {
 
 // execute a lua script in the Request context
 int execute(
-    rgw::sal::RGWStore* store,
+    rgw::sal::Store* store,
     RGWREST* rest,
     OpsLogSocket* olog,
     req_state *s, 

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -332,7 +332,7 @@ int radosgw_Main(int argc, const char **argv)
 #endif
 
   const DoutPrefix dp(cct.get(), dout_subsys, "rgw main: ");
-  rgw::sal::Store *store =
+  rgw::sal::Store* store =
     StoreManager::get_storage(&dp, g_ceph_context,
 				 "rados",
 				 g_conf()->rgw_enable_gc_threads,

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -166,7 +166,7 @@ static RGWRESTMgr *set_logging(RGWRESTMgr *mgr)
   return mgr;
 }
 
-static RGWRESTMgr *rest_filter(rgw::sal::RGWStore* store, int dialect, RGWRESTMgr *orig)
+static RGWRESTMgr *rest_filter(rgw::sal::Store* store, int dialect, RGWRESTMgr *orig)
 {
   RGWSyncModuleInstanceRef sync_module = store->get_sync_module();
   if (sync_module) {
@@ -332,8 +332,8 @@ int radosgw_Main(int argc, const char **argv)
 #endif
 
   const DoutPrefix dp(cct.get(), dout_subsys, "rgw main: ");
-  rgw::sal::RGWStore *store =
-    RGWStoreManager::get_storage(&dp, g_ceph_context,
+  rgw::sal::Store *store =
+    StoreManager::get_storage(&dp, g_ceph_context,
 				 "rados",
 				 g_conf()->rgw_enable_gc_threads,
 				 g_conf()->rgw_enable_lc_threads,
@@ -682,7 +682,7 @@ int radosgw_Main(int argc, const char **argv)
 
   delete olog;
 
-  RGWStoreManager::close_storage(store);
+  StoreManager::close_storage(store);
   rgw::auth::s3::LDAPEngine::shutdown();
   rgw_tools_cleanup();
   rgw_shutdown_resolver();

--- a/src/rgw/rgw_metadata.h
+++ b/src/rgw/rgw_metadata.h
@@ -20,7 +20,7 @@
 
 
 namespace rgw { namespace sal {
-class RGWStore;
+class Store;
 } }
 class RGWCoroutine;
 class JSONObj;

--- a/src/rgw/rgw_multi.cc
+++ b/src/rgw/rgw_multi.cc
@@ -196,7 +196,7 @@ int list_multipart_parts(struct req_state *s,
 }
 
 int abort_multipart_upload(const DoutPrefixProvider *dpp,
-			   rgw::sal::Store *store, CephContext *cct,
+			   rgw::sal::Store* store, CephContext *cct,
 			   RGWObjectCtx *obj_ctx, rgw::sal::Bucket* bucket,
 			   RGWMPObj& mp_obj)
 {
@@ -312,7 +312,7 @@ int list_bucket_multiparts(const DoutPrefixProvider *dpp,
 }
 
 int abort_bucket_multiparts(const DoutPrefixProvider *dpp,
-			    rgw::sal::Store *store, CephContext *cct,
+			    rgw::sal::Store* store, CephContext *cct,
 			    rgw::sal::Bucket* bucket, string& prefix, string& delim)
 {
   constexpr int max = 1000;

--- a/src/rgw/rgw_multi.h
+++ b/src/rgw/rgw_multi.h
@@ -10,7 +10,7 @@
 #include "rgw_compression_types.h"
 
 namespace rgw { namespace sal {
-  class RGWStore;
+  class Store;
 } }
 
 #define MULTIPART_UPLOAD_ID_PREFIX_LEGACY "2/"
@@ -108,7 +108,7 @@ public:
 
 extern bool is_v2_upload_id(const string& upload_id);
 
-extern int list_multipart_parts(rgw::sal::RGWBucket* bucket,
+extern int list_multipart_parts(rgw::sal::Bucket* bucket,
 				CephContext *cct,
                                 const string& upload_id,
                                 const string& meta_oid, int num_parts,
@@ -123,12 +123,12 @@ extern int list_multipart_parts(struct req_state *s,
                                 int *next_marker, bool *truncated,
                                 bool assume_unsorted = false);
 
-extern int abort_multipart_upload(const DoutPrefixProvider *dpp, rgw::sal::RGWStore *store,
+extern int abort_multipart_upload(const DoutPrefixProvider *dpp, rgw::sal::Store *store,
 				  CephContext *cct, RGWObjectCtx *obj_ctx,
-				  rgw::sal::RGWBucket* bucket, RGWMPObj& mp_obj);
+				  rgw::sal::Bucket* bucket, RGWMPObj& mp_obj);
 
 extern int list_bucket_multiparts(const DoutPrefixProvider *dpp,
-				  rgw::sal::RGWBucket* bucket,
+				  rgw::sal::Bucket* bucket,
 				  const string& prefix,
 				  const string& marker,
 				  const string& delim,
@@ -137,7 +137,7 @@ extern int list_bucket_multiparts(const DoutPrefixProvider *dpp,
 				  map<string, bool> *common_prefixes, bool *is_truncated);
 
 extern int abort_bucket_multiparts(const DoutPrefixProvider *dpp,
-				   rgw::sal::RGWStore *store, CephContext *cct,
-				   rgw::sal::RGWBucket* bucket,
+				   rgw::sal::Store *store, CephContext *cct,
+				   rgw::sal::Bucket* bucket,
 				   string& prefix, string& delim);
 #endif

--- a/src/rgw/rgw_multi.h
+++ b/src/rgw/rgw_multi.h
@@ -123,7 +123,7 @@ extern int list_multipart_parts(struct req_state *s,
                                 int *next_marker, bool *truncated,
                                 bool assume_unsorted = false);
 
-extern int abort_multipart_upload(const DoutPrefixProvider *dpp, rgw::sal::Store *store,
+extern int abort_multipart_upload(const DoutPrefixProvider *dpp, rgw::sal::Store* store,
 				  CephContext *cct, RGWObjectCtx *obj_ctx,
 				  rgw::sal::Bucket* bucket, RGWMPObj& mp_obj);
 
@@ -137,7 +137,7 @@ extern int list_bucket_multiparts(const DoutPrefixProvider *dpp,
 				  map<string, bool> *common_prefixes, bool *is_truncated);
 
 extern int abort_bucket_multiparts(const DoutPrefixProvider *dpp,
-				   rgw::sal::Store *store, CephContext *cct,
+				   rgw::sal::Store* store, CephContext *cct,
 				   rgw::sal::Bucket* bucket,
 				   string& prefix, string& delim);
 #endif

--- a/src/rgw/rgw_notify.cc
+++ b/src/rgw/rgw_notify.cc
@@ -474,7 +474,7 @@ public:
   Manager(CephContext* _cct, uint32_t _max_queue_size, uint32_t _queues_update_period_ms, 
           uint32_t _queues_update_retry_ms, uint32_t _queue_idle_sleep_us, u_int32_t failover_time_ms, 
           uint32_t _stale_reservations_period_s, uint32_t _reservations_cleanup_period_s,
-          uint32_t _worker_count, rgw::sal::RGWRadosStore* store) : 
+          uint32_t _worker_count, rgw::sal::RadosStore* store) :
     max_queue_size(_max_queue_size),
     queues_update_period_ms(_queues_update_period_ms),
     queues_update_retry_ms(_queues_update_retry_ms),
@@ -583,7 +583,7 @@ constexpr uint32_t WORKER_COUNT = 1;                 // 1 worker thread
 constexpr uint32_t STALE_RESERVATIONS_PERIOD_S = 120;   // cleanup reservations that are more than 2 minutes old
 constexpr uint32_t RESERVATIONS_CLEANUP_PERIOD_S = 30; // reservation cleanup every 30 seconds
 
-bool init(CephContext* cct, rgw::sal::RGWRadosStore* store, const DoutPrefixProvider *dpp) {
+bool init(CephContext* cct, rgw::sal::RadosStore* store, const DoutPrefixProvider *dpp) {
   if (s_manager) {
     return false;
   }
@@ -616,7 +616,7 @@ int remove_persistent_topic(const std::string& topic_name, optional_yield y) {
   return s_manager->remove_persistent_topic(topic_name, y);
 }
 
-rgw::sal::RGWObject* get_object_with_atttributes(const req_state* s, rgw::sal::RGWObject* obj) {
+rgw::sal::Object* get_object_with_atttributes(const req_state* s, rgw::sal::Object* obj) {
   // in case of copy obj, the tags and metadata are taken from source
   const auto src_obj = s->src_object ? s->src_object.get() : obj;
   if (src_obj->get_attrs().empty()) {
@@ -630,7 +630,7 @@ rgw::sal::RGWObject* get_object_with_atttributes(const req_state* s, rgw::sal::R
   return src_obj;
 }
 
-void metadata_from_attributes(const req_state* s, rgw::sal::RGWObject* obj, KeyValueMap& metadata) {
+void metadata_from_attributes(const req_state* s, rgw::sal::Object* obj, KeyValueMap& metadata) {
   const auto src_obj = get_object_with_atttributes(s, obj);
   if (!src_obj) {
     return;
@@ -646,7 +646,7 @@ void metadata_from_attributes(const req_state* s, rgw::sal::RGWObject* obj, KeyV
   }
 }
 
-void tags_from_attributes(const req_state* s, rgw::sal::RGWObject* obj, KeyValueMap& tags) {
+void tags_from_attributes(const req_state* s, rgw::sal::Object* obj, KeyValueMap& tags) {
   const auto src_obj = get_object_with_atttributes(s, obj);
   if (!src_obj) {
     return;
@@ -668,7 +668,7 @@ void tags_from_attributes(const req_state* s, rgw::sal::RGWObject* obj, KeyValue
 
 // populate event from request
 void populate_event_from_request(const req_state *s, 
-        rgw::sal::RGWObject* obj,
+        rgw::sal::Object* obj,
         uint64_t size,
         const ceph::real_time& mtime, 
         const std::string& etag, 
@@ -710,7 +710,7 @@ void populate_event_from_request(const req_state *s,
   // opaque data will be filled from topic configuration
 }
 
-bool notification_match(const rgw_pubsub_topic_filter& filter, const req_state* s, rgw::sal::RGWObject* obj, 
+bool notification_match(const rgw_pubsub_topic_filter& filter, const req_state* s, rgw::sal::Object* obj,
     EventType event, const RGWObjTags* req_tags) {
   if (!match(filter.events, event)) { 
     return false;
@@ -815,7 +815,7 @@ int publish_reserve(EventType event_type,
   return 0;
 }
 
-int publish_commit(rgw::sal::RGWObject* obj,
+int publish_commit(rgw::sal::Object* obj,
         uint64_t size,
         const ceph::real_time& mtime, 
         const std::string& etag, 

--- a/src/rgw/rgw_notify.h
+++ b/src/rgw/rgw_notify.h
@@ -13,7 +13,7 @@
 
 // forward declarations
 namespace rgw::sal {
-    class RGWRadosStore;
+    class RadosStore;
     class RGWObject;
 }
 
@@ -25,7 +25,7 @@ namespace rgw::notify {
 // initialize the notification manager
 // notification manager is dequeing the 2-phase-commit queues
 // and send the notifications to the endpoints
-bool init(CephContext* cct, rgw::sal::RGWRadosStore* store, const DoutPrefixProvider *dpp);
+bool init(CephContext* cct, rgw::sal::RadosStore* store, const DoutPrefixProvider *dpp);
 
 // shutdown the notification manager
 void shutdown();
@@ -53,12 +53,12 @@ struct reservation_t {
   };
 
   std::vector<topic_t> topics;
-  rgw::sal::RGWRadosStore* const store;
+  rgw::sal::RadosStore* const store;
   const req_state* const s;
   size_t size;
-  rgw::sal::RGWObject* const object;
+  rgw::sal::Object* const object;
 
-  reservation_t(rgw::sal::RGWRadosStore* _store, const req_state* _s, rgw::sal::RGWObject* _object) : 
+  reservation_t(rgw::sal::RadosStore* _store, const req_state* _s, rgw::sal::Object* _object) :
       store(_store), s(_s), object(_object) {}
 
   // dtor doing resource leak guarding
@@ -72,7 +72,7 @@ int publish_reserve(EventType event_type,
         const RGWObjTags* req_tags);
 
 // commit the reservation to the queue
-int publish_commit(rgw::sal::RGWObject* obj,
+int publish_commit(rgw::sal::Object* obj,
         uint64_t size,
         const ceph::real_time& mtime, 
         const std::string& etag, 

--- a/src/rgw/rgw_obj_manifest.h
+++ b/src/rgw/rgw_obj_manifest.h
@@ -45,7 +45,7 @@ public:
   }
 
   rgw_raw_obj get_raw_obj(const RGWZoneGroup& zonegroup, const RGWZoneParams& zone_params) const;
-  rgw_raw_obj get_raw_obj(rgw::sal::RGWStore* store) const;
+  rgw_raw_obj get_raw_obj(rgw::sal::Store* store) const;
 
   rgw_obj_select& operator=(const rgw_obj& rhs) {
     obj = rhs;
@@ -549,7 +549,7 @@ public:
     int create_next(uint64_t ofs);
 
     rgw_raw_obj get_cur_obj(RGWZoneGroup& zonegroup, RGWZoneParams& zone_params) { return cur_obj.get_raw_obj(zonegroup, zone_params); }
-    rgw_raw_obj get_cur_obj(rgw::sal::RGWStore* store) const { return cur_obj.get_raw_obj(store); }
+    rgw_raw_obj get_cur_obj(rgw::sal::Store* store) const { return cur_obj.get_raw_obj(store); }
 
     /* total max size of current stripe (including head obj) */
     uint64_t cur_stripe_max_size() const {

--- a/src/rgw/rgw_object_expirer.cc
+++ b/src/rgw/rgw_object_expirer.cc
@@ -32,16 +32,16 @@
 
 #define dout_subsys ceph_subsys_rgw
 
-static rgw::sal::RGWStore *store = NULL;
+static rgw::sal::Store *store = NULL;
 
 class StoreDestructor {
-  rgw::sal::RGWStore *store;
+  rgw::sal::Store *store;
 
 public:
-  explicit StoreDestructor(rgw::sal::RGWStore *_s) : store(_s) {}
+  explicit StoreDestructor(rgw::sal::Store *_s) : store(_s) {}
   ~StoreDestructor() {
     if (store) {
-      RGWStoreManager::close_storage(store);
+      StoreManager::close_storage(store);
     }
   }
 };
@@ -81,7 +81,7 @@ int main(const int argc, const char **argv)
   common_init_finish(g_ceph_context);
 
   const DoutPrefix dp(cct.get(), dout_subsys, "rgw object expirer: ");
-  store = RGWStoreManager::get_storage(&dp, g_ceph_context, "rados", false, false, false, false, false);
+  store = StoreManager::get_storage(&dp, g_ceph_context, "rados", false, false, false, false, false);
   if (!store) {
     std::cerr << "couldn't init storage provider" << std::endl;
     return EIO;

--- a/src/rgw/rgw_object_expirer.cc
+++ b/src/rgw/rgw_object_expirer.cc
@@ -32,13 +32,13 @@
 
 #define dout_subsys ceph_subsys_rgw
 
-static rgw::sal::Store *store = NULL;
+static rgw::sal::Store* store = NULL;
 
 class StoreDestructor {
-  rgw::sal::Store *store;
+  rgw::sal::Store* store;
 
 public:
-  explicit StoreDestructor(rgw::sal::Store *_s) : store(_s) {}
+  explicit StoreDestructor(rgw::sal::Store* _s) : store(_s) {}
   ~StoreDestructor() {
     if (store) {
       StoreManager::close_storage(store);

--- a/src/rgw/rgw_object_expirer_core.cc
+++ b/src/rgw/rgw_object_expirer_core.cc
@@ -193,7 +193,7 @@ int RGWObjExpStore::objexp_hint_trim(const string& oid,
 int RGWObjectExpirer::garbage_single_object(const DoutPrefixProvider *dpp, objexp_hint_entry& hint)
 {
   RGWBucketInfo bucket_info;
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
 
   int ret = store->get_bucket(dpp, nullptr, rgw_bucket(hint.tenant, hint.bucket_name, hint.bucket_id), &bucket, null_yield);
   if (-ENOENT == ret) {
@@ -213,7 +213,7 @@ int RGWObjectExpirer::garbage_single_object(const DoutPrefixProvider *dpp, objex
     key.instance = "null";
   }
 
-  std::unique_ptr<rgw::sal::RGWObject> obj = bucket->get_object(key);
+  std::unique_ptr<rgw::sal::Object> obj = bucket->get_object(key);
   obj->set_atomic(&rctx);
   ret = obj->delete_object(dpp, &rctx, null_yield);
 
@@ -298,7 +298,7 @@ bool RGWObjectExpirer::process_single_shard(const DoutPrefixProvider *dpp,
   utime_t time(max_secs, 0);
   l.set_duration(time);
 
-  int ret = l.lock_exclusive(&static_cast<rgw::sal::RGWRadosStore*>(store)->getRados()->objexp_pool_ctx, shard);
+  int ret = l.lock_exclusive(&static_cast<rgw::sal::RadosStore*>(store)->getRados()->objexp_pool_ctx, shard);
   if (ret == -EBUSY) { /* already locked by another processor */
     ldpp_dout(dpp, 5) << __func__ << "(): failed to acquire lock on " << shard << dendl;
     return false;
@@ -334,7 +334,7 @@ bool RGWObjectExpirer::process_single_shard(const DoutPrefixProvider *dpp,
     marker = out_marker;
   } while (truncated);
 
-  l.unlock(&static_cast<rgw::sal::RGWRadosStore*>(store)->getRados()->objexp_pool_ctx, shard);
+  l.unlock(&static_cast<rgw::sal::RadosStore*>(store)->getRados()->objexp_pool_ctx, shard);
   return done;
 }
 

--- a/src/rgw/rgw_object_expirer_core.h
+++ b/src/rgw/rgw_object_expirer_core.h
@@ -70,7 +70,7 @@ public:
 
 class RGWObjectExpirer {
 protected:
-  rgw::sal::RGWStore *store;
+  rgw::sal::Store *store;
   RGWObjExpStore exp_store;
 
   class OEWorker : public Thread, public DoutPrefixProvider {
@@ -98,9 +98,9 @@ protected:
   std::atomic<bool> down_flag = { false };
 
 public:
-  explicit RGWObjectExpirer(rgw::sal::RGWStore *_store)
+  explicit RGWObjectExpirer(rgw::sal::Store *_store)
     : store(_store),
-      exp_store(_store->ctx(), static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->rados, store->get_zone()),
+      exp_store(_store->ctx(), static_cast<rgw::sal::RadosStore*>(store)->svc()->rados, store->get_zone()),
       worker(NULL) {
   }
   ~RGWObjectExpirer() {

--- a/src/rgw/rgw_object_expirer_core.h
+++ b/src/rgw/rgw_object_expirer_core.h
@@ -70,7 +70,7 @@ public:
 
 class RGWObjectExpirer {
 protected:
-  rgw::sal::Store *store;
+  rgw::sal::Store* store;
   RGWObjExpStore exp_store;
 
   class OEWorker : public Thread, public DoutPrefixProvider {
@@ -98,7 +98,7 @@ protected:
   std::atomic<bool> down_flag = { false };
 
 public:
-  explicit RGWObjectExpirer(rgw::sal::Store *_store)
+  explicit RGWObjectExpirer(rgw::sal::Store* _store)
     : store(_store),
       exp_store(_store->ctx(), static_cast<rgw::sal::RadosStore*>(store)->svc()->rados, store->get_zone()),
       worker(NULL) {

--- a/src/rgw/rgw_oidc_provider.cc
+++ b/src/rgw/rgw_oidc_provider.cc
@@ -236,7 +236,7 @@ bool RGWOIDCProvider::validate_input()
 }
 
 int RGWOIDCProvider::get_providers(const DoutPrefixProvider *dpp,
-				   rgw::sal::RGWStore* store,
+				   rgw::sal::Store* store,
 				   const string& tenant,
 				   vector<RGWOIDCProvider>& providers)
 {

--- a/src/rgw/rgw_oidc_provider.h
+++ b/src/rgw/rgw_oidc_provider.h
@@ -24,7 +24,7 @@ class RGWOIDCProvider
   static constexpr int MAX_OIDC_URL_LEN = 255;
 
   CephContext *cct;
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
   string id;
   string provider_url;
   string arn;
@@ -40,7 +40,7 @@ class RGWOIDCProvider
 
 public:
   RGWOIDCProvider(CephContext *cct,
-                    rgw::sal::RGWStore* store,
+                    rgw::sal::Store* store,
                     string provider_url,
                     string tenant,
                     vector<string> client_ids,
@@ -54,7 +54,7 @@ public:
   }
 
   RGWOIDCProvider(CephContext *cct,
-                    rgw::sal::RGWStore* store,
+                    rgw::sal::Store* store,
                     string arn,
                     string tenant)
   : cct(cct),
@@ -64,14 +64,14 @@ public:
   }
 
   RGWOIDCProvider(CephContext *cct,
-                    rgw::sal::RGWStore* store,
+                    rgw::sal::Store* store,
                     string tenant)
   : cct(cct),
     store(store),
     tenant(std::move(tenant)) {}
 
   RGWOIDCProvider(CephContext *cct,
-          rgw::sal::RGWStore* store)
+          rgw::sal::Store* store)
   : cct(cct),
     store(store) {}
 
@@ -118,7 +118,7 @@ public:
 
   static const string& get_url_oid_prefix();
   static int get_providers(const DoutPrefixProvider *dpp,
-			   rgw::sal::RGWStore* store,
+			   rgw::sal::Store* store,
 			   const string& tenant,
 			   vector<RGWOIDCProvider>& providers);
 };

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -211,7 +211,7 @@ static int get_user_policy_from_attr(CephContext * const cct,
  */
 int rgw_op_get_bucket_policy_from_attr(const DoutPrefixProvider *dpp, 
                                        CephContext *cct,
-				       rgw::sal::RGWStore *store,
+				       rgw::sal::Store *store,
 				       RGWBucketInfo& bucket_info,
 				       map<string, bufferlist>& bucket_attrs,
 				       RGWAccessControlPolicy *policy,
@@ -225,7 +225,7 @@ int rgw_op_get_bucket_policy_from_attr(const DoutPrefixProvider *dpp,
       return ret;
   } else {
     ldpp_dout(dpp, 0) << "WARNING: couldn't find acl header for bucket, generating default" << dendl;
-    std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(bucket_info.owner);
+    std::unique_ptr<rgw::sal::User> user = store->get_user(bucket_info.owner);
     /* object exists, but policy is broken */
     int r = user->load_by_id(dpp, y);
     if (r < 0)
@@ -238,19 +238,19 @@ int rgw_op_get_bucket_policy_from_attr(const DoutPrefixProvider *dpp,
 
 static int get_obj_policy_from_attr(const DoutPrefixProvider *dpp, 
                                     CephContext *cct,
-				    rgw::sal::RGWStore *store,
+				    rgw::sal::Store *store,
 				    RGWObjectCtx& obj_ctx,
 				    RGWBucketInfo& bucket_info,
 				    map<string, bufferlist>& bucket_attrs,
 				    RGWAccessControlPolicy *policy,
                                     string *storage_class,
-				    rgw::sal::RGWObject* obj,
+				    rgw::sal::Object* obj,
                                     optional_yield y)
 {
   bufferlist bl;
   int ret = 0;
 
-  std::unique_ptr<rgw::sal::RGWObject::ReadOp> rop = obj->get_read_op(&obj_ctx);
+  std::unique_ptr<rgw::sal::Object::ReadOp> rop = obj->get_read_op(&obj_ctx);
 
   ret = rop->get_attr(dpp, RGW_ATTR_ACL, bl, y);
   if (ret >= 0) {
@@ -260,7 +260,7 @@ static int get_obj_policy_from_attr(const DoutPrefixProvider *dpp,
   } else if (ret == -ENODATA) {
     /* object exists, but policy is broken */
     ldpp_dout(dpp, 0) << "WARNING: couldn't find acl header for object, generating default" << dendl;
-    std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(bucket_info.owner);
+    std::unique_ptr<rgw::sal::User> user = store->get_user(bucket_info.owner);
     ret = user->load_by_id(dpp, y);
     if (ret < 0)
       return ret;
@@ -329,10 +329,10 @@ vector<Policy> get_iam_user_policy_from_attr(CephContext* cct,
 
 static int get_obj_head(const DoutPrefixProvider *dpp,
                         struct req_state *s,
-                        rgw::sal::RGWObject* obj,
+                        rgw::sal::Object* obj,
 			bufferlist *pbl)
 {
-  std::unique_ptr<rgw::sal::RGWObject::ReadOp> read_op = obj->get_read_op(s->obj_ctx);
+  std::unique_ptr<rgw::sal::Object::ReadOp> read_op = obj->get_read_op(s->obj_ctx);
   obj->set_prefetch_data(s->obj_ctx);
 
   int ret = read_op->prepare(s->yield, dpp);
@@ -368,7 +368,7 @@ struct multipart_upload_info
 WRITE_CLASS_ENCODER(multipart_upload_info)
 
 static int get_multipart_info(const DoutPrefixProvider *dpp, struct req_state *s,
-			      rgw::sal::RGWObject* obj,
+			      rgw::sal::Object* obj,
                               multipart_upload_info *upload_info)
 {
   bufferlist header;
@@ -404,7 +404,7 @@ static int get_multipart_info(const DoutPrefixProvider *dpp, struct req_state *s
   map<string, bufferlist>::iterator iter;
   bufferlist header;
 
-  std::unique_ptr<rgw::sal::RGWObject> meta_obj;
+  std::unique_ptr<rgw::sal::Object> meta_obj;
   meta_obj = s->bucket->get_object(rgw_obj_key(meta_oid, string(), mp_ns));
   meta_obj->set_in_extra_data(true);
 
@@ -412,7 +412,7 @@ static int get_multipart_info(const DoutPrefixProvider *dpp, struct req_state *s
 }
 
 static int read_bucket_policy(const DoutPrefixProvider *dpp, 
-                              rgw::sal::RGWStore *store,
+                              rgw::sal::Store *store,
                               struct req_state *s,
                               RGWBucketInfo& bucket_info,
                               map<string, bufferlist>& bucket_attrs,
@@ -439,21 +439,21 @@ static int read_bucket_policy(const DoutPrefixProvider *dpp,
 }
 
 static int read_obj_policy(const DoutPrefixProvider *dpp, 
-                           rgw::sal::RGWStore *store,
+                           rgw::sal::Store *store,
                            struct req_state *s,
                            RGWBucketInfo& bucket_info,
                            map<string, bufferlist>& bucket_attrs,
                            RGWAccessControlPolicy* acl,
                            string *storage_class,
 			   boost::optional<Policy>& policy,
-                           rgw::sal::RGWBucket* bucket,
-                           rgw::sal::RGWObject* object,
+                           rgw::sal::Bucket* bucket,
+                           rgw::sal::Object* object,
 			   optional_yield y,
                            bool copy_src=false)
 {
   string upload_id;
   upload_id = s->info.args.get("uploadId");
-  std::unique_ptr<rgw::sal::RGWObject> mpobj;
+  std::unique_ptr<rgw::sal::Object> mpobj;
   rgw_obj obj;
 
   if (!s->system_request && bucket_info.flags & BUCKET_SUSPENDED) {
@@ -513,7 +513,7 @@ static int read_obj_policy(const DoutPrefixProvider *dpp,
  * only_bucket: If true, reads the user and bucket ACLs rather than the object ACL.
  * Returns: 0 on success, -ERR# otherwise.
  */
-int rgw_build_bucket_policies(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* store, struct req_state* s, optional_yield y)
+int rgw_build_bucket_policies(const DoutPrefixProvider *dpp, rgw::sal::Store* store, struct req_state* s, optional_yield y)
 {
   int ret = 0;
 
@@ -542,7 +542,7 @@ int rgw_build_bucket_policies(const DoutPrefixProvider *dpp, rgw::sal::RGWStore*
 
   /* check if copy source is within the current domain */
   if (!s->src_bucket_name.empty()) {
-    std::unique_ptr<rgw::sal::RGWBucket> src_bucket;
+    std::unique_ptr<rgw::sal::Bucket> src_bucket;
     ret = store->get_bucket(dpp, nullptr,
 			    rgw_bucket(s->src_tenant_name,
 				       s->src_bucket_name,
@@ -621,7 +621,7 @@ int rgw_build_bucket_policies(const DoutPrefixProvider *dpp, rgw::sal::RGWStore*
         /* If op is get bucket location, don't redirect */
       } else if (!s->local_source ||
           (s->op != OP_PUT && s->op != OP_COPY) ||
-          rgw::sal::RGWObject::empty(s->object.get())) {
+          rgw::sal::Object::empty(s->object.get())) {
         return -ERR_PERMANENT_REDIRECT;
       }
     }
@@ -640,8 +640,8 @@ int rgw_build_bucket_policies(const DoutPrefixProvider *dpp, rgw::sal::RGWStore*
 
   /* handle user ACL only for those APIs which support it */
   if (s->user_acl) {
-    rgw::sal::RGWAttrs uattrs;
-    std::unique_ptr<rgw::sal::RGWUser> acl_user = store->get_user(acct_acl_user.uid);
+    rgw::sal::Attrs uattrs;
+    std::unique_ptr<rgw::sal::User> acl_user = store->get_user(acct_acl_user.uid);
 
     ret = acl_user->read_attrs(dpp, y, &uattrs);
     if (!ret) {
@@ -668,7 +668,7 @@ int rgw_build_bucket_policies(const DoutPrefixProvider *dpp, rgw::sal::RGWStore*
   // hence the check for user type
   if (! s->user->get_id().empty() && s->auth.identity->get_identity_type() != TYPE_ROLE) {
     try {
-      rgw::sal::RGWAttrs uattrs;
+      rgw::sal::Attrs uattrs;
       ret = s->user->read_attrs(dpp, y, &uattrs);
       if (ret == 0) {
           auto user_policies = get_iam_user_policy_from_attr(s->cct, uattrs, s->user->get_tenant());
@@ -710,12 +710,12 @@ int rgw_build_bucket_policies(const DoutPrefixProvider *dpp, rgw::sal::RGWStore*
  * only_bucket: If true, reads the bucket ACL rather than the object ACL.
  * Returns: 0 on success, -ERR# otherwise.
  */
-int rgw_build_object_policies(const DoutPrefixProvider *dpp, rgw::sal::RGWStore *store,
+int rgw_build_object_policies(const DoutPrefixProvider *dpp, rgw::sal::Store *store,
 			      struct req_state *s, bool prefetch_data, optional_yield y)
 {
   int ret = 0;
 
-  if (!rgw::sal::RGWObject::empty(s->object.get())) {
+  if (!rgw::sal::Object::empty(s->object.get())) {
     if (!s->bucket_exists) {
       return -ERR_NO_SUCH_BUCKET;
     }
@@ -758,12 +758,12 @@ static int rgw_iam_add_tags_from_bl(struct req_state* s, bufferlist& bl){
   return 0;
 }
 
-static int rgw_iam_add_existing_objtags(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* store, struct req_state* s, std::uint64_t action) {
+static int rgw_iam_add_existing_objtags(const DoutPrefixProvider *dpp, rgw::sal::Store* store, struct req_state* s, std::uint64_t action) {
   s->object->set_atomic(s->obj_ctx);
   int op_ret = s->object->get_obj_attrs(s->obj_ctx, s->yield, dpp);
   if (op_ret < 0)
     return op_ret;
-  rgw::sal::RGWAttrs attrs = s->object->get_attrs();
+  rgw::sal::Attrs attrs = s->object->get_attrs();
   auto tags = attrs.find(RGW_ATTR_TAGS);
   if (tags != attrs.end()){
     return rgw_iam_add_tags_from_bl(s, tags->second);
@@ -792,7 +792,7 @@ static void rgw_add_grant_to_iam_environment(rgw::IAM::Environment& e, struct re
   }
 }
 
-void rgw_build_iam_environment(rgw::sal::RGWStore* store,
+void rgw_build_iam_environment(rgw::sal::Store* store,
 	                              struct req_state* s)
 {
   const auto& m = s->info.env->get_map();
@@ -877,7 +877,7 @@ void rgw_bucket_object_pre_exec(struct req_state *s)
 // general, they should just return op_ret.
 namespace {
 template<typename F>
-int retry_raced_bucket_write(const DoutPrefixProvider *dpp, rgw::sal::RGWBucket* b, const F& f) {
+int retry_raced_bucket_write(const DoutPrefixProvider *dpp, rgw::sal::Bucket* b, const F& f) {
   auto r = f();
   for (auto i = 0u; i < 15u && r == -ECANCELED; ++i) {
     r = b->try_refresh_info(dpp, nullptr);
@@ -982,7 +982,7 @@ void RGWGetObjTags::pre_exec()
 
 void RGWGetObjTags::execute(optional_yield y)
 {
-  rgw::sal::RGWAttrs attrs;
+  rgw::sal::Attrs attrs;
 
   s->object->set_atomic(s->obj_ctx);
 
@@ -1029,7 +1029,7 @@ void RGWPutObjTags::execute(optional_yield y)
   if (op_ret < 0)
     return;
 
-  if (rgw::sal::RGWObject::empty(s->object.get())){
+  if (rgw::sal::Object::empty(s->object.get())){
     op_ret= -EINVAL; // we only support tagging on existing objects
     return;
   }
@@ -1049,7 +1049,7 @@ void RGWDeleteObjTags::pre_exec()
 
 int RGWDeleteObjTags::verify_permission(optional_yield y)
 {
-  if (!rgw::sal::RGWObject::empty(s->object.get())) {
+  if (!rgw::sal::Object::empty(s->object.get())) {
     auto iam_action = s->object->get_instance().empty() ?
       rgw::IAM::s3DeleteObjectTagging:
       rgw::IAM::s3DeleteObjectVersionTagging;
@@ -1072,7 +1072,7 @@ int RGWDeleteObjTags::verify_permission(optional_yield y)
 
 void RGWDeleteObjTags::execute(optional_yield y)
 {
-  if (rgw::sal::RGWObject::empty(s->object.get()))
+  if (rgw::sal::Object::empty(s->object.get()))
     return;
 
   op_ret = s->object->delete_obj_attrs(this, s->obj_ctx, RGW_ATTR_TAGS, y);
@@ -1122,7 +1122,7 @@ void RGWPutBucketTags::execute(optional_yield y)
   }
 
   op_ret = retry_raced_bucket_write(this, s->bucket.get(), [this, y] {
-    rgw::sal::RGWAttrs attrs = s->bucket->get_attrs();
+    rgw::sal::Attrs attrs = s->bucket->get_attrs();
     attrs[RGW_ATTR_TAGS] = tags_bl;
     return s->bucket->set_instance_attrs(this, attrs, y);
   });
@@ -1149,7 +1149,7 @@ void RGWDeleteBucketTags::execute(optional_yield y)
   }
 
   op_ret = retry_raced_bucket_write(this, s->bucket.get(), [this, y] {
-    rgw::sal::RGWAttrs attrs = s->bucket->get_attrs();
+    rgw::sal::Attrs attrs = s->bucket->get_attrs();
     attrs.erase(RGW_ATTR_TAGS);
     op_ret = s->bucket->set_instance_attrs(this, attrs, y);
     if (op_ret < 0) {
@@ -1286,14 +1286,14 @@ int RGWOp::init_quota()
   }
 
   /* only interested in object related ops */
-  if (rgw::sal::RGWBucket::empty(s->bucket.get())
-      || rgw::sal::RGWObject::empty(s->object.get())) {
+  if (rgw::sal::Bucket::empty(s->bucket.get())
+      || rgw::sal::Object::empty(s->object.get())) {
     return 0;
   }
 
-  std::unique_ptr<rgw::sal::RGWUser> owner_user =
+  std::unique_ptr<rgw::sal::User> owner_user =
 			store->get_user(s->bucket->get_info().owner);
-  rgw::sal::RGWUser* user;
+  rgw::sal::User* user;
 
   if (s->user->get_id() == s->bucket_owner.get_id()) {
     user = s->user.get();
@@ -1476,7 +1476,7 @@ bool RGWOp::generate_cors_headers(string& origin, string& method, string& header
   return true;
 }
 
-int RGWGetObj::read_user_manifest_part(rgw::sal::RGWBucket* bucket,
+int RGWGetObj::read_user_manifest_part(rgw::sal::Bucket* bucket,
                                        const rgw_bucket_dir_entry& ent,
                                        RGWAccessControlPolicy * const bucket_acl,
                                        const boost::optional<Policy>& bucket_policy,
@@ -1493,7 +1493,7 @@ int RGWGetObj::read_user_manifest_part(rgw::sal::RGWBucket* bucket,
   int64_t cur_ofs = start_ofs;
   int64_t cur_end = end_ofs;
 
-  std::unique_ptr<rgw::sal::RGWObject> part = bucket->get_object(ent.key);
+  std::unique_ptr<rgw::sal::Object> part = bucket->get_object(ent.key);
 
   RGWObjectCtx obj_ctx(store);
   RGWAccessControlPolicy obj_policy(s->cct);
@@ -1504,7 +1504,7 @@ int RGWGetObj::read_user_manifest_part(rgw::sal::RGWBucket* bucket,
   part->set_atomic(&obj_ctx);
   part->set_prefetch_data(&obj_ctx);
 
-  std::unique_ptr<rgw::sal::RGWObject::ReadOp> read_op = part->get_read_op(&obj_ctx);
+  std::unique_ptr<rgw::sal::Object::ReadOp> read_op = part->get_read_op(&obj_ctx);
 
   if (!swift_slo) {
     /* SLO etag is optional */
@@ -1574,17 +1574,17 @@ int RGWGetObj::read_user_manifest_part(rgw::sal::RGWBucket* bucket,
 
 static int iterate_user_manifest_parts(const DoutPrefixProvider *dpp, 
                                        CephContext * const cct,
-                                       rgw::sal::RGWStore* const store,
+                                       rgw::sal::Store* const store,
                                        const off_t ofs,
                                        const off_t end,
-                                       rgw::sal::RGWBucket* bucket,
+                                       rgw::sal::Bucket* bucket,
                                        const string& obj_prefix,
                                        RGWAccessControlPolicy * const bucket_acl,
                                        const boost::optional<Policy>& bucket_policy,
                                        uint64_t * const ptotal_len,
                                        uint64_t * const pobj_size,
                                        string * const pobj_sum,
-                                       int (*cb)(rgw::sal::RGWBucket* bucket,
+                                       int (*cb)(rgw::sal::Bucket* bucket,
                                                  const rgw_bucket_dir_entry& ent,
                                                  RGWAccessControlPolicy * const bucket_acl,
                                                  const boost::optional<Policy>& bucket_policy,
@@ -1601,11 +1601,11 @@ static int iterate_user_manifest_parts(const DoutPrefixProvider *dpp,
 
   utime_t start_time = ceph_clock_now();
 
-  rgw::sal::RGWBucket::ListParams params;
+  rgw::sal::Bucket::ListParams params;
   params.prefix = obj_prefix;
   params.delim = delim;
 
-  rgw::sal::RGWBucket::ListResults results;
+  rgw::sal::Bucket::ListResults results;
   MD5 etag_sum;
   do {
     static constexpr auto MAX_LIST_OBJS = 100u;
@@ -1671,18 +1671,18 @@ static int iterate_user_manifest_parts(const DoutPrefixProvider *dpp,
 struct rgw_slo_part {
   RGWAccessControlPolicy *bucket_acl = nullptr;
   Policy* bucket_policy = nullptr;
-  rgw::sal::RGWBucket* bucket;
+  rgw::sal::Bucket* bucket;
   string obj_name;
   uint64_t size = 0;
   string etag;
 };
 
 static int iterate_slo_parts(CephContext *cct,
-                             rgw::sal::RGWStore*store,
+                             rgw::sal::Store*store,
                              off_t ofs,
                              off_t end,
                              map<uint64_t, rgw_slo_part>& slo_parts,
-                             int (*cb)(rgw::sal::RGWBucket* bucket,
+                             int (*cb)(rgw::sal::Bucket* bucket,
                                        const rgw_bucket_dir_entry& ent,
                                        RGWAccessControlPolicy *bucket_acl,
                                        const boost::optional<Policy>& bucket_policy,
@@ -1757,7 +1757,7 @@ static int iterate_slo_parts(CephContext *cct,
   return 0;
 }
 
-static int get_obj_user_manifest_iterate_cb(rgw::sal::RGWBucket* bucket,
+static int get_obj_user_manifest_iterate_cb(rgw::sal::Bucket* bucket,
                                             const rgw_bucket_dir_entry& ent,
                                             RGWAccessControlPolicy * const bucket_acl,
                                             const boost::optional<Policy>& bucket_policy,
@@ -1790,8 +1790,8 @@ int RGWGetObj::handle_user_manifest(const char *prefix, optional_yield y)
   boost::optional<Policy> _bucket_policy;
   boost::optional<Policy>* bucket_policy;
   RGWBucketInfo bucket_info;
-  std::unique_ptr<rgw::sal::RGWBucket> ubucket;
-  rgw::sal::RGWBucket *pbucket = NULL;
+  std::unique_ptr<rgw::sal::Bucket> ubucket;
+  rgw::sal::Bucket *pbucket = NULL;
   int r = 0;
 
   if (bucket_name.compare(s->bucket->get_name()) != 0) {
@@ -1879,7 +1879,7 @@ int RGWGetObj::handle_slo_manifest(bufferlist& bl, optional_yield y)
 
   vector<RGWAccessControlPolicy> allocated_acls;
   map<string, pair<RGWAccessControlPolicy *, boost::optional<Policy>>> policies;
-  map<string, std::unique_ptr<rgw::sal::RGWBucket>> buckets;
+  map<string, std::unique_ptr<rgw::sal::Bucket>> buckets;
 
   map<uint64_t, rgw_slo_part> slo_parts;
 
@@ -1909,7 +1909,7 @@ int RGWGetObj::handle_slo_manifest(bufferlist& bl, optional_yield y)
     string bucket_name = path.substr(pos_init, pos_sep - pos_init);
     string obj_name = path.substr(pos_sep + 1);
 
-    rgw::sal::RGWBucket* bucket;
+    rgw::sal::Bucket* bucket;
     RGWAccessControlPolicy *bucket_acl;
     Policy* bucket_policy;
 
@@ -1923,7 +1923,7 @@ int RGWGetObj::handle_slo_manifest(bufferlist& bl, optional_yield y)
 	allocated_acls.push_back(RGWAccessControlPolicy(s->cct));
 	RGWAccessControlPolicy& _bucket_acl = allocated_acls.back();
 
-	std::unique_ptr<rgw::sal::RGWBucket> tmp_bucket;
+	std::unique_ptr<rgw::sal::Bucket> tmp_bucket;
 	int r = store->get_bucket(this, s->user.get(), s->user->get_tenant(), bucket_name, &tmp_bucket, y);
         if (r < 0) {
           ldpp_dout(this, 0) << "could not get bucket info for bucket="
@@ -2059,7 +2059,7 @@ void RGWGetObj::execute(optional_yield y)
 
   perfcounter->inc(l_rgw_get);
 
-  std::unique_ptr<rgw::sal::RGWObject::ReadOp> read_op(s->object->get_read_op(s->obj_ctx));
+  std::unique_ptr<rgw::sal::Object::ReadOp> read_op(s->object->get_read_op(s->obj_ctx));
 
   op_ret = get_params(y);
   if (op_ret < 0)
@@ -2296,7 +2296,7 @@ void RGWListBuckets::execute(optional_yield y)
 
   is_truncated = false;
   do {
-    rgw::sal::RGWBucketList buckets;
+    rgw::sal::BucketList buckets;
     uint64_t read_count;
     if (limit >= 0) {
       read_count = min(limit - total_count, max_buckets);
@@ -2322,7 +2322,7 @@ void RGWListBuckets::execute(optional_yield y)
                              decltype(policies_stats)::mapped_type());
     }
 
-    std::map<std::string, std::unique_ptr<rgw::sal::RGWBucket>>& m = buckets.get_buckets();
+    std::map<std::string, std::unique_ptr<rgw::sal::Bucket>>& m = buckets.get_buckets();
     for (const auto& kv : m) {
       const auto& bucket = kv.second;
 
@@ -2440,7 +2440,7 @@ int RGWStatAccount::verify_permission(optional_yield y)
 void RGWStatAccount::execute(optional_yield y)
 {
   string marker;
-  rgw::sal::RGWBucketList buckets;
+  rgw::sal::BucketList buckets;
   uint64_t max_buckets = s->cct->_conf->rgw_list_buckets_max_chunk;
   const string *lastmarker;
 
@@ -2463,7 +2463,7 @@ void RGWStatAccount::execute(optional_yield y)
                                decltype(policies_stats)::mapped_type());
       }
 
-      std::map<std::string, std::unique_ptr<rgw::sal::RGWBucket>>& m = buckets.get_buckets();
+      std::map<std::string, std::unique_ptr<rgw::sal::Bucket>>& m = buckets.get_buckets();
       for (const auto& kv : m) {
         const auto& bucket = kv.second;
 	lastmarker = &kv.first;
@@ -2593,7 +2593,7 @@ void RGWSetBucketVersioning::execute(optional_yield y)
       } else {
 	return op_ret;
       }
-      s->bucket->set_attrs(rgw::sal::RGWAttrs(s->bucket_attrs));
+      s->bucket->set_attrs(rgw::sal::Attrs(s->bucket_attrs));
       return s->bucket->put_instance_info(this, false, real_time());
     });
 
@@ -2783,7 +2783,7 @@ void RGWListBucket::execute(optional_yield y)
     op_ret = s->bucket->update_container_stats(s);
   }
 
-  rgw::sal::RGWBucket::ListParams params;
+  rgw::sal::Bucket::ListParams params;
   params.prefix = prefix;
   params.delim = delimiter;
   params.marker = marker;
@@ -2792,7 +2792,7 @@ void RGWListBucket::execute(optional_yield y)
   params.allow_unordered = allow_unordered;
   params.shard_id = shard_id;
 
-  rgw::sal::RGWBucket::ListResults results;
+  rgw::sal::Bucket::ListResults results;
 
   op_ret = s->bucket->list(this, params, max, results, y);
   if (op_ret >= 0) {
@@ -2846,7 +2846,7 @@ int RGWCreateBucket::verify_permission(optional_yield y)
   }
 
   if (s->user->get_max_buckets()) {
-    rgw::sal::RGWBucketList buckets;
+    rgw::sal::BucketList buckets;
     string marker;
     op_ret = s->user->list_buckets(this, marker, string(), s->user->get_max_buckets(),
 				   false, buckets, y);
@@ -3382,7 +3382,7 @@ int RGWPutObj::init_processing(optional_yield y) {
         return ret;
       }
     }
-    std::unique_ptr<rgw::sal::RGWBucket> bucket;
+    std::unique_ptr<rgw::sal::Bucket> bucket;
     ret = store->get_bucket(this, s->user.get(), copy_source_tenant_name, copy_source_bucket_name,
 			      &bucket, y);
     if (ret < 0) {
@@ -3442,12 +3442,12 @@ int RGWPutObj::verify_permission(optional_yield y)
     RGWAccessControlPolicy cs_acl(s->cct);
     boost::optional<Policy> policy;
     map<string, bufferlist> cs_attrs;
-    std::unique_ptr<rgw::sal::RGWBucket> cs_bucket;
+    std::unique_ptr<rgw::sal::Bucket> cs_bucket;
     int ret = store->get_bucket(NULL, copy_source_bucket_info, &cs_bucket);
     if (ret < 0)
       return ret;
 
-    std::unique_ptr<rgw::sal::RGWObject> cs_object =
+    std::unique_ptr<rgw::sal::Object> cs_object =
       cs_bucket->get_object(rgw_obj_key(copy_source_object_name, copy_source_version_id));
 
     cs_object->set_atomic(s->obj_ctx);
@@ -3610,13 +3610,13 @@ int RGWPutObj::get_data(const off_t fst, const off_t lst, bufferlist& bl)
   new_ofs = fst;
   new_end = lst;
 
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
   ret = store->get_bucket(nullptr, copy_source_bucket_info, &bucket);
   if (ret < 0)
     return ret;
 
-  std::unique_ptr<rgw::sal::RGWObject> obj = bucket->get_object(rgw_obj_key(copy_source_object_name, copy_source_version_id));
-  std::unique_ptr<rgw::sal::RGWObject::ReadOp> read_op(obj->get_read_op(s->obj_ctx));
+  std::unique_ptr<rgw::sal::Object> obj = bucket->get_object(rgw_obj_key(copy_source_object_name, copy_source_version_id));
+  std::unique_ptr<rgw::sal::Object::ReadOp> read_op(obj->get_read_op(s->obj_ctx));
 
   ret = read_op->prepare(s->yield, this);
   if (ret < 0)
@@ -3710,7 +3710,7 @@ void RGWPutObj::execute(optional_yield y)
     });
 
   op_ret = -EINVAL;
-  if (rgw::sal::RGWObject::empty(s->object.get())) {
+  if (rgw::sal::Object::empty(s->object.get())) {
     return;
   }
 
@@ -3843,13 +3843,13 @@ void RGWPutObj::execute(optional_yield y)
   }
 
   if ((! copy_source.empty()) && !copy_source_range) {
-    std::unique_ptr<rgw::sal::RGWBucket> bucket;
+    std::unique_ptr<rgw::sal::Bucket> bucket;
     op_ret = store->get_bucket(nullptr, copy_source_bucket_info, &bucket);
     if (op_ret < 0) {
       ldpp_dout(this, 0) << "ERROR: failed to get bucket with error" << op_ret << dendl;
       return;
     }
-    std::unique_ptr<rgw::sal::RGWObject> obj =
+    std::unique_ptr<rgw::sal::Object> obj =
       bucket->get_object(rgw_obj_key(copy_source_object_name, copy_source_version_id));
 
     RGWObjState *astate;
@@ -4161,7 +4161,7 @@ void RGWPostObj::execute(optional_yield y)
       ldpp_dout(this, 15) << "supplied_md5=" << supplied_md5 << dendl;
     }
 
-    std::unique_ptr<rgw::sal::RGWObject> obj =
+    std::unique_ptr<rgw::sal::Object> obj =
 		     s->bucket->get_object(rgw_obj_key(get_current_filename()));
     if (s->bucket->versioning_enabled()) {
       obj->gen_rand_obj_instance_name();
@@ -4540,7 +4540,7 @@ void RGWPutMetadataObject::pre_exec()
 void RGWPutMetadataObject::execute(optional_yield y)
 {
   rgw_obj target_obj;
-  rgw::sal::RGWAttrs attrs, rmattrs;
+  rgw::sal::Attrs attrs, rmattrs;
 
   s->object->set_atomic(s->obj_ctx);
 
@@ -4705,11 +4705,11 @@ void RGWDeleteObj::execute(optional_yield y)
   }
   s->object->set_bucket(s->bucket.get());
 
-  rgw::sal::RGWAttrs attrs;
+  rgw::sal::Attrs attrs;
 
   bool check_obj_lock = s->object->have_instance() && s->bucket->get_info().obj_lock_enabled();
 
-  if (!rgw::sal::RGWObject::empty(s->object.get())) {
+  if (!rgw::sal::Object::empty(s->object.get())) {
     op_ret = s->object->get_obj_attrs(s->obj_ctx, s->yield, this);
     if (op_ret < 0) {
       if (need_object_expiration() || multipart_delete) {
@@ -4789,7 +4789,7 @@ void RGWDeleteObj::execute(optional_yield y)
 	return;
       }
 
-      std::unique_ptr<rgw::sal::RGWObject::DeleteOp> del_op = s->object->get_delete_op(obj_ctx);
+      std::unique_ptr<rgw::sal::Object::DeleteOp> del_op = s->object->get_delete_op(obj_ctx);
       del_op->params.obj_owner = s->owner;
       del_op->params.bucket_owner = s->bucket_owner;
       del_op->params.versioning_status = s->bucket->get_info().versioning_status();
@@ -5159,7 +5159,7 @@ void RGWCopyObj::execute(optional_yield y)
 int RGWGetACLs::verify_permission(optional_yield y)
 {
   bool perm;
-  if (!rgw::sal::RGWObject::empty(s->object.get())) {
+  if (!rgw::sal::Object::empty(s->object.get())) {
     auto iam_action = s->object->get_instance().empty() ?
       rgw::IAM::s3GetObjectAcl :
       rgw::IAM::s3GetObjectVersionAcl;
@@ -5196,7 +5196,7 @@ void RGWGetACLs::execute(optional_yield y)
 {
   stringstream ss;
   RGWAccessControlPolicy* const acl = \
-    (!rgw::sal::RGWObject::empty(s->object.get()) ? s->object_acl.get() : s->bucket_acl.get());
+    (!rgw::sal::Object::empty(s->object.get()) ? s->object_acl.get() : s->bucket_acl.get());
   RGWAccessControlPolicy_S3* const s3policy = \
     static_cast<RGWAccessControlPolicy_S3*>(acl);
   s3policy->to_xml(ss);
@@ -5212,7 +5212,7 @@ int RGWPutACLs::verify_permission(optional_yield y)
   rgw_add_to_iam_environment(s->env, "s3:x-amz-acl", s->canned_acl);
 
   rgw_add_grant_to_iam_environment(s->env, s);
-  if (!rgw::sal::RGWObject::empty(s->object.get())) {
+  if (!rgw::sal::Object::empty(s->object.get())) {
     auto iam_action = s->object->get_instance().empty() ? rgw::IAM::s3PutObjectAcl : rgw::IAM::s3PutObjectVersionAcl;
     op_ret = rgw_iam_add_existing_objtags(this, store, s, iam_action);
     perm = verify_object_permission(this, s, iam_action);
@@ -5293,7 +5293,7 @@ void RGWPutACLs::execute(optional_yield y)
 
 
   RGWAccessControlPolicy* const existing_policy = \
-    (rgw::sal::RGWObject::empty(s->object.get()) ? s->bucket_acl.get() : s->object_acl.get());
+    (rgw::sal::Object::empty(s->object.get()) ? s->bucket_acl.get() : s->object_acl.get());
 
   owner = existing_policy->get_owner();
 
@@ -5357,7 +5357,7 @@ void RGWPutACLs::execute(optional_yield y)
   }
 
   // forward bucket acl requests to meta master zone
-  if ((rgw::sal::RGWObject::empty(s->object.get()))) {
+  if ((rgw::sal::Object::empty(s->object.get()))) {
     bufferlist in_data;
     // include acl data unless it was generated from a canned_acl
     if (s->canned_acl.empty()) {
@@ -5395,7 +5395,7 @@ void RGWPutACLs::execute(optional_yield y)
   new_policy.encode(bl);
   map<string, bufferlist> attrs;
 
-  if (!rgw::sal::RGWObject::empty(s->object.get())) {
+  if (!rgw::sal::Object::empty(s->object.get())) {
     s->object->set_atomic(s->obj_ctx);
     //if instance is empty, we should modify the latest object
     op_ret = s->object->modify_obj_attrs(s->obj_ctx, RGW_ATTR_ACL, bl, s->yield, this);
@@ -5555,7 +5555,7 @@ void RGWPutCORS::execute(optional_yield y)
   }
 
   op_ret = retry_raced_bucket_write(this, s->bucket.get(), [this] {
-      rgw::sal::RGWAttrs attrs(s->bucket_attrs);
+      rgw::sal::Attrs attrs(s->bucket_attrs);
       attrs[RGW_ATTR_CORS] = cors_bl;
       return s->bucket->set_instance_attrs(this, attrs, s->yield);
     });
@@ -5587,7 +5587,7 @@ void RGWDeleteCORS::execute(optional_yield y)
 	return op_ret;
       }
 
-      rgw::sal::RGWAttrs attrs(s->bucket_attrs);
+      rgw::sal::Attrs attrs(s->bucket_attrs);
       attrs.erase(RGW_ATTR_CORS);
       op_ret = s->bucket->set_instance_attrs(this, attrs, s->yield);
       if (op_ret < 0) {
@@ -5742,12 +5742,12 @@ void RGWInitMultipart::pre_exec()
 void RGWInitMultipart::execute(optional_yield y)
 {
   bufferlist aclbl;
-  rgw::sal::RGWAttrs attrs;
+  rgw::sal::Attrs attrs;
 
   if (get_params(y) < 0)
     return;
 
-  if (rgw::sal::RGWObject::empty(s->object.get()))
+  if (rgw::sal::Object::empty(s->object.get()))
     return;
 
   policy.encode(aclbl);
@@ -5775,7 +5775,7 @@ void RGWInitMultipart::execute(optional_yield y)
 
   do {
     char buf[33];
-    std::unique_ptr<rgw::sal::RGWObject> obj;
+    std::unique_ptr<rgw::sal::Object> obj;
     gen_rand_alphanumeric(s->cct, buf, sizeof(buf) - 1);
     upload_id = MULTIPART_UPLOAD_ID_PREFIX; /* v2 upload id */
     upload_id.append(buf);
@@ -5789,7 +5789,7 @@ void RGWInitMultipart::execute(optional_yield y)
     obj->set_in_extra_data(true);
     obj->set_hash_source(s->object->get_name());
 
-    std::unique_ptr<rgw::sal::RGWObject::WriteOp> obj_op = obj->get_write_op(s->obj_ctx);
+    std::unique_ptr<rgw::sal::Object::WriteOp> obj_op = obj->get_write_op(s->obj_ctx);
 
     obj_op->params.versioning_disabled = true; /* no versioning for multipart meta */
     obj_op->params.owner = s->owner;
@@ -5864,14 +5864,14 @@ void RGWCompleteMultipart::execute(optional_yield y)
   string meta_oid;
   map<uint32_t, RGWUploadPartInfo> obj_parts;
   map<uint32_t, RGWUploadPartInfo>::iterator obj_iter;
-  rgw::sal::RGWAttrs attrs;
+  rgw::sal::Attrs attrs;
   off_t ofs = 0;
   MD5 hash;
   char final_etag[CEPH_CRYPTO_MD5_DIGESTSIZE];
   char final_etag_str[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 16];
   bufferlist etag_bl;
-  std::unique_ptr<rgw::sal::RGWObject> meta_obj;
-  std::unique_ptr<rgw::sal::RGWObject> target_obj;
+  std::unique_ptr<rgw::sal::Object> meta_obj;
+  std::unique_ptr<rgw::sal::Object> target_obj;
   RGWMPObj mp;
   RGWObjManifest manifest;
   uint64_t olh_epoch = 0;
@@ -6100,7 +6100,7 @@ void RGWCompleteMultipart::execute(optional_yield y)
 
   target_obj->set_atomic(&obj_ctx);
 
-  std::unique_ptr<rgw::sal::RGWObject::WriteOp> obj_op = target_obj->get_write_op(&obj_ctx);
+  std::unique_ptr<rgw::sal::Object::WriteOp> obj_op = target_obj->get_write_op(&obj_ctx);
 
   obj_op->params.manifest = &manifest;
   obj_op->params.remove_objs = &remove_objs;
@@ -6195,7 +6195,7 @@ void RGWAbortMultipart::execute(optional_yield y)
   rgw_obj meta_obj;
   RGWMPObj mp;
 
-  if (upload_id.empty() || rgw::sal::RGWObject::empty(s->object.get()))
+  if (upload_id.empty() || rgw::sal::Object::empty(s->object.get()))
     return;
 
   mp.init(s->object->get_name(), upload_id);
@@ -6333,7 +6333,7 @@ int RGWDeleteMultiObj::verify_permission(optional_yield y)
       }
     }
 
-    bool not_versioned = rgw::sal::RGWObject::empty(s->object.get()) || s->object->get_instance().empty();
+    bool not_versioned = rgw::sal::Object::empty(s->object.get()) || s->object->get_instance().empty();
 
     auto usr_policy_res = eval_user_policies(s->iam_user_policies, s->env,
                                               boost::none,
@@ -6441,7 +6441,7 @@ void RGWDeleteMultiObj::execute(optional_yield y)
         iter != multi_delete->objects.end();
         ++iter) {
     std::string version_id;
-    std::unique_ptr<rgw::sal::RGWObject> obj = bucket->get_object(*iter);
+    std::unique_ptr<rgw::sal::Object> obj = bucket->get_object(*iter);
     if (s->iam_policy || ! s->iam_user_policies.empty()) {
       auto usr_policy_res = eval_user_policies(s->iam_user_policies, s->env,
                                               boost::none,
@@ -6507,7 +6507,7 @@ void RGWDeleteMultiObj::execute(optional_yield y)
 
     obj->set_atomic(obj_ctx);
 
-    std::unique_ptr<rgw::sal::RGWObject::DeleteOp> del_op = obj->get_delete_op(obj_ctx);
+    std::unique_ptr<rgw::sal::Object::DeleteOp> del_op = obj->get_delete_op(obj_ctx);
     del_op->params.versioning_status = obj->get_bucket()->get_info().versioning_status();
     del_op->params.obj_owner = s->owner;
     del_op->params.bucket_owner = s->bucket_owner;
@@ -6570,7 +6570,7 @@ bool RGWBulkDelete::Deleter::verify_permission(RGWBucketInfo& binfo,
 
 bool RGWBulkDelete::Deleter::delete_single(const acct_path_t& path, optional_yield y)
 {
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
   ACLOwner bowner;
   RGWObjVersionTracker ot;
 
@@ -6593,10 +6593,10 @@ bool RGWBulkDelete::Deleter::delete_single(const acct_path_t& path, optional_yie
     ACLOwner bucket_owner;
 
     bucket_owner.set_id(bucket->get_info().owner);
-    std::unique_ptr<rgw::sal::RGWObject> obj = bucket->get_object(path.obj_key);
+    std::unique_ptr<rgw::sal::Object> obj = bucket->get_object(path.obj_key);
     obj->set_atomic(s->obj_ctx);
 
-    std::unique_ptr<rgw::sal::RGWObject::DeleteOp> del_op = obj->get_delete_op(s->obj_ctx);
+    std::unique_ptr<rgw::sal::Object::DeleteOp> del_op = obj->get_delete_op(s->obj_ctx);
     del_op->params.versioning_status = obj->get_bucket()->get_info().versioning_status();
     del_op->params.obj_owner = bowner;
     del_op->params.bucket_owner = bucket_owner;
@@ -6762,7 +6762,7 @@ RGWBulkUploadOp::handle_upload_path(struct req_state *s)
   std::string bucket_path, file_prefix;
   if (! s->init_state.url_bucket.empty()) {
     file_prefix = bucket_path = s->init_state.url_bucket + "/";
-    if (!rgw::sal::RGWObject::empty(s->object.get())) {
+    if (!rgw::sal::Object::empty(s->object.get())) {
       const std::string& object_name = s->object->get_name();
 
       /* As rgw_obj_key::empty() already verified emptiness of s->object->get_name(),
@@ -6780,7 +6780,7 @@ RGWBulkUploadOp::handle_upload_path(struct req_state *s)
 int RGWBulkUploadOp::handle_dir_verify_permission(optional_yield y)
 {
   if (s->user->get_max_buckets() > 0) {
-    rgw::sal::RGWBucketList buckets;
+    rgw::sal::BucketList buckets;
     std::string marker;
     op_ret = s->user->list_buckets(this, marker, std::string(), s->user->get_max_buckets(),
                                    false, buckets, y);
@@ -6810,7 +6810,7 @@ static void forward_req_info(CephContext *cct, req_info& info, const std::string
   info.effective_uri = "/" + bucket_name;
 }
 
-void RGWBulkUploadOp::init(rgw::sal::RGWStore* const store,
+void RGWBulkUploadOp::init(rgw::sal::Store* const store,
                            struct req_state* const s,
                            RGWHandler* const h)
 {
@@ -6835,7 +6835,7 @@ int RGWBulkUploadOp::handle_dir(const std::string_view path, optional_yield y)
 
   /* we need to make sure we read bucket info, it's not read before for this
    * specific request */
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
 
   /* Create metadata: ACLs. */
   std::map<std::string, ceph::bufferlist> attrs;
@@ -6961,7 +6961,7 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
   std::tie(bucket_name, object) = *parse_path(path);
 
   auto& obj_ctx = *static_cast<RGWObjectCtx *>(s->obj_ctx);
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
   ACLOwner bowner;
 
   op_ret = store->get_bucket(this, s->user.get(), rgw_bucket(rgw_bucket_key(s->user->get_tenant(), bucket_name)), &bucket, y);
@@ -6971,7 +6971,7 @@ int RGWBulkUploadOp::handle_file(const std::string_view path,
     return op_ret;
   }
 
-  std::unique_ptr<rgw::sal::RGWObject> obj = bucket->get_object(object);
+  std::unique_ptr<rgw::sal::Object> obj = bucket->get_object(object);
 
   if (! handle_file_verify_permission(bucket->get_info(),
 				      obj->get_obj(),
@@ -7294,7 +7294,7 @@ int RGWRMAttrs::verify_permission(optional_yield y)
   // This looks to be part of the RGW-NFS machinery and has no S3 or
   // Swift equivalent.
   bool perm;
-  if (!rgw::sal::RGWObject::empty(s->object.get())) {
+  if (!rgw::sal::Object::empty(s->object.get())) {
     perm = verify_object_permission_no_policy(this, s, RGW_PERM_WRITE);
   } else {
     perm = verify_bucket_permission_no_policy(this, s, RGW_PERM_WRITE);
@@ -7331,7 +7331,7 @@ int RGWSetAttrs::verify_permission(optional_yield y)
   // This looks to be part of the RGW-NFS machinery and has no S3 or
   // Swift equivalent.
   bool perm;
-  if (!rgw::sal::RGWObject::empty(s->object.get())) {
+  if (!rgw::sal::Object::empty(s->object.get())) {
     perm = verify_object_permission_no_policy(this, s, RGW_PERM_WRITE);
   } else {
     perm = verify_bucket_permission_no_policy(this, s, RGW_PERM_WRITE);
@@ -7353,8 +7353,8 @@ void RGWSetAttrs::execute(optional_yield y)
   if (op_ret < 0)
     return;
 
-  if (!rgw::sal::RGWObject::empty(s->object.get())) {
-    rgw::sal::RGWAttrs a(attrs);
+  if (!rgw::sal::Object::empty(s->object.get())) {
+    rgw::sal::Attrs a(attrs);
     op_ret = s->object->set_obj_attrs(this, s->obj_ctx, &a, nullptr, y);
   } else {
     for (auto& iter : attrs) {
@@ -7375,7 +7375,7 @@ void RGWGetObjLayout::execute(optional_yield y)
   /* Make sure bucket is correct */
   s->object->set_bucket(s->bucket.get());
 
-  std::unique_ptr<rgw::sal::RGWObject::ReadOp> stat_op(s->object->get_read_op(s->obj_ctx));
+  std::unique_ptr<rgw::sal::Object::ReadOp> stat_op(s->object->get_read_op(s->obj_ctx));
 
 
   op_ret = stat_op->prepare(y, this);
@@ -7468,7 +7468,7 @@ RGWHandler::~RGWHandler()
 {
 }
 
-int RGWHandler::init(rgw::sal::RGWStore *_store,
+int RGWHandler::init(rgw::sal::Store *_store,
                      struct req_state *_s,
                      rgw::io::BasicClient *cio)
 {
@@ -7583,7 +7583,7 @@ void RGWPutBucketPolicy::execute(optional_yield y)
 
   try {
     const Policy p(s->cct, s->bucket_tenant, data);
-    rgw::sal::RGWAttrs attrs(s->bucket_attrs);
+    rgw::sal::Attrs attrs(s->bucket_attrs);
     if (s->bucket_access_conf &&
         s->bucket_access_conf->block_public_policy() &&
         rgw::IAM::is_public(p)) {
@@ -7624,7 +7624,7 @@ int RGWGetBucketPolicy::verify_permission(optional_yield y)
 
 void RGWGetBucketPolicy::execute(optional_yield y)
 {
-  rgw::sal::RGWAttrs attrs(s->bucket_attrs);
+  rgw::sal::Attrs attrs(s->bucket_attrs);
   auto aiter = attrs.find(RGW_ATTR_IAM_POLICY);
   if (aiter == attrs.end()) {
     ldpp_dout(this, 0) << "can't find bucket IAM POLICY attr bucket_name = "
@@ -7666,7 +7666,7 @@ int RGWDeleteBucketPolicy::verify_permission(optional_yield y)
 void RGWDeleteBucketPolicy::execute(optional_yield y)
 {
   op_ret = retry_raced_bucket_write(this, s->bucket.get(), [this] {
-      rgw::sal::RGWAttrs attrs(s->bucket_attrs);
+      rgw::sal::Attrs attrs(s->bucket_attrs);
       attrs.erase(RGW_ATTR_IAM_POLICY);
       op_ret = s->bucket->set_instance_attrs(this, attrs, s->yield);
       return op_ret;
@@ -7817,7 +7817,7 @@ void RGWPutObjRetention::execute(optional_yield y)
     ldpp_dout(this, 0) << "ERROR: get obj attr error"<< dendl;
     return;
   }
-  rgw::sal::RGWAttrs attrs = s->object->get_attrs();
+  rgw::sal::Attrs attrs = s->object->get_attrs();
   auto aiter = attrs.find(RGW_ATTR_OBJECT_RETENTION);
   if (aiter != attrs.end()) {
     RGWObjectRetention old_obj_retention;
@@ -7869,7 +7869,7 @@ void RGWGetObjRetention::execute(optional_yield y)
                        << " ret=" << op_ret << dendl;
     return;
   }
-  rgw::sal::RGWAttrs attrs = s->object->get_attrs();
+  rgw::sal::Attrs attrs = s->object->get_attrs();
   auto aiter = attrs.find(RGW_ATTR_OBJECT_RETENTION);
   if (aiter == attrs.end()) {
     op_ret = -ERR_NO_SUCH_OBJECT_LOCK_CONFIGURATION;
@@ -8054,7 +8054,7 @@ void RGWPutBucketPublicAccessBlock::execute(optional_yield y)
   bufferlist bl;
   access_conf.encode(bl);
   op_ret = retry_raced_bucket_write(this, s->bucket.get(), [this, &bl] {
-      rgw::sal::RGWAttrs attrs(s->bucket_attrs);
+      rgw::sal::Attrs attrs(s->bucket_attrs);
       attrs[RGW_ATTR_PUBLIC_ACCESS] = bl;
       return s->bucket->set_instance_attrs(this, attrs, s->yield);
     });
@@ -8113,7 +8113,7 @@ int RGWDeleteBucketPublicAccessBlock::verify_permission(optional_yield y)
 void RGWDeleteBucketPublicAccessBlock::execute(optional_yield y)
 {
   op_ret = retry_raced_bucket_write(this, s->bucket.get(), [this] {
-      rgw::sal::RGWAttrs attrs(s->bucket_attrs);
+      rgw::sal::Attrs attrs(s->bucket_attrs);
       attrs.erase(RGW_ATTR_PUBLIC_ACCESS);
       op_ret = s->bucket->set_instance_attrs(this, attrs, s->yield);
       return op_ret;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -211,7 +211,7 @@ static int get_user_policy_from_attr(CephContext * const cct,
  */
 int rgw_op_get_bucket_policy_from_attr(const DoutPrefixProvider *dpp, 
                                        CephContext *cct,
-				       rgw::sal::Store *store,
+				       rgw::sal::Store* store,
 				       RGWBucketInfo& bucket_info,
 				       map<string, bufferlist>& bucket_attrs,
 				       RGWAccessControlPolicy *policy,
@@ -238,7 +238,7 @@ int rgw_op_get_bucket_policy_from_attr(const DoutPrefixProvider *dpp,
 
 static int get_obj_policy_from_attr(const DoutPrefixProvider *dpp, 
                                     CephContext *cct,
-				    rgw::sal::Store *store,
+				    rgw::sal::Store* store,
 				    RGWObjectCtx& obj_ctx,
 				    RGWBucketInfo& bucket_info,
 				    map<string, bufferlist>& bucket_attrs,
@@ -412,7 +412,7 @@ static int get_multipart_info(const DoutPrefixProvider *dpp, struct req_state *s
 }
 
 static int read_bucket_policy(const DoutPrefixProvider *dpp, 
-                              rgw::sal::Store *store,
+                              rgw::sal::Store* store,
                               struct req_state *s,
                               RGWBucketInfo& bucket_info,
                               map<string, bufferlist>& bucket_attrs,
@@ -439,7 +439,7 @@ static int read_bucket_policy(const DoutPrefixProvider *dpp,
 }
 
 static int read_obj_policy(const DoutPrefixProvider *dpp, 
-                           rgw::sal::Store *store,
+                           rgw::sal::Store* store,
                            struct req_state *s,
                            RGWBucketInfo& bucket_info,
                            map<string, bufferlist>& bucket_attrs,
@@ -710,7 +710,7 @@ int rgw_build_bucket_policies(const DoutPrefixProvider *dpp, rgw::sal::Store* st
  * only_bucket: If true, reads the bucket ACL rather than the object ACL.
  * Returns: 0 on success, -ERR# otherwise.
  */
-int rgw_build_object_policies(const DoutPrefixProvider *dpp, rgw::sal::Store *store,
+int rgw_build_object_policies(const DoutPrefixProvider *dpp, rgw::sal::Store* store,
 			      struct req_state *s, bool prefetch_data, optional_yield y)
 {
   int ret = 0;
@@ -1791,7 +1791,7 @@ int RGWGetObj::handle_user_manifest(const char *prefix, optional_yield y)
   boost::optional<Policy>* bucket_policy;
   RGWBucketInfo bucket_info;
   std::unique_ptr<rgw::sal::Bucket> ubucket;
-  rgw::sal::Bucket *pbucket = NULL;
+  rgw::sal::Bucket* pbucket = NULL;
   int r = 0;
 
   if (bucket_name.compare(s->bucket->get_name()) != 0) {
@@ -7468,7 +7468,7 @@ RGWHandler::~RGWHandler()
 {
 }
 
-int RGWHandler::init(rgw::sal::Store *_store,
+int RGWHandler::init(rgw::sal::Store* _store,
                      struct req_state *_s,
                      rgw::io::BasicClient *cio)
 {

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -76,7 +76,7 @@ class StrategyRegistry;
 
 int rgw_op_get_bucket_policy_from_attr(const DoutPrefixProvider *dpp, 
                                        CephContext *cct,
-				       rgw::sal::RGWStore *store,
+				       rgw::sal::Store *store,
                                        RGWBucketInfo& bucket_info,
                                        map<string, bufferlist>& bucket_attrs,
                                        RGWAccessControlPolicy *policy,
@@ -84,7 +84,7 @@ int rgw_op_get_bucket_policy_from_attr(const DoutPrefixProvider *dpp,
 
 class RGWHandler {
 protected:
-  rgw::sal::RGWStore* store{nullptr};
+  rgw::sal::Store* store{nullptr};
   struct req_state *s{nullptr};
 
   int do_init_permissions(const DoutPrefixProvider *dpp, optional_yield y);
@@ -94,7 +94,7 @@ public:
   RGWHandler() {}
   virtual ~RGWHandler();
 
-  virtual int init(rgw::sal::RGWStore* store,
+  virtual int init(rgw::sal::Store* store,
                    struct req_state* _s,
                    rgw::io::BasicClient* cio);
 
@@ -172,7 +172,7 @@ class RGWOp : public DoutPrefixProvider {
 protected:
   struct req_state *s;
   RGWHandler *dialect_handler;
-  rgw::sal::RGWStore *store;
+  rgw::sal::Store *store;
   RGWCORSConfiguration bucket_cors;
   bool cors_exist;
   RGWQuotaInfo bucket_quota;
@@ -229,7 +229,7 @@ public:
     return 0;
   }
 
-  virtual void init(rgw::sal::RGWStore *store, struct req_state *s, RGWHandler *dialect_handler) {
+  virtual void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *dialect_handler) {
     this->store = store;
     this->s = s;
     this->dialect_handler = dialect_handler;
@@ -341,7 +341,7 @@ protected:
   ceph::real_time unmod_time;
   ceph::real_time *mod_ptr;
   ceph::real_time *unmod_ptr;
-  rgw::sal::RGWAttrs attrs;
+  rgw::sal::Attrs attrs;
   bool get_data;
   bool partial_content;
   bool ignore_invalid_range;
@@ -408,7 +408,7 @@ public:
   void execute(optional_yield y) override;
   int parse_range();
   int read_user_manifest_part(
-    rgw::sal::RGWBucket* bucket,
+    rgw::sal::Bucket* bucket,
     const rgw_bucket_dir_entry& ent,
     RGWAccessControlPolicy * const bucket_acl,
     const boost::optional<rgw::IAM::Policy>& bucket_policy,
@@ -594,11 +594,11 @@ public:
     unsigned int num_unfound;
     std::list<fail_desc_t> failures;
 
-    rgw::sal::RGWStore * const store;
+    rgw::sal::Store * const store;
     req_state * const s;
 
   public:
-    Deleter(const DoutPrefixProvider* dpp, rgw::sal::RGWStore * const str, req_state * const s)
+    Deleter(const DoutPrefixProvider* dpp, rgw::sal::Store * const str, req_state * const s)
       : dpp(dpp),
         num_deleted(0),
         num_unfound(0),
@@ -708,7 +708,7 @@ public:
     : num_created(0) {
   }
 
-  void init(rgw::sal::RGWStore* const store,
+  void init(rgw::sal::Store* const store,
             struct req_state* const s,
             RGWHandler* const h) override;
 
@@ -802,7 +802,7 @@ protected:
   std::string end_marker;
   int64_t limit;
   uint64_t limit_max;
-  rgw::sal::RGWAttrs attrs;
+  rgw::sal::Attrs attrs;
   bool is_truncated;
 
   RGWUsageStats global_stats;
@@ -824,7 +824,7 @@ public:
   void execute(optional_yield y) override;
 
   virtual int get_params(optional_yield y) = 0;
-  virtual void handle_listing_chunk(rgw::sal::RGWBucketList&& buckets) {
+  virtual void handle_listing_chunk(rgw::sal::BucketList&& buckets) {
     /* The default implementation, used by e.g. S3, just generates a new
      * part of listing and sends it client immediately. Swift can behave
      * differently: when the reverse option is requested, all incoming
@@ -832,7 +832,7 @@ public:
     return send_response_data(buckets);
   }
   virtual void send_response_begin(bool has_buckets) = 0;
-  virtual void send_response_data(rgw::sal::RGWBucketList& buckets) = 0;
+  virtual void send_response_data(rgw::sal::BucketList& buckets) = 0;
   virtual void send_response_end() = 0;
   void send_response() override {}
 
@@ -920,7 +920,7 @@ public:
   void pre_exec() override;
   void execute(optional_yield y) override;
 
-  void init(rgw::sal::RGWStore *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
   }
   virtual int get_params(optional_yield y) = 0;
@@ -1051,7 +1051,7 @@ public:
 
 class RGWStatBucket : public RGWOp {
 protected:
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
 
 public:
   int verify_permission(optional_yield y) override;
@@ -1093,7 +1093,7 @@ public:
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
   void execute(optional_yield y) override;
-  void init(rgw::sal::RGWStore *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
     relaxed_region_enforcement =
@@ -1199,7 +1199,7 @@ protected:
   std::unique_ptr <RGWObjTags> obj_tags;
   const char *dlo_manifest;
   RGWSLOInfo *slo_info;
-  rgw::sal::RGWAttrs attrs;
+  rgw::sal::Attrs attrs;
   ceph::real_time mtime;
   uint64_t olh_epoch;
   string version_id;
@@ -1246,7 +1246,7 @@ public:
     delete obj_legal_hold;
   }
 
-  void init(rgw::sal::RGWStore *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
@@ -1318,7 +1318,7 @@ public:
     attrs.emplace(std::move(key), std::move(bl)); /* key and bl are r-value refs */
   }
 
-  void init(rgw::sal::RGWStore *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
@@ -1359,7 +1359,7 @@ public:
       has_policy(false) {
   }
 
-  void init(rgw::sal::RGWStore *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
@@ -1380,7 +1380,7 @@ public:
 
 class RGWPutMetadataBucket : public RGWOp {
 protected:
-  rgw::sal::RGWAttrs attrs;
+  rgw::sal::Attrs attrs;
   set<string> rmattr_names;
   bool has_policy, has_cors;
   uint32_t policy_rw_mask;
@@ -1398,7 +1398,7 @@ public:
     attrs.emplace(std::move(key), std::move(bl)); /* key and bl are r-value refs */
   }
 
-  void init(rgw::sal::RGWStore *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
@@ -1425,7 +1425,7 @@ public:
     : dlo_manifest(NULL)
   {}
 
-  void init(rgw::sal::RGWStore *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
@@ -1495,13 +1495,13 @@ protected:
   ceph::real_time unmod_time;
   ceph::real_time *mod_ptr;
   ceph::real_time *unmod_ptr;
-  rgw::sal::RGWAttrs attrs;
+  rgw::sal::Attrs attrs;
   string src_tenant_name, src_bucket_name, src_obj_name;
-  std::unique_ptr<rgw::sal::RGWBucket> src_bucket;
-  std::unique_ptr<rgw::sal::RGWObject> src_object;
+  std::unique_ptr<rgw::sal::Bucket> src_bucket;
+  std::unique_ptr<rgw::sal::Object> src_object;
   string dest_tenant_name, dest_bucket_name, dest_obj_name;
-  std::unique_ptr<rgw::sal::RGWBucket> dest_bucket;
-  std::unique_ptr<rgw::sal::RGWObject> dest_object;
+  std::unique_ptr<rgw::sal::Bucket> dest_bucket;
+  std::unique_ptr<rgw::sal::Object> dest_object;
   ceph::real_time src_mtime;
   ceph::real_time mtime;
   rgw::sal::AttrsMod attrs_mod;
@@ -1546,7 +1546,7 @@ public:
     attrs.emplace(std::move(key), std::move(bl));
   }
 
-  void init(rgw::sal::RGWStore *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     dest_policy.set_ctx(s->cct);
   }
@@ -1599,7 +1599,7 @@ public:
   void pre_exec() override;
   void execute(optional_yield y) override;
 
-  virtual int get_policy_from_state(rgw::sal::RGWStore *store, struct req_state *s, stringstream& ss) { return 0; }
+  virtual int get_policy_from_state(rgw::sal::Store *store, struct req_state *s, stringstream& ss) { return 0; }
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
   const char* name() const override { return "put_acls"; }
@@ -1636,7 +1636,7 @@ public:
   }
   ~RGWPutLC() override {}
 
-  void init(rgw::sal::RGWStore *store, struct req_state *s, RGWHandler *dialect_handler) override {
+  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *dialect_handler) override {
 #define COOKIE_LEN 16
     char buf[COOKIE_LEN + 1];
 
@@ -1784,7 +1784,7 @@ protected:
 public:
   RGWInitMultipart() {}
 
-  void init(rgw::sal::RGWStore *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
@@ -1854,7 +1854,7 @@ public:
     truncated = false;
   }
 
-  void init(rgw::sal::RGWStore *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy = RGWAccessControlPolicy(s->cct);
   }
@@ -1901,7 +1901,7 @@ public:
     default_max = 0;
   }
 
-  void init(rgw::sal::RGWStore *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     max_uploads = default_max;
   }
@@ -1969,7 +1969,7 @@ public:
 class RGWDeleteMultiObj : public RGWOp {
 protected:
   bufferlist data;
-  rgw::sal::RGWBucket* bucket;
+  rgw::sal::Bucket* bucket;
   bool quiet;
   bool status_dumped;
   bool acl_allowed = false;
@@ -2010,11 +2010,11 @@ public:
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
 
-extern int rgw_build_bucket_policies(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* store,
+extern int rgw_build_bucket_policies(const DoutPrefixProvider *dpp, rgw::sal::Store* store,
 				     struct req_state* s, optional_yield y);
-extern int rgw_build_object_policies(const DoutPrefixProvider *dpp, rgw::sal::RGWStore *store,
+extern int rgw_build_object_policies(const DoutPrefixProvider *dpp, rgw::sal::Store *store,
 				     struct req_state *s, bool prefetch_data, optional_yield y);
-extern void rgw_build_iam_environment(rgw::sal::RGWStore* store,
+extern void rgw_build_iam_environment(rgw::sal::Store* store,
 				      struct req_state* s);
 extern vector<rgw::IAM::Policy> get_iam_user_policy_from_attr(CephContext* cct,
                         map<string, bufferlist>& attrs,
@@ -2249,7 +2249,7 @@ public:
 
 class RGWRMAttrs : public RGWOp {
 protected:
-  rgw::sal::RGWAttrs attrs;
+  rgw::sal::Attrs attrs;
 
 public:
   RGWRMAttrs()
@@ -2483,7 +2483,7 @@ protected:
 public:
   RGWGetClusterStat() {}
 
-  void init(rgw::sal::RGWStore *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
   }
   int verify_permission(optional_yield) override {return 0;}

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -76,7 +76,7 @@ class StrategyRegistry;
 
 int rgw_op_get_bucket_policy_from_attr(const DoutPrefixProvider *dpp, 
                                        CephContext *cct,
-				       rgw::sal::Store *store,
+				       rgw::sal::Store* store,
                                        RGWBucketInfo& bucket_info,
                                        map<string, bufferlist>& bucket_attrs,
                                        RGWAccessControlPolicy *policy,
@@ -172,7 +172,7 @@ class RGWOp : public DoutPrefixProvider {
 protected:
   struct req_state *s;
   RGWHandler *dialect_handler;
-  rgw::sal::Store *store;
+  rgw::sal::Store* store;
   RGWCORSConfiguration bucket_cors;
   bool cors_exist;
   RGWQuotaInfo bucket_quota;
@@ -229,7 +229,7 @@ public:
     return 0;
   }
 
-  virtual void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *dialect_handler) {
+  virtual void init(rgw::sal::Store* store, struct req_state *s, RGWHandler *dialect_handler) {
     this->store = store;
     this->s = s;
     this->dialect_handler = dialect_handler;
@@ -594,11 +594,11 @@ public:
     unsigned int num_unfound;
     std::list<fail_desc_t> failures;
 
-    rgw::sal::Store * const store;
+    rgw::sal::Store*  const store;
     req_state * const s;
 
   public:
-    Deleter(const DoutPrefixProvider* dpp, rgw::sal::Store * const str, req_state * const s)
+    Deleter(const DoutPrefixProvider* dpp, rgw::sal::Store*  const str, req_state * const s)
       : dpp(dpp),
         num_deleted(0),
         num_unfound(0),
@@ -920,7 +920,7 @@ public:
   void pre_exec() override;
   void execute(optional_yield y) override;
 
-  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store* store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
   }
   virtual int get_params(optional_yield y) = 0;
@@ -1093,7 +1093,7 @@ public:
   int verify_permission(optional_yield y) override;
   void pre_exec() override;
   void execute(optional_yield y) override;
-  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store* store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
     relaxed_region_enforcement =
@@ -1246,7 +1246,7 @@ public:
     delete obj_legal_hold;
   }
 
-  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store* store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
@@ -1318,7 +1318,7 @@ public:
     attrs.emplace(std::move(key), std::move(bl)); /* key and bl are r-value refs */
   }
 
-  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store* store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
@@ -1359,7 +1359,7 @@ public:
       has_policy(false) {
   }
 
-  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store* store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
@@ -1398,7 +1398,7 @@ public:
     attrs.emplace(std::move(key), std::move(bl)); /* key and bl are r-value refs */
   }
 
-  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store* store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
@@ -1425,7 +1425,7 @@ public:
     : dlo_manifest(NULL)
   {}
 
-  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store* store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
@@ -1546,7 +1546,7 @@ public:
     attrs.emplace(std::move(key), std::move(bl));
   }
 
-  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store* store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     dest_policy.set_ctx(s->cct);
   }
@@ -1599,7 +1599,7 @@ public:
   void pre_exec() override;
   void execute(optional_yield y) override;
 
-  virtual int get_policy_from_state(rgw::sal::Store *store, struct req_state *s, stringstream& ss) { return 0; }
+  virtual int get_policy_from_state(rgw::sal::Store* store, struct req_state *s, stringstream& ss) { return 0; }
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
   const char* name() const override { return "put_acls"; }
@@ -1636,7 +1636,7 @@ public:
   }
   ~RGWPutLC() override {}
 
-  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *dialect_handler) override {
+  void init(rgw::sal::Store* store, struct req_state *s, RGWHandler *dialect_handler) override {
 #define COOKIE_LEN 16
     char buf[COOKIE_LEN + 1];
 
@@ -1649,7 +1649,7 @@ public:
   void pre_exec() override;
   void execute(optional_yield y) override;
 
-//  virtual int get_policy_from_state(RGWRados *store, struct req_state *s, stringstream& ss) { return 0; }
+//  virtual int get_policy_from_state(RGWRados* store, struct req_state *s, stringstream& ss) { return 0; }
   virtual int get_params(optional_yield y) = 0;
   void send_response() override = 0;
   const char* name() const override { return "put_lifecycle"; }
@@ -1784,7 +1784,7 @@ protected:
 public:
   RGWInitMultipart() {}
 
-  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store* store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
@@ -1854,7 +1854,7 @@ public:
     truncated = false;
   }
 
-  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store* store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     policy = RGWAccessControlPolicy(s->cct);
   }
@@ -1901,7 +1901,7 @@ public:
     default_max = 0;
   }
 
-  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store* store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
     max_uploads = default_max;
   }
@@ -2012,7 +2012,7 @@ public:
 
 extern int rgw_build_bucket_policies(const DoutPrefixProvider *dpp, rgw::sal::Store* store,
 				     struct req_state* s, optional_yield y);
-extern int rgw_build_object_policies(const DoutPrefixProvider *dpp, rgw::sal::Store *store,
+extern int rgw_build_object_policies(const DoutPrefixProvider *dpp, rgw::sal::Store* store,
 				     struct req_state *s, bool prefetch_data, optional_yield y);
 extern void rgw_build_iam_environment(rgw::sal::Store* store,
 				      struct req_state* s);
@@ -2483,7 +2483,7 @@ protected:
 public:
   RGWGetClusterStat() {}
 
-  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store* store, struct req_state *s, RGWHandler *h) override {
     RGWOp::init(store, s, h);
   }
   int verify_permission(optional_yield) override {return 0;}

--- a/src/rgw/rgw_orphan.h
+++ b/src/rgw/rgw_orphan.h
@@ -123,13 +123,13 @@ struct RGWOrphanSearchState {
 WRITE_CLASS_ENCODER(RGWOrphanSearchState)
 
 class RGWOrphanStore {
-  rgw::sal::RGWStore *store;
+  rgw::sal::Store *store;
   librados::IoCtx ioctx;
 
   string oid;
 
 public:
-  explicit RGWOrphanStore(rgw::sal::RGWStore *_store) : store(_store), oid(RGW_ORPHAN_INDEX_OID) {}
+  explicit RGWOrphanStore(rgw::sal::Store *_store) : store(_store), oid(RGW_ORPHAN_INDEX_OID) {}
 
   librados::IoCtx& get_ioctx() { return ioctx; }
 
@@ -147,7 +147,7 @@ public:
 
 
 class RGWOrphanSearch {
-  rgw::sal::RGWStore *store;
+  rgw::sal::Store *store;
 
   RGWOrphanStore orphan_store;
 
@@ -179,13 +179,13 @@ class RGWOrphanSearch {
     return ceph_str_hash_linux(str.c_str(), str.size()) % RGW_ORPHANSEARCH_HASH_PRIME % search_info.num_shards;
   }
 
-  int handle_stat_result(map<int, list<string> >& oids, rgw::sal::RGWObject::StatOp::Result& result);
-  int pop_and_handle_stat_op(map<int, list<string> >& oids, std::deque<std::unique_ptr<rgw::sal::RGWObject::StatOp>>& ops);
+  int handle_stat_result(map<int, list<string> >& oids, rgw::sal::Object::StatOp::Result& result);
+  int pop_and_handle_stat_op(map<int, list<string> >& oids, std::deque<std::unique_ptr<rgw::sal::Object::StatOp>>& ops);
 
 
   int remove_index(map<int, string>& index);
 public:
-  RGWOrphanSearch(rgw::sal::RGWStore *_store, int _max_ios, uint64_t _stale_secs) : store(_store), orphan_store(store), max_concurrent_ios(_max_ios), stale_secs(_stale_secs) {}
+  RGWOrphanSearch(rgw::sal::Store *_store, int _max_ios, uint64_t _stale_secs) : store(_store), orphan_store(store), max_concurrent_ios(_max_ios), stale_secs(_stale_secs) {}
 
   int save_state() {
     RGWOrphanSearchState state;
@@ -251,7 +251,7 @@ class RGWRadosList {
     p.first->second.filter_keys.insert(obj_key);
   }
 
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
 
   uint16_t max_concurrent_ios;
   uint64_t stale_secs;
@@ -260,16 +260,16 @@ class RGWRadosList {
   bool include_rgw_obj_name;
   std::string field_separator;
 
-  int handle_stat_result(rgw::sal::RGWObject::StatOp::Result& result,
+  int handle_stat_result(rgw::sal::Object::StatOp::Result& result,
 			 std::string& bucket_name,
 			 rgw_obj_key& obj_key,
 			 std::set<string>& obj_oids);
   int pop_and_handle_stat_op(RGWObjectCtx& obj_ctx,
-			     std::deque<std::unique_ptr<rgw::sal::RGWObject::StatOp>>& ops);
+			     std::deque<std::unique_ptr<rgw::sal::Object::StatOp>>& ops);
 
 public:
 
-  RGWRadosList(rgw::sal::RGWStore* _store,
+  RGWRadosList(rgw::sal::Store* _store,
 	       int _max_ios,
 	       uint64_t _stale_secs,
 	       const std::string& _tenant_name) :
@@ -286,7 +286,7 @@ public:
 		     const std::set<rgw_obj_key>& entries_filter);
 
   int do_incomplete_multipart(const DoutPrefixProvider *dpp,
-			      rgw::sal::RGWBucket* bucket);
+			      rgw::sal::Bucket* bucket);
 
   int build_linked_oids_index();
 

--- a/src/rgw/rgw_orphan.h
+++ b/src/rgw/rgw_orphan.h
@@ -123,13 +123,13 @@ struct RGWOrphanSearchState {
 WRITE_CLASS_ENCODER(RGWOrphanSearchState)
 
 class RGWOrphanStore {
-  rgw::sal::Store *store;
+  rgw::sal::Store* store;
   librados::IoCtx ioctx;
 
   string oid;
 
 public:
-  explicit RGWOrphanStore(rgw::sal::Store *_store) : store(_store), oid(RGW_ORPHAN_INDEX_OID) {}
+  explicit RGWOrphanStore(rgw::sal::Store* _store) : store(_store), oid(RGW_ORPHAN_INDEX_OID) {}
 
   librados::IoCtx& get_ioctx() { return ioctx; }
 
@@ -147,7 +147,7 @@ public:
 
 
 class RGWOrphanSearch {
-  rgw::sal::Store *store;
+  rgw::sal::Store* store;
 
   RGWOrphanStore orphan_store;
 
@@ -185,7 +185,7 @@ class RGWOrphanSearch {
 
   int remove_index(map<int, string>& index);
 public:
-  RGWOrphanSearch(rgw::sal::Store *_store, int _max_ios, uint64_t _stale_secs) : store(_store), orphan_store(store), max_concurrent_ios(_max_ios), stale_secs(_stale_secs) {}
+  RGWOrphanSearch(rgw::sal::Store* _store, int _max_ios, uint64_t _stale_secs) : store(_store), orphan_store(store), max_concurrent_ios(_max_ios), stale_secs(_stale_secs) {}
 
   int save_state() {
     RGWOrphanSearchState state;

--- a/src/rgw/rgw_os_lib.cc
+++ b/src/rgw/rgw_os_lib.cc
@@ -11,7 +11,7 @@
 namespace rgw {
 
 /* static */
-  int RGWHandler_Lib::init_from_header(rgw::sal::RGWStore *store,
+  int RGWHandler_Lib::init_from_header(rgw::sal::Store *store,
 				       struct req_state *s)
   {
     string req;

--- a/src/rgw/rgw_os_lib.cc
+++ b/src/rgw/rgw_os_lib.cc
@@ -11,7 +11,7 @@
 namespace rgw {
 
 /* static */
-  int RGWHandler_Lib::init_from_header(rgw::sal::Store *store,
+  int RGWHandler_Lib::init_from_header(rgw::sal::Store* store,
 				       struct req_state *s)
   {
     string req;

--- a/src/rgw/rgw_otp.h
+++ b/src/rgw/rgw_otp.h
@@ -5,7 +5,7 @@
 #define CEPH_RGW_OTP_H
 
 namespace rgw { namespace sal {
-class RGWStore;
+class Store;
 } }
 
 #include "cls/otp/cls_otp_types.h"

--- a/src/rgw/rgw_period_pusher.cc
+++ b/src/rgw/rgw_period_pusher.cc
@@ -170,7 +170,7 @@ RGWPeriodPusher::RGWPeriodPusher(rgw::sal::Store* store,
   // always send out the current period on startup
   RGWPeriod period;
   // XXX dang
-  int r = period.init(cct, static_cast<rgw::sal::RadosStore *>(store)->svc()->sysobj, realm_id, y, realm.get_name());
+  int r = period.init(cct, static_cast<rgw::sal::RadosStore* >(store)->svc()->sysobj, realm_id, y, realm.get_name());
   if (r < 0) {
     lderr(cct) << "failed to load period for realm " << realm_id << dendl;
     return;

--- a/src/rgw/rgw_period_pusher.cc
+++ b/src/rgw/rgw_period_pusher.cc
@@ -158,7 +158,7 @@ class RGWPeriodPusher::CRThread {
 };
 
 
-RGWPeriodPusher::RGWPeriodPusher(rgw::sal::RGWStore* store,
+RGWPeriodPusher::RGWPeriodPusher(rgw::sal::Store* store,
 				 optional_yield y)
   : cct(store->ctx()), store(store)
 {
@@ -170,7 +170,7 @@ RGWPeriodPusher::RGWPeriodPusher(rgw::sal::RGWStore* store,
   // always send out the current period on startup
   RGWPeriod period;
   // XXX dang
-  int r = period.init(cct, static_cast<rgw::sal::RGWRadosStore *>(store)->svc()->sysobj, realm_id, y, realm.get_name());
+  int r = period.init(cct, static_cast<rgw::sal::RadosStore *>(store)->svc()->sysobj, realm_id, y, realm.get_name());
   if (r < 0) {
     lderr(cct) << "failed to load period for realm " << realm_id << dendl;
     return;
@@ -295,7 +295,7 @@ void RGWPeriodPusher::pause()
   store = nullptr;
 }
 
-void RGWPeriodPusher::resume(rgw::sal::RGWStore* store)
+void RGWPeriodPusher::resume(rgw::sal::Store* store)
 {
   std::lock_guard<std::mutex> lock(mutex);
   this->store = store;

--- a/src/rgw/rgw_period_pusher.h
+++ b/src/rgw/rgw_period_pusher.h
@@ -13,7 +13,7 @@
 
 namespace rgw {
 namespace sal {
-class RGWStore;
+class Store;
 }
 }
 
@@ -29,7 +29,7 @@ using RGWZonesNeedPeriod = RGWPeriod;
 class RGWPeriodPusher final : public RGWRealmWatcher::Watcher,
                               public RGWRealmReloader::Pauser {
  public:
-  explicit RGWPeriodPusher(rgw::sal::RGWStore* store, optional_yield y);
+  explicit RGWPeriodPusher(rgw::sal::Store* store, optional_yield y);
   ~RGWPeriodPusher() override;
 
   /// respond to realm notifications by pushing new periods to other zones
@@ -40,13 +40,13 @@ class RGWPeriodPusher final : public RGWRealmWatcher::Watcher,
   void pause() override;
 
   /// continue processing notifications with a new RGWRados instance
-  void resume(rgw::sal::RGWStore* store) override;
+  void resume(rgw::sal::Store* store) override;
 
  private:
   void handle_notify(RGWZonesNeedPeriod&& period);
 
   CephContext *const cct;
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
 
   std::mutex mutex;
   epoch_t realm_epoch{0}; //< the current realm epoch being sent

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -172,7 +172,7 @@ int rgw_process_authenticated(RGWHandler_REST * const handler,
   return 0;
 }
 
-int process_request(rgw::sal::RGWStore* const store,
+int process_request(rgw::sal::Store* const store,
                     RGWREST* const rest,
                     RGWRequest* const req,
                     const std::string& frontend_prefix,
@@ -196,7 +196,7 @@ int process_request(rgw::sal::RGWStore* const store,
   struct req_state rstate(g_ceph_context, &rgw_env, req->id);
   struct req_state *s = &rstate;
 
-  std::unique_ptr<rgw::sal::RGWUser> u = store->get_user(rgw_user());
+  std::unique_ptr<rgw::sal::User> u = store->get_user(rgw_user());
   s->set_user(u);
 
   RGWObjectCtx rados_ctx(store, s);
@@ -338,7 +338,7 @@ done:
   }
   int op_ret = 0;
 
-  if (user && !rgw::sal::RGWUser::empty(s->user.get())) {
+  if (user && !rgw::sal::User::empty(s->user.get())) {
     *user = s->user->get_id().to_str();
   }
 

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -32,7 +32,7 @@ namespace rgw::dmclock {
 }
 
 struct RGWProcessEnv {
-  rgw::sal::Store *store;
+  rgw::sal::Store* store;
   RGWREST *rest;
   OpsLogSocket *olog;
   int port;

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -32,7 +32,7 @@ namespace rgw::dmclock {
 }
 
 struct RGWProcessEnv {
-  rgw::sal::RGWStore *store;
+  rgw::sal::Store *store;
   RGWREST *rest;
   OpsLogSocket *olog;
   int port;
@@ -47,7 +47,7 @@ class RGWProcess {
   deque<RGWRequest*> m_req_queue;
 protected:
   CephContext *cct;
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
   rgw_auth_registry_ptr_t auth_registry;
   OpsLogSocket* olog;
   ThreadPool m_tp;
@@ -117,7 +117,7 @@ public:
     m_tp.pause();
   }
 
-  void unpause_with_new_config(rgw::sal::RGWStore* const store,
+  void unpause_with_new_config(rgw::sal::Store* const store,
                                rgw_auth_registry_ptr_t auth_registry) {
     this->store = store;
     this->auth_registry = std::move(auth_registry);
@@ -176,7 +176,7 @@ public:
   void set_access_key(RGWAccessKey& key) { access_key = key; }
 };
 /* process stream request */
-extern int process_request(rgw::sal::RGWStore* store,
+extern int process_request(rgw::sal::Store* store,
                            RGWREST* rest,
                            RGWRequest* req,
                            const std::string& frontend_prefix,

--- a/src/rgw/rgw_pubsub.cc
+++ b/src/rgw/rgw_pubsub.cc
@@ -424,7 +424,7 @@ void rgw_pubsub_sub_config::dump(Formatter *f) const
   encode_json("s3_id", s3_id, f);
 }
 
-RGWPubSub::RGWPubSub(rgw::sal::RGWRadosStore* _store, const std::string& _tenant) : 
+RGWPubSub::RGWPubSub(rgw::sal::RadosStore* _store, const std::string& _tenant) :
                             store(_store),
                             tenant(_tenant),
                             obj_ctx(store->svc()->sysobj->init_obj_ctx()) {
@@ -541,7 +541,7 @@ int RGWPubSub::Bucket::create_notification(const string& topic_name, const rgw::
 
 int RGWPubSub::Bucket::create_notification(const string& topic_name,const rgw::notify::EventTypeList& events, OptionalFilter s3_filter, const std::string& notif_name, optional_yield y) {
   rgw_pubsub_topic_subs topic_info;
-  rgw::sal::RGWRadosStore *store = ps->store;
+  rgw::sal::RadosStore *store = ps->store;
 
   int ret = ps->get_topic(topic_name, &topic_info);
   if (ret < 0) {
@@ -584,7 +584,7 @@ int RGWPubSub::Bucket::create_notification(const string& topic_name,const rgw::n
 int RGWPubSub::Bucket::remove_notification(const string& topic_name, optional_yield y)
 {
   rgw_pubsub_topic_subs topic_info;
-  rgw::sal::RGWRadosStore *store = ps->store;
+  rgw::sal::RadosStore *store = ps->store;
 
   int ret = ps->get_topic(topic_name, &topic_info);
   if (ret < 0) {
@@ -753,7 +753,7 @@ int RGWPubSub::Sub::subscribe(const string& topic, const rgw_pubsub_sub_dest& de
 {
   RGWObjVersionTracker objv_tracker;
   rgw_pubsub_topics topics;
-  rgw::sal::RGWRadosStore *store = ps->store;
+  rgw::sal::RadosStore *store = ps->store;
 
   int ret = ps->read_topics(&topics, &objv_tracker);
   if (ret < 0) {
@@ -797,7 +797,7 @@ int RGWPubSub::Sub::unsubscribe(const string& _topic, optional_yield y)
 {
   string topic = _topic;
   RGWObjVersionTracker sobjv_tracker;
-  rgw::sal::RGWRadosStore *store = ps->store;
+  rgw::sal::RadosStore *store = ps->store;
 
   if (topic.empty()) {
     rgw_pubsub_sub_config sub_conf;
@@ -919,7 +919,7 @@ int RGWPubSub::SubWithEvents<EventType>::list_events(const DoutPrefixProvider *d
 template<typename EventType>
 int RGWPubSub::SubWithEvents<EventType>::remove_event(const DoutPrefixProvider *dpp, const string& event_id)
 {
-  rgw::sal::RGWRadosStore *store = ps->store;
+  rgw::sal::RadosStore *store = ps->store;
   rgw_pubsub_sub_config sub_conf;
   int ret = get_conf(&sub_conf);
   if (ret < 0) {

--- a/src/rgw/rgw_pubsub.cc
+++ b/src/rgw/rgw_pubsub.cc
@@ -541,7 +541,7 @@ int RGWPubSub::Bucket::create_notification(const string& topic_name, const rgw::
 
 int RGWPubSub::Bucket::create_notification(const string& topic_name,const rgw::notify::EventTypeList& events, OptionalFilter s3_filter, const std::string& notif_name, optional_yield y) {
   rgw_pubsub_topic_subs topic_info;
-  rgw::sal::RadosStore *store = ps->store;
+  rgw::sal::RadosStore* store = ps->store;
 
   int ret = ps->get_topic(topic_name, &topic_info);
   if (ret < 0) {
@@ -584,7 +584,7 @@ int RGWPubSub::Bucket::create_notification(const string& topic_name,const rgw::n
 int RGWPubSub::Bucket::remove_notification(const string& topic_name, optional_yield y)
 {
   rgw_pubsub_topic_subs topic_info;
-  rgw::sal::RadosStore *store = ps->store;
+  rgw::sal::RadosStore* store = ps->store;
 
   int ret = ps->get_topic(topic_name, &topic_info);
   if (ret < 0) {
@@ -753,7 +753,7 @@ int RGWPubSub::Sub::subscribe(const string& topic, const rgw_pubsub_sub_dest& de
 {
   RGWObjVersionTracker objv_tracker;
   rgw_pubsub_topics topics;
-  rgw::sal::RadosStore *store = ps->store;
+  rgw::sal::RadosStore* store = ps->store;
 
   int ret = ps->read_topics(&topics, &objv_tracker);
   if (ret < 0) {
@@ -797,7 +797,7 @@ int RGWPubSub::Sub::unsubscribe(const string& _topic, optional_yield y)
 {
   string topic = _topic;
   RGWObjVersionTracker sobjv_tracker;
-  rgw::sal::RadosStore *store = ps->store;
+  rgw::sal::RadosStore* store = ps->store;
 
   if (topic.empty()) {
     rgw_pubsub_sub_config sub_conf;
@@ -919,7 +919,7 @@ int RGWPubSub::SubWithEvents<EventType>::list_events(const DoutPrefixProvider *d
 template<typename EventType>
 int RGWPubSub::SubWithEvents<EventType>::remove_event(const DoutPrefixProvider *dpp, const string& event_id)
 {
-  rgw::sal::RadosStore *store = ps->store;
+  rgw::sal::RadosStore* store = ps->store;
   rgw_pubsub_sub_config sub_conf;
   int ret = get_conf(&sub_conf);
   if (ret < 0) {

--- a/src/rgw/rgw_pubsub.h
+++ b/src/rgw/rgw_pubsub.h
@@ -593,7 +593,7 @@ class RGWPubSub
 {
   friend class Bucket;
 
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   const std::string tenant;
   RGWSysObjectCtx obj_ctx;
 
@@ -626,7 +626,7 @@ class RGWPubSub
 			RGWObjVersionTracker* objv_tracker, optional_yield y);
 
 public:
-  RGWPubSub(rgw::sal::RadosStore *_store, const std::string& tenant);
+  RGWPubSub(rgw::sal::RadosStore* _store, const std::string& tenant);
 
   class Bucket {
     friend class RGWPubSub;

--- a/src/rgw/rgw_pubsub.h
+++ b/src/rgw/rgw_pubsub.h
@@ -10,7 +10,7 @@
 #include "rgw_notify_event_type.h"
 #include <boost/container/flat_map.hpp>
 
-namespace rgw::sal { class RGWRadosStore; }
+namespace rgw::sal { class RadosStore; }
 
 class XMLObj;
 
@@ -593,7 +593,7 @@ class RGWPubSub
 {
   friend class Bucket;
 
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   const std::string tenant;
   RGWSysObjectCtx obj_ctx;
 
@@ -626,7 +626,7 @@ class RGWPubSub
 			RGWObjVersionTracker* objv_tracker, optional_yield y);
 
 public:
-  RGWPubSub(rgw::sal::RGWRadosStore *_store, const std::string& tenant);
+  RGWPubSub(rgw::sal::RadosStore *_store, const std::string& tenant);
 
   class Bucket {
     friend class RGWPubSub;

--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -161,7 +161,7 @@ int AtomicObjectProcessor::complete(size_t accounted_size,
                                     const std::string& etag,
                                     ceph::real_time *mtime,
                                     ceph::real_time set_mtime,
-                                    rgw::sal::RGWAttrs& attrs,
+                                    rgw::sal::Attrs& attrs,
                                     ceph::real_time delete_at,
                                     const char *if_match,
                                     const char *if_nomatch,
@@ -181,7 +181,7 @@ int AtomicObjectProcessor::complete(size_t accounted_size,
 
   head_obj->set_atomic(&obj_ctx);
 
-  std::unique_ptr<rgw::sal::RGWObject::WriteOp> obj_op = head_obj->get_write_op(&obj_ctx);
+  std::unique_ptr<rgw::sal::Object::WriteOp> obj_op = head_obj->get_write_op(&obj_ctx);
 
   /* some object types shouldn't be versioned, e.g., multipart parts */
   obj_op->params.versioning_disabled = !bucket->versioning_enabled();
@@ -318,7 +318,7 @@ int MultipartObjectProcessor::complete(size_t accounted_size,
     return r;
   }
 
-  std::unique_ptr<rgw::sal::RGWObject::WriteOp> obj_op = head_obj->get_write_op(&obj_ctx);
+  std::unique_ptr<rgw::sal::Object::WriteOp> obj_op = head_obj->get_write_op(&obj_ctx);
 
   obj_op->params.versioning_disabled = true;
   obj_op->params.set_mtime = set_mtime;
@@ -365,7 +365,7 @@ int MultipartObjectProcessor::complete(size_t accounted_size,
 
   encode(info, bl);
 
-  std::unique_ptr<rgw::sal::RGWObject> meta_obj =
+  std::unique_ptr<rgw::sal::Object> meta_obj =
     bucket->get_object(rgw_obj_key(mp.get_meta(), std::string(), RGW_OBJ_NS_MULTIPART));
   meta_obj->set_in_extra_data(true);
 
@@ -486,7 +486,7 @@ int AppendObjectProcessor::prepare(optional_yield y)
 }
 
 int AppendObjectProcessor::complete(size_t accounted_size, const string &etag, ceph::real_time *mtime,
-                                    ceph::real_time set_mtime, rgw::sal::RGWAttrs& attrs,
+                                    ceph::real_time set_mtime, rgw::sal::Attrs& attrs,
                                     ceph::real_time delete_at, const char *if_match, const char *if_nomatch,
                                     const string *user_data, rgw_zone_set *zones_trace, bool *pcanceled,
                                     optional_yield y)
@@ -500,7 +500,7 @@ int AppendObjectProcessor::complete(size_t accounted_size, const string &etag, c
     return r;
   }
   head_obj->set_atomic(&obj_ctx);
-  std::unique_ptr<rgw::sal::RGWObject::WriteOp> obj_op = head_obj->get_write_op(&obj_ctx);
+  std::unique_ptr<rgw::sal::Object::WriteOp> obj_op = head_obj->get_write_op(&obj_ctx);
   //For Append obj, disable versioning
   obj_op->params.versioning_disabled = true;
   if (cur_manifest) {

--- a/src/rgw/rgw_putobj_processor.h
+++ b/src/rgw/rgw_putobj_processor.h
@@ -79,7 +79,7 @@ class HeadObjectProcessor : public ObjectProcessor {
 class ManifestObjectProcessor : public HeadObjectProcessor,
                                 public StripeGenerator {
  protected:
-  rgw::sal::Store *const store;
+  rgw::sal::Store* const store;
   rgw::sal::Bucket* bucket;
   rgw_placement_rule tail_placement_rule;
   rgw_user owner;
@@ -97,7 +97,7 @@ class ManifestObjectProcessor : public HeadObjectProcessor,
   int next(uint64_t offset, uint64_t *stripe_size) override;
 
  public:
-  ManifestObjectProcessor(Aio *aio, rgw::sal::Store *store,
+  ManifestObjectProcessor(Aio *aio, rgw::sal::Store* store,
 			  rgw::sal::Bucket* bucket,
                           const rgw_placement_rule *ptail_placement_rule,
                           const rgw_user& owner, RGWObjectCtx& obj_ctx,
@@ -139,7 +139,7 @@ class AtomicObjectProcessor : public ManifestObjectProcessor {
 
   int process_first_chunk(bufferlist&& data, DataProcessor **processor) override;
  public:
-  AtomicObjectProcessor(Aio *aio, rgw::sal::Store *store,
+  AtomicObjectProcessor(Aio *aio, rgw::sal::Store* store,
 			rgw::sal::Bucket* bucket,
                         const rgw_placement_rule *ptail_placement_rule,
                         const rgw_user& owner,
@@ -184,7 +184,7 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
   // prepare the head stripe and manifest
   int prepare_head();
  public:
-  MultipartObjectProcessor(Aio *aio, rgw::sal::Store *store,
+  MultipartObjectProcessor(Aio *aio, rgw::sal::Store* store,
 			   rgw::sal::Bucket* bucket,
                            const rgw_placement_rule *ptail_placement_rule,
                            const rgw_user& owner, RGWObjectCtx& obj_ctx,
@@ -227,7 +227,7 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
     int process_first_chunk(bufferlist&& data, DataProcessor **processor) override;
 
   public:
-    AppendObjectProcessor(Aio *aio, rgw::sal::Store *store,
+    AppendObjectProcessor(Aio *aio, rgw::sal::Store* store,
 			  rgw::sal::Bucket* bucket,
                           const rgw_placement_rule *ptail_placement_rule,
                           const rgw_user& owner, RGWObjectCtx& obj_ctx,

--- a/src/rgw/rgw_putobj_processor.h
+++ b/src/rgw/rgw_putobj_processor.h
@@ -79,12 +79,12 @@ class HeadObjectProcessor : public ObjectProcessor {
 class ManifestObjectProcessor : public HeadObjectProcessor,
                                 public StripeGenerator {
  protected:
-  rgw::sal::RGWStore *const store;
-  rgw::sal::RGWBucket* bucket;
+  rgw::sal::Store *const store;
+  rgw::sal::Bucket* bucket;
   rgw_placement_rule tail_placement_rule;
   rgw_user owner;
   RGWObjectCtx& obj_ctx;
-  std::unique_ptr<rgw::sal::RGWObject> head_obj;
+  std::unique_ptr<rgw::sal::Object> head_obj;
 
   std::unique_ptr<rgw::sal::Writer> writer;
   RGWObjManifest manifest;
@@ -97,11 +97,11 @@ class ManifestObjectProcessor : public HeadObjectProcessor,
   int next(uint64_t offset, uint64_t *stripe_size) override;
 
  public:
-  ManifestObjectProcessor(Aio *aio, rgw::sal::RGWStore *store,
-			  rgw::sal::RGWBucket* bucket,
+  ManifestObjectProcessor(Aio *aio, rgw::sal::Store *store,
+			  rgw::sal::Bucket* bucket,
                           const rgw_placement_rule *ptail_placement_rule,
                           const rgw_user& owner, RGWObjectCtx& obj_ctx,
-                          std::unique_ptr<rgw::sal::RGWObject> _head_obj,
+                          std::unique_ptr<rgw::sal::Object> _head_obj,
                           const DoutPrefixProvider* dpp, optional_yield y)
     : HeadObjectProcessor(0),
       store(store), bucket(bucket),
@@ -139,12 +139,12 @@ class AtomicObjectProcessor : public ManifestObjectProcessor {
 
   int process_first_chunk(bufferlist&& data, DataProcessor **processor) override;
  public:
-  AtomicObjectProcessor(Aio *aio, rgw::sal::RGWStore *store,
-			rgw::sal::RGWBucket* bucket,
+  AtomicObjectProcessor(Aio *aio, rgw::sal::Store *store,
+			rgw::sal::Bucket* bucket,
                         const rgw_placement_rule *ptail_placement_rule,
                         const rgw_user& owner,
                         RGWObjectCtx& obj_ctx,
-			std::unique_ptr<rgw::sal::RGWObject> _head_obj,
+			std::unique_ptr<rgw::sal::Object> _head_obj,
                         std::optional<uint64_t> olh_epoch,
                         const std::string& unique_tag,
                         const DoutPrefixProvider *dpp, optional_yield y)
@@ -172,7 +172,7 @@ class AtomicObjectProcessor : public ManifestObjectProcessor {
 // part's head is written with an exclusive create to detect racing uploads of
 // the same part/upload id, which are restarted with a random oid prefix
 class MultipartObjectProcessor : public ManifestObjectProcessor {
-  std::unique_ptr<rgw::sal::RGWObject> target_obj; // target multipart object
+  std::unique_ptr<rgw::sal::Object> target_obj; // target multipart object
   const std::string upload_id;
   const int part_num;
   const std::string part_num_str;
@@ -184,11 +184,11 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
   // prepare the head stripe and manifest
   int prepare_head();
  public:
-  MultipartObjectProcessor(Aio *aio, rgw::sal::RGWStore *store,
-			   rgw::sal::RGWBucket* bucket,
+  MultipartObjectProcessor(Aio *aio, rgw::sal::Store *store,
+			   rgw::sal::Bucket* bucket,
                            const rgw_placement_rule *ptail_placement_rule,
                            const rgw_user& owner, RGWObjectCtx& obj_ctx,
-                           std::unique_ptr<rgw::sal::RGWObject> _head_obj,
+                           std::unique_ptr<rgw::sal::Object> _head_obj,
                            const std::string& upload_id, uint64_t part_num,
                            const std::string& part_num_str,
                            const DoutPrefixProvider *dpp, optional_yield y)
@@ -227,11 +227,11 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
     int process_first_chunk(bufferlist&& data, DataProcessor **processor) override;
 
   public:
-    AppendObjectProcessor(Aio *aio, rgw::sal::RGWStore *store,
-			  rgw::sal::RGWBucket* bucket,
+    AppendObjectProcessor(Aio *aio, rgw::sal::Store *store,
+			  rgw::sal::Bucket* bucket,
                           const rgw_placement_rule *ptail_placement_rule,
                           const rgw_user& owner, RGWObjectCtx& obj_ctx,
-			  std::unique_ptr<rgw::sal::RGWObject> _head_obj,
+			  std::unique_ptr<rgw::sal::Object> _head_obj,
                           const std::string& unique_tag, uint64_t position,
                           uint64_t *cur_accounted_size,
                           const DoutPrefixProvider *dpp, optional_yield y)

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -45,7 +45,7 @@ struct RGWQuotaCacheStats {
 template<class T>
 class RGWQuotaCache {
 protected:
-  rgw::sal::Store *store;
+  rgw::sal::Store* store;
   lru_map<T, RGWQuotaCacheStats> stats_map;
   RefCountedWaitObject *async_refcount;
 
@@ -74,7 +74,7 @@ protected:
 
   virtual void data_modified(const rgw_user& user, rgw_bucket& bucket) {}
 public:
-  RGWQuotaCache(rgw::sal::Store *_store, int size) : store(_store), stats_map(size) {
+  RGWQuotaCache(rgw::sal::Store* _store, int size) : store(_store), stats_map(size) {
     async_refcount = new RefCountedWaitObject;
   }
   virtual ~RGWQuotaCache() {
@@ -93,10 +93,10 @@ public:
 
   class AsyncRefreshHandler {
   protected:
-    rgw::sal::Store *store;
+    rgw::sal::Store* store;
     RGWQuotaCache<T> *cache;
   public:
-    AsyncRefreshHandler(rgw::sal::Store *_store, RGWQuotaCache<T> *_cache) : store(_store), cache(_cache) {}
+    AsyncRefreshHandler(rgw::sal::Store* _store, RGWQuotaCache<T> *_cache) : store(_store), cache(_cache) {}
     virtual ~AsyncRefreshHandler() {}
 
     virtual int init_fetch() = 0;
@@ -281,7 +281,7 @@ class BucketAsyncRefreshHandler : public RGWQuotaCache<rgw_bucket>::AsyncRefresh
                                   public RGWGetBucketStats_CB {
   rgw_user user;
 public:
-  BucketAsyncRefreshHandler(rgw::sal::Store *_store, RGWQuotaCache<rgw_bucket> *_cache,
+  BucketAsyncRefreshHandler(rgw::sal::Store* _store, RGWQuotaCache<rgw_bucket> *_cache,
                             const rgw_user& _user, const rgw_bucket& _bucket) :
                                       RGWQuotaCache<rgw_bucket>::AsyncRefreshHandler(_store, _cache),
                                       RGWGetBucketStats_CB(_bucket), user(_user) {}
@@ -353,7 +353,7 @@ protected:
   int fetch_stats_from_storage(const rgw_user& user, const rgw_bucket& bucket, RGWStorageStats& stats, optional_yield y, const DoutPrefixProvider *dpp) override;
 
 public:
-  explicit RGWBucketStatsCache(rgw::sal::Store *_store) : RGWQuotaCache<rgw_bucket>(_store, _store->ctx()->_conf->rgw_bucket_quota_cache_size) {
+  explicit RGWBucketStatsCache(rgw::sal::Store* _store) : RGWQuotaCache<rgw_bucket>(_store, _store->ctx()->_conf->rgw_bucket_quota_cache_size) {
   }
 
   AsyncRefreshHandler *allocate_refresh_handler(const rgw_user& user, const rgw_bucket& bucket) override {
@@ -400,7 +400,7 @@ class UserAsyncRefreshHandler : public RGWQuotaCache<rgw_user>::AsyncRefreshHand
                                 public RGWGetUserStats_CB {
   rgw_bucket bucket;
 public:
-  UserAsyncRefreshHandler(rgw::sal::Store *_store, RGWQuotaCache<rgw_user> *_cache,
+  UserAsyncRefreshHandler(rgw::sal::Store* _store, RGWQuotaCache<rgw_user> *_cache,
                           const rgw_user& _user, const rgw_bucket& _bucket) :
                           RGWQuotaCache<rgw_user>::AsyncRefreshHandler(_store, _cache),
                           RGWGetUserStats_CB(_user),
@@ -574,7 +574,7 @@ protected:
   }
 
 public:
-  RGWUserStatsCache(rgw::sal::Store *_store, bool quota_threads)
+  RGWUserStatsCache(rgw::sal::Store* _store, bool quota_threads)
     : RGWQuotaCache<rgw_user>(_store, _store->ctx()->_conf->rgw_bucket_quota_cache_size)
   {
     if (quota_threads) {
@@ -891,7 +891,7 @@ const RGWQuotaInfoApplier& RGWQuotaInfoApplier::get_instance(
 
 
 class RGWQuotaHandlerImpl : public RGWQuotaHandler {
-  rgw::sal::Store *store;
+  rgw::sal::Store* store;
   RGWBucketStatsCache bucket_stats_cache;
   RGWUserStatsCache user_stats_cache;
 
@@ -925,7 +925,7 @@ class RGWQuotaHandlerImpl : public RGWQuotaHandler {
     return 0;
   }
 public:
-  RGWQuotaHandlerImpl(rgw::sal::Store *_store, bool quota_threads) : store(_store),
+  RGWQuotaHandlerImpl(rgw::sal::Store* _store, bool quota_threads) : store(_store),
                                     bucket_stats_cache(_store),
                                     user_stats_cache(_store, quota_threads) {}
 
@@ -998,7 +998,7 @@ public:
 };
 
 
-RGWQuotaHandler *RGWQuotaHandler::generate_handler(rgw::sal::Store *store, bool quota_threads)
+RGWQuotaHandler *RGWQuotaHandler::generate_handler(rgw::sal::Store* store, bool quota_threads)
 {
   return new RGWQuotaHandlerImpl(store, quota_threads);
 }

--- a/src/rgw/rgw_quota.h
+++ b/src/rgw/rgw_quota.h
@@ -32,7 +32,7 @@ static inline int64_t rgw_rounded_kb(int64_t bytes)
 
 class JSONObj;
 namespace rgw { namespace sal {
-  class RGWStore;
+  class Store;
 } }
 
 struct RGWQuotaInfo {
@@ -115,7 +115,7 @@ public:
 
   virtual void update_stats(const rgw_user& bucket_owner, rgw_bucket& bucket, int obj_delta, uint64_t added_bytes, uint64_t removed_bytes) = 0;
 
-  static RGWQuotaHandler *generate_handler(rgw::sal::RGWStore *store, bool quota_threads);
+  static RGWQuotaHandler *generate_handler(rgw::sal::Store *store, bool quota_threads);
   static void free_handler(RGWQuotaHandler *handler);
 };
 

--- a/src/rgw/rgw_quota.h
+++ b/src/rgw/rgw_quota.h
@@ -115,7 +115,7 @@ public:
 
   virtual void update_stats(const rgw_user& bucket_owner, rgw_bucket& bucket, int obj_delta, uint64_t added_bytes, uint64_t removed_bytes) = 0;
 
-  static RGWQuotaHandler *generate_handler(rgw::sal::Store *store, bool quota_threads);
+  static RGWQuotaHandler *generate_handler(rgw::sal::Store* store, bool quota_threads);
   static void free_handler(RGWQuotaHandler *handler);
 };
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -149,7 +149,7 @@ rgw_raw_obj rgw_obj_select::get_raw_obj(const RGWZoneGroup& zonegroup, const RGW
   return raw_obj;
 }
 
-rgw_raw_obj rgw_obj_select::get_raw_obj(rgw::sal::RGWStore* store) const
+rgw_raw_obj rgw_obj_select::get_raw_obj(rgw::sal::Store* store) const
 {
   if (!is_raw) {
     rgw_raw_obj r;
@@ -497,7 +497,7 @@ class RGWMetaSyncProcessorThread : public RGWSyncProcessorThread
     sync.stop();
   }
 public:
-  RGWMetaSyncProcessorThread(rgw::sal::RGWRadosStore *_store, RGWAsyncRadosProcessor *async_rados)
+  RGWMetaSyncProcessorThread(rgw::sal::RadosStore *_store, RGWAsyncRadosProcessor *async_rados)
     : RGWSyncProcessorThread(_store->getRados(), "meta-sync"), sync(_store, async_rados) {}
 
   void wakeup_sync_shards(set<int>& shard_ids) {
@@ -540,7 +540,7 @@ class RGWDataSyncProcessorThread : public RGWSyncProcessorThread
     sync.stop();
   }
 public:
-  RGWDataSyncProcessorThread(rgw::sal::RGWRadosStore *_store, RGWAsyncRadosProcessor *async_rados,
+  RGWDataSyncProcessorThread(rgw::sal::RadosStore *_store, RGWAsyncRadosProcessor *async_rados,
                              const RGWZone* source_zone)
     : RGWSyncProcessorThread(_store->getRados(), "data-sync"),
       counters(sync_counters::build(store->ctx(), std::string("data-sync-from-") + source_zone->name)),
@@ -579,7 +579,7 @@ public:
 class RGWSyncLogTrimThread : public RGWSyncProcessorThread, DoutPrefixProvider
 {
   RGWCoroutinesManager crs;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   rgw::BucketTrimManager *bucket_trim;
   RGWHTTPManager http;
   const utime_t trim_interval;
@@ -587,7 +587,7 @@ class RGWSyncLogTrimThread : public RGWSyncProcessorThread, DoutPrefixProvider
   uint64_t interval_msec() override { return 0; }
   void stop_process() override { crs.stop(); }
 public:
-  RGWSyncLogTrimThread(rgw::sal::RGWRadosStore *store, rgw::BucketTrimManager *bucket_trim,
+  RGWSyncLogTrimThread(rgw::sal::RadosStore *store, rgw::BucketTrimManager *bucket_trim,
                        int interval)
     : RGWSyncProcessorThread(store->getRados(), "sync-log-trim"),
       crs(store->ctx(), store->getRados()->get_cr_registry()), store(store),
@@ -602,14 +602,14 @@ public:
   int process() override {
     list<RGWCoroutinesStack*> stacks;
     auto meta = new RGWCoroutinesStack(store->ctx(), &crs);
-    meta->call(create_meta_log_trim_cr(this, static_cast<rgw::sal::RGWRadosStore*>(store), &http,
+    meta->call(create_meta_log_trim_cr(this, static_cast<rgw::sal::RadosStore*>(store), &http,
                                        cct->_conf->rgw_md_log_max_shards,
                                        trim_interval));
     stacks.push_back(meta);
 
     if (store->svc()->zone->sync_module_exports_data()) {
       auto data = new RGWCoroutinesStack(store->ctx(), &crs);
-      data->call(create_data_log_trim_cr(static_cast<rgw::sal::RGWRadosStore*>(store), &http,
+      data->call(create_data_log_trim_cr(static_cast<rgw::sal::RadosStore*>(store), &http,
                                          cct->_conf->rgw_data_log_num_shards,
                                          trim_interval));
       stacks.push_back(data);
@@ -2778,7 +2778,7 @@ int RGWRados::on_last_entry_in_listing(const DoutPrefixProvider *dpp,
   return 0;
 }
 
-bool RGWRados::swift_versioning_enabled(rgw::sal::RGWBucket* bucket) const
+bool RGWRados::swift_versioning_enabled(rgw::sal::Bucket* bucket) const
 {
   return bucket->get_info().has_swift_versioning() &&
     bucket->get_info().swift_ver_location.size();
@@ -2786,8 +2786,8 @@ bool RGWRados::swift_versioning_enabled(rgw::sal::RGWBucket* bucket) const
 
 int RGWRados::swift_versioning_copy(RGWObjectCtx& obj_ctx,
                                     const rgw_user& user,
-                                    rgw::sal::RGWBucket* bucket,
-                                    rgw::sal::RGWObject* obj,
+                                    rgw::sal::Bucket* bucket,
+                                    rgw::sal::Object* obj,
                                     const DoutPrefixProvider *dpp,
                                     optional_yield y)
 {
@@ -2828,8 +2828,8 @@ int RGWRados::swift_versioning_copy(RGWObjectCtx& obj_ctx,
     return -ERR_PRECONDITION_FAILED;
   }
 
-  rgw::sal::RGWRadosBucket dest_bucket(store, dest_bucket_info);
-  rgw::sal::RGWRadosObject dest_obj(store, rgw_obj_key(buf), &dest_bucket);
+  rgw::sal::RadosBucket dest_bucket(store, dest_bucket_info);
+  rgw::sal::RadosObject dest_obj(store, rgw_obj_key(buf), &dest_bucket);
 
   if (dest_bucket_info.versioning_enabled()){
     dest_obj.gen_rand_obj_instance_name();
@@ -2879,8 +2879,8 @@ int RGWRados::swift_versioning_copy(RGWObjectCtx& obj_ctx,
 
 int RGWRados::swift_versioning_restore(RGWObjectCtx& obj_ctx,
                                        const rgw_user& user,
-                                       rgw::sal::RGWBucket* bucket,
-                                       rgw::sal::RGWObject* obj,
+                                       rgw::sal::Bucket* bucket,
+                                       rgw::sal::Object* obj,
                                        bool& restored,                  /* out */
                                        const DoutPrefixProvider *dpp)
 {
@@ -2924,8 +2924,8 @@ int RGWRados::swift_versioning_restore(RGWObjectCtx& obj_ctx,
      * irrelevant and may be safely skipped. */
     std::map<std::string, ceph::bufferlist> no_attrs;
 
-    rgw::sal::RGWRadosBucket archive_bucket(store, archive_binfo);
-    rgw::sal::RGWRadosObject archive_obj(store, entry.key, &archive_bucket);
+    rgw::sal::RadosBucket archive_bucket(store, archive_binfo);
+    rgw::sal::RadosObject archive_obj(store, entry.key, &archive_bucket);
 
     if (bucket->versioning_enabled()){
       obj->gen_rand_obj_instance_name();
@@ -3527,10 +3527,10 @@ static void set_copy_attrs(map<string, bufferlist>& src_attrs,
   }
 }
 
-int RGWRados::rewrite_obj(RGWBucketInfo& dest_bucket_info, rgw::sal::RGWObject* obj, const DoutPrefixProvider *dpp, optional_yield y)
+int RGWRados::rewrite_obj(RGWBucketInfo& dest_bucket_info, rgw::sal::Object* obj, const DoutPrefixProvider *dpp, optional_yield y)
 {
   RGWObjectCtx rctx(this->store);
-  rgw::sal::RGWRadosBucket bucket(store, dest_bucket_info);
+  rgw::sal::RadosBucket bucket(store, dest_bucket_info);
 
   return obj->copy_obj_data(rctx, &bucket, obj, 0, NULL, dpp, y);
 }
@@ -3633,7 +3633,7 @@ int RGWRados::stat_remote_obj(RGWObjectCtx& obj_ctx,
                const rgw_user& user_id,
                req_info *info,
                const rgw_zone_id& source_zone,
-               rgw::sal::RGWObject* src_obj,
+               rgw::sal::Object* src_obj,
                const RGWBucketInfo *src_bucket_info,
                real_time *src_mtime,
                uint64_t *psize,
@@ -3771,10 +3771,10 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
                const rgw_user& user_id,
                req_info *info,
                const rgw_zone_id& source_zone,
-               rgw::sal::RGWObject* dest_obj,
-               rgw::sal::RGWObject* src_obj,
-               rgw::sal::RGWBucket* dest_bucket,
-               rgw::sal::RGWBucket* src_bucket,
+               rgw::sal::Object* dest_obj,
+               rgw::sal::Object* src_obj,
+               rgw::sal::Bucket* dest_bucket,
+               rgw::sal::Bucket* src_bucket,
                std::optional<rgw_placement_rule> dest_placement_rule,
                real_time *src_mtime,
                real_time *mtime,
@@ -3785,7 +3785,7 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
                const char *if_nomatch,
                AttrsMod attrs_mod,
                bool copy_if_newer,
-               rgw::sal::RGWAttrs& attrs,
+               rgw::sal::Attrs& attrs,
                RGWObjCategory category,
                std::optional<uint64_t> olh_epoch,
 	       real_time delete_at,
@@ -4110,7 +4110,7 @@ int RGWRados::copy_obj_to_remote_dest(const DoutPrefixProvider *dpp,
                                       map<string, bufferlist>& src_attrs,
                                       RGWRados::Object::Read& read_op,
                                       const rgw_user& user_id,
-                                      rgw::sal::RGWObject* dest_obj,
+                                      rgw::sal::Object* dest_obj,
                                       real_time *mtime)
 {
   string etag;
@@ -4164,10 +4164,10 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
                const rgw_user& user_id,
                req_info *info,
                const rgw_zone_id& source_zone,
-               rgw::sal::RGWObject* dest_obj,
-               rgw::sal::RGWObject* src_obj,
-               rgw::sal::RGWBucket* dest_bucket,
-               rgw::sal::RGWBucket* src_bucket,
+               rgw::sal::Object* dest_obj,
+               rgw::sal::Object* src_obj,
+               rgw::sal::Bucket* dest_bucket,
+               rgw::sal::Bucket* src_bucket,
                const rgw_placement_rule& dest_placement,
                real_time *src_mtime,
                real_time *mtime,
@@ -4178,7 +4178,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
                const char *if_nomatch,
                AttrsMod attrs_mod,
                bool copy_if_newer,
-               rgw::sal::RGWAttrs& attrs,
+               rgw::sal::Attrs& attrs,
                RGWObjCategory category,
                uint64_t olh_epoch,
 	       real_time delete_at,
@@ -4459,13 +4459,13 @@ done_ret:
 
 
 int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
-               rgw::sal::RGWBucket* bucket,
+               rgw::sal::Bucket* bucket,
                const rgw_placement_rule& dest_placement,
 	       RGWRados::Object::Read& read_op, off_t end,
-               rgw::sal::RGWObject* dest_obj,
+               rgw::sal::Object* dest_obj,
 	       real_time *mtime,
 	       real_time set_mtime,
-               rgw::sal::RGWAttrs& attrs,
+               rgw::sal::Attrs& attrs,
                uint64_t olh_epoch,
 	       real_time delete_at,
                string *petag,
@@ -4540,15 +4540,15 @@ int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
 }
 
 int RGWRados::transition_obj(RGWObjectCtx& obj_ctx,
-			     rgw::sal::RGWBucket* bucket,
-                             rgw::sal::RGWObject& obj,
+			     rgw::sal::Bucket* bucket,
+                             rgw::sal::Object& obj,
                              const rgw_placement_rule& placement_rule,
                              const real_time& mtime,
                              uint64_t olh_epoch,
                              const DoutPrefixProvider *dpp,
                              optional_yield y)
 {
-  rgw::sal::RGWAttrs attrs;
+  rgw::sal::Attrs attrs;
   real_time read_mtime;
   uint64_t obj_size;
 
@@ -5261,7 +5261,7 @@ int RGWRados::delete_obj_index(const rgw_obj& obj, ceph::real_time mtime, const 
   return index_op.complete_del(dpp, -1 /* pool */, 0, mtime, NULL);
 }
 
-static void generate_fake_tag(rgw::sal::RGWStore* store, map<string, bufferlist>& attrset, RGWObjManifest& manifest, bufferlist& manifest_bl, bufferlist& tag_bl)
+static void generate_fake_tag(rgw::sal::Store* store, map<string, bufferlist>& attrset, RGWObjManifest& manifest, bufferlist& manifest_bl, bufferlist& tag_bl)
 {
   string tag;
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -292,7 +292,7 @@ void RGWObjVersionTracker::generate_new_write_ver(CephContext *cct)
 }
 
 class RGWMetaNotifierManager : public RGWCoroutinesManager {
-  RGWRados *store;
+  RGWRados* store;
   RGWHTTPManager http_manager;
 
 public:
@@ -319,7 +319,7 @@ public:
 };
 
 class RGWDataNotifierManager : public RGWCoroutinesManager {
-  RGWRados *store;
+  RGWRados* store;
   RGWHTTPManager http_manager;
 
 public:
@@ -497,7 +497,7 @@ class RGWMetaSyncProcessorThread : public RGWSyncProcessorThread
     sync.stop();
   }
 public:
-  RGWMetaSyncProcessorThread(rgw::sal::RadosStore *_store, RGWAsyncRadosProcessor *async_rados)
+  RGWMetaSyncProcessorThread(rgw::sal::RadosStore* _store, RGWAsyncRadosProcessor *async_rados)
     : RGWSyncProcessorThread(_store->getRados(), "meta-sync"), sync(_store, async_rados) {}
 
   void wakeup_sync_shards(set<int>& shard_ids) {
@@ -540,7 +540,7 @@ class RGWDataSyncProcessorThread : public RGWSyncProcessorThread
     sync.stop();
   }
 public:
-  RGWDataSyncProcessorThread(rgw::sal::RadosStore *_store, RGWAsyncRadosProcessor *async_rados,
+  RGWDataSyncProcessorThread(rgw::sal::RadosStore* _store, RGWAsyncRadosProcessor *async_rados,
                              const RGWZone* source_zone)
     : RGWSyncProcessorThread(_store->getRados(), "data-sync"),
       counters(sync_counters::build(store->ctx(), std::string("data-sync-from-") + source_zone->name)),
@@ -579,7 +579,7 @@ public:
 class RGWSyncLogTrimThread : public RGWSyncProcessorThread, DoutPrefixProvider
 {
   RGWCoroutinesManager crs;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   rgw::BucketTrimManager *bucket_trim;
   RGWHTTPManager http;
   const utime_t trim_interval;
@@ -587,7 +587,7 @@ class RGWSyncLogTrimThread : public RGWSyncProcessorThread, DoutPrefixProvider
   uint64_t interval_msec() override { return 0; }
   void stop_process() override { crs.stop(); }
 public:
-  RGWSyncLogTrimThread(rgw::sal::RadosStore *store, rgw::BucketTrimManager *bucket_trim,
+  RGWSyncLogTrimThread(rgw::sal::RadosStore* store, rgw::BucketTrimManager *bucket_trim,
                        int interval)
     : RGWSyncProcessorThread(store->getRados(), "sync-log-trim"),
       crs(store->ctx(), store->getRados()->get_cr_registry()), store(store),

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -224,20 +224,20 @@ public:
 };
 
 class RGWObjectCtx {
-  rgw::sal::Store *store;
+  rgw::sal::Store* store;
   ceph::shared_mutex lock = ceph::make_shared_mutex("RGWObjectCtx");
   void *s{nullptr};
 
   std::map<rgw_obj, RGWObjState> objs_state;
 public:
-  explicit RGWObjectCtx(rgw::sal::Store *_store) : store(_store) {}
-  explicit RGWObjectCtx(rgw::sal::Store *_store, void *_s) : store(_store), s(_s) {}
+  explicit RGWObjectCtx(rgw::sal::Store* _store) : store(_store) {}
+  explicit RGWObjectCtx(rgw::sal::Store* _store, void *_s) : store(_store), s(_s) {}
 
   void *get_private() {
     return s;
   }
 
-  rgw::sal::Store *get_store() {
+  rgw::sal::Store* get_store() {
     return store;
   }
 
@@ -400,7 +400,7 @@ class RGWRados
   ceph::mutex lock = ceph::make_mutex("rados_timer_lock");
   SafeTimer *timer;
 
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   RGWGC *gc;
   RGWLC *lc;
   RGWObjectExpirer *obj_expirer;
@@ -545,7 +545,7 @@ public:
   void set_context(CephContext *_cct) {
     cct = _cct;
   }
-  void set_store(rgw::sal::RadosStore *_store) {
+  void set_store(rgw::sal::RadosStore* _store) {
     store = _store;
   }
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -224,20 +224,20 @@ public:
 };
 
 class RGWObjectCtx {
-  rgw::sal::RGWStore *store;
+  rgw::sal::Store *store;
   ceph::shared_mutex lock = ceph::make_shared_mutex("RGWObjectCtx");
   void *s{nullptr};
 
   std::map<rgw_obj, RGWObjState> objs_state;
 public:
-  explicit RGWObjectCtx(rgw::sal::RGWStore *_store) : store(_store) {}
-  explicit RGWObjectCtx(rgw::sal::RGWStore *_store, void *_s) : store(_store), s(_s) {}
+  explicit RGWObjectCtx(rgw::sal::Store *_store) : store(_store) {}
+  explicit RGWObjectCtx(rgw::sal::Store *_store, void *_s) : store(_store), s(_s) {}
 
   void *get_private() {
     return s;
   }
 
-  rgw::sal::RGWStore *get_store() {
+  rgw::sal::Store *get_store() {
     return store;
   }
 
@@ -344,8 +344,8 @@ class RGWCoroutinesManagerRegistry;
 class RGWGetDirHeader_CB;
 class RGWGetUserHeader_CB;
 namespace rgw { namespace sal {
-  class RGWStore;
-  class RGWRadosStore;
+  class Store;
+  class RadosStore;
   class MPRadosSerializer;
   class LCRadosSerializer;
 } }
@@ -383,7 +383,7 @@ class RGWRados
   friend class BucketIndexLockGuard;
   friend class rgw::sal::MPRadosSerializer;
   friend class rgw::sal::LCRadosSerializer;
-  friend class rgw::sal::RGWRadosStore;
+  friend class rgw::sal::RadosStore;
 
   /** Open the pool used as root for this gateway */
   int open_root_pool_ctx();
@@ -400,7 +400,7 @@ class RGWRados
   ceph::mutex lock = ceph::make_mutex("rados_timer_lock");
   SafeTimer *timer;
 
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   RGWGC *gc;
   RGWLC *lc;
   RGWObjectExpirer *obj_expirer;
@@ -545,7 +545,7 @@ public:
   void set_context(CephContext *_cct) {
     cct = _cct;
   }
-  void set_store(rgw::sal::RGWRadosStore *_store) {
+  void set_store(rgw::sal::RadosStore *_store) {
     store = _store;
   }
 
@@ -1039,18 +1039,18 @@ public:
                                const std::string& obj_delim,
                                std::function<int(const rgw_bucket_dir_entry&)> handler);
 
-  bool swift_versioning_enabled(rgw::sal::RGWBucket* bucket) const;
+  bool swift_versioning_enabled(rgw::sal::Bucket* bucket) const;
 
   int swift_versioning_copy(RGWObjectCtx& obj_ctx,              /* in/out */
                             const rgw_user& user,               /* in */
-                            rgw::sal::RGWBucket* bucket,        /* in */
-                            rgw::sal::RGWObject* obj,           /* in */
+                            rgw::sal::Bucket* bucket,        /* in */
+                            rgw::sal::Object* obj,           /* in */
                             const DoutPrefixProvider *dpp,      /* in/out */ 
                             optional_yield y);                  /* in */                
   int swift_versioning_restore(RGWObjectCtx& obj_ctx,           /* in/out */
                                const rgw_user& user,            /* in */
-                               rgw::sal::RGWBucket* bucket,     /* in */
-                               rgw::sal::RGWObject* obj,        /* in */
+                               rgw::sal::Bucket* bucket,     /* in */
+                               rgw::sal::Object* obj,        /* in */
                                bool& restored,                 /* out */
                                const DoutPrefixProvider *dpp);     /* in/out */                
   int copy_obj_to_remote_dest(const DoutPrefixProvider *dpp,
@@ -1058,7 +1058,7 @@ public:
                               map<string, bufferlist>& src_attrs,
                               RGWRados::Object::Read& read_op,
                               const rgw_user& user_id,
-                              rgw::sal::RGWObject* dest_obj,
+                              rgw::sal::Object* dest_obj,
                               ceph::real_time *mtime);
 
   enum AttrsMod {
@@ -1067,13 +1067,13 @@ public:
     ATTRSMOD_MERGE   = 2
   };
 
-  int rewrite_obj(RGWBucketInfo& dest_bucket_info, rgw::sal::RGWObject* obj, const DoutPrefixProvider *dpp, optional_yield y);
+  int rewrite_obj(RGWBucketInfo& dest_bucket_info, rgw::sal::Object* obj, const DoutPrefixProvider *dpp, optional_yield y);
 
   int stat_remote_obj(RGWObjectCtx& obj_ctx,
                const rgw_user& user_id,
                req_info *info,
                const rgw_zone_id& source_zone,
-               rgw::sal::RGWObject* src_obj,
+               rgw::sal::Object* src_obj,
                const RGWBucketInfo *src_bucket_info,
                real_time *src_mtime,
                uint64_t *psize,
@@ -1092,10 +1092,10 @@ public:
                        const rgw_user& user_id,
                        req_info *info,
                        const rgw_zone_id& source_zone,
-                       rgw::sal::RGWObject* dest_obj,
-                       rgw::sal::RGWObject* src_obj,
-		       rgw::sal::RGWBucket* dest_bucket,
-		       rgw::sal::RGWBucket* src_bucket,
+                       rgw::sal::Object* dest_obj,
+                       rgw::sal::Object* src_obj,
+		       rgw::sal::Bucket* dest_bucket,
+		       rgw::sal::Bucket* src_bucket,
 		       std::optional<rgw_placement_rule> dest_placement,
                        ceph::real_time *src_mtime,
                        ceph::real_time *mtime,
@@ -1106,7 +1106,7 @@ public:
                        const char *if_nomatch,
                        AttrsMod attrs_mod,
                        bool copy_if_newer,
-                       rgw::sal::RGWAttrs& attrs,
+                       rgw::sal::Attrs& attrs,
                        RGWObjCategory category,
                        std::optional<uint64_t> olh_epoch,
 		       ceph::real_time delete_at,
@@ -1136,10 +1136,10 @@ public:
                const rgw_user& user_id,
                req_info *info,
                const rgw_zone_id& source_zone,
-               rgw::sal::RGWObject* dest_obj,
-               rgw::sal::RGWObject* src_obj,
-               rgw::sal::RGWBucket* dest_bucket,
-               rgw::sal::RGWBucket* src_bucket,
+               rgw::sal::Object* dest_obj,
+               rgw::sal::Object* src_obj,
+               rgw::sal::Bucket* dest_bucket,
+               rgw::sal::Bucket* src_bucket,
                const rgw_placement_rule& dest_placement,
                ceph::real_time *src_mtime,
                ceph::real_time *mtime,
@@ -1163,10 +1163,10 @@ public:
                optional_yield y);
 
   int copy_obj_data(RGWObjectCtx& obj_ctx,
-               rgw::sal::RGWBucket* bucket,
+               rgw::sal::Bucket* bucket,
                const rgw_placement_rule& dest_placement,
 	       RGWRados::Object::Read& read_op, off_t end,
-               rgw::sal::RGWObject* dest_obj,
+               rgw::sal::Object* dest_obj,
 	       ceph::real_time *mtime,
 	       ceph::real_time set_mtime,
                map<string, bufferlist>& attrs,
@@ -1177,8 +1177,8 @@ public:
                optional_yield y);
   
   int transition_obj(RGWObjectCtx& obj_ctx,
-                     rgw::sal::RGWBucket* bucket,
-                     rgw::sal::RGWObject& obj,
+                     rgw::sal::Bucket* bucket,
+                     rgw::sal::Object& obj,
                      const rgw_placement_rule& placement_rule,
                      const real_time& mtime,
                      uint64_t olh_epoch,

--- a/src/rgw/rgw_realm_reloader.cc
+++ b/src/rgw/rgw_realm_reloader.cc
@@ -26,7 +26,7 @@
 static constexpr bool USE_SAFE_TIMER_CALLBACKS = false;
 
 
-RGWRealmReloader::RGWRealmReloader(rgw::sal::RGWStore*& store, std::map<std::string, std::string>& service_map_meta,
+RGWRealmReloader::RGWRealmReloader(rgw::sal::Store*& store, std::map<std::string, std::string>& service_map_meta,
                                    Pauser* frontends)
   : store(store),
     service_map_meta(service_map_meta),
@@ -90,7 +90,7 @@ void RGWRealmReloader::reload()
   rgw_log_usage_finalize();
 
   // destroy the existing store
-  RGWStoreManager::close_storage(store);
+  StoreManager::close_storage(store);
   store = nullptr;
 
   ldout(cct, 1) << "Store closed" << dendl;
@@ -106,7 +106,7 @@ void RGWRealmReloader::reload()
   while (!store) {
     // recreate and initialize a new store
     store =
-      RGWStoreManager::get_storage(&dp, cct,
+      StoreManager::get_storage(&dp, cct,
 				   "rados",
 				   cct->_conf->rgw_enable_gc_threads,
 				   cct->_conf->rgw_enable_lc_threads,
@@ -117,7 +117,7 @@ void RGWRealmReloader::reload()
 
     ldout(cct, 1) << "Creating new store" << dendl;
 
-    rgw::sal::RGWStore* store_cleanup = nullptr;
+    rgw::sal::Store* store_cleanup = nullptr;
     {
       std::unique_lock lock{mutex};
 
@@ -150,7 +150,7 @@ void RGWRealmReloader::reload()
       ldout(cct, 4) << "Got another notification, restarting RGWRados "
           "initialization." << dendl;
 
-      RGWStoreManager::close_storage(store_cleanup);
+      StoreManager::close_storage(store_cleanup);
     }
   }
 

--- a/src/rgw/rgw_realm_reloader.h
+++ b/src/rgw/rgw_realm_reloader.h
@@ -9,7 +9,7 @@
 
 namespace rgw {
 namespace sal {
-class RGWStore;
+class Store;
 }
 }
 
@@ -33,10 +33,10 @@ class RGWRealmReloader : public RGWRealmWatcher::Watcher {
     /// pause all frontends while realm reconfiguration is in progress
     virtual void pause() = 0;
     /// resume all frontends with the given RGWRados instance
-    virtual void resume(rgw::sal::RGWStore* store) = 0;
+    virtual void resume(rgw::sal::Store* store) = 0;
   };
 
-  RGWRealmReloader(rgw::sal::RGWStore*& store, std::map<std::string, std::string>& service_map_meta,
+  RGWRealmReloader(rgw::sal::Store*& store, std::map<std::string, std::string>& service_map_meta,
                    Pauser* frontends);
   ~RGWRealmReloader() override;
 
@@ -49,8 +49,8 @@ class RGWRealmReloader : public RGWRealmWatcher::Watcher {
 
   class C_Reload; //< Context that calls reload()
 
-  /// main()'s RGWStore pointer as a reference, modified by reload()
-  rgw::sal::RGWStore*& store;
+  /// main()'s Store pointer as a reference, modified by reload()
+  rgw::sal::Store*& store;
   std::map<std::string, std::string>& service_map_meta;
   Pauser *const frontends;
 

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -59,7 +59,7 @@ const std::initializer_list<uint16_t> RGWBucketReshard::reshard_primes = {
 };
 
 class BucketReshardShard {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   const RGWBucketInfo& bucket_info;
   int num_shard;
   const rgw::bucket_index_layout_generation& idx_layout;
@@ -103,7 +103,7 @@ class BucketReshardShard {
 
 public:
   BucketReshardShard(const DoutPrefixProvider *dpp, 
-                     rgw::sal::RadosStore *_store, const RGWBucketInfo& _bucket_info,
+                     rgw::sal::RadosStore* _store, const RGWBucketInfo& _bucket_info,
                      int _num_shard, const rgw::bucket_index_layout_generation& _idx_layout,
                      deque<librados::AioCompletion *>& _completions) :
     store(_store), bucket_info(_bucket_info), idx_layout(_idx_layout), bs(store->getRados()),
@@ -183,7 +183,7 @@ public:
 
 
 class BucketReshardManager {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   const RGWBucketInfo& target_bucket_info;
   deque<librados::AioCompletion *> completions;
   int num_target_shards;
@@ -191,7 +191,7 @@ class BucketReshardManager {
 
 public:
   BucketReshardManager(const DoutPrefixProvider *dpp,
-                       rgw::sal::RadosStore *_store,
+                       rgw::sal::RadosStore* _store,
 		       const RGWBucketInfo& _target_bucket_info,
 		       int _num_target_shards) :
     store(_store), target_bucket_info(_target_bucket_info),
@@ -250,7 +250,7 @@ public:
   }
 }; // class BucketReshardManager
 
-RGWBucketReshard::RGWBucketReshard(rgw::sal::RadosStore *_store,
+RGWBucketReshard::RGWBucketReshard(rgw::sal::RadosStore* _store,
 				   const RGWBucketInfo& _bucket_info,
 				   const map<string, bufferlist>& _bucket_attrs,
 				   RGWBucketReshardLock* _outer_reshard_lock) :
@@ -327,7 +327,7 @@ int RGWBucketReshard::clear_index_shard_reshard_status(rgw::sal::RadosStore* sto
   return 0;
 }
 
-static int create_new_bucket_instance(rgw::sal::RadosStore *store,
+static int create_new_bucket_instance(rgw::sal::RadosStore* store,
 				      int new_num_shards,
 				      const RGWBucketInfo& bucket_info,
 				      map<string, bufferlist>& attrs,
@@ -383,7 +383,7 @@ int RGWBucketReshard::cancel()
 class BucketInfoReshardUpdate
 {
   const DoutPrefixProvider *dpp;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   RGWBucketInfo& bucket_info;
   std::map<string, bufferlist> bucket_attrs;
 
@@ -401,7 +401,7 @@ class BucketInfoReshardUpdate
 
 public:
   BucketInfoReshardUpdate(const DoutPrefixProvider *_dpp,
-                          rgw::sal::RadosStore *_store,
+                          rgw::sal::RadosStore* _store,
 			  RGWBucketInfo& _bucket_info,
                           map<string, bufferlist>& _bucket_attrs,
 			  const string& new_bucket_id) :

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -59,7 +59,7 @@ const std::initializer_list<uint16_t> RGWBucketReshard::reshard_primes = {
 };
 
 class BucketReshardShard {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   const RGWBucketInfo& bucket_info;
   int num_shard;
   const rgw::bucket_index_layout_generation& idx_layout;
@@ -103,7 +103,7 @@ class BucketReshardShard {
 
 public:
   BucketReshardShard(const DoutPrefixProvider *dpp, 
-                     rgw::sal::RGWRadosStore *_store, const RGWBucketInfo& _bucket_info,
+                     rgw::sal::RadosStore *_store, const RGWBucketInfo& _bucket_info,
                      int _num_shard, const rgw::bucket_index_layout_generation& _idx_layout,
                      deque<librados::AioCompletion *>& _completions) :
     store(_store), bucket_info(_bucket_info), idx_layout(_idx_layout), bs(store->getRados()),
@@ -183,7 +183,7 @@ public:
 
 
 class BucketReshardManager {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   const RGWBucketInfo& target_bucket_info;
   deque<librados::AioCompletion *> completions;
   int num_target_shards;
@@ -191,7 +191,7 @@ class BucketReshardManager {
 
 public:
   BucketReshardManager(const DoutPrefixProvider *dpp,
-                       rgw::sal::RGWRadosStore *_store,
+                       rgw::sal::RadosStore *_store,
 		       const RGWBucketInfo& _target_bucket_info,
 		       int _num_target_shards) :
     store(_store), target_bucket_info(_target_bucket_info),
@@ -250,7 +250,7 @@ public:
   }
 }; // class BucketReshardManager
 
-RGWBucketReshard::RGWBucketReshard(rgw::sal::RGWRadosStore *_store,
+RGWBucketReshard::RGWBucketReshard(rgw::sal::RadosStore *_store,
 				   const RGWBucketInfo& _bucket_info,
 				   const map<string, bufferlist>& _bucket_attrs,
 				   RGWBucketReshardLock* _outer_reshard_lock) :
@@ -259,7 +259,7 @@ RGWBucketReshard::RGWBucketReshard(rgw::sal::RGWRadosStore *_store,
   outer_reshard_lock(_outer_reshard_lock)
 { }
 
-int RGWBucketReshard::set_resharding_status(rgw::sal::RGWRadosStore* store,
+int RGWBucketReshard::set_resharding_status(rgw::sal::RadosStore* store,
 					    const RGWBucketInfo& bucket_info,
 					    const string& new_instance_id,
 					    int32_t num_shards,
@@ -283,7 +283,7 @@ int RGWBucketReshard::set_resharding_status(rgw::sal::RGWRadosStore* store,
 }
 
 // reshard lock assumes lock is held
-int RGWBucketReshard::clear_resharding(rgw::sal::RGWRadosStore* store,
+int RGWBucketReshard::clear_resharding(rgw::sal::RadosStore* store,
 				       const RGWBucketInfo& bucket_info)
 {
   int ret = clear_index_shard_reshard_status(store, bucket_info);
@@ -306,7 +306,7 @@ int RGWBucketReshard::clear_resharding(rgw::sal::RGWRadosStore* store,
   return 0;
 }
 
-int RGWBucketReshard::clear_index_shard_reshard_status(rgw::sal::RGWRadosStore* store,
+int RGWBucketReshard::clear_index_shard_reshard_status(rgw::sal::RadosStore* store,
 						       const RGWBucketInfo& bucket_info)
 {
   uint32_t num_shards = bucket_info.layout.current_index.layout.normal.num_shards;
@@ -327,7 +327,7 @@ int RGWBucketReshard::clear_index_shard_reshard_status(rgw::sal::RGWRadosStore* 
   return 0;
 }
 
-static int create_new_bucket_instance(rgw::sal::RGWRadosStore *store,
+static int create_new_bucket_instance(rgw::sal::RadosStore *store,
 				      int new_num_shards,
 				      const RGWBucketInfo& bucket_info,
 				      map<string, bufferlist>& attrs,
@@ -383,7 +383,7 @@ int RGWBucketReshard::cancel()
 class BucketInfoReshardUpdate
 {
   const DoutPrefixProvider *dpp;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   RGWBucketInfo& bucket_info;
   std::map<string, bufferlist> bucket_attrs;
 
@@ -401,7 +401,7 @@ class BucketInfoReshardUpdate
 
 public:
   BucketInfoReshardUpdate(const DoutPrefixProvider *_dpp,
-                          rgw::sal::RGWRadosStore *_store,
+                          rgw::sal::RadosStore *_store,
 			  RGWBucketInfo& _bucket_info,
                           map<string, bufferlist>& _bucket_attrs,
 			  const string& new_bucket_id) :
@@ -449,7 +449,7 @@ public:
 };
 
 
-RGWBucketReshardLock::RGWBucketReshardLock(rgw::sal::RGWRadosStore* _store,
+RGWBucketReshardLock::RGWBucketReshardLock(rgw::sal::RadosStore* _store,
 					   const std::string& reshard_lock_oid,
 					   bool _ephemeral) :
   store(_store),
@@ -803,7 +803,7 @@ error_out:
 } // execute
 
 
-RGWReshard::RGWReshard(rgw::sal::RGWRadosStore* _store, bool _verbose, ostream *_out,
+RGWReshard::RGWReshard(rgw::sal::RadosStore* _store, bool _verbose, ostream *_out,
                        Formatter *_formatter) :
   store(_store), instance_lock(bucket_instance_lock_name),
   verbose(_verbose), out(_out), formatter(_formatter)

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -73,7 +73,7 @@ public:
 
 private:
 
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   RGWBucketInfo bucket_info;
   std::map<string, bufferlist> bucket_attrs;
 
@@ -98,7 +98,7 @@ public:
 
   // pass nullptr for the final parameter if no outer reshard lock to
   // manage
-  RGWBucketReshard(rgw::sal::RadosStore *_store,
+  RGWBucketReshard(rgw::sal::RadosStore* _store,
 		   const RGWBucketInfo& _bucket_info,
                    const std::map<string, bufferlist>& _bucket_attrs,
 		   RGWBucketReshardLock* _outer_reshard_lock);
@@ -194,7 +194,7 @@ public:
     using Clock = ceph::coarse_mono_clock;
 
 private:
-    rgw::sal::RadosStore *store;
+    rgw::sal::RadosStore* store;
     string lock_name;
     rados::cls::lock::Lock instance_lock;
     int num_logshards;

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -25,13 +25,13 @@
 
 class RGWReshard;
 namespace rgw { namespace sal {
-  class RGWRadosStore;
+  class RadosStore;
 } }
 
 class RGWBucketReshardLock {
   using Clock = ceph::coarse_mono_clock;
 
-  rgw::sal::RGWRadosStore* store;
+  rgw::sal::RadosStore* store;
   const std::string lock_oid;
   const bool ephemeral;
   rados::cls::lock::Lock internal_lock;
@@ -46,10 +46,10 @@ class RGWBucketReshardLock {
   }
 
 public:
-  RGWBucketReshardLock(rgw::sal::RGWRadosStore* _store,
+  RGWBucketReshardLock(rgw::sal::RadosStore* _store,
 		       const std::string& reshard_lock_oid,
 		       bool _ephemeral);
-  RGWBucketReshardLock(rgw::sal::RGWRadosStore* _store,
+  RGWBucketReshardLock(rgw::sal::RadosStore* _store,
 		       const RGWBucketInfo& bucket_info,
 		       bool _ephemeral) :
     RGWBucketReshardLock(_store, bucket_info.bucket.get_key(':'), _ephemeral)
@@ -73,7 +73,7 @@ public:
 
 private:
 
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   RGWBucketInfo bucket_info;
   std::map<string, bufferlist> bucket_attrs;
 
@@ -98,7 +98,7 @@ public:
 
   // pass nullptr for the final parameter if no outer reshard lock to
   // manage
-  RGWBucketReshard(rgw::sal::RGWRadosStore *_store,
+  RGWBucketReshard(rgw::sal::RadosStore *_store,
 		   const RGWBucketInfo& _bucket_info,
                    const std::map<string, bufferlist>& _bucket_attrs,
 		   RGWBucketReshardLock* _outer_reshard_lock);
@@ -109,17 +109,17 @@ public:
 	      RGWReshard *reshard_log = nullptr);
   int get_status(std::list<cls_rgw_bucket_instance_entry> *status);
   int cancel();
-  static int clear_resharding(rgw::sal::RGWRadosStore* store,
+  static int clear_resharding(rgw::sal::RadosStore* store,
 			      const RGWBucketInfo& bucket_info);
   int clear_resharding() {
     return clear_resharding(store, bucket_info);
   }
-  static int clear_index_shard_reshard_status(rgw::sal::RGWRadosStore* store,
+  static int clear_index_shard_reshard_status(rgw::sal::RadosStore* store,
 					      const RGWBucketInfo& bucket_info);
   int clear_index_shard_reshard_status() {
     return clear_index_shard_reshard_status(store, bucket_info);
   }
-  static int set_resharding_status(rgw::sal::RGWRadosStore* store,
+  static int set_resharding_status(rgw::sal::RadosStore* store,
 				   const RGWBucketInfo& bucket_info,
 				   const string& new_instance_id,
 				   int32_t num_shards,
@@ -194,7 +194,7 @@ public:
     using Clock = ceph::coarse_mono_clock;
 
 private:
-    rgw::sal::RGWRadosStore *store;
+    rgw::sal::RadosStore *store;
     string lock_name;
     rados::cls::lock::Lock instance_lock;
     int num_logshards;
@@ -232,7 +232,7 @@ protected:
   void get_bucket_logshard_oid(const string& tenant, const string& bucket_name, string *oid);
 
 public:
-  RGWReshard(rgw::sal::RGWRadosStore* _store, bool _verbose = false, ostream *_out = nullptr, Formatter *_formatter = nullptr);
+  RGWReshard(rgw::sal::RadosStore* _store, bool _verbose = false, ostream *_out = nullptr, Formatter *_formatter = nullptr);
   int add(cls_rgw_reshard_entry& entry);
   int update(const RGWBucketInfo& bucket_info, const RGWBucketInfo& new_bucket_info);
   int get(cls_rgw_reshard_entry& entry);

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -2271,7 +2271,7 @@ int RGWREST::preprocess(struct req_state *s, rgw::io::BasicClient* cio)
 }
 
 RGWHandler_REST* RGWREST::get_handler(
-  rgw::sal::Store * const store,
+  rgw::sal::Store*  const store,
   struct req_state* const s,
   const rgw::auth::StrategyRegistry& auth_registry,
   const std::string& frontend_prefix,

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1849,7 +1849,7 @@ int RGWHandler_REST::init_permissions(RGWOp* op, optional_yield y)
     // We don't need user policies in case of STS token returned by AssumeRole, hence the check for user type
     if (! s->user->get_id().empty() && s->auth.identity->get_identity_type() != TYPE_ROLE) {
       try {
-	rgw::sal::RGWAttrs uattrs;
+	rgw::sal::Attrs uattrs;
         if (auto ret = s->user->read_attrs(s, y, &uattrs); ! ret) {
           auto user_policies = get_iam_user_policy_from_attr(s->cct, uattrs, s->user->get_tenant());
           s->iam_user_policies.insert(s->iam_user_policies.end(),
@@ -2271,7 +2271,7 @@ int RGWREST::preprocess(struct req_state *s, rgw::io::BasicClient* cio)
 }
 
 RGWHandler_REST* RGWREST::get_handler(
-  rgw::sal::RGWStore * const store,
+  rgw::sal::Store * const store,
   struct req_state* const s,
   const rgw::auth::StrategyRegistry& auth_registry,
   const std::string& frontend_prefix,

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -121,7 +121,7 @@ protected:
 public:
   RGWGetObj_ObjStore() : sent_header(false) {}
 
-  void init(rgw::sal::RGWStore *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
     RGWGetObj::init(store, s, h);
     sent_header = false;
   }
@@ -504,7 +504,7 @@ protected:
   RGWRESTFlusher flusher;
 
 public:
-  void init(rgw::sal::RGWStore *store, struct req_state *s,
+  void init(rgw::sal::Store *store, struct req_state *s,
             RGWHandler *dialect_handler) override {
     RGWOp::init(store, s, dialect_handler);
     flusher.init(s, this);
@@ -597,7 +597,7 @@ public:
   }
 
   virtual RGWHandler_REST* get_handler(
-    rgw::sal::RGWStore *store,
+    rgw::sal::Store *store,
     struct req_state* const s,
     const rgw::auth::StrategyRegistry& auth_registry,
     const std::string& frontend_prefix
@@ -629,7 +629,7 @@ class RGWREST {
   static int preprocess(struct req_state *s, rgw::io::BasicClient* rio);
 public:
   RGWREST() {}
-  RGWHandler_REST *get_handler(rgw::sal::RGWStore *store,
+  RGWHandler_REST *get_handler(rgw::sal::Store *store,
                                struct req_state *s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string& frontend_prefix,

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -121,7 +121,7 @@ protected:
 public:
   RGWGetObj_ObjStore() : sent_header(false) {}
 
-  void init(rgw::sal::Store *store, struct req_state *s, RGWHandler *h) override {
+  void init(rgw::sal::Store* store, struct req_state *s, RGWHandler *h) override {
     RGWGetObj::init(store, s, h);
     sent_header = false;
   }
@@ -504,7 +504,7 @@ protected:
   RGWRESTFlusher flusher;
 
 public:
-  void init(rgw::sal::Store *store, struct req_state *s,
+  void init(rgw::sal::Store* store, struct req_state *s,
             RGWHandler *dialect_handler) override {
     RGWOp::init(store, s, dialect_handler);
     flusher.init(s, this);
@@ -597,7 +597,7 @@ public:
   }
 
   virtual RGWHandler_REST* get_handler(
-    rgw::sal::Store *store,
+    rgw::sal::Store* store,
     struct req_state* const s,
     const rgw::auth::StrategyRegistry& auth_registry,
     const std::string& frontend_prefix
@@ -629,7 +629,7 @@ class RGWREST {
   static int preprocess(struct req_state *s, rgw::io::BasicClient* rio);
 public:
   RGWREST() {}
-  RGWHandler_REST *get_handler(rgw::sal::Store *store,
+  RGWHandler_REST *get_handler(rgw::sal::Store* store,
                                struct req_state *s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string& frontend_prefix,

--- a/src/rgw/rgw_rest_bucket.cc
+++ b/src/rgw/rgw_rest_bucket.cc
@@ -214,7 +214,7 @@ void RGWOp_Bucket_Remove::execute(optional_yield y)
 {
   std::string bucket_name;
   bool delete_children;
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
 
   RESTArgs::get_string(s, "bucket", bucket_name, &bucket_name);
   RESTArgs::get_bool(s, "purge-objects", false, &delete_children);
@@ -282,7 +282,7 @@ void RGWOp_Set_Bucket_Quota::execute(optional_yield y)
     }
   }
   if (use_http_params) {
-    std::unique_ptr<rgw::sal::RGWBucket> bucket;
+    std::unique_ptr<rgw::sal::Bucket> bucket;
     op_ret = store->get_bucket(s, nullptr, uid.tenant, bucket_name, &bucket, s->yield);
     if (op_ret < 0) {
       return;

--- a/src/rgw/rgw_rest_bucket.h
+++ b/src/rgw/rgw_rest_bucket.h
@@ -27,7 +27,7 @@ public:
   RGWRESTMgr_Bucket() = default;
   ~RGWRESTMgr_Bucket() override = default;
 
-  RGWHandler_REST* get_handler(rgw::sal::Store *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store* store,
 			       struct req_state*,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string&) override {

--- a/src/rgw/rgw_rest_bucket.h
+++ b/src/rgw/rgw_rest_bucket.h
@@ -27,7 +27,7 @@ public:
   RGWRESTMgr_Bucket() = default;
   ~RGWRESTMgr_Bucket() override = default;
 
-  RGWHandler_REST* get_handler(rgw::sal::RGWStore *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store *store,
 			       struct req_state*,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string&) override {

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -671,7 +671,7 @@ int RGWRESTGenerateHTTPHeaders::sign(RGWAccessKey& key, const bufferlist *opt_co
   return 0;
 }
 
-void RGWRESTStreamS3PutObj::send_init(rgw::sal::RGWObject* obj)
+void RGWRESTStreamS3PutObj::send_init(rgw::sal::Object* obj)
 {
   string resource_str;
   string resource;
@@ -728,7 +728,7 @@ void RGWRESTStreamS3PutObj::send_ready(RGWAccessKey& key)
   out_cb = new RGWRESTStreamOutCB(this);
 }
 
-void RGWRESTStreamS3PutObj::put_obj_init(RGWAccessKey& key, rgw::sal::RGWObject* obj, map<string, bufferlist>& attrs)
+void RGWRESTStreamS3PutObj::put_obj_init(RGWAccessKey& key, rgw::sal::Object* obj, map<string, bufferlist>& attrs)
 {
   send_init(obj);
   send_ready(key, attrs);

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -234,13 +234,13 @@ public:
                 out_cb(NULL), new_info(cct, &new_env), headers_gen(_cct, &new_env, &new_info) {}
   ~RGWRESTStreamS3PutObj() override;
 
-  void send_init(rgw::sal::RGWObject* obj);
+  void send_init(rgw::sal::Object* obj);
   void send_ready(RGWAccessKey& key, map<string, bufferlist>& rgw_attrs);
   void send_ready(RGWAccessKey& key, const map<string, string>& http_attrs,
                   RGWAccessControlPolicy& policy);
   void send_ready(RGWAccessKey& key);
 
-  void put_obj_init(RGWAccessKey& key, rgw::sal::RGWObject* obj, map<string, bufferlist>& attrs);
+  void put_obj_init(RGWAccessKey& key, rgw::sal::Object* obj, map<string, bufferlist>& attrs);
 
   RGWGetDataCB *get_out_cb() { return out_cb; }
 };

--- a/src/rgw/rgw_rest_config.cc
+++ b/src/rgw/rgw_rest_config.cc
@@ -31,7 +31,7 @@
 #define dout_subsys ceph_subsys_rgw
 
 void RGWOp_ZoneGroupMap_Get::execute(optional_yield y) {
-  op_ret = zonegroup_map.read(g_ceph_context, static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->sysobj, y);
+  op_ret = zonegroup_map.read(g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, y);
   if (op_ret < 0) {
     dout(5) << "failed to read zone_group map" << dendl;
   }

--- a/src/rgw/rgw_rest_config.h
+++ b/src/rgw/rgw_rest_config.h
@@ -79,7 +79,7 @@ public:
   RGWRESTMgr_Config() = default;
   ~RGWRESTMgr_Config() override = default;
 
-  RGWHandler_REST* get_handler(rgw::sal::Store *,
+  RGWHandler_REST* get_handler(rgw::sal::Store* ,
 			       struct req_state*,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string&) override {

--- a/src/rgw/rgw_rest_config.h
+++ b/src/rgw/rgw_rest_config.h
@@ -79,7 +79,7 @@ public:
   RGWRESTMgr_Config() = default;
   ~RGWRESTMgr_Config() override = default;
 
-  RGWHandler_REST* get_handler(rgw::sal::RGWStore *,
+  RGWHandler_REST* get_handler(rgw::sal::Store *,
 			       struct req_state*,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string&) override {

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -27,7 +27,7 @@ RGWRESTConn::RGWRESTConn(CephContext *_cct, RGWSI_Zone *zone_svc,
   }
 }
 
-RGWRESTConn::RGWRESTConn(CephContext *_cct, rgw::sal::RGWStore* store,
+RGWRESTConn::RGWRESTConn(CephContext *_cct, rgw::sal::Store* store,
                          const string& _remote_id,
                          const list<string>& remote_endpoints,
                          std::optional<string> _api_name,
@@ -62,7 +62,7 @@ RGWRESTConn::RGWRESTConn(CephContext *_cct, RGWSI_Zone *zone_svc,
   }
 }
 
-RGWRESTConn::RGWRESTConn(CephContext *_cct, rgw::sal::RGWStore* store,
+RGWRESTConn::RGWRESTConn(CephContext *_cct, rgw::sal::Store* store,
                          const string& _remote_id,
                          const list<string>& remote_endpoints,
                          RGWAccessKey _cred,
@@ -145,7 +145,7 @@ int RGWRESTConn::forward(const rgw_user& uid, req_info& info, obj_version *objv,
   return req.forward_request(key, info, max_response, inbl, outbl, y);
 }
 
-int RGWRESTConn::put_obj_send_init(rgw::sal::RGWObject* obj, const rgw_http_param_pair *extra_params, RGWRESTStreamS3PutObj **req)
+int RGWRESTConn::put_obj_send_init(rgw::sal::Object* obj, const rgw_http_param_pair *extra_params, RGWRESTStreamS3PutObj **req)
 {
   string url;
   int ret = get_url(url);
@@ -166,7 +166,7 @@ int RGWRESTConn::put_obj_send_init(rgw::sal::RGWObject* obj, const rgw_http_para
   return 0;
 }
 
-int RGWRESTConn::put_obj_async_init(const rgw_user& uid, rgw::sal::RGWObject* obj,
+int RGWRESTConn::put_obj_async_init(const rgw_user& uid, rgw::sal::Object* obj,
                                     map<string, bufferlist>& attrs,
                                     RGWRESTStreamS3PutObj **req)
 {
@@ -216,7 +216,7 @@ static void set_header(T val, map<string, string>& headers, const string& header
 }
 
 
-int RGWRESTConn::get_obj(const rgw_user& uid, req_info *info /* optional */, const rgw::sal::RGWObject* obj,
+int RGWRESTConn::get_obj(const rgw_user& uid, req_info *info /* optional */, const rgw::sal::Object* obj,
                          const real_time *mod_ptr, const real_time *unmod_ptr,
                          uint32_t mod_zone_id, uint64_t mod_pg_ver,
                          bool prepend_metadata, bool get_op, bool rgwx_stat,
@@ -237,7 +237,7 @@ int RGWRESTConn::get_obj(const rgw_user& uid, req_info *info /* optional */, con
   return get_obj(obj, params, send, req);
 }
 
-int RGWRESTConn::get_obj(const rgw::sal::RGWObject* obj, const get_obj_params& in_params, bool send, RGWRESTStreamRWRequest **req)
+int RGWRESTConn::get_obj(const rgw::sal::Object* obj, const get_obj_params& in_params, bool send, RGWRESTStreamRWRequest **req)
 {
   string url;
   int ret = get_url(url);

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -11,7 +11,7 @@
 #include <atomic>
 
 namespace rgw { namespace sal {
-  class RGWStore;
+  class Store;
 } }
 
 class RGWSI_Zone;
@@ -88,7 +88,7 @@ public:
               std::optional<string> _api_name,
               HostStyle _host_style = PathStyle);
   RGWRESTConn(CephContext *_cct,
-              rgw::sal::RGWStore* store,
+              rgw::sal::Store* store,
               const string& _remote_id,
               const list<string>& endpoints,
               std::optional<string> _api_name,
@@ -101,7 +101,7 @@ public:
               std::optional<string> _api_name,
               HostStyle _host_style = PathStyle);
   RGWRESTConn(CephContext *_cct,
-              rgw::sal::RGWStore* store,
+              rgw::sal::Store* store,
               const string& _remote_id,
               const list<string>& endpoints,
               RGWAccessKey _cred,
@@ -145,8 +145,8 @@ public:
 
 
   /* async requests */
-  int put_obj_send_init(rgw::sal::RGWObject* obj, const rgw_http_param_pair *extra_params, RGWRESTStreamS3PutObj **req);
-  int put_obj_async_init(const rgw_user& uid, rgw::sal::RGWObject* obj,
+  int put_obj_send_init(rgw::sal::Object* obj, const rgw_http_param_pair *extra_params, RGWRESTStreamS3PutObj **req);
+  int put_obj_async_init(const rgw_user& uid, rgw::sal::Object* obj,
                          map<string, bufferlist>& attrs, RGWRESTStreamS3PutObj **req);
   int complete_request(RGWRESTStreamS3PutObj *req, string& etag,
                        ceph::real_time *mtime, optional_yield y);
@@ -176,9 +176,9 @@ public:
     uint64_t range_end{0};
   };
 
-  int get_obj(const rgw::sal::RGWObject* obj, const get_obj_params& params, bool send, RGWRESTStreamRWRequest **req);
+  int get_obj(const rgw::sal::Object* obj, const get_obj_params& params, bool send, RGWRESTStreamRWRequest **req);
 
-  int get_obj(const rgw_user& uid, req_info *info /* optional */, const rgw::sal::RGWObject* obj,
+  int get_obj(const rgw_user& uid, req_info *info /* optional */, const rgw::sal::Object* obj,
               const ceph::real_time *mod_ptr, const ceph::real_time *unmod_ptr,
               uint32_t mod_zone_id, uint64_t mod_pg_ver,
               bool prepend_metadata, bool get_op, bool rgwx_stat, bool sync_manifest,
@@ -232,13 +232,13 @@ public:
   S3RESTConn(CephContext *_cct, RGWSI_Zone *svc_zone, const string& _remote_id, const list<string>& endpoints, std::optional<std::string> _api_name, HostStyle _host_style = PathStyle) :
     RGWRESTConn(_cct, svc_zone, _remote_id, endpoints, _api_name, _host_style) {}
 
-  S3RESTConn(CephContext *_cct, rgw::sal::RGWStore* store, const string& _remote_id, const list<string>& endpoints, std::optional<std::string> _api_name, HostStyle _host_style = PathStyle) :
+  S3RESTConn(CephContext *_cct, rgw::sal::Store* store, const string& _remote_id, const list<string>& endpoints, std::optional<std::string> _api_name, HostStyle _host_style = PathStyle) :
     RGWRESTConn(_cct, store, _remote_id, endpoints, _api_name, _host_style) {}
 
   S3RESTConn(CephContext *_cct, RGWSI_Zone *svc_zone, const string& _remote_id, const list<string>& endpoints, RGWAccessKey _cred, std::optional<std::string> _api_name, HostStyle _host_style = PathStyle):
     RGWRESTConn(_cct, svc_zone, _remote_id, endpoints, _cred, _api_name, _host_style) {}
 
-  S3RESTConn(CephContext *_cct, rgw::sal::RGWStore* store, const string& _remote_id, const list<string>& endpoints, RGWAccessKey _cred, std::optional<std::string> _api_name, HostStyle _host_style = PathStyle):
+  S3RESTConn(CephContext *_cct, rgw::sal::Store* store, const string& _remote_id, const list<string>& endpoints, RGWAccessKey _cred, std::optional<std::string> _api_name, HostStyle _host_style = PathStyle):
     RGWRESTConn(_cct, store, _remote_id, endpoints, _cred, _api_name, _host_style) {}
   ~S3RESTConn() override = default;
 

--- a/src/rgw/rgw_rest_iam.cc
+++ b/src/rgw/rgw_rest_iam.cc
@@ -82,7 +82,7 @@ RGWOp *RGWHandler_REST_IAM::op_post()
   return nullptr;
 }
 
-int RGWHandler_REST_IAM::init(rgw::sal::Store *store,
+int RGWHandler_REST_IAM::init(rgw::sal::Store* store,
                               struct req_state *s,
                               rgw::io::BasicClient *cio)
 {
@@ -144,7 +144,7 @@ int RGWHandler_REST_IAM::init_from_header(struct req_state* s,
 }
 
 RGWHandler_REST*
-RGWRESTMgr_IAM::get_handler(rgw::sal::Store *store,
+RGWRESTMgr_IAM::get_handler(rgw::sal::Store* store,
 			    struct req_state* const s,
 			    const rgw::auth::StrategyRegistry& auth_registry,
 			    const std::string& frontend_prefix)

--- a/src/rgw/rgw_rest_iam.cc
+++ b/src/rgw/rgw_rest_iam.cc
@@ -82,7 +82,7 @@ RGWOp *RGWHandler_REST_IAM::op_post()
   return nullptr;
 }
 
-int RGWHandler_REST_IAM::init(rgw::sal::RGWStore *store,
+int RGWHandler_REST_IAM::init(rgw::sal::Store *store,
                               struct req_state *s,
                               rgw::io::BasicClient *cio)
 {
@@ -144,7 +144,7 @@ int RGWHandler_REST_IAM::init_from_header(struct req_state* s,
 }
 
 RGWHandler_REST*
-RGWRESTMgr_IAM::get_handler(rgw::sal::RGWStore *store,
+RGWRESTMgr_IAM::get_handler(rgw::sal::Store *store,
 			    struct req_state* const s,
 			    const rgw::auth::StrategyRegistry& auth_registry,
 			    const std::string& frontend_prefix)

--- a/src/rgw/rgw_rest_iam.h
+++ b/src/rgw/rgw_rest_iam.h
@@ -22,7 +22,7 @@ public:
       post_body(post_body) {}
   ~RGWHandler_REST_IAM() override = default;
 
-  int init(rgw::sal::Store *store,
+  int init(rgw::sal::Store* store,
            struct req_state *s,
            rgw::io::BasicClient *cio) override;
   int authorize(const DoutPrefixProvider* dpp, optional_yield y) override;
@@ -40,7 +40,7 @@ public:
     return this;
   }
 
-  RGWHandler_REST* get_handler(rgw::sal::Store *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store* store,
 			       struct req_state*,
                                const rgw::auth::StrategyRegistry&,
                                const std::string&) override;

--- a/src/rgw/rgw_rest_iam.h
+++ b/src/rgw/rgw_rest_iam.h
@@ -22,7 +22,7 @@ public:
       post_body(post_body) {}
   ~RGWHandler_REST_IAM() override = default;
 
-  int init(rgw::sal::RGWStore *store,
+  int init(rgw::sal::Store *store,
            struct req_state *s,
            rgw::io::BasicClient *cio) override;
   int authorize(const DoutPrefixProvider* dpp, optional_yield y) override;
@@ -40,7 +40,7 @@ public:
     return this;
   }
 
-  RGWHandler_REST* get_handler(rgw::sal::RGWStore *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store *store,
 			       struct req_state*,
                                const rgw::auth::StrategyRegistry&,
                                const std::string&) override;

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -82,7 +82,7 @@ void RGWOp_MDLog_List::execute(optional_yield y) {
     }
   }
 
-  RGWMetadataLog meta_log{s->cct, static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->zone, static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->cls, period};
+  RGWMetadataLog meta_log{s->cct, static_cast<rgw::sal::RadosStore*>(store)->svc()->zone, static_cast<rgw::sal::RadosStore*>(store)->svc()->cls, period};
 
   meta_log.init_list_entries(shard_id, {}, {}, marker, &handle);
 
@@ -108,7 +108,7 @@ void RGWOp_MDLog_List::send_response() {
     for (list<cls_log_entry>::iterator iter = entries.begin();
 	 iter != entries.end(); ++iter) {
       cls_log_entry& entry = *iter;
-      static_cast<rgw::sal::RGWRadosStore*>(store)->ctl()->meta.mgr->dump_log_entry(entry, s->formatter);
+      static_cast<rgw::sal::RadosStore*>(store)->ctl()->meta.mgr->dump_log_entry(entry, s->formatter);
       flusher.flush();
     }
     s->formatter->close_section();
@@ -119,7 +119,7 @@ void RGWOp_MDLog_List::send_response() {
 
 void RGWOp_MDLog_Info::execute(optional_yield y) {
   num_objects = s->cct->_conf->rgw_md_log_max_shards;
-  period = static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->mdlog->read_oldest_log_period(y, s);
+  period = static_cast<rgw::sal::RadosStore*>(store)->svc()->mdlog->read_oldest_log_period(y, s);
   op_ret = period.get_error();
 }
 
@@ -160,7 +160,7 @@ void RGWOp_MDLog_ShardInfo::execute(optional_yield y) {
       return;
     }
   }
-  RGWMetadataLog meta_log{s->cct, static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->zone, static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->cls, period};
+  RGWMetadataLog meta_log{s->cct, static_cast<rgw::sal::RadosStore*>(store)->svc()->zone, static_cast<rgw::sal::RadosStore*>(store)->svc()->cls, period};
 
   op_ret = meta_log.get_info(shard_id, &info);
 }
@@ -226,7 +226,7 @@ void RGWOp_MDLog_Delete::execute(optional_yield y) {
       return;
     }
   }
-  RGWMetadataLog meta_log{s->cct, static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->zone, static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->cls, period};
+  RGWMetadataLog meta_log{s->cct, static_cast<rgw::sal::RadosStore*>(store)->svc()->zone, static_cast<rgw::sal::RadosStore*>(store)->svc()->cls, period};
 
   op_ret = meta_log.trim(shard_id, {}, {}, {}, marker);
 }
@@ -266,7 +266,7 @@ void RGWOp_MDLog_Lock::execute(optional_yield y) {
     return;
   }
 
-  RGWMetadataLog meta_log{s->cct, static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->zone, static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->cls, period};
+  RGWMetadataLog meta_log{s->cct, static_cast<rgw::sal::RadosStore*>(store)->svc()->zone, static_cast<rgw::sal::RadosStore*>(store)->svc()->cls, period};
   unsigned dur;
   dur = (unsigned)strict_strtol(duration_str.c_str(), 10, &err);
   if (!err.empty() || dur <= 0) {
@@ -313,7 +313,7 @@ void RGWOp_MDLog_Unlock::execute(optional_yield y) {
     return;
   }
 
-  RGWMetadataLog meta_log{s->cct, static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->zone, static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->cls, period};
+  RGWMetadataLog meta_log{s->cct, static_cast<rgw::sal::RadosStore*>(store)->svc()->zone, static_cast<rgw::sal::RadosStore*>(store)->svc()->cls, period};
   op_ret = meta_log.unlock(shard_id, zone_id, locker_id);
 }
 
@@ -365,7 +365,7 @@ void RGWOp_BILog_List::execute(optional_yield y) {
          marker = s->info.args.get("marker"),
          max_entries_str = s->info.args.get("max-entries"),
          bucket_instance = s->info.args.get("bucket-instance");
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
   rgw_bucket b(rgw_bucket_key(tenant_name, bucket_name));
   unsigned max_entries;
 
@@ -403,7 +403,7 @@ void RGWOp_BILog_List::execute(optional_yield y) {
   send_response();
   do {
     list<rgw_bi_log_entry> entries;
-    int ret = static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->bilog_rados->log_list(bucket->get_info(), shard_id,
+    int ret = static_cast<rgw::sal::RadosStore*>(store)->svc()->bilog_rados->log_list(bucket->get_info(), shard_id,
                                                marker, max_entries - count, 
                                                entries, &truncated);
     if (ret < 0) {
@@ -455,7 +455,7 @@ void RGWOp_BILog_Info::execute(optional_yield y) {
   string tenant_name = s->info.args.get("tenant"),
          bucket_name = s->info.args.get("bucket"),
          bucket_instance = s->info.args.get("bucket-instance");
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
   rgw_bucket b(rgw_bucket_key(tenant_name, bucket_name));
 
   if (bucket_name.empty() && bucket_instance.empty()) {
@@ -514,7 +514,7 @@ void RGWOp_BILog_Delete::execute(optional_yield y) {
          end_marker = s->info.args.get("end-marker"),
          bucket_instance = s->info.args.get("bucket-instance");
 
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
   rgw_bucket b(rgw_bucket_key(tenant_name, bucket_name));
 
   op_ret = 0;
@@ -542,7 +542,7 @@ void RGWOp_BILog_Delete::execute(optional_yield y) {
     return;
   }
 
-  op_ret = static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->bilog_rados->log_trim(bucket->get_info(), shard_id, start_marker, end_marker);
+  op_ret = static_cast<rgw::sal::RadosStore*>(store)->svc()->bilog_rados->log_trim(bucket->get_info(), shard_id, start_marker, end_marker);
   if (op_ret < 0) {
     ldpp_dout(s, 5) << "ERROR: trim_bi_log_entries() " << dendl;
   }
@@ -586,7 +586,7 @@ void RGWOp_DATALog_List::execute(optional_yield y) {
 
   // Note that last_marker is updated to be the marker of the last
   // entry listed
-  op_ret = static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->datalog_rados->list_entries(shard_id,
+  op_ret = static_cast<rgw::sal::RadosStore*>(store)->svc()->datalog_rados->list_entries(shard_id,
 						     max_entries, entries,
 						     marker, &last_marker,
 						     &truncated);
@@ -647,7 +647,7 @@ void RGWOp_DATALog_ShardInfo::execute(optional_yield y) {
     return;
   }
 
-  op_ret = static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->datalog_rados->get_info(shard_id, &info);
+  op_ret = static_cast<rgw::sal::RadosStore*>(store)->svc()->datalog_rados->get_info(shard_id, &info);
 }
 
 void RGWOp_DATALog_ShardInfo::send_response() {
@@ -745,7 +745,7 @@ void RGWOp_DATALog_Delete::execute(optional_yield y) {
     return;
   }
 
-  op_ret = static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->datalog_rados->trim_entries(shard_id, marker);
+  op_ret = static_cast<rgw::sal::RadosStore*>(store)->svc()->datalog_rados->trim_entries(shard_id, marker);
 }
 
 // not in header to avoid pulling in rgw_sync.h
@@ -765,7 +765,7 @@ public:
 
 void RGWOp_MDLog_Status::execute(optional_yield y)
 {
-  auto sync = static_cast<rgw::sal::RGWRadosStore*>(store)->getRados()->get_meta_sync_manager();
+  auto sync = static_cast<rgw::sal::RadosStore*>(store)->getRados()->get_meta_sync_manager();
   if (sync == nullptr) {
     ldout(s->cct, 1) << "no sync manager" << dendl;
     op_ret = -ENOENT;
@@ -827,7 +827,7 @@ void RGWOp_BILog_Status::execute(optional_yield y)
   }
 
   // read the bucket instance info for num_shards
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
   op_ret = store->get_bucket(s, nullptr, b, &bucket, y);
   if (op_ret < 0) {
     ldpp_dout(s, 4) << "failed to read bucket info: " << cpp_strerror(op_ret) << dendl;
@@ -858,7 +858,7 @@ void RGWOp_BILog_Status::execute(optional_yield y)
 
     ldout(s->cct, 20) << "RGWOp_BILog_Status::execute(optional_yield y): getting sync status for pipe=" << pipe << dendl;
 
-    op_ret = rgw_bucket_sync_status(this, static_cast<rgw::sal::RGWRadosStore*>(store), pipe, bucket->get_info(), nullptr, &status);
+    op_ret = rgw_bucket_sync_status(this, static_cast<rgw::sal::RadosStore*>(store), pipe, bucket->get_info(), nullptr, &status);
 
     if (op_ret < 0) {
       lderr(s->cct) << "ERROR: rgw_bucket_sync_status() on pipe=" << pipe << " returned ret=" << op_ret << dendl;
@@ -895,7 +895,7 @@ void RGWOp_BILog_Status::execute(optional_yield y)
 
     if (*pipe.dest.bucket != pinfo->bucket) {
       opt_dest_info.emplace();
-      std::unique_ptr<rgw::sal::RGWBucket> dest_bucket;
+      std::unique_ptr<rgw::sal::Bucket> dest_bucket;
       op_ret = store->get_bucket(s, nullptr, *pipe.dest.bucket, &dest_bucket, y);
       if (op_ret < 0) {
         ldpp_dout(s, 4) << "failed to read target bucket info (bucket=: " << cpp_strerror(op_ret) << dendl;
@@ -907,7 +907,7 @@ void RGWOp_BILog_Status::execute(optional_yield y)
       pipe.dest.bucket = pinfo->bucket;
     }
 
-    int r = rgw_bucket_sync_status(this, static_cast<rgw::sal::RGWRadosStore*>(store), pipe, *pinfo, &bucket->get_info(), &current_status);
+    int r = rgw_bucket_sync_status(this, static_cast<rgw::sal::RadosStore*>(store), pipe, *pinfo, &bucket->get_info(), &current_status);
     if (r < 0) {
       lderr(s->cct) << "ERROR: rgw_bucket_sync_status() on pipe=" << pipe << " returned ret=" << r << dendl;
       op_ret = r;

--- a/src/rgw/rgw_rest_log.h
+++ b/src/rgw/rgw_rest_log.h
@@ -303,7 +303,7 @@ public:
   RGWRESTMgr_Log() = default;
   ~RGWRESTMgr_Log() override = default;
 
-  RGWHandler_REST* get_handler(rgw::sal::RGWStore *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store *store,
 			       struct req_state* const,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string& frontend_prefixs) override {

--- a/src/rgw/rgw_rest_log.h
+++ b/src/rgw/rgw_rest_log.h
@@ -303,7 +303,7 @@ public:
   RGWRESTMgr_Log() = default;
   ~RGWRESTMgr_Log() override = default;
 
-  RGWHandler_REST* get_handler(rgw::sal::Store *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store* store,
 			       struct req_state* const,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string& frontend_prefixs) override {

--- a/src/rgw/rgw_rest_metadata.cc
+++ b/src/rgw/rgw_rest_metadata.cc
@@ -54,7 +54,7 @@ void RGWOp_Metadata_Get::execute(optional_yield y) {
 
   frame_metadata_key(s, metadata_key);
 
-  auto meta_mgr = static_cast<rgw::sal::RGWRadosStore*>(store)->ctl()->meta.mgr;
+  auto meta_mgr = static_cast<rgw::sal::RadosStore*>(store)->ctl()->meta.mgr;
 
   /* Get keys */
   op_ret = meta_mgr->get(metadata_key, s->formatter, s->yield, s);
@@ -261,7 +261,7 @@ void RGWOp_Metadata_Put::execute(optional_yield y) {
     }
   }
 
-  op_ret = static_cast<rgw::sal::RGWRadosStore*>(store)->ctl()->meta.mgr->put(metadata_key, bl, s->yield, s, sync_type,
+  op_ret = static_cast<rgw::sal::RadosStore*>(store)->ctl()->meta.mgr->put(metadata_key, bl, s->yield, s, sync_type,
 				       false, &ondisk_version);
   if (op_ret < 0) {
     ldpp_dout(s, 5) << "ERROR: can't put key: " << cpp_strerror(op_ret) << dendl;
@@ -292,7 +292,7 @@ void RGWOp_Metadata_Delete::execute(optional_yield y) {
   string metadata_key;
 
   frame_metadata_key(s, metadata_key);
-  op_ret = static_cast<rgw::sal::RGWRadosStore*>(store)->ctl()->meta.mgr->remove(metadata_key, s->yield, s);
+  op_ret = static_cast<rgw::sal::RadosStore*>(store)->ctl()->meta.mgr->remove(metadata_key, s->yield, s);
   if (op_ret < 0) {
     ldpp_dout(s, 5) << "ERROR: can't remove key: " << cpp_strerror(op_ret) << dendl;
     return;

--- a/src/rgw/rgw_rest_metadata.h
+++ b/src/rgw/rgw_rest_metadata.h
@@ -98,7 +98,7 @@ public:
   RGWRESTMgr_Metadata() = default;
   ~RGWRESTMgr_Metadata() override = default;
 
-  RGWHandler_REST* get_handler(rgw::sal::RGWStore *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store *store,
 			       struct req_state* const s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string& frontend_prefix) override {

--- a/src/rgw/rgw_rest_metadata.h
+++ b/src/rgw/rgw_rest_metadata.h
@@ -98,7 +98,7 @@ public:
   RGWRESTMgr_Metadata() = default;
   ~RGWRESTMgr_Metadata() override = default;
 
-  RGWHandler_REST* get_handler(rgw::sal::Store *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store* store,
 			       struct req_state* const s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string& frontend_prefix) override {

--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -492,7 +492,7 @@ void RGWPSCreateNotif_ObjStore_S3::execute(optional_yield y) {
     return;
   }
 
-  ps.emplace(static_cast<rgw::sal::RGWRadosStore*>(store), s->owner.get_id().tenant);
+  ps.emplace(static_cast<rgw::sal::RadosStore*>(store), s->owner.get_id().tenant);
   auto b = ps->get_bucket(bucket_info.bucket);
   ceph_assert(b);
   std::string data_bucket_prefix = "";
@@ -635,7 +635,7 @@ void RGWPSDeleteNotif_ObjStore_S3::execute(optional_yield y) {
     return;
   }
 
-  ps.emplace(static_cast<rgw::sal::RGWRadosStore*>(store), s->owner.get_id().tenant);
+  ps.emplace(static_cast<rgw::sal::RadosStore*>(store), s->owner.get_id().tenant);
   auto b = ps->get_bucket(bucket_info.bucket);
   ceph_assert(b);
 
@@ -734,7 +734,7 @@ public:
 };
 
 void RGWPSListNotifs_ObjStore_S3::execute(optional_yield y) {
-  ps.emplace(static_cast<rgw::sal::RGWRadosStore*>(store), s->owner.get_id().tenant);
+  ps.emplace(static_cast<rgw::sal::RadosStore*>(store), s->owner.get_id().tenant);
   auto b = ps->get_bucket(bucket_info.bucket);
   ceph_assert(b);
   

--- a/src/rgw/rgw_rest_pubsub_common.cc
+++ b/src/rgw/rgw_rest_pubsub_common.cc
@@ -53,7 +53,7 @@ void RGWPSCreateTopicOp::execute(optional_yield y) {
     return;
   }
 
-  ps.emplace(static_cast<rgw::sal::RGWRadosStore*>(store), s->owner.get_id().tenant);
+  ps.emplace(static_cast<rgw::sal::RadosStore*>(store), s->owner.get_id().tenant);
   op_ret = ps->create_topic(topic_name, dest, topic_arn, opaque_data, y);
   if (op_ret < 0) {
     ldout(s->cct, 1) << "failed to create topic '" << topic_name << "', ret=" << op_ret << dendl;
@@ -63,7 +63,7 @@ void RGWPSCreateTopicOp::execute(optional_yield y) {
 }
 
 void RGWPSListTopicsOp::execute(optional_yield y) {
-  ps.emplace(static_cast<rgw::sal::RGWRadosStore*>(store), s->owner.get_id().tenant);
+  ps.emplace(static_cast<rgw::sal::RadosStore*>(store), s->owner.get_id().tenant);
   op_ret = ps->get_topics(&result);
   // if there are no topics it is not considered an error
   op_ret = op_ret == -ENOENT ? 0 : op_ret;
@@ -84,7 +84,7 @@ void RGWPSGetTopicOp::execute(optional_yield y) {
   if (op_ret < 0) {
     return;
   }
-  ps.emplace(static_cast<rgw::sal::RGWRadosStore*>(store), s->owner.get_id().tenant);
+  ps.emplace(static_cast<rgw::sal::RadosStore*>(store), s->owner.get_id().tenant);
   op_ret = ps->get_topic(topic_name, &result);
   if (topic_has_endpoint_secret(result) && !rgw_transport_is_secure(s->cct, *(s->info.env))) {
     ldout(s->cct, 1) << "topic '" << topic_name << "' contain secret and cannot be sent over insecure transport" << dendl;
@@ -103,7 +103,7 @@ void RGWPSDeleteTopicOp::execute(optional_yield y) {
   if (op_ret < 0) {
     return;
   }
-  ps.emplace(static_cast<rgw::sal::RGWRadosStore*>(store), s->owner.get_id().tenant);
+  ps.emplace(static_cast<rgw::sal::RadosStore*>(store), s->owner.get_id().tenant);
   op_ret = ps->remove_topic(topic_name, y);
   if (op_ret < 0) {
     ldout(s->cct, 1) << "failed to remove topic '" << topic_name << ", ret=" << op_ret << dendl;
@@ -117,7 +117,7 @@ void RGWPSCreateSubOp::execute(optional_yield y) {
   if (op_ret < 0) {
     return;
   }
-  ps.emplace(static_cast<rgw::sal::RGWRadosStore*>(store), s->owner.get_id().tenant);
+  ps.emplace(static_cast<rgw::sal::RadosStore*>(store), s->owner.get_id().tenant);
   auto sub = ps->get_sub(sub_name);
   op_ret = sub->subscribe(topic_name, dest, y);
   if (op_ret < 0) {
@@ -132,7 +132,7 @@ void RGWPSGetSubOp::execute(optional_yield y) {
   if (op_ret < 0) {
     return;
   }
-  ps.emplace(static_cast<rgw::sal::RGWRadosStore*>(store), s->owner.get_id().tenant);
+  ps.emplace(static_cast<rgw::sal::RadosStore*>(store), s->owner.get_id().tenant);
   auto sub = ps->get_sub(sub_name);
   op_ret = sub->get_conf(&result);
   if (subscription_has_endpoint_secret(result) && !rgw_transport_is_secure(s->cct, *(s->info.env))) {
@@ -152,7 +152,7 @@ void RGWPSDeleteSubOp::execute(optional_yield y) {
   if (op_ret < 0) {
     return;
   }
-  ps.emplace(static_cast<rgw::sal::RGWRadosStore*>(store), s->owner.get_id().tenant);
+  ps.emplace(static_cast<rgw::sal::RadosStore*>(store), s->owner.get_id().tenant);
   auto sub = ps->get_sub(sub_name);
   op_ret = sub->unsubscribe(topic_name, y);
   if (op_ret < 0) {
@@ -167,7 +167,7 @@ void RGWPSAckSubEventOp::execute(optional_yield y) {
   if (op_ret < 0) {
     return;
   }
-  ps.emplace(static_cast<rgw::sal::RGWRadosStore*>(store), s->owner.get_id().tenant);
+  ps.emplace(static_cast<rgw::sal::RadosStore*>(store), s->owner.get_id().tenant);
   auto sub = ps->get_sub_with_events(sub_name);
   op_ret = sub->remove_event(s, event_id);
   if (op_ret < 0) {
@@ -182,7 +182,7 @@ void RGWPSPullSubEventsOp::execute(optional_yield y) {
   if (op_ret < 0) {
     return;
   }
-  ps.emplace(static_cast<rgw::sal::RGWRadosStore*>(store), s->owner.get_id().tenant);
+  ps.emplace(static_cast<rgw::sal::RadosStore*>(store), s->owner.get_id().tenant);
   sub = ps->get_sub_with_events(sub_name);
   if (!sub) {
     op_ret = -ENOENT;
@@ -204,8 +204,8 @@ int RGWPSCreateNotifOp::verify_permission(optional_yield y) {
     return ret;
   }
 
-  std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(s->owner.get_id());
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::User> user = store->get_user(s->owner.get_id());
+  std::unique_ptr<rgw::sal::Bucket> bucket;
   ret = store->get_bucket(this, user.get(), s->owner.get_id().tenant, bucket_name, &bucket, y);
   if (ret < 0) {
     ldout(s->cct, 1) << "failed to get bucket info, cannot verify ownership" << dendl;
@@ -226,8 +226,8 @@ int RGWPSDeleteNotifOp::verify_permission(optional_yield y) {
     return ret;
   }
 
-  std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(s->owner.get_id());
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::User> user = store->get_user(s->owner.get_id());
+  std::unique_ptr<rgw::sal::Bucket> bucket;
   ret = store->get_bucket(this, user.get(), s->owner.get_id().tenant, bucket_name, &bucket, y);
   if (ret < 0) {
     return ret;
@@ -247,8 +247,8 @@ int RGWPSListNotifsOp::verify_permission(optional_yield y) {
     return ret;
   }
 
-  std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(s->owner.get_id());
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::User> user = store->get_user(s->owner.get_id());
+  std::unique_ptr<rgw::sal::Bucket> bucket;
   ret = store->get_bucket(this, user.get(), s->owner.get_id().tenant, bucket_name, &bucket, y);
   if (ret < 0) {
     return ret;

--- a/src/rgw/rgw_rest_realm.cc
+++ b/src/rgw/rgw_rest_realm.cc
@@ -248,7 +248,7 @@ class RGWHandler_Period : public RGWHandler_Auth_S3 {
 
 class RGWRESTMgr_Period : public RGWRESTMgr {
  public:
-  RGWHandler_REST* get_handler(rgw::sal::Store *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store* store,
 			       struct req_state*,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string&) override {
@@ -365,7 +365,7 @@ RGWRESTMgr_Realm::RGWRESTMgr_Realm()
 }
 
 RGWHandler_REST*
-RGWRESTMgr_Realm::get_handler(rgw::sal::Store *store,
+RGWRESTMgr_Realm::get_handler(rgw::sal::Store* store,
 			      struct req_state*,
                               const rgw::auth::StrategyRegistry& auth_registry,
                               const std::string&)

--- a/src/rgw/rgw_rest_realm.cc
+++ b/src/rgw/rgw_rest_realm.cc
@@ -73,7 +73,7 @@ void RGWOp_Period_Get::execute(optional_yield y)
   period.set_id(period_id);
   period.set_epoch(epoch);
 
-  op_ret = period.init(store->ctx(), static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->sysobj, realm_id, y, realm_name);
+  op_ret = period.init(store->ctx(), static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, realm_id, y, realm_name);
   if (op_ret < 0)
     ldout(store->ctx(), 5) << "failed to read period" << dendl;
 }
@@ -97,7 +97,7 @@ void RGWOp_Period_Post::execute(optional_yield y)
   auto cct = store->ctx();
 
   // initialize the period without reading from rados
-  period.init(cct, static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->sysobj, y, false);
+  period.init(cct, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, y, false);
 
   // decode the period from input
   const auto max_size = cct->_conf->rgw_max_put_param_size;
@@ -120,7 +120,7 @@ void RGWOp_Period_Post::execute(optional_yield y)
   // period that we haven't restarted with yet. we also don't want to modify
   // the objects in use by RGWRados
   RGWRealm realm(period.get_realm());
-  op_ret = realm.init(cct, static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->sysobj, y);
+  op_ret = realm.init(cct, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, y);
   if (op_ret < 0) {
     lderr(cct) << "failed to read current realm: "
         << cpp_strerror(-op_ret) << dendl;
@@ -128,7 +128,7 @@ void RGWOp_Period_Post::execute(optional_yield y)
   }
 
   RGWPeriod current_period;
-  op_ret = current_period.init(cct, static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->sysobj, realm.get_id(), y);
+  op_ret = current_period.init(cct, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, realm.get_id(), y);
   if (op_ret < 0) {
     lderr(cct) << "failed to read current period: "
         << cpp_strerror(-op_ret) << dendl;
@@ -172,7 +172,7 @@ void RGWOp_Period_Post::execute(optional_yield y)
     return;
   }
 
-  auto period_history = static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->mdlog->get_period_history();
+  auto period_history = static_cast<rgw::sal::RadosStore*>(store)->svc()->mdlog->get_period_history();
 
   // decide whether we can set_current_period() or set_latest_epoch()
   if (period.get_id() != current_period.get_id()) {
@@ -248,7 +248,7 @@ class RGWHandler_Period : public RGWHandler_Auth_S3 {
 
 class RGWRESTMgr_Period : public RGWRESTMgr {
  public:
-  RGWHandler_REST* get_handler(rgw::sal::RGWStore *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store *store,
 			       struct req_state*,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string&) override {
@@ -281,7 +281,7 @@ void RGWOp_Realm_Get::execute(optional_yield y)
 
   // read realm
   realm.reset(new RGWRealm(id, name));
-  op_ret = realm->init(g_ceph_context, static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->sysobj, y);
+  op_ret = realm->init(g_ceph_context, static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj, y);
   if (op_ret < 0)
     lderr(store->ctx()) << "failed to read realm id=" << id
         << " name=" << name << dendl;
@@ -322,10 +322,10 @@ void RGWOp_Realm_List::execute(optional_yield y)
 {
   {
     // read default realm
-    RGWRealm realm(store->ctx(), static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->sysobj);
+    RGWRealm realm(store->ctx(), static_cast<rgw::sal::RadosStore*>(store)->svc()->sysobj);
     [[maybe_unused]] int ret = realm.read_default_id(default_id, y);
   }
-  op_ret = static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->zone->list_realms(realms);
+  op_ret = static_cast<rgw::sal::RadosStore*>(store)->svc()->zone->list_realms(realms);
   if (op_ret < 0)
     lderr(store->ctx()) << "failed to list realms" << dendl;
 }
@@ -365,7 +365,7 @@ RGWRESTMgr_Realm::RGWRESTMgr_Realm()
 }
 
 RGWHandler_REST*
-RGWRESTMgr_Realm::get_handler(rgw::sal::RGWStore *store,
+RGWRESTMgr_Realm::get_handler(rgw::sal::Store *store,
 			      struct req_state*,
                               const rgw::auth::StrategyRegistry& auth_registry,
                               const std::string&)

--- a/src/rgw/rgw_rest_realm.h
+++ b/src/rgw/rgw_rest_realm.h
@@ -9,7 +9,7 @@ class RGWRESTMgr_Realm : public RGWRESTMgr {
 public:
   RGWRESTMgr_Realm();
 
-  RGWHandler_REST* get_handler(rgw::sal::Store *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store* store,
 			       struct req_state*,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string&) override;

--- a/src/rgw/rgw_rest_realm.h
+++ b/src/rgw/rgw_rest_realm.h
@@ -9,7 +9,7 @@ class RGWRESTMgr_Realm : public RGWRESTMgr {
 public:
   RGWRESTMgr_Realm();
 
-  RGWHandler_REST* get_handler(rgw::sal::RGWStore *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store *store,
 			       struct req_state*,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string&) override;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -85,7 +85,7 @@ void list_all_buckets_end(struct req_state *s)
   s->formatter->close_section();
 }
 
-void dump_bucket(struct req_state *s, rgw::sal::RGWBucket& obj)
+void dump_bucket(struct req_state *s, rgw::sal::Bucket& obj)
 {
   s->formatter->open_object_section("Bucket");
   s->formatter->dump_string("Name", obj.get_name());
@@ -926,13 +926,13 @@ struct ReplicationConfiguration {
       }
     };
 
-    set<rgw_zone_id> get_zone_ids_from_names(rgw::sal::RGWStore *store,
+    set<rgw_zone_id> get_zone_ids_from_names(rgw::sal::Store *store,
                                              const vector<string>& zone_names) const {
       set<rgw_zone_id> ids;
 
       for (auto& name : zone_names) {
         rgw_zone_id id;
-        if (static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->zone->find_zone_id_by_name(name, &id)) {
+        if (static_cast<rgw::sal::RadosStore*>(store)->svc()->zone->find_zone_id_by_name(name, &id)) {
           ids.insert(std::move(id));
         }
       }
@@ -940,13 +940,13 @@ struct ReplicationConfiguration {
       return ids;
     }
 
-    vector<string> get_zone_names_from_ids(rgw::sal::RGWStore *store,
+    vector<string> get_zone_names_from_ids(rgw::sal::Store *store,
                                            const set<rgw_zone_id>& zone_ids) const {
       vector<string> names;
 
       for (auto& id : zone_ids) {
         RGWZone *zone;
-        if (static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->zone->find_zone(id, &zone)) {
+        if (static_cast<rgw::sal::RadosStore*>(store)->svc()->zone->find_zone(id, &zone)) {
           names.emplace_back(zone->name);
         }
       }
@@ -1010,7 +1010,7 @@ struct ReplicationConfiguration {
       return true;
     }
 
-    int to_sync_policy_pipe(req_state *s, rgw::sal::RGWStore *store,
+    int to_sync_policy_pipe(req_state *s, rgw::sal::Store *store,
                             rgw_sync_bucket_pipes *pipe,
                             bool *enabled) const {
       if (!is_valid(s->cct)) {
@@ -1061,7 +1061,7 @@ struct ReplicationConfiguration {
       return 0;
     }
 
-    void from_sync_policy_pipe(rgw::sal::RGWStore *store,
+    void from_sync_policy_pipe(rgw::sal::Store *store,
                               const rgw_sync_bucket_pipes& pipe,
                               bool enabled) {
       id = pipe.id;
@@ -1114,7 +1114,7 @@ struct ReplicationConfiguration {
     encode_xml("Rule", rules, f);
   }
 
-  int to_sync_policy_groups(req_state *s, rgw::sal::RGWStore *store,
+  int to_sync_policy_groups(req_state *s, rgw::sal::Store *store,
                             vector<rgw_sync_policy_group> *result) const {
     result->resize(2);
 
@@ -1144,7 +1144,7 @@ struct ReplicationConfiguration {
     return 0;
   }
 
-  void from_sync_policy_group(rgw::sal::RGWStore *store,
+  void from_sync_policy_group(rgw::sal::Store *store,
                               const rgw_sync_policy_group& group) {
 
     bool enabled = (group.status == rgw_sync_policy_group::Status::ENABLED);
@@ -1275,7 +1275,7 @@ void RGWListBuckets_ObjStore_S3::send_response_begin(bool has_buckets)
   }
 }
 
-void RGWListBuckets_ObjStore_S3::send_response_data(rgw::sal::RGWBucketList& buckets)
+void RGWListBuckets_ObjStore_S3::send_response_data(rgw::sal::BucketList& buckets)
 {
   if (!sent_data)
     return;
@@ -2138,7 +2138,7 @@ void RGWGetBucketWebsite_ObjStore_S3::send_response()
   rgw_flush_formatter_and_reset(s, s->formatter);
 }
 
-static void dump_bucket_metadata(struct req_state *s, rgw::sal::RGWBucket* bucket)
+static void dump_bucket_metadata(struct req_state *s, rgw::sal::Bucket* bucket)
 {
   dump_header(s, "X-RGW-Object-Count", static_cast<long long>(bucket->get_count()));
   dump_header(s, "X-RGW-Bytes-Used", static_cast<long long>(bucket->get_size()));
@@ -2166,7 +2166,7 @@ void RGWStatBucket_ObjStore_S3::send_response()
   dump_start(s);
 }
 
-static int create_s3_policy(struct req_state *s, rgw::sal::RGWStore *store,
+static int create_s3_policy(struct req_state *s, rgw::sal::Store *store,
 			    RGWAccessControlPolicy_S3& s3policy,
 			    ACLOwner& owner)
 {
@@ -2575,7 +2575,7 @@ int RGWPutObj_ObjStore_S3::get_encrypt_filter(
   int res = 0;
   if (!multipart_upload_id.empty()) {
     RGWMPObj mp(s->object->get_name(), multipart_upload_id);
-    std::unique_ptr<rgw::sal::RGWObject> obj = s->bucket->get_object(
+    std::unique_ptr<rgw::sal::Object> obj = s->bucket->get_object(
 						rgw_obj_key(mp.get_meta(),
 							    std::string(),
 							    RGW_OBJ_NS_MULTIPART));
@@ -2602,7 +2602,7 @@ int RGWPutObj_ObjStore_S3::get_encrypt_filter(
   return res;
 }
 
-void RGWPostObj_ObjStore_S3::rebuild_key(rgw::sal::RGWObject* obj)
+void RGWPostObj_ObjStore_S3::rebuild_key(rgw::sal::Object* obj)
 {
   string key = obj->get_name();
   static string var = "${filename}";
@@ -2700,7 +2700,7 @@ int RGWPostObj_ObjStore_S3::get_params(optional_yield y)
 
   rebuild_key(s->object.get());
 
-  if (rgw::sal::RGWObject::empty(s->object.get())) {
+  if (rgw::sal::Object::empty(s->object.get())) {
     err_msg = "Empty object name";
     return -EINVAL;
   }
@@ -3326,14 +3326,14 @@ int RGWPutACLs_ObjStore_S3::get_params(optional_yield y)
   return ret;
 }
 
-int RGWPutACLs_ObjStore_S3::get_policy_from_state(rgw::sal::RGWStore *store,
+int RGWPutACLs_ObjStore_S3::get_policy_from_state(rgw::sal::Store *store,
 						  struct req_state *s,
 						  stringstream& ss)
 {
   RGWAccessControlPolicy_S3 s3policy(s->cct);
 
   // bucket-* canned acls do not apply to bucket
-  if (rgw::sal::RGWObject::empty(s->object.get())) {
+  if (rgw::sal::Object::empty(s->object.get())) {
     if (s->canned_acl.find("bucket") != string::npos)
       s->canned_acl.clear();
   }
@@ -4386,7 +4386,7 @@ RGWOp *RGWHandler_REST_Bucket_S3::op_put()
   } else if (is_notification_op()) {
     return RGWHandler_REST_PSNotifs_S3::create_put_op();
   } else if (is_replication_op()) {
-    auto sync_policy_handler = static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->zone->get_sync_policy_handler(nullopt);
+    auto sync_policy_handler = static_cast<rgw::sal::RadosStore*>(store)->svc()->zone->get_sync_policy_handler(nullopt);
     if (!sync_policy_handler ||
         sync_policy_handler->is_legacy_config()) {
       return nullptr;
@@ -4538,7 +4538,7 @@ RGWOp *RGWHandler_REST_Obj_S3::op_options()
   return new RGWOptionsCORS_ObjStore_S3;
 }
 
-int RGWHandler_REST_S3::init_from_header(rgw::sal::RGWStore *store,
+int RGWHandler_REST_S3::init_from_header(rgw::sal::Store *store,
 					 struct req_state* s,
 					 int default_formatter,
 					 bool configurable_format)
@@ -4614,7 +4614,7 @@ int RGWHandler_REST_S3::init_from_header(rgw::sal::RGWStore *store,
   return 0;
 }
 
-static int verify_mfa(rgw::sal::RGWStore *store, RGWUserInfo *user,
+static int verify_mfa(rgw::sal::Store *store, RGWUserInfo *user,
 		      const string& mfa_str, bool *verified, const DoutPrefixProvider *dpp, optional_yield y)
 {
   vector<string> params;
@@ -4634,7 +4634,7 @@ static int verify_mfa(rgw::sal::RGWStore *store, RGWUserInfo *user,
     return -EACCES;
   }
 
-  int ret = static_cast<rgw::sal::RGWRadosStore*>(store)->svc()->cls->mfa.check_mfa(user->user_id, serial, pin, y);
+  int ret = static_cast<rgw::sal::RadosStore*>(store)->svc()->cls->mfa.check_mfa(user->user_id, serial, pin, y);
   if (ret < 0) {
     ldpp_dout(dpp, 20) << "NOTICE: failed to check MFA, serial=" << serial << dendl;
     return -EACCES;
@@ -4663,7 +4663,7 @@ int RGWHandler_REST_S3::postauth_init(optional_yield y)
   ret = rgw_validate_tenant_name(s->bucket_tenant);
   if (ret)
     return ret;
-  if (!s->bucket_name.empty() && !rgw::sal::RGWObject::empty(s->object.get())) {
+  if (!s->bucket_name.empty() && !rgw::sal::Object::empty(s->object.get())) {
     ret = validate_object_name(s->object->get_name());
     if (ret)
       return ret;
@@ -4685,7 +4685,7 @@ int RGWHandler_REST_S3::postauth_init(optional_yield y)
   return 0;
 }
 
-int RGWHandler_REST_S3::init(rgw::sal::RGWStore *store, struct req_state *s,
+int RGWHandler_REST_S3::init(rgw::sal::Store *store, struct req_state *s,
                              rgw::io::BasicClient *cio)
 {
   int ret;
@@ -4795,7 +4795,7 @@ discover_aws_flavour(const req_info& info)
  * it tries AWS v4 before AWS v2
  */
 int RGW_Auth_S3::authorize(const DoutPrefixProvider *dpp,
-                           rgw::sal::RGWStore* const store,
+                           rgw::sal::Store* const store,
                            const rgw::auth::StrategyRegistry& auth_registry,
                            struct req_state* const s, optional_yield y)
 {
@@ -4817,7 +4817,7 @@ int RGW_Auth_S3::authorize(const DoutPrefixProvider *dpp,
   return ret;
 }
 
-int RGWHandler_Auth_S3::init(rgw::sal::RGWStore *store, struct req_state *state,
+int RGWHandler_Auth_S3::init(rgw::sal::Store *store, struct req_state *state,
                              rgw::io::BasicClient *cio)
 {
   int ret = RGWHandler_REST_S3::init_from_header(store, state, RGW_FORMAT_JSON, true);
@@ -4827,7 +4827,7 @@ int RGWHandler_Auth_S3::init(rgw::sal::RGWStore *store, struct req_state *state,
   return RGWHandler_REST::init(store, state, cio);
 }
 
-RGWHandler_REST* RGWRESTMgr_S3::get_handler(rgw::sal::RGWStore *store,
+RGWHandler_REST* RGWRESTMgr_S3::get_handler(rgw::sal::Store *store,
 					    struct req_state* const s,
                                             const rgw::auth::StrategyRegistry& auth_registry,
                                             const std::string& frontend_prefix)
@@ -4845,7 +4845,7 @@ RGWHandler_REST* RGWRESTMgr_S3::get_handler(rgw::sal::RGWStore *store,
   if (is_s3website) {
     if (s->init_state.url_bucket.empty()) {
       handler = new RGWHandler_REST_Service_S3Website(auth_registry);
-    } else if (rgw::sal::RGWObject::empty(s->object.get())) {
+    } else if (rgw::sal::Object::empty(s->object.get())) {
       handler = new RGWHandler_REST_Bucket_S3Website(auth_registry);
     } else {
       handler = new RGWHandler_REST_Obj_S3Website(auth_registry);
@@ -4853,7 +4853,7 @@ RGWHandler_REST* RGWRESTMgr_S3::get_handler(rgw::sal::RGWStore *store,
   } else {
     if (s->init_state.url_bucket.empty()) {
       handler = new RGWHandler_REST_Service_S3(auth_registry, enable_sts, enable_iam, enable_pubsub);
-    } else if (!rgw::sal::RGWObject::empty(s->object.get())) {
+    } else if (!rgw::sal::Object::empty(s->object.get())) {
       handler = new RGWHandler_REST_Obj_S3(auth_registry);
     } else if (s->info.args.exist_obj_excl_sub_resource()) {
       return NULL;
@@ -4869,7 +4869,7 @@ RGWHandler_REST* RGWRESTMgr_S3::get_handler(rgw::sal::RGWStore *store,
 
 bool RGWHandler_REST_S3Website::web_dir() const {
   std::string subdir_name;
-  if (!rgw::sal::RGWObject::empty(s->object.get())) {
+  if (!rgw::sal::Object::empty(s->object.get())) {
     subdir_name = url_decode(s->object->get_name());
   }
 
@@ -4879,7 +4879,7 @@ bool RGWHandler_REST_S3Website::web_dir() const {
     subdir_name.pop_back();
   }
 
-  std::unique_ptr<rgw::sal::RGWObject> obj = s->bucket->get_object(rgw_obj_key(subdir_name));
+  std::unique_ptr<rgw::sal::Object> obj = s->bucket->get_object(rgw_obj_key(subdir_name));
 
   RGWObjectCtx& obj_ctx = *static_cast<RGWObjectCtx *>(s->obj_ctx);
   obj->set_atomic(&obj_ctx);
@@ -4895,13 +4895,13 @@ bool RGWHandler_REST_S3Website::web_dir() const {
   return state->exists;
 }
 
-int RGWHandler_REST_S3Website::init(rgw::sal::RGWStore *store, req_state *s,
+int RGWHandler_REST_S3Website::init(rgw::sal::Store *store, req_state *s,
                                     rgw::io::BasicClient* cio)
 {
   // save the original object name before retarget() replaces it with the
   // result of get_effective_key(). the error_handler() needs the original
   // object name for redirect handling
-  if (!rgw::sal::RGWObject::empty(s->object.get())) {
+  if (!rgw::sal::Object::empty(s->object.get())) {
     original_object_name = s->object->get_name();
   } else {
     original_object_name = "";
@@ -4932,7 +4932,7 @@ int RGWHandler_REST_S3Website::retarget(RGWOp* op, RGWOp** new_op, optional_yiel
 
   rgw_obj_key new_obj;
   string key_name;
-  if (!rgw::sal::RGWObject::empty(s->object.get())) {
+  if (!rgw::sal::Object::empty(s->object.get())) {
     key_name = s->object->get_name();
   }
   bool get_res = s->bucket->get_info().website_conf.get_effective_key(key_name, &new_obj.name, web_dir());
@@ -5069,7 +5069,7 @@ int RGWHandler_REST_S3Website::error_handler(int err_no,
   ldpp_dout(s, 10) << "RGWHandler_REST_S3Website::error_handler err_no=" << err_no << " http_ret=" << http_error_code << dendl;
 
   RGWBWRoutingRule rrule;
-  bool have_bucket = !rgw::sal::RGWBucket::empty(s->bucket.get());
+  bool have_bucket = !rgw::sal::Bucket::empty(s->bucket.get());
   bool should_redirect = false;
   if (have_bucket) {
     should_redirect =
@@ -5844,7 +5844,7 @@ rgw::auth::s3::LocalEngine::authenticate(
   optional_yield y) const
 {
   /* get the user info */
-  std::unique_ptr<rgw::sal::RGWUser> user;
+  std::unique_ptr<rgw::sal::User> user;
   const std::string access_key_id(_access_key_id);
   /* TODO(rzarzynski): we need to have string-view taking variant. */
   if (store->get_user_by_access_key(dpp, access_key_id, y, &user) < 0) {
@@ -6015,7 +6015,7 @@ rgw::auth::s3::STSEngine::authenticate(
   }
 
   // Get all the authorization info
-  std::unique_ptr<rgw::sal::RGWUser> user;
+  std::unique_ptr<rgw::sal::User> user;
   rgw_user user_id;
   string role_id;
   rgw::auth::RoleApplier::Role r;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -926,7 +926,7 @@ struct ReplicationConfiguration {
       }
     };
 
-    set<rgw_zone_id> get_zone_ids_from_names(rgw::sal::Store *store,
+    set<rgw_zone_id> get_zone_ids_from_names(rgw::sal::Store* store,
                                              const vector<string>& zone_names) const {
       set<rgw_zone_id> ids;
 
@@ -940,7 +940,7 @@ struct ReplicationConfiguration {
       return ids;
     }
 
-    vector<string> get_zone_names_from_ids(rgw::sal::Store *store,
+    vector<string> get_zone_names_from_ids(rgw::sal::Store* store,
                                            const set<rgw_zone_id>& zone_ids) const {
       vector<string> names;
 
@@ -1010,7 +1010,7 @@ struct ReplicationConfiguration {
       return true;
     }
 
-    int to_sync_policy_pipe(req_state *s, rgw::sal::Store *store,
+    int to_sync_policy_pipe(req_state *s, rgw::sal::Store* store,
                             rgw_sync_bucket_pipes *pipe,
                             bool *enabled) const {
       if (!is_valid(s->cct)) {
@@ -1061,7 +1061,7 @@ struct ReplicationConfiguration {
       return 0;
     }
 
-    void from_sync_policy_pipe(rgw::sal::Store *store,
+    void from_sync_policy_pipe(rgw::sal::Store* store,
                               const rgw_sync_bucket_pipes& pipe,
                               bool enabled) {
       id = pipe.id;
@@ -1114,7 +1114,7 @@ struct ReplicationConfiguration {
     encode_xml("Rule", rules, f);
   }
 
-  int to_sync_policy_groups(req_state *s, rgw::sal::Store *store,
+  int to_sync_policy_groups(req_state *s, rgw::sal::Store* store,
                             vector<rgw_sync_policy_group> *result) const {
     result->resize(2);
 
@@ -1144,7 +1144,7 @@ struct ReplicationConfiguration {
     return 0;
   }
 
-  void from_sync_policy_group(rgw::sal::Store *store,
+  void from_sync_policy_group(rgw::sal::Store* store,
                               const rgw_sync_policy_group& group) {
 
     bool enabled = (group.status == rgw_sync_policy_group::Status::ENABLED);
@@ -2166,7 +2166,7 @@ void RGWStatBucket_ObjStore_S3::send_response()
   dump_start(s);
 }
 
-static int create_s3_policy(struct req_state *s, rgw::sal::Store *store,
+static int create_s3_policy(struct req_state *s, rgw::sal::Store* store,
 			    RGWAccessControlPolicy_S3& s3policy,
 			    ACLOwner& owner)
 {
@@ -3326,7 +3326,7 @@ int RGWPutACLs_ObjStore_S3::get_params(optional_yield y)
   return ret;
 }
 
-int RGWPutACLs_ObjStore_S3::get_policy_from_state(rgw::sal::Store *store,
+int RGWPutACLs_ObjStore_S3::get_policy_from_state(rgw::sal::Store* store,
 						  struct req_state *s,
 						  stringstream& ss)
 {
@@ -4538,7 +4538,7 @@ RGWOp *RGWHandler_REST_Obj_S3::op_options()
   return new RGWOptionsCORS_ObjStore_S3;
 }
 
-int RGWHandler_REST_S3::init_from_header(rgw::sal::Store *store,
+int RGWHandler_REST_S3::init_from_header(rgw::sal::Store* store,
 					 struct req_state* s,
 					 int default_formatter,
 					 bool configurable_format)
@@ -4614,7 +4614,7 @@ int RGWHandler_REST_S3::init_from_header(rgw::sal::Store *store,
   return 0;
 }
 
-static int verify_mfa(rgw::sal::Store *store, RGWUserInfo *user,
+static int verify_mfa(rgw::sal::Store* store, RGWUserInfo *user,
 		      const string& mfa_str, bool *verified, const DoutPrefixProvider *dpp, optional_yield y)
 {
   vector<string> params;
@@ -4685,7 +4685,7 @@ int RGWHandler_REST_S3::postauth_init(optional_yield y)
   return 0;
 }
 
-int RGWHandler_REST_S3::init(rgw::sal::Store *store, struct req_state *s,
+int RGWHandler_REST_S3::init(rgw::sal::Store* store, struct req_state *s,
                              rgw::io::BasicClient *cio)
 {
   int ret;
@@ -4817,7 +4817,7 @@ int RGW_Auth_S3::authorize(const DoutPrefixProvider *dpp,
   return ret;
 }
 
-int RGWHandler_Auth_S3::init(rgw::sal::Store *store, struct req_state *state,
+int RGWHandler_Auth_S3::init(rgw::sal::Store* store, struct req_state *state,
                              rgw::io::BasicClient *cio)
 {
   int ret = RGWHandler_REST_S3::init_from_header(store, state, RGW_FORMAT_JSON, true);
@@ -4827,7 +4827,7 @@ int RGWHandler_Auth_S3::init(rgw::sal::Store *store, struct req_state *state,
   return RGWHandler_REST::init(store, state, cio);
 }
 
-RGWHandler_REST* RGWRESTMgr_S3::get_handler(rgw::sal::Store *store,
+RGWHandler_REST* RGWRESTMgr_S3::get_handler(rgw::sal::Store* store,
 					    struct req_state* const s,
                                             const rgw::auth::StrategyRegistry& auth_registry,
                                             const std::string& frontend_prefix)
@@ -4895,7 +4895,7 @@ bool RGWHandler_REST_S3Website::web_dir() const {
   return state->exists;
 }
 
-int RGWHandler_REST_S3Website::init(rgw::sal::Store *store, req_state *s,
+int RGWHandler_REST_S3Website::init(rgw::sal::Store* store, req_state *s,
                                     rgw::io::BasicClient* cio)
 {
   // save the original object name before retarget() replaces it with the

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -355,7 +355,7 @@ public:
   RGWPutACLs_ObjStore_S3() {}
   ~RGWPutACLs_ObjStore_S3() override {}
 
-  int get_policy_from_state(rgw::sal::Store *store, struct req_state *s, stringstream& ss) override;
+  int get_policy_from_state(rgw::sal::Store* store, struct req_state *s, stringstream& ss) override;
   void send_response() override;
   int get_params(optional_yield y) override;
 };
@@ -591,7 +591,7 @@ public:
 class RGW_Auth_S3 {
 public:
   static int authorize(const DoutPrefixProvider *dpp,
-                       rgw::sal::Store *store,
+                       rgw::sal::Store* store,
                        const rgw::auth::StrategyRegistry& auth_registry,
                        struct req_state *s, optional_yield y);
 };
@@ -611,7 +611,7 @@ public:
   static int validate_bucket_name(const string& bucket);
   static int validate_object_name(const string& bucket);
 
-  int init(rgw::sal::Store *store,
+  int init(rgw::sal::Store* store,
            struct req_state *s,
            rgw::io::BasicClient *cio) override;
   int authorize(const DoutPrefixProvider *dpp, optional_yield y) override {
@@ -625,7 +625,7 @@ class RGWHandler_REST_S3 : public RGWHandler_REST {
 protected:
   const rgw::auth::StrategyRegistry& auth_registry;
 public:
-  static int init_from_header(rgw::sal::Store *store, struct req_state *s, int default_formatter, bool configurable_format);
+  static int init_from_header(rgw::sal::Store* store, struct req_state *s, int default_formatter, bool configurable_format);
 
   explicit RGWHandler_REST_S3(const rgw::auth::StrategyRegistry& auth_registry)
     : RGWHandler_REST(),
@@ -633,7 +633,7 @@ public:
     }
   ~RGWHandler_REST_S3() override = default;
 
-  int init(rgw::sal::Store *store,
+  int init(rgw::sal::Store* store,
            struct req_state *s,
            rgw::io::BasicClient *cio) override;
   int authorize(const DoutPrefixProvider *dpp, optional_yield y) override;
@@ -765,7 +765,7 @@ public:
 
   ~RGWRESTMgr_S3() override = default;
 
-  RGWHandler_REST *get_handler(rgw::sal::Store *store,
+  RGWHandler_REST *get_handler(rgw::sal::Store* store,
 			       struct req_state* s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string& frontend_prefix) override;

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -135,7 +135,7 @@ public:
     return 0;
   }
   void send_response_begin(bool has_buckets) override;
-  void send_response_data(rgw::sal::RGWBucketList& buckets) override;
+  void send_response_data(rgw::sal::BucketList& buckets) override;
   void send_response_end() override;
 };
 
@@ -297,7 +297,7 @@ class RGWPostObj_ObjStore_S3 : public RGWPostObj_ObjStore {
 
   int get_policy(optional_yield y);
   int get_tags();
-  void rebuild_key(rgw::sal::RGWObject* obj);
+  void rebuild_key(rgw::sal::Object* obj);
 
   std::string get_current_filename() const override;
   std::string get_current_content_type() const override;
@@ -355,7 +355,7 @@ public:
   RGWPutACLs_ObjStore_S3() {}
   ~RGWPutACLs_ObjStore_S3() override {}
 
-  int get_policy_from_state(rgw::sal::RGWStore *store, struct req_state *s, stringstream& ss) override;
+  int get_policy_from_state(rgw::sal::Store *store, struct req_state *s, stringstream& ss) override;
   void send_response() override;
   int get_params(optional_yield y) override;
 };
@@ -591,7 +591,7 @@ public:
 class RGW_Auth_S3 {
 public:
   static int authorize(const DoutPrefixProvider *dpp,
-                       rgw::sal::RGWStore *store,
+                       rgw::sal::Store *store,
                        const rgw::auth::StrategyRegistry& auth_registry,
                        struct req_state *s, optional_yield y);
 };
@@ -611,7 +611,7 @@ public:
   static int validate_bucket_name(const string& bucket);
   static int validate_object_name(const string& bucket);
 
-  int init(rgw::sal::RGWStore *store,
+  int init(rgw::sal::Store *store,
            struct req_state *s,
            rgw::io::BasicClient *cio) override;
   int authorize(const DoutPrefixProvider *dpp, optional_yield y) override {
@@ -625,7 +625,7 @@ class RGWHandler_REST_S3 : public RGWHandler_REST {
 protected:
   const rgw::auth::StrategyRegistry& auth_registry;
 public:
-  static int init_from_header(rgw::sal::RGWStore *store, struct req_state *s, int default_formatter, bool configurable_format);
+  static int init_from_header(rgw::sal::Store *store, struct req_state *s, int default_formatter, bool configurable_format);
 
   explicit RGWHandler_REST_S3(const rgw::auth::StrategyRegistry& auth_registry)
     : RGWHandler_REST(),
@@ -633,7 +633,7 @@ public:
     }
   ~RGWHandler_REST_S3() override = default;
 
-  int init(rgw::sal::RGWStore *store,
+  int init(rgw::sal::Store *store,
            struct req_state *s,
            rgw::io::BasicClient *cio) override;
   int authorize(const DoutPrefixProvider *dpp, optional_yield y) override;
@@ -765,7 +765,7 @@ public:
 
   ~RGWRESTMgr_S3() override = default;
 
-  RGWHandler_REST *get_handler(rgw::sal::RGWStore *store,
+  RGWHandler_REST *get_handler(rgw::sal::Store *store,
 			       struct req_state* s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string& frontend_prefix) override;
@@ -1134,7 +1134,7 @@ class LDAPEngine : public AWSEngine {
   using result_t = rgw::auth::Engine::result_t;
 
 protected:
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
   const rgw::auth::RemoteApplier::Factory* const apl_factory;
 
   acl_strategy_t get_acl_strategy() const;
@@ -1151,7 +1151,7 @@ protected:
 			optional_yield y) const override;
 public:
   LDAPEngine(CephContext* const cct,
-             rgw::sal::RGWStore* store,
+             rgw::sal::Store* store,
              const VersionAbstractor& ver_abstractor,
              const rgw::auth::RemoteApplier::Factory* const apl_factory)
     : AWSEngine(cct, ver_abstractor),
@@ -1171,7 +1171,7 @@ public:
 };
 
 class LocalEngine : public AWSEngine {
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
   const rgw::auth::LocalApplier::Factory* const apl_factory;
 
   result_t authenticate(const DoutPrefixProvider* dpp,
@@ -1185,7 +1185,7 @@ class LocalEngine : public AWSEngine {
 			optional_yield y) const override;
 public:
   LocalEngine(CephContext* const cct,
-              rgw::sal::RGWStore* store,
+              rgw::sal::Store* store,
               const VersionAbstractor& ver_abstractor,
               const rgw::auth::LocalApplier::Factory* const apl_factory)
     : AWSEngine(cct, ver_abstractor),
@@ -1201,7 +1201,7 @@ public:
 };
 
 class STSEngine : public AWSEngine {
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
   const rgw::auth::LocalApplier::Factory* const local_apl_factory;
   const rgw::auth::RemoteApplier::Factory* const remote_apl_factory;
   const rgw::auth::RoleApplier::Factory* const role_apl_factory;
@@ -1226,7 +1226,7 @@ class STSEngine : public AWSEngine {
 			optional_yield y) const override;
 public:
   STSEngine(CephContext* const cct,
-              rgw::sal::RGWStore* store,
+              rgw::sal::Store* store,
               const VersionAbstractor& ver_abstractor,
               const rgw::auth::LocalApplier::Factory* const local_apl_factory,
               const rgw::auth::RemoteApplier::Factory* const remote_apl_factory,

--- a/src/rgw/rgw_rest_s3website.h
+++ b/src/rgw/rgw_rest_s3website.h
@@ -40,7 +40,7 @@ public:
   using RGWHandler_REST_S3::RGWHandler_REST_S3;
   ~RGWHandler_REST_S3Website() override = default;
 
-  int init(rgw::sal::RGWStore *store, req_state *s, rgw::io::BasicClient* cio) override;
+  int init(rgw::sal::Store *store, req_state *s, rgw::io::BasicClient* cio) override;
   int error_handler(int err_no, string *error_content, optional_yield y) override;
 };
 

--- a/src/rgw/rgw_rest_s3website.h
+++ b/src/rgw/rgw_rest_s3website.h
@@ -40,7 +40,7 @@ public:
   using RGWHandler_REST_S3::RGWHandler_REST_S3;
   ~RGWHandler_REST_S3Website() override = default;
 
-  int init(rgw::sal::Store *store, req_state *s, rgw::io::BasicClient* cio) override;
+  int init(rgw::sal::Store* store, req_state *s, rgw::io::BasicClient* cio) override;
   int error_handler(int err_no, string *error_content, optional_yield y) override;
 };
 

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -582,7 +582,7 @@ void RGWSTSAssumeRole::execute(optional_yield y)
 }
 
 int RGW_Auth_STS::authorize(const DoutPrefixProvider *dpp,
-                            rgw::sal::Store *store,
+                            rgw::sal::Store* store,
                             const rgw::auth::StrategyRegistry& auth_registry,
                             struct req_state *s, optional_yield y)
 {
@@ -628,7 +628,7 @@ RGWOp *RGWHandler_REST_STS::op_post()
   return nullptr;
 }
 
-int RGWHandler_REST_STS::init(rgw::sal::Store *store,
+int RGWHandler_REST_STS::init(rgw::sal::Store* store,
                               struct req_state *s,
                               rgw::io::BasicClient *cio)
 {
@@ -693,7 +693,7 @@ int RGWHandler_REST_STS::init_from_header(struct req_state* s,
 }
 
 RGWHandler_REST*
-RGWRESTMgr_STS::get_handler(rgw::sal::Store *store,
+RGWRESTMgr_STS::get_handler(rgw::sal::Store* store,
 			    struct req_state* const s,
 			    const rgw::auth::StrategyRegistry& auth_registry,
 			    const std::string& frontend_prefix)

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -582,7 +582,7 @@ void RGWSTSAssumeRole::execute(optional_yield y)
 }
 
 int RGW_Auth_STS::authorize(const DoutPrefixProvider *dpp,
-                            rgw::sal::RGWStore *store,
+                            rgw::sal::Store *store,
                             const rgw::auth::StrategyRegistry& auth_registry,
                             struct req_state *s, optional_yield y)
 {
@@ -628,7 +628,7 @@ RGWOp *RGWHandler_REST_STS::op_post()
   return nullptr;
 }
 
-int RGWHandler_REST_STS::init(rgw::sal::RGWStore *store,
+int RGWHandler_REST_STS::init(rgw::sal::Store *store,
                               struct req_state *s,
                               rgw::io::BasicClient *cio)
 {
@@ -693,7 +693,7 @@ int RGWHandler_REST_STS::init_from_header(struct req_state* s,
 }
 
 RGWHandler_REST*
-RGWRESTMgr_STS::get_handler(rgw::sal::RGWStore *store,
+RGWRESTMgr_STS::get_handler(rgw::sal::Store *store,
 			    struct req_state* const s,
 			    const rgw::auth::StrategyRegistry& auth_registry,
 			    const std::string& frontend_prefix)

--- a/src/rgw/rgw_rest_sts.h
+++ b/src/rgw/rgw_rest_sts.h
@@ -171,7 +171,7 @@ public:
 class RGW_Auth_STS {
 public:
   static int authorize(const DoutPrefixProvider *dpp,
-                       rgw::sal::Store *store,
+                       rgw::sal::Store* store,
                        const rgw::auth::StrategyRegistry& auth_registry,
                        struct req_state *s, optional_yield y);
 };
@@ -191,7 +191,7 @@ public:
       post_body(post_body) {}
   ~RGWHandler_REST_STS() override = default;
 
-  int init(rgw::sal::Store *store,
+  int init(rgw::sal::Store* store,
            struct req_state *s,
            rgw::io::BasicClient *cio) override;
   int authorize(const DoutPrefixProvider* dpp, optional_yield y) override;
@@ -209,7 +209,7 @@ public:
     return this;
   }
 
-  RGWHandler_REST* get_handler(rgw::sal::Store *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store* store,
 			       struct req_state*,
                                const rgw::auth::StrategyRegistry&,
                                const std::string&) override;

--- a/src/rgw/rgw_rest_sts.h
+++ b/src/rgw/rgw_rest_sts.h
@@ -15,7 +15,7 @@ namespace rgw::auth::sts {
 
 class WebTokenEngine : public rgw::auth::Engine {
   CephContext* const cct;
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
 
   using result_t = rgw::auth::Engine::result_t;
   using token_t = rgw::web_idp::WebTokenClaims;
@@ -44,7 +44,7 @@ class WebTokenEngine : public rgw::auth::Engine {
 
 public:
   WebTokenEngine(CephContext* const cct,
-                    rgw::sal::RGWStore* store,
+                    rgw::sal::Store* store,
                     const rgw::auth::TokenExtractor* const extractor,
                     const rgw::auth::WebIdentityApplier::Factory* const apl_factory)
     : cct(cct),
@@ -65,7 +65,7 @@ public:
 class DefaultStrategy : public rgw::auth::Strategy,
                         public rgw::auth::TokenExtractor,
                         public rgw::auth::WebIdentityApplier::Factory {
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
   ImplicitTenants& implicit_tenant_context;
 
   /* The engine. */
@@ -91,7 +91,7 @@ class DefaultStrategy : public rgw::auth::Strategy,
 public:
   DefaultStrategy(CephContext* const cct,
                   ImplicitTenants& implicit_tenant_context,
-                  rgw::sal::RGWStore* store)
+                  rgw::sal::Store* store)
     : store(store),
       implicit_tenant_context(implicit_tenant_context),
       web_token_engine(cct, store,
@@ -171,7 +171,7 @@ public:
 class RGW_Auth_STS {
 public:
   static int authorize(const DoutPrefixProvider *dpp,
-                       rgw::sal::RGWStore *store,
+                       rgw::sal::Store *store,
                        const rgw::auth::StrategyRegistry& auth_registry,
                        struct req_state *s, optional_yield y);
 };
@@ -191,7 +191,7 @@ public:
       post_body(post_body) {}
   ~RGWHandler_REST_STS() override = default;
 
-  int init(rgw::sal::RGWStore *store,
+  int init(rgw::sal::Store *store,
            struct req_state *s,
            rgw::io::BasicClient *cio) override;
   int authorize(const DoutPrefixProvider* dpp, optional_yield y) override;
@@ -209,7 +209,7 @@ public:
     return this;
   }
 
-  RGWHandler_REST* get_handler(rgw::sal::RGWStore *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store *store,
 			       struct req_state*,
                                const rgw::auth::StrategyRegistry&,
                                const std::string&) override;

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -584,7 +584,7 @@ void RGWStatBucket_ObjStore_SWIFT::send_response()
 }
 
 static int get_swift_container_settings(req_state * const s,
-                                        rgw::sal::Store * const store,
+                                        rgw::sal::Store*  const store,
                                         RGWAccessControlPolicy * const policy,
                                         bool * const has_policy,
                                         uint32_t * rw_mask,
@@ -1040,8 +1040,8 @@ void RGWPutObj_ObjStore_SWIFT::send_response()
 }
 
 static int get_swift_account_settings(req_state * const s,
-                                      rgw::sal::Store * const store,
-                                      RGWAccessControlPolicy_SWIFTAcct * const policy,
+                                      rgw::sal::Store*  const store,
+                                      RGWAccessControlPolicy_SWIFTAcct*  const policy,
                                       bool * const has_policy)
 {
   *has_policy = false;

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -192,7 +192,7 @@ void RGWListBuckets_ObjStore_SWIFT::send_response_begin(bool has_buckets)
   }
 }
 
-void RGWListBuckets_ObjStore_SWIFT::handle_listing_chunk(rgw::sal::RGWBucketList&& buckets)
+void RGWListBuckets_ObjStore_SWIFT::handle_listing_chunk(rgw::sal::BucketList&& buckets)
 {
   if (wants_reversed) {
     /* Just store in the reversal buffer. Its content will be handled later,
@@ -203,7 +203,7 @@ void RGWListBuckets_ObjStore_SWIFT::handle_listing_chunk(rgw::sal::RGWBucketList
   }
 }
 
-void RGWListBuckets_ObjStore_SWIFT::send_response_data(rgw::sal::RGWBucketList& buckets)
+void RGWListBuckets_ObjStore_SWIFT::send_response_data(rgw::sal::BucketList& buckets)
 {
   if (! sent_data) {
     return;
@@ -221,7 +221,7 @@ void RGWListBuckets_ObjStore_SWIFT::send_response_data(rgw::sal::RGWBucketList& 
   }
 }
 
-void RGWListBuckets_ObjStore_SWIFT::dump_bucket_entry(const rgw::sal::RGWBucket& bucket)
+void RGWListBuckets_ObjStore_SWIFT::dump_bucket_entry(const rgw::sal::Bucket& bucket)
 {
   s->formatter->open_object_section("container");
   s->formatter->dump_string("name", bucket.get_name());
@@ -238,7 +238,7 @@ void RGWListBuckets_ObjStore_SWIFT::dump_bucket_entry(const rgw::sal::RGWBucket&
   }
 }
 
-void RGWListBuckets_ObjStore_SWIFT::send_response_data_reversed(rgw::sal::RGWBucketList& buckets)
+void RGWListBuckets_ObjStore_SWIFT::send_response_data_reversed(rgw::sal::BucketList& buckets)
 {
   if (! sent_data) {
     return;
@@ -340,7 +340,7 @@ int RGWListBucket_ObjStore_SWIFT::get_params(optional_yield y)
 }
 
 static void dump_container_metadata(struct req_state *,
-                                    const rgw::sal::RGWBucket*,
+                                    const rgw::sal::Bucket*,
                                     const RGWQuotaInfo&,
                                     const RGWBucketWebsiteConf&);
 
@@ -450,7 +450,7 @@ next:
 } // RGWListBucket_ObjStore_SWIFT::send_response
 
 static void dump_container_metadata(struct req_state *s,
-                                    const rgw::sal::RGWBucket* bucket,
+                                    const rgw::sal::Bucket* bucket,
                                     const RGWQuotaInfo& quota,
                                     const RGWBucketWebsiteConf& ws_conf)
 {
@@ -461,7 +461,7 @@ static void dump_container_metadata(struct req_state *s,
   dump_header(s, "X-Container-Bytes-Used", bucket->get_size());
   dump_header(s, "X-Container-Bytes-Used-Actual", bucket->get_size_rounded());
 
-  if (rgw::sal::RGWObject::empty(s->object.get())) {
+  if (rgw::sal::Object::empty(s->object.get())) {
     auto swift_policy = \
       static_cast<RGWAccessControlPolicy_SWIFT*>(s->bucket_acl.get());
     std::string read_acl, write_acl;
@@ -584,7 +584,7 @@ void RGWStatBucket_ObjStore_SWIFT::send_response()
 }
 
 static int get_swift_container_settings(req_state * const s,
-                                        rgw::sal::RGWStore * const store,
+                                        rgw::sal::Store * const store,
                                         RGWAccessControlPolicy * const policy,
                                         bool * const has_policy,
                                         uint32_t * rw_mask,
@@ -844,7 +844,7 @@ int RGWPutObj_ObjStore_SWIFT::update_slo_segment_size(rgw_slo_entry& entry) {
   string bucket_name = path.substr(pos_init, pos_sep - pos_init);
   string obj_name = path.substr(pos_sep + 1);
 
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
 
   if (bucket_name.compare(s->bucket->get_name()) != 0) {
     r = store->get_bucket(s, s->user.get(), s->user->get_id().tenant, bucket_name, &bucket, s->yield);
@@ -858,7 +858,7 @@ int RGWPutObj_ObjStore_SWIFT::update_slo_segment_size(rgw_slo_entry& entry) {
   }
 
   /* fetch the stored size of the seg (or error if not valid) */
-  std::unique_ptr<rgw::sal::RGWObject> slo_seg = bucket->get_object(rgw_obj_key(obj_name));
+  std::unique_ptr<rgw::sal::Object> slo_seg = bucket->get_object(rgw_obj_key(obj_name));
 
   /* no prefetch */
   RGWObjectCtx obj_ctx(store);
@@ -1040,7 +1040,7 @@ void RGWPutObj_ObjStore_SWIFT::send_response()
 }
 
 static int get_swift_account_settings(req_state * const s,
-                                      rgw::sal::RGWStore * const store,
+                                      rgw::sal::Store * const store,
                                       RGWAccessControlPolicy_SWIFTAcct * const policy,
                                       bool * const has_policy)
 {
@@ -1867,7 +1867,7 @@ void RGWInfo_ObjStore_SWIFT::send_response()
 
 void RGWInfo_ObjStore_SWIFT::list_swift_data(Formatter& formatter,
                                               const ConfigProxy& config,
-                                              rgw::sal::RGWStore* store)
+                                              rgw::sal::Store* store)
 {
   formatter.open_object_section("swift");
   formatter.dump_int("max_file_size", config->rgw_max_put_size);
@@ -1915,7 +1915,7 @@ void RGWInfo_ObjStore_SWIFT::list_swift_data(Formatter& formatter,
 
 void RGWInfo_ObjStore_SWIFT::list_tempauth_data(Formatter& formatter,
                                                  const ConfigProxy& config,
-                                                 rgw::sal::RGWStore* store)
+                                                 rgw::sal::Store* store)
 {
   formatter.open_object_section("tempauth");
   formatter.dump_bool("account_acls", true);
@@ -1923,7 +1923,7 @@ void RGWInfo_ObjStore_SWIFT::list_tempauth_data(Formatter& formatter,
 }
 void RGWInfo_ObjStore_SWIFT::list_tempurl_data(Formatter& formatter,
                                                 const ConfigProxy& config,
-                                                rgw::sal::RGWStore* store)
+                                                rgw::sal::Store* store)
 {
   formatter.open_object_section("tempurl");
   formatter.open_array_section("methods");
@@ -1938,7 +1938,7 @@ void RGWInfo_ObjStore_SWIFT::list_tempurl_data(Formatter& formatter,
 
 void RGWInfo_ObjStore_SWIFT::list_slo_data(Formatter& formatter,
                                             const ConfigProxy& config,
-                                            rgw::sal::RGWStore* store)
+                                            rgw::sal::Store* store)
 {
   formatter.open_object_section("slo");
   formatter.dump_int("max_manifest_segments", config->rgw_max_slo_entries);
@@ -1965,7 +1965,7 @@ bool RGWInfo_ObjStore_SWIFT::is_expired(const std::string& expires, const DoutPr
 }
 
 
-void RGWFormPost::init(rgw::sal::RGWStore* const store,
+void RGWFormPost::init(rgw::sal::Store* const store,
                        req_state* const s,
                        RGWHandler* const dialect_handler)
 {
@@ -2066,7 +2066,7 @@ void RGWFormPost::get_owner_info(const req_state* const s,
    * now. It will be initialized in RGWHandler_REST_SWIFT::postauth_init(). */
   const string& bucket_name = s->init_state.url_bucket;
 
-  std::unique_ptr<rgw::sal::RGWUser> user;
+  std::unique_ptr<rgw::sal::User> user;
 
   /* TempURL in Formpost only requires that bucket name is specified. */
   if (bucket_name.empty()) {
@@ -2097,7 +2097,7 @@ void RGWFormPost::get_owner_info(const req_state* const s,
   }
 
   /* Need to get user info of bucket owner. */
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
   int ret = store->get_bucket(s, user.get(), user->get_tenant(), bucket_name, &bucket, s->yield);
   if (ret < 0) {
     throw ret;
@@ -2343,7 +2343,7 @@ int RGWSwiftWebsiteHandler::serve_errordoc(const int http_ret,
 
   class RGWGetErrorPage : public RGWGetObj_ObjStore_SWIFT {
   public:
-    RGWGetErrorPage(rgw::sal::RGWStore* const store,
+    RGWGetErrorPage(rgw::sal::Store* const store,
                     RGWHandler_REST* const handler,
                     req_state* const s,
                     const int http_ret) {
@@ -2363,7 +2363,7 @@ int RGWSwiftWebsiteHandler::serve_errordoc(const int http_ret,
     }
   } get_errpage_op(store, handler, s, http_ret);
 
-  if (!rgw::sal::RGWBucket::empty(s->bucket.get())) {
+  if (!rgw::sal::Bucket::empty(s->bucket.get())) {
     s->object = s->bucket->get_object(rgw_obj_key(std::to_string(http_ret) + error_doc));
   } else {
     s->object = store->get_object(rgw_obj_key(std::to_string(http_ret) + error_doc));
@@ -2552,7 +2552,7 @@ bool RGWSwiftWebsiteHandler::is_web_dir() const
     subdir_name.pop_back();
   }
 
-  std::unique_ptr<rgw::sal::RGWObject> obj = s->bucket->get_object(rgw_obj_key(std::move(subdir_name)));
+  std::unique_ptr<rgw::sal::Object> obj = s->bucket->get_object(rgw_obj_key(std::move(subdir_name)));
 
   /* First, get attrset of the object we'll try to retrieve. */
   RGWObjectCtx& obj_ctx = *static_cast<RGWObjectCtx *>(s->obj_ctx);
@@ -2583,7 +2583,7 @@ bool RGWSwiftWebsiteHandler::is_web_dir() const
 
 bool RGWSwiftWebsiteHandler::is_index_present(const std::string& index) const
 {
-  std::unique_ptr<rgw::sal::RGWObject> obj = s->bucket->get_object(rgw_obj_key(index));
+  std::unique_ptr<rgw::sal::Object> obj = s->bucket->get_object(rgw_obj_key(index));
 
   RGWObjectCtx& obj_ctx = *static_cast<RGWObjectCtx *>(s->obj_ctx);
   obj->set_atomic(&obj_ctx);
@@ -2897,7 +2897,7 @@ static void next_tok(string& str, string& tok, char delim)
   }
 }
 
-int RGWHandler_REST_SWIFT::init_from_header(rgw::sal::RGWStore* store,
+int RGWHandler_REST_SWIFT::init_from_header(rgw::sal::Store* store,
 					    struct req_state* const s,
                                             const std::string& frontend_prefix)
 {
@@ -3023,7 +3023,7 @@ int RGWHandler_REST_SWIFT::init_from_header(rgw::sal::RGWStore* store,
   return 0;
 }
 
-int RGWHandler_REST_SWIFT::init(rgw::sal::RGWStore* store, struct req_state* s,
+int RGWHandler_REST_SWIFT::init(rgw::sal::Store* store, struct req_state* s,
 				rgw::io::BasicClient *cio)
 {
   struct req_init_state *t = &s->init_state;
@@ -3070,7 +3070,7 @@ int RGWHandler_REST_SWIFT::init(rgw::sal::RGWStore* store, struct req_state* s,
 }
 
 RGWHandler_REST*
-RGWRESTMgr_SWIFT::get_handler(rgw::sal::RGWStore* store,
+RGWRESTMgr_SWIFT::get_handler(rgw::sal::Store* store,
 			      struct req_state* const s,
                               const rgw::auth::StrategyRegistry& auth_registry,
                               const std::string& frontend_prefix)
@@ -3087,7 +3087,7 @@ RGWRESTMgr_SWIFT::get_handler(rgw::sal::RGWStore* store,
     return new RGWHandler_REST_Service_SWIFT(auth_strategy);
   }
 
-  if (rgw::sal::RGWObject::empty(s->object.get())) {
+  if (rgw::sal::Object::empty(s->object.get())) {
     return new RGWHandler_REST_Bucket_SWIFT(auth_strategy);
   }
 
@@ -3095,7 +3095,7 @@ RGWRESTMgr_SWIFT::get_handler(rgw::sal::RGWStore* store,
 }
 
 RGWHandler_REST* RGWRESTMgr_SWIFT_Info::get_handler(
-  rgw::sal::RGWStore* store,
+  rgw::sal::Store* store,
   struct req_state* const s,
   const rgw::auth::StrategyRegistry& auth_registry,
   const std::string& frontend_prefix)

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -395,7 +395,7 @@ public:
 
   int validate_bucket_name(const string& bucket);
 
-  int init(rgw::sal::Store *store, struct req_state *s, rgw::io::BasicClient *cio) override;
+  int init(rgw::sal::Store* store, struct req_state *s, rgw::io::BasicClient *cio) override;
   int authorize(const DoutPrefixProvider *dpp, optional_yield y) override;
   int postauth_init(optional_yield y) override;
 
@@ -502,7 +502,7 @@ public:
   RGWRESTMgr_SWIFT() = default;
   ~RGWRESTMgr_SWIFT() override = default;
 
-  RGWHandler_REST *get_handler(rgw::sal::Store *store,
+  RGWHandler_REST *get_handler(rgw::sal::Store* store,
 			       struct req_state *s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string& frontend_prefix) override;
@@ -574,7 +574,7 @@ public:
   RGWRESTMgr_SWIFT_CrossDomain() = default;
   ~RGWRESTMgr_SWIFT_CrossDomain() override = default;
 
-  RGWHandler_REST* get_handler(rgw::sal::Store *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store* store,
 			       struct req_state* const s,
                                const rgw::auth::StrategyRegistry&,
                                const std::string&) override {
@@ -631,7 +631,7 @@ public:
   RGWRESTMgr_SWIFT_HealthCheck() = default;
   ~RGWRESTMgr_SWIFT_HealthCheck() override = default;
 
-  RGWHandler_REST* get_handler(rgw::sal::Store *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store* store,
 			       struct req_state* const s,
                                const rgw::auth::StrategyRegistry&,
                                const std::string&) override {
@@ -678,7 +678,7 @@ public:
   RGWRESTMgr_SWIFT_Info() = default;
   ~RGWRESTMgr_SWIFT_Info() override = default;
 
-  RGWHandler_REST *get_handler(rgw::sal::Store *store,
+  RGWHandler_REST *get_handler(rgw::sal::Store* store,
 			       struct req_state* s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string& frontend_prefix) override;

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -39,7 +39,7 @@ class RGWListBuckets_ObjStore_SWIFT : public RGWListBuckets_ObjStore {
   bool need_stats;
   bool wants_reversed;
   std::string prefix;
-  std::vector<rgw::sal::RGWBucketList> reverse_buffer;
+  std::vector<rgw::sal::BucketList> reverse_buffer;
 
   uint64_t get_default_max() const override {
     return 0;
@@ -53,11 +53,11 @@ public:
   ~RGWListBuckets_ObjStore_SWIFT() override {}
 
   int get_params(optional_yield y) override;
-  void handle_listing_chunk(rgw::sal::RGWBucketList&& buckets) override;
+  void handle_listing_chunk(rgw::sal::BucketList&& buckets) override;
   void send_response_begin(bool has_buckets) override;
-  void send_response_data(rgw::sal::RGWBucketList& buckets) override;
-  void send_response_data_reversed(rgw::sal::RGWBucketList& buckets);
-  void dump_bucket_entry(const rgw::sal::RGWBucket& obj);
+  void send_response_data(rgw::sal::BucketList& buckets) override;
+  void send_response_data_reversed(rgw::sal::BucketList& buckets);
+  void dump_bucket_entry(const rgw::sal::Bucket& obj);
   void send_response_end() override;
 
   bool should_get_stats() override { return need_stats; }
@@ -235,7 +235,7 @@ protected:
   struct info
   {
     bool is_admin_info;
-    function<void (Formatter&, const ConfigProxy&, rgw::sal::RGWStore*)> list_data;
+    function<void (Formatter&, const ConfigProxy&, rgw::sal::Store*)> list_data;
   };
 
   static const vector<pair<string, struct info>> swift_info;
@@ -245,10 +245,10 @@ public:
 
   void execute(optional_yield y) override;
   void send_response() override;
-  static void list_swift_data(Formatter& formatter, const ConfigProxy& config, rgw::sal::RGWStore* store);
-  static void list_tempauth_data(Formatter& formatter, const ConfigProxy& config, rgw::sal::RGWStore* store);
-  static void list_tempurl_data(Formatter& formatter, const ConfigProxy& config, rgw::sal::RGWStore* store);
-  static void list_slo_data(Formatter& formatter, const ConfigProxy& config, rgw::sal::RGWStore* store);
+  static void list_swift_data(Formatter& formatter, const ConfigProxy& config, rgw::sal::Store* store);
+  static void list_tempauth_data(Formatter& formatter, const ConfigProxy& config, rgw::sal::Store* store);
+  static void list_tempurl_data(Formatter& formatter, const ConfigProxy& config, rgw::sal::Store* store);
+  static void list_slo_data(Formatter& formatter, const ConfigProxy& config, rgw::sal::Store* store);
   static bool is_expired(const std::string& expires, const DoutPrefixProvider* dpp);
 };
 
@@ -273,7 +273,7 @@ public:
   RGWFormPost() = default;
   ~RGWFormPost() = default;
 
-  void init(rgw::sal::RGWStore* store,
+  void init(rgw::sal::Store* store,
             req_state* s,
             RGWHandler* dialect_handler) override;
 
@@ -344,7 +344,7 @@ public:
 
 
 class RGWSwiftWebsiteHandler {
-  rgw::sal::RGWStore* const store;
+  rgw::sal::Store* const store;
   req_state* const s;
   RGWHandler_REST* const handler;
 
@@ -359,7 +359,7 @@ class RGWSwiftWebsiteHandler {
   RGWOp* get_ws_index_op();
   RGWOp* get_ws_listing_op();
 public:
-  RGWSwiftWebsiteHandler(rgw::sal::RGWStore* const store,
+  RGWSwiftWebsiteHandler(rgw::sal::Store* const store,
                          req_state* const s,
                          RGWHandler_REST* const handler)
     : store(store),
@@ -385,7 +385,7 @@ protected:
     return false;
   }
 
-  static int init_from_header(rgw::sal::RGWStore* store, struct req_state* s,
+  static int init_from_header(rgw::sal::Store* store, struct req_state* s,
                               const std::string& frontend_prefix);
 public:
   explicit RGWHandler_REST_SWIFT(const rgw::auth::Strategy& auth_strategy)
@@ -395,7 +395,7 @@ public:
 
   int validate_bucket_name(const string& bucket);
 
-  int init(rgw::sal::RGWStore *store, struct req_state *s, rgw::io::BasicClient *cio) override;
+  int init(rgw::sal::Store *store, struct req_state *s, rgw::io::BasicClient *cio) override;
   int authorize(const DoutPrefixProvider *dpp, optional_yield y) override;
   int postauth_init(optional_yield y) override;
 
@@ -443,7 +443,7 @@ public:
     return website_handler->retarget_bucket(op, new_op);
   }
 
-  int init(rgw::sal::RGWStore* const store,
+  int init(rgw::sal::Store* const store,
            struct req_state* const s,
            rgw::io::BasicClient* const cio) override {
     website_handler = boost::in_place<RGWSwiftWebsiteHandler>(store, s, this);
@@ -482,7 +482,7 @@ public:
     return website_handler->retarget_object(op, new_op);
   }
 
-  int init(rgw::sal::RGWStore* const store,
+  int init(rgw::sal::Store* const store,
            struct req_state* const s,
            rgw::io::BasicClient* const cio) override {
     website_handler = boost::in_place<RGWSwiftWebsiteHandler>(store, s, this);
@@ -502,7 +502,7 @@ public:
   RGWRESTMgr_SWIFT() = default;
   ~RGWRESTMgr_SWIFT() override = default;
 
-  RGWHandler_REST *get_handler(rgw::sal::RGWStore *store,
+  RGWHandler_REST *get_handler(rgw::sal::Store *store,
 			       struct req_state *s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string& frontend_prefix) override;
@@ -536,7 +536,7 @@ public:
     return new RGWGetCrossDomainPolicy_ObjStore_SWIFT();
   }
 
-  int init(rgw::sal::RGWStore* const store,
+  int init(rgw::sal::Store* const store,
            struct req_state* const state,
            rgw::io::BasicClient* const cio) override {
     state->dialect = "swift";
@@ -574,7 +574,7 @@ public:
   RGWRESTMgr_SWIFT_CrossDomain() = default;
   ~RGWRESTMgr_SWIFT_CrossDomain() override = default;
 
-  RGWHandler_REST* get_handler(rgw::sal::RGWStore *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store *store,
 			       struct req_state* const s,
                                const rgw::auth::StrategyRegistry&,
                                const std::string&) override {
@@ -593,7 +593,7 @@ public:
     return new RGWGetHealthCheck_ObjStore_SWIFT();
   }
 
-  int init(rgw::sal::RGWStore* const store,
+  int init(rgw::sal::Store* const store,
            struct req_state* const state,
            rgw::io::BasicClient* const cio) override {
     state->dialect = "swift";
@@ -631,7 +631,7 @@ public:
   RGWRESTMgr_SWIFT_HealthCheck() = default;
   ~RGWRESTMgr_SWIFT_HealthCheck() override = default;
 
-  RGWHandler_REST* get_handler(rgw::sal::RGWStore *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store *store,
 			       struct req_state* const s,
                                const rgw::auth::StrategyRegistry&,
                                const std::string&) override {
@@ -650,7 +650,7 @@ public:
     return new RGWInfo_ObjStore_SWIFT();
   }
 
-  int init(rgw::sal::RGWStore* const store,
+  int init(rgw::sal::Store* const store,
            struct req_state* const state,
            rgw::io::BasicClient* const cio) override {
     state->dialect = "swift";
@@ -678,7 +678,7 @@ public:
   RGWRESTMgr_SWIFT_Info() = default;
   ~RGWRESTMgr_SWIFT_Info() override = default;
 
-  RGWHandler_REST *get_handler(rgw::sal::RGWStore *store,
+  RGWHandler_REST *get_handler(rgw::sal::Store *store,
 			       struct req_state* s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string& frontend_prefix) override;

--- a/src/rgw/rgw_rest_usage.cc
+++ b/src/rgw/rgw_rest_usage.cc
@@ -34,8 +34,8 @@ void RGWOp_Usage_Get::execute(optional_yield y) {
 
   RESTArgs::get_string(s, "uid", uid_str, &uid_str);
   RESTArgs::get_string(s, "bucket", bucket_name, &bucket_name);
-  std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(rgw_user(uid_str));
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::User> user = store->get_user(rgw_user(uid_str));
+  std::unique_ptr<rgw::sal::Bucket> bucket;
 
   if (!bucket_name.empty()) {
     store->get_bucket(nullptr, user.get(), std::string(), bucket_name, &bucket, null_yield);
@@ -81,8 +81,8 @@ void RGWOp_Usage_Delete::execute(optional_yield y) {
 
   RESTArgs::get_string(s, "uid", uid_str, &uid_str);
   RESTArgs::get_string(s, "bucket", bucket_name, &bucket_name);
-  std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(rgw_user(uid_str));
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::User> user = store->get_user(rgw_user(uid_str));
+  std::unique_ptr<rgw::sal::Bucket> bucket;
 
   if (!bucket_name.empty()) {
     store->get_bucket(nullptr, user.get(), std::string(), bucket_name, &bucket, null_yield);
@@ -91,7 +91,7 @@ void RGWOp_Usage_Delete::execute(optional_yield y) {
   RESTArgs::get_epoch(s, "start", 0, &start);
   RESTArgs::get_epoch(s, "end", (uint64_t)-1, &end);
 
-  if (rgw::sal::RGWUser::empty(user.get()) &&
+  if (rgw::sal::User::empty(user.get()) &&
       !bucket_name.empty() &&
       !start &&
       end == (uint64_t)-1) {

--- a/src/rgw/rgw_rest_usage.h
+++ b/src/rgw/rgw_rest_usage.h
@@ -25,7 +25,7 @@ public:
   RGWRESTMgr_Usage() = default;
   ~RGWRESTMgr_Usage() override = default;
 
-  RGWHandler_REST* get_handler(rgw::sal::RGWStore* store,
+  RGWHandler_REST* get_handler(rgw::sal::Store* store,
 			       struct req_state*,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string&) override {

--- a/src/rgw/rgw_rest_user.h
+++ b/src/rgw/rgw_rest_user.h
@@ -27,7 +27,7 @@ public:
   RGWRESTMgr_User() = default;
   ~RGWRESTMgr_User() override = default;
 
-  RGWHandler_REST *get_handler(rgw::sal::Store *store,
+  RGWHandler_REST *get_handler(rgw::sal::Store* store,
 			       struct req_state*,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string&) override {

--- a/src/rgw/rgw_rest_user.h
+++ b/src/rgw/rgw_rest_user.h
@@ -27,7 +27,7 @@ public:
   RGWRESTMgr_User() = default;
   ~RGWRESTMgr_User() override = default;
 
-  RGWHandler_REST *get_handler(rgw::sal::RGWStore *store,
+  RGWHandler_REST *get_handler(rgw::sal::Store *store,
 			       struct req_state*,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string&) override {

--- a/src/rgw/rgw_rest_user_policy.cc
+++ b/src/rgw/rgw_rest_user_policy.cc
@@ -118,7 +118,7 @@ void RGWPutUserPolicy::execute(optional_yield y)
 
   bufferlist bl = bufferlist::static_from_string(policy);
 
-  std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(rgw_user(user_name));
+  std::unique_ptr<rgw::sal::User> user = store->get_user(rgw_user(user_name));
 
   op_ret = user->load_by_id(s, s->yield);
   if (op_ret < 0) {
@@ -126,7 +126,7 @@ void RGWPutUserPolicy::execute(optional_yield y)
     return;
   }
 
-  rgw::sal::RGWAttrs uattrs;
+  rgw::sal::Attrs uattrs;
   op_ret = user->read_attrs(s, s->yield, &uattrs);
   if (op_ret == -ENOENT) {
     op_ret = -ERR_NO_SUCH_ENTITY;
@@ -200,8 +200,8 @@ void RGWGetUserPolicy::execute(optional_yield y)
     return;
   }
 
-  std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(rgw_user(user_name));
-  rgw::sal::RGWAttrs uattrs;
+  std::unique_ptr<rgw::sal::User> user = store->get_user(rgw_user(user_name));
+  rgw::sal::Attrs uattrs;
   op_ret = user->read_attrs(s, s->yield, &uattrs);
   if (op_ret == -ENOENT) {
     ldpp_dout(this, 0) << "ERROR: attrs not found for user" << user_name << dendl;
@@ -264,8 +264,8 @@ void RGWListUserPolicies::execute(optional_yield y)
     return;
   }
 
-  std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(rgw_user(user_name));
-  rgw::sal::RGWAttrs uattrs;
+  std::unique_ptr<rgw::sal::User> user = store->get_user(rgw_user(user_name));
+  rgw::sal::Attrs uattrs;
   op_ret = user->read_attrs(s, s->yield, &uattrs);
   if (op_ret == -ENOENT) {
     ldpp_dout(this, 0) << "ERROR: attrs not found for user" << user_name << dendl;
@@ -326,14 +326,14 @@ void RGWDeleteUserPolicy::execute(optional_yield y)
     return;
   }
 
-  std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(rgw_user(user_name));
+  std::unique_ptr<rgw::sal::User> user = store->get_user(rgw_user(user_name));
   op_ret = user->load_by_id(s, s->yield);
   if (op_ret < 0) {
     op_ret = -ERR_NO_SUCH_ENTITY;
     return;
   }
 
-  rgw::sal::RGWAttrs uattrs;
+  rgw::sal::Attrs uattrs;
   op_ret = user->read_attrs(this, s->yield, &uattrs);
   if (op_ret == -ENOENT) {
     op_ret = -ERR_NO_SUCH_ENTITY;

--- a/src/rgw/rgw_role.cc
+++ b/src/rgw/rgw_role.cc
@@ -425,7 +425,7 @@ void RGWRole::update_trust_policy(string& trust_policy)
 }
 
 int RGWRole::get_roles_by_path_prefix(const DoutPrefixProvider *dpp,
-				      rgw::sal::RGWStore *store,
+				      rgw::sal::Store *store,
                                       CephContext *cct,
                                       const string& path_prefix,
                                       const string& tenant,

--- a/src/rgw/rgw_role.cc
+++ b/src/rgw/rgw_role.cc
@@ -425,7 +425,7 @@ void RGWRole::update_trust_policy(string& trust_policy)
 }
 
 int RGWRole::get_roles_by_path_prefix(const DoutPrefixProvider *dpp,
-				      rgw::sal::Store *store,
+				      rgw::sal::Store* store,
                                       CephContext *cct,
                                       const string& path_prefix,
                                       const string& tenant,

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -158,7 +158,7 @@ public:
   static const string& get_info_oid_prefix();
   static const string& get_path_oid_prefix();
   static int get_roles_by_path_prefix(const DoutPrefixProvider *dpp,
-				      rgw::sal::Store *store,
+				      rgw::sal::Store* store,
                                       CephContext *cct,
                                       const string& path_prefix,
                                       const string& tenant,

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -13,7 +13,7 @@
 
 #include "rgw/rgw_rados.h"
 
-namespace rgw { namespace sal { class RGWStore; } }
+namespace rgw { namespace sal { class Store; } }
 
 class RGWRole
 {
@@ -28,7 +28,7 @@ class RGWRole
   static constexpr uint64_t SESSION_DURATION_MAX = 43200; // in seconds
 
   CephContext *cct;
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
   string id;
   string name;
   string path;
@@ -50,7 +50,7 @@ class RGWRole
 
 public:
   RGWRole(CephContext *cct,
-          rgw::sal::RGWStore* store,
+          rgw::sal::Store* store,
           string name,
           string path,
           string trust_policy,
@@ -73,7 +73,7 @@ public:
   }
 
   RGWRole(CephContext *cct,
-          rgw::sal::RGWStore* store,
+          rgw::sal::Store* store,
           string name,
           string tenant)
   : cct(cct),
@@ -84,14 +84,14 @@ public:
   }
 
   RGWRole(CephContext *cct,
-          rgw::sal::RGWStore* store,
+          rgw::sal::Store* store,
           string id)
   : cct(cct),
     store(store),
     id(std::move(id)) {}
 
   RGWRole(CephContext *cct,
-          rgw::sal::RGWStore* store)
+          rgw::sal::Store* store)
   : cct(cct),
     store(store) {}
 
@@ -158,7 +158,7 @@ public:
   static const string& get_info_oid_prefix();
   static const string& get_path_oid_prefix();
   static int get_roles_by_path_prefix(const DoutPrefixProvider *dpp,
-				      rgw::sal::RGWStore *store,
+				      rgw::sal::Store *store,
                                       CephContext *cct,
                                       const string& path_prefix,
                                       const string& tenant,

--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -27,15 +27,15 @@
 #define dout_subsys ceph_subsys_rgw
 
 extern "C" {
-extern rgw::sal::RGWStore* newRGWStore(void);
+extern rgw::sal::Store* newStore(void);
 }
 
-rgw::sal::RGWStore *RGWStoreManager::init_storage_provider(const DoutPrefixProvider *dpp, CephContext *cct, const std::string svc, bool use_gc_thread, bool use_lc_thread, bool quota_threads, bool run_sync_thread, bool run_reshard_thread, bool use_cache)
+rgw::sal::Store *StoreManager::init_storage_provider(const DoutPrefixProvider *dpp, CephContext *cct, const std::string svc, bool use_gc_thread, bool use_lc_thread, bool quota_threads, bool run_sync_thread, bool run_reshard_thread, bool use_cache)
 {
-  rgw::sal::RGWStore *store = nullptr;
+  rgw::sal::Store *store = nullptr;
   if (svc.compare("rados") == 0) {
-    store = newRGWStore();
-    RGWRados *rados = static_cast<rgw::sal::RGWRadosStore *>(store)->getRados();
+    store = newStore();
+    RGWRados *rados = static_cast<rgw::sal::RadosStore *>(store)->getRados();
 
     if ((*rados).set_use_cache(use_cache)
                 .set_run_gc_thread(use_gc_thread)
@@ -51,12 +51,12 @@ rgw::sal::RGWStore *RGWStoreManager::init_storage_provider(const DoutPrefixProvi
   return store;
 }
 
-rgw::sal::RGWStore *RGWStoreManager::init_raw_storage_provider(const DoutPrefixProvider *dpp, CephContext *cct, const std::string svc)
+rgw::sal::Store *StoreManager::init_raw_storage_provider(const DoutPrefixProvider *dpp, CephContext *cct, const std::string svc)
 {
-  rgw::sal::RGWStore *store = nullptr;
+  rgw::sal::Store *store = nullptr;
   if (svc.compare("rados") == 0) {
-    store = newRGWStore();
-    RGWRados *rados = static_cast<rgw::sal::RGWRadosStore *>(store)->getRados();
+    store = newStore();
+    RGWRados *rados = static_cast<rgw::sal::RadosStore *>(store)->getRados();
 
     rados->set_context(cct);
 
@@ -75,7 +75,7 @@ rgw::sal::RGWStore *RGWStoreManager::init_raw_storage_provider(const DoutPrefixP
   return store;
 }
 
-void RGWStoreManager::close_storage(rgw::sal::RGWStore *store)
+void StoreManager::close_storage(rgw::sal::Store *store)
 {
   if (!store)
     return;

--- a/src/rgw/rgw_sal.cc
+++ b/src/rgw/rgw_sal.cc
@@ -30,12 +30,12 @@ extern "C" {
 extern rgw::sal::Store* newStore(void);
 }
 
-rgw::sal::Store *StoreManager::init_storage_provider(const DoutPrefixProvider *dpp, CephContext *cct, const std::string svc, bool use_gc_thread, bool use_lc_thread, bool quota_threads, bool run_sync_thread, bool run_reshard_thread, bool use_cache)
+rgw::sal::Store* StoreManager::init_storage_provider(const DoutPrefixProvider* dpp, CephContext* cct, const std::string svc, bool use_gc_thread, bool use_lc_thread, bool quota_threads, bool run_sync_thread, bool run_reshard_thread, bool use_cache)
 {
-  rgw::sal::Store *store = nullptr;
+  rgw::sal::Store* store = nullptr;
   if (svc.compare("rados") == 0) {
     store = newStore();
-    RGWRados *rados = static_cast<rgw::sal::RadosStore *>(store)->getRados();
+    RGWRados* rados = static_cast<rgw::sal::RadosStore* >(store)->getRados();
 
     if ((*rados).set_use_cache(use_cache)
                 .set_run_gc_thread(use_gc_thread)
@@ -51,12 +51,12 @@ rgw::sal::Store *StoreManager::init_storage_provider(const DoutPrefixProvider *d
   return store;
 }
 
-rgw::sal::Store *StoreManager::init_raw_storage_provider(const DoutPrefixProvider *dpp, CephContext *cct, const std::string svc)
+rgw::sal::Store* StoreManager::init_raw_storage_provider(const DoutPrefixProvider* dpp, CephContext* cct, const std::string svc)
 {
-  rgw::sal::Store *store = nullptr;
+  rgw::sal::Store* store = nullptr;
   if (svc.compare("rados") == 0) {
     store = newStore();
-    RGWRados *rados = static_cast<rgw::sal::RadosStore *>(store)->getRados();
+    RGWRados* rados = static_cast<rgw::sal::RadosStore* >(store)->getRados();
 
     rados->set_context(cct);
 
@@ -75,7 +75,7 @@ rgw::sal::Store *StoreManager::init_raw_storage_provider(const DoutPrefixProvide
   return store;
 }
 
-void StoreManager::close_storage(rgw::sal::Store *store)
+void StoreManager::close_storage(rgw::sal::Store* store)
 {
   if (!store)
     return;

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -43,7 +43,7 @@ namespace rgw {
 }
 
 struct RGWUsageIter {
-  string read_iter;
+  std::string read_iter;
   uint32_t index;
 
   RGWUsageIter() : index(0) {}
@@ -180,12 +180,12 @@ class Store {
     virtual int get_raw_chunk_size(const DoutPrefixProvider* dpp, const rgw_raw_obj& obj, uint64_t* chunk_size) = 0;
 
     virtual int log_usage(map<rgw_user_bucket, RGWUsageBatch>& usage_info) = 0;
-    virtual int log_op(string& oid, bufferlist& bl) = 0;
-    virtual int register_to_service_map(const string& daemon_type,
-					const map<string, string>& meta) = 0;
+    virtual int log_op(std::string& oid, bufferlist& bl) = 0;
+    virtual int register_to_service_map(const std::string& daemon_type,
+					const map<std::string, std::string>& meta) = 0;
     virtual void get_quota(RGWQuotaInfo& bucket_quota, RGWQuotaInfo& user_quota) = 0;
-    virtual int list_raw_objects(const rgw_pool& pool, const string& prefix_filter,
-				 int max, RGWListRawObjsCtx& ctx, std::list<string>& oids,
+    virtual int list_raw_objects(const rgw_pool& pool, const std::string& prefix_filter,
+				 int max, RGWListRawObjsCtx& ctx, std::list<std::string>& oids,
 				 bool* is_truncated) = 0;
     virtual int set_buckets_enabled(const DoutPrefixProvider* dpp, vector<rgw_bucket>& buckets, bool enabled) = 0;
     virtual uint64_t get_new_req_id() = 0;
@@ -196,32 +196,32 @@ class Store {
 					optional_yield y) = 0;
     virtual RGWDataSyncStatusManager* get_data_sync_manager(const rgw_zone_id& source_zone) = 0;
     virtual void wakeup_meta_sync_shards(set<int>& shard_ids) = 0;
-    virtual void wakeup_data_sync_shards(const rgw_zone_id& source_zone, map<int, set<string> >& shard_ids) = 0;
+    virtual void wakeup_data_sync_shards(const rgw_zone_id& source_zone, map<int, set<std::string> >& shard_ids) = 0;
     virtual int clear_usage() = 0;
     virtual int read_all_usage(uint64_t start_epoch, uint64_t end_epoch,
 			       uint32_t max_entries, bool* is_truncated,
 			       RGWUsageIter& usage_iter,
 			       map<rgw_user_bucket, rgw_usage_log_entry>& usage) = 0;
     virtual int trim_all_usage(uint64_t start_epoch, uint64_t end_epoch) = 0;
-    virtual int get_config_key_val(string name, bufferlist* bl) = 0;
-    virtual int put_system_obj(const rgw_pool& pool, const string& oid,
+    virtual int get_config_key_val(std::string name, bufferlist* bl) = 0;
+    virtual int put_system_obj(const rgw_pool& pool, const std::string& oid,
 			       bufferlist& data, bool exclusive,
 			       RGWObjVersionTracker* objv_tracker, real_time set_mtime,
-			       optional_yield y, map<string, bufferlist>* pattrs = nullptr) = 0;
+			       optional_yield y, map<std::string, bufferlist>* pattrs = nullptr) = 0;
     virtual int get_system_obj(const DoutPrefixProvider* dpp,
-			       const rgw_pool& pool, const string& key,
+			       const rgw_pool& pool, const std::string& key,
 			       bufferlist& bl,
 			       RGWObjVersionTracker* objv_tracker, real_time* pmtime,
-			       optional_yield y, map<string, bufferlist>* pattrs = nullptr,
+			       optional_yield y, map<std::string, bufferlist>* pattrs = nullptr,
 			       rgw_cache_entry_info* cache_info = nullptr,
 			       boost::optional<obj_version> refresh_version = boost::none) = 0;
-    virtual int delete_system_obj(const rgw_pool& pool, const string& oid,
+    virtual int delete_system_obj(const rgw_pool& pool, const std::string& oid,
 				  RGWObjVersionTracker* objv_tracker, optional_yield y) = 0;
-    virtual int meta_list_keys_init(const string& section, const string& marker, void** phandle) = 0;
-    virtual int meta_list_keys_next(void* handle, int max, list<string>& keys, bool* truncated) = 0;
+    virtual int meta_list_keys_init(const std::string& section, const std::string& marker, void** phandle) = 0;
+    virtual int meta_list_keys_next(void* handle, int max, list<std::string>& keys, bool* truncated) = 0;
     virtual void meta_list_keys_complete(void* handle) = 0;
     virtual std::string meta_get_marker(void* handle) = 0;
-    virtual int meta_remove(const DoutPrefixProvider* dpp, string& metadata_key, optional_yield y) = 0;
+    virtual int meta_remove(const DoutPrefixProvider* dpp, std::string& metadata_key, optional_yield y) = 0;
     virtual const RGWSyncModuleInstanceRef& get_sync_module() = 0;
     virtual std::string get_host_id() = 0;
 
@@ -549,7 +549,7 @@ class Object {
 	Attrs* rmattrs{nullptr};
 	const bufferlist* data{nullptr};
 	RGWObjManifest* manifest{nullptr};
-	const string* ptag{nullptr};
+	const std::string* ptag{nullptr};
 	std::list<rgw_obj_index_key>* remove_objs{nullptr};
 	ceph::real_time set_mtime;
 	ACLOwner owner;
@@ -560,7 +560,7 @@ class Object {
 	std::optional<uint64_t> olh_epoch;
 	ceph::real_time delete_at;
 	bool canceled{false};
-	const string* user_data{nullptr};
+	const std::string* user_data{nullptr};
 	rgw_zone_set* zones_trace{nullptr};
 	bool modify_tail{false};
 	bool completeMultipart{false};
@@ -581,7 +581,7 @@ class Object {
         ACLOwner obj_owner;
         int versioning_status{0};
         uint64_t olh_epoch{0};
-        string marker_version_id;
+	std::string marker_version_id;
         uint32_t bilog_flags{0};
         list<rgw_obj_index_key>* remove_objs{nullptr};
         ceph::real_time expiration_time;
@@ -595,7 +595,7 @@ class Object {
 
       struct Result {
         bool delete_marker{false};
-        string version_id;
+	std::string version_id;
       } result;
 
       virtual ~DeleteOp() = default;
@@ -655,7 +655,7 @@ class Object {
                AttrsMod attrs_mod, bool copy_if_newer, Attrs& attrs,
                RGWObjCategory category, uint64_t olh_epoch,
 	       boost::optional<ceph::real_time> delete_at,
-               string* version_id, string* tag, string* etag,
+               std::string* version_id, std::string* tag, std::string* etag,
                void (*progress_cb)(off_t, void *), void* progress_data,
                const DoutPrefixProvider* dpp, optional_yield y) = 0;
     virtual RGWAccessControlPolicy& get_acl(void) = 0;
@@ -729,10 +729,10 @@ class Object {
     virtual std::unique_ptr<StatOp> get_stat_op(RGWObjectCtx*) = 0;
 
     /* OMAP */
-    virtual int omap_get_vals(const string& marker, uint64_t count,
-			      std::map<string, bufferlist>* m,
+    virtual int omap_get_vals(const std::string& marker, uint64_t count,
+			      std::map<std::string, bufferlist>* m,
 			      bool* pmore, optional_yield y) = 0;
-    virtual int omap_get_all(std::map<string, bufferlist>* m,
+    virtual int omap_get_all(std::map<std::string, bufferlist>* m,
 			     optional_yield y) = 0;
     virtual int omap_get_vals_by_keys(const std::string& oid,
 			      const std::set<std::string>& keys,
@@ -816,14 +816,14 @@ public:
   Lifecycle() = default;
   virtual ~Lifecycle() = default;
 
-  virtual int get_entry(const string& oid, const std::string& marker, LCEntry& entry) = 0;
-  virtual int get_next_entry(const string& oid, std::string& marker, LCEntry& entry) = 0;
-  virtual int set_entry(const string& oid, const LCEntry& entry) = 0;
-  virtual int list_entries(const string& oid, const string& marker,
+  virtual int get_entry(const std::string& oid, const std::string& marker, LCEntry& entry) = 0;
+  virtual int get_next_entry(const std::string& oid, std::string& marker, LCEntry& entry) = 0;
+  virtual int set_entry(const std::string& oid, const LCEntry& entry) = 0;
+  virtual int list_entries(const std::string& oid, const std::string& marker,
 			   uint32_t max_entries, vector<LCEntry>& entries) = 0;
-  virtual int rm_entry(const string& oid, const LCEntry& entry) = 0;
-  virtual int get_head(const string& oid, LCHead& head) = 0;
-  virtual int put_head(const string& oid, const LCHead& head) = 0;
+  virtual int rm_entry(const std::string& oid, const LCEntry& entry) = 0;
+  virtual int get_head(const std::string& oid, LCHead& head) = 0;
+  virtual int put_head(const std::string& oid, const LCHead& head) = 0;
 
   virtual LCSerializer* get_serializer(const std::string& lock_name, const std::string& oid, const std::string& cookie) = 0;
 };
@@ -901,15 +901,15 @@ class Zone {
     virtual ~Zone() = default;
 
     virtual const RGWZoneGroup& get_zonegroup() = 0;
-    virtual int get_zonegroup(const string& id, RGWZoneGroup& zonegroup) = 0;
+    virtual int get_zonegroup(const std::string& id, RGWZoneGroup& zonegroup) = 0;
     virtual const RGWZoneParams& get_params() = 0;
     virtual const rgw_zone_id& get_id() = 0;
     virtual const RGWRealm& get_realm() = 0;
     virtual const std::string& get_name() const = 0;
     virtual bool is_writeable() = 0;
-    virtual bool get_redirect_endpoint(string* endpoint) = 0;
+    virtual bool get_redirect_endpoint(std::string* endpoint) = 0;
     virtual bool has_zonegroup_api(const std::string& api) const = 0;
-    virtual const string& get_current_period_id() = 0;
+    virtual const std::string& get_current_period_id() = 0;
 };
 
 } } // namespace rgw::sal

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -67,12 +67,12 @@ struct RGWClusterStat {
 class RGWGetBucketStats_CB : public RefCountedObject {
 protected:
   rgw_bucket bucket;
-  map<RGWObjCategory, RGWStorageStats> *stats;
+  map<RGWObjCategory, RGWStorageStats>* stats;
 public:
   explicit RGWGetBucketStats_CB(const rgw_bucket& _bucket) : bucket(_bucket), stats(NULL) {}
   ~RGWGetBucketStats_CB() override {}
   virtual void handle_response(int r) = 0;
-  virtual void set_response(map<RGWObjCategory, RGWStorageStats> *_stats) {
+  virtual void set_response(map<RGWObjCategory, RGWStorageStats>* _stats) {
     stats = _stats;
   }
 };
@@ -132,34 +132,34 @@ class Store {
     /* This one does not query the cluster for info */
     virtual std::unique_ptr<User> get_user(const rgw_user& u) = 0;
     /* These three do query the cluster for info */
-    virtual int get_user_by_access_key(const DoutPrefixProvider *dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user) = 0;
-    virtual int get_user_by_email(const DoutPrefixProvider *dpp, const std::string& email, optional_yield y, std::unique_ptr<User>* user) = 0;
-    virtual int get_user_by_swift(const DoutPrefixProvider *dpp, const std::string& user_str, optional_yield y, std::unique_ptr<User>* user) = 0;
+    virtual int get_user_by_access_key(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user) = 0;
+    virtual int get_user_by_email(const DoutPrefixProvider* dpp, const std::string& email, optional_yield y, std::unique_ptr<User>* user) = 0;
+    virtual int get_user_by_swift(const DoutPrefixProvider* dpp, const std::string& user_str, optional_yield y, std::unique_ptr<User>* user) = 0;
     virtual std::unique_ptr<Object> get_object(const rgw_obj_key& k) = 0;
-    virtual int get_bucket(const DoutPrefixProvider *dpp, User* u, const rgw_bucket& b, std::unique_ptr<Bucket>* bucket, optional_yield y) = 0;
+    virtual int get_bucket(const DoutPrefixProvider* dpp, User* u, const rgw_bucket& b, std::unique_ptr<Bucket>* bucket, optional_yield y) = 0;
     virtual int get_bucket(User* u, const RGWBucketInfo& i, std::unique_ptr<Bucket>* bucket) = 0;
-    virtual int get_bucket(const DoutPrefixProvider *dpp, User* u, const std::string& tenant, const std::string& name, std::unique_ptr<Bucket>* bucket, optional_yield y) = 0;
-    virtual int create_bucket(const DoutPrefixProvider *dpp, 
+    virtual int get_bucket(const DoutPrefixProvider* dpp, User* u, const std::string& tenant, const std::string& name, std::unique_ptr<Bucket>* bucket, optional_yield y) = 0;
+    virtual int create_bucket(const DoutPrefixProvider* dpp,
                             User& u, const rgw_bucket& b,
                             const std::string& zonegroup_id,
                             rgw_placement_rule& placement_rule,
                             std::string& swift_ver_location,
-                            const RGWQuotaInfo * pquota_info,
+                            const RGWQuotaInfo* pquota_info,
                             const RGWAccessControlPolicy& policy,
 			    Attrs& attrs,
                             RGWBucketInfo& info,
                             obj_version& ep_objv,
 			    bool exclusive,
 			    bool obj_lock_enabled,
-			    bool *existed,
+			    bool* existed,
 			    req_info& req_info,
 			    std::unique_ptr<Bucket>* bucket,
 			    optional_yield y) = 0;
     virtual bool is_meta_master() = 0;
-    virtual int forward_request_to_master(User* user, obj_version *objv,
-					  bufferlist& in_data, JSONParser *jp, req_info& info,
+    virtual int forward_request_to_master(User* user, obj_version* objv,
+					  bufferlist& in_data, JSONParser* jp, req_info& info,
 					  optional_yield y) = 0;
-    virtual int defer_gc(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, Bucket* bucket, Object* obj,
+    virtual int defer_gc(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, Bucket* bucket, Object* obj,
 			 optional_yield y) = 0;
     virtual Zone* get_zone() = 0;
     virtual std::string zone_unique_id(uint64_t unique_num) = 0;
@@ -169,15 +169,15 @@ class Store {
     virtual std::unique_ptr<Completions> get_completions(void) = 0;
     virtual std::unique_ptr<Notification> get_notification(rgw::sal::Object* obj, struct req_state* s, rgw::notify::EventType event_type) = 0;
     virtual std::unique_ptr<GCChain> get_gc_chain(rgw::sal::Object* obj) = 0;
-    virtual std::unique_ptr<Writer> get_writer(Aio *aio, rgw::sal::Bucket* bucket,
+    virtual std::unique_ptr<Writer> get_writer(Aio* aio, rgw::sal::Bucket* bucket,
               RGWObjectCtx& obj_ctx, std::unique_ptr<rgw::sal::Object> _head_obj,
-              const DoutPrefixProvider *dpp, optional_yield y) = 0;
+              const DoutPrefixProvider* dpp, optional_yield y) = 0;
     virtual RGWLC* get_rgwlc(void) = 0;
     virtual RGWCoroutinesManagerRegistry* get_cr_registry() = 0;
     virtual int delete_raw_obj(const rgw_raw_obj& obj) = 0;
     virtual int delete_raw_obj_aio(const rgw_raw_obj& obj, Completions* aio) = 0;
     virtual void get_raw_obj(const rgw_placement_rule& placement_rule, const rgw_obj& obj, rgw_raw_obj* raw_obj) = 0;
-    virtual int get_raw_chunk_size(const DoutPrefixProvider *dpp, const rgw_raw_obj& obj, uint64_t* chunk_size) = 0;
+    virtual int get_raw_chunk_size(const DoutPrefixProvider* dpp, const rgw_raw_obj& obj, uint64_t* chunk_size) = 0;
 
     virtual int log_usage(map<rgw_user_bucket, RGWUsageBatch>& usage_info) = 0;
     virtual int log_op(string& oid, bufferlist& bl) = 0;
@@ -186,48 +186,48 @@ class Store {
     virtual void get_quota(RGWQuotaInfo& bucket_quota, RGWQuotaInfo& user_quota) = 0;
     virtual int list_raw_objects(const rgw_pool& pool, const string& prefix_filter,
 				 int max, RGWListRawObjsCtx& ctx, std::list<string>& oids,
-				 bool *is_truncated) = 0;
-    virtual int set_buckets_enabled(const DoutPrefixProvider *dpp, vector<rgw_bucket>& buckets, bool enabled) = 0;
+				 bool* is_truncated) = 0;
+    virtual int set_buckets_enabled(const DoutPrefixProvider* dpp, vector<rgw_bucket>& buckets, bool enabled) = 0;
     virtual uint64_t get_new_req_id() = 0;
-    virtual int get_sync_policy_handler(const DoutPrefixProvider *dpp,
+    virtual int get_sync_policy_handler(const DoutPrefixProvider* dpp,
 					std::optional<rgw_zone_id> zone,
 					std::optional<rgw_bucket> bucket,
-					RGWBucketSyncPolicyHandlerRef *phandler,
+					RGWBucketSyncPolicyHandlerRef* phandler,
 					optional_yield y) = 0;
     virtual RGWDataSyncStatusManager* get_data_sync_manager(const rgw_zone_id& source_zone) = 0;
     virtual void wakeup_meta_sync_shards(set<int>& shard_ids) = 0;
     virtual void wakeup_data_sync_shards(const rgw_zone_id& source_zone, map<int, set<string> >& shard_ids) = 0;
     virtual int clear_usage() = 0;
     virtual int read_all_usage(uint64_t start_epoch, uint64_t end_epoch,
-			       uint32_t max_entries, bool *is_truncated,
+			       uint32_t max_entries, bool* is_truncated,
 			       RGWUsageIter& usage_iter,
 			       map<rgw_user_bucket, rgw_usage_log_entry>& usage) = 0;
     virtual int trim_all_usage(uint64_t start_epoch, uint64_t end_epoch) = 0;
-    virtual int get_config_key_val(string name, bufferlist *bl) = 0;
+    virtual int get_config_key_val(string name, bufferlist* bl) = 0;
     virtual int put_system_obj(const rgw_pool& pool, const string& oid,
 			       bufferlist& data, bool exclusive,
-			       RGWObjVersionTracker *objv_tracker, real_time set_mtime,
-			       optional_yield y, map<string, bufferlist> *pattrs = nullptr) = 0;
-    virtual int get_system_obj(const DoutPrefixProvider *dpp,
+			       RGWObjVersionTracker* objv_tracker, real_time set_mtime,
+			       optional_yield y, map<string, bufferlist>* pattrs = nullptr) = 0;
+    virtual int get_system_obj(const DoutPrefixProvider* dpp,
 			       const rgw_pool& pool, const string& key,
 			       bufferlist& bl,
-			       RGWObjVersionTracker *objv_tracker, real_time *pmtime,
-			       optional_yield y, map<string, bufferlist> *pattrs = nullptr,
-			       rgw_cache_entry_info *cache_info = nullptr,
+			       RGWObjVersionTracker* objv_tracker, real_time* pmtime,
+			       optional_yield y, map<string, bufferlist>* pattrs = nullptr,
+			       rgw_cache_entry_info* cache_info = nullptr,
 			       boost::optional<obj_version> refresh_version = boost::none) = 0;
     virtual int delete_system_obj(const rgw_pool& pool, const string& oid,
-				  RGWObjVersionTracker *objv_tracker, optional_yield y) = 0;
+				  RGWObjVersionTracker* objv_tracker, optional_yield y) = 0;
     virtual int meta_list_keys_init(const string& section, const string& marker, void** phandle) = 0;
     virtual int meta_list_keys_next(void* handle, int max, list<string>& keys, bool* truncated) = 0;
     virtual void meta_list_keys_complete(void* handle) = 0;
-    virtual std::string meta_get_marker(void *handle) = 0;
-    virtual int meta_remove(const DoutPrefixProvider *dpp, string& metadata_key, optional_yield y) = 0;
+    virtual std::string meta_get_marker(void* handle) = 0;
+    virtual int meta_remove(const DoutPrefixProvider* dpp, string& metadata_key, optional_yield y) = 0;
     virtual const RGWSyncModuleInstanceRef& get_sync_module() = 0;
     virtual std::string get_host_id() = 0;
 
     virtual void finalize(void) = 0;
 
-    virtual CephContext *ctx(void) = 0;
+    virtual CephContext* ctx(void) = 0;
     
     // get the location of where lua packages are installed
     virtual const std::string& get_luarocks_path() const = 0;
@@ -248,7 +248,7 @@ class User {
     virtual ~User() = default;
 
     virtual std::unique_ptr<User> clone() = 0;
-    virtual int list_buckets(const DoutPrefixProvider *dpp,
+    virtual int list_buckets(const DoutPrefixProvider* dpp,
 			     const std::string& marker, const std::string& end_marker,
 			     uint64_t max, bool need_stats, BucketList& buckets,
 			     optional_yield y) = 0;
@@ -267,22 +267,22 @@ class User {
     const RGWUserCaps& get_caps() const { return info.caps; }
     static bool empty(User* u) { return (!u || u->info.user_id.id.empty()); }
     static bool empty(std::unique_ptr<User>& u) { return (!u || u->info.user_id.id.empty()); }
-    virtual int read_attrs(const DoutPrefixProvider *dpp, optional_yield y, Attrs* uattrs, RGWObjVersionTracker* tracker = nullptr) = 0;
+    virtual int read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs* uattrs, RGWObjVersionTracker* tracker = nullptr) = 0;
     virtual int read_stats(optional_yield y, RGWStorageStats* stats,
-			   ceph::real_time *last_stats_sync = nullptr,
-			   ceph::real_time *last_stats_update = nullptr) = 0;
-    virtual int read_stats_async(RGWGetUserStats_CB *cb) = 0;
+			   ceph::real_time* last_stats_sync = nullptr,
+			   ceph::real_time* last_stats_update = nullptr) = 0;
+    virtual int read_stats_async(RGWGetUserStats_CB* cb) = 0;
     virtual int complete_flush_stats(optional_yield y) = 0;
     virtual int read_usage(uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries,
-			   bool *is_truncated, RGWUsageIter& usage_iter,
+			   bool* is_truncated, RGWUsageIter& usage_iter,
 			   map<rgw_user_bucket, rgw_usage_log_entry>& usage) = 0;
     virtual int trim_usage(uint64_t start_epoch, uint64_t end_epoch) = 0;
     virtual RGWObjVersionTracker& get_version_tracker() { return objv_tracker; }
 
     /* Placeholders */
-    virtual int load_by_id(const DoutPrefixProvider *dpp, optional_yield y) = 0;
-    virtual int store_info(const DoutPrefixProvider *dpp, optional_yield y, const RGWUserCtl::PutParams& params = {}) = 0;
-    virtual int remove_info(const DoutPrefixProvider *dpp, optional_yield y, const RGWUserCtl::RemoveParams& params = {}) = 0;
+    virtual int load_by_id(const DoutPrefixProvider* dpp, optional_yield y) = 0;
+    virtual int store_info(const DoutPrefixProvider* dpp, optional_yield y, const RGWUserCtl::PutParams& params = {}) = 0;
+    virtual int remove_info(const DoutPrefixProvider* dpp, optional_yield y, const RGWUserCtl::RemoveParams& params = {}) = 0;
 
     /* dang temporary; will be removed when User is complete */
     RGWUserInfo& get_info() { return info; }
@@ -325,7 +325,7 @@ class Bucket {
       rgw_obj_key end_marker;
       std::string ns;
       bool enforce_ns{true};
-      RGWAccessListFilter *filter{nullptr};
+      RGWAccessListFilter* filter{nullptr};
       bool list_versions{false};
       bool allow_unordered{false};
       int shard_id{RGW_NO_SHARD};
@@ -366,46 +366,46 @@ class Bucket {
     virtual ~Bucket() = default;
 
     virtual std::unique_ptr<Object> get_object(const rgw_obj_key& key) = 0;
-    virtual int list(const DoutPrefixProvider *dpp, ListParams&, int, ListResults&, optional_yield y) = 0;
+    virtual int list(const DoutPrefixProvider* dpp, ListParams&, int, ListResults&, optional_yield y) = 0;
     virtual Object* create_object(const rgw_obj_key& key /* Attributes */) = 0;
     virtual Attrs& get_attrs(void) { return attrs; }
     virtual int set_attrs(Attrs a) { attrs = a; return 0; }
-    virtual int remove_bucket(const DoutPrefixProvider *dpp, bool delete_children, std::string prefix, std::string delimiter, bool forward_to_master, req_info* req_info, optional_yield y) = 0;
+    virtual int remove_bucket(const DoutPrefixProvider* dpp, bool delete_children, std::string prefix, std::string delimiter, bool forward_to_master, req_info* req_info, optional_yield y) = 0;
     virtual RGWAccessControlPolicy& get_acl(void) = 0;
-    virtual int set_acl(const DoutPrefixProvider *dpp, RGWAccessControlPolicy& acl, optional_yield y) = 0;
-    virtual int get_bucket_info(const DoutPrefixProvider *dpp, optional_yield y) = 0;
+    virtual int set_acl(const DoutPrefixProvider* dpp, RGWAccessControlPolicy& acl, optional_yield y) = 0;
+    virtual int get_bucket_info(const DoutPrefixProvider* dpp, optional_yield y) = 0;
     virtual int get_bucket_stats(int shard_id,
-				 std::string *bucket_ver, std::string *master_ver,
+				 std::string* bucket_ver, std::string* master_ver,
 				 std::map<RGWObjCategory, RGWStorageStats>& stats,
-				 std::string *max_marker = nullptr,
-				 bool *syncstopped = nullptr) = 0;
-    virtual int get_bucket_stats_async(int shard_id, RGWGetBucketStats_CB *ctx) = 0;
-    virtual int read_bucket_stats(const DoutPrefixProvider *dpp, optional_yield y) = 0;
+				 std::string* max_marker = nullptr,
+				 bool* syncstopped = nullptr) = 0;
+    virtual int get_bucket_stats_async(int shard_id, RGWGetBucketStats_CB* ctx) = 0;
+    virtual int read_bucket_stats(const DoutPrefixProvider* dpp, optional_yield y) = 0;
     virtual int sync_user_stats(optional_yield y) = 0;
-    virtual int update_container_stats(const DoutPrefixProvider *dpp) = 0;
-    virtual int check_bucket_shards(const DoutPrefixProvider *dpp) = 0;
-    virtual int link(const DoutPrefixProvider *dpp, User* new_user, optional_yield y, bool update_entrypoint = true, RGWObjVersionTracker* objv = nullptr) = 0;
-    virtual int unlink(const DoutPrefixProvider *dpp, User* new_user, optional_yield y, bool update_entrypoint = true) = 0;
-    virtual int chown(const DoutPrefixProvider *dpp, User* new_user, User* old_user, optional_yield y, const std::string* marker = nullptr) = 0;
-    virtual int put_instance_info(const DoutPrefixProvider *dpp, bool exclusive, ceph::real_time mtime) = 0;
-    virtual int remove_entrypoint(const DoutPrefixProvider *dpp, RGWObjVersionTracker* objv, optional_yield y) = 0;
-    virtual int remove_instance_info(const DoutPrefixProvider *dpp, RGWObjVersionTracker* objv, optional_yield y) = 0;
+    virtual int update_container_stats(const DoutPrefixProvider* dpp) = 0;
+    virtual int check_bucket_shards(const DoutPrefixProvider* dpp) = 0;
+    virtual int link(const DoutPrefixProvider* dpp, User* new_user, optional_yield y, bool update_entrypoint = true, RGWObjVersionTracker* objv = nullptr) = 0;
+    virtual int unlink(const DoutPrefixProvider* dpp, User* new_user, optional_yield y, bool update_entrypoint = true) = 0;
+    virtual int chown(const DoutPrefixProvider* dpp, User* new_user, User* old_user, optional_yield y, const std::string* marker = nullptr) = 0;
+    virtual int put_instance_info(const DoutPrefixProvider* dpp, bool exclusive, ceph::real_time mtime) = 0;
+    virtual int remove_entrypoint(const DoutPrefixProvider* dpp, RGWObjVersionTracker* objv, optional_yield y) = 0;
+    virtual int remove_instance_info(const DoutPrefixProvider* dpp, RGWObjVersionTracker* objv, optional_yield y) = 0;
     virtual bool is_owner(User* user) = 0;
     virtual User* get_owner(void) { return owner; };
     virtual ACLOwner get_acl_owner(void) { return ACLOwner(info.owner); };
-    virtual int check_empty(const DoutPrefixProvider *dpp, optional_yield y) = 0;
+    virtual int check_empty(const DoutPrefixProvider* dpp, optional_yield y) = 0;
     virtual int check_quota(RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota, uint64_t obj_size, optional_yield y, bool check_size_only = false) = 0;
-    virtual int set_instance_attrs(const DoutPrefixProvider *dpp, Attrs& attrs, optional_yield y) = 0;
-    virtual int try_refresh_info(const DoutPrefixProvider *dpp, ceph::real_time *pmtime) = 0;
+    virtual int set_instance_attrs(const DoutPrefixProvider* dpp, Attrs& attrs, optional_yield y) = 0;
+    virtual int try_refresh_info(const DoutPrefixProvider* dpp, ceph::real_time* pmtime) = 0;
     virtual int read_usage(uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries,
-			   bool *is_truncated, RGWUsageIter& usage_iter,
+			   bool* is_truncated, RGWUsageIter& usage_iter,
 			   map<rgw_user_bucket, rgw_usage_log_entry>& usage) = 0;
     virtual int trim_usage(uint64_t start_epoch, uint64_t end_epoch) = 0;
     virtual int remove_objs_from_index(std::list<rgw_obj_index_key>& objs_to_unlink) = 0;
     virtual int check_index(std::map<RGWObjCategory, RGWStorageStats>& existing_stats, std::map<RGWObjCategory, RGWStorageStats>& calculated_stats) = 0;
     virtual int rebuild_index() = 0;
     virtual int set_tag_timeout(uint64_t timeout) = 0;
-    virtual int purge_instance(const DoutPrefixProvider *dpp) = 0;
+    virtual int purge_instance(const DoutPrefixProvider* dpp) = 0;
 
     bool empty() const { return info.bucket.name.empty(); }
     const std::string& get_name() const { return info.bucket.name; }
@@ -423,7 +423,7 @@ class Bucket {
     bool versioned() { return info.versioned(); }
     bool versioning_enabled() { return info.versioning_enabled(); }
 
-    void convert(cls_user_bucket_entry *b) const {
+    void convert(cls_user_bucket_entry* b) const {
       ent.convert(b);
     }
 
@@ -516,15 +516,15 @@ class Object {
 
     struct ReadOp {
       struct Params {
-        const ceph::real_time *mod_ptr{nullptr};
-        const ceph::real_time *unmod_ptr{nullptr};
+        const ceph::real_time* mod_ptr{nullptr};
+        const ceph::real_time* unmod_ptr{nullptr};
         bool high_precision_time{false};
         uint32_t mod_zone_id{0};
         uint64_t mod_pg_ver{0};
-        const char *if_match{nullptr};
-        const char *if_nomatch{nullptr};
-        ceph::real_time *lastmod{nullptr};
-        rgw_obj *target_obj{nullptr}; // XXX dang remove?
+        const char* if_match{nullptr};
+        const char* if_nomatch{nullptr};
+        ceph::real_time* lastmod{nullptr};
+        rgw_obj* target_obj{nullptr}; // XXX dang remove?
       } params;
 
       struct Result {
@@ -535,11 +535,11 @@ class Object {
 
       virtual ~ReadOp() = default;
 
-      virtual int prepare(optional_yield y, const DoutPrefixProvider *dpp) = 0;
-      virtual int read(int64_t ofs, int64_t end, bufferlist& bl, optional_yield y, const DoutPrefixProvider *dpp) = 0;
-      virtual int iterate(const DoutPrefixProvider *dpp, int64_t ofs, int64_t end, RGWGetDataCB *cb, optional_yield y) = 0;
-      virtual int get_manifest(const DoutPrefixProvider *dpp, RGWObjManifest **pmanifest, optional_yield y) = 0;
-      virtual int get_attr(const DoutPrefixProvider *dpp, const char *name, bufferlist& dest, optional_yield y) = 0;
+      virtual int prepare(optional_yield y, const DoutPrefixProvider* dpp) = 0;
+      virtual int read(int64_t ofs, int64_t end, bufferlist& bl, optional_yield y, const DoutPrefixProvider* dpp) = 0;
+      virtual int iterate(const DoutPrefixProvider* dpp, int64_t ofs, int64_t end, RGWGetDataCB* cb, optional_yield y) = 0;
+      virtual int get_manifest(const DoutPrefixProvider* dpp, RGWObjManifest **pmanifest, optional_yield y) = 0;
+      virtual int get_attr(const DoutPrefixProvider* dpp, const char* name, bufferlist& dest, optional_yield y) = 0;
     };
 
     struct WriteOp {
@@ -571,8 +571,8 @@ class Object {
       virtual ~WriteOp() = default;
 
       virtual int prepare(optional_yield y) = 0;
-      virtual int write_meta(const DoutPrefixProvider *dpp, uint64_t size, uint64_t accounted_size, optional_yield y) = 0;
-      //virtual int write_data(const char *data, uint64_t ofs, uint64_t len, bool exclusive) = 0;
+      virtual int write_meta(const DoutPrefixProvider* dpp, uint64_t size, uint64_t accounted_size, optional_yield y) = 0;
+      //virtual int write_data(const char* data, uint64_t ofs, uint64_t len, bool exclusive) = 0;
     };
 
     struct DeleteOp {
@@ -583,12 +583,12 @@ class Object {
         uint64_t olh_epoch{0};
         string marker_version_id;
         uint32_t bilog_flags{0};
-        list<rgw_obj_index_key> *remove_objs{nullptr};
+        list<rgw_obj_index_key>* remove_objs{nullptr};
         ceph::real_time expiration_time;
         ceph::real_time unmod_since;
         ceph::real_time mtime;
         bool high_precision_time{false};
-        rgw_zone_set *zones_trace{nullptr};
+        rgw_zone_set* zones_trace{nullptr};
 	bool abortmp{false};
 	uint64_t parts_accounted_size{0};
       } params;
@@ -600,7 +600,7 @@ class Object {
 
       virtual ~DeleteOp() = default;
 
-      virtual int delete_obj(const DoutPrefixProvider *dpp, optional_yield y) = 0;
+      virtual int delete_obj(const DoutPrefixProvider* dpp, optional_yield y) = 0;
     };
 
     struct StatOp {
@@ -640,38 +640,38 @@ class Object {
 
     virtual ~Object() = default;
 
-    virtual int delete_object(const DoutPrefixProvider *dpp, RGWObjectCtx* obj_ctx, optional_yield y) = 0;
-    virtual int delete_obj_aio(const DoutPrefixProvider *dpp, RGWObjState *astate, Completions* aio,
+    virtual int delete_object(const DoutPrefixProvider* dpp, RGWObjectCtx* obj_ctx, optional_yield y) = 0;
+    virtual int delete_obj_aio(const DoutPrefixProvider* dpp, RGWObjState* astate, Completions* aio,
 			       bool keep_index_consistent, optional_yield y) = 0;
     virtual int copy_object(RGWObjectCtx& obj_ctx, User* user,
-               req_info *info, const rgw_zone_id& source_zone,
+               req_info* info, const rgw_zone_id& source_zone,
                rgw::sal::Object* dest_object, rgw::sal::Bucket* dest_bucket,
                rgw::sal::Bucket* src_bucket,
                const rgw_placement_rule& dest_placement,
-               ceph::real_time *src_mtime, ceph::real_time *mtime,
-               const ceph::real_time *mod_ptr, const ceph::real_time *unmod_ptr,
+               ceph::real_time* src_mtime, ceph::real_time* mtime,
+               const ceph::real_time* mod_ptr, const ceph::real_time* unmod_ptr,
                bool high_precision_time,
-               const char *if_match, const char *if_nomatch,
+               const char* if_match, const char* if_nomatch,
                AttrsMod attrs_mod, bool copy_if_newer, Attrs& attrs,
                RGWObjCategory category, uint64_t olh_epoch,
 	       boost::optional<ceph::real_time> delete_at,
-               string *version_id, string *tag, string *etag,
-               void (*progress_cb)(off_t, void *), void *progress_data,
-               const DoutPrefixProvider *dpp, optional_yield y) = 0;
+               string* version_id, string* tag, string* etag,
+               void (*progress_cb)(off_t, void *), void* progress_data,
+               const DoutPrefixProvider* dpp, optional_yield y) = 0;
     virtual RGWAccessControlPolicy& get_acl(void) = 0;
     virtual int set_acl(const RGWAccessControlPolicy& acl) = 0;
-    virtual void set_atomic(RGWObjectCtx *rctx) const = 0;
-    virtual void set_prefetch_data(RGWObjectCtx *rctx) = 0;
+    virtual void set_atomic(RGWObjectCtx* rctx) const = 0;
+    virtual void set_prefetch_data(RGWObjectCtx* rctx) = 0;
 
     bool empty() const { return key.empty(); }
     const std::string &get_name() const { return key.name; }
 
-    virtual int get_obj_state(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWObjState **state, optional_yield y, bool follow_olh = false) = 0;
-    virtual int set_obj_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx* rctx, Attrs* setattrs, Attrs* delattrs, optional_yield y, rgw_obj* target_obj = NULL) = 0;
-    virtual int get_obj_attrs(RGWObjectCtx *rctx, optional_yield y, const DoutPrefixProvider *dpp, rgw_obj* target_obj = NULL) = 0;
-    virtual int modify_obj_attrs(RGWObjectCtx *rctx, const char *attr_name, bufferlist& attr_val, optional_yield y, const DoutPrefixProvider *dpp) = 0;
-    virtual int delete_obj_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, const char *attr_name, optional_yield y) = 0;
-    virtual int copy_obj_data(RGWObjectCtx& rctx, Bucket* dest_bucket, Object* dest_obj, uint16_t olh_epoch, std::string* petag, const DoutPrefixProvider *dpp, optional_yield y) = 0;
+    virtual int get_obj_state(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, RGWObjState **state, optional_yield y, bool follow_olh = false) = 0;
+    virtual int set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, Attrs* setattrs, Attrs* delattrs, optional_yield y, rgw_obj* target_obj = NULL) = 0;
+    virtual int get_obj_attrs(RGWObjectCtx* rctx, optional_yield y, const DoutPrefixProvider* dpp, rgw_obj* target_obj = NULL) = 0;
+    virtual int modify_obj_attrs(RGWObjectCtx* rctx, const char* attr_name, bufferlist& attr_val, optional_yield y, const DoutPrefixProvider* dpp) = 0;
+    virtual int delete_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, const char* attr_name, optional_yield y) = 0;
+    virtual int copy_obj_data(RGWObjectCtx& rctx, Bucket* dest_bucket, Object* dest_obj, uint16_t olh_epoch, std::string* petag, const DoutPrefixProvider* dpp, optional_yield y) = 0;
     virtual bool is_expired() = 0;
     virtual void gen_rand_obj_instance_name() = 0;
     virtual void raw_obj_to_obj(const rgw_raw_obj& raw_obj) = 0;
@@ -682,13 +682,13 @@ class Object {
 			   const rgw_placement_rule& placement_rule,
 			   const real_time& mtime,
 			   uint64_t olh_epoch,
-			   const DoutPrefixProvider *dpp,
+			   const DoutPrefixProvider* dpp,
 			   optional_yield y) = 0;
-    virtual int get_max_chunk_size(const DoutPrefixProvider *dpp, 
+    virtual int get_max_chunk_size(const DoutPrefixProvider* dpp,
                                    rgw_placement_rule placement_rule,
 				   uint64_t* max_chunk_size,
 				   uint64_t* alignment = nullptr) = 0;
-    virtual void get_max_aligned_size(uint64_t size, uint64_t alignment, uint64_t *max_size) = 0;
+    virtual void get_max_aligned_size(uint64_t size, uint64_t alignment, uint64_t* max_size) = 0;
     virtual bool placement_rules_match(rgw_placement_rule& r1, rgw_placement_rule& r2) = 0;
 
     Attrs& get_attrs(void) { return attrs; }
@@ -717,9 +717,9 @@ class Object {
     /* Swift versioning */
     virtual int swift_versioning_restore(RGWObjectCtx* obj_ctx,
 					 bool& restored,   /* out */
-					 const DoutPrefixProvider *dpp) = 0;
+					 const DoutPrefixProvider* dpp) = 0;
     virtual int swift_versioning_copy(RGWObjectCtx* obj_ctx,
-				      const DoutPrefixProvider *dpp,
+				      const DoutPrefixProvider* dpp,
 				      optional_yield y) = 0;
 
     /* OPs */
@@ -730,13 +730,13 @@ class Object {
 
     /* OMAP */
     virtual int omap_get_vals(const string& marker, uint64_t count,
-			      std::map<string, bufferlist> *m,
-			      bool *pmore, optional_yield y) = 0;
-    virtual int omap_get_all(std::map<string, bufferlist> *m,
+			      std::map<string, bufferlist>* m,
+			      bool* pmore, optional_yield y) = 0;
+    virtual int omap_get_all(std::map<string, bufferlist>* m,
 			     optional_yield y) = 0;
     virtual int omap_get_vals_by_keys(const std::string& oid,
 			      const std::set<std::string>& keys,
-			      Attrs *vals) = 0;
+			      Attrs* vals) = 0;
     virtual int omap_set_val_by_key(const std::string& key, bufferlist& val,
 				    bool must_exist, optional_yield y) = 0;
 
@@ -838,7 +838,7 @@ protected:
     virtual ~Notification() = default;
 
     virtual int publish_reserve(RGWObjTags* obj_tags = nullptr) = 0;
-    virtual int publish_commit(const DoutPrefixProvider *dpp, uint64_t size,
+    virtual int publish_commit(const DoutPrefixProvider* dpp, uint64_t size,
 			       const ceph::real_time& mtime, const std::string& etag) = 0;
 };
 
@@ -859,19 +859,19 @@ using RawObjSet = std::set<rgw_raw_obj>;
 
 class Writer : public rgw::putobj::DataProcessor {
 protected:
-  Aio *const aio;
+  Aio* const aio;
   rgw::sal::Bucket* bucket;
   RGWObjectCtx& obj_ctx;
   std::unique_ptr<rgw::sal::Object> head_obj;
   RawObjSet written; // set of written objects for deletion
-  const DoutPrefixProvider *dpp;
+  const DoutPrefixProvider* dpp;
   optional_yield y;
 
  public:
-  Writer(Aio *aio,
+  Writer(Aio* aio,
 	      rgw::sal::Bucket* bucket,
               RGWObjectCtx& obj_ctx, std::unique_ptr<rgw::sal::Object> _head_obj,
-              const DoutPrefixProvider *dpp, optional_yield y)
+              const DoutPrefixProvider* dpp, optional_yield y)
     : aio(aio), bucket(bucket),
       obj_ctx(obj_ctx), head_obj(std::move(_head_obj)), dpp(dpp), y(y)
   {}
@@ -907,7 +907,7 @@ class Zone {
     virtual const RGWRealm& get_realm() = 0;
     virtual const std::string& get_name() const = 0;
     virtual bool is_writeable() = 0;
-    virtual bool get_redirect_endpoint(string *endpoint) = 0;
+    virtual bool get_redirect_endpoint(string* endpoint) = 0;
     virtual bool has_zonegroup_api(const std::string& api) const = 0;
     virtual const string& get_current_period_id() = 0;
 };
@@ -917,18 +917,18 @@ class Zone {
 class StoreManager {
 public:
   StoreManager() {}
-  static rgw::sal::Store *get_storage(const DoutPrefixProvider *dpp, CephContext *cct, const std::string svc, bool use_gc_thread, bool use_lc_thread, bool quota_threads,
+  static rgw::sal::Store* get_storage(const DoutPrefixProvider* dpp, CephContext* cct, const std::string svc, bool use_gc_thread, bool use_lc_thread, bool quota_threads,
                                bool run_sync_thread, bool run_reshard_thread, bool use_cache = true) {
-    rgw::sal::Store *store = init_storage_provider(dpp, cct, svc, use_gc_thread, use_lc_thread,
+    rgw::sal::Store* store = init_storage_provider(dpp, cct, svc, use_gc_thread, use_lc_thread,
         quota_threads, run_sync_thread, run_reshard_thread, use_cache);
     return store;
   }
-  static rgw::sal::Store *get_raw_storage(const DoutPrefixProvider *dpp, CephContext *cct, const std::string svc) {
-    rgw::sal::Store *store = init_raw_storage_provider(dpp, cct, svc);
+  static rgw::sal::Store* get_raw_storage(const DoutPrefixProvider* dpp, CephContext* cct, const std::string svc) {
+    rgw::sal::Store* store = init_raw_storage_provider(dpp, cct, svc);
     return store;
   }
-  static rgw::sal::Store *init_storage_provider(const DoutPrefixProvider *dpp, CephContext *cct, const std::string svc, bool use_gc_thread, bool use_lc_thread, bool quota_threads, bool run_sync_thread, bool run_reshard_thread, bool use_metadata_cache);
-  static rgw::sal::Store *init_raw_storage_provider(const DoutPrefixProvider *dpp, CephContext *cct, const std::string svc);
-  static void close_storage(rgw::sal::Store *store);
+  static rgw::sal::Store* init_storage_provider(const DoutPrefixProvider* dpp, CephContext* cct, const std::string svc, bool use_gc_thread, bool use_lc_thread, bool quota_threads, bool run_sync_thread, bool run_reshard_thread, bool use_metadata_cache);
+  static rgw::sal::Store* init_raw_storage_provider(const DoutPrefixProvider* dpp, CephContext* cct, const std::string svc);
+  static void close_storage(rgw::sal::Store* store);
 
 };

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -95,10 +95,10 @@ namespace rgw { namespace sal {
 
 #define RGW_SAL_VERSION 1
 
-class RGWUser;
-class RGWBucket;
-class RGWObject;
-class RGWBucketList;
+class User;
+class Bucket;
+class Object;
+class BucketList;
 struct MPSerializer;
 class Lifecycle;
 class Notification;
@@ -122,44 +122,44 @@ class Completions {
     virtual int drain() = 0;
 };
 
-using RGWAttrs = std::map<std::string, ceph::buffer::list>;
+using Attrs = std::map<std::string, ceph::buffer::list>;
 
-class RGWStore {
+class Store {
   public:
-    RGWStore() {}
-    virtual ~RGWStore() = default;
+    Store() {}
+    virtual ~Store() = default;
 
     /* This one does not query the cluster for info */
-    virtual std::unique_ptr<RGWUser> get_user(const rgw_user& u) = 0;
+    virtual std::unique_ptr<User> get_user(const rgw_user& u) = 0;
     /* These three do query the cluster for info */
-    virtual int get_user_by_access_key(const DoutPrefixProvider *dpp, const std::string& key, optional_yield y, std::unique_ptr<RGWUser>* user) = 0;
-    virtual int get_user_by_email(const DoutPrefixProvider *dpp, const std::string& email, optional_yield y, std::unique_ptr<RGWUser>* user) = 0;
-    virtual int get_user_by_swift(const DoutPrefixProvider *dpp, const std::string& user_str, optional_yield y, std::unique_ptr<RGWUser>* user) = 0;
-    virtual std::unique_ptr<RGWObject> get_object(const rgw_obj_key& k) = 0;
-    virtual int get_bucket(const DoutPrefixProvider *dpp, RGWUser* u, const rgw_bucket& b, std::unique_ptr<RGWBucket>* bucket, optional_yield y) = 0;
-    virtual int get_bucket(RGWUser* u, const RGWBucketInfo& i, std::unique_ptr<RGWBucket>* bucket) = 0;
-    virtual int get_bucket(const DoutPrefixProvider *dpp, RGWUser* u, const std::string& tenant, const std::string& name, std::unique_ptr<RGWBucket>* bucket, optional_yield y) = 0;
+    virtual int get_user_by_access_key(const DoutPrefixProvider *dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user) = 0;
+    virtual int get_user_by_email(const DoutPrefixProvider *dpp, const std::string& email, optional_yield y, std::unique_ptr<User>* user) = 0;
+    virtual int get_user_by_swift(const DoutPrefixProvider *dpp, const std::string& user_str, optional_yield y, std::unique_ptr<User>* user) = 0;
+    virtual std::unique_ptr<Object> get_object(const rgw_obj_key& k) = 0;
+    virtual int get_bucket(const DoutPrefixProvider *dpp, User* u, const rgw_bucket& b, std::unique_ptr<Bucket>* bucket, optional_yield y) = 0;
+    virtual int get_bucket(User* u, const RGWBucketInfo& i, std::unique_ptr<Bucket>* bucket) = 0;
+    virtual int get_bucket(const DoutPrefixProvider *dpp, User* u, const std::string& tenant, const std::string& name, std::unique_ptr<Bucket>* bucket, optional_yield y) = 0;
     virtual int create_bucket(const DoutPrefixProvider *dpp, 
-                            RGWUser& u, const rgw_bucket& b,
+                            User& u, const rgw_bucket& b,
                             const std::string& zonegroup_id,
                             rgw_placement_rule& placement_rule,
                             std::string& swift_ver_location,
                             const RGWQuotaInfo * pquota_info,
                             const RGWAccessControlPolicy& policy,
-			    RGWAttrs& attrs,
+			    Attrs& attrs,
                             RGWBucketInfo& info,
                             obj_version& ep_objv,
 			    bool exclusive,
 			    bool obj_lock_enabled,
 			    bool *existed,
 			    req_info& req_info,
-			    std::unique_ptr<RGWBucket>* bucket,
+			    std::unique_ptr<Bucket>* bucket,
 			    optional_yield y) = 0;
     virtual bool is_meta_master() = 0;
-    virtual int forward_request_to_master(RGWUser* user, obj_version *objv,
+    virtual int forward_request_to_master(User* user, obj_version *objv,
 					  bufferlist& in_data, JSONParser *jp, req_info& info,
 					  optional_yield y) = 0;
-    virtual int defer_gc(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWBucket* bucket, RGWObject* obj,
+    virtual int defer_gc(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, Bucket* bucket, Object* obj,
 			 optional_yield y) = 0;
     virtual Zone* get_zone() = 0;
     virtual std::string zone_unique_id(uint64_t unique_num) = 0;
@@ -167,10 +167,10 @@ class RGWStore {
     virtual int cluster_stat(RGWClusterStat& stats) = 0;
     virtual std::unique_ptr<Lifecycle> get_lifecycle(void) = 0;
     virtual std::unique_ptr<Completions> get_completions(void) = 0;
-    virtual std::unique_ptr<Notification> get_notification(rgw::sal::RGWObject* obj, struct req_state* s, rgw::notify::EventType event_type) = 0;
-    virtual std::unique_ptr<GCChain> get_gc_chain(rgw::sal::RGWObject* obj) = 0;
-    virtual std::unique_ptr<Writer> get_writer(Aio *aio, rgw::sal::RGWBucket* bucket,
-              RGWObjectCtx& obj_ctx, std::unique_ptr<rgw::sal::RGWObject> _head_obj,
+    virtual std::unique_ptr<Notification> get_notification(rgw::sal::Object* obj, struct req_state* s, rgw::notify::EventType event_type) = 0;
+    virtual std::unique_ptr<GCChain> get_gc_chain(rgw::sal::Object* obj) = 0;
+    virtual std::unique_ptr<Writer> get_writer(Aio *aio, rgw::sal::Bucket* bucket,
+              RGWObjectCtx& obj_ctx, std::unique_ptr<rgw::sal::Object> _head_obj,
               const DoutPrefixProvider *dpp, optional_yield y) = 0;
     virtual RGWLC* get_rgwlc(void) = 0;
     virtual RGWCoroutinesManagerRegistry* get_cr_registry() = 0;
@@ -235,25 +235,25 @@ class RGWStore {
     virtual void set_luarocks_path(const std::string& path) = 0;
 };
 
-class RGWUser {
+class User {
   protected:
     RGWUserInfo info;
     RGWObjVersionTracker objv_tracker;
 
   public:
-    RGWUser() : info() {}
-    RGWUser(const rgw_user& _u) : info() { info.user_id = _u; }
-    RGWUser(const RGWUserInfo& _i) : info(_i) {}
-    RGWUser(RGWUser& _o) = default;
-    virtual ~RGWUser() = default;
+    User() : info() {}
+    User(const rgw_user& _u) : info() { info.user_id = _u; }
+    User(const RGWUserInfo& _i) : info(_i) {}
+    User(User& _o) = default;
+    virtual ~User() = default;
 
-    virtual std::unique_ptr<RGWUser> clone() = 0;
+    virtual std::unique_ptr<User> clone() = 0;
     virtual int list_buckets(const DoutPrefixProvider *dpp,
 			     const std::string& marker, const std::string& end_marker,
-			     uint64_t max, bool need_stats, RGWBucketList& buckets,
+			     uint64_t max, bool need_stats, BucketList& buckets,
 			     optional_yield y) = 0;
-    virtual RGWBucket* create_bucket(rgw_bucket& bucket, ceph::real_time creation_time) = 0;
-    friend class RGWBucket;
+    virtual Bucket* create_bucket(rgw_bucket& bucket, ceph::real_time creation_time) = 0;
+    friend class Bucket;
     virtual std::string& get_display_name() { return info.display_name; }
 
     const std::string& get_tenant() { return info.user_id.tenant; }
@@ -265,9 +265,9 @@ class RGWUser {
     uint32_t get_type() const { return info.type; }
     int32_t get_max_buckets() const { return info.max_buckets; }
     const RGWUserCaps& get_caps() const { return info.caps; }
-    static bool empty(RGWUser* u) { return (!u || u->info.user_id.id.empty()); }
-    static bool empty(std::unique_ptr<RGWUser>& u) { return (!u || u->info.user_id.id.empty()); }
-    virtual int read_attrs(const DoutPrefixProvider *dpp, optional_yield y, RGWAttrs* uattrs, RGWObjVersionTracker* tracker = nullptr) = 0;
+    static bool empty(User* u) { return (!u || u->info.user_id.id.empty()); }
+    static bool empty(std::unique_ptr<User>& u) { return (!u || u->info.user_id.id.empty()); }
+    virtual int read_attrs(const DoutPrefixProvider *dpp, optional_yield y, Attrs* uattrs, RGWObjVersionTracker* tracker = nullptr) = 0;
     virtual int read_stats(optional_yield y, RGWStorageStats* stats,
 			   ceph::real_time *last_stats_sync = nullptr,
 			   ceph::real_time *last_stats_update = nullptr) = 0;
@@ -287,12 +287,12 @@ class RGWUser {
     /* dang temporary; will be removed when User is complete */
     RGWUserInfo& get_info() { return info; }
 
-    friend inline ostream& operator<<(ostream& out, const RGWUser& u) {
+    friend inline ostream& operator<<(ostream& out, const User& u) {
       out << u.info.user_id;
       return out;
     }
 
-    friend inline ostream& operator<<(ostream& out, const RGWUser* u) {
+    friend inline ostream& operator<<(ostream& out, const User* u) {
       if (!u)
 	out << "<NULL>";
       else
@@ -300,19 +300,19 @@ class RGWUser {
       return out;
     }
 
-    friend inline ostream& operator<<(ostream& out, const std::unique_ptr<RGWUser>& p) {
+    friend inline ostream& operator<<(ostream& out, const std::unique_ptr<User>& p) {
       out << p.get();
       return out;
     }
 
 };
 
-class RGWBucket {
+class Bucket {
   protected:
     RGWBucketEnt ent;
     RGWBucketInfo info;
-    RGWUser* owner = nullptr;
-    RGWAttrs attrs;
+    User* owner = nullptr;
+    Attrs attrs;
     obj_version bucket_version;
     ceph::real_time mtime;
 
@@ -337,39 +337,39 @@ class RGWBucket {
       rgw_obj_key next_marker;
     };
 
-    RGWBucket() = default;
-    RGWBucket(RGWUser* _u) :
+    Bucket() = default;
+    Bucket(User* _u) :
       owner(_u) { }
-    RGWBucket(const rgw_bucket& _b) { ent.bucket = _b; info.bucket = _b; }
-    RGWBucket(const RGWBucketEnt& _e) : ent(_e) {
+    Bucket(const rgw_bucket& _b) { ent.bucket = _b; info.bucket = _b; }
+    Bucket(const RGWBucketEnt& _e) : ent(_e) {
       info.bucket = ent.bucket;
       info.placement_rule = ent.placement_rule;
       info.creation_time = ent.creation_time;
     }
-    RGWBucket(const RGWBucketInfo& _i) : info(_i) {
+    Bucket(const RGWBucketInfo& _i) : info(_i) {
       ent.bucket = info.bucket;
       ent.placement_rule = info.placement_rule;
       ent.creation_time = info.creation_time;
     }
-    RGWBucket(const rgw_bucket& _b, RGWUser* _u) :
+    Bucket(const rgw_bucket& _b, User* _u) :
       owner(_u) { ent.bucket = _b; info.bucket = _b; }
-    RGWBucket(const RGWBucketEnt& _e, RGWUser* _u) : ent(_e), owner(_u) {
+    Bucket(const RGWBucketEnt& _e, User* _u) : ent(_e), owner(_u) {
       info.bucket = ent.bucket;
       info.placement_rule = ent.placement_rule;
       info.creation_time = ent.creation_time;
     }
-    RGWBucket(const RGWBucketInfo& _i, RGWUser* _u) : info(_i), owner(_u) {
+    Bucket(const RGWBucketInfo& _i, User* _u) : info(_i), owner(_u) {
       ent.bucket = info.bucket;
       ent.placement_rule = info.placement_rule;
       ent.creation_time = info.creation_time;
     }
-    virtual ~RGWBucket() = default;
+    virtual ~Bucket() = default;
 
-    virtual std::unique_ptr<RGWObject> get_object(const rgw_obj_key& key) = 0;
+    virtual std::unique_ptr<Object> get_object(const rgw_obj_key& key) = 0;
     virtual int list(const DoutPrefixProvider *dpp, ListParams&, int, ListResults&, optional_yield y) = 0;
-    virtual RGWObject* create_object(const rgw_obj_key& key /* Attributes */) = 0;
-    virtual RGWAttrs& get_attrs(void) { return attrs; }
-    virtual int set_attrs(RGWAttrs a) { attrs = a; return 0; }
+    virtual Object* create_object(const rgw_obj_key& key /* Attributes */) = 0;
+    virtual Attrs& get_attrs(void) { return attrs; }
+    virtual int set_attrs(Attrs a) { attrs = a; return 0; }
     virtual int remove_bucket(const DoutPrefixProvider *dpp, bool delete_children, std::string prefix, std::string delimiter, bool forward_to_master, req_info* req_info, optional_yield y) = 0;
     virtual RGWAccessControlPolicy& get_acl(void) = 0;
     virtual int set_acl(const DoutPrefixProvider *dpp, RGWAccessControlPolicy& acl, optional_yield y) = 0;
@@ -384,18 +384,18 @@ class RGWBucket {
     virtual int sync_user_stats(optional_yield y) = 0;
     virtual int update_container_stats(const DoutPrefixProvider *dpp) = 0;
     virtual int check_bucket_shards(const DoutPrefixProvider *dpp) = 0;
-    virtual int link(const DoutPrefixProvider *dpp, RGWUser* new_user, optional_yield y, bool update_entrypoint = true, RGWObjVersionTracker* objv = nullptr) = 0;
-    virtual int unlink(const DoutPrefixProvider *dpp, RGWUser* new_user, optional_yield y, bool update_entrypoint = true) = 0;
-    virtual int chown(const DoutPrefixProvider *dpp, RGWUser* new_user, RGWUser* old_user, optional_yield y, const std::string* marker = nullptr) = 0;
+    virtual int link(const DoutPrefixProvider *dpp, User* new_user, optional_yield y, bool update_entrypoint = true, RGWObjVersionTracker* objv = nullptr) = 0;
+    virtual int unlink(const DoutPrefixProvider *dpp, User* new_user, optional_yield y, bool update_entrypoint = true) = 0;
+    virtual int chown(const DoutPrefixProvider *dpp, User* new_user, User* old_user, optional_yield y, const std::string* marker = nullptr) = 0;
     virtual int put_instance_info(const DoutPrefixProvider *dpp, bool exclusive, ceph::real_time mtime) = 0;
     virtual int remove_entrypoint(const DoutPrefixProvider *dpp, RGWObjVersionTracker* objv, optional_yield y) = 0;
     virtual int remove_instance_info(const DoutPrefixProvider *dpp, RGWObjVersionTracker* objv, optional_yield y) = 0;
-    virtual bool is_owner(RGWUser* user) = 0;
-    virtual RGWUser* get_owner(void) { return owner; };
+    virtual bool is_owner(User* user) = 0;
+    virtual User* get_owner(void) { return owner; };
     virtual ACLOwner get_acl_owner(void) { return ACLOwner(info.owner); };
     virtual int check_empty(const DoutPrefixProvider *dpp, optional_yield y) = 0;
     virtual int check_quota(RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota, uint64_t obj_size, optional_yield y, bool check_size_only = false) = 0;
-    virtual int set_instance_attrs(const DoutPrefixProvider *dpp, RGWAttrs& attrs, optional_yield y) = 0;
+    virtual int set_instance_attrs(const DoutPrefixProvider *dpp, Attrs& attrs, optional_yield y) = 0;
     virtual int try_refresh_info(const DoutPrefixProvider *dpp, ceph::real_time *pmtime) = 0;
     virtual int read_usage(uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries,
 			   bool *is_truncated, RGWUsageIter& usage_iter,
@@ -427,19 +427,19 @@ class RGWBucket {
       ent.convert(b);
     }
 
-    static bool empty(RGWBucket* b) { return (!b || b->empty()); }
-    virtual std::unique_ptr<RGWBucket> clone() = 0;
+    static bool empty(Bucket* b) { return (!b || b->empty()); }
+    virtual std::unique_ptr<Bucket> clone() = 0;
 
     /* dang - This is temporary, until the API is completed */
     rgw_bucket& get_key() { return info.bucket; }
     RGWBucketInfo& get_info() { return info; }
 
-    friend inline ostream& operator<<(ostream& out, const RGWBucket& b) {
+    friend inline ostream& operator<<(ostream& out, const Bucket& b) {
       out << b.info.bucket;
       return out;
     }
 
-    friend inline ostream& operator<<(ostream& out, const RGWBucket* b) {
+    friend inline ostream& operator<<(ostream& out, const Bucket* b) {
       if (!b)
 	out << "<NULL>";
       else
@@ -447,40 +447,40 @@ class RGWBucket {
       return out;
     }
 
-    friend inline ostream& operator<<(ostream& out, const std::unique_ptr<RGWBucket>& p) {
+    friend inline ostream& operator<<(ostream& out, const std::unique_ptr<Bucket>& p) {
       out << p.get();
       return out;
     }
 
-    bool operator==(const RGWBucket& b) const {
+    bool operator==(const Bucket& b) const {
       return (info.bucket.tenant == b.info.bucket.tenant) &&
 	     (info.bucket.name == b.info.bucket.name) &&
 	     (info.bucket.bucket_id == b.info.bucket.bucket_id);
     }
-    bool operator!=(const RGWBucket& b) const {
+    bool operator!=(const Bucket& b) const {
       return (info.bucket.tenant != b.info.bucket.tenant) ||
 	     (info.bucket.name != b.info.bucket.name) ||
 	     (info.bucket.bucket_id != b.info.bucket.bucket_id);
     }
 
-    friend class RGWBucketList;
+    friend class BucketList;
   protected:
     virtual void set_ent(RGWBucketEnt& _ent) { ent = _ent; info.bucket = ent.bucket; info.placement_rule = ent.placement_rule; }
 };
 
 
-class RGWBucketList {
-  std::map<std::string, std::unique_ptr<RGWBucket>> buckets;
+class BucketList {
+  std::map<std::string, std::unique_ptr<Bucket>> buckets;
   bool truncated;
 
 public:
-  RGWBucketList() : buckets(), truncated(false) {}
-  RGWBucketList(RGWBucketList&& _bl) :
+  BucketList() : buckets(), truncated(false) {}
+  BucketList(BucketList&& _bl) :
     buckets(std::move(_bl.buckets)),
     truncated(_bl.truncated)
     { }
-  RGWBucketList& operator=(const RGWBucketList&) = delete;
-  RGWBucketList& operator=(RGWBucketList&& _bl) {
+  BucketList& operator=(const BucketList&) = delete;
+  BucketList& operator=(BucketList&& _bl) {
     for (auto& ent : _bl.buckets) {
       buckets.emplace(ent.first, std::move(ent.second));
     }
@@ -488,10 +488,10 @@ public:
     return *this;
   };
 
-  map<std::string, std::unique_ptr<RGWBucket>>& get_buckets() { return buckets; }
+  map<std::string, std::unique_ptr<Bucket>>& get_buckets() { return buckets; }
   bool is_truncated(void) const { return truncated; }
   void set_truncated(bool trunc) { truncated = trunc; }
-  void add(std::unique_ptr<RGWBucket> bucket) {
+  void add(std::unique_ptr<Bucket> bucket) {
     buckets.emplace(bucket->info.bucket.name, std::move(bucket));
   }
   size_t count() const { return buckets.size(); }
@@ -501,13 +501,13 @@ public:
   }
 };
 
-class RGWObject {
+class Object {
   protected:
     rgw_obj_key key;
-    RGWBucket* bucket;
+    Bucket* bucket;
     std::string index_hash_source;
     uint64_t obj_size;
-    RGWAttrs attrs;
+    Attrs attrs;
     ceph::real_time mtime;
     bool delete_marker{false};
     bool in_extra_data{false};
@@ -546,7 +546,7 @@ class RGWObject {
       struct Params {
 	bool versioning_disabled{false};
 	ceph::real_time* mtime{nullptr};
-	RGWAttrs* rmattrs{nullptr};
+	Attrs* rmattrs{nullptr};
 	const bufferlist* data{nullptr};
 	RGWObjManifest* manifest{nullptr};
 	const string* ptag{nullptr};
@@ -565,7 +565,7 @@ class RGWObject {
 	bool modify_tail{false};
 	bool completeMultipart{false};
 	bool appendable{false};
-	RGWAttrs* attrs{nullptr};
+	Attrs* attrs{nullptr};
       } params;
 
       virtual ~WriteOp() = default;
@@ -605,7 +605,7 @@ class RGWObject {
 
     struct StatOp {
       struct Result {
-	RGWObject* obj;
+	Object* obj;
         RGWObjManifest* manifest;
       } result;
 
@@ -615,44 +615,44 @@ class RGWObject {
       virtual int wait() = 0;
     };
 
-    RGWObject()
+    Object()
       : key(),
       bucket(nullptr),
       index_hash_source(),
       obj_size(),
       attrs(),
       mtime() {}
-    RGWObject(const rgw_obj_key& _k)
+    Object(const rgw_obj_key& _k)
       : key(_k),
       bucket(),
       index_hash_source(),
       obj_size(),
       attrs(),
       mtime() {}
-    RGWObject(const rgw_obj_key& _k, RGWBucket* _b)
+    Object(const rgw_obj_key& _k, Bucket* _b)
       : key(_k),
       bucket(_b),
       index_hash_source(),
       obj_size(),
       attrs(),
       mtime() {}
-    RGWObject(RGWObject& _o) = default;
+    Object(Object& _o) = default;
 
-    virtual ~RGWObject() = default;
+    virtual ~Object() = default;
 
     virtual int delete_object(const DoutPrefixProvider *dpp, RGWObjectCtx* obj_ctx, optional_yield y) = 0;
     virtual int delete_obj_aio(const DoutPrefixProvider *dpp, RGWObjState *astate, Completions* aio,
 			       bool keep_index_consistent, optional_yield y) = 0;
-    virtual int copy_object(RGWObjectCtx& obj_ctx, RGWUser* user,
+    virtual int copy_object(RGWObjectCtx& obj_ctx, User* user,
                req_info *info, const rgw_zone_id& source_zone,
-               rgw::sal::RGWObject* dest_object, rgw::sal::RGWBucket* dest_bucket,
-               rgw::sal::RGWBucket* src_bucket,
+               rgw::sal::Object* dest_object, rgw::sal::Bucket* dest_bucket,
+               rgw::sal::Bucket* src_bucket,
                const rgw_placement_rule& dest_placement,
                ceph::real_time *src_mtime, ceph::real_time *mtime,
                const ceph::real_time *mod_ptr, const ceph::real_time *unmod_ptr,
                bool high_precision_time,
                const char *if_match, const char *if_nomatch,
-               AttrsMod attrs_mod, bool copy_if_newer, RGWAttrs& attrs,
+               AttrsMod attrs_mod, bool copy_if_newer, Attrs& attrs,
                RGWObjCategory category, uint64_t olh_epoch,
 	       boost::optional<ceph::real_time> delete_at,
                string *version_id, string *tag, string *etag,
@@ -667,18 +667,18 @@ class RGWObject {
     const std::string &get_name() const { return key.name; }
 
     virtual int get_obj_state(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWObjState **state, optional_yield y, bool follow_olh = false) = 0;
-    virtual int set_obj_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx* rctx, RGWAttrs* setattrs, RGWAttrs* delattrs, optional_yield y, rgw_obj* target_obj = NULL) = 0;
+    virtual int set_obj_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx* rctx, Attrs* setattrs, Attrs* delattrs, optional_yield y, rgw_obj* target_obj = NULL) = 0;
     virtual int get_obj_attrs(RGWObjectCtx *rctx, optional_yield y, const DoutPrefixProvider *dpp, rgw_obj* target_obj = NULL) = 0;
     virtual int modify_obj_attrs(RGWObjectCtx *rctx, const char *attr_name, bufferlist& attr_val, optional_yield y, const DoutPrefixProvider *dpp) = 0;
     virtual int delete_obj_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, const char *attr_name, optional_yield y) = 0;
-    virtual int copy_obj_data(RGWObjectCtx& rctx, RGWBucket* dest_bucket, RGWObject* dest_obj, uint16_t olh_epoch, std::string* petag, const DoutPrefixProvider *dpp, optional_yield y) = 0;
+    virtual int copy_obj_data(RGWObjectCtx& rctx, Bucket* dest_bucket, Object* dest_obj, uint16_t olh_epoch, std::string* petag, const DoutPrefixProvider *dpp, optional_yield y) = 0;
     virtual bool is_expired() = 0;
     virtual void gen_rand_obj_instance_name() = 0;
     virtual void raw_obj_to_obj(const rgw_raw_obj& raw_obj) = 0;
     virtual void get_raw_obj(rgw_raw_obj* raw_obj) = 0;
     virtual MPSerializer* get_serializer(const std::string& lock_name) = 0;
     virtual int transition(RGWObjectCtx& rctx,
-			   RGWBucket* bucket,
+			   Bucket* bucket,
 			   const rgw_placement_rule& placement_rule,
 			   const real_time& mtime,
 			   uint64_t olh_epoch,
@@ -691,12 +691,12 @@ class RGWObject {
     virtual void get_max_aligned_size(uint64_t size, uint64_t alignment, uint64_t *max_size) = 0;
     virtual bool placement_rules_match(rgw_placement_rule& r1, rgw_placement_rule& r2) = 0;
 
-    RGWAttrs& get_attrs(void) { return attrs; }
-    const RGWAttrs& get_attrs(void) const { return attrs; }
+    Attrs& get_attrs(void) { return attrs; }
+    const Attrs& get_attrs(void) const { return attrs; }
     ceph::real_time get_mtime(void) const { return mtime; }
     uint64_t get_obj_size(void) const { return obj_size; }
-    RGWBucket* get_bucket(void) const { return bucket; }
-    void set_bucket(RGWBucket* b) { bucket = b; }
+    Bucket* get_bucket(void) const { return bucket; }
+    void set_bucket(Bucket* b) { bucket = b; }
     std::string get_hash_source(void) { return index_hash_source; }
     void set_hash_source(std::string s) { index_hash_source = s; }
     std::string get_oid(void) const { return key.get_oid(); }
@@ -736,12 +736,12 @@ class RGWObject {
 			     optional_yield y) = 0;
     virtual int omap_get_vals_by_keys(const std::string& oid,
 			      const std::set<std::string>& keys,
-			      RGWAttrs *vals) = 0;
+			      Attrs *vals) = 0;
     virtual int omap_set_val_by_key(const std::string& key, bufferlist& val,
 				    bool must_exist, optional_yield y) = 0;
 
-    static bool empty(RGWObject* o) { return (!o || o->empty()); }
-    virtual std::unique_ptr<RGWObject> clone() = 0;
+    static bool empty(Object* o) { return (!o || o->empty()); }
+    virtual std::unique_ptr<Object> clone() = 0;
 
     /* dang - Not sure if we want this, but it simplifies things a lot */
 
@@ -751,20 +751,20 @@ class RGWObject {
     const std::string &get_instance() const { return key.instance; }
     bool have_instance(void) { return key.have_instance(); }
 
-    friend inline ostream& operator<<(ostream& out, const RGWObject& o) {
+    friend inline ostream& operator<<(ostream& out, const Object& o) {
       if (o.bucket)
 	out << o.bucket << ":";
       out << o.key;
       return out;
     }
-    friend inline ostream& operator<<(ostream& out, const RGWObject* o) {
+    friend inline ostream& operator<<(ostream& out, const Object* o) {
       if (!o)
 	out << "<NULL>";
       else
 	out << *o;
       return out;
     }
-    friend inline ostream& operator<<(ostream& out, const std::unique_ptr<RGWObject>& p) {
+    friend inline ostream& operator<<(ostream& out, const std::unique_ptr<Object>& p) {
       out << p.get();
       return out;
     }
@@ -830,11 +830,11 @@ public:
 
 class Notification {
 protected:
-  RGWObject* obj;
+  Object* obj;
   rgw::notify::EventType event_type;
 
   public:
-    Notification(RGWObject* _obj, rgw::notify::EventType _type) : obj(_obj), event_type(_type) {}
+    Notification(Object* _obj, rgw::notify::EventType _type) : obj(_obj), event_type(_type) {}
     virtual ~Notification() = default;
 
     virtual int publish_reserve(RGWObjTags* obj_tags = nullptr) = 0;
@@ -844,10 +844,10 @@ protected:
 
 class GCChain {
 protected:
-  RGWObject* obj;
+  Object* obj;
 
   public:
-    GCChain(RGWObject* _obj) : obj(_obj) {}
+    GCChain(Object* _obj) : obj(_obj) {}
     virtual ~GCChain() = default;
 
     virtual void update(RGWObjManifest* manifest) = 0;
@@ -860,17 +860,17 @@ using RawObjSet = std::set<rgw_raw_obj>;
 class Writer : public rgw::putobj::DataProcessor {
 protected:
   Aio *const aio;
-  rgw::sal::RGWBucket* bucket;
+  rgw::sal::Bucket* bucket;
   RGWObjectCtx& obj_ctx;
-  std::unique_ptr<rgw::sal::RGWObject> head_obj;
+  std::unique_ptr<rgw::sal::Object> head_obj;
   RawObjSet written; // set of written objects for deletion
   const DoutPrefixProvider *dpp;
   optional_yield y;
 
  public:
   Writer(Aio *aio,
-	      rgw::sal::RGWBucket* bucket,
-              RGWObjectCtx& obj_ctx, std::unique_ptr<rgw::sal::RGWObject> _head_obj,
+	      rgw::sal::Bucket* bucket,
+              RGWObjectCtx& obj_ctx, std::unique_ptr<rgw::sal::Object> _head_obj,
               const DoutPrefixProvider *dpp, optional_yield y)
     : aio(aio), bucket(bucket),
       obj_ctx(obj_ctx), head_obj(std::move(_head_obj)), dpp(dpp), y(y)
@@ -914,21 +914,21 @@ class Zone {
 
 } } // namespace rgw::sal
 
-class RGWStoreManager {
+class StoreManager {
 public:
-  RGWStoreManager() {}
-  static rgw::sal::RGWStore *get_storage(const DoutPrefixProvider *dpp, CephContext *cct, const std::string svc, bool use_gc_thread, bool use_lc_thread, bool quota_threads,
+  StoreManager() {}
+  static rgw::sal::Store *get_storage(const DoutPrefixProvider *dpp, CephContext *cct, const std::string svc, bool use_gc_thread, bool use_lc_thread, bool quota_threads,
                                bool run_sync_thread, bool run_reshard_thread, bool use_cache = true) {
-    rgw::sal::RGWStore *store = init_storage_provider(dpp, cct, svc, use_gc_thread, use_lc_thread,
+    rgw::sal::Store *store = init_storage_provider(dpp, cct, svc, use_gc_thread, use_lc_thread,
         quota_threads, run_sync_thread, run_reshard_thread, use_cache);
     return store;
   }
-  static rgw::sal::RGWStore *get_raw_storage(const DoutPrefixProvider *dpp, CephContext *cct, const std::string svc) {
-    rgw::sal::RGWStore *store = init_raw_storage_provider(dpp, cct, svc);
+  static rgw::sal::Store *get_raw_storage(const DoutPrefixProvider *dpp, CephContext *cct, const std::string svc) {
+    rgw::sal::Store *store = init_raw_storage_provider(dpp, cct, svc);
     return store;
   }
-  static rgw::sal::RGWStore *init_storage_provider(const DoutPrefixProvider *dpp, CephContext *cct, const std::string svc, bool use_gc_thread, bool use_lc_thread, bool quota_threads, bool run_sync_thread, bool run_reshard_thread, bool use_metadata_cache);
-  static rgw::sal::RGWStore *init_raw_storage_provider(const DoutPrefixProvider *dpp, CephContext *cct, const std::string svc);
-  static void close_storage(rgw::sal::RGWStore *store);
+  static rgw::sal::Store *init_storage_provider(const DoutPrefixProvider *dpp, CephContext *cct, const std::string svc, bool use_gc_thread, bool use_lc_thread, bool quota_threads, bool run_sync_thread, bool run_reshard_thread, bool use_metadata_cache);
+  static rgw::sal::Store *init_raw_storage_provider(const DoutPrefixProvider *dpp, CephContext *cct, const std::string svc);
+  static void close_storage(rgw::sal::Store *store);
 
 };

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -67,9 +67,9 @@ static int decode_policy(CephContext *cct,
 }
 
 static int rgw_op_get_bucket_policy_from_attr(const DoutPrefixProvider *dpp,
-					      RGWRadosStore *store,
-					      RGWUser& user,
-					      RGWAttrs& bucket_attrs,
+					      RadosStore *store,
+					      User& user,
+					      Attrs& bucket_attrs,
 					      RGWAccessControlPolicy *policy,
 					      optional_yield y)
 {
@@ -120,9 +120,9 @@ int RadosCompletions::drain()
   return ret;
 }
 
-int RGWRadosUser::list_buckets(const DoutPrefixProvider *dpp, const string& marker,
+int RadosUser::list_buckets(const DoutPrefixProvider *dpp, const string& marker,
 			       const string& end_marker, uint64_t max, bool need_stats,
-			       RGWBucketList &buckets, optional_yield y)
+			       BucketList &buckets, optional_yield y)
 {
   RGWUserBuckets ulist;
   bool is_truncated = false;
@@ -136,41 +136,41 @@ int RGWRadosUser::list_buckets(const DoutPrefixProvider *dpp, const string& mark
 
   buckets.set_truncated(is_truncated);
   for (const auto& ent : ulist.get_buckets()) {
-    buckets.add(std::unique_ptr<RGWBucket>(new RGWRadosBucket(this->store, ent.second, this)));
+    buckets.add(std::unique_ptr<Bucket>(new RadosBucket(this->store, ent.second, this)));
   }
 
   return 0;
 }
 
-RGWBucket* RGWRadosUser::create_bucket(rgw_bucket& bucket,
+Bucket* RadosUser::create_bucket(rgw_bucket& bucket,
 				       ceph::real_time creation_time)
 {
   return NULL;
 }
 
-int RGWRadosUser::read_attrs(const DoutPrefixProvider *dpp, optional_yield y, RGWAttrs* uattrs, RGWObjVersionTracker* tracker)
+int RadosUser::read_attrs(const DoutPrefixProvider *dpp, optional_yield y, Attrs* uattrs, RGWObjVersionTracker* tracker)
 {
   return store->ctl()->user->get_attrs_by_uid(dpp, get_id(), uattrs, y, tracker);
 }
 
-int RGWRadosUser::read_stats(optional_yield y, RGWStorageStats* stats,
+int RadosUser::read_stats(optional_yield y, RGWStorageStats* stats,
 			     ceph::real_time *last_stats_sync,
 			     ceph::real_time *last_stats_update)
 {
   return store->ctl()->user->read_stats(get_id(), stats, y, last_stats_sync, last_stats_update);
 }
 
-int RGWRadosUser::read_stats_async(RGWGetUserStats_CB *cb)
+int RadosUser::read_stats_async(RGWGetUserStats_CB *cb)
 {
   return store->ctl()->user->read_stats_async(get_id(), cb);
 }
 
-int RGWRadosUser::complete_flush_stats(optional_yield y)
+int RadosUser::complete_flush_stats(optional_yield y)
 {
   return store->ctl()->user->complete_flush_stats(get_id(), y);
 }
 
-int RGWRadosUser::read_usage(uint64_t start_epoch, uint64_t end_epoch,
+int RadosUser::read_usage(uint64_t start_epoch, uint64_t end_epoch,
 			       uint32_t max_entries, bool *is_truncated,
 			       RGWUsageIter& usage_iter,
 			       map<rgw_user_bucket, rgw_usage_log_entry>& usage)
@@ -181,35 +181,35 @@ int RGWRadosUser::read_usage(uint64_t start_epoch, uint64_t end_epoch,
 				       usage_iter, usage);
 }
 
-int RGWRadosUser::trim_usage(uint64_t start_epoch, uint64_t end_epoch)
+int RadosUser::trim_usage(uint64_t start_epoch, uint64_t end_epoch)
 {
   std::string bucket_name;
 
   return store->getRados()->trim_usage(get_id(), bucket_name, start_epoch, end_epoch);
 }
 
-int RGWRadosUser::load_by_id(const DoutPrefixProvider *dpp, optional_yield y)
+int RadosUser::load_by_id(const DoutPrefixProvider *dpp, optional_yield y)
 {
     return store->ctl()->user->get_info_by_uid(dpp, info.user_id, &info, y, RGWUserCtl::GetParams().set_objv_tracker(&objv_tracker));
 }
 
-int RGWRadosUser::store_info(const DoutPrefixProvider *dpp, optional_yield y, const RGWUserCtl::PutParams& params)
+int RadosUser::store_info(const DoutPrefixProvider *dpp, optional_yield y, const RGWUserCtl::PutParams& params)
 {
     return store->ctl()->user->store_info(dpp, info, y, params);
 }
 
-int RGWRadosUser::remove_info(const DoutPrefixProvider *dpp, optional_yield y, const RGWUserCtl::RemoveParams& params)
+int RadosUser::remove_info(const DoutPrefixProvider *dpp, optional_yield y, const RGWUserCtl::RemoveParams& params)
 {
     return store->ctl()->user->remove_info(dpp, info, y, params);
 }
 
 /* Placeholder */
-RGWObject *RGWRadosBucket::create_object(const rgw_obj_key &key)
+Object *RadosBucket::create_object(const rgw_obj_key &key)
 {
   return nullptr;
 }
 
-int RGWRadosBucket::remove_bucket(const DoutPrefixProvider *dpp, bool delete_children, std::string prefix, std::string delimiter, bool forward_to_master, req_info* req_info, optional_yield y)
+int RadosBucket::remove_bucket(const DoutPrefixProvider *dpp, bool delete_children, std::string prefix, std::string delimiter, bool forward_to_master, req_info* req_info, optional_yield y)
 {
   int ret;
 
@@ -302,7 +302,7 @@ int RGWRadosBucket::remove_bucket(const DoutPrefixProvider *dpp, bool delete_chi
   return ret;
 }
 
-int RGWRadosBucket::get_bucket_info(const DoutPrefixProvider *dpp, optional_yield y)
+int RadosBucket::get_bucket_info(const DoutPrefixProvider *dpp, optional_yield y)
 {
   auto obj_ctx = store->svc()->sysobj->init_obj_ctx();
   int ret;
@@ -330,7 +330,7 @@ int RGWRadosBucket::get_bucket_info(const DoutPrefixProvider *dpp, optional_yiel
   return ret;
 }
 
-int RGWRadosBucket::get_bucket_stats(int shard_id,
+int RadosBucket::get_bucket_stats(int shard_id,
 				     std::string *bucket_ver, std::string *master_ver,
 				     std::map<RGWObjCategory, RGWStorageStats>& stats,
 				     std::string *max_marker, bool *syncstopped)
@@ -338,24 +338,24 @@ int RGWRadosBucket::get_bucket_stats(int shard_id,
   return store->getRados()->get_bucket_stats(info, shard_id, bucket_ver, master_ver, stats, max_marker, syncstopped);
 }
 
-int RGWRadosBucket::get_bucket_stats_async(int shard_id, RGWGetBucketStats_CB *ctx)
+int RadosBucket::get_bucket_stats_async(int shard_id, RGWGetBucketStats_CB *ctx)
 {
   return store->getRados()->get_bucket_stats_async(get_info(), shard_id, ctx);
 }
 
-int RGWRadosBucket::read_bucket_stats(const DoutPrefixProvider *dpp, optional_yield y)
+int RadosBucket::read_bucket_stats(const DoutPrefixProvider *dpp, optional_yield y)
 {
       int ret = store->ctl()->bucket->read_bucket_stats(info.bucket, &ent, y, dpp);
       info.placement_rule = ent.placement_rule;
       return ret;
 }
 
-int RGWRadosBucket::sync_user_stats(optional_yield y)
+int RadosBucket::sync_user_stats(optional_yield y)
 {
   return store->ctl()->bucket->sync_user_stats(owner->get_id(), info, y);
 }
 
-int RGWRadosBucket::update_container_stats(const DoutPrefixProvider *dpp)
+int RadosBucket::update_container_stats(const DoutPrefixProvider *dpp)
 {
   int ret;
   map<std::string, RGWBucketEnt> m;
@@ -383,19 +383,19 @@ int RGWRadosBucket::update_container_stats(const DoutPrefixProvider *dpp)
   return 0;
 }
 
-int RGWRadosBucket::check_bucket_shards(const DoutPrefixProvider *dpp)
+int RadosBucket::check_bucket_shards(const DoutPrefixProvider *dpp)
 {
       return store->getRados()->check_bucket_shards(info, info.bucket, get_count(), dpp);
 }
 
-int RGWRadosBucket::link(const DoutPrefixProvider *dpp, RGWUser* new_user, optional_yield y, bool update_entrypoint, RGWObjVersionTracker* objv)
+int RadosBucket::link(const DoutPrefixProvider *dpp, User* new_user, optional_yield y, bool update_entrypoint, RGWObjVersionTracker* objv)
 {
   RGWBucketEntryPoint ep;
   ep.bucket = info.bucket;
   ep.owner = new_user->get_id();
   ep.creation_time = get_creation_time();
   ep.linked = true;
-  RGWAttrs ep_attrs;
+  Attrs ep_attrs;
   rgw_ep_info ep_data{ep, ep_attrs};
 
   int r = store->ctl()->bucket->link_bucket(new_user->get_id(), info.bucket,
@@ -410,12 +410,12 @@ int RGWRadosBucket::link(const DoutPrefixProvider *dpp, RGWUser* new_user, optio
   return r;
 }
 
-int RGWRadosBucket::unlink(const DoutPrefixProvider *dpp, RGWUser* new_user, optional_yield y, bool update_entrypoint)
+int RadosBucket::unlink(const DoutPrefixProvider *dpp, User* new_user, optional_yield y, bool update_entrypoint)
 {
   return store->ctl()->bucket->unlink_bucket(new_user->get_id(), info.bucket, y, dpp, update_entrypoint);
 }
 
-int RGWRadosBucket::chown(const DoutPrefixProvider *dpp, RGWUser* new_user, RGWUser* old_user, optional_yield y, const std::string* marker)
+int RadosBucket::chown(const DoutPrefixProvider *dpp, User* new_user, User* old_user, optional_yield y, const std::string* marker)
 {
   string obj_marker;
 
@@ -426,20 +426,20 @@ int RGWRadosBucket::chown(const DoutPrefixProvider *dpp, RGWUser* new_user, RGWU
 			   old_user->get_display_name(), *marker, y, dpp);
 }
 
-int RGWRadosBucket::put_instance_info(const DoutPrefixProvider *dpp, bool exclusive, ceph::real_time _mtime)
+int RadosBucket::put_instance_info(const DoutPrefixProvider *dpp, bool exclusive, ceph::real_time _mtime)
 {
   mtime = _mtime;
   return store->getRados()->put_bucket_instance_info(info, exclusive, mtime, &attrs, dpp);
 }
 
-int RGWRadosBucket::remove_entrypoint(const DoutPrefixProvider *dpp, RGWObjVersionTracker* objv, optional_yield y)
+int RadosBucket::remove_entrypoint(const DoutPrefixProvider *dpp, RGWObjVersionTracker* objv, optional_yield y)
 {
   return store->ctl()->bucket->remove_bucket_entrypoint_info(get_key(), y, dpp,
                                            RGWBucketCtl::Bucket::RemoveParams()
                                            .set_objv_tracker(objv));
 }
 
-int RGWRadosBucket::remove_instance_info(const DoutPrefixProvider *dpp, RGWObjVersionTracker* objv, optional_yield y)
+int RadosBucket::remove_instance_info(const DoutPrefixProvider *dpp, RGWObjVersionTracker* objv, optional_yield y)
 {
   return store->ctl()->bucket->remove_bucket_instance_info(get_key(), info, y, dpp,
                                            RGWBucketCtl::BucketInstance::RemoveParams()
@@ -447,35 +447,35 @@ int RGWRadosBucket::remove_instance_info(const DoutPrefixProvider *dpp, RGWObjVe
 }
 
 /* Make sure to call get_bucket_info() if you need it first */
-bool RGWRadosBucket::is_owner(RGWUser* user)
+bool RadosBucket::is_owner(User* user)
 {
   return (info.owner.compare(user->get_id()) == 0);
 }
 
-int RGWRadosBucket::check_empty(const DoutPrefixProvider *dpp, optional_yield y)
+int RadosBucket::check_empty(const DoutPrefixProvider *dpp, optional_yield y)
 {
   return store->getRados()->check_bucket_empty(dpp, info, y);
 }
 
-int RGWRadosBucket::check_quota(RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota, uint64_t obj_size,
+int RadosBucket::check_quota(RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota, uint64_t obj_size,
 				optional_yield y, bool check_size_only)
 {
     return store->getRados()->check_quota(owner->get_id(), get_key(),
 					  user_quota, bucket_quota, obj_size, y, check_size_only);
 }
 
-int RGWRadosBucket::set_instance_attrs(const DoutPrefixProvider *dpp, RGWAttrs& attrs, optional_yield y)
+int RadosBucket::set_instance_attrs(const DoutPrefixProvider *dpp, Attrs& attrs, optional_yield y)
 {
     return store->ctl()->bucket->set_bucket_instance_attrs(get_info(),
 				attrs, &get_info().objv_tracker, y, dpp);
 }
 
-int RGWRadosBucket::try_refresh_info(const DoutPrefixProvider *dpp, ceph::real_time *pmtime)
+int RadosBucket::try_refresh_info(const DoutPrefixProvider *dpp, ceph::real_time *pmtime)
 {
   return store->getRados()->try_refresh_bucket_info(info, pmtime, dpp, &attrs);
 }
 
-int RGWRadosBucket::read_usage(uint64_t start_epoch, uint64_t end_epoch,
+int RadosBucket::read_usage(uint64_t start_epoch, uint64_t end_epoch,
 			       uint32_t max_entries, bool *is_truncated,
 			       RGWUsageIter& usage_iter,
 			       map<rgw_user_bucket, rgw_usage_log_entry>& usage)
@@ -485,32 +485,32 @@ int RGWRadosBucket::read_usage(uint64_t start_epoch, uint64_t end_epoch,
 				       usage_iter, usage);
 }
 
-int RGWRadosBucket::trim_usage(uint64_t start_epoch, uint64_t end_epoch)
+int RadosBucket::trim_usage(uint64_t start_epoch, uint64_t end_epoch)
 {
   return store->getRados()->trim_usage(owner->get_id(), get_name(), start_epoch, end_epoch);
 }
 
-int RGWRadosBucket::remove_objs_from_index(std::list<rgw_obj_index_key>& objs_to_unlink)
+int RadosBucket::remove_objs_from_index(std::list<rgw_obj_index_key>& objs_to_unlink)
 {
   return store->getRados()->remove_objs_from_index(info, objs_to_unlink);
 }
 
-int RGWRadosBucket::check_index(std::map<RGWObjCategory, RGWStorageStats>& existing_stats, std::map<RGWObjCategory, RGWStorageStats>& calculated_stats)
+int RadosBucket::check_index(std::map<RGWObjCategory, RGWStorageStats>& existing_stats, std::map<RGWObjCategory, RGWStorageStats>& calculated_stats)
 {
   return store->getRados()->bucket_check_index(info, &existing_stats, &calculated_stats);
 }
 
-int RGWRadosBucket::rebuild_index()
+int RadosBucket::rebuild_index()
 {
   return store->getRados()->bucket_rebuild_index(info);
 }
 
-int RGWRadosBucket::set_tag_timeout(uint64_t timeout)
+int RadosBucket::set_tag_timeout(uint64_t timeout)
 {
   return store->getRados()->cls_obj_set_bucket_tag_timeout(info, timeout);
 }
 
-int RGWRadosBucket::purge_instance(const DoutPrefixProvider *dpp)
+int RadosBucket::purge_instance(const DoutPrefixProvider *dpp)
 {
   int max_shards = (info.layout.current_index.layout.normal.num_shards > 0 ? info.layout.current_index.layout.normal.num_shards : 1);
   for (int i = 0; i < max_shards; i++) {
@@ -532,7 +532,7 @@ int RGWRadosBucket::purge_instance(const DoutPrefixProvider *dpp)
   return 0;
 }
 
-int RGWRadosBucket::set_acl(const DoutPrefixProvider *dpp, RGWAccessControlPolicy &acl, optional_yield y)
+int RadosBucket::set_acl(const DoutPrefixProvider *dpp, RGWAccessControlPolicy &acl, optional_yield y)
 {
   bufferlist aclbl;
 
@@ -542,12 +542,12 @@ int RGWRadosBucket::set_acl(const DoutPrefixProvider *dpp, RGWAccessControlPolic
   return store->ctl()->bucket->set_acl(acl.get_owner(), info.bucket, info, aclbl, y, dpp);
 }
 
-std::unique_ptr<RGWObject> RGWRadosBucket::get_object(const rgw_obj_key& k)
+std::unique_ptr<Object> RadosBucket::get_object(const rgw_obj_key& k)
 {
-  return std::unique_ptr<RGWObject>(new RGWRadosObject(this->store, k, this));
+  return std::unique_ptr<Object>(new RadosObject(this->store, k, this));
 }
 
-int RGWRadosBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max, ListResults& results, optional_yield y)
+int RadosBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max, ListResults& results, optional_yield y)
 {
   RGWRados::Bucket target(store->getRados(), get_info());
   if (params.shard_id >= 0) {
@@ -575,22 +575,22 @@ int RGWRadosBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int 
   return ret;
 }
 
-std::unique_ptr<RGWUser> RGWRadosStore::get_user(const rgw_user &u)
+std::unique_ptr<User> RadosStore::get_user(const rgw_user &u)
 {
-  return std::unique_ptr<RGWUser>(new RGWRadosUser(this, u));
+  return std::unique_ptr<User>(new RadosUser(this, u));
 }
 
-int RGWRadosStore::get_user_by_access_key(const DoutPrefixProvider *dpp, const std::string& key, optional_yield y, std::unique_ptr<RGWUser>* user)
+int RadosStore::get_user_by_access_key(const DoutPrefixProvider *dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user)
 {
   RGWUserInfo uinfo;
-  RGWUser *u;
+  User *u;
   RGWObjVersionTracker objv_tracker;
 
   int r = ctl()->user->get_info_by_access_key(dpp, key, &uinfo, y, RGWUserCtl::GetParams().set_objv_tracker(&objv_tracker));
   if (r < 0)
     return r;
 
-  u = new RGWRadosUser(this, uinfo);
+  u = new RadosUser(this, uinfo);
   if (!u)
     return -ENOMEM;
 
@@ -600,17 +600,17 @@ int RGWRadosStore::get_user_by_access_key(const DoutPrefixProvider *dpp, const s
   return 0;
 }
 
-int RGWRadosStore::get_user_by_email(const DoutPrefixProvider *dpp, const std::string& email, optional_yield y, std::unique_ptr<RGWUser>* user)
+int RadosStore::get_user_by_email(const DoutPrefixProvider *dpp, const std::string& email, optional_yield y, std::unique_ptr<User>* user)
 {
   RGWUserInfo uinfo;
-  RGWUser *u;
+  User *u;
   RGWObjVersionTracker objv_tracker;
 
   int r = ctl()->user->get_info_by_email(dpp, email, &uinfo, y, RGWUserCtl::GetParams().set_objv_tracker(&objv_tracker));
   if (r < 0)
     return r;
 
-  u = new RGWRadosUser(this, uinfo);
+  u = new RadosUser(this, uinfo);
   if (!u)
     return -ENOMEM;
 
@@ -620,17 +620,17 @@ int RGWRadosStore::get_user_by_email(const DoutPrefixProvider *dpp, const std::s
   return 0;
 }
 
-int RGWRadosStore::get_user_by_swift(const DoutPrefixProvider *dpp, const std::string& user_str, optional_yield y, std::unique_ptr<RGWUser>* user)
+int RadosStore::get_user_by_swift(const DoutPrefixProvider *dpp, const std::string& user_str, optional_yield y, std::unique_ptr<User>* user)
 {
   RGWUserInfo uinfo;
-  RGWUser *u;
+  User *u;
   RGWObjVersionTracker objv_tracker;
 
   int r = ctl()->user->get_info_by_swift(dpp, user_str, &uinfo, y, RGWUserCtl::GetParams().set_objv_tracker(&objv_tracker));
   if (r < 0)
     return r;
 
-  u = new RGWRadosUser(this, uinfo);
+  u = new RadosUser(this, uinfo);
   if (!u)
     return -ENOMEM;
 
@@ -640,17 +640,17 @@ int RGWRadosStore::get_user_by_swift(const DoutPrefixProvider *dpp, const std::s
   return 0;
 }
 
-std::unique_ptr<RGWObject> RGWRadosStore::get_object(const rgw_obj_key& k)
+std::unique_ptr<Object> RadosStore::get_object(const rgw_obj_key& k)
 {
-  return std::unique_ptr<RGWObject>(new RGWRadosObject(this, k));
+  return std::unique_ptr<Object>(new RadosObject(this, k));
 }
 
-int RGWRadosStore::get_bucket(const DoutPrefixProvider *dpp, RGWUser* u, const rgw_bucket& b, std::unique_ptr<RGWBucket>* bucket, optional_yield y)
+int RadosStore::get_bucket(const DoutPrefixProvider *dpp, User* u, const rgw_bucket& b, std::unique_ptr<Bucket>* bucket, optional_yield y)
 {
   int ret;
-  RGWBucket* bp;
+  Bucket* bp;
 
-  bp = new RGWRadosBucket(this, b, u);
+  bp = new RadosBucket(this, b, u);
   ret = bp->get_bucket_info(dpp, y);
   if (ret < 0) {
     delete bp;
@@ -661,18 +661,18 @@ int RGWRadosStore::get_bucket(const DoutPrefixProvider *dpp, RGWUser* u, const r
   return 0;
 }
 
-int RGWRadosStore::get_bucket(RGWUser* u, const RGWBucketInfo& i, std::unique_ptr<RGWBucket>* bucket)
+int RadosStore::get_bucket(User* u, const RGWBucketInfo& i, std::unique_ptr<Bucket>* bucket)
 {
-  RGWBucket* bp;
+  Bucket* bp;
 
-  bp = new RGWRadosBucket(this, i, u);
+  bp = new RadosBucket(this, i, u);
   /* Don't need to fetch the bucket info, use the provided one */
 
   bucket->reset(bp);
   return 0;
 }
 
-int RGWRadosStore::get_bucket(const DoutPrefixProvider *dpp, RGWUser* u, const std::string& tenant, const std::string& name, std::unique_ptr<RGWBucket>* bucket, optional_yield y)
+int RadosStore::get_bucket(const DoutPrefixProvider *dpp, User* u, const std::string& tenant, const std::string& name, std::unique_ptr<Bucket>* bucket, optional_yield y)
 {
   rgw_bucket b;
 
@@ -682,21 +682,21 @@ int RGWRadosStore::get_bucket(const DoutPrefixProvider *dpp, RGWUser* u, const s
   return get_bucket(dpp, u, b, bucket, y);
 }
 
-int RGWRadosStore::create_bucket(const DoutPrefixProvider *dpp,
-				 RGWUser& u, const rgw_bucket& b,
+int RadosStore::create_bucket(const DoutPrefixProvider *dpp,
+				 User& u, const rgw_bucket& b,
 				 const string& zonegroup_id,
 				 rgw_placement_rule& placement_rule,
 				 string& swift_ver_location,
 				 const RGWQuotaInfo * pquota_info,
 				 const RGWAccessControlPolicy& policy,
-				 RGWAttrs& attrs,
+				 Attrs& attrs,
 				 RGWBucketInfo& info,
 				 obj_version& ep_objv,
 				 bool exclusive,
 				 bool obj_lock_enabled,
 				 bool *existed,
 				 req_info& req_info,
-				 std::unique_ptr<RGWBucket>* bucket_out,
+				 std::unique_ptr<Bucket>* bucket_out,
 				 optional_yield y)
 {
   int ret;
@@ -705,7 +705,7 @@ int RGWRadosStore::create_bucket(const DoutPrefixProvider *dpp,
   rgw_bucket *pmaster_bucket;
   uint32_t *pmaster_num_shards;
   real_time creation_time;
-  std::unique_ptr<RGWBucket> bucket;
+  std::unique_ptr<Bucket> bucket;
   obj_version objv, *pobjv = NULL;
 
   /* If it exists, look it up; otherwise create it */
@@ -729,7 +729,7 @@ int RGWRadosStore::create_bucket(const DoutPrefixProvider *dpp,
       return -EEXIST;
     }
   } else {
-    bucket = std::unique_ptr<RGWBucket>(new RGWRadosBucket(this, b, &u));
+    bucket = std::unique_ptr<Bucket>(new RadosBucket(this, b, &u));
     *existed = false;
     bucket->set_attrs(attrs);
   }
@@ -799,12 +799,12 @@ int RGWRadosStore::create_bucket(const DoutPrefixProvider *dpp,
   return ret;
 }
 
-bool RGWRadosStore::is_meta_master()
+bool RadosStore::is_meta_master()
 {
   return svc()->zone->is_meta_master();
 }
 
-int RGWRadosStore::forward_request_to_master(RGWUser* user, obj_version *objv,
+int RadosStore::forward_request_to_master(User* user, obj_version *objv,
 					     bufferlist& in_data,
 					     JSONParser *jp, req_info& info,
 					     optional_yield y)
@@ -837,22 +837,22 @@ int RGWRadosStore::forward_request_to_master(RGWUser* user, obj_version *objv,
   return 0;
 }
 
-int RGWRadosStore::defer_gc(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWBucket* bucket, RGWObject* obj, optional_yield y)
+int RadosStore::defer_gc(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, Bucket* bucket, Object* obj, optional_yield y)
 {
   return rados->defer_gc(dpp, rctx, bucket->get_info(), obj->get_obj(), y);
 }
 
-std::string RGWRadosStore::zone_unique_id(uint64_t unique_num)
+std::string RadosStore::zone_unique_id(uint64_t unique_num)
 {
   return svc()->zone_utils->unique_id(unique_num);
 }
 
-std::string RGWRadosStore::zone_unique_trans_id(const uint64_t unique_num)
+std::string RadosStore::zone_unique_trans_id(const uint64_t unique_num)
 {
   return svc()->zone_utils->unique_trans_id(unique_num);
 }
 
-int RGWRadosStore::cluster_stat(RGWClusterStat& stats)
+int RadosStore::cluster_stat(RGWClusterStat& stats)
 {
   rados_cluster_stat_t rados_stats;
   int ret;
@@ -869,63 +869,63 @@ int RGWRadosStore::cluster_stat(RGWClusterStat& stats)
   return ret;
 }
 
-std::unique_ptr<Lifecycle> RGWRadosStore::get_lifecycle(void)
+std::unique_ptr<Lifecycle> RadosStore::get_lifecycle(void)
 {
   return std::unique_ptr<Lifecycle>(new RadosLifecycle(this));
 }
 
-std::unique_ptr<Completions> RGWRadosStore::get_completions(void)
+std::unique_ptr<Completions> RadosStore::get_completions(void)
 {
   return std::unique_ptr<Completions>(new RadosCompletions());
 }
 
-std::unique_ptr<Notification> RGWRadosStore::get_notification(rgw::sal::RGWObject* obj,
+std::unique_ptr<Notification> RadosStore::get_notification(rgw::sal::Object* obj,
 							    struct req_state* s,
 							    rgw::notify::EventType event_type)
 {
   return std::unique_ptr<Notification>(new RadosNotification(this, obj, s, event_type));
 }
 
-std::unique_ptr<GCChain> RGWRadosStore::get_gc_chain(rgw::sal::RGWObject* obj)
+std::unique_ptr<GCChain> RadosStore::get_gc_chain(rgw::sal::Object* obj)
 {
   return std::unique_ptr<GCChain>(new RadosGCChain(this, obj));
 }
 
-std::unique_ptr<Writer> RGWRadosStore::get_writer(Aio *aio, rgw::sal::RGWBucket* bucket,
-              RGWObjectCtx& obj_ctx, std::unique_ptr<rgw::sal::RGWObject> _head_obj,
+std::unique_ptr<Writer> RadosStore::get_writer(Aio *aio, rgw::sal::Bucket* bucket,
+              RGWObjectCtx& obj_ctx, std::unique_ptr<rgw::sal::Object> _head_obj,
               const DoutPrefixProvider *dpp, optional_yield y)
 {
   return std::unique_ptr<Writer>(new RadosWriter(aio, this, bucket, obj_ctx, std::move(_head_obj), dpp, y));
 }
 
-int RGWRadosStore::delete_raw_obj(const rgw_raw_obj& obj)
+int RadosStore::delete_raw_obj(const rgw_raw_obj& obj)
 {
   return rados->delete_raw_obj(obj);
 }
 
-int RGWRadosStore::delete_raw_obj_aio(const rgw_raw_obj& obj, Completions* aio)
+int RadosStore::delete_raw_obj_aio(const rgw_raw_obj& obj, Completions* aio)
 {
   RadosCompletions *raio = static_cast<RadosCompletions*>(aio);
 
   return rados->delete_raw_obj_aio(obj, raio->handles);
 }
 
-void RGWRadosStore::get_raw_obj(const rgw_placement_rule& placement_rule, const rgw_obj& obj, rgw_raw_obj* raw_obj)
+void RadosStore::get_raw_obj(const rgw_placement_rule& placement_rule, const rgw_obj& obj, rgw_raw_obj* raw_obj)
 {
     rados->obj_to_raw(placement_rule, obj, raw_obj);
 }
 
-int RGWRadosStore::get_raw_chunk_size(const DoutPrefixProvider *dpp, const rgw_raw_obj& obj, uint64_t* chunk_size)
+int RadosStore::get_raw_chunk_size(const DoutPrefixProvider *dpp, const rgw_raw_obj& obj, uint64_t* chunk_size)
 {
   return rados->get_max_chunk_size(obj.pool, chunk_size, dpp);
 }
 
-int RGWRadosStore::log_usage(map<rgw_user_bucket, RGWUsageBatch>& usage_info)
+int RadosStore::log_usage(map<rgw_user_bucket, RGWUsageBatch>& usage_info)
 {
     return rados->log_usage(usage_info);
 }
 
-int RGWRadosStore::log_op(string& oid, bufferlist& bl)
+int RadosStore::log_op(string& oid, bufferlist& bl)
 {
   rgw_raw_obj obj(svc()->zone->get_zone_params().log_pool, oid);
 
@@ -941,31 +941,31 @@ int RGWRadosStore::log_op(string& oid, bufferlist& bl)
   return ret;
 }
 
-int RGWRadosStore::register_to_service_map(const string& daemon_type,
+int RadosStore::register_to_service_map(const string& daemon_type,
 					   const map<string, string>& meta)
 {
   return rados->register_to_service_map(daemon_type, meta);
 }
 
-void RGWRadosStore::get_quota(RGWQuotaInfo& bucket_quota, RGWQuotaInfo& user_quota)
+void RadosStore::get_quota(RGWQuotaInfo& bucket_quota, RGWQuotaInfo& user_quota)
 {
     bucket_quota = svc()->quota->get_bucket_quota();
     user_quota = svc()->quota->get_user_quota();
 }
 
-int RGWRadosStore::list_raw_objects(const rgw_pool& pool, const string& prefix_filter,
+int RadosStore::list_raw_objects(const rgw_pool& pool, const string& prefix_filter,
 				    int max, RGWListRawObjsCtx& ctx, list<string>& oids,
 				    bool *is_truncated)
 {
     return rados->list_raw_objects(pool, prefix_filter, max, ctx, oids, is_truncated);
 }
 
-int RGWRadosStore::set_buckets_enabled(const DoutPrefixProvider *dpp, vector<rgw_bucket>& buckets, bool enabled)
+int RadosStore::set_buckets_enabled(const DoutPrefixProvider *dpp, vector<rgw_bucket>& buckets, bool enabled)
 {
     return rados->set_buckets_enabled(buckets, enabled, dpp);
 }
 
-int RGWRadosStore::get_sync_policy_handler(const DoutPrefixProvider *dpp,
+int RadosStore::get_sync_policy_handler(const DoutPrefixProvider *dpp,
 					   std::optional<rgw_zone_id> zone,
 					   std::optional<rgw_bucket> bucket,
 					   RGWBucketSyncPolicyHandlerRef *phandler,
@@ -974,12 +974,12 @@ int RGWRadosStore::get_sync_policy_handler(const DoutPrefixProvider *dpp,
   return ctl()->bucket->get_sync_policy_handler(zone, bucket, phandler, y, dpp);
 }
 
-RGWDataSyncStatusManager* RGWRadosStore::get_data_sync_manager(const rgw_zone_id& source_zone)
+RGWDataSyncStatusManager* RadosStore::get_data_sync_manager(const rgw_zone_id& source_zone)
 {
   return rados->get_data_sync_manager(source_zone);
 }
 
-int RGWRadosStore::read_all_usage(uint64_t start_epoch, uint64_t end_epoch,
+int RadosStore::read_all_usage(uint64_t start_epoch, uint64_t end_epoch,
 				  uint32_t max_entries, bool *is_truncated,
 				  RGWUsageIter& usage_iter,
 				  map<rgw_user_bucket, rgw_usage_log_entry>& usage)
@@ -991,7 +991,7 @@ int RGWRadosStore::read_all_usage(uint64_t start_epoch, uint64_t end_epoch,
 			   is_truncated, usage_iter, usage);
 }
 
-int RGWRadosStore::trim_all_usage(uint64_t start_epoch, uint64_t end_epoch)
+int RadosStore::trim_all_usage(uint64_t start_epoch, uint64_t end_epoch)
 {
   rgw_user uid;
   std::string bucket_name;
@@ -999,12 +999,12 @@ int RGWRadosStore::trim_all_usage(uint64_t start_epoch, uint64_t end_epoch)
   return rados->trim_usage(uid, bucket_name, start_epoch, end_epoch);
 }
 
-int RGWRadosStore::get_config_key_val(string name, bufferlist *bl)
+int RadosStore::get_config_key_val(string name, bufferlist *bl)
 {
   return svc()->config_key->get(name, true, bl);
 }
 
-int RGWRadosStore::put_system_obj(const rgw_pool& pool, const string& oid,
+int RadosStore::put_system_obj(const rgw_pool& pool, const string& oid,
 				  bufferlist& data, bool exclusive,
 				  RGWObjVersionTracker *objv_tracker, real_time set_mtime,
 				  optional_yield y, map<string, bufferlist> *pattrs)
@@ -1013,7 +1013,7 @@ int RGWRadosStore::put_system_obj(const rgw_pool& pool, const string& oid,
   return rgw_put_system_obj(obj_ctx, pool, oid, data, exclusive, objv_tracker, set_mtime, y, pattrs);
 }
 
-int RGWRadosStore::get_system_obj(const DoutPrefixProvider *dpp,
+int RadosStore::get_system_obj(const DoutPrefixProvider *dpp,
 				  const rgw_pool& pool, const string& key,
 				  bufferlist& bl,
 				  RGWObjVersionTracker *objv_tracker, real_time *pmtime,
@@ -1025,49 +1025,49 @@ int RGWRadosStore::get_system_obj(const DoutPrefixProvider *dpp,
   return rgw_get_system_obj(obj_ctx, pool, key, bl, objv_tracker, pmtime, y, dpp, pattrs, cache_info, refresh_version);
 }
 
-int RGWRadosStore::delete_system_obj(const rgw_pool& pool, const string& oid,
+int RadosStore::delete_system_obj(const rgw_pool& pool, const string& oid,
 				     RGWObjVersionTracker *objv_tracker, optional_yield y)
 {
     return rgw_delete_system_obj(svc()->sysobj, pool, oid, objv_tracker, y);
 }
 
-int RGWRadosStore::meta_list_keys_init(const string& section, const string& marker, void** phandle)
+int RadosStore::meta_list_keys_init(const string& section, const string& marker, void** phandle)
 {
   return ctl()->meta.mgr->list_keys_init(section, marker, phandle);
 }
 
-int RGWRadosStore::meta_list_keys_next(void* handle, int max, list<string>& keys, bool* truncated)
+int RadosStore::meta_list_keys_next(void* handle, int max, list<string>& keys, bool* truncated)
 {
   return ctl()->meta.mgr->list_keys_next(handle, max, keys, truncated);
 }
 
-void RGWRadosStore::meta_list_keys_complete(void* handle)
+void RadosStore::meta_list_keys_complete(void* handle)
 {
   ctl()->meta.mgr->list_keys_complete(handle);
 }
 
-std::string RGWRadosStore::meta_get_marker(void* handle)
+std::string RadosStore::meta_get_marker(void* handle)
 {
   return ctl()->meta.mgr->get_marker(handle);
 }
 
-int RGWRadosStore::meta_remove(const DoutPrefixProvider *dpp, string& metadata_key, optional_yield y)
+int RadosStore::meta_remove(const DoutPrefixProvider *dpp, string& metadata_key, optional_yield y)
 {
   return ctl()->meta.mgr->remove(metadata_key, y, dpp);
 }
 
-void RGWRadosStore::finalize(void)
+void RadosStore::finalize(void)
 {
   if (rados)
     rados->finalize();
 }
 
-int RGWRadosStore::get_obj_head_ioctx(const RGWBucketInfo& bucket_info, const rgw_obj& obj, librados::IoCtx *ioctx)
+int RadosStore::get_obj_head_ioctx(const RGWBucketInfo& bucket_info, const rgw_obj& obj, librados::IoCtx *ioctx)
 {
   return rados->get_obj_head_ioctx(bucket_info, obj, ioctx);
 }
 
-int RGWObject::range_to_ofs(uint64_t obj_size, int64_t &ofs, int64_t &end)
+int Object::range_to_ofs(uint64_t obj_size, int64_t &ofs, int64_t &end)
 {
   if (ofs < 0) {
     ofs += obj_size;
@@ -1089,12 +1089,12 @@ int RGWObject::range_to_ofs(uint64_t obj_size, int64_t &ofs, int64_t &end)
   return 0;
 }
 
-int RGWRadosObject::get_obj_state(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWObjState **state, optional_yield y, bool follow_olh)
+int RadosObject::get_obj_state(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWObjState **state, optional_yield y, bool follow_olh)
 {
   return store->getRados()->get_obj_state(dpp, rctx, bucket->get_info(), get_obj(), state, follow_olh, y);
 }
 
-int RGWRadosObject::read_attrs(const DoutPrefixProvider *dpp, RGWRados::Object::Read &read_op, optional_yield y, rgw_obj *target_obj)
+int RadosObject::read_attrs(const DoutPrefixProvider *dpp, RGWRados::Object::Read &read_op, optional_yield y, rgw_obj *target_obj)
 {
   read_op.params.attrs = &attrs;
   read_op.params.target_obj = target_obj;
@@ -1104,9 +1104,9 @@ int RGWRadosObject::read_attrs(const DoutPrefixProvider *dpp, RGWRados::Object::
   return read_op.prepare(y, dpp);
 }
 
-int RGWRadosObject::set_obj_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx* rctx, RGWAttrs* setattrs, RGWAttrs* delattrs, optional_yield y, rgw_obj* target_obj)
+int RadosObject::set_obj_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx* rctx, Attrs* setattrs, Attrs* delattrs, optional_yield y, rgw_obj* target_obj)
 {
-  RGWAttrs empty;
+  Attrs empty;
   rgw_obj target = get_obj();
 
   if (!target_obj)
@@ -1120,7 +1120,7 @@ int RGWRadosObject::set_obj_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx* r
 			y);
 }
 
-int RGWRadosObject::get_obj_attrs(RGWObjectCtx *rctx, optional_yield y, const DoutPrefixProvider *dpp, rgw_obj* target_obj)
+int RadosObject::get_obj_attrs(RGWObjectCtx *rctx, optional_yield y, const DoutPrefixProvider *dpp, rgw_obj* target_obj)
 {
   RGWRados::Object op_target(store->getRados(), bucket->get_info(), *rctx, get_obj());
   RGWRados::Object::Read read_op(&op_target);
@@ -1128,7 +1128,7 @@ int RGWRadosObject::get_obj_attrs(RGWObjectCtx *rctx, optional_yield y, const Do
   return read_attrs(dpp, read_op, y, target_obj);
 }
 
-int RGWRadosObject::modify_obj_attrs(RGWObjectCtx *rctx, const char *attr_name, bufferlist& attr_val, optional_yield y, const DoutPrefixProvider *dpp)
+int RadosObject::modify_obj_attrs(RGWObjectCtx *rctx, const char *attr_name, bufferlist& attr_val, optional_yield y, const DoutPrefixProvider *dpp)
 {
   rgw_obj target = get_obj();
   int r = get_obj_attrs(rctx, y, dpp, &target);
@@ -1140,9 +1140,9 @@ int RGWRadosObject::modify_obj_attrs(RGWObjectCtx *rctx, const char *attr_name, 
   return set_obj_attrs(dpp, rctx, &attrs, nullptr, y, &target);
 }
 
-int RGWRadosObject::delete_obj_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, const char *attr_name, optional_yield y)
+int RadosObject::delete_obj_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, const char *attr_name, optional_yield y)
 {
-  RGWAttrs rmattr;
+  Attrs rmattr;
   bufferlist bl;
 
   set_atomic(rctx);
@@ -1150,14 +1150,14 @@ int RGWRadosObject::delete_obj_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx
   return set_obj_attrs(dpp, rctx, nullptr, &rmattr, y);
 }
 
-int RGWRadosObject::copy_obj_data(RGWObjectCtx& rctx, RGWBucket* dest_bucket,
-				  RGWObject* dest_obj,
+int RadosObject::copy_obj_data(RGWObjectCtx& rctx, Bucket* dest_bucket,
+				  Object* dest_obj,
 				  uint16_t olh_epoch,
 				  std::string* petag,
 				  const DoutPrefixProvider *dpp,
 				  optional_yield y)
 {
-  RGWAttrs attrset;
+  Attrs attrset;
   RGWRados::Object op_target(store->getRados(), dest_bucket->get_info(), rctx, get_obj());
   RGWRados::Object::Read read_op(&op_target);
 
@@ -1176,19 +1176,19 @@ int RGWRadosObject::copy_obj_data(RGWObjectCtx& rctx, RGWBucket* dest_bucket,
 					  real_time(), NULL, dpp, y);
 }
 
-void RGWRadosObject::set_atomic(RGWObjectCtx *rctx) const
+void RadosObject::set_atomic(RGWObjectCtx *rctx) const
 {
   rgw_obj obj = get_obj();
   store->getRados()->set_atomic(rctx, obj);
 }
 
-void RGWRadosObject::set_prefetch_data(RGWObjectCtx *rctx)
+void RadosObject::set_prefetch_data(RGWObjectCtx *rctx)
 {
   rgw_obj obj = get_obj();
   store->getRados()->set_prefetch_data(rctx, obj);
 }
 
-bool RGWRadosObject::is_expired() {
+bool RadosObject::is_expired() {
   auto iter = attrs.find(RGW_ATTR_DELETE_AT);
   if (iter != attrs.end()) {
     utime_t delete_at;
@@ -1208,24 +1208,24 @@ bool RGWRadosObject::is_expired() {
   return false;
 }
 
-void RGWRadosObject::gen_rand_obj_instance_name()
+void RadosObject::gen_rand_obj_instance_name()
 {
   store->getRados()->gen_rand_obj_instance_name(&key);
 }
 
-void RGWRadosObject::raw_obj_to_obj(const rgw_raw_obj& raw_obj)
+void RadosObject::raw_obj_to_obj(const rgw_raw_obj& raw_obj)
 {
   rgw_obj tobj = get_obj();
   RGWSI_Tier_RADOS::raw_obj_to_obj(get_bucket()->get_key(), raw_obj, &tobj);
   set_key(tobj.key);
 }
 
-void RGWRadosObject::get_raw_obj(rgw_raw_obj* raw_obj)
+void RadosObject::get_raw_obj(rgw_raw_obj* raw_obj)
 {
   store->getRados()->obj_to_raw((bucket->get_info()).placement_rule, get_obj(), raw_obj);
 }
 
-int RGWRadosObject::omap_get_vals(const string& marker, uint64_t count,
+int RadosObject::omap_get_vals(const string& marker, uint64_t count,
 				  std::map<string, bufferlist> *m,
 				  bool *pmore, optional_yield y)
 {
@@ -1237,7 +1237,7 @@ int RGWRadosObject::omap_get_vals(const string& marker, uint64_t count,
   return sysobj.omap().get_vals(marker, count, m, pmore, y);
 }
 
-int RGWRadosObject::omap_get_all(std::map<string, bufferlist> *m,
+int RadosObject::omap_get_all(std::map<string, bufferlist> *m,
 				 optional_yield y)
 {
   auto obj_ctx = store->svc()->sysobj->init_obj_ctx();
@@ -1248,9 +1248,9 @@ int RGWRadosObject::omap_get_all(std::map<string, bufferlist> *m,
   return sysobj.omap().get_all(m, y);
 }
 
-int RGWRadosObject::omap_get_vals_by_keys(const std::string& oid,
+int RadosObject::omap_get_vals_by_keys(const std::string& oid,
 					  const std::set<std::string>& keys,
-					  RGWAttrs *vals)
+					  Attrs *vals)
 {
   int ret;
   rgw_raw_obj head_obj;
@@ -1266,7 +1266,7 @@ int RGWRadosObject::omap_get_vals_by_keys(const std::string& oid,
   return cur_ioctx.omap_get_vals_by_keys(oid, keys, vals);
 }
 
-int RGWRadosObject::omap_set_val_by_key(const std::string& key, bufferlist& val,
+int RadosObject::omap_set_val_by_key(const std::string& key, bufferlist& val,
 					bool must_exist, optional_yield y)
 {
   rgw_raw_obj raw_meta_obj;
@@ -1280,13 +1280,13 @@ int RGWRadosObject::omap_set_val_by_key(const std::string& key, bufferlist& val,
   return sysobj.omap().set_must_exist(must_exist).set(key, val, y);
 }
 
-MPSerializer* RGWRadosObject::get_serializer(const std::string& lock_name)
+MPSerializer* RadosObject::get_serializer(const std::string& lock_name)
 {
   return new MPRadosSerializer(store, this, lock_name);
 }
 
-int RGWRadosObject::transition(RGWObjectCtx& rctx,
-			       RGWBucket* bucket,
+int RadosObject::transition(RGWObjectCtx& rctx,
+			       Bucket* bucket,
 			       const rgw_placement_rule& placement_rule,
 			       const real_time& mtime,
 			       uint64_t olh_epoch,
@@ -1296,18 +1296,18 @@ int RGWRadosObject::transition(RGWObjectCtx& rctx,
   return store->getRados()->transition_obj(rctx, bucket, *this, placement_rule, mtime, olh_epoch, dpp, y);
 }
 
-int RGWRadosObject::get_max_chunk_size(const DoutPrefixProvider *dpp, rgw_placement_rule placement_rule, uint64_t *max_chunk_size, uint64_t *alignment)
+int RadosObject::get_max_chunk_size(const DoutPrefixProvider *dpp, rgw_placement_rule placement_rule, uint64_t *max_chunk_size, uint64_t *alignment)
 {
   return store->getRados()->get_max_chunk_size(placement_rule, get_obj(), max_chunk_size, dpp, alignment);
 }
 
-void RGWRadosObject::get_max_aligned_size(uint64_t size, uint64_t alignment,
+void RadosObject::get_max_aligned_size(uint64_t size, uint64_t alignment,
 				     uint64_t *max_size)
 {
   store->getRados()->get_max_aligned_size(size, alignment, max_size);
 }
 
-bool RGWRadosObject::placement_rules_match(rgw_placement_rule& r1, rgw_placement_rule& r2)
+bool RadosObject::placement_rules_match(rgw_placement_rule& r1, rgw_placement_rule& r2)
 {
   rgw_obj obj;
   rgw_pool p1, p2;
@@ -1327,12 +1327,12 @@ bool RGWRadosObject::placement_rules_match(rgw_placement_rule& r1, rgw_placement
   return p1 == p2;
 }
 
-std::unique_ptr<RGWObject::ReadOp> RGWRadosObject::get_read_op(RGWObjectCtx *ctx)
+std::unique_ptr<Object::ReadOp> RadosObject::get_read_op(RGWObjectCtx *ctx)
 {
-  return std::unique_ptr<RGWObject::ReadOp>(new RGWRadosObject::RadosReadOp(this, ctx));
+  return std::unique_ptr<Object::ReadOp>(new RadosObject::RadosReadOp(this, ctx));
 }
 
-RGWRadosObject::RadosReadOp::RadosReadOp(RGWRadosObject *_source, RGWObjectCtx *_rctx) :
+RadosObject::RadosReadOp::RadosReadOp(RadosObject *_source, RGWObjectCtx *_rctx) :
 	source(_source),
 	rctx(_rctx),
 	op_target(_source->store->getRados(),
@@ -1342,7 +1342,7 @@ RGWRadosObject::RadosReadOp::RadosReadOp(RGWRadosObject *_source, RGWObjectCtx *
 	parent_op(&op_target)
 { }
 
-int RGWRadosObject::RadosReadOp::prepare(optional_yield y, const DoutPrefixProvider *dpp)
+int RadosObject::RadosReadOp::prepare(optional_yield y, const DoutPrefixProvider *dpp)
 {
   uint64_t obj_size;
 
@@ -1369,28 +1369,28 @@ int RGWRadosObject::RadosReadOp::prepare(optional_yield y, const DoutPrefixProvi
   return ret;
 }
 
-int RGWRadosObject::RadosReadOp::read(int64_t ofs, int64_t end, bufferlist& bl, optional_yield y, const DoutPrefixProvider *dpp)
+int RadosObject::RadosReadOp::read(int64_t ofs, int64_t end, bufferlist& bl, optional_yield y, const DoutPrefixProvider *dpp)
 {
   return parent_op.read(ofs, end, bl, y, dpp);
 }
 
-int RGWRadosObject::RadosReadOp::get_manifest(const DoutPrefixProvider *dpp, RGWObjManifest **pmanifest,
+int RadosObject::RadosReadOp::get_manifest(const DoutPrefixProvider *dpp, RGWObjManifest **pmanifest,
 					      optional_yield y)
 {
   return op_target.get_manifest(dpp, pmanifest, y);
 }
 
-int RGWRadosObject::RadosReadOp::get_attr(const DoutPrefixProvider *dpp, const char *name, bufferlist& dest, optional_yield y)
+int RadosObject::RadosReadOp::get_attr(const DoutPrefixProvider *dpp, const char *name, bufferlist& dest, optional_yield y)
 {
   return parent_op.get_attr(dpp, name, dest, y);
 }
 
-std::unique_ptr<RGWObject::DeleteOp> RGWRadosObject::get_delete_op(RGWObjectCtx *ctx)
+std::unique_ptr<Object::DeleteOp> RadosObject::get_delete_op(RGWObjectCtx *ctx)
 {
-  return std::unique_ptr<RGWObject::DeleteOp>(new RGWRadosObject::RadosDeleteOp(this, ctx));
+  return std::unique_ptr<Object::DeleteOp>(new RadosObject::RadosDeleteOp(this, ctx));
 }
 
-RGWRadosObject::RadosDeleteOp::RadosDeleteOp(RGWRadosObject *_source, RGWObjectCtx *_rctx) :
+RadosObject::RadosDeleteOp::RadosDeleteOp(RadosObject *_source, RGWObjectCtx *_rctx) :
 	source(_source),
 	rctx(_rctx),
 	op_target(_source->store->getRados(),
@@ -1400,7 +1400,7 @@ RGWRadosObject::RadosDeleteOp::RadosDeleteOp(RGWRadosObject *_source, RGWObjectC
 	parent_op(&op_target)
 { }
 
-int RGWRadosObject::RadosDeleteOp::delete_obj(const DoutPrefixProvider *dpp, optional_yield y)
+int RadosObject::RadosDeleteOp::delete_obj(const DoutPrefixProvider *dpp, optional_yield y)
 {
   parent_op.params.bucket_owner = params.bucket_owner.get_id();
   parent_op.params.versioning_status = params.versioning_status;
@@ -1427,7 +1427,7 @@ int RGWRadosObject::RadosDeleteOp::delete_obj(const DoutPrefixProvider *dpp, opt
   return ret;
 }
 
-int RGWRadosObject::delete_object(const DoutPrefixProvider *dpp, RGWObjectCtx* obj_ctx, optional_yield y)
+int RadosObject::delete_object(const DoutPrefixProvider *dpp, RGWObjectCtx* obj_ctx, optional_yield y)
 {
   RGWRados::Object del_target(store->getRados(), bucket->get_info(), *obj_ctx, get_obj());
   RGWRados::Object::Delete del_op(&del_target);
@@ -1438,7 +1438,7 @@ int RGWRadosObject::delete_object(const DoutPrefixProvider *dpp, RGWObjectCtx* o
   return del_op.delete_obj(y, dpp);
 }
 
-int RGWRadosObject::delete_obj_aio(const DoutPrefixProvider *dpp, RGWObjState *astate,
+int RadosObject::delete_obj_aio(const DoutPrefixProvider *dpp, RGWObjState *astate,
 				   Completions* aio, bool keep_index_consistent,
 				   optional_yield y)
 {
@@ -1448,12 +1448,12 @@ int RGWRadosObject::delete_obj_aio(const DoutPrefixProvider *dpp, RGWObjState *a
 					   raio->handles, keep_index_consistent, y);
 }
 
-std::unique_ptr<RGWObject::StatOp> RGWRadosObject::get_stat_op(RGWObjectCtx *ctx)
+std::unique_ptr<Object::StatOp> RadosObject::get_stat_op(RGWObjectCtx *ctx)
 {
-  return std::unique_ptr<RGWObject::StatOp>(new RGWRadosObject::RadosStatOp(this, ctx));
+  return std::unique_ptr<Object::StatOp>(new RadosObject::RadosStatOp(this, ctx));
 }
 
-RGWRadosObject::RadosStatOp::RadosStatOp(RGWRadosObject *_source, RGWObjectCtx *_rctx) :
+RadosObject::RadosStatOp::RadosStatOp(RadosObject *_source, RGWObjectCtx *_rctx) :
 	source(_source),
 	rctx(_rctx),
 	op_target(_source->store->getRados(),
@@ -1463,12 +1463,12 @@ RGWRadosObject::RadosStatOp::RadosStatOp(RGWRadosObject *_source, RGWObjectCtx *
 	parent_op(&op_target)
 { }
 
-int RGWRadosObject::RadosStatOp::stat_async()
+int RadosObject::RadosStatOp::stat_async()
 {
   return parent_op.stat_async();
 }
 
-int RGWRadosObject::RadosStatOp::wait()
+int RadosObject::RadosStatOp::wait()
 {
   result.obj = source;
   int ret =  parent_op.wait();
@@ -1489,13 +1489,13 @@ int RGWRadosObject::RadosStatOp::wait()
   return ret;
 }
 
-int RGWRadosObject::copy_object(RGWObjectCtx& obj_ctx,
-				RGWUser* user,
+int RadosObject::copy_object(RGWObjectCtx& obj_ctx,
+				User* user,
 				req_info *info,
 				const rgw_zone_id& source_zone,
-				rgw::sal::RGWObject* dest_object,
-				rgw::sal::RGWBucket* dest_bucket,
-				rgw::sal::RGWBucket* src_bucket,
+				rgw::sal::Object* dest_object,
+				rgw::sal::Bucket* dest_bucket,
+				rgw::sal::Bucket* src_bucket,
 				const rgw_placement_rule& dest_placement,
 				ceph::real_time *src_mtime,
 				ceph::real_time *mtime,
@@ -1506,7 +1506,7 @@ int RGWRadosObject::copy_object(RGWObjectCtx& obj_ctx,
 				const char *if_nomatch,
 				AttrsMod attrs_mod,
 				bool copy_if_newer,
-				RGWAttrs& attrs,
+				Attrs& attrs,
 				RGWObjCategory category,
 				uint64_t olh_epoch,
 				boost::optional<ceph::real_time> delete_at,
@@ -1549,17 +1549,17 @@ int RGWRadosObject::copy_object(RGWObjectCtx& obj_ctx,
 				     y);
 }
 
-int RGWRadosObject::RadosReadOp::iterate(const DoutPrefixProvider *dpp, int64_t ofs, int64_t end, RGWGetDataCB *cb, optional_yield y)
+int RadosObject::RadosReadOp::iterate(const DoutPrefixProvider *dpp, int64_t ofs, int64_t end, RGWGetDataCB *cb, optional_yield y)
 {
   return parent_op.iterate(dpp, ofs, end, cb, y);
 }
 
-std::unique_ptr<RGWObject::WriteOp> RGWRadosObject::get_write_op(RGWObjectCtx* ctx)
+std::unique_ptr<Object::WriteOp> RadosObject::get_write_op(RGWObjectCtx* ctx)
 {
-  return std::unique_ptr<RGWObject::WriteOp>(new RGWRadosObject::RadosWriteOp(this, ctx));
+  return std::unique_ptr<Object::WriteOp>(new RadosObject::RadosWriteOp(this, ctx));
 }
 
-RGWRadosObject::RadosWriteOp::RadosWriteOp(RGWRadosObject* _source, RGWObjectCtx* _rctx) :
+RadosObject::RadosWriteOp::RadosWriteOp(RadosObject* _source, RGWObjectCtx* _rctx) :
 	source(_source),
 	rctx(_rctx),
 	op_target(_source->store->getRados(),
@@ -1569,7 +1569,7 @@ RGWRadosObject::RadosWriteOp::RadosWriteOp(RGWRadosObject* _source, RGWObjectCtx
 	parent_op(&op_target)
 { }
 
-int RGWRadosObject::RadosWriteOp::prepare(optional_yield y)
+int RadosObject::RadosWriteOp::prepare(optional_yield y)
 {
   op_target.set_versioning_disabled(params.versioning_disabled);
   parent_op.meta.mtime = params.mtime;
@@ -1596,7 +1596,7 @@ int RGWRadosObject::RadosWriteOp::prepare(optional_yield y)
   return 0;
 }
 
-int RGWRadosObject::RadosWriteOp::write_meta(const DoutPrefixProvider *dpp, uint64_t size, uint64_t accounted_size, optional_yield y)
+int RadosObject::RadosWriteOp::write_meta(const DoutPrefixProvider *dpp, uint64_t size, uint64_t accounted_size, optional_yield y)
 {
   int ret = parent_op.write_meta(dpp, size, accounted_size, *params.attrs, y);
   params.canceled = parent_op.meta.canceled;
@@ -1604,7 +1604,7 @@ int RGWRadosObject::RadosWriteOp::write_meta(const DoutPrefixProvider *dpp, uint
   return ret;
 }
 
-int RGWRadosObject::swift_versioning_restore(RGWObjectCtx* obj_ctx,
+int RadosObject::swift_versioning_restore(RGWObjectCtx* obj_ctx,
 					     bool& restored,
 					     const DoutPrefixProvider *dpp)
 {
@@ -1616,7 +1616,7 @@ int RGWRadosObject::swift_versioning_restore(RGWObjectCtx* obj_ctx,
 						     dpp);
 }
 
-int RGWRadosObject::swift_versioning_copy(RGWObjectCtx* obj_ctx,
+int RadosObject::swift_versioning_copy(RGWObjectCtx* obj_ctx,
 					  const DoutPrefixProvider *dpp,
 					  optional_yield y)
 {
@@ -1628,7 +1628,7 @@ int RGWRadosObject::swift_versioning_copy(RGWObjectCtx* obj_ctx,
                                         y);
 }
 
-MPRadosSerializer::MPRadosSerializer(RGWRadosStore* store, RGWRadosObject* obj, const std::string& lock_name) :
+MPRadosSerializer::MPRadosSerializer(RadosStore* store, RadosObject* obj, const std::string& lock_name) :
   lock(lock_name)
 {
   rgw_pool meta_pool;
@@ -1653,7 +1653,7 @@ int MPRadosSerializer::try_lock(utime_t dur, optional_yield y)
   return ret;
 }
 
-LCRadosSerializer::LCRadosSerializer(RGWRadosStore* store, const std::string& _oid, const std::string& lock_name, const std::string& cookie) :
+LCRadosSerializer::LCRadosSerializer(RadosStore* store, const std::string& _oid, const std::string& lock_name, const std::string& cookie) :
   lock(lock_name), oid(_oid)
 {
   ioctx = &store->getRados()->lc_pool_ctx;
@@ -1837,7 +1837,7 @@ RadosWriter::~RadosWriter()
 
   bool need_to_remove_head = false;
   std::optional<rgw_raw_obj> raw_head;
-  if (!rgw::sal::RGWObject::empty(head_obj.get())) {
+  if (!rgw::sal::Object::empty(head_obj.get())) {
     raw_head.emplace();
     head_obj->get_raw_obj(&*raw_head);
   }
@@ -1869,7 +1869,7 @@ RadosWriter::~RadosWriter()
 
   if (need_to_remove_head) {
     ldpp_dout(dpp, 5) << "NOTE: we are going to process the head obj (" << *raw_head << ")" << dendl;
-    std::unique_ptr<rgw::sal::RGWObject::DeleteOp> del_op = head_obj->get_delete_op(&obj_ctx);
+    std::unique_ptr<rgw::sal::Object::DeleteOp> del_op = head_obj->get_delete_op(&obj_ctx);
     del_op->params.bucket_owner = bucket->get_acl_owner();
 
     int r = del_op->delete_obj(dpp, y);
@@ -1933,9 +1933,9 @@ const string& RadosZone::get_current_period_id()
 
 extern "C" {
 
-void *newRGWStore(void)
+void *newStore(void)
 {
-  rgw::sal::RGWRadosStore *store = new rgw::sal::RGWRadosStore();
+  rgw::sal::RadosStore *store = new rgw::sal::RadosStore();
   if (store) {
     RGWRados *rados = new RGWRados();
 

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -46,9 +46,9 @@
 
 namespace rgw::sal {
 
-static int decode_policy(CephContext *cct,
+static int decode_policy(CephContext* cct,
                          bufferlist& bl,
-                         RGWAccessControlPolicy *policy)
+                         RGWAccessControlPolicy* policy)
 {
   auto iter = bl.cbegin();
   try {
@@ -59,18 +59,18 @@ static int decode_policy(CephContext *cct,
   }
   if (cct->_conf->subsys.should_gather<ceph_subsys_rgw, 15>()) {
     ldout(cct, 15) << __func__ << " Read AccessControlPolicy";
-    RGWAccessControlPolicy_S3 *s3policy = static_cast<RGWAccessControlPolicy_S3 *>(policy);
+    RGWAccessControlPolicy_S3* s3policy = static_cast<RGWAccessControlPolicy_S3 *>(policy);
     s3policy->to_xml(*_dout);
     *_dout << dendl;
   }
   return 0;
 }
 
-static int rgw_op_get_bucket_policy_from_attr(const DoutPrefixProvider *dpp,
-					      RadosStore *store,
+static int rgw_op_get_bucket_policy_from_attr(const DoutPrefixProvider* dpp,
+					      RadosStore* store,
 					      User& user,
 					      Attrs& bucket_attrs,
-					      RGWAccessControlPolicy *policy,
+					      RGWAccessControlPolicy* policy,
 					      optional_yield y)
 {
   auto aiter = bucket_attrs.find(RGW_ATTR_ACL);
@@ -91,7 +91,7 @@ static int rgw_op_get_bucket_policy_from_attr(const DoutPrefixProvider *dpp,
   return 0;
 }
 
-static int process_completed(const AioResultList& completed, RawObjSet *written)
+static int process_completed(const AioResultList& completed, RawObjSet* written)
 {
   std::optional<int> error;
   for (auto& r : completed) {
@@ -108,7 +108,7 @@ int RadosCompletions::drain()
 {
   int ret = 0;
   while (!handles.empty()) {
-    librados::AioCompletion *handle = handles.front();
+    librados::AioCompletion* handle = handles.front();
     handles.pop_front();
     handle->wait_for_complete();
     int r = handle->get_return_value();
@@ -120,7 +120,7 @@ int RadosCompletions::drain()
   return ret;
 }
 
-int RadosUser::list_buckets(const DoutPrefixProvider *dpp, const string& marker,
+int RadosUser::list_buckets(const DoutPrefixProvider* dpp, const string& marker,
 			       const string& end_marker, uint64_t max, bool need_stats,
 			       BucketList &buckets, optional_yield y)
 {
@@ -148,19 +148,19 @@ Bucket* RadosUser::create_bucket(rgw_bucket& bucket,
   return NULL;
 }
 
-int RadosUser::read_attrs(const DoutPrefixProvider *dpp, optional_yield y, Attrs* uattrs, RGWObjVersionTracker* tracker)
+int RadosUser::read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs* uattrs, RGWObjVersionTracker* tracker)
 {
   return store->ctl()->user->get_attrs_by_uid(dpp, get_id(), uattrs, y, tracker);
 }
 
 int RadosUser::read_stats(optional_yield y, RGWStorageStats* stats,
-			     ceph::real_time *last_stats_sync,
-			     ceph::real_time *last_stats_update)
+			     ceph::real_time* last_stats_sync,
+			     ceph::real_time* last_stats_update)
 {
   return store->ctl()->user->read_stats(get_id(), stats, y, last_stats_sync, last_stats_update);
 }
 
-int RadosUser::read_stats_async(RGWGetUserStats_CB *cb)
+int RadosUser::read_stats_async(RGWGetUserStats_CB* cb)
 {
   return store->ctl()->user->read_stats_async(get_id(), cb);
 }
@@ -171,7 +171,7 @@ int RadosUser::complete_flush_stats(optional_yield y)
 }
 
 int RadosUser::read_usage(uint64_t start_epoch, uint64_t end_epoch,
-			       uint32_t max_entries, bool *is_truncated,
+			       uint32_t max_entries, bool* is_truncated,
 			       RGWUsageIter& usage_iter,
 			       map<rgw_user_bucket, rgw_usage_log_entry>& usage)
 {
@@ -188,28 +188,28 @@ int RadosUser::trim_usage(uint64_t start_epoch, uint64_t end_epoch)
   return store->getRados()->trim_usage(get_id(), bucket_name, start_epoch, end_epoch);
 }
 
-int RadosUser::load_by_id(const DoutPrefixProvider *dpp, optional_yield y)
+int RadosUser::load_by_id(const DoutPrefixProvider* dpp, optional_yield y)
 {
     return store->ctl()->user->get_info_by_uid(dpp, info.user_id, &info, y, RGWUserCtl::GetParams().set_objv_tracker(&objv_tracker));
 }
 
-int RadosUser::store_info(const DoutPrefixProvider *dpp, optional_yield y, const RGWUserCtl::PutParams& params)
+int RadosUser::store_info(const DoutPrefixProvider* dpp, optional_yield y, const RGWUserCtl::PutParams& params)
 {
     return store->ctl()->user->store_info(dpp, info, y, params);
 }
 
-int RadosUser::remove_info(const DoutPrefixProvider *dpp, optional_yield y, const RGWUserCtl::RemoveParams& params)
+int RadosUser::remove_info(const DoutPrefixProvider* dpp, optional_yield y, const RGWUserCtl::RemoveParams& params)
 {
     return store->ctl()->user->remove_info(dpp, info, y, params);
 }
 
 /* Placeholder */
-Object *RadosBucket::create_object(const rgw_obj_key &key)
+Object* RadosBucket::create_object(const rgw_obj_key &key)
 {
   return nullptr;
 }
 
-int RadosBucket::remove_bucket(const DoutPrefixProvider *dpp, bool delete_children, std::string prefix, std::string delimiter, bool forward_to_master, req_info* req_info, optional_yield y)
+int RadosBucket::remove_bucket(const DoutPrefixProvider* dpp, bool delete_children, std::string prefix, std::string delimiter, bool forward_to_master, req_info* req_info, optional_yield y)
 {
   int ret;
 
@@ -302,7 +302,7 @@ int RadosBucket::remove_bucket(const DoutPrefixProvider *dpp, bool delete_childr
   return ret;
 }
 
-int RadosBucket::get_bucket_info(const DoutPrefixProvider *dpp, optional_yield y)
+int RadosBucket::get_bucket_info(const DoutPrefixProvider* dpp, optional_yield y)
 {
   auto obj_ctx = store->svc()->sysobj->init_obj_ctx();
   int ret;
@@ -331,19 +331,19 @@ int RadosBucket::get_bucket_info(const DoutPrefixProvider *dpp, optional_yield y
 }
 
 int RadosBucket::get_bucket_stats(int shard_id,
-				     std::string *bucket_ver, std::string *master_ver,
+				     std::string* bucket_ver, std::string* master_ver,
 				     std::map<RGWObjCategory, RGWStorageStats>& stats,
-				     std::string *max_marker, bool *syncstopped)
+				     std::string* max_marker, bool* syncstopped)
 {
   return store->getRados()->get_bucket_stats(info, shard_id, bucket_ver, master_ver, stats, max_marker, syncstopped);
 }
 
-int RadosBucket::get_bucket_stats_async(int shard_id, RGWGetBucketStats_CB *ctx)
+int RadosBucket::get_bucket_stats_async(int shard_id, RGWGetBucketStats_CB* ctx)
 {
   return store->getRados()->get_bucket_stats_async(get_info(), shard_id, ctx);
 }
 
-int RadosBucket::read_bucket_stats(const DoutPrefixProvider *dpp, optional_yield y)
+int RadosBucket::read_bucket_stats(const DoutPrefixProvider* dpp, optional_yield y)
 {
       int ret = store->ctl()->bucket->read_bucket_stats(info.bucket, &ent, y, dpp);
       info.placement_rule = ent.placement_rule;
@@ -355,7 +355,7 @@ int RadosBucket::sync_user_stats(optional_yield y)
   return store->ctl()->bucket->sync_user_stats(owner->get_id(), info, y);
 }
 
-int RadosBucket::update_container_stats(const DoutPrefixProvider *dpp)
+int RadosBucket::update_container_stats(const DoutPrefixProvider* dpp)
 {
   int ret;
   map<std::string, RGWBucketEnt> m;
@@ -383,12 +383,12 @@ int RadosBucket::update_container_stats(const DoutPrefixProvider *dpp)
   return 0;
 }
 
-int RadosBucket::check_bucket_shards(const DoutPrefixProvider *dpp)
+int RadosBucket::check_bucket_shards(const DoutPrefixProvider* dpp)
 {
       return store->getRados()->check_bucket_shards(info, info.bucket, get_count(), dpp);
 }
 
-int RadosBucket::link(const DoutPrefixProvider *dpp, User* new_user, optional_yield y, bool update_entrypoint, RGWObjVersionTracker* objv)
+int RadosBucket::link(const DoutPrefixProvider* dpp, User* new_user, optional_yield y, bool update_entrypoint, RGWObjVersionTracker* objv)
 {
   RGWBucketEntryPoint ep;
   ep.bucket = info.bucket;
@@ -410,12 +410,12 @@ int RadosBucket::link(const DoutPrefixProvider *dpp, User* new_user, optional_yi
   return r;
 }
 
-int RadosBucket::unlink(const DoutPrefixProvider *dpp, User* new_user, optional_yield y, bool update_entrypoint)
+int RadosBucket::unlink(const DoutPrefixProvider* dpp, User* new_user, optional_yield y, bool update_entrypoint)
 {
   return store->ctl()->bucket->unlink_bucket(new_user->get_id(), info.bucket, y, dpp, update_entrypoint);
 }
 
-int RadosBucket::chown(const DoutPrefixProvider *dpp, User* new_user, User* old_user, optional_yield y, const std::string* marker)
+int RadosBucket::chown(const DoutPrefixProvider* dpp, User* new_user, User* old_user, optional_yield y, const std::string* marker)
 {
   string obj_marker;
 
@@ -426,20 +426,20 @@ int RadosBucket::chown(const DoutPrefixProvider *dpp, User* new_user, User* old_
 			   old_user->get_display_name(), *marker, y, dpp);
 }
 
-int RadosBucket::put_instance_info(const DoutPrefixProvider *dpp, bool exclusive, ceph::real_time _mtime)
+int RadosBucket::put_instance_info(const DoutPrefixProvider* dpp, bool exclusive, ceph::real_time _mtime)
 {
   mtime = _mtime;
   return store->getRados()->put_bucket_instance_info(info, exclusive, mtime, &attrs, dpp);
 }
 
-int RadosBucket::remove_entrypoint(const DoutPrefixProvider *dpp, RGWObjVersionTracker* objv, optional_yield y)
+int RadosBucket::remove_entrypoint(const DoutPrefixProvider* dpp, RGWObjVersionTracker* objv, optional_yield y)
 {
   return store->ctl()->bucket->remove_bucket_entrypoint_info(get_key(), y, dpp,
                                            RGWBucketCtl::Bucket::RemoveParams()
                                            .set_objv_tracker(objv));
 }
 
-int RadosBucket::remove_instance_info(const DoutPrefixProvider *dpp, RGWObjVersionTracker* objv, optional_yield y)
+int RadosBucket::remove_instance_info(const DoutPrefixProvider* dpp, RGWObjVersionTracker* objv, optional_yield y)
 {
   return store->ctl()->bucket->remove_bucket_instance_info(get_key(), info, y, dpp,
                                            RGWBucketCtl::BucketInstance::RemoveParams()
@@ -452,7 +452,7 @@ bool RadosBucket::is_owner(User* user)
   return (info.owner.compare(user->get_id()) == 0);
 }
 
-int RadosBucket::check_empty(const DoutPrefixProvider *dpp, optional_yield y)
+int RadosBucket::check_empty(const DoutPrefixProvider* dpp, optional_yield y)
 {
   return store->getRados()->check_bucket_empty(dpp, info, y);
 }
@@ -464,19 +464,19 @@ int RadosBucket::check_quota(RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quot
 					  user_quota, bucket_quota, obj_size, y, check_size_only);
 }
 
-int RadosBucket::set_instance_attrs(const DoutPrefixProvider *dpp, Attrs& attrs, optional_yield y)
+int RadosBucket::set_instance_attrs(const DoutPrefixProvider* dpp, Attrs& attrs, optional_yield y)
 {
     return store->ctl()->bucket->set_bucket_instance_attrs(get_info(),
 				attrs, &get_info().objv_tracker, y, dpp);
 }
 
-int RadosBucket::try_refresh_info(const DoutPrefixProvider *dpp, ceph::real_time *pmtime)
+int RadosBucket::try_refresh_info(const DoutPrefixProvider* dpp, ceph::real_time* pmtime)
 {
   return store->getRados()->try_refresh_bucket_info(info, pmtime, dpp, &attrs);
 }
 
 int RadosBucket::read_usage(uint64_t start_epoch, uint64_t end_epoch,
-			       uint32_t max_entries, bool *is_truncated,
+			       uint32_t max_entries, bool* is_truncated,
 			       RGWUsageIter& usage_iter,
 			       map<rgw_user_bucket, rgw_usage_log_entry>& usage)
 {
@@ -510,7 +510,7 @@ int RadosBucket::set_tag_timeout(uint64_t timeout)
   return store->getRados()->cls_obj_set_bucket_tag_timeout(info, timeout);
 }
 
-int RadosBucket::purge_instance(const DoutPrefixProvider *dpp)
+int RadosBucket::purge_instance(const DoutPrefixProvider* dpp)
 {
   int max_shards = (info.layout.current_index.layout.normal.num_shards > 0 ? info.layout.current_index.layout.normal.num_shards : 1);
   for (int i = 0; i < max_shards; i++) {
@@ -532,7 +532,7 @@ int RadosBucket::purge_instance(const DoutPrefixProvider *dpp)
   return 0;
 }
 
-int RadosBucket::set_acl(const DoutPrefixProvider *dpp, RGWAccessControlPolicy &acl, optional_yield y)
+int RadosBucket::set_acl(const DoutPrefixProvider* dpp, RGWAccessControlPolicy &acl, optional_yield y)
 {
   bufferlist aclbl;
 
@@ -547,7 +547,7 @@ std::unique_ptr<Object> RadosBucket::get_object(const rgw_obj_key& k)
   return std::unique_ptr<Object>(new RadosObject(this->store, k, this));
 }
 
-int RadosBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max, ListResults& results, optional_yield y)
+int RadosBucket::list(const DoutPrefixProvider* dpp, ListParams& params, int max, ListResults& results, optional_yield y)
 {
   RGWRados::Bucket target(store->getRados(), get_info());
   if (params.shard_id >= 0) {
@@ -580,10 +580,10 @@ std::unique_ptr<User> RadosStore::get_user(const rgw_user &u)
   return std::unique_ptr<User>(new RadosUser(this, u));
 }
 
-int RadosStore::get_user_by_access_key(const DoutPrefixProvider *dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user)
+int RadosStore::get_user_by_access_key(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user)
 {
   RGWUserInfo uinfo;
-  User *u;
+  User* u;
   RGWObjVersionTracker objv_tracker;
 
   int r = ctl()->user->get_info_by_access_key(dpp, key, &uinfo, y, RGWUserCtl::GetParams().set_objv_tracker(&objv_tracker));
@@ -600,10 +600,10 @@ int RadosStore::get_user_by_access_key(const DoutPrefixProvider *dpp, const std:
   return 0;
 }
 
-int RadosStore::get_user_by_email(const DoutPrefixProvider *dpp, const std::string& email, optional_yield y, std::unique_ptr<User>* user)
+int RadosStore::get_user_by_email(const DoutPrefixProvider* dpp, const std::string& email, optional_yield y, std::unique_ptr<User>* user)
 {
   RGWUserInfo uinfo;
-  User *u;
+  User* u;
   RGWObjVersionTracker objv_tracker;
 
   int r = ctl()->user->get_info_by_email(dpp, email, &uinfo, y, RGWUserCtl::GetParams().set_objv_tracker(&objv_tracker));
@@ -620,10 +620,10 @@ int RadosStore::get_user_by_email(const DoutPrefixProvider *dpp, const std::stri
   return 0;
 }
 
-int RadosStore::get_user_by_swift(const DoutPrefixProvider *dpp, const std::string& user_str, optional_yield y, std::unique_ptr<User>* user)
+int RadosStore::get_user_by_swift(const DoutPrefixProvider* dpp, const std::string& user_str, optional_yield y, std::unique_ptr<User>* user)
 {
   RGWUserInfo uinfo;
-  User *u;
+  User* u;
   RGWObjVersionTracker objv_tracker;
 
   int r = ctl()->user->get_info_by_swift(dpp, user_str, &uinfo, y, RGWUserCtl::GetParams().set_objv_tracker(&objv_tracker));
@@ -645,7 +645,7 @@ std::unique_ptr<Object> RadosStore::get_object(const rgw_obj_key& k)
   return std::unique_ptr<Object>(new RadosObject(this, k));
 }
 
-int RadosStore::get_bucket(const DoutPrefixProvider *dpp, User* u, const rgw_bucket& b, std::unique_ptr<Bucket>* bucket, optional_yield y)
+int RadosStore::get_bucket(const DoutPrefixProvider* dpp, User* u, const rgw_bucket& b, std::unique_ptr<Bucket>* bucket, optional_yield y)
 {
   int ret;
   Bucket* bp;
@@ -672,7 +672,7 @@ int RadosStore::get_bucket(User* u, const RGWBucketInfo& i, std::unique_ptr<Buck
   return 0;
 }
 
-int RadosStore::get_bucket(const DoutPrefixProvider *dpp, User* u, const std::string& tenant, const std::string& name, std::unique_ptr<Bucket>* bucket, optional_yield y)
+int RadosStore::get_bucket(const DoutPrefixProvider* dpp, User* u, const std::string& tenant, const std::string& name, std::unique_ptr<Bucket>* bucket, optional_yield y)
 {
   rgw_bucket b;
 
@@ -682,7 +682,7 @@ int RadosStore::get_bucket(const DoutPrefixProvider *dpp, User* u, const std::st
   return get_bucket(dpp, u, b, bucket, y);
 }
 
-int RadosStore::create_bucket(const DoutPrefixProvider *dpp,
+int RadosStore::create_bucket(const DoutPrefixProvider* dpp,
 				 User& u, const rgw_bucket& b,
 				 const string& zonegroup_id,
 				 rgw_placement_rule& placement_rule,
@@ -694,7 +694,7 @@ int RadosStore::create_bucket(const DoutPrefixProvider *dpp,
 				 obj_version& ep_objv,
 				 bool exclusive,
 				 bool obj_lock_enabled,
-				 bool *existed,
+				 bool* existed,
 				 req_info& req_info,
 				 std::unique_ptr<Bucket>* bucket_out,
 				 optional_yield y)
@@ -702,11 +702,11 @@ int RadosStore::create_bucket(const DoutPrefixProvider *dpp,
   int ret;
   bufferlist in_data;
   RGWBucketInfo master_info;
-  rgw_bucket *pmaster_bucket;
-  uint32_t *pmaster_num_shards;
+  rgw_bucket* pmaster_bucket;
+  uint32_t* pmaster_num_shards;
   real_time creation_time;
   std::unique_ptr<Bucket> bucket;
-  obj_version objv, *pobjv = NULL;
+  obj_version objv,* pobjv = NULL;
 
   /* If it exists, look it up; otherwise create it */
   ret = get_bucket(dpp, &u, b, &bucket, y);
@@ -804,9 +804,9 @@ bool RadosStore::is_meta_master()
   return svc()->zone->is_meta_master();
 }
 
-int RadosStore::forward_request_to_master(User* user, obj_version *objv,
+int RadosStore::forward_request_to_master(User* user, obj_version* objv,
 					     bufferlist& in_data,
-					     JSONParser *jp, req_info& info,
+					     JSONParser* jp, req_info& info,
 					     optional_yield y)
 {
   if (is_meta_master()) {
@@ -837,7 +837,7 @@ int RadosStore::forward_request_to_master(User* user, obj_version *objv,
   return 0;
 }
 
-int RadosStore::defer_gc(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, Bucket* bucket, Object* obj, optional_yield y)
+int RadosStore::defer_gc(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, Bucket* bucket, Object* obj, optional_yield y)
 {
   return rados->defer_gc(dpp, rctx, bucket->get_info(), obj->get_obj(), y);
 }
@@ -891,9 +891,9 @@ std::unique_ptr<GCChain> RadosStore::get_gc_chain(rgw::sal::Object* obj)
   return std::unique_ptr<GCChain>(new RadosGCChain(this, obj));
 }
 
-std::unique_ptr<Writer> RadosStore::get_writer(Aio *aio, rgw::sal::Bucket* bucket,
+std::unique_ptr<Writer> RadosStore::get_writer(Aio* aio, rgw::sal::Bucket* bucket,
               RGWObjectCtx& obj_ctx, std::unique_ptr<rgw::sal::Object> _head_obj,
-              const DoutPrefixProvider *dpp, optional_yield y)
+              const DoutPrefixProvider* dpp, optional_yield y)
 {
   return std::unique_ptr<Writer>(new RadosWriter(aio, this, bucket, obj_ctx, std::move(_head_obj), dpp, y));
 }
@@ -905,7 +905,7 @@ int RadosStore::delete_raw_obj(const rgw_raw_obj& obj)
 
 int RadosStore::delete_raw_obj_aio(const rgw_raw_obj& obj, Completions* aio)
 {
-  RadosCompletions *raio = static_cast<RadosCompletions*>(aio);
+  RadosCompletions* raio = static_cast<RadosCompletions*>(aio);
 
   return rados->delete_raw_obj_aio(obj, raio->handles);
 }
@@ -915,7 +915,7 @@ void RadosStore::get_raw_obj(const rgw_placement_rule& placement_rule, const rgw
     rados->obj_to_raw(placement_rule, obj, raw_obj);
 }
 
-int RadosStore::get_raw_chunk_size(const DoutPrefixProvider *dpp, const rgw_raw_obj& obj, uint64_t* chunk_size)
+int RadosStore::get_raw_chunk_size(const DoutPrefixProvider* dpp, const rgw_raw_obj& obj, uint64_t* chunk_size)
 {
   return rados->get_max_chunk_size(obj.pool, chunk_size, dpp);
 }
@@ -955,20 +955,20 @@ void RadosStore::get_quota(RGWQuotaInfo& bucket_quota, RGWQuotaInfo& user_quota)
 
 int RadosStore::list_raw_objects(const rgw_pool& pool, const string& prefix_filter,
 				    int max, RGWListRawObjsCtx& ctx, list<string>& oids,
-				    bool *is_truncated)
+				    bool* is_truncated)
 {
     return rados->list_raw_objects(pool, prefix_filter, max, ctx, oids, is_truncated);
 }
 
-int RadosStore::set_buckets_enabled(const DoutPrefixProvider *dpp, vector<rgw_bucket>& buckets, bool enabled)
+int RadosStore::set_buckets_enabled(const DoutPrefixProvider* dpp, vector<rgw_bucket>& buckets, bool enabled)
 {
     return rados->set_buckets_enabled(buckets, enabled, dpp);
 }
 
-int RadosStore::get_sync_policy_handler(const DoutPrefixProvider *dpp,
+int RadosStore::get_sync_policy_handler(const DoutPrefixProvider* dpp,
 					   std::optional<rgw_zone_id> zone,
 					   std::optional<rgw_bucket> bucket,
-					   RGWBucketSyncPolicyHandlerRef *phandler,
+					   RGWBucketSyncPolicyHandlerRef* phandler,
 					   optional_yield y)
 {
   return ctl()->bucket->get_sync_policy_handler(zone, bucket, phandler, y, dpp);
@@ -980,7 +980,7 @@ RGWDataSyncStatusManager* RadosStore::get_data_sync_manager(const rgw_zone_id& s
 }
 
 int RadosStore::read_all_usage(uint64_t start_epoch, uint64_t end_epoch,
-				  uint32_t max_entries, bool *is_truncated,
+				  uint32_t max_entries, bool* is_truncated,
 				  RGWUsageIter& usage_iter,
 				  map<rgw_user_bucket, rgw_usage_log_entry>& usage)
 {
@@ -999,26 +999,26 @@ int RadosStore::trim_all_usage(uint64_t start_epoch, uint64_t end_epoch)
   return rados->trim_usage(uid, bucket_name, start_epoch, end_epoch);
 }
 
-int RadosStore::get_config_key_val(string name, bufferlist *bl)
+int RadosStore::get_config_key_val(string name, bufferlist* bl)
 {
   return svc()->config_key->get(name, true, bl);
 }
 
 int RadosStore::put_system_obj(const rgw_pool& pool, const string& oid,
 				  bufferlist& data, bool exclusive,
-				  RGWObjVersionTracker *objv_tracker, real_time set_mtime,
-				  optional_yield y, map<string, bufferlist> *pattrs)
+				  RGWObjVersionTracker* objv_tracker, real_time set_mtime,
+				  optional_yield y, map<string, bufferlist>* pattrs)
 {
   auto obj_ctx = svc()->sysobj->init_obj_ctx();
   return rgw_put_system_obj(obj_ctx, pool, oid, data, exclusive, objv_tracker, set_mtime, y, pattrs);
 }
 
-int RadosStore::get_system_obj(const DoutPrefixProvider *dpp,
+int RadosStore::get_system_obj(const DoutPrefixProvider* dpp,
 				  const rgw_pool& pool, const string& key,
 				  bufferlist& bl,
-				  RGWObjVersionTracker *objv_tracker, real_time *pmtime,
-				  optional_yield y, map<string, bufferlist> *pattrs,
-				  rgw_cache_entry_info *cache_info,
+				  RGWObjVersionTracker* objv_tracker, real_time* pmtime,
+				  optional_yield y, map<string, bufferlist>* pattrs,
+				  rgw_cache_entry_info* cache_info,
 				  boost::optional<obj_version> refresh_version)
 {
   auto obj_ctx = svc()->sysobj->init_obj_ctx();
@@ -1026,7 +1026,7 @@ int RadosStore::get_system_obj(const DoutPrefixProvider *dpp,
 }
 
 int RadosStore::delete_system_obj(const rgw_pool& pool, const string& oid,
-				     RGWObjVersionTracker *objv_tracker, optional_yield y)
+				     RGWObjVersionTracker* objv_tracker, optional_yield y)
 {
     return rgw_delete_system_obj(svc()->sysobj, pool, oid, objv_tracker, y);
 }
@@ -1051,7 +1051,7 @@ std::string RadosStore::meta_get_marker(void* handle)
   return ctl()->meta.mgr->get_marker(handle);
 }
 
-int RadosStore::meta_remove(const DoutPrefixProvider *dpp, string& metadata_key, optional_yield y)
+int RadosStore::meta_remove(const DoutPrefixProvider* dpp, string& metadata_key, optional_yield y)
 {
   return ctl()->meta.mgr->remove(metadata_key, y, dpp);
 }
@@ -1062,7 +1062,7 @@ void RadosStore::finalize(void)
     rados->finalize();
 }
 
-int RadosStore::get_obj_head_ioctx(const RGWBucketInfo& bucket_info, const rgw_obj& obj, librados::IoCtx *ioctx)
+int RadosStore::get_obj_head_ioctx(const RGWBucketInfo& bucket_info, const rgw_obj& obj, librados::IoCtx* ioctx)
 {
   return rados->get_obj_head_ioctx(bucket_info, obj, ioctx);
 }
@@ -1089,12 +1089,12 @@ int Object::range_to_ofs(uint64_t obj_size, int64_t &ofs, int64_t &end)
   return 0;
 }
 
-int RadosObject::get_obj_state(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWObjState **state, optional_yield y, bool follow_olh)
+int RadosObject::get_obj_state(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, RGWObjState **state, optional_yield y, bool follow_olh)
 {
   return store->getRados()->get_obj_state(dpp, rctx, bucket->get_info(), get_obj(), state, follow_olh, y);
 }
 
-int RadosObject::read_attrs(const DoutPrefixProvider *dpp, RGWRados::Object::Read &read_op, optional_yield y, rgw_obj *target_obj)
+int RadosObject::read_attrs(const DoutPrefixProvider* dpp, RGWRados::Object::Read &read_op, optional_yield y, rgw_obj* target_obj)
 {
   read_op.params.attrs = &attrs;
   read_op.params.target_obj = target_obj;
@@ -1104,7 +1104,7 @@ int RadosObject::read_attrs(const DoutPrefixProvider *dpp, RGWRados::Object::Rea
   return read_op.prepare(y, dpp);
 }
 
-int RadosObject::set_obj_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx* rctx, Attrs* setattrs, Attrs* delattrs, optional_yield y, rgw_obj* target_obj)
+int RadosObject::set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, Attrs* setattrs, Attrs* delattrs, optional_yield y, rgw_obj* target_obj)
 {
   Attrs empty;
   rgw_obj target = get_obj();
@@ -1120,7 +1120,7 @@ int RadosObject::set_obj_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx* rctx
 			y);
 }
 
-int RadosObject::get_obj_attrs(RGWObjectCtx *rctx, optional_yield y, const DoutPrefixProvider *dpp, rgw_obj* target_obj)
+int RadosObject::get_obj_attrs(RGWObjectCtx* rctx, optional_yield y, const DoutPrefixProvider* dpp, rgw_obj* target_obj)
 {
   RGWRados::Object op_target(store->getRados(), bucket->get_info(), *rctx, get_obj());
   RGWRados::Object::Read read_op(&op_target);
@@ -1128,7 +1128,7 @@ int RadosObject::get_obj_attrs(RGWObjectCtx *rctx, optional_yield y, const DoutP
   return read_attrs(dpp, read_op, y, target_obj);
 }
 
-int RadosObject::modify_obj_attrs(RGWObjectCtx *rctx, const char *attr_name, bufferlist& attr_val, optional_yield y, const DoutPrefixProvider *dpp)
+int RadosObject::modify_obj_attrs(RGWObjectCtx* rctx, const char* attr_name, bufferlist& attr_val, optional_yield y, const DoutPrefixProvider* dpp)
 {
   rgw_obj target = get_obj();
   int r = get_obj_attrs(rctx, y, dpp, &target);
@@ -1140,7 +1140,7 @@ int RadosObject::modify_obj_attrs(RGWObjectCtx *rctx, const char *attr_name, buf
   return set_obj_attrs(dpp, rctx, &attrs, nullptr, y, &target);
 }
 
-int RadosObject::delete_obj_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, const char *attr_name, optional_yield y)
+int RadosObject::delete_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, const char* attr_name, optional_yield y)
 {
   Attrs rmattr;
   bufferlist bl;
@@ -1154,7 +1154,7 @@ int RadosObject::copy_obj_data(RGWObjectCtx& rctx, Bucket* dest_bucket,
 				  Object* dest_obj,
 				  uint16_t olh_epoch,
 				  std::string* petag,
-				  const DoutPrefixProvider *dpp,
+				  const DoutPrefixProvider* dpp,
 				  optional_yield y)
 {
   Attrs attrset;
@@ -1176,13 +1176,13 @@ int RadosObject::copy_obj_data(RGWObjectCtx& rctx, Bucket* dest_bucket,
 					  real_time(), NULL, dpp, y);
 }
 
-void RadosObject::set_atomic(RGWObjectCtx *rctx) const
+void RadosObject::set_atomic(RGWObjectCtx* rctx) const
 {
   rgw_obj obj = get_obj();
   store->getRados()->set_atomic(rctx, obj);
 }
 
-void RadosObject::set_prefetch_data(RGWObjectCtx *rctx)
+void RadosObject::set_prefetch_data(RGWObjectCtx* rctx)
 {
   rgw_obj obj = get_obj();
   store->getRados()->set_prefetch_data(rctx, obj);
@@ -1227,7 +1227,7 @@ void RadosObject::get_raw_obj(rgw_raw_obj* raw_obj)
 
 int RadosObject::omap_get_vals(const string& marker, uint64_t count,
 				  std::map<string, bufferlist> *m,
-				  bool *pmore, optional_yield y)
+				  bool* pmore, optional_yield y)
 {
   auto obj_ctx = store->svc()->sysobj->init_obj_ctx();
   rgw_raw_obj raw_obj;
@@ -1250,7 +1250,7 @@ int RadosObject::omap_get_all(std::map<string, bufferlist> *m,
 
 int RadosObject::omap_get_vals_by_keys(const std::string& oid,
 					  const std::set<std::string>& keys,
-					  Attrs *vals)
+					  Attrs* vals)
 {
   int ret;
   rgw_raw_obj head_obj;
@@ -1290,19 +1290,19 @@ int RadosObject::transition(RGWObjectCtx& rctx,
 			       const rgw_placement_rule& placement_rule,
 			       const real_time& mtime,
 			       uint64_t olh_epoch,
-			       const DoutPrefixProvider *dpp,
+			       const DoutPrefixProvider* dpp,
 			       optional_yield y)
 {
   return store->getRados()->transition_obj(rctx, bucket, *this, placement_rule, mtime, olh_epoch, dpp, y);
 }
 
-int RadosObject::get_max_chunk_size(const DoutPrefixProvider *dpp, rgw_placement_rule placement_rule, uint64_t *max_chunk_size, uint64_t *alignment)
+int RadosObject::get_max_chunk_size(const DoutPrefixProvider* dpp, rgw_placement_rule placement_rule, uint64_t* max_chunk_size, uint64_t* alignment)
 {
   return store->getRados()->get_max_chunk_size(placement_rule, get_obj(), max_chunk_size, dpp, alignment);
 }
 
 void RadosObject::get_max_aligned_size(uint64_t size, uint64_t alignment,
-				     uint64_t *max_size)
+				     uint64_t* max_size)
 {
   store->getRados()->get_max_aligned_size(size, alignment, max_size);
 }
@@ -1327,7 +1327,7 @@ bool RadosObject::placement_rules_match(rgw_placement_rule& r1, rgw_placement_ru
   return p1 == p2;
 }
 
-std::unique_ptr<Object::ReadOp> RadosObject::get_read_op(RGWObjectCtx *ctx)
+std::unique_ptr<Object::ReadOp> RadosObject::get_read_op(RGWObjectCtx* ctx)
 {
   return std::unique_ptr<Object::ReadOp>(new RadosObject::RadosReadOp(this, ctx));
 }
@@ -1342,7 +1342,7 @@ RadosObject::RadosReadOp::RadosReadOp(RadosObject *_source, RGWObjectCtx *_rctx)
 	parent_op(&op_target)
 { }
 
-int RadosObject::RadosReadOp::prepare(optional_yield y, const DoutPrefixProvider *dpp)
+int RadosObject::RadosReadOp::prepare(optional_yield y, const DoutPrefixProvider* dpp)
 {
   uint64_t obj_size;
 
@@ -1369,23 +1369,23 @@ int RadosObject::RadosReadOp::prepare(optional_yield y, const DoutPrefixProvider
   return ret;
 }
 
-int RadosObject::RadosReadOp::read(int64_t ofs, int64_t end, bufferlist& bl, optional_yield y, const DoutPrefixProvider *dpp)
+int RadosObject::RadosReadOp::read(int64_t ofs, int64_t end, bufferlist& bl, optional_yield y, const DoutPrefixProvider* dpp)
 {
   return parent_op.read(ofs, end, bl, y, dpp);
 }
 
-int RadosObject::RadosReadOp::get_manifest(const DoutPrefixProvider *dpp, RGWObjManifest **pmanifest,
+int RadosObject::RadosReadOp::get_manifest(const DoutPrefixProvider* dpp, RGWObjManifest **pmanifest,
 					      optional_yield y)
 {
   return op_target.get_manifest(dpp, pmanifest, y);
 }
 
-int RadosObject::RadosReadOp::get_attr(const DoutPrefixProvider *dpp, const char *name, bufferlist& dest, optional_yield y)
+int RadosObject::RadosReadOp::get_attr(const DoutPrefixProvider* dpp, const char* name, bufferlist& dest, optional_yield y)
 {
   return parent_op.get_attr(dpp, name, dest, y);
 }
 
-std::unique_ptr<Object::DeleteOp> RadosObject::get_delete_op(RGWObjectCtx *ctx)
+std::unique_ptr<Object::DeleteOp> RadosObject::get_delete_op(RGWObjectCtx* ctx)
 {
   return std::unique_ptr<Object::DeleteOp>(new RadosObject::RadosDeleteOp(this, ctx));
 }
@@ -1400,7 +1400,7 @@ RadosObject::RadosDeleteOp::RadosDeleteOp(RadosObject *_source, RGWObjectCtx *_r
 	parent_op(&op_target)
 { }
 
-int RadosObject::RadosDeleteOp::delete_obj(const DoutPrefixProvider *dpp, optional_yield y)
+int RadosObject::RadosDeleteOp::delete_obj(const DoutPrefixProvider* dpp, optional_yield y)
 {
   parent_op.params.bucket_owner = params.bucket_owner.get_id();
   parent_op.params.versioning_status = params.versioning_status;
@@ -1427,7 +1427,7 @@ int RadosObject::RadosDeleteOp::delete_obj(const DoutPrefixProvider *dpp, option
   return ret;
 }
 
-int RadosObject::delete_object(const DoutPrefixProvider *dpp, RGWObjectCtx* obj_ctx, optional_yield y)
+int RadosObject::delete_object(const DoutPrefixProvider* dpp, RGWObjectCtx* obj_ctx, optional_yield y)
 {
   RGWRados::Object del_target(store->getRados(), bucket->get_info(), *obj_ctx, get_obj());
   RGWRados::Object::Delete del_op(&del_target);
@@ -1438,7 +1438,7 @@ int RadosObject::delete_object(const DoutPrefixProvider *dpp, RGWObjectCtx* obj_
   return del_op.delete_obj(y, dpp);
 }
 
-int RadosObject::delete_obj_aio(const DoutPrefixProvider *dpp, RGWObjState *astate,
+int RadosObject::delete_obj_aio(const DoutPrefixProvider* dpp, RGWObjState* astate,
 				   Completions* aio, bool keep_index_consistent,
 				   optional_yield y)
 {
@@ -1448,7 +1448,7 @@ int RadosObject::delete_obj_aio(const DoutPrefixProvider *dpp, RGWObjState *asta
 					   raio->handles, keep_index_consistent, y);
 }
 
-std::unique_ptr<Object::StatOp> RadosObject::get_stat_op(RGWObjectCtx *ctx)
+std::unique_ptr<Object::StatOp> RadosObject::get_stat_op(RGWObjectCtx* ctx)
 {
   return std::unique_ptr<Object::StatOp>(new RadosObject::RadosStatOp(this, ctx));
 }
@@ -1491,31 +1491,31 @@ int RadosObject::RadosStatOp::wait()
 
 int RadosObject::copy_object(RGWObjectCtx& obj_ctx,
 				User* user,
-				req_info *info,
+				req_info* info,
 				const rgw_zone_id& source_zone,
 				rgw::sal::Object* dest_object,
 				rgw::sal::Bucket* dest_bucket,
 				rgw::sal::Bucket* src_bucket,
 				const rgw_placement_rule& dest_placement,
-				ceph::real_time *src_mtime,
-				ceph::real_time *mtime,
-				const ceph::real_time *mod_ptr,
-				const ceph::real_time *unmod_ptr,
+				ceph::real_time* src_mtime,
+				ceph::real_time* mtime,
+				const ceph::real_time* mod_ptr,
+				const ceph::real_time* unmod_ptr,
 				bool high_precision_time,
-				const char *if_match,
-				const char *if_nomatch,
+				const char* if_match,
+				const char* if_nomatch,
 				AttrsMod attrs_mod,
 				bool copy_if_newer,
 				Attrs& attrs,
 				RGWObjCategory category,
 				uint64_t olh_epoch,
 				boost::optional<ceph::real_time> delete_at,
-				string *version_id,
-				string *tag,
-				string *etag,
+				string* version_id,
+				string* tag,
+				string* etag,
 				void (*progress_cb)(off_t, void *),
-				void *progress_data,
-				const DoutPrefixProvider *dpp,
+				void* progress_data,
+				const DoutPrefixProvider* dpp,
 				optional_yield y)
 {
   return store->getRados()->copy_obj(obj_ctx,
@@ -1549,7 +1549,7 @@ int RadosObject::copy_object(RGWObjectCtx& obj_ctx,
 				     y);
 }
 
-int RadosObject::RadosReadOp::iterate(const DoutPrefixProvider *dpp, int64_t ofs, int64_t end, RGWGetDataCB *cb, optional_yield y)
+int RadosObject::RadosReadOp::iterate(const DoutPrefixProvider* dpp, int64_t ofs, int64_t end, RGWGetDataCB* cb, optional_yield y)
 {
   return parent_op.iterate(dpp, ofs, end, cb, y);
 }
@@ -1596,7 +1596,7 @@ int RadosObject::RadosWriteOp::prepare(optional_yield y)
   return 0;
 }
 
-int RadosObject::RadosWriteOp::write_meta(const DoutPrefixProvider *dpp, uint64_t size, uint64_t accounted_size, optional_yield y)
+int RadosObject::RadosWriteOp::write_meta(const DoutPrefixProvider* dpp, uint64_t size, uint64_t accounted_size, optional_yield y)
 {
   int ret = parent_op.write_meta(dpp, size, accounted_size, *params.attrs, y);
   params.canceled = parent_op.meta.canceled;
@@ -1606,7 +1606,7 @@ int RadosObject::RadosWriteOp::write_meta(const DoutPrefixProvider *dpp, uint64_
 
 int RadosObject::swift_versioning_restore(RGWObjectCtx* obj_ctx,
 					     bool& restored,
-					     const DoutPrefixProvider *dpp)
+					     const DoutPrefixProvider* dpp)
 {
   return store->getRados()->swift_versioning_restore(*obj_ctx,
 						     bucket->get_owner()->get_id(),
@@ -1617,7 +1617,7 @@ int RadosObject::swift_versioning_restore(RGWObjectCtx* obj_ctx,
 }
 
 int RadosObject::swift_versioning_copy(RGWObjectCtx* obj_ctx,
-					  const DoutPrefixProvider *dpp,
+					  const DoutPrefixProvider* dpp,
 					  optional_yield y)
 {
   return store->getRados()->swift_versioning_copy(*obj_ctx,
@@ -1764,7 +1764,7 @@ int RadosNotification::publish_reserve(RGWObjTags* obj_tags)
   return rgw::notify::publish_reserve(event_type, res, obj_tags);
 }
 
-int RadosNotification::publish_commit(const DoutPrefixProvider *dpp, uint64_t size,
+int RadosNotification::publish_commit(const DoutPrefixProvider* dpp, uint64_t size,
 				     const ceph::real_time& mtime, const std::string& etag)
 {
   return rgw::notify::publish_commit(obj, size, mtime, etag, event_type, res, dpp);
@@ -1914,7 +1914,7 @@ bool RadosZone::is_writeable()
   return store->svc()->zone->zone_is_writeable();
 }
 
-bool RadosZone::get_redirect_endpoint(std::string *endpoint)
+bool RadosZone::get_redirect_endpoint(std::string* endpoint)
 {
   return store->svc()->zone->get_redirect_zone_endpoint(endpoint);
 }
@@ -1933,11 +1933,11 @@ const string& RadosZone::get_current_period_id()
 
 extern "C" {
 
-void *newStore(void)
+void* newStore(void)
 {
-  rgw::sal::RadosStore *store = new rgw::sal::RadosStore();
+  rgw::sal::RadosStore* store = new rgw::sal::RadosStore();
   if (store) {
-    RGWRados *rados = new RGWRados();
+    RGWRados* rados = new RGWRados();
 
     if (!rados) {
       delete store; store = nullptr;

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -120,8 +120,8 @@ int RadosCompletions::drain()
   return ret;
 }
 
-int RadosUser::list_buckets(const DoutPrefixProvider* dpp, const string& marker,
-			       const string& end_marker, uint64_t max, bool need_stats,
+int RadosUser::list_buckets(const DoutPrefixProvider* dpp, const std::string& marker,
+			       const std::string& end_marker, uint64_t max, bool need_stats,
 			       BucketList &buckets, optional_yield y)
 {
   RGWUserBuckets ulist;
@@ -367,7 +367,7 @@ int RadosBucket::update_container_stats(const DoutPrefixProvider* dpp)
   if (ret < 0)
     return ret;
 
-  map<string, RGWBucketEnt>::iterator iter = m.find(info.bucket.name);
+  map<std::string, RGWBucketEnt>::iterator iter = m.find(info.bucket.name);
   if (iter == m.end())
     return -EINVAL;
 
@@ -417,7 +417,7 @@ int RadosBucket::unlink(const DoutPrefixProvider* dpp, User* new_user, optional_
 
 int RadosBucket::chown(const DoutPrefixProvider* dpp, User* new_user, User* old_user, optional_yield y, const std::string* marker)
 {
-  string obj_marker;
+  std::string obj_marker;
 
   if (marker == nullptr)
     marker = &obj_marker;
@@ -684,9 +684,9 @@ int RadosStore::get_bucket(const DoutPrefixProvider* dpp, User* u, const std::st
 
 int RadosStore::create_bucket(const DoutPrefixProvider* dpp,
 				 User& u, const rgw_bucket& b,
-				 const string& zonegroup_id,
+				 const std::string& zonegroup_id,
 				 rgw_placement_rule& placement_rule,
-				 string& swift_ver_location,
+				 std::string& swift_ver_location,
 				 const RGWQuotaInfo * pquota_info,
 				 const RGWAccessControlPolicy& policy,
 				 Attrs& attrs,
@@ -820,7 +820,7 @@ int RadosStore::forward_request_to_master(User* user, obj_version* objv,
   }
   ldout(ctx(), 0) << "sending request to master zonegroup" << dendl;
   bufferlist response;
-  string uid_str = user->get_id().to_str();
+  std::string uid_str = user->get_id().to_str();
 #define MAX_REST_RESPONSE (128 * 1024) // we expect a very small response
   int ret = svc()->zone->get_master_conn()->forward(rgw_user(uid_str), info,
                                                     objv, MAX_REST_RESPONSE,
@@ -925,7 +925,7 @@ int RadosStore::log_usage(map<rgw_user_bucket, RGWUsageBatch>& usage_info)
     return rados->log_usage(usage_info);
 }
 
-int RadosStore::log_op(string& oid, bufferlist& bl)
+int RadosStore::log_op(std::string& oid, bufferlist& bl)
 {
   rgw_raw_obj obj(svc()->zone->get_zone_params().log_pool, oid);
 
@@ -941,8 +941,8 @@ int RadosStore::log_op(string& oid, bufferlist& bl)
   return ret;
 }
 
-int RadosStore::register_to_service_map(const string& daemon_type,
-					   const map<string, string>& meta)
+int RadosStore::register_to_service_map(const std::string& daemon_type,
+					   const map<std::string, std::string>& meta)
 {
   return rados->register_to_service_map(daemon_type, meta);
 }
@@ -953,8 +953,8 @@ void RadosStore::get_quota(RGWQuotaInfo& bucket_quota, RGWQuotaInfo& user_quota)
     user_quota = svc()->quota->get_user_quota();
 }
 
-int RadosStore::list_raw_objects(const rgw_pool& pool, const string& prefix_filter,
-				    int max, RGWListRawObjsCtx& ctx, list<string>& oids,
+int RadosStore::list_raw_objects(const rgw_pool& pool, const std::string& prefix_filter,
+				    int max, RGWListRawObjsCtx& ctx, list<std::string>& oids,
 				    bool* is_truncated)
 {
     return rados->list_raw_objects(pool, prefix_filter, max, ctx, oids, is_truncated);
@@ -999,25 +999,25 @@ int RadosStore::trim_all_usage(uint64_t start_epoch, uint64_t end_epoch)
   return rados->trim_usage(uid, bucket_name, start_epoch, end_epoch);
 }
 
-int RadosStore::get_config_key_val(string name, bufferlist* bl)
+int RadosStore::get_config_key_val(std::string name, bufferlist* bl)
 {
   return svc()->config_key->get(name, true, bl);
 }
 
-int RadosStore::put_system_obj(const rgw_pool& pool, const string& oid,
+int RadosStore::put_system_obj(const rgw_pool& pool, const std::string& oid,
 				  bufferlist& data, bool exclusive,
 				  RGWObjVersionTracker* objv_tracker, real_time set_mtime,
-				  optional_yield y, map<string, bufferlist>* pattrs)
+				  optional_yield y, map<std::string, bufferlist>* pattrs)
 {
   auto obj_ctx = svc()->sysobj->init_obj_ctx();
   return rgw_put_system_obj(obj_ctx, pool, oid, data, exclusive, objv_tracker, set_mtime, y, pattrs);
 }
 
 int RadosStore::get_system_obj(const DoutPrefixProvider* dpp,
-				  const rgw_pool& pool, const string& key,
+				  const rgw_pool& pool, const std::string& key,
 				  bufferlist& bl,
 				  RGWObjVersionTracker* objv_tracker, real_time* pmtime,
-				  optional_yield y, map<string, bufferlist>* pattrs,
+				  optional_yield y, map<std::string, bufferlist>* pattrs,
 				  rgw_cache_entry_info* cache_info,
 				  boost::optional<obj_version> refresh_version)
 {
@@ -1025,18 +1025,18 @@ int RadosStore::get_system_obj(const DoutPrefixProvider* dpp,
   return rgw_get_system_obj(obj_ctx, pool, key, bl, objv_tracker, pmtime, y, dpp, pattrs, cache_info, refresh_version);
 }
 
-int RadosStore::delete_system_obj(const rgw_pool& pool, const string& oid,
+int RadosStore::delete_system_obj(const rgw_pool& pool, const std::string& oid,
 				     RGWObjVersionTracker* objv_tracker, optional_yield y)
 {
     return rgw_delete_system_obj(svc()->sysobj, pool, oid, objv_tracker, y);
 }
 
-int RadosStore::meta_list_keys_init(const string& section, const string& marker, void** phandle)
+int RadosStore::meta_list_keys_init(const std::string& section, const std::string& marker, void** phandle)
 {
   return ctl()->meta.mgr->list_keys_init(section, marker, phandle);
 }
 
-int RadosStore::meta_list_keys_next(void* handle, int max, list<string>& keys, bool* truncated)
+int RadosStore::meta_list_keys_next(void* handle, int max, list<std::string>& keys, bool* truncated)
 {
   return ctl()->meta.mgr->list_keys_next(handle, max, keys, truncated);
 }
@@ -1051,7 +1051,7 @@ std::string RadosStore::meta_get_marker(void* handle)
   return ctl()->meta.mgr->get_marker(handle);
 }
 
-int RadosStore::meta_remove(const DoutPrefixProvider* dpp, string& metadata_key, optional_yield y)
+int RadosStore::meta_remove(const DoutPrefixProvider* dpp, std::string& metadata_key, optional_yield y)
 {
   return ctl()->meta.mgr->remove(metadata_key, y, dpp);
 }
@@ -1225,8 +1225,8 @@ void RadosObject::get_raw_obj(rgw_raw_obj* raw_obj)
   store->getRados()->obj_to_raw((bucket->get_info()).placement_rule, get_obj(), raw_obj);
 }
 
-int RadosObject::omap_get_vals(const string& marker, uint64_t count,
-				  std::map<string, bufferlist> *m,
+int RadosObject::omap_get_vals(const std::string& marker, uint64_t count,
+				  std::map<std::string, bufferlist> *m,
 				  bool* pmore, optional_yield y)
 {
   auto obj_ctx = store->svc()->sysobj->init_obj_ctx();
@@ -1237,7 +1237,7 @@ int RadosObject::omap_get_vals(const string& marker, uint64_t count,
   return sysobj.omap().get_vals(marker, count, m, pmore, y);
 }
 
-int RadosObject::omap_get_all(std::map<string, bufferlist> *m,
+int RadosObject::omap_get_all(std::map<std::string, bufferlist> *m,
 				 optional_yield y)
 {
   auto obj_ctx = store->svc()->sysobj->init_obj_ctx();
@@ -1510,9 +1510,9 @@ int RadosObject::copy_object(RGWObjectCtx& obj_ctx,
 				RGWObjCategory category,
 				uint64_t olh_epoch,
 				boost::optional<ceph::real_time> delete_at,
-				string* version_id,
-				string* tag,
-				string* etag,
+				std::string* version_id,
+				std::string* tag,
+				std::string* etag,
 				void (*progress_cb)(off_t, void *),
 				void* progress_data,
 				const DoutPrefixProvider* dpp,
@@ -1666,7 +1666,7 @@ int LCRadosSerializer::try_lock(utime_t dur, optional_yield y)
   return lock.lock_exclusive(ioctx, oid);
 }
 
-int RadosLifecycle::get_entry(const string& oid, const std::string& marker,
+int RadosLifecycle::get_entry(const std::string& oid, const std::string& marker,
 			      LCEntry& entry)
 {
   cls_rgw_lc_entry cls_entry;
@@ -1679,7 +1679,7 @@ int RadosLifecycle::get_entry(const string& oid, const std::string& marker,
   return ret;
 }
 
-int RadosLifecycle::get_next_entry(const string& oid, std::string& marker,
+int RadosLifecycle::get_next_entry(const std::string& oid, std::string& marker,
 				   LCEntry& entry)
 {
   cls_rgw_lc_entry cls_entry;
@@ -1693,7 +1693,7 @@ int RadosLifecycle::get_next_entry(const string& oid, std::string& marker,
   return ret;
 }
 
-int RadosLifecycle::set_entry(const string& oid, const LCEntry& entry)
+int RadosLifecycle::set_entry(const std::string& oid, const LCEntry& entry)
 {
   cls_rgw_lc_entry cls_entry;
 
@@ -1704,7 +1704,7 @@ int RadosLifecycle::set_entry(const string& oid, const LCEntry& entry)
   return cls_rgw_lc_set_entry(*store->getRados()->get_lc_pool_ctx(), oid, cls_entry);
 }
 
-int RadosLifecycle::list_entries(const string& oid, const string& marker,
+int RadosLifecycle::list_entries(const std::string& oid, const std::string& marker,
 				 uint32_t max_entries, vector<LCEntry>& entries)
 {
   entries.clear();
@@ -1722,7 +1722,7 @@ int RadosLifecycle::list_entries(const string& oid, const string& marker,
   return ret;
 }
 
-int RadosLifecycle::rm_entry(const string& oid, const LCEntry& entry)
+int RadosLifecycle::rm_entry(const std::string& oid, const LCEntry& entry)
 {
   cls_rgw_lc_entry cls_entry;
 
@@ -1733,7 +1733,7 @@ int RadosLifecycle::rm_entry(const string& oid, const LCEntry& entry)
   return cls_rgw_lc_rm_entry(*store->getRados()->get_lc_pool_ctx(), oid, cls_entry);
 }
 
-int RadosLifecycle::get_head(const string& oid, LCHead& head)
+int RadosLifecycle::get_head(const std::string& oid, LCHead& head)
 {
   cls_rgw_lc_obj_head cls_head;
   int ret = cls_rgw_lc_get_head(*store->getRados()->get_lc_pool_ctx(), oid, cls_head);
@@ -1744,7 +1744,7 @@ int RadosLifecycle::get_head(const string& oid, LCHead& head)
   return ret;
 }
 
-int RadosLifecycle::put_head(const string& oid, const LCHead& head)
+int RadosLifecycle::put_head(const std::string& oid, const LCHead& head)
 {
   cls_rgw_lc_obj_head cls_head;
 
@@ -1884,7 +1884,7 @@ const RGWZoneGroup& RadosZone::get_zonegroup()
   return store->svc()->zone->get_zonegroup();
 }
 
-int RadosZone::get_zonegroup(const string& id, RGWZoneGroup& zonegroup)
+int RadosZone::get_zonegroup(const std::string& id, RGWZoneGroup& zonegroup)
 {
   return store->svc()->zone->get_zonegroup(id, zonegroup);
 }
@@ -1924,7 +1924,7 @@ bool RadosZone::has_zonegroup_api(const std::string& api) const
   return store->svc()->zone->has_zonegroup_api(api);
 }
 
-const string& RadosZone::get_current_period_id()
+const std::string& RadosZone::get_current_period_id()
 {
   return store->svc()->zone->get_current_period_id();
 }

--- a/src/rgw/rgw_sal_rados.h
+++ b/src/rgw/rgw_sal_rados.h
@@ -22,7 +22,7 @@
 
 namespace rgw { namespace sal {
 
-class RGWRadosStore;
+class RadosStore;
 
 class RadosCompletions : public Completions {
   public:
@@ -32,25 +32,25 @@ class RadosCompletions : public Completions {
     virtual int drain() override;
 };
 
-class RGWRadosUser : public RGWUser {
+class RadosUser : public User {
   private:
-    RGWRadosStore *store;
+    RadosStore *store;
 
   public:
-    RGWRadosUser(RGWRadosStore *_st, const rgw_user& _u) : RGWUser(_u), store(_st) { }
-    RGWRadosUser(RGWRadosStore *_st, const RGWUserInfo& _i) : RGWUser(_i), store(_st) { }
-    RGWRadosUser(RGWRadosStore *_st) : store(_st) { }
-    RGWRadosUser(RGWRadosUser& _o) = default;
-    RGWRadosUser() {}
+    RadosUser(RadosStore *_st, const rgw_user& _u) : User(_u), store(_st) { }
+    RadosUser(RadosStore *_st, const RGWUserInfo& _i) : User(_i), store(_st) { }
+    RadosUser(RadosStore *_st) : store(_st) { }
+    RadosUser(RadosUser& _o) = default;
+    RadosUser() {}
 
-    virtual std::unique_ptr<RGWUser> clone() override {
-      return std::unique_ptr<RGWUser>(new RGWRadosUser(*this));
+    virtual std::unique_ptr<User> clone() override {
+      return std::unique_ptr<User>(new RadosUser(*this));
     }
     int list_buckets(const DoutPrefixProvider *dpp, const std::string& marker, const std::string& end_marker,
-		     uint64_t max, bool need_stats, RGWBucketList& buckets,
+		     uint64_t max, bool need_stats, BucketList& buckets,
 		     optional_yield y) override;
-    virtual RGWBucket* create_bucket(rgw_bucket& bucket, ceph::real_time creation_time) override;
-    virtual int read_attrs(const DoutPrefixProvider *dpp, optional_yield y, RGWAttrs* uattrs, RGWObjVersionTracker* tracker) override;
+    virtual Bucket* create_bucket(rgw_bucket& bucket, ceph::real_time creation_time) override;
+    virtual int read_attrs(const DoutPrefixProvider *dpp, optional_yield y, Attrs* uattrs, RGWObjVersionTracker* tracker) override;
     virtual int read_stats(optional_yield y, RGWStorageStats* stats,
 			   ceph::real_time *last_stats_sync = nullptr,
 			   ceph::real_time *last_stats_update = nullptr) override;
@@ -66,25 +66,25 @@ class RGWRadosUser : public RGWUser {
     virtual int store_info(const DoutPrefixProvider *dpp, optional_yield y, const RGWUserCtl::PutParams& params = {}) override;
     virtual int remove_info(const DoutPrefixProvider *dpp, optional_yield y, const RGWUserCtl::RemoveParams& params = {}) override;
 
-    friend class RGWRadosBucket;
+    friend class RadosBucket;
 };
 
-class RGWRadosObject : public RGWObject {
+class RadosObject : public Object {
   private:
-    RGWRadosStore *store;
+    RadosStore *store;
     RGWAccessControlPolicy acls;
 
   public:
 
     struct RadosReadOp : public ReadOp {
     private:
-      RGWRadosObject* source;
+      RadosObject* source;
       RGWObjectCtx* rctx;
       RGWRados::Object op_target;
       RGWRados::Object::Read parent_op;
 
     public:
-      RadosReadOp(RGWRadosObject *_source, RGWObjectCtx *_rctx);
+      RadosReadOp(RadosObject *_source, RGWObjectCtx *_rctx);
 
       virtual int prepare(optional_yield y, const DoutPrefixProvider *dpp) override;
       virtual int read(int64_t ofs, int64_t end, bufferlist& bl, optional_yield y, const DoutPrefixProvider *dpp) override;
@@ -95,13 +95,13 @@ class RGWRadosObject : public RGWObject {
 
     struct RadosWriteOp : public WriteOp {
     private:
-      RGWRadosObject* source;
+      RadosObject* source;
       RGWObjectCtx* rctx;
       RGWRados::Object op_target;
       RGWRados::Object::Write parent_op;
 
     public:
-      RadosWriteOp(RGWRadosObject* _source, RGWObjectCtx* _rctx);
+      RadosWriteOp(RadosObject* _source, RGWObjectCtx* _rctx);
 
       virtual int prepare(optional_yield y) override;
       virtual int write_meta(const DoutPrefixProvider *dpp, uint64_t size, uint64_t accounted_size, optional_yield y) override;
@@ -110,58 +110,58 @@ class RGWRadosObject : public RGWObject {
 
     struct RadosDeleteOp : public DeleteOp {
     private:
-      RGWRadosObject* source;
+      RadosObject* source;
       RGWObjectCtx* rctx;
       RGWRados::Object op_target;
       RGWRados::Object::Delete parent_op;
 
     public:
-      RadosDeleteOp(RGWRadosObject* _source, RGWObjectCtx* _rctx);
+      RadosDeleteOp(RadosObject* _source, RGWObjectCtx* _rctx);
 
       virtual int delete_obj(const DoutPrefixProvider *dpp, optional_yield y) override;
     };
 
     struct RadosStatOp : public StatOp {
     private:
-      RGWRadosObject* source;
+      RadosObject* source;
       RGWObjectCtx* rctx;
       RGWRados::Object op_target;
       RGWRados::Object::Stat parent_op;
 
     public:
-      RadosStatOp(RGWRadosObject* _source, RGWObjectCtx* _rctx);
+      RadosStatOp(RadosObject* _source, RGWObjectCtx* _rctx);
 
       virtual int stat_async() override;
       virtual int wait() override;
     };
 
-    RGWRadosObject() = default;
+    RadosObject() = default;
 
-    RGWRadosObject(RGWRadosStore *_st, const rgw_obj_key& _k)
-      : RGWObject(_k),
+    RadosObject(RadosStore *_st, const rgw_obj_key& _k)
+      : Object(_k),
 	store(_st),
         acls() {
     }
-    RGWRadosObject(RGWRadosStore *_st, const rgw_obj_key& _k, RGWBucket* _b)
-      : RGWObject(_k, _b),
+    RadosObject(RadosStore *_st, const rgw_obj_key& _k, Bucket* _b)
+      : Object(_k, _b),
 	store(_st),
         acls() {
     }
-    RGWRadosObject(RGWRadosObject& _o) = default;
+    RadosObject(RadosObject& _o) = default;
 
     virtual int delete_object(const DoutPrefixProvider *dpp, RGWObjectCtx* obj_ctx, optional_yield y) override;
     virtual int delete_obj_aio(const DoutPrefixProvider *dpp, RGWObjState *astate, Completions* aio,
 			       bool keep_index_consistent, optional_yield y) override;
-    virtual int copy_object(RGWObjectCtx& obj_ctx, RGWUser* user,
+    virtual int copy_object(RGWObjectCtx& obj_ctx, User* user,
                req_info *info, const rgw_zone_id& source_zone,
-               rgw::sal::RGWObject* dest_object, rgw::sal::RGWBucket* dest_bucket,
-               rgw::sal::RGWBucket* src_bucket,
+               rgw::sal::Object* dest_object, rgw::sal::Bucket* dest_bucket,
+               rgw::sal::Bucket* src_bucket,
                const rgw_placement_rule& dest_placement,
                ceph::real_time *src_mtime, ceph::real_time *mtime,
                const ceph::real_time *mod_ptr, const ceph::real_time *unmod_ptr,
                bool high_precision_time,
                const char *if_match, const char *if_nomatch,
-               AttrsMod attrs_mod, bool copy_if_newer, RGWAttrs& attrs,
+               AttrsMod attrs_mod, bool copy_if_newer, Attrs& attrs,
                RGWObjCategory category, uint64_t olh_epoch,
 	       boost::optional<ceph::real_time> delete_at,
                string *version_id, string *tag, string *etag,
@@ -173,21 +173,21 @@ class RGWRadosObject : public RGWObject {
     virtual void set_prefetch_data(RGWObjectCtx *rctx) override;
 
     virtual int get_obj_state(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWObjState **state, optional_yield y, bool follow_olh = true) override;
-    virtual int set_obj_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx* rctx, RGWAttrs* setattrs, RGWAttrs* delattrs, optional_yield y, rgw_obj* target_obj = NULL) override;
+    virtual int set_obj_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx* rctx, Attrs* setattrs, Attrs* delattrs, optional_yield y, rgw_obj* target_obj = NULL) override;
     virtual int get_obj_attrs(RGWObjectCtx *rctx, optional_yield y, const DoutPrefixProvider *dpp, rgw_obj* target_obj = NULL) override;
     virtual int modify_obj_attrs(RGWObjectCtx *rctx, const char *attr_name, bufferlist& attr_val, optional_yield y, const DoutPrefixProvider *dpp) override;
     virtual int delete_obj_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, const char *attr_name, optional_yield y) override;
-    virtual int copy_obj_data(RGWObjectCtx& rctx, RGWBucket* dest_bucket, RGWObject* dest_obj, uint16_t olh_epoch, std::string* petag, const DoutPrefixProvider *dpp, optional_yield y) override;
+    virtual int copy_obj_data(RGWObjectCtx& rctx, Bucket* dest_bucket, Object* dest_obj, uint16_t olh_epoch, std::string* petag, const DoutPrefixProvider *dpp, optional_yield y) override;
     virtual bool is_expired() override;
     virtual void gen_rand_obj_instance_name() override;
     virtual void raw_obj_to_obj(const rgw_raw_obj& raw_obj) override;
     virtual void get_raw_obj(rgw_raw_obj* raw_obj) override;
-    virtual std::unique_ptr<RGWObject> clone() override {
-      return std::unique_ptr<RGWObject>(new RGWRadosObject(*this));
+    virtual std::unique_ptr<Object> clone() override {
+      return std::unique_ptr<Object>(new RadosObject(*this));
     }
     virtual MPSerializer* get_serializer(const std::string& lock_name) override;
     virtual int transition(RGWObjectCtx& rctx,
-			   RGWBucket* bucket,
+			   Bucket* bucket,
 			   const rgw_placement_rule& placement_rule,
 			   const real_time& mtime,
 			   uint64_t olh_epoch,
@@ -222,7 +222,7 @@ class RGWRadosObject : public RGWObject {
 			     optional_yield y) override;
     virtual int omap_get_vals_by_keys(const std::string& oid,
 			      const std::set<std::string>& keys,
-			      RGWAttrs *vals) override;
+			      Attrs *vals) override;
     virtual int omap_set_val_by_key(const std::string& key, bufferlist& val,
 				    bool must_exist, optional_yield y) override;
 
@@ -230,64 +230,64 @@ class RGWRadosObject : public RGWObject {
     int read_attrs(const DoutPrefixProvider *dpp, RGWRados::Object::Read &read_op, optional_yield y, rgw_obj *target_obj = nullptr);
 };
 
-class RGWRadosBucket : public RGWBucket {
+class RadosBucket : public Bucket {
   private:
-    RGWRadosStore *store;
+    RadosStore *store;
     RGWAccessControlPolicy acls;
 
   public:
-    RGWRadosBucket(RGWRadosStore *_st)
+    RadosBucket(RadosStore *_st)
       : store(_st),
         acls() {
     }
 
-    RGWRadosBucket(RGWRadosStore *_st, RGWUser* _u)
-      : RGWBucket(_u),
+    RadosBucket(RadosStore *_st, User* _u)
+      : Bucket(_u),
 	store(_st),
         acls() {
     }
 
-    RGWRadosBucket(RGWRadosStore *_st, const rgw_bucket& _b)
-      : RGWBucket(_b),
+    RadosBucket(RadosStore *_st, const rgw_bucket& _b)
+      : Bucket(_b),
 	store(_st),
         acls() {
     }
 
-    RGWRadosBucket(RGWRadosStore *_st, const RGWBucketEnt& _e)
-      : RGWBucket(_e),
+    RadosBucket(RadosStore *_st, const RGWBucketEnt& _e)
+      : Bucket(_e),
 	store(_st),
         acls() {
     }
 
-    RGWRadosBucket(RGWRadosStore *_st, const RGWBucketInfo& _i)
-      : RGWBucket(_i),
+    RadosBucket(RadosStore *_st, const RGWBucketInfo& _i)
+      : Bucket(_i),
 	store(_st),
         acls() {
     }
 
-    RGWRadosBucket(RGWRadosStore *_st, const rgw_bucket& _b, RGWUser* _u)
-      : RGWBucket(_b, _u),
+    RadosBucket(RadosStore *_st, const rgw_bucket& _b, User* _u)
+      : Bucket(_b, _u),
 	store(_st),
         acls() {
     }
 
-    RGWRadosBucket(RGWRadosStore *_st, const RGWBucketEnt& _e, RGWUser* _u)
-      : RGWBucket(_e, _u),
+    RadosBucket(RadosStore *_st, const RGWBucketEnt& _e, User* _u)
+      : Bucket(_e, _u),
 	store(_st),
         acls() {
     }
 
-    RGWRadosBucket(RGWRadosStore *_st, const RGWBucketInfo& _i, RGWUser* _u)
-      : RGWBucket(_i, _u),
+    RadosBucket(RadosStore *_st, const RGWBucketInfo& _i, User* _u)
+      : Bucket(_i, _u),
 	store(_st),
         acls() {
     }
 
-    ~RGWRadosBucket() { }
+    ~RadosBucket() { }
 
-    virtual std::unique_ptr<RGWObject> get_object(const rgw_obj_key& k) override;
+    virtual std::unique_ptr<Object> get_object(const rgw_obj_key& k) override;
     virtual int list(const DoutPrefixProvider *dpp, ListParams&, int, ListResults&, optional_yield y) override;
-    RGWObject* create_object(const rgw_obj_key& key /* Attributes */) override;
+    Object* create_object(const rgw_obj_key& key /* Attributes */) override;
     virtual int remove_bucket(const DoutPrefixProvider *dpp, bool delete_children, std::string prefix, std::string delimiter, bool forward_to_master, req_info* req_info, optional_yield y) override;
     virtual RGWAccessControlPolicy& get_acl(void) override { return acls; }
     virtual int set_acl(const DoutPrefixProvider *dpp, RGWAccessControlPolicy& acl, optional_yield y) override;
@@ -302,16 +302,16 @@ class RGWRadosBucket : public RGWBucket {
     virtual int sync_user_stats(optional_yield y) override;
     virtual int update_container_stats(const DoutPrefixProvider *dpp) override;
     virtual int check_bucket_shards(const DoutPrefixProvider *dpp) override;
-    virtual int link(const DoutPrefixProvider *dpp, RGWUser* new_user, optional_yield y, bool update_entrypoint, RGWObjVersionTracker* objv) override;
-    virtual int unlink(const DoutPrefixProvider *dpp, RGWUser* new_user, optional_yield y, bool update_entrypoint = true) override;
-    virtual int chown(const DoutPrefixProvider *dpp, RGWUser* new_user, RGWUser* old_user, optional_yield y, const std::string* marker = nullptr) override;
+    virtual int link(const DoutPrefixProvider *dpp, User* new_user, optional_yield y, bool update_entrypoint, RGWObjVersionTracker* objv) override;
+    virtual int unlink(const DoutPrefixProvider *dpp, User* new_user, optional_yield y, bool update_entrypoint = true) override;
+    virtual int chown(const DoutPrefixProvider *dpp, User* new_user, User* old_user, optional_yield y, const std::string* marker = nullptr) override;
     virtual int put_instance_info(const DoutPrefixProvider *dpp, bool exclusive, ceph::real_time mtime) override;
     virtual int remove_entrypoint(const DoutPrefixProvider *dpp, RGWObjVersionTracker* objv, optional_yield y) override;
     virtual int remove_instance_info(const DoutPrefixProvider *dpp, RGWObjVersionTracker* objv, optional_yield y) override;
-    virtual bool is_owner(RGWUser* user) override;
+    virtual bool is_owner(User* user) override;
     virtual int check_empty(const DoutPrefixProvider *dpp, optional_yield y) override;
     virtual int check_quota(RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota, uint64_t obj_size, optional_yield y, bool check_size_only = false) override;
-    virtual int set_instance_attrs(const DoutPrefixProvider *dpp, RGWAttrs& attrs, optional_yield y) override;
+    virtual int set_instance_attrs(const DoutPrefixProvider *dpp, Attrs& attrs, optional_yield y) override;
     virtual int try_refresh_info(const DoutPrefixProvider *dpp, ceph::real_time *pmtime) override;
     virtual int read_usage(uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries,
 			   bool *is_truncated, RGWUsageIter& usage_iter,
@@ -322,18 +322,18 @@ class RGWRadosBucket : public RGWBucket {
     virtual int rebuild_index() override;
     virtual int set_tag_timeout(uint64_t timeout) override;
     virtual int purge_instance(const DoutPrefixProvider *dpp) override;
-    virtual std::unique_ptr<RGWBucket> clone() override {
-      return std::make_unique<RGWRadosBucket>(*this);
+    virtual std::unique_ptr<Bucket> clone() override {
+      return std::make_unique<RadosBucket>(*this);
     }
 
-    friend class RGWRadosStore;
+    friend class RadosStore;
 };
 
 class RadosZone : public Zone {
   protected:
-    RGWRadosStore* store;
+    RadosStore* store;
   public:
-    RadosZone(RGWRadosStore* _store) : store(_store) {}
+    RadosZone(RadosStore* _store) : store(_store) {}
     ~RadosZone() = default;
 
     virtual const RGWZoneGroup& get_zonegroup() override;
@@ -348,7 +348,7 @@ class RadosZone : public Zone {
     virtual const string& get_current_period_id() override;
 };
 
-class RGWRadosStore : public RGWStore {
+class RadosStore : public Store {
   private:
     RGWRados *rados;
     RGWUserCtl *user_ctl;
@@ -356,42 +356,42 @@ class RGWRadosStore : public RGWStore {
     RadosZone zone;
 
   public:
-    RGWRadosStore()
+    RadosStore()
       : rados(nullptr), zone(this) {
       }
-    ~RGWRadosStore() {
+    ~RadosStore() {
       delete rados;
     }
 
-    virtual std::unique_ptr<RGWUser> get_user(const rgw_user& u) override;
-    virtual int get_user_by_access_key(const DoutPrefixProvider *dpp, const std::string& key, optional_yield y, std::unique_ptr<RGWUser>* user) override;
-    virtual int get_user_by_email(const DoutPrefixProvider *dpp, const std::string& email, optional_yield y, std::unique_ptr<RGWUser>* user) override;
-    virtual int get_user_by_swift(const DoutPrefixProvider *dpp, const std::string& user_str, optional_yield y, std::unique_ptr<RGWUser>* user) override;
-    virtual std::unique_ptr<RGWObject> get_object(const rgw_obj_key& k) override;
-    virtual int get_bucket(const DoutPrefixProvider *dpp, RGWUser* u, const rgw_bucket& b, std::unique_ptr<RGWBucket>* bucket, optional_yield y) override;
-    virtual int get_bucket(RGWUser* u, const RGWBucketInfo& i, std::unique_ptr<RGWBucket>* bucket) override;
-    virtual int get_bucket(const DoutPrefixProvider *dpp, RGWUser* u, const std::string& tenant, const std::string&name, std::unique_ptr<RGWBucket>* bucket, optional_yield y) override;
+    virtual std::unique_ptr<User> get_user(const rgw_user& u) override;
+    virtual int get_user_by_access_key(const DoutPrefixProvider *dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user) override;
+    virtual int get_user_by_email(const DoutPrefixProvider *dpp, const std::string& email, optional_yield y, std::unique_ptr<User>* user) override;
+    virtual int get_user_by_swift(const DoutPrefixProvider *dpp, const std::string& user_str, optional_yield y, std::unique_ptr<User>* user) override;
+    virtual std::unique_ptr<Object> get_object(const rgw_obj_key& k) override;
+    virtual int get_bucket(const DoutPrefixProvider *dpp, User* u, const rgw_bucket& b, std::unique_ptr<Bucket>* bucket, optional_yield y) override;
+    virtual int get_bucket(User* u, const RGWBucketInfo& i, std::unique_ptr<Bucket>* bucket) override;
+    virtual int get_bucket(const DoutPrefixProvider *dpp, User* u, const std::string& tenant, const std::string&name, std::unique_ptr<Bucket>* bucket, optional_yield y) override;
     virtual int create_bucket(const DoutPrefixProvider *dpp, 
-                            RGWUser& u, const rgw_bucket& b,
+                            User& u, const rgw_bucket& b,
                             const std::string& zonegroup_id,
                             rgw_placement_rule& placement_rule,
                             std::string& swift_ver_location,
                             const RGWQuotaInfo * pquota_info,
                             const RGWAccessControlPolicy& policy,
-			    RGWAttrs& attrs,
+			    Attrs& attrs,
                             RGWBucketInfo& info,
                             obj_version& ep_objv,
 			    bool exclusive,
 			    bool obj_lock_enabled,
 			    bool *existed,
 			    req_info& req_info,
-			    std::unique_ptr<RGWBucket>* bucket,
+			    std::unique_ptr<Bucket>* bucket,
 			    optional_yield y) override;
     virtual bool is_meta_master() override;
-    virtual int forward_request_to_master(RGWUser* user, obj_version *objv,
+    virtual int forward_request_to_master(User* user, obj_version *objv,
 					  bufferlist& in_data, JSONParser *jp, req_info& info,
 					  optional_yield y) override;
-    virtual int defer_gc(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWBucket* bucket, RGWObject* obj,
+    virtual int defer_gc(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, Bucket* bucket, Object* obj,
 			 optional_yield y) override;
     virtual Zone* get_zone() { return &zone; }
     virtual std::string zone_unique_id(uint64_t unique_num) override;
@@ -399,10 +399,10 @@ class RGWRadosStore : public RGWStore {
     virtual int cluster_stat(RGWClusterStat& stats) override;
     virtual std::unique_ptr<Lifecycle> get_lifecycle(void) override;
     virtual std::unique_ptr<Completions> get_completions(void) override;
-    virtual std::unique_ptr<Notification> get_notification(rgw::sal::RGWObject* obj, struct req_state* s, rgw::notify::EventType event_type) override;
-    virtual std::unique_ptr<GCChain> get_gc_chain(rgw::sal::RGWObject* obj) override;
-    virtual std::unique_ptr<Writer> get_writer(Aio *aio, rgw::sal::RGWBucket* bucket,
-              RGWObjectCtx& obj_ctx, std::unique_ptr<rgw::sal::RGWObject> _head_obj,
+    virtual std::unique_ptr<Notification> get_notification(rgw::sal::Object* obj, struct req_state* s, rgw::notify::EventType event_type) override;
+    virtual std::unique_ptr<GCChain> get_gc_chain(rgw::sal::Object* obj) override;
+    virtual std::unique_ptr<Writer> get_writer(Aio *aio, rgw::sal::Bucket* bucket,
+              RGWObjectCtx& obj_ctx, std::unique_ptr<rgw::sal::Object> _head_obj,
               const DoutPrefixProvider *dpp, optional_yield y) override;
     virtual RGWLC* get_rgwlc(void) override { return rados->get_lc(); }
     virtual RGWCoroutinesManagerRegistry* get_cr_registry() override { return rados->get_cr_registry(); }
@@ -470,7 +470,7 @@ class RGWRadosStore : public RGWStore {
       luarocks_path = path;
     }
 
-    /* Unique to RGWRadosStore */
+    /* Unique to RadosStore */
     int get_obj_head_ioctx(const RGWBucketInfo& bucket_info, const rgw_obj& obj,
 			   librados::IoCtx *ioctx);
 
@@ -491,7 +491,7 @@ class MPRadosSerializer : public MPSerializer {
   librados::ObjectWriteOperation op;
 
 public:
-  MPRadosSerializer(RGWRadosStore* store, RGWRadosObject* obj, const std::string& lock_name);
+  MPRadosSerializer(RadosStore* store, RadosObject* obj, const std::string& lock_name);
 
   virtual int try_lock(utime_t dur, optional_yield y) override;
   virtual int unlock() override {
@@ -505,7 +505,7 @@ class LCRadosSerializer : public LCSerializer {
   const std::string oid;
 
 public:
-  LCRadosSerializer(RGWRadosStore* store, const std::string& oid, const std::string& lock_name, const std::string& cookie);
+  LCRadosSerializer(RadosStore* store, const std::string& oid, const std::string& lock_name, const std::string& cookie);
 
   virtual int try_lock(utime_t dur, optional_yield y) override;
   virtual int unlock() override {
@@ -514,10 +514,10 @@ public:
 };
 
 class RadosLifecycle : public Lifecycle {
-  RGWRadosStore* store;
+  RadosStore* store;
 
 public:
-  RadosLifecycle(RGWRadosStore* _st) : store(_st) {}
+  RadosLifecycle(RadosStore* _st) : store(_st) {}
 
   virtual int get_entry(const string& oid, const std::string& marker, LCEntry& entry) override;
   virtual int get_next_entry(const string& oid, std::string& marker, LCEntry& entry) override;
@@ -531,11 +531,11 @@ public:
 };
 
 class RadosNotification : public Notification {
-  RGWRadosStore* store;
+  RadosStore* store;
   rgw::notify::reservation_t res;
 
   public:
-    RadosNotification(RGWRadosStore* _store, RGWObject* _obj, req_state* _s, rgw::notify::EventType _type) : Notification(_obj, _type), store(_store), res(_store, _s, _obj) { }
+    RadosNotification(RadosStore* _store, Object* _obj, req_state* _s, rgw::notify::EventType _type) : Notification(_obj, _type), store(_store), res(_store, _s, _obj) { }
     ~RadosNotification() = default;
 
     virtual int publish_reserve(RGWObjTags* obj_tags = nullptr) override;
@@ -545,11 +545,11 @@ class RadosNotification : public Notification {
 
 class RadosGCChain : public GCChain {
 protected:
-  RGWRadosStore* store;
+  RadosStore* store;
   cls_rgw_obj_chain chain;
 
   public:
-    RadosGCChain(RGWRadosStore* _store, RGWObject* _obj) : GCChain(_obj), store(_store) {}
+    RadosGCChain(RadosStore* _store, Object* _obj) : GCChain(_obj), store(_store) {}
     ~RadosGCChain() = default;
 
     virtual void update(RGWObjManifest* manifest) override;
@@ -558,13 +558,13 @@ protected:
 };
 
 class RadosWriter : public Writer {
-  rgw::sal::RGWRadosStore* store;
+  rgw::sal::RadosStore* store;
   RGWSI_RADOS::Obj stripe_obj; // current stripe object
 
  public:
-  RadosWriter(Aio *aio, rgw::sal::RGWRadosStore* _store,
-	      rgw::sal::RGWBucket* bucket,
-              RGWObjectCtx& obj_ctx, std::unique_ptr<rgw::sal::RGWObject> _head_obj,
+  RadosWriter(Aio *aio, rgw::sal::RadosStore* _store,
+	      rgw::sal::Bucket* bucket,
+              RGWObjectCtx& obj_ctx, std::unique_ptr<rgw::sal::Object> _head_obj,
               const DoutPrefixProvider *dpp, optional_yield y)
     : Writer(aio, bucket, obj_ctx, std::move(_head_obj), dpp, y), store(_store)
   {}

--- a/src/rgw/rgw_sal_rados.h
+++ b/src/rgw/rgw_sal_rados.h
@@ -164,7 +164,7 @@ class RadosObject : public Object {
                AttrsMod attrs_mod, bool copy_if_newer, Attrs& attrs,
                RGWObjCategory category, uint64_t olh_epoch,
 	       boost::optional<ceph::real_time> delete_at,
-               string* version_id, string* tag, string* etag,
+               std::string* version_id, std::string* tag, std::string* etag,
                void (*progress_cb)(off_t, void *), void* progress_data,
                const DoutPrefixProvider* dpp, optional_yield y) override;
     virtual RGWAccessControlPolicy& get_acl(void) override { return acls; }
@@ -215,10 +215,10 @@ class RadosObject : public Object {
     virtual std::unique_ptr<StatOp> get_stat_op(RGWObjectCtx*) override;
 
     /* OMAP */
-    virtual int omap_get_vals(const string& marker, uint64_t count,
-			      std::map<string, bufferlist> *m,
+    virtual int omap_get_vals(const std::string& marker, uint64_t count,
+			      std::map<std::string, bufferlist> *m,
 			      bool* pmore, optional_yield y) override;
-    virtual int omap_get_all(std::map<string, bufferlist> *m,
+    virtual int omap_get_all(std::map<std::string, bufferlist> *m,
 			     optional_yield y) override;
     virtual int omap_get_vals_by_keys(const std::string& oid,
 			      const std::set<std::string>& keys,
@@ -337,15 +337,15 @@ class RadosZone : public Zone {
     ~RadosZone() = default;
 
     virtual const RGWZoneGroup& get_zonegroup() override;
-    virtual int get_zonegroup(const string& id, RGWZoneGroup& zonegroup) override;
+    virtual int get_zonegroup(const std::string& id, RGWZoneGroup& zonegroup) override;
     virtual const RGWZoneParams& get_params() override;
     virtual const rgw_zone_id& get_id() override;
     virtual const RGWRealm& get_realm() override;
     virtual const std::string& get_name() const override;
     virtual bool is_writeable() override;
-    virtual bool get_redirect_endpoint(string* endpoint) override;
+    virtual bool get_redirect_endpoint(std::string* endpoint) override;
     virtual bool has_zonegroup_api(const std::string& api) const override;
-    virtual const string& get_current_period_id() override;
+    virtual const std::string& get_current_period_id() override;
 };
 
 class RadosStore : public Store {
@@ -412,12 +412,12 @@ class RadosStore : public Store {
     virtual int get_raw_chunk_size(const DoutPrefixProvider* dpp, const rgw_raw_obj& obj, uint64_t* chunk_size) override;
 
     virtual int log_usage(map<rgw_user_bucket, RGWUsageBatch>& usage_info) override;
-    virtual int log_op(string& oid, bufferlist& bl) override;
-    virtual int register_to_service_map(const string& daemon_type,
-				const map<string, string>& meta) override;
+    virtual int log_op(std::string& oid, bufferlist& bl) override;
+    virtual int register_to_service_map(const std::string& daemon_type,
+				const map<std::string, std::string>& meta) override;
     virtual void get_quota(RGWQuotaInfo& bucket_quota, RGWQuotaInfo& user_quota) override;
-    virtual int list_raw_objects(const rgw_pool& pool, const string& prefix_filter,
-				 int max, RGWListRawObjsCtx& ctx, std::list<string>& oids,
+    virtual int list_raw_objects(const rgw_pool& pool, const std::string& prefix_filter,
+				 int max, RGWListRawObjsCtx& ctx, std::list<std::string>& oids,
 				 bool* is_truncated) override;
     virtual int set_buckets_enabled(const DoutPrefixProvider* dpp, vector<rgw_bucket>& buckets, bool enabled) override;
     virtual uint64_t get_new_req_id() override { return rados->get_new_req_id(); }
@@ -428,33 +428,33 @@ class RadosStore : public Store {
 					optional_yield y) override;
     virtual RGWDataSyncStatusManager* get_data_sync_manager(const rgw_zone_id& source_zone) override;
     virtual void wakeup_meta_sync_shards(set<int>& shard_ids) override { rados->wakeup_meta_sync_shards(shard_ids); }
-    virtual void wakeup_data_sync_shards(const rgw_zone_id& source_zone, map<int, set<string> >& shard_ids) override { rados->wakeup_data_sync_shards(source_zone, shard_ids); }
+    virtual void wakeup_data_sync_shards(const rgw_zone_id& source_zone, map<int, set<std::string> >& shard_ids) override { rados->wakeup_data_sync_shards(source_zone, shard_ids); }
     virtual int clear_usage() override { return rados->clear_usage(); }
     virtual int read_all_usage(uint64_t start_epoch, uint64_t end_epoch,
 			       uint32_t max_entries, bool* is_truncated,
 			       RGWUsageIter& usage_iter,
 			       map<rgw_user_bucket, rgw_usage_log_entry>& usage) override;
     virtual int trim_all_usage(uint64_t start_epoch, uint64_t end_epoch) override;
-    virtual int get_config_key_val(string name, bufferlist* bl) override;
-    virtual int put_system_obj(const rgw_pool& pool, const string& oid,
+    virtual int get_config_key_val(std::string name, bufferlist* bl) override;
+    virtual int put_system_obj(const rgw_pool& pool, const std::string& oid,
 			       bufferlist& data, bool exclusive,
 			       RGWObjVersionTracker* objv_tracker, real_time set_mtime,
-			       optional_yield y, map<string, bufferlist> *pattrs = nullptr)
+			       optional_yield y, map<std::string, bufferlist> *pattrs = nullptr)
       override;
     virtual int get_system_obj(const DoutPrefixProvider* dpp,
-			       const rgw_pool& pool, const string& key,
+			       const rgw_pool& pool, const std::string& key,
 			       bufferlist& bl,
 			       RGWObjVersionTracker* objv_tracker, real_time* pmtime,
-			       optional_yield y, map<string, bufferlist> *pattrs = nullptr,
+			       optional_yield y, map<std::string, bufferlist> *pattrs = nullptr,
 			       rgw_cache_entry_info* cache_info = nullptr,
 			       boost::optional<obj_version> refresh_version = boost::none) override;
-    virtual int delete_system_obj(const rgw_pool& pool, const string& oid,
+    virtual int delete_system_obj(const rgw_pool& pool, const std::string& oid,
 				  RGWObjVersionTracker* objv_tracker, optional_yield y) override;
-    virtual int meta_list_keys_init(const string& section, const string& marker, void** phandle) override;
-    virtual int meta_list_keys_next(void* handle, int max, list<string>& keys, bool* truncated) override;
+    virtual int meta_list_keys_init(const std::string& section, const std::string& marker, void** phandle) override;
+    virtual int meta_list_keys_next(void* handle, int max, list<std::string>& keys, bool* truncated) override;
     virtual void meta_list_keys_complete(void* handle) override;
     virtual std::string meta_get_marker(void* handle) override;
-    virtual int meta_remove(const DoutPrefixProvider* dpp, string& metadata_key, optional_yield y) override;
+    virtual int meta_remove(const DoutPrefixProvider* dpp, std::string& metadata_key, optional_yield y) override;
     virtual const RGWSyncModuleInstanceRef& get_sync_module() { return rados->get_sync_module(); }
     virtual std::string get_host_id() { return rados->host_id; }
 
@@ -519,14 +519,14 @@ class RadosLifecycle : public Lifecycle {
 public:
   RadosLifecycle(RadosStore* _st) : store(_st) {}
 
-  virtual int get_entry(const string& oid, const std::string& marker, LCEntry& entry) override;
-  virtual int get_next_entry(const string& oid, std::string& marker, LCEntry& entry) override;
-  virtual int set_entry(const string& oid, const LCEntry& entry) override;
-  virtual int list_entries(const string& oid, const string& marker,
+  virtual int get_entry(const std::string& oid, const std::string& marker, LCEntry& entry) override;
+  virtual int get_next_entry(const std::string& oid, std::string& marker, LCEntry& entry) override;
+  virtual int set_entry(const std::string& oid, const LCEntry& entry) override;
+  virtual int list_entries(const std::string& oid, const std::string& marker,
 			   uint32_t max_entries, vector<LCEntry>& entries) override;
-  virtual int rm_entry(const string& oid, const LCEntry& entry) override;
-  virtual int get_head(const string& oid, LCHead& head) override;
-  virtual int put_head(const string& oid, const LCHead& head) override;
+  virtual int rm_entry(const std::string& oid, const LCEntry& entry) override;
+  virtual int get_head(const std::string& oid, LCHead& head) override;
+  virtual int put_head(const std::string& oid, const LCHead& head) override;
   virtual LCSerializer* get_serializer(const std::string& lock_name, const std::string& oid, const std::string& cookie) override;
 };
 

--- a/src/rgw/rgw_sal_rados.h
+++ b/src/rgw/rgw_sal_rados.h
@@ -34,7 +34,7 @@ class RadosCompletions : public Completions {
 
 class RadosUser : public User {
   private:
-    RadosStore *store;
+    RadosStore* store;
 
   public:
     RadosUser(RadosStore *_st, const rgw_user& _u) : User(_u), store(_st) { }
@@ -46,32 +46,32 @@ class RadosUser : public User {
     virtual std::unique_ptr<User> clone() override {
       return std::unique_ptr<User>(new RadosUser(*this));
     }
-    int list_buckets(const DoutPrefixProvider *dpp, const std::string& marker, const std::string& end_marker,
+    int list_buckets(const DoutPrefixProvider* dpp, const std::string& marker, const std::string& end_marker,
 		     uint64_t max, bool need_stats, BucketList& buckets,
 		     optional_yield y) override;
     virtual Bucket* create_bucket(rgw_bucket& bucket, ceph::real_time creation_time) override;
-    virtual int read_attrs(const DoutPrefixProvider *dpp, optional_yield y, Attrs* uattrs, RGWObjVersionTracker* tracker) override;
+    virtual int read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs* uattrs, RGWObjVersionTracker* tracker) override;
     virtual int read_stats(optional_yield y, RGWStorageStats* stats,
-			   ceph::real_time *last_stats_sync = nullptr,
-			   ceph::real_time *last_stats_update = nullptr) override;
-    virtual int read_stats_async(RGWGetUserStats_CB *cb) override;
+			   ceph::real_time* last_stats_sync = nullptr,
+			   ceph::real_time* last_stats_update = nullptr) override;
+    virtual int read_stats_async(RGWGetUserStats_CB* cb) override;
     virtual int complete_flush_stats(optional_yield y) override;
     virtual int read_usage(uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries,
-			   bool *is_truncated, RGWUsageIter& usage_iter,
+			   bool* is_truncated, RGWUsageIter& usage_iter,
 			   map<rgw_user_bucket, rgw_usage_log_entry>& usage) override;
     virtual int trim_usage(uint64_t start_epoch, uint64_t end_epoch) override;
 
     /* Placeholders */
-    virtual int load_by_id(const DoutPrefixProvider *dpp, optional_yield y) override;
-    virtual int store_info(const DoutPrefixProvider *dpp, optional_yield y, const RGWUserCtl::PutParams& params = {}) override;
-    virtual int remove_info(const DoutPrefixProvider *dpp, optional_yield y, const RGWUserCtl::RemoveParams& params = {}) override;
+    virtual int load_by_id(const DoutPrefixProvider* dpp, optional_yield y) override;
+    virtual int store_info(const DoutPrefixProvider* dpp, optional_yield y, const RGWUserCtl::PutParams& params = {}) override;
+    virtual int remove_info(const DoutPrefixProvider* dpp, optional_yield y, const RGWUserCtl::RemoveParams& params = {}) override;
 
     friend class RadosBucket;
 };
 
 class RadosObject : public Object {
   private:
-    RadosStore *store;
+    RadosStore* store;
     RGWAccessControlPolicy acls;
 
   public:
@@ -86,11 +86,11 @@ class RadosObject : public Object {
     public:
       RadosReadOp(RadosObject *_source, RGWObjectCtx *_rctx);
 
-      virtual int prepare(optional_yield y, const DoutPrefixProvider *dpp) override;
-      virtual int read(int64_t ofs, int64_t end, bufferlist& bl, optional_yield y, const DoutPrefixProvider *dpp) override;
-      virtual int iterate(const DoutPrefixProvider *dpp, int64_t ofs, int64_t end, RGWGetDataCB *cb, optional_yield y) override;
-      virtual int get_manifest(const DoutPrefixProvider *dpp, RGWObjManifest **pmanifest, optional_yield y) override;
-      virtual int get_attr(const DoutPrefixProvider *dpp, const char *name, bufferlist& dest, optional_yield y) override;
+      virtual int prepare(optional_yield y, const DoutPrefixProvider* dpp) override;
+      virtual int read(int64_t ofs, int64_t end, bufferlist& bl, optional_yield y, const DoutPrefixProvider* dpp) override;
+      virtual int iterate(const DoutPrefixProvider* dpp, int64_t ofs, int64_t end, RGWGetDataCB* cb, optional_yield y) override;
+      virtual int get_manifest(const DoutPrefixProvider* dpp, RGWObjManifest **pmanifest, optional_yield y) override;
+      virtual int get_attr(const DoutPrefixProvider* dpp, const char* name, bufferlist& dest, optional_yield y) override;
     };
 
     struct RadosWriteOp : public WriteOp {
@@ -104,8 +104,8 @@ class RadosObject : public Object {
       RadosWriteOp(RadosObject* _source, RGWObjectCtx* _rctx);
 
       virtual int prepare(optional_yield y) override;
-      virtual int write_meta(const DoutPrefixProvider *dpp, uint64_t size, uint64_t accounted_size, optional_yield y) override;
-      //virtual int write_data(const char *data, uint64_t ofs, uint64_t len, bool exclusive) override;
+      virtual int write_meta(const DoutPrefixProvider* dpp, uint64_t size, uint64_t accounted_size, optional_yield y) override;
+      //virtual int write_data(const char* data, uint64_t ofs, uint64_t len, bool exclusive) override;
     };
 
     struct RadosDeleteOp : public DeleteOp {
@@ -118,7 +118,7 @@ class RadosObject : public Object {
     public:
       RadosDeleteOp(RadosObject* _source, RGWObjectCtx* _rctx);
 
-      virtual int delete_obj(const DoutPrefixProvider *dpp, optional_yield y) override;
+      virtual int delete_obj(const DoutPrefixProvider* dpp, optional_yield y) override;
     };
 
     struct RadosStatOp : public StatOp {
@@ -149,35 +149,35 @@ class RadosObject : public Object {
     }
     RadosObject(RadosObject& _o) = default;
 
-    virtual int delete_object(const DoutPrefixProvider *dpp, RGWObjectCtx* obj_ctx, optional_yield y) override;
-    virtual int delete_obj_aio(const DoutPrefixProvider *dpp, RGWObjState *astate, Completions* aio,
+    virtual int delete_object(const DoutPrefixProvider* dpp, RGWObjectCtx* obj_ctx, optional_yield y) override;
+    virtual int delete_obj_aio(const DoutPrefixProvider* dpp, RGWObjState* astate, Completions* aio,
 			       bool keep_index_consistent, optional_yield y) override;
     virtual int copy_object(RGWObjectCtx& obj_ctx, User* user,
-               req_info *info, const rgw_zone_id& source_zone,
+               req_info* info, const rgw_zone_id& source_zone,
                rgw::sal::Object* dest_object, rgw::sal::Bucket* dest_bucket,
                rgw::sal::Bucket* src_bucket,
                const rgw_placement_rule& dest_placement,
-               ceph::real_time *src_mtime, ceph::real_time *mtime,
-               const ceph::real_time *mod_ptr, const ceph::real_time *unmod_ptr,
+               ceph::real_time* src_mtime, ceph::real_time* mtime,
+               const ceph::real_time* mod_ptr, const ceph::real_time* unmod_ptr,
                bool high_precision_time,
-               const char *if_match, const char *if_nomatch,
+               const char* if_match, const char* if_nomatch,
                AttrsMod attrs_mod, bool copy_if_newer, Attrs& attrs,
                RGWObjCategory category, uint64_t olh_epoch,
 	       boost::optional<ceph::real_time> delete_at,
-               string *version_id, string *tag, string *etag,
-               void (*progress_cb)(off_t, void *), void *progress_data,
-               const DoutPrefixProvider *dpp, optional_yield y) override;
+               string* version_id, string* tag, string* etag,
+               void (*progress_cb)(off_t, void *), void* progress_data,
+               const DoutPrefixProvider* dpp, optional_yield y) override;
     virtual RGWAccessControlPolicy& get_acl(void) override { return acls; }
     virtual int set_acl(const RGWAccessControlPolicy& acl) override { acls = acl; return 0; }
-    virtual void set_atomic(RGWObjectCtx *rctx) const override;
-    virtual void set_prefetch_data(RGWObjectCtx *rctx) override;
+    virtual void set_atomic(RGWObjectCtx* rctx) const override;
+    virtual void set_prefetch_data(RGWObjectCtx* rctx) override;
 
-    virtual int get_obj_state(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, RGWObjState **state, optional_yield y, bool follow_olh = true) override;
-    virtual int set_obj_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx* rctx, Attrs* setattrs, Attrs* delattrs, optional_yield y, rgw_obj* target_obj = NULL) override;
-    virtual int get_obj_attrs(RGWObjectCtx *rctx, optional_yield y, const DoutPrefixProvider *dpp, rgw_obj* target_obj = NULL) override;
-    virtual int modify_obj_attrs(RGWObjectCtx *rctx, const char *attr_name, bufferlist& attr_val, optional_yield y, const DoutPrefixProvider *dpp) override;
-    virtual int delete_obj_attrs(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, const char *attr_name, optional_yield y) override;
-    virtual int copy_obj_data(RGWObjectCtx& rctx, Bucket* dest_bucket, Object* dest_obj, uint16_t olh_epoch, std::string* petag, const DoutPrefixProvider *dpp, optional_yield y) override;
+    virtual int get_obj_state(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, RGWObjState **state, optional_yield y, bool follow_olh = true) override;
+    virtual int set_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, Attrs* setattrs, Attrs* delattrs, optional_yield y, rgw_obj* target_obj = NULL) override;
+    virtual int get_obj_attrs(RGWObjectCtx* rctx, optional_yield y, const DoutPrefixProvider* dpp, rgw_obj* target_obj = NULL) override;
+    virtual int modify_obj_attrs(RGWObjectCtx* rctx, const char* attr_name, bufferlist& attr_val, optional_yield y, const DoutPrefixProvider* dpp) override;
+    virtual int delete_obj_attrs(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, const char* attr_name, optional_yield y) override;
+    virtual int copy_obj_data(RGWObjectCtx& rctx, Bucket* dest_bucket, Object* dest_obj, uint16_t olh_epoch, std::string* petag, const DoutPrefixProvider* dpp, optional_yield y) override;
     virtual bool is_expired() override;
     virtual void gen_rand_obj_instance_name() override;
     virtual void raw_obj_to_obj(const rgw_raw_obj& raw_obj) override;
@@ -191,21 +191,21 @@ class RadosObject : public Object {
 			   const rgw_placement_rule& placement_rule,
 			   const real_time& mtime,
 			   uint64_t olh_epoch,
-			   const DoutPrefixProvider *dpp,
+			   const DoutPrefixProvider* dpp,
 			   optional_yield y) override;
-    virtual int get_max_chunk_size(const DoutPrefixProvider *dpp, 
+    virtual int get_max_chunk_size(const DoutPrefixProvider* dpp,
                                    rgw_placement_rule placement_rule,
-				   uint64_t *max_chunk_size,
-				   uint64_t *alignment = nullptr) override;
-    virtual void get_max_aligned_size(uint64_t size, uint64_t alignment, uint64_t *max_size) override;
+				   uint64_t* max_chunk_size,
+				   uint64_t* alignment = nullptr) override;
+    virtual void get_max_aligned_size(uint64_t size, uint64_t alignment, uint64_t* max_size) override;
     virtual bool placement_rules_match(rgw_placement_rule& r1, rgw_placement_rule& r2) override;
 
     /* Swift versioning */
     virtual int swift_versioning_restore(RGWObjectCtx* obj_ctx,
 					 bool& restored,
-					 const DoutPrefixProvider *dpp) override;
+					 const DoutPrefixProvider* dpp) override;
     virtual int swift_versioning_copy(RGWObjectCtx* obj_ctx,
-				      const DoutPrefixProvider *dpp,
+				      const DoutPrefixProvider* dpp,
 				      optional_yield y) override;
 
     /* OPs */
@@ -217,22 +217,22 @@ class RadosObject : public Object {
     /* OMAP */
     virtual int omap_get_vals(const string& marker, uint64_t count,
 			      std::map<string, bufferlist> *m,
-			      bool *pmore, optional_yield y) override;
+			      bool* pmore, optional_yield y) override;
     virtual int omap_get_all(std::map<string, bufferlist> *m,
 			     optional_yield y) override;
     virtual int omap_get_vals_by_keys(const std::string& oid,
 			      const std::set<std::string>& keys,
-			      Attrs *vals) override;
+			      Attrs* vals) override;
     virtual int omap_set_val_by_key(const std::string& key, bufferlist& val,
 				    bool must_exist, optional_yield y) override;
 
   private:
-    int read_attrs(const DoutPrefixProvider *dpp, RGWRados::Object::Read &read_op, optional_yield y, rgw_obj *target_obj = nullptr);
+    int read_attrs(const DoutPrefixProvider* dpp, RGWRados::Object::Read &read_op, optional_yield y, rgw_obj* target_obj = nullptr);
 };
 
 class RadosBucket : public Bucket {
   private:
-    RadosStore *store;
+    RadosStore* store;
     RGWAccessControlPolicy acls;
 
   public:
@@ -286,42 +286,42 @@ class RadosBucket : public Bucket {
     ~RadosBucket() { }
 
     virtual std::unique_ptr<Object> get_object(const rgw_obj_key& k) override;
-    virtual int list(const DoutPrefixProvider *dpp, ListParams&, int, ListResults&, optional_yield y) override;
+    virtual int list(const DoutPrefixProvider* dpp, ListParams&, int, ListResults&, optional_yield y) override;
     Object* create_object(const rgw_obj_key& key /* Attributes */) override;
-    virtual int remove_bucket(const DoutPrefixProvider *dpp, bool delete_children, std::string prefix, std::string delimiter, bool forward_to_master, req_info* req_info, optional_yield y) override;
+    virtual int remove_bucket(const DoutPrefixProvider* dpp, bool delete_children, std::string prefix, std::string delimiter, bool forward_to_master, req_info* req_info, optional_yield y) override;
     virtual RGWAccessControlPolicy& get_acl(void) override { return acls; }
-    virtual int set_acl(const DoutPrefixProvider *dpp, RGWAccessControlPolicy& acl, optional_yield y) override;
-    virtual int get_bucket_info(const DoutPrefixProvider *dpp, optional_yield y) override;
+    virtual int set_acl(const DoutPrefixProvider* dpp, RGWAccessControlPolicy& acl, optional_yield y) override;
+    virtual int get_bucket_info(const DoutPrefixProvider* dpp, optional_yield y) override;
     virtual int get_bucket_stats(int shard_id,
-				 std::string *bucket_ver, std::string *master_ver,
+				 std::string* bucket_ver, std::string* master_ver,
 				 std::map<RGWObjCategory, RGWStorageStats>& stats,
-				 std::string *max_marker = nullptr,
-				 bool *syncstopped = nullptr) override;
-    virtual int get_bucket_stats_async(int shard_id, RGWGetBucketStats_CB *ctx) override;
-    virtual int read_bucket_stats(const DoutPrefixProvider *dpp, optional_yield y) override;
+				 std::string* max_marker = nullptr,
+				 bool* syncstopped = nullptr) override;
+    virtual int get_bucket_stats_async(int shard_id, RGWGetBucketStats_CB* ctx) override;
+    virtual int read_bucket_stats(const DoutPrefixProvider* dpp, optional_yield y) override;
     virtual int sync_user_stats(optional_yield y) override;
-    virtual int update_container_stats(const DoutPrefixProvider *dpp) override;
-    virtual int check_bucket_shards(const DoutPrefixProvider *dpp) override;
-    virtual int link(const DoutPrefixProvider *dpp, User* new_user, optional_yield y, bool update_entrypoint, RGWObjVersionTracker* objv) override;
-    virtual int unlink(const DoutPrefixProvider *dpp, User* new_user, optional_yield y, bool update_entrypoint = true) override;
-    virtual int chown(const DoutPrefixProvider *dpp, User* new_user, User* old_user, optional_yield y, const std::string* marker = nullptr) override;
-    virtual int put_instance_info(const DoutPrefixProvider *dpp, bool exclusive, ceph::real_time mtime) override;
-    virtual int remove_entrypoint(const DoutPrefixProvider *dpp, RGWObjVersionTracker* objv, optional_yield y) override;
-    virtual int remove_instance_info(const DoutPrefixProvider *dpp, RGWObjVersionTracker* objv, optional_yield y) override;
+    virtual int update_container_stats(const DoutPrefixProvider* dpp) override;
+    virtual int check_bucket_shards(const DoutPrefixProvider* dpp) override;
+    virtual int link(const DoutPrefixProvider* dpp, User* new_user, optional_yield y, bool update_entrypoint, RGWObjVersionTracker* objv) override;
+    virtual int unlink(const DoutPrefixProvider* dpp, User* new_user, optional_yield y, bool update_entrypoint = true) override;
+    virtual int chown(const DoutPrefixProvider* dpp, User* new_user, User* old_user, optional_yield y, const std::string* marker = nullptr) override;
+    virtual int put_instance_info(const DoutPrefixProvider* dpp, bool exclusive, ceph::real_time mtime) override;
+    virtual int remove_entrypoint(const DoutPrefixProvider* dpp, RGWObjVersionTracker* objv, optional_yield y) override;
+    virtual int remove_instance_info(const DoutPrefixProvider* dpp, RGWObjVersionTracker* objv, optional_yield y) override;
     virtual bool is_owner(User* user) override;
-    virtual int check_empty(const DoutPrefixProvider *dpp, optional_yield y) override;
+    virtual int check_empty(const DoutPrefixProvider* dpp, optional_yield y) override;
     virtual int check_quota(RGWQuotaInfo& user_quota, RGWQuotaInfo& bucket_quota, uint64_t obj_size, optional_yield y, bool check_size_only = false) override;
-    virtual int set_instance_attrs(const DoutPrefixProvider *dpp, Attrs& attrs, optional_yield y) override;
-    virtual int try_refresh_info(const DoutPrefixProvider *dpp, ceph::real_time *pmtime) override;
+    virtual int set_instance_attrs(const DoutPrefixProvider* dpp, Attrs& attrs, optional_yield y) override;
+    virtual int try_refresh_info(const DoutPrefixProvider* dpp, ceph::real_time* pmtime) override;
     virtual int read_usage(uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries,
-			   bool *is_truncated, RGWUsageIter& usage_iter,
+			   bool* is_truncated, RGWUsageIter& usage_iter,
 			   map<rgw_user_bucket, rgw_usage_log_entry>& usage) override;
     virtual int trim_usage(uint64_t start_epoch, uint64_t end_epoch) override;
     virtual int remove_objs_from_index(std::list<rgw_obj_index_key>& objs_to_unlink) override;
     virtual int check_index(std::map<RGWObjCategory, RGWStorageStats>& existing_stats, std::map<RGWObjCategory, RGWStorageStats>& calculated_stats) override;
     virtual int rebuild_index() override;
     virtual int set_tag_timeout(uint64_t timeout) override;
-    virtual int purge_instance(const DoutPrefixProvider *dpp) override;
+    virtual int purge_instance(const DoutPrefixProvider* dpp) override;
     virtual std::unique_ptr<Bucket> clone() override {
       return std::make_unique<RadosBucket>(*this);
     }
@@ -343,15 +343,15 @@ class RadosZone : public Zone {
     virtual const RGWRealm& get_realm() override;
     virtual const std::string& get_name() const override;
     virtual bool is_writeable() override;
-    virtual bool get_redirect_endpoint(string *endpoint) override;
+    virtual bool get_redirect_endpoint(string* endpoint) override;
     virtual bool has_zonegroup_api(const std::string& api) const override;
     virtual const string& get_current_period_id() override;
 };
 
 class RadosStore : public Store {
   private:
-    RGWRados *rados;
-    RGWUserCtl *user_ctl;
+    RGWRados* rados;
+    RGWUserCtl* user_ctl;
     std::string luarocks_path;
     RadosZone zone;
 
@@ -364,14 +364,14 @@ class RadosStore : public Store {
     }
 
     virtual std::unique_ptr<User> get_user(const rgw_user& u) override;
-    virtual int get_user_by_access_key(const DoutPrefixProvider *dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user) override;
-    virtual int get_user_by_email(const DoutPrefixProvider *dpp, const std::string& email, optional_yield y, std::unique_ptr<User>* user) override;
-    virtual int get_user_by_swift(const DoutPrefixProvider *dpp, const std::string& user_str, optional_yield y, std::unique_ptr<User>* user) override;
+    virtual int get_user_by_access_key(const DoutPrefixProvider* dpp, const std::string& key, optional_yield y, std::unique_ptr<User>* user) override;
+    virtual int get_user_by_email(const DoutPrefixProvider* dpp, const std::string& email, optional_yield y, std::unique_ptr<User>* user) override;
+    virtual int get_user_by_swift(const DoutPrefixProvider* dpp, const std::string& user_str, optional_yield y, std::unique_ptr<User>* user) override;
     virtual std::unique_ptr<Object> get_object(const rgw_obj_key& k) override;
-    virtual int get_bucket(const DoutPrefixProvider *dpp, User* u, const rgw_bucket& b, std::unique_ptr<Bucket>* bucket, optional_yield y) override;
+    virtual int get_bucket(const DoutPrefixProvider* dpp, User* u, const rgw_bucket& b, std::unique_ptr<Bucket>* bucket, optional_yield y) override;
     virtual int get_bucket(User* u, const RGWBucketInfo& i, std::unique_ptr<Bucket>* bucket) override;
-    virtual int get_bucket(const DoutPrefixProvider *dpp, User* u, const std::string& tenant, const std::string&name, std::unique_ptr<Bucket>* bucket, optional_yield y) override;
-    virtual int create_bucket(const DoutPrefixProvider *dpp, 
+    virtual int get_bucket(const DoutPrefixProvider* dpp, User* u, const std::string& tenant, const std::string&name, std::unique_ptr<Bucket>* bucket, optional_yield y) override;
+    virtual int create_bucket(const DoutPrefixProvider* dpp,
                             User& u, const rgw_bucket& b,
                             const std::string& zonegroup_id,
                             rgw_placement_rule& placement_rule,
@@ -383,15 +383,15 @@ class RadosStore : public Store {
                             obj_version& ep_objv,
 			    bool exclusive,
 			    bool obj_lock_enabled,
-			    bool *existed,
+			    bool* existed,
 			    req_info& req_info,
 			    std::unique_ptr<Bucket>* bucket,
 			    optional_yield y) override;
     virtual bool is_meta_master() override;
-    virtual int forward_request_to_master(User* user, obj_version *objv,
-					  bufferlist& in_data, JSONParser *jp, req_info& info,
+    virtual int forward_request_to_master(User* user, obj_version* objv,
+					  bufferlist& in_data, JSONParser* jp, req_info& info,
 					  optional_yield y) override;
-    virtual int defer_gc(const DoutPrefixProvider *dpp, RGWObjectCtx *rctx, Bucket* bucket, Object* obj,
+    virtual int defer_gc(const DoutPrefixProvider* dpp, RGWObjectCtx* rctx, Bucket* bucket, Object* obj,
 			 optional_yield y) override;
     virtual Zone* get_zone() { return &zone; }
     virtual std::string zone_unique_id(uint64_t unique_num) override;
@@ -401,15 +401,15 @@ class RadosStore : public Store {
     virtual std::unique_ptr<Completions> get_completions(void) override;
     virtual std::unique_ptr<Notification> get_notification(rgw::sal::Object* obj, struct req_state* s, rgw::notify::EventType event_type) override;
     virtual std::unique_ptr<GCChain> get_gc_chain(rgw::sal::Object* obj) override;
-    virtual std::unique_ptr<Writer> get_writer(Aio *aio, rgw::sal::Bucket* bucket,
+    virtual std::unique_ptr<Writer> get_writer(Aio* aio, rgw::sal::Bucket* bucket,
               RGWObjectCtx& obj_ctx, std::unique_ptr<rgw::sal::Object> _head_obj,
-              const DoutPrefixProvider *dpp, optional_yield y) override;
+              const DoutPrefixProvider* dpp, optional_yield y) override;
     virtual RGWLC* get_rgwlc(void) override { return rados->get_lc(); }
     virtual RGWCoroutinesManagerRegistry* get_cr_registry() override { return rados->get_cr_registry(); }
     virtual int delete_raw_obj(const rgw_raw_obj& obj) override;
     virtual int delete_raw_obj_aio(const rgw_raw_obj& obj, Completions* aio) override;
     virtual void get_raw_obj(const rgw_placement_rule& placement_rule, const rgw_obj& obj, rgw_raw_obj* raw_obj) override;
-    virtual int get_raw_chunk_size(const DoutPrefixProvider *dpp, const rgw_raw_obj& obj, uint64_t* chunk_size) override;
+    virtual int get_raw_chunk_size(const DoutPrefixProvider* dpp, const rgw_raw_obj& obj, uint64_t* chunk_size) override;
 
     virtual int log_usage(map<rgw_user_bucket, RGWUsageBatch>& usage_info) override;
     virtual int log_op(string& oid, bufferlist& bl) override;
@@ -418,49 +418,49 @@ class RadosStore : public Store {
     virtual void get_quota(RGWQuotaInfo& bucket_quota, RGWQuotaInfo& user_quota) override;
     virtual int list_raw_objects(const rgw_pool& pool, const string& prefix_filter,
 				 int max, RGWListRawObjsCtx& ctx, std::list<string>& oids,
-				 bool *is_truncated) override;
-    virtual int set_buckets_enabled(const DoutPrefixProvider *dpp, vector<rgw_bucket>& buckets, bool enabled) override;
+				 bool* is_truncated) override;
+    virtual int set_buckets_enabled(const DoutPrefixProvider* dpp, vector<rgw_bucket>& buckets, bool enabled) override;
     virtual uint64_t get_new_req_id() override { return rados->get_new_req_id(); }
-    virtual int get_sync_policy_handler(const DoutPrefixProvider *dpp,
+    virtual int get_sync_policy_handler(const DoutPrefixProvider* dpp,
 					std::optional<rgw_zone_id> zone,
 					std::optional<rgw_bucket> bucket,
-					RGWBucketSyncPolicyHandlerRef *phandler,
+					RGWBucketSyncPolicyHandlerRef* phandler,
 					optional_yield y) override;
     virtual RGWDataSyncStatusManager* get_data_sync_manager(const rgw_zone_id& source_zone) override;
     virtual void wakeup_meta_sync_shards(set<int>& shard_ids) override { rados->wakeup_meta_sync_shards(shard_ids); }
     virtual void wakeup_data_sync_shards(const rgw_zone_id& source_zone, map<int, set<string> >& shard_ids) override { rados->wakeup_data_sync_shards(source_zone, shard_ids); }
     virtual int clear_usage() override { return rados->clear_usage(); }
     virtual int read_all_usage(uint64_t start_epoch, uint64_t end_epoch,
-			       uint32_t max_entries, bool *is_truncated,
+			       uint32_t max_entries, bool* is_truncated,
 			       RGWUsageIter& usage_iter,
 			       map<rgw_user_bucket, rgw_usage_log_entry>& usage) override;
     virtual int trim_all_usage(uint64_t start_epoch, uint64_t end_epoch) override;
-    virtual int get_config_key_val(string name, bufferlist *bl) override;
+    virtual int get_config_key_val(string name, bufferlist* bl) override;
     virtual int put_system_obj(const rgw_pool& pool, const string& oid,
 			       bufferlist& data, bool exclusive,
-			       RGWObjVersionTracker *objv_tracker, real_time set_mtime,
+			       RGWObjVersionTracker* objv_tracker, real_time set_mtime,
 			       optional_yield y, map<string, bufferlist> *pattrs = nullptr)
       override;
-    virtual int get_system_obj(const DoutPrefixProvider *dpp,
+    virtual int get_system_obj(const DoutPrefixProvider* dpp,
 			       const rgw_pool& pool, const string& key,
 			       bufferlist& bl,
-			       RGWObjVersionTracker *objv_tracker, real_time *pmtime,
+			       RGWObjVersionTracker* objv_tracker, real_time* pmtime,
 			       optional_yield y, map<string, bufferlist> *pattrs = nullptr,
-			       rgw_cache_entry_info *cache_info = nullptr,
+			       rgw_cache_entry_info* cache_info = nullptr,
 			       boost::optional<obj_version> refresh_version = boost::none) override;
     virtual int delete_system_obj(const rgw_pool& pool, const string& oid,
-				  RGWObjVersionTracker *objv_tracker, optional_yield y) override;
+				  RGWObjVersionTracker* objv_tracker, optional_yield y) override;
     virtual int meta_list_keys_init(const string& section, const string& marker, void** phandle) override;
     virtual int meta_list_keys_next(void* handle, int max, list<string>& keys, bool* truncated) override;
     virtual void meta_list_keys_complete(void* handle) override;
-    virtual std::string meta_get_marker(void *handle) override;
-    virtual int meta_remove(const DoutPrefixProvider *dpp, string& metadata_key, optional_yield y) override;
+    virtual std::string meta_get_marker(void* handle) override;
+    virtual int meta_remove(const DoutPrefixProvider* dpp, string& metadata_key, optional_yield y) override;
     virtual const RGWSyncModuleInstanceRef& get_sync_module() { return rados->get_sync_module(); }
     virtual std::string get_host_id() { return rados->host_id; }
 
     virtual void finalize(void) override;
 
-    virtual CephContext *ctx(void) override { return rados->ctx(); }
+    virtual CephContext* ctx(void) override { return rados->ctx(); }
 
     virtual const std::string& get_luarocks_path() const override {
       return luarocks_path;
@@ -472,15 +472,15 @@ class RadosStore : public Store {
 
     /* Unique to RadosStore */
     int get_obj_head_ioctx(const RGWBucketInfo& bucket_info, const rgw_obj& obj,
-			   librados::IoCtx *ioctx);
+			   librados::IoCtx* ioctx);
 
     void setRados(RGWRados * st) { rados = st; }
-    RGWRados *getRados(void) { return rados; }
+    RGWRados* getRados(void) { return rados; }
 
-    RGWServices *svc() { return &rados->svc; }
-    const RGWServices *svc() const { return &rados->svc; }
-    RGWCtl *ctl() { return &rados->ctl; }
-    const RGWCtl *ctl() const { return &rados->ctl; }
+    RGWServices* svc() { return &rados->svc; }
+    const RGWServices* svc() const { return &rados->svc; }
+    RGWCtl* ctl() { return &rados->ctl; }
+    const RGWCtl* ctl() const { return &rados->ctl; }
 
     void setUserCtl(RGWUserCtl *_ctl) { user_ctl = _ctl; }
 };
@@ -539,7 +539,7 @@ class RadosNotification : public Notification {
     ~RadosNotification() = default;
 
     virtual int publish_reserve(RGWObjTags* obj_tags = nullptr) override;
-    virtual int publish_commit(const DoutPrefixProvider *dpp, uint64_t size,
+    virtual int publish_commit(const DoutPrefixProvider* dpp, uint64_t size,
 			       const ceph::real_time& mtime, const std::string& etag) override;
 };
 
@@ -562,10 +562,10 @@ class RadosWriter : public Writer {
   RGWSI_RADOS::Obj stripe_obj; // current stripe object
 
  public:
-  RadosWriter(Aio *aio, rgw::sal::RadosStore* _store,
+  RadosWriter(Aio* aio, rgw::sal::RadosStore* _store,
 	      rgw::sal::Bucket* bucket,
               RGWObjectCtx& obj_ctx, std::unique_ptr<rgw::sal::Object> _head_obj,
-              const DoutPrefixProvider *dpp, optional_yield y)
+              const DoutPrefixProvider* dpp, optional_yield y)
     : Writer(aio, bucket, obj_ctx, std::move(_head_obj), dpp, y), store(_store)
   {}
 

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -152,7 +152,7 @@ void AssumedRoleUser::dump(Formatter *f) const
 }
 
 int AssumedRoleUser::generateAssumedRoleUser(CephContext* cct,
-                                              rgw::sal::Store *store,
+                                              rgw::sal::Store* store,
                                               const string& roleId,
                                               const rgw::ARN& roleArn,
                                               const string& roleSessionName)

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -152,7 +152,7 @@ void AssumedRoleUser::dump(Formatter *f) const
 }
 
 int AssumedRoleUser::generateAssumedRoleUser(CephContext* cct,
-                                              rgw::sal::RGWStore *store,
+                                              rgw::sal::Store *store,
                                               const string& roleId,
                                               const rgw::ARN& roleArn,
                                               const string& roleSessionName)
@@ -315,7 +315,7 @@ std::tuple<int, RGWRole> STSService::getRoleInfo(const DoutPrefixProvider *dpp,
 int STSService::storeARN(const DoutPrefixProvider *dpp, string& arn, optional_yield y)
 {
   int ret = 0;
-  std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(user_id);
+  std::unique_ptr<rgw::sal::User> user = store->get_user(user_id);
   if ((ret = user->load_by_id(dpp, y)) < 0) {
     return -ERR_NO_SUCH_ENTITY;
   }

--- a/src/rgw/rgw_sts.h
+++ b/src/rgw/rgw_sts.h
@@ -112,7 +112,7 @@ class AssumedRoleUser {
   string assumeRoleId;
 public:
   int generateAssumedRoleUser( CephContext* cct,
-                                rgw::sal::Store *store,
+                                rgw::sal::Store* store,
                                 const string& roleId,
                                 const rgw::ARN& roleArn,
                                 const string& roleSessionName);
@@ -225,14 +225,14 @@ using AssumeRoleWithWebIdentityResponse = struct AssumeRoleWithWebIdentityRespon
 
 class STSService {
   CephContext* cct;
-  rgw::sal::Store *store;
+  rgw::sal::Store* store;
   rgw_user user_id;
   RGWRole role;
   rgw::auth::Identity* identity;
   int storeARN(const DoutPrefixProvider *dpp, string& arn, optional_yield y);
 public:
   STSService() = default;
-  STSService(CephContext* cct, rgw::sal::Store *store, rgw_user user_id,
+  STSService(CephContext* cct, rgw::sal::Store* store, rgw_user user_id,
 	     rgw::auth::Identity* identity)
     : cct(cct), store(store), user_id(user_id), identity(identity) {}
   std::tuple<int, RGWRole> getRoleInfo(const DoutPrefixProvider *dpp, const string& arn, optional_yield y);

--- a/src/rgw/rgw_sts.h
+++ b/src/rgw/rgw_sts.h
@@ -112,7 +112,7 @@ class AssumedRoleUser {
   string assumeRoleId;
 public:
   int generateAssumedRoleUser( CephContext* cct,
-                                rgw::sal::RGWStore *store,
+                                rgw::sal::Store *store,
                                 const string& roleId,
                                 const rgw::ARN& roleArn,
                                 const string& roleSessionName);
@@ -225,14 +225,14 @@ using AssumeRoleWithWebIdentityResponse = struct AssumeRoleWithWebIdentityRespon
 
 class STSService {
   CephContext* cct;
-  rgw::sal::RGWStore *store;
+  rgw::sal::Store *store;
   rgw_user user_id;
   RGWRole role;
   rgw::auth::Identity* identity;
   int storeARN(const DoutPrefixProvider *dpp, string& arn, optional_yield y);
 public:
   STSService() = default;
-  STSService(CephContext* cct, rgw::sal::RGWStore *store, rgw_user user_id,
+  STSService(CephContext* cct, rgw::sal::Store *store, rgw_user user_id,
 	     rgw::auth::Identity* identity)
     : cct(cct), store(store), user_id(user_id), identity(identity) {}
   std::tuple<int, RGWRole> getRoleInfo(const DoutPrefixProvider *dpp, const string& arn, optional_yield y);

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -86,7 +86,7 @@ void TempURLEngine::get_owner_info(const DoutPrefixProvider* dpp, const req_stat
   string bucket_tenant;
   if (!s->account_name.empty()) {
     bool found = false;
-    std::unique_ptr<rgw::sal::RGWUser> user;
+    std::unique_ptr<rgw::sal::User> user;
 
     rgw_user uid(s->account_name);
     if (uid.tenant.empty()) {
@@ -111,7 +111,7 @@ void TempURLEngine::get_owner_info(const DoutPrefixProvider* dpp, const req_stat
   rgw_bucket b;
   b.tenant = std::move(bucket_tenant);
   b.name = std::move(bucket_name);
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
   int ret = store->get_bucket(dpp, nullptr, b, &bucket, s->yield);
   if (ret < 0) {
     throw ret;
@@ -120,7 +120,7 @@ void TempURLEngine::get_owner_info(const DoutPrefixProvider* dpp, const req_stat
   ldpp_dout(dpp, 20) << "temp url user (bucket owner): " << bucket->get_info().owner
                  << dendl;
 
-  std::unique_ptr<rgw::sal::RGWUser> user;
+  std::unique_ptr<rgw::sal::User> user;
   user = store->get_user(bucket->get_info().owner);
   if (user->load_by_id(dpp, s->yield) < 0) {
     throw -EPERM;
@@ -451,7 +451,7 @@ ExternalTokenEngine::authenticate(const DoutPrefixProvider* dpp,
 
   ldpp_dout(dpp, 10) << "swift user=" << swift_user << dendl;
 
-  std::unique_ptr<rgw::sal::RGWUser> user;
+  std::unique_ptr<rgw::sal::User> user;
   ret = store->get_user_by_swift(dpp, swift_user, s->yield, &user);
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "NOTICE: couldn't map swift user" << dendl;
@@ -572,7 +572,7 @@ SignedTokenEngine::authenticate(const DoutPrefixProvider* dpp,
     return result_t::deny(-EPERM);
   }
 
-  std::unique_ptr<rgw::sal::RGWUser> user;
+  std::unique_ptr<rgw::sal::User> user;
   ret = store->get_user_by_swift(dpp, swift_user, s->yield, &user);
   if (ret < 0) {
     throw ret;
@@ -633,7 +633,7 @@ void RGW_SWIFT_Auth_Get::execute(optional_yield y)
   s->prot_flags |= RGW_REST_SWIFT;
 
   string user_str;
-  std::unique_ptr<rgw::sal::RGWUser> user;
+  std::unique_ptr<rgw::sal::User> user;
   bufferlist bl;
   RGWAccessKey *swift_key;
   map<string, RGWAccessKey>::iterator siter;
@@ -744,7 +744,7 @@ done:
   end_header(s);
 }
 
-int RGWHandler_SWIFT_Auth::init(rgw::sal::RGWStore *store, struct req_state *state,
+int RGWHandler_SWIFT_Auth::init(rgw::sal::Store *store, struct req_state *state,
 				rgw::io::BasicClient *cio)
 {
   state->dialect = "swift-auth";

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -744,7 +744,7 @@ done:
   end_header(s);
 }
 
-int RGWHandler_SWIFT_Auth::init(rgw::sal::Store *store, struct req_state *state,
+int RGWHandler_SWIFT_Auth::init(rgw::sal::Store* store, struct req_state *state,
 				rgw::io::BasicClient *cio)
 {
   state->dialect = "swift-auth";

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -315,7 +315,7 @@ public:
   ~RGWHandler_SWIFT_Auth() override {}
   RGWOp *op_get() override;
 
-  int init(rgw::sal::Store *store, struct req_state *state, rgw::io::BasicClient *cio) override;
+  int init(rgw::sal::Store* store, struct req_state *state, rgw::io::BasicClient *cio) override;
   int authorize(const DoutPrefixProvider *dpp, optional_yield y) override;
   int postauth_init(optional_yield) override { return 0; }
   int read_permissions(RGWOp *op, optional_yield) override { return 0; }
@@ -335,7 +335,7 @@ public:
     return this;
   }
 
-  RGWHandler_REST* get_handler(rgw::sal::Store *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store* store,
 			       struct req_state*,
                                const rgw::auth::StrategyRegistry&,
                                const std::string&) override {

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -42,7 +42,7 @@ class TempURLEngine : public rgw::auth::Engine {
   using result_t = rgw::auth::Engine::result_t;
 
   CephContext* const cct;
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
   const TempURLApplier::Factory* const apl_factory;
 
   /* Helper methods. */
@@ -60,7 +60,7 @@ class TempURLEngine : public rgw::auth::Engine {
 
 public:
   TempURLEngine(CephContext* const cct,
-                rgw::sal::RGWStore* _store ,
+                rgw::sal::Store* _store ,
                 const TempURLApplier::Factory* const apl_factory)
     : cct(cct),
       store(_store),
@@ -81,7 +81,7 @@ class SignedTokenEngine : public rgw::auth::Engine {
   using result_t = rgw::auth::Engine::result_t;
 
   CephContext* const cct;
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
   const rgw::auth::TokenExtractor* const extractor;
   const rgw::auth::LocalApplier::Factory* const apl_factory;
 
@@ -93,7 +93,7 @@ class SignedTokenEngine : public rgw::auth::Engine {
 
 public:
   SignedTokenEngine(CephContext* const cct,
-                    rgw::sal::RGWStore* _store,
+                    rgw::sal::Store* _store,
                     const rgw::auth::TokenExtractor* const extractor,
                     const rgw::auth::LocalApplier::Factory* const apl_factory)
     : cct(cct),
@@ -118,7 +118,7 @@ class ExternalTokenEngine : public rgw::auth::Engine {
   using result_t = rgw::auth::Engine::result_t;
 
   CephContext* const cct;
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
   const rgw::auth::TokenExtractor* const extractor;
   const rgw::auth::LocalApplier::Factory* const apl_factory;
 
@@ -129,7 +129,7 @@ class ExternalTokenEngine : public rgw::auth::Engine {
 
 public:
   ExternalTokenEngine(CephContext* const cct,
-                      rgw::sal::RGWStore* _store,
+                      rgw::sal::Store* _store,
                       const rgw::auth::TokenExtractor* const extractor,
                       const rgw::auth::LocalApplier::Factory* const apl_factory)
     : cct(cct),
@@ -185,7 +185,7 @@ class DefaultStrategy : public rgw::auth::Strategy,
                         public rgw::auth::RemoteApplier::Factory,
                         public rgw::auth::LocalApplier::Factory,
                         public rgw::auth::swift::TempURLApplier::Factory {
-  rgw::sal::RGWStore* store;
+  rgw::sal::Store* store;
   ImplicitTenants& implicit_tenant_context;
 
   /* The engines. */
@@ -246,7 +246,7 @@ class DefaultStrategy : public rgw::auth::Strategy,
 public:
   DefaultStrategy(CephContext* const cct,
                   ImplicitTenants& implicit_tenant_context,
-                  rgw::sal::RGWStore* _store)
+                  rgw::sal::Store* _store)
     : store(_store),
       implicit_tenant_context(implicit_tenant_context),
       tempurl_engine(cct,
@@ -315,7 +315,7 @@ public:
   ~RGWHandler_SWIFT_Auth() override {}
   RGWOp *op_get() override;
 
-  int init(rgw::sal::RGWStore *store, struct req_state *state, rgw::io::BasicClient *cio) override;
+  int init(rgw::sal::Store *store, struct req_state *state, rgw::io::BasicClient *cio) override;
   int authorize(const DoutPrefixProvider *dpp, optional_yield y) override;
   int postauth_init(optional_yield) override { return 0; }
   int read_permissions(RGWOp *op, optional_yield) override { return 0; }
@@ -335,7 +335,7 @@ public:
     return this;
   }
 
-  RGWHandler_REST* get_handler(rgw::sal::RGWStore *store,
+  RGWHandler_REST* get_handler(rgw::sal::Store *store,
 			       struct req_state*,
                                const rgw::auth::StrategyRegistry&,
                                const std::string&) override {

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -40,7 +40,7 @@ static string mdlog_sync_status_oid = "mdlog.sync-status";
 static string mdlog_sync_status_shard_prefix = "mdlog.sync-status.shard";
 static string mdlog_sync_full_sync_index_prefix = "meta.full-sync.index";
 
-RGWSyncErrorLogger::RGWSyncErrorLogger(rgw::sal::RadosStore *_store, const string &oid_prefix, int _num_shards) : store(_store), num_shards(_num_shards) {
+RGWSyncErrorLogger::RGWSyncErrorLogger(rgw::sal::RadosStore* _store, const string &oid_prefix, int _num_shards) : store(_store), num_shards(_num_shards) {
   for (int i = 0; i < num_shards; i++) {
     oids.push_back(get_shard_oid(oid_prefix, i));
   }
@@ -364,7 +364,7 @@ std::ostream&  RGWMetaSyncStatusManager::gen_prefix(std::ostream& out) const
   return out << "meta sync: ";
 }
 
-void RGWMetaSyncEnv::init(const DoutPrefixProvider *_dpp, CephContext *_cct, rgw::sal::RadosStore *_store, RGWRESTConn *_conn,
+void RGWMetaSyncEnv::init(const DoutPrefixProvider *_dpp, CephContext *_cct, rgw::sal::RadosStore* _store, RGWRESTConn *_conn,
                           RGWAsyncRadosProcessor *_async_rados, RGWHTTPManager *_http_manager,
                           RGWSyncErrorLogger *_error_logger, RGWSyncTraceManager *_sync_tracer) {
   dpp = _dpp;
@@ -391,7 +391,7 @@ string RGWMetaSyncEnv::shard_obj_name(int shard_id)
 }
 
 class RGWAsyncReadMDLogEntries : public RGWAsyncRadosRequest {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   RGWMetadataLog *mdlog;
   int shard_id;
   int max_entries;
@@ -416,7 +416,7 @@ public:
   list<cls_log_entry> entries;
   bool truncated;
 
-  RGWAsyncReadMDLogEntries(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *_store,
+  RGWAsyncReadMDLogEntries(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore* _store,
                            RGWMetadataLog* mdlog, int _shard_id,
                            std::string _marker, int _max_entries)
     : RGWAsyncRadosRequest(caller, cn), store(_store), mdlog(mdlog),
@@ -651,7 +651,7 @@ public:
         set_status("acquiring sync lock");
 	uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
         string lock_name = "sync_lock";
-	rgw::sal::RadosStore *store = sync_env->store;
+	rgw::sal::RadosStore* store = sync_env->store;
         lease_cr.reset(new RGWContinuousLeaseCR(sync_env->async_rados, store,
                                                 rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, sync_env->status_oid()),
                                                 lock_name, lock_duration, this));
@@ -668,7 +668,7 @@ public:
       }
       yield {
         set_status("writing sync status");
-	rgw::sal::RadosStore *store = sync_env->store;
+	rgw::sal::RadosStore* store = sync_env->store;
         call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(sync_env->async_rados, store->svc()->sysobj,
                                                            rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, sync_env->status_oid()),
                                                            status));
@@ -698,7 +698,7 @@ public:
           RGWMetadataLogInfo& info = shards_info[i];
 	  marker.next_step_marker = info.marker;
 	  marker.timestamp = info.last_update;
-	  rgw::sal::RadosStore *store = sync_env->store;
+	  rgw::sal::RadosStore* store = sync_env->store;
           spawn(new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(sync_env->async_rados,
                                                                 store->svc()->sysobj,
                                                                 rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, sync_env->shard_obj_name(i)),
@@ -708,7 +708,7 @@ public:
       yield {
         set_status("changing sync state: build full sync maps");
 	status.state = rgw_meta_sync_info::StateBuildingFullSyncMaps;
-	rgw::sal::RadosStore *store = sync_env->store;
+	rgw::sal::RadosStore* store = sync_env->store;
         call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(sync_env->async_rados, store->svc()->sysobj,
                                                            rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, sync_env->status_oid()),
                                                            status));
@@ -952,7 +952,7 @@ public:
             tn->log(20, SSTR("list metadata: section=" << *sections_iter << " key=" << *iter));
             string s = *sections_iter + ":" + *iter;
             int shard_id;
-	    rgw::sal::RadosStore *store = sync_env->store;
+	    rgw::sal::RadosStore* store = sync_env->store;
             int ret = store->ctl()->meta.mgr->get_shard_id(*sections_iter, *iter, &shard_id);
             if (ret < 0) {
               tn->log(0, SSTR("ERROR: could not determine shard id for " << *sections_iter << ":" << *iter));
@@ -1080,7 +1080,7 @@ public:
 };
 
 class RGWAsyncMetaStoreEntry : public RGWAsyncRadosRequest {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   string raw_key;
   bufferlist bl;
   const DoutPrefixProvider *dpp;
@@ -1094,7 +1094,7 @@ protected:
     return 0;
   }
 public:
-  RGWAsyncMetaStoreEntry(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *_store,
+  RGWAsyncMetaStoreEntry(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore* _store,
                        const string& _raw_key,
                        bufferlist& _bl,
                        const DoutPrefixProvider *dpp) : RGWAsyncRadosRequest(caller, cn), store(_store),
@@ -1135,7 +1135,7 @@ public:
 };
 
 class RGWAsyncMetaRemoveEntry : public RGWAsyncRadosRequest {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   string raw_key;
   const DoutPrefixProvider *dpp;
 protected:
@@ -1148,7 +1148,7 @@ protected:
     return 0;
   }
 public:
-  RGWAsyncMetaRemoveEntry(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *_store,
+  RGWAsyncMetaRemoveEntry(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore* _store,
                        const string& _raw_key, const DoutPrefixProvider *dpp) : RGWAsyncRadosRequest(caller, cn), store(_store),
                                           raw_key(_raw_key), dpp(dpp) {}
 };
@@ -1235,7 +1235,7 @@ public:
 
     ldpp_dout(sync_env->dpp, 20) << __func__ << "(): updating marker marker_oid=" << marker_oid << " marker=" << new_marker << " realm_epoch=" << sync_marker.realm_epoch << dendl;
     tn->log(20, SSTR("new marker=" << new_marker));
-    rgw::sal::RadosStore *store = sync_env->store;
+    rgw::sal::RadosStore* store = sync_env->store;
     return new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(sync_env->async_rados,
                                                            store->svc()->sysobj,
                                                            rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, marker_oid),
@@ -1556,7 +1556,7 @@ public:
       yield {
 	uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
         string lock_name = "sync_lock";
-	rgw::sal::RadosStore *store = sync_env->store;
+	rgw::sal::RadosStore* store = sync_env->store;
         lease_cr.reset(new RGWContinuousLeaseCR(sync_env->async_rados, store,
                                                 rgw_raw_obj(pool, sync_env->shard_obj_name(shard_id)),
                                                 lock_name, lock_duration, this));
@@ -1702,7 +1702,7 @@ public:
         yield {
           uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
           string lock_name = "sync_lock";
-	  rgw::sal::RadosStore *store = sync_env->store;
+	  rgw::sal::RadosStore* store = sync_env->store;
           lease_cr.reset( new RGWContinuousLeaseCR(sync_env->async_rados, store,
                                                    rgw_raw_obj(pool, sync_env->shard_obj_name(shard_id)),
                                                    lock_name, lock_duration, this));
@@ -1891,7 +1891,7 @@ public:
   }
 
   RGWCoroutine *alloc_finisher_cr() override {
-    rgw::sal::RadosStore *store = sync_env->store;
+    rgw::sal::RadosStore* store = sync_env->store;
     return new RGWSimpleRadosReadCR<rgw_meta_sync_marker>(sync_env->async_rados, store->svc()->sysobj,
                                                           rgw_raw_obj(pool, sync_env->shard_obj_name(shard_id)),
                                                           &sync_marker);

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -40,7 +40,7 @@ static string mdlog_sync_status_oid = "mdlog.sync-status";
 static string mdlog_sync_status_shard_prefix = "mdlog.sync-status.shard";
 static string mdlog_sync_full_sync_index_prefix = "meta.full-sync.index";
 
-RGWSyncErrorLogger::RGWSyncErrorLogger(rgw::sal::RGWRadosStore *_store, const string &oid_prefix, int _num_shards) : store(_store), num_shards(_num_shards) {
+RGWSyncErrorLogger::RGWSyncErrorLogger(rgw::sal::RadosStore *_store, const string &oid_prefix, int _num_shards) : store(_store), num_shards(_num_shards) {
   for (int i = 0; i < num_shards; i++) {
     oids.push_back(get_shard_oid(oid_prefix, i));
   }
@@ -364,7 +364,7 @@ std::ostream&  RGWMetaSyncStatusManager::gen_prefix(std::ostream& out) const
   return out << "meta sync: ";
 }
 
-void RGWMetaSyncEnv::init(const DoutPrefixProvider *_dpp, CephContext *_cct, rgw::sal::RGWRadosStore *_store, RGWRESTConn *_conn,
+void RGWMetaSyncEnv::init(const DoutPrefixProvider *_dpp, CephContext *_cct, rgw::sal::RadosStore *_store, RGWRESTConn *_conn,
                           RGWAsyncRadosProcessor *_async_rados, RGWHTTPManager *_http_manager,
                           RGWSyncErrorLogger *_error_logger, RGWSyncTraceManager *_sync_tracer) {
   dpp = _dpp;
@@ -391,7 +391,7 @@ string RGWMetaSyncEnv::shard_obj_name(int shard_id)
 }
 
 class RGWAsyncReadMDLogEntries : public RGWAsyncRadosRequest {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   RGWMetadataLog *mdlog;
   int shard_id;
   int max_entries;
@@ -416,7 +416,7 @@ public:
   list<cls_log_entry> entries;
   bool truncated;
 
-  RGWAsyncReadMDLogEntries(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RGWRadosStore *_store,
+  RGWAsyncReadMDLogEntries(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *_store,
                            RGWMetadataLog* mdlog, int _shard_id,
                            std::string _marker, int _max_entries)
     : RGWAsyncRadosRequest(caller, cn), store(_store), mdlog(mdlog),
@@ -651,7 +651,7 @@ public:
         set_status("acquiring sync lock");
 	uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
         string lock_name = "sync_lock";
-	rgw::sal::RGWRadosStore *store = sync_env->store;
+	rgw::sal::RadosStore *store = sync_env->store;
         lease_cr.reset(new RGWContinuousLeaseCR(sync_env->async_rados, store,
                                                 rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, sync_env->status_oid()),
                                                 lock_name, lock_duration, this));
@@ -668,7 +668,7 @@ public:
       }
       yield {
         set_status("writing sync status");
-	rgw::sal::RGWRadosStore *store = sync_env->store;
+	rgw::sal::RadosStore *store = sync_env->store;
         call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(sync_env->async_rados, store->svc()->sysobj,
                                                            rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, sync_env->status_oid()),
                                                            status));
@@ -698,7 +698,7 @@ public:
           RGWMetadataLogInfo& info = shards_info[i];
 	  marker.next_step_marker = info.marker;
 	  marker.timestamp = info.last_update;
-	  rgw::sal::RGWRadosStore *store = sync_env->store;
+	  rgw::sal::RadosStore *store = sync_env->store;
           spawn(new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(sync_env->async_rados,
                                                                 store->svc()->sysobj,
                                                                 rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, sync_env->shard_obj_name(i)),
@@ -708,7 +708,7 @@ public:
       yield {
         set_status("changing sync state: build full sync maps");
 	status.state = rgw_meta_sync_info::StateBuildingFullSyncMaps;
-	rgw::sal::RGWRadosStore *store = sync_env->store;
+	rgw::sal::RadosStore *store = sync_env->store;
         call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(sync_env->async_rados, store->svc()->sysobj,
                                                            rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, sync_env->status_oid()),
                                                            status));
@@ -952,7 +952,7 @@ public:
             tn->log(20, SSTR("list metadata: section=" << *sections_iter << " key=" << *iter));
             string s = *sections_iter + ":" + *iter;
             int shard_id;
-	    rgw::sal::RGWRadosStore *store = sync_env->store;
+	    rgw::sal::RadosStore *store = sync_env->store;
             int ret = store->ctl()->meta.mgr->get_shard_id(*sections_iter, *iter, &shard_id);
             if (ret < 0) {
               tn->log(0, SSTR("ERROR: could not determine shard id for " << *sections_iter << ":" << *iter));
@@ -1080,7 +1080,7 @@ public:
 };
 
 class RGWAsyncMetaStoreEntry : public RGWAsyncRadosRequest {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   string raw_key;
   bufferlist bl;
   const DoutPrefixProvider *dpp;
@@ -1094,7 +1094,7 @@ protected:
     return 0;
   }
 public:
-  RGWAsyncMetaStoreEntry(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RGWRadosStore *_store,
+  RGWAsyncMetaStoreEntry(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *_store,
                        const string& _raw_key,
                        bufferlist& _bl,
                        const DoutPrefixProvider *dpp) : RGWAsyncRadosRequest(caller, cn), store(_store),
@@ -1135,7 +1135,7 @@ public:
 };
 
 class RGWAsyncMetaRemoveEntry : public RGWAsyncRadosRequest {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   string raw_key;
   const DoutPrefixProvider *dpp;
 protected:
@@ -1148,7 +1148,7 @@ protected:
     return 0;
   }
 public:
-  RGWAsyncMetaRemoveEntry(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RGWRadosStore *_store,
+  RGWAsyncMetaRemoveEntry(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, rgw::sal::RadosStore *_store,
                        const string& _raw_key, const DoutPrefixProvider *dpp) : RGWAsyncRadosRequest(caller, cn), store(_store),
                                           raw_key(_raw_key), dpp(dpp) {}
 };
@@ -1235,7 +1235,7 @@ public:
 
     ldpp_dout(sync_env->dpp, 20) << __func__ << "(): updating marker marker_oid=" << marker_oid << " marker=" << new_marker << " realm_epoch=" << sync_marker.realm_epoch << dendl;
     tn->log(20, SSTR("new marker=" << new_marker));
-    rgw::sal::RGWRadosStore *store = sync_env->store;
+    rgw::sal::RadosStore *store = sync_env->store;
     return new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(sync_env->async_rados,
                                                            store->svc()->sysobj,
                                                            rgw_raw_obj(store->svc()->zone->get_zone_params().log_pool, marker_oid),
@@ -1556,7 +1556,7 @@ public:
       yield {
 	uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
         string lock_name = "sync_lock";
-	rgw::sal::RGWRadosStore *store = sync_env->store;
+	rgw::sal::RadosStore *store = sync_env->store;
         lease_cr.reset(new RGWContinuousLeaseCR(sync_env->async_rados, store,
                                                 rgw_raw_obj(pool, sync_env->shard_obj_name(shard_id)),
                                                 lock_name, lock_duration, this));
@@ -1702,7 +1702,7 @@ public:
         yield {
           uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
           string lock_name = "sync_lock";
-	  rgw::sal::RGWRadosStore *store = sync_env->store;
+	  rgw::sal::RadosStore *store = sync_env->store;
           lease_cr.reset( new RGWContinuousLeaseCR(sync_env->async_rados, store,
                                                    rgw_raw_obj(pool, sync_env->shard_obj_name(shard_id)),
                                                    lock_name, lock_duration, this));
@@ -1891,7 +1891,7 @@ public:
   }
 
   RGWCoroutine *alloc_finisher_cr() override {
-    rgw::sal::RGWRadosStore *store = sync_env->store;
+    rgw::sal::RadosStore *store = sync_env->store;
     return new RGWSimpleRadosReadCR<rgw_meta_sync_marker>(sync_env->async_rados, store->svc()->sysobj,
                                                           rgw_raw_obj(pool, sync_env->shard_obj_name(shard_id)),
                                                           &sync_marker);
@@ -2089,7 +2089,7 @@ int RGWRemoteMetaLog::store_sync_info(const rgw_meta_sync_info& sync_info)
 }
 
 // return a cursor to the period at our sync position
-static RGWPeriodHistory::Cursor get_period_at(rgw::sal::RGWRadosStore* store,
+static RGWPeriodHistory::Cursor get_period_at(rgw::sal::RadosStore* store,
                                               const rgw_meta_sync_info& info,
 					      optional_yield y)
 {

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -70,14 +70,14 @@ class RGWRESTConn;
 class RGWSyncTraceManager;
 
 class RGWSyncErrorLogger {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
 
   vector<string> oids;
   int num_shards;
 
   std::atomic<int64_t> counter = { 0 };
 public:
-  RGWSyncErrorLogger(rgw::sal::RGWRadosStore *_store, const string &oid_prefix, int _num_shards);
+  RGWSyncErrorLogger(rgw::sal::RadosStore *_store, const string &oid_prefix, int _num_shards);
   RGWCoroutine *log_error_cr(const string& source_zone, const string& section, const string& name, uint32_t error_code, const string& message);
 
   static string get_shard_oid(const string& oid_prefix, int shard_id);
@@ -175,7 +175,7 @@ public:
 struct RGWMetaSyncEnv {
   const DoutPrefixProvider *dpp;
   CephContext *cct{nullptr};
-  rgw::sal::RGWRadosStore *store{nullptr};
+  rgw::sal::RadosStore *store{nullptr};
   RGWRESTConn *conn{nullptr};
   RGWAsyncRadosProcessor *async_rados{nullptr};
   RGWHTTPManager *http_manager{nullptr};
@@ -184,7 +184,7 @@ struct RGWMetaSyncEnv {
 
   RGWMetaSyncEnv() {}
 
-  void init(const DoutPrefixProvider *_dpp, CephContext *_cct, rgw::sal::RGWRadosStore *_store, RGWRESTConn *_conn,
+  void init(const DoutPrefixProvider *_dpp, CephContext *_cct, rgw::sal::RadosStore *_store, RGWRESTConn *_conn,
             RGWAsyncRadosProcessor *_async_rados, RGWHTTPManager *_http_manager,
             RGWSyncErrorLogger *_error_logger, RGWSyncTraceManager *_sync_tracer);
 
@@ -194,7 +194,7 @@ struct RGWMetaSyncEnv {
 
 class RGWRemoteMetaLog : public RGWCoroutinesManager {
   const DoutPrefixProvider *dpp;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   RGWRESTConn *conn;
   RGWAsyncRadosProcessor *async_rados;
 
@@ -217,7 +217,7 @@ class RGWRemoteMetaLog : public RGWCoroutinesManager {
   RGWSyncTraceNodeRef tn;
 
 public:
-  RGWRemoteMetaLog(const DoutPrefixProvider *dpp, rgw::sal::RGWRadosStore *_store,
+  RGWRemoteMetaLog(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *_store,
                    RGWAsyncRadosProcessor *async_rados,
                    RGWMetaSyncStatusManager *_sm)
     : RGWCoroutinesManager(_store->ctx(), _store->getRados()->get_cr_registry()),
@@ -245,7 +245,7 @@ public:
 };
 
 class RGWMetaSyncStatusManager : public DoutPrefixProvider {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   librados::IoCtx ioctx;
 
   RGWRemoteMetaLog master_log;
@@ -271,7 +271,7 @@ class RGWMetaSyncStatusManager : public DoutPrefixProvider {
   vector<string> clone_markers;
 
 public:
-  RGWMetaSyncStatusManager(rgw::sal::RGWRadosStore *_store, RGWAsyncRadosProcessor *async_rados)
+  RGWMetaSyncStatusManager(rgw::sal::RadosStore *_store, RGWAsyncRadosProcessor *async_rados)
     : store(_store), master_log(this, store, async_rados, this)
   {}
   int init();

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -70,14 +70,14 @@ class RGWRESTConn;
 class RGWSyncTraceManager;
 
 class RGWSyncErrorLogger {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
 
   vector<string> oids;
   int num_shards;
 
   std::atomic<int64_t> counter = { 0 };
 public:
-  RGWSyncErrorLogger(rgw::sal::RadosStore *_store, const string &oid_prefix, int _num_shards);
+  RGWSyncErrorLogger(rgw::sal::RadosStore* _store, const string &oid_prefix, int _num_shards);
   RGWCoroutine *log_error_cr(const string& source_zone, const string& section, const string& name, uint32_t error_code, const string& message);
 
   static string get_shard_oid(const string& oid_prefix, int shard_id);
@@ -175,7 +175,7 @@ public:
 struct RGWMetaSyncEnv {
   const DoutPrefixProvider *dpp;
   CephContext *cct{nullptr};
-  rgw::sal::RadosStore *store{nullptr};
+  rgw::sal::RadosStore* store{nullptr};
   RGWRESTConn *conn{nullptr};
   RGWAsyncRadosProcessor *async_rados{nullptr};
   RGWHTTPManager *http_manager{nullptr};
@@ -184,7 +184,7 @@ struct RGWMetaSyncEnv {
 
   RGWMetaSyncEnv() {}
 
-  void init(const DoutPrefixProvider *_dpp, CephContext *_cct, rgw::sal::RadosStore *_store, RGWRESTConn *_conn,
+  void init(const DoutPrefixProvider *_dpp, CephContext *_cct, rgw::sal::RadosStore* _store, RGWRESTConn *_conn,
             RGWAsyncRadosProcessor *_async_rados, RGWHTTPManager *_http_manager,
             RGWSyncErrorLogger *_error_logger, RGWSyncTraceManager *_sync_tracer);
 
@@ -194,7 +194,7 @@ struct RGWMetaSyncEnv {
 
 class RGWRemoteMetaLog : public RGWCoroutinesManager {
   const DoutPrefixProvider *dpp;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   RGWRESTConn *conn;
   RGWAsyncRadosProcessor *async_rados;
 
@@ -217,7 +217,7 @@ class RGWRemoteMetaLog : public RGWCoroutinesManager {
   RGWSyncTraceNodeRef tn;
 
 public:
-  RGWRemoteMetaLog(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *_store,
+  RGWRemoteMetaLog(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* _store,
                    RGWAsyncRadosProcessor *async_rados,
                    RGWMetaSyncStatusManager *_sm)
     : RGWCoroutinesManager(_store->ctx(), _store->getRados()->get_cr_registry()),
@@ -245,7 +245,7 @@ public:
 };
 
 class RGWMetaSyncStatusManager : public DoutPrefixProvider {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   librados::IoCtx ioctx;
 
   RGWRemoteMetaLog master_log;
@@ -271,7 +271,7 @@ class RGWMetaSyncStatusManager : public DoutPrefixProvider {
   vector<string> clone_markers;
 
 public:
-  RGWMetaSyncStatusManager(rgw::sal::RadosStore *_store, RGWAsyncRadosProcessor *async_rados)
+  RGWMetaSyncStatusManager(rgw::sal::RadosStore* _store, RGWAsyncRadosProcessor *async_rados)
     : store(_store), master_log(this, store, async_rados, this)
   {}
   int init();

--- a/src/rgw/rgw_sync_checkpoint.cc
+++ b/src/rgw/rgw_sync_checkpoint.cc
@@ -82,7 +82,7 @@ std::ostream& operator<<(std::ostream& out, const BucketIndexShardsManager& rhs)
 }
 
 int bucket_source_sync_checkpoint(const DoutPrefixProvider* dpp,
-                                  rgw::sal::RGWRadosStore *store,
+                                  rgw::sal::RadosStore *store,
                                   const RGWBucketInfo& bucket_info,
                                   const RGWBucketInfo& source_bucket_info,
                                   const rgw_sync_bucket_pipe& pipe,
@@ -146,7 +146,7 @@ int source_bilog_markers(RGWSI_Zone* zone_svc,
 } // anonymous namespace
 
 int rgw_bucket_sync_checkpoint(const DoutPrefixProvider* dpp,
-                               rgw::sal::RGWRadosStore *store,
+                               rgw::sal::RadosStore *store,
                                const RGWBucketSyncPolicyHandler& policy,
                                const RGWBucketInfo& info,
                                std::optional<rgw_zone_id> opt_source_zone,

--- a/src/rgw/rgw_sync_checkpoint.cc
+++ b/src/rgw/rgw_sync_checkpoint.cc
@@ -82,7 +82,7 @@ std::ostream& operator<<(std::ostream& out, const BucketIndexShardsManager& rhs)
 }
 
 int bucket_source_sync_checkpoint(const DoutPrefixProvider* dpp,
-                                  rgw::sal::RadosStore *store,
+                                  rgw::sal::RadosStore* store,
                                   const RGWBucketInfo& bucket_info,
                                   const RGWBucketInfo& source_bucket_info,
                                   const rgw_sync_bucket_pipe& pipe,
@@ -146,7 +146,7 @@ int source_bilog_markers(RGWSI_Zone* zone_svc,
 } // anonymous namespace
 
 int rgw_bucket_sync_checkpoint(const DoutPrefixProvider* dpp,
-                               rgw::sal::RadosStore *store,
+                               rgw::sal::RadosStore* store,
                                const RGWBucketSyncPolicyHandler& policy,
                                const RGWBucketInfo& info,
                                std::optional<rgw_zone_id> opt_source_zone,

--- a/src/rgw/rgw_sync_checkpoint.h
+++ b/src/rgw/rgw_sync_checkpoint.h
@@ -26,7 +26,7 @@ class RGWBucketSyncPolicyHandler;
 
 // poll the bucket's sync status until it's caught up against all sync sources
 int rgw_bucket_sync_checkpoint(const DoutPrefixProvider* dpp,
-                               rgw::sal::RadosStore *store,
+                               rgw::sal::RadosStore* store,
                                const RGWBucketSyncPolicyHandler& policy,
                                const RGWBucketInfo& info,
                                std::optional<rgw_zone_id> opt_source_zone,

--- a/src/rgw/rgw_sync_checkpoint.h
+++ b/src/rgw/rgw_sync_checkpoint.h
@@ -20,13 +20,13 @@
 #include "rgw_basic_types.h"
 
 class DoutPrefixProvider;
-namespace rgw::sal { class RGWRadosStore; }
+namespace rgw::sal { class RadosStore; }
 class RGWBucketInfo;
 class RGWBucketSyncPolicyHandler;
 
 // poll the bucket's sync status until it's caught up against all sync sources
 int rgw_bucket_sync_checkpoint(const DoutPrefixProvider* dpp,
-                               rgw::sal::RGWRadosStore *store,
+                               rgw::sal::RadosStore *store,
                                const RGWBucketSyncPolicyHandler& policy,
                                const RGWBucketInfo& info,
                                std::optional<rgw_zone_id> opt_source_zone,

--- a/src/rgw/rgw_sync_module_aws.cc
+++ b/src/rgw/rgw_sync_module_aws.cc
@@ -35,7 +35,7 @@ static string get_key_oid(const rgw_obj_key& key)
   return oid;
 }
 
-static string obj_to_aws_path(rgw::sal::RGWObject* obj)
+static string obj_to_aws_path(rgw::sal::Object* obj)
 {
   string path = obj->get_bucket()->get_name() + "/" + get_key_oid(obj->get_key());
 
@@ -728,7 +728,7 @@ class RGWRESTStreamGetCRF : public RGWStreamReadHTTPResourceCRF
 {
   RGWDataSyncCtx *sc;
   RGWRESTConn *conn;
-  rgw::sal::RGWObject* src_obj;
+  rgw::sal::Object* src_obj;
   RGWRESTConn::get_obj_params req_params;
 
   rgw_sync_aws_src_obj_properties src_properties;
@@ -738,7 +738,7 @@ public:
                                RGWCoroutine *_caller,
                                RGWDataSyncCtx *_sc,
                                RGWRESTConn *_conn,
-                               rgw::sal::RGWObject* _src_obj,
+                               rgw::sal::Object* _src_obj,
                                const rgw_sync_aws_src_obj_properties& _src_properties) : RGWStreamReadHTTPResourceCRF(_cct, _env, _caller,
                                                                                                                       _sc->env->http_manager, _src_obj->get_key()),
                                                                                  sc(_sc), conn(_conn), src_obj(_src_obj),
@@ -807,7 +807,7 @@ class RGWAWSStreamPutCRF : public RGWStreamWriteHTTPResourceCRF
   RGWDataSyncCtx *sc;
   rgw_sync_aws_src_obj_properties src_properties;
   std::shared_ptr<AWSSyncConfig_Profile> target;
-  rgw::sal::RGWObject* dest_obj;
+  rgw::sal::Object* dest_obj;
   string etag;
 public:
   RGWAWSStreamPutCRF(CephContext *_cct,
@@ -816,7 +816,7 @@ public:
                                RGWDataSyncCtx *_sc,
                                const rgw_sync_aws_src_obj_properties&  _src_properties,
                                std::shared_ptr<AWSSyncConfig_Profile>& _target,
-                               rgw::sal::RGWObject* _dest_obj) : RGWStreamWriteHTTPResourceCRF(_cct, _env, _caller, _sc->env->http_manager),
+                               rgw::sal::Object* _dest_obj) : RGWStreamWriteHTTPResourceCRF(_cct, _env, _caller, _sc->env->http_manager),
                                                      sc(_sc), src_properties(_src_properties), target(_target), dest_obj(_dest_obj) {
   }
 
@@ -1004,8 +1004,8 @@ class RGWAWSStreamObjToCloudPlainCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWRESTConn *source_conn;
   std::shared_ptr<AWSSyncConfig_Profile> target;
-  rgw::sal::RGWObject* src_obj;
-  rgw::sal::RGWObject* dest_obj;
+  rgw::sal::Object* src_obj;
+  rgw::sal::Object* dest_obj;
 
   rgw_sync_aws_src_obj_properties src_properties;
 
@@ -1015,10 +1015,10 @@ class RGWAWSStreamObjToCloudPlainCR : public RGWCoroutine {
 public:
   RGWAWSStreamObjToCloudPlainCR(RGWDataSyncCtx *_sc,
                                 RGWRESTConn *_source_conn,
-                                rgw::sal::RGWObject* _src_obj,
+                                rgw::sal::Object* _src_obj,
                                 const rgw_sync_aws_src_obj_properties& _src_properties,
                                 std::shared_ptr<AWSSyncConfig_Profile> _target,
-                                rgw::sal::RGWObject* _dest_obj) : RGWCoroutine(_sc->cct),
+                                rgw::sal::Object* _dest_obj) : RGWCoroutine(_sc->cct),
                                                    sc(_sc),
                                                    source_conn(_source_conn),
                                                    target(_target),
@@ -1053,8 +1053,8 @@ class RGWAWSStreamObjToCloudMultipartPartCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWRESTConn *source_conn;
   std::shared_ptr<AWSSyncConfig_Profile> target;
-  rgw::sal::RGWObject* src_obj;
-  rgw::sal::RGWObject* dest_obj;
+  rgw::sal::Object* src_obj;
+  rgw::sal::Object* dest_obj;
 
   rgw_sync_aws_src_obj_properties src_properties;
 
@@ -1070,9 +1070,9 @@ class RGWAWSStreamObjToCloudMultipartPartCR : public RGWCoroutine {
 public:
   RGWAWSStreamObjToCloudMultipartPartCR(RGWDataSyncCtx *_sc,
                                 RGWRESTConn *_source_conn,
-                                rgw::sal::RGWObject* _src_obj,
+                                rgw::sal::Object* _src_obj,
                                 std::shared_ptr<AWSSyncConfig_Profile>& _target,
-                                rgw::sal::RGWObject* _dest_obj,
+                                rgw::sal::Object* _dest_obj,
                                 const rgw_sync_aws_src_obj_properties& _src_properties,
                                 const string& _upload_id,
                                 const rgw_sync_aws_multipart_part_info& _part_info,
@@ -1122,14 +1122,14 @@ public:
 class RGWAWSAbortMultipartCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWRESTConn *dest_conn;
-  rgw::sal::RGWObject* dest_obj;
+  rgw::sal::Object* dest_obj;
 
   string upload_id;
 
 public:
   RGWAWSAbortMultipartCR(RGWDataSyncCtx *_sc,
                         RGWRESTConn *_dest_conn,
-                        rgw::sal::RGWObject* _dest_obj,
+                        rgw::sal::Object* _dest_obj,
                         const string& _upload_id) : RGWCoroutine(_sc->cct),
                                                    sc(_sc),
                                                    dest_conn(_dest_conn),
@@ -1161,7 +1161,7 @@ public:
 class RGWAWSInitMultipartCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWRESTConn *dest_conn;
-  rgw::sal::RGWObject* dest_obj;
+  rgw::sal::Object* dest_obj;
 
   uint64_t obj_size;
   map<string, string> attrs;
@@ -1185,7 +1185,7 @@ class RGWAWSInitMultipartCR : public RGWCoroutine {
 public:
   RGWAWSInitMultipartCR(RGWDataSyncCtx *_sc,
                         RGWRESTConn *_dest_conn,
-                        rgw::sal::RGWObject* _dest_obj,
+                        rgw::sal::Object* _dest_obj,
                         uint64_t _obj_size,
                         const map<string, string>& _attrs,
                         string *_upload_id) : RGWCoroutine(_sc->cct),
@@ -1251,7 +1251,7 @@ public:
 class RGWAWSCompleteMultipartCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWRESTConn *dest_conn;
-  rgw::sal::RGWObject* dest_obj;
+  rgw::sal::Object* dest_obj;
 
   bufferlist out_bl;
 
@@ -1289,7 +1289,7 @@ class RGWAWSCompleteMultipartCR : public RGWCoroutine {
 public:
   RGWAWSCompleteMultipartCR(RGWDataSyncCtx *_sc,
                         RGWRESTConn *_dest_conn,
-                        rgw::sal::RGWObject* _dest_obj,
+                        rgw::sal::Object* _dest_obj,
                         string _upload_id,
                         const map<int, rgw_sync_aws_multipart_part_info>& _parts) : RGWCoroutine(_sc->cct),
                                                    sc(_sc),
@@ -1361,7 +1361,7 @@ public:
 class RGWAWSStreamAbortMultipartUploadCR : public RGWCoroutine {
   RGWDataSyncCtx *sc;
   RGWRESTConn *dest_conn;
-  rgw::sal::RGWObject* dest_obj;
+  rgw::sal::Object* dest_obj;
   const rgw_raw_obj status_obj;
 
   string upload_id;
@@ -1370,7 +1370,7 @@ public:
 
   RGWAWSStreamAbortMultipartUploadCR(RGWDataSyncCtx *_sc,
                                 RGWRESTConn *_dest_conn,
-                                rgw::sal::RGWObject* _dest_obj,
+                                rgw::sal::Object* _dest_obj,
                                 const rgw_raw_obj& _status_obj,
                                 const string& _upload_id) : RGWCoroutine(_sc->cct), sc(_sc),
                                                             dest_conn(_dest_conn),
@@ -1403,8 +1403,8 @@ class RGWAWSStreamObjToCloudMultipartCR : public RGWCoroutine {
   AWSSyncConfig& conf;
   RGWRESTConn *source_conn;
   std::shared_ptr<AWSSyncConfig_Profile> target;
-  rgw::sal::RGWObject* src_obj;
-  rgw::sal::RGWObject* dest_obj;
+  rgw::sal::Object* src_obj;
+  rgw::sal::Object* dest_obj;
 
   uint64_t obj_size;
   string src_etag;
@@ -1426,9 +1426,9 @@ public:
 				    rgw_bucket_sync_pipe& _sync_pipe,
                                 AWSSyncConfig& _conf,
                                 RGWRESTConn *_source_conn,
-                                rgw::sal::RGWObject* _src_obj,
+                                rgw::sal::Object* _src_obj,
                                 std::shared_ptr<AWSSyncConfig_Profile>& _target,
-                                rgw::sal::RGWObject* _dest_obj,
+                                rgw::sal::Object* _dest_obj,
                                 uint64_t _obj_size,
                                 const rgw_sync_aws_src_obj_properties& _src_properties,
                                 const rgw_rest_obj& _rest_obj) : RGWCoroutine(_sc->cct),
@@ -1669,15 +1669,15 @@ public:
       }
 
       yield {
-	rgw::sal::RGWRadosBucket bucket(sync_env->store, src_bucket);
-        rgw::sal::RGWRadosObject src_obj(sync_env->store, key, &bucket);
+	rgw::sal::RadosBucket bucket(sync_env->store, src_bucket);
+        rgw::sal::RadosObject src_obj(sync_env->store, key, &bucket);
 
         /* init output */
         rgw_bucket target_bucket;
         target_bucket.name = target_bucket_name; /* this is only possible because we only use bucket name for
                                                     uri resolution */
-	rgw::sal::RGWRadosBucket dest_bucket(sync_env->store, target_bucket);
-        rgw::sal::RGWRadosObject dest_obj(sync_env->store, rgw_obj_key(target_obj_name), &dest_bucket);
+	rgw::sal::RadosBucket dest_bucket(sync_env->store, target_bucket);
+        rgw::sal::RadosObject dest_obj(sync_env->store, rgw_obj_key(target_obj_name), &dest_bucket);
 
 
         rgw_sync_aws_src_obj_properties src_properties;

--- a/src/rgw/rgw_sync_module_es_rest.cc
+++ b/src/rgw/rgw_sync_module_es_rest.cc
@@ -401,7 +401,7 @@ public:
 };
 
 
-RGWHandler_REST* RGWRESTMgr_MDSearch_S3::get_handler(rgw::sal::Store *store,
+RGWHandler_REST* RGWRESTMgr_MDSearch_S3::get_handler(rgw::sal::Store* store,
 						     struct req_state* const s,
                                                      const rgw::auth::StrategyRegistry& auth_registry,
                                                      const std::string& frontend_prefix)

--- a/src/rgw/rgw_sync_module_es_rest.cc
+++ b/src/rgw/rgw_sync_module_es_rest.cc
@@ -401,7 +401,7 @@ public:
 };
 
 
-RGWHandler_REST* RGWRESTMgr_MDSearch_S3::get_handler(rgw::sal::RGWStore *store,
+RGWHandler_REST* RGWRESTMgr_MDSearch_S3::get_handler(rgw::sal::Store *store,
 						     struct req_state* const s,
                                                      const rgw::auth::StrategyRegistry& auth_registry,
                                                      const std::string& frontend_prefix)

--- a/src/rgw/rgw_sync_module_es_rest.h
+++ b/src/rgw/rgw_sync_module_es_rest.h
@@ -11,7 +11,7 @@ class RGWRESTMgr_MDSearch_S3 : public RGWRESTMgr {
 public:
   explicit RGWRESTMgr_MDSearch_S3() {}
 
-  RGWHandler_REST *get_handler(rgw::sal::RGWStore *store,
+  RGWHandler_REST *get_handler(rgw::sal::Store *store,
 			       struct req_state* s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string& frontend_prefix) override;

--- a/src/rgw/rgw_sync_module_es_rest.h
+++ b/src/rgw/rgw_sync_module_es_rest.h
@@ -11,7 +11,7 @@ class RGWRESTMgr_MDSearch_S3 : public RGWRESTMgr {
 public:
   explicit RGWRESTMgr_MDSearch_S3() {}
 
-  RGWHandler_REST *get_handler(rgw::sal::Store *store,
+  RGWHandler_REST *get_handler(rgw::sal::Store* store,
 			       struct req_state* s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string& frontend_prefix) override;

--- a/src/rgw/rgw_sync_module_pubsub.cc
+++ b/src/rgw/rgw_sync_module_pubsub.cc
@@ -456,7 +456,7 @@ class PSSubscription {
   public:
     InitBucketLifecycleCR(RGWDataSyncCtx *_sc,
            PSConfigRef& _conf,
-           rgw::sal::RGWBucket* _bucket) : RGWCoroutine(_sc->cct),
+           rgw::sal::Bucket* _bucket) : RGWCoroutine(_sc->cct),
                                                      sc(_sc), sync_env(_sc->env),
                                                      conf(_conf) {
       lc_config.bucket = _bucket;

--- a/src/rgw/rgw_sync_module_pubsub_rest.cc
+++ b/src/rgw/rgw_sync_module_pubsub_rest.cc
@@ -496,7 +496,7 @@ public:
 };
 
 // factory for ceph specific PubSub REST handlers 
-RGWHandler_REST* RGWRESTMgr_PubSub::get_handler(rgw::sal::Store *store,
+RGWHandler_REST* RGWRESTMgr_PubSub::get_handler(rgw::sal::Store* store,
 						struct req_state* const s,
 						const rgw::auth::StrategyRegistry& auth_registry,
 						const std::string& frontend_prefix)

--- a/src/rgw/rgw_sync_module_pubsub_rest.cc
+++ b/src/rgw/rgw_sync_module_pubsub_rest.cc
@@ -374,7 +374,7 @@ public:
 
 void RGWPSCreateNotif_ObjStore::execute(optional_yield y)
 {
-  ps.emplace(static_cast<rgw::sal::RGWRadosStore*>(store), s->owner.get_id().tenant);
+  ps.emplace(static_cast<rgw::sal::RadosStore*>(store), s->owner.get_id().tenant);
 
   auto b = ps->get_bucket(bucket_info.bucket);
   op_ret = b->create_notification(topic_name, events, y);
@@ -411,7 +411,7 @@ void RGWPSDeleteNotif_ObjStore::execute(optional_yield y) {
     return;
   }
 
-  ps.emplace(static_cast<rgw::sal::RGWRadosStore*>(store), s->owner.get_id().tenant);
+  ps.emplace(static_cast<rgw::sal::RadosStore*>(store), s->owner.get_id().tenant);
   auto b = ps->get_bucket(bucket_info.bucket);
   op_ret = b->remove_notification(topic_name, y);
   if (op_ret < 0) {
@@ -450,7 +450,7 @@ public:
 
 void RGWPSListNotifs_ObjStore::execute(optional_yield y)
 {
-  ps.emplace(static_cast<rgw::sal::RGWRadosStore*>(store), s->owner.get_id().tenant);
+  ps.emplace(static_cast<rgw::sal::RadosStore*>(store), s->owner.get_id().tenant);
   auto b = ps->get_bucket(bucket_info.bucket);
   op_ret = b->get_topics(&result);
   if (op_ret < 0) {
@@ -496,7 +496,7 @@ public:
 };
 
 // factory for ceph specific PubSub REST handlers 
-RGWHandler_REST* RGWRESTMgr_PubSub::get_handler(rgw::sal::RGWStore *store,
+RGWHandler_REST* RGWRESTMgr_PubSub::get_handler(rgw::sal::Store *store,
 						struct req_state* const s,
 						const rgw::auth::StrategyRegistry& auth_registry,
 						const std::string& frontend_prefix)

--- a/src/rgw/rgw_sync_module_pubsub_rest.h
+++ b/src/rgw/rgw_sync_module_pubsub_rest.h
@@ -7,7 +7,7 @@
 
 class RGWRESTMgr_PubSub : public RGWRESTMgr {
 public:
-  virtual RGWHandler_REST* get_handler(rgw::sal::RGWStore *store,
+  virtual RGWHandler_REST* get_handler(rgw::sal::Store *store,
 			       struct req_state* s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string& frontend_prefix) override;

--- a/src/rgw/rgw_sync_module_pubsub_rest.h
+++ b/src/rgw/rgw_sync_module_pubsub_rest.h
@@ -7,7 +7,7 @@
 
 class RGWRESTMgr_PubSub : public RGWRESTMgr {
 public:
-  virtual RGWHandler_REST* get_handler(rgw::sal::Store *store,
+  virtual RGWHandler_REST* get_handler(rgw::sal::Store* store,
 			       struct req_state* s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string& frontend_prefix) override;

--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -409,7 +409,7 @@ void rgw_filter_attrset(map<string, bufferlist>& unfiltered_attrset, const strin
   }
 }
 
-RGWDataAccess::RGWDataAccess(rgw::sal::Store *_store) : store(_store)
+RGWDataAccess::RGWDataAccess(rgw::sal::Store* _store) : store(_store)
 {
 }
 
@@ -466,7 +466,7 @@ int RGWDataAccess::Object::put(bufferlist& data,
                                const DoutPrefixProvider *dpp,
                                optional_yield y)
 {
-  rgw::sal::Store *store = sd->store;
+  rgw::sal::Store* store = sd->store;
   CephContext *cct = store->ctx();
 
   string tag;

--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -409,7 +409,7 @@ void rgw_filter_attrset(map<string, bufferlist>& unfiltered_attrset, const strin
   }
 }
 
-RGWDataAccess::RGWDataAccess(rgw::sal::RGWStore *_store) : store(_store)
+RGWDataAccess::RGWDataAccess(rgw::sal::Store *_store) : store(_store)
 {
 }
 
@@ -433,7 +433,7 @@ int RGWDataAccess::Bucket::finish_init()
 
 int RGWDataAccess::Bucket::init(const DoutPrefixProvider *dpp, optional_yield y)
 {
-  std::unique_ptr<rgw::sal::RGWBucket> bucket;
+  std::unique_ptr<rgw::sal::Bucket> bucket;
   int ret = sd->store->get_bucket(dpp, nullptr, tenant, name, &bucket, y);
   if (ret < 0) {
     return ret;
@@ -466,7 +466,7 @@ int RGWDataAccess::Object::put(bufferlist& data,
                                const DoutPrefixProvider *dpp,
                                optional_yield y)
 {
-  rgw::sal::RGWStore *store = sd->store;
+  rgw::sal::Store *store = sd->store;
   CephContext *cct = store->ctx();
 
   string tag;
@@ -477,9 +477,9 @@ int RGWDataAccess::Object::put(bufferlist& data,
   rgw::BlockingAioThrottle aio(store->ctx()->_conf->rgw_put_obj_min_window_size);
 
   RGWObjectCtx obj_ctx(store);
-  std::unique_ptr<rgw::sal::RGWBucket> b;
+  std::unique_ptr<rgw::sal::Bucket> b;
   store->get_bucket(NULL, bucket_info, &b);
-  std::unique_ptr<rgw::sal::RGWObject> obj = b->get_object(key);
+  std::unique_ptr<rgw::sal::Object> obj = b->get_object(key);
 
   auto& owner = bucket->policy.get_owner();
 

--- a/src/rgw/rgw_tools.h
+++ b/src/rgw/rgw_tools.h
@@ -20,7 +20,7 @@ class RGWSysObjectCtx;
 struct RGWObjVersionTracker;
 class optional_yield;
 namespace rgw { namespace sal {
-  class RGWStore;
+  class Store;
 } }
 
 struct obj_version;
@@ -142,10 +142,10 @@ using RGWMD5Etag = RGWEtag<MD5, CEPH_CRYPTO_MD5_DIGESTSIZE>;
 
 class RGWDataAccess
 {
-  rgw::sal::RGWStore *store;
+  rgw::sal::Store *store;
 
 public:
-  RGWDataAccess(rgw::sal::RGWStore *_store);
+  RGWDataAccess(rgw::sal::Store *_store);
 
   class Object;
   class Bucket;

--- a/src/rgw/rgw_tools.h
+++ b/src/rgw/rgw_tools.h
@@ -142,10 +142,10 @@ using RGWMD5Etag = RGWEtag<MD5, CEPH_CRYPTO_MD5_DIGESTSIZE>;
 
 class RGWDataAccess
 {
-  rgw::sal::Store *store;
+  rgw::sal::Store* store;
 
 public:
-  RGWDataAccess(rgw::sal::Store *_store);
+  RGWDataAccess(rgw::sal::Store* _store);
 
   class Object;
   class Bucket;

--- a/src/rgw/rgw_torrent.cc
+++ b/src/rgw/rgw_torrent.cc
@@ -37,7 +37,7 @@ seed::~seed()
   store = NULL;
 }
 
-void seed::init(struct req_state *p_req, rgw::sal::Store *p_store)
+void seed::init(struct req_state *p_req, rgw::sal::Store* p_store)
 {
   s = p_req;
   store = p_store;

--- a/src/rgw/rgw_torrent.cc
+++ b/src/rgw/rgw_torrent.cc
@@ -37,13 +37,13 @@ seed::~seed()
   store = NULL;
 }
 
-void seed::init(struct req_state *p_req, rgw::sal::RGWStore *p_store)
+void seed::init(struct req_state *p_req, rgw::sal::Store *p_store)
 {
   s = p_req;
   store = p_store;
 }
 
-int seed::get_torrent_file(rgw::sal::RGWObject* object,
+int seed::get_torrent_file(rgw::sal::Object* object,
                            uint64_t &total_len,
                            ceph::bufferlist &bl_data,
                            rgw_obj &obj)

--- a/src/rgw/rgw_torrent.h
+++ b/src/rgw/rgw_torrent.h
@@ -108,7 +108,7 @@ private:
   bufferlist bl;  // bufflist ready to send
 
   struct req_state *s{nullptr};
-  rgw::sal::Store *store{nullptr};
+  rgw::sal::Store* store{nullptr};
   SHA1 h;
 
   TorrentBencode dencode;
@@ -117,7 +117,7 @@ public:
   ~seed();
 
   int get_params();
-  void init(struct req_state *p_req, rgw::sal::Store *p_store);
+  void init(struct req_state *p_req, rgw::sal::Store* p_store);
   int get_torrent_file(rgw::sal::Object* object,
                        uint64_t &total_len,
                        ceph::bufferlist &bl_data,

--- a/src/rgw/rgw_torrent.h
+++ b/src/rgw/rgw_torrent.h
@@ -108,7 +108,7 @@ private:
   bufferlist bl;  // bufflist ready to send
 
   struct req_state *s{nullptr};
-  rgw::sal::RGWStore *store{nullptr};
+  rgw::sal::Store *store{nullptr};
   SHA1 h;
 
   TorrentBencode dencode;
@@ -117,8 +117,8 @@ public:
   ~seed();
 
   int get_params();
-  void init(struct req_state *p_req, rgw::sal::RGWStore *p_store);
-  int get_torrent_file(rgw::sal::RGWObject* object,
+  void init(struct req_state *p_req, rgw::sal::Store *p_store);
+  int get_torrent_file(rgw::sal::Object* object,
                        uint64_t &total_len,
                        ceph::bufferlist &bl_data,
                        rgw_obj &obj);

--- a/src/rgw/rgw_trim_bilog.cc
+++ b/src/rgw/rgw_trim_bilog.cc
@@ -238,7 +238,7 @@ void TrimComplete::Handler::handle(bufferlist::const_iterator& input,
 
 /// rados watcher for bucket trim notifications
 class BucketTrimWatcher : public librados::WatchCtx2 {
-  rgw::sal::RGWRadosStore *const store;
+  rgw::sal::RadosStore *const store;
   const rgw_raw_obj& obj;
   rgw_rados_ref ref;
   uint64_t handle{0};
@@ -247,7 +247,7 @@ class BucketTrimWatcher : public librados::WatchCtx2 {
   boost::container::flat_map<TrimNotifyType, HandlerPtr> handlers;
 
  public:
-  BucketTrimWatcher(rgw::sal::RGWRadosStore *store, const rgw_raw_obj& obj,
+  BucketTrimWatcher(rgw::sal::RadosStore *store, const rgw_raw_obj& obj,
                     TrimCounters::Server *counters)
     : store(store), obj(obj) {
     handlers.emplace(NotifyTrimCounters, new TrimCounters::Handler(counters));
@@ -381,12 +381,12 @@ int take_min_status(CephContext *cct, Iter first, Iter last,
 /// concurrent requests
 class BucketTrimShardCollectCR : public RGWShardCollectCR {
   static constexpr int MAX_CONCURRENT_SHARDS = 16;
-  rgw::sal::RGWRadosStore *const store;
+  rgw::sal::RadosStore *const store;
   const RGWBucketInfo& bucket_info;
   const std::vector<std::string>& markers; //< shard markers to trim
   size_t i{0}; //< index of current shard marker
  public:
-  BucketTrimShardCollectCR(rgw::sal::RGWRadosStore *store, const RGWBucketInfo& bucket_info,
+  BucketTrimShardCollectCR(rgw::sal::RadosStore *store, const RGWBucketInfo& bucket_info,
                            const std::vector<std::string>& markers)
     : RGWShardCollectCR(store->ctx(), MAX_CONCURRENT_SHARDS),
       store(store), bucket_info(bucket_info), markers(markers)
@@ -415,7 +415,7 @@ bool BucketTrimShardCollectCR::spawn_next()
 
 /// trim the bilog of all of the given bucket instance's shards
 class BucketTrimInstanceCR : public RGWCoroutine {
-  rgw::sal::RGWRadosStore *const store;
+  rgw::sal::RadosStore *const store;
   RGWHTTPManager *const http;
   BucketTrimObserver *const observer;
   std::string bucket_instance;
@@ -433,7 +433,7 @@ class BucketTrimInstanceCR : public RGWCoroutine {
   std::vector<std::string> min_markers; //< min marker per shard
 
  public:
-  BucketTrimInstanceCR(rgw::sal::RGWRadosStore *store, RGWHTTPManager *http,
+  BucketTrimInstanceCR(rgw::sal::RadosStore *store, RGWHTTPManager *http,
                        BucketTrimObserver *observer,
                        const std::string& bucket_instance,
                        const DoutPrefixProvider *dpp)
@@ -567,14 +567,14 @@ int BucketTrimInstanceCR::operate()
 
 /// trim each bucket instance while limiting the number of concurrent operations
 class BucketTrimInstanceCollectCR : public RGWShardCollectCR {
-  rgw::sal::RGWRadosStore *const store;
+  rgw::sal::RadosStore *const store;
   RGWHTTPManager *const http;
   BucketTrimObserver *const observer;
   std::vector<std::string>::const_iterator bucket;
   std::vector<std::string>::const_iterator end;
   const DoutPrefixProvider *dpp;
  public:
-  BucketTrimInstanceCollectCR(rgw::sal::RGWRadosStore *store, RGWHTTPManager *http,
+  BucketTrimInstanceCollectCR(rgw::sal::RadosStore *store, RGWHTTPManager *http,
                               BucketTrimObserver *observer,
                               const std::vector<std::string>& buckets,
                               int max_concurrent,
@@ -771,7 +771,7 @@ class MetadataListCR : public RGWSimpleCoroutine {
 };
 
 class BucketTrimCR : public RGWCoroutine {
-  rgw::sal::RGWRadosStore *const store;
+  rgw::sal::RadosStore *const store;
   RGWHTTPManager *const http;
   const BucketTrimConfig& config;
   BucketTrimObserver *const observer;
@@ -787,7 +787,7 @@ class BucketTrimCR : public RGWCoroutine {
 
   static const std::string section; //< metadata section for bucket instances
  public:
-  BucketTrimCR(rgw::sal::RGWRadosStore *store, RGWHTTPManager *http,
+  BucketTrimCR(rgw::sal::RadosStore *store, RGWHTTPManager *http,
                const BucketTrimConfig& config, BucketTrimObserver *observer,
                const rgw_raw_obj& obj, const DoutPrefixProvider *dpp)
     : RGWCoroutine(store->ctx()), store(store), http(http), config(config),
@@ -935,7 +935,7 @@ int BucketTrimCR::operate()
 }
 
 class BucketTrimPollCR : public RGWCoroutine {
-  rgw::sal::RGWRadosStore *const store;
+  rgw::sal::RadosStore *const store;
   RGWHTTPManager *const http;
   const BucketTrimConfig& config;
   BucketTrimObserver *const observer;
@@ -945,7 +945,7 @@ class BucketTrimPollCR : public RGWCoroutine {
   const DoutPrefixProvider *dpp;
 
  public:
-  BucketTrimPollCR(rgw::sal::RGWRadosStore *store, RGWHTTPManager *http,
+  BucketTrimPollCR(rgw::sal::RadosStore *store, RGWHTTPManager *http,
                    const BucketTrimConfig& config,
                    BucketTrimObserver *observer, const rgw_raw_obj& obj,
                    const DoutPrefixProvider *dpp)
@@ -1060,7 +1060,7 @@ void configure_bucket_trim(CephContext *cct, BucketTrimConfig& config)
 class BucketTrimManager::Impl : public TrimCounters::Server,
                                 public BucketTrimObserver {
  public:
-   rgw::sal::RGWRadosStore *const store;
+   rgw::sal::RadosStore *const store;
   const BucketTrimConfig config;
 
   const rgw_raw_obj status_obj;
@@ -1079,7 +1079,7 @@ class BucketTrimManager::Impl : public TrimCounters::Server,
   /// protect data shared between data sync, trim, and watch/notify threads
   std::mutex mutex;
 
-  Impl(rgw::sal::RGWRadosStore *store, const BucketTrimConfig& config)
+  Impl(rgw::sal::RadosStore *store, const BucketTrimConfig& config)
     : store(store), config(config),
       status_obj(store->get_zone()->get_params().log_pool, BucketTrimStatus::oid),
       counter(config.counter_size),
@@ -1117,7 +1117,7 @@ class BucketTrimManager::Impl : public TrimCounters::Server,
   }
 };
 
-BucketTrimManager::BucketTrimManager(rgw::sal::RGWRadosStore *store,
+BucketTrimManager::BucketTrimManager(rgw::sal::RadosStore *store,
                                      const BucketTrimConfig& config)
   : impl(new Impl(store, config))
 {

--- a/src/rgw/rgw_trim_bilog.cc
+++ b/src/rgw/rgw_trim_bilog.cc
@@ -238,7 +238,7 @@ void TrimComplete::Handler::handle(bufferlist::const_iterator& input,
 
 /// rados watcher for bucket trim notifications
 class BucketTrimWatcher : public librados::WatchCtx2 {
-  rgw::sal::RadosStore *const store;
+  rgw::sal::RadosStore* const store;
   const rgw_raw_obj& obj;
   rgw_rados_ref ref;
   uint64_t handle{0};
@@ -247,7 +247,7 @@ class BucketTrimWatcher : public librados::WatchCtx2 {
   boost::container::flat_map<TrimNotifyType, HandlerPtr> handlers;
 
  public:
-  BucketTrimWatcher(rgw::sal::RadosStore *store, const rgw_raw_obj& obj,
+  BucketTrimWatcher(rgw::sal::RadosStore* store, const rgw_raw_obj& obj,
                     TrimCounters::Server *counters)
     : store(store), obj(obj) {
     handlers.emplace(NotifyTrimCounters, new TrimCounters::Handler(counters));
@@ -381,12 +381,12 @@ int take_min_status(CephContext *cct, Iter first, Iter last,
 /// concurrent requests
 class BucketTrimShardCollectCR : public RGWShardCollectCR {
   static constexpr int MAX_CONCURRENT_SHARDS = 16;
-  rgw::sal::RadosStore *const store;
+  rgw::sal::RadosStore* const store;
   const RGWBucketInfo& bucket_info;
   const std::vector<std::string>& markers; //< shard markers to trim
   size_t i{0}; //< index of current shard marker
  public:
-  BucketTrimShardCollectCR(rgw::sal::RadosStore *store, const RGWBucketInfo& bucket_info,
+  BucketTrimShardCollectCR(rgw::sal::RadosStore* store, const RGWBucketInfo& bucket_info,
                            const std::vector<std::string>& markers)
     : RGWShardCollectCR(store->ctx(), MAX_CONCURRENT_SHARDS),
       store(store), bucket_info(bucket_info), markers(markers)
@@ -415,7 +415,7 @@ bool BucketTrimShardCollectCR::spawn_next()
 
 /// trim the bilog of all of the given bucket instance's shards
 class BucketTrimInstanceCR : public RGWCoroutine {
-  rgw::sal::RadosStore *const store;
+  rgw::sal::RadosStore* const store;
   RGWHTTPManager *const http;
   BucketTrimObserver *const observer;
   std::string bucket_instance;
@@ -433,7 +433,7 @@ class BucketTrimInstanceCR : public RGWCoroutine {
   std::vector<std::string> min_markers; //< min marker per shard
 
  public:
-  BucketTrimInstanceCR(rgw::sal::RadosStore *store, RGWHTTPManager *http,
+  BucketTrimInstanceCR(rgw::sal::RadosStore* store, RGWHTTPManager *http,
                        BucketTrimObserver *observer,
                        const std::string& bucket_instance,
                        const DoutPrefixProvider *dpp)
@@ -567,14 +567,14 @@ int BucketTrimInstanceCR::operate()
 
 /// trim each bucket instance while limiting the number of concurrent operations
 class BucketTrimInstanceCollectCR : public RGWShardCollectCR {
-  rgw::sal::RadosStore *const store;
+  rgw::sal::RadosStore* const store;
   RGWHTTPManager *const http;
   BucketTrimObserver *const observer;
   std::vector<std::string>::const_iterator bucket;
   std::vector<std::string>::const_iterator end;
   const DoutPrefixProvider *dpp;
  public:
-  BucketTrimInstanceCollectCR(rgw::sal::RadosStore *store, RGWHTTPManager *http,
+  BucketTrimInstanceCollectCR(rgw::sal::RadosStore* store, RGWHTTPManager *http,
                               BucketTrimObserver *observer,
                               const std::vector<std::string>& buckets,
                               int max_concurrent,
@@ -771,7 +771,7 @@ class MetadataListCR : public RGWSimpleCoroutine {
 };
 
 class BucketTrimCR : public RGWCoroutine {
-  rgw::sal::RadosStore *const store;
+  rgw::sal::RadosStore* const store;
   RGWHTTPManager *const http;
   const BucketTrimConfig& config;
   BucketTrimObserver *const observer;
@@ -787,7 +787,7 @@ class BucketTrimCR : public RGWCoroutine {
 
   static const std::string section; //< metadata section for bucket instances
  public:
-  BucketTrimCR(rgw::sal::RadosStore *store, RGWHTTPManager *http,
+  BucketTrimCR(rgw::sal::RadosStore* store, RGWHTTPManager *http,
                const BucketTrimConfig& config, BucketTrimObserver *observer,
                const rgw_raw_obj& obj, const DoutPrefixProvider *dpp)
     : RGWCoroutine(store->ctx()), store(store), http(http), config(config),
@@ -935,7 +935,7 @@ int BucketTrimCR::operate()
 }
 
 class BucketTrimPollCR : public RGWCoroutine {
-  rgw::sal::RadosStore *const store;
+  rgw::sal::RadosStore* const store;
   RGWHTTPManager *const http;
   const BucketTrimConfig& config;
   BucketTrimObserver *const observer;
@@ -945,7 +945,7 @@ class BucketTrimPollCR : public RGWCoroutine {
   const DoutPrefixProvider *dpp;
 
  public:
-  BucketTrimPollCR(rgw::sal::RadosStore *store, RGWHTTPManager *http,
+  BucketTrimPollCR(rgw::sal::RadosStore* store, RGWHTTPManager *http,
                    const BucketTrimConfig& config,
                    BucketTrimObserver *observer, const rgw_raw_obj& obj,
                    const DoutPrefixProvider *dpp)
@@ -1060,7 +1060,7 @@ void configure_bucket_trim(CephContext *cct, BucketTrimConfig& config)
 class BucketTrimManager::Impl : public TrimCounters::Server,
                                 public BucketTrimObserver {
  public:
-   rgw::sal::RadosStore *const store;
+   rgw::sal::RadosStore* const store;
   const BucketTrimConfig config;
 
   const rgw_raw_obj status_obj;
@@ -1079,7 +1079,7 @@ class BucketTrimManager::Impl : public TrimCounters::Server,
   /// protect data shared between data sync, trim, and watch/notify threads
   std::mutex mutex;
 
-  Impl(rgw::sal::RadosStore *store, const BucketTrimConfig& config)
+  Impl(rgw::sal::RadosStore* store, const BucketTrimConfig& config)
     : store(store), config(config),
       status_obj(store->get_zone()->get_params().log_pool, BucketTrimStatus::oid),
       counter(config.counter_size),
@@ -1117,7 +1117,7 @@ class BucketTrimManager::Impl : public TrimCounters::Server,
   }
 };
 
-BucketTrimManager::BucketTrimManager(rgw::sal::RadosStore *store,
+BucketTrimManager::BucketTrimManager(rgw::sal::RadosStore* store,
                                      const BucketTrimConfig& config)
   : impl(new Impl(store, config))
 {

--- a/src/rgw/rgw_trim_bilog.h
+++ b/src/rgw/rgw_trim_bilog.h
@@ -31,7 +31,7 @@ class RGWHTTPManager;
 namespace rgw {
 
 namespace sal {
-  class RGWRadosStore;
+  class RadosStore;
 }
 
 /// Interface to inform the trim process about which buckets are most active
@@ -74,7 +74,7 @@ class BucketTrimManager : public BucketChangeObserver, public DoutPrefixProvider
   class Impl;
   std::unique_ptr<Impl> impl;
  public:
-  BucketTrimManager(sal::RGWRadosStore *store, const BucketTrimConfig& config);
+  BucketTrimManager(sal::RadosStore *store, const BucketTrimConfig& config);
   ~BucketTrimManager();
 
   int init();

--- a/src/rgw/rgw_trim_datalog.cc
+++ b/src/rgw/rgw_trim_datalog.cc
@@ -26,14 +26,14 @@
 namespace {
 
 class DatalogTrimImplCR : public RGWSimpleCoroutine {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
   int shard;
   std::string marker;
   std::string* last_trim_marker;
 
  public:
-  DatalogTrimImplCR(rgw::sal::RGWRadosStore* store, int shard,
+  DatalogTrimImplCR(rgw::sal::RadosStore* store, int shard,
 		    const std::string& marker, std::string* last_trim_marker)
   : RGWSimpleCoroutine(store->ctx()), store(store), shard(shard),
     marker(marker), last_trim_marker(last_trim_marker) {
@@ -95,7 +95,7 @@ void take_min_markers(IterIn first, IterIn last, IterOut dest)
 
 class DataLogTrimCR : public RGWCoroutine {
   using TrimCR = DatalogTrimImplCR;
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   RGWHTTPManager *http;
   const int num_shards;
   const std::string& zone_id; //< my zone id
@@ -105,7 +105,7 @@ class DataLogTrimCR : public RGWCoroutine {
   int ret{0};
 
  public:
-  DataLogTrimCR(rgw::sal::RGWRadosStore *store, RGWHTTPManager *http,
+  DataLogTrimCR(rgw::sal::RadosStore *store, RGWHTTPManager *http,
                    int num_shards, std::vector<std::string>& last_trim)
     : RGWCoroutine(store->ctx()), store(store), http(http),
       num_shards(num_shards),
@@ -180,7 +180,7 @@ int DataLogTrimCR::operate()
   return 0;
 }
 
-RGWCoroutine* create_admin_data_log_trim_cr(rgw::sal::RGWRadosStore *store,
+RGWCoroutine* create_admin_data_log_trim_cr(rgw::sal::RadosStore *store,
                                             RGWHTTPManager *http,
                                             int num_shards,
                                             std::vector<std::string>& markers)
@@ -189,7 +189,7 @@ RGWCoroutine* create_admin_data_log_trim_cr(rgw::sal::RGWRadosStore *store,
 }
 
 class DataLogTrimPollCR : public RGWCoroutine {
-  rgw::sal::RGWRadosStore *store;
+  rgw::sal::RadosStore *store;
   RGWHTTPManager *http;
   const int num_shards;
   const utime_t interval; //< polling interval
@@ -198,7 +198,7 @@ class DataLogTrimPollCR : public RGWCoroutine {
   std::vector<std::string> last_trim; //< last trimmed marker per shard
 
  public:
-  DataLogTrimPollCR(rgw::sal::RGWRadosStore *store, RGWHTTPManager *http,
+  DataLogTrimPollCR(rgw::sal::RadosStore *store, RGWHTTPManager *http,
                     int num_shards, utime_t interval)
     : RGWCoroutine(store->ctx()), store(store), http(http),
       num_shards(num_shards), interval(interval),
@@ -241,7 +241,7 @@ int DataLogTrimPollCR::operate()
   return 0;
 }
 
-RGWCoroutine* create_data_log_trim_cr(rgw::sal::RGWRadosStore *store,
+RGWCoroutine* create_data_log_trim_cr(rgw::sal::RadosStore *store,
                                       RGWHTTPManager *http,
                                       int num_shards, utime_t interval)
 {

--- a/src/rgw/rgw_trim_datalog.cc
+++ b/src/rgw/rgw_trim_datalog.cc
@@ -26,7 +26,7 @@
 namespace {
 
 class DatalogTrimImplCR : public RGWSimpleCoroutine {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
   int shard;
   std::string marker;
@@ -95,7 +95,7 @@ void take_min_markers(IterIn first, IterIn last, IterOut dest)
 
 class DataLogTrimCR : public RGWCoroutine {
   using TrimCR = DatalogTrimImplCR;
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   RGWHTTPManager *http;
   const int num_shards;
   const std::string& zone_id; //< my zone id
@@ -105,7 +105,7 @@ class DataLogTrimCR : public RGWCoroutine {
   int ret{0};
 
  public:
-  DataLogTrimCR(rgw::sal::RadosStore *store, RGWHTTPManager *http,
+  DataLogTrimCR(rgw::sal::RadosStore* store, RGWHTTPManager *http,
                    int num_shards, std::vector<std::string>& last_trim)
     : RGWCoroutine(store->ctx()), store(store), http(http),
       num_shards(num_shards),
@@ -180,7 +180,7 @@ int DataLogTrimCR::operate()
   return 0;
 }
 
-RGWCoroutine* create_admin_data_log_trim_cr(rgw::sal::RadosStore *store,
+RGWCoroutine* create_admin_data_log_trim_cr(rgw::sal::RadosStore* store,
                                             RGWHTTPManager *http,
                                             int num_shards,
                                             std::vector<std::string>& markers)
@@ -189,7 +189,7 @@ RGWCoroutine* create_admin_data_log_trim_cr(rgw::sal::RadosStore *store,
 }
 
 class DataLogTrimPollCR : public RGWCoroutine {
-  rgw::sal::RadosStore *store;
+  rgw::sal::RadosStore* store;
   RGWHTTPManager *http;
   const int num_shards;
   const utime_t interval; //< polling interval
@@ -198,7 +198,7 @@ class DataLogTrimPollCR : public RGWCoroutine {
   std::vector<std::string> last_trim; //< last trimmed marker per shard
 
  public:
-  DataLogTrimPollCR(rgw::sal::RadosStore *store, RGWHTTPManager *http,
+  DataLogTrimPollCR(rgw::sal::RadosStore* store, RGWHTTPManager *http,
                     int num_shards, utime_t interval)
     : RGWCoroutine(store->ctx()), store(store), http(http),
       num_shards(num_shards), interval(interval),
@@ -241,7 +241,7 @@ int DataLogTrimPollCR::operate()
   return 0;
 }
 
-RGWCoroutine* create_data_log_trim_cr(rgw::sal::RadosStore *store,
+RGWCoroutine* create_data_log_trim_cr(rgw::sal::RadosStore* store,
                                       RGWHTTPManager *http,
                                       int num_shards, utime_t interval)
 {

--- a/src/rgw/rgw_trim_datalog.h
+++ b/src/rgw/rgw_trim_datalog.h
@@ -11,16 +11,16 @@ class RGWRados;
 class RGWHTTPManager;
 class utime_t;
 namespace rgw { namespace sal {
-  class RGWRadosStore;
+  class RadosStore;
 } }
 
 // DataLogTrimCR factory function
-extern RGWCoroutine* create_data_log_trim_cr(rgw::sal::RGWRadosStore *store,
+extern RGWCoroutine* create_data_log_trim_cr(rgw::sal::RadosStore *store,
                                              RGWHTTPManager *http,
                                              int num_shards, utime_t interval);
 
 // factory function for datalog trim via radosgw-admin
-RGWCoroutine* create_admin_data_log_trim_cr(rgw::sal::RGWRadosStore *store,
+RGWCoroutine* create_admin_data_log_trim_cr(rgw::sal::RadosStore *store,
                                             RGWHTTPManager *http,
                                             int num_shards,
                                             std::vector<std::string>& markers);

--- a/src/rgw/rgw_trim_datalog.h
+++ b/src/rgw/rgw_trim_datalog.h
@@ -15,12 +15,12 @@ namespace rgw { namespace sal {
 } }
 
 // DataLogTrimCR factory function
-extern RGWCoroutine* create_data_log_trim_cr(rgw::sal::RadosStore *store,
+extern RGWCoroutine* create_data_log_trim_cr(rgw::sal::RadosStore* store,
                                              RGWHTTPManager *http,
                                              int num_shards, utime_t interval);
 
 // factory function for datalog trim via radosgw-admin
-RGWCoroutine* create_admin_data_log_trim_cr(rgw::sal::RadosStore *store,
+RGWCoroutine* create_admin_data_log_trim_cr(rgw::sal::RadosStore* store,
                                             RGWHTTPManager *http,
                                             int num_shards,
                                             std::vector<std::string>& markers);

--- a/src/rgw/rgw_trim_mdlog.cc
+++ b/src/rgw/rgw_trim_mdlog.cc
@@ -22,7 +22,7 @@
 
 /// purge all log shards for the given mdlog
 class PurgeLogShardsCR : public RGWShardCollectCR {
-  rgw::sal::RGWRadosStore *const store;
+  rgw::sal::RadosStore *const store;
   const RGWMetadataLog* mdlog;
   const int num_shards;
   rgw_raw_obj obj;
@@ -31,7 +31,7 @@ class PurgeLogShardsCR : public RGWShardCollectCR {
   static constexpr int max_concurrent = 16;
 
  public:
-  PurgeLogShardsCR(rgw::sal::RGWRadosStore *store, const RGWMetadataLog* mdlog,
+  PurgeLogShardsCR(rgw::sal::RadosStore *store, const RGWMetadataLog* mdlog,
                    const rgw_pool& pool, int num_shards)
     : RGWShardCollectCR(store->ctx(), max_concurrent),
       store(store), mdlog(mdlog), num_shards(num_shards), obj(pool, "")
@@ -55,7 +55,7 @@ class PurgePeriodLogsCR : public RGWCoroutine {
     RGWSI_Zone *zone;
     RGWSI_MDLog *mdlog;
   } svc;
-  rgw::sal::RGWRadosStore *const store;
+  rgw::sal::RadosStore *const store;
   RGWMetadataManager *const metadata;
   RGWObjVersionTracker objv;
   Cursor cursor;
@@ -63,7 +63,7 @@ class PurgePeriodLogsCR : public RGWCoroutine {
   epoch_t *last_trim_epoch; //< update last trim on success
 
  public:
-  PurgePeriodLogsCR(rgw::sal::RGWRadosStore *store, epoch_t realm_epoch, epoch_t *last_trim)
+  PurgePeriodLogsCR(rgw::sal::RadosStore *store, epoch_t realm_epoch, epoch_t *last_trim)
     : RGWCoroutine(store->ctx()), store(store), metadata(store->ctl()->meta.mgr),
       realm_epoch(realm_epoch), last_trim_epoch(last_trim) {
     svc.zone = store->svc()->zone;
@@ -136,7 +136,7 @@ using connection_map = std::map<std::string, std::unique_ptr<RGWRESTConn>>;
 
 /// construct a RGWRESTConn for each zone in the realm
 template <typename Zonegroups>
-connection_map make_peer_connections(rgw::sal::RGWRadosStore *store,
+connection_map make_peer_connections(rgw::sal::RadosStore *store,
                                      const Zonegroups& zonegroups)
 {
   connection_map connections;
@@ -202,14 +202,14 @@ int take_min_status(CephContext *cct, Iter first, Iter last,
 
 struct TrimEnv {
   const DoutPrefixProvider *dpp;
-  rgw::sal::RGWRadosStore *const store;
+  rgw::sal::RadosStore *const store;
   RGWHTTPManager *const http;
   int num_shards;
   const rgw_zone_id& zone;
   Cursor current; //< cursor to current period
   epoch_t last_trim_epoch{0}; //< epoch of last mdlog that was purged
 
-  TrimEnv(const DoutPrefixProvider *dpp, rgw::sal::RGWRadosStore *store, RGWHTTPManager *http, int num_shards)
+  TrimEnv(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *store, RGWHTTPManager *http, int num_shards)
     : dpp(dpp), store(store), http(http), num_shards(num_shards),
       zone(store->svc()->zone->zone_id()),
       current(store->svc()->mdlog->get_period_history()->get_current())
@@ -222,7 +222,7 @@ struct MasterTrimEnv : public TrimEnv {
   /// last trim marker for each shard, only applies to current period's mdlog
   std::vector<std::string> last_trim_markers;
 
-  MasterTrimEnv(const DoutPrefixProvider *dpp, rgw::sal::RGWRadosStore *store, RGWHTTPManager *http, int num_shards)
+  MasterTrimEnv(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *store, RGWHTTPManager *http, int num_shards)
     : TrimEnv(dpp, store, http, num_shards),
       last_trim_markers(num_shards)
   {
@@ -237,7 +237,7 @@ struct PeerTrimEnv : public TrimEnv {
   /// last trim timestamp for each shard, only applies to current period's mdlog
   std::vector<ceph::real_time> last_trim_timestamps;
 
-  PeerTrimEnv(const DoutPrefixProvider *dpp, rgw::sal::RGWRadosStore *store, RGWHTTPManager *http, int num_shards)
+  PeerTrimEnv(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *store, RGWHTTPManager *http, int num_shards)
     : TrimEnv(dpp, store, http, num_shards),
       last_trim_timestamps(num_shards)
   {}
@@ -600,7 +600,7 @@ int MetaPeerTrimCR::operate()
 }
 
 class MetaTrimPollCR : public RGWCoroutine {
-  rgw::sal::RGWRadosStore *const store;
+  rgw::sal::RadosStore *const store;
   const utime_t interval; //< polling interval
   const rgw_raw_obj obj;
   const std::string name{"meta_trim"}; //< lock name
@@ -611,7 +611,7 @@ class MetaTrimPollCR : public RGWCoroutine {
   virtual RGWCoroutine* alloc_cr() = 0;
 
  public:
-  MetaTrimPollCR(rgw::sal::RGWRadosStore *store, utime_t interval)
+  MetaTrimPollCR(rgw::sal::RadosStore *store, utime_t interval)
     : RGWCoroutine(store->ctx()), store(store), interval(interval),
       obj(store->svc()->zone->get_zone_params().log_pool, RGWMetadataLogHistory::oid),
       cookie(RGWSimpleRadosLockCR::gen_random_cookie(cct))
@@ -656,7 +656,7 @@ class MetaMasterTrimPollCR : public MetaTrimPollCR  {
     return new MetaMasterTrimCR(env);
   }
  public:
-  MetaMasterTrimPollCR(const DoutPrefixProvider *dpp, rgw::sal::RGWRadosStore *store, RGWHTTPManager *http,
+  MetaMasterTrimPollCR(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *store, RGWHTTPManager *http,
                        int num_shards, utime_t interval)
     : MetaTrimPollCR(store, interval),
       env(dpp, store, http, num_shards)
@@ -669,14 +669,14 @@ class MetaPeerTrimPollCR : public MetaTrimPollCR {
     return new MetaPeerTrimCR(env);
   }
  public:
-  MetaPeerTrimPollCR(const DoutPrefixProvider *dpp, rgw::sal::RGWRadosStore *store, RGWHTTPManager *http,
+  MetaPeerTrimPollCR(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *store, RGWHTTPManager *http,
                      int num_shards, utime_t interval)
     : MetaTrimPollCR(store, interval),
       env(dpp, store, http, num_shards)
   {}
 };
 
-RGWCoroutine* create_meta_log_trim_cr(const DoutPrefixProvider *dpp, rgw::sal::RGWRadosStore *store, RGWHTTPManager *http,
+RGWCoroutine* create_meta_log_trim_cr(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *store, RGWHTTPManager *http,
                                       int num_shards, utime_t interval)
 {
   if (store->svc()->zone->is_meta_master()) {
@@ -687,20 +687,20 @@ RGWCoroutine* create_meta_log_trim_cr(const DoutPrefixProvider *dpp, rgw::sal::R
 
 
 struct MetaMasterAdminTrimCR : private MasterTrimEnv, public MetaMasterTrimCR {
-  MetaMasterAdminTrimCR(const DoutPrefixProvider *dpp, rgw::sal::RGWRadosStore *store, RGWHTTPManager *http, int num_shards)
+  MetaMasterAdminTrimCR(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *store, RGWHTTPManager *http, int num_shards)
     : MasterTrimEnv(dpp, store, http, num_shards),
       MetaMasterTrimCR(*static_cast<MasterTrimEnv*>(this))
   {}
 };
 
 struct MetaPeerAdminTrimCR : private PeerTrimEnv, public MetaPeerTrimCR {
-  MetaPeerAdminTrimCR(const DoutPrefixProvider *dpp, rgw::sal::RGWRadosStore *store, RGWHTTPManager *http, int num_shards)
+  MetaPeerAdminTrimCR(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *store, RGWHTTPManager *http, int num_shards)
     : PeerTrimEnv(dpp, store, http, num_shards),
       MetaPeerTrimCR(*static_cast<PeerTrimEnv*>(this))
   {}
 };
 
-RGWCoroutine* create_admin_meta_log_trim_cr(const DoutPrefixProvider *dpp, rgw::sal::RGWRadosStore *store,
+RGWCoroutine* create_admin_meta_log_trim_cr(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *store,
                                             RGWHTTPManager *http,
                                             int num_shards)
 {

--- a/src/rgw/rgw_trim_mdlog.cc
+++ b/src/rgw/rgw_trim_mdlog.cc
@@ -22,7 +22,7 @@
 
 /// purge all log shards for the given mdlog
 class PurgeLogShardsCR : public RGWShardCollectCR {
-  rgw::sal::RadosStore *const store;
+  rgw::sal::RadosStore* const store;
   const RGWMetadataLog* mdlog;
   const int num_shards;
   rgw_raw_obj obj;
@@ -31,7 +31,7 @@ class PurgeLogShardsCR : public RGWShardCollectCR {
   static constexpr int max_concurrent = 16;
 
  public:
-  PurgeLogShardsCR(rgw::sal::RadosStore *store, const RGWMetadataLog* mdlog,
+  PurgeLogShardsCR(rgw::sal::RadosStore* store, const RGWMetadataLog* mdlog,
                    const rgw_pool& pool, int num_shards)
     : RGWShardCollectCR(store->ctx(), max_concurrent),
       store(store), mdlog(mdlog), num_shards(num_shards), obj(pool, "")
@@ -55,7 +55,7 @@ class PurgePeriodLogsCR : public RGWCoroutine {
     RGWSI_Zone *zone;
     RGWSI_MDLog *mdlog;
   } svc;
-  rgw::sal::RadosStore *const store;
+  rgw::sal::RadosStore* const store;
   RGWMetadataManager *const metadata;
   RGWObjVersionTracker objv;
   Cursor cursor;
@@ -63,7 +63,7 @@ class PurgePeriodLogsCR : public RGWCoroutine {
   epoch_t *last_trim_epoch; //< update last trim on success
 
  public:
-  PurgePeriodLogsCR(rgw::sal::RadosStore *store, epoch_t realm_epoch, epoch_t *last_trim)
+  PurgePeriodLogsCR(rgw::sal::RadosStore* store, epoch_t realm_epoch, epoch_t *last_trim)
     : RGWCoroutine(store->ctx()), store(store), metadata(store->ctl()->meta.mgr),
       realm_epoch(realm_epoch), last_trim_epoch(last_trim) {
     svc.zone = store->svc()->zone;
@@ -136,7 +136,7 @@ using connection_map = std::map<std::string, std::unique_ptr<RGWRESTConn>>;
 
 /// construct a RGWRESTConn for each zone in the realm
 template <typename Zonegroups>
-connection_map make_peer_connections(rgw::sal::RadosStore *store,
+connection_map make_peer_connections(rgw::sal::RadosStore* store,
                                      const Zonegroups& zonegroups)
 {
   connection_map connections;
@@ -202,14 +202,14 @@ int take_min_status(CephContext *cct, Iter first, Iter last,
 
 struct TrimEnv {
   const DoutPrefixProvider *dpp;
-  rgw::sal::RadosStore *const store;
+  rgw::sal::RadosStore* const store;
   RGWHTTPManager *const http;
   int num_shards;
   const rgw_zone_id& zone;
   Cursor current; //< cursor to current period
   epoch_t last_trim_epoch{0}; //< epoch of last mdlog that was purged
 
-  TrimEnv(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *store, RGWHTTPManager *http, int num_shards)
+  TrimEnv(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store, RGWHTTPManager *http, int num_shards)
     : dpp(dpp), store(store), http(http), num_shards(num_shards),
       zone(store->svc()->zone->zone_id()),
       current(store->svc()->mdlog->get_period_history()->get_current())
@@ -222,7 +222,7 @@ struct MasterTrimEnv : public TrimEnv {
   /// last trim marker for each shard, only applies to current period's mdlog
   std::vector<std::string> last_trim_markers;
 
-  MasterTrimEnv(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *store, RGWHTTPManager *http, int num_shards)
+  MasterTrimEnv(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store, RGWHTTPManager *http, int num_shards)
     : TrimEnv(dpp, store, http, num_shards),
       last_trim_markers(num_shards)
   {
@@ -237,7 +237,7 @@ struct PeerTrimEnv : public TrimEnv {
   /// last trim timestamp for each shard, only applies to current period's mdlog
   std::vector<ceph::real_time> last_trim_timestamps;
 
-  PeerTrimEnv(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *store, RGWHTTPManager *http, int num_shards)
+  PeerTrimEnv(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store, RGWHTTPManager *http, int num_shards)
     : TrimEnv(dpp, store, http, num_shards),
       last_trim_timestamps(num_shards)
   {}
@@ -600,7 +600,7 @@ int MetaPeerTrimCR::operate()
 }
 
 class MetaTrimPollCR : public RGWCoroutine {
-  rgw::sal::RadosStore *const store;
+  rgw::sal::RadosStore* const store;
   const utime_t interval; //< polling interval
   const rgw_raw_obj obj;
   const std::string name{"meta_trim"}; //< lock name
@@ -611,7 +611,7 @@ class MetaTrimPollCR : public RGWCoroutine {
   virtual RGWCoroutine* alloc_cr() = 0;
 
  public:
-  MetaTrimPollCR(rgw::sal::RadosStore *store, utime_t interval)
+  MetaTrimPollCR(rgw::sal::RadosStore* store, utime_t interval)
     : RGWCoroutine(store->ctx()), store(store), interval(interval),
       obj(store->svc()->zone->get_zone_params().log_pool, RGWMetadataLogHistory::oid),
       cookie(RGWSimpleRadosLockCR::gen_random_cookie(cct))
@@ -656,7 +656,7 @@ class MetaMasterTrimPollCR : public MetaTrimPollCR  {
     return new MetaMasterTrimCR(env);
   }
  public:
-  MetaMasterTrimPollCR(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *store, RGWHTTPManager *http,
+  MetaMasterTrimPollCR(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store, RGWHTTPManager *http,
                        int num_shards, utime_t interval)
     : MetaTrimPollCR(store, interval),
       env(dpp, store, http, num_shards)
@@ -669,14 +669,14 @@ class MetaPeerTrimPollCR : public MetaTrimPollCR {
     return new MetaPeerTrimCR(env);
   }
  public:
-  MetaPeerTrimPollCR(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *store, RGWHTTPManager *http,
+  MetaPeerTrimPollCR(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store, RGWHTTPManager *http,
                      int num_shards, utime_t interval)
     : MetaTrimPollCR(store, interval),
       env(dpp, store, http, num_shards)
   {}
 };
 
-RGWCoroutine* create_meta_log_trim_cr(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *store, RGWHTTPManager *http,
+RGWCoroutine* create_meta_log_trim_cr(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store, RGWHTTPManager *http,
                                       int num_shards, utime_t interval)
 {
   if (store->svc()->zone->is_meta_master()) {
@@ -687,20 +687,20 @@ RGWCoroutine* create_meta_log_trim_cr(const DoutPrefixProvider *dpp, rgw::sal::R
 
 
 struct MetaMasterAdminTrimCR : private MasterTrimEnv, public MetaMasterTrimCR {
-  MetaMasterAdminTrimCR(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *store, RGWHTTPManager *http, int num_shards)
+  MetaMasterAdminTrimCR(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store, RGWHTTPManager *http, int num_shards)
     : MasterTrimEnv(dpp, store, http, num_shards),
       MetaMasterTrimCR(*static_cast<MasterTrimEnv*>(this))
   {}
 };
 
 struct MetaPeerAdminTrimCR : private PeerTrimEnv, public MetaPeerTrimCR {
-  MetaPeerAdminTrimCR(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *store, RGWHTTPManager *http, int num_shards)
+  MetaPeerAdminTrimCR(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store, RGWHTTPManager *http, int num_shards)
     : PeerTrimEnv(dpp, store, http, num_shards),
       MetaPeerTrimCR(*static_cast<PeerTrimEnv*>(this))
   {}
 };
 
-RGWCoroutine* create_admin_meta_log_trim_cr(const DoutPrefixProvider *dpp, rgw::sal::RadosStore *store,
+RGWCoroutine* create_admin_meta_log_trim_cr(const DoutPrefixProvider *dpp, rgw::sal::RadosStore* store,
                                             RGWHTTPManager *http,
                                             int num_shards)
 {

--- a/src/rgw/rgw_trim_mdlog.h
+++ b/src/rgw/rgw_trim_mdlog.h
@@ -9,17 +9,17 @@ class RGWRados;
 class RGWHTTPManager;
 class utime_t;
 namespace rgw { namespace sal {
-  class RGWRadosStore;
+  class RadosStore;
 } }
 
 // MetaLogTrimCR factory function
 RGWCoroutine* create_meta_log_trim_cr(const DoutPrefixProvider *dpp,
-                                      rgw::sal::RGWRadosStore *store,
+                                      rgw::sal::RadosStore *store,
                                       RGWHTTPManager *http,
                                       int num_shards, utime_t interval);
 
 // factory function for mdlog trim via radosgw-admin
 RGWCoroutine* create_admin_meta_log_trim_cr(const DoutPrefixProvider *dpp,
-                                            rgw::sal::RGWRadosStore *store,
+                                            rgw::sal::RadosStore *store,
                                             RGWHTTPManager *http,
                                             int num_shards);

--- a/src/rgw/rgw_trim_mdlog.h
+++ b/src/rgw/rgw_trim_mdlog.h
@@ -14,12 +14,12 @@ namespace rgw { namespace sal {
 
 // MetaLogTrimCR factory function
 RGWCoroutine* create_meta_log_trim_cr(const DoutPrefixProvider *dpp,
-                                      rgw::sal::RadosStore *store,
+                                      rgw::sal::RadosStore* store,
                                       RGWHTTPManager *http,
                                       int num_shards, utime_t interval);
 
 // factory function for mdlog trim via radosgw-admin
 RGWCoroutine* create_admin_meta_log_trim_cr(const DoutPrefixProvider *dpp,
-                                            rgw::sal::RadosStore *store,
+                                            rgw::sal::RadosStore* store,
                                             RGWHTTPManager *http,
                                             int num_shards);

--- a/src/rgw/rgw_usage.cc
+++ b/src/rgw/rgw_usage.cc
@@ -30,8 +30,8 @@ static void dump_usage_categories_info(Formatter *formatter, const rgw_usage_log
   formatter->close_section(); // categories
 }
 
-int RGWUsage::show(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* store,
-		  rgw::sal::RGWUser* user , rgw::sal::RGWBucket* bucket,
+int RGWUsage::show(const DoutPrefixProvider *dpp, rgw::sal::Store* store,
+		  rgw::sal::User* user , rgw::sal::Bucket* bucket,
 		   uint64_t start_epoch, uint64_t end_epoch, bool show_log_entries,
 		   bool show_log_sum,
 		   map<string, bool> *categories, RGWFormatterFlusher& flusher)
@@ -152,8 +152,8 @@ int RGWUsage::show(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* store,
   return 0;
 }
 
-int RGWUsage::trim(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* store,
-		   rgw::sal::RGWUser* user , rgw::sal::RGWBucket* bucket,
+int RGWUsage::trim(const DoutPrefixProvider *dpp, rgw::sal::Store* store,
+		   rgw::sal::User* user , rgw::sal::Bucket* bucket,
 		   uint64_t start_epoch, uint64_t end_epoch)
 {
   if (bucket) {
@@ -165,7 +165,7 @@ int RGWUsage::trim(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* store,
   }
 }
 
-int RGWUsage::clear(rgw::sal::RGWStore* store)
+int RGWUsage::clear(rgw::sal::Store* store)
 {
   return store->clear_usage();
 }

--- a/src/rgw/rgw_usage.h
+++ b/src/rgw/rgw_usage.h
@@ -11,23 +11,23 @@
 #include "rgw_formats.h"
 #include "rgw_user.h"
 
-namespace rgw { namespace sal { class RGWStore; } }
+namespace rgw { namespace sal { class Store; } }
 
 
 class RGWUsage
 {
 public:
-  static int show(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* store,
-		  rgw::sal::RGWUser* user , rgw::sal::RGWBucket* bucket,
+  static int show(const DoutPrefixProvider *dpp, rgw::sal::Store* store,
+		  rgw::sal::User* user , rgw::sal::Bucket* bucket,
 		  uint64_t start_epoch, uint64_t end_epoch, bool show_log_entries,
 		  bool show_log_sum,
 		  std::map<std::string, bool> *categories, RGWFormatterFlusher& flusher);
 
-  static int trim(const DoutPrefixProvider *dpp, rgw::sal::RGWStore *store,
-		  rgw::sal::RGWUser* user , rgw::sal::RGWBucket* bucket,
+  static int trim(const DoutPrefixProvider *dpp, rgw::sal::Store *store,
+		  rgw::sal::User* user , rgw::sal::Bucket* bucket,
 		  uint64_t start_epoch, uint64_t end_epoch);
 
-  static int clear(rgw::sal::RGWStore *store);
+  static int clear(rgw::sal::Store *store);
 };
 
 

--- a/src/rgw/rgw_usage.h
+++ b/src/rgw/rgw_usage.h
@@ -23,11 +23,11 @@ public:
 		  bool show_log_sum,
 		  std::map<std::string, bool> *categories, RGWFormatterFlusher& flusher);
 
-  static int trim(const DoutPrefixProvider *dpp, rgw::sal::Store *store,
+  static int trim(const DoutPrefixProvider *dpp, rgw::sal::Store* store,
 		  rgw::sal::User* user , rgw::sal::Bucket* bucket,
 		  uint64_t start_epoch, uint64_t end_epoch);
 
-  static int clear(rgw::sal::Store *store);
+  static int clear(rgw::sal::Store* store);
 };
 
 

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -95,7 +95,7 @@ int rgw_user_sync_all_stats(const DoutPrefixProvider *dpp, rgw::sal::Store* stor
 }
 
 int rgw_user_get_all_buckets_stats(const DoutPrefixProvider *dpp,
-				   rgw::sal::Store *store,
+				   rgw::sal::Store* store,
 				   rgw::sal::User* user,
 				   map<string, cls_user_bucket_entry>& buckets_usage_map,
 				   optional_yield y)
@@ -1420,7 +1420,7 @@ RGWUser::RGWUser() : caps(this), keys(this), subusers(this)
   init_default();
 }
 
-int RGWUser::init(const DoutPrefixProvider *dpp, rgw::sal::Store *storage,
+int RGWUser::init(const DoutPrefixProvider *dpp, rgw::sal::Store* storage,
 		  RGWUserAdminOpState& op_state, optional_yield y)
 {
   init_default();
@@ -1444,7 +1444,7 @@ void RGWUser::init_default()
   clear_populated();
 }
 
-int RGWUser::init_storage(rgw::sal::Store *storage)
+int RGWUser::init_storage(rgw::sal::Store* storage)
 {
   if (!storage) {
     return -EINVAL;
@@ -2243,7 +2243,7 @@ int RGWUser::list(RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher)
   return 0;
 }
 
-int RGWUserAdminOp_User::list(rgw::sal::Store *store, RGWUserAdminOpState& op_state,
+int RGWUserAdminOp_User::list(rgw::sal::Store* store, RGWUserAdminOpState& op_state,
                   RGWFormatterFlusher& flusher)
 {
   RGWUser user;
@@ -2260,7 +2260,7 @@ int RGWUserAdminOp_User::list(rgw::sal::Store *store, RGWUserAdminOpState& op_st
 }
 
 int RGWUserAdminOp_User::info(const DoutPrefixProvider *dpp,
-			      rgw::sal::Store *store, RGWUserAdminOpState& op_state,
+			      rgw::sal::Store* store, RGWUserAdminOpState& op_state,
 			      RGWFormatterFlusher& flusher,
 			      optional_yield y)
 {
@@ -2312,7 +2312,7 @@ int RGWUserAdminOp_User::info(const DoutPrefixProvider *dpp,
 }
 
 int RGWUserAdminOp_User::create(const DoutPrefixProvider *dpp,
-				rgw::sal::Store *store,
+				rgw::sal::Store* store,
 				RGWUserAdminOpState& op_state,
 				RGWFormatterFlusher& flusher, optional_yield y)
 {
@@ -2346,7 +2346,7 @@ int RGWUserAdminOp_User::create(const DoutPrefixProvider *dpp,
 }
 
 int RGWUserAdminOp_User::modify(const DoutPrefixProvider *dpp,
-				rgw::sal::Store *store,
+				rgw::sal::Store* store,
 				RGWUserAdminOpState& op_state,
 				RGWFormatterFlusher& flusher, optional_yield y)
 {
@@ -2379,7 +2379,7 @@ int RGWUserAdminOp_User::modify(const DoutPrefixProvider *dpp,
 }
 
 int RGWUserAdminOp_User::remove(const DoutPrefixProvider *dpp,
-				rgw::sal::Store *store, RGWUserAdminOpState& op_state,
+				rgw::sal::Store* store, RGWUserAdminOpState& op_state,
 				RGWFormatterFlusher& flusher, optional_yield y)
 {
   RGWUserInfo info;
@@ -2397,7 +2397,7 @@ int RGWUserAdminOp_User::remove(const DoutPrefixProvider *dpp,
 }
 
 int RGWUserAdminOp_Subuser::create(const DoutPrefixProvider *dpp,
-				   rgw::sal::Store *store,
+				   rgw::sal::Store* store,
 				   RGWUserAdminOpState& op_state,
 				   RGWFormatterFlusher& flusher,
 				   optional_yield y)
@@ -2432,7 +2432,7 @@ int RGWUserAdminOp_Subuser::create(const DoutPrefixProvider *dpp,
 }
 
 int RGWUserAdminOp_Subuser::modify(const DoutPrefixProvider *dpp,
-				   rgw::sal::Store *store, RGWUserAdminOpState& op_state,
+				   rgw::sal::Store* store, RGWUserAdminOpState& op_state,
 				   RGWFormatterFlusher& flusher, optional_yield y)
 {
   RGWUserInfo info;
@@ -2465,7 +2465,7 @@ int RGWUserAdminOp_Subuser::modify(const DoutPrefixProvider *dpp,
 }
 
 int RGWUserAdminOp_Subuser::remove(const DoutPrefixProvider *dpp,
-				   rgw::sal::Store *store,
+				   rgw::sal::Store* store,
 				   RGWUserAdminOpState& op_state,
 				   RGWFormatterFlusher& flusher,
 				   optional_yield y)
@@ -2488,7 +2488,7 @@ int RGWUserAdminOp_Subuser::remove(const DoutPrefixProvider *dpp,
 }
 
 int RGWUserAdminOp_Key::create(const DoutPrefixProvider *dpp,
-			       rgw::sal::Store *store, RGWUserAdminOpState& op_state,
+			       rgw::sal::Store* store, RGWUserAdminOpState& op_state,
 			       RGWFormatterFlusher& flusher,
 			       optional_yield y)
 {
@@ -2529,7 +2529,7 @@ int RGWUserAdminOp_Key::create(const DoutPrefixProvider *dpp,
 }
 
 int RGWUserAdminOp_Key::remove(const DoutPrefixProvider *dpp,
-			       rgw::sal::Store *store,
+			       rgw::sal::Store* store,
 			       RGWUserAdminOpState& op_state,
 			       RGWFormatterFlusher& flusher,
 			       optional_yield y)
@@ -2552,7 +2552,7 @@ int RGWUserAdminOp_Key::remove(const DoutPrefixProvider *dpp,
 }
 
 int RGWUserAdminOp_Caps::add(const DoutPrefixProvider *dpp,
-			     rgw::sal::Store *store,
+			     rgw::sal::Store* store,
 			     RGWUserAdminOpState& op_state,
 			     RGWFormatterFlusher& flusher, optional_yield y)
 {
@@ -2587,7 +2587,7 @@ int RGWUserAdminOp_Caps::add(const DoutPrefixProvider *dpp,
 
 
 int RGWUserAdminOp_Caps::remove(const DoutPrefixProvider *dpp,
-				rgw::sal::Store *store,
+				rgw::sal::Store* store,
 				RGWUserAdminOpState& op_state,
 				RGWFormatterFlusher& flusher, optional_yield y)
 {

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -46,10 +46,10 @@ void rgw_get_anon_user(RGWUserInfo& info)
   info.access_keys.clear();
 }
 
-int rgw_user_sync_all_stats(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* store,
-			    rgw::sal::RGWUser* user, optional_yield y)
+int rgw_user_sync_all_stats(const DoutPrefixProvider *dpp, rgw::sal::Store* store,
+			    rgw::sal::User* user, optional_yield y)
 {
-  rgw::sal::RGWBucketList user_buckets;
+  rgw::sal::BucketList user_buckets;
 
   CephContext *cct = store->ctx();
   size_t max_entries = cct->_conf->rgw_list_buckets_max_chunk;
@@ -95,8 +95,8 @@ int rgw_user_sync_all_stats(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* s
 }
 
 int rgw_user_get_all_buckets_stats(const DoutPrefixProvider *dpp,
-				   rgw::sal::RGWStore *store,
-				   rgw::sal::RGWUser* user,
+				   rgw::sal::Store *store,
+				   rgw::sal::User* user,
 				   map<string, cls_user_bucket_entry>& buckets_usage_map,
 				   optional_yield y)
 {
@@ -107,7 +107,7 @@ int rgw_user_get_all_buckets_stats(const DoutPrefixProvider *dpp,
   int ret;
 
   do {
-    rgw::sal::RGWBucketList buckets;
+    rgw::sal::BucketList buckets;
     ret = user->list_buckets(dpp, marker, string(), max_entries, false, buckets, y);
     if (ret < 0) {
       ldpp_dout(dpp, 0) << "failed to read user buckets: ret=" << ret << dendl;
@@ -387,7 +387,7 @@ int RGWAccessKeyPool::init(RGWUserAdminOpState& op_state)
   return 0;
 }
 
-RGWUserAdminOpState::RGWUserAdminOpState(rgw::sal::RGWStore* store)
+RGWUserAdminOpState::RGWUserAdminOpState(rgw::sal::Store* store)
 {
   user = store->get_user(rgw_user(RGW_USER_ANON_ID));
 }
@@ -613,7 +613,7 @@ int RGWAccessKeyPool::generate_key(const DoutPrefixProvider *dpp, RGWUserAdminOp
 
   std::pair<std::string, RGWAccessKey> key_pair;
   RGWAccessKey new_key;
-  std::unique_ptr<rgw::sal::RGWUser> duplicate_check;
+  std::unique_ptr<rgw::sal::User> duplicate_check;
 
   int key_type = op_state.get_key_type();
   bool gen_access = op_state.will_gen_access();
@@ -1420,7 +1420,7 @@ RGWUser::RGWUser() : caps(this), keys(this), subusers(this)
   init_default();
 }
 
-int RGWUser::init(const DoutPrefixProvider *dpp, rgw::sal::RGWStore *storage,
+int RGWUser::init(const DoutPrefixProvider *dpp, rgw::sal::Store *storage,
 		  RGWUserAdminOpState& op_state, optional_yield y)
 {
   init_default();
@@ -1444,7 +1444,7 @@ void RGWUser::init_default()
   clear_populated();
 }
 
-int RGWUser::init_storage(rgw::sal::RGWStore *storage)
+int RGWUser::init_storage(rgw::sal::Store *storage)
 {
   if (!storage) {
     return -EINVAL;
@@ -1477,7 +1477,7 @@ int RGWUser::init(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state, 
     access_key.clear();
   }
 
-  std::unique_ptr<rgw::sal::RGWUser> user;
+  std::unique_ptr<rgw::sal::User> user;
 
   clear_populated();
 
@@ -1556,7 +1556,7 @@ int RGWUser::update(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state
 {
   int ret;
   std::string subprocess_msg;
-  rgw::sal::RGWUser* user = op_state.get_user();
+  rgw::sal::User* user = op_state.get_user();
 
   if (!store) {
     set_err_msg(err_msg, "couldn't initialize storage");
@@ -1651,8 +1651,8 @@ int RGWUser::execute_rename(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
     }
   }
 
-  std::unique_ptr<rgw::sal::RGWUser> old_user = store->get_user(op_state.get_user_info().user_id);
-  std::unique_ptr<rgw::sal::RGWUser> new_user = store->get_user(op_state.get_new_uid());
+  std::unique_ptr<rgw::sal::User> old_user = store->get_user(op_state.get_user_info().user_id);
+  std::unique_ptr<rgw::sal::User> new_user = store->get_user(op_state.get_new_uid());
   if (old_user->get_tenant() != new_user->get_tenant()) {
     set_err_msg(err_msg, "users have to be under the same tenant namespace "
                 + old_user->get_tenant() + " != " + new_user->get_tenant());
@@ -1660,7 +1660,7 @@ int RGWUser::execute_rename(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
   }
 
   // create a stub user and write only the uid index and buckets object
-  std::unique_ptr<rgw::sal::RGWUser> user;
+  std::unique_ptr<rgw::sal::User> user;
   user = store->get_user(new_user->get_id());
 
   RGWObjVersionTracker objv;
@@ -1685,7 +1685,7 @@ int RGWUser::execute_rename(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
   string marker;
   CephContext *cct = store->ctx();
   size_t max_buckets = cct->_conf->rgw_list_buckets_max_chunk;
-  rgw::sal::RGWBucketList buckets;
+  rgw::sal::BucketList buckets;
 
   do {
     ret = old_user->list_buckets(dpp, marker, "", max_buckets, false, buckets, y);
@@ -1914,14 +1914,14 @@ int RGWUser::execute_remove(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
   int ret;
 
   bool purge_data = op_state.will_purge_data();
-  rgw::sal::RGWUser* user = op_state.get_user();
+  rgw::sal::User* user = op_state.get_user();
 
   if (!op_state.has_existing_user()) {
     set_err_msg(err_msg, "user does not exist");
     return -ENOENT;
   }
 
-  rgw::sal::RGWBucketList buckets;
+  rgw::sal::BucketList buckets;
   string marker;
   CephContext *cct = store->ctx();
   size_t max_buckets = cct->_conf->rgw_list_buckets_max_chunk;
@@ -1992,7 +1992,7 @@ int RGWUser::execute_modify(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
   std::string display_name = op_state.get_display_name();
 
   RGWUserInfo user_info;
-  std::unique_ptr<rgw::sal::RGWUser> duplicate_check;
+  std::unique_ptr<rgw::sal::User> duplicate_check;
 
   // ensure that the user info has been populated or is populate-able
   if (!op_state.has_existing_user() && !populated) {
@@ -2068,7 +2068,7 @@ int RGWUser::execute_modify(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
     __u8 suspended = op_state.get_suspension_status();
     user_info.suspended = suspended;
 
-    rgw::sal::RGWBucketList buckets;
+    rgw::sal::BucketList buckets;
 
     if (user_id.empty()) {
       set_err_msg(err_msg, "empty user id passed...aborting");
@@ -2078,7 +2078,7 @@ int RGWUser::execute_modify(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
     string marker;
     CephContext *cct = store->ctx();
     size_t max_buckets = cct->_conf->rgw_list_buckets_max_chunk;
-    std::unique_ptr<rgw::sal::RGWUser> user = store->get_user(user_id);
+    std::unique_ptr<rgw::sal::User> user = store->get_user(user_id);
     do {
       ret = user->list_buckets(dpp, marker, string(), max_buckets, false, buckets, y);
       if (ret < 0) {
@@ -2243,7 +2243,7 @@ int RGWUser::list(RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher)
   return 0;
 }
 
-int RGWUserAdminOp_User::list(rgw::sal::RGWStore *store, RGWUserAdminOpState& op_state,
+int RGWUserAdminOp_User::list(rgw::sal::Store *store, RGWUserAdminOpState& op_state,
                   RGWFormatterFlusher& flusher)
 {
   RGWUser user;
@@ -2260,13 +2260,13 @@ int RGWUserAdminOp_User::list(rgw::sal::RGWStore *store, RGWUserAdminOpState& op
 }
 
 int RGWUserAdminOp_User::info(const DoutPrefixProvider *dpp,
-			      rgw::sal::RGWStore *store, RGWUserAdminOpState& op_state,
+			      rgw::sal::Store *store, RGWUserAdminOpState& op_state,
 			      RGWFormatterFlusher& flusher,
 			      optional_yield y)
 {
   RGWUserInfo info;
   RGWUser user;
-  std::unique_ptr<rgw::sal::RGWUser> ruser;
+  std::unique_ptr<rgw::sal::User> ruser;
 
   int ret = user.init(dpp, store, op_state, y);
   if (ret < 0)
@@ -2312,7 +2312,7 @@ int RGWUserAdminOp_User::info(const DoutPrefixProvider *dpp,
 }
 
 int RGWUserAdminOp_User::create(const DoutPrefixProvider *dpp,
-				rgw::sal::RGWStore *store,
+				rgw::sal::Store *store,
 				RGWUserAdminOpState& op_state,
 				RGWFormatterFlusher& flusher, optional_yield y)
 {
@@ -2346,7 +2346,7 @@ int RGWUserAdminOp_User::create(const DoutPrefixProvider *dpp,
 }
 
 int RGWUserAdminOp_User::modify(const DoutPrefixProvider *dpp,
-				rgw::sal::RGWStore *store,
+				rgw::sal::Store *store,
 				RGWUserAdminOpState& op_state,
 				RGWFormatterFlusher& flusher, optional_yield y)
 {
@@ -2379,7 +2379,7 @@ int RGWUserAdminOp_User::modify(const DoutPrefixProvider *dpp,
 }
 
 int RGWUserAdminOp_User::remove(const DoutPrefixProvider *dpp,
-				rgw::sal::RGWStore *store, RGWUserAdminOpState& op_state,
+				rgw::sal::Store *store, RGWUserAdminOpState& op_state,
 				RGWFormatterFlusher& flusher, optional_yield y)
 {
   RGWUserInfo info;
@@ -2397,7 +2397,7 @@ int RGWUserAdminOp_User::remove(const DoutPrefixProvider *dpp,
 }
 
 int RGWUserAdminOp_Subuser::create(const DoutPrefixProvider *dpp,
-				   rgw::sal::RGWStore *store,
+				   rgw::sal::Store *store,
 				   RGWUserAdminOpState& op_state,
 				   RGWFormatterFlusher& flusher,
 				   optional_yield y)
@@ -2432,7 +2432,7 @@ int RGWUserAdminOp_Subuser::create(const DoutPrefixProvider *dpp,
 }
 
 int RGWUserAdminOp_Subuser::modify(const DoutPrefixProvider *dpp,
-				   rgw::sal::RGWStore *store, RGWUserAdminOpState& op_state,
+				   rgw::sal::Store *store, RGWUserAdminOpState& op_state,
 				   RGWFormatterFlusher& flusher, optional_yield y)
 {
   RGWUserInfo info;
@@ -2465,7 +2465,7 @@ int RGWUserAdminOp_Subuser::modify(const DoutPrefixProvider *dpp,
 }
 
 int RGWUserAdminOp_Subuser::remove(const DoutPrefixProvider *dpp,
-				   rgw::sal::RGWStore *store,
+				   rgw::sal::Store *store,
 				   RGWUserAdminOpState& op_state,
 				   RGWFormatterFlusher& flusher,
 				   optional_yield y)
@@ -2488,7 +2488,7 @@ int RGWUserAdminOp_Subuser::remove(const DoutPrefixProvider *dpp,
 }
 
 int RGWUserAdminOp_Key::create(const DoutPrefixProvider *dpp,
-			       rgw::sal::RGWStore *store, RGWUserAdminOpState& op_state,
+			       rgw::sal::Store *store, RGWUserAdminOpState& op_state,
 			       RGWFormatterFlusher& flusher,
 			       optional_yield y)
 {
@@ -2529,7 +2529,7 @@ int RGWUserAdminOp_Key::create(const DoutPrefixProvider *dpp,
 }
 
 int RGWUserAdminOp_Key::remove(const DoutPrefixProvider *dpp,
-			       rgw::sal::RGWStore *store,
+			       rgw::sal::Store *store,
 			       RGWUserAdminOpState& op_state,
 			       RGWFormatterFlusher& flusher,
 			       optional_yield y)
@@ -2552,7 +2552,7 @@ int RGWUserAdminOp_Key::remove(const DoutPrefixProvider *dpp,
 }
 
 int RGWUserAdminOp_Caps::add(const DoutPrefixProvider *dpp,
-			     rgw::sal::RGWStore *store,
+			     rgw::sal::Store *store,
 			     RGWUserAdminOpState& op_state,
 			     RGWFormatterFlusher& flusher, optional_yield y)
 {
@@ -2587,7 +2587,7 @@ int RGWUserAdminOp_Caps::add(const DoutPrefixProvider *dpp,
 
 
 int RGWUserAdminOp_Caps::remove(const DoutPrefixProvider *dpp,
-				rgw::sal::RGWStore *store,
+				rgw::sal::Store *store,
 				RGWUserAdminOpState& op_state,
 				RGWFormatterFlusher& flusher, optional_yield y)
 {

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -414,7 +414,7 @@ class RGWAccessKeyPool
 
   std::map<std::string, int, ltstr_nocase> key_type_map;
   rgw_user user_id;
-  rgw::sal::Store *store{nullptr};
+  rgw::sal::Store* store{nullptr};
 
   map<std::string, RGWAccessKey> *swift_keys{nullptr};
   map<std::string, RGWAccessKey> *access_keys{nullptr};
@@ -467,7 +467,7 @@ class RGWSubUserPool
   RGWUser *user{nullptr};
 
   rgw_user user_id;
-  rgw::sal::Store *store{nullptr};
+  rgw::sal::Store* store{nullptr};
   bool subusers_allowed{false};
 
   map<string, RGWSubUser> *subuser_map{nullptr};
@@ -529,7 +529,7 @@ class RGWUser
 
 private:
   RGWUserInfo old_info;
-  rgw::sal::Store *store{nullptr};
+  rgw::sal::Store* store{nullptr};
 
   rgw_user user_id;
   bool info_stored{false};
@@ -555,14 +555,14 @@ private:
 public:
   RGWUser();
 
-  int init(const DoutPrefixProvider *dpp, rgw::sal::Store *storage, RGWUserAdminOpState& op_state,
+  int init(const DoutPrefixProvider *dpp, rgw::sal::Store* storage, RGWUserAdminOpState& op_state,
 	   optional_yield y);
 
-  int init_storage(rgw::sal::Store *storage);
+  int init_storage(rgw::sal::Store* storage);
   int init(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state, optional_yield y);
   int init_members(RGWUserAdminOpState& op_state);
 
-  rgw::sal::Store *get_store() { return store; }
+  rgw::sal::Store* get_store() { return store; }
 
   /* API Contracted Members */
   RGWUserCapPool caps;
@@ -601,24 +601,24 @@ public:
 class RGWUserAdminOp_User
 {
 public:
-  static int list(rgw::sal::Store *store,
+  static int list(rgw::sal::Store* store,
                   RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher);
 
   static int info(const DoutPrefixProvider *dpp,
-		  rgw::sal::Store *store,
+		  rgw::sal::Store* store,
                   RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
 		  optional_yield y);
 
   static int create(const DoutPrefixProvider *dpp,
-		    rgw::sal::Store *store,
+		    rgw::sal::Store* store,
 		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
 		    optional_yield y);
 
   static int modify(const DoutPrefixProvider *dpp,
-		    rgw::sal::Store *store,
+		    rgw::sal::Store* store,
 		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher, optional_yield y);
 
-  static int remove(const DoutPrefixProvider *dpp, rgw::sal::Store *store,
+  static int remove(const DoutPrefixProvider *dpp, rgw::sal::Store* store,
                   RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher, optional_yield y);
 };
 
@@ -626,17 +626,17 @@ class RGWUserAdminOp_Subuser
 {
 public:
   static int create(const DoutPrefixProvider *dpp,
-		    rgw::sal::Store *store,
+		    rgw::sal::Store* store,
 		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
 		    optional_yield y);
 
   static int modify(const DoutPrefixProvider *dpp,
-		    rgw::sal::Store *store,
+		    rgw::sal::Store* store,
 		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
 		    optional_yield y);
 
   static int remove(const DoutPrefixProvider *dpp,
-		    rgw::sal::Store *store,
+		    rgw::sal::Store* store,
 		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
 		    optional_yield y);
 };
@@ -644,12 +644,12 @@ public:
 class RGWUserAdminOp_Key
 {
 public:
-  static int create(const DoutPrefixProvider *dpp, rgw::sal::Store *store,
+  static int create(const DoutPrefixProvider *dpp, rgw::sal::Store* store,
 		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
 		    optional_yield y);
 
   static int remove(const DoutPrefixProvider *dpp,
-		    rgw::sal::Store *store,
+		    rgw::sal::Store* store,
 		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
 		    optional_yield y);
 };
@@ -658,12 +658,12 @@ class RGWUserAdminOp_Caps
 {
 public:
   static int add(const DoutPrefixProvider *dpp,
-		 rgw::sal::Store *store,
+		 rgw::sal::Store* store,
 		 RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
 		 optional_yield y);
 
   static int remove(const DoutPrefixProvider *dpp,
-		    rgw::sal::Store *store,
+		    rgw::sal::Store* store,
 		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
 		    optional_yield y);
 };

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -32,7 +32,7 @@ class RGWUserBuckets;
 
 class RGWGetUserStats_CB;
 namespace rgw { namespace sal {
-class RGWStore;
+class Store;
 } }
 
 /**
@@ -57,9 +57,9 @@ struct RGWUID
 };
 WRITE_CLASS_ENCODER(RGWUID)
 
-extern int rgw_user_sync_all_stats(const DoutPrefixProvider *dpp, rgw::sal::RGWStore* store, rgw::sal::RGWUser* user, optional_yield y);
+extern int rgw_user_sync_all_stats(const DoutPrefixProvider *dpp, rgw::sal::Store* store, rgw::sal::User* user, optional_yield y);
 extern int rgw_user_get_all_buckets_stats(const DoutPrefixProvider *dpp,
-  rgw::sal::RGWStore* store, rgw::sal::RGWUser* user,
+  rgw::sal::Store* store, rgw::sal::User* user,
   map<string, cls_user_bucket_entry>& buckets_usage_map, optional_yield y);
 
 /**
@@ -96,7 +96,7 @@ enum RGWUserId {
  */
 struct RGWUserAdminOpState {
   // user attributes
-  std::unique_ptr<rgw::sal::RGWUser> user;
+  std::unique_ptr<rgw::sal::User> user;
   std::string user_email;
   std::string display_name;
   rgw_user new_user_id;
@@ -379,7 +379,7 @@ struct RGWUserAdminOpState {
   RGWQuotaInfo& get_user_quota() { return user_quota; }
   set<string>& get_mfa_ids() { return mfa_ids; }
 
-  rgw::sal::RGWUser* get_user() { return user.get(); }
+  rgw::sal::User* get_user() { return user.get(); }
   const rgw_user& get_user_id();
   std::string get_subuser() { return subuser; }
   std::string get_access_key() { return id; }
@@ -403,7 +403,7 @@ struct RGWUserAdminOpState {
 
   std::string generate_subuser();
 
-  RGWUserAdminOpState(rgw::sal::RGWStore* store);
+  RGWUserAdminOpState(rgw::sal::Store* store);
 };
 
 class RGWUser;
@@ -414,7 +414,7 @@ class RGWAccessKeyPool
 
   std::map<std::string, int, ltstr_nocase> key_type_map;
   rgw_user user_id;
-  rgw::sal::RGWStore *store{nullptr};
+  rgw::sal::Store *store{nullptr};
 
   map<std::string, RGWAccessKey> *swift_keys{nullptr};
   map<std::string, RGWAccessKey> *access_keys{nullptr};
@@ -467,7 +467,7 @@ class RGWSubUserPool
   RGWUser *user{nullptr};
 
   rgw_user user_id;
-  rgw::sal::RGWStore *store{nullptr};
+  rgw::sal::Store *store{nullptr};
   bool subusers_allowed{false};
 
   map<string, RGWSubUser> *subuser_map{nullptr};
@@ -529,7 +529,7 @@ class RGWUser
 
 private:
   RGWUserInfo old_info;
-  rgw::sal::RGWStore *store{nullptr};
+  rgw::sal::Store *store{nullptr};
 
   rgw_user user_id;
   bool info_stored{false};
@@ -555,14 +555,14 @@ private:
 public:
   RGWUser();
 
-  int init(const DoutPrefixProvider *dpp, rgw::sal::RGWStore *storage, RGWUserAdminOpState& op_state,
+  int init(const DoutPrefixProvider *dpp, rgw::sal::Store *storage, RGWUserAdminOpState& op_state,
 	   optional_yield y);
 
-  int init_storage(rgw::sal::RGWStore *storage);
+  int init_storage(rgw::sal::Store *storage);
   int init(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state, optional_yield y);
   int init_members(RGWUserAdminOpState& op_state);
 
-  rgw::sal::RGWStore *get_store() { return store; }
+  rgw::sal::Store *get_store() { return store; }
 
   /* API Contracted Members */
   RGWUserCapPool caps;
@@ -601,24 +601,24 @@ public:
 class RGWUserAdminOp_User
 {
 public:
-  static int list(rgw::sal::RGWStore *store,
+  static int list(rgw::sal::Store *store,
                   RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher);
 
   static int info(const DoutPrefixProvider *dpp,
-		  rgw::sal::RGWStore *store,
+		  rgw::sal::Store *store,
                   RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
 		  optional_yield y);
 
   static int create(const DoutPrefixProvider *dpp,
-		    rgw::sal::RGWStore *store,
+		    rgw::sal::Store *store,
 		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
 		    optional_yield y);
 
   static int modify(const DoutPrefixProvider *dpp,
-		    rgw::sal::RGWStore *store,
+		    rgw::sal::Store *store,
 		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher, optional_yield y);
 
-  static int remove(const DoutPrefixProvider *dpp, rgw::sal::RGWStore *store,
+  static int remove(const DoutPrefixProvider *dpp, rgw::sal::Store *store,
                   RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher, optional_yield y);
 };
 
@@ -626,17 +626,17 @@ class RGWUserAdminOp_Subuser
 {
 public:
   static int create(const DoutPrefixProvider *dpp,
-		    rgw::sal::RGWStore *store,
+		    rgw::sal::Store *store,
 		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
 		    optional_yield y);
 
   static int modify(const DoutPrefixProvider *dpp,
-		    rgw::sal::RGWStore *store,
+		    rgw::sal::Store *store,
 		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
 		    optional_yield y);
 
   static int remove(const DoutPrefixProvider *dpp,
-		    rgw::sal::RGWStore *store,
+		    rgw::sal::Store *store,
 		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
 		    optional_yield y);
 };
@@ -644,12 +644,12 @@ public:
 class RGWUserAdminOp_Key
 {
 public:
-  static int create(const DoutPrefixProvider *dpp, rgw::sal::RGWStore *store,
+  static int create(const DoutPrefixProvider *dpp, rgw::sal::Store *store,
 		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
 		    optional_yield y);
 
   static int remove(const DoutPrefixProvider *dpp,
-		    rgw::sal::RGWStore *store,
+		    rgw::sal::Store *store,
 		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
 		    optional_yield y);
 };
@@ -658,12 +658,12 @@ class RGWUserAdminOp_Caps
 {
 public:
   static int add(const DoutPrefixProvider *dpp,
-		 rgw::sal::RGWStore *store,
+		 rgw::sal::Store *store,
 		 RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
 		 optional_yield y);
 
   static int remove(const DoutPrefixProvider *dpp,
-		    rgw::sal::RGWStore *store,
+		    rgw::sal::Store *store,
 		    RGWUserAdminOpState& op_state, RGWFormatterFlusher& flusher,
 		    optional_yield y);
 };

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -1359,7 +1359,7 @@ void RGWPeriod::fork()
   realm_epoch++;
 }
 
-static int read_sync_status(rgw::sal::RGWRadosStore *store, rgw_meta_sync_status *sync_status)
+static int read_sync_status(rgw::sal::RadosStore *store, rgw_meta_sync_status *sync_status)
 {
   // initialize a sync status manager to read the status
   RGWMetaSyncStatusManager mgr(store, store->svc()->rados->get_async_processor());
@@ -1372,13 +1372,13 @@ static int read_sync_status(rgw::sal::RGWRadosStore *store, rgw_meta_sync_status
   return r;
 }
 
-int RGWPeriod::update_sync_status(rgw::sal::RGWStore *store, /* for now */
+int RGWPeriod::update_sync_status(rgw::sal::Store *store, /* for now */
 				  const RGWPeriod &current_period,
                                   std::ostream& error_stream,
                                   bool force_if_stale)
 {
   rgw_meta_sync_status status;
-  int r = read_sync_status(static_cast<rgw::sal::RGWRadosStore*>(store), &status);
+  int r = read_sync_status(static_cast<rgw::sal::RadosStore*>(store), &status);
   if (r < 0) {
     ldout(cct, 0) << "period failed to read sync status: "
         << cpp_strerror(-r) << dendl;
@@ -1423,7 +1423,7 @@ int RGWPeriod::update_sync_status(rgw::sal::RGWStore *store, /* for now */
 }
 
 int RGWPeriod::commit(const DoutPrefixProvider *dpp,
-		      rgw::sal::RGWStore *store,
+		      rgw::sal::Store *store,
 		      RGWRealm& realm, const RGWPeriod& current_period,
                       std::ostream& error_stream, optional_yield y,
 		      bool force_if_stale)

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -1359,7 +1359,7 @@ void RGWPeriod::fork()
   realm_epoch++;
 }
 
-static int read_sync_status(rgw::sal::RadosStore *store, rgw_meta_sync_status *sync_status)
+static int read_sync_status(rgw::sal::RadosStore* store, rgw_meta_sync_status *sync_status)
 {
   // initialize a sync status manager to read the status
   RGWMetaSyncStatusManager mgr(store, store->svc()->rados->get_async_processor());
@@ -1372,7 +1372,7 @@ static int read_sync_status(rgw::sal::RadosStore *store, rgw_meta_sync_status *s
   return r;
 }
 
-int RGWPeriod::update_sync_status(rgw::sal::Store *store, /* for now */
+int RGWPeriod::update_sync_status(rgw::sal::Store* store, /* for now */
 				  const RGWPeriod &current_period,
                                   std::ostream& error_stream,
                                   bool force_if_stale)
@@ -1423,7 +1423,7 @@ int RGWPeriod::update_sync_status(rgw::sal::Store *store, /* for now */
 }
 
 int RGWPeriod::commit(const DoutPrefixProvider *dpp,
-		      rgw::sal::Store *store,
+		      rgw::sal::Store* store,
 		      RGWRealm& realm, const RGWPeriod& current_period,
                       std::ostream& error_stream, optional_yield y,
 		      bool force_if_stale)

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -1070,7 +1070,7 @@ class RGWPeriod
   const std::string get_period_oid_prefix() const;
 
   // gather the metadata sync status for each shard; only for use on master zone
-  int update_sync_status(rgw::sal::Store *store,
+  int update_sync_status(rgw::sal::Store* store,
                          const RGWPeriod &current_period,
                          std::ostream& error_stream, bool force_if_stale);
 
@@ -1166,7 +1166,7 @@ public:
 
   // commit a staging period; only for use on master zone
   int commit(const DoutPrefixProvider *dpp,
-	     rgw::sal::Store *store,
+	     rgw::sal::Store* store,
              RGWRealm& realm, const RGWPeriod &current_period,
              std::ostream& error_stream, optional_yield y,
 	     bool force_if_stale = false);

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -1070,7 +1070,7 @@ class RGWPeriod
   const std::string get_period_oid_prefix() const;
 
   // gather the metadata sync status for each shard; only for use on master zone
-  int update_sync_status(rgw::sal::RGWStore *store,
+  int update_sync_status(rgw::sal::Store *store,
                          const RGWPeriod &current_period,
                          std::ostream& error_stream, bool force_if_stale);
 
@@ -1166,7 +1166,7 @@ public:
 
   // commit a staging period; only for use on master zone
   int commit(const DoutPrefixProvider *dpp,
-	     rgw::sal::RGWStore *store,
+	     rgw::sal::Store *store,
              RGWRealm& realm, const RGWPeriod &current_period,
              std::ostream& error_stream, optional_yield y,
 	     bool force_if_stale = false);

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -910,8 +910,8 @@ TEST_F(IPPolicyTest, asNetworkInvalid) {
 TEST_F(IPPolicyTest, IPEnvironment) {
   // Unfortunately RGWCivetWeb is too tightly tied to civetweb to test RGWCivetWeb::init_env.
   RGWEnv rgw_env;
-  rgw::sal::RGWRadosStore store;
-  std::unique_ptr<rgw::sal::RGWUser> user = store.get_user(rgw_user());
+  rgw::sal::RadosStore store;
+  std::unique_ptr<rgw::sal::User> user = store.get_user(rgw_user());
   rgw_env.set("REMOTE_ADDR", "192.168.1.1");
   rgw_env.set("HTTP_HOST", "1.2.3.4");
   req_state rgw_req_state(cct.get(), &rgw_env, 0);

--- a/src/test/rgw/test_rgw_lua.cc
+++ b/src/test/rgw/test_rgw_lua.cc
@@ -20,21 +20,21 @@ public:
   }
 };
 
-class TestRGWUser : public sal::RGWUser {
+class TestUser : public sal::User {
 public:
-  virtual std::unique_ptr<RGWUser> clone() override {
-    return std::unique_ptr<RGWUser>(new TestRGWUser(*this));
+  virtual std::unique_ptr<User> clone() override {
+    return std::unique_ptr<User>(new TestUser(*this));
   }
 
-  virtual int list_buckets(const DoutPrefixProvider *dpp, const string&, const string&, uint64_t, bool, sal::RGWBucketList&, optional_yield y) override {
+  virtual int list_buckets(const DoutPrefixProvider *dpp, const string&, const string&, uint64_t, bool, sal::BucketList&, optional_yield y) override {
     return 0;
   }
 
-  virtual sal::RGWBucket* create_bucket(rgw_bucket& bucket, ceph::real_time creation_time) override {
+  virtual sal::Bucket* create_bucket(rgw_bucket& bucket, ceph::real_time creation_time) override {
     return nullptr;
   }
 
-  virtual int read_attrs(const DoutPrefixProvider *dpp, optional_yield y, sal::RGWAttrs* uattrs, RGWObjVersionTracker* tracker) override {
+  virtual int read_attrs(const DoutPrefixProvider *dpp, optional_yield y, sal::Attrs* uattrs, RGWObjVersionTracker* tracker) override {
     return 0;
   }
 
@@ -70,7 +70,7 @@ public:
     return 0;
   }
 
-  virtual ~TestRGWUser() = default;
+  virtual ~TestUser() = default;
 };
 
 class TestAccounter : public io::Accounter, public io::BasicClient {
@@ -286,7 +286,7 @@ TEST(TestRGWLua, Bucket)
   b.name = "myname";
   b.marker = "mymarker";
   b.bucket_id = "myid"; 
-  s.bucket.reset(new sal::RGWRadosBucket(nullptr, b));
+  s.bucket.reset(new sal::RadosBucket(nullptr, b));
 
   const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "put_obj", script);
   ASSERT_EQ(rc, 0);
@@ -508,7 +508,7 @@ TEST(TestRGWLua, WithLib)
 
   rgw_bucket b;
   b.name = "my-bucket-name-is-fish";
-  s.bucket.reset(new sal::RGWRadosBucket(nullptr, b));
+  s.bucket.reset(new sal::RadosBucket(nullptr, b));
 
   const auto rc = lua::request::execute(nullptr, nullptr, nullptr, &s, "put_obj", script);
   ASSERT_EQ(rc, 0);
@@ -575,7 +575,7 @@ TEST(TestRGWLua, OpsLog)
 		end
   )";
 
-  auto store = std::unique_ptr<sal::RGWRadosStore>(new sal::RGWRadosStore);
+  auto store = std::unique_ptr<sal::RadosStore>(new sal::RadosStore);
   store->setRados(new RGWRados);
   auto olog = std::unique_ptr<OpsLogSocket>(new OpsLogSocket(cct, 1024));
   ASSERT_TRUE(olog->init(unix_socket_path));
@@ -590,11 +590,11 @@ TEST(TestRGWLua, OpsLog)
   b.name = "name";
   b.marker = "marker";
   b.bucket_id = "id"; 
-  s.bucket.reset(new sal::RGWRadosBucket(nullptr, b));
+  s.bucket.reset(new sal::RadosBucket(nullptr, b));
   s.bucket_name = "name";
 	s.enable_ops_log = true;
 	s.enable_usage_log = false;
-	s.user.reset(new TestRGWUser());
+	s.user.reset(new TestUser());
   TestAccounter ac;
   s.cio = &ac; 
 	s.cct->_conf->rgw_ops_log_rados	= false;


### PR DESCRIPTION
Rename RGWFoo to Foo.  It's all in the rgw::sal namespace anyway, so the
RGW is redundant.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>

Note that this should not be merged until after the DPP PR is merged.
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
