### PR TITLE
pacific: auth: require CEPHX_V2 by default

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -113,6 +113,15 @@
   and scrubs). Other built-in profiles include "high_recovery_ops" and "balanced". These
   built-in profiles optimize the QoS provided to clients of mclock scheduler.
 
+* Version 2 of the cephx authentication protocol (``CEPHX_V2`` feature bit) is
+  now required by default.  It was introduced in 2018, adding replay attack
+  protection for authorizers and making msgr v1 message signatures stronger
+  (CVE-2018-1128 and CVE-2018-1129).  Support is present in Jewel 10.2.11,
+  Luminous 12.2.6, Mimic 13.2.1, Nautilus 14.2.0 and later; upstream kernels
+  4.9.150, 4.14.86, 4.19 and later; various distribution kernels, in particular
+  CentOS 7.6 and later.  To enable older clients, set ``cephx_require_version``
+  and ``cephx_service_require_version`` config options to 1.
+
 >=15.0.0
 --------
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2337,7 +2337,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("cephx_require_version", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(1)
+    .set_default(2)
     .set_description("Cephx version required (1 = pre-mimic, 2 = mimic+)"),
 
     Option("cephx_cluster_require_signatures", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
@@ -2345,7 +2345,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("cephx_cluster_require_version", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(1)
+    .set_default(2)
     .set_description("Cephx version required by the cluster from clients (1 = pre-mimic, 2 = mimic+)"),
 
     Option("cephx_service_require_signatures", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
@@ -2353,7 +2353,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("cephx_service_require_version", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(1)
+    .set_default(2)
     .set_description("Cephx version required from ceph services (1 = pre-mimic, 2 = mimic+)"),
 
     Option("cephx_sign_messages", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
backport #40404

It's been almost three years and support is present in all relevant
clients.

From the security perspective, roughly the same could be achieved
with "ceph osd set-require-min-compat-client nautilus", but this is
more user friendly as the client gets ENOTSUP instead of spinning on
"feature set mismatch" faults.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>
(cherry picked from commit e5744672dbde2a897f5f4959339472b7b10c5688)