### PR TITLE
crimson/onode-staged-tree: allow non-empty DeltaRecorder to be destructed

### DIFF
--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_delta_recorder.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_delta_recorder.h
@@ -18,7 +18,10 @@ namespace crimson::os::seastore::onode {
 class DeltaRecorder {
  public:
   virtual ~DeltaRecorder() {
-    assert(is_empty());
+    /* May be non-empty if transaction is abandoned without
+     * being submitted -- conflicts are a particularly common
+     * example (denoted generally by returning crimson::ct_error::eagain).
+     */
   }
 
   bool is_empty() const {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
@@ -729,7 +729,7 @@ MatchKindCMP compare_full_key(
   ret = toMatchKindCMP(l.pool(), r.pool());
   if (ret != MatchKindCMP::EQ)
     return ret;
-  ret = toMatchKindCMP(l.crush() != r.crush());
+  ret = toMatchKindCMP(l.crush(), r.crush());
   if (ret != MatchKindCMP::EQ)
     return ret;
   ret = toMatchKindCMP(l.nspace(), r.nspace());

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -218,6 +218,8 @@ TransactionManager::submit_transaction_direct(
 	 -> submit_transaction_ertr::future<> {
     auto record = cache->try_construct_record(tref);
     if (!record) {
+      logger().debug("TransactionManager::submit_transaction_direct: "
+                     "conflict detected, returning eagain.");
       return crimson::ct_error::eagain::make();
     }
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/50028
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
