### PR TITLE
bluestore: revert to basic locking if a OS does not have F_OFD_SETLK

### DIFF
--- a/src/blk/kernel/KernelDevice.cc
+++ b/src/blk/kernel/KernelDevice.cc
@@ -94,8 +94,8 @@ int KernelDevice::_lock()
   int fd = fd_directs[WRITE_LIFE_NOT_SET];
   uint64_t nr_tries = 0;
   for (;;) {
-    struct flock fl = { F_WRLCK,
-                        SEEK_SET };
+    struct flock fl = { .l_type = F_WRLCK,
+                        .l_whence = SEEK_SET };
     int r = ::fcntl(fd, F_OFD_SETLK, &fl);
     if (r < 0) {
       if (errno == EINVAL) {

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -21,6 +21,11 @@
 #define PROCPREFIX
 #endif
 
+#include <fcntl.h>
+#ifndef F_OFD_SETLK
+#define F_OFD_SETLK F_SETLK 
+#endif 
+
 #include <sys/stat.h>
 #ifndef ACCESSPERMS
 #define ACCESSPERMS (S_IRWXU|S_IRWXG|S_IRWXO)


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>