### PR TITLE
cephadm: use debug verbosity during container exec

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -289,14 +289,14 @@ class Monitoring(object):
                 _, err, code = call(ctx, [
                     ctx.container_path, 'exec', container_id, cmd,
                     '--version'
-                ], verbosity=CallVerbosity.SILENT)
+                ], verbosity=CallVerbosity.DEBUG)
                 if code == 0:
                     break
             cmd = 'alertmanager'  # reset cmd for version extraction
         else:
             _, err, code = call(ctx, [
                 ctx.container_path, 'exec', container_id, cmd, '--version'
-            ])
+            ], verbosity=CallVerbosity.DEBUG)
         if code == 0 and \
                 err.startswith('%s, version ' % cmd):
             version = err.split(' ')[2]
@@ -386,7 +386,8 @@ class NFSGanesha(object):
         version = None
         out, err, code = call(ctx,
                               [ctx.container_path, 'exec', container_id,
-                               NFSGanesha.entrypoint, '-v'])
+                               NFSGanesha.entrypoint, '-v'],
+                              verbosity=CallVerbosity.DEBUG)
         if code == 0:
             match = re.search(r'NFS-Ganesha Release\s*=\s*[V]*([\d.]+)', out)
             if match:
@@ -547,7 +548,8 @@ class CephIscsi(object):
         version = None
         out, err, code = call(ctx,
                               [ctx.container_path, 'exec', container_id,
-                               '/usr/bin/python3', '-c', "import pkg_resources; print(pkg_resources.require('ceph_iscsi')[0].version)"])
+                               '/usr/bin/python3', '-c', "import pkg_resources; print(pkg_resources.require('ceph_iscsi')[0].version)"],
+                              verbosity=CallVerbosity.DEBUG)
         if code == 0:
             version = out.strip()
         return version
@@ -4596,7 +4598,9 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                             check_unit(ctx, legacy_unit_name)
                         if not host_version:
                             try:
-                                out, err, code = call(ctx, ['ceph', '-v'])
+                                out, err, code = call(ctx,
+                                                      ['ceph', '-v'],
+                                                      verbosity=CallVerbosity.DEBUG)
                                 if not code and out.startswith('ceph version '):
                                     host_version = out.split(' ')[2]
                             except Exception:
@@ -4669,7 +4673,8 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                                 if daemon_type in Ceph.daemons:
                                     out, err, code = call(ctx,
                                                           [container_path, 'exec', container_id,
-                                                           'ceph', '-v'])
+                                                           'ceph', '-v'],
+                                                          verbosity=CallVerbosity.DEBUG)
                                     if not code and \
                                        out.startswith('ceph version '):
                                         version = out.split(' ')[2]
@@ -4677,7 +4682,8 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                                 elif daemon_type == 'grafana':
                                     out, err, code = call(ctx,
                                                           [container_path, 'exec', container_id,
-                                                           'grafana-server', '-v'])
+                                                           'grafana-server', '-v'],
+                                                          verbosity=CallVerbosity.DEBUG)
                                     if not code and \
                                        out.startswith('Version '):
                                         version = out.split(' ')[1]
@@ -4690,7 +4696,8 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                                 elif daemon_type == 'haproxy':
                                     out, err, code = call(ctx,
                                                           [container_path, 'exec', container_id,
-                                                           'haproxy', '-v'])
+                                                           'haproxy', '-v'],
+                                                          verbosity=CallVerbosity.DEBUG)
                                     if not code and \
                                        out.startswith('HA-Proxy version '):
                                         version = out.split(' ')[2]
@@ -4698,7 +4705,8 @@ def list_daemons(ctx, detail=True, legacy_dir=None):
                                 elif daemon_type == 'keepalived':
                                     out, err, code = call(ctx,
                                                           [container_path, 'exec', container_id,
-                                                           'keepalived', '--version'])
+                                                           'keepalived', '--version'],
+                                                          verbosity=CallVerbosity.DEBUG)
                                     if not code and \
                                        err.startswith('Keepalived '):
                                         version = err.split(' ')[1]


### PR DESCRIPTION
avoid failures from appearing on the consle when exec'ing within the
container during the `ls` command

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
