### PR TITLE
mon/ConfigMonitor: do not indent 'config dump' output

### DIFF
--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -168,17 +168,6 @@ bool ConfigMonitor::preprocess_query(MonOpRequestRef op)
   return false;
 }
 
-static string indent_who(const string& who)
-{
-  if (who == "global") {
-    return who;
-  }
-  if (who.find('.') == string::npos) {
-    return "  " + who;
-  }
-  return "    " + who;
-}
-
 bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
 {
   auto m = op->get_req<MMonCommand>();
@@ -278,7 +267,7 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
     for (auto s : sections) {
       for (auto& i : s.second->options) {
 	if (!f) {
-	  tbl << indent_who(s.first);
+	  tbl << s.first;
 	  tbl << i.second.mask.to_str();
 	  tbl << Option::level_to_str(i.second.opt->level);
           tbl << i.first;


### PR DESCRIPTION
The indentation is misleading.  For example,
```
  mgr                                  advanced  mgr/telemetry/last_opt_revision       3                                                                                  *
  osd                                  advanced  osd_max_backfills                     10
  osd                                  basic     osd_memory_target                     6442450944
  osd                                  advanced  osd_scrub_auto_repair                 true
    mds.ar                             basic     mds_join_fs                           ar
    client.rgw.foo                     basic     rgw_frontends                         beast port=8080                                                                    *
```
The indentation kind of implies that mds.ar (or client.whatever) is
beneath 'osd', which it is not, and there rarely a 'client' scoped
option to make it look right.  Same problem for osd.foo etc.

Also, it is IMO easier to see the nesting structure when things align
naturally. e.g.
```
global
osd
osd.1
osd.2
mds
mds.foo
mds.foo.bar
client.foo.bar
...
```
Signed-off-by: Sage Weil <sage@newdream.net>