### PR TITLE
nautilus: mgr/PyModule: put mgr_module_path before Py_GetPath()

### DIFF
--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -340,15 +340,15 @@ int PyModule::load(PyThreadState *pMainThreadState)
       PySys_SetArgv(1, (char**)argv);
 #endif
       // Configure sys.path to include mgr_module_path
-      string paths = (":" + g_conf().get_val<std::string>("mgr_module_path") +
-		      ":" + get_site_packages());
+      string paths = (g_conf().get_val<std::string>("mgr_module_path") + ":" +
+                      get_site_packages() + ':');
 #if PY_MAJOR_VERSION >= 3
-      wstring sys_path(Py_GetPath() + wstring(begin(paths), end(paths)));
+      wstring sys_path(wstring(begin(paths), end(paths)) + Py_GetPath());
       PySys_SetPath(const_cast<wchar_t*>(sys_path.c_str()));
       dout(10) << "Computed sys.path '"
 	       << string(begin(sys_path), end(sys_path)) << "'" << dendl;
 #else
-      string sys_path(Py_GetPath() + paths);
+      string sys_path(paths + Py_GetPath());
       PySys_SetPath(const_cast<char*>(sys_path.c_str()));
       dout(10) << "Computed sys.path '" << sys_path << "'" << dendl;
 #endif


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50073

---

backport of https://github.com/ceph/ceph/pull/40505
parent tracker: https://tracker.ceph.com/issues/50046

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh