### PR TITLE
doc/cephadm: explicitly show host requirments in adding host section

### DIFF
--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -15,6 +15,9 @@ To list hosts associated with the cluster:
 Adding Hosts
 ============
 
+Hosts must have these :ref:`cephadm-host-requirements` installed.
+Hosts without all the necessary requirements will fail to be added to the cluster.
+
 To add each new host to the cluster, perform two steps:
 
 #. Install the cluster's public SSH key in the new host's root user's ``authorized_keys`` file:

--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -8,6 +8,9 @@ then deploying the needed services.
 
 .. highlight:: console
 
+
+.. _cephadm-host-requirements:
+
 Requirements
 ============
 


### PR DESCRIPTION
[requirements](https://docs.ceph.com/en/latest/cephadm/install/) are listed in the beginning of "deploying a new cluster" page but dont explicitly say they are the requirements for all hosts.  

users could potentially think they are requirements only for the bootstrap host.

explicitly linking back to the requirements at in the "adding hosts" section clears up any potential confusion a user could have.
 
Signed-off-by: Daniel Pivonka <dpivonka@redhat.com>



