### PR TITLE
pacific: win32*.sh: disable libcephsqlite when targeting Windows

### DIFF
--- a/win32_build.sh
+++ b/win32_build.sh
@@ -150,6 +150,7 @@ fi
 # or circular), we'll have to stick to static linking.
 cmake -D CMAKE_PREFIX_PATH=$depsDirs \
       -D CMAKE_TOOLCHAIN_FILE="$MINGW_CMAKE_FILE" \
+      -D WITH_LIBCEPHSQLITE=OFF \
       -D WITH_RDMA=OFF -D WITH_OPENLDAP=OFF \
       -D WITH_GSSAPI=OFF -D WITH_XFS=OFF \
       -D WITH_FUSE=OFF -D WITH_DOKAN=ON \


### PR DESCRIPTION
backport #40428

The Windows build is failing as sqlite can't be retrieved:
http://paste.openstack.org/raw/803940/

We don't support libcephsqlite on Windows for the time being,
so we'll just pass WITH_LIBCEPHSQLITE=OFF.

Signed-off-by: Lucian Petrut <lpetrut@cloudbasesolutions.com>
(cherry picked from commit 03f1dabaea103a84fa9459d28466ddbf3ff363a1)