### PR TITLE
pacific: mgr: add mon metada using type of "mon"

### DIFF
--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -554,12 +554,12 @@ void Mgr::handle_mon_map()
     }
   });
   for (const auto& name : names_exist) {
-    const auto k = DaemonKey{"osd", name};
+    const auto k = DaemonKey{"mon", name};
     if (daemon_state.is_updating(k)) {
       continue;
     }
     auto c = new MetadataUpdate(daemon_state, k);
-    const char* cmd = R"(P{{"prefix": "mon metadata", "id": "{}"}})";
+    const char* cmd = R"({{"prefix": "mon metadata", "id": "{}"}})";
     monc->start_mon_command({fmt::format(cmd, name)}, {},
 			    &c->outbl, &c->outs, c);
   }


### PR DESCRIPTION
backport of #39937

backport ticket: https://tracker.ceph.com/issues/49006

---
this change addresses a regression introduced by
c037f4cb5d7436879d58c34748ef516b5269781f

also remove the "P" before the json command.

see also: https://tracker.ceph.com/issues/48905

Fixes: https://tracker.ceph.com/issues/49661
Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 8fc290bfba4d71a60d30c2374ce4bcba37e649de)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
