### PR TITLE
mgr/dashboard: Fix for broken User management role cloning

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/role.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/role.service.spec.ts
@@ -46,8 +46,9 @@ describe('RoleService', () => {
 
   it('should call clone', () => {
     service.clone('foo', 'bar').subscribe();
-    const req = httpTesting.expectOne('api/role/foo/clone?new_name=bar');
+    const req = httpTesting.expectOne('api/role/foo/clone');
     expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ new_name: 'bar' });
   });
 
   it('should check if role name exists', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/role.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/role.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
 import { Observable, of as observableOf } from 'rxjs';
@@ -29,9 +29,7 @@ export class RoleService {
   }
 
   clone(name: string, newName: string) {
-    let params = new HttpParams();
-    params = params.append('new_name', newName);
-    return this.http.post(`api/role/${name}/clone`, null, { params });
+    return this.http.post(`api/role/${name}/clone`, { new_name: newName });
   }
 
   update(role: RoleFormModel) {


### PR DESCRIPTION
Cloning a role in user management gets hit with a 415 error.

Fixes: https://tracker.ceph.com/issues/49880
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
