### PR TITLE
octopus: mds: reject lookup ino requests for mds dirs

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3863,6 +3863,19 @@ void Server::handle_client_lookup_ino(MDRequestRef& mdr,
     return _lookup_snap_ino(mdr);
 
   inodeno_t ino = req->get_filepath().get_ino();
+  auto _ino = ino.val;
+
+  /* It's been observed [1] that a client may lookup a private ~mdsdir inode.
+   * I do not have an explanation for how that happened organically but this
+   * check will ensure that the client can no longer do that.
+   *
+   * [1] https://tracker.ceph.com/issues/49922
+   */
+  if (_ino < MDS_INO_SYSTEM_BASE && _ino != CEPH_INO_ROOT) {
+    respond_to_request(mdr, -ESTALE);
+    return;
+  }
+
   CInode *in = mdcache->get_inode(ino);
   if (in && in->state_test(CInode::STATE_PURGING)) {
     respond_to_request(mdr, -ESTALE);

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3871,7 +3871,7 @@ void Server::handle_client_lookup_ino(MDRequestRef& mdr,
    *
    * [1] https://tracker.ceph.com/issues/49922
    */
-  if (_ino < MDS_INO_SYSTEM_BASE && _ino != CEPH_INO_ROOT) {
+  if (MDS_IS_PRIVATE_INO(_ino)) {
     respond_to_request(mdr, -ESTALE);
     return;
   }

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -2463,6 +2463,22 @@ TEST(LibCephFS, Lseek) {
   ceph_shutdown(cmount);
 }
 
+TEST(LibCephFS, LookupInoMDSDir) {
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(ceph_mount(cmount, NULL), 0);
+
+  Inode *inode;
+  auto ino = inodeno_t(0x100); /* rank 0 ~mdsdir */
+  ASSERT_EQ(-ESTALE, ceph_ll_lookup_inode(cmount, ino, &inode));
+  ino = inodeno_t(0x600); /* rank 0 first stray dir */
+  ASSERT_EQ(-ESTALE, ceph_ll_lookup_inode(cmount, ino, &inode));
+
+  ceph_shutdown(cmount);
+}
+
 static int ceph_mksnap(struct ceph_mount_info *cmount, const char *path, const char *name,
 		       mode_t mode, void *unused, size_t nr_unused)
 {


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50283

---

backport of https://github.com/ceph/ceph/pull/40389
parent tracker: https://tracker.ceph.com/issues/49922

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh