### PR TITLE
cephfs-top: allow configurable stats refresh interval

### DIFF
--- a/doc/cephfs/cephfs-top.rst
+++ b/doc/cephfs/cephfs-top.rst
@@ -70,6 +70,12 @@ By default, `cephfs-top` connects to cluster name `ceph`. To use a non-default c
 
   $ cephfs-top --cluster <cluster>
 
+`cephfs-top` refreshes stats every second by default. To chose a different refresh interval use::
+
+  $ cephfs-top -d <seconds>
+
+Interval should be greater or equal to 0.5 second. Fractional seconds are honoured.
+
 Sample screenshot running `cephfs-top` with 2 clients:
 
 .. image:: cephfs-top.png

--- a/src/tools/cephfs/top/cephfs-top
+++ b/src/tools/cephfs/top/cephfs-top
@@ -37,6 +37,9 @@ FS_TOP_SUPPORTED_VER = 1
 
 ITEMS_PAD_LEN = 1
 ITEMS_PAD = "  " * ITEMS_PAD_LEN
+DEFAULT_REFRESH_INTERVAL = 1
+# min refresh interval allowed
+MIN_REFRESH_INTERVAL = 0.5
 
 # metadata provided by mgr/stats
 FS_TOP_MAIN_WINDOW_COL_CLIENT_ID = "CLIENT_ID"
@@ -98,6 +101,7 @@ class FSTop(object):
         self.client_name = args.id
         self.cluster_name = args.cluster
         self.conffile = args.conffile
+        self.refresh_interval_secs = args.delay
 
     def handle_signal(self, signum, _):
         self.stop = True
@@ -279,10 +283,17 @@ class FSTop(object):
                 self.refresh_main_window(x_coord_map, stats_json)
             self.header.refresh()
             self.mainw.refresh()
-            time.sleep(1)
+            time.sleep(self.refresh_interval_secs)
 
 
 if __name__ == '__main__':
+    def float_greater_than(x):
+        value = float(x)
+        if value < MIN_REFRESH_INTERVAL:
+            raise argparse.ArgumentTypeError(f'{value} should be greater than '
+                                             f'{MIN_REFRESH_INTERVAL}')
+        return value
+
     parser = argparse.ArgumentParser(description='Ceph Filesystem top utility')
     parser.add_argument('--cluster', nargs='?', const='ceph', default='ceph',
                         help='Ceph cluster to connect (defualt: ceph)')
@@ -292,6 +303,10 @@ if __name__ == '__main__':
                         help='Path to cluster configuration file')
     parser.add_argument('--selftest', dest='selftest', action='store_true',
                         help='run in selftest mode')
+    parser.add_argument('-d', '--delay', nargs='?', default=DEFAULT_REFRESH_INTERVAL,
+                        type=float_greater_than, help='Interval to refresh data '
+                        f'(default: {DEFAULT_REFRESH_INTERVAL})')
+
     args = parser.parse_args()
     err = False
     ft = FSTop(args)

--- a/src/tools/cephfs/top/cephfs-top
+++ b/src/tools/cephfs/top/cephfs-top
@@ -6,11 +6,11 @@ import curses
 import errno
 import json
 import signal
-import time
 
 from collections import OrderedDict
 from datetime import datetime
 from enum import Enum, unique
+from threading import Event
 
 import rados
 
@@ -96,15 +96,15 @@ def wrap(s, sl):
 class FSTop(object):
     def __init__(self, args):
         self.rados = None
-        self.stop = False
         self.stdscr = None  # curses instance
         self.client_name = args.id
         self.cluster_name = args.cluster
         self.conffile = args.conffile
         self.refresh_interval_secs = args.delay
+        self.exit_ev = Event()
 
     def handle_signal(self, signum, _):
-        self.stop = True
+        self.exit_ev.set()
 
     def init(self):
         try:
@@ -275,7 +275,7 @@ class FSTop(object):
     def display(self, _):
         x_coord_map = self.refresh_top_line_and_build_coord()
         self.topl.refresh()
-        while not self.stop:
+        while not self.exit_ev.is_set():
             stats_json = self.perf_stats_query()
             self.header.clear()
             self.mainw.clear()
@@ -283,7 +283,7 @@ class FSTop(object):
                 self.refresh_main_window(x_coord_map, stats_json)
             self.header.refresh()
             self.mainw.refresh()
-            time.sleep(self.refresh_interval_secs)
+            self.exit_ev.wait(timeout=self.refresh_interval_secs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Signed-off-by: Rachana Patel <racpatel@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
