### PR TITLE
pacific: cmake: use --smp 1 --memory 256M to crimson tests

### DIFF
--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -16,7 +16,7 @@ target_link_libraries(unittest-seastar-buffer crimson)
 
 add_executable(unittest-seastar-denc
   test_denc.cc)
-add_ceph_unittest(unittest-seastar-denc)
+add_ceph_unittest(unittest-seastar-denc --memory 256M --smp 1)
 target_link_libraries(unittest-seastar-denc crimson GTest::Main)
 
 add_executable(unittest-seastar-socket test_socket.cc)

--- a/src/test/crimson/seastore/CMakeLists.txt
+++ b/src/test/crimson/seastore/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(
 add_executable(unittest-seastore-journal
   test_seastore_journal.cc)
 add_ceph_test(unittest-seastore-journal
-  unittest-seastore-journal)
+  unittest-seastore-journal --memory 256M --smp 1)
 target_link_libraries(
   unittest-seastore-journal
   crimson::gtest
@@ -32,7 +32,7 @@ add_executable(unittest-seastore-cache
   test_block.cc
   test_seastore_cache.cc)
 add_ceph_test(unittest-seastore-cache
-  unittest-seastore-cache)
+  unittest-seastore-cache --memory 256M --smp 1)
 target_link_libraries(
   unittest-seastore-cache
   crimson::gtest


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/49229

---

to reduce the resource usage when running tests

there is an exception though, as we want to test test_config.cc with
multiple reactors.

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit afdafee74c5d7af89353f903cfd551f6f5defa2b)

Conflicts:
	src/test/crimson/CMakeLists.txt
	src/test/crimson/seastore/CMakeLists.txt
	src/test/crimson/seastore/onode_tree/CMakeLists.txt


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
