### PR TITLE
[WIP] mgr/cephadm: Delay reconfig until daemon deployed by correct image

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3222,22 +3222,32 @@ def _pull_image(ctx, image):
 ##################################
 
 
-@infer_image
 def command_inspect_image(ctx):
     # type: (CephadmContext) -> int
+    try:
+        info_from = _inspect_image(ctx)
+    except RuntimeError as e:
+        print(str(e))
+        return errno.ENOENT
+
+    print(json.dumps(info_from, indent=4, sort_keys=True))
+    return 0
+
+
+@infer_image
+def _inspect_image(ctx):
+    # type: (CephadmContext) -> Dict[str, Union[str,List[str]]]
     out, err, ret = call_throws(ctx, [
         ctx.container_path, 'inspect',
         '--format', '{{.ID}},{{.RepoDigests}}',
         ctx.image])
     if ret:
-        return errno.ENOENT
+        raise RuntimeError('inspect image command failed: %s' % err)
     info_from = get_image_info_from_inspect(out.strip(), ctx.image)
 
     ver = CephContainer(ctx, ctx.image, 'ceph', ['--version']).run().strip()
     info_from['ceph_version'] = ver
-
-    print(json.dumps(info_from, indent=4, sort_keys=True))
-    return 0
+    return info_from
 
 
 def get_image_info_from_inspect(out, image):
@@ -3525,7 +3535,9 @@ def create_mon(
     fsid: str, mon_id: str
 ) -> None:
     mon_c = get_container(ctx, fsid, 'mon', mon_id)
-    ctx.meta_json = json.dumps({'service_name': 'mon'})
+    container_info = _inspect_image(ctx)
+    ctx.meta_json = json.dumps({'service_name': 'mon',
+                                'deployed_by': container_info['repo_digests']})
     deploy_daemon(ctx, fsid, 'mon', mon_id, mon_c, uid, gid,
                   config=None, keyring=None)
 
@@ -3571,7 +3583,9 @@ def create_mgr(
     mgr_keyring = '[mgr.%s]\n\tkey = %s\n' % (mgr_id, mgr_key)
     mgr_c = get_container(ctx, fsid, 'mgr', mgr_id)
     # Note:the default port used by the Prometheus node exporter is opened in fw
-    ctx.meta_json = json.dumps({'service_name': 'mgr'})
+    container_info = _inspect_image(ctx)
+    ctx.meta_json = json.dumps({'service_name': 'mgr',
+                                'deployed_by': container_info['repo_digests']})
     deploy_daemon(ctx, fsid, 'mgr', mgr_id, mgr_c, uid, gid,
                   config=config, keyring=mgr_keyring, ports=[9283])
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -59,7 +59,7 @@ from .schedule import HostAssignment
 from .inventory import Inventory, SpecStore, HostCache, EventStore
 from .upgrade import CephadmUpgrade
 from .template import TemplateMgr
-from .utils import CEPH_TYPES, GATEWAY_TYPES, forall_hosts, cephadmNoImage
+from .utils import CEPH_TYPES, forall_hosts, cephadmNoImage
 from .configchecks import CephadmConfigChecks
 
 try:
@@ -1225,8 +1225,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
     def _get_container_image(self, daemon_name: str) -> Optional[str]:
         daemon_type = daemon_name.split('.', 1)[0]  # type: ignore
         image: Optional[str] = None
-        if daemon_type in CEPH_TYPES or \
-                daemon_type in GATEWAY_TYPES:
+        if daemon_type in CEPH_TYPES:
             # get container image
             image = str(self.get_foreign_ceph_option(
                 utils.name_to_config_section(daemon_name),
@@ -1726,10 +1725,10 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             if action != 'redeploy':
                 raise OrchestratorError(
                     f'Cannot execute {action} with new image. `action` needs to be `redeploy`')
-            if daemon_type not in CEPH_TYPES and daemon_type not in GATEWAY_TYPES:
+            if daemon_type not in CEPH_TYPES:
                 raise OrchestratorError(
                     f'Cannot redeploy {daemon_type}.{daemon_id} with a new image: Supported '
-                    f'types are: {", ".join(CEPH_TYPES + GATEWAY_TYPES)}')
+                    f'types are: {", ".join(CEPH_TYPES)}')
 
             self.check_mon_command({
                 'prefix': 'config set',

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -731,6 +731,11 @@ class CephadmServe:
                     action = 'redeploy'
                 try:
                     daemon_spec = CephadmDaemonDeploySpec.from_daemon_description(dd)
+                    if (action == 'reconfig' and self.mgr.get_active_mgr_digests()
+                            and (not dd.deployed_by or not any(d in dd.deployed_by for d in (self.mgr.get_active_mgr_digests() or [])))):
+                        self.log.info(
+                            "Delaying reconfiguration of %s daemon until it has been deployed by mgr with correct version", dd.name())
+                        continue
                     self.mgr._daemon_action(daemon_spec, action=action)
                     self.mgr.cache.rm_scheduled_daemon_action(dd.hostname, dd.name())
                 except OrchestratorError as e:

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -21,10 +21,10 @@ class CephadmNoImage(Enum):
 
 # ceph daemon types that use the ceph container image.
 # NOTE: order important here as these are used for upgrade order
-CEPH_TYPES = ['mgr', 'mon', 'crash', 'osd', 'mds', 'rgw', 'rbd-mirror', 'cephfs-mirror']
-GATEWAY_TYPES = ['iscsi', 'nfs']
+CEPH_TYPES = ['mgr', 'mon', 'crash', 'osd', 'mds',
+              'rgw', 'rbd-mirror', 'cephfs-mirror', 'iscsi', 'nfs']
 MONITORING_STACK_TYPES = ['node-exporter', 'prometheus', 'alertmanager', 'grafana']
-CEPH_UPGRADE_ORDER = CEPH_TYPES + GATEWAY_TYPES + MONITORING_STACK_TYPES
+CEPH_UPGRADE_ORDER = CEPH_TYPES + MONITORING_STACK_TYPES
 
 
 # Used for _run_cephadm used for check-host etc that don't require an --image parameter


### PR DESCRIPTION
While this does fix the issue of bad reconfigs mid upgrade, it does have the issue that all daemons must have deployed_by set outside of upgrade scenarios to work properly. If you are upgrading from a cluster without deployed_by its fine because the fields will get added in as the daemons are upgraded and the reconfigs are delayed as expected. This was an issue, however, with the mgr/mon deployed on bootstrap so a change that adds deployed_by to the bootstrap mgr/mon is included. I'm also concerned about how this would work with adopted daemons.

This also adds iscsi and nfs to ceph types. With the reconfigs being delayed there shouldn't be any issues with having them there anymore.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
