### PR TITLE
nautilus: mgr/dashboard: python 2: fix error when non-ASCII password

### DIFF
--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -21,24 +21,21 @@ from ..exceptions import RoleAlreadyExists, RoleDoesNotExist, ScopeNotValid, \
                          RoleNotInUser
 
 
-# replicates tools.ensure_str() to avoid recursive import:
-# ..tools -> .services.auth -> .access_control -> ..tools
-def ensure_str(s, encoding='utf-8', errors='strict'):
+def ensure_text(s, encoding='utf-8', errors='strict'):
     """Ported from six."""
-    if not isinstance(s, (six.text_type, six.binary_type)):
+    if isinstance(s, six.binary_type):
+        return s.decode(encoding, errors)
+    elif isinstance(s, six.text_type):
+        return s
+    else:
         raise TypeError("not expecting type '%s'" % type(s))
-    if six.PY2 and isinstance(s, six.text_type):
-        s = s.encode(encoding, errors)
-    elif six.PY3 and isinstance(s, six.binary_type):
-        s = s.decode(encoding, errors)
-    return s
 
 
 # password hashing algorithm
 def password_hash(password, salt_password=None):
     if not password:
         return None
-    password = ensure_str(password)
+    password = ensure_text(password)
     if not salt_password:
         salt_password = bcrypt.gensalt()
     else:

--- a/src/pybind/mgr/dashboard/tests/test_access_control.py
+++ b/src/pybind/mgr/dashboard/tests/test_access_control.py
@@ -13,7 +13,8 @@ from mgr_module import ERROR_MSG_EMPTY_INPUT_FILE
 from . import CmdException, CLICommandTestMixin
 from .. import mgr
 from ..security import Scope, Permission
-from ..services.access_control import load_access_control_db, \
+from ..services.access_control import ensure_text, \
+                                      load_access_control_db, \
                                       password_hash, AccessControlDB, \
                                       SYSTEM_ROLES
 
@@ -571,9 +572,9 @@ class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
 
     def test_unicode_password(self):
         self.test_create_user()
-        password = '章鱼不是密码'
+        password = ensure_text('章鱼不是密码')
         user = self.exec_cmd('ac-user-set-password', username='admin',
-                             inbuf=password.encode(), force_password=True)
+                             inbuf=password.encode('utf-8'), force_password=True)
         pass_hash = password_hash(password, user['password'])
         self.assertEqual(user['password'], pass_hash)
 


### PR DESCRIPTION
After https://github.com/ceph/ceph/pull/40522 there is a regression for py2 when setting non-ASCII password.

Instead of using ```six.ensure_str``` port we use ```six.ensure_text``` port as per this comment in the original fix:
https://github.com/ceph/ceph/pull/39441#discussion_r576146122

Fixes: https://tracker.ceph.com/issues/50155

Signed-off-by: Alfonso Martínez <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
