### PR TITLE
qa/suites/rados/thrash: shorten radosbench

### DIFF
--- a/qa/suites/rados/thrash/workloads/radosbench.yaml
+++ b/qa/suites/rados/thrash/workloads/radosbench.yaml
@@ -22,12 +22,3 @@ tasks:
   - radosbench:
       clients: [client.0]
       time: 90
-  - radosbench:
-      clients: [client.0]
-      time: 90
-  - radosbench:
-      clients: [client.0]
-      time: 90
-  - radosbench:
-      clients: [client.0]
-      time: 90


### PR DESCRIPTION
This is the longest of the thrash workloads; reducing it will bring
this test in line with the others (<= 45 min).

Signed-off-by: Sage Weil <sage@newdream.net>