### PR TITLE
octopus: mgr/dashboard: Revoke read-only user's access to Manager modules   

### DIFF
--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -219,7 +219,7 @@ ADMIN_ROLE = Role('administrator', 'Administrator', {
 # read-only role provides read-only permission for all scopes
 READ_ONLY_ROLE = Role('read-only', 'Read-Only', {
     scope_name: [_P.READ] for scope_name in Scope.all_scopes()
-    if scope_name != Scope.DASHBOARD_SETTINGS
+    if scope_name not in (Scope.DASHBOARD_SETTINGS, Scope.CONFIG_OPT)
 })
 
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50204

---

backport of https://github.com/ceph/ceph/pull/40624
parent tracker: https://tracker.ceph.com/issues/50174

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh