### PR TITLE
crimson/os/seastore: add set/get attrs and write/read meta methods for seastore

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -209,8 +209,9 @@ std::optional<record_t> Cache::try_construct_record(Transaction &t)
 {
   // First, validate read set
   for (auto &i: t.read_set) {
-    if (i->state == CachedExtent::extent_state_t::INVALID)
+    if (i->state == CachedExtent::extent_state_t::INVALID) {
       return std::nullopt;
+    }
   }
 
   record_t record;

--- a/src/crimson/os/seastore/onode.h
+++ b/src/crimson/os/seastore/onode.h
@@ -14,10 +14,29 @@
 namespace crimson::os::seastore {
 
 struct onode_layout_t {
+  // around 350 bytes for fixed fields in object_info_t,
+  // the left are for the variable-sized fields like oid
+  // FIXME: object_info_t may need to shrinked, at least
+  // 	    oid doesn't need to be held in it.
+  static constexpr int MAX_OI_LENGTH = 1024;
+  // We might want to move the ss field out of onode_layout_t.
+  // The reason is that ss_attr may grow to relative large, as
+  // its clone_overlap may grow to a large size, if applications
+  // set objects to a relative large size(for the purpose of reducing
+  // the number of objects per OSD, so that all objects' metadata
+  // can be cached in memory) and do many modifications between
+  // snapshots.
+  static constexpr int MAX_SS_LENGTH = 128;
+
   ceph_le32 size{0};
+  ceph_le32 oi_size{0};
+  ceph_le32 ss_size{0};
   omap_root_le_t omap_root;
 
   object_data_le_t object_data;
+
+  char oi[MAX_OI_LENGTH];
+  char ss[MAX_SS_LENGTH];
 } __attribute__((packed));
 
 class Transaction;

--- a/src/crimson/os/seastore/onode_manager.h
+++ b/src/crimson/os/seastore/onode_manager.h
@@ -37,7 +37,8 @@ public:
     return seastar::make_ready_future<OnodeRef>();
   }
 
-  using get_or_create_onode_ertr = base_ertr;
+  using get_or_create_onode_ertr = base_ertr::extend<
+    crimson::ct_error::value_too_large>;
   using get_or_create_onode_ret = get_or_create_onode_ertr::future<
     OnodeRef>;
   virtual get_or_create_onode_ret get_or_create_onode(
@@ -46,7 +47,8 @@ public:
     return seastar::make_ready_future<OnodeRef>();
   }
 
-  using get_or_create_onodes_ertr = base_ertr;
+  using get_or_create_onodes_ertr = base_ertr::extend<
+    crimson::ct_error::value_too_large>;
   using get_or_create_onodes_ret = get_or_create_onodes_ertr::future<
     std::vector<OnodeRef>>;
   virtual get_or_create_onodes_ret get_or_create_onodes(

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.h"
+#include "crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h"
 
 namespace {
 [[maybe_unused]] seastar::logger& logger() {
@@ -41,6 +42,10 @@ FLTreeOnodeManager::get_or_create_onode_ret
 FLTreeOnodeManager::get_or_create_onode(
   Transaction &trans,
   const ghobject_t &hoid) {
+  if (hoid.hobj.oid.name.length() + hoid.hobj.nspace.length()
+      > key_view_t::MAX_NS_OID_LENGTH) {
+    return crimson::ct_error::value_too_large::make();
+  }
   return tree.insert(
     trans, hoid,
     OnodeTree::tree_value_config_t{sizeof(onode_layout_t)}

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/key_layout.h
@@ -9,6 +9,7 @@
 #include <ostream>
 
 #include "common/hobject.h"
+#include "crimson/os/seastore/onode.h"
 #include "crimson/os/seastore/onode_manager/staged-fltree/fwd.h"
 
 namespace crimson::os::seastore::onode {
@@ -555,6 +556,13 @@ inline std::ostream& operator<<(std::ostream& os, const key_hobj_t& key) {
  */
 class key_view_t {
  public:
+  //FIXME: the length of ns and oid should be defined by osd_max_object_name_len
+  //       and object_max_object_namespace_len in the future
+  static constexpr int MAX_NS_OID_LENGTH =
+    (4096 - sizeof(onode_layout_t) * 2) / 4
+    - sizeof(shard_pool_t) - sizeof(crush_t) - sizeof(snap_gen_t)
+    - 8; // size of length field of oid and ns
+
   /**
    * common interfaces as a full_key_t
    */

--- a/src/crimson/os/seastore/root_block.h
+++ b/src/crimson/os/seastore/root_block.h
@@ -38,6 +38,8 @@ struct RootBlock : CachedExtent {
 
   root_t root;
 
+  std::map<std::string, std::string> meta;
+
   RootBlock() : CachedExtent(0) {}
 
   RootBlock(const RootBlock &rhs) = default;
@@ -66,6 +68,11 @@ struct RootBlock : CachedExtent {
     ceph::bufferlist bl = _bl;
     bl.rebuild();
     root = *reinterpret_cast<const root_t*>(bl.front().c_str());
+    if (root.have_meta) {
+      ceph::bufferlist meta_bl;
+      meta_bl.rebuild(ceph::buffer::ptr_node::create(&root.meta[0], root_t::MAX_META_LENGTH));
+      decode(meta, meta_bl);
+    }
     root.adjust_addrs_from_base(base);
   }
 
@@ -83,6 +90,7 @@ struct RootBlock : CachedExtent {
   }
 
   root_t &get_root() { return root; }
+
 };
 using RootBlockRef = RootBlock::Ref;
 

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -655,9 +655,14 @@ public:
  * TODO: generalize this to permit more than one lba_manager implementation
  */
 struct __attribute__((packed)) root_t {
+
+  static constexpr int MAX_META_LENGTH = 1024;
+
   lba_root_t lba_root;
   laddr_le_t onode_root;
   coll_root_le_t collection_root;
+  char meta[MAX_META_LENGTH];
+  bool have_meta = false;
 
   void adjust_addrs_from_base(paddr_t base) {
     lba_root.adjust_addrs_from_base(base);

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -15,6 +15,7 @@
 namespace crimson::os::seastore {
 
 struct retired_extent_gate_t;
+class SeaStore;
 
 /**
  * Transaction
@@ -161,6 +162,8 @@ public:
       write_set.erase(*i++);
     }
   }
+
+  friend class crimson::os::seastore::SeaStore;
 };
 using TransactionRef = Transaction::Ref;
 

--- a/src/test/crimson/seastore/test_seastore.cc
+++ b/src/test/crimson/seastore/test_seastore.cc
@@ -1,5 +1,5 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
-// vim: ts=8 sw=2 smarttab
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab expandtab
 
 #include <string>
 #include <iostream>
@@ -51,6 +51,17 @@ struct seastore_test_t :
     return seastore->do_transaction(
       coll,
       std::move(t)).get0();
+  }
+
+  void set_meta(
+    const std::string& key,
+    const std::string& value) {
+    return seastore->write_meta(key, value).get0();
+  }
+
+  std::tuple<int, std::string> get_meta(
+    const std::string& key) {
+    return seastore->read_meta(key).get();
   }
 
   struct object_state_t {
@@ -265,6 +276,20 @@ TEST_F(seastore_test_t, collection_create_list_remove)
       EXPECT_EQ(collections.size(), 1);
       EXPECT_TRUE(contains(collections, coll_name));
     }
+  });
+}
+
+TEST_F(seastore_test_t, meta) {
+  run_async([this] {
+    set_meta("key1", "value1");
+    set_meta("key2", "value2");
+
+    const auto [ret1, value1] = get_meta("key1");
+    const auto [ret2, value2] = get_meta("key2");
+    EXPECT_EQ(ret1, 0);
+    EXPECT_EQ(ret2, 0);
+    EXPECT_EQ(value1, "value1");
+    EXPECT_EQ(value2, "value2");
   });
 }
 


### PR DESCRIPTION
Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
