### PR TITLE
mgr/cephadm: identify iscsi service by the pool

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1131,7 +1131,7 @@ Usage:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
         spec = IscsiServiceSpec(
-            service_id='iscsi',
+            service_id=pool,
             pool=pool,
             api_user=api_user,
             api_password=api_password,


### PR DESCRIPTION
Since we deploy one of these per pool, name the service by the pool.

Signed-off-by: Sage Weil <sage@newdream.net>