### PR TITLE
nautilus: mgr/dashboard: debug nodeenv hangs

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -67,7 +67,7 @@ build_dashboard_frontend() {
 
   $CURR_DIR/src/tools/setup-virtualenv.sh $TEMP_DIR
   $TEMP_DIR/bin/pip install nodeenv
-  $TEMP_DIR/bin/nodeenv -p --node=10.13.0
+  $TEMP_DIR/bin/nodeenv --verbose -p --node=10.13.0
   cd src/pybind/mgr/dashboard/frontend
 
   DEFAULT_LANG=`jq -r .config.locale package.json`

--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -43,7 +43,7 @@ else()
     OUTPUT "${mgr-dashboard-nodeenv-dir}/bin/npm"
     COMMAND ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python=${MGR_PYTHON_EXECUTABLE} ${mgr-dashboard-nodeenv-dir}
     COMMAND ${mgr-dashboard-nodeenv-dir}/bin/pip install nodeenv
-    COMMAND ${mgr-dashboard-nodeenv-dir}/bin/nodeenv -p --node=10.13.0
+    COMMAND ${mgr-dashboard-nodeenv-dir}/bin/nodeenv --verbose -p --node=10.13.0
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "dashboard nodeenv is being installed"
   )


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50172

---

backport of https://github.com/ceph/ceph/pull/40616
parent tracker: https://tracker.ceph.com/issues/50044

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh