### PR TITLE
pacific: rgw: radoslist incomplete multipart parts marker

### DIFF
--- a/qa/workunits/rgw/test_rgw_orphan_list.sh
+++ b/qa/workunits/rgw/test_rgw_orphan_list.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-set -ex
+# set -x
+set -e
 
 # if defined, debug messages will be displayed and prepended with the string
 # debug="DEBUG"
 
-huge_size=2222 # in megabytes
-big_size=6 # in megabytes
+huge_size=5100 # in megabytes
+big_size=7 # in megabytes
 
 huge_obj=/tmp/huge_obj.temp.$$
 big_obj=/tmp/big_obj.temp.$$
@@ -160,7 +161,6 @@ mys3uploadkill() {
 	exit 1
     fi
 
-    set -v
     local_file="$1"
     remote_bkt="$2"
     remote_obj="$3"
@@ -229,8 +229,16 @@ mys3cmd ls s3://multipart-bkt
 bkt="incomplete-mp-bkt-1"
 
 mys3cmd mb s3://$bkt
-mys3uploadkill $huge_obj $bkt incomplete-mp-obj-1 $fifo 20
-mys3uploadkill $huge_obj $bkt incomplete-mp-obj-2 $fifo 100
+
+mys3uploadkill $huge_obj $bkt incomplete-mp-obj-c $fifo 20
+
+# generate an incomplete multipart with more than 1,000 parts
+mys3uploadkill $huge_obj $bkt incomplete-mp-obj-b $fifo 1005
+
+# generate more than 1000 incomplet multiparts
+for c in $(seq 1005) ;do
+    mys3uploadkill $huge_obj $bkt incomplete-mp-obj-c-$c $fifo 3
+done
 
 ####################################
 # resharded bucket

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -1500,7 +1500,7 @@ int RGWRadosList::do_incomplete_multipart(
 			       &is_listing_truncated, null_yield);
     if (ret == -ENOENT) {
       // could bucket have been removed while this is running?
-      ldpp_dout(dpp, 20) << "RGWRadosList::" << __func__ <<
+      ldpp_dout(dpp, 5) << "RGWRadosList::" << __func__ <<
 	": WARNING: call to list_objects of multipart namespace got ENOENT; "
 	"assuming bucket removal race" << dendl;
       break;
@@ -1527,22 +1527,28 @@ int RGWRadosList::do_incomplete_multipart(
       }
 
       // now process the uploads vector
-      int parts_marker = 0;
-      bool is_parts_truncated = false;
-      do {
-	map<uint32_t, RGWUploadPartInfo> parts;
+      for (const auto& upload : uploads) {
+	const RGWMPObj& mp = upload.mp;
+	int parts_marker = 0;
+	bool is_parts_truncated = false;
 
-	for (const auto& upload : uploads) {
-	  const RGWMPObj& mp = upload.mp;
+
+	do { // while (is_parts_truncated);
+	  std::map<uint32_t, RGWUploadPartInfo> parts;
 	  ret = list_multipart_parts(dpp, store, bucket_info, store->ctx(),
 				     mp.get_upload_id(), mp.get_meta(),
-				     max_parts,
-				     parts_marker, parts, NULL, &is_parts_truncated);
+				     max_parts, parts_marker,
+				     parts, &parts_marker,
+				     &is_parts_truncated);
 	  if (ret == -ENOENT) {
-	    continue;
+	    ldpp_dout(dpp, 5) << "RGWRadosList::" << __func__ <<
+	      ": WARNING: list_multipart_parts returned ret=-ENOENT "
+	      "for " << mp.get_upload_id() << ", moving on" << dendl;
+	    break;
 	  } else if (ret < 0) {
 	    ldpp_dout(dpp, -1) << "RGWRadosList::" << __func__ <<
-	      ": ERROR: list_multipart_parts returned ret=" << ret << dendl;
+	      ": ERROR: list_multipart_parts returned ret=" << ret <<
+	      dendl;
 	    return ret;
 	  }
 
@@ -1554,10 +1560,10 @@ int RGWRadosList::do_incomplete_multipart(
 	      const rgw_raw_obj& loc =
 		obj_it.get_location().get_raw_obj(store);
 	      std::cout << loc.oid << std::endl;
-	    }
-	  }
-	}
-      } while (is_parts_truncated);
+	    } // for (auto obj_it
+	  } // for (auto& p
+	} while (is_parts_truncated);
+      } // for (const auto& upload
     } // if objs not empty
   } while (is_listing_truncated);
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50301

---

backport of https://github.com/ceph/ceph/pull/40801
parent tracker: https://tracker.ceph.com/issues/50293

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh