### PR TITLE
cephadm: only bootstrap using image that matches cephadm version

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -47,6 +47,7 @@ from urllib.request import urlopen
 # Default container images -----------------------------------------------------
 DEFAULT_IMAGE = 'quay.ceph.io/ceph-ci/ceph:master'
 DEFAULT_IMAGE_IS_MASTER = True
+DEFAULT_IMAGE_RELEASE = 'quincy'
 DEFAULT_PROMETHEUS_IMAGE = 'docker.io/prom/prometheus:v2.18.1'
 DEFAULT_NODE_EXPORTER_IMAGE = 'docker.io/prom/node-exporter:v0.18.1'
 DEFAULT_GRAFANA_IMAGE = 'docker.io/ceph/ceph-grafana:6.7.4'
@@ -3757,9 +3758,6 @@ def prepare_bootstrap_config(
     if ctx.registry_json or ctx.registry_url:
         command_registry_login(ctx)
 
-    if not ctx.skip_pull:
-        _pull_image(ctx, image)
-
     return config
 
 
@@ -3868,6 +3866,20 @@ def command_bootstrap(ctx):
     cluster_network, ipv6_cluster_network = prepare_cluster_network(ctx)
 
     config = prepare_bootstrap_config(ctx, fsid, addr_arg, ctx.image)
+
+    if not ctx.skip_pull:
+        _pull_image(ctx, ctx.image)
+
+    image_ver = CephContainer(ctx, ctx.image, 'ceph', ['--version']).run().strip()
+    logger.info(f'Ceph version: {image_ver}')
+    image_release = image_ver.split()[4]
+    if (
+        not ctx.allow_mismatched_release
+        and image_release not in [DEFAULT_IMAGE_RELEASE, LATEST_STABLE_RELEASE]
+    ):
+        raise Error(
+            f'Container release {image_release} != cephadm release {DEFAULT_IMAGE_RELEASE}; please use matching version of cephadm (pass --allow-mismatched-release to continue anyway)'
+        )
 
     logger.info('Extracting ceph user uid/gid from container image...')
     (uid, gid) = extract_uid_gid(ctx)
@@ -7564,6 +7576,10 @@ def _get_parser():
         '--allow-fqdn-hostname',
         action='store_true',
         help='allow hostname that is fully-qualified (contains ".")')
+    parser_bootstrap.add_argument(
+        '--allow-mismatched-release',
+        action='store_true',
+        help="allow bootstrap of ceph that doesn't match this version of cephadm")
     parser_bootstrap.add_argument(
         '--skip-prepare-host',
         action='store_true',


### PR DESCRIPTION
Only allow bootstrap to deploy if the cephadm version matches the
ceph version in the container.  Allow the master branch version of cephadm
to deploy the latest stable version as well (at least for now).

Provide a flag to force bootstrap to continue despite the check.

Move the _pull_image call up into bootstrap so that it is easier to see
when it happens.

Fixes: https://tracker.ceph.com/issues/49884



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>