### PR TITLE
pacific: rgw: fix sts get_session_token duration check failed

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -167,6 +167,9 @@ static inline void get_v2_qs_map(const req_info& info,
     if (k.find("x-amz-meta-") == /* offset */ 0) {
       rgw_add_amz_meta_header(qs_map, k, elt.second);
     }
+    if (k == "x-amz-security-token") {
+      qs_map[k] = elt.second;
+    }
   }
 }
 

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -434,9 +434,10 @@ int RGWSTSGetSessionToken::get_params()
     }
 
     if (duration_in_secs < STS::GetSessionTokenRequest::getMinDuration() ||
-            duration_in_secs > s->cct->_conf->rgw_sts_max_session_duration)
+            duration_in_secs > s->cct->_conf->rgw_sts_max_session_duration) {
       ldout(s->cct, 0) << "Invalid duration in secs: " << duration_in_secs << dendl;
       return -EINVAL;
+    }
   }
 
   return 0;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49362

---

backport of https://github.com/ceph/ceph/pull/38917
parent tracker: https://tracker.ceph.com/issues/48883

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh