### PR TITLE
pacific: qa/rgw: add librgw_file unit tests to rgw/verify task

### DIFF
--- a/qa/suites/rgw/verify/tasks/cls.yaml
+++ b/qa/suites/rgw/verify/tasks/cls.yaml
@@ -11,3 +11,4 @@ tasks:
         - rgw/test_rgw_gc_log.sh
         - rgw/test_rgw_obj.sh
         - rgw/test_rgw_throttle.sh
+        - rgw/test_librgw_file.sh

--- a/qa/workunits/rgw/test_librgw_file.sh
+++ b/qa/workunits/rgw/test_librgw_file.sh
@@ -11,45 +11,49 @@ then
        --secret $AWS_SECRET_ACCESS_KEY \
        --display-name "librgw test user" \
        --email librgw@example.com || echo "librgw user exists"
+
+    # keyring override for teuthology env
+    KEYRING="/etc/ceph/ceph.keyring"
+    K="-k ${KEYRING}"
 fi
 
 # nfsns is the main suite
 
 # create herarchy, and then list it
 echo "phase 1.1"
-ceph_test_librgw_file_nfsns  --hier1 --dirs1 --create --rename --verbose
+ceph_test_librgw_file_nfsns ${K} --hier1 --dirs1 --create --rename --verbose
 
 # the older librgw_file can consume the namespace
 echo "phase 1.2"
-ceph_test_librgw_file_nfsns --getattr --verbose
+ceph_test_librgw_file_nfsns ${K} --getattr --verbose
 
 # and delete the hierarchy
 echo "phase 1.3"
-ceph_test_librgw_file_nfsns --hier1 --dirs1 --delete --verbose
+ceph_test_librgw_file_nfsns ${K} --hier1 --dirs1 --delete --verbose
 
 # bulk create/delete buckets
 echo "phase 2.1"
-ceph_test_librgw_file_cd --create --multi --verbose
+ceph_test_librgw_file_cd ${K} --create --multi --verbose
 echo "phase 2.2"
-ceph_test_librgw_file_cd --delete --multi --verbose
+ceph_test_librgw_file_cd ${K} --delete --multi --verbose
 
 # write continuation test
 echo "phase 3.1"
-ceph_test_librgw_file_aw --create --large --verify
+ceph_test_librgw_file_aw ${K} --create --large --verify
 echo "phase 3.2"
-ceph_test_librgw_file_aw --delete --large
+ceph_test_librgw_file_aw ${K} --delete --large
 
 # continued readdir
 echo "phase 4.1"
-ceph_test_librgw_file_marker --create --marker1 --marker2 --nobjs=100 --verbose
+ceph_test_librgw_file_marker ${K} --create --marker1 --marker2 --nobjs=100 --verbose
 echo "phase 4.2"
-ceph_test_librgw_file_marker --delete --verbose
+ceph_test_librgw_file_marker ${K} --delete --verbose
 
 # advanced i/o--but skip readv/writev for now--split delete from
 # create and stat ops to avoid fault in sysobject cache
 echo "phase 5.1"
-ceph_test_librgw_file_gp --get --stat --put --create
+ceph_test_librgw_file_gp ${K} --get --stat --put --create
 echo "phase 5.2"
-ceph_test_librgw_file_gp --delete
+ceph_test_librgw_file_gp ${K} --delete
 
 exit 0

--- a/qa/workunits/rgw/test_librgw_file.sh
+++ b/qa/workunits/rgw/test_librgw_file.sh
@@ -1,19 +1,51 @@
 #!/bin/sh -e
 
-export AWS_ACCESS_KEY_ID=`openssl rand -base64 20`
-export AWS_SECRET_ACCESS_KEY=`openssl rand -base64 40`
 
-radosgw-admin user create --uid ceph-test-librgw-file \
+if [ -z ${AWS_ACCESS_KEY_ID} ]
+then
+    export AWS_ACCESS_KEY_ID=`openssl rand -base64 20`
+    export AWS_SECRET_ACCESS_KEY=`openssl rand -base64 40`
+
+    radosgw-admin user create --uid ceph-test-librgw-file \
        --access-key $AWS_ACCESS_KEY_ID \
        --secret $AWS_SECRET_ACCESS_KEY \
        --display-name "librgw test user" \
        --email librgw@example.com || echo "librgw user exists"
+fi
 
-ceph_test_librgw_file
-ceph_test_librgw_file_aw
-ceph_test_librgw_file_cd
-ceph_test_librgw_file_gp
-ceph_test_librgw_file_marker
-ceph_test_librgw_file_nfsns
+# nfsns is the main suite
+
+# create herarchy, and then list it
+echo "phase 1.1"
+ceph_test_librgw_file_nfsns  --hier1 --dirs1 --create --rename --verbose
+
+# the older librgw_file can consume the namespace
+echo "phase 1.2"
+ceph_test_librgw_file_nfsns --getattr --verbose
+
+# and delete the hierarchy
+echo "phase 1.3"
+ceph_test_librgw_file_nfsns --hier1 --dirs1 --delete --verbose
+
+# bulk create/delete buckets
+echo "phase 2.1"
+ceph_test_librgw_file_cd --create --multi --verbose
+echo "phase 2.2"
+ceph_test_librgw_file_cd --delete --multi --verbose
+
+# write continuation test
+echo "phase 3.1"
+ceph_test_librgw_file_aw --create --delete --large --verify
+
+# continued readdir
+echo "phase 4.1"
+ceph_test_librgw_file_marker --create --marker1 --marker2 --nobjs=100 --verbose
+
+# advanced i/o--but skip readv/writev for now--split delete from
+# create and stat ops to avoid fault in sysobject cache
+echo "phase 5.1"
+ceph_test_librgw_file_gp --get --stat --put --create
+echo "phase 5.2"
+ceph_test_librgw_file_gp --delete
 
 exit 0

--- a/qa/workunits/rgw/test_librgw_file.sh
+++ b/qa/workunits/rgw/test_librgw_file.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+
+ceph_test_librgw_file
+ceph_test_librgw_file_aw
+ceph_test_librgw_file_cd
+ceph_test_librgw_file_gp
+ceph_test_librgw_file_marker
+ceph_test_librgw_file_nfsns
+
+exit 0

--- a/qa/workunits/rgw/test_librgw_file.sh
+++ b/qa/workunits/rgw/test_librgw_file.sh
@@ -35,11 +35,15 @@ ceph_test_librgw_file_cd --delete --multi --verbose
 
 # write continuation test
 echo "phase 3.1"
-ceph_test_librgw_file_aw --create --delete --large --verify
+ceph_test_librgw_file_aw --create --large --verify
+echo "phase 3.2"
+ceph_test_librgw_file_aw --delete --large
 
 # continued readdir
 echo "phase 4.1"
 ceph_test_librgw_file_marker --create --marker1 --marker2 --nobjs=100 --verbose
+echo "phase 4.2"
+ceph_test_librgw_file_marker --delete --verbose
 
 # advanced i/o--but skip readv/writev for now--split delete from
 # create and stat ops to avoid fault in sysobject cache

--- a/qa/workunits/rgw/test_librgw_file.sh
+++ b/qa/workunits/rgw/test_librgw_file.sh
@@ -1,5 +1,14 @@
 #!/bin/sh -e
 
+export AWS_ACCESS_KEY_ID=`openssl rand -base64 20`
+export AWS_SECRET_ACCESS_KEY=`openssl rand -base64 40`
+
+radosgw-admin user create --uid ceph-test-librgw-file \
+       --access-key $AWS_ACCESS_KEY_ID \
+       --secret $AWS_SECRET_ACCESS_KEY \
+       --display-name "librgw test user" \
+       --email librgw@example.com || echo "librgw user exists"
+
 ceph_test_librgw_file
 ceph_test_librgw_file_aw
 ceph_test_librgw_file_cd

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -278,6 +278,7 @@ target_link_libraries(ceph_test_librgw_file
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
   )
+install(TARGETS ceph_test_librgw_file DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ceph_test_librgw_file_cd (just the rgw_file create-delete bucket ops)
 add_executable(ceph_test_librgw_file_cd
@@ -290,6 +291,7 @@ target_link_libraries(ceph_test_librgw_file_cd
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
   )
+install(TARGETS ceph_test_librgw_file_cd DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ceph_test_librgw_file_gp (just the rgw_file get-put bucket ops)
 add_executable(ceph_test_librgw_file_gp
@@ -302,6 +304,7 @@ target_link_libraries(ceph_test_librgw_file_gp
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
   )
+install(TARGETS ceph_test_librgw_file_gp DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ceph_test_librgw_file_nfsns (nfs namespace tests)
 add_executable(ceph_test_librgw_file_nfsns
@@ -319,6 +322,7 @@ target_link_libraries(ceph_test_librgw_file_nfsns
   ${EXTRALIBS}
   )
   target_link_libraries(ceph_test_librgw_file_nfsns spawn)
+install(TARGETS ceph_test_librgw_file_nfsns DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ceph_test_librgw_file_aw (nfs write transaction [atomic write] tests)
 add_executable(ceph_test_librgw_file_aw
@@ -331,6 +335,7 @@ target_link_libraries(ceph_test_librgw_file_aw
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
   )
+install(TARGETS ceph_test_librgw_file_aw DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ceph_test_librgw_file_marker (READDIR with string and uint64 offsets)
 add_executable(ceph_test_librgw_file_marker
@@ -345,6 +350,7 @@ target_link_libraries(ceph_test_librgw_file_marker
   ${EXTRALIBS}
   )
   target_link_libraries(ceph_test_librgw_file_marker spawn)
+install(TARGETS ceph_test_librgw_file_marker DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ceph_test_librgw_file_xattr (attribute ops)
 add_executable(ceph_test_librgw_file_xattr

--- a/src/test/librgw_file_aw.cc
+++ b/src/test/librgw_file_aw.cc
@@ -333,6 +333,14 @@ TEST(LibRGW, DELETE_OBJECT) {
   }
 }
 
+TEST(LibRGW, DELETE_BUCKET) {
+  if (do_delete) {
+    int ret = rgw_unlink(fs, fs->root_fh, bucket_name.c_str(),
+			 RGW_UNLINK_FLAG_NONE);
+    ASSERT_EQ(ret, 0);
+  }
+}
+
 TEST(LibRGW, CLEANUP) {
   int ret;
   if (object_fh) {

--- a/src/test/librgw_file_aw.cc
+++ b/src/test/librgw_file_aw.cc
@@ -47,7 +47,7 @@ namespace {
   bool do_verify = false;
   bool do_hexdump = false;
 
-  string bucket_name = "sorry_dave";
+  string bucket_name = "sorrydave";
   string object_name = "jocaml";
 
   struct rgw_file_handle *bucket_fh = nullptr;

--- a/src/test/librgw_file_cd.cc
+++ b/src/test/librgw_file_cd.cc
@@ -41,7 +41,7 @@ namespace {
   bool do_multi = false;
   int multi_cnt = 10;
 
-  string bucket_name = "sorry_dave";
+  string bucket_name = "sorrydave";
 
   struct {
     int argc;

--- a/src/test/librgw_file_nfsns.cc
+++ b/src/test/librgw_file_nfsns.cc
@@ -595,6 +595,7 @@ TEST(LibRGW, RGW_CROSSBUCKET_RENAME1) {
   }
 }
 
+#if 0 /* XXX inconsistent failure here */
 TEST(LibRGW, BAD_DELETES_DIRS1) {
   if (do_dirs1) {
     int rc;
@@ -624,6 +625,7 @@ TEST(LibRGW, BAD_DELETES_DIRS1) {
 #endif
   }
 }
+#endif
 
 TEST(LibRGW, GETATTR_DIRS1)
 {

--- a/src/test/librgw_file_nfsns.cc
+++ b/src/test/librgw_file_nfsns.cc
@@ -520,7 +520,7 @@ TEST(LibRGW, RGW_SETUP_RENAME1) {
     st.st_mode = 755;
 
     for (int b_ix : {0, 1}) {
-      std::string bname{"brename_" + to_string(b_ix)};
+      std::string bname{"brename" + to_string(b_ix)};
       obj_rec brec{bname, nullptr, nullptr, nullptr};
       (void) rgw_lookup(fs, fs->root_fh, brec.name.c_str(), &brec.fh,
 			nullptr, 0, RGW_LOOKUP_FLAG_NONE);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49722

---

backport of https://github.com/ceph/ceph/pull/37250
parent tracker: https://tracker.ceph.com/issues/49721

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh