### PR TITLE
librbd/cache/pwl: Discard write back cache in removing image request

### DIFF
--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -210,6 +210,7 @@ namespace librbd {
     bool ignore_migrating = false;
     bool disable_zero_copy = false;
     bool enable_sparse_copyup = false;
+    bool removing_image = false;
 
     /// Cached latency-sensitive configuration settings
     bool non_blocking_aio;

--- a/src/librbd/Types.h
+++ b/src/librbd/Types.h
@@ -96,7 +96,8 @@ struct SnapInfo {
 enum {
   OPEN_FLAG_SKIP_OPEN_PARENT = 1 << 0,
   OPEN_FLAG_OLD_FORMAT       = 1 << 1,
-  OPEN_FLAG_IGNORE_MIGRATING = 1 << 2
+  OPEN_FLAG_IGNORE_MIGRATING = 1 << 2,
+  OPEN_FLAG_REMOVE_IMAGE     = 1 << 3
 };
 
 enum ImageReadOnlyFlag {

--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -70,7 +70,7 @@ bool compare(const librbd::linked_image_spec_t& lhs,
 template <typename I>
 int pre_remove_image(librados::IoCtx& io_ctx, const std::string& image_id) {
   I *image_ctx = I::create("", image_id, nullptr, io_ctx, false);
-  int r = image_ctx->state->open(OPEN_FLAG_SKIP_OPEN_PARENT);
+  int r = image_ctx->state->open(OPEN_FLAG_SKIP_OPEN_PARENT | OPEN_FLAG_REMOVE_IMAGE);
   if (r < 0) {
     return r;
   }

--- a/src/librbd/api/Trash.cc
+++ b/src/librbd/api/Trash.cc
@@ -163,7 +163,7 @@ int Trash<I>::move(librados::IoCtx &io_ctx, rbd_trash_image_source_t source,
                  << dendl;
 
   auto ictx = new I("", image_id, nullptr, io_ctx, false);
-  int r = ictx->state->open(OPEN_FLAG_SKIP_OPEN_PARENT);
+  int r = ictx->state->open(OPEN_FLAG_SKIP_OPEN_PARENT | OPEN_FLAG_REMOVE_IMAGE);
 
   if (r < 0 && r != -ENOENT) {
     lderr(cct) << "failed to open image: " << cpp_strerror(r) << dendl;

--- a/src/librbd/cache/pwl/InitRequest.h
+++ b/src/librbd/cache/pwl/InitRequest.h
@@ -76,6 +76,7 @@ private:
 
   bool is_pwl_enabled();
 
+  void handle_remove_request();
   void get_image_cache_state();
 
   void init_image_cache();

--- a/src/librbd/image/OpenRequest.cc
+++ b/src/librbd/image/OpenRequest.cc
@@ -40,6 +40,9 @@ OpenRequest<I>::OpenRequest(I *image_ctx, uint64_t flags,
   if ((flags & OPEN_FLAG_IGNORE_MIGRATING) != 0) {
     m_image_ctx->ignore_migrating = true;
   }
+  if ((flags & OPEN_FLAG_REMOVE_IMAGE) != 0) {
+    m_image_ctx->removing_image = true;
+  }
 }
 
 template <typename I>

--- a/src/librbd/image/RemoveRequest.cc
+++ b/src/librbd/image/RemoveRequest.cc
@@ -77,7 +77,7 @@ void RemoveRequest<I>::open_image() {
   Context *ctx = create_context_callback<klass, &klass::handle_open_image>(
     this);
 
-  m_image_ctx->state->open(OPEN_FLAG_SKIP_OPEN_PARENT, ctx);
+  m_image_ctx->state->open(OPEN_FLAG_SKIP_OPEN_PARENT | OPEN_FLAG_REMOVE_IMAGE, ctx);
 }
 
 template<typename I>


### PR DESCRIPTION
In the remove operation, discard the write back cache and skip the PWL initialization. so that the remove command can succeed and clean up the cache no matter what the cache state is in.

Scenario: if the PWL directory is deleted before the remove operation, ensure that the remove operation will not fail.

Method:
command: "rbd remove" will dispatch 3 request in: 
```
1. Image::pre_remove_image()
2. RemoveRequest<I>::open_image() 
3. Trash<I>::move
```
Pass remove flag to OpenRequest.cc, then set m_image_ctx->removing_image flag(New addition). Finally, deal in pwl/InitRequest.cc.

Signed-off-by: Yin Congmin <congmin.yin@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
