### PR TITLE
octopus: qa/tasks/mgr/test_progress.py:  remove calling of _osd_in_out_completed_events_count()

### DIFF
--- a/qa/tasks/mgr/test_progress.py
+++ b/qa/tasks/mgr/test_progress.py
@@ -83,29 +83,6 @@ class TestProgress(MgrTestCase):
 
     def _osd_in_out_events_count(self, marked='both'):
         """
-        Return the event that deals with OSDs being
-        marked in, out or both
-        """
-
-        marked_in_events = []
-        marked_out_events = []
-
-        events_in_progress = self._events_in_progress()
-        for ev in events_in_progress:
-            if self.is_osd_marked_out(ev):
-                marked_out_events.append(ev)
-            elif self.is_osd_marked_in(ev):
-                marked_in_events.append(ev)
-
-        if marked == 'both':
-            return [marked_in_events] + [marked_out_events]
-        elif marked == 'in':
-            return marked_in_events
-        else:
-            return marked_out_events
-
-    def _osd_in_out_events_count(self, marked='both'):
-        """
         Count the number of on going recovery events that deals with
         OSDs being marked in, out or both.
         """
@@ -350,9 +327,7 @@ class TestProgress(MgrTestCase):
         # Check that no event is created
         time.sleep(self.EVENT_CREATION_PERIOD)
 
-        self.assertEqual(
-            self._osd_in_out_completed_events_count('out'),
-            osd_count - pool_size)
+        self.assertEqual(len(self._all_events()), osd_count - pool_size)
 
     def test_turn_off_module(self):
         """


### PR DESCRIPTION
delete the part where  _osd_in_out_completed_events_count()
was called in test_osd_cannot_recover() and revert to initial
state of the function since we don't need to use this function
in octopus. Also delete a duplicate of _osd_in_out_events_count().
This must be added by mistake in #39289 as well.

No need to fix for the backport in Nautilus: #38173
since the bugs are occured by adding additional code to
the cherry-pick specifically for Octopus.

fixes: https://tracker.ceph.com/issues/49891

Signed-off-by: Kamoltat <ksirivad@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
