### PR TITLE
nautilus: test/rgw: test_datalog_autotrim filters out new entries

### DIFF
--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -5,6 +5,7 @@ import sys
 import time
 import logging
 import errno
+import dateutil.parser
 
 try:
     from itertools import izip_longest as zip_longest
@@ -92,8 +93,13 @@ def meta_sync_status(zone):
 def mdlog_autotrim(zone):
     zone.cluster.admin(['mdlog', 'autotrim'])
 
-def datalog_list(zone, period = None):
-    cmd = ['datalog', 'list']
+def datalog_list(zone, args = None):
+    cmd = ['datalog', 'list'] + (args or [])
+    (datalog_json, _) = zone.cluster.admin(cmd, read_only=True)
+    return json.loads(datalog_json)
+
+def datalog_status(zone):
+    cmd = ['datalog', 'status']
     (datalog_json, _) = zone.cluster.admin(cmd, read_only=True)
     return json.loads(datalog_json)
 
@@ -975,9 +981,21 @@ def test_datalog_autotrim():
 
     # trim each datalog
     for zone, _ in zone_bucket:
+        # read max markers for each shard
+        status = datalog_status(zone.zone)
+
         datalog_autotrim(zone.zone)
-        datalog = datalog_list(zone.zone)
-        assert len(datalog) == 0
+
+        for shard_id, shard_status in enumerate(status):
+            try:
+                before_trim = dateutil.parser.isoparse(shard_status['last_update'])
+            except: # empty timestamps look like "0.000000" and will fail here
+                continue
+            entries = datalog_list(zone.zone, ['--shard-id', str(shard_id), '--max-entries', '1'])
+            if not len(entries):
+                continue
+            after_trim = dateutil.parser.isoparse(entries[0]['timestamp'])
+            assert before_trim < after_trim, "any datalog entries must be newer than trim"
 
 def test_multi_zone_redirect():
     zonegroup = realm.master_zonegroup()


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50158

---

backport of https://github.com/ceph/ceph/pull/35575
parent tracker: https://tracker.ceph.com/issues/45626

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh