### PR TITLE
doc/cephadm: fix a typo

### DIFF
--- a/doc/cephadm/iscsi.rst
+++ b/doc/cephadm/iscsi.rst
@@ -7,7 +7,7 @@ iSCSI Service
 Deploying iSCSI
 ===============
 
-To deploy an iSCSI Ganesha gateway, create a yaml file containing a 
+To deploy an iSCSI gateway, create a yaml file containing a
 service specification for iscsi:
 
 .. code-block:: yaml


### PR DESCRIPTION
This fixes a small typo in the cephadm/iscsi documentation

s/iSCSI Ganesha gateway/iSCSI gateway/

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>
