### PR TITLE
cephadm: specify addr on bootstrap's host add

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3668,7 +3668,10 @@ def prepare_ssh(
     host = get_hostname()
     logger.info('Adding host %s...' % host)
     try:
-        cli(['orch', 'host', 'add', host])
+        args = ['orch', 'host', 'add', host]
+        if ctx.mon_ip:
+            args.append(ctx.mon_ip)
+        cli(args)
     except RuntimeError as e:
         raise Error('Failed to add host <%s>: %s' % (host, e))
 


### PR DESCRIPTION
Otherwise we may end up with an `address` that may or may not resolve, depending on how resolvable the hostname, by itself, really is. Or, worse, in a Vagrant deployment this might even resolve to `127.0.0.1` :shrug:

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>