### PR TITLE
nautilus: common/mempool: only fail tests if sharding is very bad

### DIFF
--- a/src/include/mempool.h
+++ b/src/include/mempool.h
@@ -258,7 +258,7 @@ public:
     // Dirt cheap, see:
     //   https://fossies.org/dox/glibc-2.32/pthread__self_8c_source.html
     size_t me = (size_t)pthread_self();
-    size_t i = (me >> 12) & ((1 << num_shard_bits) - 1);
+    size_t i = (me >> CEPH_PAGE_SHIFT) & ((1 << num_shard_bits) - 1);
     return i;
   }
 

--- a/src/test/test_mempool.cc
+++ b/src/test/test_mempool.cc
@@ -385,7 +385,7 @@ TEST(mempool, bufferlist_c_str)
 
 TEST(mempool, check_shard_select)
 {
-  const size_t samples = 100;
+  const size_t samples = mempool::num_shards * 100;
   std::atomic_int shards[mempool::num_shards] = {0};
   std::vector<std::thread> workers;
   for (size_t i = 0; i < samples; i++) {
@@ -400,15 +400,16 @@ TEST(mempool, check_shard_select)
   }
   workers.clear();
 
-  double EX = (double)samples / (double)mempool::num_shards;
-  double VarX = 0;
+  size_t missed = 0;
   for (size_t i = 0; i < mempool::num_shards; i++) {
-    VarX += (EX - shards[i]) * (EX - shards[i]);
+    if (shards[i] == 0) {
+      missed++;
+    }
   }
-  //random gives VarX below 200
-  //when half slots are 0, we get ~300
-  //when all samples go into one slot, we get ~9000
-  EXPECT_LT(VarX, 200);
+
+  // If more than half of the shards did not get anything,
+  // the distribution is bad enough to deserve a failure.
+  EXPECT_LT(missed, mempool::num_shards / 2);
 }
 
 TEST(mempool, btree_map_test)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49991

---

backport of https://github.com/ceph/ceph/pull/40167
parent tracker: https://tracker.ceph.com/issues/49781

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh