### PR TITLE
qa/cephfs: don't use sudo to write files in /tmp

### DIFF
--- a/qa/tasks/cephfs/caps_helper.py
+++ b/qa/tasks/cephfs/caps_helper.py
@@ -8,7 +8,7 @@ from teuthology.orchestra.run import Raw
 class CapsHelper(CephFSTestCase):
 
     def run_mon_cap_tests(self, moncap, keyring):
-        keyring_path = self.create_keyring_file(self.fs.admin_remote, keyring)
+        keyring_path = self.fs.admin_remote.mktemp(data=keyring)
 
         fsls = self.run_cluster_cmd(f'fs ls --id {self.client_id} -k '
                                     f'{keyring_path}')

--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -442,6 +442,3 @@ class CephFSTestCase(CephTestCase):
 
         self.run_cluster_cmd(cmd)
         return self.run_cluster_cmd(f'auth get {self.client_name}')
-
-    def create_keyring_file(self, remote, keyring):
-        return remote.mktemp(data=keyring)

--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -4,12 +4,10 @@ import os
 import re
 
 from shlex import split as shlex_split
-from io import StringIO
 
 from tasks.ceph_test_case import CephTestCase
 
 from teuthology import contextutil
-from teuthology.misc import sudo_write_file
 from teuthology.orchestra import run
 from teuthology.orchestra.run import CommandFailedError
 
@@ -446,11 +444,4 @@ class CephFSTestCase(CephTestCase):
         return self.run_cluster_cmd(f'auth get {self.client_name}')
 
     def create_keyring_file(self, remote, keyring):
-        keyring_path = remote.run(args=['mktemp'], stdout=StringIO()).\
-            stdout.getvalue().strip()
-        sudo_write_file(remote, keyring_path, keyring)
-
-        # required when triggered using vstart_runner.py.
-        remote.run(args=['chmod', '644', keyring_path])
-
-        return keyring_path
+        return remote.mktemp(data=keyring)

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -481,8 +481,7 @@ class TestSubCmdFsAuthorize(CapsHelper):
         self.mount_a.write_file(filepath, filedata)
 
         keyring = self.fs.authorize(self.client_id, ('/', 'rw', 'root_squash'))
-        keyring_path = self.create_keyring_file(self.mount_a.client_remote,
-                                                keyring)
+        keyring_path = self.mount_a.client_remote.mktemp(data=keyring)
         self.mount_a.remount(client_id=self.client_id,
                              client_keyring_path=keyring_path,
                              cephfs_mntpt='/')
@@ -517,8 +516,7 @@ class TestSubCmdFsAuthorize(CapsHelper):
         filepaths, filedata, mounts, keyring = self.setup_test_env(perm, paths)
         moncap = self.get_mon_cap_from_keyring(self.client_name)
 
-        keyring_path = self.create_keyring_file(self.mount_a.client_remote,
-                                                keyring)
+        keyring_path = self.mount_a.client_remote.mktemp(data=keyring)
         for path in paths:
             self.mount_a.remount(client_id=self.client_id,
                                  client_keyring_path=keyring_path,
@@ -534,8 +532,7 @@ class TestSubCmdFsAuthorize(CapsHelper):
         filepaths, filedata, mounts, keyring = self.setup_test_env(perm, paths)
         moncap = self.get_mon_cap_from_keyring(self.client_name)
 
-        keyring_path = self.create_keyring_file(self.mount_a.client_remote,
-                                                keyring)
+        keyring_path = self.mount_a.client_remote.mktemp(data=keyring)
         for path in paths:
             self.mount_a.remount(client_id=self.client_id,
                                  client_keyring_path=keyring_path,
@@ -559,8 +556,7 @@ class TestSubCmdFsAuthorize(CapsHelper):
         self.mount_a.write_file(filepath, filedata)
 
         keyring = self.fs.authorize(self.client_id, ('/', perm))
-        keyring_path = self.create_keyring_file(self.mount_a.client_remote,
-                                                keyring)
+        keyring_path = self.mount_a.client_remote.mktemp(data=keyring)
 
         self.mount_a.remount(client_id=self.client_id,
                              client_keyring_path=keyring_path,

--- a/qa/tasks/cephfs/test_multifs_auth.py
+++ b/qa/tasks/cephfs/test_multifs_auth.py
@@ -179,8 +179,7 @@ class TestMDSCaps(TestMultiFS):
         keyring = self.create_client(self.client_id, moncap, osdcap, mdscap)
         keyring_paths = []
         for mount_x in (self.mount_a, self.mount_b):
-            keyring_paths.append(self.create_keyring_file(
-                mount_x.client_remote, keyring))
+            keyring_paths.append(mount_x.client_remote.mktemp(data=keyring))
 
         return keyring_paths
 
@@ -275,8 +274,7 @@ class TestClientsWithoutAuth(TestMultiFS):
     def test_mount_all_caps_absent(self):
         # setup part...
         keyring = self.fs1.authorize(self.client_id, ('/', 'rw'))
-        keyring_path = self.create_keyring_file(self.mount_a.client_remote,
-                                                keyring)
+        keyring_path = self.mount_a.client_remote.mktemp(data=keyring)
 
         # mount the FS for which client has no auth...
         retval = self.mount_a.remount(client_id=self.client_id,
@@ -297,8 +295,7 @@ class TestClientsWithoutAuth(TestMultiFS):
         osdcap = (f'allow rw tag cephfs data={self.fs1.name}, allow rw tag '
                   f'cephfs data={self.fs2.name}')
         keyring = self.create_client(self.client_id, moncap, osdcap, mdscap)
-        keyring_path = self.create_keyring_file(self.mount_a.client_remote,
-                                                keyring)
+        keyring_path = self.mount_a.client_remote.mktemp(data=keyring)
 
         # mount the FS for which client has no auth...
         retval = self.mount_a.remount(client_id=self.client_id,

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -306,14 +306,23 @@ class LocalRemote(object):
         # None
         return mkdtemp(suffix=suffix, prefix='', dir=parentdir)
 
-    def mktemp(self, suffix=None, parentdir=None):
+    def mktemp(self, suffix='', parentdir='', path=None, data=None,
+               owner=None, mode=None):
         """
         Make a remote temporary file
 
         Returns: the path of the temp file created.
         """
         from tempfile import mktemp
-        return mktemp(suffix=suffix, dir=parentdir)
+        if not path:
+            path = mktemp(suffix=suffix, dir=parentdir)
+
+        if data:
+            # sudo is set to False since root user can't write files in /tmp
+            # owned by other users.
+            self.write_file(path=path, data=data, sudo=False)
+
+        return path
 
     def write_file(self, path, data, sudo=False, mode=None, owner=None,
                                      mkdir=False, append=False):

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -316,6 +316,8 @@ class LocalRemote(object):
         from tempfile import mktemp
         if not path:
             path = mktemp(suffix=suffix, dir=parentdir)
+        if not parentdir:
+            path = os.path.join('/tmp', path)
 
         if data:
             # sudo is set to False since root user can't write files in /tmp


### PR DESCRIPTION
Files in /tmp cannot be written by any user( including the root user)
other than the file owner even if the permission mode on the file is
777.

Fixes: https://tracker.ceph.com/issues/49466

Marked DNM because -
Depends on https://github.com/ceph/teuthology/pull/1634.
To fix the same issue for vstart_runner.py this PR depends on https://github.com/ceph/ceph/pull/37655.



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>