### PR TITLE
rpm: make ceph-common own the new denc directory

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1591,6 +1591,7 @@ exit 0
 %{_bindir}/rbd-replay-prep
 %endif
 %{_bindir}/ceph-post-file
+%dir {_libdir}/ceph/denc/
 %{_libdir}/ceph/denc/denc-mod-*.so
 %{_tmpfilesdir}/ceph-common.conf
 %{_mandir}/man8/ceph-authtool.8*


### PR DESCRIPTION
2d3c6561b4ac1473a728e81c232d7dfe6fc0188c introduced a new library directory
"%{_libdir}/ceph/denc/" in ceph-common but did not explicitly state that it
should be owned by the package. This caused OBS builds to fail as follows:

[ 5515s] ceph-common-17.0.0-2786.1.x86_64.rpm: directories not owned by a package:
[ 5515s]  - /usr/lib64/ceph/denc

Fixes: 2d3c6561b4ac1473a728e81c232d7dfe6fc0188c
Signed-off-by: Nathan Cutler <ncutler@suse.com>