### PR TITLE
doc/rgw-nfs: use same pattern for keyring name

### DIFF
--- a/doc/radosgw/nfs.rst
+++ b/doc/radosgw/nfs.rst
@@ -117,7 +117,7 @@ ceph.conf
 
 Required ceph.conf configuration for RGW NFS includes:
 
-* valid [client.radosgw.{instance-name}] section
+* valid [client.rgw.{instance-name}] section
 * valid values for minimal instance configuration, in particular, an installed and correct ``keyring``
 
 Other config variables are optional, front-end-specific and front-end
@@ -304,7 +304,7 @@ Ceph configuration file to change the refresh rate.
 
 If exporting Swift containers that do not conform to valid S3 bucket
 naming requirements, set ``rgw_relaxed_s3_bucket_names`` to true in the
-[client.radosgw] section of the Ceph configuration file. For example,
+[client.rgw] section of the Ceph configuration file. For example,
 if a Swift container name contains underscores, it is not a valid S3
 bucket name and will be rejected unless ``rgw_relaxed_s3_bucket_names``
 is set to true.


### PR DESCRIPTION
Just to keep consistency everywhere this documentation mentions a
keyring name.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>