### PR TITLE
pacific: pybind/mgr/dashboard: bump flake8 to 3.9.0

### DIFF
--- a/src/pybind/mgr/dashboard/requirements-lint.txt
+++ b/src/pybind/mgr/dashboard/requirements-lint.txt
@@ -1,5 +1,5 @@
 pylint==2.6.0
-flake8==3.8.4; python_version >= '3'
+flake8==3.9.0; python_version >= '3'
 flake8-colors==0.1.6; python_version >= '3'
 #TODO: Fix docstring issues: https://tracker.ceph.com/issues/41224
 #flake8-docstrings

--- a/src/pybind/mgr/dashboard/requirements-lint.txt
+++ b/src/pybind/mgr/dashboard/requirements-lint.txt
@@ -1,11 +1,11 @@
 pylint==2.6.0
-flake8==3.9.0; python_version >= '3'
-flake8-colors==0.1.6; python_version >= '3'
+flake8==3.9.0
+flake8-colors==0.1.6
 #TODO: Fix docstring issues: https://tracker.ceph.com/issues/41224
 #flake8-docstrings
 #pep8-naming
-rstcheck==3.3.1; python_version >= '3'
-autopep8; python_version >= '3'
-pyfakefs; python_version >= '3'
+rstcheck==3.3.1
+autopep8
+pyfakefs
 isort==5.5.3
 pytest


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49907

---

backport of https://github.com/ceph/ceph/pull/40229
parent tracker: https://tracker.ceph.com/issues/49906

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh