### PR TITLE
mgr/orchestrator: fix rgw realm and zone flags

### DIFF
--- a/doc/cephadm/adoption.rst
+++ b/doc/cephadm/adoption.rst
@@ -189,7 +189,7 @@ Adoption process
 
    .. prompt:: bash #
 
-      ceph orch apply rgw <svc_id> [--rgw-realm=<realm>] [--rgw-zone=<zone>] [--port=<port>] [--ssl] [--placement=<placement>]
+      ceph orch apply rgw <svc_id> [--realm=<realm>] [--zone=<zone>] [--port=<port>] [--ssl] [--placement=<placement>]
 
    where *<placement>* can be a simple daemon count, or a list of
    specific hosts (see :ref:`orchestrator-cli-placement-spec`), and the

--- a/doc/cephadm/rgw.rst
+++ b/doc/cephadm/rgw.rst
@@ -24,7 +24,7 @@ To deploy a set of radosgw daemons, with an arbitrary service name
 
 .. prompt:: bash #
 
-  ceph orch apply rgw *<name>* [--rgw-realm=*<realm-name>*] [--rgw-zone=*<zone-name>*] --placement="*<num-daemons>* [*<host1>* ...]"
+  ceph orch apply rgw *<name>* [--realm=*<realm-name>*] [--zone=*<zone-name>*] --placement="*<num-daemons>* [*<host1>* ...]"
 
 Trivial setup
 -------------
@@ -57,7 +57,7 @@ To deploy RGWs serving the multisite *myorg* realm and the *us-east-1* zone on
 
 .. prompt:: bash #
 
-   ceph orch apply rgw east --rgw-realm=myorg --rgw-zone=us-east-1 --placement="2 myhost1 myhost2"
+   ceph orch apply rgw east --realm=myorg --zone=us-east-1 --placement="2 myhost1 myhost2"
 
 Note that in a multisite situation, cephadm only deploys the daemons.  It does not create
 or update the realm or zone configurations.  To create a new realm and zone, you need to do

--- a/doc/mgr/orchestrator.rst
+++ b/doc/mgr/orchestrator.rst
@@ -103,7 +103,7 @@ The ``name`` parameter is an identifier of the group of instances:
 Creating/growing/shrinking/removing services::
 
     ceph orch apply mds <fs_name> [--placement=<placement>] [--dry-run]
-    ceph orch apply rgw <name> [--rgw-realm=<realm>] [--rgw-zone=<zone>] [--port=<port>] [--ssl] [--placement=<placement>] [--dry-run]
+    ceph orch apply rgw <name> [--realm=<realm>] [--zone=<zone>] [--port=<port>] [--ssl] [--placement=<placement>] [--dry-run]
     ceph orch apply nfs <name> <pool> [--namespace=<namespace>] [--placement=<placement>] [--dry-run]
     ceph orch rm <service_name> [--force]
 

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1061,8 +1061,8 @@ Usage:
     @_cli_write_command('orch apply rgw')
     def _apply_rgw(self,
                    svc_id: str,
-                   realm_name: Optional[str] = None,
-                   zone_name: Optional[str] = None,
+                   realm: Optional[str] = None,
+                   zone: Optional[str] = None,
                    port: Optional[int] = None,
                    ssl: bool = False,
                    placement: Optional[str] = None,
@@ -1076,8 +1076,8 @@ Usage:
 
         spec = RGWSpec(
             service_id=svc_id,
-            rgw_realm=realm_name,
-            rgw_zone=zone_name,
+            rgw_realm=realm,
+            rgw_zone=zone,
             rgw_frontend_port=port,
             ssl=ssl,
             placement=PlacementSpec.from_string(placement),


### PR DESCRIPTION
wrong flags were documented [here.](https://docs.ceph.com/en/latest/cephadm/rgw/#deploy-rgws) using them did nothing, realm and zone were not saved in spec.
![image](https://user-images.githubusercontent.com/22037319/112684337-479a8d80-8e49-11eb-8b5f-2a47aa592e9b.png)
weird thing is they did not throw an error saying they were invalid flags. 
![image](https://user-images.githubusercontent.com/22037319/112684471-7a448600-8e49-11eb-8adb-149e2214257a.png)
you can actually use these flags anywhere
![image](https://user-images.githubusercontent.com/22037319/112684349-4c5f4180-8e49-11eb-9d77-82af375a5351.png)

Signed-off-by: Daniel Pivonka <dpivonka@redhat.com>
