### PR TITLE
octopus: mount.ceph: collect v2 addresses for non-legacy ms_mode options

### DIFF
--- a/src/mount/conf.cc
+++ b/src/mount/conf.cc
@@ -16,6 +16,7 @@
 
 extern "C" void mount_ceph_get_config_info(const char *config_file,
 					   const char *name,
+					   bool v2_addrs,
 					   struct ceph_config_info *cci)
 {
   int err;
@@ -48,9 +49,17 @@ extern "C" void mount_ceph_get_config_info(const char *config_file,
   for (const auto& mon : monc.monmap.addr_mons) {
     auto& eaddr = mon.first;
 
-    // For now, kernel client only accepts legacy addrs
-    if (!eaddr.is_legacy())
-      continue;
+    /*
+     * Filter v1 addrs if we're running in ms_mode=legacy. Filter
+     * v2 addrs for any other ms_mode.
+     */
+    if (v2_addrs) {
+      if (!eaddr.is_msgr2())
+	continue;
+    } else {
+      if (!eaddr.is_legacy())
+	continue;
+    }
 
     std::string addr;
     addr += eaddr.ip_only_to_str();

--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -19,6 +19,7 @@
 
 bool verboseflag = false;
 bool skip_mtab_flag = false;
+bool v2_addrs = false;
 static const char * const EMPTY_STRING = "";
 
 /* TODO duplicates logic from kernel */
@@ -155,7 +156,7 @@ static int fetch_config_info(struct ceph_mount_info *cmi)
 		ret = drop_capabilities();
 		if (ret)
 			exit(1);
-		mount_ceph_get_config_info(cmi->cmi_conf, cmi->cmi_name, cci);
+		mount_ceph_get_config_info(cmi->cmi_conf, cmi->cmi_name, v2_addrs, cci);
 		exit(0);
 	} else {
 		/* parent */
@@ -314,6 +315,14 @@ static int parse_options(const char *data, struct ceph_mount_info *cmi)
 			}
 			/* keep pointer to value */
 			name = value;
+			skip = false;
+		} else if (strcmp(data, "ms_mode") == 0) {
+			if (!value || !*value) {
+				fprintf(stderr, "mount option ms_mode requires a value.\n");
+				return -EINVAL;
+			}
+			/* Only legacy ms_mode needs v1 addrs */
+			v2_addrs = strcmp(value, "legacy");
 			skip = false;
 		} else {
 			skip = false;

--- a/src/mount/mount.ceph.h
+++ b/src/mount/mount.ceph.h
@@ -32,7 +32,7 @@ struct ceph_config_info {
 };
 
 void mount_ceph_get_config_info(const char *config_file, const char *name,
-				struct ceph_config_info *cci);
+				bool v2_addrs, struct ceph_config_info *cci);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/48836

---

backport of https://github.com/ceph/ceph/pull/38788
parent tracker: https://tracker.ceph.com/issues/48765

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh