### PR TITLE
pacific: rgw: Fix spurious error on empty datalog shard

### DIFF
--- a/src/rgw/cls_fifo_legacy.cc
+++ b/src/rgw/cls_fifo_legacy.cc
@@ -39,7 +39,7 @@
 #include "cls_fifo_legacy.h"
 
 namespace rgw::cls::fifo {
-static constexpr auto dout_subsys = ceph_subsys_rgw;
+static constexpr auto dout_subsys = ceph_subsys_objclass;
 namespace cb = ceph::buffer;
 namespace fifo = rados::cls::fifo;
 

--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -192,6 +192,10 @@ public:
 			      max_entries, log_entries,
 			      std::string(marker.value_or("")),
 			      out_marker, truncated, null_yield);
+    if (r == -ENOENT) {
+      *truncated = false;
+      return 0;
+    }
     if (r < 0) {
       lderr(cct) << __PRETTY_FUNCTION__
 		 << ": failed to list " << oids[index]


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49176

---

backport of https://github.com/ceph/ceph/pull/38977
parent tracker: https://tracker.ceph.com/issues/48929

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh