### PR TITLE
pacific: rgw: added missing documentation on "pubsub" in rgw_enable_apis

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -40,7 +40,7 @@ instances or all radosgw-admin options can be put into the ``[global]`` or the
                         participate in a `multi-site <../multisite>`_
                         configuration.
 :Type: String
-:Default: ``s3, swift, swift_auth, admin`` All APIs.
+:Default: ``s3, s3website, swift, swift_auth, admin, sts, iam, notifications`` All APIs.
 
 
 ``rgw_cache_enabled``

--- a/doc/radosgw/notifications.rst
+++ b/doc/radosgw/notifications.rst
@@ -29,6 +29,7 @@ mechanism. This API is similar to the one defined as the S3-compatible API of th
 
    S3 Bucket Notification Compatibility <s3-notification-compatibility>
 
+.. note:: To enable bucket notifications API, the `rgw_enable_apis` configuration parameter should contain: "notifications".
 
 Notification Reliability
 ------------------------

--- a/doc/radosgw/pubsub-module.rst
+++ b/doc/radosgw/pubsub-module.rst
@@ -38,6 +38,8 @@ be accessed directly, but need to be pulled and acked using the new REST API.
 
    S3 Bucket Notification Compatibility <s3-notification-compatibility>
 
+.. note:: To enable bucket notifications API, the `rgw_enable_apis` configuration parameter should contain: "notifications".
+
 PubSub Zone Configuration
 -------------------------
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5729,7 +5729,7 @@ std::vector<Option> get_rgw_options() {
         "will be located in the path that is specified here. "),
 
     Option("rgw_enable_apis", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("s3, s3website, swift, swift_auth, admin, sts, iam, pubsub")
+    .set_default("s3, s3website, swift, swift_auth, admin, sts, iam, notifications")
     .set_description("A list of set of RESTful APIs that rgw handles."),
 
     Option("rgw_cache_enabled", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -380,7 +380,7 @@ int radosgw_Main(int argc, const char **argv)
   const bool s3website_enabled = apis_map.count("s3website") > 0;
   const bool sts_enabled = apis_map.count("sts") > 0;
   const bool iam_enabled = apis_map.count("iam") > 0;
-  const bool pubsub_enabled = apis_map.count("pubsub") > 0;
+  const bool pubsub_enabled = apis_map.count("pubsub") > 0 || apis_map.count("notifications") > 0;
   // Swift API entrypoint could placed in the root instead of S3
   const bool swift_at_root = g_conf()->rgw_swift_url_prefix == "/";
   if (apis_map.count("s3") > 0 || s3website_enabled) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49587

---

backport of https://github.com/ceph/ceph/pull/39382
parent tracker: https://tracker.ceph.com/issues/49203

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh