### PR TITLE
doc: detail `fs snapshot mirror daemon status` mgr command

### DIFF
--- a/doc/dev/cephfs-mirroring.rst
+++ b/doc/dev/cephfs-mirroring.rst
@@ -210,8 +210,44 @@ Mirror Daemon Status
 --------------------
 
 Mirror daemons get asynchronously notified about changes in file system mirroring status
-and/or peer updates. CephFS mirror daemons provide admin socket commands for querying
-mirror status. To check available commands for mirror status use::
+and/or peer updates.
+
+CephFS mirroring module provides `mirror daemon status` interface to check mirror daemon
+status::
+
+  $ ceph fs snapshot mirror daemon status <fs_name>
+
+E.g::
+
+  $ ceph fs snapshot mirror daemon status a | jq
+  {
+  "14135": {
+    "1": {
+      "name": "a",
+      "directory_count": 0,
+      "peers": {
+        "ae3f22e6-1c72-4a81-8d5d-eebca3bfd29d": {
+          "remote": {
+            "client_name": "client.mirror_remote",
+            "cluster_name": "site-remote",
+            "fs_name": "backup_fs"
+          },
+          "stats": {
+            "failure_count": 0,
+            "recovery_count": 0
+            }
+          }
+        }
+      }
+    }
+  }
+
+An entry per mirror daemon instance is displayed along with information such as configured
+peers and basic stats. For more detailed stats, use the admin socket interface as detailed
+below.
+
+CephFS mirror daemons provide admin socket commands for querying mirror status. To check
+available commands for mirror status use::
 
   $ ceph --admin-daemon /path/to/mirror/daemon/admin/socket help
   {

--- a/doc/dev/cephfs-mirroring.rst
+++ b/doc/dev/cephfs-mirroring.rst
@@ -115,7 +115,7 @@ Mirroring module provides a family of commands to control mirroring of directory
 snapshots. To add or remove directories, mirroring needs to be enabled for a given
 file system. To enable mirroring use::
 
-  $ ceph fs snapshot mirror enable <fs>
+  $ ceph fs snapshot mirror enable <fs_name>
 
 .. note:: Mirroring module commands use `fs snapshot mirror` prefix as compared to
           the monitor commands which `fs mirror` prefix. Make sure to use module
@@ -123,7 +123,7 @@ file system. To enable mirroring use::
 
 To disable mirroring, use::
 
-  $ ceph fs snapshot mirror disable <fs>
+  $ ceph fs snapshot mirror disable <fs_name>
 
 Once mirroring is enabled, add a peer to which directory snapshots are to be mirrored.
 Peers follow `<client>@<cluster>` specification and get assigned a unique-id (UUID)
@@ -131,9 +131,9 @@ when added. See `Creating Users` section on how to create Ceph users for mirrori
 
 To add a peer use::
 
-  $ ceph fs snapshot mirror peer_add <fs> <remote_cluster_spec> [<remote_fs_name>] [<remote_mon_host>] [<cephx_key>]
+  $ ceph fs snapshot mirror peer_add <fs_name> <remote_cluster_spec> [<remote_fs_name>] [<remote_mon_host>] [<cephx_key>]
 
-`<remote_fs_name>` is optional, and default to `<fs>` (on the remote cluster).
+`<remote_fs_name>` is optional, and default to `<fs_name>` (on the remote cluster).
 
 This requires the remote cluster ceph configuration and user keyring to be available in
 the primary cluster. See `Bootstrap Peers` section to avoid this. `peer_add` additionally
@@ -144,21 +144,21 @@ a peer is the recommended way to add a peer.
 
 To remove a peer use::
 
-  $ ceph fs snapshot mirror peer_remove <fs> <peer_uuid>
+  $ ceph fs snapshot mirror peer_remove <fs_name> <peer_uuid>
 
 .. note:: See `Mirror Daemon Status` section on how to figure out Peer UUID.
 
 To list file system mirror peers use::
 
-  $ ceph fs snapshot mirror peer_list <fs>
+  $ ceph fs snapshot mirror peer_list <fs_name>
 
 To configure a directory for mirroring, use::
 
-  $ ceph fs snapshot mirror add <fs> <path>
+  $ ceph fs snapshot mirror add <fs_name> <path>
 
 To stop a mirroring directory snapshots use::
 
-  $ ceph fs snapshot mirror remove <fs> <path>
+  $ ceph fs snapshot mirror remove <fs_name> <path>
 
 Only absolute directory paths are allowed. Also, paths are normalized by the mirroring
 module, therfore, `/a/b/../b` is equivalent to `/a/b`.


### PR DESCRIPTION
@leseb noticed that this interface did not have any documentation. Thanks!

Signed-off-by: Venky Shankar <vshankar@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
