### PR TITLE
pacific: osd: remove a ceph_assert() from a legitimate path

### DIFF
--- a/src/osd/pg_scrubber.cc
+++ b/src/osd/pg_scrubber.cc
@@ -807,7 +807,6 @@ void PgScrubber::on_init()
 
 void PgScrubber::on_replica_init()
 {
-  ceph_assert(!m_active);
   m_active = true;
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49895

---

backport of https://github.com/ceph/ceph/pull/40185
parent tracker: https://tracker.ceph.com/issues/49867

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh