### PR TITLE
doc/_themes: remove spacing after `ul li p`

### DIFF
--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -1,4 +1,4 @@
-Sphinx == 3.2.1
+Sphinx >= 3.2.1
 git+https://github.com/ceph/sphinx-ditaa.git@py3#egg=sphinx-ditaa
 breathe >= 4.20.0
 Jinja2
@@ -8,7 +8,7 @@ pcpp
 prettytable
 sphinx-autodoc-typehints
 sphinx-prompt
-sphinx_rtd_theme
+sphinx_rtd_theme >=0.4.3
 Sphinx-Substitution-Extensions
 typed-ast
 sphinxcontrib-openapi

--- a/doc/_themes/ceph/static/ceph.css_t
+++ b/doc/_themes/ceph/static/ceph.css_t
@@ -142,6 +142,20 @@ html.writer-html5 .rst-content table.docutils th,
   margin-left: 24px;
 }
 
+.rst-content section ol li>p,
+.rst-content section ol li>p:last-child,
+.rst-content section ul li>p,
+.rst-content section ul li>p:last-child {
+  margin-bottom: 12px;
+}
+
+.rst-content section ol li>p:only-child,
+.rst-content section ol li>p:only-child:last-child,
+.rst-content section ul li>p:only-child,
+.rst-content section ul li>p:only-child:last-child {
+  margin-bottom: 0;
+}
+
 /* versions */
 .injected .rst-versions.rst-badge {
   left: 0;
@@ -173,4 +187,8 @@ html.writer-html5 .rst-content table.docutils th,
 
 .columns-3 > div {
   width: 33.33%;
+}
+
+div[class*="highlight-"] {
+  margin-bottom: 12px;
 }

--- a/doc/radosgw/orphans.rst
+++ b/doc/radosgw/orphans.rst
@@ -22,10 +22,11 @@ The `radosgw-admin` tool has/had three subcommands to help manage
 orphans, however these subcommands are (or will soon be)
 deprecated. These subcommands are:
 
-::
-   # radosgw-admin orphans find ...
-   # radosgw-admin orphans finish ...
-   # radosgw-admin orphans list-jobs ...
+.. prompt:: bash #
+
+   radosgw-admin orphans find ...
+   radosgw-admin orphans finish ...
+   radosgw-admin orphans list-jobs ...
 
 There are two key problems with these subcommands, however. First,
 these subcommands have not been actively maintained and therefore have
@@ -88,8 +89,9 @@ One of the sub-steps in computing a list of orphans is to map each RGW
 object into its corresponding set of RADOS objects. This is done using
 a subcommand of 'radosgw-admin'.
 
-::
-   # radosgw-admin bucket radoslist [--bucket={bucket-name}]
+.. prompt:: bash #
+
+   radosgw-admin bucket radoslist [--bucket={bucket-name}]
 
 The subcommand will produce a list of RADOS objects that support all
 of the RGW objects. If a bucket is specified then the subcommand will


### PR DESCRIPTION
in the latest document generated from RtD, the spacing after `ul li p`
elements is set to 24px as the plain `p` elements. but this the lists
more sparse and difficult to read.

in this change, the spacing is restored to 0 as it was in old theme.css
in sphinx_rtd_theme.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
