### PR TITLE
nautilus: tests: ceph_test_rados_api_watch_notify: Allow for reconnect

### DIFF
--- a/src/test/librados/watch_notify.cc
+++ b/src/test/librados/watch_notify.cc
@@ -590,7 +590,10 @@ TEST_F(LibRadosWatchNotify, AioWatchDelete2) {
   }
   ASSERT_TRUE(left > 0);
   ASSERT_EQ(-ENOTCONN, notify_err);
-  ASSERT_EQ(-ENOTCONN, rados_watch_check(ioctx, handle));
+  int rados_watch_check_err = rados_watch_check(ioctx, handle);
+  // We may hit ENOENT due to socket failure injection and a forced reconnect
+  EXPECT_TRUE(rados_watch_check_err == -ENOTCONN || rados_watch_check_err == -ENOENT)
+    << "Where rados_watch_check_err = " << rados_watch_check_err;
   ASSERT_EQ(0, rados_aio_create_completion(NULL, NULL, NULL, &comp));
   rados_aio_unwatch(ioctx, handle, comp);
   ASSERT_EQ(0, rados_aio_wait_for_complete(comp));


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49567

---

backport of https://github.com/ceph/ceph/pull/39601
parent tracker: https://tracker.ceph.com/issues/47719

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh