### PR TITLE
pacific: mgr/dashboard: Revoke read-only user's access to Manager modules  

### DIFF
--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -217,9 +217,10 @@ ADMIN_ROLE = Role(
 
 # read-only role provides read-only permission for all scopes
 READ_ONLY_ROLE = Role(
-    'read-only', 'allows read permission for all security scopes except dashboard settings', {
+    'read-only',
+    'allows read permission for all security scope except dashboard settings and config-opt', {
         scope_name: [_P.READ] for scope_name in Scope.all_scopes()
-        if scope_name != Scope.DASHBOARD_SETTINGS
+        if scope_name not in (Scope.DASHBOARD_SETTINGS, Scope.CONFIG_OPT)
     })
 
 
@@ -246,7 +247,7 @@ RGW_MGR_ROLE = Role(
 # Config options
 CLUSTER_MGR_ROLE = Role(
     'cluster-manager', """allows full permissions for the hosts, osd, mon, mgr,
-    and config-opt scopes.""", {
+    and config-opt scopes""", {
         Scope.HOSTS: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
         Scope.OSD: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
         Scope.MONITOR: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],

--- a/src/pybind/mgr/dashboard/tests/test_access_control.py
+++ b/src/pybind/mgr/dashboard/tests/test_access_control.py
@@ -154,8 +154,10 @@ class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
     def test_show_system_role(self):
         role = self.exec_cmd('ac-role-show', rolename="read-only")
         self.assertEqual(role['name'], 'read-only')
-        self.assertEqual(role['description'],
-                         'allows read permission for all security scopes except dashboard settings')
+        self.assertEqual(
+            role['description'],
+            'allows read permission for all security scope except dashboard settings and config-opt'
+        )
 
     def test_delete_system_role(self):
         with self.assertRaises(CmdException) as ctx:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50203

---

backport of https://github.com/ceph/ceph/pull/40624
parent tracker: https://tracker.ceph.com/issues/50174

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh