### PR TITLE
[mgr/telemetry]: Additional safeguards in JSON handling

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -384,9 +384,13 @@ class Module(MgrModule):
             if serial:
                 m_str = json.dumps(m)
                 if len(m_str) > 0:
-                    m = json.loads(m_str.replace(serial, 'deleted'))
+                    try:
+                        m = json.loads(m_str.replace(serial, 'deleted'))
+                    except ValueError:
+                        self.log.info(('devid %s, host %s - error handling JSON' % (devid, host))
+                        m = json.loads("{}")
                 else:
-                    self.log.info('devid %s, host %s - error handling JSON' % (devid, host))
+                    self.log.info('devid %s, host %s - empty string received' % (devid, host))
                     m = json.loads("{}")
 
             if anon_host not in res:

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -387,7 +387,7 @@ class Module(MgrModule):
                     try:
                         m = json.loads(m_str.replace(serial, 'deleted'))
                     except ValueError:
-                        self.log.info(('devid %s, host %s - error handling JSON' % (devid, host))
+                        self.log.info('devid %s, host %s - error handling JSON' % (devid, host))
                         m = json.loads("{}")
                 else:
                     self.log.info('devid %s, host %s - empty string received' % (devid, host))

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -383,7 +383,11 @@ class Module(MgrModule):
             # anonymize the smartctl report itself
             if serial:
                 m_str = json.dumps(m)
-                m = json.loads(m_str.replace(serial, 'deleted'))
+                if len(m_str) > 0:
+                    m = json.loads(m_str.replace(serial, 'deleted'))
+                else:
+                    self.log.info('devid %s, host %s - error handling JSON' % (devid, host))
+                    m = json.loads("{}")
 
             if anon_host not in res:
                 res[anon_host] = {}


### PR DESCRIPTION
mgr/telemetry: Additional safeguards in JSON handling

Telemetry module fails (and renders cluster in HEALTH_ERR state) if empty string is received instead of JSON object. This fixes 

Fixes: https://tracker.ceph.com/issues/50205
Signed-off-by: Michal Chybowski <mchybowski@cloudferro.com>
"""

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug
