### PR TITLE
octopus: librbd: fixed librbd qos assert m_io_throttled failed,sometimes appeared coredump

### DIFF
--- a/src/librbd/io/ImageRequestWQ.cc
+++ b/src/librbd/io/ImageRequestWQ.cc
@@ -877,10 +877,10 @@ void ImageRequestWQ<I>::handle_throttle_ready(int r, ImageDispatchSpec<I> *item,
   ldout(cct, 15) << "r=" << r << ", " << "req=" << item << dendl;
 
   std::lock_guard pool_locker{this->get_pool_lock()};
-  ceph_assert(m_io_throttled.load() > 0);
   item->set_throttled(flag);
   if (item->were_all_throttled()) {
     this->requeue_back(pool_locker, item);
+    ceph_assert(m_io_throttled.load() > 0);
     --m_io_throttled;
     this->signal(pool_locker);
   }


### PR DESCRIPTION
After investigation, I found that the operation of ++m_io_throttled and --m_io_throttled is done in the main thread and the timer thread respectively. Although m_io_throttled is an atomic variable, ++ The operation of m_io_throttled in the main thread may be slower than --m_io_throttled in the timer thread, so a coredump will appear when ceph_assert(m_io_throttled.load()> 0) is performed The code is as follows:
```c++
if (needs_throttle(peek_item)) {
ldout(cct, 15) << "throttling IO " << peek_item << dendl;

++m_io_throttled;
// dequeue the throttled item
ThreadPool::PointerWQ<ImageDispatchSpec<I> >::_void_dequeue();
return nullptr;
}
```
```c++
void ImageRequestWQ::handle_throttle_ready(int r, ImageDispatchSpec *item, uint64_t flag) {
CephContext *cct = m_image_ctx.cct;
ldout(cct, 15) << "r=" << r << ", " << "req=" << item << dendl;

item->set_throttled(flag);
if (item->were_all_throttled()) {
this->requeue_back(item);
ceph_assert(m_io_throttled.load() > 0);
--m_io_throttled;
this->signal();
}
}
```
Putting ceph_assert behind requeue_back can guarantee ++m_io_throttled occuring first ，This is because _void_dequeue and requeue_back need to use the same lock and _void_dequeue hold the lock.

fixed:https://tracker.ceph.com/issues/49949
Signed-off-by: pkulijiawei <lijiawei1@chinatelecom.cn>
Reviewed-by: wuxuehan@chinatelecom.cn


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
