### PR TITLE
mgr/dashboard: Revoke read-only user's access to Manager modules 

### DIFF
--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -217,9 +217,10 @@ ADMIN_ROLE = Role(
 
 # read-only role provides read-only permission for all scopes
 READ_ONLY_ROLE = Role(
-    'read-only', 'allows read permission for all security scopes except dashboard settings', {
+    'read-only',
+    'allows read permission for all security scope except dashboard settings and config-opt', {
         scope_name: [_P.READ] for scope_name in Scope.all_scopes()
-        if scope_name != Scope.DASHBOARD_SETTINGS
+        if scope_name not in (Scope.DASHBOARD_SETTINGS, Scope.CONFIG_OPT)
     })
 
 
@@ -246,7 +247,7 @@ RGW_MGR_ROLE = Role(
 # Config options
 CLUSTER_MGR_ROLE = Role(
     'cluster-manager', """allows full permissions for the hosts, osd, mon, mgr,
-    and config-opt scopes.""", {
+    and config-opt scopes""", {
         Scope.HOSTS: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
         Scope.OSD: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
         Scope.MONITOR: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],

--- a/src/pybind/mgr/dashboard/tests/test_access_control.py
+++ b/src/pybind/mgr/dashboard/tests/test_access_control.py
@@ -154,8 +154,10 @@ class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
     def test_show_system_role(self):
         role = self.exec_cmd('ac-role-show', rolename="read-only")
         self.assertEqual(role['name'], 'read-only')
-        self.assertEqual(role['description'],
-                         'allows read permission for all security scopes except dashboard settings')
+        self.assertEqual(
+            role['description'],
+            'allows read permission for all security scope except dashboard settings and config-opt'
+        )
 
     def test_delete_system_role(self):
         with self.assertRaises(CmdException) as ctx:


### PR DESCRIPTION
This will disable read only user to read/open Manager Modules page in
Ceph Dashboard where some of the security related informations are
shown.

Fixes: https://tracker.ceph.com/issues/50174
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
