### PR TITLE
nautilus: rgw: radoslist incomplete multipart parts marker

### DIFF
--- a/qa/workunits/rgw/test_rgw_orphan_list.sh
+++ b/qa/workunits/rgw/test_rgw_orphan_list.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-set -ex
+# set -x
+set -e
 
 # if defined, debug messages will be displayed and prepended with the string
 # debug="DEBUG"
 
-huge_size=2222 # in megabytes
-big_size=6 # in megabytes
+huge_size=5100 # in megabytes
+big_size=7 # in megabytes
 
 huge_obj=/tmp/huge_obj.temp.$$
 big_obj=/tmp/big_obj.temp.$$
@@ -160,7 +161,6 @@ mys3uploadkill() {
 	exit 1
     fi
 
-    set -v
     local_file="$1"
     remote_bkt="$2"
     remote_obj="$3"
@@ -229,8 +229,16 @@ mys3cmd ls s3://multipart-bkt
 bkt="incomplete-mp-bkt-1"
 
 mys3cmd mb s3://$bkt
-mys3uploadkill $huge_obj $bkt incomplete-mp-obj-1 $fifo 20
-mys3uploadkill $huge_obj $bkt incomplete-mp-obj-2 $fifo 100
+
+mys3uploadkill $huge_obj $bkt incomplete-mp-obj-c $fifo 20
+
+# generate an incomplete multipart with more than 1,000 parts
+mys3uploadkill $huge_obj $bkt incomplete-mp-obj-b $fifo 1005
+
+# generate more than 1000 incomplet multiparts
+for c in $(seq 1005) ;do
+    mys3uploadkill $huge_obj $bkt incomplete-mp-obj-c-$c $fifo 3
+done
 
 ####################################
 # resharded bucket


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50300

---

backport of https://github.com/ceph/ceph/pull/40801
parent tracker: https://tracker.ceph.com/issues/50293

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh