### PR TITLE
cephadm: prevent podman from breaking socket.getfqdn()

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3036,9 +3036,13 @@ class CephContainer:
             '--ipc=host',
         ]
 
-        if 'podman' in self.ctx.container_path and \
-           os.path.exists('/etc/ceph/podman-auth.json'):
-            cmd_args.append('--authfile=/etc/ceph/podman-auth.json')
+        if 'podman' in self.ctx.container_path:
+            # podman adds the container *name* to /etc/hosts (for 127.0.1.1)
+            # by default, which makes python's socket.getfqdn() return that
+            # instead of a valid hostname.
+            cmd_args.append('--no-hosts')
+            if os.path.exists('/etc/ceph/podman-auth.json'):
+                cmd_args.append('--authfile=/etc/ceph/podman-auth.json')
 
         envs: List[str] = [
             '-e', 'CONTAINER_IMAGE=%s' % self.image,


### PR DESCRIPTION
socket.getfqdn() will return the reverse lookup for 127.0.1.1, which is
the last item listed for that IP in /etc/hosts.  Podman, by default, will
append the container name (ceph-$fsid-$name) to that line, which is not
a valid hostname, and not what we want the dashbaord to use for the URI
it advertises in the service map.

Pass --no-hosts to podman to disable this.

Docker does not appear to modify /etc/hosts by default--or, more
importantly, does not add the container name there.

Explicitly instruct podman (and docker) to add a

Fixes: https://tracker.ceph.com/issues/49890



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>