### PR TITLE
os/bluestore: yet another modifications around onode pinning

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3990,10 +3990,15 @@ void BlueStore::Collection::split_cache(
 {
   ldout(store->cct, 10) << __func__ << " to " << dest << dendl;
 
-  // lock (one or both) cache shards
-  std::lock(cache->lock, dest->cache->lock);
-  std::lock_guard l(cache->lock, std::adopt_lock);
-  std::lock_guard l2(dest->cache->lock, std::adopt_lock);
+  auto *ocache = get_onode_cache();
+  auto *ocache_dest = dest->get_onode_cache();
+
+ // lock cache shards
+  std::lock(ocache->lock, ocache_dest->lock, cache->lock, dest->cache->lock);
+  std::lock_guard l(ocache->lock, std::adopt_lock);
+  std::lock_guard l2(ocache_dest->lock, std::adopt_lock);
+  std::lock_guard l3(cache->lock, std::adopt_lock);
+  std::lock_guard l4(dest->cache->lock, std::adopt_lock);
 
   int destbits = dest->cnode.bits;
   spg_t destpg;


### PR DESCRIPTION
Aside from split_cache fix to acquire proper locks this patch refactors onode pinning in the following way:
1. Onode:get() increments ref counter only
2. That's CacheShard::_trim_to which removes pinned onodes from lru if their nrefs match the cnref > 1 condition
3. Once met nref = 1 Onode::put requests CacheShard to  touch and unpin onode via touch_and_maybe_unpin() call. This might need locking in CacheShard. Concurring puts need to wait until such an unpin is completed. Which is achieved via using atonic's compare_and_exchange  call.
4. LruOnodeCacheShard's touch_and_maybe_unpin(Onode*) implementation takes internal lock (used to control access to lru list only) and inserts provided Onode into a proper position (head or tail, the latter one is used to trim non-existent entries on the next trim_to() call) of the lru.
5. Every LruOnodeCacheShard's methods use internal lock to access lru list.
6. LruOnodeCacheShard's internal lock is private hence it's not used from outside which avoids deadlock conditions with arbitrary outer calls to Onode::put - they might happen under or out of OnodeCacheShard regular lock.
7. It's forbidden (implicitly) to allocate/release OnodeRef instances under the internal lock.


Fixes: https://tracker.ceph.com/issues/49900
Presumably Fixes: https://tracker.ceph.com/issues/49818
Signed-off-by: Igor Fedotov <ifedotov@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
