### PR TITLE
cephadm: make default image the daily master build

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -45,7 +45,7 @@ from urllib.error import HTTPError
 from urllib.request import urlopen
 
 # Default container images -----------------------------------------------------
-DEFAULT_IMAGE = 'docker.io/ceph/daemon-base:latest-master-devel'
+DEFAULT_IMAGE = 'quay.ceph.io/ceph-ci/ceph:master'
 DEFAULT_IMAGE_IS_MASTER = True
 DEFAULT_PROMETHEUS_IMAGE = 'docker.io/prom/prometheus:v2.18.1'
 DEFAULT_NODE_EXPORTER_IMAGE = 'docker.io/prom/node-exporter:v0.18.1'


### PR DESCRIPTION
This mostly doesn't matter, except that (1) pulls inside the ceph lab will be faster, and (2) we remove another dependency on the latest-$foo-devel tags on the docker repo (which are generated by some magic I am unfamiliar with).  I have a general desire to reduce the number of dependencies on unknown magic (to me at least), and the branch tags in quay.ceph.io are needed everywhere, and I don't expect too many users of that default image outside the lab, so this is a small step forward.