### PR TITLE
octopus: cephadm: fix failure when using --apply-spec and --shh-user

### DIFF
--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3304,7 +3304,7 @@ def command_bootstrap():
                         ssh_key = '/etc/ceph/ceph.pub'
                         if args.ssh_public_key:
                             ssh_key = args.ssh_public_key.name
-                        out, err, code = call_throws(['ssh-copy-id', '-f', '-i', ssh_key, '%s@%s' % (args.ssh_user, split[1])])
+                        out, err, code = call_throws(['sudo', '-u', args.ssh_user, 'ssh-copy-id', '-f', '-i', ssh_key, '-o StrictHostKeyChecking=no', '%s@%s' % (args.ssh_user, split[1])])
 
         mounts = {}
         mounts[pathify(args.apply_spec)] = '/tmp/spec.yml:z'


### PR DESCRIPTION
backport: #40477

bug is present in octopus

Fixes: https://tracker.ceph.com/issues/50041
Signed-off-by: Daniel Pivonka <dpivonka@redhat.com>
cherry picked from commit (33c843f8a275d6f01d824c6fa066fbd771b6e9fc)

