### PR TITLE
pacific: mon/MDSMonitor: standby-replay daemons should be removed when the flag is turned off

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,5 +1,8 @@
 >=16.0.0
 --------
+* CephFS: Disabling allow_standby_replay on a file system will also stop all
+  standby-replay daemons for that file system.
+
 * New bluestore_rocksdb_options_annex config parameter. Complements
   bluestore_rocksdb_options and allows setting rocksdb options without repeating
   the existing defaults.

--- a/doc/cephfs/upgrading.rst
+++ b/doc/cephfs/upgrading.rst
@@ -12,45 +12,60 @@ via the MDSMap to all MDS and cause older MDS to suicide.
 
 The proper sequence for upgrading the MDS cluster is:
 
-1. Reduce the number of ranks to 1:
+1. Disable and stop standby-replay daemons.
+
+::
+
+    ceph fs set <fs_name> allow_standby_replay false
+
+In Pacific, the standby-replay daemons are stopped for you after running this
+command. Older versions of Ceph require you to stop these daemons manually.
+
+::
+
+    ceph fs dump # find standby-replay daemons
+    ceph mds fail mds.<X>
+
+
+2. Reduce the number of ranks to 1:
 
 ::
 
     ceph fs set <fs_name> max_mds 1
 
-2. Wait for cluster to stop non-zero ranks where only rank 0 is active and the rest are standbys.
+3. Wait for cluster to stop non-zero ranks where only rank 0 is active and the rest are standbys.
 
 ::
 
     ceph status # wait for MDS to finish stopping
 
-3. Take all standbys offline, e.g. using systemctl:
+4. Take all standbys offline, e.g. using systemctl:
 
 ::
 
     systemctl stop ceph-mds.target
 
-4. Confirm only one MDS is online and is rank 0 for your FS:
+5. Confirm only one MDS is online and is rank 0 for your FS:
 
 ::
 
     ceph status
 
-5. Upgrade the single active MDS, e.g. using systemctl:
+6. Upgrade the single active MDS, e.g. using systemctl:
 
 ::
 
     # use package manager to update cluster
     systemctl restart ceph-mds.target
 
-6. Upgrade/start the standby daemons.
+7. Upgrade/start the standby daemons.
 
 ::
 
     # use package manager to update cluster
     systemctl restart ceph-mds.target
 
-7. Restore the previous max_mds for your cluster:
+8. Restore the previous max_mds for your cluster:
 
 ::
 

--- a/qa/tasks/cephfs/test_failover.py
+++ b/qa/tasks/cephfs/test_failover.py
@@ -460,6 +460,7 @@ class TestFailover(CephFSTestCase):
         self.fs.rank_freeze(False, rank=0)
 
 class TestStandbyReplay(CephFSTestCase):
+    CLIENTS_REQUIRED = 0
     MDSS_REQUIRED = 4
 
     def _confirm_no_replay(self):
@@ -516,6 +517,18 @@ class TestStandbyReplay(CephFSTestCase):
         self.fs.set_allow_standby_replay(True)
         time.sleep(30)
         self._confirm_single_replay()
+
+    def test_standby_replay_disable(self):
+        """
+        That turning off allow_standby_replay fails all standby-replay daemons.
+        """
+
+        self._confirm_no_replay()
+        self.fs.set_allow_standby_replay(True)
+        time.sleep(30)
+        self._confirm_single_replay()
+        self.fs.set_allow_standby_replay(False)
+        self._confirm_no_replay()
 
     def test_standby_replay_singleton_fail(self):
         """


### PR DESCRIPTION
https://tracker.ceph.com/issues/49930