### PR TITLE
pacific: rgw: add latency to the request summary of an op

### DIFF
--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -254,10 +254,11 @@ void handle_connection(boost::asio::io_context& context,
       int http_ret = 0;
       string user = "-";
       const auto started = ceph::coarse_real_clock::now();
+      ceph::coarse_real_clock::duration latency{};
 
       process_request(env.store, env.rest, &req, env.uri_prefix,
                       *env.auth_registry, &client, env.olog, y,
-                      scheduler, &user, &http_ret);
+                      scheduler, &user, &latency, &http_ret);
 
       if (cct->_conf->subsys.should_gather(dout_subsys, 1)) {
         // access log line elements begin per Apache Combined Log Format with additions following
@@ -268,7 +269,8 @@ void handle_connection(boost::asio::io_context& context,
             << client.get_bytes_sent() + client.get_bytes_received() << ' '
             << log_header{message, http::field::referer, "\""} << ' '
             << log_header{message, http::field::user_agent, "\""} << ' '
-            << log_header{message, http::field::range} << dendl;
+            << log_header{message, http::field::range} << " latency="
+            << latency << dendl;
       }
     }
 

--- a/src/rgw/rgw_civetweb_frontend.cc
+++ b/src/rgw/rgw_civetweb_frontend.cc
@@ -66,10 +66,11 @@ int RGWCivetWebFrontend::process(struct mg_connection*  const conn)
 
   RGWRequest req(env.store->getRados()->get_new_req_id());
   int http_ret = 0;
+  ceph::coarse_real_clock::duration latency{};
   //assert (scheduler != nullptr);
   int ret = process_request(env.store, env.rest, &req, env.uri_prefix,
                             *env.auth_registry, &client_io, env.olog,
-                            null_yield, scheduler.get(), nullptr, &http_ret);
+                            null_yield, scheduler.get(), nullptr, &latency, &http_ret);
   if (ret < 0) {
     /* We don't really care about return code. */
     dout(20) << "process_request() returned " << ret << dendl;

--- a/src/rgw/rgw_loadgen_process.cc
+++ b/src/rgw/rgw_loadgen_process.cc
@@ -134,7 +134,7 @@ void RGWLoadGenProcess::handle_request(RGWRequest* r)
 
   int ret = process_request(store, rest, req, uri_prefix,
                             *auth_registry, &client_io, olog,
-                            null_yield, nullptr, nullptr);
+                            null_yield, nullptr, nullptr, nullptr);
   if (ret < 0) {
     /* we don't really care about return code */
     dout(20) << "process_request() returned " << ret << dendl;

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -182,6 +182,7 @@ int process_request(rgw::sal::RGWRadosStore* const store,
                     optional_yield yield,
 		    rgw::dmclock::Scheduler *scheduler,
                     string* user,
+                    ceph::coarse_real_clock::duration* latency,
                     int* http_ret)
 {
   int ret = client_io->init(g_ceph_context);
@@ -355,10 +356,15 @@ done:
     handler->put_op(op);
   rest->put_handler(handler);
 
+  const auto lat = s->time_elapsed();
+  if (latency) {
+    *latency = lat;
+  }
+
   dout(1) << "====== req done req=" << hex << req << dec
 	  << " op status=" << op_ret
 	  << " http_status=" << s->err.http_ret
-	  << " latency=" << s->time_elapsed()
+	  << " latency=" << lat
 	  << " ======"
 	  << dendl;
 

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -186,6 +186,7 @@ extern int process_request(rgw::sal::RGWRadosStore* store,
                            optional_yield y,
                            rgw::dmclock::Scheduler *scheduler,
                            std::string* user,
+                           ceph::coarse_real_clock::duration* latency,
                            int* http_ret = nullptr);
 
 extern int rgw_process_authenticated(RGWHandler_REST* handler,


### PR DESCRIPTION
Latency of a request added at the end of request
summary rgw log line. This summary line also contains
information about the request like the op, bucket,
object, http status.

Signed-off-by: Ali Maredia <amaredia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
