### PR TITLE
common/Formatter: include used header

### DIFF
--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -19,6 +19,7 @@
 #include "include/buffer.h"
 
 #include <fmt/format.h>
+#include <algorithm>
 #include <set>
 #include <limits>
 

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -39,6 +39,7 @@
 #include <boost/intrusive/set.hpp>
 #include <boost/optional.hpp>
 
+#include "include/compat.h"
 #include "include/intarith.h"
 #include "include/int_types.h"
 #include "include/scope_guard.h"

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3698,7 +3698,7 @@ void Monitor::handle_command(MonOpRequestRef op)
     rs = ss2.str();
     r = 0;
   } else if (prefix == "osd last-stat-seq") {
-    int64_t osd;
+    int64_t osd = 0;
     cmd_getval(cmdmap, "id", osd);
     uint64_t seq = mgrstatmon()->get_last_osd_stat_seq(osd);
     if (f) {

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1631,12 +1631,12 @@ public:
   }
 
   int64_t get_dedup_tier() const {
-    int64_t tier_id;
+    int64_t tier_id = 0;
     opts.get(pool_opts_t::DEDUP_TIER, &tier_id);
     return tier_id;
   }
   int64_t get_dedup_cdc_chunk_size() const {
-    int64_t chunk_size;
+    int64_t chunk_size = 0;
     opts.get(pool_opts_t::DEDUP_CDC_CHUNK_SIZE, &chunk_size);
     return chunk_size;
   }


### PR DESCRIPTION
otherwise it fails to build with gcc-toolset-10, like:

../src/common/Formatter.cc: In member function ‘virtual void ceph::XMLFormatter::close_section()’:
../src/common/Formatter.cc:449:8: error: ‘transform’ is not a member of ‘std’
  449 |   std::transform(section.begin(), section.end(), section.begin(),
      |        ^~~~~~~~~

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
