### PR TITLE
qa/tasks/ceph.conf: shorten cephx TTL for testing

### DIFF
--- a/qa/tasks/ceph.conf.template
+++ b/qa/tasks/ceph.conf.template
@@ -91,6 +91,10 @@
 	mon osd prime pg temp = true
 	mon reweight min bytes per osd = 10
 
+	# rotate auth tickets quickly to exercise renewal paths
+	auth mon ticket ttl = 660      # 11m
+	auth service ticket ttl = 240  # 4m
+
 [client]
 	rgw cache enabled = true
 	rgw enable ops log = true

--- a/qa/tasks/cephadm.conf
+++ b/qa/tasks/cephadm.conf
@@ -73,6 +73,10 @@ mon osd reporter subtree level = osd
 mon osd prime pg temp = true
 mon reweight min bytes per osd = 10
 
+# rotate auth tickets quickly to exercise renewal paths
+auth mon ticket ttl = 660      # 11m
+auth service ticket ttl = 240  # 4m
+
 [client.rgw]
 rgw cache enabled = true
 rgw enable ops log = true


### PR DESCRIPTION
Rotate tickets frequently to exercise those code paths during testing.

Signed-off-by: Sage Weil <sage@newdream.net>