### PR TITLE
pacific: common/options: turn off bluestore_fsck_quick_fix_on_mount by default

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4634,7 +4634,7 @@ std::vector<Option> get_global_options() {
     .set_description("Run deep fsck at mount when bluestore_fsck_on_mount is set to true"),
 
     Option("bluestore_fsck_quick_fix_on_mount", Option::TYPE_BOOL, Option::LEVEL_DEV)
-      .set_default(true)
+      .set_default(false)
       .set_description("Do quick-fix for the store at mount"),
 
     Option("bluestore_fsck_on_umount", Option::TYPE_BOOL, Option::LEVEL_DEV)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49920

---

backport of https://github.com/ceph/ceph/pull/40198
parent tracker: https://tracker.ceph.com/issues/45265

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh