### PR TITLE
nautilus: test/pybind: s/nosetests/python3/

### DIFF
--- a/src/pybind/mgr/dashboard/.pylintrc
+++ b/src/pybind/mgr/dashboard/.pylintrc
@@ -118,7 +118,9 @@ disable=import-star-module-level,
         too-many-arguments,
         too-many-locals,
         too-many-statements,
-        useless-object-inheritance
+        useless-object-inheritance,
+        no-else-raise,
+        no-else-return
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/src/pybind/mgr/dashboard/requirements-py3.txt
+++ b/src/pybind/mgr/dashboard/requirements-py3.txt
@@ -1,3 +1,3 @@
-astroid==2.1.0
-pylint==2.2.2
+astroid==2.5.2
+pylint==2.3.1
 python3-saml==1.4.1

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -7,6 +7,7 @@ import errno
 import json
 import threading
 import time
+import six
 
 import bcrypt
 
@@ -14,11 +15,23 @@ from mgr_module import CLICheckNonemptyFileInput, CLIReadCommand, CLIWriteComman
 
 from .. import mgr, logger
 from ..security import Scope, Permission
-from ..tools import ensure_str
 from ..exceptions import RoleAlreadyExists, RoleDoesNotExist, ScopeNotValid, \
                          PermissionNotValid, RoleIsAssociatedWithUser, \
                          UserAlreadyExists, UserDoesNotExist, ScopeNotInRole, \
                          RoleNotInUser
+
+
+# replicates tools.ensure_str() to avoid recursive import:
+# ..tools -> .services.auth -> .access_control -> ..tools
+def ensure_str(s, encoding='utf-8', errors='strict'):
+    """Ported from six."""
+    if not isinstance(s, (six.text_type, six.binary_type)):
+        raise TypeError("not expecting type '%s'" % type(s))
+    if six.PY2 and isinstance(s, six.text_type):
+        s = s.encode(encoding, errors)
+    elif six.PY3 and isinstance(s, six.binary_type):
+        s = s.decode(encoding, errors)
+    return s
 
 
 # password hashing algorithm

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env nosetests 
+#!/usr/bin/env python3
 # -*- mode:python; tab-width:4; indent-tabs-mode:t; coding:utf-8 -*-
 # vim: ts=4 sw=4 smarttab expandtab fileencoding=utf-8
 #

--- a/src/test/pybind/test_ceph_daemon.py
+++ b/src/test/pybind/test_ceph_daemon.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env nosetests
+#!/usr/bin/env python3
 # -*- mode:python; tab-width:4; indent-tabs-mode:t -*-
 # vim: ts=4 sw=4 smarttab expandtab
 #


### PR DESCRIPTION
we still support python2 in nautilus. but we need to run "make check" in python3. hence the change.

this change should address the test failure like
```
117/180 Test #163: test_ceph_daemon.py .....................***Failed    0.04 sec
/usr/bin/env: 'nosetests': No such file or directory
```

see https://jenkins.ceph.com/job/ceph-pull-requests/72581/console

---

different distros package python3-nose in different ways by adding
different postfix to "/usr/bin/nosetests" to differentiate it from
its python2 counterpart.

* on bionic, python3-nose offers "nosetests3"
* on el8, python3-nose offers "nosetests-3" and "nosetests-3.6"

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 717aaad9edb295d15998f37a5d92d11bc8345b33)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
