### PR TITLE
pacific: tools/cephfs_mirror/PeerReplayer.cc: add missing include

### DIFF
--- a/src/tools/cephfs_mirror/PeerReplayer.cc
+++ b/src/tools/cephfs_mirror/PeerReplayer.cc
@@ -5,6 +5,7 @@
 #include <fcntl.h>
 #include <algorithm>
 #include <sys/time.h>
+#include <sys/file.h>
 
 #include "common/admin_socket.h"
 #include "common/ceph_context.h"


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50199

---

backport of https://github.com/ceph/ceph/pull/40583
parent tracker: https://tracker.ceph.com/issues/50134

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh