### PR TITLE
cmake: do not pass extra param to crimson tests

### DIFF
--- a/src/test/crimson/seastore/onode_tree/CMakeLists.txt
+++ b/src/test/crimson/seastore/onode_tree/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(unittest-staged-fltree
   test_staged_fltree.cc
   ../../gtest_seastar.cc)
 add_ceph_unittest(unittest-staged-fltree
-  unittest-staged-fltree --memory 256M --smp 1)
+  --memory 256M --smp 1)
 target_link_libraries(unittest-staged-fltree
   crimson-seastore)
 
@@ -10,6 +10,6 @@ add_executable(unittest-fltree-onode-manager
   test_fltree_onode_manager.cc
   ../../gtest_seastar.cc)
 add_ceph_unittest(unittest-fltree-onode-manager
-  unittest-fltree-onode-manager --memory 256M --smp 1)
+  --memory 256M --smp 1)
 target_link_libraries(unittest-fltree-onode-manager
   crimson-seastore)


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/50079
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
