### PR TITLE
rpm: drop extraneous explicit sqlite-libs runtime dependency

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -932,7 +932,6 @@ Summary:	SQLite3 VFS for Ceph
 Group:		System/Libraries
 %endif
 Requires:	librados2 = %{_epoch_prefix}%{version}-%{release}
-Requires:	sqlite-libs
 %description -n libcephsqlite
 A SQLite3 VFS for storing and manipulating databases stored on Ceph's RADOS
 distributed object store.


### PR DESCRIPTION
Commit 75980798f19b8c11efd75ba4aae3e491d4c99f98 introduced a new package,
libcephsqlite, with a hard RPM dependency on a package "sqlite-libs" which
does not exist in openSUSE.

Since the runtime library dependencies of libcephsqlite are handled by RPM
transparently, this line is not needed.

Fixes: https://tracker.ceph.com/issues/50007
Signed-off-by: Nathan Cutler <ncutler@suse.com>
