### PR TITLE
octopus: rbd-mirror: fix UB while registering perf counters

### DIFF
--- a/src/tools/rbd_mirror/image_replayer/journal/Replayer.cc
+++ b/src/tools/rbd_mirror/image_replayer/journal/Replayer.cc
@@ -148,11 +148,6 @@ Replayer<I>::Replayer(
     m_lock(ceph::make_mutex(librbd::util::unique_lock_name(
       "rbd::mirror::image_replayer::journal::Replayer", this))) {
   dout(10) << dendl;
-
-  {
-    std::unique_lock locker{m_lock};
-    register_perf_counters();
-  }
 }
 
 template <typename I>
@@ -184,6 +179,11 @@ void Replayer<I>::init(Context* on_finish) {
     std::shared_lock image_locker{local_image_ctx->image_lock};
     m_image_spec = util::compute_image_spec(local_image_ctx->md_ctx,
                                             local_image_ctx->name);
+  }
+
+  {
+    std::unique_lock locker{m_lock};
+    register_perf_counters();
   }
 
   ceph_assert(m_on_init_shutdown == nullptr);


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50081

---

backport of https://github.com/ceph/ceph/pull/40370
parent tracker: https://tracker.ceph.com/issues/49959

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh