### PR TITLE
test/pybind/rbd: fixed functional change in encryption API

### DIFF
--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -1362,23 +1362,43 @@ class TestImage(object):
     @require_linux()
     @blocklist_features([RBD_FEATURE_JOURNALING])
     def test_encryption_luks1(self):
-        self.image.write(b'hello world', 0)
-        self.image.encryption_format(RBD_ENCRYPTION_FORMAT_LUKS1, "password")
-        read_bytes = self.image.read(0, 11)
-        assert_not_equal(b'hello world', read_bytes)
-        self.image.encryption_load(RBD_ENCRYPTION_FORMAT_LUKS1, "password")
-        assert_not_equal(read_bytes, self.image.read(0, 11))
+        data = b'hello world'
+        offset = 16<<20
+        image_size = 32<<20
+
+        with Image(ioctx, image_name) as image:
+            image.resize(image_size)
+            image.write(data, offset)
+            image.encryption_format(RBD_ENCRYPTION_FORMAT_LUKS1, "password")
+            assert_not_equal(data, image.read(offset, len(data)))
+        with Image(ioctx, image_name) as image:
+            image.encryption_load(RBD_ENCRYPTION_FORMAT_LUKS1, "password")
+            assert_not_equal(data, image.read(offset, len(data)))
+            image.write(data, offset)
+        with Image(ioctx, image_name) as image:
+            image.encryption_load(RBD_ENCRYPTION_FORMAT_LUKS1, "password")
+            eq(data, image.read(offset, len(data)))
 
     @require_linux()
     @blocklist_features([RBD_FEATURE_JOURNALING])
     def test_encryption_luks2(self):
-        self.image.resize(256 << 20)
-        self.image.write(b'hello world', 0)
-        self.image.encryption_format(RBD_ENCRYPTION_FORMAT_LUKS2, "password")
-        read_bytes = self.image.read(0, 11)
-        assert_not_equal(b'hello world', read_bytes)
-        self.image.encryption_load(RBD_ENCRYPTION_FORMAT_LUKS2, "password")
-        assert_not_equal(read_bytes, self.image.read(0, 11))
+        data = b'hello world'
+        offset = 16<<20
+        image_size = 256<<20
+
+        with Image(ioctx, image_name) as image:
+            image.resize(image_size)
+            image.write(data, offset)
+            image.encryption_format(RBD_ENCRYPTION_FORMAT_LUKS2, "password")
+            assert_not_equal(data, image.read(offset, len(data)))
+        with Image(ioctx, image_name) as image:
+            image.encryption_load(RBD_ENCRYPTION_FORMAT_LUKS2, "password")
+            assert_not_equal(data, image.read(offset, len(data)))
+            image.write(data, offset)
+        with Image(ioctx, image_name) as image:
+            image.encryption_load(RBD_ENCRYPTION_FORMAT_LUKS2, "password")
+            eq(data, image.read(offset, len(data)))
+
 
 class TestImageId(object):
 


### PR DESCRIPTION
The encryption format API now also implicitly loads the encryption
layer. This tweaks the tests to account for this functional
difference.

Fixes: https://tracker.ceph.com/issues/49848
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
