### PR TITLE
rbd-nbd: add ability to restore nbd devices

### DIFF
--- a/doc/man/8/rbd-nbd.rst
+++ b/doc/man/8/rbd-nbd.rst
@@ -14,6 +14,7 @@ Synopsis
 | **rbd-nbd** list-mapped
 | **rbd-nbd** attach --device *nbd device* *image-spec* | *snap-spec*
 | **rbd-nbd** detach *nbd device* | *image-spec* | *snap-spec*
+| **rbd-nbd** restore [--attach-list *<nbd-device,image-spec,snap-spec,...>* | --saveconfig-file *file*]
 
 Description
 ===========
@@ -66,6 +67,19 @@ Options
    Specify timeout for the kernel to wait for a new rbd-nbd process is
    attached after the old process is detached. The default is 30
    second.
+
+.. option:: --attach-list *<nbd-device,image-spec,snap-spec,...>*
+
+   Should be used with the restore command, it specifies the comma-separated
+   list of nbd-devices and/or image-specs and/or snap-specs which needs to be
+   re-attached. If this option is not specified, the restore command will
+   attempt to re-attach all the rbd-nbd devices available in the saveconfig
+   file.
+
+.. option:: --saveconfig-file *file*
+
+   Path of the JSON file that will contain data about the rbd-nbd devices.
+   The default file path is /etc/ceph/saveconfig.json
 
 Image and snap specs
 ====================

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -703,6 +703,7 @@ int md_config_t::parse_argv(ConfigValues& values,
 	r = bl.read_fd(STDIN_FILENO, 1024);
       } else {
 	r = bl.read_file(val.c_str(), &err);
+	set_val_or_die(values, tracker, "keyfile", val.c_str());
       }
       if (r >= 0) {
 	string k(bl.c_str(), bl.length());

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -84,6 +84,18 @@ namespace fs = std::experimental::filesystem;
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd-nbd: "
 
+#define DEFAULT_QUIESCE_HOOK      CMAKE_INSTALL_LIBEXECDIR "/rbd-nbd/rbd-nbd_quiesce"
+
+#define DEFAULT_REATTACH_TIMEOUT  30
+#define DEFAULT_IO_TIMEOUT        -1
+#define DEFAULT_NBDS_MAX          0
+#define DEFAULT_MAX_PART          255
+
+#define DEFAULT_EXCLUSIVE         false
+#define DEFAULT_QUIESCE           false
+#define DEFAULT_READONLY          false
+#define DEFAULT_TRY_NETLINK       false
+
 enum Command {
   None,
   Map,
@@ -94,23 +106,23 @@ enum Command {
 };
 
 struct Config {
-  int nbds_max = 0;
-  int max_part = 255;
-  int io_timeout = -1;
-  int reattach_timeout = 30;
+  int nbds_max = DEFAULT_NBDS_MAX;
+  int max_part = DEFAULT_MAX_PART;
+  int io_timeout = DEFAULT_IO_TIMEOUT;
+  int reattach_timeout = DEFAULT_REATTACH_TIMEOUT;
 
-  bool exclusive = false;
-  bool quiesce = false;
-  bool readonly = false;
+  bool exclusive = DEFAULT_EXCLUSIVE;
+  bool quiesce = DEFAULT_QUIESCE;
+  bool readonly = DEFAULT_READONLY;
+  bool try_netlink = DEFAULT_TRY_NETLINK;
   bool set_max_part = false;
-  bool try_netlink = false;
 
   std::string poolname;
   std::string nsname;
   std::string imgname;
   std::string snapname;
   std::string devpath;
-  std::string quiesce_hook = CMAKE_INSTALL_LIBEXECDIR "/rbd-nbd/rbd-nbd_quiesce";
+  std::string quiesce_hook = DEFAULT_QUIESCE_HOOK;
 
   std::string format;
   bool pretty_format = false;


### PR DESCRIPTION
Problem:                                                                       
-------                                                                        
Currently, with the rbd-nbd tool, we can map the nbd devices and scale         
them as needed. But in case if the node is rebooted, there is no way to restore
the nbd device mappings and one has to do remap of the big list of devices     
manually. This is a serious problem in container environments, if the container
hosting the rbd-nbd processes is restarted, all the mapping is just gone and   
The application will start seeing the IO errors.                               
                                                                               
Solution:                                                                      
--------                                                                       
With these changes, on every successful Map operation, we save the             
details of the nbd device mappings to a persistent file (here on called as     
saveconfig file) in the JSON format which will be used for restore. Similarly, 
on Unmap we clean the JSON object related to the device.                       
                                                                               
Thanks to the attach command, the restore command will leverage it and         
brings the rbd-nbd processes to life.                                          
                                                                               
The default path of the JSON file is /etc/ceph/saveconfig.json                 
                                                                               
Example usage:                                                                 
-------------
```                                                                  
$ rbd-nbd list-mapped                                                          
id      pool           namespace  image    snap  device                        
617318  rbd-pool                  image1   -     /dev/nbd0                     
617356  rbd-pool                  image2   -     /dev/nbd1                     
617394  rbd-pool                  image3   -     /dev/nbd2                     
617433  rbd-pool                  image4   -     /dev/nbd3                     
617472  rbd-pool                  image5   -     /dev/nbd4                     
                                                                               
$ pkill -9 rbd-nbd                                                             
```

#### Restore all from default location:
```
$ rbd-nbd restore                                                              
=> Attempting to attach: /dev/nbd0 -> rbd-pool/image1                          
SUCCESS                                                                        
=> Attempting to attach: /dev/nbd1 -> rbd-pool/image2                          
SUCCESS                                                                        
=> Attempting to attach: /dev/nbd2 -> rbd-pool/image3                          
SUCCESS                                                                        
=> Attempting to attach: /dev/nbd3 -> rbd-pool/image4                          
SUCCESS                                                                        
=> Attempting to attach: /dev/nbd4 -> rbd-pool/image5                          
SUCCESS                                                                        
```

#### Restore partial list from default location:
```
$ rbd-nbd restore --attach-list="rbd-pool/image1,/dev/nbd4"
=> Attempting to attach: /dev/nbd0 -> rbd-pool/image1      
SUCCESS                                                    
=> Attempting to attach: /dev/nbd4 -> rbd-pool/image5      
SUCCESS                                                    
```

#### Restore partial list from default location with id, keyfile and mon_host:
```
$ rbd-nbd --id="admin" --keyfile=/tmp/keyfile -m "10.70.1.100:6789" restore --attach-list="rbd-pool/image2,/dev/nbd3"
=> Attempting to attach: /dev/nbd1 -> rbd-pool/image2
SUCCESS
=> Attempting to attach: /dev/nbd3 -> rbd-pool/image4
SUCCESS
```

#### Restore from configurable saveconfig file location:
```
$ ./bin/rbd-nbd map --saveconfig-file /tmp/rbd-nbd-cfg.json
$ ./bin/rbd-nbd restore --saveconfig-file /tmp/rbd-nbd-cfg.json
$ ./bin/rbd-nbd unmap
```


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
