### PR TITLE
pacific: qa/suites/rados/cephadm: stop testing on broken focal kubic podman

### DIFF
--- a/qa/suites/rados/cephadm/smoke/distro/ubuntu_20.04_kubic_stable.yaml
+++ b/qa/suites/rados/cephadm/smoke/distro/ubuntu_20.04_kubic_stable.yaml
@@ -1,1 +1,0 @@
-.qa/distros/podman/ubuntu_20.04_kubic_stable.yaml

--- a/qa/suites/rados/cephadm/smoke/distro/ubuntu_20.04_kubic_testing.yaml
+++ b/qa/suites/rados/cephadm/smoke/distro/ubuntu_20.04_kubic_testing.yaml
@@ -1,1 +1,0 @@
-.qa/distros/podman/ubuntu_20.04_kubic_testing.yaml

--- a/qa/suites/rados/cephadm/workunits/0-distro/ubuntu_20.04_kubic_stable.yaml
+++ b/qa/suites/rados/cephadm/workunits/0-distro/ubuntu_20.04_kubic_stable.yaml
@@ -1,1 +1,0 @@
-.qa/distros/podman/ubuntu_20.04_kubic_stable.yaml

--- a/qa/suites/rados/cephadm/workunits/0-distro/ubuntu_20.04_kubic_testing.yaml
+++ b/qa/suites/rados/cephadm/workunits/0-distro/ubuntu_20.04_kubic_testing.yaml
@@ -1,1 +1,0 @@
-.qa/distros/podman/ubuntu_20.04_kubic_testing.yaml


### PR DESCRIPTION
backport #40471

See https://tracker.ceph.com/issues/49633

Signed-off-by: Sage Weil <sage@newdream.net>
(cherry picked from commit 64668275b5fa54dd3fc0761809a6538c9ccd1eeb)