### PR TITLE
pybind/mgr: add support for common sqlite3 databases

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -17,6 +17,9 @@
   that were storing state in RADOS omap, especially without striping which
   limits scalability.
 
+* The ``device_health_metrics`` pool has been renamed ``.mgr``. It is now
+  used as a common store for all ``ceph-mgr`` modules.
+
 * RGW: `radosgw-admin realm delete` is now renamed to `radosgw-admin realm rm`. This
   is consistent with the help message.
 

--- a/doc/mgr/administrator.rst
+++ b/doc/mgr/administrator.rst
@@ -121,6 +121,21 @@ this to your ``ceph.conf``:
     [mon]
         mgr_initial_modules = dashboard balancer
 
+Module Pool
+-----------
+
+The manager creates a pool for use by its module to store state. The name of
+this pool is ``.mgr`` (with the leading ``.`` indicating a reserved pool
+name).
+
+.. note::
+
+   Prior to Quincy, the ``devicehealth`` module created a
+   ``device_health_metrics`` pool to store device SMART statistics. With
+   Quincy, this pool is automatically renamed to be the common manager module
+   pool.
+
+
 Calling module commands
 -----------------------
 

--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -30,6 +30,14 @@ pools for storing data. A pool provides you with:
 To organize data into pools, you can list, create, and remove pools.
 You can also view the utilization statistics for each pool.
 
+Pool Names
+==========
+
+Pool names beginning with ``.`` are reserved for use by Ceph's internal
+operations. Please do not create or manipulate pools with these names.
+
+
+
 List Pools
 ==========
 

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -556,7 +556,7 @@ function run_mgr() {
     shift
     local data=$dir/$id
 
-    ceph config set mgr mgr/devicehealth/enable_monitoring off --force
+    ceph config set mgr mgr_pool false --force
     ceph-mgr \
         --id $id \
         $EXTRA_OPTS \

--- a/qa/suites/rados/multimon/no_pools.yaml
+++ b/qa/suites/rados/multimon/no_pools.yaml
@@ -2,4 +2,4 @@ overrides:
   ceph:
     create_rbd_pool: false
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force

--- a/qa/suites/rados/singleton-nomsgr/all/admin_socket_output.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/admin_socket_output.yaml
@@ -19,7 +19,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
 - rgw:
   - client.0
 - exec:

--- a/qa/suites/rados/singleton-nomsgr/all/balancer.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/balancer.yaml
@@ -4,7 +4,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     fs: xfs
     log-ignorelist:
       - \(PG_AVAILABILITY\)

--- a/qa/suites/rados/singleton-nomsgr/all/cache-fs-trunc.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/cache-fs-trunc.yaml
@@ -8,7 +8,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)

--- a/qa/suites/rados/singleton-nomsgr/all/ceph-kvstore-tool.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/ceph-kvstore-tool.yaml
@@ -8,7 +8,7 @@ roles:
 overrides:
   ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
     - but it is still running
     - overall HEALTH_

--- a/qa/suites/rados/singleton-nomsgr/all/export-after-evict.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/export-after-evict.yaml
@@ -13,7 +13,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)

--- a/qa/suites/rados/singleton-nomsgr/all/full-tiering.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/full-tiering.yaml
@@ -18,7 +18,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     conf:
       global:
         osd max object name len: 460

--- a/qa/suites/rados/singleton-nomsgr/all/health-warnings.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/health-warnings.yaml
@@ -4,7 +4,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     conf:
       osd:
 # we may land on ext4

--- a/qa/suites/rados/singleton-nomsgr/all/large-omap-object-warnings.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/large-omap-object-warnings.yaml
@@ -7,7 +7,7 @@ roles:
 overrides:
   ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
       - \(OSDMAP_FLAGS\)
       - \(OSD_FULL\)

--- a/qa/suites/rados/singleton-nomsgr/all/lazy_omap_stats_output.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/lazy_omap_stats_output.yaml
@@ -12,7 +12,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
 - exec:
     client.0:
       - ceph_test_lazy_omap_stats

--- a/qa/suites/rados/singleton-nomsgr/all/librados_hello_world.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/librados_hello_world.yaml
@@ -17,7 +17,7 @@ tasks:
         - libradospp-devel
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton-nomsgr/all/msgr.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/msgr.yaml
@@ -17,7 +17,7 @@ openstack:
 overrides:
   ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     conf:
       client:
         debug ms: 20

--- a/qa/suites/rados/singleton-nomsgr/all/multi-backfill-reject.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/multi-backfill-reject.yaml
@@ -16,7 +16,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
       - overall HEALTH_
       - \(PG_

--- a/qa/suites/rados/singleton-nomsgr/all/osd_stale_reads.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/osd_stale_reads.yaml
@@ -23,7 +23,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
 - exec:
     client.0:
       - ceph_test_osd_stale_read

--- a/qa/suites/rados/singleton-nomsgr/all/pool-access.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/pool-access.yaml
@@ -8,7 +8,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton-nomsgr/all/recovery-unfound-found.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/recovery-unfound-found.yaml
@@ -13,7 +13,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     fs: xfs
     conf:
       osd:

--- a/qa/suites/rados/singleton-nomsgr/all/version-number-sanity.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/version-number-sanity.yaml
@@ -8,7 +8,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton/all/deduptool.yaml
+++ b/qa/suites/rados/singleton/all/deduptool.yaml
@@ -13,7 +13,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
     - but it is still running
     - had wrong client addr

--- a/qa/suites/rados/singleton/all/divergent_priors.yaml
+++ b/qa/suites/rados/singleton/all/divergent_priors.yaml
@@ -24,5 +24,5 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
 - divergent_priors:

--- a/qa/suites/rados/singleton/all/divergent_priors2.yaml
+++ b/qa/suites/rados/singleton/all/divergent_priors2.yaml
@@ -24,5 +24,5 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
 - divergent_priors2:

--- a/qa/suites/rados/singleton/all/dump-stuck.yaml
+++ b/qa/suites/rados/singleton/all/dump-stuck.yaml
@@ -11,7 +11,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
       - but it is still running
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/ec-lost-unfound.yaml
+++ b/qa/suites/rados/singleton/all/ec-lost-unfound.yaml
@@ -16,7 +16,7 @@ tasks:
 - ceph:
     create_rbd_pool: false
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
       - objects unfound and apparently lost
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/lost-unfound-delete.yaml
+++ b/qa/suites/rados/singleton/all/lost-unfound-delete.yaml
@@ -14,7 +14,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
       - objects unfound and apparently lost
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/lost-unfound.yaml
+++ b/qa/suites/rados/singleton/all/lost-unfound.yaml
@@ -14,7 +14,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
       - objects unfound and apparently lost
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/max-pg-per-osd.from-mon.yaml
+++ b/qa/suites/rados/singleton/all/max-pg-per-osd.from-mon.yaml
@@ -11,7 +11,7 @@ overrides:
   ceph:
     create_rbd_pool: False
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     conf:
       mon:
         osd pool default size: 2

--- a/qa/suites/rados/singleton/all/max-pg-per-osd.from-primary.yaml
+++ b/qa/suites/rados/singleton/all/max-pg-per-osd.from-primary.yaml
@@ -13,7 +13,7 @@ overrides:
   ceph:
     create_rbd_pool: False
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     conf:
       mon:
         osd pool default size: 2

--- a/qa/suites/rados/singleton/all/max-pg-per-osd.from-replica.yaml
+++ b/qa/suites/rados/singleton/all/max-pg-per-osd.from-replica.yaml
@@ -13,7 +13,7 @@ overrides:
   ceph:
     create_rbd_pool: False
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     conf:
       mon:
         osd pool default size: 2

--- a/qa/suites/rados/singleton/all/mon-auth-caps.yaml
+++ b/qa/suites/rados/singleton/all/mon-auth-caps.yaml
@@ -9,7 +9,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
     - overall HEALTH_
     - \(AUTH_BAD_CAPS\)

--- a/qa/suites/rados/singleton/all/mon-config-key-caps.yaml
+++ b/qa/suites/rados/singleton/all/mon-config-key-caps.yaml
@@ -9,7 +9,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
     - overall HEALTH_
     - \(AUTH_BAD_CAPS\)

--- a/qa/suites/rados/singleton/all/mon-config-keys.yaml
+++ b/qa/suites/rados/singleton/all/mon-config-keys.yaml
@@ -15,7 +15,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton/all/mon-config.yaml
+++ b/qa/suites/rados/singleton/all/mon-config.yaml
@@ -15,7 +15,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton/all/mon-memory-target-compliance.yaml.disabled
+++ b/qa/suites/rados/singleton/all/mon-memory-target-compliance.yaml.disabled
@@ -43,7 +43,7 @@ tasks:
 - ceph:
     create_rbd_pool: false
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)

--- a/qa/suites/rados/singleton/all/osd-backfill.yaml
+++ b/qa/suites/rados/singleton/all/osd-backfill.yaml
@@ -14,7 +14,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
       - but it is still running
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/osd-recovery-incomplete.yaml
+++ b/qa/suites/rados/singleton/all/osd-recovery-incomplete.yaml
@@ -15,7 +15,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
       - but it is still running
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/osd-recovery.yaml
+++ b/qa/suites/rados/singleton/all/osd-recovery.yaml
@@ -14,7 +14,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
       - but it is still running
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/peer.yaml
+++ b/qa/suites/rados/singleton/all/peer.yaml
@@ -14,7 +14,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     config:
       global:
         osd pool default min size : 1

--- a/qa/suites/rados/singleton/all/pg-autoscaler-progress-off.yaml
+++ b/qa/suites/rados/singleton/all/pg-autoscaler-progress-off.yaml
@@ -21,7 +21,7 @@ tasks:
 - ceph:
     create_rbd_pool: false
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)

--- a/qa/suites/rados/singleton/all/pg-autoscaler.yaml
+++ b/qa/suites/rados/singleton/all/pg-autoscaler.yaml
@@ -21,7 +21,7 @@ tasks:
 - ceph:
     create_rbd_pool: false
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)

--- a/qa/suites/rados/singleton/all/pg-removal-interruption.yaml
+++ b/qa/suites/rados/singleton/all/pg-removal-interruption.yaml
@@ -13,7 +13,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
       - but it is still running
       - slow request

--- a/qa/suites/rados/singleton/all/radostool.yaml
+++ b/qa/suites/rados/singleton/all/radostool.yaml
@@ -13,7 +13,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
     - but it is still running
     - had wrong client addr

--- a/qa/suites/rados/singleton/all/random-eio.yaml
+++ b/qa/suites/rados/singleton/all/random-eio.yaml
@@ -16,7 +16,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
     - missing primary copy of
     - objects unfound and apparently lost

--- a/qa/suites/rados/singleton/all/rebuild-mondb.yaml
+++ b/qa/suites/rados/singleton/all/rebuild-mondb.yaml
@@ -15,7 +15,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
       - no reply from
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/recovery-preemption.yaml
+++ b/qa/suites/rados/singleton/all/recovery-preemption.yaml
@@ -15,7 +15,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     conf:
       osd:
         osd recovery sleep: .1

--- a/qa/suites/rados/singleton/all/resolve_stuck_peering.yaml
+++ b/qa/suites/rados/singleton/all/resolve_stuck_peering.yaml
@@ -6,7 +6,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     fs: xfs
     log-ignorelist:
       - overall HEALTH_

--- a/qa/suites/rados/singleton/all/test-crash.yaml
+++ b/qa/suites/rados/singleton/all/test-crash.yaml
@@ -5,7 +5,7 @@ tasks:
   - install:
   - ceph:
       pre-mgr-commands:
-        - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+        - sudo ceph config set mgr mgr_pool false --force
       log-ignorelist:
         - Reduced data availability
         - OSD_.*DOWN

--- a/qa/suites/rados/singleton/all/test_envlibrados_for_rocksdb.yaml
+++ b/qa/suites/rados/singleton/all/test_envlibrados_for_rocksdb.yaml
@@ -12,7 +12,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
       - overall HEALTH_
       - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rados/singleton/all/thrash-backfill-full.yaml
+++ b/qa/suites/rados/singleton/all/thrash-backfill-full.yaml
@@ -23,7 +23,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
     - but it is still running
     - missing primary copy of

--- a/qa/suites/rados/singleton/all/thrash-eio.yaml
+++ b/qa/suites/rados/singleton/all/thrash-eio.yaml
@@ -21,7 +21,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
     - but it is still running
     - missing primary copy of

--- a/qa/suites/rados/singleton/all/thrash_cache_writeback_proxy_none.yaml
+++ b/qa/suites/rados/singleton/all/thrash_cache_writeback_proxy_none.yaml
@@ -16,7 +16,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     log-ignorelist:
       - but it is still running
       - slow request

--- a/qa/suites/rados/singleton/all/watch-notify-same-primary.yaml
+++ b/qa/suites/rados/singleton/all/watch-notify-same-primary.yaml
@@ -15,7 +15,7 @@ tasks:
 - install:
 - ceph:
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     config:
       global:
         osd pool default min size : 1

--- a/qa/suites/rados/thrash-erasure-code/thrashers/minsize_recovery.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/minsize_recovery.yaml
@@ -5,7 +5,7 @@ overrides:
     - objects unfound and apparently lost
     create_rbd_pool: False
     pre-mgr-commands:
-      - sudo ceph config set mgr mgr/devicehealth/enable_monitoring false --force
+      - sudo ceph config set mgr mgr_pool false --force
     conf:
       osd:
         osd debug reject backfill probability: .3

--- a/qa/suites/upgrade/octopus-x/parallel/1-tasks.yaml
+++ b/qa/suites/upgrade/octopus-x/parallel/1-tasks.yaml
@@ -30,6 +30,23 @@ tasks:
       - ceph config set mon mon_warn_on_insecure_global_id_reclaim false --force
       - ceph config set mon mon_warn_on_insecure_global_id_reclaim_allowed false --force
 
+- print: "**** verifying SMART data exists"
+
+- cephadm.shell:
+    mon.a:
+      # debugging
+      - ceph device ls
+      # ensure something is scraped
+      - ceph device scrape-health-metrics
+      # more than 0 devices
+      - ceph device ls --format=json | jq -e  '. | length > 0'
+      # dump metrics
+      - "for devid in $(ceph device ls --format=json | jq -r  '.[].devid'); do ceph device get-health-metrics $devid; done"
+      # check scraped sanity
+      - "for devid in $(ceph device ls --format=json | jq -r  '.[].devid'); do ceph device get-health-metrics $devid | jq -e '. | length > 0'; done"
+      # check device_health_metrics pool exists
+      - rados --pool=device_health_metrics ls | wc -l
+
 - print: "**** done cephadm.shell ceph config set mgr..."
 
 - print: "**** done start parallel"

--- a/qa/suites/upgrade/octopus-x/parallel/upgrade-sequence.yaml
+++ b/qa/suites/upgrade/octopus-x/parallel/upgrade-sequence.yaml
@@ -13,3 +13,20 @@ upgrade-sequence:
          - ceph versions | jq -e '.overall | keys' | grep $sha1
    - print: "**** done end upgrade, wait..."
 
+   - print: "**** verifying SMART data upgrade"
+
+   - cephadm.shell:
+       mon.a:
+         # check device_health_metrics pool is gone
+         - rados --pool=device_health_metrics ls && exit 1 || true
+         # check device_health_metrics pool is now .mgr
+         - rados --pool=.mgr --all ls | wc -l
+         # debugging
+         - ceph device ls
+         # more than 0 devices
+         - ceph device ls --format=json | jq -e  '. | length > 0'
+         # dump metrics
+         - "for devid in $(ceph device ls --format=json | jq -r  '.[].devid'); do ceph device get-health-metrics $devid; done"
+         # check scraped sanity
+         - "for devid in $(ceph device ls --format=json | jq -r  '.[].devid'); do ceph device get-health-metrics $devid | jq '. | length > 0'; done"
+

--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -163,7 +163,7 @@ class PoolTest(DashboardTestCase):
         self.assertStatus(403)
 
     def test_pool_configuration(self):
-        pool_name = 'device_health_metrics'
+        pool_name = '.mgr'
         data = self._get('/api/pool/{}/configuration'.format(pool_name))
         self.assertStatus(200)
         self.assertSchema(data, JList(JObj({

--- a/qa/tasks/mgr/test_module_selftest.py
+++ b/qa/tasks/mgr/test_module_selftest.py
@@ -68,12 +68,6 @@ class TestModuleSelftest(MgrTestCase):
 
     def test_devicehealth(self):
         self._selftest_plugin("devicehealth")
-        # Clean up the pool that the module creates, because otherwise
-        # it's low PG count causes test failures.
-        pool_name = "device_health_metrics"
-        self.mgr_cluster.mon_manager.raw_cluster_cmd(
-                "osd", "pool", "delete", pool_name, pool_name,
-                "--yes-i-really-really-mean-it")
 
     def test_selftest_run(self):
         self._load_module("selftest")

--- a/qa/workunits/cephadm/test_dashboard_e2e.sh
+++ b/qa/workunits/cephadm/test_dashboard_e2e.sh
@@ -68,12 +68,6 @@ npm ci --unsafe-perm
 npx cypress verify
 npx cypress info
 
-# Remove device_health_metrics pool
-# Low pg count causes OSD removal failure.
-ceph device monitoring off
-ceph tell mon.\* injectargs '--mon-allow-pool-delete=true'
-ceph osd pool rm device_health_metrics device_health_metrics --yes-i-really-really-mean-it
-
 # Take `orch device ls` and `orch ps` as ground truth.
 ceph orch device ls --refresh
 ceph orch ps --refresh

--- a/src/common/options/mgr.yaml.in
+++ b/src/common/options/mgr.yaml.in
@@ -12,6 +12,15 @@ options:
   - mgr
   flags:
   - no_mon_update
+- name: mgr_pool
+  type: bool
+  level: dev
+  desc: Allow use/creation of .mgr pool.
+  default: true
+  services:
+  - mgr
+  flags:
+  - startup
 - name: mgr_stats_period
   type: int
   level: basic

--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/mgr-modules.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/cluster/mgr-modules.e2e-spec.ts
@@ -53,7 +53,7 @@ describe('Manager modules page', () => {
         {
           id: 'pool_name',
           newValue: 'sox',
-          oldValue: 'device_health_metrics'
+          oldValue: '.mgr'
         },
         {
           id: 'retention_period',

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -4,7 +4,7 @@ Device health monitoring
 
 import errno
 import json
-from mgr_module import MgrModule, CommandResult, CLICommand, Option
+from mgr_module import MgrModule, CommandResult, CLIRequiresDB, CLICommand, Option
 import operator
 import rados
 from threading import Event
@@ -21,8 +21,6 @@ HEALTH_MESSAGES = {
     DEVICE_HEALTH_IN_USE: '%d daemon(s) expected to fail soon and still contain data',
     DEVICE_HEALTH_TOOMANY: 'Too many daemons are expected to fail soon',
 }
-
-MAX_SAMPLES = 500
 
 
 def get_ata_wear_level(data: Dict[Any, Any]) -> Optional[float]:
@@ -49,6 +47,35 @@ def get_nvme_wear_level(data: Dict[Any, Any]) -> Optional[float]:
 
 
 class Module(MgrModule):
+
+    # latest (if db does not exist)
+    SCHEMA = """
+CREATE TABLE Device (
+  devid TEXT PRIMARY KEY
+) WITHOUT ROWID;
+CREATE TABLE DeviceHealthMetrics (
+  time DATETIME DEFAULT (strftime('%s', 'now')),
+  devid TEXT NOT NULL REFERENCES Device (devid),
+  raw_smart TEXT NOT NULL,
+  PRIMARY KEY (time, devid)
+);
+"""
+
+    SCHEMA_VERSIONED = [
+        # v1
+        """
+CREATE TABLE Device (
+  devid TEXT PRIMARY KEY
+) WITHOUT ROWID;
+CREATE TABLE DeviceHealthMetrics (
+  time DATETIME DEFAULT (strftime('%s', 'now')),
+  devid TEXT NOT NULL REFERENCES Device (devid),
+  raw_smart TEXT NOT NULL,
+  PRIMARY KEY (time, devid)
+);
+"""
+    ]
+
     MODULE_OPTIONS = [
         Option(
             name='enable_monitoring',
@@ -118,7 +145,6 @@ class Module(MgrModule):
         # other
         self.run = True
         self.event = Event()
-        self.has_device_pool = False
 
         # for mypy which does not run the code
         if TYPE_CHECKING:
@@ -154,6 +180,7 @@ class Module(MgrModule):
         }), '')
         return result.wait()
 
+    @CLIRequiresDB
     @CLICommand('device scrape-daemon-health-metrics',
                 perm='r')
     def do_scrape_daemon_health_metrics(self, who: str) -> Tuple[int, str, str]:
@@ -165,6 +192,7 @@ class Module(MgrModule):
         (daemon_type, daemon_id) = who.split('.')
         return self.scrape_daemon(daemon_type, daemon_id)
 
+    @CLIRequiresDB
     @CLICommand('device scrape-health-metrics',
                 perm='r')
     def do_scrape_health_metrics(self, devid: Optional[str] = None) -> Tuple[int, str, str]:
@@ -176,6 +204,7 @@ class Module(MgrModule):
         else:
             return self.scrape_device(devid)
 
+    @CLIRequiresDB
     @CLICommand('device get-health-metrics',
                 perm='r')
     def do_get_health_metrics(self, devid: str, sample: Optional[str] = None) -> Tuple[int, str, str]:
@@ -184,6 +213,7 @@ class Module(MgrModule):
         '''
         return self.show_device_metrics(devid, sample)
 
+    @CLIRequiresDB
     @CLICommand('device check-health',
                 perm='rw')
     def do_check_health(self) -> Tuple[int, str, str]:
@@ -212,6 +242,7 @@ class Module(MgrModule):
         self.set_health_checks({})  # avoid stuck health alerts
         return 0, '', ''
 
+    @CLIRequiresDB
     @CLICommand('device predict-life-expectancy',
                 perm='r')
     def do_predict_life_expectancy(self, devid: str) -> Tuple[int, str, str]:
@@ -221,6 +252,7 @@ class Module(MgrModule):
         return self.predict_lift_expectancy(devid)
 
     def self_test(self) -> None:
+        assert self.db_ready()
         self.config_notify()
         osdmap = self.get('osd_map')
         osd_id = osdmap['osds'][0]['osd']
@@ -228,12 +260,15 @@ class Module(MgrModule):
         devs = osdmeta.get(str(osd_id), {}).get('device_ids')
         if devs:
             devid = devs.split()[0].split('=')[1]
-            (r, before, err) = self.show_device_metrics(devid, '')
+            self.log.debug(f"getting devid {devid}")
+            (r, before, err) = self.show_device_metrics(devid, None)
             assert r == 0
+            self.log.debug(f"before: {before}")
             (r, out, err) = self.scrape_device(devid)
             assert r == 0
-            (r, after, err) = self.show_device_metrics(devid, '')
+            (r, after, err) = self.show_device_metrics(devid, None)
             assert r == 0
+            self.log.debug(f"after: {after}")
             assert before != after
 
     def config_notify(self) -> None:
@@ -243,70 +278,24 @@ class Module(MgrModule):
                     self.get_module_option(opt['name']))
             self.log.debug(' %s = %s', opt['name'], getattr(self, opt['name']))
 
-    def notify(self, notify_type: str, notify_id: str) -> None:
-        if notify_type == "osd_map" and self.enable_monitoring:
-            # create device_health_metrics pool if it doesn't exist
-            self.maybe_create_device_pool()
-
-    def have_enough_osds(self) -> bool:
-        # wait until we have enough OSDs to allow the pool to be healthy
-        up = 0
-        for osd in self.get("osd_map")["osds"]:
-            if osd["up"]:
-                up += 1
-
-        need = cast(int, self.get_ceph_option("osd_pool_default_size"))
-        return up >= need
-
-    def maybe_create_device_pool(self) -> bool:
-        if not self.has_device_pool:
-            if not self.have_enough_osds():
-                self.log.warning("Not enough OSDs yet to create monitoring pool")
-                return False
-            self.create_device_pool()
-            self.has_device_pool = True
-        return True
-
-    def create_device_pool(self) -> None:
-        self.log.debug('create %s pool' % self.pool_name)
-        # create pool
-        result = CommandResult('')
-        self.send_command(result, 'mon', '', json.dumps({
-            'prefix': 'osd pool create',
-            'format': 'json',
-            'pool': self.pool_name,
-            'pg_num': 1,
-            'pg_num_min': 1,
-        }), '')
-        r, outb, outs = result.wait()
-        assert r == 0
-        # set pool application
-        result = CommandResult('')
-        self.send_command(result, 'mon', '', json.dumps({
-            'prefix': 'osd pool application enable',
-            'format': 'json',
-            'pool': self.pool_name,
-            'app': 'mgr_devicehealth',
-        }), '')
-        r, outb, outs = result.wait()
-        assert r == 0
-
     def serve(self) -> None:
         self.log.info("Starting")
         self.config_notify()
 
         last_scrape = None
-        ls = self.get_store('last_scrape')
-        if ls:
-            try:
-                last_scrape = datetime.strptime(ls, TIME_FORMAT)
-            except ValueError:
-                pass
-        self.log.debug('Last scrape %s', last_scrape)
-
         while self.run:
-            if self.enable_monitoring:
+            if self.db_ready() and self.enable_monitoring:
                 self.log.debug('Running')
+
+                if last_scrape is None:
+                    ls = self.get_kv('last_scrape')
+                    if ls:
+                        try:
+                            last_scrape = datetime.strptime(ls, TIME_FORMAT)
+                        except ValueError:
+                            pass
+                    self.log.debug('Last scrape %s', last_scrape)
+
                 self.check_health()
 
                 now = datetime.utcnow()
@@ -330,7 +319,7 @@ class Module(MgrModule):
                     self.scrape_all()
                     self.predict_all_devices()
                     last_scrape = now
-                    self.set_store('last_scrape', last_scrape.strftime(TIME_FORMAT))
+                    self.set_kv('last_scrape', last_scrape.strftime(TIME_FORMAT))
 
             # sleep
             sleep_interval = self.sleep_interval or 60
@@ -343,32 +332,22 @@ class Module(MgrModule):
         self.run = False
         self.event.set()
 
-    def open_connection(self, create_if_missing: bool = True) -> rados.Ioctx:
-        if create_if_missing:
-            if not self.maybe_create_device_pool():
-                return None
-        ioctx = self.rados.open_ioctx(self.pool_name)
-        return ioctx
-
     def scrape_daemon(self, daemon_type: str, daemon_id: str) -> Tuple[int, str, str]:
-        ioctx = self.open_connection()
-        if not ioctx:
-            return -errno.EAGAIN, "", "device_health_metrics pool not yet available"
+        if not self.db_ready():
+            return -errno.EAGAIN, "", "mgr db not yet available"
         raw_smart_data = self.do_scrape_daemon(daemon_type, daemon_id)
         if raw_smart_data:
             for device, raw_data in raw_smart_data.items():
                 data = self.extract_smart_features(raw_data)
                 if device and data:
-                    self.put_device_metrics(ioctx, device, data)
-        ioctx.close()
+                    self.put_device_metrics(device, data)
         return 0, "", ""
 
     def scrape_all(self) -> Tuple[int, str, str]:
+        if not self.db_ready():
+            return -errno.EAGAIN, "", "mgr db not yet available"
         osdmap = self.get("osd_map")
         assert osdmap is not None
-        ioctx = self.open_connection()
-        if not ioctx:
-            return -errno.EAGAIN, "", "device_health_metrics pool not yet available"
         did_device = {}
         ids = []
         for osd in osdmap['osds']:
@@ -387,11 +366,12 @@ class Module(MgrModule):
                 did_device[device] = 1
                 data = self.extract_smart_features(raw_data)
                 if device and data:
-                    self.put_device_metrics(ioctx, device, data)
-        ioctx.close()
+                    self.put_device_metrics(device, data)
         return 0, "", ""
 
     def scrape_device(self, devid: str) -> Tuple[int, str, str]:
+        if not self.db_ready():
+            return -errno.EAGAIN, "", "mgr db not yet available"
         r = self.get("device " + devid)
         if not r or 'device' not in r.keys():
             return -errno.ENOENT, '', 'device ' + devid + ' not found'
@@ -400,17 +380,13 @@ class Module(MgrModule):
             return (-errno.EAGAIN, '',
                     'device ' + devid + ' not claimed by any active daemons')
         (daemon_type, daemon_id) = daemons[0].split('.')
-        ioctx = self.open_connection()
-        if not ioctx:
-            return -errno.EAGAIN, "", "device_health_metrics pool not yet available"
         raw_smart_data = self.do_scrape_daemon(daemon_type, daemon_id,
                                                devid=devid)
         if raw_smart_data:
             for device, raw_data in raw_smart_data.items():
                 data = self.extract_smart_features(raw_data)
                 if device and data:
-                    self.put_device_metrics(ioctx, device, data)
-        ioctx.close()
+                    self.put_device_metrics(device, data)
         return 0, "", ""
 
     def do_scrape_daemon(self,
@@ -437,41 +413,37 @@ class Module(MgrModule):
                     daemon_type, daemon_id, outb))
             return None
 
-    def put_device_metrics(self, ioctx: rados.Ioctx, devid: str, data: Any) -> None:
-        assert devid
-        old_key = datetime.utcnow() - timedelta(
-            seconds=self.retention_period)
-        prune = old_key.strftime(TIME_FORMAT)
-        self.log.debug('put_device_metrics device %s prune %s' %
-                       (devid, prune))
-        erase = []
-        try:
-            with rados.ReadOpCtx() as op:
-                # FIXME
-                omap_iter, ret = ioctx.get_omap_keys(op, "", MAX_SAMPLES)
-                assert ret == 0
-                ioctx.operate_read_op(op, devid)
-                for key, _ in list(omap_iter):
-                    if key >= prune:
-                        break
-                    erase.append(key)
-        except rados.ObjectNotFound:
-            # The object doesn't already exist, no problem.
-            pass
-        except rados.Error as e:
-            # Do not proceed with writes if something unexpected
-            # went wrong with the reads.
-            self.log.exception("Error reading OMAP: {0}".format(e))
-            return
+    def _prune_device_metrics(self) -> None:
+        SQL = """
+        DELETE FROM DeviceHealthMetrics
+            WHERE time < (strftime('%s', 'now') - ?);
+        """
 
-        key = datetime.utcnow().strftime(TIME_FORMAT)
-        self.log.debug('put_device_metrics device %s key %s = %s, erase %s' %
-                       (devid, key, data, erase))
-        with rados.WriteOpCtx() as op:
-            ioctx.set_omap(op, (key,), (str(json.dumps(data)),))
-            if len(erase):
-                ioctx.remove_omap_keys(op, tuple(erase))
-            ioctx.operate_write_op(op, devid)
+        cursor = self.db.execute(SQL, (self.retention_period,))
+        if cursor.rowcount >= 1:
+            self.log.info(f"pruned {cursor.rowcount} metrics")
+
+    def _create_device(self, devid: str) -> None:
+        SQL = """
+        INSERT OR IGNORE INTO Device VALUES (?);
+        """
+
+        cursor = self.db.execute(SQL, (devid,))
+        if cursor.rowcount >= 1:
+            self.log.info(f"created device {devid}")
+        else:
+            self.log.debug(f"device {devid} already exists")
+
+    def put_device_metrics(self, devid: str, data: Any) -> None:
+        SQL = """
+        INSERT INTO DeviceHealthMetrics (devid, raw_smart)
+            VALUES (?, ?);
+        """
+
+        with self._db_lock, self.db:
+            self._create_device(devid)
+            self.db.execute(SQL, (devid, json.dumps(data)))
+            self._prune_device_metrics()
 
         # extract wear level?
         wear_level = get_ata_wear_level(data)
@@ -489,37 +461,39 @@ class Module(MgrModule):
                 self.log.debug(f"removing {devid} wear level")
                 self.set_device_wear_level(devid, -1.0)
 
+    def _t2epoch(self, t: Optional[str]) -> int:
+        if t is None:
+            return 0
+        else:
+            return int(datetime.strptime(t, TIME_FORMAT).strftime("%s"))
+
     def _get_device_metrics(self, devid: str,
                             sample: Optional[str] = None,
                             min_sample: Optional[str] = None) -> Dict[str, Dict[str, Any]]:
         res = {}
-        ioctx = self.open_connection(create_if_missing=False)
-        if not ioctx:
-            return {}
-        with ioctx:
-            with rados.ReadOpCtx() as op:
-                omap_iter, ret = ioctx.get_omap_vals(op, min_sample or '', sample or '',
-                                                     MAX_SAMPLES)  # fixme
-                assert ret == 0
+
+        SQL = """
+        SELECT time, raw_smart
+            FROM DeviceHealthMetrics
+            WHERE devid = ? AND (time = ? OR ? <= time)
+            ORDER BY time DESC;
+        """
+
+        isample = self._t2epoch(sample)
+        imin_sample = self._t2epoch(min_sample)
+
+        self.log.debug(f"_get_device_metrics: {devid} {sample} {min_sample}")
+
+        with self._db_lock, self.db:
+            cursor = self.db.execute(SQL, (devid, isample, imin_sample))
+            for row in cursor:
+                t = row['time']
+                dt = datetime.utcfromtimestamp(t).strftime(TIME_FORMAT)
                 try:
-                    ioctx.operate_read_op(op, devid)
-                    for key, value in list(omap_iter):
-                        if sample and key != sample:
-                            break
-                        if min_sample and key < min_sample:
-                            break
-                        try:
-                            v = json.loads(value)
-                        except (ValueError, IndexError):
-                            self.log.debug('unable to parse value for %s: "%s"' %
-                                           (key, value))
-                            pass
-                        res[key] = v
-                except rados.ObjectNotFound:
+                    res[dt] = json.loads(row['raw_smart'])
+                except (ValueError, IndexError):
+                    self.log.debug(f"unable to parse value for {devid}:{t}")
                     pass
-                except rados.Error as e:
-                    self.log.exception("RADOS error reading omap: {0}".format(e))
-                    raise
         return res
 
     def show_device_metrics(self, devid: str, sample: Optional[str]) -> Tuple[int, str, str]:

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -20,6 +20,7 @@ from enum import IntEnum
 import rados
 import re
 import socket
+import sqlite3
 import sys
 import time
 from ceph_argparse import CephArgtype
@@ -122,6 +123,7 @@ class HandleCommandResult(NamedTuple):
 
 
 class MonCommandFailed(RuntimeError): pass
+class MgrDBNotReady(RuntimeError): pass
 
 
 class OSDMap(ceph_module.BasePyOSDMap):
@@ -444,6 +446,14 @@ def CLICheckNonemptyFileInput(desc: str) -> Callable[[HandlerFuncType], HandlerF
         return check
     return CheckFileInput
 
+def CLIRequiresDB(func: HandlerFuncType) -> HandlerFuncType:
+    @functools.wraps(func)
+    def check(self, *args: Any, **kwargs: Any) -> Tuple[int, str, str]:
+        if not self.db_ready():
+            return -errno.EAGAIN, "", "mgr db not yet available"
+        return func(self, *args, **kwargs)
+    check.__signature__ = inspect.signature(func)  # type: ignore[attr-defined]
+    return check
 
 def _get_localized_key(prefix: str, key: str) -> str:
     return '{}/{}'.format(prefix, key)
@@ -835,9 +845,15 @@ PerfCounterT = Dict[str, Any]
 
 
 class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
+    MGR_POOL_NAME = ".mgr"
+
     COMMANDS = []  # type: List[Any]
     MODULE_OPTIONS: List[Option] = []
     MODULE_OPTION_DEFAULTS = {}  # type: Dict[str, Any]
+
+    # Database Schema
+    SCHEMA = None # type: Optional[str]
+    SCHEMA_VERSIONED = None # type: Optional[List[str]]
 
     # Priority definitions for perf counters
     PRIO_CRITICAL = 10
@@ -897,12 +913,16 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         # for backwards compatibility
         self._logger = self.getLogger()
 
+        self._db = None # type: Optional[sqlite3.Connection]
+
         self._version = self._ceph_get_version()
 
         self._perf_schema_cache = None
 
         # Keep a librados instance for those that need it.
         self._rados: Optional[rados.Rados] = None
+
+        self._db_lock = threading.Lock()
 
     def __del__(self) -> None:
         self._unconfigure_logging()
@@ -944,6 +964,173 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
     @property
     def version(self) -> str:
         return self._version
+
+    def pool_exists(self, name: str) -> bool:
+        pools = [p['pool_name'] for p in self.get('osd_map')['pools']]
+        return name in pools
+
+    def have_enough_osds(self) -> bool:
+        # wait until we have enough OSDs to allow the pool to be healthy
+        ready = 0
+        for osd in self.get("osd_map")["osds"]:
+            if osd["up"] and osd["in"]:
+                ready += 1
+
+        need = cast(int, self.get_ceph_option("osd_pool_default_size"))
+        return ready >= need
+
+    def rename_pool(self, srcpool: str, destpool: str) -> None:
+        c = {
+            'prefix': 'osd pool rename',
+            'format': 'json',
+            'srcpool': srcpool,
+            'destpool': destpool,
+        }
+        self.check_mon_command(c)
+
+    def create_pool(self, pool: str) -> None:
+        c = {
+            'prefix': 'osd pool create',
+            'format': 'json',
+            'pool': pool,
+            'pg_num': 1,
+            'pg_num_min': 1,
+        }
+        self.check_mon_command(c)
+
+    def appify_pool(self, pool: str, app: str) -> None:
+        c = {
+            'prefix': 'osd pool application enable',
+            'format': 'json',
+            'pool': pool,
+            'app': app,
+            'yes_i_really_mean_it': True
+        }
+        self.check_mon_command(c)
+
+    def create_mgr_pool(self) -> None:
+        self.log.info("creating mgr pool")
+
+        ov = self.get_module_option_ex('devicehealth', 'pool_name', 'device_health_metrics')
+        devhealth = cast(str, ov)
+        if devhealth is not None and self.pool_exists(devhealth):
+            self.log.debug("reusing devicehealth pool")
+            self.rename_pool(devhealth, self.MGR_POOL_NAME)
+            self.appify_pool(self.MGR_POOL_NAME, 'mgr')
+        else:
+            self.log.debug("creating new mgr pool")
+            self.create_pool(self.MGR_POOL_NAME)
+            self.appify_pool(self.MGR_POOL_NAME, 'mgr')
+
+    def create_skeleton_schema(self, db: sqlite3.Connection) -> None:
+        SQL = """
+        CREATE TABLE IF NOT EXISTS MgrModuleKV (
+          key TEXT PRIMARY KEY,
+          value NOT NULL
+        ) WITHOUT ROWID;
+        INSERT OR IGNORE INTO MgrModuleKV (key, value) VALUES ('__version', 0);
+        """
+
+        db.executescript(SQL)
+
+    def update_schema_version(self, db: sqlite3.Connection, version: int) -> None:
+        SQL = "UPDATE OR ROLLBACK MgrModuleKV SET value = ? WHERE key = '__version';"
+
+        db.execute(SQL, (version,))
+
+    def set_kv(self, key: str, value: Any) -> None:
+        SQL = "INSERT OR REPLACE INTO MgrModuleKV (key, value) VALUES (?, ?);"
+
+        assert key[:2] != "__"
+
+        self.log.debug(f"set_kv('{key}', '{value}')")
+
+        with self._db_lock, self.db:
+            self.db.execute(SQL, (key, value))
+
+    def get_kv(self, key: str) -> Any:
+        SQL = "SELECT value FROM MgrModuleKV WHERE key = ?;"
+
+        assert key[:2] != "__"
+
+        self.log.debug(f"get_kv('{key}')")
+
+        with self._db_lock, self.db:
+            cur = self.db.execute(SQL, (key,))
+            row = cur.fetchone()
+            if row is None:
+                return None
+            else:
+                v = row['value']
+                self.log.debug(f" = {v}")
+                return v
+
+    def maybe_upgrade(self, db: sqlite3.Connection, version: int) -> None:
+        if version <= 0:
+            self.log.info(f"creating main.db for {self.module_name}")
+            assert self.SCHEMA is not None
+            cur = db.executescript(self.SCHEMA)
+            self.update_schema_version(db, 1)
+        else:
+            assert self.SCHEMA_VERSIONED is not None
+            latest = len(self.SCHEMA_VERSIONED)
+            if latest < version:
+                raise RuntimeError(f"main.db version is newer ({version}) than module ({latest})")
+            for i in range(version, latest):
+                self.log.info(f"upgrading main.db for {self.module_name} from {i-1}:{i}")
+                SQL = self.SCHEMA_VERSIONED[i]
+                db.executescript(SQL)
+            if version < latest:
+                self.update_schema_version(db, latest)
+
+    def load_schema(self, db: sqlite3.Connection) -> None:
+        SQL = """
+        SELECT value FROM MgrModuleKV WHERE key = '__version';
+        """
+
+        with db:
+            self.create_skeleton_schema(db)
+            cur = db.execute(SQL)
+            row = cur.fetchone()
+            self.maybe_upgrade(db, int(row['value']))
+            assert cur.fetchone() is None
+            cur.close()
+
+    def configure_db(self, db: sqlite3.Connection) -> None:
+        db.execute('PRAGMA FOREIGN_KEYS = 1')
+        db.execute('PRAGMA JOURNAL_MODE = PERSIST')
+        db.execute('PRAGMA PAGE_SIZE = 65536')
+        db.execute('PRAGMA CACHE_SIZE = 64')
+        db.row_factory = sqlite3.Row
+        self.load_schema(db)
+
+    def open_db(self) -> Optional[sqlite3.Connection]:
+        if not self.pool_exists(self.MGR_POOL_NAME):
+            if not self.have_enough_osds():
+                return None
+            self.create_mgr_pool()
+        uri = f"file:///{self.MGR_POOL_NAME}:{self.module_name}/main.db?vfs=ceph";
+        self.log.debug(f"using uri {uri}")
+        db = sqlite3.connect(uri, check_same_thread=False, uri=True)
+        self.configure_db(db)
+        return db
+
+    def db_ready(self) -> bool:
+        with self._db_lock:
+            try:
+                return self.db is not None
+            except MgrDBNotReady:
+                return False
+
+    @property
+    def db(self) -> sqlite3.Connection:
+        assert self._db_lock.locked()
+        if self._db is not None:
+            return self._db
+        self._db = self.open_db()
+        if self._db is None:
+            raise MgrDBNotReady();
+        return self._db
 
     @property
     def release_name(self) -> str:

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1127,6 +1127,9 @@ class MgrModule(ceph_module.BaseMgrModule, MgrModuleLoggingMixin):
         assert self._db_lock.locked()
         if self._db is not None:
             return self._db
+        db_allowed = self.get_ceph_option("mgr_pool")
+        if not db_allowed:
+            raise MgrDBNotReady();
         self._db = self.open_db()
         if self._db is None:
             raise MgrDBNotReady();


### PR DESCRIPTION
And update "devicehealth" pool to use it.

The one nit in this PR is that the mgr normally can't delete the "device_health_metrics" pool because `mon_allow_pool_delete` is normally false. I'm not yet sure how we want to address this; I'm open to suggestions.

I've manually imported the LRC device_health_metrics to test loading a legacy pool.