### PR TITLE
pybind/mgr/mds_autoscaler: add type annotation

### DIFF
--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -52,6 +52,9 @@ disallow_untyped_defs = True
 [mypy-localpool.*]
 disallow_untyped_defs = True
 
+[mypy-mds_autoscaler.*]
+disallow_untyped_defs = True
+
 [mypy-orchestrator.*]
 disallow_untyped_defs = True
 

--- a/src/pybind/mgr/mds_autoscaler/module.py
+++ b/src/pybind/mgr/mds_autoscaler/module.py
@@ -3,7 +3,7 @@ Automatically scale MDSs based on status of the file-system using the FSMap
 """
 
 import logging
-from typing import Optional, List, Set
+from typing import Any, Optional
 from mgr_module import MgrModule
 from ceph.deployment.service_spec import ServiceSpec
 import orchestrator
@@ -16,7 +16,7 @@ class MDSAutoscaler(orchestrator.OrchestratorClientMixin, MgrModule):
     """
     MDS autoscaler.
     """
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         MgrModule.__init__(self, *args, **kwargs)
         self.set_mgr(self)
 
@@ -52,7 +52,7 @@ class MDSAutoscaler(orchestrator.OrchestratorClientMixin, MgrModule):
                 return fs['mdsmap']['max_mds']
         assert False
 
-    def verify_and_manage_mds_instance(self, fs_map: dict, fs_name: str):
+    def verify_and_manage_mds_instance(self, fs_map: dict, fs_name: str) -> None:
         assert fs_map is not None
 
         try:
@@ -84,7 +84,7 @@ class MDSAutoscaler(orchestrator.OrchestratorClientMixin, MgrModule):
             self.log.exception(f"fs {fs_name}: exception while updating service: {e}")
             pass
 
-    def notify(self, notify_type, notify_id):
+    def notify(self, notify_type: str, notify_id: str) -> None:
         if notify_type != 'fs_map':
             return
         fs_map = self.get('fs_map')


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
