### PR TITLE
rgw/multisite: handle case when empty marker is provided

### DIFF
--- a/src/rgw/rgw_log_backing.h
+++ b/src/rgw/rgw_log_backing.h
@@ -251,7 +251,7 @@ cursorgen(std::string_view cursor_) {
 
 inline std::pair<uint64_t, std::string_view>
 cursorgeno(std::optional<std::string_view> cursor) {
-  if (cursor) {
+  if (cursor && !cursor->empty()) {
     return cursorgen(*cursor);
   } else {
     return { 0, ""s };


### PR DESCRIPTION
marker is potional, however, it may also be provided empty

Fixes: https://tracker.ceph.com/issues/50135

Signed-off-by: Yuval Lifshitz <ylifshit@redhat.com>

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
