### PR TITLE
test: ignore failures to force-enable lockdep

### DIFF
--- a/src/test/immutable_object_cache/test_main.cc
+++ b/src/test/immutable_object_cache/test_main.cc
@@ -23,8 +23,7 @@ int main(int argc, char **argv)
 
   int r = rados.conf_set("lockdep", "true");
   if (r < 0) {
-    std::cerr << "failed to enable lockdep" << std::endl;
-    return -r;
+    std::cerr << "warning: failed to enable lockdep" << std::endl;
   }
   return RUN_ALL_TESTS();
 }

--- a/src/test/librbd/test_main.cc
+++ b/src/test/librbd/test_main.cc
@@ -60,8 +60,7 @@ int main(int argc, char **argv)
 
   int r = rados.conf_set("lockdep", "true");
   if (r < 0) {
-    std::cerr << "failed to enable lockdep" << std::endl;
-    return -r;
+    std::cerr << "warning: failed to enable lockdep" << std::endl;
   }
 
   int seed = getpid();

--- a/src/test/rbd_mirror/test_main.cc
+++ b/src/test/rbd_mirror/test_main.cc
@@ -46,8 +46,7 @@ int main(int argc, char **argv)
 
   int r = rados.conf_set("lockdep", "true");
   if (r < 0) {
-    std::cerr << "failed to enable lockdep" << std::endl;
-    return -r;
+    std::cerr << "warning: failed to enable lockdep" << std::endl;
   }
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
PR #40062 tweaked the behavior of lockdep to compile it out
of the code entirely for release builds. This fixes several
gtests where lockdep was force-enabled.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
