### PR TITLE
run-make-check.sh: increase fs.aio-max-nr

### DIFF
--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -32,7 +32,11 @@ function run() {
 
     # increase the aio-max-nr, which is by default 65536. we could reach this
     # limit while running seastar tests and bluestore tests.
-    $DRY_RUN sudo /sbin/sysctl -q -w fs.aio-max-nr=$((65536 * 16))
+    local m=16
+    if [ $(nproc) -gt $m ]; then
+        m=$(nproc)
+    fi
+    $DRY_RUN sudo /sbin/sysctl -q -w fs.aio-max-nr=$((65536 * $(nproc)))
 
     CHECK_MAKEOPTS=${CHECK_MAKEOPTS:-$DEFAULT_MAKEOPTS}
     if ! $DRY_RUN ctest $CHECK_MAKEOPTS --output-on-failure; then

--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -4,7 +4,8 @@ add_executable(unittest-crimson-backfill
   ${PROJECT_SOURCE_DIR}/src/auth/Crypto.cc
   ${PROJECT_SOURCE_DIR}/src/crimson/osd/backfill_state.cc
   ${PROJECT_SOURCE_DIR}/src/osd/recovery_types.cc)
-add_ceph_unittest(unittest-crimson-backfill)
+add_ceph_unittest(unittest-crimson-backfill
+  unittest-crimson-backfill --memory 256M --smp 1)
 target_link_libraries(unittest-crimson-backfill crimson GTest::Main)
 
 add_executable(unittest-seastar-buffer
@@ -15,7 +16,7 @@ target_link_libraries(unittest-seastar-buffer crimson)
 
 add_executable(unittest-seastar-denc
   test_denc.cc)
-add_ceph_unittest(unittest-seastar-denc)
+add_ceph_unittest(unittest-seastar-denc --memory 256M --smp 1)
 target_link_libraries(unittest-seastar-denc crimson GTest::Main)
 
 add_executable(unittest-seastar-socket test_socket.cc)
@@ -50,7 +51,7 @@ target_link_libraries(unittest-seastar-alienstore-thread-pool
 add_executable(unittest-seastar-config
   test_config.cc)
 add_ceph_test(unittest-seastar-config
-  unittest-seastar-config --memory 256M)
+  unittest-seastar-config --memory 256M --smp 4)
 target_link_libraries(unittest-seastar-config crimson)
 
 add_executable(unittest-seastar-monc
@@ -75,7 +76,8 @@ add_ceph_unittest(unittest-fixed-kv-node-layout)
 add_executable(unittest_interruptible_future
   test_interruptible_future.cc
   gtest_seastar.cc)
-add_ceph_unittest(unittest_interruptible_future)
+add_ceph_unittest(unittest_interruptible_future
+  unittest_interruptible_future --memory 256M --smp 1)
 target_link_libraries(
   unittest_interruptible_future
   crimson-common)
@@ -92,4 +94,5 @@ add_executable(unittest-seastar-errorator
 target_link_libraries(
   unittest-seastar-errorator
   crimson::gtest)
-add_ceph_unittest(unittest-seastar-errorator)
+add_ceph_unittest(unittest-seastar-errorator
+  unittest-seastar-errorator --memory 256M --smp 1)

--- a/src/test/crimson/seastore/CMakeLists.txt
+++ b/src/test/crimson/seastore/CMakeLists.txt
@@ -2,7 +2,8 @@ add_executable(unittest-transaction-manager
   test_block.cc
   test_transaction_manager.cc
   ../gtest_seastar.cc)
-add_ceph_unittest(unittest-transaction-manager)
+add_ceph_unittest(unittest-transaction-manager
+  unittest-seastar-socket --memory 256M --smp 1)
 target_link_libraries(
   unittest-transaction-manager
   ${CMAKE_DL_LIBS}
@@ -11,7 +12,8 @@ target_link_libraries(
 add_executable(unittest-btree-lba-manager
   test_btree_lba_manager.cc
   ../gtest_seastar.cc)
-add_ceph_unittest(unittest-btree-lba-manager)
+add_ceph_unittest(unittest-btree-lba-manager
+  unittest-btree-lba-manager --memory 256M --smp 1)
 target_link_libraries(
   unittest-btree-lba-manager
   ${CMAKE_DL_LIBS}
@@ -20,7 +22,7 @@ target_link_libraries(
 add_executable(unittest-seastore-journal
   test_seastore_journal.cc)
 add_ceph_test(unittest-seastore-journal
-  unittest-seastore-journal)
+  unittest-seastore-journal --memory 256M --smp 1)
 target_link_libraries(
   unittest-seastore-journal
   crimson::gtest
@@ -30,7 +32,7 @@ add_executable(unittest-seastore-cache
   test_block.cc
   test_seastore_cache.cc)
 add_ceph_test(unittest-seastore-cache
-  unittest-seastore-cache)
+  unittest-seastore-cache --memory 256M --smp 1)
 target_link_libraries(
   unittest-seastore-cache
   crimson::gtest
@@ -39,7 +41,8 @@ target_link_libraries(
 add_executable(unittest-extmap-manager
   test_extmap_manager.cc
   ../gtest_seastar.cc)
-add_ceph_unittest(unittest-extmap-manager)
+add_ceph_unittest(unittest-extmap-manager
+  unittest-extmap-manager --memory 256M --smp 1)
 target_link_libraries(
   unittest-extmap-manager
   crimson::gtest
@@ -50,7 +53,8 @@ target_link_libraries(
 add_executable(unittest-collection-manager
   test_collection_manager.cc
   ../gtest_seastar.cc)
-add_ceph_unittest(unittest-collection-manager)
+add_ceph_unittest(unittest-collection-manager
+  unittest-collection-manager --memory 256M --smp 1)
 target_link_libraries(
   unittest-collection-manager
   crimson::gtest
@@ -61,7 +65,8 @@ target_link_libraries(
 add_executable(unittest-omap-manager
   test_omap_manager.cc
   ../gtest_seastar.cc)
-add_ceph_unittest(unittest-omap-manager)
+add_ceph_unittest(unittest-omap-manager
+  unittest-omap-manager --memory 256M --smp 1)
 target_link_libraries(
   unittest-omap-manager
   ${CMAKE_DL_LIBS}
@@ -70,7 +75,8 @@ target_link_libraries(
 add_executable(unittest-seastore
   test_seastore.cc
   ../gtest_seastar.cc)
-add_ceph_unittest(unittest-seastore)
+add_ceph_unittest(unittest-seastore
+  unittest-seastore --memory 256M --smp 1)
 target_link_libraries(
   unittest-seastore
   ${CMAKE_DL_LIBS}

--- a/src/test/crimson/seastore/onode_tree/CMakeLists.txt
+++ b/src/test/crimson/seastore/onode_tree/CMakeLists.txt
@@ -1,13 +1,15 @@
 add_executable(unittest-staged-fltree
   test_staged_fltree.cc
   ../../gtest_seastar.cc)
-add_ceph_unittest(unittest-staged-fltree)
+add_ceph_unittest(unittest-staged-fltree
+  unittest-staged-fltree --memory 256M --smp 1)
 target_link_libraries(unittest-staged-fltree
   crimson-seastore)
 
 add_executable(unittest-fltree-onode-manager
   test_fltree_onode_manager.cc
   ../../gtest_seastar.cc)
-add_ceph_unittest(unittest-fltree-onode-manager)
+add_ceph_unittest(unittest-fltree-onode-manager
+  unittest-fltree-onode-manager --memory 256M --smp 1)
 target_link_libraries(unittest-fltree-onode-manager
   crimson-seastore)


### PR DESCRIPTION
without this change the seastar based tests fail on host with 48 cores,
because the /proc/sys/fs/aio-nr used by the tests is greater than
1048576. if run-make-check.sh is used to launch the test, the default
job number is `$(nproc) / 2`, and the peak number of /proc/sys/fs/aio-nr
when running ctest was 3190848 when testing on the 48-core host.

so we need to increase fs.aio-max-nr accordingly to the available cores
on the host.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
