### PR TITLE
pacific: qa/tasks: Add additional wait_for_clean() check in lost_unfound tasks.

### DIFF
--- a/qa/tasks/ec_lost_unfound.py
+++ b/qa/tasks/ec_lost_unfound.py
@@ -156,3 +156,4 @@ def task(ctx, config):
     manager.wait_till_osd_is_up(1)
     manager.wait_for_clean()
     run.wait(procs)
+    manager.wait_for_clean()

--- a/qa/tasks/lost_unfound.py
+++ b/qa/tasks/lost_unfound.py
@@ -177,3 +177,4 @@ def task(ctx, config):
     manager.wait_till_osd_is_up(1)
     manager.wait_for_clean()
     run.wait(procs)
+    manager.wait_for_clean()

--- a/qa/tasks/rep_lost_unfound_delete.py
+++ b/qa/tasks/rep_lost_unfound_delete.py
@@ -175,4 +175,5 @@ def task(ctx, config):
     manager.wait_till_osd_is_up(1)
     manager.wait_for_clean()
     run.wait(procs)
+    manager.wait_for_clean()
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49886

---

backport of https://github.com/ceph/ceph/pull/40161
parent tracker: https://tracker.ceph.com/issues/49844

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh