### PR TITLE
pacific: mgr/dashboard: Device health status is not getting listed under hosts section

### DIFF
--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -232,12 +232,20 @@ class CephService(object):
 
             for daemon in daemons:
                 svc_type, svc_id = daemon.split('.')
-                try:
-                    dev_smart_data = CephService.send_command(
-                        svc_type, 'smart', svc_id, devid=device['devid'])
-                except SendCommandError:
-                    # Try to retrieve SMART data from another daemon.
-                    continue
+                if 'osd' in svc_type:
+                    try:
+                        dev_smart_data = CephService.send_command(
+                            svc_type, 'smart', svc_id, devid=device['devid'])
+                    except SendCommandError:
+                        # Try to retrieve SMART data from another daemon.
+                        continue
+                else:
+                    try:
+                        dev_smart_data = CephService.send_command(
+                            svc_type, 'device get-health-metrics', svc_id, devid=device['devid'])
+                    except SendCommandError:
+                        # Try to retrieve SMART data from another daemon.
+                        continue
                 for dev_id, dev_data in dev_smart_data.items():
                     if 'error' in dev_data:
                         logger.warning(


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50053

---

backport of https://github.com/ceph/ceph/pull/40023
parent tracker: https://tracker.ceph.com/issues/49354

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh