### PR TITLE
tools/ceph-dencoder: build dencoders as plugins

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1591,6 +1591,7 @@ exit 0
 %{_bindir}/rbd-replay-prep
 %endif
 %{_bindir}/ceph-post-file
+%{_libdir}/ceph/denc/denc-mod-*.so
 %{_tmpfilesdir}/ceph-common.conf
 %{_mandir}/man8/ceph-authtool.8*
 %{_mandir}/man8/ceph-conf.8*

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -23,6 +23,7 @@ usr/bin/rbd-replay*
 usr/bin/ceph-post-file
 usr/sbin/mount.ceph sbin
 usr/lib/ceph/compressor/*
+usr/lib/ceph/denc/*
 usr/lib/ceph/crypto/* [amd64]
 usr/share/man/man8/ceph-authtool.8
 usr/share/man/man8/ceph-conf.8

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -954,6 +954,7 @@ add_custom_target(cephfs_testing DEPENDS
     cls_cephfs
     ceph-fuse
     ceph-dencoder
+    ceph-dencoder-modules
     cephfs-journal-tool
     cephfs-meta-injection
     cephfs-data-scan

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -531,6 +531,7 @@ if(NOT WIN32)
   ceph-mon
   get_command_descriptions
   ceph-dencoder
+  ceph-dencoder-modules
   ceph-objectstore-tool
   ceph-kvstore-tool
   ceph-monstore-tool

--- a/src/tools/ceph-dencoder/CMakeLists.txt
+++ b/src/tools/ceph-dencoder/CMakeLists.txt
@@ -11,67 +11,93 @@ endif()
 set(dencoder_srcs
   denc_registry.cc
   ceph_dencoder.cc
-  common_types.cc
-  mds_types.cc
-  osd_types.cc
-  rbd_types.cc
-  rgw_types.cc
   ../../include/uuid.cc
   ../../include/utime.cc
   $<TARGET_OBJECTS:common_texttable_obj>)
-if(WITH_RADOSGW)
-  list(APPEND dencoder_srcs
-    ${CMAKE_SOURCE_DIR}/src/rgw/rgw_dencoder.cc)
-endif()
-
 add_executable(ceph-dencoder ${dencoder_srcs})
 
+set(denc_plugin_dir ${CEPH_INSTALL_PKGLIBDIR}/denc)
+add_custom_target(ceph-dencoder-modules)
+
+function(add_denc_mod name)
+  add_library(${name} SHARED
+    ${ARGN})
+  set_target_properties(${name} PROPERTIES
+    PREFIX ""
+    OUTPUT_NAME ${name}
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON)
+  install(
+    TARGETS ${name}
+    DESTINATION ${denc_plugin_dir})
+  add_dependencies(ceph-dencoder-modules
+    ${name})
+endfunction()
+
+add_denc_mod(denc-mod-common
+  common_types.cc)
+target_link_libraries(denc-mod-common
+  journal
+  cls_cas_internal
+  cls_lock_client
+  cls_refcount_client
+  cls_timeindex_client)
+add_denc_mod(denc-mod-osd
+  osd_types.cc)
+target_link_libraries(denc-mod-osd
+  os
+  osd
+  mon)
+
 if(WITH_RADOSGW)
-  list(APPEND DENCODER_EXTRALIBS
+  add_denc_mod(denc-mod-rgw
+    rgw_types.cc
+    ${CMAKE_SOURCE_DIR}/src/rgw/rgw_dencoder.cc)
+  target_link_libraries(denc-mod-rgw
     rgw_a
-    cls_rgw_client)
+    cls_rgw_client
+    cls_journal_client)
   if(WITH_RADOSGW_AMQP_ENDPOINT)
-    list(APPEND DENCODER_EXTRALIBS
+    target_link_libraries(denc-mod-rgw
       rabbitmq ssl)
   endif()
   if(WITH_RADOSGW_KAFKA_ENDPOINT)
-    list(APPEND DENCODER_EXTRALIBS
+    target_link_libraries(denc-mod-rgw
       rdkafka)
   endif()
 endif()
 
 if(WITH_RBD)
-  list(APPEND DENCODER_EXTRALIBS
+  add_denc_mod(denc-mod-rbd
+    rbd_types.cc)
+  target_link_libraries(denc-mod-rbd
     cls_rbd_client
     rbd_mirror_types
     rbd_types
     rbd_replay_types)
   if(WITH_KRBD)
-    list(APPEND DENCODER_EXTRALIBS
+    target_link_libraries(denc-mod-rbd
       krbd)
   endif()
 endif()
 
 if(WITH_CEPHFS)
-  list(APPEND DENCODER_EXTRALIBS
+  add_denc_mod(denc-mod-cephfs
+    mds_types.cc)
+  target_link_libraries(denc-mod-cephfs
     mds)
 endif()
 
+target_compile_definitions(ceph-dencoder PRIVATE
+  "CEPH_DENC_MOD_DIR=\"${denc_plugin_dir}\"")
+
 target_link_libraries(ceph-dencoder
+  StdFilesystem::filesystem
   global
-  os
-  osd
-  mon
-  journal
   ${DENCODER_EXTRALIBS}
-  cls_lock_client
-  cls_refcount_client
   cls_log_client
   cls_version_client
   cls_user_client
-  cls_journal_client
-  cls_timeindex_client
-  cls_cas_internal
   cls_cas_client
   ${EXTRALIBS}
   ${CMAKE_DL_LIBS})

--- a/src/tools/ceph-dencoder/common_types.cc
+++ b/src/tools/ceph-dencoder/common_types.cc
@@ -25,7 +25,7 @@ using namespace std;
 
 #include "denc_registry.h"
 
-void register_common_dencoders()
+DENC_API void register_dencoders()
 {
 #include "common_types.h"
 }

--- a/src/tools/ceph-dencoder/denc_registry.h
+++ b/src/tools/ceph-dencoder/denc_registry.h
@@ -253,8 +253,4 @@ void make_and_register_dencoder(const char* name, Args&&...args)
 #define TYPE_NOCOPY(t) make_and_register_dencoder<DencoderImplNoFeatureNoCopy<t>>(#t, false, false);
 #define MESSAGE(t) make_and_register_dencoder<MessageDencoderImpl<t>>(#t);
 
-void register_common_dencoders();
-void register_mds_dencoders();
-void register_osd_dencoders();
-void register_rbd_dencoders();
-void register_rgw_dencoders();
+#define DENC_API extern "C" [[gnu::visibility("default")]]

--- a/src/tools/ceph-dencoder/mds_types.cc
+++ b/src/tools/ceph-dencoder/mds_types.cc
@@ -25,7 +25,7 @@ using namespace std;
 
 #include "denc_registry.h"
 
-void register_mds_dencoders()
+DENC_API void register_dencoders()
 {
 #include "mds_types.h"
 }

--- a/src/tools/ceph-dencoder/osd_types.cc
+++ b/src/tools/ceph-dencoder/osd_types.cc
@@ -28,7 +28,7 @@ using namespace std;
 // cannot initialize dencoders when initializing static variables, as some of
 // the types are allocated using mempool, and the mempools are initialized as
 // static variables.
-void register_osd_dencoders()
+DENC_API void register_dencoders()
 {
 #include "osd_types.h"
 }

--- a/src/tools/ceph-dencoder/rbd_types.cc
+++ b/src/tools/ceph-dencoder/rbd_types.cc
@@ -25,7 +25,7 @@ using namespace std;
 
 #include "denc_registry.h"
 
-void register_rbd_dencoders()
+DENC_API void register_dencoders()
 {
 #include "rbd_types.h"
 }

--- a/src/tools/ceph-dencoder/rgw_types.cc
+++ b/src/tools/ceph-dencoder/rgw_types.cc
@@ -25,7 +25,7 @@ using namespace std;
 
 #include "denc_registry.h"
 
-void register_rgw_dencoders()
+DENC_API void register_dencoders()
 {
 #include "rgw_types.h"
 }


### PR DESCRIPTION
to reduce the memory footprint when linking ceph-dencoder.

* src/tools/ceph-dencoder:
  * build dencoders as shared libraries named with the prefix of
    "den-mod-". so ceph-dencoder can find them
  * install dencoders into $prefix/lib/ceph/denc, so ceph-dencoder
    can find them
  * only expose "register_dencoders()" function from plugins.
  * load plugins in specified directory
* ceph.spec.in: package plugins
* debian: package plugins

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
