### PR TITLE
mgr,cephadm: add option to disable standby modules for standby mgrs

### DIFF
--- a/qa/suites/rados/cephadm/smoke-roleless/2-services/iscsi.yaml
+++ b/qa/suites/rados/cephadm/smoke-roleless/2-services/iscsi.yaml
@@ -4,4 +4,5 @@ tasks:
       - ceph osd pool create foo
       - rbd pool init foo
       - ceph orch apply iscsi foo u p
-      - sleep 120
+- cephadm.wait_for_service:
+    service: iscsi.foo

--- a/qa/suites/rados/cephadm/smoke-roleless/2-services/mirror.yaml
+++ b/qa/suites/rados/cephadm/smoke-roleless/2-services/mirror.yaml
@@ -3,4 +3,7 @@ tasks:
     host.a:
       - ceph orch apply rbd-mirror "--placement=*"
       - ceph orch apply cephfs-mirror "--placement=*"
-      - sleep 120
+- cephadm.wait_for_service:
+    service: rbd-mirror
+- cephadm.wait_for_service:
+    service: cephfs-mirror

--- a/qa/suites/rados/cephadm/smoke-roleless/2-services/rgw-ingress.yaml
+++ b/qa/suites/rados/cephadm/smoke-roleless/2-services/rgw-ingress.yaml
@@ -1,4 +1,12 @@
 tasks:
+- vip:
+
+# make sure cephadm notices the new IP
+- cephadm.shell:
+    host.a:
+      - ceph orch device ls --refresh
+
+# deploy rgw + ingress
 - cephadm.apply:
     specs:
       - service_type: rgw
@@ -16,21 +24,37 @@ tasks:
           backend_service: rgw.foo
           frontend_port: 9000
           monitor_port: 9001
-          virtual_ip: {{VIP}}
+          virtual_ip: "{{VIP0}}/{{VIPPREFIXLEN}}"
+- cephadm.wait_for_service:
+    service: rgw.foo
+- cephadm.wait_for_service:
+    service: ingress.rgw.foo
+
+# take each component down in turn and ensure things still work
 - cephadm.shell:
     host.a:
       - |
-        while ! ceph orch ls | grep ^rgw.foo | grep 4/4; do sleep 1; done
-        while ! ceph orch ls | grep ^ingress.rgw.foo | grep 2/2; do sleep 1; done
-        curl http://{{VIP}}/
+        echo "Check while healthy..."
+        curl http://{{VIP0}}:9000/
 
         # stop each rgw in turn
-        for rgw in `ceph orch ps | grep ^rgw.foo.`; do
+        echo "Check with each rgw stopped in turn..."
+        for rgw in `ceph orch ps | grep ^rgw.foo. | awk '{print $1}'`; do
           ceph orch daemon stop $rgw
-          while ! ceph orch ls | grep ^rgw.foo | grep 3/4; do sleep 1; done
-          curl http://{{VIP}}/
+          while ! ceph orch ps | grep $rgw | grep stopped; do sleep 1 ; done
+          while ! curl http://{{VIP0}}:9000/ ; do sleep 1 ; done
           ceph orch daemon start $rgw
-          while ! ceph orch ls | grep ^rgw.foo | grep 4/4; do sleep 1; done
+          while ! ceph orch ps | grep $rgw | grep running; do sleep 1 ; done
         done
-- sleep:
-    interval: 60
+
+        # stop each haproxy in turn
+        echo "Check with each haproxy down in turn..."
+        for haproxy in `ceph orch ps | grep ^haproxy.rgw.foo. | awk '{print $1}'`; do
+          ceph orch daemon stop $haproxy
+          while ! ceph orch ps | grep $haproxy | grep stopped; do sleep 1 ; done
+          while ! curl http://{{VIP0}}:9000/ ; do sleep 1 ; done
+          ceph orch daemon start $haproxy
+          while ! ceph orch ps | grep $haproxy | grep running; do sleep 1 ; done
+        done
+
+        while ! curl http://{{VIP0}}:9000/ ; do sleep 1 ; done

--- a/qa/suites/rados/cephadm/smoke-roleless/2-services/rgw-ingress.yaml
+++ b/qa/suites/rados/cephadm/smoke-roleless/2-services/rgw-ingress.yaml
@@ -1,0 +1,36 @@
+tasks:
+- cephadm.apply:
+    specs:
+      - service_type: rgw
+        service_id: foo
+        placement:
+          count: 4
+          host_pattern: "*"
+        spec:
+          rgw_frontend_port: 8000
+      - service_type: ingress
+        service_id: rgw.foo
+        placement:
+          count: 2
+        spec:
+          backend_service: rgw.foo
+          frontend_port: 9000
+          monitor_port: 9001
+          virtual_ip: {{VIP}}
+- cephadm.shell:
+    host.a:
+      - |
+        while ! ceph orch ls | grep ^rgw.foo | grep 4/4; do sleep 1; done
+        while ! ceph orch ls | grep ^ingress.rgw.foo | grep 2/2; do sleep 1; done
+        curl http://{{VIP}}/
+
+        # stop each rgw in turn
+        for rgw in `ceph orch ps | grep ^rgw.foo.`; do
+          ceph orch daemon stop $rgw
+          while ! ceph orch ls | grep ^rgw.foo | grep 3/4; do sleep 1; done
+          curl http://{{VIP}}/
+          ceph orch daemon start $rgw
+          while ! ceph orch ls | grep ^rgw.foo | grep 4/4; do sleep 1; done
+        done
+- sleep:
+    interval: 60

--- a/qa/suites/rados/cephadm/smoke-roleless/2-services/rgw.yaml
+++ b/qa/suites/rados/cephadm/smoke-roleless/2-services/rgw.yaml
@@ -8,5 +8,5 @@ tasks:
           host_pattern: "*"
         spec:
           rgw_frontend_port: 8000
-- sleep:
-    interval: 60
+- cephadm.wait_for_service:
+    service: rgw.foo

--- a/qa/suites/rados/cephadm/smoke-singlehost/0-distro$
+++ b/qa/suites/rados/cephadm/smoke-singlehost/0-distro$
@@ -1,0 +1,1 @@
+../smoke/distro

--- a/qa/suites/rados/cephadm/smoke-singlehost/1-start.yaml
+++ b/qa/suites/rados/cephadm/smoke-singlehost/1-start.yaml
@@ -1,0 +1,27 @@
+tasks:
+- cephadm:
+    roleless: true
+    single_host_defaults: true
+- cephadm.shell:
+    host.a:
+      - ceph orch status
+      - ceph orch ps
+      - ceph orch ls
+      - ceph orch host ls
+      - ceph orch device ls
+roles:
+- - host.a
+  - osd.0
+  - osd.1
+  - osd.2
+  - osd.3
+  - client.0
+openstack:
+- volumes: # attached to each instance
+    count: 4
+    size: 10 # GB
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd shutdown pgref assert: true

--- a/qa/suites/rados/cephadm/smoke-singlehost/2-services/rgw.yaml
+++ b/qa/suites/rados/cephadm/smoke-singlehost/2-services/rgw.yaml
@@ -1,0 +1,12 @@
+tasks:
+- cephadm.apply:
+    specs:
+      - service_type: rgw
+        service_id: foo
+        placement:
+          count_per_host: 4
+          host_pattern: "*"
+        spec:
+          rgw_frontend_port: 8000
+- sleep:
+    interval: 60

--- a/qa/suites/rados/cephadm/smoke-singlehost/2-services/rgw.yaml
+++ b/qa/suites/rados/cephadm/smoke-singlehost/2-services/rgw.yaml
@@ -8,5 +8,5 @@ tasks:
           host_pattern: "*"
         spec:
           rgw_frontend_port: 8000
-- sleep:
-    interval: 60
+- cephadm.wait_for_service:
+    service: rgw.foo

--- a/qa/suites/rados/cephadm/smoke-singlehost/3-final.yaml
+++ b/qa/suites/rados/cephadm/smoke-singlehost/3-final.yaml
@@ -1,0 +1,8 @@
+tasks:
+- cephadm.shell:
+    host.a:
+      - ceph orch status
+      - ceph orch ps
+      - ceph orch ls
+      - ceph orch host ls
+      - ceph orch device ls

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -1004,6 +1004,49 @@ def apply(ctx, config):
     )
 
 
+def wait_for_service(ctx, config):
+    """
+    Wait for a service to be fully started
+
+      tasks:
+        - cephadm.wait_for_service:
+            service: rgw.foo
+            timeout: 60    # defaults to 300
+
+    """
+    cluster_name = config.get('cluster', 'ceph')
+    timeout = config.get('timeout', 300)
+    service = config.get('service')
+    assert service
+
+    log.info(
+        f'Waiting for {cluster_name} service {service} to start (timeout {timeout})...'
+    )
+    with contextutil.safe_while(sleep=1, tries=timeout) as proceed:
+        while proceed():
+            r = _shell(
+                ctx=ctx,
+                cluster_name=cluster_name,
+                remote=ctx.ceph[cluster_name].bootstrap_remote,
+                args=[
+                    'ceph', 'orch', 'ls', '-f', 'json',
+                ],
+                stdout=StringIO(),
+            )
+            j = json.loads(r.stdout.getvalue())
+            svc = None
+            for s in j:
+                if s['service_name'] == service:
+                    svc = s
+                    break
+            if svc:
+                log.info(
+                    f"{service} has {s['status']['running']}/{s['status']['size']}"
+                )
+                if s['status']['running'] == s['status']['size']:
+                    break
+
+
 @contextlib.contextmanager
 def tweaked_option(ctx, config):
     """

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -481,14 +481,17 @@ def ceph_bootstrap(ctx, config):
                 raise
 
         # tear down anything left (but leave the logs behind)
-        ctx.cluster.run(args=[
-            'sudo',
-            ctx.cephadm,
-            'rm-cluster',
-            '--fsid', fsid,
-            '--force',
-            '--keep-logs',
-        ])
+        ctx.cluster.run(
+            args=[
+                'sudo',
+                ctx.cephadm,
+                'rm-cluster',
+                '--fsid', fsid,
+                '--force',
+                '--keep-logs',
+            ],
+            check_status=False,  # may fail if upgrading from old cephadm
+        )
 
         # clean up /etc/ceph
         ctx.cluster.run(args=[

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -943,10 +943,14 @@ def shell(ctx, config):
             env.extend(['-e', k + '=' + ctx.config.get(k, '')])
         del config['env']
 
-    if 'all' in config and len(config) == 1:
-        a = config['all']
+    if 'all-roles' in config and len(config) == 1:
+        a = config['all-roles']
         roles = teuthology.all_roles(ctx.cluster)
-        config = dict((id_, a) for id_ in roles)
+        config = dict((id_, a) for id_ in roles if not id_.startswith('host.'))
+    elif 'all-hosts' in config and len(config) == 1:
+        a = config['all-hosts']
+        roles = teuthology.all_roles(ctx.cluster)
+        config = dict((id_, a) for id_ in roles if id_.startswith('host.'))
 
     for role, cmd in config.items():
         (remote,) = ctx.cluster.only(role).remotes.keys()

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -393,6 +393,8 @@ def ceph_bootstrap(ctx, config):
             cmd += ['--skip-dashboard']
         if config.get('skip_monitoring_stack'):
             cmd += ['--skip-monitoring-stack']
+        if config.get('single_host_defaults'):
+            cmd += ['--single-host-defaults']
         # bootstrap makes the keyring root 0600, so +r it for our purposes
         cmd += [
             run.Raw('&&'),

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -391,6 +391,8 @@ def ceph_bootstrap(ctx, config):
             cmd += ['--mon-ip', mons[first_mon_role]]
         if config.get('skip_dashboard'):
             cmd += ['--skip-dashboard']
+        if config.get('skip_monitoring_stack'):
+            cmd += ['--skip-monitoring-stack']
         # bootstrap makes the keyring root 0600, so +r it for our purposes
         cmd += [
             run.Raw('&&'),

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -471,7 +471,7 @@ def ceph_bootstrap(ctx, config):
         # this doesn't block until they are all stopped...
         #ctx.cluster.run(args=['sudo', 'systemctl', 'stop', 'ceph.target'])
 
-        # so, stop them individually
+        # stop the daemons we know
         for role in ctx.daemons.resolve_role_list(None, CEPH_ROLE_TYPES, True):
             cluster, type_, id_ = teuthology.split_role(role)
             try:
@@ -479,6 +479,16 @@ def ceph_bootstrap(ctx, config):
             except Exception:
                 log.exception(f'Failed to stop "{role}"')
                 raise
+
+        # tear down anything left (but leave the logs behind)
+        ctx.cluster.run(args=[
+            'sudo',
+            ctx.cephadm,
+            'rm-cluster',
+            '--fsid', fsid,
+            '--force',
+            '--keep-logs',
+        ])
 
         # clean up /etc/ceph
         ctx.cluster.run(args=[

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -948,13 +948,20 @@ def shell(ctx, config):
         roles = teuthology.all_roles(ctx.cluster)
         config = dict((id_, a) for id_ in roles)
 
-    for role, ls in config.items():
+    for role, cmd in config.items():
         (remote,) = ctx.cluster.only(role).remotes.keys()
         log.info('Running commands on role %s host %s', role, remote.name)
-        for c in ls:
+        if isinstance(cmd, list):
+            for c in cmd:
+                _shell(ctx, cluster_name, remote,
+                       ['bash', '-c', c],
+                       extra_cephadm_args=env)
+        else:
+            assert isinstance(cmd, str)
             _shell(ctx, cluster_name, remote,
-                   ['bash', '-c', c],
+                   ['bash', '-ex', '-c', cmd],
                    extra_cephadm_args=env)
+
 
 def apply(ctx, config):
     """

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -22,6 +22,7 @@ from teuthology.config import config as teuth_config
 
 # these items we use from ceph.py should probably eventually move elsewhere
 from tasks.ceph import get_mons, healthy
+from tasks.vip import subst_vip
 
 CEPH_ROLE_TYPES = ['mon', 'mgr', 'osd', 'mds', 'rgw', 'prometheus']
 
@@ -958,12 +959,12 @@ def shell(ctx, config):
         if isinstance(cmd, list):
             for c in cmd:
                 _shell(ctx, cluster_name, remote,
-                       ['bash', '-c', c],
+                       ['bash', '-c', subst_vip(ctx, c)],
                        extra_cephadm_args=env)
         else:
             assert isinstance(cmd, str)
             _shell(ctx, cluster_name, remote,
-                   ['bash', '-ex', '-c', cmd],
+                   ['bash', '-ex', '-c', subst_vip(ctx, cmd)],
                    extra_cephadm_args=env)
 
 
@@ -990,6 +991,8 @@ def apply(ctx, config):
 
     specs = config.get('specs', [])
     y = '\n---\n'.join(map(yaml.dump, specs))
+
+    y = subst_vip(ctx, y)
 
     log.info(f'Applying spec:\n{y}')
     _shell(

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -1002,11 +1002,9 @@ def apply(ctx, config):
     cluster_name = config.get('cluster', 'ceph')
 
     specs = config.get('specs', [])
-    y = '\n---\n'.join(map(yaml.dump, specs))
+    y = subst_vip(ctx, yaml.dump_all(specs))
 
-    y = subst_vip(ctx, y)
-
-    log.info(f'Applying spec:\n{y}')
+    log.info(f'Applying spec(s):\n{y}')
     _shell(
         ctx, cluster_name, ctx.ceph[cluster_name].bootstrap_remote,
         ['ceph', 'orch', 'apply', '-i', '-'],

--- a/qa/tasks/mgr/test_dashboard.py
+++ b/qa/tasks/mgr/test_dashboard.py
@@ -39,6 +39,12 @@ class TestDashboard(MgrTestCase):
         self.wait_until_true(_check_connection, timeout=30)
 
     def test_standby(self):
+        # skip this test if mgr_standby_modules=false
+        if self.mgr_cluster.mon_manager.raw_cluster_cmd(
+                "config", "get", "mgr", "mgr_standby_modules").strip() == "false":
+            log.info("Skipping test_standby since mgr_standby_modules=false")
+            return
+
         original_active_id = self.mgr_cluster.get_active_id()
         original_uri = self._get_uri("dashboard")
         log.info("Originally running manager '{}' at {}".format(

--- a/qa/tasks/vip.py
+++ b/qa/tasks/vip.py
@@ -1,0 +1,171 @@
+import contextlib
+import ipaddress
+import logging
+import re
+
+from teuthology.config import config as teuth_config
+
+log = logging.getLogger(__name__)
+
+
+def subst_vip(ctx, cmd):
+    p = re.compile(r'({{VIP(\d+)}})')
+    for m in p.findall(cmd):
+        n = int(m[1])
+        if n >= len(ctx.vip["vips"]):
+            log.warning(f'no VIP{n} (we have {len(ctx.vip["vips"])})')
+        else:
+            cmd = cmd.replace(m[0], str(ctx.vip["vips"][n]))
+
+    if '{{VIPPREFIXLEN}}' in cmd:
+        cmd = cmd.replace('{{VIPPREFIXLEN}}', str(ctx.vip["vnet"].prefixlen))
+
+    if '{{VIPSUBNET}}' in cmd:
+        cmd = cmd.replace('{{VIPSUBNET}}', str(ctx.vip["vnet"].network_address))
+
+    return cmd
+
+
+def echo(ctx, config):
+    """
+    This is mostly for debugging
+    """
+    for remote in ctx.cluster.remotes.keys():
+        log.info(subst_vip(ctx, config))
+
+
+def map_vips(mip, count):
+    for mapping in teuth_config.get('vip', []):
+        mnet = ipaddress.ip_network(mapping['machine_subnet'])
+        vnet = ipaddress.ip_network(mapping['virtual_subnet'])
+        if vnet.prefixlen >= mnet.prefixlen:
+            log.error(f"virtual_subnet {vnet} prefix >= machine_subnet {mnet} prefix")
+            return None
+        if mip in mnet:
+            pos = list(mnet.hosts()).index(mip)
+            log.info(f"{mip} in {mnet}, pos {pos}")
+            r = []
+            for sub in vnet.subnets(new_prefix=mnet.prefixlen):
+                r += [list(sub.hosts())[pos]]
+                count -= 1
+                if count == 0:
+                    break
+            return vnet, r
+    return None
+
+
+@contextlib.contextmanager
+def task(ctx, config):
+    """
+    Set up a virtual network and allocate virtual IP(s) for each machine.
+
+    The strategy here is to set up a private virtual subnet that is larger than
+    the subnet the machine(s) exist in, and allocate virtual IPs from that pool.
+
+    - The teuthology.yaml must include a section like::
+
+        vip:
+          - machine_subnet: 172.21.0.0/20
+            virtual_subnet: 10.0.0.0/16
+
+      At least one item's machine_subnet should map the subnet the test machine's
+      primary IP lives in (the one DNS resolves to).  The virtual_subnet must have a
+      shorter prefix (i.e., larger than the machine_subnet).  If there are multiple
+      machine_subnets, they cannot map into the same virtual_subnet.
+
+    - Each machine gets an IP in the virtual_subset statically configured by the vip
+      task. This lets all test machines reach each other and (most importantly) any
+      virtual IPs.
+
+    - 1 or more virtual IPs are then mapped for the task.  These IPs are chosen based
+      on one of the remotes.  This uses a lot of network space but it avoids any
+      conflicts between tests.
+
+    To use a virtual IP, the {{VIP0}}, {{VIP1}}, etc. substitutions can be used.
+    
+    {{VIPSUBNET}} is the virtual_subnet address (10.0.0.0 in the example).
+
+    {{VIPPREFIXLEN}} is the virtual_subnet prefix (16 in the example.
+
+    These substitutions work for vip.echo, and (at the time of writing) cephadm.apply
+    and cephadm.shell.
+    """
+    if config is None:
+        config = {}
+    count = config.get('count', 1)
+
+    ctx.vip_static = {}
+    ctx.vip = {}
+
+    log.info("Allocating static IPs for each host...")
+    for remote in ctx.cluster.remotes.keys():
+        ip = remote.ssh.get_transport().getpeername()[0]
+        log.info(f'peername {ip}')
+        mip = ipaddress.ip_address(ip)
+        vnet, vips = map_vips(mip, count + 1)
+        static = vips.pop(0)
+        log.info(f"{remote.hostname} static {static}, vnet {vnet}")
+
+        if not ctx.vip:
+            # do this only once (use the first remote we see), since we only need 1
+            # set of virtual IPs, regardless of how many remotes we have.
+            log.info("VIPs are {map(str, vips)}")
+            ctx.vip = {
+                'vnet': vnet,
+                'vips': vips,
+            }
+        else:
+            # all remotes must be in the same virtual network...
+            assert vnet == ctx.vip['vnet']
+
+        # pick interface
+        p = re.compile(r'^(\S+) dev (\S+) (.*)scope link (.*)src (\S+)')
+        iface = None
+        for line in remote.sh(['sudo', 'ip','route','ls']).splitlines():
+            m = p.findall(line)
+            if not m:
+                continue
+            route_iface = m[0][1]
+            route_ip = m[0][4]
+            if route_ip == ip:
+                iface = route_iface
+                break
+
+        if not iface:
+            log.error(f"Unable to find {remote.hostname} interface for {ip}")
+            continue
+
+        # configure
+        log.info(f"Configuring {static} on {remote.hostname} iface {iface}...")
+        remote.sh(['sudo',
+                   'ip', 'addr', 'add',
+                   str(static) + '/' + str(vnet.prefixlen),
+                   'dev', iface])
+
+        ctx.vip_static[remote] = {
+            "iface": iface,
+            "static": static,
+        }
+
+    try:
+        yield
+
+    finally:
+        for remote, m in ctx.vip_static.items():
+            log.info(f"Removing {m['static']} (and any VIPs) on {remote.hostname} iface {m['iface']}...")
+            remote.sh(['sudo',
+                       'ip', 'addr', 'del',
+                       str(m['static']) + '/' + str(ctx.vip['vnet'].prefixlen),
+                       'dev', m['iface']])
+
+            for vip in ctx.vip['vips']:
+                remote.sh(
+                    [
+                        'sudo',
+                        'ip', 'addr', 'del',
+                        str(vip) + '/' + str(ctx.vip['vnet'].prefixlen),
+                        'dev', m['iface']
+                    ],
+                    check_status=False,
+                )
+            

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3839,6 +3839,7 @@ def prepare_bootstrap_config(
     cp.set('global', 'fsid', fsid)
     cp.set('global', 'mon_host', mon_addr)
     cp.set('global', 'container_image', image)
+
     if not cp.has_section('mon'):
         cp.add_section('mon')
     if (
@@ -3846,6 +3847,30 @@ def prepare_bootstrap_config(
             and not cp.has_option('mon', 'auth allow insecure global id reclaim')
     ):
         cp.set('mon', 'auth_allow_insecure_global_id_reclaim', 'false')
+
+    if ctx.single_host_defaults:
+        logger.info('Adjusting default settings to suit single-host cluster...')
+        # replicate across osds, not hosts
+        if (
+                not cp.has_option('global', 'osd_crush_choose_leaf_type')
+                and not cp.has_option('global', 'osd crush choose leaf type')
+        ):
+            cp.set('global', 'osd_crush_choose_leaf_type', '0')
+        # replica 2x
+        if (
+                not cp.has_option('global', 'osd_pool_default_size')
+                and not cp.has_option('global', 'osd pool default size')
+        ):
+            cp.set('global', 'osd_pool_default_size', '2')
+        # disable mgr standby modules (so we can colocate multiple mgrs on one host)
+        if not cp.has_section('mgr'):
+            cp.add_section('mgr')
+        if (
+                not cp.has_option('mgr', 'mgr_standby_modules')
+                and not cp.has_option('mgr', 'mgr standby modules')
+        ):
+            cp.set('mgr', 'mgr_standby_modules', 'false')
+
     cpf = StringIO()
     cp.write(cpf)
     config = cpf.getvalue()
@@ -7771,6 +7796,10 @@ def _get_parser():
     parser_bootstrap.add_argument(
         '--cluster-network',
         help='subnet to use for cluster replication, recovery and heartbeats (in CIDR notation network/mask)')
+    parser_bootstrap.add_argument(
+        '--single-host-defaults',
+        action='store_true',
+        help='adjust configuration defaults to suit a single-host cluster')
 
     parser_deploy = subparsers.add_parser(
         'deploy', help='deploy a daemon')

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -5385,10 +5385,13 @@ def command_rm_cluster(ctx):
                       ctx.unit_dir + '/ceph-%s.target.wants' % ctx.fsid])
     # rm data
     call_throws(ctx, ['rm', '-rf', ctx.data_dir + '/' + ctx.fsid])
-    # rm logs
-    call_throws(ctx, ['rm', '-rf', ctx.log_dir + '/' + ctx.fsid])
-    call_throws(ctx, ['rm', '-rf', ctx.log_dir +  # noqa: W504
-                      '/*.wants/ceph-%s@*' % ctx.fsid])
+
+    if not ctx.keep_logs:
+        # rm logs
+        call_throws(ctx, ['rm', '-rf', ctx.log_dir + '/' + ctx.fsid])
+        call_throws(ctx, ['rm', '-rf', ctx.log_dir +  # noqa: W504
+                          '/*.wants/ceph-%s@*' % ctx.fsid])
+
     # rm logrotate config
     call_throws(ctx, ['rm', '-f', ctx.logrotate_dir + '/ceph-%s' % ctx.fsid])
 
@@ -7480,6 +7483,10 @@ def _get_parser():
         '--force',
         action='store_true',
         help='proceed, even though this may destroy valuable data')
+    parser_rm_cluster.add_argument(
+        '--keep-logs',
+        action='store_true',
+        help='do not remove log files')
 
     parser_run = subparsers.add_parser(
         'run', help='run a ceph daemon, in a container, in the foreground')

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2540,7 +2540,14 @@ def deploy_daemon(ctx, fsid, daemon_type, daemon_id, c, uid, gid,
 
     ports = ports or []
     if any([port_in_use(ctx, port) for port in ports]):
-        raise Error("TCP Port(s) '{}' required for {} already in use".format(','.join(map(str, ports)), daemon_type))
+        if daemon_type == 'mgr':
+            # non-fatal for mgr when we are in mgr_standby_modules=false, but we can't
+            # tell whether that is the case here.
+            logger.warning(
+                f"ceph-mgr TCP port(s) {','.join(map(str, ports))} already in use"
+            )
+        else:
+            raise Error("TCP Port(s) '{}' required for {} already in use".format(','.join(map(str, ports)), daemon_type))
 
     data_dir = get_data_dir(fsid, ctx.data_dir, daemon_type, daemon_id)
     if reconfig and not os.path.exists(data_dir):

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -7814,6 +7814,17 @@ options:
   default: @CEPH_INSTALL_DATADIR@/mgr
   services:
   - mgr
+- name: mgr_standby_modules
+  type: bool
+  default: true
+  level: advanced
+  desc: Start modules in standby (redirect) mode when mgr is standby
+  long_desc: By default, the standby modules will answer incoming requests with a
+    HTTP redirect to the active manager, allowing users to point their browser at any
+    mgr node and find their way to an active mgr.  However, this mode is problematic
+    when using a load balancer because (1) the redirect locations are usually private
+    IPs and (2) the load balancer can't identify which mgr is the right one to send
+    traffic to. If a load balancer is being used, set this to false.
 - name: mgr_disabled_modules
   type: str
   level: advanced

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -425,7 +425,8 @@ void MgrStandby::handle_mgr_map(ref_t<MMgrMap> mmap)
     if (map.active_gid != 0 && map.active_name != g_conf()->name.get_id()) {
       // I am the standby and someone else is active, start modules
       // in standby mode to do redirects if needed
-      if (!py_module_registry.is_standby_running()) {
+      if (!py_module_registry.is_standby_running() &&
+	  g_conf().get_val<bool>("mgr_standby_modules")) {
         py_module_registry.standby_start(monc, finisher);
       }
     }

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -116,6 +116,8 @@ int MgrStandby::init()
   init_async_signal_handler();
   register_async_signal_handler(SIGHUP, sighup_handler);
 
+  cct->_conf.add_observer(this);
+
   std::lock_guard l(lock);
 
   // Start finisher

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -75,6 +75,7 @@ const char** MgrStandby::get_tracked_conf_keys() const
     "clog_to_graylog",
     "clog_to_graylog_host",
     "clog_to_graylog_port",
+    "mgr_standby_modules",
     "host",
     "fsid",
     NULL
@@ -96,6 +97,17 @@ void MgrStandby::handle_conf_change(
       changed.count("host") ||
       changed.count("fsid")) {
     _update_log_config();
+  }
+  if (changed.count("mgr_standby_modules") && !active_mgr) {
+    if (g_conf().get_val<bool>("mgr_standby_modules") != py_module_registry.have_standby_modules()) {
+      dout(1) << "mgr_standby_modules now "
+	      << (int)g_conf().get_val<bool>("mgr_standby_modules")
+	      << ", standby modules are "
+	      << (py_module_registry.have_standby_modules() ? "":"not ")
+	      << "active, respawning"
+	      << dendl;
+      respawn();
+    }
   }
 }
 

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -98,6 +98,10 @@ public:
    */
   bool handle_mgr_map(const MgrMap &mgr_map_);
 
+  bool have_standby_modules() const {
+    return !!standby_modules;
+  }
+
   void init();
 
   void upgrade_config(

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -544,17 +544,6 @@ class CephadmServe:
             # host
             return len(self.mgr.cache.networks[host].get(public_network, [])) > 0
 
-        def virtual_ip_allowed(host):
-            # type: (str) -> bool
-            # Verify that it is possible to use Virtual IPs in the host
-            try:
-                if self.mgr.cache.facts[host]['kernel_parameters']['net.ipv4.ip_nonlocal_bind'] == '0':
-                    return False
-            except KeyError:
-                return False
-
-            return True
-
         ha = HostAssignment(
             spec=spec,
             hosts=self.mgr._hosts_with_daemon_inventory(),
@@ -562,7 +551,6 @@ class CephadmServe:
             networks=self.mgr.cache.networks,
             filter_new_host=(
                 matches_network if service_type == 'mon'
-                else virtual_ip_allowed if service_type == 'ingress'
                 else None
             ),
             allow_colo=svc.allow_colo(),

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -551,6 +551,18 @@ class MonService(CephService):
 class MgrService(CephService):
     TYPE = 'mgr'
 
+    def allow_colo(self) -> bool:
+        if self.mgr.get_ceph_option('mgr_standby_modules'):
+            # traditional mgr mode: standby daemons' modules listen on
+            # ports and redirect to the primary.  we must not schedule
+            # multiple mgrs on the same host or else ports will
+            # conflict.
+            return False
+        else:
+            # standby daemons do nothing, and therefore port conflicts
+            # are not a concern.
+            return True
+
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
         """
         Create a new manager instance on a host.

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -1067,7 +1067,7 @@ class ServiceDescription(object):
     def get_port_summary(self) -> str:
         if not self.ports:
             return ''
-        return f"{self.virtual_ip or '?'}:{','.join(map(str, self.ports or []))}"
+        return f"{(self.virtual_ip or '?').split('/')[0]}:{','.join(map(str, self.ports or []))}"
 
     def to_json(self) -> OrderedDict:
         out = self.spec.to_json()


### PR DESCRIPTION
Normally the standby mgr modules bind to ports and forward to the active mgr.  Add an option to disable that.

Modify cephadm so that it can colocate mgrs on the same host when standby modules are disabled.




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>