### PR TITLE
octopus: librbd/io: send alloc_hint when compression hint is set

### DIFF
--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -371,7 +371,8 @@ void AbstractObjectWriteRequest<I>::add_write_hint(
     librados::ObjectWriteOperation *wr) {
   I *image_ctx = this->m_ictx;
   std::shared_lock image_locker{image_ctx->image_lock};
-  if (image_ctx->object_map == nullptr || !this->m_object_may_exist) {
+  if (image_ctx->object_map == nullptr || !this->m_object_may_exist ||
+      image_ctx->alloc_hint_flags != 0U) {
     ObjectRequest<I>::add_write_hint(*image_ctx, wr);
   }
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49772

---

backport of https://github.com/ceph/ceph/pull/40050
parent tracker: https://tracker.ceph.com/issues/49690

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh