### PR TITLE
pacific: ceph-volume: show devices with GPT headers as not available

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -203,6 +203,18 @@ class TestDevice(object):
         disk = device.Device("/dev/sdb")
         assert not disk.available
 
+    def test_reject_device_with_gpt_headers(self, device_info):
+        data = {"/dev/sdb": {"removable": 0, "size": 5368709120}}
+        lsblk = {"TYPE": "disk"}
+        blkid= {"PTTYPE": "gpt"}
+        device_info(
+            devices=data,
+            blkid=blkid,
+            lsblk=lsblk,
+        )
+        disk = device.Device("/dev/sdb")
+        assert not disk.available
+
     def test_accept_non_removable_device(self, device_info):
         data = {"/dev/sdb": {"removable": 0, "size": 5368709120}}
         lsblk = {"TYPE": "disk"}

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -478,6 +478,8 @@ class Device(object):
             rejected.append("Used by ceph-disk")
         if self.has_bluestore_label:
             rejected.append('Has BlueStore device label')
+        if self.has_gpt_headers:
+            rejected.append('Has GPT headers')
         return rejected
 
     def _check_lvm_reject_reasons(self):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49924

---

backport of https://github.com/ceph/ceph/pull/40201
parent tracker: https://tracker.ceph.com/issues/48697

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh