### PR TITLE
cephadm: synchronize container timezone with host

### DIFF
--- a/qa/workunits/cephadm/test_cephadm.sh
+++ b/qa/workunits/cephadm/test_cephadm.sh
@@ -389,6 +389,8 @@ $CEPHADM shell --fsid $FSID -- test -d /var/log/ceph
 expect_false $CEPHADM --timeout 10 shell --fsid $FSID -- sleep 60
 $CEPHADM --timeout 60 shell --fsid $FSID -- sleep 10
 $CEPHADM shell --fsid $FSID --mount $TMPDIR $TMPDIR_TEST_MULTIPLE_MOUNTS -- stat /mnt/$(basename $TMPDIR)
+sync_timezone=$($CEPHADM shell -- date)
+[[ "$sync_timezone" != *"UTC"* ]] && echo "synchronized timezone in container"
 
 ## enter
 expect_false $CEPHADM enter

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -866,6 +866,7 @@ class CustomContainer(object):
         }
         """
         mounts = {}
+        mounts['/etc/localtime'] = '/etc/localtime:ro'
         for source, destination in self.volume_mounts.items():
             source = os.path.join(data_dir, source)
             mounts[source] = destination
@@ -2250,6 +2251,8 @@ def get_container_mounts(ctx, fsid, daemon_type, daemon_id,
                          no_config=False):
     # type: (CephadmContext, str, str, Union[int, str, None], Optional[bool]) -> Dict[str, str]
     mounts = dict()
+
+    mounts['/etc/localtime'] = '/etc/localtime:ro'
 
     if daemon_type in Ceph.daemons:
         if fsid:

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -489,6 +489,7 @@ class TestCustomContainer(unittest.TestCase):
     def test_get_container_mounts(self):
         result = self.cc.get_container_mounts('/xyz')
         self.assertDictEqual(result, {
+            '/etc/localtime': '/etc/localtime:ro',
             '/CONFIG_DIR': '/foo/conf',
             '/xyz/bar/config': '/bar:ro'
         })


### PR DESCRIPTION
synchronize timezone in podman and docker containers from default UTC to host's timezone

Fixes: https://tracker.ceph.com/issues/49449
Signed-off-by: Melissa Li <li.melissa.kun@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
