### PR TITLE
doc/_themes: fix the styling of section header

### DIFF
--- a/doc/_themes/ceph/static/ceph.css_t
+++ b/doc/_themes/ceph/static/ceph.css_t
@@ -41,12 +41,12 @@ body {
   font-size: 0.9em;
 }
 
-div.section h1,
-div.section h2,
-div.section h3,
-div.section h4,
-div.section h5,
-div.section h6 {
+section h1,
+section h2,
+section h3,
+section h4,
+section h5,
+section h6 {
   font-weight: normal;
   margin: 30px 0px 10px 0px;
   padding: 5px 0 5px 10px;
@@ -54,16 +54,16 @@ div.section h6 {
   text-transform: uppercase;
 }
 
-div.section h1 {
+section h1 {
   border-top: 20px solid white; margin-top: 0;
 }
 
-div.section h1 { font-family: Titillium Web; font-size: 200%; background-color: #99DAE3;}
-div.section h2 { font-family: Titillium Web; font-size: 150%; background-color: #B2E3EA; }
-div.section h3 { font-family: Titillium Web; font-size: 120%; background-color: #CCECF1; }
-div.section h4 { font-family: Helvetica, Arial, sans-serif; font-size: 110%; background-color: #CCECF1; }
-div.section h5 { font-family: Helvetica, Arial, sans-serif; font-size: 100%; background-color: #CCECF1; }
-div.section h6 { font-family: Helvetica, Arial, sans-serif; font-size: 100%; background-color: #CCECF1; }
+section h1 { font-family: Titillium Web; font-size: 200%; background-color: #99DAE3;}
+section h2 { font-family: Titillium Web; font-size: 150%; background-color: #B2E3EA; }
+section h3 { font-family: Titillium Web; font-size: 120%; background-color: #CCECF1; }
+section h4 { font-family: Helvetica, Arial, sans-serif; font-size: 110%; background-color: #CCECF1; }
+section h5 { font-family: Helvetica, Arial, sans-serif; font-size: 100%; background-color: #CCECF1; }
+section h6 { font-family: Helvetica, Arial, sans-serif; font-size: 100%; background-color: #CCECF1; }
 
 /* nature theme */
 div.highlight {
@@ -135,6 +135,11 @@ html.writer-html5 .rst-content table.docutils th,
 
 .rst-content table.docutils ul + ul {
   margin-top: 1em;
+}
+
+.rst-content section ul li {
+  list-style: disc;
+  margin-left: 24px;
 }
 
 /* versions */


### PR DESCRIPTION
in the latest document generated from RtD, the section headers are now
in `<section>` tags instead of `<div class="section">`, so update the css
accordingly.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
