### PR TITLE
pacific: qa/tasks/vstart_runner.py: start max required mgrs

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -434,6 +434,7 @@ class LocalRemote(object):
                                        stderr=subprocess.PIPE,
                                        stdin=subprocess.PIPE,
                                        cwd=cwd,
+                                       env=env,
                                        shell=True)
         else:
             # Sanity check that we've got a list of strings


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50145

---

backport of https://github.com/ceph/ceph/pull/40519
parent tracker: https://tracker.ceph.com/issues/50077

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh