### PR TITLE
ceph.spec: prepare openSUSE usrmerge (boo#1029961)

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1409,7 +1409,7 @@ touch %{buildroot}%{_sharedstatedir}/cephadm/.ssh/authorized_keys
 chmod 0600 %{buildroot}%{_sharedstatedir}/cephadm/.ssh/authorized_keys
 
 # firewall templates and /sbin/mount.ceph symlink
-%if 0%{?suse_version}
+%if 0%{?suse_version} && !0%{?usrmerged}
 mkdir -p %{buildroot}/sbin
 ln -sf %{_sbindir}/mount.ceph %{buildroot}/sbin/mount.ceph
 %endif
@@ -1585,7 +1585,7 @@ exit 0
 %{_bindir}/rbd-replay-many
 %{_bindir}/rbdmap
 %{_sbindir}/mount.ceph
-%if 0%{?suse_version}
+%if 0%{?suse_version} && !0%{?usrmerged}
 /sbin/mount.ceph
 %endif
 %if %{with lttng}


### PR DESCRIPTION
The compat symlink in /sbin is no longer required and actually in
the way in the usrmerge case.

Signed-off-by: Ludwig Nussel <ludwig.nussel@suse.de>