### PR TITLE
pacific: debian/ceph-common.postinst: do not chown cephadm log dirs

### DIFF
--- a/debian/ceph-common.postinst
+++ b/debian/ceph-common.postinst
@@ -78,7 +78,9 @@ case "$1" in
        fi
        if ! dpkg-statoverride --list /var/log/ceph >/dev/null
        then
-           chown -R $SERVER_USER:$SERVER_GROUP /var/log/ceph
+	   # take care not to touch cephadm log subdirs
+           chown $SERVER_USER:$SERVER_GROUP /var/log/ceph
+	   chown $SERVER_USER:$SERVER_GROUP /var/log/ceph/*.log* || true
 	   # members of group ceph can log here, but cannot remove
 	   # others' files.  non-members cannot read any logs.
            chmod u=rwx,g=rwxs,o=t /var/log/ceph


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49728

---

backport of https://github.com/ceph/ceph/pull/39953
parent tracker: https://tracker.ceph.com/issues/49677

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh