### PR TITLE
mgr/prometheus:Improve the pool metadata

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -13,7 +13,7 @@ from mgr_util import get_default_addr, profile_method
 from rbd import RBD
 from collections import namedtuple
 try:
-    from typing import DefaultDict, Optional, Dict, Any, List, Set, Tuple, Union, cast
+    from typing import DefaultDict, Optional, Dict, Any, Set, cast, Tuple, Union, List
 except ImportError:
     pass
 
@@ -68,7 +68,7 @@ DF_CLUSTER = ['total_bytes', 'total_used_bytes', 'total_used_raw_bytes']
 
 DF_POOL = ['max_avail', 'stored', 'stored_raw', 'objects', 'dirty',
            'quota_bytes', 'quota_objects', 'rd', 'rd_bytes', 'wr', 'wr_bytes',
-           'compress_bytes_used', 'compress_under_bytes']
+           'compress_bytes_used', 'compress_under_bytes', 'bytes_used', 'percent_used']
 
 OSD_POOL_STATS = ('recovering_objects_per_sec', 'recovering_bytes_per_sec',
                   'recovering_keys_per_sec', 'num_objects_recovered',
@@ -101,7 +101,7 @@ OSD_STATUS = ['weight', 'up', 'in']
 
 OSD_STATS = ['apply_latency_ms', 'commit_latency_ms']
 
-POOL_METADATA = ('pool_id', 'name')
+POOL_METADATA = ('pool_id', 'name', 'type', 'description', 'compression_mode')
 
 RGW_METADATA = ('ceph_daemon', 'hostname', 'ceph_version')
 
@@ -125,7 +125,8 @@ class Metric(object):
         self.name = name
         self.desc = desc
         self.labelnames = labels    # tuple if present
-        self.value: Dict[Tuple[str, ...], Union[float, int]] = {}             # indexed by label values
+        self.value: Dict[Tuple[str, ...], Union[float, int]
+                         ] = {}             # indexed by label values
 
     def clear(self) -> None:
         self.value = {}
@@ -820,9 +821,42 @@ class Module(MgrModule):
                 self.log.info("Missing dev node metadata for osd {0}, skipping "
                               "occupation record for this osd".format(id_))
 
+        ec_profiles = osd_map.get('erasure_code_profiles', {})
+
+        def _get_pool_info(pool: Dict[str, Any]) -> Tuple[str, str]:
+            pool_type = 'unknown'
+            description = 'unknown'
+
+            if pool['type'] == 1:
+                pool_type = "replicated"
+                description = f"replica:{pool['size']}"
+            elif pool['type'] == 3:
+                pool_type = "erasure"
+                name = pool.get('erasure_code_profile', '')
+                profile = ec_profiles.get(name, {})
+                if profile:
+                    description = f"ec:{profile['k']}+{profile['m']}"
+                else:
+                    description = "ec:unknown"
+
+            return pool_type, description
+
         for pool in osd_map['pools']:
+
+            compression_mode = 'none'
+            pool_type, pool_description = _get_pool_info(pool)
+
+            if 'options' in pool:
+                compression_mode = pool['options'].get('compression_mode', 'none')
+
             self.metrics['pool_metadata'].set(
-                1, (pool['pool'], pool['pool_name']))
+                1, (
+                    pool['pool'],
+                    pool['pool_name'],
+                    pool_type,
+                    pool_description,
+                    compression_mode)
+            )
 
         # Populate other servers metadata
         for key, value in servers.items():


### PR DESCRIPTION
Adds percent_used and used_bytes to the per pool
metrics group, and add additional labels to the ceph_pool_metadata
metric
- compression_mode - so consumers can tell whether compression
  is active
- description - provide a text string showing the protection
  scheme of the pool (e.g. replica2, or ec:4+2
- type - text string showing replicated or erasure enabling
  easy filtering across the pools

These additional fields allow compression savings to be more
easily shown. The inclusion of percent_used ensures that any
prometheus based view of pool usage will ALWAYS match the CLI.

Fixes: https://tracker.ceph.com/issues/49049

Signed-off-by: Paul Cuzner <pcuzner@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
