### PR TITLE
mgr/dashboard: decouple unit tests from build artifacts

### DIFF
--- a/src/pybind/mgr/dashboard/__init__.py
+++ b/src/pybind/mgr/dashboard/__init__.py
@@ -48,7 +48,38 @@ else:
     # raise an ImportError
     import sys
     import mock
-    sys.modules['ceph_module'] = mock.Mock()
 
     mgr = mock.Mock()
     mgr.get_frontend_path.side_effect = lambda: os.path.abspath("./frontend/dist")
+
+    def mock_ceph_modules():
+        class MockRadosError(Exception):
+            def __init__(self, message, errno=None):
+                super(MockRadosError, self).__init__(message)
+                self.errno = errno
+
+            def __str__(self):
+                msg = super(MockRadosError, self).__str__()
+                if self.errno is None:
+                    return msg
+                return '[errno {0}] {1}'.format(self.errno, msg)
+
+        rbd = mock.Mock()
+        rbd.RBD_FEATURE_LAYERING = 1
+        rbd.RBD_FEATURE_STRIPINGV2 = 2
+        rbd.RBD_FEATURE_EXCLUSIVE_LOCK = 4
+        rbd.RBD_FEATURE_OBJECT_MAP = 8
+        rbd.RBD_FEATURE_FAST_DIFF = 16
+        rbd.RBD_FEATURE_DEEP_FLATTEN = 32
+        rbd.RBD_FEATURE_JOURNALING = 64
+        rbd.RBD_FEATURE_DATA_POOL = 128
+        rbd.RBD_FEATURE_OPERATIONS = 256
+
+        sys.modules.update({
+            'rados': mock.Mock(Error=MockRadosError, OSError=MockRadosError),
+            'rbd': rbd,
+            'cephfs': mock.Mock(),
+            'ceph_module': mock.Mock(),
+        })
+
+    mock_ceph_modules()

--- a/src/pybind/mgr/dashboard/controllers/iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/iscsi.py
@@ -8,8 +8,8 @@ import re
 import json
 import cherrypy
 
-import rados
-import rbd
+import rados  # pylint: disable=import-error
+import rbd  # pylint: disable=import-error
 
 from . import ApiController, UiApiController, RESTController, BaseController, Endpoint,\
     ReadPermission, UpdatePermission, Task

--- a/src/pybind/mgr/dashboard/controllers/nfsganesha.py
+++ b/src/pybind/mgr/dashboard/controllers/nfsganesha.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from functools import partial
 
 import cherrypy
-import cephfs
+import cephfs  # pylint: disable=import-error
 
 from . import ApiController, RESTController, UiApiController, BaseController, \
               Endpoint, Task, ReadPermission, ControllerDoc, EndpointDoc

--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 import cherrypy
 
-import rbd
+import rbd  # pylint: disable=import-error
 
 from . import ApiController, RESTController, Task, UpdatePermission, \
               DeletePermission, CreatePermission, ReadPermission, allow_empty_body

--- a/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
@@ -8,7 +8,7 @@ from functools import partial
 
 import cherrypy
 
-import rbd
+import rbd  # pylint: disable=import-error
 
 from . import ApiController, Endpoint, Task, BaseController, ReadPermission, \
     RESTController

--- a/src/pybind/mgr/dashboard/exceptions.py
+++ b/src/pybind/mgr/dashboard/exceptions.py
@@ -42,7 +42,7 @@ class DashboardException(Exception):
     def code(self):
         if self._code:
             return str(self._code)
-        return str(abs(self.errno))
+        return str(abs(self.errno)) if self.errno is not None else 'Error'
 
 
 # access control module exceptions

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -14,11 +14,13 @@ import sys
 import tempfile
 import threading
 import time
+
 from uuid import uuid4
 from OpenSSL import crypto
-import _strptime  # pylint: disable=unused-import
 from mgr_module import MgrModule, MgrStandbyModule, Option, CLIWriteCommand
 from mgr_util import get_default_addr, ServerConfigException, verify_tls_files
+
+import _strptime  # pylint: disable=unused-import
 
 try:
     import cherrypy

--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import json
 
-import rados
+import rados  # pylint: disable=import-error
 
 from mgr_module import CommandResult
 from mgr_util import get_time_series_rates, get_most_recent_rate

--- a/src/pybind/mgr/dashboard/services/cephfs.py
+++ b/src/pybind/mgr/dashboard/services/cephfs.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 from contextlib import contextmanager
 
-import cephfs
+import cephfs  # pylint: disable=import-error
 
 from .. import mgr, logger
 

--- a/src/pybind/mgr/dashboard/services/exception.py
+++ b/src/pybind/mgr/dashboard/services/exception.py
@@ -7,8 +7,8 @@ from contextlib import contextmanager
 
 import cherrypy
 
-import rbd
-import rados
+import rbd  # pylint: disable=import-error
+import rados  # pylint: disable=import-error
 
 from .. import logger
 from ..services.ceph_service import SendCommandError

--- a/src/pybind/mgr/dashboard/services/rbd.py
+++ b/src/pybind/mgr/dashboard/services/rbd.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import six
 
-import rbd
+import rbd  # pylint: disable=import-error
 
 from .. import mgr
 from .ceph_service import CephService

--- a/src/pybind/mgr/dashboard/tests/test_exceptions.py
+++ b/src/pybind/mgr/dashboard/tests/test_exceptions.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import time
 
-import rados
+import rados  # pylint: disable=import-error
 
 from . import ControllerTestCase
 from ..services.ceph_service import SendCommandError


### PR DESCRIPTION
Unit tests should not depend on build artifacts as they only test our business logic.

Decoupling was implemented in octopus through several PRs but due to code divergence
this atomic decoupling is preferable for nautilus.

Signed-off-by: Alfonso Martínez <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
