### PR TITLE
octopus: qa: add sleep for blocklisting to take effect

### DIFF
--- a/qa/suites/fs/upgrade/featureful_client/old_client/tasks/3-compat_client/mimic.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/old_client/tasks/3-compat_client/mimic.yaml
@@ -7,4 +7,6 @@ tasks:
     mon.a:
       - ceph fs dump --format=json-pretty
       - ceph fs set cephfs min_compat_client octopus
+- sleep:
+    duration: 5
 - fs.clients_evicted:

--- a/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/4-compat_client.yaml
+++ b/qa/suites/fs/upgrade/featureful_client/upgraded_client/tasks/4-compat_client.yaml
@@ -7,6 +7,8 @@ tasks:
     mon.a:
       - ceph fs dump --format=json-pretty
       - ceph fs set cephfs min_compat_client octopus
+- sleep:
+    duration: 5
 - fs.clients_evicted:
     clients:
       client.0: False


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49611

---

backport of https://github.com/ceph/ceph/pull/39502
parent tracker: https://tracker.ceph.com/issues/49318

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh