### PR TITLE
mon/PGMap: nicely format pg acting in health messages

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2552,11 +2552,11 @@ void PGMap::get_health_checks(
             ss << " for " << utimespan_str(dur);
           }
           ss << ", current state " << pg_state_string(pg_info.state)
-             << ", last acting " << pg_info.acting;
+             << ", last acting " << pg_vector_string(pg_info.acting);
         } else {
           ss << "pg " << pg_id << " is "
              << pg_state_string(pg_info.state);
-          ss << ", acting " << pg_info.acting;
+          ss << ", acting " << pg_vector_string(pg_info.acting);
           if (pg_info.stats.sum.num_objects_unfound) {
             ss << ", " << pg_info.stats.sum.num_objects_unfound
                << " unfound";


### PR DESCRIPTION
For 'pg ls' we show CRUSH_ITEM_NONE as "NONE" and not "2147483647". Do
the same for the health messages.

Signed-off-by: Sage Weil <sage@newdream.net>