### PR TITLE
octopus: mgr/dashboard: Fix for broken User management role cloning 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/role.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/role.service.spec.ts
@@ -46,8 +46,9 @@ describe('RoleService', () => {
 
   it('should call clone', () => {
     service.clone('foo', 'bar').subscribe();
-    const req = httpTesting.expectOne('api/role/foo/clone?new_name=bar');
+    const req = httpTesting.expectOne('api/role/foo/clone');
     expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ new_name: 'bar' });
   });
 
   it('should check if role name exists', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/role.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/role.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
 import { Observable, of as observableOf } from 'rxjs';
@@ -30,9 +30,7 @@ export class RoleService {
   }
 
   clone(name: string, newName: string) {
-    let params = new HttpParams();
-    params = params.append('new_name', newName);
-    return this.http.post(`api/role/${name}/clone`, null, { params });
+    return this.http.post(`api/role/${name}/clone`, { new_name: newName });
   }
 
   update(role: RoleFormModel) {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49971

---

backport of https://github.com/ceph/ceph/pull/40216
parent tracker: https://tracker.ceph.com/issues/49880

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh