### PR TITLE
make-dist: refuse to run if script path contains a colon

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -1,7 +1,21 @@
 #!/bin/bash -e
 
+SCRIPTNAME="$(basename "${0}")"
+BASEDIR="$(readlink -f "$(dirname "${0}")")"
+
 if [ ! -d .git ]; then
-    echo "no .git present.  run this from the base dir of the git checkout."
+    echo "$SCRIPTNAME: Full path to the script: $BASEDIR/$SCRIPTNAME"
+    echo "$SCRIPTNAME: No .git present. Run this from the base dir of the git checkout."
+    exit 1
+fi
+
+# Running the script from a directory containing a colon anywhere in the path
+# will expose us to the dreaded "[BUG] npm run [command] failed if the directory
+# path contains colon" bug https://github.com/npm/cli/issues/633
+# (see https://tracker.ceph.com/issues/39556 for details)
+if [[ "$BASEDIR" == *:* ]] ; then
+    echo "$SCRIPTNAME: Full path to the script: $BASEDIR/$SCRIPTNAME"
+    echo "$SCRIPTNAME: The path to the script contains a colon. Their presence has been known to break the script."
     exit 1
 fi
 


### PR DESCRIPTION
Colons are not permissible in POSIX paths and their presence is known to break
the script.

Fixes: https://tracker.ceph.com/issues/39556
Signed-off-by: Nathan Cutler <ncutler@suse.com>