### PR TITLE
nautilus: common/ipaddr: skip loopback interfaces named 'lo' and test it

### DIFF
--- a/src/common/ipaddr.cc
+++ b/src/common/ipaddr.cc
@@ -56,7 +56,7 @@ const struct ifaddrs *find_ipv4_in_subnet(const struct ifaddrs *addrs,
     if (addrs->ifa_addr == NULL)
       continue;
 
-    if (boost::starts_with(addrs->ifa_name, "lo:"))
+    if (strcmp(addrs->ifa_name, "lo") == 0 || boost::starts_with(addrs->ifa_name, "lo:"))
       continue;
 
     if (numa_node >= 0 && !match_numa_node(addrs->ifa_name, numa_node))
@@ -103,7 +103,7 @@ const struct ifaddrs *find_ipv6_in_subnet(const struct ifaddrs *addrs,
     if (addrs->ifa_addr == NULL)
       continue;
 
-    if (boost::starts_with(addrs->ifa_name, "lo"))
+    if (strcmp(addrs->ifa_name, "lo") == 0 || boost::starts_with(addrs->ifa_name, "lo:"))
       continue;
 
     if (numa_node >= 0 && !match_numa_node(addrs->ifa_name, numa_node))

--- a/src/test/test_ipaddr.cc
+++ b/src/test/test_ipaddr.cc
@@ -182,6 +182,41 @@ TEST(CommonIPAddr, TestV4_PrefixZero)
   ASSERT_EQ((struct sockaddr*)&a_two, result->ifa_addr);
 }
 
+static char lo[] = "lo";
+static char lo0[] = "lo:0";
+
+TEST(CommonIPAddr, TestV4_SkipLoopback)
+{
+  struct ifaddrs one, two, three;
+  struct sockaddr_in a_one;
+  struct sockaddr_in a_two;
+  struct sockaddr_in a_three;
+  struct sockaddr_in net;
+  const struct ifaddrs *result;
+
+  memset(&net, 0, sizeof(net));
+
+  one.ifa_next = &two;
+  one.ifa_addr = (struct sockaddr*)&a_one;
+  one.ifa_name = lo;
+
+  two.ifa_next = &three;
+  two.ifa_addr = (struct sockaddr*)&a_two;
+  two.ifa_name = lo0;
+
+  three.ifa_next = NULL;
+  three.ifa_addr = (struct sockaddr*)&a_three;
+  three.ifa_name = eth0;
+
+  ipv4(&a_one, "127.0.0.1");
+  ipv4(&a_two, "127.0.0.1");
+  ipv4(&a_three, "10.1.2.3");
+  ipv4(&net, "255.0.0.0");
+
+  result = find_ip_in_subnet(&one, (struct sockaddr*)&net, 0);
+  ASSERT_EQ((struct sockaddr*)&a_three, result->ifa_addr);
+}
+
 TEST(CommonIPAddr, TestV6_Simple)
 {
   struct ifaddrs one, two;
@@ -276,6 +311,38 @@ TEST(CommonIPAddr, TestV6_PrefixZero)
 
   result = find_ip_in_subnet(&one, (struct sockaddr*)&net, 0);
   ASSERT_EQ((struct sockaddr*)&a_two, result->ifa_addr);
+}
+
+TEST(CommonIPAddr, TestV6_SkipLoopback)
+{
+  struct ifaddrs one, two, three;
+  struct sockaddr_in6 a_one;
+  struct sockaddr_in6 a_two;
+  struct sockaddr_in6 a_three;
+  struct sockaddr_in6 net;
+  const struct ifaddrs *result;
+
+  memset(&net, 0, sizeof(net));
+
+  one.ifa_next = &two;
+  one.ifa_addr = (struct sockaddr*)&a_one;
+  one.ifa_name = lo;
+
+  two.ifa_next = &three;
+  two.ifa_addr = (struct sockaddr*)&a_two;
+  two.ifa_name = lo0;
+
+  three.ifa_next = NULL;
+  three.ifa_addr = (struct sockaddr*)&a_three;
+  three.ifa_name = eth0;
+
+  ipv6(&a_one, "::1");
+  ipv6(&a_two, "::1");
+  ipv6(&a_three, "2001:1234:5678:90ab::beef");
+  ipv6(&net, "ff00::1");
+
+  result = find_ip_in_subnet(&one, (struct sockaddr*)&net, 0);
+  ASSERT_EQ((struct sockaddr*)&a_three, result->ifa_addr);
 }
 
 TEST(CommonIPAddr, ParseNetwork_Empty)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49996

---

backport of https://github.com/ceph/ceph/pull/40334
parent tracker: https://tracker.ceph.com/issues/49938

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh