### PR TITLE
client: don't allow access to MDS-private inodes

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -156,6 +156,14 @@ void client_flush_set_callback(void *p, ObjectCacher::ObjectSet *oset)
   client->flush_set_callback(oset);
 }
 
+bool Client::is_reserved_vino(vinodeno_t &vino) {
+  if (vino.ino < MDS_INO_SYSTEM_BASE && vino.ino != MDS_INO_ROOT) {
+    ldout(cct, -1) << __func__ << "attempt to access reserved inode number " << vino << dendl;
+    return true;
+  }
+  return false;
+}
+
 
 // -------------
 
@@ -9150,6 +9158,9 @@ int Client::_lookup_vino(vinodeno_t vino, const UserPerm& perms, Inode **inode)
   if (!mref_reader.is_state_satisfied())
     return -CEPHFS_ENOTCONN;
 
+  if (is_reserved_vino(vino))
+    return -CEPHFS_ESTALE;
+
   MetaRequest *req = new MetaRequest(CEPH_MDS_OP_LOOKUPINO);
   filepath path(vino.ino);
   req->set_filepath(path);
@@ -11406,6 +11417,9 @@ int Client::ll_lookup_vino(
   if (!mref_reader.is_state_satisfied())
     return -CEPHFS_ENOTCONN;
 
+  if (is_reserved_vino(vino))
+    return -CEPHFS_ESTALE;
+
   std::scoped_lock lock(client_lock);
   ldout(cct, 3) << __func__ << " " << vino << dendl;
 
@@ -11658,6 +11672,9 @@ Inode *Client::ll_get_inode(vinodeno_t vino)
 {
   RWRef_t mref_reader(mount_state, CLIENT_MOUNTING);
   if (!mref_reader.is_state_satisfied())
+    return NULL;
+
+  if (is_reserved_vino(vino))
     return NULL;
 
   std::scoped_lock lock(client_lock);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1223,6 +1223,7 @@ private:
   static const VXattr _common_vxattrs[];
 
 
+  bool is_reserved_vino(vinodeno_t &vino);
 
   void fill_dirent(struct dirent *de, const char *name, int type, uint64_t ino, loff_t next_off);
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/50112
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
