### PR TITLE
octopus: test: use std::atomic<bool> instead of volatile for cb_done var

### DIFF
--- a/src/test/fs/test_ino_release_cb.cc
+++ b/src/test/fs/test_ino_release_cb.cc
@@ -6,7 +6,7 @@
 #define MAX_CEPH_FILES	1000
 #define DIRNAME		"ino_release_cb"
 
-static volatile bool cb_done = false;
+static std::atomic<bool> cb_done = false;
 
 static void cb(void *hdl, vinodeno_t vino)
 {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49475

---

backport of https://github.com/ceph/ceph/pull/39498
parent tracker: https://tracker.ceph.com/issues/49309

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh