### PR TITLE
octopus: mgr/dashboard: Remove redundant pytest requirement

### DIFF
--- a/src/pybind/mgr/dashboard/requirements-lint.txt
+++ b/src/pybind/mgr/dashboard/requirements-lint.txt
@@ -9,4 +9,3 @@ flake8-colors==0.1.6; python_version >= '3'
 rstcheck==3.3.1; python_version >= '3'
 autopep8; python_version >= '3'
 pyfakefs; python_version >= '3'
-pytest

--- a/src/pybind/mgr/dashboard/requirements-test.txt
+++ b/src/pybind/mgr/dashboard/requirements-test.txt
@@ -1,5 +1,4 @@
 mock; python_version <= '3.3'
-pytest
 pytest-cov
 pytest-instafail
 pyfakefs

--- a/src/pybind/mgr/dashboard/requirements-test.txt
+++ b/src/pybind/mgr/dashboard/requirements-test.txt
@@ -1,5 +1,5 @@
 mock; python_version <= '3.3'
-pytest<4
+pytest
 pytest-cov
 pytest-instafail
 pyfakefs

--- a/src/pybind/mgr/dashboard/requirements.txt
+++ b/src/pybind/mgr/dashboard/requirements.txt
@@ -10,4 +10,5 @@ Routes
 six
 -e ../../../python-common
 prettytable
+pytest
 pyyaml

--- a/src/pybind/mgr/dashboard/tests/__init__.py
+++ b/src/pybind/mgr/dashboard/tests/__init__.py
@@ -19,6 +19,7 @@ from .. import mgr
 from ..controllers import json_error_page, generate_controller_routes
 from ..services.auth import AuthManagerTool
 from ..services.exception import dashboard_exception_handler
+from ..tools import RequestLoggingTool
 
 from ..plugins import PLUGIN_MANAGER
 from ..plugins import feature_toggles, debug  # noqa
@@ -133,7 +134,11 @@ class ControllerTestCase(helper.CPWebCase):
         cherrypy.tree.mount(None, config={
             base_url: {'request.dispatch': mapper}})
 
-    def __init__(self, *args, **kwargs):
+    _request_logging = False
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
         cherrypy.tools.authenticate = AuthManagerTool()
         cherrypy.tools.dashboard_exception_handler = HandlerWrapperTool(dashboard_exception_handler,
                                                                         priority=31)
@@ -143,7 +148,15 @@ class ControllerTestCase(helper.CPWebCase):
             'tools.json_in.force': False
         })
         PLUGIN_MANAGER.hook.configure_cherrypy(config=cherrypy.config)
-        super(ControllerTestCase, self).__init__(*args, **kwargs)
+
+        if cls._request_logging:
+            cherrypy.tools.request_logging = RequestLoggingTool()
+            cherrypy.config.update({'tools.request_logging.on': True})
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._request_logging:
+            cherrypy.config.update({'tools.request_logging.on': False})
 
     def _request(self, url, method, data=None, headers=None):
         if not data:

--- a/src/pybind/mgr/dashboard/tests/test_api_auditing.py
+++ b/src/pybind/mgr/dashboard/tests/test_api_auditing.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import re
 import json
-import cherrypy
+
 try:
     import mock
 except ImportError:
@@ -11,7 +11,6 @@ except ImportError:
 
 from . import ControllerTestCase, KVStoreMockMixin  # pylint: disable=no-name-in-module
 from ..controllers import RESTController, Controller
-from ..tools import RequestLoggingTool
 from .. import mgr
 
 
@@ -33,10 +32,7 @@ class FooResource(RESTController):
 
 class ApiAuditingTest(ControllerTestCase, KVStoreMockMixin):
 
-    def __init__(self, *args, **kwargs):
-        cherrypy.tools.request_logging = RequestLoggingTool()
-        cherrypy.config.update({'tools.request_logging.on': True})
-        super(ApiAuditingTest, self).__init__(*args, **kwargs)
+    _request_logging = True
 
     @classmethod
     def setup_server(cls):

--- a/src/pybind/mgr/dashboard/tests/test_settings.py
+++ b/src/pybind/mgr/dashboard/tests/test_settings.py
@@ -135,7 +135,19 @@ class SettingsControllerTest(ControllerTestCase, KVStoreMockMixin):
         SettingsController._cp_config['tools.authenticate.on'] = False
         cls.setup_controllers([SettingsController])
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # pylint: disable=protected-access
+        settings.Options.GRAFANA_API_HOST = ('localhost', str)
+        settings.Options.GRAFANA_ENABLED = (False, bool)
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+
     def setUp(self):
+        super().setUp()
         self.mock_kv_store()
 
     def test_settings_list(self):

--- a/src/pybind/mgr/dashboard/tests/test_tools.py
+++ b/src/pybind/mgr/dashboard/tests/test_tools.py
@@ -11,11 +11,10 @@ except ImportError:
     from unittest.mock import patch
 
 from . import ControllerTestCase  # pylint: disable=no-name-in-module
+from ..tools import dict_contains_path, dict_get, json_str_to_object, partial_dict
 from ..services.exception import handle_rados_error
 from ..controllers import RESTController, ApiController, Controller, \
                           BaseController, Proxy
-from ..tools import dict_contains_path, json_str_to_object, partial_dict,\
-                    dict_get, RequestLoggingTool
 
 
 # pylint: disable=W0613
@@ -151,10 +150,7 @@ class RESTControllerTest(ControllerTestCase):
 
 class RequestLoggingToolTest(ControllerTestCase):
 
-    def __init__(self, *args, **kwargs):
-        cherrypy.tools.request_logging = RequestLoggingTool()
-        cherrypy.config.update({'tools.request_logging.on': True})
-        super(RequestLoggingToolTest, self).__init__(*args, **kwargs)
+    _request_logging = True
 
     @classmethod
     def setup_server(cls):

--- a/src/tools/setup-virtualenv.sh
+++ b/src/tools/setup-virtualenv.sh
@@ -66,9 +66,17 @@ else
     DISABLE_PIP_VERSION_CHECK=
 fi
 
+if pip --help | grep -q use-feature; then
+    USE_FEATURE=--use-feature=2020-resolver
+else
+    USE_FEATURE=
+fi
+
 # older versions of pip will not install wrap_console scripts
 # when using wheel packages
-pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install --upgrade 'pip >= 6.1'
+pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install \
+    $USE_FEATURE \
+    --upgrade 'pip >= 6.1'
 
 if pip --help | grep -q disable-pip-version-check; then
     DISABLE_PIP_VERSION_CHECK=--disable-pip-version-check
@@ -80,7 +88,10 @@ if test -d wheelhouse ; then
     export NO_INDEX=--no-index
 fi
 
-pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install $NO_INDEX --find-links=file://$(pwd)/wheelhouse 'tox >=2.9.1'
+pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install \
+    $USE_FEATURE \
+    $NO_INDEX \
+    --find-links=file://$(pwd)/wheelhouse 'tox >=2.9.1'
 
 require_files=$(ls *requirements*.txt 2>/dev/null) || true
 constraint_files=$(ls *constraints*.txt 2>/dev/null) || true
@@ -91,6 +102,8 @@ if test "$require"; then
     if ! test -f $md5 || ! md5sum -c wheelhouse/md5 > /dev/null; then
         NO_INDEX=''
     fi
-    pip --exists-action i $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install $NO_INDEX \
-      --find-links=file://$(pwd)/wheelhouse $require $constraint 
+    pip --exists-action i $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install \
+        $USE_FEATURE \
+        $NO_INDEX \
+        --find-links=file://$(pwd)/wheelhouse $require $constraint
 fi


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/50228

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
