### PR TITLE
cephadm: normalize repo digests

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -52,6 +52,7 @@ DEFAULT_PROMETHEUS_IMAGE = 'docker.io/prom/prometheus:v2.18.1'
 DEFAULT_NODE_EXPORTER_IMAGE = 'docker.io/prom/node-exporter:v0.18.1'
 DEFAULT_GRAFANA_IMAGE = 'docker.io/ceph/ceph-grafana:6.7.4'
 DEFAULT_ALERT_MANAGER_IMAGE = 'docker.io/prom/alertmanager:v0.20.0'
+DEFAULT_REGISTRY = 'docker.io'   # normalize unqualified digests to this
 # ------------------------------------------------------------------------------
 
 LATEST_STABLE_RELEASE = 'pacific'
@@ -3246,6 +3247,20 @@ def command_inspect_image(ctx):
     return 0
 
 
+def normalize_image_digest(digest):
+    # normal case:
+    #   ceph/ceph -> docker.io/ceph/ceph
+    # edge cases that shouldn't ever come up:
+    #   ubuntu -> docker.io/ubuntu    (ubuntu alias for library/ubuntu)
+    # no change:
+    #   quay.ceph.io/ceph/ceph -> ceph
+    #   docker.io/ubuntu -> no change
+    bits = digest.split('/')
+    if '.' not in bits[0] or len(bits) < 3:
+        digest = DEFAULT_REGISTRY + '/' + digest
+    return digest
+
+
 def get_image_info_from_inspect(out, image):
     # type: (str, str) -> Dict[str, Union[str,List[str]]]
     image_id, digests = out.split(',', 1)
@@ -3255,7 +3270,7 @@ def get_image_info_from_inspect(out, image):
         'image_id': normalize_container_id(image_id)
     }  # type: Dict[str, Union[str,List[str]]]
     if digests:
-        r['repo_digests'] = digests[1:-1].split(' ')
+        r['repo_digests'] = list(map(normalize_image_digest, digests[1:-1].split(' ')))
     return r
 
 ##################################

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -313,6 +313,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             default=False,
             desc='Enable or disable the cephadm configuration analysis',
         ),
+        Option(
+            'default_registry',
+            type='str',
+            default='docker.io',
+            desc='Registry to which we should normalize unqualified image names',
+        ),
     ]
 
     def __init__(self, *args: Any, **kwargs: Any):
@@ -357,6 +363,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.registry_username: Optional[str] = None
             self.registry_password: Optional[str] = None
             self.use_repo_digest = True
+            self.default_registry = ''
 
         self._cons: Dict[str, Tuple[remoto.backends.BaseConnection,
                                     remoto.backends.LegacyModuleExecute]] = {}

--- a/src/pybind/mgr/cephadm/tests/test_upgrade.py
+++ b/src/pybind/mgr/cephadm/tests/test_upgrade.py
@@ -14,16 +14,16 @@ from .fixtures import _run_cephadm, wait, with_host, with_service
 def test_upgrade_start(cephadm_module: CephadmOrchestrator):
     with with_host(cephadm_module, 'test'):
         assert wait(cephadm_module, cephadm_module.upgrade_start(
-            'image_id', None)) == 'Initiating upgrade to image_id'
+            'image_id', None)) == 'Initiating upgrade to docker.io/image_id'
 
-        assert wait(cephadm_module, cephadm_module.upgrade_status()).target_image == 'image_id'
+        assert wait(cephadm_module, cephadm_module.upgrade_status()).target_image == 'docker.io/image_id'
 
-        assert wait(cephadm_module, cephadm_module.upgrade_pause()) == 'Paused upgrade to image_id'
+        assert wait(cephadm_module, cephadm_module.upgrade_pause()) == 'Paused upgrade to docker.io/image_id'
 
         assert wait(cephadm_module, cephadm_module.upgrade_resume()
-                    ) == 'Resumed upgrade to image_id'
+                    ) == 'Resumed upgrade to docker.io/image_id'
 
-        assert wait(cephadm_module, cephadm_module.upgrade_stop()) == 'Stopped upgrade to image_id'
+        assert wait(cephadm_module, cephadm_module.upgrade_stop()) == 'Stopped upgrade to docker.io/image_id'
 
 
 @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
@@ -50,10 +50,10 @@ def test_upgrade_run(use_repo_digest, cephadm_module: CephadmOrchestrator):
                            }):
                 version_mock.return_value = 'ceph version 18.2.1 (somehash)'
                 assert wait(cephadm_module, cephadm_module.upgrade_start(
-                    'to_image', None)) == 'Initiating upgrade to to_image'
+                    'to_image', None)) == 'Initiating upgrade to docker.io/to_image'
 
                 assert wait(cephadm_module, cephadm_module.upgrade_status()
-                            ).target_image == 'to_image'
+                            ).target_image == 'docker.io/to_image'
 
                 def _versions_mock(cmd):
                     return json.dumps({
@@ -106,7 +106,7 @@ def test_upgrade_run(use_repo_digest, cephadm_module: CephadmOrchestrator):
                 if use_repo_digest:
                     assert image == 'to_image@repo_digest'
                 else:
-                    assert image == 'to_image'
+                    assert image == 'docker.io/to_image'
 
 
 def test_upgrade_state_null(cephadm_module: CephadmOrchestrator):


### PR DESCRIPTION
A RepoDigests returned by docker|podman image inspect can either include
the docker.io/ prefix or not.  For reasons that aren't entirely clear,
this may vary between hosts in a cluster.  However, ceph/ceph@sha256:abc...
is the same thing as docker.io/ceph/ceph@sha256:abc..., and should be
treated as such.  Otherwise, upgrade can get into a loop where it pulls
the image on a new host, finds the other variant of the repodigests,
sees no overlap, updates target_digests, and restarts.  (It will then
find the first variant again on the first host and loop.)

Avoid this by normalizing any docker.io digests by always including the
docker.io/ prefix.

Fixes: https://tracker.ceph.com/issues/50114



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>