### PR TITLE
nautilus:  crush/CrushLocation: do not print logging message in constructor

### DIFF
--- a/src/crush/CrushLocation.cc
+++ b/src/crush/CrushLocation.cc
@@ -119,6 +119,5 @@ int CrushLocation::init_on_startup()
   loc.clear();
   loc.insert(make_pair<std::string,std::string>("host", hostname));
   loc.insert(make_pair<std::string,std::string>("root", "default"));
-  lgeneric_dout(cct, 10) << "crush_location is (default) " << loc << dendl;
   return 0;
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50122

---

backport of https://github.com/ceph/ceph/pull/40457
parent tracker: https://tracker.ceph.com/issues/50047

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh