### PR TITLE
[mgr/telemetry]: Additional safeguards in JSON handling in serial number anonymization

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -383,7 +383,15 @@ class Module(MgrModule):
             # anonymize the smartctl report itself
             if serial:
                 m_str = json.dumps(m)
-                m = json.loads(m_str.replace(serial, 'deleted'))
+                if len(m_str) > 0:
+                    try:
+                        m = json.loads(m_str.replace(serial, 'deleted'))
+                    except ValueError:
+                        self.log.info('devid %s, host %s - error handling JSON' % (devid, host))
+                        m = json.loads("{}")
+                else:
+                    self.log.info('devid %s, host %s - empty string received' % (devid, host))
+                    m = json.loads("{}")
 
             if anon_host not in res:
                 res[anon_host] = {}


### PR DESCRIPTION

During anonymization process of hard drives' serial numbers, telemetry module might fail (and render cluster in HEALTH_ERR state) if empty string is received instead of JSON object.

Fixes: https://tracker.ceph.com/issues/50205
Signed-off-by: Michal Chybowski <mchybowski@cloudferro.com>


## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
