### PR TITLE
pacific: Warning Cleanup and Clang Compile Fix

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -157,7 +157,7 @@ set(librgw_common_srcs
   rgw_kms.cc
   rgw_kmip_client.cc
   rgw_url.cc
-  rgw_oidc_provider
+  rgw_oidc_provider.cc
   rgw_datalog.cc
   cls_fifo_legacy.cc
   rgw_lua_utils.cc

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -1,4 +1,4 @@
-// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab ft=cpp
 
 /**
@@ -110,8 +110,6 @@ sort_and_write(rapidjson::Value &d, H &writer, canonical_char_sorter<MyMember>& 
     } cmp_functor{ccs};
         if (!(r = writer.StartObject()))
             break;
-        const auto &o{d.GetObject()};
-        auto b{o.begin()},e{o.end()};
         std::vector<MyMember*> q;
         for (auto &m: d.GetObject())
             q.push_back(&m);

--- a/src/rgw/rgw_datalog.cc
+++ b/src/rgw/rgw_datalog.cc
@@ -727,7 +727,7 @@ int DataLogBackends::list(int shard, int max_entries,
     for (auto& g : gentries) {
       g.log_id = gencursor(gen_id, g.log_id);
     }
-    if (gentries.size() > max_entries)
+    if (int s = gentries.size(); s < 0 || s > max_entries)
       max_entries = 0;
     else
       max_entries -= gentries.size();

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -961,7 +961,7 @@ namespace rgw {
   static inline std::string prefix_xattr_keystr(const rgw_xattrstr& key) {
     std::string keystr;
     keystr.reserve(sizeof(RGW_ATTR_META_PREFIX) + key.len);
-    keystr += {RGW_ATTR_META_PREFIX};
+    keystr += string{RGW_ATTR_META_PREFIX};
     keystr += string{key.val, key.len};
     return keystr;
   }
@@ -1845,7 +1845,7 @@ namespace rgw {
                       &state->dest_placement,
                       state->bucket_owner.get_id(),
                       *static_cast<RGWObjectCtx *>(state->obj_ctx),
-                      std::move(state->object->clone()), olh_epoch, state->req_id,
+                      state->object->clone(), olh_epoch, state->req_id,
 		      this, state->yield);
 
     op_ret = processor->prepare(state->yield);

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -18,7 +18,10 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/tokenizer.hpp>
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wimplicit-const-int-float-conversion"
 #include <s3select/include/s3select.h>
+#pragma clang diagnostic pop
 #undef BOOST_BIND_GLOBAL_PLACEHOLDERS
 
 #include <liboath/oath.h>

--- a/src/test/librados/service.cc
+++ b/src/test/librados/service.cc
@@ -115,7 +115,7 @@ TEST(LibRadosService, StatusFormat) {
 
   {
     std::unique_lock<std::mutex> l(lock);
-    cond.wait(l, [nthreads, &threads_started] {
+    cond.wait(l, [&threads_started] {
       return nthreads == threads_started;
     });
   }

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -1455,7 +1455,7 @@ int cls_cxx_list_watchers(cls_method_context_t hctx,
     watcher.name = entity_name_t::CLIENT(w.watcher_id);
     watcher.cookie = w.cookie;
     watcher.timeout_seconds = w.timeout_seconds;
-    watcher.addr.parse(w.addr, 0);
+    watcher.addr.parse(w.addr);
     watchers->entries.push_back(watcher);
   }
 

--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -1925,7 +1925,7 @@ TEST_F(OSDMapTest, BUG_48884)
   JSONParser parser;
   parser.parse(ss.str().c_str(), static_cast<int>(ss.str().size()));
   auto iter = parser.find_first();
-  for (const auto bucket : (*iter)->get_array_elements()) {
+  for (const auto& bucket : (*iter)->get_array_elements()) {
     JSONParser parser2;
     parser2.parse(bucket.c_str(), static_cast<int>(bucket.size()));
     auto* obj = parser2.find_obj("name");


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50240

---

backport of https://github.com/ceph/ceph/pull/40632
parent tracker: https://tracker.ceph.com/issues/50148

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh