### PR TITLE
nautilus: mgr/dashboard: encode non-ascii string before passing it to exec_cmd()

### DIFF
--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -7,7 +7,6 @@ import errno
 import json
 import threading
 import time
-import six
 
 import bcrypt
 
@@ -15,6 +14,7 @@ from mgr_module import CLICheckNonemptyFileInput, CLIReadCommand, CLIWriteComman
 
 from .. import mgr, logger
 from ..security import Scope, Permission
+from ..tools import ensure_str
 from ..exceptions import RoleAlreadyExists, RoleDoesNotExist, ScopeNotValid, \
                          PermissionNotValid, RoleIsAssociatedWithUser, \
                          UserAlreadyExists, UserDoesNotExist, ScopeNotInRole, \
@@ -25,8 +25,7 @@ from ..exceptions import RoleAlreadyExists, RoleDoesNotExist, ScopeNotValid, \
 def password_hash(password, salt_password=None):
     if not password:
         return None
-    if six.PY2:
-        password = unicode(password, 'utf-8') if isinstance(password, str) else password
+    password = ensure_str(password)
     if not salt_password:
         salt_password = bcrypt.gensalt()
     else:

--- a/src/pybind/mgr/dashboard/tests/test_access_control.py
+++ b/src/pybind/mgr/dashboard/tests/test_access_control.py
@@ -572,13 +572,10 @@ class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
     def test_unicode_password(self):
         self.test_create_user()
         password = '章鱼不是密码'
-        with tempfile.TemporaryFile(mode='w+') as pwd_file:
-            pwd_file.write(password)
-            pwd_file.seek(0)
-            user = self.exec_cmd('ac-user-set-password', username='admin',
-                                 inbuf=pwd_file.read(), force_password=True)
-            pass_hash = password_hash(password, user['password'])
-            self.assertEqual(user['password'], pass_hash)
+        user = self.exec_cmd('ac-user-set-password', username='admin',
+                             inbuf=password.encode(), force_password=True)
+        pass_hash = password_hash(password, user['password'])
+        self.assertEqual(user['password'], pass_hash)
 
     def test_set_user_password_nonexistent_user(self):
         with self.assertRaises(CmdException) as ctx:


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
