### PR TITLE
pacific: libcephfs: test termination "what(): Too many open files"

### DIFF
--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -2028,7 +2028,7 @@ static void shutdown_racer_func()
 // See tracker #20988
 TEST(LibCephFS, ShutdownRace)
 {
-  const int nthreads = 128;
+  const int nthreads = 32;
   std::thread threads[nthreads];
 
   // Need a bunch of fd's for this test


### PR DESCRIPTION
https://tracker.ceph.com/issues/49935