### PR TITLE
octopus: client: only check pool permissions for regular files

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -14370,6 +14370,10 @@ int Client::check_pool_perm(Inode *in, int need)
   if (!cct->_conf->client_check_pool_perm)
     return 0;
 
+  /* Only need to do this for regular files */
+  if (!in->is_file())
+    return 0;
+
   int64_t pool_id = in->layout.pool_id;
   std::string pool_ns = in->layout.pool_ns;
   std::pair<int64_t, std::string> perm_key(pool_id, pool_ns);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50181

---

backport of https://github.com/ceph/ceph/pull/40460
parent tracker: https://tracker.ceph.com/issues/50090

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh