### PR TITLE
doc/install: update about ninja

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,15 @@ Build instructions:
 	cd build
 	ninja
 
-(Note: do_cmake.sh now defaults to creating a debug build of ceph that can
+(do_cmake.sh now defaults to creating a debug build of ceph that can
 be up to 5x slower with some workloads. Please pass 
 "-DCMAKE_BUILD_TYPE=RelWithDebInfo" to do_cmake.sh to create a non-debug
-release.)
+release.
 
-(Note: the number of jobs used by `ninja` is derived from the the number of
-CPU cores of the building host if unspecified. Use the `-j` option to limit
-the job number if the build jobs are running out of memory. On average, each
-job takes around 2.5GiB memory.
+The number of jobs used by `ninja` is derived from the number of CPU cores of
+the building host if unspecified. Use the `-j` option to limit the job number
+if the build jobs are running out of memory. On average, each job takes around
+2.5GiB memory.)
 
 This assumes you make your build dir a subdirectory of the ceph.git
 checkout. If you put it elsewhere, just point `CEPH_GIT_DIR` to the correct

--- a/doc/install/build-ceph.rst
+++ b/doc/install/build-ceph.rst
@@ -38,17 +38,12 @@ repository and execute the following::
     cd ceph
     ./do_cmake.sh
     cd build
-    make
+    ninja
 
 .. note:: By default do_cmake.sh will build a debug version of ceph that may
    perform up to 5 times slower with certain workloads. Pass 
    '-DCMAKE_BUILD_TYPE=RelWithDebInfo' to do_cmake.sh if you would like to
    build a release version of the ceph executables instead.
-
-.. topic:: Hyperthreading
-
-	You can use ``make -j`` to execute multiple jobs depending upon your system. For 
-	example, ``make -j4`` for a dual core processor may build faster.
 
 See `Installing a Build`_ to install a build in user space.
 

--- a/doc/install/build-ceph.rst
+++ b/doc/install/build-ceph.rst
@@ -40,12 +40,8 @@ repository and execute the following::
     cd build
     ninja
 
-.. note:: By default do_cmake.sh will build a debug version of ceph that may
-   perform up to 5 times slower with certain workloads. Pass 
-   '-DCMAKE_BUILD_TYPE=RelWithDebInfo' to do_cmake.sh if you would like to
-   build a release version of the ceph executables instead.
-
-See `Installing a Build`_ to install a build in user space.
+See `Installing a Build`_ to install a build in user space and `Ceph README.md`_
+doc for more details on build.
 
 Build Ceph Packages
 ===================
@@ -108,3 +104,4 @@ For multi-processor CPUs use the ``-j`` option to accelerate the build.
 
 .. _Ceph: ../clone-source
 .. _Installing a Build: ../install-storage-cluster#installing-a-build
+.. _Ceph README.md: https://github.com/ceph/ceph#building-ceph

--- a/doc/install/install-storage-cluster.rst
+++ b/doc/install/install-storage-cluster.rst
@@ -78,9 +78,9 @@ Installing a Build
 If you build Ceph from source code, you may install Ceph in user space
 by executing the following:: 
 
-	sudo make install
+	sudo ninja install
 
-If you install Ceph locally, ``make`` will place the executables in
+If you install Ceph locally, ``ninja`` will place the executables in
 ``usr/local/bin``. You may add the Ceph configuration file to the
 ``usr/local/bin`` directory to run Ceph from a single directory.
 


### PR DESCRIPTION
'ninja' replaced 'make' in this PR[1]. This patch updates the doc about it.

[1] #39826

Signed-off-by: Varsha Rao <varao@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst


## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---
-->
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
