### PR TITLE
cephadm,servicemap: fix rbd-mirror, cephfs-mirror, rgw servicemap identification; adjust servicemap reporting

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2372,7 +2372,7 @@ def get_container(ctx: CephadmContext,
         name = 'client.rgw.%s' % daemon_id
     elif daemon_type == 'rbd-mirror':
         entrypoint = '/usr/bin/rbd-mirror'
-        name = 'client.cephfs-mirror.%s' % daemon_id
+        name = 'client.rbd-mirror.%s' % daemon_id
     elif daemon_type == 'cephfs-mirror':
         entrypoint = '/usr/bin/cephfs-mirror'
         name = 'client.cephfs-mirror.%s' % daemon_id

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -409,15 +409,18 @@ class CephadmServe:
                     daemon_id = s.get('id')
                     assert daemon_id
                     name = '%s.%s' % (s.get('type'), daemon_id)
-                    if s.get('type') == 'rbd-mirror':
+                    if s.get('type') in ['rbd-mirror', 'cephfs-mirror', 'rgw']:
                         metadata = self.mgr.get_metadata(
-                            "rbd-mirror", daemon_id, {})
+                            cast(str, s.get('type')), daemon_id, {})
                         assert metadata is not None
                         try:
                             name = '%s.%s' % (s.get('type'), metadata['id'])
                         except (KeyError, TypeError):
                             self.log.debug(
-                                "Failed to find daemon id for rbd-mirror service %s" % (s.get('id')))
+                                "Failed to find daemon id for %s service %s" % (
+                                    s.get('type'), s.get('id')
+                                )
+                            )
                     elif s.get('type') == 'rgw-nfs':
                         # https://tracker.ceph.com/issues/49573
                         name = daemon_id.split('-rgw')[0]

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1126,17 +1126,21 @@ int RGWRados::init_rados()
 
 int RGWRados::register_to_service_map(const string& daemon_type, const map<string, string>& meta)
 {
+  string name = cct->_conf->name.get_id();
+  if (name.compare(0, 4, "rgw.") == 0) {
+    name = name.substr(4);
+  }
   map<string,string> metadata = meta;
   metadata["num_handles"] = "1"s;
   metadata["zonegroup_id"] = svc.zone->get_zonegroup().get_id();
   metadata["zonegroup_name"] = svc.zone->get_zonegroup().get_name();
   metadata["zone_name"] = svc.zone->zone_name();
   metadata["zone_id"] = svc.zone->zone_id().id;
-  string name = cct->_conf->name.get_id();
-  if (name.compare(0, 4, "rgw.") == 0) {
-    name = name.substr(4);
-  }
-  int ret = rados.service_daemon_register(daemon_type, name, metadata);
+  metadata["id"] = name;
+  int ret = rados.service_daemon_register(
+    daemon_type,
+    stringify(rados.get_instance_id()),
+    metadata);
   if (ret < 0) {
     ldout(cct, 0) << "ERROR: service_daemon_register() returned ret=" << ret << ": " << cpp_strerror(-ret) << dendl;
     return ret;


### PR DESCRIPTION
- make cephfs-mirror and rgw do what rbd-mirror does: register under a gid, and include an ``id`` key with their auth id/name
- fix rbd-mirror deployment
- adjust cephadm to identify daemons registering under gid (look for their ``id`` key, if present)
- change the ``ceph -s`` summary code to count total daemons and groupings (distinct hosts, zones)

```
  services:
    mon:           1 daemons, quorum a (age 15s)
    mgr:           x(active, since 92s)
    osd:           1 osds: 1 up (since 71s), 1 in (since 88s)
    cephfs-mirror: 1 daemon active (1 hosts)
    rbd-mirror:    2 daemons active (1 hosts)
    rgw:           2 daemons active (1 hosts, 1 zones)
```
