### PR TITLE
pacific: ceph-fuse: src/include/buffer.h: 1187: FAILED ceph_assert(_num <= 1024)

### DIFF
--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -673,6 +673,9 @@ static void fuse_ll_read(fuse_req_t req, fuse_ino_t ino, size_t size, off_t off,
     size_t len;
     struct fuse_bufvec *bufv;
 
+    if (bl.get_num_buffers() > IOV_MAX)
+      bl.rebuild();
+
     bl.prepare_iov(&iov);
     len = sizeof(struct fuse_bufvec) + sizeof(struct fuse_buf) * (iov.size() - 1);
     bufv = (struct fuse_bufvec *)calloc(1, len);


### PR DESCRIPTION
https://tracker.ceph.com/issues/50022