### PR TITLE
nautilus: cmake: set empty RPATH for some test executables

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -401,7 +401,7 @@ target_link_libraries(ceph-common ${ceph_common_deps})
 # appease dpkg-shlibdeps
 set_target_properties(ceph-common PROPERTIES
   SOVERSION 0
-  INSTALL_RPATH "")
+  SKIP_RPATH TRUE)
 if(NOT APPLE AND NOT FREEBSD)
   # Apple uses Mach-O, not ELF. so this option does not apply to APPLE.
   #

--- a/src/test/mon/CMakeLists.txt
+++ b/src/test/mon/CMakeLists.txt
@@ -49,24 +49,19 @@ target_link_libraries(unittest_mon_montypes mon global)
 
 # ceph_test_mon_memory_target
 add_executable(ceph_test_mon_memory_target
-  test_mon_memory_target.cc
-  )
-target_link_libraries(ceph_test_mon_memory_target ${UNITTEST_LIBS} Boost::system)
+  test_mon_memory_target.cc)
+target_link_libraries(ceph_test_mon_memory_target Boost::system Threads::Threads)
 install(TARGETS ceph_test_mon_memory_target
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ceph_test_mon_log_rss_usage
 add_executable(ceph_test_log_rss_usage
-  test_log_rss_usage.cc
-  )
-target_link_libraries(ceph_test_log_rss_usage ${UNITTEST_LIBS})
+  test_log_rss_usage.cc)
 install(TARGETS ceph_test_log_rss_usage
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ceph_test_mon_rss_usage
 add_executable(ceph_test_mon_rss_usage
-  test_mon_rss_usage.cc
-  )
-target_link_libraries(ceph_test_mon_rss_usage ${UNITTEST_LIBS})
+  test_mon_rss_usage.cc)
 install(TARGETS ceph_test_mon_rss_usage
   DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/mon/CMakeLists.txt
+++ b/src/test/mon/CMakeLists.txt
@@ -52,7 +52,8 @@ add_executable(ceph_test_mon_memory_target
   test_mon_memory_target.cc)
 target_link_libraries(ceph_test_mon_memory_target Boost::system Threads::Threads)
 set_target_properties(ceph_test_mon_memory_target PROPERTIES
-  SKIP_RPATH TRUE)
+  SKIP_RPATH TRUE
+  INSTALL_RPATH "")
 install(TARGETS ceph_test_mon_memory_target
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 
@@ -60,7 +61,8 @@ install(TARGETS ceph_test_mon_memory_target
 add_executable(ceph_test_log_rss_usage
   test_log_rss_usage.cc)
 set_target_properties(ceph_test_log_rss_usage PROPERTIES
-  SKIP_RPATH TRUE)
+  SKIP_RPATH TRUE
+  INSTALL_RPATH "")
 install(TARGETS ceph_test_log_rss_usage
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 
@@ -68,6 +70,7 @@ install(TARGETS ceph_test_log_rss_usage
 add_executable(ceph_test_mon_rss_usage
   test_mon_rss_usage.cc)
 set_target_properties(ceph_test_mon_rss_usage PROPERTIES
-  SKIP_RPATH TRUE)
+  SKIP_RPATH TRUE
+  INSTALL_RPATH "")
 install(TARGETS ceph_test_mon_rss_usage
   DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/mon/CMakeLists.txt
+++ b/src/test/mon/CMakeLists.txt
@@ -51,17 +51,23 @@ target_link_libraries(unittest_mon_montypes mon global)
 add_executable(ceph_test_mon_memory_target
   test_mon_memory_target.cc)
 target_link_libraries(ceph_test_mon_memory_target Boost::system Threads::Threads)
+set_target_properties(ceph_test_mon_memory_target PROPERTIES
+  SKIP_RPATH TRUE)
 install(TARGETS ceph_test_mon_memory_target
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ceph_test_mon_log_rss_usage
 add_executable(ceph_test_log_rss_usage
   test_log_rss_usage.cc)
+set_target_properties(ceph_test_log_rss_usage PROPERTIES
+  SKIP_RPATH TRUE)
 install(TARGETS ceph_test_log_rss_usage
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ceph_test_mon_rss_usage
 add_executable(ceph_test_mon_rss_usage
   test_mon_rss_usage.cc)
+set_target_properties(ceph_test_mon_rss_usage PROPERTIES
+  SKIP_RPATH TRUE)
 install(TARGETS ceph_test_mon_rss_usage
   DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50164

---

backport of 

* https://github.com/ceph/ceph/pull/29922
* https://github.com/ceph/ceph/pull/30028

parent tracker: https://tracker.ceph.com/issues/41524

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh