### PR TITLE
pacific: doc/cephfs/nfs: add user id, fs name and key to FSAL block

### DIFF
--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -133,8 +133,17 @@ Example use cases
      Squash = None;
      FSAL {
        Name = CEPH;
+       Filesystem = "filesystem name";
+       User_Id = "user id";
+       Secret_Access_Key = "secret key";
      }
    }
+
+.. note:: User specified in FSAL block should have proper caps for NFS-Ganesha
+   daemons to access ceph cluster. User can be created in following way using
+   `auth get-or-create`::
+
+         # ceph auth get-or-create client.<user_id> mon 'allow r' osd 'allow rw pool=nfs-ganesha namespace=<nfs_cluster_name>, allow rw tag cephfs data=<fs_name>' mds 'allow rw path=<export_path>'
 
 Reset NFS Ganesha Configuration
 ===============================


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50173

---

backport of https://github.com/ceph/ceph/pull/40613
parent tracker: https://tracker.ceph.com/issues/50161

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh