### PR TITLE
cephadm: quick fix in upgrade.py

### DIFF
--- a/src/pybind/mgr/cephadm/upgrade.py
+++ b/src/pybind/mgr/cephadm/upgrade.py
@@ -438,7 +438,7 @@ class CephadmUpgrade:
             # tolerate/fix upgrade state from older version
             self.upgrade_state.target_version = target_version.split(' ')[2]
             target_version = self.upgrade_state.target_version
-        target_major, target_minor, target_patch = target_version.split('.')
+        target_major, target_minor, target_patch, *target_distrib = target_version.split('.')
         target_major_name = self.mgr.lookup_release_name(int(target_major))
 
         if first:


### PR DESCRIPTION
I went to an issue when trying to upgrade in a RHCS/downstream context
where `target_release.split('.')` returns something like: `16.1.0-1084.el8cp`

there's a difference between upstream and dowstream release of Ceph
since upstream it would return a pattern with 3 digits like :
`16.1.0-1325-geb5d7a86`

With a downstream release, the upgrade process fails and throws the following error:

```
Mar 31 08:44:41 ceph-vasi-node2-mon-mgr conmon[346502]:   File "/usr/share/ceph/mgr/cephadm/module.py", line 462, in serve
Mar 31 08:44:41 ceph-vasi-node2-mon-mgr conmon[346502]:     serve.serve()
Mar 31 08:44:41 ceph-vasi-node2-mon-mgr conmon[346502]:   File "/usr/share/ceph/mgr/cephadm/serve.py", line 92, in serve
Mar 31 08:44:41 ceph-vasi-node2-mon-mgr conmon[346502]:     if self.mgr.upgrade.continue_upgrade():
Mar 31 08:44:41 ceph-vasi-node2-mon-mgr conmon[346502]:   File "/usr/share/ceph/mgr/cephadm/upgrade.py", line 239, in continue_upgrade
Mar 31 08:44:41 ceph-vasi-node2-mon-mgr conmon[346502]:     self._do_upgrade()
Mar 31 08:44:41 ceph-vasi-node2-mon-mgr conmon[346502]:   File "/usr/share/ceph/mgr/cephadm/upgrade.py", line 438, in _do_upgrade
Mar 31 08:44:41 ceph-vasi-node2-mon-mgr conmon[346502]:     target_major, target_minor, target_patch = target_version.split('.')
Mar 31 08:44:41 ceph-vasi-node2-mon-mgr conmon[346502]: ValueError: too many values to unpack (expected 3)
```

The current code assumes `target_version.split('.')` will always return
a list of 3 elements, which is false in a downstream deployment.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1945260
Fixes: https://tracker.ceph.com/issues/50085

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>

