### PR TITLE
pacific: rgw/notification: fix persistent notification hang when ack-levl=none

### DIFF
--- a/src/rgw/rgw_notify.cc
+++ b/src/rgw/rgw_notify.cc
@@ -141,6 +141,9 @@ class Manager {
       timer(io_context) {}  
  
     void async_wait(spawn::yield_context yield) { 
+      if (pending_tokens == 0) {
+        return;
+      }
       timer.expires_from_now(infinite_duration);
       boost::system::error_code ec; 
       timer.async_wait(yield[ec]);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50156

---

backport of https://github.com/ceph/ceph/pull/39790
parent tracker: https://tracker.ceph.com/issues/49557

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh