### PR TITLE
octopus: qa/suites/rados/cephadm/upgrade: change starting version by distro

### DIFF
--- a/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-centos_8.yaml
+++ b/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-centos_8.yaml
@@ -1,0 +1,13 @@
+tasks:
+- cephadm:
+    image: docker.io/ceph/ceph:v15.2.5
+    cephadm_branch: v15.2.5
+    cephadm_git_url: https://github.com/ceph/ceph
+    # avoid --cap-add=PTRACE + --privileged for older cephadm versions
+    allow_ptrace: false
+os_type: centos
+os_version: "8.2"
+overrides:
+  selinux:
+    whitelist:
+      - scontext=system_u:system_r:logrotate_t:s0

--- a/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-ubuntu_20.04.yaml
+++ b/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-ubuntu_20.04.yaml
@@ -1,0 +1,9 @@
+tasks:
+- cephadm:
+    image: docker.io/ceph/ceph:v15.2.0
+    cephadm_branch: v15.2.0
+    cephadm_git_url: https://github.com/ceph/ceph
+    # avoid --cap-add=PTRACE + --privileged for older cephadm versions
+    allow_ptrace: false
+os_type: ubuntu
+os_version: "20.04"

--- a/qa/suites/rados/cephadm/upgrade/1-start.yaml
+++ b/qa/suites/rados/cephadm/upgrade/1-start.yaml
@@ -1,4 +1,0 @@
-tasks:
-- cephadm:
-    image: docker.io/ceph/ceph:v15.2.0
-    cephadm_branch: v15.2.0

--- a/qa/suites/rados/cephadm/upgrade/distro$
+++ b/qa/suites/rados/cephadm/upgrade/distro$
@@ -1,1 +1,0 @@
-../smoke/distro


### PR DESCRIPTION
centos/rhel have podman 2, which does not like conflicting --cap-add and
--privileged arguments.  cephadm versions prior to 15.2.5 use both args,
however, which means the rhel/centos upgrade test has to start at 15.2.5
to work at all on those distros (with the updated podman).

Fixes: https://tracker.ceph.com/issues/48142
Signed-off-by: Sage Weil <sage@newdream.net>
(cherry picked from commit 38e14f923508efc4a18e942869065771598ef915)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
