### PR TITLE
octopus: qa: for the latest kclient it will also return EIO

### DIFF
--- a/qa/tasks/cephfs/test_damage.py
+++ b/qa/tasks/cephfs/test_damage.py
@@ -440,8 +440,8 @@ class TestDamage(CephFSTestCase):
             if isinstance(self.mount_a, FuseMount):
                 self.assertEqual(e.exitstatus, errno.EIO)
             else:
-                # Kernel client handles this case differently
-                self.assertEqual(e.exitstatus, errno.ENOENT)
+                # Old kernel client handles this case differently
+                self.assertIn(e.exitstatus, [errno.ENOENT, errno.EIO])
         else:
             raise AssertionError("Expected EIO")
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49347

---

backport of https://github.com/ceph/ceph/pull/37869
parent tracker: https://tracker.ceph.com/issues/45100

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh