### PR TITLE
nautilus: rgw: return error when trying to copy encrypted object without key

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3604,7 +3604,7 @@ int RGWPutObj::get_data(const off_t fst, const off_t lst, bufferlist& bl)
     filter = decrypt.get();
   }
   if (op_ret < 0) {
-    return ret;
+    return op_ret;
   }
 
   ret = read_op.range_to_ofs(obj_size, new_ofs, new_end);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50095

---

backport of https://github.com/ceph/ceph/pull/38537
parent tracker: https://tracker.ceph.com/issues/48554

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh