### PR TITLE
rgw: silence some unused variable warnings

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -5188,9 +5188,6 @@ AWSSignerV4::prepare(const DoutPrefixProvider *dpp,
 {
   std::string signed_hdrs;
 
-  std::string_view client_signature;
-  std::string_view session_token;
-
   ceph::real_time timestamp = ceph::real_clock::now();
 
   map<string, string> extra_headers;


### PR DESCRIPTION
```
../src/rgw/rgw_rest_s3.cc:5191:20: warning: unused variable 'client_signature' [-Wunused-variable]
  std::string_view client_signature;
                   ^
../src/rgw/rgw_rest_s3.cc:5192:20: warning: unused variable 'session_token' [-Wunused-variable]
  std::string_view session_token;
                   ^
../src/rgw/rgw_zone.cc:1817:17: warning: unused variable 'zgid' [-Wunused-variable]
    const auto& zgid = zonegroup.get_id();
                ^
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
