### PR TITLE
pacific: rpm: drop extraneous explicit sqlite-libs runtime dependency

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -896,7 +896,6 @@ Summary:	SQLite3 VFS for Ceph
 Group:		System/Libraries
 %endif
 Requires:	librados2 = %{_epoch_prefix}%{version}-%{release}
-Requires:	sqlite-libs
 %description -n libcephsqlite
 A SQLite3 VFS for storing and manipulating databases stored on Ceph's RADOS
 distributed object store.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50029

---

backport of https://github.com/ceph/ceph/pull/40450
parent tracker: https://tracker.ceph.com/issues/50007

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh