### PR TITLE
 crush/CrushLocation: do not print logging message in constructor

### DIFF
--- a/src/crush/CrushLocation.cc
+++ b/src/crush/CrushLocation.cc
@@ -122,7 +122,6 @@ int CrushLocation::init_on_startup()
   loc.clear();
   loc.insert(std::make_pair<std::string,std::string>("host", hostname));
   loc.insert(std::make_pair<std::string,std::string>("root", "default"));
-  lgeneric_dout(cct, 10) << "crush_location is (default) " << loc << dendl;
   return 0;
 }
 


### PR DESCRIPTION
### **ceph-conf core dump when using vstart.sh**

```
#0 __GI___pthread_mutex_lock (mutex=0x38) at ../nptl/pthread_mutex_lock.c:65
#1 0x00007fea43d76275 in __gthread_mutex_lock (__mutex=0x38) at /opt/rh/devtoolset-7/root/usr/include/c++/7/x86_64-redhat-linux/bits/gthr-default.h:748
#2 0x00007fea43d79444 in std::mutex::lock (this=0x38) at /opt/rh/devtoolset-7/root/usr/include/c++/7/bits/std_mutex.h:103
#3 0x00007fea43dd38ff in std::unique_lockstd::mutex::lock (this=0x7ffe60eb9d40) at /opt/rh/devtoolset-7/root/usr/include/c++/7/bits/std_mutex.h:267
#4 0x00007fea43dd3146 in std::unique_lockstd::mutex::unique_lock (this=0x7ffe60eb9d40, __m=...) at /opt/rh/devtoolset-7/root/usr/include/c++/7/bits/std_mutex.h:197
#5 0x00007fea4424c5ed in ceph::logging::Log::submit_entry (this=0x0, e=...) at ./ceph/src/log/Log.cc:180
#6 0x00007fea44627f4f in CrushLocation::init_on_startup (this=0x55ad5a5a72e8) at ./ceph/src/crush/CrushLocation.cc:122
#7 0x00007fea43e53674 in CrushLocation::CrushLocation (this=0x55ad5a5a72e8, c=0x55ad5a5a4c80) at ./ceph/src/crush/CrushLocation.h:22
#8 0x00007fea43e4ce6c in CephContext::CephContext (this=0x55ad5a5a4c80, module_type_=8, code_env=CODE_ENVIRONMENT_DAEMON, init_flags_=40) at ./ceph/src/common/ceph_context.cc:639
#9 0x00007fea43eadeef in common_preinit (iparams=..., code_env=CODE_ENVIRONMENT_DAEMON, flags=40) at ./ceph/src/common/common_init.cc:40
#10 0x000055ad5a0bda6d in global_pre_init (defaults=0x0, args=std::vector of length 2, capacity 4 = {...}, module_type=8, code_env=CODE_ENVIRONMENT_DAEMON, flags=40) at ./ceph/src/global/global_init.cc:100
```
Signed-off-by: lihuibng notmycupoftea@163.com