### PR TITLE
pacific: cephfs: minor ceph-dokan improvements

### DIFF
--- a/doc/cephfs/ceph-dokan.rst
+++ b/doc/cephfs/ceph-dokan.rst
@@ -32,6 +32,14 @@ changed using the following ``ceph.conf`` options::
 
 Please use ``ceph-dokan --help`` for a full list of arguments.
 
+The mount can be removed by either issuing ctrl-c or using the unmap command,
+like so::
+
+    ceph-dokan.exe unmap -l x
+
+Note that when unmapping Ceph filesystems, the exact same mountpoint argument
+must be used as when the mapping was created.
+
 Credentials
 -----------
 

--- a/doc/cephfs/ceph-dokan.rst
+++ b/doc/cephfs/ceph-dokan.rst
@@ -11,6 +11,9 @@ Please check the `installation guide`_ to get started.
 Usage
 =====
 
+Mounting filesystems
+--------------------
+
 In order to mount a ceph filesystem, the following command can be used::
 
     ceph-dokan.exe -c c:\ceph.conf -l x
@@ -30,15 +33,28 @@ changed using the following ``ceph.conf`` options::
     client_mount_uid = 1000
     client_mount_gid = 1000
 
+If you have more than one FS on your Ceph cluster, use the option
+``--client_fs`` to mount the non-default FS::
+
+    mkdir -Force C:\mnt\mycephfs2
+    ceph-dokan.exe --mountpoint C:\mnt\mycephfs2 --client_fs mycephfs2
+
+CephFS subdirectories can be mounted using the ``--root-path`` parameter::
+
+    ceph-dokan -l y --root-path /a
+
+If the ``-o --removable`` flags are set, the mounts will show up in the
+``Get-Volume`` results::
+
+    PS C:\> Get-Volume -FriendlyName "Ceph*" | `
+            Select-Object -Property @("DriveLetter", "Filesystem", "FilesystemLabel")
+
+    DriveLetter Filesystem FilesystemLabel
+    ----------- ---------- ---------------
+              Z Ceph       Ceph
+              W Ceph       Ceph - new_fs
+
 Please use ``ceph-dokan --help`` for a full list of arguments.
-
-The mount can be removed by either issuing ctrl-c or using the unmap command,
-like so::
-
-    ceph-dokan.exe unmap -l x
-
-Note that when unmapping Ceph filesystems, the exact same mountpoint argument
-must be used as when the mapping was created.
 
 Credentials
 -----------
@@ -48,6 +64,17 @@ use for mounting CephFS. The following commands are equivalent::
 
     ceph-dokan --id foo -l x
     ceph-dokan --name client.foo -l x
+
+Unmounting filesystems
+----------------------
+
+The mount can be removed by either issuing ctrl-c or using the unmap command,
+like so::
+
+    ceph-dokan.exe unmap -l x
+
+Note that when unmapping Ceph filesystems, the exact same mountpoint argument
+must be used as when the mapping was created.
 
 Limitations
 -----------

--- a/src/dokan/ceph_dokan.cc
+++ b/src/dokan/ceph_dokan.cc
@@ -950,7 +950,7 @@ int do_map() {
   }
 
   atexit(unmount_atexit);
-  dout(0) << "Mounted cephfs directory: " << ceph_getcwd(cmount)
+  dout(0) << "Mounted cephfs directory: " << g_cfg->root_path.c_str()
           <<". Mountpoint: " << to_string(g_cfg->mountpoint) << dendl;
 
   DWORD status = DokanMain(dokan_options, dokan_operations);

--- a/src/dokan/ceph_dokan.h
+++ b/src/dokan/ceph_dokan.h
@@ -36,12 +36,13 @@ struct Config {
 
 extern Config *g_cfg;
 
-// TODO: list and unmap commands.
+// TODO: list and service commands.
 enum class Command {
   None,
   Version,
   Help,
   Map,
+  Unmap,
 };
 
 void print_usage();

--- a/src/dokan/ceph_dokan.h
+++ b/src/dokan/ceph_dokan.h
@@ -32,6 +32,9 @@ struct Config {
 
   std::wstring mountpoint = L"";
   std::string root_path = "";
+
+  std::wstring win_vol_name = L"";
+  unsigned long win_vol_serial = 0;
 };
 
 extern Config *g_cfg;

--- a/src/dokan/ceph_dokan.h
+++ b/src/dokan/ceph_dokan.h
@@ -31,7 +31,7 @@ struct Config {
   int thread_count = CEPH_DOKAN_DEFAULT_THREAD_COUNT;
 
   std::wstring mountpoint = L"";
-  std::string root_path = "";
+  std::string root_path = "/";
 
   std::wstring win_vol_name = L"";
   unsigned long win_vol_serial = 0;

--- a/src/dokan/options.cc
+++ b/src/dokan/options.cc
@@ -21,7 +21,9 @@
 
 void print_usage() {
   const char* usage_str = R"(
-Usage: ceph-dokan.exe -l <drive_letter>
+Usage: ceph-dokan.exe -l <mountpoint>
+                      map -l <mountpoint>    Map a CephFS filesystem
+                      unmap -l <mountpoint>  Unmap a CephFS filesystem
 
 Map options:
   -l [ --mountpoint ] arg     mountpoint (path or drive letter) (e.g -l x)
@@ -37,6 +39,11 @@ Map options:
   -o [ --win-mount-mgr]       use the Windows mount manager
   --current-session-only      expose the mount only to the current user session
   -m [ --removable ]          use a removable drive
+
+Unmap options:
+  -l [ --mountpoint ] arg     mountpoint (path or drive letter) (e.g -l x).
+                              It has to be the exact same mountpoint that was
+                              used when the mapping was created.
 
 Common Options:
 )";
@@ -138,6 +145,8 @@ int parse_args(
       cmd = Command::Version;
     } else if (strcmp(*args.begin(), "map") == 0) {
       cmd = Command::Map;
+    } else if (strcmp(*args.begin(), "unmap") == 0) {
+      cmd = Command::Unmap;
     } else {
       *err_msg << "ceph-dokan: unknown command: " <<  *args.begin();
       return -EINVAL;
@@ -151,6 +160,7 @@ int parse_args(
 
   switch (cmd) {
     case Command::Map:
+    case Command::Unmap:
       if (cfg->mountpoint.empty()) {
         *err_msg << "ceph-dokan: missing mountpoint.";
         return -EINVAL;

--- a/src/dokan/options.cc
+++ b/src/dokan/options.cc
@@ -39,6 +39,7 @@ Map options:
   -o [ --win-mount-mgr]       use the Windows mount manager
   --current-session-only      expose the mount only to the current user session
   -m [ --removable ]          use a removable drive
+  --win-vol-name arg          The Windows volume name. Default: Ceph - <fs_name>.
 
 Unmap options:
   -l [ --mountpoint ] arg     mountpoint (path or drive letter) (e.g -l x).
@@ -82,6 +83,7 @@ int parse_args(
   std::vector<const char*>::iterator i;
   std::ostringstream err;
   std::string mountpoint;
+  std::string win_vol_name;
 
   for (i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
@@ -104,6 +106,9 @@ int parse_args(
       cfg->removable = true;
     } else if (ceph_argparse_flag(args, i, "--win-mount-mgr", "-o", (char *)NULL)) {
       cfg->use_win_mount_mgr = true;
+    } else if (ceph_argparse_witharg(args, i, &win_vol_name,
+                                     "--win-vol-name", (char *)NULL)) {
+      cfg->win_vol_name = to_wstring(win_vol_name);
     } else if (ceph_argparse_flag(args, i, "--current-session-only", (char *)NULL)) {
       cfg->current_session_only = true;
     } else if (ceph_argparse_witharg(args, i, (int*)&cfg->thread_count,

--- a/src/dokan/options.cc
+++ b/src/dokan/options.cc
@@ -38,7 +38,7 @@ Map options:
   --read-only                 read-only mount
   -o [ --win-mount-mgr]       use the Windows mount manager
   --current-session-only      expose the mount only to the current user session
-  -m [ --removable ]          use a removable drive
+  --removable                 use a removable drive
   --win-vol-name arg          The Windows volume name. Default: Ceph - <fs_name>.
 
 Unmap options:
@@ -102,7 +102,7 @@ int parse_args(
       cfg->dokan_stderr = true;
     } else if (ceph_argparse_flag(args, i, "--read-only", (char *)NULL)) {
       cfg->readonly = true;
-    } else if (ceph_argparse_flag(args, i, "--removable", "-m", (char *)NULL)) {
+    } else if (ceph_argparse_flag(args, i, "--removable", (char *)NULL)) {
       cfg->removable = true;
     } else if (ceph_argparse_flag(args, i, "--win-mount-mgr", "-o", (char *)NULL)) {
       cfg->use_win_mount_mgr = true;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50187

---

backport of https://github.com/ceph/ceph/pull/39939
parent tracker: https://tracker.ceph.com/issues/49662

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh