### PR TITLE
octopus: rgw/amqp: fix race condition in amqp manager initialization

### DIFF
--- a/src/rgw/rgw_amqp.cc
+++ b/src/rgw/rgw_amqp.cc
@@ -547,9 +547,9 @@ private:
   std::atomic<size_t> dequeued;
   CephContext* const cct;
   mutable std::mutex connections_lock;
-  std::thread runner;
   const ceph::coarse_real_clock::duration idle_time;
   const ceph::coarse_real_clock::duration reconnect_time;
+  std::thread runner;
 
   void publish_internal(message_wrapper_t* message) {
     const std::unique_ptr<message_wrapper_t> msg_owner(message);
@@ -819,9 +819,9 @@ public:
     queued(0),
     dequeued(0),
     cct(_cct),
-    runner(&Manager::run, this),
     idle_time(std::chrono::milliseconds(idle_time_ms)),
-    reconnect_time(std::chrono::milliseconds(reconnect_time_ms)) {
+    reconnect_time(std::chrono::milliseconds(reconnect_time_ms)),
+    runner(&Manager::run, this) {
       // The hashmap has "max connections" as the initial number of buckets, 
       // and allows for 10 collisions per bucket before rehash.
       // This is to prevent rehashing so that iterators are not invalidated 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48934

---

backport of https://github.com/ceph/ceph/pull/38903
parent tracker: https://tracker.ceph.com/issues/48869

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh