### PR TITLE
ceph-volume,python-common: Data allocate fraction

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -1,6 +1,7 @@
 import argparse
 from collections import namedtuple
 import json
+import math
 import logging
 from textwrap import dedent
 from ceph_volume import terminal, decorators
@@ -53,7 +54,7 @@ def get_physical_osds(devices, args):
     data_slots = args.osds_per_device
     if args.data_slots:
         data_slots = max(args.data_slots, args.osds_per_device)
-    rel_data_size = 1.0 / data_slots
+    rel_data_size = args.data_allocate_fraction / data_slots
     mlogger.debug('relative data size: {}'.format(rel_data_size))
     ret = []
     for dev in devices:
@@ -268,6 +269,17 @@ class Batch(object):
             help=('Provision more than 1 (the default) OSD slot per device'
                   ' if more slots then osds-per-device are specified, slots'
                   'will stay unoccupied'),
+        )
+        def data_allocate_fraction(pct):
+            pct_float = float(pct)
+            if math.isnan(pct_float) or pct_float == 0.0  or pct_float < 0.0 or pct_float > 1.0:
+                raise argparse.ArgumentTypeError('Percentage not in (0,1.0]')
+            return pct_float
+        parser.add_argument(
+            '--data-allocate-fraction',
+            type=data_allocate_fraction,
+            help='Fraction to allocate from data device (0,1.0]',
+            default=1.0
         )
         parser.add_argument(
             '--block-db-size',

--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -1,7 +1,6 @@
 import argparse
 from collections import namedtuple
 import json
-import math
 import logging
 from textwrap import dedent
 from ceph_volume import terminal, decorators
@@ -270,14 +269,9 @@ class Batch(object):
                   ' if more slots then osds-per-device are specified, slots'
                   'will stay unoccupied'),
         )
-        def data_allocate_fraction(pct):
-            pct_float = float(pct)
-            if math.isnan(pct_float) or pct_float == 0.0  or pct_float < 0.0 or pct_float > 1.0:
-                raise argparse.ArgumentTypeError('Percentage not in (0,1.0]')
-            return pct_float
         parser.add_argument(
             '--data-allocate-fraction',
-            type=data_allocate_fraction,
+            type=arg_validators.ValidFraction(),
             help='Fraction to allocate from data device (0,1.0]',
             default=1.0
         )

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -293,3 +293,7 @@ def device_info(monkeypatch, patch_bluestore_label):
         monkeypatch.setattr("ceph_volume.util.device.disk.blkid", lambda path: blkid)
         monkeypatch.setattr("ceph_volume.util.disk.udevadm_property", lambda *a, **kw: udevadm)
     return apply
+
+@pytest.fixture(params=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.999, 1.0])
+def data_allocate_fraction(request):
+    return request.param

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
@@ -49,6 +49,7 @@ class TestBatch(object):
                        bluestore=True,
                        block_db_size="1G",
                        dmcrypt=True,
+                       data_allocate_fraction=1.0,
                       )
         b = batch.Batch([])
         plan = b.get_plan(args)
@@ -71,6 +72,7 @@ class TestBatch(object):
                        bluestore=True,
                        block_db_size="1G",
                        dmcrypt=True,
+                       data_allocate_fraction=1.0,
                       )
         b = batch.Batch([])
         plan = b.get_plan(args)
@@ -96,6 +98,7 @@ class TestBatch(object):
                        bluestore=True,
                        block_db_size="1G",
                        dmcrypt=True,
+                       data_allocate_fraction=1.0,
                       )
         b = batch.Batch([])
         plan = b.get_plan(args)
@@ -123,6 +126,7 @@ class TestBatch(object):
                        bluestore=True,
                        block_db_size="1G",
                        dmcrypt=True,
+                       data_allocate_fraction=1.0,
                       )
         b = batch.Batch([])
         plan = b.get_plan(args)
@@ -170,30 +174,35 @@ class TestBatch(object):
                                           osds_per_device):
         conf_ceph_stub('[global]\nfsid=asdf-lkjh')
         args = factory(data_slots=1, osds_per_device=osds_per_device,
-                       osd_ids=[], dmcrypt=False)
+                       osd_ids=[], dmcrypt=False,
+                       data_allocate_fraction=1.0)
         osds = batch.get_physical_osds(mock_devices_available, args)
         assert len(osds) == len(mock_devices_available) * osds_per_device
 
     def test_get_physical_osds_rel_size(self, factory,
                                           mock_devices_available,
                                           conf_ceph_stub,
-                                          osds_per_device):
+                                          osds_per_device,
+                                          data_allocate_fraction):
         args = factory(data_slots=1, osds_per_device=osds_per_device,
-                       osd_ids=[], dmcrypt=False)
+                       osd_ids=[], dmcrypt=False,
+                       data_allocate_fraction=data_allocate_fraction)
         osds = batch.get_physical_osds(mock_devices_available, args)
         for osd in osds:
-            assert osd.data[1] == 1.0 / osds_per_device
+            assert osd.data[1] == data_allocate_fraction / osds_per_device
 
     def test_get_physical_osds_abs_size(self, factory,
                                           mock_devices_available,
                                           conf_ceph_stub,
-                                          osds_per_device):
+                                          osds_per_device,
+                                          data_allocate_fraction):
         conf_ceph_stub('[global]\nfsid=asdf-lkjh')
         args = factory(data_slots=1, osds_per_device=osds_per_device,
-                       osd_ids=[], dmcrypt=False)
+                       osd_ids=[], dmcrypt=False,
+                       data_allocate_fraction=data_allocate_fraction)
         osds = batch.get_physical_osds(mock_devices_available, args)
         for osd, dev in zip(osds, mock_devices_available):
-            assert osd.data[2] == int(dev.vg_size[0] / osds_per_device)
+            assert osd.data[2] == int(dev.vg_size[0] * (data_allocate_fraction / osds_per_device))
 
     def test_get_physical_osds_osd_ids(self, factory,
                                           mock_devices_available,

--- a/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
@@ -87,3 +87,30 @@ class TestValidDevice(object):
     def test_path_is_invalid(self, fake_call):
         with pytest.raises(argparse.ArgumentError):
             self.validator('/device/does/not/exist')
+
+
+class TestValidFraction(object):
+
+    def setup(self):
+        self.validator = arg_validators.ValidFraction()
+
+    def test_fraction_is_valid(self, fake_call):
+        result = self.validator('0.8')
+        assert result == 0.8
+
+    def test_fraction_is_nan(self, fake_call):
+        with pytest.raises(argparse.ArgumentError):
+            self.validator('NaN')
+
+    def test_fraction_is_negative(self, fake_call):
+        with pytest.raises(argparse.ArgumentError):
+            self.validator('-1.0')
+
+    def test_fraction_is_zero(self, fake_call):
+        with pytest.raises(argparse.ArgumentError):
+            self.validator('0.0')
+
+    def test_fraction_is_greater_one(self, fake_call):
+        with pytest.raises(argparse.ArgumentError):
+            self.validator('1.1')
+

--- a/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
@@ -98,6 +98,10 @@ class TestValidFraction(object):
         result = self.validator('0.8')
         assert result == 0.8
 
+    def test_fraction_not_float(self, fake_call):
+        with pytest.raises(ValueError):
+            self.validator('xyz')
+
     def test_fraction_is_nan(self, fake_call):
         with pytest.raises(argparse.ArgumentError):
             self.validator('NaN')

--- a/src/ceph-volume/ceph_volume/util/arg_validators.py
+++ b/src/ceph-volume/ceph_volume/util/arg_validators.py
@@ -158,5 +158,5 @@ class ValidFraction(object):
     def __call__(self, fraction):
         fraction_float = float(fraction)
         if math.isnan(fraction_float) or fraction_float <= 0.0 or fraction_float > 1.0:
-            raise argparse.ArgumentTypeError('Fraction not in (0,1.0]')
+            raise argparse.ArgumentError(None, 'Fraction %f not in (0,1.0]' % fraction_float)
         return fraction_float

--- a/src/ceph-volume/ceph_volume/util/arg_validators.py
+++ b/src/ceph-volume/ceph_volume/util/arg_validators.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import math
 from ceph_volume import terminal
 from ceph_volume import decorators
 from ceph_volume.util import disk
@@ -148,3 +149,14 @@ def exclude_group_options(parser, groups, argv=None):
                     terminal.warning(msg)
             last_group = group_name
         last_flag = flag
+
+class ValidFraction(object):
+    """
+    Validate fraction is in (0, 1.0]
+    """
+
+    def __call__(self, fraction):
+        fraction_float = float(fraction)
+        if math.isnan(fraction_float) or fraction_float <= 0.0 or fraction_float > 1.0:
+            raise argparse.ArgumentTypeError('Fraction not in (0,1.0]')
+        return fraction_float

--- a/src/python-common/ceph/deployment/drive_group.py
+++ b/src/python-common/ceph/deployment/drive_group.py
@@ -143,7 +143,8 @@ class DriveGroupSpec(ServiceSpec):
         "db_slots", "wal_slots", "block_db_size", "placement", "service_id", "service_type",
         "data_devices", "db_devices", "wal_devices", "journal_devices",
         "data_directories", "osds_per_device", "objectstore", "osd_id_claims",
-        "journal_size", "unmanaged", "filter_logic", "preview_only"
+        "journal_size", "unmanaged", "filter_logic", "preview_only",
+        "data_allocate_fraction"
     ]
 
     def __init__(self,
@@ -167,6 +168,7 @@ class DriveGroupSpec(ServiceSpec):
                  unmanaged=False,  # type: bool
                  filter_logic='AND',  # type: str
                  preview_only=False,  # type: bool
+                 data_allocate_fraction=None,  # type: Optional[float]
                  ):
         assert service_type is None or service_type == 'osd'
         super(DriveGroupSpec, self).__init__('osd', service_id=service_id,
@@ -224,6 +226,9 @@ class DriveGroupSpec(ServiceSpec):
 
         #: If this should be treated as a 'preview' spec
         self.preview_only = preview_only
+
+        #: Allocate a fraction of the data device (0,1.0]
+        self.data_allocate_fraction = data_allocate_fraction
 
     @classmethod
     def _from_json_impl(cls, json_drive_group):

--- a/src/python-common/ceph/deployment/translate.py
+++ b/src/python-common/ceph/deployment/translate.py
@@ -72,6 +72,9 @@ class to_ceph_volume(object):
         if self.spec.osds_per_device:
             cmd += " --osds-per-device {}".format(self.spec.osds_per_device)
 
+        if self.spec.data_allocate_fraction:
+            cmd += " --data-allocate-fraction {}".format(self.spec.data_allocate_fraction)
+
         if self.osd_id_claims:
             cmd += " --osd-ids {}".format(" ".join(self.osd_id_claims))
 

--- a/src/python-common/ceph/tests/test_drive_group.py
+++ b/src/python-common/ceph/tests/test_drive_group.py
@@ -253,3 +253,16 @@ def test_ceph_volume_command_8():
     sel = drive_selection.DriveSelection(spec, inventory)
     cmd = translate.to_ceph_volume(sel, []).run()
     assert cmd == 'lvm batch --no-auto /dev/sda /dev/sdb --db-devices /dev/sdc --yes --no-systemd'
+
+
+def test_ceph_volume_command_9():
+    spec = DriveGroupSpec(placement=PlacementSpec(host_pattern='*'),
+                          service_id='foobar',
+                          data_devices=DeviceSelection(all=True),
+                          data_allocate_fraction=0.8
+                          )
+    spec.validate()
+    inventory = _mk_inventory(_mk_device()*2)
+    sel = drive_selection.DriveSelection(spec, inventory)
+    cmd = translate.to_ceph_volume(sel, []).run()
+    assert cmd == 'lvm batch --no-auto /dev/sda /dev/sdb --data-allocate-fraction 0.8 --yes --no-systemd'


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

This PR allows to partially allocate a data device when preparing/deploying an OSD with ceph-volume or through the device group specification. The fraction can be between (0,1.0] where a fraction of e.g. 0.8 will allocate 80% of the data device, i.e. the lvm size will only account for 80% of the device's capacity. The rest of the device will not be allocated. This can be used to alleviate write performance degradation of Flash SSDs.
This PR adds `--data-allocate-fraciton` to ceph-volume lvm batch and the `data_allocate_fraction` feature to the device group specification.

## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
