### PR TITLE
qa/tasks/mgr: skip test_diskprediction_local on python>=3.8

### DIFF
--- a/qa/suites/rados/mgr/tasks/module_selftest.yaml
+++ b/qa/suites/rados/mgr/tasks/module_selftest.yaml
@@ -23,3 +23,4 @@ tasks:
   - cephfs_test_runner:
       modules:
         - tasks.mgr.test_module_selftest
+      fail_on_skip: false

--- a/qa/tasks/mgr/test_module_selftest.py
+++ b/qa/tasks/mgr/test_module_selftest.py
@@ -3,7 +3,6 @@ import time
 import requests
 import errno
 import logging
-import sys
 
 from teuthology.exceptions import CommandFailedError
 
@@ -52,10 +51,13 @@ class TestModuleSelftest(MgrTestCase):
         self._selftest_plugin("influx")
 
     def test_diskprediction_local(self):
-        if sys.version_info >= (3, 8):
+        self._load_module("selftest")
+        python_version = self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            "mgr", "self-test", "python-version")
+        if tuple(int(v) for v in python_version.split('.')) >= (3, 8):
             # https://tracker.ceph.com/issues/45147
-            python_version = f'python {sys.version_info.major}.{sys.version_info.minor}'
-            self.skipTest(f'{python_version} not compatible with diskprediction_local')
+            self.skipTest(f'python {python_version} not compatible with '
+                          'diskprediction_local')
         self._selftest_plugin("diskprediction_local")
 
     def test_telegraf(self):

--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -1,9 +1,10 @@
 
 from mgr_module import MgrModule, CommandResult
-import threading
-import random
-import json
 import errno
+import json
+import random
+import sys
+import threading
 
 
 class Module(MgrModule):
@@ -101,6 +102,11 @@ class Module(MgrModule):
                 "desc": "Create an audit log record.",
                 "perm": "rw"
             },
+            {
+                "cmd": "mgr self-test python-version",
+                "desc": "Query the version of the embedded Python runtime",
+                "perm": "r"
+            },
             ]
 
     def __init__(self, *args, **kwargs):
@@ -110,7 +116,13 @@ class Module(MgrModule):
         self._health = {}
 
     def handle_command(self, inbuf, command):
-        if command['prefix'] == 'mgr self-test run':
+        if command['prefix'] == 'mgr self-test python-version':
+            major = sys.version_info.major
+            minor = sys.version_info.minor
+            micro = sys.version_info.micro
+            return 0, f'{major}.{minor}.{micro}', ''
+
+        elif command['prefix'] == 'mgr self-test run':
             self._self_test()
             return 0, '', 'Self-test succeeded'
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/50196
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
