### PR TITLE
pacific: tools/cephfs-shell: fix listing of symbolic links

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -801,60 +801,64 @@ class CephFSShell(Cmd):
         for path in paths:
             values = []
             items = []
-            if path.count(b'*') > 0:
-                all_items = get_all_possible_paths(path)
-                if len(all_items) == 0:
-                    continue
-                path = all_items[0].rsplit(b'/', 1)[0]
-                if path == b'':
-                    path = b'/'
-                dirs = []
-                for i in all_items:
-                    for item in ls(path):
-                        d_name = item.d_name
-                        if os.path.basename(i) == d_name:
-                            if item.is_dir():
-                                dirs.append(os.path.join(path, d_name))
-                            else:
-                                items.append(item)
-                if dirs:
-                    paths.extend(dirs)
+            try:
+                if path.count(b'*') > 0:
+                    all_items = get_all_possible_paths(path)
+                    if len(all_items) == 0:
+                        continue
+                    path = all_items[0].rsplit(b'/', 1)[0]
+                    if path == b'':
+                        path = b'/'
+                    dirs = []
+                    for i in all_items:
+                        for item in ls(path):
+                            d_name = item.d_name
+                            if os.path.basename(i) == d_name:
+                                if item.is_dir():
+                                    dirs.append(os.path.join(path, d_name))
+                                else:
+                                    items.append(item)
+                    if dirs:
+                        paths.extend(dirs)
+                    else:
+                        poutput(path.decode('utf-8'), end=':\n')
+                    items = sorted(items, key=lambda item: item.d_name)
                 else:
-                    poutput(path.decode('utf-8'), end=':\n')
-                items = sorted(items, key=lambda item: item.d_name)
-            else:
-                if path != b'' and path != cephfs.getcwd() and len(paths) > 1:
-                    poutput(path.decode('utf-8'), end=':\n')
-                items = sorted(ls(path),
-                               key=lambda item: item.d_name)
-            if not args.all:
-                items = [i for i in items if not i.d_name.startswith(b'.')]
-
-            if args.S:
-                items = sorted(items, key=lambda item: cephfs.stat(
-                    path + b'/' + item.d_name, follow_symlink=(not item.is_symbol_file())).st_size)
-
-            if args.reverse:
-                items = reversed(items)
-            for item in items:
-                filepath = item.d_name
-                is_dir = item.is_dir()
-                is_sym_lnk = item.is_symbol_file()
-
-                if args.long and args.H:
-                    print_long(os.path.join(cephfs.getcwd(), path, filepath),
-                               is_dir, is_sym_lnk, True)
-                elif args.long:
-                    print_long(os.path.join(cephfs.getcwd(), path, filepath),
-                               is_dir, is_sym_lnk, False)
-                elif is_sym_lnk or is_dir:
-                    values.append(style_listing(filepath.decode('utf-8'), is_dir, is_sym_lnk))
-                else:
-                    values.append(filepath)
-            if not args.long:
-                print_list(values, shutil.get_terminal_size().columns)
-                if path != paths[-1]:
-                    poutput('')
+                    if path != b'' and path != cephfs.getcwd() and len(paths) > 1:
+                        poutput(path.decode('utf-8'), end=':\n')
+                    items = sorted(ls(path), key=lambda item: item.d_name)
+                if not args.all:
+                    items = [i for i in items if not i.d_name.startswith(b'.')]
+                if args.S:
+                    items = sorted(items, key=lambda item: cephfs.stat(
+                        path + b'/' + item.d_name, follow_symlink=(
+                            not item.is_symbol_file())).st_size)
+                if args.reverse:
+                    items = reversed(items)
+                for item in items:
+                    filepath = item.d_name
+                    is_dir = item.is_dir()
+                    is_sym_lnk = item.is_symbol_file()
+                    try:
+                        if args.long and args.H:
+                            print_long(os.path.join(cephfs.getcwd(), path, filepath), is_dir,
+                                       is_sym_lnk, True)
+                        elif args.long:
+                            print_long(os.path.join(cephfs.getcwd(), path, filepath), is_dir,
+                                       is_sym_lnk, False)
+                        elif is_sym_lnk or is_dir:
+                            values.append(style_listing(filepath.decode('utf-8'), is_dir,
+                                          is_sym_lnk))
+                        else:
+                            values.append(filepath)
+                    except libcephfs.Error as e:
+                        set_exit_code_msg(msg=e)
+                if not args.long:
+                    print_list(values, shutil.get_terminal_size().columns)
+                    if path != paths[-1]:
+                        poutput('')
+            except libcephfs.Error as e:
+                set_exit_code_msg(msg=e)
 
     def complete_rmdir(self, text, line, begidx, endidx):
         """

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -227,26 +227,30 @@ def humansize(nbytes):
     return '%s%s' % (f, suffixes[i])
 
 
-def print_long(path, is_dir, is_symlink, human_readable):
-    pretty = os.path.basename(path.decode('utf-8'))
-    info = cephfs.stat(path, follow_symlink=(not is_symlink))
-
+def style_listing(path, is_dir, is_symlink, ls_long=False):
+    if not (is_dir or is_symlink):
+        return path
+    pretty = colorama.Style.BRIGHT
     if is_symlink:
-        target_file = cephfs.readlink(path, size=255).decode('utf-8')
-        pretty = colorama.Style.BRIGHT + colorama.Fore.CYAN + pretty + ' -> ' + target_file
-        pretty += colorama.Style.RESET_ALL
+        pretty += colorama.Fore.CYAN + path
+        if ls_long:
+            # Add target path
+            pretty += ' -> ' + cephfs.readlink(path, size=255).decode('utf-8')
     elif is_dir:
-        pretty = colorama.Style.BRIGHT + colorama.Fore.BLUE + pretty + '/'
-        pretty += colorama.Style.RESET_ALL
+        pretty += colorama.Fore.BLUE + path + '/'
+    pretty += colorama.Style.RESET_ALL
+    return pretty
+
+
+def print_long(path, is_dir, is_symlink, human_readable):
+    info = cephfs.stat(path, follow_symlink=(not is_symlink))
+    pretty = style_listing(os.path.basename(path.decode('utf-8')), is_dir, is_symlink, True)
     if human_readable:
-        poutput('{}\t{:10s} {} {} {} {}'.format(
-            mode_notation(info.st_mode),
-            humansize(info.st_size), info.st_uid,
-            info.st_gid, info.st_mtime, pretty))
+        sizefmt = '\t {:10s}'.format(humansize(info.st_size))
     else:
-        poutput('{} {:12d} {} {} {} {}'.format(
-            mode_notation(info.st_mode), info.st_size, info.st_uid,
-            info.st_gid, info.st_mtime, pretty))
+        sizefmt = '{:12d}'.format(info.st_size)
+    poutput(f'{mode_notation(info.st_mode)} {sizefmt} {info.st_uid} {info.st_gid} {info.st_mtime}'
+            f' {pretty}')
 
 
 def word_len(word):
@@ -843,17 +847,8 @@ class CephFSShell(Cmd):
                 elif args.long:
                     print_long(os.path.join(cephfs.getcwd(), path, filepath),
                                is_dir, is_sym_lnk, False)
-                elif is_sym_lnk:
-                    values.append(colorama.Style.BRIGHT
-                                  + colorama.Fore.CYAN
-                                  + filepath.decode('utf-8')
-                                  + colorama.Style.RESET_ALL)
-                elif is_dir:
-                    values.append(colorama.Style.BRIGHT
-                                  + colorama.Fore.BLUE
-                                  + filepath.decode('utf-8')
-                                  + '/'
-                                  + colorama.Style.RESET_ALL)
+                elif is_sym_lnk or is_dir:
+                    values.append(style_listing(filepath.decode('utf-8'), is_dir, is_sym_lnk))
                 else:
                     values.append(filepath)
             if not args.long:

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -124,6 +124,8 @@ def mode_notation(mode):
     notation = '-'
     if mode[2] == '4':
         notation = 'd'
+    elif mode[2:4] == '12':
+        notation = 'l'
     for i in mode[-3:]:
         notation += permission_bits[i]
     return notation
@@ -225,11 +227,16 @@ def humansize(nbytes):
     return '%s%s' % (f, suffixes[i])
 
 
-def print_long(path, is_dir, human_readable):
-    info = cephfs.stat(path)
+def print_long(path, is_dir, is_symlink, human_readable):
     pretty = os.path.basename(path.decode('utf-8'))
-    if is_dir:
-        pretty = colorama.Style.BRIGHT + colorama.Fore.CYAN + pretty + '/'
+    info = cephfs.stat(path, follow_symlink=(not is_symlink))
+
+    if is_symlink:
+        target_file = cephfs.readlink(path, size=255).decode('utf-8')
+        pretty = colorama.Style.BRIGHT + colorama.Fore.CYAN + pretty + ' -> ' + target_file
+        pretty += colorama.Style.RESET_ALL
+    elif is_dir:
+        pretty = colorama.Style.BRIGHT + colorama.Fore.BLUE + pretty + '/'
         pretty += colorama.Style.RESET_ALL
     if human_readable:
         poutput('{}\t{:10s} {} {} {} {}'.format(
@@ -821,23 +828,29 @@ class CephFSShell(Cmd):
 
             if args.S:
                 items = sorted(items, key=lambda item: cephfs.stat(
-                    path + b'/' + item.d_name).st_size)
+                    path + b'/' + item.d_name, follow_symlink=(not item.is_symbol_file())).st_size)
 
             if args.reverse:
                 items = reversed(items)
             for item in items:
                 filepath = item.d_name
                 is_dir = item.is_dir()
+                is_sym_lnk = item.is_symbol_file()
 
                 if args.long and args.H:
                     print_long(os.path.join(cephfs.getcwd(), path, filepath),
-                               is_dir, True)
+                               is_dir, is_sym_lnk, True)
                 elif args.long:
                     print_long(os.path.join(cephfs.getcwd(), path, filepath),
-                               is_dir, False)
-                elif is_dir:
+                               is_dir, is_sym_lnk, False)
+                elif is_sym_lnk:
                     values.append(colorama.Style.BRIGHT
                                   + colorama.Fore.CYAN
+                                  + filepath.decode('utf-8')
+                                  + colorama.Style.RESET_ALL)
+                elif is_dir:
+                    values.append(colorama.Style.BRIGHT
+                                  + colorama.Fore.BLUE
                                   + filepath.decode('utf-8')
                                   + '/'
                                   + colorama.Style.RESET_ALL)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49685
backport of #39687

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
