### PR TITLE
mgr/dashboard: improve telemetry opt-in reminder notification message

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/telemetry-notification/telemetry-notification.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/telemetry-notification/telemetry-notification.component.html
@@ -2,8 +2,8 @@
            type="warning"
            *ngIf="displayNotification"
            (close)="close($event)">
-  <div i18n>The Telemetry module is not submitting telemetry data at the
-    moment. Click
-  <a routerLink="/telemetry"
-     class="alert-link">here</a> to activate it now.</div>
+  <div i18n>The Ceph community needs your help to continue improving: please
+    <a routerLink="/telemetry"
+       class="btn activate-button alert-link activate-text">Activate</a> the
+  <a href="https://docs.ceph.com/en/latest/mgr/telemetry/">Telemetry</a> module.</div>
 </ngb-alert>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/telemetry-notification/telemetry-notification.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/telemetry-notification/telemetry-notification.component.scss
@@ -1,3 +1,17 @@
+@use './src/styles/vendor/variables' as vv;
+
 ::ng-deep cd-telemetry-notification .no-margin-bottom {
   margin-bottom: 0;
+}
+
+.activate-button {
+  background-color: vv.$barley-white;
+  border: vv.$gray-700 solid 0.5px;
+  border-radius: 10%;
+  padding: 0.1rem 0.4rem;
+}
+
+.activate-text {
+  color: vv.$gray-700;
+  font-weight: bold;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/styles/defaults/_bootstrap-defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles/defaults/_bootstrap-defaults.scss
@@ -22,6 +22,7 @@ $yellow: #ffc200 !default;
 $green: #0b0 !default;
 $teal: #20c997 !default;
 $cyan: #17a2b8 !default;
+$barley-white: #fcecba !default;
 
 $primary: #2b99a8 !default;
 $secondary: #374249 !default;


### PR DESCRIPTION
This PR to improve the telemetry opt-in reminder notification. by adding Activate button instead of the "Click here" text and add a hyperlink over the "telemetry" word that direct to the telemetry documentation.

The following image shows the modification.
![Telemetry](https://user-images.githubusercontent.com/56444536/112189051-e635ad00-8c03-11eb-886c-1df8da27e221.png)
     

Fixes: https://tracker.ceph.com/issues/49606
Signed-off-by: Waad Alkhoury walkhour@redhat.com

## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
