### PR TITLE
mgr/volumes/nfs: drop `type` param during cluster create

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -11,6 +11,11 @@
 
 >=16.0.0
 --------
+* volumes/nfs: The ``cephfs`` cluster type has been removed from the
+  ``nfs cluster create`` subcommand. Clusters deployed by cephadm can
+  support an NFS export of both ``rgw`` and ``cephfs`` from a single
+  NFS cluster instance.
+
 * mgr-pg_autoscaler: Autoscaler will now start out by scaling each
   pool to have a full complements of pgs from the start and will only
   decrease it when other pools need more pgs due to increased usage.

--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -16,7 +16,7 @@ Create NFS Ganesha Cluster
 
 .. code:: bash
 
-    $ ceph nfs cluster create <type> <clusterid> [<placement>]
+    $ ceph nfs cluster create <clusterid> [<placement>]
 
 This creates a common recovery pool for all NFS Ganesha daemons, new user based on
 ``clusterid``, and a common NFS Ganesha config RADOS object.
@@ -27,10 +27,6 @@ This creates a common recovery pool for all NFS Ganesha daemons, new user based 
 
    Currently, NFS Ganesha daemon deployed by cephadm listens on the standard
    port. So only one daemon will be deployed on a host.
-
-``<type>`` signifies the export type, which corresponds to the NFS Ganesha file
-system abstraction layer (FSAL). Permissible values are ``"cephfs`` or
-``rgw``, but currently only ``cephfs`` is supported.
 
 ``<clusterid>`` is an arbitrary string by which this NFS Ganesha cluster will be
 known.

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -118,7 +118,7 @@ class TestNFS(MgrTestCase):
         '''
         # Disable any running nfs ganesha daemon
         self._check_nfs_server_status()
-        self._nfs_cmd('cluster', 'create', self.export_type, self.cluster_id)
+        self._nfs_cmd('cluster', 'create', self.cluster_id)
         # Check for expected status and daemon name (nfs.<cluster_id>)
         self._check_nfs_cluster_status('running', 'NFS Ganesha cluster deployment failed')
 
@@ -295,8 +295,7 @@ class TestNFS(MgrTestCase):
         '''
         Test idempotency of cluster create and delete commands.
         '''
-        self._test_idempotency(self._test_create_cluster, ['nfs', 'cluster', 'create', self.export_type,
-                                                           self.cluster_id])
+        self._test_idempotency(self._test_create_cluster, ['nfs', 'cluster', 'create', self.cluster_id])
         self._test_idempotency(self._test_delete_cluster, ['nfs', 'cluster', 'delete', self.cluster_id])
 
     def test_create_cluster_with_invalid_cluster_id(self):
@@ -305,21 +304,8 @@ class TestNFS(MgrTestCase):
         '''
         try:
             invalid_cluster_id = '/cluster_test'  # Only [A-Za-z0-9-_.] chars are valid
-            self._nfs_cmd('cluster', 'create', self.export_type, invalid_cluster_id)
+            self._nfs_cmd('cluster', 'create', invalid_cluster_id)
             self.fail(f"Cluster successfully created with invalid cluster id {invalid_cluster_id}")
-        except CommandFailedError as e:
-            # Command should fail for test to pass
-            if e.exitstatus != errno.EINVAL:
-                raise
-
-    def test_create_cluster_with_invalid_export_type(self):
-        '''
-        Test nfs cluster deployment failure with invalid export type.
-        '''
-        try:
-            invalid_export_type = 'rgw'  # Only cephfs is valid
-            self._nfs_cmd('cluster', 'create', invalid_export_type, self.cluster_id)
-            self.fail(f"Cluster successfully created with invalid export type {invalid_export_type}")
         except CommandFailedError as e:
             # Command should fail for test to pass
             if e.exitstatus != errno.EINVAL:

--- a/src/pybind/mgr/volumes/fs/nfs.py
+++ b/src/pybind/mgr/volumes/fs/nfs.py
@@ -869,9 +869,7 @@ class NFSCluster:
                  f"{self.pool_ns}")
 
     @cluster_setter
-    def create_nfs_cluster(self, export_type, cluster_id, placement):
-        if export_type != 'cephfs':
-            return -errno.EINVAL, "", f"Invalid export type: {export_type}"
+    def create_nfs_cluster(self, cluster_id, placement):
         try:
             pool_list = [p['pool_name'] for p in self.mgr.get_osdmap().dump().get('pools', [])]
 

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -359,7 +359,6 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         },
         {
             'cmd': 'nfs cluster create '
-                   'name=type,type=CephString '
                    f'name=clusterid,type=CephString,goodchars={goodchars} '
                    'name=placement,type=CephString,req=false ',
             'desc': "Create an NFS Cluster",
@@ -717,7 +716,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
 
     @mgr_cmd_wrap
     def _cmd_nfs_cluster_create(self, inbuf, cmd):
-        return self.nfs.create_nfs_cluster(cluster_id=cmd['clusterid'], export_type=cmd['type'],
+        return self.nfs.create_nfs_cluster(cluster_id=cmd['clusterid'],
                                            placement=cmd.get('placement', None))
 
     @mgr_cmd_wrap

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1140,7 +1140,7 @@ start_ganesha() {
     ceph_adm mgr module enable test_orchestrator
     ceph_adm orch set backend test_orchestrator
     ceph_adm test_orchestrator load_data -i $CEPH_ROOT/src/pybind/mgr/test_orchestrator/dummy_data.json
-    prun ceph_adm nfs cluster create cephfs $cluster_id
+    prun ceph_adm nfs cluster create $cluster_id
     prun ceph_adm nfs export create cephfs "a" $cluster_id "/cephfs"
 
     for name in a b c d e f g h i j k l m n o p
@@ -1427,7 +1427,7 @@ if [ $GANESHA_DAEMON_NUM -gt 0 ]; then
     pseudo_path="/cephfs"
     if [ "$cephadm" -gt 0 ]; then
         cluster_id="vstart"
-        prun ceph_adm nfs cluster create cephfs $cluster_id
+        prun ceph_adm nfs cluster create $cluster_id
         prun ceph_adm nfs export create cephfs "a" $cluster_id $pseudo_path
         port="2049"
     else


### PR DESCRIPTION
PR #37600 introduced support for both `cephfs` and `rgw` exports
to be configured using a single nfs-ganesha cluster

Fixes: https://tracker.ceph.com/issues/50369
Signed-off-by: Michael Fritch <mfritch@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
