### PR TITLE
build-integration-branch: retry when running into network failures 

### DIFF
--- a/src/script/build-integration-branch
+++ b/src/script/build-integration-branch
@@ -93,8 +93,20 @@ for pr in prs:
     pr_url = pr['head']['repo']['clone_url']
     pr_ref = pr['head']['ref']
     print(f'--- pr {pr_number} --- pulling {pr_url} branch {pr_ref}')
-    r = call(['git', 'pull', '--no-edit', pr_url, pr_ref])
-    assert not r
+    while True:
+        r = call(['git', 'pull', '--no-edit', pr_url, pr_ref])
+        if r == 0:
+            break
+        elif r == 1:
+            print(f'Unable to access {pr_url}, retrying..')
+        elif r == 128:
+            message = f'Unable to resolve conflict when merging PR#{pr_number}'
+            raise Exception(message)
+        else:
+            message = ('Exiting due to an unknown failure when pulling '
+                       f'PR#{pr_number}')
+            raise Exception(message)
+
 print('--- done. these PRs were included:')
 print('\n'.join(prtext).encode('ascii', errors='ignore').decode())
 print('--- perhaps you want to: make && ctest -j12 && git push ci %s' % branch)

--- a/src/script/build-integration-branch
+++ b/src/script/build-integration-branch
@@ -89,13 +89,11 @@ r = call(['git', 'branch', '-D', branch])
 r = call(['git', 'checkout', '-b', branch])
 assert not r
 for pr in prs:
-    print('--- pr %d --- pulling %s branch %s' % (
-        pr['number'],
-        pr['head']['repo']['clone_url'],
-        pr['head']['ref']))
-    r = call(['git', 'pull', '--no-edit',
-              pr['head']['repo']['clone_url'],
-              pr['head']['ref']])
+    pr_number = pr['number']
+    pr_url = pr['head']['repo']['clone_url']
+    pr_ref = pr['head']['ref']
+    print(f'--- pr {pr_number} --- pulling {pr_url} branch {pr_ref}')
+    r = call(['git', 'pull', '--no-edit', pr_url, pr_ref])
     assert not r
 print('--- done. these PRs were included:')
 print('\n'.join(prtext).encode('ascii', errors='ignore').decode())


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
