### PR TITLE
octopus: test: cancelling both noscrub *and* nodeep-scrub

### DIFF
--- a/qa/standalone/scrub/osd-scrub-test.sh
+++ b/qa/standalone/scrub/osd-scrub-test.sh
@@ -303,6 +303,10 @@ function _scrub_abort() {
     fi
 
     ceph osd set $stopscrub
+    if [ "$type" = "deep_scrub" ];
+    then
+      ceph osd set noscrub
+    fi
 
     # Wait for scrubbing to end
     set -o pipefail
@@ -327,7 +331,13 @@ function _scrub_abort() {
     fi
 
     local last_scrub=$(get_last_scrub_stamp $pgid)
-    ceph osd unset noscrub
+    ceph config set osd "osd_scrub_sleep" "0.1"
+
+    ceph osd unset $stopscrub
+    if [ "$type" = "deep_scrub" ];
+    then
+      ceph osd unset noscrub
+    fi
     TIMEOUT=$(($objects / 2))
     wait_for_scrub $pgid "$last_scrub" || return 1
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48596

---

backport of https://github.com/ceph/ceph/pull/38472
parent tracker: https://tracker.ceph.com/issues/48566

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh