### PR TITLE
Improve mon location handling for stretch clusters

### DIFF
--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -210,6 +210,8 @@ static void usage()
        << "        extract the monmap from the local monitor store and exit\n"
        << "  --mon-data <directory>\n"
        << "        where the mon store and keyring are located\n"
+       << "  --set-crush-location <bucket>=<foo>"
+       << "        sets monitor's crush bucket location (only for stretch mode)"
        << std::endl;
   generic_server_usage();
 }
@@ -248,7 +250,7 @@ int main(int argc, const char **argv)
   bool compact = false;
   bool force_sync = false;
   bool yes_really = false;
-  std::string osdmapfn, inject_monmap, extract_monmap;
+  std::string osdmapfn, inject_monmap, extract_monmap, crush_loc;
 
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
@@ -331,6 +333,8 @@ int main(int argc, const char **argv)
       inject_monmap = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--extract-monmap", (char*)NULL)) {
       extract_monmap = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--set-crush-location", (char*)NULL)) {
+      crush_loc = val;
     } else {
       ++i;
     }
@@ -896,6 +900,7 @@ int main(int argc, const char **argv)
   msgr->start();
   mgr_msgr->start();
 
+  mon->set_mon_crush_location(crush_loc);
   mon->init();
 
   register_async_signal_handler_oneshot(SIGINT, handle_mon_signal);

--- a/src/messages/MMonJoin.h
+++ b/src/messages/MMonJoin.h
@@ -19,17 +19,29 @@
 
 class MMonJoin final : public PaxosServiceMessage {
 public:
-  static constexpr int HEAD_VERSION = 2;
+  static constexpr int HEAD_VERSION = 3;
   static constexpr int COMPAT_VERSION = 2;
 
   uuid_d fsid;
   std::string name;
   entity_addrvec_t addrs;
+  /* The location members are for stretch mode. crush_loc is the location
+   * (generally just a "datacenter=<foo>" statement) of the monitor. The
+   * force_loc is whether the mon cluster should replace a previously-known
+   * location. Generally the monitor will force an update if it's given a
+   * location from the CLI on boot-up, and then never force again (so that it
+   * can be moved/updated via the ceph tool from elsewhere). */
+  map<string,string> crush_loc;
+  bool force_loc{false};
 
   MMonJoin() : PaxosServiceMessage{MSG_MON_JOIN, 0, HEAD_VERSION, COMPAT_VERSION} {}
   MMonJoin(uuid_d &f, std::string n, const entity_addrvec_t& av)
     : PaxosServiceMessage{MSG_MON_JOIN, 0, HEAD_VERSION, COMPAT_VERSION},
       fsid(f), name(n), addrs(av)
+  { }
+  MMonJoin(uuid_d &f, std::string n, const entity_addrvec_t& av, const map<string,string>& cloc, bool force)
+    : PaxosServiceMessage{MSG_MON_JOIN, 0, HEAD_VERSION, COMPAT_VERSION},
+      fsid(f), name(n), addrs(av), crush_loc(cloc), force_loc(force)
   { }
   
 private:
@@ -38,7 +50,7 @@ private:
 public:
   std::string_view get_type_name() const override { return "mon_join"; }
   void print(std::ostream& o) const override {
-    o << "mon_join(" << name << " " << addrs << ")";
+    o << "mon_join(" << name << " " << addrs << " " << crush_loc << ")";
   }
 
   void encode_payload(uint64_t features) override {
@@ -50,6 +62,8 @@ public:
     header.version = HEAD_VERSION;
     header.compat_version = COMPAT_VERSION;
     encode(addrs, payload, features);
+    encode(crush_loc, payload);
+    encode(force_loc, payload);
   }
   void decode_payload() override {
     using ceph::decode;
@@ -59,6 +73,10 @@ public:
     decode(name, p);
     assert(header.version > 1);
     decode(addrs, p);
+    if (header.version >= 3) {
+      decode(crush_loc, p);
+      decode(force_loc, p);
+    }
   }
 };
 

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -633,6 +633,7 @@ void Elector::dispatch(MonOpRequestRef op)
         mon->store->apply_transaction(t);
 	//mon->monmon()->paxos->stash_latest(mon->monmap->epoch, em->monmap_bl);
 	cancel_timer();
+	mon->notify_new_monmap(false);
 	mon->bootstrap();
 	return;
       }

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -368,6 +368,8 @@ class Elector : public ElectionOwner, RankProvider {
   void notify_rank_changed(int new_rank);
   /**
    * A peer has been removed so we should clean up state related to it.
+   * This is safe to call even if we haven't joined or are currently
+   * in a quorum.
    */
   void notify_rank_removed(int rank_removed);
   void notify_strategy_maybe_changed(int strategy);

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -1999,6 +1999,7 @@ void Monitor::handle_probe_reply(MonOpRequestRef op)
 	       << ", mine was " << monmap->get_epoch() << dendl;
       delete newmap;
       monmap->decode(m->monmap_bl);
+      notify_new_monmap(false);
 
       bootstrap();
       return;
@@ -6484,7 +6485,7 @@ int Monitor::ms_handle_authentication(Connection *con)
   return ret;
 }
 
-void Monitor::notify_new_monmap()
+void Monitor::notify_new_monmap(bool can_change_external_state)
 {
   elector.notify_strategy_maybe_changed(monmap->strategy);
   dout(30) << __func__ << "we have " << monmap->removed_ranks.size() << " removed ranks" << dendl;
@@ -6504,7 +6505,7 @@ void Monitor::notify_new_monmap()
       set_degraded_stretch_mode();
     }
   }
-  set_elector_disallowed_leaders(true);
+  set_elector_disallowed_leaders(can_change_external_state);
 }
 
 void Monitor::set_elector_disallowed_leaders(bool allow_election)

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2104,16 +2104,25 @@ void Monitor::handle_probe_reply(MonOpRequestRef op)
              << " vs my version " << paxos->get_version()
              << " (ok)"
              << dendl;
-
-    if (monmap->contains(name) &&
-        !monmap->get_addrs(name).front().is_blank_ip()) {
+    bool in_map = false;
+    const auto my_info = monmap->mon_info.find(name);
+    const map<string,string> *map_crush_loc{nullptr};
+    if (my_info != monmap->mon_info.end()) {
+      in_map = true;
+      map_crush_loc = &my_info->second.crush_loc;
+    }
+    if (in_map &&
+	!monmap->get_addrs(name).front().is_blank_ip() &&
+	(!need_set_crush_loc || (*map_crush_loc == crush_loc))) {
       // i'm part of the cluster; just initiate a new election
       start_election();
     } else {
-      dout(10) << " ready to join, but i'm not in the monmap or my addr is blank, trying to join" << dendl;
-      send_mon_message(
-	new MMonJoin(monmap->fsid, name, messenger->get_myaddrs()),
-	*m->quorum.begin());
+      dout(10) << " ready to join, but i'm not in the monmap/"
+	"my addr is blank/location is wrong, trying to join" << dendl;
+      send_mon_message(new MMonJoin(monmap->fsid, name,
+				    messenger->get_myaddrs(), crush_loc,
+				    need_set_crush_loc),
+		       *m->quorum.begin());
     }
   } else {
     if (monmap->contains(m->name)) {
@@ -2377,13 +2386,18 @@ void Monitor::finish_election()
     authmon()->_set_mon_num_rank(monmap->size(), rank);
   }
 
-  // am i named properly?
+  // am i named and located properly?
   string cur_name = monmap->get_name(messenger->get_myaddrs());
-  if (cur_name != name) {
-    dout(10) << " renaming myself from " << cur_name << " -> " << name << dendl;
-    send_mon_message(
-      new MMonJoin(monmap->fsid, name, messenger->get_myaddrs()),
-      *quorum.begin());
+  const auto my_infop = monmap->mon_info.find(cur_name);
+  const map<string,string>& map_crush_loc = my_infop->second.crush_loc;
+  
+  if (cur_name != name ||
+      (need_set_crush_loc && map_crush_loc != crush_loc)) {
+    dout(10) << " renaming/moving myself from " << cur_name << "/"
+	     << map_crush_loc <<" -> " << name << "/" << crush_loc << dendl;
+    send_mon_message(new MMonJoin(monmap->fsid, name, messenger->get_myaddrs(),
+				  crush_loc, need_set_crush_loc),
+		     *quorum.begin());
     return;
   }
   do_stretch_mode_election_work();
@@ -6485,8 +6499,26 @@ int Monitor::ms_handle_authentication(Connection *con)
   return ret;
 }
 
+void Monitor::set_mon_crush_location(const string& loc)
+{
+  if (loc.empty()) {
+    return;
+  }
+  vector<string> loc_vec;
+  loc_vec.push_back(loc);
+  CrushWrapper::parse_loc_map(loc_vec, &crush_loc);
+  need_set_crush_loc = true;
+}
+
 void Monitor::notify_new_monmap(bool can_change_external_state)
 {
+  if (need_set_crush_loc) {
+    auto my_info_i = monmap->mon_info.find(name);
+    if (my_info_i != monmap->mon_info.end() &&
+	my_info_i->second.crush_loc == crush_loc) {
+      need_set_crush_loc = false;
+    }
+  }
   elector.notify_strategy_maybe_changed(monmap->strategy);
   dout(30) << __func__ << "we have " << monmap->removed_ranks.size() << " removed ranks" << dendl;
   for (auto i = monmap->removed_ranks.rbegin();

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -840,7 +840,10 @@ public:
   void waitlist_or_zap_client(MonOpRequestRef op);
 
   void send_mon_message(Message *m, int rank);
-  void notify_new_monmap();
+  /** can_change_external_state if we can do things like
+   *  call elections as a result of the new map.
+   */
+  void notify_new_monmap(bool can_change_external_state=false);
 
 public:
   struct C_Command : public C_MonOp {

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -259,6 +259,9 @@ private:
   bool session_stretch_allowed(MonSession *s, MonOpRequestRef& op);
   void disconnect_disallowed_stretch_sessions();
   void set_elector_disallowed_leaders(bool allow_election);
+
+  map <string,string> crush_loc;
+  bool need_set_crush_loc{false};
 public:
   bool is_stretch_mode() { return stretch_mode_engaged; }
   bool is_degraded_stretch_mode() { return degraded_stretch_mode; }
@@ -272,6 +275,7 @@ public:
   void trigger_healthy_stretch_mode();
   void set_healthy_stretch_mode();
   void enable_stretch_mode();
+  void set_mon_crush_location(const string& loc);
 
   
 private:

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -1249,13 +1249,27 @@ bool MonmapMonitor::preprocess_join(MonOpRequestRef op)
     dout(10) << " already have " << join->name << dendl;
     return true;
   }
-  if (pending_map.contains(join->addrs) &&
-      pending_map.get_name(join->addrs) == join->name) {
+  string addr_name;
+  if (pending_map.contains(join->addrs)) {
+    addr_name = pending_map.get_name(join->addrs);
+  }
+  if (!addr_name.empty() &&
+      addr_name == join->name) {
     dout(10) << " already have " << join->addrs << dendl;
+    return true;
+  }
+  if (pending_map.stretch_mode_enabled &&
+      (addr_name.empty() ||
+       pending_map.mon_info[addr_name].crush_loc.empty())) {
+    dout(10) << "stretch mode engaged but no source of crush_loc" << dendl;
+    mon.clog->info() << join->name << " attempted to join from " << join->name
+		      << ' ' << join->addrs
+		      << "; but lacks a crush_location for stretch mode";
     return true;
   }
   return false;
 }
+
 bool MonmapMonitor::prepare_join(MonOpRequestRef op)
 {
   auto join = op->get_req<MMonJoin>();

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -121,7 +121,7 @@ void MonmapMonitor::update_from_paxos(bool *need_bootstrap)
 			   stringify(ceph_release()));
   }
 
-  mon.notify_new_monmap();
+  mon.notify_new_monmap(true);
 }
 
 void MonmapMonitor::create_pending()

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -1244,8 +1244,10 @@ bool MonmapMonitor::preprocess_join(MonOpRequestRef op)
     return true;
   }
 
-  if (pending_map.contains(join->name) &&
-      !pending_map.get_addrs(join->name).front().is_blank_ip()) {
+  const auto name_info_i = pending_map.mon_info.find(join->name);
+  if (name_info_i != pending_map.mon_info.end() &&
+      !name_info_i->second.public_addrs.front().is_blank_ip() &&
+      (!join->force_loc || join->crush_loc == name_info_i->second.crush_loc)) {
     dout(10) << " already have " << join->name << dendl;
     return true;
   }
@@ -1254,11 +1256,14 @@ bool MonmapMonitor::preprocess_join(MonOpRequestRef op)
     addr_name = pending_map.get_name(join->addrs);
   }
   if (!addr_name.empty() &&
-      addr_name == join->name) {
+      addr_name == join->name &&
+      (!join->force_loc || join->crush_loc.empty() ||
+       pending_map.mon_info[addr_name].crush_loc == join->crush_loc)) {
     dout(10) << " already have " << join->addrs << dendl;
     return true;
   }
   if (pending_map.stretch_mode_enabled &&
+      join->crush_loc.empty() &&
       (addr_name.empty() ||
        pending_map.mon_info[addr_name].crush_loc.empty())) {
     dout(10) << "stretch mode engaged but no source of crush_loc" << dendl;
@@ -1284,7 +1289,9 @@ bool MonmapMonitor::prepare_join(MonOpRequestRef op)
   if (pending_map.contains(join->name))
     pending_map.remove(join->name);
   pending_map.add(join->name, join->addrs);
-  pending_map.mon_info[join->name].crush_loc = existing_loc;
+  pending_map.mon_info[join->name].crush_loc =
+    ((join->force_loc || existing_loc.empty()) ?
+     join->crush_loc : existing_loc);
   pending_map.last_changed = ceph_clock_now();
   return true;
 }

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -655,7 +655,6 @@ void OSDMap::Incremental::encode(ceph::buffer::list& bl, uint64_t features) cons
       target_v = 6;
     }
     if (change_stretch_mode) {
-      ceph_assert(target_v >= 9);
       target_v = std::max((uint8_t)10, target_v);
     }
     ENCODE_START(target_v, 1, bl); // extended, osd-only data


### PR DESCRIPTION
This PR has two parts, one a short bug fix and one handling a hole
in location handling. The bug fix is yet another invalid assert on structure
encoding triggered by kernel clients, but after an audit session it's the
last one. The hole in location handling is caused by monitors being able
to auto-join a cluster if they have the right keys, even if stretch mode
is engaged and there's no provided location. This PR closes the hole and
provides a mechanism for the daemons and admins/orchestrator to set
that location even when using this auto-bootstrap functionality instead
of creating the monitor in the monmap ahead of time.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
