### PR TITLE
mon: take additional exclusive lock

### DIFF
--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1250,6 +1250,7 @@ void RocksDBStore::close()
     must_close_default_cf = false;
   }
   default_cf = nullptr;
+  db->Close();
   delete db;
   db = nullptr;
 }

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -462,7 +462,7 @@ esac
 shift
 done
 
-if [ $kill_all -eq 1 ]; then
+if [ $kill_all -eq 1 ] || [ $new -eq 1 ]; then
     $SUDO $INIT_CEPH stop
 fi
 


### PR DESCRIPTION
Currently the only thing preventing multiple mons from starting is a lock
on the pidfile, which may not be reliably present for all instances in
containerize environments.

- take a lock on the kv_backend file, which is always present in the mon data dir
- fix vstart to stop existing daemons before creating a new cluster
- be a bit more careful when shutting down rocksdb

This addresses rocksdb corruption that I was observing with vstart
when running vstart.sh -n without stopping the old daemon.  It turns
out the mon locking wasn't sufficient since vstart was also deleting
all of the files, and the old monitory was walking on top of the
new mons data only because a new rocksdb was created in the same location,
but this seems like a reasonable additional set of guardrails to help
prevent mon db corruption.



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>