### PR TITLE
ceph-debug-docker: podman build doesn't accept input via stdin

### DIFF
--- a/src/script/ceph-debug-docker.sh
+++ b/src/script/ceph-debug-docker.sh
@@ -115,7 +115,7 @@ EOF
         if [ "${FLAVOR}" = "crimson" ]; then
             ceph_debuginfo+=" ceph-crimson-osd-debuginfo ceph-crimson-osd"
         fi
-        time run docker build $CACHE --tag "$tag" - <<EOF
+        cat > Dockerfile <<EOF
 FROM ${env}
 
 WORKDIR /root
@@ -126,6 +126,7 @@ RUN wget -O /etc/yum.repos.d/ceph-dev.repo $repo_url && \
     yum upgrade -y && \
     yum install -y ceph ${ceph_debuginfo} ceph-fuse ${python_bindings}
 EOF
+        time run docker build $CACHE --tag "$tag" .
     fi
     popd
     rm -rf -- "$T"


### PR DESCRIPTION
podman on centos 8 at least doesn't accept the Dockerfile being fed to
it via stdin. Change that branch of the script to use the same method
that the ubuntu side does.

This gets the script working on senta03 for me.

Signed-off-by: Jeff Layton <jlayton@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
