### PR TITLE
nautilus: rgw: limit rgw_gc_max_objs to RGW_SHARDS_PRIME_1

### DIFF
--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -161,11 +161,11 @@ class RGWGCIOManager {
 
 public:
   RGWGCIOManager(const DoutPrefixProvider* _dpp, CephContext *_cct, RGWGC *_gc) : dpp(_dpp),
-                                                  cct(_cct),
-                                                  gc(_gc),
-                                                  remove_tags(cct->_conf->rgw_gc_max_objs),
-                                                  tag_io_size(cct->_conf->rgw_gc_max_objs) {
+                                                                                  cct(_cct),
+                                                                                  gc(_gc) {
     max_aio = cct->_conf->rgw_gc_max_concurrent_io;
+    remove_tags.resize(min(static_cast<int>(cct->_conf->rgw_gc_max_objs), rgw_shards_max()));
+    tag_io_size.resize(min(static_cast<int>(cct->_conf->rgw_gc_max_objs), rgw_shards_max()));
   }
 
   ~RGWGCIOManager() {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49744

---

backport of https://github.com/ceph/ceph/pull/39515
parent tracker: https://tracker.ceph.com/issues/49321

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh