### PR TITLE
cephadm: fix a typo

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -634,7 +634,7 @@ class CephadmServe:
                     r = True
                 except (RuntimeError, OrchestratorError) as e:
                     self.mgr.events.for_service(spec, 'ERROR',
-                                                f"Failed while placing {daemon_type}.{daemon_id}"
+                                                f"Failed while placing {daemon_type}.{daemon_id} "
                                                 f"on {slot.hostname}: {e}")
                     # only return "no change" if no one else has already succeeded.
                     # later successes will also change to True


### PR DESCRIPTION
this adds a space in order to avoid displaying this:

```
"2021-03-29T10:51:32.595782Z service:rgw.default [ERROR] \"Failed while placing rgw.default.ceph-vasi-node5-osd-rgw-iscsi-gw.hpuesfon ceph-vasi-node5-osd-rgw-iscsi-gw
```

instead of:

```
"2021-03-29T10:51:32.595782Z service:rgw.default [ERROR] \"Failed while placing rgw.default.ceph-vasi-node5-osd-rgw-iscsi-gw.hpuesf on ceph-vasi-node5-osd-rgw-iscsi-rgw
```

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
