### PR TITLE
pacific: osd/PeeringState: fix acting_set_writeable min_size check

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -1054,10 +1054,10 @@ unsigned PeeringState::get_backfill_priority()
   if (state & PG_STATE_FORCED_BACKFILL) {
     ret = OSD_BACKFILL_PRIORITY_FORCED;
   } else {
-    if (acting.size() < pool.info.min_size) {
+    if (actingset.size() < pool.info.min_size) {
       base = OSD_BACKFILL_INACTIVE_PRIORITY_BASE;
       // inactive: no. of replicas < min_size, highest priority since it blocks IO
-      ret = base + (pool.info.min_size - acting.size());
+      ret = base + (pool.info.min_size - actingset.size());
 
     } else if (is_undersized()) {
       // undersized: OSD_BACKFILL_DEGRADED_PRIORITY_BASE + num missing replicas

--- a/src/osd/PeeringState.h
+++ b/src/osd/PeeringState.h
@@ -2313,7 +2313,7 @@ public:
    * applicable stretch cluster constraints.
    */
   bool acting_set_writeable() {
-    return (acting.size() >= pool.info.min_size) &&
+    return (actingset.size() >= pool.info.min_size) &&
       (pool.info.stretch_set_can_peer(acting, *get_osdmap(), NULL));
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50154

---

backport of https://github.com/ceph/ceph/pull/40572
parent tracker: https://tracker.ceph.com/issues/48613

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh