### PR TITLE
doc/cephadm: add podman version note to install

### DIFF
--- a/doc/cephadm/compatibility.rst
+++ b/doc/cephadm/compatibility.rst
@@ -3,6 +3,8 @@
 Compatibility and Stability
 ===========================
 
+.. _cephadm-compatibility-with-podman:
+
 Compatibility with Podman Versions
 ----------------------------------
 
@@ -24,6 +26,10 @@ Those versions are expected to work:
 +-----------+-------+-------+-------+-------+-------+
 | >= 16.2.1 | False | True  | True  | False | True  |
 +-----------+-------+-------+-------+-------+-------+
+
+.. warning:: 
+  Only podman versions that are 2.0.0 and higher work with Ceph Pacific, with the exception of podman version 2.2.1, which does not work with Ceph Pacific. kubic stable is known to work with Ceph Pacific, but it must be run with a newer kernel.
+
 
 .. _cephadm-stability:
 

--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -23,6 +23,13 @@ Requirements
 Any modern Linux distribution should be sufficient.  Dependencies
 are installed automatically by the bootstrap process below.
 
+See the section :ref:`Compatibility With Podman
+Versions<cephadm-compatibility-with-podman>` for a table of Ceph versions that
+are compatible with Podman. Not every version of Podman is compatible with
+Ceph.
+
+
+
 .. _get-cephadm:
 
 Install cephadm


### PR DESCRIPTION
This PR adds a note to the cephadm installation
guide that informs users that only podman version
2.0.0 and higher work with Ceph, with the
exception of podman version 2.2.1, which does
not work with Ceph. There is also a note regarding
kubic stable 3.0.1 working, but only with newer
kernels.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
