### PR TITLE
pacific: mon: Modifying trim logic to change paxos_service_trim_max dynamically

### DIFF
--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -766,7 +766,15 @@ Trimming requires that the placement groups are ``active+clean``.
 :Default: ``500``
 
 
-``mon_mds_force_trim_to``
+``paxos service trim max multiplier``
+
+:Description: The factor by which paxos service trim max will be multiplied
+              to get a new upper bound when trim sizes are high (0 disables it)
+:Type: Integer
+:Default: ``20``
+
+
+``mon mds force trim to``
 
 :Description: Force monitor to trim mdsmaps to this point (0 disables it.
               dangerous, use with care)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2285,15 +2285,22 @@ std::vector<Option> get_global_options() {
     .add_service("mon")
     .set_description(""),
 
-    Option("paxos_service_trim_min", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    Option("paxos_service_trim_min", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(250)
     .add_service("mon")
     .set_description(""),
 
-    Option("paxos_service_trim_max", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    Option("paxos_service_trim_max", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(500)
     .add_service("mon")
     .set_description(""),
+
+    Option("paxos_service_trim_max_multiplier", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(20)
+    .set_min(0)
+    .add_service("mon")
+    .set_description("factor by which paxos_service_trim_max will be multiplied to get a new upper bound when trim sizes are high  (0 disables it)")
+    .set_flag(Option::FLAG_RUNTIME),
 
     Option("paxos_kill_at", Option::TYPE_INT, Option::LEVEL_DEV)
     .set_default(0)

--- a/src/mon/PaxosService.cc
+++ b/src/mon/PaxosService.cc
@@ -385,20 +385,22 @@ void PaxosService::maybe_trim()
   }
 
   version_t to_remove = trim_to - get_first_committed();
-  if (g_conf()->paxos_service_trim_min > 0 &&
-      to_remove < (version_t)g_conf()->paxos_service_trim_min) {
+  const version_t trim_min = g_conf().get_val<version_t>("paxos_service_trim_min");
+  if (trim_min > 0 &&
+      to_remove < trim_min) {
     dout(10) << __func__ << " trim_to " << trim_to << " would only trim " << to_remove
-	     << " < paxos_service_trim_min " << g_conf()->paxos_service_trim_min << dendl;
+	     << " < paxos_service_trim_min " << trim_min << dendl;
     return;
   }
 
-  if (g_conf()->paxos_service_trim_max > 0 &&
-      to_remove > (version_t)g_conf()->paxos_service_trim_max) {
+  const version_t trim_max = g_conf().get_val<version_t>("paxos_service_trim_max");
+  if (trim_max > 0 &&
+      to_remove > trim_max) {
     dout(10) << __func__ << " trim_to " << trim_to << " would only trim " << to_remove
-	     << " > paxos_service_trim_max, limiting to " << g_conf()->paxos_service_trim_max
+	     << " > paxos_service_trim_max, limiting to " << trim_max
 	     << dendl;
-    trim_to = get_first_committed() + g_conf()->paxos_service_trim_max;
-    to_remove = g_conf()->paxos_service_trim_max;
+    trim_to = get_first_committed() + trim_max;
+    to_remove = trim_max;
   }
 
   dout(10) << __func__ << " trimming to " << trim_to << ", " << to_remove << " states" << dendl;

--- a/src/mon/PaxosService.cc
+++ b/src/mon/PaxosService.cc
@@ -393,15 +393,26 @@ void PaxosService::maybe_trim()
     return;
   }
 
-  const version_t trim_max = g_conf().get_val<version_t>("paxos_service_trim_max");
-  if (trim_max > 0 &&
-      to_remove > trim_max) {
-    dout(10) << __func__ << " trim_to " << trim_to << " would only trim " << to_remove
-	     << " > paxos_service_trim_max, limiting to " << trim_max
-	     << dendl;
-    trim_to = get_first_committed() + trim_max;
-    to_remove = trim_max;
-  }
+  to_remove = [to_remove, this] {
+    const version_t trim_max = g_conf().get_val<version_t>("paxos_service_trim_max");
+    if (trim_max == 0 || to_remove < trim_max) {
+      return to_remove;
+    }
+    if (to_remove < trim_max * 1.5) {
+      dout(10) << __func__ << " trim to " << get_trim_to() << " would only trim " << to_remove
+             << " > paxos_service_trim_max, limiting to " << trim_max
+             << dendl;
+      return trim_max;
+    }
+    const version_t new_trim_max = (trim_max + to_remove) / 2;
+    const uint64_t trim_max_multiplier = g_conf().get_val<uint64_t>("paxos_service_trim_max_multiplier");
+    if (trim_max_multiplier) {
+      return std::min(new_trim_max, trim_max * trim_max_multiplier);
+    } else {
+      return new_trim_max;
+    }
+  }();
+  trim_to = get_first_committed() + to_remove;
 
   dout(10) << __func__ << " trimming to " << trim_to << ", " << to_remove << " states" << dendl;
   MonitorDBStore::TransactionRef t = paxos.get_pending_transaction();


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50124

---

backport of https://github.com/ceph/ceph/pull/40168
parent tracker: https://tracker.ceph.com/issues/50004

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh