### PR TITLE
pacific: mds: skip the buffer in UnknownPayload::decode()

### DIFF
--- a/src/include/cephfs/metrics/Types.h
+++ b/src/include/cephfs/metrics/Types.h
@@ -367,6 +367,10 @@ struct UnknownPayload {
   }
 
   void decode(bufferlist::const_iterator &iter) {
+    using ceph::decode;
+    DECODE_START(254, iter);
+    iter.seek(struct_len);
+    DECODE_FINISH(iter);
   }
 
   void dump(Formatter *f) const {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50225

---

backport of https://github.com/ceph/ceph/pull/40427
parent tracker: https://tracker.ceph.com/issues/49972

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh