### PR TITLE
octopus: mon/MgrMonitor: populate available_modules from promote_standby()

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -810,6 +810,8 @@ bool MgrMonitor::promote_standby()
     auto replacement_gid = pending_map.standbys.begin()->first;
     pending_map.active_gid = replacement_gid;
     pending_map.active_name = pending_map.standbys.at(replacement_gid).name;
+    pending_map.available_modules =
+      pending_map.standbys.at(replacement_gid).available_modules;
     pending_map.active_mgr_features =
       pending_map.standbys.at(replacement_gid).mgr_features;
     pending_map.available = false;


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49816

---

backport of

* https://github.com/ceph/ceph/pull/40078 (only cd0094678d0e01fd7b74e2f6f5ff47a16a60dddd because the other commit in this PR is not applicable to octopus and earlier)

parent tracker: https://tracker.ceph.com/issues/49778

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh