### PR TITLE
mon/PGMap: change hard coded 0x10000 to macro CEPH_OSD_IN

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -3,6 +3,7 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include "include/rados.h"
 #include "PGMap.h"
 
 #define dout_subsys ceph_subsys_mon
@@ -3990,7 +3991,7 @@ int reweight::by_utilization(
   // but aggressively adjust weights up whenever possible.
   const double underload_util = average_util;
 
-  const unsigned max_change = (unsigned)(max_changef * (double)0x10000);
+  const unsigned max_change = (unsigned)(max_changef * (double)CEPH_OSD_IN);
 
   ostringstream oss;
   if (f) {
@@ -4067,13 +4068,13 @@ int reweight::by_utilization(
       if (f) {
 	f->open_object_section("osd");
 	f->dump_int("osd", p.first);
-	f->dump_float("weight", (float)weight / (float)0x10000);
-	f->dump_float("new_weight", (float)new_weight / (float)0x10000);
+	f->dump_float("weight", (float)weight / (float)CEPH_OSD_IN);
+	f->dump_float("new_weight", (float)new_weight / (float)CEPH_OSD_IN);
 	f->close_section();
       } else {
         oss << "osd." << p.first << " weight "
-            << (float)weight / (float)0x10000 << " -> "
-            << (float)new_weight / (float)0x10000 << "\n";
+            << (float)weight / (float)CEPH_OSD_IN << " -> "
+            << (float)new_weight / (float)CEPH_OSD_IN << "\n";
       }
       if (++num_changed >= max_osds)
 	break;
@@ -4082,13 +4083,13 @@ int reweight::by_utilization(
       // assign a higher weight.. if we can.
       unsigned new_weight = (unsigned)((average_util / util) * (float)weight);
       new_weight = std::min(new_weight, weight + max_change);
-      if (new_weight > 0x10000)
-	new_weight = 0x10000;
+      if (new_weight > CEPH_OSD_IN)
+	new_weight = CEPH_OSD_IN;
       if (new_weight > weight) {
 	new_weights->insert({p.first, new_weight});
         oss << "osd." << p.first << " weight "
-            << (float)weight / (float)0x10000 << " -> "
-            << (float)new_weight / (float)0x10000 << "\n";
+            << (float)weight / (float)CEPH_OSD_IN << " -> "
+            << (float)new_weight / (float)CEPH_OSD_IN << "\n";
 	if (++num_changed >= max_osds)
 	  break;
       }


### PR DESCRIPTION
0x10000 is same with CEPH_OSD_IN for osd weight, so change them to
that macro, more meaningful.

Signed-off-by: haoyixing <haoyixing@kuaishou.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
