### PR TITLE
pacific: MDS should return -ENODATA when asked to remove xattr that doesn't exist

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5903,7 +5903,7 @@ int Server::xattr_validate(CInode *cur, const InodeStoreBase::xattr_map_const_pt
   }
 
   if (op == CEPH_MDS_OP_RMXATTR) {
-    if (xattrs && xattrs->count(mempool::mds_co::string(xattr_name)) == 0) {
+    if (!xattrs || xattrs->count(mempool::mds_co::string(xattr_name)) == 0) {
       dout(10) << "removexattr '" << xattr_name << "' and CEPHFS_ENODATA on " << *cur << dendl;
       return -CEPHFS_ENODATA;
     }

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -540,6 +540,9 @@ TEST(LibCephFS, Xattrs) {
   int fd = ceph_open(cmount, test_xattr_file, O_CREAT, 0666);
   ASSERT_GT(fd, 0);
 
+  // test removing non-existent xattr
+  ASSERT_EQ(-ENODATA, ceph_removexattr(cmount, test_xattr_file, "user.nosuchxattr"));
+
   char i = 'a';
   char xattrk[128];
   char xattrv[128];


### PR DESCRIPTION
https://tracker.ceph.com/issues/49932