### PR TITLE
pacific: doc/cephfs/nfs: Add rook pod restart note, export and log block example

### DIFF
--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -102,6 +102,37 @@ Set Customized NFS Ganesha Configuration
 With this the nfs cluster will use the specified config and it will have
 precedence over default config blocks.
 
+Example use cases
+
+1) Changing log level
+
+  It can be done by adding LOG block in the following way::
+
+   LOG {
+    COMPONENTS {
+        ALL = FULL_DEBUG;
+    }
+   }
+
+2) Adding custom export block
+
+  The following sample block creates a single export. This export will not be
+  managed by `ceph nfs export` interface::
+
+   EXPORT {
+     Export_Id = 100;
+     Transports = TCP;
+     Path = /;
+     Pseudo = /ceph/;
+     Protocols = 4;
+     Access_Type = RW;
+     Attr_Expiration_Time = 0;
+     Squash = None;
+     FSAL {
+       Name = CEPH;
+     }
+   }
+
 Reset NFS Ganesha Configuration
 ===============================
 
@@ -110,6 +141,9 @@ Reset NFS Ganesha Configuration
     $ ceph nfs cluster config reset <clusterid>
 
 This removes the user defined configuration.
+
+.. note:: With a rook deployment, ganesha pods must be explicitly restarted
+   for the new config blocks to be effective.
 
 Create CephFS Export
 ====================


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49414
backport of #38955

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst
-->

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
