### PR TITLE
rgw: fix lambda capture of a non-variable

### DIFF
--- a/src/rgw/rgw_log_backing.cc
+++ b/src/rgw/rgw_log_backing.cc
@@ -665,7 +665,7 @@ bs::error_code logback_generations::remove_empty(optional_yield y) noexcept {
       for (const auto& [gen_id, e] : es) {
 	ceph_assert(e.pruned);
 	auto ec = log_remove(ioctx, shards,
-			     [this, gen_id](int shard) {
+			     [this, gen_id=gen_id](int shard) {
 			       return this->get_oid(gen_id, shard);
 			     }, (gen_id == 0), y);
 	if (ec) {


### PR DESCRIPTION
One cannot just capture a structured binding "non-variable".

```
../src/rgw/rgw_log_backing.cc:668:16: error: 'gen_id' in capture list does not name a variable
                             [this, gen_id](int shard) {...
```
Signed-off-by: Ronen Friedman <rfriedma@redhat.com>
