### PR TITLE
octopus: librbd: allow interrupted trash move request to be restarted

### DIFF
--- a/src/librbd/trash/MoveRequest.cc
+++ b/src/librbd/trash/MoveRequest.cc
@@ -101,7 +101,10 @@ template <typename I>
 void MoveRequest<I>::handle_directory_remove(int r) {
   ldout(m_cct, 10) << "r=" << r << dendl;
 
-  if (r < 0 && r != -ENOENT) {
+  if (r == -ENOENT) {
+    r = 0;
+  }
+  if (r < 0) {
     lderr(m_cct) << "failed to remove image from directory: " << cpp_strerror(r)
                  << dendl;
   }

--- a/src/tools/rbd/action/Trash.cc
+++ b/src/tools/rbd/action/Trash.cc
@@ -146,6 +146,9 @@ int execute_remove(const po::variables_map &vm,
       std::cerr << "rbd: image has snapshots - these must be deleted"
                 << " with 'rbd snap purge' before the image can be removed."
                 << std::endl;
+    } else if (r == -EUCLEAN) {
+      std::cerr << "rbd: error: image not fully moved to trash."
+                << std::endl;
     } else if (r == -EBUSY) {
       std::cerr << "rbd: error: image still has watchers"
                 << std::endl


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49766

---

backport of https://github.com/ceph/ceph/pull/40010
parent tracker: https://tracker.ceph.com/issues/49716

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh