### PR TITLE
mgr/cephadm: fix orch host add with multiple labels and no addr

### DIFF
--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -104,7 +104,12 @@ are free form and have no particular meaning by itself and each host
 can have multiple labels. They can be used to specify placement
 of daemons. See :ref:`orch-placement-by-labels`
 
-To add a label, run::
+Labels can be added when adding a host with the ``--labels`` flag::
+
+  ceph orch host add my_hostname --labels=my_label1
+  ceph orch host add my_hostname --labels=my_label1,my_label2
+
+To add a label a existing host, run::
 
   ceph orch host label add my_hostname my_label
 

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1187,13 +1187,13 @@ Please make sure that the host is reachable and accepts connections using the ce
 
 To add the cephadm SSH key to the host:
 > ceph cephadm get-pub-key > ~/ceph.pub
-> ssh-copy-id -f -i ~/ceph.pub {user}@{host}
+> ssh-copy-id -f -i ~/ceph.pub {user}@{addr}
 
 To check that the host is reachable:
 > ceph cephadm get-ssh-config > ssh_config
 > ceph config-key get mgr/cephadm/ssh_identity_key > ~/cephadm_private_key
 > chmod 0600 ~/cephadm_private_key
-> ssh -F ssh_config -i ~/cephadm_private_key {user}@{host}'''
+> ssh -F ssh_config -i ~/cephadm_private_key {user}@{addr}'''
             raise OrchestratorError(msg) from e
         except Exception as ex:
             self.log.exception(ex)

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -326,6 +326,11 @@ class OrchestratorCli(OrchestratorClientMixin, MgrModule,
     def _add_host(self, hostname: str, addr: Optional[str] = None, labels: Optional[List[str]] = None, maintenance: Optional[bool] = False) -> HandleCommandResult:
         """Add a host"""
         _status = 'maintenance' if maintenance else ''
+
+        # split multiple labels passed in with --labels=label1,label2
+        if labels and len(labels) == 1:
+            labels = labels[0].split(',')
+
         s = HostSpec(hostname=hostname, addr=addr, labels=labels, status=_status)
 
         return self._apply_misc([s], False, Format.plain)


### PR DESCRIPTION
the first problem: 
ceph orch host add <hosnamet> <addr>   provides a misleading error message if addr is not valid

switching the error message to use the addr variable will show its trying to make a connection to that address
(addr = hostname if no addr is provided)


second problem:
orch host add command can not add a host with multiple labels and no addr (its possible if you put '' in the addr positional argument)

previously using the --labels flag there was no way to specify multiple labels. everything was taken as a single large label 
ex: --labels=label1,label2    would evaluate to a list of labels as ["label1,label2"]

now you can use command separated labels 

ceph orch host add vm-01 --labels=label1,label2,label3
and the labels will save separately  ex:  ["label1","label2","labe3"]

additionally i have documented this functionality
 











Fixes: https://tracker.ceph.com/issues/50062
Signed-off-by: Daniel Pivonka <dpivonka@redhat.com>

