### PR TITLE
doc/crimson: improve wording about the pipeline / wait states.

### DIFF
--- a/doc/dev/crimson/pipeline.rst
+++ b/doc/dev/crimson/pipeline.rst
@@ -24,19 +24,21 @@ There are a few cases when the blocking of a client request can happen.
   ``ClientRequest::PGPipeline::await_map``
     wait on a PG being advanced to particular epoch
   ``ClientRequest::PGPipeline::wait_for_active``
-    wait on a PG becomes ``is_active()``
+    wait for a PG to become *active* (i.e. have ``is_active()`` asserted)
   ``ClientRequest::PGPipeline::recover_missing``
-    wait on an object has been recovered
+    wait on an object to be recovered (i.e. leaving the ``missing`` set)
   ``ClientRequest::PGPipeline::get_obc``
-    wait on an object context becomes locked
+    wait on an object to be available for locking. The ``obc`` will be locked
+    before this operation is allowed to continue
   ``ClientRequest::PGPipeline::process``
     wait if any other ``MOSDOp`` message is handled against this PG
 
 At any moment, a ``ClientRequest`` being served should be in one and only one
-of these  phases. Similarly, an object denoting particular phase can host not
-more than a single ``ClientRequest`` the same time. At low-level this is achieved
-with a combination of a barrier and an exclusive lock. They implement the
-semantic of a semaphore with a single slot for these exclusive phases.
+of the phases described above. Similarly, an object denoting particular phase
+can host not more than a single ``ClientRequest`` the same time. At low-level
+this is achieved with a combination of a barrier and an exclusive lock.
+They implement the semantic of a semaphore with a single slot for these exclusive
+phases.
 
 As the execution advances, request enters next phase and leaves the current one
 freeing it for another ``ClientRequest`` instance. All these phases form a pipeline


### PR DESCRIPTION
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

-----------

This is a follow-up PR to #40282 after the review of #40303 by @ronen-fr 

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
