### PR TITLE
pacific: rgw/notification: fixing the "persistent=false" flag

### DIFF
--- a/src/rgw/rgw_rest_pubsub.cc
+++ b/src/rgw/rgw_rest_pubsub.cc
@@ -38,7 +38,7 @@ public:
     opaque_data = s->info.args.get("OpaqueData");
 
     dest.push_endpoint = s->info.args.get("push-endpoint");
-    dest.persistent = s->info.args.exists("persistent");
+    s->info.args.get_bool("persistent", &dest.persistent, false);
 
     if (!validate_and_update_endpoint_secret(dest, s->cct, *(s->info.env))) {
       return -EINVAL;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50157

---

backport of https://github.com/ceph/ceph/pull/39782
parent tracker: https://tracker.ceph.com/issues/49552

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh