### PR TITLE
pacific: mgr/dashboard: fix broken feature toggles 

### DIFF
--- a/src/pybind/mgr/dashboard/tests/test_feature_toggles.py
+++ b/src/pybind/mgr/dashboard/tests/test_feature_toggles.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     from unittest.mock import Mock, patch
 
-from ..plugins.feature_toggles import Features, FeatureToggles
+from ..plugins.feature_toggles import Actions, Features, FeatureToggles
 from . import KVStoreMockMixin  # pylint: disable=no-name-in-module
 
 
@@ -56,7 +56,7 @@ class SettingsTest(unittest.TestCase, KVStoreMockMixin):
         import cherrypy
 
         self.plugin.register_commands()['handle_command'](
-            self.mgr, 'disable', ['cephfs'])
+            self.mgr, Actions.DISABLE, [Features.CEPHFS])
 
         with patch.object(self.plugin, '_get_feature_from_request',
                           return_value=Features.CEPHFS):


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50038

---

backport of https://github.com/ceph/ceph/pull/40188
parent tracker: https://tracker.ceph.com/issues/49869

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh