### PR TITLE
octopus: mon: check mdsmap is resizeable before promoting standby-replay

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -2135,7 +2135,7 @@ bool MDSMonitor::maybe_promote_standby(FSMap &fsmap, Filesystem& fs)
     }
   }
 
-  if (!fs.mds_map.is_degraded() && fs.mds_map.allows_standby_replay()) {
+  if (fs.mds_map.is_resizeable() && fs.mds_map.allows_standby_replay()) {
     // There were no failures to replace, so try using any available standbys
     // as standby-replay daemons. Don't do this when the cluster is degraded
     // as a standby-replay daemon may try to read a journal being migrated.


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50286

---

backport of https://github.com/ceph/ceph/pull/40653
parent tracker: https://tracker.ceph.com/issues/50215

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh