### PR TITLE
os/bluestore: [RFC] onode_map changes, better documentation for bluefs_buffered_io

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4200,8 +4200,9 @@ std::vector<Option> get_global_options() {
 
     Option("bluefs_buffered_io", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
+    .add_see_also("osd_memory_target")
     .set_description("Enabled buffered IO for bluefs reads.")
-    .set_long_description("When this option is enabled, bluefs will in some cases perform buffered reads.  This allows the kernel page cache to act as a secondary cache for things like RocksDB compaction.  For example, if the rocksdb block cache isn't large enough to hold blocks from the compressed SST files itself, they can be read from page cache instead of from the disk."),
+    .set_long_description("When this option is enabled, bluefs will in some cases perform buffered reads.  This allows the kernel page cache to act as a secondary cache for things like RocksDB compaction.  For example, if the rocksdb block cache isn't large enough to hold all blocks during OMAP iteration, it may be possible to read them from page cache instead of from the disk.  This can dramatically improve performance when the osd_memory_target is too small to hold all entries in block cache but it does come with downsides.  It has been reported to occasionally cause excessive kernel swapping (and associated stalls) in rare scenarios.  On the balance right now it appears to be better to leave this enabled, however in cases where the osd_memory_target is very high it may not always be a clear win and may need to be set based on the rest of the environment."),
 
     Option("bluefs_sync_write", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1855,7 +1855,7 @@ BlueStore::OnodeRef BlueStore::OnodeSpace::lookup(const ghobject_t& oid)
 
   {
     std::lock_guard l(cache->lock);
-    ceph::unordered_map<ghobject_t,OnodeRef>::iterator p = onode_map.find(oid);
+    auto p = onode_map.find(oid);
     if (p == onode_map.end()) {
       ldout(cache->cct, 30) << __func__ << " " << oid << " miss" << dendl;
     } else {
@@ -1906,9 +1906,8 @@ void BlueStore::OnodeSpace::rename(
   std::lock_guard l(cache->lock);
   ldout(cache->cct, 30) << __func__ << " " << old_oid << " -> " << new_oid
 			<< dendl;
-  ceph::unordered_map<ghobject_t,OnodeRef>::iterator po, pn;
-  po = onode_map.find(old_oid);
-  pn = onode_map.find(new_oid);
+  auto po = onode_map.find(old_oid);
+  auto pn = onode_map.find(new_oid);
   ceph_assert(po != pn);
 
   ceph_assert(po != onode_map.end());

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1289,7 +1289,7 @@ public:
 
   private:
     /// forward lookups
-    mempool::bluestore_cache_meta::unordered_map<ghobject_t,OnodeRef> onode_map;
+    mempool::bluestore_cache_meta::map<ghobject_t,OnodeRef> onode_map;
 
     friend struct Collection; // for split_cache()
     friend struct Onode; // for put()


### PR DESCRIPTION
This is the first part in (hopefully) a series to try to improve bluefs omap performance, especially based on the multiple user issues that have been reported in various bugs, issues, and PRs (see especially #38044) with the bluefs_buffered_io=false change.  

In #39976 a new benchmark was introduced to try and better understand how OMAP performs in different situations.  A number of tests were performed with 100K objects each with 100 omap entries for 10M total entries.  100 unique hobject_t hashes were used to simulate the effect of spreading those objects across 100 PGs.  Each omap entry has a 64byte key and 256byte value which roughly aligns with values pulled from rocksdb sst files from an RBD volume (though especially with RGW these values could be highly variable).  The aggregate dataset size (~3GB) was chosen specifically to not quite fully fit inside the rocksdb block cache once populated at the default 4GB osd_memory_target but easily will fit with a larger memory target (16GB).  Debug 5 was used to confirm that the priority cache memory autotuning gave rocksdb as much memory as it could to cache OMAP data (about 2.6-2.8GB in the 4GB target tests).  cgroups were used to limit the process memory to 4GB or 16GB for each respective test which appears to also be setting a quota for page cache usage (Need to verify?).

The following tables showcase some of the most interesting behaviors observed:

<b>omap_setkeys:</b>
onode_map<br>Data Structure | Store | 4G Buffered | 4G Direct | 16G Buffered | 16G Direct | 4G Buffered | 4G Direct | 16G Buffered | 16G Direct
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
| | | name sorted | name sorted | name sorted | name sorted | std sorted | std sorted | std sorted | std sorted
| | filestore |   |   |   |   | <b>33.87</b> |   | <b>33.61</b> |  
unordered_map | bluestore | 6.10 | 5.82 | 5.90 | 5.88 | 4.64 | 4.72 | 4.72 | 4.67
map | bluestore | 4.01 |   |   |   | 4.11 | 4.09 | 4.09 | 4.13

<b>omap_get:</b>
onode_map<br>Data Structure | Store | 4G Buffered | 4G Direct | 16G Buffered | 16G Direct | 4G Buffered | 4G Direct | 16G Buffered | 16G Direct
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
| | | name sorted | name sorted | name sorted | name sorted | std sorted | std sorted | std sorted | std sorted
| | filestore |   |   |   |   | 19.80 |   | 11.56 |  
unordered_map | bluestore | <b>54.19 | <b>66.01 | 10.67 | <b>66.32 | 38.31 | <b>53.53 | 8.25 | <b>53.70 
map | bluestore | <b>50.38 |   |   |   | 37.30 | <b>52.37 | 7.31 | <b>51.98

<b>seek_to_first iteration:</b>
onode_map<br>Data Structure | Store | 4G Buffered | 4G Direct | 16G Buffered | 16G Direct | 4G Buffered | 4G Direct | 16G Buffered | 16G Direct
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
| | | name sorted | name sorted | name sorted | name sorted | std sorted | std sorted | std sorted | std sorted
| | filestore |   |   |   |   | 7.48 |   | 7.37 |  
unordered_map | bluestore | 48.88 | 59.44 | 6.64 | 6.02 | 35.34 | 50.76 | 6.52 | 5.34
map | bluestore | 49.70 |   |   |   | 34.99 | 50.92 | 5.90 | 5.38

<b>lower_bound iteration:</b>
onode_map<br>Data Structure | Store | 4G Buffered | 4G Direct | 16G Buffered | 16G Direct | 4G Buffered | 4G Direct | 16G Buffered | 16G Direct
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
| | | name sorted | name sorted | name sorted | name sorted | std sorted | std sorted | std sorted | std sorted
| | filestore |   |   |   |   | 7.19 |   | 7.23 |  
unordered_map | bluestore | <b>48.67 | <b>59.32 | 6.60 | 5.63 | 37.51 | <b>50.64 | 6.58 | 5.39
map | bluestore | <b>48.94 |   |   |   | 38.06 | <b>50.50 | 5.96 | 5.32

<b>remove</b>
onode_map<br>Data Structure | Store | 4G Buffered | 4G Direct | 16G Buffered | 16G Direct | 4G Buffered | 4G Direct | 16G Buffered | 16G Direct
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
| | | name sorted | name sorted | name sorted | name sorted | std sorted | std sorted | std sorted | std sorted
| | filestore |   |   |   |   | 73.56 |   | 46.37 |  
unordered_map | bluestore | <b>2393 | <b>1835 | <b>1994 | <b>1659 | 106.32 | 115.34 | 11.87 | 45.09
map | bluestore | <b>2380 |   |   |   | 108.99 | 115.18 | 12.54 | 47.07

Some conclusions that appear to be reasonable to draw from these tests:

1) Bluestore appears to be much faster than filestore for omap_setkeys.  In bluestore, the onode_map is implemented with an unordered_map that is vulnerable to slow performance when there are collisions hash function.  With the way we populate the hobject_t hash, this manifests when the pg count is low.  These tests try to simulate a pg count of 100, but in reality a lower pg count could result in a worse performance discrepancy than shown here (In cases with many collisions the effect can be significant).  There are two options for improving this:  (a) Simply use a data structure like std::map, btree, flatmap, etc that isn't impacted by hash collisions. (b) provide a custom std::hash specialization for the onode_map that has fewer collisions.  This PR currently switches the data structure to std::map based on the belief that the onode_map will not grow excessively large due to sharding (@aclamk) and remain fast, but it's possible that with a better hash specialization for ghobject_t, unordered_map would be faster yet.  

2) omap_get performs significantly faster when using buffered IO than direct IO.  This seems to be the case even when there is enough memory available for rocksdb to cache all blocks.  The primary benefit for the buffered IO tests appears to be the availability of additional page cache rather than increased block cache.  This is likely the reason that filestore is faster when memory limited (filestore uses less memory than bluestore, thus more page cache is available), but in the 16GB test bluestore is faster (both have sufficient page cache to cache all SST files).  Calling omap_get on ghobject_ts in the proper order (ie using std::sort rather than sorting based on object name) improves performance in all tested cases.

3) Iteration performance is extremely fast when all OMAP entries fit in the block cache and significantly worse when they don't.  It's possible that bluestore may do better with lots of page cache and buffered IO even if the block cache isn't big enough based on the filestore results.  @aclamk and I believe we may be seeing a pathologically bad case here where blocks at the beginning of an iteration may be forced out of cache at the end of the iteration, causing repeated iterations to continually reload blocks from disk.  More investigation needs to happen here, though using buffered IO provides a crutch in this case when there is sufficient page cache to allow repeated iteration to proceed quickly.

4) remove performance is excessively slow in all cases when objects are removed in the wrong sorting order (ie when sorting by object name rather than by std::sort).  This was the primary reason that several of the test cases were not completed in these charts.  The best remove performance was removing in the properly sorted order using buffered io with lots of memory for page cache (or block cache).  This was around 160x faster than the same test but removing in object name order.  Using direct IO even with 16GB of memory for block cache was still 4x slower than using buffered IO, so there's more evidence here that we are doing extra disk reads even with a large block cache.


Given these findings, this PR does two things:

1) reverts bluefs_buffered_io=false until we can at least show direct IO to be as fast as buffered IO in the new OmapBench tests from #39976 (with the knowledge that users may still see the excessive page cache usage issue that was reported by the perf and scale team.  Provide documentation in the configuration option stating such).

2) switch onode_map to std::map. This is a little controversial as if there are any unexpected situations where the onode_map can grow excessively large, this should be slower than unordered_map.  This is a very straightforward way to avoid the hash collision issue however and in practice @aclamk believes we should not see the onode_map grow excessively large due to sharding.  There still may be a reasonable argument that we should keep unordered_map and instead provide a custom hash specialization for ghobject_t that avoids collisions, but ultimately if onode_map stays small both may be reasonable solutions to the issue.

Additional things that should be done in the future:

1) Audit all places we keep lists/vectors/etc of ghobject_t objects and make sure we are performing operations against them in the proper sorted order when possible.
2) Continue to debug why rocksdb's block cache does not appear to be as effective as the page cache in many of these tests.
3) Continue to debug what's going on with rocksdb prefetch and how different versions work (there has been significant code churn over the last 3 years).
4) Consider alternate solutions to the rocksdb block cache such as a higher level OMAP cache, KeyValueDB cache, or lower level bluefs cache.

## Checklist
- [ ] References tracker ticket
- [X] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
