### PR TITLE
mgr/dashboard: Fix for alert notification message being undefined

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/prometheus-alerts.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/prometheus-alerts.ts
@@ -7,7 +7,6 @@ export class PrometheusAlertLabels {
 
 class Annotations {
   description: string;
-  summary: string;
 }
 
 class CommonAlertmanagerAlert {
@@ -80,6 +79,6 @@ export class PrometheusCustomAlert {
   status: 'resolved' | 'unprocessed' | 'active' | 'suppressed';
   name: string;
   url: string;
-  summary: string;
+  description: string;
   fingerprint?: string | boolean;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert-formatter.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert-formatter.spec.ts
@@ -51,7 +51,7 @@ describe('PrometheusAlertFormatter', () => {
         {
           status: 'active',
           name: 'Something',
-          summary: 'Something is active',
+          description: 'Something is active',
           url: 'http://Something',
           fingerprint: 'Something'
         } as PrometheusCustomAlert
@@ -66,7 +66,7 @@ describe('PrometheusAlertFormatter', () => {
           fingerprint: false,
           status: 'active',
           name: 'Something',
-          summary: 'Something is firing',
+          description: 'Something is firing',
           url: 'http://Something'
         } as PrometheusCustomAlert
       ]);
@@ -77,7 +77,7 @@ describe('PrometheusAlertFormatter', () => {
     const alert: PrometheusCustomAlert = {
       status: 'active',
       name: 'Some alert',
-      summary: 'Some alert is active',
+      description: 'Some alert is active',
       url: 'http://some-alert',
       fingerprint: '42'
     };

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert-formatter.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/prometheus-alert-formatter.ts
@@ -33,7 +33,7 @@ export class PrometheusAlertFormatter {
             : this.getPrometheusNotificationStatus(alert as AlertmanagerNotificationAlert),
           name: alert.labels.alertname,
           url: alert.generatorURL,
-          summary: alert.annotations.summary,
+          description: alert.annotations.description,
           fingerprint: _.isObject(alert.status) && (alert as AlertmanagerAlert).fingerprint
         };
       }),
@@ -53,7 +53,7 @@ export class PrometheusAlertFormatter {
     return new CdNotificationConfig(
       this.formatType(alert.status),
       `${alert.name} (${alert.status})`,
-      this.appendSourceLink(alert, alert.summary),
+      this.appendSourceLink(alert, alert.description),
       undefined,
       'Prometheus'
     );

--- a/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
@@ -324,7 +324,7 @@ export class PrometheusHelper {
         severity: 'someSeverity'
       },
       annotations: {
-        summary: `${name} is ${state}`
+        description: `${name} is ${state}`
       },
       generatorURL: `http://${name}`,
       startsAt: new Date(new Date('2022-02-22').getTime() * timeMultiplier).toString()
@@ -338,7 +338,7 @@ export class PrometheusHelper {
         alertname: name
       },
       annotations: {
-        summary: `${name} is ${status}`
+        description: `${name} is ${status}`
       },
       generatorURL: `http://${name}`
     } as AlertmanagerNotificationAlert;


### PR DESCRIPTION
Prometheus alert notification message in the dashboard always comes up
as undefined. Its because we were showing the alert.summary instead of
alert.description for displaying the message. I couldn't find the
summary field in the ceph_default_alerts.yml file. So removed all the
Summary fields from the dashboard code.

**BEFORE**
![alert_issues](https://user-images.githubusercontent.com/71764184/112108317-0b132b80-8bd6-11eb-8174-7c4afb6cdd59.png)

**AFTER**
![Screenshot from 2021-03-23 12-22-45](https://user-images.githubusercontent.com/71764184/112108269-f898f200-8bd5-11eb-8b6f-67c15dabdd52.png)

Fixes: https://tracker.ceph.com/issues/49342
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
