### PR TITLE
rgw/test: Changing force-branch to master

### DIFF
--- a/qa/suites/rgw/notifications/tasks/test_kafka.yaml
+++ b/qa/suites/rgw/notifications/tasks/test_kafka.yaml
@@ -5,6 +5,5 @@ tasks:
       kafka_version: 2.6.0
 - notification-tests:
     client.0:
-      force-branch: wip-rgw-bucket-tests-separation-new
+      force-branch: master
       rgw_server: client.0
-      git_remote: https://github.com/TRYTOBE8TME/

--- a/qa/tasks/kafka.py
+++ b/qa/tasks/kafka.py
@@ -56,6 +56,10 @@ def install_kafka(ctx, config):
         current_version = get_kafka_version(config)
         for client in config:
             ctx.cluster.only(client).run(
+                args=['rm', '-rf', '{tdir}/logs'.format(tdir=test_dir)],
+            )
+
+            ctx.cluster.only(client).run(
                 args=['rm', '-rf', test_dir],
             )
 


### PR DESCRIPTION
This PR includes changing force-branch to master and removing the git-remote. This change was forgetten for PR #39139.

Signed-off-by: Kalpesh Pandya <kapandya@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
