### PR TITLE
cephsqlite: add julian day offset in milliseconds

### DIFF
--- a/src/libcephsqlite.cc
+++ b/src/libcephsqlite.cc
@@ -690,7 +690,7 @@ static int CurrentTime(sqlite3_vfs* vfs, sqlite3_int64* time)
   dv(5) << time << dendl;
 
   auto t = ceph_clock_now();
-  *time = t.to_msec() + 2440587.5;
+  *time = t.to_msec() + 2440587.5*86400000; /* julian days since 1970 converted to ms */
 
   auto end = ceph::coarse_mono_clock::now();
   getdata(vfs).logger->tinc(P_OP_CURRENTTIME, end-start);

--- a/src/test/libcephsqlite/main.cc
+++ b/src/test/libcephsqlite/main.cc
@@ -18,6 +18,7 @@
 #include <string>
 #include <string_view>
 
+#include <stdlib.h>
 #include <string.h>
 
 #include <sqlite3.h>
@@ -1029,6 +1030,32 @@ out:
   sqlite3_finalize(stmt);
   ASSERT_EQ(0, rc);
 }
+
+TEST_F(CephSQLiteTest, CurrentTime) {
+  static const char SQL[] =
+    "SELECT strftime('%s', 'now');"
+    ;
+
+  int rc;
+  const char *current = SQL;
+  sqlite3_stmt *stmt = NULL;
+
+  std::cout << SQL << std::endl;
+  sqlcatch(sqlite3_prepare_v2(db, current, -1, &stmt, &current));
+  sqlcatchcode(sqlite3_step(stmt), SQLITE_ROW);
+  {
+    time_t now = time(0);
+    auto t = sqlite3_column_int64(stmt, 0);
+    ASSERT_LT(abs(now-t), 5);
+  }
+  sqlcatch(sqlite3_finalize(stmt); stmt = NULL);
+
+  rc = 0;
+out:
+  sqlite3_finalize(stmt);
+  ASSERT_EQ(0, rc);
+}
+
 
 TEST_F(CephSQLiteTest, StatusFields) {
   static const char SQL[] =


### PR DESCRIPTION
This magic number was copied from another VFS but was not adjusted for
the xCurrentTimeInt64 interface.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
