### PR TITLE
mgr/cephadm: don't have upgrade fail if "." in patch section of version

### DIFF
--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -127,7 +127,7 @@ class CephadmUpgrade:
 
     def _check_target_version(self, version: str) -> Optional[str]:
         try:
-            (major, minor, patch) = version.split('.')
+            (major, minor, _) = version.split('.', 2)
             assert int(minor) >= 0
             # patch might be a number or {number}-g{sha1}
         except ValueError:
@@ -137,7 +137,7 @@ class CephadmUpgrade:
 
         # to far a jump?
         current_version = self.mgr.version.split('ceph version ')[1]
-        current_major, current_minor, current_patch = current_version.split('-')[0].split('.')
+        (current_major, current_minor, _) = current_version.split('-')[0].split('.', 2)
         if int(current_major) < int(major) - 2:
             return f'ceph can only upgrade 1 or 2 major versions at a time; {current_version} -> {version} is too big a jump'
         if int(current_major) > int(major):
@@ -436,7 +436,7 @@ class CephadmUpgrade:
             # tolerate/fix upgrade state from older version
             self.upgrade_state.target_version = target_version.split(' ')[2]
             target_version = self.upgrade_state.target_version
-        target_major, target_minor, target_patch = target_version.split('.')
+        (target_major, _) = target_version.split('.', 1)
         target_major_name = self.mgr.lookup_release_name(int(target_major))
 
         if first:


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/50043

Signed-off-by: Adam King <adking@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
