### PR TITLE
pacific: qa/tasks: Add wait_for_clean() check prior to initiating scrubbing.

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1899,6 +1899,9 @@ def task(ctx, config):
             ctx.managers[config['cluster']].stop_pg_num_changes()
 
             if config.get('wait-for-scrub', True):
+                # wait for pgs to become active+clean in case any
+                # recoveries were triggered since the last health check
+                ctx.managers[config['cluster']].wait_for_clean()
                 osd_scrub_pgs(ctx, config)
 
             # stop logging health to clog during shutdown, or else we generate


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50018

---

backport of https://github.com/ceph/ceph/pull/40415
parent tracker: https://tracker.ceph.com/issues/49983

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh