### PR TITLE
mgr/orchestrator: validate lists in spec jsons

### DIFF
--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -6,7 +6,8 @@ from typing import NamedTuple, List, Dict
 import pytest
 
 from ceph.deployment.hostspec import HostSpec
-from ceph.deployment.service_spec import ServiceSpec, PlacementSpec, ServiceSpecValidationError, IngressSpec
+from ceph.deployment.service_spec import ServiceSpec, PlacementSpec, IngressSpec
+from ceph.deployment.hostspec import SpecValidationError
 
 from cephadm.module import HostAssignment
 from cephadm.schedule import DaemonPlacement
@@ -164,7 +165,7 @@ def run_scheduler_test(results, mk_spec, hosts, daemons, key_elems):
 #       |   |   | |     + expected result
 #       |   |   | |     |
 test_explicit_scheduler_results = [
-    (k("*   *   0 *"), error(ServiceSpecValidationError, 'num/count must be > 1')),
+    (k("*   *   0 *"), error(SpecValidationError, 'num/count must be > 1')),
     (k("*   e   N l"), error(OrchestratorValidationError, 'Cannot place <ServiceSpec for service_name=mgr>: No matching hosts for label mylabel')),
     (k("*   e   N p"), error(OrchestratorValidationError, 'Cannot place <ServiceSpec for service_name=mgr>: No matching hosts')),
     (k("*   e   N h"), error(OrchestratorValidationError, 'placement spec is empty: no hosts, no label, no pattern, no count')),
@@ -908,7 +909,7 @@ def test_bad_placements(placement):
     try:
         PlacementSpec.from_string(placement.split(' '))
         assert False
-    except ServiceSpecValidationError:
+    except SpecValidationError:
         pass
 
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -31,9 +31,9 @@ import yaml
 
 from ceph.deployment import inventory
 from ceph.deployment.service_spec import ServiceSpec, NFSServiceSpec, RGWSpec, \
-    ServiceSpecValidationError, IscsiServiceSpec, IngressSpec
+    IscsiServiceSpec, IngressSpec
 from ceph.deployment.drive_group import DriveGroupSpec
-from ceph.deployment.hostspec import HostSpec
+from ceph.deployment.hostspec import HostSpec, SpecValidationError
 from ceph.utils import datetime_to_str, str_to_datetime
 
 from mgr_module import MgrModule, CLICommand, HandleCommandResult
@@ -94,7 +94,7 @@ def handle_exception(prefix: str, perm: str, func: FuncT) -> FuncT:
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         try:
             return func(*args, **kwargs)
-        except (OrchestratorError, ServiceSpecValidationError) as e:
+        except (OrchestratorError, SpecValidationError) as e:
             # Do not print Traceback for expected errors.
             return HandleCommandResult(e.errno, stderr=str(e))
         except ImportError as e:

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -10,8 +10,8 @@ from prettytable import PrettyTable
 
 from ceph.deployment.inventory import Device
 from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection
-from ceph.deployment.service_spec import PlacementSpec, ServiceSpec, \
-    ServiceSpecValidationError
+from ceph.deployment.service_spec import PlacementSpec, ServiceSpec
+from ceph.deployment.hostspec import SpecValidationError
 from ceph.utils import datetime_now
 
 from mgr_util import to_pretty_timedelta, format_dimless
@@ -1020,7 +1020,7 @@ Usage:
                         try:
                             self.get_foreign_ceph_option('mon', k)
                         except KeyError:
-                            raise ServiceSpecValidationError(f'Invalid config option {k} in spec')
+                            raise SpecValidationError(f'Invalid config option {k} in spec')
 
                 if dry_run and not isinstance(spec, HostSpec):
                     spec.preview_only = dry_run

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -1,7 +1,8 @@
 import yaml
 
 from ceph.deployment.inventory import Device
-from ceph.deployment.service_spec import ServiceSpecValidationError, ServiceSpec, PlacementSpec
+from ceph.deployment.service_spec import ServiceSpec, PlacementSpec
+from ceph.deployment.hostspec import SpecValidationError
 
 try:
     from typing import Optional, List, Dict, Any, Union
@@ -121,7 +122,7 @@ class DeviceSelection(object):
         return repr(self) == repr(other)
 
 
-class DriveGroupValidationError(ServiceSpecValidationError):
+class DriveGroupValidationError(SpecValidationError):
     """
     Defining an exception here is a bit problematic, cause you cannot properly catch it,
     if it was raised in a different mgr module.

--- a/src/python-common/ceph/deployment/hostspec.py
+++ b/src/python-common/ceph/deployment/hostspec.py
@@ -1,7 +1,20 @@
+import errno
 try:
     from typing import Optional, List, Any
 except ImportError:
     pass  # just for type checking
+
+
+class SpecValidationError(Exception):
+    """
+    Defining an exception here is a bit problematic, cause you cannot properly catch it,
+    if it was raised in a different mgr module.
+    """
+    def __init__(self,
+                 msg: str,
+                 errno: int = -errno.EINVAL):
+        super(SpecValidationError, self).__init__(msg)
+        self.errno = errno
 
 
 class HostSpec(object):
@@ -38,11 +51,24 @@ class HostSpec(object):
 
     @classmethod
     def from_json(cls, host_spec: dict) -> 'HostSpec':
+        host_spec = cls.normalize_json(host_spec)
         _cls = cls(host_spec['hostname'],
                    host_spec['addr'] if 'addr' in host_spec else None,
                    list(set(host_spec['labels'])) if 'labels' in host_spec else None,
                    host_spec['status'] if 'status' in host_spec else None)
         return _cls
+
+    @staticmethod
+    def normalize_json(host_spec: dict) -> dict:
+        labels = host_spec.get('labels')
+        if labels is None:
+            return host_spec
+        if isinstance(labels, list):
+            return host_spec
+        if not isinstance(labels, str):
+            raise SpecValidationError(f'Labels ({labels}) must be a string or list of strings')
+        host_spec['labels'] = [labels]
+        return host_spec
 
     def __repr__(self) -> str:
         args = [self.hostname]  # type: List[Any]

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -5,9 +5,9 @@ import pytest
 import yaml
 
 from ceph.deployment import drive_selection, translate
-from ceph.deployment.hostspec import HostSpec
+from ceph.deployment.hostspec import HostSpec, SpecValidationError
 from ceph.deployment.inventory import Device
-from ceph.deployment.service_spec import PlacementSpec, ServiceSpecValidationError
+from ceph.deployment.service_spec import PlacementSpec
 from ceph.tests.utils import _mk_inventory, _mk_device
 from ceph.deployment.drive_group import DriveGroupSpec, DeviceSelection, \
     DriveGroupValidationError
@@ -76,7 +76,7 @@ spec:
     ),
 ])
 def test_DriveGroup_fail(match, test_input):
-    with pytest.raises(ServiceSpecValidationError, match=match):
+    with pytest.raises(SpecValidationError, match=match):
         osd_spec = DriveGroupSpec.from_json(yaml.safe_load(test_input))
         osd_spec.validate()
 

--- a/src/python-common/ceph/tests/test_service_spec.py
+++ b/src/python-common/ceph/tests/test_service_spec.py
@@ -5,8 +5,9 @@ import yaml
 import pytest
 
 from ceph.deployment.service_spec import HostPlacementSpec, PlacementSpec, \
-    ServiceSpec, ServiceSpecValidationError, RGWSpec, NFSServiceSpec, IscsiServiceSpec
+    ServiceSpec, RGWSpec, NFSServiceSpec, IscsiServiceSpec
 from ceph.deployment.drive_group import DriveGroupSpec
+from ceph.deployment.hostspec import SpecValidationError
 
 
 @pytest.mark.parametrize("test_input,expected, require_network",
@@ -84,7 +85,7 @@ def test_parse_placement_specs(test_input, expected):
     ]
 )
 def test_parse_placement_specs_raises(test_input):
-    with pytest.raises(ServiceSpecValidationError):
+    with pytest.raises(SpecValidationError):
         PlacementSpec.from_string(test_input)
 
 @pytest.mark.parametrize("test_input",
@@ -331,6 +332,6 @@ def test_service_name(s_type, s_id, s_name):
     ])
 
 def test_service_id_raises_invalid_char(s_type, s_id):
-    with pytest.raises(ServiceSpecValidationError):
+    with pytest.raises(SpecValidationError):
         spec = ServiceSpec.from_json(_get_dict_spec(s_type, s_id))
         spec.validate()


### PR DESCRIPTION
validate that expected lists in specs are actually lists in spec json
allow a single string to be given by converting it into a list containing that string
return error for all other unexpected types

Fixes: https://tracker.ceph.com/issues/50102
Signed-off-by: Daniel Pivonka <dpivonka@redhat.com>