### PR TITLE
octopus: qa: bump osd heartbeat grace for ffsb workload

### DIFF
--- a/qa/cephfs/tasks/cfuse_workunit_suites_ffsb.yaml
+++ b/qa/cephfs/tasks/cfuse_workunit_suites_ffsb.yaml
@@ -6,6 +6,7 @@ overrides:
     conf:
       osd:
         filestore flush min: 0
+        osd heartbeat grace: 60
 tasks:
 - check-counter:
     counters:


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49472

---

backport of https://github.com/ceph/ceph/pull/38914
parent tracker: https://tracker.ceph.com/issues/48877

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh