### PR TITLE
rgwlc: remove explicit lc shard resets at start-of-run

### DIFF
--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -1239,23 +1239,31 @@ struct cls_rgw_lc_obj_head
 {
   time_t start_date = 0;
   std::string marker;
+  time_t shard_rollover_date = 0;
 
   cls_rgw_lc_obj_head() {}
 
   void encode(ceph::buffer::list& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 2, bl);
     uint64_t t = start_date;
     encode(t, bl);
     encode(marker, bl);
+    encode(shard_rollover_date, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(ceph::buffer::list::const_iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     uint64_t t;
     decode(t, bl);
     start_date = static_cast<time_t>(t);
     decode(marker, bl);
+    if (struct_v < 2) {
+      shard_rollover_date = 0;
+    } else {
+      decode(t, bl);
+      shard_rollover_date = static_cast<time_t>(t);
+    }
     DECODE_FINISH(bl);
   }
 

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3288,3 +3288,11 @@ options:
   - rgw
   flags:
   - startup
+- name: rgwlc_auto_session_clear
+  type: bool
+  level: advanced
+  desc: Automatically clear stale lifecycle sessions (i.e., after 2 idle processing cycles)
+  default: true
+  services:
+  - rgw
+  with_legacy: true

--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3296,3 +3296,11 @@ options:
   services:
   - rgw
   with_legacy: true
+- name: rgwlc_skip_bucket_step
+  type: bool
+  level: advanced
+  desc: Conditionally skip the processing (but not the scheduling) of bucket lifecycle
+  default: false
+  services:
+  - rgw
+  with_legacy: true

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7879,6 +7879,7 @@ next:
       for (const auto& entry : bucket_lc_map) {
         formatter->open_object_section("bucket_lc_info");
         formatter->dump_string("bucket", entry.bucket);
+	formatter->dump_string("shard", entry.oid);
 	char exp_buf[100];
 	time_t t{time_t(entry.start_time)};
 	if (std::strftime(

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -1720,6 +1720,12 @@ int RGWLC::bucket_lc_process(string& shard_id, LCWorker* worker,
   string bucket_tenant = result[0];
   string bucket_name = result[1];
   string bucket_marker = result[2];
+
+  ldpp_dout(this, 5) << "RGWLC::bucket_lc_process ENTER " << bucket_name << dendl;
+  if (unlikely(cct->_conf->rgwlc_skip_bucket_step)) {
+    return 0;
+  }
+
   int ret = store->get_bucket(this, nullptr, bucket_tenant, bucket_name, &bucket, null_yield);
   if (ret < 0) {
     ldpp_dout(this, 0) << "LC:get_bucket for " << bucket_name

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -280,9 +280,9 @@ static inline std::ostream& operator<<(std::ostream &os, rgw::sal::Lifecycle::LC
   os << "; start_time=";
   os << rgw_to_asctime(utime_t(time_t(ent.start_time), 0));
   os << "; status=";
-    os << ent.status;
-    os << ">";
-    return os;
+  os << LC_STATUS[ent.status];
+  os << ">";
+  return os;
 }
 
 static bool obj_has_expired(const DoutPrefixProvider *dpp, CephContext *cct, ceph::real_time mtime, int days,

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -2005,6 +2005,10 @@ int RGWLC::process(LCWorker* worker,
 
 bool RGWLC::expired_session(time_t started)
 {
+  if (! cct->_conf->rgwlc_auto_session_clear) {
+    return false;
+  }
+
   time_t interval = (cct->_conf->rgw_lc_debug_interval > 0)
     ? cct->_conf->rgw_lc_debug_interval
     : 24*60*60;

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -2155,9 +2155,11 @@ int RGWLC::process(int index, int max_lock_secs, LCWorker* worker,
 			   << "entries) returned error ret==" << ret << dendl;
 	goto exit;
       }
-      entry = entries.front();
-      head.marker = entry.bucket;
-      head.start_date = now;
+      if (entries.size() > 0) {
+	entry = entries.front();
+	head.marker = entry.bucket;
+	head.start_date = now;
+      }
     } else {
       ldpp_dout(this, 0) << "RGWLC::process() head.marker !empty() at START for shard=="
 			 << lc_shard << " head last stored at "

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -518,6 +518,10 @@ public:
   int process(LCWorker* worker,
 	      const std::unique_ptr<rgw::sal::Bucket>& optional_bucket,
 	      bool once);
+  int advance_head(const std::string& lc_shard,
+		   rgw::sal::Lifecycle::LCHead& head,
+		   rgw::sal::Lifecycle::LCEntry& entry,
+		   time_t start_date);
   int process(int index, int max_lock_secs, LCWorker* worker, bool once);
   int process_bucket(int index, int max_lock_secs, LCWorker* worker,
 		     const std::string& bucket_entry_marker, bool once);

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -525,7 +525,6 @@ public:
   time_t thread_stop_at();
   int list_lc_progress(std::string& marker, uint32_t max_entries,
 		       std::vector<rgw::sal::Lifecycle::LCEntry>&, int& index);
-  int bucket_lc_prepare(int index, LCWorker* worker);
   int bucket_lc_process(std::string& shard_id, LCWorker* worker, time_t stop_at,
 			bool once);
   int bucket_lc_post(int index, int max_lock_sec,

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -521,7 +521,6 @@ public:
   int process(int index, int max_lock_secs, LCWorker* worker, bool once);
   int process_bucket(int index, int max_lock_secs, LCWorker* worker,
 		     const std::string& bucket_entry_marker, bool once);
-  bool if_already_run_today(time_t start_date);
   bool expired_session(time_t started);
   time_t thread_stop_at();
   int list_lc_progress(std::string& marker, uint32_t max_entries,

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -1295,11 +1295,13 @@ public:
    * buckets. */
   struct LCEntry {
     std::string bucket;
+    std::string oid;
     uint64_t start_time{0};
     uint32_t status{0};
 
     LCEntry() = default;
     LCEntry(std::string& _bucket, uint64_t _time, uint32_t _status) : bucket(_bucket), start_time(_time), status(_status) {}
+    LCEntry(std::string& _bucket, std::string _oid, uint64_t _time, uint32_t _status) : bucket(_bucket), oid(_oid), start_time(_time), status(_status) {}
   };
 
   Lifecycle() = default;

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -1286,6 +1286,7 @@ public:
   struct LCHead {
     time_t start_date{0};
     std::string marker;
+    time_t shard_rollover_date{0};
 
     LCHead() = default;
     LCHead(time_t _date, std::string& _marker) : start_date(_date), marker(_marker) {}

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -2562,6 +2562,7 @@ int RadosLifecycle::get_head(const std::string& oid, LCHead& head)
 
   head.marker = cls_head.marker;
   head.start_date = cls_head.start_date;
+  head.shard_rollover_date = cls_head.shard_rollover_date;
 
   return ret;
 }
@@ -2572,6 +2573,7 @@ int RadosLifecycle::put_head(const std::string& oid, const LCHead& head)
 
   cls_head.marker = head.marker;
   cls_head.start_date = head.start_date;
+  cls_head.shard_rollover_date = head.shard_rollover_date;
 
   return cls_rgw_lc_put_head(*store->getRados()->get_lc_pool_ctx(), oid, cls_head);
 }

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -2537,7 +2537,8 @@ int RadosLifecycle::list_entries(const std::string& oid, const std::string& mark
     return ret;
 
   for (auto& entry : cls_entries) {
-    entries.push_back(LCEntry(entry.bucket, entry.start_time, entry.status));
+    entries.push_back(LCEntry(entry.bucket, oid, entry.start_time,
+			      entry.status));
   }
 
   return ret;


### PR DESCRIPTION
This is an alternative solution to the (newly exposed) lifecycle
shard starvation problem reported by Jeegen Chen.

There was always an implied starvation condition implied by the
reset of lc shard head at the start of processing.  The introduction
of "stale sessions" in parallel lifecycle changes made it more
visible, in particular when rgw_lc_debug_interval was set to a small
value and many buckets had lifecycle policy.

My hypothesis in this change is that lifecycle processing for each
lc shard should /always/ continue through the full set of eligible
buckets for the shard, regardless of how many processing cycles might
be required to do so.  There is no semantic basis for restarting at the
first eligible bucket in any circumstance, and doing so was itself
a latent bug.

Fixes: https://tracker.ceph.com/issues/49446

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
