### PR TITLE
mgr/cephadm: fix nfs-rgw stray daemon

### DIFF
--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -410,21 +410,22 @@ class CephadmServe:
                     daemon_id = s.get('id')
                     assert daemon_id
                     name = '%s.%s' % (s.get('type'), daemon_id)
-                    if s.get('type') in ['rbd-mirror', 'cephfs-mirror', 'rgw']:
+                    if s.get('type') in ['rbd-mirror', 'cephfs-mirror', 'rgw', 'rgw-nfs']:
                         metadata = self.mgr.get_metadata(
                             cast(str, s.get('type')), daemon_id, {})
                         assert metadata is not None
                         try:
-                            name = '%s.%s' % (s.get('type'), metadata['id'])
+                            if s.get('type') == 'rgw-nfs':
+                                # https://tracker.ceph.com/issues/49573
+                                name = metadata['id'][:-4]
+                            else:
+                                name = '%s.%s' % (s.get('type'), metadata['id'])
                         except (KeyError, TypeError):
                             self.log.debug(
                                 "Failed to find daemon id for %s service %s" % (
                                     s.get('type'), s.get('id')
                                 )
                             )
-                    elif s.get('type') == 'rgw-nfs':
-                        # https://tracker.ceph.com/issues/49573
-                        name = daemon_id.split('-rgw')[0]
 
                     if host not in self.mgr.inventory:
                         missing_names.append(name)


### PR DESCRIPTION
nfs-rgw registers under a gid 
cephadm needs covert that to its known name during the stray daemon check
this is already done for rbd-mirror, cephfs-mirror, rgw so ive added nfs-rgw to that logic


additional i changed the strip of '-rgw' to account for a nfs service with '-rgw' in its service_id  `ceph orch apply nfs foo-rgw --pool nfs-ganesha --namespace foo-rgw`
`.split('-rgw')[0]` would not have worked and resulted in a stray daemon warning

Related PRs: #37397 #39825 #40220
Fixes: https://tracker.ceph.com/issues/50248
Signed-off-by: Daniel Pivonka <dpivonka@redhat.com>
