### PR TITLE
nautilus: pybind/cephfs: DT_REG and DT_LNK values are wrong

### DIFF
--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -316,8 +316,8 @@ cdef make_ex(ret, msg):
 class DirEntry(namedtuple('DirEntry',
                ['d_ino', 'd_off', 'd_reclen', 'd_type', 'd_name'])):
     DT_DIR = 0x4
-    DT_REG = 0xA
-    DT_LNK = 0xC
+    DT_REG = 0x8
+    DT_LNK = 0xA
     def is_dir(self):
         return self.d_type == self.DT_DIR
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49516

---

backport of https://github.com/ceph/ceph/pull/39664
parent tracker: https://tracker.ceph.com/issues/49459

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh