### PR TITLE
nautilus: osd: do not dump an osd multiple times

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -5023,7 +5023,7 @@ protected:
   }
 
   void dump_item(const CrushTreeDumper::Item &qi, F *f) override {
-    if (!tree && qi.is_bucket())
+    if (!tree && (qi.is_bucket() || dumped_osds.count(qi.id)))
       return;
     if (!should_dump(qi.id))
       return;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49731

---

backport of https://github.com/ceph/ceph/pull/39859
parent tracker: https://tracker.ceph.com/issues/49627

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh