### PR TITLE
pacific: client: avoid cct being released while instances are still using it

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -341,6 +341,14 @@ Client::~Client()
 {
   ceph_assert(ceph_mutex_is_not_locked(client_lock));
 
+  // If the task is crashed or aborted and doesn't
+  // get any chance to run the umount and shutdow.
+  {
+    std::scoped_lock l{client_lock};
+    tick_thread_stopped = true;
+    upkeep_cond.notify_one();
+  }
+
   if (upkeeper.joinable())
     upkeeper.join();
 

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -288,7 +288,7 @@ vinodeno_t Client::map_faked_ino(ino_t ino)
 // cons/des
 
 Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
-  : Dispatcher(m->cct),
+  : Dispatcher(m->cct->get()),
     timer(m->cct, timer_lock, false),
     messenger(m),
     monclient(mc),
@@ -296,6 +296,7 @@ Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
     whoami(mc->get_global_id()),
     mount_state(CLIENT_UNMOUNTED, "Client::mountstate_lock"),
     initialize_state(CLIENT_NEW, "Client::initstate_lock"),
+    cct_deleter{m->cct, [](CephContext *p) {p->put();}},
     async_ino_invalidator(m->cct),
     async_dentry_invalidator(m->cct),
     interrupt_finisher(m->cct),

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1181,6 +1181,7 @@ private:
     MAY_READ = 4,
   };
 
+  std::unique_ptr<CephContext, std::function<void(CephContext*)>> cct_deleter;
 
   /* Flags for VXattr */
   static const unsigned VXATTR_RSTAT = 0x1;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49854

---

backport of https://github.com/ceph/ceph/pull/40028
parent tracker: https://tracker.ceph.com/issues/49725

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh