### PR TITLE
octopus: packaging: require ceph-common for immutable object cache daemon

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -702,6 +702,7 @@ Summary:	Ceph daemon for immutable object cache
 %if 0%{?suse_version}
 Group:		System/Filesystems
 %endif
+Requires:	ceph-base = %{_epoch_prefix}%{version}-%{release}
 Requires:	librados2 = %{_epoch_prefix}%{version}-%{release}
 %description immutable-object-cache
 Daemon for immutable object cache.

--- a/debian/control
+++ b/debian/control
@@ -505,7 +505,8 @@ Description: debugging symbols for rbd-fuse
 
 Package: ceph-immutable-object-cache
 Architecture: linux-any
-Depends: librados2 (= ${binary:Version}),
+Depends: ceph-common (= ${binary:Version}),
+         librados2 (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends},
 Description: Ceph daemon for immutable object cache


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50232

---

backport of https://github.com/ceph/ceph/pull/40641
parent tracker: https://tracker.ceph.com/issues/50207