### PR TITLE
qa/suites/rados/cephadm/upgrade: wait for rgw servicemap entries to refresh

### DIFF
--- a/qa/suites/rados/cephadm/upgrade/4-wait.yaml
+++ b/qa/suites/rados/cephadm/upgrade/4-wait.yaml
@@ -5,5 +5,9 @@ tasks:
       - while ceph orch upgrade status | jq '.in_progress' | grep true ; do ceph orch ps ; ceph versions ; sleep 30 ; done
       - ceph orch ps
       - ceph versions
+      - echo "wait for servicemap items w/ changing names to refresh"
+      - sleep 60
+      - ceph orch ps
+      - ceph versions
       - ceph versions | jq -e '.overall | length == 1'
       - ceph versions | jq -e '.overall | keys' | grep $sha1


### PR DESCRIPTION
rgw changed the way it registered in the service map.  Wait a bit for
the old entries to be flushed out (the default grade period is 60s).

Signed-off-by: Sage Weil <sage@newdream.net>