### PR TITLE
rpm: libcephsqlite requires sqlite-libs on Fedora/RHEL only

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -932,7 +932,9 @@ Summary:	SQLite3 VFS for Ceph
 Group:		System/Libraries
 %endif
 Requires:	librados2 = %{_epoch_prefix}%{version}-%{release}
+%if 0%{?fedora} || 0%{?rhel}
 Requires:	sqlite-libs
+%endif
 %description -n libcephsqlite
 A SQLite3 VFS for storing and manipulating databases stored on Ceph's RADOS
 distributed object store.


### PR DESCRIPTION
Commit 75980798f19b8c11efd75ba4aae3e491d4c99f98 introduced a new package,
libcephsqlite, with a hard RPM dependency on a package "sqlite-libs" which
does not exist in openSUSE.

It's not clear what this line is for, since the runtime library dependencies of
libcephsqlite should be handled by RPM transparently. I'm afraid to outright
remove it, though, since it might really be needed on Fedora/RHEL systems.

Fixes: https://tracker.ceph.com/issues/50007
Signed-off-by: Nathan Cutler <ncutler@suse.com>
