### PR TITLE
common/ipaddr: skip loopback interfaces named 'lo' and test it

### DIFF
--- a/src/common/ipaddr.cc
+++ b/src/common/ipaddr.cc
@@ -60,7 +60,7 @@ const struct ifaddrs *find_ipv4_in_subnet(const struct ifaddrs *addrs,
     if (addrs->ifa_addr == NULL)
       continue;
 
-    if (boost::starts_with(addrs->ifa_name, "lo:"))
+    if (strcmp(addrs->ifa_name, "lo") == 0 || boost::starts_with(addrs->ifa_name, "lo:"))
       continue;
 
     if (numa_node >= 0 && !match_numa_node(addrs->ifa_name, numa_node))
@@ -107,7 +107,7 @@ const struct ifaddrs *find_ipv6_in_subnet(const struct ifaddrs *addrs,
     if (addrs->ifa_addr == NULL)
       continue;
 
-    if (boost::starts_with(addrs->ifa_name, "lo:"))
+    if (strcmp(addrs->ifa_name, "lo") == 0 || boost::starts_with(addrs->ifa_name, "lo:"))
       continue;
 
     if (numa_node >= 0 && !match_numa_node(addrs->ifa_name, numa_node))


### PR DESCRIPTION
Skip iface's with name like 'lo' or of the form 'lo:0', 'lo:1'.
Ceph has skipped ifaces named `lo` since v10.0.3, so this is not a new idea: https://github.com/ceph/ceph/commit/b6d0fc9e0e515e50894c08217d688a8c94db7570

I don't understand the use-case described in https://tracker.ceph.com/issues/48893 but this might break it.

And add a test!

Fixes: https://tracker.ceph.com/issues/49938

