### PR TITLE
pacific: doc/cephadm: curl-based-installation link correction

### DIFF
--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -45,7 +45,7 @@ curl-based installation
   
   .. prompt:: bash #
 
-   curl --silent --remote-name --location https://github.com/ceph/ceph/raw/octopus/src/cephadm/cephadm
+   curl --silent --remote-name --location https://github.com/ceph/ceph/raw/pacific/src/cephadm/cephadm
 
   Make the ``cephadm`` script executable:
 


### PR DESCRIPTION
the link in the curl command here https://docs.ceph.com/en/pacific/cephadm/install/#curl-based-installation currently points to https://github.com/ceph/ceph/raw/****octopus****/src/cephadm/cephadm

should be https://github.com/ceph/ceph/raw/pacific/src/cephadm/cephadm

Fixes: https://tracker.ceph.com/issues/50362
Signed-off-by: Daniel Pivonka <dpivonka@redhat.com>

