### PR TITLE
octopus: ceph.spec: fix mgr diskprediction_local dependency

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -556,6 +556,7 @@ Group:          System/Filesystems
 %endif
 Requires:       ceph-mgr = %{_epoch_prefix}%{version}-%{release}
 Requires:       python%{python3_pkgversion}-numpy
+Requires:       python%{python3_pkgversion}-scikit-learn
 Requires:       python3-scipy
 %if 0%{?rhel} == 7
 Requires:       numpy


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/47097

---

backport of https://github.com/ceph/ceph/pull/35648
parent tracker: https://tracker.ceph.com/issues/44948

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh