### PR TITLE
mgr/cephadm/configchecks: do not spam info every minute

### DIFF
--- a/src/pybind/mgr/cephadm/configchecks.py
+++ b/src/pybind/mgr/cephadm/configchecks.py
@@ -676,8 +676,6 @@ class CephadmConfigChecks:
     def run_checks(self) -> None:
         checks_enabled = self.mgr.get_module_option('config_checks_enabled')
         if checks_enabled is not True:
-            self.log.info("ALL cephadm checks are disabled, use 'ceph config set mgr "
-                          "mgr/cephadm/config_checks_enabled true' to enable")
             return
 
         self.reset()

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1781,7 +1781,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                     args.append((name, host))
         if not args:
             raise OrchestratorError('Unable to find daemon(s) %s' % (names))
-        self.log.info('Remove daemons %s' % [a[0] for a in args])
+        self.log.info('Remove daemons %s' % ' '.join([a[0] for a in args]))
         return self._remove_daemons(args)
 
     @handle_orch_error

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -442,7 +442,7 @@ class CephService(CephadmService):
 
         entity = self.get_auth_entity(daemon_id, host=host)
 
-        logger.info(f'Remove keyring: {entity}')
+        logger.info(f'Removing key for {entity}')
         ret, out, err = self.mgr.mon_command({
             'prefix': 'auth rm',
             'entity': entity,

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -117,7 +117,7 @@ class NFSService(CephService):
         if spec.namespace:
             osd_caps = '%s namespace=%s' % (osd_caps, spec.namespace)
 
-        logger.info('Create keyring: %s' % entity)
+        logger.info('Creating key for %s' % entity)
         keyring = self.get_keyring_with_caps(entity,
                                              ['mon', 'allow r',
                                               'osd', osd_caps])
@@ -128,7 +128,7 @@ class NFSService(CephService):
         daemon_id = daemon_spec.daemon_id
         entity: AuthEntity = self.get_auth_entity(f'{daemon_id}-rgw')
 
-        logger.info('Create keyring: %s' % entity)
+        logger.info('Creating key for %s' % entity)
         keyring = self.get_keyring_with_caps(entity,
                                              ['mon', 'allow r',
                                               'osd', 'allow rwx tag rgw *=*'])
@@ -140,7 +140,7 @@ class NFSService(CephService):
         daemon_id: str = daemon.daemon_id
         entity: AuthEntity = self.get_auth_entity(f'{daemon_id}-rgw')
 
-        logger.info(f'Remove keyring: {entity}')
+        logger.info(f'Removing key for {entity}')
         ret, out, err = self.mgr.check_mon_command({
             'prefix': 'auth rm',
             'entity': entity,


### PR DESCRIPTION
It doesn't make to spam INF every minute.  Reducing this to DBG means it'll never be seen.  Just remove it.
