### PR TITLE
octopus: pybind/mgr/dashboard: bump flake8 to 3.9.0

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -59,7 +59,11 @@ cd build-doc
 if [ ! -e $vdir ]; then
     virtualenv --python=python3 $vdir
 fi
-$vdir/bin/pip install --use-feature=2020-resolver --quiet -r $TOPDIR/admin/doc-requirements.txt -r $TOPDIR/admin/doc-python-common-requirements.txt
+
+$vdir/bin/pip install --quiet --upgrade pip setuptools
+$vdir/bin/pip install --quiet \
+              -r $TOPDIR/admin/doc-requirements.txt \
+              -r $TOPDIR/admin/doc-python-common-requirements.txt
 
 install -d -m0755 \
     $TOPDIR/build-doc/output/html \

--- a/src/pybind/mgr/dashboard/.pylintrc
+++ b/src/pybind/mgr/dashboard/.pylintrc
@@ -15,7 +15,7 @@ ignore-patterns=
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-#init-hook=
+init-hook='import sys; sys.path.append("./")'
 
 # Use multiple processes to speed up Pylint.
 jobs=1
@@ -118,7 +118,11 @@ disable=import-star-module-level,
         too-many-arguments,
         too-many-locals,
         too-many-statements,
-        useless-object-inheritance
+        useless-object-inheritance,
+        relative-beyond-top-level,
+        raise-missing-from,
+        super-with-arguments,
+        import-outside-toplevel
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/src/pybind/mgr/dashboard/constraints.txt
+++ b/src/pybind/mgr/dashboard/constraints.txt
@@ -4,6 +4,6 @@ more-itertools==4.1.0
 PyJWT==2.0.1
 bcrypt==3.1.4
 python3-saml==1.4.1
-requests==2.20.0
+requests==2.25.1
 Routes==2.4.1
 six==1.14.0

--- a/src/pybind/mgr/dashboard/controllers/nfsganesha.py
+++ b/src/pybind/mgr/dashboard/controllers/nfsganesha.py
@@ -258,7 +258,7 @@ class NFSGaneshaUi(BaseController):
     @Endpoint('GET', '/cephx/clients')
     @ReadPermission
     def cephx_clients(self):
-        return [client for client in CephX.list_clients()]
+        return list(CephX.list_clients())
 
     @Endpoint('GET', '/fsals')
     @ReadPermission

--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -295,7 +295,7 @@ class Osd(RESTController):
 
     @CreatePermission
     @osd_task('create', {'tracking_id': '{tracking_id}'})
-    def create(self, method, data, tracking_id):  # pylint: disable=W0622
+    def create(self, method, data, tracking_id):  # pylint: disable=unused-argument
         if method == 'bare':
             return self._create_bare(data)
         if method == 'drive_groups':

--- a/src/pybind/mgr/dashboard/plugins/__init__.py
+++ b/src/pybind/mgr/dashboard/plugins/__init__.py
@@ -71,4 +71,4 @@ class DashboardPluginManager(object):
 PLUGIN_MANAGER = DashboardPluginManager("ceph-mgr.dashboard")
 
 # Load all interfaces and their hooks
-from . import interfaces  # noqa: F401 pylint: disable=wrong-import-position,cyclic-import
+from . import interfaces  # noqa pylint: disable=C0413,W0406

--- a/src/pybind/mgr/dashboard/requirements-lint.txt
+++ b/src/pybind/mgr/dashboard/requirements-lint.txt
@@ -1,4 +1,4 @@
-pylint==2.3.1; python_version >= '3'
+pylint==2.6.0; python_version >= '3'
 flake8==3.9.0; python_version >= '3'
 flake8-colors==0.1.6; python_version >= '3'
 #TODO: Fix docstring issues: https://tracker.ceph.com/issues/41224

--- a/src/pybind/mgr/dashboard/requirements-lint.txt
+++ b/src/pybind/mgr/dashboard/requirements-lint.txt
@@ -1,5 +1,5 @@
 pylint==2.3.1; python_version >= '3'
-flake8==3.7.8; python_version >= '3'
+flake8==3.9.0; python_version >= '3'
 flake8-colors==0.1.6; python_version >= '3'
 #TODO: Fix docstring issues: https://tracker.ceph.com/issues/41224
 #flake8-docstrings
@@ -9,4 +9,4 @@ flake8-colors==0.1.6; python_version >= '3'
 rstcheck==3.3.1; python_version >= '3'
 autopep8; python_version >= '3'
 pyfakefs; python_version >= '3'
-pytest<4
+pytest

--- a/src/pybind/mgr/dashboard/services/auth.py
+++ b/src/pybind/mgr/dashboard/services/auth.py
@@ -192,7 +192,6 @@ class AuthManagerTool(cherrypy.Tool):
 
     def _check_authorization(self, username):
         self.logger.debug("checking authorization...")
-        username = username
         handler = cherrypy.request.handler.callable
         controller = handler.__self__
         sec_scope = getattr(controller, '_security_scope', None)

--- a/src/pybind/mgr/dashboard/services/cephx.py
+++ b/src/pybind/mgr/dashboard/services/cephx.py
@@ -22,7 +22,7 @@ class CephX(object):
 
     @classmethod
     def list_clients(cls):
-        return [client for client in cls._clients_map()]
+        return list(cls._clients_map())
 
     @classmethod
     def get_client_key(cls, client_id):

--- a/src/pybind/mgr/dashboard/services/ganesha.py
+++ b/src/pybind/mgr/dashboard/services/ganesha.py
@@ -109,7 +109,7 @@ class Ganesha(object):
 
     @classmethod
     def get_ganesha_clusters(cls):
-        return [cluster_id for cluster_id in cls._get_clusters_locations()]
+        return list(cls._get_clusters_locations())
 
     @staticmethod
     def _get_orch_nfs_services() -> List[ServiceDescription]:
@@ -322,7 +322,7 @@ class GaneshaConfParser(object):
         for key, val in block.items():
             if key == 'block_name':
                 continue
-            elif key == '_blocks_':
+            if key == '_blocks_':
                 for blo in val:
                     conf_str += GaneshaConfParser.write_block(blo, depth)
             elif val:
@@ -687,21 +687,21 @@ class Export(object):
             result['attr_expiration_time'] = self.attr_expiration_time
             result['security_label'] = self.security_label
         if 'protocols' not in defaults:
-            result['protocols'] = [p for p in self.protocols]
+            result['protocols'] = list(self.protocols)
         else:
             def_proto = defaults['protocols']
             if not isinstance(def_proto, list):
                 def_proto = set([def_proto])
             if self.protocols != def_proto:
-                result['protocols'] = [p for p in self.protocols]
+                result['protocols'] = list(self.protocols)
         if 'transports' not in defaults:
-            result['transports'] = [t for t in self.transports]
+            result['transports'] = list(self.transports)
         else:
             def_transp = defaults['transports']
             if not isinstance(def_transp, list):
                 def_transp = set([def_transp])
             if self.transports != def_transp:
-                result['transports'] = [t for t in self.transports]
+                result['transports'] = list(self.transports)
 
         result['_blocks_'] = [self.fsal.to_fsal_block()]
         result['_blocks_'].extend([client.to_client_block()
@@ -731,14 +731,14 @@ class Export(object):
             'path': self.path,
             'fsal': self.fsal.to_dict(),
             'cluster_id': self.cluster_id,
-            'daemons': sorted([d for d in self.daemons]),
+            'daemons': sorted(list(self.daemons)),
             'pseudo': self.pseudo,
             'tag': self.tag,
             'access_type': self.access_type,
             'squash': self.squash,
             'security_label': self.security_label,
-            'protocols': sorted([p for p in self.protocols]),
-            'transports': sorted([t for t in self.transports]),
+            'protocols': sorted(list(self.protocols)),
+            'transports': sorted(list(self.transports)),
             'clients': [client.to_dict() for client in self.clients]
         }
 

--- a/src/pybind/mgr/dashboard/services/iscsi_client.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_client.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     from urllib.parse import urlparse
 
-from .iscsi_config import IscsiGatewaysConfig  # pylint: disable=cyclic-import
+from .iscsi_config import IscsiGatewaysConfig
 from ..settings import Settings
 from ..rest_client import RestClient
 

--- a/src/pybind/mgr/dashboard/services/iscsi_config.py
+++ b/src/pybind/mgr/dashboard/services/iscsi_config.py
@@ -57,7 +57,7 @@ class IscsiGatewaysConfig(object):
         """
         for gateway_name, gateway_config in config['gateways'].items():
             if '.' not in gateway_name:
-                from .iscsi_client import IscsiClient
+                from .iscsi_client import IscsiClient  # pylint: disable=cyclic-import
                 from ..rest_client import RequestException
                 try:
                     service_url = gateway_config['service_url']

--- a/src/pybind/mgr/dashboard/services/progress.py
+++ b/src/pybind/mgr/dashboard/services/progress.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import
 from datetime import datetime
 import logging
 
-from . import rbd
+from . import rbd  # pylint: disable=no-name-in-module
 from .. import mgr
 
 

--- a/src/pybind/mgr/dashboard/services/rgw_client.py
+++ b/src/pybind/mgr/dashboard/services/rgw_client.py
@@ -314,6 +314,7 @@ class RgwClient(RestClient):
         if self.userid != RgwClient._SYSTEM_USERID:
             logger.info("Fetching new keys for user: %s", self.userid)
             keys = RgwClient.admin_instance().get_user_keys(self.userid)
+            # pylint: disable=attribute-defined-outside-init
             self.auth = S3Auth(keys['access_key'], keys['secret_key'],
                                service_url=self.service_url)
         else:

--- a/src/pybind/mgr/dashboard/tests/__init__.py
+++ b/src/pybind/mgr/dashboard/tests/__init__.py
@@ -21,7 +21,7 @@ from ..services.auth import AuthManagerTool
 from ..services.exception import dashboard_exception_handler
 
 from ..plugins import PLUGIN_MANAGER
-from ..plugins import feature_toggles, debug  # noqa # pylint: disable=unused-import
+from ..plugins import feature_toggles, debug  # noqa
 
 
 PLUGIN_MANAGER.hook.init()

--- a/src/pybind/mgr/dashboard/tests/helper.py
+++ b/src/pybind/mgr/dashboard/tests/helper.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 try:
-    from typing import Dict, Any  # pylint: disable=unused-import
+    from typing import Dict, Any
 except ImportError:
     pass
 

--- a/src/pybind/mgr/dashboard/tests/test_access_control.py
+++ b/src/pybind/mgr/dashboard/tests/test_access_control.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 
 from mgr_module import ERROR_MSG_EMPTY_INPUT_FILE
 
-from . import CmdException, CLICommandTestMixin
+from . import CmdException, CLICommandTestMixin  # pylint: disable=no-name-in-module
 from .. import mgr
 from ..security import Scope, Permission
 from ..services.access_control import load_access_control_db, \

--- a/src/pybind/mgr/dashboard/tests/test_api_auditing.py
+++ b/src/pybind/mgr/dashboard/tests/test_api_auditing.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     import unittest.mock as mock
 
-from . import ControllerTestCase, KVStoreMockMixin
+from . import ControllerTestCase, KVStoreMockMixin  # pylint: disable=no-name-in-module
 from ..controllers import RESTController, Controller
 from ..tools import RequestLoggingTool
 from .. import mgr

--- a/src/pybind/mgr/dashboard/tests/test_cephfs.py
+++ b/src/pybind/mgr/dashboard/tests/test_cephfs.py
@@ -6,7 +6,7 @@ except ImportError:
     from unittest.mock import Mock
 
 from .. import mgr
-from . import ControllerTestCase
+from . import ControllerTestCase  # pylint: disable=no-name-in-module
 from ..controllers.cephfs import CephFS
 
 

--- a/src/pybind/mgr/dashboard/tests/test_controllers.py
+++ b/src/pybind/mgr/dashboard/tests/test_controllers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from . import ControllerTestCase
+from . import ControllerTestCase  # pylint: disable=no-name-in-module
 from ..controllers import BaseController, RESTController, Controller, \
                           ApiController, Endpoint
 

--- a/src/pybind/mgr/dashboard/tests/test_docs.py
+++ b/src/pybind/mgr/dashboard/tests/test_docs.py
@@ -1,7 +1,7 @@
 # # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from . import ControllerTestCase
+from . import ControllerTestCase  # pylint: disable=no-name-in-module
 from ..controllers import RESTController, ApiController, Endpoint, EndpointDoc, ControllerDoc
 from ..controllers.docs import Docs
 

--- a/src/pybind/mgr/dashboard/tests/test_erasure_code_profile.py
+++ b/src/pybind/mgr/dashboard/tests/test_erasure_code_profile.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from .. import mgr
-from . import ControllerTestCase
+from . import ControllerTestCase  # pylint: disable=no-name-in-module
 from ..controllers.erasure_code_profile import ErasureCodeProfile
 
 

--- a/src/pybind/mgr/dashboard/tests/test_exceptions.py
+++ b/src/pybind/mgr/dashboard/tests/test_exceptions.py
@@ -5,7 +5,7 @@ import time
 
 import rados
 
-from . import ControllerTestCase
+from . import ControllerTestCase  # pylint: disable=no-name-in-module
 from ..services.ceph_service import SendCommandError
 from ..controllers import RESTController, Controller, Task, Endpoint
 from ..services.exception import handle_rados_error, handle_send_command_error, \

--- a/src/pybind/mgr/dashboard/tests/test_feature_toggles.py
+++ b/src/pybind/mgr/dashboard/tests/test_feature_toggles.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     from unittest.mock import Mock, patch
 
-from . import KVStoreMockMixin
+from . import KVStoreMockMixin  # pylint: disable=no-name-in-module
 from ..plugins.feature_toggles import FeatureToggles, Features
 
 

--- a/src/pybind/mgr/dashboard/tests/test_grafana.py
+++ b/src/pybind/mgr/dashboard/tests/test_grafana.py
@@ -8,7 +8,7 @@ except ImportError:
 
 from requests import RequestException
 
-from . import ControllerTestCase, KVStoreMockMixin
+from . import ControllerTestCase, KVStoreMockMixin  # pylint: disable=no-name-in-module
 from ..controllers.grafana import Grafana
 from ..grafana import GrafanaRestClient
 from ..settings import Settings

--- a/src/pybind/mgr/dashboard/tests/test_home.py
+++ b/src/pybind/mgr/dashboard/tests/test_home.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     import unittest.mock as mock
 
-from . import ControllerTestCase, FakeFsMixin
+from . import ControllerTestCase, FakeFsMixin  # pylint: disable=no-name-in-module
 from .. import mgr
 
 from ..controllers.home import HomeController, LanguageMixin

--- a/src/pybind/mgr/dashboard/tests/test_host.py
+++ b/src/pybind/mgr/dashboard/tests/test_host.py
@@ -7,7 +7,7 @@ except ImportError:
 
 from orchestrator import HostSpec
 
-from . import ControllerTestCase
+from . import ControllerTestCase  # pylint: disable=no-name-in-module
 from ..controllers.host import get_hosts, Host, HostUi
 from .. import mgr
 

--- a/src/pybind/mgr/dashboard/tests/test_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_iscsi.py
@@ -12,7 +12,8 @@ except ImportError:
 
 from mgr_module import ERROR_MSG_NO_INPUT_FILE
 
-from . import CmdException, ControllerTestCase, CLICommandTestMixin, KVStoreMockMixin
+from . import CmdException, ControllerTestCase, CLICommandTestMixin, \
+    KVStoreMockMixin  # pylint: disable=no-name-in-module
 from .. import mgr
 from ..controllers.iscsi import Iscsi, IscsiTarget
 from ..services.iscsi_client import IscsiClient

--- a/src/pybind/mgr/dashboard/tests/test_orchestrator.py
+++ b/src/pybind/mgr/dashboard/tests/test_orchestrator.py
@@ -6,7 +6,7 @@ except ImportError:
 
 from orchestrator import InventoryHost
 
-from . import ControllerTestCase
+from . import ControllerTestCase  # pylint: disable=no-name-in-module
 from .. import mgr
 from ..controllers.orchestrator import get_device_osd_map
 from ..controllers.orchestrator import Orchestrator

--- a/src/pybind/mgr/dashboard/tests/test_osd.py
+++ b/src/pybind/mgr/dashboard/tests/test_osd.py
@@ -11,11 +11,11 @@ except ImportError:
 from ceph.deployment.drive_group import DeviceSelection, DriveGroupSpec
 from ceph.deployment.service_spec import PlacementSpec
 
-from . import ControllerTestCase
+from . import ControllerTestCase  # pylint: disable=no-name-in-module
 from ..controllers.osd import Osd
 from ..tools import NotificationQueue, TaskManager
 from .. import mgr
-from .helper import update_dict
+from .helper import update_dict  # pylint: disable=import-error
 
 try:
     from typing import List, Dict, Any  # pylint: disable=unused-import

--- a/src/pybind/mgr/dashboard/tests/test_plugin_debug.py
+++ b/src/pybind/mgr/dashboard/tests/test_plugin_debug.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from . import CLICommandTestMixin, ControllerTestCase
+from . import CLICommandTestMixin, ControllerTestCase  # pylint: disable=no-name-in-module
 
 
 class TestPluginDebug(ControllerTestCase, CLICommandTestMixin):

--- a/src/pybind/mgr/dashboard/tests/test_pool.py
+++ b/src/pybind/mgr/dashboard/tests/test_pool.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     import unittest.mock as mock
 
-from . import ControllerTestCase
+from . import ControllerTestCase  # pylint: disable=no-name-in-module
 from ..controllers.pool import Pool
 from ..controllers.task import Task
 from ..tools import NotificationQueue, TaskManager

--- a/src/pybind/mgr/dashboard/tests/test_prometheus.py
+++ b/src/pybind/mgr/dashboard/tests/test_prometheus.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     from unittest.mock import patch
 
-from . import ControllerTestCase
+from . import ControllerTestCase  # pylint: disable=no-name-in-module
 from .. import mgr
 from ..controllers.prometheus import Prometheus, PrometheusReceiver, PrometheusNotifications
 

--- a/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     import unittest.mock as mock
 
-from . import ControllerTestCase
+from . import ControllerTestCase  # pylint: disable=no-name-in-module
 from .. import mgr
 from ..controllers.summary import Summary
 from ..controllers.rbd_mirroring import RbdMirroring, RbdMirroringSummary, \

--- a/src/pybind/mgr/dashboard/tests/test_rest_tasks.py
+++ b/src/pybind/mgr/dashboard/tests/test_rest_tasks.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     import unittest.mock as mock
 
-from . import ControllerTestCase
+from . import ControllerTestCase  # pylint: disable=no-name-in-module
 from ..controllers import Controller, RESTController, Task
 from ..controllers.task import Task as TaskController
 from ..services import progress

--- a/src/pybind/mgr/dashboard/tests/test_rgw_client.py
+++ b/src/pybind/mgr/dashboard/tests/test_rgw_client.py
@@ -9,7 +9,7 @@ except ImportError:
 
 from ..services.rgw_client import RgwClient, _parse_frontend_config
 from ..settings import Settings
-from . import KVStoreMockMixin
+from . import KVStoreMockMixin  # pylint: disable=no-name-in-module
 
 
 def _dummy_daemon_info():

--- a/src/pybind/mgr/dashboard/tests/test_settings.py
+++ b/src/pybind/mgr/dashboard/tests/test_settings.py
@@ -6,7 +6,7 @@ import unittest
 
 from mgr_module import ERROR_MSG_EMPTY_INPUT_FILE
 
-from . import KVStoreMockMixin, ControllerTestCase
+from . import KVStoreMockMixin, ControllerTestCase  # pylint: disable=no-name-in-module
 from .. import settings
 from ..controllers.settings import Settings as SettingsController
 from ..settings import Settings, handle_option_command

--- a/src/pybind/mgr/dashboard/tests/test_sso.py
+++ b/src/pybind/mgr/dashboard/tests/test_sso.py
@@ -5,7 +5,8 @@ from __future__ import absolute_import
 import errno
 import unittest
 
-from . import CmdException, exec_dashboard_cmd, KVStoreMockMixin
+from . import CmdException, exec_dashboard_cmd, \
+    KVStoreMockMixin  # pylint: disable=no-name-in-module
 from ..services.sso import handle_sso_command, load_sso_db
 
 

--- a/src/pybind/mgr/dashboard/tests/test_tools.py
+++ b/src/pybind/mgr/dashboard/tests/test_tools.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     from unittest.mock import patch
 
-from . import ControllerTestCase
+from . import ControllerTestCase  # pylint: disable=no-name-in-module
 from ..services.exception import handle_rados_error
 from ..controllers import RESTController, ApiController, Controller, \
                           BaseController, Proxy

--- a/src/pybind/mgr/dashboard/tools.py
+++ b/src/pybind/mgr/dashboard/tools.py
@@ -30,7 +30,7 @@ from .services.auth import JwtManager
 
 try:
     from typing import Any, AnyStr, Callable, DefaultDict, Deque,\
-        Dict, List, Set, Tuple, Union  # noqa pylint: disable=unused-import
+        Dict, List, Set, Tuple, Union  # noqa
 except ImportError:
     pass  # For typing only
 


### PR DESCRIPTION
to address the failure of

ERROR: Cannot install -r requirements-lint.txt (line 2) and -r requirements-lint.txt (line 8) because these package versions have conflicting dependencies.

The conflict is caused by:
    flake8 3.8.4 depends on pycodestyle<2.7.0 and >=2.6.0a1
    autopep8 1.5.6 depends on pycodestyle>=2.7.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 152964ca360293d9accd18f435efcd66d145063e)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
