### PR TITLE
RGW Zipper - Remove rgw_pool from API

### DIFF
--- a/src/rgw/rgw_lua.h
+++ b/src/rgw/rgw_lua.h
@@ -26,13 +26,13 @@ context to_context(const std::string& s);
 bool verify(const std::string& script, std::string& err_msg);
 
 // store a lua script in a context
-int write_script(rgw::sal::Store* store, const std::string& tenant, optional_yield y, context ctx, const std::string& script);
+int write_script(const DoutPrefixProvider *dpp, rgw::sal::Store* store, const std::string& tenant, optional_yield y, context ctx, const std::string& script);
 
 // read the stored lua script from a context
 int read_script(const DoutPrefixProvider *dpp, rgw::sal::Store* store, const std::string& tenant, optional_yield y, context ctx, std::string& script);
 
 // delete the stored lua script from a context
-int delete_script(rgw::sal::Store* store, const std::string& tenant, optional_yield y, context ctx);
+int delete_script(const DoutPrefixProvider *dpp, rgw::sal::Store* store, const std::string& tenant, optional_yield y, context ctx);
 
 #ifdef WITH_RADOSGW_LUA_PACKAGES
 #include <set>

--- a/src/rgw/rgw_oidc_provider.cc
+++ b/src/rgw/rgw_oidc_provider.cc
@@ -24,20 +24,10 @@
 
 #define dout_subsys ceph_subsys_rgw
 
+namespace rgw { namespace sal {
+
 const string RGWOIDCProvider::oidc_url_oid_prefix = "oidc_url.";
 const string RGWOIDCProvider::oidc_arn_prefix = "arn:aws:iam::";
-
-int RGWOIDCProvider::store_url(const string& url, bool exclusive,
-			       optional_yield y)
-{
-  using ceph::encode;
-  string oid = tenant + get_url_oid_prefix() + url;
-
-  bufferlist bl;
-  encode(*this, bl);
-  return store->put_system_obj(store->get_zone()->get_params().oidc_pool, oid,
-			       bl, exclusive, NULL, real_time(), y);
-}
 
 int RGWOIDCProvider::get_tenant_url_from_arn(string& tenant, string& url)
 {
@@ -58,7 +48,7 @@ int RGWOIDCProvider::create(const DoutPrefixProvider *dpp, bool exclusive, optio
 {
   int ret;
 
-  if (! validate_input()) {
+  if (! validate_input(dpp)) {
     return -EINVAL;
   }
 
@@ -92,43 +82,14 @@ int RGWOIDCProvider::create(const DoutPrefixProvider *dpp, bool exclusive, optio
   sprintf(buf + strlen(buf),".%dZ",(int)tv.tv_usec/1000);
   creation_date.assign(buf, strlen(buf));
 
-  auto& pool = store->get_zone()->get_params().oidc_pool;
-  ret = store_url(idp_url, exclusive, y);
+  ret = store_url(dpp, idp_url, exclusive, y);
   if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR:  storing role info in pool: " << pool.name << ": "
+    ldpp_dout(dpp, 0) << "ERROR:  storing role info in OIDC pool: "
                   << provider_url << ": " << cpp_strerror(-ret) << dendl;
     return ret;
   }
 
   return 0;
-}
-
-int RGWOIDCProvider::delete_obj(optional_yield y)
-{
-  auto& pool = store->get_zone()->get_params().oidc_pool;
-
-  string url, tenant;
-  auto ret = get_tenant_url_from_arn(tenant, url);
-  if (ret < 0) {
-    ldout(cct, 0) << "ERROR: failed to parse arn" << dendl;
-    return -EINVAL;
-  }
-
-  if (this->tenant != tenant) {
-    ldout(cct, 0) << "ERROR: tenant in arn doesn't match that of user " << this->tenant << ", "
-                  << tenant << ": " << dendl;
-    return -EINVAL;
-  }
-
-  // Delete url
-  string oid = tenant + get_url_oid_prefix() + url;
-  ret = store->delete_system_obj(pool, oid, NULL, y);
-  if (ret < 0) {
-    ldout(cct, 0) << "ERROR: deleting oidc url from pool: " << pool.name << ": "
-                  << provider_url << ": " << cpp_strerror(-ret) << dendl;
-  }
-
-  return ret;
 }
 
 int RGWOIDCProvider::get(const DoutPrefixProvider *dpp)
@@ -180,38 +141,14 @@ void RGWOIDCProvider::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("OpenIDConnectProviderArn", arn, obj);
 }
 
-int RGWOIDCProvider::read_url(const DoutPrefixProvider *dpp, const string& url, const string& tenant)
-{
-  auto& pool = store->get_zone()->get_params().oidc_pool;
-  string oid = tenant + get_url_oid_prefix() + url;
-  bufferlist bl;
-
-  int ret = store->get_system_obj(dpp, pool, oid, bl, NULL, NULL, null_yield);
-  if (ret < 0) {
-    return ret;
-  }
-
-  try {
-    using ceph::decode;
-    auto iter = bl.cbegin();
-    decode(*this, iter);
-  } catch (buffer::error& err) {
-    ldpp_dout(dpp, 0) << "ERROR: failed to decode oidc provider info from pool: " << pool.name <<
-                  ": " << url << dendl;
-    return -EIO;
-  }
-
-  return 0;
-}
-
-bool RGWOIDCProvider::validate_input()
+bool RGWOIDCProvider::validate_input(const DoutPrefixProvider *dpp)
 {
   if (provider_url.length() > MAX_OIDC_URL_LEN) {
-    ldout(cct, 0) << "ERROR: Invalid length of url " << dendl;
+    ldpp_dout(dpp, 0) << "ERROR: Invalid length of url " << dendl;
     return false;
   }
   if (client_ids.size() > MAX_OIDC_NUM_CLIENT_IDS) {
-    ldout(cct, 0) << "ERROR: Invalid number of client ids " << dendl;
+    ldpp_dout(dpp, 0) << "ERROR: Invalid number of client ids " << dendl;
     return false;
   }
 
@@ -222,7 +159,7 @@ bool RGWOIDCProvider::validate_input()
   }
 
   if (thumbprints.size() > MAX_OIDC_NUM_THUMBPRINTS) {
-    ldout(cct, 0) << "ERROR: Invalid number of thumbprints " << thumbprints.size() << dendl;
+    ldpp_dout(dpp, 0) << "ERROR: Invalid number of thumbprints " << thumbprints.size() << dendl;
     return false;
   }
 
@@ -235,53 +172,9 @@ bool RGWOIDCProvider::validate_input()
   return true;
 }
 
-int RGWOIDCProvider::get_providers(const DoutPrefixProvider *dpp,
-				   rgw::sal::Store* store,
-				   const string& tenant,
-				   vector<RGWOIDCProvider>& providers)
-{
-  auto pool = store->get_zone()->get_params().oidc_pool;
-  string prefix = tenant + oidc_url_oid_prefix;
-
-  //Get the filtered objects
-  list<string> result;
-  bool is_truncated;
-  RGWListRawObjsCtx ctx;
-  do {
-    list<string> oids;
-    int r = store->list_raw_objects(pool, prefix, 1000, ctx, oids, &is_truncated);
-    if (r < 0) {
-      ldpp_dout(dpp, 0) << "ERROR: listing filtered objects failed: " << pool.name << ": "
-                  << prefix << ": " << cpp_strerror(-r) << dendl;
-      return r;
-    }
-    for (const auto& iter : oids) {
-      RGWOIDCProvider provider(store->ctx(), store);
-      bufferlist bl;
-
-      int ret = store->get_system_obj(dpp, pool, iter, bl, NULL, NULL, null_yield);
-      if (ret < 0) {
-        return ret;
-      }
-
-      try {
-        using ceph::decode;
-        auto iter = bl.cbegin();
-        decode(provider, iter);
-      } catch (buffer::error& err) {
-        ldpp_dout(dpp, 0) << "ERROR: failed to decode oidc provider info from pool: " << pool.name <<
-                    ": " << iter << dendl;
-        return -EIO;
-      }
-
-      providers.push_back(std::move(provider));
-    }
-  } while (is_truncated);
-
-  return 0;
-}
-
 const string& RGWOIDCProvider::get_url_oid_prefix()
 {
   return oidc_url_oid_prefix;
 }
+
+} } // namespace rgw::sal

--- a/src/rgw/rgw_oidc_provider.h
+++ b/src/rgw/rgw_oidc_provider.h
@@ -11,73 +11,72 @@
 
 #include "rgw/rgw_sal.h"
 
+namespace rgw { namespace sal {
 
 class RGWOIDCProvider
 {
-  using string = std::string;
-  static const string oidc_url_oid_prefix;
-  static const string oidc_arn_prefix;
+public:
+  static const std::string oidc_url_oid_prefix;
+  static const std::string oidc_arn_prefix;
   static constexpr int MAX_OIDC_NUM_CLIENT_IDS = 100;
   static constexpr int MAX_OIDC_CLIENT_ID_LEN = 255;
   static constexpr int MAX_OIDC_NUM_THUMBPRINTS = 5;
   static constexpr int MAX_OIDC_THUMBPRINT_LEN = 40;
   static constexpr int MAX_OIDC_URL_LEN = 255;
 
-  CephContext *cct;
-  rgw::sal::Store* store;
-  string id;
-  string provider_url;
-  string arn;
-  string creation_date;
-  string tenant;
-  vector<string> client_ids;
-  vector<string> thumbprints;
+protected:
+  std::string id;
+  std::string provider_url;
+  std::string arn;
+  std::string creation_date;
+  std::string tenant;
+  vector<std::string> client_ids;
+  vector<std::string> thumbprints;
 
-  int get_tenant_url_from_arn(string& tenant, string& url);
-  int store_url(const string& url, bool exclusive, optional_yield y);
-  int read_url(const DoutPrefixProvider *dpp, const string& url, const string& tenant);
-  bool validate_input();
+  int get_tenant_url_from_arn(std::string& tenant, std::string& url);
+  virtual int store_url(const DoutPrefixProvider *dpp, const std::string& url, bool exclusive, optional_yield y) = 0;
+  virtual int read_url(const DoutPrefixProvider *dpp, const std::string& url, const std::string& tenant) = 0;
+  bool validate_input(const DoutPrefixProvider *dpp);
 
 public:
-  RGWOIDCProvider(CephContext *cct,
-                    rgw::sal::Store* store,
-                    string provider_url,
-                    string tenant,
-                    vector<string> client_ids,
-                    vector<string> thumbprints)
-  : cct(cct),
-    store(store),
-    provider_url(std::move(provider_url)),
+  void set_arn(std::string _arn) {
+    arn = _arn;
+  }
+  void set_url(std::string _provider_url) {
+    provider_url = _provider_url;
+  }
+  void set_tenant(std::string _tenant) {
+    tenant = _tenant;
+  }
+  void set_client_ids(std::vector<std::string>& _client_ids) {
+    client_ids = std::move(_client_ids);
+  }
+  void set_thumbprints(std::vector<std::string>& _thumbprints) {
+    thumbprints = std::move(_thumbprints);
+  }
+
+  RGWOIDCProvider(std::string provider_url,
+                    std::string tenant,
+                    vector<std::string> client_ids,
+                    vector<std::string> thumbprints)
+  : provider_url(std::move(provider_url)),
     tenant(std::move(tenant)),
     client_ids(std::move(client_ids)),
     thumbprints(std::move(thumbprints)) {
   }
 
-  RGWOIDCProvider(CephContext *cct,
-                    rgw::sal::Store* store,
-                    string arn,
-                    string tenant)
-  : cct(cct),
-    store(store),
-    arn(std::move(arn)),
+  RGWOIDCProvider( std::string arn,
+                    std::string tenant)
+  : arn(std::move(arn)),
     tenant(std::move(tenant)) {
   }
 
-  RGWOIDCProvider(CephContext *cct,
-                    rgw::sal::Store* store,
-                    string tenant)
-  : cct(cct),
-    store(store),
-    tenant(std::move(tenant)) {}
-
-  RGWOIDCProvider(CephContext *cct,
-          rgw::sal::Store* store)
-  : cct(cct),
-    store(store) {}
+  RGWOIDCProvider(std::string tenant)
+  : tenant(std::move(tenant)) {}
 
   RGWOIDCProvider() {}
 
-  ~RGWOIDCProvider() = default;
+  virtual ~RGWOIDCProvider() = default;
 
   void encode(bufferlist& bl) const {
     ENCODE_START(3, 1, bl);
@@ -103,25 +102,23 @@ public:
     DECODE_FINISH(bl);
   }
 
-  const string& get_provider_url() const { return provider_url; }
-  const string& get_arn() const { return arn; }
-  const string& get_create_date() const { return creation_date; }
-  const vector<string>& get_client_ids() const { return client_ids;}
-  const vector<string>& get_thumbprints() const { return thumbprints; }
+  const std::string& get_provider_url() const { return provider_url; }
+  const std::string& get_arn() const { return arn; }
+  const std::string& get_create_date() const { return creation_date; }
+  const vector<std::string>& get_client_ids() const { return client_ids;}
+  const vector<std::string>& get_thumbprints() const { return thumbprints; }
 
   int create(const DoutPrefixProvider *dpp, bool exclusive, optional_yield y);
-  int delete_obj(optional_yield y);
+  virtual int delete_obj(const DoutPrefixProvider *dpp, optional_yield y) = 0;
   int get(const DoutPrefixProvider *dpp);
   void dump(Formatter *f) const;
   void dump_all(Formatter *f) const;
   void decode_json(JSONObj *obj);
 
-  static const string& get_url_oid_prefix();
-  static int get_providers(const DoutPrefixProvider *dpp,
-			   rgw::sal::Store* store,
-			   const string& tenant,
-			   vector<RGWOIDCProvider>& providers);
+  static const std::string& get_url_oid_prefix();
 };
 WRITE_CLASS_ENCODER(RGWOIDCProvider)
+
+} } // namespace rgw::sal
 #endif /* CEPH_RGW_OIDC_PROVIDER_H */
 

--- a/src/rgw/rgw_rest_oidc_provider.cc
+++ b/src/rgw/rgw_rest_oidc_provider.cc
@@ -121,14 +121,17 @@ void RGWCreateOIDCProvider::execute(optional_yield y)
     return;
   }
 
-  RGWOIDCProvider provider(s->cct, store, provider_url,
-                            s->user->get_tenant(), client_ids, thumbprints);
-  op_ret = provider.create(s, true, y);
+  std::unique_ptr<rgw::sal::RGWOIDCProvider> provider = store->get_oidc_provider();
+  provider->set_url(provider_url);
+  provider->set_tenant(s->user->get_tenant());
+  provider->set_client_ids(client_ids);
+  provider->set_thumbprints(thumbprints);
+  op_ret = provider->create(s, true, y);
 
   if (op_ret == 0) {
     s->formatter->open_object_section("CreateOpenIDConnectProviderResponse");
     s->formatter->open_object_section("CreateOpenIDConnectProviderResult");
-    provider.dump(s->formatter);
+    provider->dump(s->formatter);
     s->formatter->close_section();
     s->formatter->open_object_section("ResponseMetadata");
     s->formatter->dump_string("RequestId", s->trans_id);
@@ -140,8 +143,10 @@ void RGWCreateOIDCProvider::execute(optional_yield y)
 
 void RGWDeleteOIDCProvider::execute(optional_yield y)
 {
-  RGWOIDCProvider provider(s->cct, store, provider_arn, s->user->get_tenant());
-  op_ret = provider.delete_obj(y);
+  std::unique_ptr<rgw::sal::RGWOIDCProvider> provider = store->get_oidc_provider();
+  provider->set_arn(provider_arn);
+  provider->set_tenant(s->user->get_tenant());
+  op_ret = provider->delete_obj(this, y);
 
   if (op_ret < 0 && op_ret != -ENOENT && op_ret != -EINVAL) {
     op_ret = ERR_INTERNAL_ERROR;
@@ -158,8 +163,10 @@ void RGWDeleteOIDCProvider::execute(optional_yield y)
 
 void RGWGetOIDCProvider::execute(optional_yield y)
 {
-  RGWOIDCProvider provider(s->cct, store, provider_arn, s->user->get_tenant());
-  op_ret = provider.get(s);
+  std::unique_ptr<rgw::sal::RGWOIDCProvider> provider = store->get_oidc_provider();
+  provider->set_arn(provider_arn);
+  provider->set_tenant(s->user->get_tenant());
+  op_ret = provider->get(s);
 
   if (op_ret < 0 && op_ret != -ENOENT && op_ret != -EINVAL) {
     op_ret = ERR_INTERNAL_ERROR;
@@ -171,7 +178,7 @@ void RGWGetOIDCProvider::execute(optional_yield y)
     s->formatter->dump_string("RequestId", s->trans_id);
     s->formatter->close_section();
     s->formatter->open_object_section("GetOpenIDConnectProviderResult");
-    provider.dump_all(s->formatter);
+    provider->dump_all(s->formatter);
     s->formatter->close_section();
     s->formatter->close_section();
   }
@@ -199,8 +206,8 @@ int RGWListOIDCProviders::verify_permission(optional_yield y)
 
 void RGWListOIDCProviders::execute(optional_yield y)
 {
-  vector<RGWOIDCProvider> result;
-  op_ret = RGWOIDCProvider::get_providers(s, store, s->user->get_tenant(), result);
+  vector<std::unique_ptr<rgw::sal::RGWOIDCProvider>> result;
+  op_ret = store->get_oidc_providers(s, s->user->get_tenant(), result);
 
   if (op_ret == 0) {
     s->formatter->open_array_section("ListOpenIDConnectProvidersResponse");
@@ -211,7 +218,7 @@ void RGWListOIDCProviders::execute(optional_yield y)
     s->formatter->open_array_section("OpenIDConnectProviderList");
     for (const auto& it : result) {
       s->formatter->open_object_section("Arn");
-      auto& arn = it.get_arn();
+      auto& arn = it->get_arn();
       ldpp_dout(s, 0) << "ARN: " << arn << dendl;
       s->formatter->dump_string("Arn", arn);
       s->formatter->close_section();

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -26,8 +26,9 @@ int RGWRestRole::verify_permission(optional_yield y)
   }
 
   string role_name = s->info.args.get("RoleName");
-  RGWRole role(s->cct, store, role_name, s->user->get_tenant());
-  if (op_ret = role.get(s, y); op_ret < 0) {
+  std::unique_ptr<rgw::sal::RGWRole> role = store->get_role(role_name,
+							    s->user->get_tenant());
+  if (op_ret = role->get(s, y); op_ret < 0) {
     if (op_ret == -ENOENT) {
       op_ret = -ERR_NO_ROLE_FOUND;
     }
@@ -39,7 +40,7 @@ int RGWRestRole::verify_permission(optional_yield y)
     return ret;
   }
 
-  string resource_name = role.get_path() + role_name;
+  string resource_name = role->get_path() + role_name;
   uint64_t op = get_op();
   if (!verify_user_permission(this,
                               s,
@@ -130,9 +131,12 @@ void RGWCreateRole::execute(optional_yield y)
   if (op_ret < 0) {
     return;
   }
-  RGWRole role(s->cct, store, role_name, role_path, trust_policy,
-                s->user->get_tenant(), max_session_duration);
-  op_ret = role.create(s, true, y);
+  std::unique_ptr<rgw::sal::RGWRole> role = store->get_role(role_name,
+							    s->user->get_tenant(),
+							    role_path,
+							    trust_policy,
+							    max_session_duration);
+  op_ret = role->create(s, true, y);
 
   if (op_ret == -EEXIST) {
     op_ret = -ERR_ROLE_EXISTS;
@@ -142,7 +146,7 @@ void RGWCreateRole::execute(optional_yield y)
     s->formatter->open_object_section("CreateRoleResponse");
     s->formatter->open_object_section("CreateRoleResult");
     s->formatter->open_object_section("Role");
-    role.dump(s->formatter);
+    role->dump(s->formatter);
     s->formatter->close_section();
     s->formatter->close_section();
     s->formatter->open_object_section("ResponseMetadata");
@@ -171,7 +175,7 @@ void RGWDeleteRole::execute(optional_yield y)
     return;
   }
 
-  op_ret = _role.delete_obj(s, y);
+  op_ret = _role->delete_obj(s, y);
 
   if (op_ret == -ENOENT) {
     op_ret = -ERR_NO_ROLE_FOUND;
@@ -189,7 +193,7 @@ int RGWGetRole::verify_permission(optional_yield y)
   return 0;
 }
 
-int RGWGetRole::_verify_permission(const RGWRole& role)
+int RGWGetRole::_verify_permission(const rgw::sal::RGWRole* role)
 {
   if (s->auth.identity->is_anonymous()) {
     return -EACCES;
@@ -199,7 +203,7 @@ int RGWGetRole::_verify_permission(const RGWRole& role)
     return ret;
   }
 
-  string resource_name = role.get_path() + role.get_name();
+  string resource_name = role->get_path() + role->get_name();
   if (!verify_user_permission(this,
                               s,
                               rgw::ARN(resource_name,
@@ -229,15 +233,16 @@ void RGWGetRole::execute(optional_yield y)
   if (op_ret < 0) {
     return;
   }
-  RGWRole role(s->cct, store, role_name, s->user->get_tenant());
-  op_ret = role.get(s, y);
+  std::unique_ptr<rgw::sal::RGWRole> role = store->get_role(role_name,
+							    s->user->get_tenant());
+  op_ret = role->get(s, y);
 
   if (op_ret == -ENOENT) {
     op_ret = -ERR_NO_ROLE_FOUND;
     return;
   }
 
-  op_ret = _verify_permission(role);
+  op_ret = _verify_permission(role.get());
 
   if (op_ret == 0) {
     s->formatter->open_object_section("GetRoleResponse");
@@ -246,7 +251,7 @@ void RGWGetRole::execute(optional_yield y)
     s->formatter->close_section();
     s->formatter->open_object_section("GetRoleResult");
     s->formatter->open_object_section("Role");
-    role.dump(s->formatter);
+    role->dump(s->formatter);
     s->formatter->close_section();
     s->formatter->close_section();
     s->formatter->close_section();
@@ -278,8 +283,8 @@ void RGWModifyRole::execute(optional_yield y)
     return;
   }
 
-  _role.update_trust_policy(trust_policy);
-  op_ret = _role.update(y);
+  _role->update_trust_policy(trust_policy);
+  op_ret = _role->update(this, y);
 
   s->formatter->open_object_section("UpdateAssumeRolePolicyResponse");
   s->formatter->open_object_section("ResponseMetadata");
@@ -321,8 +326,8 @@ void RGWListRoles::execute(optional_yield y)
   if (op_ret < 0) {
     return;
   }
-  vector<RGWRole> result;
-  op_ret = RGWRole::get_roles_by_path_prefix(s, store, s->cct, path_prefix, s->user->get_tenant(), result, y);
+  vector<std::unique_ptr<rgw::sal::RGWRole>> result;
+  op_ret = store->get_roles(s, y, path_prefix, s->user->get_tenant(), result);
 
   if (op_ret == 0) {
     s->formatter->open_array_section("ListRolesResponse");
@@ -333,7 +338,7 @@ void RGWListRoles::execute(optional_yield y)
     s->formatter->open_object_section("Roles");
     for (const auto& it : result) {
       s->formatter->open_object_section("member");
-      it.dump(s->formatter);
+      it->dump(s->formatter);
       s->formatter->close_section();
     }
     s->formatter->close_section();
@@ -370,8 +375,8 @@ void RGWPutRolePolicy::execute(optional_yield y)
     return;
   }
 
-  _role.set_perm_policy(policy_name, perm_policy);
-  op_ret = _role.update(y);
+  _role->set_perm_policy(policy_name, perm_policy);
+  op_ret = _role->update(this, y);
 
   if (op_ret == 0) {
     s->formatter->open_object_section("PutRolePolicyResponse");
@@ -402,7 +407,7 @@ void RGWGetRolePolicy::execute(optional_yield y)
   }
 
   string perm_policy;
-  op_ret = _role.get_role_policy(policy_name, perm_policy);
+  op_ret = _role->get_role_policy(this, policy_name, perm_policy);
   if (op_ret == -ENOENT) {
     op_ret = -ERR_NO_SUCH_ENTITY;
   }
@@ -439,7 +444,7 @@ void RGWListRolePolicies::execute(optional_yield y)
     return;
   }
 
-  std::vector<string> policy_names = _role.get_role_policy_names();
+  std::vector<string> policy_names = _role->get_role_policy_names();
   s->formatter->open_object_section("ListRolePoliciesResponse");
   s->formatter->open_object_section("ResponseMetadata");
   s->formatter->dump_string("RequestId", s->trans_id);
@@ -473,13 +478,13 @@ void RGWDeleteRolePolicy::execute(optional_yield y)
     return;
   }
 
-  op_ret = _role.delete_policy(policy_name);
+  op_ret = _role->delete_policy(this, policy_name);
   if (op_ret == -ENOENT) {
     op_ret = -ERR_NO_ROLE_FOUND;
   }
 
   if (op_ret == 0) {
-    op_ret = _role.update(y);
+    op_ret = _role->update(this, y);
   }
 
   s->formatter->open_object_section("DeleteRolePoliciesResponse");

--- a/src/rgw/rgw_rest_role.h
+++ b/src/rgw/rgw_rest_role.h
@@ -17,7 +17,7 @@ protected:
   string perm_policy;
   string path_prefix;
   string max_session_duration;
-  RGWRole _role;
+  std::unique_ptr<rgw::sal::RGWRole> _role;
 public:
   int verify_permission(optional_yield y) override;
   void send_response() override;
@@ -58,7 +58,7 @@ public:
 };
 
 class RGWGetRole : public RGWRoleRead {
-  int _verify_permission(const RGWRole& role);
+  int _verify_permission(const rgw::sal::RGWRole* role);
 public:
   RGWGetRole() = default;
   int verify_permission(optional_yield y) override;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -6020,18 +6020,18 @@ rgw::auth::s3::STSEngine::authenticate(
   string role_id;
   rgw::auth::RoleApplier::Role r;
   if (! token.roleId.empty()) {
-    RGWRole role(s->cct, store, token.roleId);
-    if (role.get_by_id(dpp, y) < 0) {
+    std::unique_ptr<rgw::sal::RGWRole> role = store->get_role(token.roleId);
+    if (role->get_by_id(dpp, y) < 0) {
       return result_t::deny(-EPERM);
     }
     r.id = token.roleId;
-    r.name = role.get_name();
-    r.tenant = role.get_tenant();
+    r.name = role->get_name();
+    r.tenant = role->get_tenant();
 
-    vector<string> role_policy_names = role.get_role_policy_names();
+    vector<string> role_policy_names = role->get_role_policy_names();
     for (auto& policy_name : role_policy_names) {
       string perm_policy;
-      if (int ret = role.get_role_policy(policy_name, perm_policy); ret == 0) {
+      if (int ret = role->get_role_policy(dpp, policy_name, perm_policy); ret == 0) {
         r.role_policies.push_back(std::move(perm_policy));
       }
     }

--- a/src/rgw/rgw_rest_sts.h
+++ b/src/rgw/rgw_rest_sts.h
@@ -29,7 +29,7 @@ class WebTokenEngine : public rgw::auth::Engine {
 
   bool is_cert_valid(const vector<string>& thumbprints, const string& cert) const;
 
-  boost::optional<RGWOIDCProvider> get_provider(const DoutPrefixProvider *dpp, const string& role_arn, const string& iss) const;
+  std::unique_ptr<rgw::sal::RGWOIDCProvider> get_provider(const DoutPrefixProvider *dpp, const string& role_arn, const string& iss) const;
 
   std::string get_role_tenant(const string& role_arn) const;
 

--- a/src/rgw/rgw_role.cc
+++ b/src/rgw/rgw_role.cc
@@ -24,180 +24,12 @@
 
 #define dout_subsys ceph_subsys_rgw
 
+namespace rgw { namespace sal {
 
 const string RGWRole::role_name_oid_prefix = "role_names.";
 const string RGWRole::role_oid_prefix = "roles.";
 const string RGWRole::role_path_oid_prefix = "role_paths.";
 const string RGWRole::role_arn_prefix = "arn:aws:iam::";
-
-int RGWRole::store_info(bool exclusive, optional_yield y)
-{
-  using ceph::encode;
-  string oid = get_info_oid_prefix() + id;
-
-  bufferlist bl;
-  encode(*this, bl);
-
-  return store->put_system_obj(store->get_zone()->get_params().roles_pool, oid,
-			       bl, exclusive, NULL, real_time(), y, NULL);
-}
-
-int RGWRole::store_name(bool exclusive, optional_yield y)
-{
-  RGWNameToId nameToId;
-  nameToId.obj_id = id;
-
-  string oid = tenant + get_names_oid_prefix() + name;
-
-  bufferlist bl;
-  using ceph::encode;
-  encode(nameToId, bl);
-
-  return store->put_system_obj(store->get_zone()->get_params().roles_pool, oid,
-			       bl, exclusive, NULL, real_time(), y, NULL);
-}
-
-int RGWRole::store_path(bool exclusive, optional_yield y)
-{
-  string oid = tenant + get_path_oid_prefix() + path + get_info_oid_prefix() + id;
-
-  bufferlist bl;
-  return store->put_system_obj(store->get_zone()->get_params().roles_pool, oid,
-			       bl, exclusive, NULL, real_time(), y, NULL);
-}
-
-int RGWRole::create(const DoutPrefixProvider *dpp, bool exclusive, optional_yield y)
-{
-  int ret;
-
-  if (! validate_input()) {
-    return -EINVAL;
-  }
-
-  /* check to see the name is not used */
-  ret = read_id(dpp, name, tenant, id, y);
-  if (exclusive && ret == 0) {
-    ldpp_dout(dpp, 0) << "ERROR: name " << name << " already in use for role id "
-                    << id << dendl;
-    return -EEXIST;
-  } else if ( ret < 0 && ret != -ENOENT) {
-    ldpp_dout(dpp, 0) << "failed reading role id  " << id << ": "
-                  << cpp_strerror(-ret) << dendl;
-    return ret;
-  }
-
-  /* create unique id */
-  uuid_d new_uuid;
-  char uuid_str[37];
-  new_uuid.generate_random();
-  new_uuid.print(uuid_str);
-  id = uuid_str;
-
-  //arn
-  arn = role_arn_prefix + tenant + ":role" + path + name;
-
-  // Creation time
-  real_clock::time_point t = real_clock::now();
-
-  struct timeval tv;
-  real_clock::to_timeval(t, tv);
-
-  char buf[30];
-  struct tm result;
-  gmtime_r(&tv.tv_sec, &result);
-  strftime(buf,30,"%Y-%m-%dT%H:%M:%S", &result);
-  sprintf(buf + strlen(buf),".%dZ",(int)tv.tv_usec/1000);
-  creation_date.assign(buf, strlen(buf));
-
-  auto& pool = store->get_zone()->get_params().roles_pool;
-  ret = store_info(exclusive, y);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR:  storing role info in pool: " << pool.name << ": "
-                  << id << ": " << cpp_strerror(-ret) << dendl;
-    return ret;
-  }
-
-  ret = store_name(exclusive, y);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: storing role name in pool: " << pool.name << ": "
-                  << name << ": " << cpp_strerror(-ret) << dendl;
-
-    //Delete the role info that was stored in the previous call
-    string oid = get_info_oid_prefix() + id;
-    int info_ret = store->delete_system_obj(pool, oid, nullptr, y);
-    if (info_ret < 0) {
-      ldpp_dout(dpp, 0) << "ERROR: cleanup of role id from pool: " << pool.name << ": "
-                  << id << ": " << cpp_strerror(-info_ret) << dendl;
-    }
-    return ret;
-  }
-
-  ret = store_path(exclusive, y);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: storing role path in pool: " << pool.name << ": "
-                  << path << ": " << cpp_strerror(-ret) << dendl;
-    //Delete the role info that was stored in the previous call
-    string oid = get_info_oid_prefix() + id;
-    int info_ret = store->delete_system_obj(pool, oid, nullptr, y);
-    if (info_ret < 0) {
-      ldpp_dout(dpp, 0) << "ERROR: cleanup of role id from pool: " << pool.name << ": "
-                  << id << ": " << cpp_strerror(-info_ret) << dendl;
-    }
-    //Delete role name that was stored in previous call
-    oid = tenant + get_names_oid_prefix() + name;
-    int name_ret = store->delete_system_obj(pool, oid, nullptr, y);
-    if (name_ret < 0) {
-      ldpp_dout(dpp, 0) << "ERROR: cleanup of role name from pool: " << pool.name << ": "
-                  << name << ": " << cpp_strerror(-name_ret) << dendl;
-    }
-    return ret;
-  }
-  return 0;
-}
-
-int RGWRole::delete_obj(const DoutPrefixProvider *dpp, optional_yield y)
-{
-  auto& pool = store->get_zone()->get_params().roles_pool;
-
-  int ret = read_name(dpp, y);
-  if (ret < 0) {
-    return ret;
-  }
-
-  ret = read_info(dpp, y);
-  if (ret < 0) {
-    return ret;
-  }
-
-  if (! perm_policy_map.empty()) {
-    return -ERR_DELETE_CONFLICT;
-  }
-
-  // Delete id
-  string oid = get_info_oid_prefix() + id;
-  ret = store->delete_system_obj(pool, oid, nullptr, y);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: deleting role id from pool: " << pool.name << ": "
-                  << id << ": " << cpp_strerror(-ret) << dendl;
-  }
-
-  // Delete name
-  oid = tenant + get_names_oid_prefix() + name;
-  ret = store->delete_system_obj(pool, oid, nullptr, y);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: deleting role name from pool: " << pool.name << ": "
-                  << name << ": " << cpp_strerror(-ret) << dendl;
-  }
-
-  // Delete path
-  oid = tenant + get_path_oid_prefix() + path + get_info_oid_prefix() + id;
-  ret = store->delete_system_obj(pool, oid, nullptr, y);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: deleting role path from pool: " << pool.name << ": "
-                  << path << ": " << cpp_strerror(-ret) << dendl;
-  }
-  return ret;
-}
 
 int RGWRole::get(const DoutPrefixProvider *dpp, optional_yield y)
 {
@@ -224,13 +56,11 @@ int RGWRole::get_by_id(const DoutPrefixProvider *dpp, optional_yield y)
   return 0;
 }
 
-int RGWRole::update(optional_yield y)
+int RGWRole::update(const DoutPrefixProvider *dpp, optional_yield y)
 {
-  auto& pool = store->get_zone()->get_params().roles_pool;
-
-  int ret = store_info(false, y);
+  int ret = store_info(dpp, false, y);
   if (ret < 0) {
-    ldout(cct, 0) << "ERROR:  storing info in pool: " << pool.name << ": "
+    ldpp_dout(dpp, 0) << "ERROR:  storing info in Role pool: "
                   << id << ": " << cpp_strerror(-ret) << dendl;
     return ret;
   }
@@ -254,11 +84,11 @@ vector<string> RGWRole::get_role_policy_names()
   return policy_names;
 }
 
-int RGWRole::get_role_policy(const string& policy_name, string& perm_policy)
+int RGWRole::get_role_policy(const DoutPrefixProvider* dpp, const string& policy_name, string& perm_policy)
 {
   const auto it = perm_policy_map.find(policy_name);
   if (it == perm_policy_map.end()) {
-    ldout(cct, 0) << "ERROR: Policy name: " << policy_name << " not found" << dendl;
+    ldpp_dout(dpp, 0) << "ERROR: Policy name: " << policy_name << " not found" << dendl;
     return -ENOENT;
   } else {
     perm_policy = it->second;
@@ -266,11 +96,11 @@ int RGWRole::get_role_policy(const string& policy_name, string& perm_policy)
   return 0;
 }
 
-int RGWRole::delete_policy(const string& policy_name)
+int RGWRole::delete_policy(const DoutPrefixProvider* dpp, const string& policy_name)
 {
   const auto& it = perm_policy_map.find(policy_name);
   if (it == perm_policy_map.end()) {
-    ldout(cct, 0) << "ERROR: Policy name: " << policy_name << " not found" << dendl;
+    ldpp_dout(dpp, 0) << "ERROR: Policy name: " << policy_name << " not found" << dendl;
     return -ENOENT;
   } else {
     perm_policy_map.erase(it);
@@ -300,111 +130,33 @@ void RGWRole::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("assume_role_policy_document", trust_policy, obj);
 }
 
-int RGWRole::read_id(const DoutPrefixProvider *dpp, const string& role_name, const string& tenant, string& role_id, optional_yield y)
-{
-  auto& pool = store->get_zone()->get_params().roles_pool;
-  string oid = tenant + get_names_oid_prefix() + role_name;
-  bufferlist bl;
-
-  int ret = store->get_system_obj(dpp, pool, oid, bl, NULL, NULL, y);
-  if (ret < 0) {
-    return ret;
-  }
-
-  RGWNameToId nameToId;
-  try {
-    auto iter = bl.cbegin();
-    using ceph::decode;
-    decode(nameToId, iter);
-  } catch (buffer::error& err) {
-    ldpp_dout(dpp, 0) << "ERROR: failed to decode role from pool: " << pool.name << ": "
-                  << role_name << dendl;
-    return -EIO;
-  }
-  role_id = nameToId.obj_id;
-  return 0;
-}
-
-int RGWRole::read_info(const DoutPrefixProvider *dpp, optional_yield y)
-{
-  auto& pool = store->get_zone()->get_params().roles_pool;
-  string oid = get_info_oid_prefix() + id;
-  bufferlist bl;
-
-  int ret = store->get_system_obj(dpp, pool, oid, bl, NULL, NULL, y);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: failed reading role info from pool: " << pool.name <<
-                  ": " << id << ": " << cpp_strerror(-ret) << dendl;
-    return ret;
-  }
-
-  try {
-    using ceph::decode;
-    auto iter = bl.cbegin();
-    decode(*this, iter);
-  } catch (buffer::error& err) {
-    ldpp_dout(dpp, 0) << "ERROR: failed to decode role info from pool: " << pool.name <<
-                  ": " << id << dendl;
-    return -EIO;
-  }
-
-  return 0;
-}
-
-int RGWRole::read_name(const DoutPrefixProvider *dpp, optional_yield y)
-{
-  auto& pool = store->get_zone()->get_params().roles_pool;
-  string oid = tenant + get_names_oid_prefix() + name;
-  bufferlist bl;
-
-  int ret = store->get_system_obj(dpp, pool, oid, bl, NULL, NULL, y);
-  if (ret < 0) {
-    ldpp_dout(dpp, 0) << "ERROR: failed reading role name from pool: " << pool.name << ": "
-                  << name << ": " << cpp_strerror(-ret) << dendl;
-    return ret;
-  }
-
-  RGWNameToId nameToId;
-  try {
-    using ceph::decode;
-    auto iter = bl.cbegin();
-    decode(nameToId, iter);
-  } catch (buffer::error& err) {
-    ldpp_dout(dpp, 0) << "ERROR: failed to decode role name from pool: " << pool.name << ": "
-                  << name << dendl;
-    return -EIO;
-  }
-  id = nameToId.obj_id;
-  return 0;
-}
-
-bool RGWRole::validate_input()
+bool RGWRole::validate_input(const DoutPrefixProvider* dpp)
 {
   if (name.length() > MAX_ROLE_NAME_LEN) {
-    ldout(cct, 0) << "ERROR: Invalid name length " << dendl;
+    ldpp_dout(dpp, 0) << "ERROR: Invalid name length " << dendl;
     return false;
   }
 
   if (path.length() > MAX_PATH_NAME_LEN) {
-    ldout(cct, 0) << "ERROR: Invalid path length " << dendl;
+    ldpp_dout(dpp, 0) << "ERROR: Invalid path length " << dendl;
     return false;
   }
 
   std::regex regex_name("[A-Za-z0-9:=,.@-]+");
   if (! std::regex_match(name, regex_name)) {
-    ldout(cct, 0) << "ERROR: Invalid chars in name " << dendl;
+    ldpp_dout(dpp, 0) << "ERROR: Invalid chars in name " << dendl;
     return false;
   }
 
   std::regex regex_path("(/[!-~]+/)|(/)");
   if (! std::regex_match(path,regex_path)) {
-    ldout(cct, 0) << "ERROR: Invalid chars in path " << dendl;
+    ldpp_dout(dpp, 0) << "ERROR: Invalid chars in path " << dendl;
     return false;
   }
 
   if (max_session_duration < SESSION_DURATION_MIN ||
           max_session_duration > SESSION_DURATION_MAX) {
-    ldout(cct, 0) << "ERROR: Invalid session duration, should be between 3600 and 43200 seconds " << dendl;
+    ldpp_dout(dpp, 0) << "ERROR: Invalid session duration, should be between 3600 and 43200 seconds " << dendl;
     return false;
   }
   return true;
@@ -424,69 +176,6 @@ void RGWRole::update_trust_policy(string& trust_policy)
   this->trust_policy = trust_policy;
 }
 
-int RGWRole::get_roles_by_path_prefix(const DoutPrefixProvider *dpp,
-				      rgw::sal::Store* store,
-                                      CephContext *cct,
-                                      const string& path_prefix,
-                                      const string& tenant,
-                                      vector<RGWRole>& roles,
-				      optional_yield y)
-{
-  auto pool = store->get_zone()->get_params().roles_pool;
-  string prefix;
-
-  // List all roles if path prefix is empty
-  if (! path_prefix.empty()) {
-    prefix = tenant + role_path_oid_prefix + path_prefix;
-  } else {
-    prefix = tenant + role_path_oid_prefix;
-  }
-
-  //Get the filtered objects
-  list<string> result;
-  bool is_truncated;
-  RGWListRawObjsCtx ctx;
-  do {
-    list<string> oids;
-    int r = store->list_raw_objects(pool, prefix, 1000, ctx, oids, &is_truncated);
-    if (r < 0) {
-      ldpp_dout(dpp, 0) << "ERROR: listing filtered objects failed: " << pool.name << ": "
-                  << prefix << ": " << cpp_strerror(-r) << dendl;
-      return r;
-    }
-    for (const auto& iter : oids) {
-      result.push_back(iter.substr(role_path_oid_prefix.size()));
-    }
-  } while (is_truncated);
-
-  for (const auto& it : result) {
-    //Find the role oid prefix from the end
-    size_t pos = it.rfind(role_oid_prefix);
-    if (pos == string::npos) {
-        continue;
-    }
-    // Split the result into path and info_oid + id
-    string path = it.substr(0, pos);
-
-    /*Make sure that prefix is part of path (False results could've been returned)
-      because of the role info oid + id appended to the path)*/
-    if(path_prefix.empty() || path.find(path_prefix) != string::npos) {
-      //Get id from info oid prefix + id
-      string id = it.substr(pos + role_oid_prefix.length());
-
-      RGWRole role(cct, store);
-      role.set_id(id);
-      int ret = role.read_info(dpp, y);
-      if (ret < 0) {
-        return ret;
-      }
-      roles.push_back(std::move(role));
-    }
-  }
-
-  return 0;
-}
-
 const string& RGWRole::get_names_oid_prefix()
 {
   return role_name_oid_prefix;
@@ -501,3 +190,5 @@ const string& RGWRole::get_path_oid_prefix()
 {
   return role_path_oid_prefix;
 }
+
+} } // namespace rgw::sal

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -13,52 +13,47 @@
 
 #include "rgw/rgw_rados.h"
 
-namespace rgw { namespace sal { class Store; } }
+namespace rgw { namespace sal {
 
 class RGWRole
 {
-  using string = std::string;
-  static const string role_name_oid_prefix;
-  static const string role_oid_prefix;
-  static const string role_path_oid_prefix;
-  static const string role_arn_prefix;
+public:
+  static const std::string role_name_oid_prefix;
+  static const std::string role_oid_prefix;
+  static const std::string role_path_oid_prefix;
+  static const std::string role_arn_prefix;
   static constexpr int MAX_ROLE_NAME_LEN = 64;
   static constexpr int MAX_PATH_NAME_LEN = 512;
   static constexpr uint64_t SESSION_DURATION_MIN = 3600; // in seconds
   static constexpr uint64_t SESSION_DURATION_MAX = 43200; // in seconds
+protected:
 
-  CephContext *cct;
-  rgw::sal::Store* store;
-  string id;
-  string name;
-  string path;
-  string arn;
-  string creation_date;
-  string trust_policy;
-  map<string, string> perm_policy_map;
-  string tenant;
+  std::string id;
+  std::string name;
+  std::string path;
+  std::string arn;
+  std::string creation_date;
+  std::string trust_policy;
+  map<std::string, std::string> perm_policy_map;
+  std::string tenant;
   uint64_t max_session_duration;
 
-  int store_info(bool exclusive, optional_yield y);
-  int store_name(bool exclusive, optional_yield y);
-  int store_path(bool exclusive, optional_yield y);
-  int read_id(const DoutPrefixProvider *dpp, const string& role_name, const string& tenant, string& role_id, optional_yield y);
-  int read_name(const DoutPrefixProvider *dpp, optional_yield y);
-  int read_info(const DoutPrefixProvider *dpp, optional_yield y);
-  bool validate_input();
+public:
+  virtual int store_info(const DoutPrefixProvider *dpp, bool exclusive, optional_yield y) = 0;
+  virtual int store_name(const DoutPrefixProvider *dpp, bool exclusive, optional_yield y) = 0;
+  virtual int store_path(const DoutPrefixProvider *dpp, bool exclusive, optional_yield y) = 0;
+  virtual int read_id(const DoutPrefixProvider *dpp, const std::string& role_name, const std::string& tenant, std::string& role_id, optional_yield y) = 0;
+  virtual int read_name(const DoutPrefixProvider *dpp, optional_yield y) = 0;
+  virtual int read_info(const DoutPrefixProvider *dpp, optional_yield y) = 0;
+  bool validate_input(const DoutPrefixProvider* dpp);
   void extract_name_tenant(const std::string& str);
 
-public:
-  RGWRole(CephContext *cct,
-          rgw::sal::Store* store,
-          string name,
-          string path,
-          string trust_policy,
-          string tenant,
-          string max_session_duration_str="")
-  : cct(cct),
-    store(store),
-    name(std::move(name)),
+  RGWRole(std::string name,
+          std::string tenant,
+          std::string path="",
+          std::string trust_policy="",
+          std::string max_session_duration_str="")
+  : name(std::move(name)),
     path(std::move(path)),
     trust_policy(std::move(trust_policy)),
     tenant(std::move(tenant)) {
@@ -72,32 +67,9 @@ public:
     }
   }
 
-  RGWRole(CephContext *cct,
-          rgw::sal::Store* store,
-          string name,
-          string tenant)
-  : cct(cct),
-    store(store),
-    name(std::move(name)),
-    tenant(std::move(tenant)) {
-    extract_name_tenant(this->name);
-  }
+  RGWRole(std::string id) : id(std::move(id)) {}
 
-  RGWRole(CephContext *cct,
-          rgw::sal::Store* store,
-          string id)
-  : cct(cct),
-    store(store),
-    id(std::move(id)) {}
-
-  RGWRole(CephContext *cct,
-          rgw::sal::Store* store)
-  : cct(cct),
-    store(store) {}
-
-  RGWRole() {}
-
-  ~RGWRole() = default;
+  virtual ~RGWRole() = default;
 
   void encode(bufferlist& bl) const {
     ENCODE_START(3, 1, bl);
@@ -131,39 +103,33 @@ public:
     DECODE_FINISH(bl);
   }
 
-  const string& get_id() const { return id; }
-  const string& get_name() const { return name; }
-  const string& get_tenant() const { return tenant; }
-  const string& get_path() const { return path; }
-  const string& get_create_date() const { return creation_date; }
-  const string& get_assume_role_policy() const { return trust_policy;}
+  const std::string& get_id() const { return id; }
+  const std::string& get_name() const { return name; }
+  const std::string& get_tenant() const { return tenant; }
+  const std::string& get_path() const { return path; }
+  const std::string& get_create_date() const { return creation_date; }
+  const std::string& get_assume_role_policy() const { return trust_policy;}
   const uint64_t& get_max_session_duration() const { return max_session_duration; }
 
-  void set_id(const string& id) { this->id = id; }
+  void set_id(const std::string& id) { this->id = id; }
 
-  int create(const DoutPrefixProvider *dpp, bool exclusive, optional_yield y);
-  int delete_obj(const DoutPrefixProvider *dpp, optional_yield y);
+  virtual int create(const DoutPrefixProvider *dpp, bool exclusive, optional_yield y) = 0;
+  virtual int delete_obj(const DoutPrefixProvider *dpp, optional_yield y) = 0;
   int get(const DoutPrefixProvider *dpp, optional_yield y);
   int get_by_id(const DoutPrefixProvider *dpp, optional_yield y);
-  int update(optional_yield y);
-  void update_trust_policy(string& trust_policy);
-  void set_perm_policy(const string& policy_name, const string& perm_policy);
-  vector<string> get_role_policy_names();
-  int get_role_policy(const string& policy_name, string& perm_policy);
-  int delete_policy(const string& policy_name);
+  int update(const DoutPrefixProvider *dpp, optional_yield y);
+  void update_trust_policy(std::string& trust_policy);
+  void set_perm_policy(const std::string& policy_name, const std::string& perm_policy);
+  vector<std::string> get_role_policy_names();
+  int get_role_policy(const DoutPrefixProvider* dpp, const std::string& policy_name, std::string& perm_policy);
+  int delete_policy(const DoutPrefixProvider* dpp, const std::string& policy_name);
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
 
-  static const string& get_names_oid_prefix();
-  static const string& get_info_oid_prefix();
-  static const string& get_path_oid_prefix();
-  static int get_roles_by_path_prefix(const DoutPrefixProvider *dpp,
-				      rgw::sal::Store* store,
-                                      CephContext *cct,
-                                      const string& path_prefix,
-                                      const string& tenant,
-                                      vector<RGWRole>& roles,
-				      optional_yield y);
+  static const std::string& get_names_oid_prefix();
+  static const std::string& get_info_oid_prefix();
+  static const std::string& get_path_oid_prefix();
 };
 WRITE_CLASS_ENCODER(RGWRole)
+} } // namespace rgw::sal
 #endif /* CEPH_RGW_ROLE_H */

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -276,20 +276,20 @@ int AssumeRoleRequest::validate_input() const
   return AssumeRoleRequestBase::validate_input();
 }
 
-std::tuple<int, RGWRole> STSService::getRoleInfo(const DoutPrefixProvider *dpp, 
+std::tuple<int, rgw::sal::RGWRole*> STSService::getRoleInfo(const DoutPrefixProvider *dpp,
                                                  const string& arn,
 						 optional_yield y)
 {
   if (auto r_arn = rgw::ARN::parse(arn); r_arn) {
     auto pos = r_arn->resource.find_last_of('/');
     string roleName = r_arn->resource.substr(pos + 1);
-    RGWRole role(cct, store, roleName, r_arn->account);
-    if (int ret = role.get(dpp, y); ret < 0) {
+    std::unique_ptr<rgw::sal::RGWRole> role = store->get_role(roleName, r_arn->account);
+    if (int ret = role->get(dpp, y); ret < 0) {
       if (ret == -ENOENT) {
         ldpp_dout(dpp, 0) << "Role doesn't exist: " << roleName << dendl;
         ret = -ERR_NO_ROLE_FOUND;
       }
-      return make_tuple(ret, this->role);
+      return make_tuple(ret, nullptr);
     } else {
       auto path_pos = r_arn->resource.find('/');
       string path;
@@ -298,17 +298,17 @@ std::tuple<int, RGWRole> STSService::getRoleInfo(const DoutPrefixProvider *dpp,
       } else {
         path = r_arn->resource.substr(path_pos, ((pos - path_pos) + 1));
       }
-      string r_path = role.get_path();
+      string r_path = role->get_path();
       if (path != r_path) {
         ldpp_dout(dpp, 0) << "Invalid Role ARN: Path in ARN does not match with the role path: " << path << " " << r_path << dendl;
-        return make_tuple(-EACCES, this->role);
+        return make_tuple(-EACCES, nullptr);
       }
       this->role = std::move(role);
-      return make_tuple(0, this->role);
+      return make_tuple(0, this->role.get());
     }
   } else {
     ldpp_dout(dpp, 0) << "Invalid role arn: " << arn << dendl;
-    return make_tuple(-EINVAL, this->role);
+    return make_tuple(-EINVAL, nullptr);
   }
 }
 
@@ -355,8 +355,8 @@ AssumeRoleWithWebIdentityResponse STSService::assumeRoleWithWebIdentity(AssumeRo
     return response;
   }
 
-  string roleId = role.get_id();
-  uint64_t roleMaxSessionDuration = role.get_max_session_duration();
+  string roleId = role->get_id();
+  uint64_t roleMaxSessionDuration = role->get_max_session_duration();
   req.setMaxDuration(roleMaxSessionDuration);
 
   //Validate input
@@ -409,8 +409,8 @@ AssumeRoleResponse STSService::assumeRole(const DoutPrefixProvider *dpp,
     return response;
   }
 
-  string roleId = role.get_id();
-  uint64_t roleMaxSessionDuration = role.get_max_session_duration();
+  string roleId = role->get_id();
+  uint64_t roleMaxSessionDuration = role->get_max_session_duration();
   req.setMaxDuration(roleMaxSessionDuration);
 
   //Validate input

--- a/src/rgw/rgw_sts.h
+++ b/src/rgw/rgw_sts.h
@@ -227,7 +227,7 @@ class STSService {
   CephContext* cct;
   rgw::sal::Store* store;
   rgw_user user_id;
-  RGWRole role;
+  std::unique_ptr<rgw::sal::RGWRole> role;
   rgw::auth::Identity* identity;
   int storeARN(const DoutPrefixProvider *dpp, string& arn, optional_yield y);
 public:
@@ -235,7 +235,7 @@ public:
   STSService(CephContext* cct, rgw::sal::Store* store, rgw_user user_id,
 	     rgw::auth::Identity* identity)
     : cct(cct), store(store), user_id(user_id), identity(identity) {}
-  std::tuple<int, RGWRole> getRoleInfo(const DoutPrefixProvider *dpp, const string& arn, optional_yield y);
+  std::tuple<int, rgw::sal::RGWRole*> getRoleInfo(const DoutPrefixProvider *dpp, const string& arn, optional_yield y);
   AssumeRoleResponse assumeRole(const DoutPrefixProvider *dpp, AssumeRoleRequest& req, optional_yield y);
   GetSessionTokenResponse getSessionToken(GetSessionTokenRequest& req);
   AssumeRoleWithWebIdentityResponse assumeRoleWithWebIdentity(AssumeRoleWithWebIdentityRequest& req);


### PR DESCRIPTION
This PR is based on the Great Zipper Rename, but won't include it eventually.  It's here so review can start, so just review the one commit.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
