### PR TITLE
cmake: update civetweb.h on demand

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -1,9 +1,14 @@
-add_custom_target(civetweb_h
+set(civetweb_h
+  "${CMAKE_BINARY_DIR}/src/include/civetweb/civetweb.h")
+
+add_custom_command(
+  OUTPUT ${civetweb_h}
   COMMAND ${CMAKE_COMMAND} -E make_directory
-  "${CMAKE_BINARY_DIR}/src/include/civetweb"
+    "${CMAKE_BINARY_DIR}/src/include/civetweb"
   COMMAND ${CMAKE_COMMAND} -E copy_if_different
-  "${CMAKE_SOURCE_DIR}/src/civetweb/include/civetweb.h"
-  "${CMAKE_BINARY_DIR}/src/include/civetweb"
+    "${CMAKE_SOURCE_DIR}/src/civetweb/include/civetweb.h"
+    ${civetweb_h}
+  DEPENDS "${CMAKE_SOURCE_DIR}/src/civetweb/include/civetweb.h"
   COMMENT "keep civetweb.h up-to-date")
 
 find_program(GPERF gperf)
@@ -231,7 +236,8 @@ set(rgw_a_srcs
   rgw_usage.cc
   rgw_opa.cc
   rgw_sts.cc
-  rgw_rest_sts.cc)
+  rgw_rest_sts.cc
+  ${civetweb_h})
 
 gperf_generate(${CMAKE_SOURCE_DIR}/src/rgw/rgw_iam_policy_keywords.gperf
   rgw_iam_policy_keywords.frag.cc)
@@ -247,8 +253,6 @@ endif()
 add_library(rgw_a STATIC
     ${rgw_a_srcs}
     $<TARGET_OBJECTS:rgw_common>)
-
-add_dependencies(rgw_a civetweb_h)
 
 target_compile_definitions(rgw_a PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
 target_include_directories(rgw_a PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src")
@@ -305,7 +309,8 @@ set(radosgw_srcs
   rgw_loadgen_process.cc
   rgw_civetweb.cc
   rgw_civetweb_frontend.cc
-  rgw_civetweb_log.cc)
+  rgw_civetweb_log.cc
+  ${civetweb_h})
 if (WITH_RADOSGW_FCGI_FRONTEND)
   list(APPEND radosgw_srcs rgw_fcgi_process.cc)
 endif()
@@ -325,8 +330,6 @@ target_link_libraries(rgw_schedulers
 add_library(radosgw SHARED ${radosgw_srcs} ${rgw_a_srcs} rgw_main.cc
   $<TARGET_OBJECTS:rgw_kmip>
   $<TARGET_OBJECTS:civetweb_common_objs>)
-
-add_dependencies(radosgw civetweb_h)
 
 target_compile_definitions(radosgw PUBLIC "-DCLS_CLIENT_HIDE_IOCTX")
 target_include_directories(radosgw PUBLIC "${CMAKE_SOURCE_DIR}/src/dmclock/support/src")


### PR DESCRIPTION
instead of using a dedicated target for updating civetweb.h, use
add_custom_command() with OUTPUT option.

so the generated rule does not rerun the command specified by the
civetweb_h target every time we build the targets depending on it.

use the header file as the dependency helps to improve the readability
as there is one less link in the dependency chain, and by specifying the
OUTPUT, cmake is able to figure out the dependency on the header file so
it does not try to regenerate it every time.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
