### PR TITLE
pacific: qa/suites/krbd: don't require CEPHX_V2 for unmap subsuite

### DIFF
--- a/qa/suites/krbd/unmap/ceph/ceph.yaml
+++ b/qa/suites/krbd/unmap/ceph/ceph.yaml
@@ -5,6 +5,8 @@ overrides:
     mon_bind_msgr2: false
     conf:
       global:
+        cephx require version: 1
+        cephx service require version: 1
         ms bind msgr2: false
 tasks:
 - install:


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/40576.