### PR TITLE
pacific: rgw: multisite: fix single-part-MPU object etag misidentify problem

### DIFF
--- a/src/rgw/rgw_etag_verifier.cc
+++ b/src/rgw/rgw_etag_verifier.cc
@@ -29,7 +29,7 @@ int create_etag_verifier(CephContext* cct, DataProcessor* filter,
     return -EIO;
   }
 
-  if (rule.part_size == 0) {
+  if (rule.start_part_num == 0) {
     /* Atomic object */
     verifier.emplace<ETagVerifier_Atomic>(cct, filter);
     return 0;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49381

---

backport of https://github.com/ceph/ceph/pull/39569
parent tracker: https://tracker.ceph.com/issues/49357

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh