### PR TITLE
crimson/osd: implement timeout support for watches

### DIFF
--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(crimson-osd
   osd_operation.cc
   osd_operations/client_request.cc
   osd_operations/compound_peering_request.cc
+  osd_operations/internal_client_request.cc
   osd_operations/peering_event.cc
   osd_operations/pg_advance_map.cc
   osd_operations/replicated_request.cc

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(crimson-osd
   ops_executer.cc
   osd_operation.cc
   osd_operations/client_request.cc
+  osd_operations/client_request_common.cc
   osd_operations/compound_peering_request.cc
   osd_operations/internal_client_request.cc
   osd_operations/peering_event.cc

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -49,7 +49,7 @@ public:
   using watch_key_t = std::pair<uint64_t, entity_name_t>;
   std::map<watch_key_t, seastar::shared_ptr<crimson::osd::Watch>> watchers;
 
-  ObjectContext(const hobject_t &hoid) : obs(hoid) {}
+  ObjectContext(hobject_t hoid) : obs(std::move(hoid)) {}
 
   const hobject_t &get_oid() const {
     return obs.oi.soid;

--- a/src/crimson/osd/object_context.h
+++ b/src/crimson/osd/object_context.h
@@ -59,6 +59,14 @@ public:
     return get_oid().is_head();
   }
 
+  Ref get_head_obc() const {
+    return head;
+  }
+
+  hobject_t get_head_oid() const {
+    return get_oid().get_head();
+  }
+
   const SnapSet &get_ro_ss() const {
     if (is_head()) {
       ceph_assert(ss);

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -180,11 +180,12 @@ OpsExecuter::watch_ierrorator::future<> OpsExecuter::do_op_watch_subop_watch(
       }
       return seastar::now();
     },
-    [] (auto&& ctx, ObjectContextRef obc, Ref<PG>) {
+    [] (auto&& ctx, ObjectContextRef obc, Ref<PG> pg) {
       auto [it, emplaced] = obc->watchers.try_emplace(ctx.key, nullptr);
       if (emplaced) {
         const auto& [cookie, entity] = ctx.key;
-        it->second = crimson::osd::Watch::create(obc, ctx.info, entity);
+        it->second = crimson::osd::Watch::create(
+          obc, ctx.info, entity, std::move(pg));
         logger().info("op_effect: added new watcher: {}", ctx.key);
       } else {
         logger().info("op_effect: found existing watcher: {}", ctx.key);

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -137,7 +137,7 @@ OpsExecuter::call_ierrorator::future<> OpsExecuter::do_op_call(OSDOp& osd_op)
 }
 
 static watch_info_t create_watch_info(const OSDOp& osd_op,
-                                      const MOSDOp& msg)
+                                      const OpsExecuter::ExecutableMessage& msg)
 {
   using crimson::common::local_conf;
   const uint32_t timeout =
@@ -161,7 +161,7 @@ OpsExecuter::watch_ierrorator::future<> OpsExecuter::do_op_watch_subop_watch(
     crimson::net::ConnectionRef conn;
     watch_info_t info;
 
-    connect_ctx_t(const OSDOp& osd_op, const MOSDOp& msg)
+    connect_ctx_t(const OSDOp& osd_op, const ExecutableMessage& msg)
       : key(osd_op.op.watch.cookie, msg.get_reqid().name),
         conn(msg.get_connection()),
         info(create_watch_info(osd_op, msg)) {
@@ -219,7 +219,7 @@ OpsExecuter::watch_ierrorator::future<> OpsExecuter::do_op_watch_subop_unwatch(
     ObjectContext::watch_key_t key;
     bool send_disconnect{ false };
 
-    disconnect_ctx_t(const OSDOp& osd_op, const MOSDOp& msg)
+    disconnect_ctx_t(const OSDOp& osd_op, const ExecutableMessage& msg)
       : key(osd_op.op.watch.cookie, msg.get_reqid().name) {
     }
   };
@@ -320,7 +320,7 @@ OpsExecuter::watch_ierrorator::future<> OpsExecuter::do_op_notify(
     const uint64_t client_gid;
     const epoch_t epoch;
 
-    notify_ctx_t(const MOSDOp& msg)
+    notify_ctx_t(const ExecutableMessage& msg)
       : conn(msg.get_connection()),
         client_gid(msg.get_reqid().name.num()),
         epoch(msg.get_map_epoch()) {
@@ -376,7 +376,8 @@ OpsExecuter::watch_ierrorator::future<> OpsExecuter::do_op_notify_ack(
     uint64_t notify_id;
     ceph::bufferlist reply_bl;
 
-    notifyack_ctx_t(const MOSDOp& msg) : entity(msg.get_reqid().name) {
+    notifyack_ctx_t(const ExecutableMessage& msg)
+      : entity(msg.get_reqid().name) {
     }
   };
   return with_effect_on_obc(notifyack_ctx_t{ get_message() },

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -218,8 +218,6 @@ OpsExecuter::watch_ierrorator::future<> OpsExecuter::do_op_watch_subop_unwatch(
 
   struct disconnect_ctx_t {
     ObjectContext::watch_key_t key;
-    bool send_disconnect{ false };
-
     disconnect_ctx_t(const OSDOp& osd_op, const ExecutableMessage& msg)
       : key(osd_op.op.watch.cookie, msg.get_reqid().name) {
     }
@@ -240,7 +238,7 @@ OpsExecuter::watch_ierrorator::future<> OpsExecuter::do_op_watch_subop_unwatch(
         return seastar::do_with(std::move(nh.mapped()),
                          [ctx](auto&& watcher) {
           logger().info("op_effect: disconnect watcher {}", ctx.key);
-          return watcher->remove(ctx.send_disconnect);
+          return watcher->remove();
         });
       } else {
         logger().info("op_effect: disconnect failed to find watcher {}", ctx.key);

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -180,7 +180,7 @@ OpsExecuter::watch_ierrorator::future<> OpsExecuter::do_op_watch_subop_watch(
       }
       return seastar::now();
     },
-    [] (auto&& ctx, ObjectContextRef obc) {
+    [] (auto&& ctx, ObjectContextRef obc, Ref<PG>) {
       auto [it, emplaced] = obc->watchers.try_emplace(ctx.key, nullptr);
       if (emplaced) {
         const auto& [cookie, entity] = ctx.key;
@@ -234,7 +234,7 @@ OpsExecuter::watch_ierrorator::future<> OpsExecuter::do_op_watch_subop_unwatch(
       }
       return seastar::now();
     },
-    [] (auto&& ctx, ObjectContextRef obc) {
+    [] (auto&& ctx, ObjectContextRef obc, Ref<PG>) {
       if (auto nh = obc->watchers.extract(ctx.key); !nh.empty()) {
         return seastar::do_with(std::move(nh.mapped()),
                          [ctx](auto&& watcher) {
@@ -347,7 +347,7 @@ OpsExecuter::watch_ierrorator::future<> OpsExecuter::do_op_notify(
       ceph::encode(ctx.ninfo.notify_id, osd_op.outdata);
       return seastar::now();
     },
-    [] (auto&& ctx, ObjectContextRef obc) {
+    [] (auto&& ctx, ObjectContextRef obc, Ref<PG>) {
       auto alive_watchers = obc->watchers | boost::adaptors::map_values
                                           | boost::adaptors::filtered(
         [] (const auto& w) {
@@ -396,7 +396,7 @@ OpsExecuter::watch_ierrorator::future<> OpsExecuter::do_op_notify_ack(
       }
       return watch_errorator::now();
     },
-    [] (auto&& ctx, ObjectContextRef obc) {
+    [] (auto&& ctx, ObjectContextRef obc, Ref<PG>) {
       logger().info("notify_ack watch_cookie={}, notify_id={}",
                     ctx.watch_cookie, ctx.notify_id);
       return seastar::do_for_each(obc->watchers,

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -329,6 +329,8 @@ OpsExecuter::flush_changes_n_do_ops_effects(Ref<PG> pg, MutFunc&& mut_func) &&
   assert(obc);
   auto maybe_mutated = interruptor::make_interruptible(osd_op_errorator::now());
   if (want_mutate) {
+    osd_op_params->req_id = msg->get_reqid();
+    //osd_op_params->mtime = msg->get_mtime();
     maybe_mutated = std::forward<MutFunc>(mut_func)(std::move(txn),
                                                     std::move(obc),
                                                     std::move(*osd_op_params),

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -241,6 +241,9 @@ public:
   template <class Func>
   struct RollbackHelper {
     interruptible_future<> rollback_obc_if_modified(const std::error_code& e);
+    ObjectContextRef get_obc() const {
+      return ox.obc;
+    }
     OpsExecuter& ox;
     Func func;
   };

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -28,11 +28,10 @@
 #include "crimson/osd/pg_interval_interrupt_condition.h"
 #include "crimson/osd/shard_services.h"
 
-class PG;
-class PGLSFilter;
 class OSDOp;
 
 namespace crimson::osd {
+class PG;
 
 // OpsExecuter -- a class for executing ops targeting a certain object.
 class OpsExecuter {

--- a/src/crimson/osd/ops_executer.h
+++ b/src/crimson/osd/ops_executer.h
@@ -86,6 +86,7 @@ public:
   struct ExecutableMessage {
     virtual crimson::net::ConnectionRef get_connection() const = 0;
     virtual osd_reqid_t get_reqid() const = 0;
+    virtual utime_t get_mtime() const = 0;
     virtual epoch_t get_map_epoch() const = 0;
     virtual entity_inst_t get_orig_source_inst() const = 0;
     virtual uint64_t get_features() const = 0;
@@ -103,6 +104,9 @@ public:
     osd_reqid_t get_reqid() const final {
       return pimpl->get_reqid();
     }
+    utime_t get_mtime() const final {
+      return pimpl->get_mtime();
+    };
     epoch_t get_map_epoch() const final {
       return pimpl->get_map_epoch();
     }
@@ -330,7 +334,7 @@ OpsExecuter::flush_changes_n_do_ops_effects(Ref<PG> pg, MutFunc&& mut_func) &&
   auto maybe_mutated = interruptor::make_interruptible(osd_op_errorator::now());
   if (want_mutate) {
     osd_op_params->req_id = msg->get_reqid();
-    //osd_op_params->mtime = msg->get_mtime();
+    osd_op_params->mtime = msg->get_mtime();
     maybe_mutated = std::forward<MutFunc>(mut_func)(std::move(txn),
                                                     std::move(obc),
                                                     std::move(*osd_op_params),

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -39,9 +39,7 @@ static_assert(
   (sizeof(OP_NAMES)/sizeof(OP_NAMES[0])) ==
   static_cast<int>(OperationTypeCode::last_op));
 
-template <typename T>
-class OperationT : public Operation {
-public:
+struct InterruptibleOperation : Operation {
   template <typename ValuesT = void>
   using interruptible_future =
     ::crimson::interruptible::interruptible_future<
@@ -49,6 +47,11 @@ public:
   using interruptor =
     ::crimson::interruptible::interruptor<
       ::crimson::osd::IOInterruptCondition>;
+};
+
+template <typename T>
+class OperationT : public InterruptibleOperation {
+public:
   static constexpr const char *type_name = OP_NAMES[static_cast<int>(T::type)];
   using IRef = boost::intrusive_ptr<T>;
 

--- a/src/crimson/osd/osd_operation.h
+++ b/src/crimson/osd/osd_operation.h
@@ -18,6 +18,7 @@ enum class OperationTypeCode {
   replicated_request,
   background_recovery,
   background_recovery_sub,
+  internal_client_request,
   last_op
 };
 
@@ -30,6 +31,7 @@ static constexpr const char* const OP_NAMES[] = {
   "replicated_request",
   "background_recovery",
   "background_recovery_sub",
+  "internal_client_request",
 };
 
 // prevent the addition of OperationTypeCode-s with no matching OP_NAMES entry:

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -182,7 +182,8 @@ ClientRequest::process_op(Ref<PG> &pg)
           [this, pg]() mutable -> PG::load_obc_iertr::future<> {
           logger().debug("{}: got obc lock", *this);
           op_info.set_from_op(&*m, *pg->get_osdmap());
-          return pg->with_locked_obc(m, op_info, [this, pg](auto obc) mutable {
+          return pg->with_locked_obc(m->get_hobj(), op_info,
+                                     [this, pg](auto obc) mutable {
             return with_blocking_future_interruptible<IOInterruptCondition>(
               handle.enter(pp(*pg).process)
             ).then_interruptible([this, pg, obc]() mutable {

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -215,8 +215,8 @@ ClientRequest::do_recover_missing(Ref<PG>& pg, const hobject_t& soid)
     return pg->get_recovery_backend()->get_recovering(soid).wait_for_recovered();
   } else {
     auto [op, fut] =
-      osd.get_shard_services().start_operation<UrgentRecovery>(
-        soid, ver, pg, osd.get_shard_services(), pg->get_osdmap_epoch());
+      pg->get_shard_services().start_operation<UrgentRecovery>(
+        soid, ver, pg, pg->get_shard_services(), pg->get_osdmap_epoch());
     return std::move(fut);
   }
 }

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -7,6 +7,7 @@
 #include "crimson/net/Connection.h"
 #include "crimson/osd/object_context.h"
 #include "crimson/osd/osd_operation.h"
+#include "crimson/osd/osd_operations/common/pg_pipeline.h"
 #include "crimson/common/type_helpers.h"
 #include "messages/MOSDOp.h"
 
@@ -31,21 +32,9 @@ public:
     };
     friend class ClientRequest;
   };
-  class PGPipeline {
+  class PGPipeline : public CommonPGPipeline {
     OrderedExclusivePhase await_map = {
       "ClientRequest::PGPipeline::await_map"
-    };
-    OrderedExclusivePhase wait_for_active = {
-      "ClientRequest::PGPipeline::wait_for_active"
-    };
-    OrderedExclusivePhase recover_missing = {
-      "ClientRequest::PGPipeline::recover_missing"
-    };
-    OrderedExclusivePhase get_obc = {
-      "ClientRequest::PGPipeline::get_obc"
-    };
-    OrderedExclusivePhase process = {
-      "ClientRequest::PGPipeline::process"
     };
     friend class ClientRequest;
   };

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -7,6 +7,7 @@
 #include "crimson/net/Connection.h"
 #include "crimson/osd/object_context.h"
 #include "crimson/osd/osd_operation.h"
+#include "crimson/osd/osd_operations/client_request_common.h"
 #include "crimson/osd/osd_operations/common/pg_pipeline.h"
 #include "crimson/common/type_helpers.h"
 #include "messages/MOSDOp.h"
@@ -15,7 +16,8 @@ namespace crimson::osd {
 class PG;
 class OSD;
 
-class ClientRequest final : public OperationT<ClientRequest> {
+class ClientRequest final : public OperationT<ClientRequest>,
+                            private CommonClientRequest {
   OSD &osd;
   crimson::net::ConnectionRef conn;
   Ref<MOSDOp> m;
@@ -51,7 +53,6 @@ public:
   seastar::future<> start();
 
 private:
-  interruptible_future<> do_recover_missing(Ref<PG>& pgref, const hobject_t& soid);
   interruptible_future<> do_process(
     Ref<PG>& pg,
     crimson::osd::ObjectContextRef obc);

--- a/src/crimson/osd/osd_operations/client_request.h
+++ b/src/crimson/osd/osd_operations/client_request.h
@@ -62,7 +62,7 @@ public:
   seastar::future<> start();
 
 private:
-  interruptible_future<> do_recover_missing(Ref<PG>& pgref);
+  interruptible_future<> do_recover_missing(Ref<PG>& pgref, const hobject_t& soid);
   interruptible_future<> do_process(
     Ref<PG>& pg,
     crimson::osd::ObjectContextRef obc);

--- a/src/crimson/osd/osd_operations/client_request_common.cc
+++ b/src/crimson/osd/osd_operations/client_request_common.cc
@@ -33,4 +33,28 @@ CommonClientRequest::do_recover_missing(
   }
 }
 
+bool CommonClientRequest::should_abort_request(std::exception_ptr eptr)
+{
+  if (*eptr.__cxa_exception_type() ==
+      typeid(::crimson::common::actingset_changed)) {
+    try {
+      std::rethrow_exception(eptr);
+    } catch(::crimson::common::actingset_changed& e) {
+      if (e.is_primary()) {
+        logger().debug("{} operation restart, acting set changed", __func__);
+        return false;
+      } else {
+        logger().debug("{} operation abort, up primary changed", __func__);
+        return true;
+      }
+    }
+  } else {
+    assert(*eptr.__cxa_exception_type() ==
+      typeid(crimson::common::system_shutdown_exception));
+    crimson::get_logger(ceph_subsys_osd).debug(
+        "{} operation skipped, system shutdown", __func__);
+    return true;
+  }
+}
+
 } // namespace crimson::osd

--- a/src/crimson/osd/osd_operations/client_request_common.cc
+++ b/src/crimson/osd/osd_operations/client_request_common.cc
@@ -1,0 +1,36 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab expandtab
+
+#include "crimson/osd/osd_operations/client_request_common.h"
+#include "crimson/osd/pg.h"
+
+namespace {
+  seastar::logger& logger() {
+    return crimson::get_logger(ceph_subsys_osd);
+  }
+}
+
+namespace crimson::osd {
+
+typename InterruptibleOperation::template interruptible_future<>
+CommonClientRequest::do_recover_missing(
+  Ref<PG>& pg, const hobject_t& soid)
+{
+  eversion_t ver;
+  logger().debug("{} check for recovery, {}", __func__, soid);
+  if (!pg->is_unreadable_object(soid, &ver) &&
+      !pg->is_degraded_or_backfilling_object(soid)) {
+    return seastar::now();
+  }
+  logger().debug("{} need to wait for recovery, {}", __func__, soid);
+  if (pg->get_recovery_backend()->is_recovering(soid)) {
+    return pg->get_recovery_backend()->get_recovering(soid).wait_for_recovered();
+  } else {
+    auto [op, fut] =
+      pg->get_shard_services().start_operation<UrgentRecovery>(
+        soid, ver, pg, pg->get_shard_services(), pg->get_osdmap_epoch());
+    return std::move(fut);
+  }
+}
+
+} // namespace crimson::osd

--- a/src/crimson/osd/osd_operations/client_request_common.h
+++ b/src/crimson/osd/osd_operations/client_request_common.h
@@ -11,6 +11,8 @@ namespace crimson::osd {
 struct CommonClientRequest {
   static InterruptibleOperation::template interruptible_future<>
   do_recover_missing(Ref<PG>& pg, const hobject_t& soid);
+
+  static bool should_abort_request(std::exception_ptr eptr);
 };
 
 } // namespace crimson::osd

--- a/src/crimson/osd/osd_operations/client_request_common.h
+++ b/src/crimson/osd/osd_operations/client_request_common.h
@@ -1,0 +1,16 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "crimson/common/type_helpers.h"
+#include "crimson/osd/osd_operation.h"
+
+namespace crimson::osd {
+
+struct CommonClientRequest {
+  static InterruptibleOperation::template interruptible_future<>
+  do_recover_missing(Ref<PG>& pg, const hobject_t& soid);
+};
+
+} // namespace crimson::osd

--- a/src/crimson/osd/osd_operations/common/pg_pipeline.h
+++ b/src/crimson/osd/osd_operations/common/pg_pipeline.h
@@ -1,0 +1,27 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "osd/osd_op_util.h"
+#include "crimson/osd/osd_operation.h"
+
+namespace crimson::osd {
+
+class CommonPGPipeline {
+protected:
+  OrderedExclusivePhase wait_for_active = {
+    "CommonPGPipeline:::wait_for_active"
+  };
+  OrderedExclusivePhase recover_missing = {
+    "CommonPGPipeline::recover_missing"
+  };
+  OrderedExclusivePhase get_obc = {
+    "CommonPGPipeline::get_obc"
+  };
+  OrderedExclusivePhase process = {
+    "CommonPGPipeline::process"
+  };
+};
+
+} // namespace crimson::osd

--- a/src/crimson/osd/osd_operations/common/pg_pipeline.h
+++ b/src/crimson/osd/osd_operations/common/pg_pipeline.h
@@ -10,6 +10,8 @@ namespace crimson::osd {
 
 class CommonPGPipeline {
 protected:
+  friend class InternalClientRequest;
+
   OrderedExclusivePhase wait_for_active = {
     "CommonPGPipeline:::wait_for_active"
   };

--- a/src/crimson/osd/osd_operations/internal_client_request.cc
+++ b/src/crimson/osd/osd_operations/internal_client_request.cc
@@ -122,13 +122,5 @@ seastar::future<> InternalClientRequest::start()
   });
 }
 
-InternalClientRequest::interruptible_future<>
-InternalClientRequest::do_recover_missing(
-  Ref<PG>& pgref, const hobject_t& soid)
-{
-  // TODO: share this with ClientRequest
-  return seastar::now();
-}
-
 } // namespace crimson::osd
 

--- a/src/crimson/osd/osd_operations/internal_client_request.cc
+++ b/src/crimson/osd/osd_operations/internal_client_request.cc
@@ -1,0 +1,134 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab expandtab
+
+#include <seastar/core/future.hh>
+
+#include "crimson/osd/osd_operations/internal_client_request.h"
+
+namespace {
+  seastar::logger& logger() {
+    return crimson::get_logger(ceph_subsys_osd);
+  }
+}
+
+namespace crimson::osd {
+
+InternalClientRequest::InternalClientRequest(Ref<PG> pg)
+  : pg(std::move(pg))
+{
+  assert(bool(pg));
+}
+
+InternalClientRequest::~InternalClientRequest()
+{
+  logger().debug("{}: destroying", *this);
+}
+
+void InternalClientRequest::print(std::ostream &) const
+{
+}
+
+void InternalClientRequest::dump_detail(Formatter *f) const
+{
+}
+
+CommonPGPipeline& InternalClientRequest::pp()
+{
+  return pg->client_request_pg_pipeline;
+}
+
+seastar::future<> InternalClientRequest::start()
+{
+  return crimson::common::handle_system_shutdown([this] {
+    return seastar::repeat([this] {
+      logger().debug("{}: in repeat", *this);
+      return interruptor::with_interruption([this]() mutable {
+        return with_blocking_future_interruptible<IOInterruptCondition>(
+          handle.enter(pp().wait_for_active)
+        ).then_interruptible([this] {
+          return with_blocking_future_interruptible<IOInterruptCondition>(
+            pg->wait_for_active_blocker.wait());
+        }).then_interruptible([this] {
+          return with_blocking_future_interruptible<IOInterruptCondition>(
+            handle.enter(pp().recover_missing)
+          ).then_interruptible([this] {
+            return do_recover_missing(pg, {});
+          }).then_interruptible([this] {
+            return with_blocking_future_interruptible<IOInterruptCondition>(
+              handle.enter(pp().get_obc)
+            ).then_interruptible([this] () -> PG::load_obc_iertr::future<> {
+              logger().debug("{}: getting obc lock", *this);
+              auto osd_ops = create_osd_ops();
+              logger().debug("InternalClientRequest: got {} OSDOps to execute",
+                             std::size(osd_ops));
+              [[maybe_unused]] const int ret = op_info.set_from_op(
+                std::as_const(osd_ops), pg->get_pgid().pgid, *pg->get_osdmap());
+              assert(ret == 0);
+              return pg->with_locked_obc(get_target_oid(), op_info,
+                [osd_ops=std::move(osd_ops), this](auto obc) {
+                return with_blocking_future_interruptible<IOInterruptCondition>(
+                  handle.enter(pp().process)
+                ).then_interruptible(
+                  [obc=std::move(obc), osd_ops=std::move(osd_ops), this] {
+                  return pg->do_osd_ops(
+                    std::move(obc),
+                    std::move(osd_ops),
+                    std::as_const(op_info),
+                    get_do_osd_ops_params(),
+                    [] {
+                      return PG::do_osd_ops_iertr::now();
+                    },
+                    [] (const std::error_code& e) {
+                      return PG::do_osd_ops_iertr::now();
+                    }
+                  ).safe_then_interruptible(
+                    [] {
+                      return interruptor::now();
+                    }, crimson::ct_error::eagain::handle([] {
+                      return interruptor::now();
+                    })
+                  );
+                });
+              });
+            }).handle_error_interruptible(PG::load_obc_ertr::all_same_way([] {
+              return seastar::now();
+            })).then_interruptible([] {
+              return seastar::stop_iteration::yes;
+            });
+          });
+        });
+      }, [this](std::exception_ptr eptr) mutable {
+        if (*eptr.__cxa_exception_type() ==
+            typeid(::crimson::common::actingset_changed)) {
+          try {
+            std::rethrow_exception(eptr);
+          } catch(::crimson::common::actingset_changed& e) {
+            if (e.is_primary()) {
+              logger().debug("{} operation restart, acting set changed", *this);
+              return seastar::stop_iteration::no;
+            } else {
+              logger().debug("{} operation abort, up primary changed", *this);
+              return seastar::stop_iteration::yes;
+            }
+          }
+        }
+        assert(*eptr.__cxa_exception_type() ==
+          typeid(crimson::common::system_shutdown_exception));
+        crimson::get_logger(ceph_subsys_osd).debug(
+            "{} operation skipped, system shutdown", *this);
+        return seastar::stop_iteration::yes;
+      }, pg);
+    });
+  });
+}
+
+InternalClientRequest::interruptible_future<>
+InternalClientRequest::do_recover_missing(
+  Ref<PG>& pgref, const hobject_t& soid)
+{
+  // TODO: share this with ClientRequest
+  return seastar::now();
+}
+
+} // namespace crimson::osd
+

--- a/src/crimson/osd/osd_operations/internal_client_request.h
+++ b/src/crimson/osd/osd_operations/internal_client_request.h
@@ -1,0 +1,48 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "crimson/common/type_helpers.h"
+#include "crimson/osd/osd_operation.h"
+#include "crimson/osd/pg.h"
+
+namespace crimson::osd {
+
+class InternalClientRequest : public OperationT<InternalClientRequest> {
+public:
+  explicit InternalClientRequest(Ref<PG> pg);
+  ~InternalClientRequest();
+
+  // imposed by `ShardService::start_operation<T>(...)`.
+  seastar::future<> start();
+
+protected:
+  virtual const hobject_t& get_target_oid() const = 0;
+  virtual PG::do_osd_ops_params_t get_do_osd_ops_params() const = 0;
+  virtual std::vector<OSDOp> create_osd_ops() = 0;
+
+  const PG& get_pg() const {
+    return *pg;
+  }
+
+private:
+  friend OperationT<InternalClientRequest>;
+
+  static constexpr OperationTypeCode type =
+    OperationTypeCode::internal_client_request;
+
+  void print(std::ostream &) const final;
+  void dump_detail(Formatter *f) const final;
+
+  CommonPGPipeline& pp();
+
+  interruptible_future<> do_recover_missing(Ref<PG>& pgref, const hobject_t& soid);
+  seastar::future<> do_process();
+
+  Ref<PG> pg;
+  PipelineHandle handle;
+  OpInfo op_info;
+};
+
+} // namespace crimson::osd

--- a/src/crimson/osd/osd_operations/internal_client_request.h
+++ b/src/crimson/osd/osd_operations/internal_client_request.h
@@ -5,11 +5,13 @@
 
 #include "crimson/common/type_helpers.h"
 #include "crimson/osd/osd_operation.h"
+#include "crimson/osd/osd_operations/client_request_common.h"
 #include "crimson/osd/pg.h"
 
 namespace crimson::osd {
 
-class InternalClientRequest : public OperationT<InternalClientRequest> {
+class InternalClientRequest : public OperationT<InternalClientRequest>,
+                              private CommonClientRequest {
 public:
   explicit InternalClientRequest(Ref<PG> pg);
   ~InternalClientRequest();
@@ -37,7 +39,6 @@ private:
 
   CommonPGPipeline& pp();
 
-  interruptible_future<> do_recover_missing(Ref<PG>& pgref, const hobject_t& soid);
   seastar::future<> do_process();
 
   Ref<PG> pg;

--- a/src/crimson/osd/osd_operations/osdop_params.h
+++ b/src/crimson/osd/osd_operations/osdop_params.h
@@ -8,7 +8,8 @@
 // level of processing. I inclosed all those parameters in this struct to
 // avoid passing each of them as a method parameter.
 struct osd_op_params_t {
-  Ref<MOSDOp> req;
+  osd_reqid_t req_id;
+  utime_t mtime;
   eversion_t at_version;
   eversion_t pg_trim_to;
   eversion_t min_last_complete_ondisk;

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1042,7 +1042,7 @@ PG::with_locked_obc(Ref<MOSDOp> &m, const OpInfo &op_info,
 
 template <RWState::State State>
 PG::interruptible_future<>
-PG::with_locked_obc(ObjectContextRef obc, PG::with_obc_func_t &&f)
+PG::with_locked_obc(ObjectContextRef obc, with_obc_func_t &&f)
 {
   // TODO: a question from rebase: do we really need such checks when
   // the interruptible stuff is being used?

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -848,11 +848,9 @@ PG::interruptible_future<Ref<MOSDOpReply>> PG::do_pg_ops(Ref<MOSDOp> m)
   });
 }
 
-hobject_t PG::get_oid(const MOSDOp &m)
+hobject_t PG::get_oid(const hobject_t& hobj)
 {
-  return (m.get_snapid() == CEPH_SNAPDIR ?
-          m.get_hobj().get_head() :
-          m.get_hobj());
+  return hobj.snap == CEPH_SNAPDIR ? hobj.get_head() : hobj;
 }
 
 RWState::State PG::get_lock_type(const OpInfo &op_info)
@@ -1060,7 +1058,7 @@ PG::with_locked_obc(Ref<MOSDOp> &m, const OpInfo &op_info,
   if (__builtin_expect(stopping, false)) {
     throw crimson::common::system_shutdown_exception();
   }
-  const hobject_t oid = get_oid(*m);
+  const hobject_t oid = get_oid(m->get_hobj());
   switch (get_lock_type(op_info)) {
   case RWState::RWREAD:
     if (oid.is_head()) {

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -1052,13 +1052,14 @@ PG::reload_obc(crimson::osd::ObjectContext& obc) const
 }
 
 PG::load_obc_iertr::future<>
-PG::with_locked_obc(Ref<MOSDOp> &m, const OpInfo &op_info,
-		    with_obc_func_t &&f)
+PG::with_locked_obc(const hobject_t &hobj,
+                    const OpInfo &op_info,
+                    with_obc_func_t &&f)
 {
   if (__builtin_expect(stopping, false)) {
     throw crimson::common::system_shutdown_exception();
   }
-  const hobject_t oid = get_oid(m->get_hobj());
+  const hobject_t oid = get_oid(hobj);
   switch (get_lock_type(op_info)) {
   case RWState::RWREAD:
     if (oid.is_head()) {

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -727,7 +727,8 @@ PG::do_osd_ops(
       "do_osd_ops: {} - object {} all operations successful",
       *m,
       ox->get_target());
-    return std::move(*ox).flush_changes(
+    return std::move(*ox).flush_changes_n_do_ops_effects(
+      Ref<PG>{this},
       [this, m, &op_info] (auto&& txn,
 			   auto&& obc,
 			   auto&& osd_op_p,

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -803,6 +803,26 @@ PG::do_osd_ops(
   ).finally([ox_deleter=std::move(ox)] {});
 }
 
+PG::do_osd_ops_iertr::future<>
+PG::do_osd_ops(
+  ObjectContextRef obc,
+  std::vector<OSDOp> ops,
+  const OpInfo &op_info,
+  const do_osd_ops_params_t& msg_params,
+  do_osd_ops_success_func_t success_func,
+  do_osd_ops_failure_func_t failure_func)
+{
+  auto ox = std::make_unique<OpsExecuter>(
+    std::move(obc), op_info, get_pool().info, get_backend(), msg_params);
+  return do_osd_ops_execute<void>(
+    std::move(*ox),
+    std::move(ops),
+    std::as_const(op_info),
+    std::move(success_func),
+    std::move(failure_func)
+  ).finally([ox_deleter=std::move(ox)] {});
+}
+
 PG::interruptible_future<Ref<MOSDOpReply>> PG::do_pg_ops(Ref<MOSDOp> m)
 {
   if (__builtin_expect(stopping, false)) {

--- a/src/crimson/osd/pg.cc
+++ b/src/crimson/osd/pg.cc
@@ -708,6 +708,10 @@ PG::do_osd_ops_iertr::future<Ret> PG::do_osd_ops_execute(
   SuccessFunc&& success_func,
   FailureFunc&& failure_func)
 {
+  auto rollbacker = ox.create_rollbacker([this] (auto& obc) {
+    return reload_obc(obc).handle_error_interruptible(
+      load_obc_ertr::assert_all{"can't live with object state messed up"});
+  });
   return interruptor::do_for_each(ops, [m, &ox](OSDOp& osd_op) {
     logger().debug(
       "do_osd_ops_execute: {} - object {} - handling op {}",
@@ -744,21 +748,12 @@ PG::do_osd_ops_iertr::future<Ret> PG::do_osd_ops_execute(
       return do_osd_ops_iertr::future<Ret>{crimson::ct_error::eagain::make()};
     });
   }), OpsExecuter::osd_op_errorator::all_same_way(
-    [&ox, m, obc, failure_func=std::move(failure_func), this] (const std::error_code& e) mutable {
-    const bool need_reload_obc = ox.has_seen_write();
-    logger().debug(
-      "do_osd_ops_execute: {} - object {} got error {}, {}; need_reload_obc {}",
-      m,
-      obc->obs.oi.soid,
-      e.value(),
-      e.message(),
-      need_reload_obc);
-    return (
-      need_reload_obc ? reload_obc(*obc)
-                      : interruptor::make_interruptible(load_obc_ertr::now())
-    ).safe_then_interruptible([&e, failure_func=std::move(failure_func)] {
+    [rollbacker, failure_func=std::move(failure_func), m]
+    (const std::error_code& e) mutable {
+    return rollbacker.rollback_obc_if_modified(e).then_interruptible(
+      [&e, failure_func=std::move(failure_func)] {
       return std::move(failure_func)(e);
-    }, load_obc_ertr::assert_all{ "can't live with object state messed up" });
+    });
   }));
 }
 

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -734,6 +734,7 @@ private:
   friend class RepRequest;
   friend class BackfillRecovery;
   friend struct PGFacade;
+  friend class InternalClientRequest;
 private:
   seastar::future<bool> find_unfound() {
     return seastar::make_ready_future<bool>(true);

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -587,10 +587,12 @@ private:
     SuccessFunc&& success_func,
     FailureFunc&& failure_func);
   interruptible_future<Ref<MOSDOpReply>> do_pg_ops(Ref<MOSDOp> m);
-  interruptible_future<> submit_transaction(const OpInfo& op_info,
-				       ObjectContextRef&& obc,
-				       ceph::os::Transaction&& txn,
-				       osd_op_params_t&& oop);
+  interruptible_future<> submit_transaction(
+    const OpInfo& op_info,
+    const std::vector<OSDOp>& ops,
+    ObjectContextRef&& obc,
+    ceph::os::Transaction&& txn,
+    osd_op_params_t&& oop);
   interruptible_future<> repair_object(
     const hobject_t& oid,
     eversion_t& v);

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -592,9 +592,9 @@ private:
 				       ObjectContextRef&& obc,
 				       ceph::os::Transaction&& txn,
 				       osd_op_params_t&& oop);
-  interruptible_future<> repair_object(Ref<MOSDOp> m,
-               const hobject_t& oid,
-               eversion_t& v);
+  interruptible_future<> repair_object(
+    const hobject_t& oid,
+    eversion_t& v);
 
 private:
   OSDMapGate osdmap_gate;

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -729,6 +729,7 @@ private:
 
   friend std::ostream& operator<<(std::ostream&, const PG& pg);
   friend class ClientRequest;
+  friend struct CommonClientRequest;
   friend class PGAdvanceMap;
   friend class PeeringEvent;
   friend class RepRequest;

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -24,6 +24,7 @@
 #include "crimson/os/futurized_collection.h"
 #include "crimson/osd/backfill_state.h"
 #include "crimson/osd/pg_interval_interrupt_condition.h"
+#include "crimson/osd/ops_executer.h"
 #include "crimson/osd/osd_operations/client_request.h"
 #include "crimson/osd/osd_operations/peering_event.h"
 #include "crimson/osd/osd_operations/replicated_request.h"
@@ -577,6 +578,15 @@ private:
     Ref<MOSDOp> m,
     ObjectContextRef obc,
     const OpInfo &op_info);
+  template <class Ret, class SuccessFunc, class FailureFunc>
+  do_osd_ops_iertr::future<Ret> do_osd_ops_execute(
+    OpsExecuter&& ox,
+    std::vector<OSDOp> ops,
+    Ref<MOSDOp> m,
+    ObjectContextRef obc,
+    const OpInfo &op_info,
+    SuccessFunc&& success_func,
+    FailureFunc&& failure_func);
   interruptible_future<Ref<MOSDOpReply>> do_pg_ops(Ref<MOSDOp> m);
   interruptible_future<> submit_transaction(const OpInfo& op_info,
 				       ObjectContextRef&& obc,

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -523,7 +523,7 @@ public:
     ObjectContextRef obc,
     with_obc_func_t&& f);
   load_obc_iertr::future<> with_locked_obc(
-    Ref<MOSDOp> &m,
+    const hobject_t &hobj,
     const OpInfo &op_info,
     with_obc_func_t&& f);
 
@@ -769,6 +769,9 @@ struct PG::do_osd_ops_params_t {
   osd_reqid_t get_reqid() const {
     return reqid;
   }
+  utime_t get_mtime() const {
+    return mtime;
+  };
   epoch_t get_map_epoch() const {
     return map_epoch;
   }
@@ -780,6 +783,7 @@ struct PG::do_osd_ops_params_t {
   }
   crimson::net::ConnectionRef conn;
   osd_reqid_t reqid;
+  utime_t mtime;
   epoch_t map_epoch;
   entity_inst_t orig_source_inst;
   uint64_t features;

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -735,6 +735,7 @@ private:
   friend class BackfillRecovery;
   friend struct PGFacade;
   friend class InternalClientRequest;
+  friend class WatchTimeoutRequest;
 private:
   seastar::future<bool> find_unfound() {
     return seastar::make_ready_future<bool>(true);

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -583,7 +583,6 @@ private:
     OpsExecuter&& ox,
     std::vector<OSDOp> ops,
     Ref<MOSDOp> m,
-    ObjectContextRef obc,
     const OpInfo &op_info,
     SuccessFunc&& success_func,
     FailureFunc&& failure_func);

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -477,7 +477,7 @@ public:
   void handle_activate_map(PeeringCtx &rctx);
   void handle_initialize(PeeringCtx &rctx);
 
-  static hobject_t get_oid(const MOSDOp &m);
+  static hobject_t get_oid(const hobject_t& hobj);
   static RWState::State get_lock_type(const OpInfo &op_info);
   static std::optional<hobject_t> resolve_oid(
     const SnapSet &snapset,

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -577,6 +577,18 @@ private:
     Ref<MOSDOp> m,
     ObjectContextRef obc,
     const OpInfo &op_info);
+  using do_osd_ops_success_func_t =
+    std::function<do_osd_ops_iertr::future<>()>;
+  using do_osd_ops_failure_func_t =
+    std::function<do_osd_ops_iertr::future<>(const std::error_code&)>;
+  struct do_osd_ops_params_t;
+  do_osd_ops_iertr::future<> do_osd_ops(
+    ObjectContextRef obc,
+    std::vector<OSDOp> ops,
+    const OpInfo &op_info,
+    const do_osd_ops_params_t& params,
+    do_osd_ops_success_func_t success_func,
+    do_osd_ops_failure_func_t failure_func);
   template <class Ret, class SuccessFunc, class FailureFunc>
   do_osd_ops_iertr::future<Ret> do_osd_ops_execute(
     OpsExecuter&& ox,
@@ -748,6 +760,29 @@ private:
   BackfillRecovery::BackfillRecoveryPipeline backfill_pipeline;
 
   friend class IOInterruptCondition;
+};
+
+struct PG::do_osd_ops_params_t {
+  crimson::net::ConnectionRef get_connection() const {
+    return nullptr;
+  }
+  osd_reqid_t get_reqid() const {
+    return reqid;
+  }
+  epoch_t get_map_epoch() const {
+    return map_epoch;
+  }
+  entity_inst_t get_orig_source_inst() const {
+    return orig_source_inst;
+  }
+  uint64_t get_features() const {
+    return features;
+  }
+  crimson::net::ConnectionRef conn;
+  osd_reqid_t reqid;
+  epoch_t map_epoch;
+  entity_inst_t orig_source_inst;
+  uint64_t features;
 };
 
 std::ostream& operator<<(std::ostream&, const PG& pg);

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -517,6 +517,10 @@ public:
   template<RWState::State State>
   load_obc_iertr::future<> with_head_obc(hobject_t oid, with_obc_func_t&& func);
 
+  template<RWState::State State>
+  interruptible_future<> with_locked_obc(
+    ObjectContextRef obc,
+    with_obc_func_t&& f);
   load_obc_iertr::future<> with_locked_obc(
     Ref<MOSDOp> &m,
     const OpInfo &op_info,
@@ -531,7 +535,20 @@ public:
 
 private:
   template<RWState::State State>
+  load_obc_iertr::future<> with_head_obc(
+    ObjectContextRef obc,
+    bool existed,
+    with_obc_func_t&& func);
+  template<RWState::State State>
+  interruptible_future<> with_existing_head_obc(
+    ObjectContextRef head,
+    with_obc_func_t&& func);
+
+  template<RWState::State State>
   load_obc_iertr::future<> with_clone_obc(hobject_t oid, with_obc_func_t&& func);
+  template<RWState::State State>
+  interruptible_future<> with_existing_clone_obc(
+    ObjectContextRef clone, with_obc_func_t&& func);
 
   load_obc_iertr::future<ObjectContextRef> get_locked_obc(
     Operation *op,

--- a/src/crimson/osd/pg.h
+++ b/src/crimson/osd/pg.h
@@ -561,7 +561,6 @@ private:
     PeeringCtx &rctx);
   void fill_op_params_bump_pg_version(
     osd_op_params_t& osd_op_p,
-    Ref<MOSDOp> m,
     const bool user_modify);
   interruptible_future<Ref<MOSDOpReply>> handle_failed_op(
     const std::error_code& e,
@@ -582,7 +581,6 @@ private:
   do_osd_ops_iertr::future<Ret> do_osd_ops_execute(
     OpsExecuter&& ox,
     std::vector<OSDOp> ops,
-    Ref<MOSDOp> m,
     const OpInfo &op_info,
     SuccessFunc&& success_func,
     FailureFunc&& failure_func);

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -136,13 +136,12 @@ PGBackend::mutate_object(
     obc->obs.oi.prior_version = ctx->obs->oi.version;
 #endif
 
-    auto& m = osd_op_p.req;
     obc->obs.oi.prior_version = obc->obs.oi.version;
     obc->obs.oi.version = osd_op_p.at_version;
     if (osd_op_p.user_at_version > obc->obs.oi.user_version)
       obc->obs.oi.user_version = osd_op_p.user_at_version;
-    obc->obs.oi.last_reqid = m->get_reqid();
-    obc->obs.oi.mtime = m->get_mtime();
+    obc->obs.oi.last_reqid = osd_op_p.req_id;
+    obc->obs.oi.mtime = osd_op_p.mtime;
     obc->obs.oi.local_mtime = ceph_clock_now();
 
     // object_info_t

--- a/src/crimson/osd/watch.cc
+++ b/src/crimson/osd/watch.cc
@@ -7,6 +7,8 @@
 #include <boost/range/algorithm_ext/insert.hpp>
 
 #include "crimson/osd/watch.h"
+#include "crimson/osd/osd_operations/internal_client_request.h"
+
 #include "messages/MWatchNotify.h"
 
 
@@ -18,6 +20,58 @@ namespace {
 
 namespace crimson::osd {
 
+// a watcher can remove itself if it has not seen a notification after a period of time.
+// in the case, we need to drop it also from the persisted `ObjectState` instance.
+// this operation resembles a bit the `_UNWATCH` subop.
+class WatchTimeoutRequest final : public InternalClientRequest {
+public:
+  WatchTimeoutRequest(WatchRef watch, Ref<PG> pg)
+    : InternalClientRequest(std::move(pg)),
+      watch(std::move(watch)) {
+  }
+
+  const hobject_t& get_target_oid() const final;
+  PG::do_osd_ops_params_t get_do_osd_ops_params() const final;
+  std::vector<OSDOp> create_osd_ops() final;
+
+private:
+  WatchRef watch;
+};
+
+const hobject_t& WatchTimeoutRequest::get_target_oid() const
+{
+  assert(watch->obc);
+  return watch->obc->get_oid();
+}
+
+PG::do_osd_ops_params_t
+WatchTimeoutRequest::get_do_osd_ops_params() const
+{
+  PG::do_osd_ops_params_t params;
+  params.conn = watch->conn;
+  params.reqid.name = watch->entity_name;
+  // as in the classical's simple_opc_create()
+  params.mtime = ceph_clock_now();
+  params.map_epoch = get_pg().get_osdmap_epoch();
+  params.orig_source_inst = { watch->entity_name, watch->winfo.addr };
+  //entity_inst_t orig_source_inst;
+  params.features = 0;
+  logger().debug("{}: params.reqid={}", __func__, params.reqid);
+  return params;
+}
+
+std::vector<OSDOp> WatchTimeoutRequest::create_osd_ops()
+{
+  logger().debug("{}", __func__);
+  assert(watch);
+  OSDOp osd_op;
+  osd_op.op.op = CEPH_OSD_OP_WATCH;
+  osd_op.op.flags = 0;
+  osd_op.op.watch.op = CEPH_OSD_WATCH_OP_UNWATCH;
+  osd_op.op.watch.cookie = watch->winfo.cookie;
+  return std::vector{std::move(osd_op)};
+}
+
 Watch::~Watch()
 {
   logger().debug("{} gid={} cookie={}", __func__, get_watcher_gid(), get_cookie());
@@ -27,8 +81,10 @@ seastar::future<> Watch::connect(crimson::net::ConnectionRef conn, bool)
 {
   if (this->conn == conn) {
     logger().debug("conn={} already connected", conn);
+    timeout_timer.cancel();
   }
 
+  timeout_timer.arm(std::chrono::seconds{winfo.timeout_seconds});
   this->conn = std::move(conn);
   return seastar::now();
 }
@@ -87,6 +143,16 @@ void Watch::discard_state()
 {
   ceph_assert(obc);
   in_progress_notifies.clear();
+  timeout_timer.cancel();
+}
+
+void Watch::got_ping(utime_t)
+{
+  if (is_connected()) {
+    // using cancel() + arm() as rearm() has no overload for time delta.
+    timeout_timer.cancel();
+    timeout_timer.arm(std::chrono::seconds{winfo.timeout_seconds});
+  }
 }
 
 seastar::future<> Watch::remove(const bool send_disconnect)
@@ -111,6 +177,12 @@ void Watch::cancel_notify(const uint64_t notify_id)
   const auto it = in_progress_notifies.find(notify_id);
   assert(it != std::end(in_progress_notifies));
   in_progress_notifies.erase(it);
+}
+
+void Watch::do_watch_timeout(Ref<PG> pg)
+{
+  pg->get_shard_services().start_operation<WatchTimeoutRequest>(
+    shared_from_this(), pg);
 }
 
 bool notify_reply_t::operator<(const notify_reply_t& rhs) const

--- a/src/crimson/osd/watch.cc
+++ b/src/crimson/osd/watch.cc
@@ -209,7 +209,7 @@ seastar::future<> Notify::send_completion(
   return conn->send(std::move(reply));
 }
 
-void Notify::do_timeout()
+void Notify::do_notify_timeout()
 {
   logger().debug("{} complete={}", __func__, complete);
   if (complete) {

--- a/src/crimson/osd/watch.h
+++ b/src/crimson/osd/watch.h
@@ -75,7 +75,7 @@ public:
   }
   void got_ping(utime_t);
 
-  seastar::future<> remove(bool send_disconnect);
+  seastar::future<> remove();
 
   /// Call when notify_ack received on notify_id
   seastar::future<> notify_ack(

--- a/src/crimson/osd/watch.h
+++ b/src/crimson/osd/watch.h
@@ -116,7 +116,7 @@ class Notify : public seastar::enable_shared_from_this<Notify> {
   bool complete{false};
   bool discarded{false};
   seastar::timer<seastar::lowres_clock> timeout_timer{
-    [this] { do_timeout(); }
+    [this] { do_notify_timeout(); }
   };
 
   /// (gid,cookie) -> reply_bl for everyone who acked the notify
@@ -129,7 +129,7 @@ class Notify : public seastar::enable_shared_from_this<Notify> {
     std::set<WatchRef> timedout_watchers = {});
 
   /// Called on Notify timeout
-  void do_timeout();
+  void do_notify_timeout();
 
   Notify(crimson::net::ConnectionRef conn,
          const notify_info_t& ninfo,

--- a/src/osd/osd_op_util.h
+++ b/src/osd/osd_op_util.h
@@ -74,6 +74,10 @@ public:
   int set_from_op(
     const MOSDOp *m,
     const OSDMap &osdmap);
+  int set_from_op(
+    const std::vector<OSDOp> &ops,
+    const pg_t &pg,
+    const OSDMap &osdmap);
 
   std::vector<ClassInfo> get_classes() const {
     return classes;


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
