### PR TITLE
mon/PGMap: remove DIRTY field in `ceph df detail` when cache tiering  is not in use 

### DIFF
--- a/doc/rados/operations/monitoring.rst
+++ b/doc/rados/operations/monitoring.rst
@@ -410,10 +410,9 @@ on the number of replicas, clones and snapshots.
   to this pool.
 - **QUOTA OBJECTS:** The number of quota objects.
 - **QUOTA BYTES:** The number of bytes in the quota objects.
-- **DIRTY:** "DIRTY" is meaningful only when cache tiering is in use. If cache
-  tiering is in use, the "DIRTY" column lists the number of objects in the
-  cache pool that have been written to the cache pool but have not flushed yet
-  to the base pool.
+- **DIRTY:** The number of objects in the cache pool that have been written to
+  the cache pool but have not been flushed yet to the base pool. This field is
+  only available when cache tiering is in use.
 - **USED COMPR:** amount of space allocated for compressed data (i.e. this
   includes comrpessed data plus all the allocation, replication and erasure
   coding overhead).

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -925,7 +925,11 @@ void PGMapDigest::dump_object_stat_sum(
     if (verbose) {
       f->dump_int("quota_objects", pool->quota_max_objects);
       f->dump_int("quota_bytes", pool->quota_max_bytes);
-      f->dump_int("dirty", sum.num_objects_dirty);
+      if (pool->is_tier()) {
+        f->dump_int("dirty", sum.num_objects_dirty);
+      } else {
+        f->dump_int("dirty", 0);
+      }
       f->dump_int("rd", sum.num_rd);
       f->dump_int("rd_bytes", sum.num_rd_kb * 1024ull);
       f->dump_int("wr", sum.num_wr);
@@ -955,16 +959,17 @@ void PGMapDigest::dump_object_stat_sum(
         tbl << "N/A";
       else
         tbl << stringify(si_u_t(pool->quota_max_objects));
-
       if (pool->quota_max_bytes == 0)
         tbl << "N/A";
       else
         tbl << stringify(byte_u_t(pool->quota_max_bytes));
-
-      tbl << stringify(si_u_t(sum.num_objects_dirty))
-	  << stringify(byte_u_t(statfs.data_compressed_allocated))
-	  << stringify(byte_u_t(statfs.data_compressed_original))
-	  ;
+      if (pool->is_tier()) {
+        tbl << stringify(si_u_t(sum.num_objects_dirty));
+      } else {
+        tbl << "N/A";
+      }
+      tbl << stringify(byte_u_t(statfs.data_compressed_allocated));
+      tbl << stringify(byte_u_t(statfs.data_compressed_original));
     }
   }
 }

--- a/src/test/mon/PGMap.cc
+++ b/src/test/mon/PGMap.cc
@@ -79,8 +79,9 @@ TEST(pgmap, dump_object_stat_sum_0)
   pool.quota_max_bytes = 2000 * 1024 * 1024;
   pool.size = 2;
   pool.type = pg_pool_t::TYPE_REPLICATED;
+  pool.tier_of = 0;
   PGMap::dump_object_stat_sum(tbl, nullptr, pool_stat, avail,
-			      pool.get_size(), verbose, true, true, &pool);  
+			      pool.get_size(), verbose, true, true, &pool);
   float copies_rate =
     (static_cast<float>(sum.num_object_copies - sum.num_objects_degraded) /
       sum.num_object_copies) * pool.get_size();
@@ -120,8 +121,9 @@ TEST(pgmap, dump_object_stat_sum_1)
   pool.quota_max_bytes = 2000 * 1024 * 1024;
   pool.size = 2;
   pool.type = pg_pool_t::TYPE_REPLICATED;
+  pool.tier_of = 0;
   PGMap::dump_object_stat_sum(tbl, nullptr, pool_stat, avail,
-			      pool.get_size(), verbose, true, true, &pool);  
+			      pool.get_size(), verbose, true, true, &pool);
   unsigned col = 0;
   ASSERT_EQ(stringify(byte_u_t(0)), tbl.get(0, col++));
   ASSERT_EQ(stringify(byte_u_t(0)), tbl.get(0, col++));


### PR DESCRIPTION
```
[ideepika@vossi03 build]$ bin/ceph df detail
*** DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***
2021-03-23T09:15:27.623+0000 7f5134720700 -1 WARNING: all dangerous and experimental features are enabled.
2021-03-23T09:15:27.644+0000 7f5134720700 -1 WARNING: all dangerous and experimental features are enabled.
--- RAW STORAGE ---
CLASS  SIZE  AVAIL  USED  RAW USED  %RAW USED
TOTAL   0 B    0 B   0 B       0 B          0

--- POOLS ---
POOL  ID  PGS  STORED  (DATA)  (OMAP)  OBJECTS  USED  (DATA)  (OMAP)  %USED  MAX AVAIL  QUOTA OBJECTS  QUOTA BYTES  USED COMPR  UNDER COMPR
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
