### PR TITLE
client: always register callbacks before mount() and clean up the snaprealm

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4771,37 +4771,6 @@ void Client::early_kick_flushing_caps(MetaSession *session)
   }
 }
 
-void SnapRealm::build_snap_context()
-{
-  set<snapid_t> snaps;
-  snapid_t max_seq = seq;
-  
-  // start with prior_parents?
-  for (unsigned i=0; i<prior_parent_snaps.size(); i++)
-    snaps.insert(prior_parent_snaps[i]);
-
-  // current parent's snaps
-  if (pparent) {
-    const SnapContext& psnapc = pparent->get_snap_context();
-    for (unsigned i=0; i<psnapc.snaps.size(); i++)
-      if (psnapc.snaps[i] >= parent_since)
-	snaps.insert(psnapc.snaps[i]);
-    if (psnapc.seq > max_seq)
-      max_seq = psnapc.seq;
-  }
-
-  // my snaps
-  for (unsigned i=0; i<my_snaps.size(); i++)
-    snaps.insert(my_snaps[i]);
-
-  // ok!
-  cached_snap_context.seq = max_seq;
-  cached_snap_context.snaps.resize(0);
-  cached_snap_context.snaps.reserve(snaps.size());
-  for (set<snapid_t>::reverse_iterator p = snaps.rbegin(); p != snaps.rend(); ++p)
-    cached_snap_context.snaps.push_back(*p);
-}
-
 void Client::invalidate_snaprealm_and_children(SnapRealm *realm)
 {
   list<SnapRealm*> q;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -623,7 +623,9 @@ public:
   int ll_osdaddr(int osd, uint32_t *addr);
   int ll_osdaddr(int osd, char* buf, size_t size);
 
-  void ll_register_callbacks(struct ceph_client_callback_args *args);
+  void _ll_register_callbacks(struct ceph_client_callback_args *args);
+  void ll_register_callbacks(struct ceph_client_callback_args *args); // deprecated
+  int ll_register_callbacks2(struct ceph_client_callback_args *args);
   int test_dentry_handling(bool can_invalidate);
 
   const char** get_tracked_conf_keys() const override;

--- a/src/client/ClientSnapRealm.cc
+++ b/src/client/ClientSnapRealm.cc
@@ -4,6 +4,37 @@
 #include "ClientSnapRealm.h"
 #include "common/Formatter.h"
 
+void SnapRealm::build_snap_context()
+{
+  set<snapid_t> snaps;
+  snapid_t max_seq = seq;
+
+  // start with prior_parents?
+  for (unsigned i=0; i<prior_parent_snaps.size(); i++)
+    snaps.insert(prior_parent_snaps[i]);
+
+  // current parent's snaps
+  if (pparent) {
+    const SnapContext& psnapc = pparent->get_snap_context();
+    for (unsigned i=0; i<psnapc.snaps.size(); i++)
+      if (psnapc.snaps[i] >= parent_since)
+	snaps.insert(psnapc.snaps[i]);
+    if (psnapc.seq > max_seq)
+      max_seq = psnapc.seq;
+  }
+
+  // my snaps
+  for (unsigned i=0; i<my_snaps.size(); i++)
+    snaps.insert(my_snaps[i]);
+
+  // ok!
+  cached_snap_context.seq = max_seq;
+  cached_snap_context.snaps.resize(0);
+  cached_snap_context.snaps.reserve(snaps.size());
+  for (set<snapid_t>::reverse_iterator p = snaps.rbegin(); p != snaps.rend(); ++p)
+    cached_snap_context.snaps.push_back(*p);
+}
+
 void SnapRealm::dump(Formatter *f) const
 {
   f->dump_stream("ino") << ino;

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -1322,6 +1322,26 @@ int CephFuse::Handle::init(int argc, const char *argv[])
 
   ceph_assert(args.allocated);  // Checking fuse has realloc'd args so we can free newargv
   free(newargv);
+
+  struct ceph_client_callback_args cb_args = {
+    handle: this,
+    ino_cb: client->cct->_conf.get_val<bool>("fuse_use_invalidate_cb") ?
+      ino_invalidate_cb : NULL,
+    dentry_cb: dentry_invalidate_cb,
+    switch_intr_cb: switch_interrupt_cb,
+#if defined(__linux__)
+    remount_cb: remount_cb,
+#endif
+#if !defined(__APPLE__)
+    umask_cb: umask_cb,
+#endif
+  };
+  r = client->ll_register_callbacks2(&cb_args);
+  if (r) {
+    derr << "registering callbacks failed: " << r << dendl;
+    return r;
+  }
+
   return 0;
 }
 
@@ -1362,22 +1382,6 @@ int CephFuse::Handle::start()
 #else
   fuse_session_add_chan(se, ch);
 #endif
-
-
-  struct ceph_client_callback_args args = {
-    handle: this,
-    ino_cb: client->cct->_conf.get_val<bool>("fuse_use_invalidate_cb") ?
-      ino_invalidate_cb : NULL,
-    dentry_cb: dentry_invalidate_cb,
-    switch_intr_cb: switch_interrupt_cb,
-#if defined(__linux__)
-    remount_cb: remount_cb,
-#endif
-#if !defined(__APPLE__)
-    umask_cb: umask_cb,
-#endif
-  };
-  client->ll_register_callbacks(&args);
 
   return 0;
 }

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -39,7 +39,7 @@ extern "C" {
 
 #define LIBCEPHFS_VER_MAJOR 10
 #define LIBCEPHFS_VER_MINOR 0
-#define LIBCEPHFS_VER_EXTRA 2
+#define LIBCEPHFS_VER_EXTRA 3
 
 #define LIBCEPHFS_VERSION(maj, min, extra) ((maj << 16) + (min << 8) + extra)
 #define LIBCEPHFS_VERSION_CODE LIBCEPHFS_VERSION(LIBCEPHFS_VER_MAJOR, LIBCEPHFS_VER_MINOR, LIBCEPHFS_VER_EXTRA)
@@ -1955,6 +1955,9 @@ void ceph_finish_reclaim(struct ceph_mount_info *cmount);
 
 /**
  * Register a set of callbacks to be used with this cmount
+ *
+ * This is deprecated, use ceph_ll_register_callbacks2() instead.
+ *
  * @param cmount the ceph mount handle on which the cb's should be registerd
  * @param args   callback arguments to register with the cmount
  *
@@ -1962,6 +1965,19 @@ void ceph_finish_reclaim(struct ceph_mount_info *cmount);
  * unregister these callbacks, so this is a one-way change.
  */
 void ceph_ll_register_callbacks(struct ceph_mount_info *cmount,
+				struct ceph_client_callback_args *args);
+
+/**
+ * Register a set of callbacks to be used with this cmount
+ * @param cmount the ceph mount handle on which the cb's should be registerd
+ * @param args   callback arguments to register with the cmount
+ *
+ * Any fields set to NULL will be ignored. There currently is no way to
+ * unregister these callbacks, so this is a one-way change.
+ *
+ * Returns 0 on success or -EBUSY if the cmount is mounting or already mounted.
+ */
+int ceph_ll_register_callbacks2(struct ceph_mount_info *cmount,
 				struct ceph_client_callback_args *args);
 
 /**

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -2075,11 +2075,17 @@ extern "C" void ceph_finish_reclaim(class ceph_mount_info *cmount)
   cmount->get_client()->finish_reclaim();
 }
 
+// This is deprecated, use ceph_ll_register_callbacks2 instead.
 extern "C" void ceph_ll_register_callbacks(class ceph_mount_info *cmount,
 					   struct ceph_client_callback_args *args)
 {
   cmount->get_client()->ll_register_callbacks(args);
+}
 
+extern "C" int ceph_ll_register_callbacks2(class ceph_mount_info *cmount,
+					    struct ceph_client_callback_args *args)
+{
+  return cmount->get_client()->ll_register_callbacks2(args);
 }
 
 

--- a/src/test/fs/test_ino_release_cb.cc
+++ b/src/test/fs/test_ino_release_cb.cc
@@ -56,7 +56,8 @@ int main(int argc, char *argv[])
 
 	struct ceph_client_callback_args args = { 0 };
 	args.ino_release_cb = cb;
-	ceph_ll_register_callbacks(cmount, &args);
+	ret = ceph_ll_register_callbacks2(cmount, &args);
+	assert(ret == 0);
 
 	ret = ceph_mount(cmount, NULL);
 	assert(ret >= 0);


### PR DESCRIPTION
This can help get rid of the client_lock in ll_register_callbacks()
and later the inode lock patches can benefit from it.

Fixes: https://tracker.ceph.com/issues/50149
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
