### PR TITLE
nautilus: pybind/ceph_daemon: do not fail if prettytable is not available

### DIFF
--- a/src/pybind/ceph_daemon.py
+++ b/src/pybind/ceph_daemon.py
@@ -21,7 +21,11 @@ except ImportError:
     from collections import OrderedDict
 from fcntl import ioctl
 from fnmatch import fnmatch
-from prettytable import PrettyTable, HEADER
+try:
+    from prettytable import PrettyTable, HEADER
+except ImportError:
+    # only allowed for test
+    PrettyTable = None
 from signal import signal, SIGWINCH
 from termios import TIOCGWINSZ
 
@@ -399,6 +403,9 @@ class DaemonWatcher(object):
         """
         Show all selected stats with section, full name, nick, and prio
         """
+        if PrettyTable is None:
+            ostr.write('unable to import prettytable\n')
+            return
         table = PrettyTable(('section', 'name', 'nick', 'prio'))
         table.align['section'] = 'l'
         table.align['name'] = 'l'


### PR DESCRIPTION
ubuntu focal does not package python-prettytable. but we need to run
"make check" on focal. it turns out the prettytable is not a must have
for running "make check", so just skip it if it is not around.

this change is not cherry-picked from master, as we have dropped python2
support in master, and python3-prettytable is packged fro python3 on
ubuntu focal. also nautilus is the latest release which has python2
support.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
