### PR TITLE
octopus: rgw/http: add timeout to http client

### DIFF
--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -53,6 +53,8 @@ protected:
 
   param_vec_t headers;
 
+  long  req_timeout{0L};
+
   RGWHTTPManager *get_manager();
 
   int init_request(rgw_http_req_data *req_data);
@@ -134,6 +136,12 @@ public:
 
   void set_verify_ssl(bool flag) {
     verify_ssl = flag;
+  }
+
+  // set request timeout in seconds
+  // zero (default) mean that request will never timeout
+  void set_req_timeout(long timeout) {
+    req_timeout = timeout;
   }
 
   int process(optional_yield y);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49091

---

backport of https://github.com/ceph/ceph/pull/34414
parent tracker: https://tracker.ceph.com/issues/49090

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh