### PR TITLE
rgw: adds a preemptive mode to rgw's dynamic resharding

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7220,6 +7220,40 @@ std::vector<Option> get_rgw_options() {
     .add_see_also("rgw_dynamic_resharding")
     .add_see_also("rgw_max_objs_per_shard"),
 
+    Option("rgw_dynamic_resharding_static_shards", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("The target number of shards for any dynamically resharded bucket")
+    .set_long_description(
+        "Dynamic resharding takes linear time to reshard buckets relative the "
+        "number of index entries in that bucket's index. For clusters with an "
+        "exponentially distributed number of entries per bucket and a small "
+        "number of very large buckets, it may be advantageous to focus on "
+        "aggressively resharding buckets once they reach a certain size. This "
+        "helps avoid longer dynamic resharding jobs for large buckets which "
+        "limit bucket availability. Must be used in conjunction with "
+        "rgw_dynamic_resharding_min_object_count and "
+        "rgw_dynamic_resharding_max_object_count to determine a size range for "
+        "resharding.")
+    .add_see_also("rgw_dynamic_resharding")
+    .add_see_also("rgw_dynamic_resharding_min_object_count")
+    .add_see_also("rgw_dynamic_resharding_max_object_count"),
+
+    Option("rgw_dynamic_resharding_min_object_count", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("Minimum number of objects for a dynamic resharding candidate bucket")
+    .set_long_description(
+        "If greater than zero, a bucket must have at least this many objects "
+        "for dynamic resharding to proceed")
+    .add_see_also("rgw_dynamic_resharding_static_shards"),
+
+    Option("rgw_dynamic_resharding_max_object_count", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("Maximum number of objects for a dynamic resharding candidate bucket")
+    .set_long_description(
+        "If greater than zero, a bucket must have less than this number of "
+        "objects for dynamic resharding to proceed")
+    .add_see_also("rgw_dynamic_resharding_static_shards"),
+
     Option("rgw_reshard_thread_interval", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(10_min)
     .set_min(10)

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -995,6 +995,16 @@ public:
       need_resharding = false;
     }
   }
+
+  void check_bucket_shards_static(uint64_t min_bucket_objs, uint64_t max_bucket_objs, uint64_t num_shards,
+                                  uint64_t num_objs, bool& need_resharding, uint64_t configured_shards) override
+  {
+    if (num_objs  >= min_bucket_objs && num_objs <= max_bucket_objs) {
+      need_resharding = num_shards != configured_shards;
+    } else {
+      need_resharding = false;
+    }
+  }
 };
 
 

--- a/src/rgw/rgw_quota.h
+++ b/src/rgw/rgw_quota.h
@@ -113,6 +113,9 @@ public:
   virtual void check_bucket_shards(uint64_t max_objs_per_shard, uint64_t num_shards,
 				   uint64_t num_objs, bool& need_resharding, uint32_t *suggested_num_shards) = 0;
 
+  virtual void check_bucket_shards_static(uint64_t min_bucket_objs, uint64_t max_bucket_objs, uint64_t num_shards,
+                                          uint64_t num_objs, bool& need_resharding, uint64_t configured_shards) = 0;
+
   virtual void update_stats(const rgw_user& bucket_owner, rgw_bucket& bucket, int obj_delta, uint64_t added_bytes, uint64_t removed_bytes) = 0;
 
   static RGWQuotaHandler *generate_handler(rgw::sal::RGWStore *store, bool quota_threads);


### PR DESCRIPTION
There's a longer description in the commit message, but tldr: this patch adds some configuration options to have dynamic resharding work on buckets within a certain range of object counts, resharding them to a specified, static number of shards. This is a bit of a special case, and I'm not sure if upstream would like to add yet another dimension of configuration to RGW, but at least one team member thought you folks might find this interesting. Happy to answer any questions and go into further detail about our use case. If this does look like something worth merging, I'd be happy to add a section to the dynamic resharding docs too.

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
