### PR TITLE
octopus: common: remove log_early configuration option

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1352,7 +1352,6 @@ class CephManager:
                 'ceph',
                 '--cluster',
                 self.cluster,
-                '--log-early',
             ]
             ceph_args.extend(args)
             proc = self.controller.run(

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -649,9 +649,6 @@ int md_config_t::parse_argv(ConfigValues& values,
     else if (ceph_argparse_flag(args, i, "--no-mon-config", (char*)NULL)) {
       values.no_mon_config = true;
     }
-    else if (ceph_argparse_flag(args, i, "--log-early", (char*)NULL)) {
-      values.log_early = true;
-    }
     else if (ceph_argparse_flag(args, i, "--mon-config", (char*)NULL)) {
       values.no_mon_config = false;
     }

--- a/src/common/config_values.h
+++ b/src/common/config_values.h
@@ -28,7 +28,6 @@ public:
   std::string cluster;
   ceph::logging::SubsystemMap subsys;
   bool no_mon_config = false;
-  bool log_early = false;
   // Set of configuration options that have changed since the last
   // apply_changes
   using changed_set_t = std::set<std::string>;

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -149,11 +149,6 @@ void global_pre_init(
   // command line (as passed by caller)
   conf.parse_argv(args);
 
-  if (conf->log_early &&
-      !cct->_log->is_started()) {
-    cct->_log->start();
-  }
-
   if (!cct->_log->is_started()) {
     cct->_log->start();
   }

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -78,8 +78,7 @@ public:
   {
     int ret;
 
-    if (cct->_conf->log_early &&
-	!cct->_log->is_started()) {
+    if (!cct->_log->is_started()) {
       cct->_log->start();
     }
 

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -228,8 +228,7 @@ int librados::RadosClient::connect()
     return -EISCONN;
   state = CONNECTING;
 
-  if (cct->_conf->log_early &&
-      !cct->_log->is_started()) {
+  if (!cct->_log->is_started()) {
     cct->_log->start();
   }
 


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/37175.

I kept chasing my tail trying to make sense of a set of nautilus logs, where a few key lines were missing due to `log-early` not being on by default in nautilus.  What would have been obvious in an instant took almost three days...  Fix this for octopus as well.