### PR TITLE
nautilus: monmaptool: Don't call set_port on an invalid address

### DIFF
--- a/src/msg/msg_types.cc
+++ b/src/msg/msg_types.cc
@@ -62,6 +62,14 @@ void entity_inst_t::generate_test_instances(list<entity_inst_t*>& o)
   o.push_back(a);
 }
 
+bool entity_addr_t::parse(const std::string_view s)
+{
+  const char* start = s.data();
+  const char* end = nullptr;
+  bool got = parse(start, &end);
+  return got && end == start + s.size();
+}
+
 bool entity_addr_t::parse(const char *s, const char **end, int default_type)
 {
   *this = entity_addr_t();

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -439,6 +439,7 @@ struct entity_addr_t {
     return ss.str();
   }
 
+  bool parse(const std::string_view s);
   bool parse(const char *s, const char **end = 0, int type=0);
 
   void decode_legacy_addr_after_marker(bufferlist::const_iterator& bl)

--- a/src/tools/monmaptool.cc
+++ b/src/tools/monmaptool.cc
@@ -229,7 +229,8 @@ int main(int argc, const char **argv)
       if (i == args.end())
 	helpful_exit();
       entity_addr_t addr;
-      if (!addr.parse(*i)) {
+      if (!addr.parse(string_view{*i})) {
+        // Either we couldn't parse the address or we didn't consume the entire token
 	cerr << me << ": invalid ip:port '" << *i << "'" << std::endl;
 	return -1;
       }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50130

---

backport of https://github.com/ceph/ceph/pull/38258
parent tracker: https://tracker.ceph.com/issues/48336

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh