### PR TITLE
cephadm: ignore apparmor if profiles file is empty

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -6400,6 +6400,8 @@ class HostFacts():
                     security['description'] = 'AppArmor: Enabled'
                     try:
                         profiles = read_file(['/sys/kernel/security/apparmor/profiles'])
+                        if len(profiles) == 0:
+                            return {}
                     except OSError:
                         pass
                     else:


### PR DESCRIPTION
If `/sys/kernel/security/apparmor/profiles` happens to be empty, cephadm will end up failing trying to split an empty line. Instead, return an empty dictionary.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>