### PR TITLE
cmake: use fixture for preparing venv

### DIFF
--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -70,14 +70,17 @@ function(add_tox_test name)
   endif()
   string(REPLACE ";" "," tox_envs "${tox_envs}")
   find_package(Python3 QUIET REQUIRED)
-  add_custom_command(
-    OUTPUT ${venv_path}/bin/activate
-    COMMAND ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python="${Python3_EXECUTABLE}" ${venv_path}
-    WORKING_DIRECTORY ${tox_path}
-    COMMENT "preparing venv for ${name}")
-  add_custom_target(${name}-venv
-    DEPENDS ${venv_path}/bin/activate)
-  add_dependencies(tests ${name}-venv)
+  add_test(
+    NAME setup-venv-for-${name}
+    COMMAND ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python=${Python3_EXECUTABLE} ${venv_path}
+    WORKING_DIRECTORY ${tox_path})
+  set_tests_properties(setup-venv-for-${name} PROPERTIES
+    FIXTURES_SETUP venv-for-${name})
+  add_test(
+    NAME teardown-venv-for-${name}
+    COMMAND ${CMAKE_COMMAND} -E remove_directory ${venv_path})
+  set_tests_properties(teardown-venv-for-${name} PROPERTIES
+    FIXTURES_CLEANUP venv-for-${name})
   add_test(
     NAME ${test_name}
     COMMAND ${CMAKE_SOURCE_DIR}/src/script/run_tox.sh
@@ -86,6 +89,8 @@ function(add_tox_test name)
               --tox-path ${tox_path}
               --tox-envs ${tox_envs}
               --venv-path ${venv_path})
+  set_tests_properties(${test_name} PROPERTIES
+    FIXTURES_REQUIRED venv-for-${name})
   set_property(
     TEST ${test_name}
     PROPERTY ENVIRONMENT


### PR DESCRIPTION
this change should allow us to decouple "ninja tests" from "ctest".
in other words, we can just run

ctest -R run-tox-python-common -V

without running "ninja tests" first. before this change

${name}-venv is added as a dependency of "tests" target.

after this change,

setup-venv-for-${name} is added as a test, which is in turn a test of
run-tox-${name}, so we can just

ctest -R run-tox-${name}

now for preparing the venv and then testing the tox test of ${name}.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
