### PR TITLE
rbd: rbd export/import for consistent group

### DIFF
--- a/qa/workunits/rbd/rbd_groups.sh
+++ b/qa/workunits/rbd/rbd_groups.sh
@@ -158,6 +158,57 @@ check_snapshot_not_in_group()
     return 0
 }
 
+write_image()
+{
+    local image_name=$1
+    rbd bench --io-total 10M --io-type write --io-pattern rand $image_name
+}
+
+export_to_file()
+{
+    local group_name=$1
+    local file_path=$2
+    rbd group export $group_name $file_path
+}
+
+export_diff_to_file()
+{
+    local group_name=$1
+    local file_path=$2
+    local group_from_snap=$3
+    local group_end_snap=$4
+    if [ "$group_from_snap" == "start" ] && [ "$group_end_snap" == "end" ];then
+        rbd group export-diff $group_name $file_path
+    elif [ "$group_from_snap" == "start" ];then
+        rbd group export-diff $group_name@$group_end_snap $file_path
+    elif [ "$group_end_snap" == "end" ];then
+        rbd group export-diff $group_name --from-snap $group_from_snap $file_path
+    else
+        rbd group export-diff $group_name@$group_end_snap --from-snap $group_from_snap $file_path
+    fi
+}
+
+import_from_file()
+{
+    local file_path=$1
+    local group_name=$2
+    rbd group import $file_path $group_name
+}
+
+import_diff_from_file()
+{
+    local file_path=$1
+    local group_name=$2
+    rbd group import-diff $file_path $group_name
+}
+
+cmp_file()
+{
+    local file1=$1
+    local file2=$2
+    cmp $file1 $file2
+}
+
 echo "TEST: create remove consistency group"
 group="test_consistency_group"
 new_group="test_new_consistency_group"
@@ -204,6 +255,80 @@ remove_snapshot $group $sec_snap
 check_snapshot_not_in_group $group $sec_snap
 remove_group $group
 remove_image $image
+echo "PASSED"
+
+echo "TEST: export/import of consistency group"
+image="test_image"
+group="test_consistency_group"
+group_import="test_consistency_group_import"
+snap1="group_snap_v1"
+snap2="group_snap_v2"
+export_file="/tmp/${group}_export"
+export_start_to_v1_file="/tmp/${group}_export_v1"
+export_v1_to_v2_file="/tmp/${group}_export_v1_to_v2"
+export_v2_to_end_file="/tmp/${group}_export_v2_to_end"
+group_import_export_file="/tmp/${group_import}_export"
+group_import_export_start_to_v1_file="/tmp/${group_import}_export_v1"
+group_import_export_v1_to_v2_file="/tmp/${group_import}_export_v1_to_v2"
+group_import_export_v2_to_end_file="/tmp/${group_import}_export_v2_to_end"
+create_image $image
+create_group $group
+add_image_to_group $image $group
+write_image $image
+create_snapshot $group $snap1
+write_image $image
+create_snapshot $group $snap2
+write_image $image
+export_to_file $group $export_file
+export_diff_to_file $group $export_start_to_v1_file "start" $snap1
+export_diff_to_file $group $export_v1_to_v2_file $snap1 $snap2
+export_diff_to_file $group $export_v2_to_end_file $snap2 "end"
+remove_snapshot $group $snap2
+remove_snapshot $group $snap1
+remove_image_from_group $image $group
+remove_image $image
+remove_group $group
+import_from_file $export_file $group_import
+export_to_file $group_import $group_import_export_file
+export_diff_to_file $group_import $group_import_export_start_to_v1_file "start" $snap1
+export_diff_to_file $group_import $group_import_export_v1_to_v2_file $snap1 $snap2
+export_diff_to_file $group_import $group_import_export_v2_to_end_file $snap2 "end"
+cmp_file $export_file $group_import_export_file
+cmp_file $export_start_to_v1_file $group_import_export_start_to_v1_file
+cmp_file $export_v1_to_v2_file $group_import_export_v1_to_v2_file
+cmp_file $export_v2_to_end_file $group_import_export_v2_to_end_file
+remove_snapshot $group_import $snap2
+remove_snapshot $group_import $snap1
+remove_image_from_group $image $group_import
+remove_image $image
+rm -f $group_import_export_file
+rm -f $group_import_export_start_to_v1_file
+rm -f $group_import_export_v1_to_v2_file
+rm -f $group_import_export_v2_to_end_file
+import_diff_from_file $export_start_to_v1_file $group_import
+import_diff_from_file $export_v1_to_v2_file $group_import
+import_diff_from_file $export_v2_to_end_file $group_import
+export_to_file $group_import $group_import_export_file
+export_diff_to_file $group_import $group_import_export_start_to_v1_file "start" $snap1
+export_diff_to_file $group_import $group_import_export_v1_to_v2_file $snap1 $snap2
+export_diff_to_file $group_import $group_import_export_v2_to_end_file $snap2 "end"
+cmp_file $export_file $group_import_export_file
+cmp_file $export_start_to_v1_file $group_import_export_start_to_v1_file
+cmp_file $export_v1_to_v2_file $group_import_export_v1_to_v2_file
+cmp_file $export_v2_to_end_file $group_import_export_v2_to_end_file
+remove_snapshot $group_import $snap2
+remove_snapshot $group_import $snap1
+remove_image_from_group $image $group_import
+remove_image $image
+remove_group $group_import
+rm -f $group_import_export_file
+rm -f $group_import_export_start_to_v1_file
+rm -f $group_import_export_v1_to_v2_file
+rm -f $group_import_export_v2_to_end_file
+rm -f $export_file
+rm -f $export_start_to_v1_file
+rm -f $export_v1_to_v2_file
+rm -f $export_v2_to_end_file
 echo "PASSED"
 
 echo "OK"

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -1146,6 +1146,10 @@ CEPH_RBD_API int rbd_diff_iterate2(rbd_image_t image,
                                    uint8_t include_parent, uint8_t whole_object,
 		                   int (*cb)(uint64_t, size_t, int, void *),
                                    void *arg);
+CEPH_RBD_API int rbd_diff_iterate_group_image_snap(rbd_image_t image,
+                      const char *from_snap_name, uint64_t ofs, uint64_t len,
+                      uint8_t include_parent, uint8_t whole_object,
+                      int (*cb)(uint64_t, size_t, int, void *), void *arg);
 CEPH_RBD_API ssize_t rbd_write(rbd_image_t image, uint64_t ofs, size_t len,
                                const char *buf);
 /*

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -248,6 +248,12 @@ typedef enum {
 } rbd_group_snap_state_t;
 
 typedef struct {
+  int64_t pool_id;
+  char *image_name;
+  uint64_t snap_id;
+} rbd_group_image_snap_info_t;
+
+typedef struct {
   char *name;
   rbd_group_snap_state_t state;
 } rbd_group_snap_info_t;
@@ -1418,6 +1424,15 @@ CEPH_RBD_API int rbd_group_snap_list(rados_ioctx_t group_p,
 CEPH_RBD_API int rbd_group_snap_list_cleanup(rbd_group_snap_info_t *snaps,
                                              size_t group_snap_info_size,
                                              size_t num_entries);
+CEPH_RBD_API int rbd_group_image_snap_list(rados_ioctx_t group_p,
+                      const char *group_name,
+                      const char *group_snap_name,
+                      rbd_group_image_snap_info_t *snaps,
+                      size_t group_snap_info_size,
+                      size_t *num_entries);
+CEPH_RBD_API int rbd_group_image_snap_list_cleanup(rbd_group_image_snap_info_t *snaps,
+                                           size_t group_image_snap_info_size,
+                                           size_t len);
 CEPH_RBD_API int rbd_group_snap_rollback(rados_ioctx_t group_p,
                                          const char *group_name,
                                          const char *snap_name);

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -150,6 +150,12 @@ namespace librbd {
   } group_image_info_t;
 
   typedef struct {
+    int64_t pool_id;
+    std::string image_name;
+    uint64_t snap_id;
+  } group_image_snap_info_t;
+
+  typedef struct {
     std::string name;
     int64_t pool;
   } group_info_t;
@@ -428,6 +434,10 @@ public:
                         const char *old_snap_name, const char *new_snap_name);
   int group_snap_list(IoCtx& group_ioctx, const char *group_name,
                       std::vector<group_snap_info_t> *snaps,
+                      size_t group_snap_info_size);
+  int group_image_snap_list(IoCtx& group_ioctx, const char *group_name,
+                      const char *group_snap_name,
+                      std::vector<group_image_snap_info_t> *snaps,
                       size_t group_snap_info_size);
   int group_snap_rollback(IoCtx& io_ctx, const char *group_name,
                           const char *snap_name);

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -711,6 +711,9 @@ public:
 		    uint64_t ofs, uint64_t len,
                     bool include_parent, bool whole_object,
 		    int (*cb)(uint64_t, size_t, int, void *), void *arg);
+  int diff_iterate_group_image_snap(const char *from_snap_name, uint64_t ofs,
+        uint64_t len, bool include_parent, bool whole_object,
+        int (*cb)(uint64_t, size_t, int, void *), void *arg);
 
   ssize_t write(uint64_t ofs, size_t len, ceph::bufferlist& bl);
   /* @param op_flags see librados.h constants beginning with LIBRADOS_OP_FLAG */

--- a/src/librbd/api/Group.h
+++ b/src/librbd/api/Group.h
@@ -46,6 +46,9 @@ struct Group {
                          const char *old_snap_name, const char *new_snap_name);
   static int snap_list(librados::IoCtx& group_ioctx, const char *group_name,
                        std::vector<group_snap_info_t> *snaps);
+  static int image_snap_list(librados::IoCtx& group_ioctx, const char *group_name,
+			                    const char *group_snap_name,
+                          std::vector<group_image_snap_info_t> *image_snaps);
   static int snap_rollback(librados::IoCtx& group_ioctx,
                            const char *group_name, const char *snap_name,
                            ProgressContext& pctx);

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -2577,6 +2577,17 @@ namespace librbd {
     return r;
   }
 
+  int Image::diff_iterate_group_image_snap(const char *from_snap_name, uint64_t ofs,
+        uint64_t len, bool include_parent, bool whole_object,
+        int (*cb)(uint64_t, size_t, int, void *), void *arg)
+  {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    int r = librbd::api::DiffIterate<>::diff_iterate(ictx,
+                cls::rbd::GroupSnapshotNamespace(), from_snap_name, ofs, len,
+                include_parent, whole_object, cb, arg);
+    return r;
+  }
+
   ssize_t Image::write(uint64_t ofs, size_t len, bufferlist& bl)
   {
     ImageCtx *ictx = (ImageCtx *)ctx;
@@ -6013,6 +6024,18 @@ extern "C" int rbd_diff_iterate2(rbd_image_t image, const char *fromsnapname,
                                                    include_parent, whole_object,
                                                    cb, arg);
   tracepoint(librbd, diff_iterate_exit, r);
+  return r;
+}
+
+extern "C" int rbd_diff_iterate_group_image_snap(rbd_image_t image,
+                        const char *from_snap_name, uint64_t ofs, uint64_t len,
+                        uint8_t include_parent, uint8_t whole_object,
+                        int (*cb)(uint64_t, size_t, int, void *), void *arg)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  int r = librbd::api::DiffIterate<>::diff_iterate(ictx,
+              cls::rbd::GroupSnapshotNamespace(), from_snap_name, ofs, len,
+              include_parent, whole_object, cb, arg);
   return r;
 }
 

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -45,9 +45,13 @@
       flatten                           Fill clone with parent data (make it
                                         independent).
       group create                      Create a group.
+      group export                      Export group to file.
+      group export-diff                 Export group incremental diff to file.
       group image add                   Add an image to a group.
       group image list (... ls)         List images in a group.
       group image remove (... rm)       Remove an image from a group.
+      group import                      Import group from file.
+      group import-diff                 Import group incremental diff from file.
       group list (group ls)             List rbd groups.
       group remove (group rm)           Delete a group.
       group rename                      Rename a group within pool.
@@ -880,6 +884,51 @@
     --namespace arg      namespace name
     --group arg          group name
   
+  rbd help group export
+  usage: rbd group export [--pool <pool>] [--namespace <namespace>] 
+                          [--group <group>] [--path <path>] [--no-progress] 
+                          <source-group-spec> <path-name> 
+  
+  Export group to file.
+  
+  Positional arguments
+    <source-group-spec>  source group specification
+                         (example: [<pool-name>/[<namespace>/]]<group-name>)
+    <path-name>          export file (or '-' for stdout)
+  
+  Optional arguments
+    -p [ --pool ] arg    source pool name
+    --namespace arg      source namespace name
+    --group arg          source group name
+    --path arg           export file (or '-' for stdout)
+    --no-progress        disable progress output
+  
+  rbd help group export-diff
+  usage: rbd group export-diff [--pool <pool>] [--namespace <namespace>] 
+                               [--group <group>] [--snap <snap>] 
+                               [--from-snap <from-snap>] [--whole-object] 
+                               [--path <path>] [--no-progress] 
+                               <source-group-or-snap-spec> <path-name> 
+  
+  Export group incremental diff to file.
+  
+  Positional arguments
+    <source-group-or-snap-spec>  source group or snapshot specification
+                                 (example:
+                                 [<pool-name>/[<namespace>/]]<group-name>[@<snap-n
+                                 ame>])
+    <path-name>                  export file (or '-' for stdout)
+  
+  Optional arguments
+    -p [ --pool ] arg            source pool name
+    --namespace arg              source namespace name
+    --group arg                  source group name
+    --snap arg                   source snapshot name
+    --from-snap arg              snapshot starting point
+    --whole-object               compare whole object
+    --path arg                   export file (or '-' for stdout)
+    --no-progress                disable progress output
+  
   rbd help group image add
   usage: rbd group image add [--group-pool <group-pool>] 
                              [--group-namespace <group-namespace>] 
@@ -950,6 +999,96 @@
     --image arg           image name
     -p [ --pool ] arg     pool name unless overridden
     --image-id arg        image id
+  
+  rbd help group import
+  usage: rbd group import [--path <path>] [--dest-pool <dest-pool>] 
+                          [--dest-namespace <dest-namespace>] 
+                          [--dest-group <dest-group>] 
+                          [--image-format <image-format>] [--new-format] 
+                          [--order <order>] [--object-size <object-size>] 
+                          [--image-feature <image-feature>] [--image-shared] 
+                          [--stripe-unit <stripe-unit>] 
+                          [--stripe-count <stripe-count>] 
+                          [--data-pool <data-pool>] 
+                          [--mirror-image-mode <mirror-image-mode>] 
+                          [--journal-splay-width <journal-splay-width>] 
+                          [--journal-object-size <journal-object-size>] 
+                          [--journal-pool <journal-pool>] 
+                          [--sparse-size <sparse-size>] [--no-progress] 
+                          <path-name> <dest-group-spec> 
+  
+  Import group from file.
+  
+  Positional arguments
+    <path-name>               import file (or '-' for stdin)
+    <dest-group-spec>         destination group specification
+                              (example: [<pool-name>/[<namespace>/]]<group-name>)
+  
+  Optional arguments
+    --path arg                import file (or '-' for stdin)
+    --dest-pool arg           destination pool name
+    --dest-namespace arg      destination namespace name
+    --dest-group arg          destination group name
+    --image-format arg        image format [default: 2]
+    --object-size arg         object size in B/K/M [4K <= object size <= 32M]
+    --image-feature arg       image features
+                              [layering(+), exclusive-lock(+*), object-map(+*),
+                              deep-flatten(+-), journaling(*)]
+    --image-shared            shared image
+    --stripe-unit arg         stripe unit in B/K/M
+    --stripe-count arg        stripe count
+    --data-pool arg           data pool
+    --mirror-image-mode arg   mirror image mode [journal or snapshot]
+    --journal-splay-width arg number of active journal objects
+    --journal-object-size arg size of journal objects [4K <= size <= 64M]
+    --journal-pool arg        pool for journal objects
+    --sparse-size arg         sparse size in B/K/M [default: 4K]
+    --no-progress             disable progress output
+  
+  rbd help group import-diff
+  usage: rbd group import-diff [--path <path>] [--dest-pool <dest-pool>] 
+                               [--dest-namespace <dest-namespace>] 
+                               [--dest-group <dest-group>] 
+                               [--image-format <image-format>] [--new-format] 
+                               [--order <order>] [--object-size <object-size>] 
+                               [--image-feature <image-feature>] 
+                               [--image-shared] [--stripe-unit <stripe-unit>] 
+                               [--stripe-count <stripe-count>] 
+                               [--data-pool <data-pool>] 
+                               [--mirror-image-mode <mirror-image-mode>] 
+                               [--journal-splay-width <journal-splay-width>] 
+                               [--journal-object-size <journal-object-size>] 
+                               [--journal-pool <journal-pool>] 
+                               [--sparse-size <sparse-size>] [--no-progress] 
+                               <path-name> <dest-group-spec> 
+  
+  Import group incremental diff from file.
+  
+  Positional arguments
+    <path-name>               import file (or '-' for stdin)
+    <dest-group-spec>         destination group specification
+                              (example: [<pool-name>/[<namespace>/]]<group-name>)
+  
+  Optional arguments
+    --path arg                import file (or '-' for stdin)
+    --dest-pool arg           destination pool name
+    --dest-namespace arg      destination namespace name
+    --dest-group arg          destination group name
+    --image-format arg        image format [default: 2]
+    --object-size arg         object size in B/K/M [4K <= object size <= 32M]
+    --image-feature arg       image features
+                              [layering(+), exclusive-lock(+*), object-map(+*),
+                              deep-flatten(+-), journaling(*)]
+    --image-shared            shared image
+    --stripe-unit arg         stripe unit in B/K/M
+    --stripe-count arg        stripe count
+    --data-pool arg           data pool
+    --mirror-image-mode arg   mirror image mode [journal or snapshot]
+    --journal-splay-width arg number of active journal objects
+    --journal-object-size arg size of journal objects [4K <= size <= 64M]
+    --journal-pool arg        pool for journal objects
+    --sparse-size arg         sparse size in B/K/M [default: 4K]
+    --no-progress             disable progress output
   
   rbd help group list
   usage: rbd group list [--pool <pool>] [--namespace <namespace>] 

--- a/src/tools/rbd/CMakeLists.txt
+++ b/src/tools/rbd/CMakeLists.txt
@@ -11,6 +11,7 @@ set(rbd_srcs
   Schedule.cc
   Shell.cc
   Utils.cc
+  ExportImport.cc
   action/Bench.cc
   action/Children.cc
   action/Clone.cc

--- a/src/tools/rbd/ExportImport.cc
+++ b/src/tools/rbd/ExportImport.cc
@@ -1,0 +1,715 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <iostream>
+#include "common/errno.h"
+#include "tools/rbd/Utils.h"
+#include "tools/rbd/ExportImport.h"
+
+namespace rbd {
+namespace utils {
+
+int C_ExportDiff::send()
+{
+  if (m_export_diff_context->throttle.pending_error()) {
+    return m_export_diff_context->throttle.wait_for_ret();
+  }
+
+  C_OrderedThrottle *ctx = m_export_diff_context->throttle.start_op(this);
+  if (m_exists) {
+    librbd::RBD::AioCompletion *aio_completion =
+      new librbd::RBD::AioCompletion(ctx, &utils::aio_context_callback);
+
+    int op_flags = LIBRADOS_OP_FLAG_FADVISE_NOCACHE;
+    int r = m_export_diff_context->image->aio_read2(
+      m_offset, m_length, m_read_data, aio_completion, op_flags);
+    if (r < 0) {
+      aio_completion->release();
+      ctx->complete(r);
+    }
+  } else {
+    ctx->complete(0);
+  }
+  return 0;
+}
+
+int C_ExportDiff::export_diff_cb(uint64_t offset, size_t length, int exists,
+			    void *arg)
+{
+  ExportDiffContext *edc = reinterpret_cast<ExportDiffContext *>(arg);
+
+  C_ExportDiff *context = new C_ExportDiff(edc, offset, length,
+                                          exists, edc->export_format);
+  return context->send();
+}
+
+void C_ExportDiff::finish(int r)
+{
+  if (r >= 0) {
+    if (m_exists) {
+      m_exists = !m_read_data.is_zero();
+    }
+    r = write_extent(m_export_diff_context, m_offset, m_length,
+                    m_exists, m_export_format);
+    if (r == 0 && m_exists) {
+      r = m_read_data.write_fd(m_export_diff_context->fd);
+    }
+  }
+  m_export_diff_context->throttle.end_op(r);
+}
+
+int C_ExportDiff::write_extent(ExportDiffContext *edc, uint64_t offset,
+                          uint64_t length, bool exists, int export_format)
+{
+  // extent
+  bufferlist bl;
+  __u8 tag = exists ? RBD_DIFF_WRITE : RBD_DIFF_ZERO;
+  uint64_t len = 0;
+  encode(tag, bl);
+  if (export_format == 2) {
+    if (tag == RBD_DIFF_WRITE)
+      len = 8 + 8 + length;
+    else
+      len = 8 + 8;
+    encode(len, bl);
+  }
+  encode(offset, bl);
+  encode(length, bl);
+  int r = bl.write_fd(edc->fd);
+
+  edc->pc.update_progress(offset, edc->totalsize);
+  return r;
+}
+
+int C_ImportDiff::send()
+{
+  if (m_idiffctx->throttle.pending_error()) {
+    return m_idiffctx->throttle.wait_for_ret();
+  }
+
+  C_OrderedThrottle *ctx = m_idiffctx->throttle.start_op(this);
+  librbd::RBD::AioCompletion *aio_completion =
+    new librbd::RBD::AioCompletion(ctx, &utils::aio_context_callback);
+
+  int r;
+  if (m_write_zeroes) {
+    r = m_idiffctx->image->aio_write_zeroes(m_offset, m_length,
+                                            aio_completion, 0U,
+                                            LIBRADOS_OP_FLAG_FADVISE_NOCACHE);
+  } else {
+    r = m_idiffctx->image->aio_write2(m_offset, m_length, m_data,
+                                      aio_completion,
+                                      LIBRADOS_OP_FLAG_FADVISE_NOCACHE);
+  }
+
+  if (r < 0) {
+    aio_completion->release();
+    ctx->complete(r);
+  }
+
+  return r;
+}
+
+int open_export_file(const char *path, int &fd, bool &to_stdout)
+{
+  to_stdout = (strcmp(path, "-") == 0);
+
+  if (to_stdout) {
+    fd = STDOUT_FILENO;
+  } else {
+    fd = open(path, O_WRONLY | O_CREAT | O_EXCL | O_BINARY, 0644);
+    if (fd < 0) {
+      std::cerr << "Open file err:" << cpp_strerror(errno) << std::endl;
+      return -errno;
+    }
+#ifdef HAVE_POSIX_FADVISE
+    posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL);
+#endif
+  }
+
+  return 0;
+}
+
+int image_export_metadata(librbd::Image& image, librbd::image_info_t &info, int fd)
+{
+  int r = 0;
+  // header
+  bufferlist bl;
+  bl.append(RBD_IMAGE_BANNER_V2);
+
+  __u8 tag;
+  uint64_t length;
+  // encode order
+  tag = RBD_EXPORT_IMAGE_ORDER;
+  length = 8;
+  encode(tag, bl);
+  encode(length, bl);
+  encode(uint64_t(info.order), bl);
+
+  // encode features
+  tag = RBD_EXPORT_IMAGE_FEATURES;
+  uint64_t features;
+  image.features(&features);
+  length = 8;
+  encode(tag, bl);
+  encode(length, bl);
+  encode(features, bl);
+
+  // encode stripe_unit and stripe_count
+  tag = RBD_EXPORT_IMAGE_STRIPE_UNIT;
+  uint64_t stripe_unit;
+  stripe_unit = image.get_stripe_unit();
+  length = 8;
+  encode(tag, bl);
+  encode(length, bl);
+  encode(stripe_unit, bl);
+
+  tag = RBD_EXPORT_IMAGE_STRIPE_COUNT;
+  uint64_t stripe_count;
+  stripe_count = image.get_stripe_count();
+  length = 8;
+  encode(tag, bl);
+  encode(length, bl);
+  encode(stripe_count, bl);
+
+  //retrieve metadata of image
+  std::map<std::string, std::string> imagemetas;
+  std::string last_key;
+  bool more_results = true;
+  while (more_results) {
+    std::map<std::string, bufferlist> pairs;
+    r = image.metadata_list(last_key, MAX_KEYS, &pairs);
+    if (r < 0) {
+      std::cerr << "failed to retrieve metadata of image : " << cpp_strerror(r)
+                << std::endl;
+      return r;
+    }
+
+    if (!pairs.empty()) {
+      last_key = pairs.rbegin()->first;
+
+      for (auto kv : pairs) {
+        std::string key = kv.first;
+        std::string val(kv.second.c_str(), kv.second.length());
+        imagemetas[key] = val;
+      }
+    }
+    more_results = (pairs.size() == MAX_KEYS);
+  }
+
+  //encode imageMeta key and value
+  for (std::map<std::string, std::string>::iterator it = imagemetas.begin();
+       it != imagemetas.end(); ++it) {
+    std::string key = it->first;
+    std::string value = it->second;
+
+    tag = RBD_EXPORT_IMAGE_META;
+    length = key.length() + value.length() + 4 * 2;
+    encode(tag, bl);
+    encode(length, bl);
+    encode(key, bl);
+    encode(value, bl);
+  }
+
+  // encode end tag
+  tag = RBD_EXPORT_IMAGE_END;
+  encode(tag, bl);
+
+  // write bl to fd.
+  r = bl.write_fd(fd);
+  if (r < 0) {
+    return r;
+  }
+
+  return r;
+}
+
+int image_export_diff_header(librbd::Image& image, librbd::image_info_t &info,
+                            const char *fromsnapname, const char *endsnapname,
+                            int fd, const int export_format)
+{
+  int r = 0;
+  // header
+  bufferlist bl;
+  if (export_format == 1)
+    bl.append(utils::RBD_DIFF_BANNER);
+  else
+    bl.append(utils::RBD_DIFF_BANNER_V2);
+
+  __u8 tag;
+  uint64_t len = 0;
+  if (fromsnapname) {
+    tag = RBD_DIFF_FROM_SNAP;
+    encode(tag, bl);
+    std::string from(fromsnapname);
+    if (export_format == 2) {
+      len = from.length() + 4;
+      encode(len, bl);
+    }
+    encode(from, bl);
+  }
+
+  if (endsnapname) {
+    tag = RBD_DIFF_TO_SNAP;
+    encode(tag, bl);
+    std::string to(endsnapname);
+    if (export_format == 2) {
+      len = to.length() + 4;
+      encode(len, bl);
+    }
+    encode(to, bl);
+  }
+
+  if (endsnapname && export_format == 2) {
+    tag = RBD_SNAP_PROTECTION_STATUS;
+    encode(tag, bl);
+    bool is_protected = false;
+    r = image.snap_is_protected(endsnapname, &is_protected);
+    if (r < 0) {
+      return r;
+    }
+    len = 1;
+    encode(len, bl);
+    encode(is_protected, bl);
+  }
+
+  tag = RBD_DIFF_IMAGE_SIZE;
+  encode(tag, bl);
+  uint64_t endsize = info.size;
+  if (export_format == 2) {
+    len = 8;
+    encode(len, bl);
+  }
+  encode(endsize, bl);
+
+  r = bl.write_fd(fd);
+  if (r < 0) {
+    return r;
+  }
+
+  return r;
+}
+
+int read_tag(int fd, __u8 end_tag, int format, __u8 *tag, uint64_t *readlen)
+{
+  int r;
+  __u8 read_tag;
+
+  r = safe_read_exact(fd, &read_tag, sizeof(read_tag));
+  if (r < 0) {
+    std::cerr << "rbd: failed to decode tag" << std::endl;
+    return r;
+  }
+
+  *tag = read_tag;
+  if (read_tag != end_tag && format == 2) {
+    char buf[sizeof(uint64_t)];
+    r = safe_read_exact(fd, buf, sizeof(buf));
+    if (r < 0) {
+      std::cerr << "rbd: failed to decode tag length" << std::endl;
+      return r;
+    }
+
+    bufferlist bl;
+    bl.append(buf, sizeof(buf));
+    auto p = bl.cbegin();
+    decode(*readlen, p);
+  }
+
+  return 0;
+}
+
+int skip_tag(int fd, uint64_t length)
+{
+  int r;
+
+  if (fd == STDIN_FILENO) {
+    // read the appending data out to skip this tag.
+    char buf[4096];
+    uint64_t len = std::min<uint64_t>(length, sizeof(buf));
+    while (len > 0) {
+      r = safe_read_exact(fd, buf, len);
+      if (r < 0) {
+        std::cerr << "rbd: failed to decode skipped tag data" << std::endl;
+        return r;
+      }
+      length -= len;
+      len = std::min<uint64_t>(length, sizeof(buf));
+    }
+  } else {
+    // lseek to skip this tag
+    off64_t offs = lseek64(fd, length, SEEK_CUR);
+    if (offs < 0) {
+      return -errno;
+    }
+  }
+
+  return 0;
+}
+
+int validate_banner(int fd, std::string banner)
+{
+  int r;
+  char buf[banner.size() + 1];
+  memset(buf, 0, sizeof(buf));
+  r = safe_read_exact(fd, buf, banner.size());
+  if (r < 0) {
+    std::cerr << "rbd: failed to decode diff banner" << std::endl;
+    return r;
+  }
+
+  buf[banner.size()] = '\0';
+  if (strcmp(buf, banner.c_str())) {
+    std::cerr << "rbd: invalid or unexpected diff banner" << std::endl;
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
+static int decode_and_set_image_option(int fd, uint64_t imageopt,
+                                      librbd::ImageOptions& opts)
+{
+  int r;
+  char buf[sizeof(uint64_t)];
+
+  r = safe_read_exact(fd, buf, sizeof(buf));
+  if (r < 0) {
+    std::cerr << "rbd: failed to decode image option" << std::endl;
+    return r;
+  }
+
+  bufferlist bl;
+  bl.append(buf, sizeof(buf));
+  auto it = bl.cbegin();
+
+  uint64_t val;
+  decode(val, it);
+
+  if (opts.get(imageopt, &val) != 0) {
+    opts.set(imageopt, val);
+  }
+
+  return 0;
+}
+
+static int decode_imagemeta(int fd, uint64_t length,
+                            std::map<std::string, std::string>* imagemetas)
+{
+  int r;
+  std::string key;
+  std::string value;
+
+  r = utils::read_string(fd, length, &key);
+  if (r < 0) {
+    std::cerr << "rbd: failed to decode metadata key" << std::endl;
+    return r;
+  }
+
+  r = utils::read_string(fd, length, &value);
+  if (r < 0) {
+    std::cerr << "rbd: failed to decode metadata value" << std::endl;
+    return r;
+  }
+
+  (*imagemetas)[key] = value;
+  return 0;
+}
+
+int do_import_header(int fd, int import_format, librbd::ImageOptions& opts,
+                            std::map<std::string, std::string>* imagemetas)
+{
+  // There is no header in v1 image.
+  if (import_format == 1) {
+    return 0;
+  }
+
+  int r;
+  r = validate_banner(fd, utils::RBD_IMAGE_BANNER_V2);
+  if (r < 0) {
+    return r;
+  }
+
+  // As V1 format for image is already deprecated, import image in V2 by default.
+  uint64_t image_format = 2;
+  if (opts.get(RBD_IMAGE_OPTION_FORMAT, &image_format) != 0) {
+    opts.set(RBD_IMAGE_OPTION_FORMAT, image_format);
+  }
+
+  while (r == 0) {
+    __u8 tag;
+    uint64_t length = 0;
+    r = read_tag(fd, RBD_EXPORT_IMAGE_END, image_format, &tag, &length);
+    if (r < 0 || tag == RBD_EXPORT_IMAGE_END) {
+      break;
+    }
+
+    if (tag == RBD_EXPORT_IMAGE_ORDER) {
+      r = decode_and_set_image_option(fd, RBD_IMAGE_OPTION_ORDER, opts);
+    } else if (tag == RBD_EXPORT_IMAGE_FEATURES) {
+      r = decode_and_set_image_option(fd, RBD_IMAGE_OPTION_FEATURES, opts);
+    } else if (tag == RBD_EXPORT_IMAGE_STRIPE_UNIT) {
+      r = decode_and_set_image_option(fd, RBD_IMAGE_OPTION_STRIPE_UNIT, opts);
+    } else if (tag == RBD_EXPORT_IMAGE_STRIPE_COUNT) {
+      r = decode_and_set_image_option(fd, RBD_IMAGE_OPTION_STRIPE_COUNT, opts);
+    } else if (tag == RBD_EXPORT_IMAGE_META) {
+      r = decode_imagemeta(fd, length, imagemetas);
+    } else {
+      std::cerr << "rbd: invalid tag in image properties zone: " << tag << "Skip it."
+                << std::endl;
+      r = skip_tag(fd, length);
+    }
+  }
+
+  return r;
+}
+
+static int do_image_io(ImportDiffContext *idiffctx, bool write_zeroes,
+                       size_t sparse_size)
+{
+  int r;
+  char buf[16];
+  r = safe_read_exact(idiffctx->fd, buf, sizeof(buf));
+  if (r < 0) {
+    std::cerr << "rbd: failed to decode IO length" << std::endl;
+    return r;
+  }
+
+  bufferlist bl;
+  bl.append(buf, sizeof(buf));
+  auto p = bl.cbegin();
+
+  uint64_t image_offset, buffer_length;
+  decode(image_offset, p);
+  decode(buffer_length, p);
+
+  if (!write_zeroes) {
+    bufferptr bp = buffer::create(buffer_length);
+    r = safe_read_exact(idiffctx->fd, bp.c_str(), buffer_length);
+    if (r < 0) {
+      std::cerr << "rbd: failed to decode write data" << std::endl;
+      return r;
+    }
+
+    size_t buffer_offset = 0;
+    while (buffer_offset < buffer_length) {
+      size_t write_length = 0;
+      bool zeroed = false;
+      utils::calc_sparse_extent(bp, sparse_size, buffer_offset, buffer_length,
+				&write_length, &zeroed);
+      ceph_assert(write_length > 0);
+
+      bufferlist write_bl;
+      if (!zeroed) {
+        bufferptr write_ptr(bp, buffer_offset, write_length);
+        write_bl.push_back(write_ptr);
+        ceph_assert(write_bl.length() == write_length);
+      }
+
+      C_ImportDiff *ctx = new C_ImportDiff(idiffctx, write_bl,
+					   image_offset + buffer_offset,
+					   write_length, zeroed);
+      r = ctx->send();
+      if (r < 0) {
+        return r;
+      }
+
+      buffer_offset += write_length;
+    }
+  } else {
+    bufferlist data;
+    C_ImportDiff *ctx = new C_ImportDiff(idiffctx, data, image_offset,
+					 buffer_length, true);
+    return ctx->send();
+  }
+  return r;
+}
+
+static int do_image_snap_from(utils::ImportDiffContext *idiffctx)
+{
+  int r;
+  std::string from;
+  r = utils::read_string(idiffctx->fd, 4096, &from);   // 4k limit to make sure we don't get a garbage string
+  if (r < 0) {
+    std::cerr << "rbd: failed to decode start snap name" << std::endl;
+    return r;
+  }
+
+  bool exists;
+  r = idiffctx->image->snap_exists2(from.c_str(), &exists);
+  if (r < 0) {
+    std::cerr << "rbd: failed to query start snap state" << std::endl;
+    return r;
+  }
+
+  if (!exists) {
+    std::cerr << "start snapshot '" << from
+              << "' does not exist in the image, aborting" << std::endl;
+    return -EINVAL;
+  }
+
+  idiffctx->update_progress();
+  return 0;
+}
+
+static int do_image_snap_to(utils::ImportDiffContext *idiffctx, std::string *tosnap)
+{
+  int r;
+  std::string to;
+  r = utils::read_string(idiffctx->fd, 4096, &to);   // 4k limit to make sure we don't get a garbage string
+  if (r < 0) {
+    std::cerr << "rbd: failed to decode end snap name" << std::endl;
+    return r;
+  }
+
+  bool exists;
+  r = idiffctx->image->snap_exists2(to.c_str(), &exists);
+  if (r < 0) {
+    std::cerr << "rbd: failed to query end snap state" << std::endl;
+    return r;
+  }
+
+  if (exists) {
+    std::cerr << "end snapshot '" << to << "' already exists, aborting"
+              << std::endl;
+    return -EEXIST;
+  }
+
+  *tosnap = to;
+  idiffctx->update_progress();
+
+  return 0;
+}
+
+static int get_snap_protection_status(utils::ImportDiffContext *idiffctx,
+                                      bool *is_protected)
+{
+  int r;
+  char buf[sizeof(__u8)];
+  r = safe_read_exact(idiffctx->fd, buf, sizeof(buf));
+  if (r < 0) {
+    std::cerr << "rbd: failed to decode snap protection status" << std::endl;
+    return r;
+  }
+
+  *is_protected = (buf[0] != 0);
+  idiffctx->update_progress();
+
+  return 0;
+}
+
+static int do_image_resize(utils::ImportDiffContext *idiffctx)
+{
+  int r;
+  char buf[sizeof(uint64_t)];
+  uint64_t end_size;
+  r = safe_read_exact(idiffctx->fd, buf, sizeof(buf));
+  if (r < 0) {
+    std::cerr << "rbd: failed to decode image size" << std::endl;
+    return r;
+  }
+
+  bufferlist bl;
+  bl.append(buf, sizeof(buf));
+  auto p = bl.cbegin();
+  decode(end_size, p);
+
+  uint64_t cur_size;
+  idiffctx->image->size(&cur_size);
+  if (cur_size != end_size) {
+    idiffctx->image->resize(end_size);
+  }
+
+  idiffctx->update_size(end_size);
+  idiffctx->update_progress();
+  return 0;
+}
+
+int do_import_diff_fd(librados::Rados &rados, librbd::Image &image, int fd,
+          bool no_progress, int format, size_t sparse_size)
+{
+  int r;
+
+  uint64_t size = 0;
+  bool from_stdin = (fd == STDIN_FILENO);
+  if (!from_stdin) {
+    struct stat stat_buf;
+    r = ::fstat(fd, &stat_buf);
+    if (r < 0) {
+      std::cerr << "rbd: failed to stat specified diff file" << std::endl;
+      return r;
+    }
+    size = (uint64_t)stat_buf.st_size;
+  }
+
+  r = validate_banner(fd, (format == 1 ? RBD_DIFF_BANNER :
+                           RBD_DIFF_BANNER_V2));
+  if (r < 0) {
+    return r;
+  }
+
+  // begin image import
+  std::string tosnap;
+  bool is_protected = false;
+  ImportDiffContext idiffctx(&image, fd, size, no_progress);
+  while (r == 0) {
+    __u8 tag;
+    uint64_t length = 0;
+
+    r = utils::read_tag(fd, RBD_DIFF_END, format, &tag, &length);
+    if (r < 0 || tag == RBD_DIFF_END) {
+      break;
+    }
+
+    if (tag == RBD_DIFF_FROM_SNAP) {
+      r = do_image_snap_from(&idiffctx);
+    } else if (tag == RBD_DIFF_TO_SNAP) {
+      r = do_image_snap_to(&idiffctx, &tosnap);
+    } else if (tag == RBD_SNAP_PROTECTION_STATUS) {
+      r = get_snap_protection_status(&idiffctx, &is_protected);
+    } else if (tag == RBD_DIFF_IMAGE_SIZE) {
+      r = do_image_resize(&idiffctx);
+    } else if (tag == RBD_DIFF_WRITE || tag == RBD_DIFF_ZERO) {
+      r = do_image_io(&idiffctx, (tag == RBD_DIFF_ZERO), sparse_size);
+    } else {
+      std::cerr << "unrecognized tag byte " << (int)tag << " in stream; skipping"
+                << std::endl;
+      r = utils::skip_tag(fd, length);
+    }
+  }
+
+  int temp_r = idiffctx.throttle.wait_for_ret();
+  r = (r < 0) ? r : temp_r; // preserve original error
+  if (r == 0 && tosnap.length()) {
+    r = idiffctx.image->snap_create(tosnap.c_str());
+    if (r == 0 && is_protected) {
+      r = idiffctx.image->snap_protect(tosnap.c_str());
+    }
+  }
+
+  idiffctx.finish(r);
+  return r;
+}
+
+int do_import_metadata(int import_format, librbd::Image& image,
+                      const std::map<std::string, std::string> &imagemetas)
+{
+  int r = 0;
+
+  //v1 format
+  if (import_format == 1) {
+    return 0;
+  }
+
+  for (std::map<std::string, std::string>::const_iterator it = imagemetas.begin();
+       it != imagemetas.end(); ++it) {
+    r = image.metadata_set(it->first, it->second);
+    if (r < 0)
+      return r;
+  }
+
+  return 0;
+}
+
+} // namespace utils
+} // namespace rbd

--- a/src/tools/rbd/ExportImport.h
+++ b/src/tools/rbd/ExportImport.h
@@ -1,0 +1,160 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_RBD_EXPORTIMPORT_H
+#define CEPH_RBD_EXPORTIMPORT_H
+
+#include "include/rados/librados.hpp"
+#include "include/rbd/librbd.hpp"
+#include "common/Throttle.h"
+
+namespace rbd {
+namespace utils {
+
+const uint32_t MAX_KEYS = 64;
+
+struct ExportDiffContext {
+  librbd::Image *image;
+  int fd;
+  int export_format;
+  uint64_t totalsize;
+  utils::ProgressContext pc;
+  OrderedThrottle throttle;
+
+  ExportDiffContext(librbd::Image *i, int f, uint64_t t, int max_ops,
+                    bool no_progress, int eformat) :
+    image(i), fd(f), export_format(eformat), totalsize(t),
+    pc("Exporting image", no_progress), throttle(max_ops, true) {
+  }
+};
+
+class C_ExportDiff : public Context {
+public:
+  C_ExportDiff(ExportDiffContext *edc, uint64_t offset, uint64_t length,
+               bool exists, int export_format)
+    : m_export_diff_context(edc), m_offset(offset), m_length(length),
+      m_exists(exists), m_export_format(export_format) {
+  }
+
+  int send();
+
+  static int export_diff_cb(uint64_t offset, size_t length, int exists,
+			    void *arg);
+
+protected:
+  void finish(int r) override;
+
+private:
+  ExportDiffContext *m_export_diff_context;
+  uint64_t m_offset;
+  uint64_t m_length;
+  bool m_exists;
+  int m_export_format;
+  bufferlist m_read_data;
+
+  static int write_extent(ExportDiffContext *edc, uint64_t offset,
+                          uint64_t length, bool exists, int export_format);
+};
+
+struct ImportDiffContext {
+  librbd::Image *image;
+  int fd;
+  size_t size;
+  utils::ProgressContext pc;
+  OrderedThrottle throttle;
+  uint64_t last_offset;
+
+  ImportDiffContext(librbd::Image *image, int fd, size_t size, bool no_progress)
+    : image(image), fd(fd), size(size), pc("Importing image diff", no_progress),
+      throttle((fd == STDIN_FILENO) ? 1 :
+                  g_conf().get_val<uint64_t>("rbd_concurrent_management_ops"),
+               false),
+      last_offset(0) {
+  }
+
+  void update_size(size_t new_size)
+  {
+    if (fd == STDIN_FILENO) {
+      size = new_size;
+    }
+  }
+
+  void update_progress(uint64_t off)
+  {
+    if (size) {
+      pc.update_progress(off, size);
+      last_offset = off;
+    }
+  }
+
+  void update_progress()
+  {
+    uint64_t off = last_offset;
+    if (fd != STDIN_FILENO) {
+      off = lseek(fd, 0, SEEK_CUR);
+    }
+
+    update_progress(off);
+  }
+
+  void finish(int r)
+  {
+    if (r < 0) {
+      pc.fail();
+    } else {
+      pc.finish();
+    }
+  }
+};
+
+class C_ImportDiff : public Context {
+public:
+  C_ImportDiff(ImportDiffContext *idiffctx, bufferlist data, uint64_t offset,
+               uint64_t length, bool write_zeroes)
+    : m_idiffctx(idiffctx), m_data(data), m_offset(offset), m_length(length),
+      m_write_zeroes(write_zeroes) {
+    // use block offset (stdin) or import file position to report
+    // progress.
+    if (m_idiffctx->fd == STDIN_FILENO) {
+      m_prog_offset = offset;
+    } else {
+      m_prog_offset  = lseek(m_idiffctx->fd, 0, SEEK_CUR);
+    }
+  }
+
+  int send();
+
+  void finish(int r) override
+  {
+    m_idiffctx->update_progress(m_prog_offset);
+    m_idiffctx->throttle.end_op(r);
+  }
+
+private:
+  ImportDiffContext *m_idiffctx;
+  bufferlist m_data;
+  uint64_t m_offset;
+  uint64_t m_length;
+  bool m_write_zeroes;
+  uint64_t m_prog_offset;
+};
+
+int open_export_file(const char *path, int &fd, bool &to_stdout);
+int image_export_metadata(librbd::Image& image, librbd::image_info_t &info, int fd);
+int image_export_diff_header(librbd::Image& image, librbd::image_info_t &info,
+                            const char *fromsnapname, const char *endsnapname,
+                            int fd, const int export_format);
+int read_tag(int fd, __u8 end_tag, int format, __u8 *tag, uint64_t *readlen);
+int skip_tag(int fd, uint64_t length);
+int validate_banner(int fd, std::string banner);
+int do_import_header(int fd, int import_format, librbd::ImageOptions& opts,
+                            std::map<std::string, std::string>* imagemetas);
+int do_import_diff_fd(librados::Rados &rados, librbd::Image &image, int fd,
+          bool no_progress, int format, size_t sparse_size);
+int do_import_metadata(int import_format, librbd::Image& image,
+                      const std::map<std::string, std::string> &imagemetas);
+
+} //namespace utils
+} //namespace rbd
+
+#endif //CEPH_RBD_EXPORTIMPORT_H

--- a/src/tools/rbd/action/Export.cc
+++ b/src/tools/rbd/action/Export.cc
@@ -5,9 +5,9 @@
 #include "tools/rbd/ArgumentTypes.h"
 #include "tools/rbd/Shell.h"
 #include "tools/rbd/Utils.h"
+#include "tools/rbd/ExportImport.h"
 #include "include/Context.h"
 #include "common/errno.h"
-#include "common/Throttle.h"
 #include "include/encoding.h"
 #include <iostream>
 #include <fcntl.h>
@@ -22,106 +22,6 @@ namespace rbd {
 namespace action {
 namespace export_full {
 
-struct ExportDiffContext {
-  librbd::Image *image;
-  int fd;
-  int export_format;
-  uint64_t totalsize;
-  utils::ProgressContext pc;
-  OrderedThrottle throttle;
-
-  ExportDiffContext(librbd::Image *i, int f, uint64_t t, int max_ops,
-                    bool no_progress, int eformat) :
-    image(i), fd(f), export_format(eformat), totalsize(t), pc("Exporting image", no_progress),
-    throttle(max_ops, true) {
-  }
-};
-
-class C_ExportDiff : public Context {
-public:
-  C_ExportDiff(ExportDiffContext *edc, uint64_t offset, uint64_t length,
-               bool exists, int export_format)
-    : m_export_diff_context(edc), m_offset(offset), m_length(length),
-      m_exists(exists), m_export_format(export_format) {
-  }
-
-  int send() {
-    if (m_export_diff_context->throttle.pending_error()) {
-      return m_export_diff_context->throttle.wait_for_ret();
-    }
-
-    C_OrderedThrottle *ctx = m_export_diff_context->throttle.start_op(this);
-    if (m_exists) {
-      librbd::RBD::AioCompletion *aio_completion =
-        new librbd::RBD::AioCompletion(ctx, &utils::aio_context_callback);
-
-      int op_flags = LIBRADOS_OP_FLAG_FADVISE_NOCACHE;
-      int r = m_export_diff_context->image->aio_read2(
-        m_offset, m_length, m_read_data, aio_completion, op_flags);
-      if (r < 0) {
-        aio_completion->release();
-        ctx->complete(r);
-      }
-    } else {
-      ctx->complete(0);
-    }
-    return 0;
-  }
-
-  static int export_diff_cb(uint64_t offset, size_t length, int exists,
-			    void *arg) {
-    ExportDiffContext *edc = reinterpret_cast<ExportDiffContext *>(arg);
-
-    C_ExportDiff *context = new C_ExportDiff(edc, offset, length, exists, edc->export_format);
-    return context->send();
-  }
-
-protected:
-  void finish(int r) override {
-    if (r >= 0) {
-      if (m_exists) {
-        m_exists = !m_read_data.is_zero();
-      }
-      r = write_extent(m_export_diff_context, m_offset, m_length, m_exists, m_export_format);
-      if (r == 0 && m_exists) {
-        r = m_read_data.write_fd(m_export_diff_context->fd);
-      }
-    }
-    m_export_diff_context->throttle.end_op(r);
-  }
-
-private:
-  ExportDiffContext *m_export_diff_context;
-  uint64_t m_offset;
-  uint64_t m_length;
-  bool m_exists;
-  int m_export_format;
-  bufferlist m_read_data;
-
-  static int write_extent(ExportDiffContext *edc, uint64_t offset,
-                          uint64_t length, bool exists, int export_format) {
-    // extent
-    bufferlist bl;
-    __u8 tag = exists ? RBD_DIFF_WRITE : RBD_DIFF_ZERO;
-    uint64_t len = 0;
-    encode(tag, bl);
-    if (export_format == 2) {
-      if (tag == RBD_DIFF_WRITE)
-	len = 8 + 8 + length;
-      else
-	len = 8 + 8;
-      encode(len, bl);
-    }
-    encode(offset, bl);
-    encode(length, bl);
-    int r = bl.write_fd(edc->fd);
-
-    edc->pc.update_progress(offset, edc->totalsize);
-    return r;
-  }
-};
-
-
 int do_export_diff_fd(librbd::Image& image, const char *fromsnapname,
 		   const char *endsnapname, bool whole_object,
 		   int fd, bool no_progress, int export_format)
@@ -133,70 +33,16 @@ int do_export_diff_fd(librbd::Image& image, const char *fromsnapname,
   if (r < 0)
     return r;
 
-  {
-    // header
-    bufferlist bl;
-    if (export_format == 1)
-      bl.append(utils::RBD_DIFF_BANNER);
-    else
-      bl.append(utils::RBD_DIFF_BANNER_V2);
+  r = utils::image_export_diff_header(image, info, fromsnapname, endsnapname,
+                              fd, export_format);
+  if (r < 0)
+    return r;
 
-    __u8 tag;
-    uint64_t len = 0;
-    if (fromsnapname) {
-      tag = RBD_DIFF_FROM_SNAP;
-      encode(tag, bl);
-      std::string from(fromsnapname);
-      if (export_format == 2) {
-	len = from.length() + 4;
-	encode(len, bl);
-      }
-      encode(from, bl);
-    }
-
-    if (endsnapname) {
-      tag = RBD_DIFF_TO_SNAP;
-      encode(tag, bl);
-      std::string to(endsnapname);
-      if (export_format == 2) {
-        len = to.length() + 4;
-        encode(len, bl);
-      }
-      encode(to, bl);
-    }
-
-    if (endsnapname && export_format == 2) {
-      tag = RBD_SNAP_PROTECTION_STATUS;
-      encode(tag, bl);
-      bool is_protected = false;
-      r = image.snap_is_protected(endsnapname, &is_protected);
-      if (r < 0) {
-        return r;
-      }
-      len = 1;
-      encode(len, bl);
-      encode(is_protected, bl);
-    }
-
-    tag = RBD_DIFF_IMAGE_SIZE;
-    encode(tag, bl);
-    uint64_t endsize = info.size;
-    if (export_format == 2) {
-      len = 8;
-      encode(len, bl);
-    }
-    encode(endsize, bl);
-
-    r = bl.write_fd(fd);
-    if (r < 0) {
-      return r;
-    }
-  }
-  ExportDiffContext edc(&image, fd, info.size,
+  utils::ExportDiffContext edc(&image, fd, info.size,
                         g_conf().get_val<uint64_t>("rbd_concurrent_management_ops"),
                         no_progress, export_format);
   r = image.diff_iterate2(fromsnapname, 0, info.size, true, whole_object,
-                          &C_ExportDiff::export_diff_cb, (void *)&edc);
+                          &utils::C_ExportDiff::export_diff_cb, (void *)&edc);
   if (r < 0) {
     goto out;
   }
@@ -387,102 +233,17 @@ private:
   int m_fd;
 };
 
-const uint32_t MAX_KEYS = 64;
-
 static int do_export_v2(librbd::Image& image, librbd::image_info_t &info, int fd,
 		        uint64_t period, int max_concurrent_ops, utils::ProgressContext &pc)
 {
   int r = 0;
-  // header
-  bufferlist bl;
-  bl.append(utils::RBD_IMAGE_BANNER_V2);
-
-  __u8 tag;
-  uint64_t length;
-  // encode order
-  tag = RBD_EXPORT_IMAGE_ORDER;
-  length = 8;
-  encode(tag, bl);
-  encode(length, bl);
-  encode(uint64_t(info.order), bl);
-
-  // encode features
-  tag = RBD_EXPORT_IMAGE_FEATURES;
-  uint64_t features;
-  image.features(&features);
-  length = 8;
-  encode(tag, bl);
-  encode(length, bl);
-  encode(features, bl);
-
-  // encode stripe_unit and stripe_count
-  tag = RBD_EXPORT_IMAGE_STRIPE_UNIT;
-  uint64_t stripe_unit;
-  stripe_unit = image.get_stripe_unit();
-  length = 8;
-  encode(tag, bl);
-  encode(length, bl);
-  encode(stripe_unit, bl);
-
-  tag = RBD_EXPORT_IMAGE_STRIPE_COUNT;
-  uint64_t stripe_count;
-  stripe_count = image.get_stripe_count();
-  length = 8;
-  encode(tag, bl);
-  encode(length, bl);
-  encode(stripe_count, bl);
-
-  //retrieve metadata of image
-  std::map<std::string, string> imagemetas;
-  std::string last_key;
-  bool more_results = true;
-  while (more_results) {
-    std::map<std::string, bufferlist> pairs;
-    r = image.metadata_list(last_key, MAX_KEYS, &pairs);
-    if (r < 0) {
-      std::cerr << "failed to retrieve metadata of image : " << cpp_strerror(r)
-                << std::endl;
-      return r;
-    }
-
-    if (!pairs.empty()) {
-      last_key = pairs.rbegin()->first;
-
-      for (auto kv : pairs) {
-        std::string key = kv.first;
-        std::string val(kv.second.c_str(), kv.second.length());
-        imagemetas[key] = val;
-      }
-    }
-    more_results = (pairs.size() == MAX_KEYS);
-  }
-
-  //encode imageMeta key and value
-  for (std::map<std::string, string>::iterator it = imagemetas.begin();
-       it != imagemetas.end(); ++it) {
-    string key = it->first;
-    string value = it->second;
-
-    tag = RBD_EXPORT_IMAGE_META;
-    length = key.length() + value.length() + 4 * 2;
-    encode(tag, bl);
-    encode(length, bl);
-    encode(key, bl);
-    encode(value, bl);
-  }
-
-  // encode end tag
-  tag = RBD_EXPORT_IMAGE_END;
-  encode(tag, bl);
-
-  // write bl to fd.
-  r = bl.write_fd(fd);
+  r = utils::image_export_metadata(image, info, fd);
   if (r < 0) {
     return r;
   }
 
   // header for snapshots
-  bl.clear();
+  bufferlist bl;
   bl.append(utils::RBD_IMAGE_DIFFS_BANNER_V2);
 
   std::vector<librbd::snap_info_t> snaps;
@@ -564,17 +325,10 @@ static int do_export(librbd::Image& image, const char *path, bool no_progress,
 
   int fd;
   int max_concurrent_ops = g_conf().get_val<uint64_t>("rbd_concurrent_management_ops");
-  bool to_stdout = (strcmp(path, "-") == 0);
-  if (to_stdout) {
-    fd = STDOUT_FILENO;
-  } else {
-    fd = open(path, O_WRONLY | O_CREAT | O_EXCL | O_BINARY, 0644);
-    if (fd < 0) {
-      return -errno;
-    }
-#ifdef HAVE_POSIX_FADVISE
-    posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL);
-#endif
+  bool to_stdout;
+  r = utils::open_export_file(path, fd, to_stdout);
+  if (r < 0) {
+    return r;
   }
 
   utils::ProgressContext pc("Exporting image", no_progress);

--- a/src/tools/rbd/action/Group.cc
+++ b/src/tools/rbd/action/Group.cc
@@ -6,11 +6,14 @@
 #include "tools/rbd/ArgumentTypes.h"
 #include "tools/rbd/Shell.h"
 #include "tools/rbd/Utils.h"
+#include "tools/rbd/ExportImport.h"
 #include "include/rbd_types.h"
 #include "cls/rbd/cls_rbd_types.h"
+#include "cls/rbd/cls_rbd_client.h"
 #include "common/errno.h"
 #include "common/Formatter.h"
 #include "common/TextTable.h"
+#include "librbd/Utils.h"
 
 namespace rbd {
 namespace action {
@@ -21,12 +24,22 @@ namespace po = boost::program_options;
 
 static const std::string GROUP_SPEC("group-spec");
 static const std::string GROUP_SNAP_SPEC("group-snap-spec");
+static const std::string GROUP_OR_SNAP_SPEC("group-or-snap-spec");
 
 static const std::string GROUP_NAME("group");
 static const std::string DEST_GROUP_NAME("dest-group");
 
 static const std::string GROUP_POOL_NAME("group-" + at::POOL_NAME);
 static const std::string IMAGE_POOL_NAME("image-" + at::POOL_NAME);
+
+static const std::string RBD_GROUP_BANNER ("rbd group\n");
+static const std::string RBD_GROUP_BANNER_SNAP ("rbd group snap\n");
+static const std::string RBD_GROUP_BANNER_DIFF ("rbd group diff\n");
+static const std::string RBD_GROUP_BANNER_IMAGE_INFO ("rbd group image info\n");
+
+#define RBD_EXPORT_GROUP_IMAGE_POOL_NAME  'L'
+#define RBD_EXPORT_GROUP_IMAGE_NAME       'N'
+#define RBD_EXPORT_GROUP_CREATE_IMAGE     'G'
 
 void add_group_option(po::options_description *opt,
 		      at::ArgumentModifier modifier) {
@@ -82,6 +95,26 @@ void add_group_spec_options(po::options_description *pos,
       ((get_name_prefix(modifier) + GROUP_SNAP_SPEC).c_str(),
        (get_description_prefix(modifier) + "group specification\n" +
          "(example: [<pool-name>/[<namespace>/]]<group-name>@<snap-name>)").c_str());
+  }
+}
+
+void add_group_or_snap_spec_options(po::options_description *pos,
+			    po::options_description *opt,
+			    at::ArgumentModifier modifier, bool snap) {
+  at::add_pool_option(opt, modifier);
+  at::add_namespace_option(opt, modifier);
+  add_group_option(opt, modifier);
+  if (!snap) {
+    pos->add_options()
+      ((get_name_prefix(modifier) + GROUP_SPEC).c_str(),
+       (get_description_prefix(modifier) + "group specification\n" +
+         "(example: [<pool-name>/[<namespace>/]]<group-name>)").c_str());
+  } else {
+    add_snap_option(opt, modifier);
+    pos->add_options()
+      ((get_name_prefix(modifier) + GROUP_OR_SNAP_SPEC).c_str(),
+       (get_description_prefix(modifier) + "group or snapshot specification\n" +
+         "(example: [<pool-name>/[<namespace>/]]<group-name>[@<snap-name>])").c_str());
   }
 }
 
@@ -745,6 +778,1363 @@ int execute_group_snap_rollback(const po::variables_map &vm,
   return 0;
 }
 
+typedef struct {
+  std::string snap_name;
+  std::vector<librbd::group_image_snap_info_t> images_snap;
+}group_snap_info;
+
+typedef struct {
+  std::string image_pool_name;
+  librbd::Image image;
+}image_export_info;
+
+static int create_ioctx(librados::IoCtx& src_io_ctx, const std::string& pool_desc,
+                 int64_t pool_id,
+                 const std::optional<std::string>& pool_namespace,
+                 librados::IoCtx* dst_io_ctx) {
+
+  librados::Rados rados(src_io_ctx);
+  int r = rados.ioctx_create2(pool_id, *dst_io_ctx);
+  if (r == -ENOENT) {
+    std::cerr  << pool_desc << " pool " << pool_id << " no longer exists"
+                  << std::endl;
+    return r;
+  } else if (r < 0) {
+    std::cerr << "error accessing " << pool_desc << " pool " << pool_id
+               << std::endl;
+    return r;
+  }
+
+  dst_io_ctx->set_namespace(
+    pool_namespace ? *pool_namespace : src_io_ctx.get_namespace());
+  return 0;
+}
+
+static int get_image_key(const int64_t pool_id, const char *image_name,
+                        std::string *image_key)
+{
+  std::stringstream sstream;
+  sstream << pool_id;
+
+  std::string &key = *image_key;
+  sstream >> key;
+  key.append("_").append(image_name);
+
+  return 0;
+}
+
+static int open_export_image(librbd::RBD &rbd, librados::IoCtx& group_ioctx,
+                            const int64_t pool_id, const char *image_name,
+                            std::map<std::string, image_export_info> *images,
+                            std::vector<librbd::RBD::AioCompletion*> &on_finishes)
+{
+  std::string key;
+  get_image_key(pool_id, image_name, &key);
+
+  auto it = images->find(key);
+  if (it != images->end()) {
+    return 0;
+  }
+
+  librados::IoCtx image_io_ctx;
+  int r = create_ioctx(group_ioctx, "image", pool_id,
+                              {}, &image_io_ctx);
+  if (r < 0) {
+    std::cerr << "Create io ctx failed." << std::endl;
+    return r;
+  }
+
+  image_export_info &image_info = (*images)[key];
+  image_info.image_pool_name = image_io_ctx.get_pool_name();
+
+  librbd::RBD::AioCompletion *open_comp =
+    new librbd::RBD::AioCompletion(NULL, NULL);
+
+  r = rbd.aio_open_read_only(image_io_ctx, image_info.image, image_name,
+                            NULL, open_comp);
+  if (r < 0) {
+    std::cerr << "Open image failed. image name:" << image_name << std::endl;
+    return r;
+  }
+
+  on_finishes.push_back(open_comp);
+
+  return r;
+}
+
+static int open_group_image(librbd::RBD &rbd, librados::IoCtx& group_ioctx,
+                     const char *group_name,
+                     const std::vector<group_snap_info> &group_snaps,
+                     const std::vector<librbd::group_image_info_t> &image_list,
+                     std::map<std::string, image_export_info> *images)
+{
+  int open_ret = 0, r = 0;
+  std::vector<librbd::RBD::AioCompletion*> on_finishes;
+  for (auto &group_snap: group_snaps) {
+    for (auto &image_snap: group_snap.images_snap) {
+      r = open_export_image(rbd, group_ioctx, image_snap.pool_id,
+                            image_snap.image_name.c_str(), images, on_finishes);
+      if (r < 0) {
+        open_ret = r;
+        goto err;
+      }
+    }
+  }
+
+  for (auto &image_info: image_list) {
+    r = open_export_image(rbd, group_ioctx, image_info.pool,
+                    image_info.name.c_str(), images, on_finishes);
+    if (r < 0) {
+      open_ret = r;
+      goto err;
+    }
+  }
+
+  err:
+  for (uint32_t i = 0; i < on_finishes.size(); ++i) {
+    on_finishes[i]->wait_for_complete();
+    r = on_finishes[i]->get_return_value();
+    if (r < 0) {
+      open_ret = r;
+    }
+    on_finishes[i]->release();
+  }
+
+  return open_ret;
+}
+
+static int group_export_header(const std::string &flag, const uint64_t num, int fd)
+{
+  bufferlist bl;
+  bl.append(flag);
+
+  encode(num, bl);
+
+  return bl.write_fd(fd);
+}
+
+static int group_export_snap_info(const std::string &fromsnapname,
+                      const std::string &endsnapname,
+                      int fd, const int export_format)
+{
+  /* snap header */
+  bufferlist bl;
+  bl.append(RBD_GROUP_BANNER_SNAP);
+
+  __u8 tag;
+  uint64_t len = 0;
+
+  if (!fromsnapname.empty()) {
+    tag = RBD_DIFF_FROM_SNAP;
+    encode(tag, bl);
+    if (export_format == 2) {
+      len = fromsnapname.length() + 4;
+      encode(len, bl);
+    }
+    encode(fromsnapname, bl);
+  }
+
+  if (!endsnapname.empty()) {
+    tag = RBD_DIFF_TO_SNAP;
+    encode(tag, bl);
+    if (export_format == 2) {
+      len = endsnapname.length() + 4;
+      encode(len, bl);
+    }
+    encode(endsnapname, bl);
+  }
+
+  // encode end tag
+  tag = RBD_EXPORT_IMAGE_END;
+  encode(tag, bl);
+
+  int r = bl.write_fd(fd);
+  if (r < 0) {
+    std::cerr << "group export snap info failed." << std::endl;
+    return r;
+  }
+
+  return r;
+}
+
+static int group_export_image_diff_fd(librbd::Image &image,
+                const std::string &fromsnapname, const librados::snap_t endsnapid,
+                const int64_t group_pool,
+                const std::string &group_id,
+                const bool whole_object, int fd,
+                const int export_format, const bool no_progress)
+{
+  int r;
+  librbd::image_info_t info;
+
+  r = image.stat(info, sizeof(info));
+  if (r < 0) {
+    return r;
+  }
+
+  r = utils::image_export_diff_header(image, info, nullptr, nullptr,
+                                      fd, export_format);
+  if (r < 0) {
+    return r;
+  }
+
+  utils::ExportDiffContext edc(&image, fd, info.size,
+                  g_conf().get_val<uint64_t>("rbd_concurrent_management_ops"),
+                  no_progress, export_format);
+  r = image.diff_iterate_group_image_snap(
+              fromsnapname.empty() ? nullptr : fromsnapname.c_str(),
+              0, info.size, true, whole_object,
+              &utils::C_ExportDiff::export_diff_cb, (void *)&edc);
+  if (r < 0) {
+    goto out;
+  }
+
+  r = edc.throttle.wait_for_ret();
+  if (r < 0) {
+    goto out;
+  }
+
+  {
+    __u8 tag = RBD_DIFF_END;
+    bufferlist bl;
+    encode(tag, bl);
+    r = bl.write_fd(fd);
+  }
+
+out:
+  if (r < 0)
+    edc.pc.fail();
+  else
+    edc.pc.finish();
+
+  return r;
+}
+
+static void group_encode_string(bufferlist &bl, const std::string &str, const __u8 tag,
+                                const int export_format)
+{
+  if (!str.empty()) {
+    encode(tag, bl);
+    if (export_format == 2) {
+      uint64_t length = str.length() + 4;
+      encode(length, bl);
+    }
+    encode(str, bl);
+  }
+}
+
+static void group_encode_uint64(bufferlist &bl, const uint64_t num,
+                                const __u8 tag, const int export_format)
+{
+  encode(tag, bl);
+  if (export_format == 2) {
+    uint64_t len = 8;
+    encode(len, bl);
+  }
+  encode(num, bl);
+}
+
+static int group_export_image_info(const std::string &image_pool_name,
+                librbd::Image& image, const librados::snap_t from_snap_id,
+                int fd, const int export_format)
+{
+  __u8 tag;
+  bufferlist bl;
+
+  /* image banner*/
+  bl.append(RBD_GROUP_BANNER_IMAGE_INFO);
+
+  /* record image pool name */
+  group_encode_string(bl, image_pool_name,
+                      RBD_EXPORT_GROUP_IMAGE_POOL_NAME, export_format);
+
+  /* record image name */
+  std::string src_image_name;
+  image.get_name(&src_image_name);
+  group_encode_string(bl, src_image_name, RBD_EXPORT_GROUP_IMAGE_NAME, export_format);
+
+  /* encode is create image */
+  const uint64_t is_create = (from_snap_id == CEPH_NOSNAP ? 1 : 0);
+  group_encode_uint64(bl, is_create, RBD_EXPORT_GROUP_CREATE_IMAGE, export_format);
+
+  // encode end tag
+  tag = RBD_EXPORT_IMAGE_END;
+  encode(tag, bl);
+
+  // write bl to fd.
+  return bl.write_fd(fd);
+}
+
+static int group_export_image_diff(librados::IoCtx& group_ioctx,
+                      const std::string& group_id,
+                      const group_snap_info* group_from_snap,
+                      const int64_t end_pool_id, const std::string &end_image_name,
+                      const snapid_t end_snap_id,
+                      const std::map<std::string, image_export_info> &images,
+                      const bool whole_object, int fd,
+                      const int export_format, const bool no_progress)
+{
+  int64_t r = 0;
+  librados::snap_t from_snap_id = CEPH_NOSNAP;
+  /* find image from snap */
+  if (group_from_snap) {
+    for (auto &image_snap : group_from_snap->images_snap) {
+      if (end_pool_id == image_snap.pool_id &&
+          end_image_name == image_snap.image_name) {
+        from_snap_id = image_snap.snap_id;
+        break;
+      }
+    }
+  }
+
+  std::string key;
+  get_image_key(end_pool_id, end_image_name.c_str(), &key);
+  auto image_it = images.find(key);
+
+  if (image_it == images.end()) {
+    std::cerr << "Can't find image by key:" << key << std::endl;
+    return -1;
+  }
+
+  image_export_info &image_info = const_cast<image_export_info&>(image_it->second);
+
+  /*export header*/
+  {
+    r = group_export_image_info(image_info.image_pool_name, image_info.image,
+                                from_snap_id, fd, export_format);
+    if (r < 0) {
+      return r;
+    }
+
+    /* have new image add */
+    if (from_snap_id == CEPH_NOSNAP){
+      librbd::image_info_t info;
+      int r = image_info.image.stat(info, sizeof(info));
+      if (r < 0) {
+        return r;
+      }
+
+      r = utils::image_export_metadata(image_info.image, info, fd);
+      if (r < 0) {
+        return r;
+      }
+    }
+  }
+
+  std::string from_snap_name;
+  if (from_snap_id != CEPH_NOSNAP) {
+    r = image_info.image.snap_get_name(from_snap_id, &from_snap_name);
+    if (r < 0) {
+      return r;
+    }
+  }
+
+  /* image diff export */
+  image_info.image.snap_set_by_id(end_snap_id);
+  r = group_export_image_diff_fd(image_info.image, from_snap_name, end_snap_id,
+                  group_ioctx.get_id(), group_id,
+                  whole_object, fd, export_format, no_progress);
+
+  return r;
+}
+
+static int group_export_diff(librados::IoCtx& group_ioctx,
+                      const char *group_name,
+                      const std::string &group_id,
+                      const group_snap_info* group_from_snap,
+                      const group_snap_info* group_end_snap,
+                      const std::vector<librbd::group_image_info_t> &image_list,
+                      const std::map<std::string, image_export_info> &images,
+                      const bool whole_object, int fd,
+                      const int export_format, const bool no_progress)
+{
+  int r = group_export_snap_info(group_from_snap ? group_from_snap->snap_name : "",
+                        group_end_snap ? group_end_snap->snap_name : "",
+                        fd, export_format);
+  if (r < 0) {
+    return r;
+  }
+
+  int pc_cnt = 1;
+  utils::ProgressContext pc("Exporting group diff", no_progress);
+  if (group_end_snap) {
+    /* group diff header */
+    r = group_export_header(RBD_GROUP_BANNER_DIFF,
+                            group_end_snap->images_snap.size(), fd);
+    if (r < 0) {
+      goto err;
+    }
+
+    for (auto &end_snap : group_end_snap->images_snap) {
+      r = group_export_image_diff(group_ioctx,group_id, group_from_snap,
+                              end_snap.pool_id, end_snap.image_name, end_snap.snap_id,
+                              images, whole_object, fd, export_format, true);
+      if (r < 0) {
+        goto err;
+      }
+
+      pc.update_progress(pc_cnt++, group_end_snap->images_snap.size());
+    }
+  }
+  else
+  {
+    /* group diff header */
+    r = group_export_header(RBD_GROUP_BANNER_DIFF, image_list.size(), fd);
+    if (r < 0) {
+      goto err;
+    }
+
+    for (auto &image_info: image_list) {
+      r = group_export_image_diff(group_ioctx, group_id, group_from_snap,
+                              image_info.pool,
+                              image_info.name, CEPH_NOSNAP,
+                              images, whole_object, fd, export_format, true);
+      if (r < 0) {
+        goto err;
+      }
+      pc.update_progress(pc_cnt++, image_list.size());
+    }
+  }
+
+  err:
+  if (r < 0)
+    pc.fail();
+  else
+    pc.finish();
+
+  return r;
+}
+
+static int group_export(librados::IoCtx& group_ioctx, const char *group_name,
+                     int fd, std::map<std::string, image_export_info> &images,
+                     const bool no_progress, librbd::ProgressContext& pc)
+{
+  librbd::RBD rbd;
+
+  /* snap list */
+  std::vector<group_snap_info> snaps;
+  int r = 0;
+  {
+    std::vector<librbd::group_snap_info_t> snaps_info;
+    r = rbd.group_snap_list(group_ioctx, group_name, &snaps_info,
+                              sizeof(librbd::group_snap_info_t));
+    if (r < 0) {
+      return r;
+    }
+
+    for (auto snap: snaps_info) {
+      auto it = snaps.insert(snaps.end(), group_snap_info{snap.name, {}});
+      r = rbd.group_image_snap_list(group_ioctx, group_name, snap.name.c_str(),
+                      &(it->images_snap), sizeof(librbd::group_image_snap_info_t));
+      if (r < 0) {
+        return r;
+      }
+    }
+  }
+
+  /* image list */
+  std::vector<librbd::group_image_info_t> image_list;
+  {
+    r = rbd.group_image_list(group_ioctx, group_name, &image_list,
+                            sizeof(librbd::group_image_info_t));
+    if (r < 0) {
+      return r;
+    }
+  }
+
+  /* open all image */
+  r = open_group_image(rbd, group_ioctx, group_name, snaps, image_list, &images);
+  if (r < 0) {
+    return r;
+  }
+
+  /* group diff header */
+  r = group_export_header(RBD_GROUP_BANNER, snaps.size() + 1, fd);
+  if (r < 0) {
+    return r;
+  }
+
+  std::string group_id;
+  r = librbd::cls_client::dir_get_id(&group_ioctx, RBD_GROUP_DIRECTORY,
+                                 group_name, &group_id);
+  if (r < 0) {
+    std::cerr << "error reading group id object: " << cpp_strerror(r) << std::endl;
+    return r;
+  }
+
+  group_snap_info *last_snap = NULL;
+  for (size_t i = 0; i < snaps.size(); ++i)
+  {
+    r = group_export_diff(group_ioctx, group_name, group_id, last_snap, &snaps[i],
+                          image_list, images, false, fd, 2, no_progress);
+    if (r < 0) {
+      return r;
+    }
+
+    pc.update_progress(i + 1, snaps.size() + 1);
+    last_snap = &snaps[i];
+  }
+
+  r = group_export_diff(group_ioctx, group_name, group_id, last_snap, nullptr,
+                        image_list, images, false, fd, 2, no_progress);
+  if (r < 0) {
+    return r;
+  }
+  pc.update_progress(snaps.size() + 1, snaps.size() + 1);
+
+  return r;
+}
+
+static int do_group_export(librados::IoCtx& group_ioctx, const char *group_name,
+                     const char *path, const bool no_progress)
+{
+  int r = 0;
+  int fd;
+  bool to_stdout;
+
+  /* open file */
+  r = utils::open_export_file(path, fd, to_stdout);
+  if (r < 0) {
+    return r;
+  }
+
+  std::map<std::string, image_export_info> images;
+  utils::ProgressContext pc("Exporting group", no_progress);
+  r = group_export(group_ioctx, group_name, fd, images, true, pc);
+
+  if (!to_stdout)
+    close(fd);
+
+  if (r < 0)
+    pc.fail();
+  else
+    pc.finish();
+
+  return r;
+}
+
+int execute_group_export(const po::variables_map &vm,
+                        const std::vector<std::string> &global_args) {
+  size_t arg_index = 0;
+
+  std::string group_name;
+  std::string namespace_name;
+  std::string pool_name;
+  std::string snap_name;
+
+  int r = utils::get_pool_generic_snapshot_names(
+    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, at::POOL_NAME, &pool_name,
+    &namespace_name, GROUP_NAME, "group", &group_name, &snap_name, true,
+    utils::SNAPSHOT_PRESENCE_NONE, utils::SPEC_VALIDATION_FULL);
+  if (r < 0) {
+    return r;
+  }
+
+  std::string path;
+  r = utils::get_path(vm, &arg_index, &path);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::IoCtx io_ctx;
+  librados::Rados rados;
+
+  r = utils::init(pool_name, namespace_name, &rados, &io_ctx);
+  if (r < 0) {
+    return r;
+  }
+
+  r = do_group_export(io_ctx, group_name.c_str(),
+                      path.c_str(), vm[at::NO_PROGRESS].as<bool>());
+  if (r < 0) {
+    std::cerr << "rbd: group export error: " << cpp_strerror(r) << std::endl;
+    return r;
+  }
+
+  return r;
+}
+
+static int do_group_export_diff(librados::IoCtx& group_ioctx,
+                const char *group_name, const std::string &fromsnapname,
+                const std::string &endsnapname, const bool whole_object,
+                const char *path, const bool no_progress)
+{
+  librbd::RBD rbd;
+  std::vector<group_snap_info> snaps;
+  int r = 0;
+  group_snap_info *group_from_snap = nullptr;
+  if (!fromsnapname.empty()) {
+    auto it = snaps.insert(snaps.end(), group_snap_info{fromsnapname, {}});
+    r = rbd.group_image_snap_list(group_ioctx, group_name, fromsnapname.c_str(),
+                      &(it->images_snap), sizeof(librbd::group_image_snap_info_t));
+    if (r < 0) {
+      return r;
+    }
+  }
+
+  group_snap_info *group_end_snap = nullptr;
+  if (!endsnapname.empty()) {
+    auto it = snaps.insert(snaps.end(), group_snap_info{endsnapname, {}});
+    r = rbd.group_image_snap_list(group_ioctx, group_name, endsnapname.c_str(),
+                      &(it->images_snap), sizeof(librbd::group_image_snap_info_t));
+    if (r < 0) {
+      return r;
+    }
+    group_end_snap = &(*it);
+  }
+
+  if (!fromsnapname.empty()) {
+    group_from_snap = &snaps[0];
+  }
+
+  std::vector<librbd::group_image_info_t> image_list;
+  if (group_end_snap == nullptr) {
+    /* image list */
+    r =rbd.group_image_list(group_ioctx, group_name, &image_list,
+                            sizeof(librbd::group_image_info_t));
+    if (r < 0) {
+      return r;
+    }
+  }
+
+  std::map<std::string, image_export_info> images;
+  std::string group_id;
+  r = librbd::cls_client::dir_get_id(&group_ioctx, RBD_GROUP_DIRECTORY,
+                                 group_name, &group_id);
+  if (r < 0) {
+    std::cerr << "error reading group id object: " << cpp_strerror(r) << std::endl;
+    return r;
+  }
+
+  /* open file */
+  int fd;
+  bool to_stdout;
+  r = utils::open_export_file(path, fd, to_stdout);
+  if (r < 0) {
+    return r;
+  }
+
+  std::vector<group_snap_info> group_snap;
+  if (group_end_snap) {
+    group_snap.push_back(*group_end_snap);
+  }
+
+  /* open image */
+  r = open_group_image(rbd, group_ioctx, group_name, group_snap, image_list, &images);
+  if (r < 0) {
+    goto err;
+  }
+
+  r = group_export_diff(group_ioctx, group_name, group_id, group_from_snap,
+                        group_end_snap, image_list, images,
+                        whole_object, fd, 2, no_progress);
+
+  err:
+  if (!to_stdout)
+    close(fd);
+
+  return r;
+}
+
+int execute_group_export_diff(const po::variables_map &vm,
+                        const std::vector<std::string> &global_args)
+{
+  size_t arg_index = 0;
+
+  std::string group_name;
+  std::string namespace_name;
+  std::string pool_name;
+  std::string snap_name;
+
+  int r = utils::get_pool_generic_snapshot_names(
+    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, at::POOL_NAME, &pool_name,
+    &namespace_name, GROUP_NAME, "group", &group_name, &snap_name, true,
+    utils::SNAPSHOT_PRESENCE_PERMITTED, utils::SPEC_VALIDATION_FULL);
+  if (r < 0) {
+    return r;
+  }
+
+  std::string path;
+  r = utils::get_path(vm, &arg_index, &path);
+  if (r < 0) {
+    return r;
+  }
+
+  std::string from_snap_name;
+  if (vm.count(at::FROM_SNAPSHOT_NAME)) {
+    from_snap_name = vm[at::FROM_SNAPSHOT_NAME].as<std::string>();
+  }
+
+  librados::IoCtx io_ctx;
+  librados::Rados rados;
+
+  r = utils::init(pool_name, namespace_name, &rados, &io_ctx);
+  if (r < 0) {
+    return r;
+  }
+
+  r = do_group_export_diff(io_ctx, group_name.c_str(),
+                     from_snap_name,
+                     snap_name,
+                     vm[at::WHOLE_OBJECT].as<bool>(), path.c_str(),
+                     vm[at::NO_PROGRESS].as<bool>());
+  if (r < 0) {
+    std::cerr << "rbd: group export diff error: " << cpp_strerror(r) << std::endl;
+    return r;
+  }
+
+  return r;
+}
+
+static int group_decode_uint64(int fd, uint64_t *val)
+{
+  char buf[sizeof(uint64_t)];
+
+  int64_t r = safe_read_exact(fd, buf, sizeof(buf));
+  if (r < 0) {
+    std::cerr << "rbd: failed to decode image option" << std::endl;
+    return r;
+  }
+
+  bufferlist bl;
+  bl.append(buf, sizeof(buf));
+  auto it = bl.cbegin();
+
+  decode(*val, it);
+
+  return r;
+}
+
+int group_read_string(int fd, unsigned max, std::string *out) {
+  char buf[4];
+
+  int r = safe_read_exact(fd, buf, 4);
+  if (r < 0)
+    return r;
+
+  bufferlist bl;
+  bl.append(buf, 4);
+  auto p = bl.cbegin();
+  uint32_t len;
+  decode(len, p);
+  if (len > max)
+    return -EINVAL;
+
+  char sbuf[len];
+  r = safe_read_exact(fd, sbuf, len);
+  if (r < 0)
+    return r;
+  out->assign(sbuf, len);
+
+  return r;
+}
+
+static int group_snap_is_exist(librbd::RBD &rbd, librados::IoCtx& group_ioctx,
+                              const char *group_name,
+                               const std::string &group_snap_name, bool &is_exist)
+{
+  std::vector<librbd::group_snap_info_t> snaps;
+
+  int r = rbd.group_snap_list(group_ioctx, group_name, &snaps,
+                              sizeof(librbd::group_snap_info_t));
+  if (r < 0) {
+    return r;
+  }
+
+  is_exist = false;
+  for (auto snap : snaps) {
+    if (snap.name == group_snap_name) {
+      is_exist = true;
+      break;
+    }
+  }
+
+  return r;
+}
+
+static int do_group_snap_from(librbd::RBD &rbd, librados::IoCtx& group_ioctx,
+                              const char *group_name, int fd)
+{
+  int r;
+  std::string from;
+
+  // 4k limit to make sure we don't get a garbage string
+  r = group_read_string(fd, 4096, &from);
+  if (r < 0) {
+    std::cerr << "rbd: failed to decode start snap name" << std::endl;
+    return r;
+  }
+
+  bool exist = false;
+  r = group_snap_is_exist(rbd, group_ioctx, group_name, from, exist);
+  if (r < 0) {
+    return r;
+  }
+
+  if (!exist) {
+    std::cerr << "start snapshot '" << from
+              << "' does not exist in the image, aborting" << std::endl;
+    return -EINVAL;
+  }
+
+  return r;
+}
+
+static int do_group_image_snap_to(librbd::RBD &rbd, librados::IoCtx& group_ioctx,
+                                  const char *group_name,
+                                  int fd, std::string &tosnap)
+{
+  int r;
+  std::string to;
+  // 4k limit to make sure we don't get a garbage string
+  r = group_read_string(fd, 4096, &to);
+  if (r < 0) {
+    std::cerr << "rbd: failed to decode end snap name" << std::endl;
+    return r;
+  }
+
+  bool exists;
+  r = group_snap_is_exist(rbd, group_ioctx, group_name, to, exists);
+  if (r < 0) {
+    return r;
+  }
+
+  if (exists) {
+    std::cerr << "end snapshot '" << to << "' already exists, aborting" << std::endl;
+    return -EEXIST;
+  }
+
+  tosnap = to;
+
+  return r;
+}
+
+static int group_import_snap_info(librbd::RBD &rbd, librados::IoCtx& group_ioctx,
+                        const char *group_name, int fd,
+                        std::string &to_snap, const int import_format)
+{
+  int r = utils::validate_banner(fd, RBD_GROUP_BANNER_SNAP);
+  if (r < 0) {
+    return r;
+  }
+
+  while (r == 0) {
+    __u8 tag;
+    uint64_t length = 0;
+    r = utils::read_tag(fd, RBD_EXPORT_IMAGE_END, import_format, &tag, &length);
+    if (r < 0 || tag == RBD_EXPORT_IMAGE_END) {
+      break;
+    }
+
+    if (RBD_DIFF_FROM_SNAP == tag) {
+      r = do_group_snap_from(rbd, group_ioctx, group_name, fd);
+    } else if (RBD_DIFF_TO_SNAP == tag) {
+      r = do_group_image_snap_to(rbd, group_ioctx, group_name, fd, to_snap);
+    } else {
+      std::cerr << "rbd: invalid tag in image properties zone: " << tag
+                << ", Skip it." << std::endl;
+      r = utils::skip_tag(fd, length);
+    }
+  }
+
+  return r;
+}
+
+static int group_import_image_info(int fd,
+                        std::string *src_pool_name, std::string *src_image_name,
+                        uint64_t *is_create_image, const int import_format)
+{
+  int r = utils::validate_banner(fd, RBD_GROUP_BANNER_IMAGE_INFO);
+  if (r < 0) {
+    return r;
+  }
+
+  while (r == 0) {
+    __u8 tag;
+    uint64_t length = 0;
+    r = utils::read_tag(fd, RBD_EXPORT_IMAGE_END, import_format, &tag, &length);
+    if (r < 0 || tag == RBD_EXPORT_IMAGE_END) {
+      break;
+    }
+
+    if (RBD_EXPORT_GROUP_IMAGE_POOL_NAME == tag) {
+      r = group_read_string(fd, 4096, src_pool_name);
+    } else if (RBD_EXPORT_GROUP_IMAGE_NAME == tag) {
+      r = group_read_string(fd, 4096, src_image_name);
+    } else if (RBD_EXPORT_GROUP_CREATE_IMAGE == tag) {
+      r = group_decode_uint64(fd, is_create_image);
+    } else {
+      std::cerr << "rbd: invalid tag in image properties zone: "
+                << tag << ", Skip it." << std::endl;
+      r = utils::skip_tag(fd, length);
+    }
+  }
+
+  return r;
+}
+
+static int group_image_import_diff(librbd::RBD &rbd,
+                        librados::Rados &rados, librados::IoCtx& group_ioctx,
+                        const char *group_name, const std::string &to_snap, int fd,
+                        librbd::ImageOptions& opts, const size_t sparse_size,
+                        std::map<std::string, librbd::Image> *images,
+                        const std::vector<librbd::group_image_info_t> &images_list,
+                        const int import_format, bool no_progress)
+{
+  std::string src_pool_name;
+  std::string src_image_name;
+  uint64_t is_create_image;
+  /* import image info */
+  int r = group_import_image_info(fd, &src_pool_name, &src_image_name,
+                              &is_create_image, import_format);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::IoCtx image_io_ctx;
+  int64_t image_pool_id = 0;
+  {
+    image_pool_id = rados.pool_lookup(src_pool_name.c_str());
+    if (image_pool_id < 0) {
+      std::cerr << "get image pool id err. image pool name:"
+                << src_pool_name << std::endl;
+      return r;
+    }
+
+    r = create_ioctx(group_ioctx, "image", image_pool_id,
+                                  {}, &image_io_ctx);
+    if (r < 0) {
+      return r;
+    }
+
+    std::string group_id;
+    r = librbd::cls_client::dir_get_id(&group_ioctx, RBD_GROUP_DIRECTORY,
+                              group_name, &group_id);
+    if (r < 0) {
+      std::cerr << "error reading group id object: " << cpp_strerror(r) << std::endl;
+      return r;
+    }
+  }
+
+  librbd::Image* image = nullptr;
+  std::string image_key(src_pool_name);
+  image_key.append("_").append(src_image_name);
+  auto image_it = images->find(image_key);
+  if (image_it != images->end()) {
+    image = &image_it->second;
+  } else {
+    std::map<std::string, std::string> imagemetas;
+    if (1 == is_create_image) {
+      librbd::ImageOptions image_opts(opts);
+      /* import metadata */
+      r = utils::do_import_header(fd, import_format, image_opts, &imagemetas);
+      if (r < 0) {
+        std::cerr << "rbd: import header failed." << std::endl;
+        return r;
+      }
+
+      /* create image */
+      r = rbd.create4(image_io_ctx, src_image_name.c_str(), (uint64_t)1, image_opts);
+      if (r < 0) {
+        return r;
+      }
+
+      /* add image to group */
+      r = rbd.group_image_add(group_ioctx, group_name,
+                              image_io_ctx, src_image_name.c_str());
+      if (r < 0) {
+        int rm_ret = rbd.remove(image_io_ctx, src_image_name.c_str());
+        if (rm_ret < 0) {
+          std::cerr << "remove image err, image:" << src_image_name << std::endl;
+        }
+
+        return r;
+      }
+    } else {
+      /* check group image */
+      bool is_find = false;
+      for (auto &image_info : images_list) {
+        if(image_info.name == src_image_name && image_info.pool == image_pool_id) {
+          is_find = true;
+          break;
+        }
+      }
+      if(!is_find) {
+        std::cerr << "Can't find image in group, image:" << src_pool_name << "/" <<
+                      src_image_name << ", group:" << group_name << std::endl;
+        return -1;
+      }
+    }
+
+    image = &((*images)[image_key]);
+
+    r = rbd.open(image_io_ctx, *image, src_image_name.c_str());
+    if (r < 0) {
+      std::cerr << "rbd: failed to open image" << std::endl;
+      return r;
+    }
+
+    if (1 == is_create_image) {
+      r = utils::do_import_metadata(import_format, *image, imagemetas);
+      if (r < 0) {
+        std::cerr << "rbd: failed to import image-meta" << std::endl;
+        return r;
+      }
+    }
+  }
+
+  /* import image diff */
+  return utils::do_import_diff_fd(rados, *image, fd, true,
+                          import_format, sparse_size);
+}
+
+static int group_import_diff(librbd::RBD &rbd,
+                        librados::Rados &rados, librados::IoCtx& group_ioctx,
+                        const char *group_name, int fd,
+                        librbd::ImageOptions& opts, const size_t sparse_size,
+                        std::map<std::string, librbd::Image> *images,
+                        const std::vector<librbd::group_image_info_t> &images_list,
+                        const int import_format, const bool no_progress)
+{
+  std::string to_snap;
+  int r = group_import_snap_info(rbd, group_ioctx, group_name,
+                                fd, to_snap, import_format);
+  if (r < 0) {
+    return r;
+  }
+
+  r = utils::validate_banner(fd, RBD_GROUP_BANNER_DIFF);
+  if (r < 0) {
+    return r;
+  }
+
+  uint64_t image_num = 0;
+  r = group_decode_uint64(fd, &image_num);
+  if (r < 0) {
+    return r;
+  }
+
+  utils::ProgressContext pc("Importing group", no_progress);
+  int pc_cnt = 1;
+  for (size_t i = 0; i < image_num; i++) {
+    r = group_image_import_diff(rbd, rados, group_ioctx, group_name, to_snap, fd,
+                opts, sparse_size, images, images_list, import_format, no_progress);
+    if (r < 0) {
+      goto err;
+    }
+
+    pc.update_progress(pc_cnt++, image_num);
+  }
+
+  if (!to_snap.empty()) {
+    /* create group snap */
+    r = rbd.group_snap_create(group_ioctx, group_name, to_snap.c_str());
+  }
+
+  err:
+  if (r < 0)
+    pc.fail();
+  else
+    pc.finish();
+
+  return r;
+}
+
+static int group_import_recover(librbd::RBD &rbd, librados::IoCtx& group_ioctx,
+                                 const char *group_name)
+{
+  int r = 0;
+  std::vector<librbd::group_snap_info_t> snaps;
+  rbd.group_snap_list(group_ioctx, group_name, &snaps,
+                      sizeof(librbd::group_snap_info_t));
+  for (auto snap: snaps) {
+    r = rbd.group_snap_remove(group_ioctx, group_name, snap.name.c_str());
+    if (r < 0) {
+      return r;
+    }
+  }
+
+  std::vector<librbd::group_image_info_t> images_list;
+  /* get image list */
+  r = rbd.group_image_list(group_ioctx, group_name, &images_list,
+                              sizeof(librbd::group_image_info_t));
+  if (r < 0) {
+    return r;
+  }
+
+  /* remove images of group */
+  for(auto image : images_list) {
+    librados::IoCtx image_io_ctx;
+    r = create_ioctx(group_ioctx, "image", image.pool, {}, &image_io_ctx);
+    if (r < 0) {
+      return r;
+    }
+
+    r = rbd.group_image_remove(group_ioctx, group_name,
+                                           image_io_ctx, image.name.c_str());
+    if (r < 0) {
+      return r;
+    }
+
+    r = rbd.remove(image_io_ctx, image.name.c_str());
+    if (r < 0) {
+      return r;
+    }
+  }
+
+  /* remove group */
+  return rbd.group_remove(group_ioctx, group_name);
+}
+
+static int group_import(librados::Rados &rados, librados::IoCtx& group_ioctx,
+                        const char *group_name, int fd,
+                        librbd::ImageOptions& opts, const size_t sparse_size,
+                        const bool no_progress, librbd::ProgressContext& pc)
+{
+  int r = utils::validate_banner(fd, RBD_GROUP_BANNER);
+  if (r < 0) {
+    return r;
+  }
+
+  uint64_t diff_num = 0;
+  r = group_decode_uint64(fd, &diff_num);
+  if (r < 0) {
+    return r;
+  }
+
+  librbd::RBD rbd;
+  /* create group */
+  r = rbd.group_create(group_ioctx, group_name);
+  if (r < 0) {
+    return r;
+  }
+
+  std::map<std::string, librbd::Image> images;
+  for (size_t i = 0; i < diff_num; i++) {
+    /* get image list */
+    std::vector<librbd::group_image_info_t> images_list;
+    r = rbd.group_image_list(group_ioctx, group_name, &images_list,
+                            sizeof(librbd::group_image_info_t));
+    if (r < 0) {
+      goto err;
+    }
+
+    /* import group diff */
+    r = group_import_diff(rbd, rados, group_ioctx, group_name, fd, opts, sparse_size,
+                          &images, images_list, 2, true);
+    if (r < 0) {
+      goto err;
+    }
+
+    pc.update_progress(i+1, diff_num);
+  }
+
+  err:
+  if (r < 0) {
+    /* recover */
+    group_import_recover(rbd, group_ioctx, group_name);
+  }
+
+  return r;
+}
+
+static int open_import_file(const char *path, int &fd, bool &from_stdin)
+{
+  from_stdin = !strcmp(path, "-");
+  if (from_stdin) {
+    fd = STDIN_FILENO;
+  } else {
+    if ((fd = open(path, O_RDONLY)) < 0) {
+      std::cerr << "rbd: error opening " << path << std::endl;
+      return -errno;
+    }
+
+    struct stat stat_buf;
+    if ((fstat(fd, &stat_buf)) < 0) {
+      std::cerr << "rbd: stat error " << path << std::endl;
+      return -errno;
+    }
+    if (S_ISDIR(stat_buf.st_mode)) {
+      std::cerr << "rbd: cannot import a directory" << std::endl;
+      return -EISDIR;
+    }
+
+#ifdef HAVE_POSIX_FADVISE
+    posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL);
+#endif
+  }
+
+  return 0;
+}
+
+static int do_group_import(librados::Rados &rados, librados::IoCtx& group_ioctx,
+                        const char *group_name,
+                        const char *path, librbd::ImageOptions& opts,
+                        const size_t sparse_size, const bool no_progress)
+{
+  int r = 0;
+  if (!group_name) {
+    std::cerr << "rbd: group name is null." << path << std::endl;
+    return -1;
+  }
+
+  int fd = -1;
+  bool from_stdin = false;
+  r = open_import_file(path, fd, from_stdin);
+  if(r < 0) {
+    return r;
+  }
+
+  utils::ProgressContext pc("Importing group", no_progress);
+  r = group_import(rados, group_ioctx, group_name, fd, opts,
+                  sparse_size, no_progress, pc);
+
+  if (!from_stdin)
+    close(fd);
+
+  if (r < 0)
+    pc.fail();
+  else
+    pc.finish();
+
+  return r;
+}
+
+int execute_group_import(const po::variables_map &vm,
+                        const std::vector<std::string> &global_args) {
+  std::string path;
+  size_t arg_index = 0;
+
+  std::string group_name;
+  std::string namespace_name;
+  std::string pool_name;
+  std::string snap_name;
+
+  int r = utils::get_path(vm, &arg_index, &path);
+  if (r < 0) {
+    return r;
+  }
+
+  r = utils::get_pool_generic_snapshot_names(
+    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, at::POOL_NAME, &pool_name,
+    &namespace_name, GROUP_NAME, "group", &group_name, &snap_name, true,
+    utils::SNAPSHOT_PRESENCE_PERMITTED, utils::SPEC_VALIDATION_FULL);
+  if (r < 0) {
+    return r;
+  }
+
+  size_t sparse_size = utils::RBD_DEFAULT_SPARSE_SIZE;
+  if (vm.count(at::IMAGE_SPARSE_SIZE)) {
+    sparse_size = vm[at::IMAGE_SPARSE_SIZE].as<size_t>();
+  }
+
+  librbd::ImageOptions opts;
+  r = utils::get_image_options(vm, true, &opts);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::Rados rados;
+  librados::IoCtx io_ctx;
+  r = utils::init(pool_name, namespace_name, &rados, &io_ctx);
+  if (r < 0) {
+    return r;
+  }
+
+  r = do_group_import(rados, io_ctx, group_name.c_str(), path.c_str(),
+                opts, sparse_size, vm[at::NO_PROGRESS].as<bool>());
+  if (r < 0) {
+    std::cerr << "rbd: import failed: " << cpp_strerror(r) << std::endl;
+    return r;
+  }
+
+  return r;
+}
+
+static int do_group_import_diff(librados::Rados &rados, librados::IoCtx& group_ioctx,
+                        const char *group_name,
+                        const char *path, librbd::ImageOptions& opts,
+                        const size_t sparse_size, const bool no_progress)
+{
+  int fd = -1;
+  bool from_stdin = false;
+  int r = open_import_file(path, fd, from_stdin);
+  if(r < 0) {
+    return r;
+  }
+
+  std::map<std::string, librbd::Image> images;
+  librbd::RBD rbd;
+  /* get image list */
+  std::vector<librbd::group_image_info_t> images_list;
+  r = rbd.group_image_list(group_ioctx, group_name, &images_list,
+                          sizeof(librbd::group_image_info_t));
+  if (r < 0) {
+    goto err;
+  }
+
+  r = group_import_diff(rbd, rados, group_ioctx, group_name, fd, opts, sparse_size,
+                          &images, images_list, 2, no_progress);
+
+  err:
+  if (!from_stdin)
+    close(fd);
+
+  return r;
+}
+
+int execute_group_import_diff(const po::variables_map &vm,
+                        const std::vector<std::string> &global_args)
+{
+  std::string path;
+  size_t arg_index = 0;
+
+  std::string group_name;
+  std::string namespace_name;
+  std::string pool_name;
+  std::string snap_name;
+
+  int r = utils::get_path(vm, &arg_index, &path);
+  if (r < 0) {
+    return r;
+  }
+
+  r = utils::get_pool_generic_snapshot_names(
+    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, at::POOL_NAME, &pool_name,
+    &namespace_name, GROUP_NAME, "group", &group_name, &snap_name, true,
+    utils::SNAPSHOT_PRESENCE_PERMITTED, utils::SPEC_VALIDATION_FULL);
+  if (r < 0) {
+    return r;
+  }
+
+  size_t sparse_size = utils::RBD_DEFAULT_SPARSE_SIZE;
+  if (vm.count(at::IMAGE_SPARSE_SIZE)) {
+    sparse_size = vm[at::IMAGE_SPARSE_SIZE].as<size_t>();
+  }
+
+  librbd::ImageOptions opts;
+  r = utils::get_image_options(vm, true, &opts);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::Rados rados;
+  librados::IoCtx io_ctx;
+  r = utils::init(pool_name, namespace_name, &rados, &io_ctx);
+  if (r < 0) {
+    return r;
+  }
+
+  r = do_group_import_diff(rados, io_ctx, group_name.c_str(), path.c_str(),
+                opts, sparse_size, vm[at::NO_PROGRESS].as<bool>());
+  if (r < 0) {
+    std::cerr << "rbd: import failed: " << cpp_strerror(r) << std::endl;
+    return r;
+  }
+
+  return r;
+}
+
 void get_create_arguments(po::options_description *positional,
                           po::options_description *options) {
   add_group_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE,
@@ -865,6 +2255,53 @@ void get_group_snap_rollback_arguments(po::options_description *positional,
                          true);
 }
 
+void get_group_export_arguments(po::options_description *positional,
+                                       po::options_description *options) {
+
+  add_group_or_snap_spec_options(positional, options, at::ARGUMENT_MODIFIER_SOURCE,
+                         false);
+  at::add_path_options(positional, options,
+                       "export file (or '-' for stdout)");
+  at::add_no_progress_option(options);
+}
+
+void get_group_export_diff_arguments(po::options_description *positional,
+                                       po::options_description *options) {
+
+  add_group_or_snap_spec_options(positional, options, at::ARGUMENT_MODIFIER_SOURCE,
+                         true);
+  options->add_options()
+    (at::FROM_SNAPSHOT_NAME.c_str(), po::value<std::string>(),
+     "snapshot starting point")
+    (at::WHOLE_OBJECT.c_str(), po::bool_switch(), "compare whole object");
+  at::add_path_options(positional, options,
+                       "export file (or '-' for stdout)");
+  at::add_no_progress_option(options);
+}
+
+void get_group_import_arguments(po::options_description *positional,
+                                       po::options_description *options) {
+  at::add_path_options(positional, options,
+                       "import file (or '-' for stdin)");
+  add_group_spec_options(positional, options, at::ARGUMENT_MODIFIER_DEST,
+                         false);
+  at::add_create_image_options(options, true);
+  at::add_sparse_size_option(options);
+  at::add_no_progress_option(options);
+}
+
+void get_group_import_diff_arguments(po::options_description *positional,
+                                       po::options_description *options)
+{
+  at::add_path_options(positional, options,
+                       "import file (or '-' for stdin)");
+  add_group_spec_options(positional, options, at::ARGUMENT_MODIFIER_DEST,
+                         false);
+  at::add_create_image_options(options, true);
+  at::add_sparse_size_option(options);
+  at::add_no_progress_option(options);
+}
+
 Shell::Action action_create(
   {"group", "create"}, {}, "Create a group.",
   "", &get_create_arguments, &execute_create);
@@ -906,6 +2343,22 @@ Shell::Action action_group_snap_rollback(
   {"group", "snap", "rollback"}, {},
   "Rollback group to snapshot.",
   "", &get_group_snap_rollback_arguments, &execute_group_snap_rollback);
+Shell::Action action_group_export(
+  {"group", "export"}, {},
+  "Export group to file.",
+  "", &get_group_export_arguments, &execute_group_export);
+Shell::Action action_group_export_diff(
+  {"group", "export-diff"}, {},
+  "Export group incremental diff to file.",
+  "", &get_group_export_diff_arguments, &execute_group_export_diff);
+Shell::Action action_group_import(
+  {"group", "import"}, {},
+  "Import group from file.",
+  "", &get_group_import_arguments, &execute_group_import);
+Shell::Action action_group_import_diff(
+  {"group", "import-diff"}, {},
+  "Import group incremental diff from file.",
+  "", &get_group_import_diff_arguments, &execute_group_import_diff);
 
 } // namespace group
 } // namespace action


### PR DESCRIPTION
Export data from a consistent group to a file, and import data from a file to a consistent group, both incremental and full, in a manner similar to import and export of image.

Added four new commands:
```
rbd group export [--pool <pool>] [--namespace <namespace>] 
                        [--group <group>] [--path <path>] [--no-progress] 
                        <source-group-spec> <path-name> 
rbd group export-diff [--pool <pool>] [--namespace <namespace>] 
                         [--group <group>] [--snap <snap>] 
                         [--from-snap <from-snap>] [--whole-object] 
                         [--path <path>] [--no-progress] 
                         <source-group-or-snap-spec> <path-name>
rbd group import [--path <path>] [--dest-pool <dest-pool>] 
                        [--dest-namespace <dest-namespace>] 
                        [--dest-group <dest-group>] 
                        [--image-format <image-format>] [--new-format] 
                        [--order <order>] [--object-size <object-size>] 
                        [--image-feature <image-feature>] [--image-shared] 
                        [--stripe-unit <stripe-unit>] 
                        [--stripe-count <stripe-count>] 
                        [--data-pool <data-pool>] 
                        [--mirror-image-mode <mirror-image-mode>] 
                        [--journal-splay-width <journal-splay-width>] 
                        [--journal-object-size <journal-object-size>] 
                        [--journal-pool <journal-pool>] 
                        [--sparse-size <sparse-size>] [--no-progress] 
                        <path-name> <dest-group-spec>
rbd group import-diff [--path <path>] [--dest-pool <dest-pool>] 
                         [--dest-namespace <dest-namespace>] 
                         [--dest-group <dest-group>] 
                         [--image-format <image-format>] [--new-format] 
                         [--order <order>] [--object-size <object-size>] 
                         [--image-feature <image-feature>] 
                         [--image-shared] [--stripe-unit <stripe-unit>] 
                         [--stripe-count <stripe-count>] 
                         [--data-pool <data-pool>] 
                         [--mirror-image-mode <mirror-image-mode>] 
                         [--journal-splay-width <journal-splay-width>] 
                         [--journal-object-size <journal-object-size>] 
                         [--journal-pool <journal-pool>] 
                         [--sparse-size <sparse-size>] [--no-progress] 
                         <path-name> <dest-group-spec>
```

The format of the full export file:
```
RBD_GROUP_BANNER
group_snap_diff_num（group_snap_num + 1）
  for{
    RBD_GROUP_BANNER_SNAP
    RBD_DIFF_FROM_SNAP
    RBD_DIFF_TO_SNAP
    RBD_EXPORT_IMAGE_END
      RBD_GROUP_BANNER_DIFF
      image_num_in_this_group_diff
        for{
          RBD_GROUP_BANNER_IMAGE_INFO
          RBD_EXPORT_GROUP_IMAGE_POOL_NAME
          RBD_EXPORT_GROUP_IMAGE_NAME
          RBD_EXPORT_GROUP_IMAGE_ID
          RBD_EXPORT_GROUP_IS_CREATE_IMAGE
          RBD_EXPORT_IMAGE_END
            if new add image in this diff{
              RBD_IMAGE_BANNER_V2
              RBD_EXPORT_IMAGE_ORDER
              RBD_EXPORT_IMAGE_FEATURES
              RBD_EXPORT_IMAGE_STRIPE_UNIT
              RBD_EXPORT_IMAGE_STRIPE_COUNT
              RBD_EXPORT_IMAGE_META
              RBD_EXPORT_IMAGE_END
            }
              RBD_DIFF_BANNER
              RBD_DIFF_IMAGE_SIZE
              image_data
              RBD_DIFF_END
        }
  }
```

The format of the incremental export file:
```
RBD_GROUP_BANNER_SNAP
RBD_DIFF_FROM_SNAP
RBD_DIFF_TO_SNAP
RBD_EXPORT_IMAGE_END
  RBD_GROUP_BANNER_DIFF
  image_num_in_this_group_diff
    for{
      RBD_GROUP_BANNER_IMAGE_INFO
      RBD_EXPORT_GROUP_IMAGE_POOL_NAME
      RBD_EXPORT_GROUP_IMAGE_NAME
      RBD_EXPORT_GROUP_IMAGE_ID
      RBD_EXPORT_GROUP_IS_CREATE_IMAGE
      RBD_EXPORT_IMAGE_END
        if new add image in this diff{
          RBD_IMAGE_BANNER_V2
          RBD_EXPORT_IMAGE_ORDER
          RBD_EXPORT_IMAGE_FEATURES
          RBD_EXPORT_IMAGE_STRIPE_UNIT
          RBD_EXPORT_IMAGE_STRIPE_COUNT
          RBD_EXPORT_IMAGE_META
          RBD_EXPORT_IMAGE_END
        }
          RBD_DIFF_BANNER
          RBD_DIFF_IMAGE_SIZE
          image_data
          RBD_DIFF_END
    }
```

Fixes: https://tracker.ceph.com/issues/18864

Signed-off-by: Wang ShuaiChao <wangshuaich@chinatelecom.cn>

Review-by: wuxuehan@chinatelecom.cn
Review-by: lijiawei1@chinatelecom.cn

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
