### PR TITLE
nautilus: client: wake up the front pos waiter

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9055,8 +9055,15 @@ void Client::lock_fh_pos(Fh *f)
 
 void Client::unlock_fh_pos(Fh *f)
 {
+  ceph_assert(ceph_mutex_is_locked_by_me(client_lock));
+
   ldout(cct, 10) << __func__ << " " << f << dendl;
   f->pos_locked = false;
+  if (!f->pos_waiters.empty()) {
+    // only wake up the oldest waiter
+    auto cond = f->pos_waiters.front();
+    cond->notify_one();
+  }
 }
 
 int Client::uninline_data(Inode *in, Context *onfinish)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49519

---

backport of https://github.com/ceph/ceph/pull/39574
parent tracker: https://tracker.ceph.com/issues/49379

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh