### PR TITLE
cephadm: fix failure when using --apply-spec and --shh-user

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3824,8 +3824,6 @@ def finish_bootstrap_config(
 def command_bootstrap(ctx):
     # type: (CephadmContext) -> int
 
-    host: Optional[str] = None
-
     if not ctx.output_config:
         ctx.output_config = os.path.join(ctx.output_dir, 'ceph.conf')
     if not ctx.output_keyring:
@@ -3980,7 +3978,6 @@ def command_bootstrap(ctx):
         is_available(ctx, 'mgr epoch %d' % epoch, mgr_has_latest_epoch)
 
     # ssh
-    host = None
     if not ctx.skip_ssh:
         prepare_ssh(ctx, cli, wait_for_mgr_restart)
 
@@ -4023,13 +4020,13 @@ def command_bootstrap(ctx):
                 if 'hostname:' in line:
                     line = line.replace('\n', '')
                     split = line.split(': ')
-                    if split[1] != host:
+                    if split[1] != hostname:
                         logger.info('Adding ssh key to %s' % split[1])
 
                         ssh_key = '/etc/ceph/ceph.pub'
                         if ctx.ssh_public_key:
                             ssh_key = ctx.ssh_public_key.name
-                        out, err, code = call_throws(ctx, ['ssh-copy-id', '-f', '-i', ssh_key, '%s@%s' % (ctx.ssh_user, split[1])])
+                        out, err, code = call_throws(ctx, ['sudo', '-u', ctx.ssh_user, 'ssh-copy-id', '-f', '-i', ssh_key, '-o StrictHostKeyChecking=no', '%s@%s' % (ctx.ssh_user, split[1])])
 
         mounts = {}
         mounts[pathify(ctx.apply_spec)] = '/tmp/spec.yml:z'


### PR DESCRIPTION
ssh-copy-id was being run as the root user because cephadm requires sudo
so it was trying to use the root users ssh keys to copy the cephadm ssh key to the hosts in the spec
this would fail if the root user did not has passwordless ssh to the host being added
solution run ssh-copy-id as the user ssh-user

additionally fix the check to not copy the cephadm ssh key to the bootstrap host

Fixes: https://tracker.ceph.com/issues/50041
Signed-off-by: Daniel Pivonka <dpivonka@redhat.com>