### PR TITLE
pacific: client: fix the opened inodes counter increasing

### DIFF
--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -138,8 +138,9 @@ void Inode::make_nosnap_relative_path(filepath& p)
 void Inode::get_open_ref(int mode)
 {
   client->inc_opened_files();
-  if (open_by_mode.count(mode) == 0)
+  if (open_by_mode[mode] == 0) {
     client->inc_opened_inodes();
+  }
   open_by_mode[mode]++;
   break_deleg(!(mode & CEPH_FILE_MODE_WR));
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50183

---

backport of https://github.com/ceph/ceph/pull/40501
parent tracker: https://tracker.ceph.com/issues/50057

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh