### PR TITLE
cmake: pass compile options by fio interface library

### DIFF
--- a/cmake/modules/BuildFIO.cmake
+++ b/cmake/modules/BuildFIO.cmake
@@ -9,14 +9,15 @@ function(build_fio)
   include(FindMake)
   find_make("MAKE_EXECUTABLE" "make_cmd")
 
+  set(source_dir ${CMAKE_BINARY_DIR}/src/fio)
+  file(MAKE_DIRECTORY ${source_dir})
   ExternalProject_Add(fio_ext
-    DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/src/
     UPDATE_COMMAND "" # this disables rebuild on each run
     GIT_REPOSITORY "https://github.com/axboe/fio.git"
     GIT_CONFIG advice.detachedHead=false
     GIT_SHALLOW 1
     GIT_TAG "fio-3.15"
-    SOURCE_DIR ${CMAKE_BINARY_DIR}/src/fio
+    SOURCE_DIR ${source_dir}
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND <SOURCE_DIR>/configure
     BUILD_COMMAND ${make_cmd} fio EXTFLAGS=-Wno-format-truncation ${FIO_EXTLIBS}
@@ -25,5 +26,6 @@ function(build_fio)
   add_library(fio INTERFACE IMPORTED)
   add_dependencies(fio fio_ext)
   set_target_properties(fio PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/src/fio)
+    INTERFACE_INCLUDE_DIRECTORIES ${source_dir}
+    INTERFACE_COMPILE_OPTIONS "-include;${source_dir}/config-host.h;$<$<COMPILE_LANGUAGE:C>:-std=gnu99>$<$<COMPILE_LANGUAGE:CXX>:-std=gnu++17>")
 endfunction()

--- a/src/test/fio/CMakeLists.txt
+++ b/src/test/fio/CMakeLists.txt
@@ -10,30 +10,6 @@ target_link_libraries(fio_ceph_messenger fio)
 add_library(fio_librgw SHARED fio_librgw.cc)
 target_link_libraries(fio_librgw rgw fio)
 
-# prevent fio from adding 'typedef int bool' and gettid()
-if(HAVE_GETTID)
-  set(FIO_CFLAGS "-DCONFIG_HAVE_BOOL -DCONFIG_HAVE_GETTID")
-else()
-  set(FIO_CFLAGS "-DCONFIG_HAVE_BOOL")
-endif()
-
-# fio headers use typeof(), which requires c++11 extensions
-set_target_properties(fio_ceph_objectstore PROPERTIES
-  CXX_EXTENSIONS ON
-  COMPILE_FLAGS "${FIO_CFLAGS}")
-set_target_properties(fio_ceph_messenger PROPERTIES
-  CXX_EXTENSIONS ON
-  COMPILE_FLAGS "${FIO_CFLAGS}")
-set_target_properties(fio_librgw PROPERTIES
-  CXX_EXTENSIONS ON
-  COMPILE_FLAGS "${FIO_CFLAGS}")
-
-if(WITH_FIO)
-  add_dependencies(fio_ceph_objectstore fio_ext)
-  add_dependencies(fio_ceph_messenger fio_ext)
-  add_dependencies(fio_librgw fio_ext)
-endif()
-
 target_link_libraries(fio_ceph_objectstore os global)
 install(TARGETS fio_ceph_objectstore DESTINATION lib)
 


### PR DESCRIPTION
for better readability and maintainability

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
