### PR TITLE
octopus: osd: fix potential null pointer dereference when sending ping

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5680,6 +5680,11 @@ void OSD::heartbeat()
        i != heartbeat_peers.end();
        ++i) {
     int peer = i->first;
+    Session *s = static_cast<Session*>(i->second.con_back->get_priv().get());
+    if (!s) {
+      dout(30) << "heartbeat osd." << peer << " has no open con" << dendl;
+      continue;
+    }
     dout(30) << "heartbeat sending ping to osd." << peer << dendl;
 
     i->second.last_tx = now;
@@ -5690,7 +5695,6 @@ void OSD::heartbeat()
     if (i->second.hb_interval_start == utime_t())
       i->second.hb_interval_start = now;
 
-    Session *s = static_cast<Session*>(i->second.con_back->get_priv().get());
     std::optional<ceph::signedspan> delta_ub;
     s->stamps->sent_ping(&delta_ub);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49009

---

backport of https://github.com/ceph/ceph/pull/38931
parent tracker: https://tracker.ceph.com/issues/48821

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh