### PR TITLE
cephadm: enable log to journald by default

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -116,6 +116,7 @@ class BaseConfig:
         self.env: List[str] = []
         self.memory_request: Optional[int] = None
         self.memory_limit: Optional[int] = None
+        self.log_to_journald: Optional[bool] = None
 
         self.container_init: bool = CONTAINER_INIT
         self.container_engine: Optional[ContainerEngine] = None
@@ -2101,6 +2102,13 @@ def get_legacy_daemon_fsid(ctx, cluster,
     return fsid
 
 
+def should_log_to_journald(ctx):
+    if ctx.log_to_journald is not None:
+        return ctx.log_to_journald
+    return isinstance(ctx.container_engine, Podman) and \
+        ctx.container_engine.version >= CGROUPS_SPLIT_PODMAN_VERSION
+
+
 def get_daemon_args(ctx, fsid, daemon_type, daemon_id):
     # type: (CephadmContext, str, str, Union[int, str]) -> List[str]
     r = list()  # type: List[str]
@@ -2110,14 +2118,29 @@ def get_daemon_args(ctx, fsid, daemon_type, daemon_id):
             '--setuser', 'ceph',
             '--setgroup', 'ceph',
             '--default-log-to-file=false',
-            '--default-log-to-stderr=true',
-            '--default-log-stderr-prefix=debug ',
         ]
+        log_to_journald = should_log_to_journald(ctx)
+        if log_to_journald:
+            r += [
+                '--default-log-to-journald=true',
+                '--default-log-to-stderr=false',
+            ]
+        else:
+            r += [
+                '--default-log-to-stderr=true',
+                '--default-log-stderr-prefix=debug ',
+            ]
         if daemon_type == 'mon':
             r += [
                 '--default-mon-cluster-log-to-file=false',
-                '--default-mon-cluster-log-to-stderr=true',
             ]
+            if log_to_journald:
+                r += [
+                    '--default-mon-cluster-log-to-journald=true',
+                    '--default-mon-cluster-log-to-stderr=false',
+                ]
+            else:
+                r += ['--default-mon-cluster-log-to-stderr=true']
     elif daemon_type in Monitoring.components:
         metadata = Monitoring.components[daemon_type]
         r += metadata.get('args', list())
@@ -2312,6 +2335,9 @@ def get_container_mounts(ctx, fsid, daemon_type, daemon_id,
             crash_dir = '/var/lib/ceph/%s/crash' % fsid
             if os.path.exists(crash_dir):
                 mounts[crash_dir] = '/var/lib/ceph/crash:z'
+            if daemon_type != 'crash' and should_log_to_journald(ctx):
+                journald_sock_dir = '/run/systemd/journal'
+                mounts[journald_sock_dir] = journald_sock_dir
 
     if daemon_type in Ceph.daemons and daemon_id:
         data_dir = get_data_dir(fsid, ctx.data_dir, daemon_type, daemon_id)

--- a/src/cephadm/tests/test_cephadm.py
+++ b/src/cephadm/tests/test_cephadm.py
@@ -524,6 +524,26 @@ docker.io/ceph/daemon-base:octopus
         image = cd._filter_last_local_ceph_image(out)
         assert image == 'docker.io/ceph/ceph:v15.2.5'
 
+    def test_should_log_to_journald(self):
+        ctx = mock.Mock()
+        # explicit
+        ctx.log_to_journald = True
+        assert cd.should_log_to_journald(ctx)
+
+        ctx.log_to_journald = None
+        # enable if podman support --cgroup=split
+        ctx.container_engine = self.mock_podman()
+        ctx.container_engine.version = (2, 1, 0)
+        assert cd.should_log_to_journald(ctx)
+
+        # disable on old podman
+        ctx.container_engine.version = (2, 0, 0)
+        assert not cd.should_log_to_journald(ctx)
+
+        # disable on docker
+        ctx.container_engine = self.mock_docker()
+        assert not cd.should_log_to_journald(ctx)
+
 
 class TestCustomContainer(unittest.TestCase):
     cc: cd.CustomContainer

--- a/src/common/Journald.cc
+++ b/src/common/Journald.cc
@@ -72,9 +72,17 @@ class EntryEncoderBase {
  public:
   EntryEncoderBase():
     m_msg_vec {
-      {}, {}, { (char *)"\n", 1 },
-    } 
+     {}, {}, {}, { (char *)"\n", 1 },
+    }
   {
+    std::string id = program_invocation_short_name;
+    for (auto& c : id) {
+      if (c == '\n')
+        c = '_';
+    }
+    static_segment = "SYSLOG_IDENTIFIER=" + id + "\n";
+    m_msg_vec[0].iov_base = static_segment.data();
+    m_msg_vec[0].iov_len = static_segment.size();
   }
 
   constexpr struct iovec *iovec() { return this->m_msg_vec; }
@@ -83,9 +91,15 @@ class EntryEncoderBase {
     return sizeof(m_msg_vec) / sizeof(m_msg_vec[0]);
   }
 
+ private:
+  struct iovec m_msg_vec[4];
+  std::string static_segment;
+
  protected:
   fmt::memory_buffer meta_buf;
-  struct iovec m_msg_vec[3];
+
+  struct iovec &meta_vec() { return m_msg_vec[1]; }
+  struct iovec &msg_vec() { return m_msg_vec[2]; }
 };
 
 class EntryEncoder : public EntryEncoderBase {
@@ -111,11 +125,11 @@ MESSAGE
     meta_buf.resize(meta_buf.size() + sizeof(msg_len));
     *(reinterpret_cast<uint64_t*>(meta_buf.end()) - 1) = htole64(e.size());
 
-    m_msg_vec[0].iov_base = meta_buf.data();
-    m_msg_vec[0].iov_len = meta_buf.size();
+    meta_vec().iov_base = meta_buf.data();
+    meta_vec().iov_len = meta_buf.size();
 
-    m_msg_vec[1].iov_base = (void *)e.strv().data();
-    m_msg_vec[1].iov_len = e.size();
+    msg_vec().iov_base = (void *)e.strv().data();
+    msg_vec().iov_len = e.size();
   }
 };
 
@@ -144,11 +158,11 @@ MESSAGE
     meta_buf.resize(meta_buf.size() + sizeof(msg_len));
     *(reinterpret_cast<uint64_t*>(meta_buf.end()) - 1) = htole64(le.msg.size());
 
-    m_msg_vec[0].iov_base = meta_buf.data();
-    m_msg_vec[0].iov_len = meta_buf.size();
+    meta_vec().iov_base = meta_buf.data();
+    meta_vec().iov_len = meta_buf.size();
 
-    m_msg_vec[1].iov_base = (void *)le.msg.data();
-    m_msg_vec[1].iov_len = le.msg.size();
+    msg_vec().iov_base = (void *)le.msg.data();
+    msg_vec().iov_len = le.msg.size();
   }
 };
 


### PR DESCRIPTION
Currently, when deployed with cephadm and podman, logs from ceph daemons are
routed as stderr -> conmon -> journald. We can send logs to journald directly
by connecting to its socket. And this has the following advantages:

- record structured metadata along with log message
  - prettier output from journalctl
    - no duplicated timestamp
    - colorized according to priority
    - multi-line logs are indented properly
  - easier to filter the logs afterward
- theoretically better performance
- workaround https://tracker.ceph.com/issues/49551

Signed-off-by: 胡玮文 <huww98@outlook.com>

For reference: #39738 #40025

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
