### PR TITLE
octopus: test: reduce number of threads to 32 in LibCephFS.ShutdownRace

### DIFF
--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -2027,7 +2027,7 @@ static void shutdown_racer_func()
 // See tracker #20988
 TEST(LibCephFS, ShutdownRace)
 {
-  const int nthreads = 128;
+  const int nthreads = 32;
   std::thread threads[nthreads];
 
   // Need a bunch of fd's for this test


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/49934

---

backport of https://github.com/ceph/ceph/pull/40192
parent tracker: https://tracker.ceph.com/issues/49559

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh