### PR TITLE
doc: remove duplicated 'quota' parameter in URL

### DIFF
--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -1929,7 +1929,7 @@ Set Quota for an Individual Bucket
 To set a quota, the user must have ``buckets`` capability set with ``write``
 permission. ::
 
-	PUT /admin/bucket?quota&uid=<uid>&bucket=<bucket-name>&quota
+	PUT /admin/bucket?quota&uid=<uid>&bucket=<bucket-name>
 
 The content must include a JSON representation of the quota settings
 as mentioned in Set Bucket Quota section above.


### PR DESCRIPTION
doc:duplicate 'quota' parameter in URL

Only one "quota" parameter is needed in the URL to indicate that it is a quota request.

Signed-off-by: wangyingbin <ybwang0211@163.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
