### PR TITLE
crimson/osd: fix the lifetime of Notify during timeouts

### DIFF
--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -155,6 +155,7 @@ OpsExecuter::watch_ierrorator::future<> OpsExecuter::do_op_watch_subop_watch(
   ObjectState& os,
   ceph::os::Transaction& txn)
 {
+  logger().debug("{}", __func__);
   struct connect_ctx_t {
     ObjectContext::watch_key_t key;
     crimson::net::ConnectionRef conn;

--- a/src/crimson/osd/watch.cc
+++ b/src/crimson/osd/watch.cc
@@ -18,6 +18,11 @@ namespace {
 
 namespace crimson::osd {
 
+Watch::~Watch()
+{
+  logger().debug("{} gid={} cookie={}", __func__, get_watcher_gid(), get_cookie());
+}
+
 seastar::future<> Watch::connect(crimson::net::ConnectionRef conn, bool)
 {
   if (this->conn == conn) {
@@ -215,6 +220,10 @@ void Notify::do_timeout()
   // to avoid use-after-free we bump up the ref counter with `guard_ptr`.
   [[maybe_unused]] auto guard_ptr = shared_from_this();
   for (auto& watcher : watchers) {
+    logger().debug("canceling watcher cookie={} gid={} use_count={}",
+      watcher->get_cookie(),
+      watcher->get_watcher_gid(),
+      watcher->use_count());
     watcher->cancel_notify(ninfo.notify_id);
   }
   std::ignore = send_completion(std::move(watchers));

--- a/src/crimson/osd/watch.cc
+++ b/src/crimson/osd/watch.cc
@@ -210,6 +210,10 @@ void Notify::do_timeout()
   if (complete) {
     return;
   }
+  // it might be that `this` is kept alive only because of the reference
+  // a watcher stores and which is being removed by `cancel_notify()`.
+  // to avoid use-after-free we bump up the ref counter with `guard_ptr`.
+  [[maybe_unused]] auto guard_ptr = shared_from_this();
   for (auto& watcher : watchers) {
     watcher->cancel_notify(ninfo.notify_id);
   }

--- a/src/crimson/osd/watch.h
+++ b/src/crimson/osd/watch.h
@@ -55,6 +55,7 @@ public:
       winfo(winfo),
       entity_name(entity_name) {
   }
+  ~Watch();
 
   seastar::future<> connect(crimson::net::ConnectionRef, bool);
   bool is_alive() const {

--- a/src/crimson/osd/watch.h
+++ b/src/crimson/osd/watch.h
@@ -106,7 +106,7 @@ struct notify_reply_t {
 };
 std::ostream &operator<<(std::ostream &out, const notify_reply_t &rhs);
 
-class Notify {
+class Notify : public seastar::enable_shared_from_this<Notify> {
   std::set<WatchRef> watchers;
   const notify_info_t ninfo;
   crimson::net::ConnectionRef conn;


### PR DESCRIPTION
This fixes a segfault during `LibRadosWatchNotify.WatchNotify2Timeout`.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
