### PR TITLE
mgr/orchestractor: rgw realm and zone flags must both be provided

### DIFF
--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1083,6 +1083,13 @@ Usage:
         if inbuf:
             raise OrchestratorValidationError('unrecognized command -i; -h or --help for usage')
 
+        if realm and not zone:
+            raise OrchestratorValidationError(
+                'Cannot add RGW: Realm specified but no zone specified')
+        if zone and not realm:
+            raise OrchestratorValidationError(
+                'Cannot add RGW: Zone specified but no realm specified')
+
         spec = RGWSpec(
             service_id=svc_id,
             rgw_realm=realm,

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -760,6 +760,16 @@ class RGWSpec(ServiceSpec):
         else:
             return 80
 
+    def validate(self) -> None:
+        super(RGWSpec, self).validate()
+
+        if self.rgw_realm and not self.rgw_zone:
+            raise ServiceSpecValidationError(
+                    'Cannot add RGW: Realm specified but no zone specified')
+        if self.rgw_zone and not self.rgw_realm:
+            raise ServiceSpecValidationError(
+                    'Cannot add RGW: Zone specified but no realm specified')
+
 
 yaml.add_representer(RGWSpec, ServiceSpec.yaml_representer)
 


### PR DESCRIPTION
if only realm was provided rgw runs in default(nonmultisite) mode which is not the expected behavior.
if only zone was provided the daemons would crash. error was obvious in the containers logs but user would have had to go looking there to figure it out.

adding check that both flags are provided and error if not so the user is clearly aware of the problem.

Fixes: https://tracker.ceph.com/issues/50267
Signed-off-by: Daniel Pivonka <dpivonka@redhat.com>


