### PR TITLE
rgw: Add ipsec_mb crypto accelerator plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -81,3 +81,7 @@
 	path = src/libkmip
 	url = https://github.com/ceph/libkmip
 	branch = ceph-master
+[submodule "src/crypto/ipsec_mb/intel-ipsec-mb"]
+    path = src/crypto/ipsec_mb/intel-ipsec-mb
+    url = https://github.com/intel/intel-ipsec-mb
+    branch = v0.55

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -3,6 +3,8 @@ set(crypto_plugin_dir ${CEPH_INSTALL_PKGLIBDIR}/crypto)
 
 add_subdirectory(openssl)
 
+add_subdirectory(ipsec_mb)
+
 if(HAVE_INTEL AND HAVE_NASM_X64_AVX2 AND (NOT APPLE))
   add_subdirectory(isa-l)
 endif()

--- a/src/crypto/crypto_accel.h
+++ b/src/crypto/crypto_accel.h
@@ -20,6 +20,18 @@
 class CryptoAccel;
 typedef std::shared_ptr<CryptoAccel> CryptoAccelRef;
 
+class CryptoEngine {
+ public:
+  static const int AES_256_KEYSIZE = 256 / 8;
+  unsigned char m_key[AES_256_KEYSIZE];
+
+  CryptoEngine() {}
+  CryptoEngine(const unsigned char(&key)[AES_256_KEYSIZE]) {
+    memcpy(m_key, key, sizeof(key));
+  }
+  virtual ~CryptoEngine() {}
+};
+
 class CryptoAccel {
  public:
   CryptoAccel() {}
@@ -33,5 +45,28 @@ class CryptoAccel {
   virtual bool cbc_decrypt(unsigned char* out, const unsigned char* in, size_t size,
                    const unsigned char (&iv)[AES_256_IVSIZE],
                    const unsigned char (&key)[AES_256_KEYSIZE]) = 0;
+
+  /*
+  * Operate on multiple buffers in parallel and flush at the end, aim to promote performance.
+  * Need to configure ipsec as the accelerator, refer to:
+  *  - option: plugin_crypto_accelerator
+  *  - value: crypto_ipsec
+  *
+  * Others like openssl/isa-l/QAT don't have multi-buffer functionality, so switch to traditional interface
+  */
+  virtual CryptoEngine* get_engine(const unsigned char(&key)[AES_256_KEYSIZE]) { return new CryptoEngine(key); }
+  virtual void put_engine(CryptoEngine* eng) { delete eng; }
+
+  virtual bool flush(CryptoEngine* engine) { return true; }
+  virtual bool cbc_encrypt_mb(CryptoEngine* engine, unsigned char* out, const unsigned char* in, size_t size,
+    const unsigned char(&iv)[AES_256_IVSIZE]) {
+    if (!engine) return false;
+    return cbc_encrypt(out, in, size, iv, engine->m_key);
+  };
+  virtual bool cbc_decrypt_mb(CryptoEngine* engine, unsigned char* out, const unsigned char* in, size_t size,
+    const unsigned char(&iv)[AES_256_IVSIZE]) {
+    if (!engine) return false;
+    return cbc_decrypt(out, in, size, iv, engine->m_key);
+  };
 };
 #endif

--- a/src/crypto/ipsec_mb/CMakeLists.txt
+++ b/src/crypto/ipsec_mb/CMakeLists.txt
@@ -1,0 +1,32 @@
+set(ipsec_dir ${CMAKE_SOURCE_DIR}/src/crypto/ipsec_mb/intel-ipsec-mb/lib)
+set(CMAKE_ASM_FLAGS "-i ${ipsec_dir}/include/ ${CMAKE_ASM_FLAGS}")
+
+add_custom_target(ipsec_mb_so ALL
+	COMMAND bash -c "make OBJ_DIR=${CMAKE_BINARY_DIR}/src/crypto/ipsec_mb/obj LIB_DIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+	WORKING_DIRECTORY ${ipsec_dir}
+	COMMENT "build libIPSec_MB.so")
+
+set(ipsec_crypto_plugin_srcs
+  ipsec_crypto_accel.cc
+  ipsec_crypto_plugin.cc)
+
+if(HAVE_NASM_X64)
+add_dependencies(crypto_plugins ceph_crypto_ipsec)
+endif(HAVE_NASM_X64)
+
+link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+
+add_library(ceph_crypto_ipsec SHARED ${ipsec_crypto_plugin_srcs})
+add_dependencies(ceph_crypto_ipsec ipsec_mb_so)
+target_link_libraries(ceph_crypto_ipsec IPSec_MB)
+target_include_directories(ceph_crypto_ipsec PRIVATE ${ipsec_dir}/include)
+set_target_properties(ceph_crypto_ipsec PROPERTIES
+  VERSION 1.0.0
+  SOVERSION 1
+  INSTALL_RPATH "")
+install(TARGETS ceph_crypto_ipsec DESTINATION ${crypto_plugin_dir})
+install(FILES
+	${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libIPSec_MB.so.0.55.0
+	${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libIPSec_MB.so.0
+	${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libIPSec_MB.so
+	DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/crypto/ipsec_mb/ipsec_crypto_accel.cc
+++ b/src/crypto/ipsec_mb/ipsec_crypto_accel.cc
@@ -1,0 +1,245 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2021 Intel Corporation
+ *
+ * Author: Liang Fang <liang.a.fang@intel.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+#include "crypto/ipsec_mb/ipsec_crypto_accel.h"
+
+IPSECCryptoEngine::IPSECCryptoEngine() {
+  bool ret = false;
+
+  ret = detect_arch_and_init_mgr();
+  if (!ret)
+    return;
+}
+
+IPSECCryptoEngine::IPSECCryptoEngine(const unsigned char(&key)[AES_256_KEYSIZE]) {
+  bool ret = false;
+
+  ret = detect_arch_and_init_mgr();
+  if (!ret)
+    return;
+
+  set_key(key);
+}
+
+IPSECCryptoEngine::~IPSECCryptoEngine() {
+  if (m_mgr)
+    free_mb_mgr(m_mgr);
+}
+
+void IPSECCryptoEngine::set_key(const unsigned char(&key)[AES_256_KEYSIZE]) {
+  if(memcmp(m_key, key, AES_256_KEYSIZE)) { //key changed
+    memcpy(m_key, key, sizeof(key));
+    IMB_AES_KEYEXP_256(m_mgr, m_key, enc_keys, dec_keys);
+  }
+}
+
+bool IPSECCryptoEngine::detect_arch_and_init_mgr()
+{
+  const uint64_t detect_avx = IMB_FEATURE_AVX | IMB_FEATURE_CMOV | IMB_FEATURE_AESNI;
+  const uint64_t detect_avx2 = IMB_FEATURE_AVX2 | detect_avx;
+  const uint64_t detect_avx512 = IMB_FEATURE_AVX512_SKX | detect_avx2;
+
+  if (m_mgr)
+    return true;
+
+  m_mgr = alloc_mb_mgr(0);
+  if (m_mgr == NULL) {
+    return false;
+  }
+
+  if ((m_mgr->features & detect_avx512) == detect_avx512)
+    init_mb_mgr_avx512(m_mgr);
+  else if ((m_mgr->features & detect_avx2) == detect_avx2)
+    init_mb_mgr_avx2(m_mgr);
+  else if ((m_mgr->features & detect_avx) == detect_avx)
+    init_mb_mgr_avx(m_mgr);
+  else
+    init_mb_mgr_sse(m_mgr);
+
+  return true;
+}
+
+bool IPSECCryptoAccel::cbc_encrypt(unsigned char* out, const unsigned char* in, size_t size,
+                             const unsigned char (&iv)[AES_256_IVSIZE],
+                             const unsigned char (&key)[AES_256_KEYSIZE])
+{
+  CryptoEngine* engine = get_engine(key);
+  bool ret;
+
+  ret = cbc_encrypt_mb(engine, out, in, size, iv);
+  flush(engine);
+  put_engine(engine);
+
+  return ret;
+}
+
+bool IPSECCryptoAccel::cbc_decrypt(unsigned char* out, const unsigned char* in, size_t size,
+                             const unsigned char (&iv)[AES_256_IVSIZE],
+                             const unsigned char (&key)[AES_256_KEYSIZE])
+{
+  CryptoEngine* engine = get_engine(key);
+  bool ret;
+
+  ret = cbc_decrypt_mb(engine, out, in, size, iv);
+  flush(engine);
+  put_engine(engine);
+
+  return ret;
+}
+
+/*
+ * global variables for getting engine
+ *
+ * get_engine is called very frequently, so should make it efficient:
+ * - Don't put these variables inside get_engine as static, otherwise compiler will
+ *   add instructions to check if the variables been initialized or not
+ * - Don't use locks such as mutex, otherwise thread may be scheduled out, use atomic instead
+ */
+#define MAX_ENG 256                     //256 is a big enough CPU core number
+static IPSECCryptoEngine engs[MAX_ENG]; //array is most efficient
+static std::atomic<int> initer = 0;     //Only initer 1 win the right to do initialization
+static std::atomic<int> inited = 0;     //1: inited 0: not yet
+static std::atomic<int> last_i = 0;     //last index of engine that in-use, get next engine from last_i+1
+CryptoEngine* IPSECCryptoAccel::get_engine(const unsigned char(&key)[AES_256_KEYSIZE])
+{
+  int i;
+
+  if(initer == 0) {
+    if((++initer) == 1) { //returned 1, I'm the right initer
+      //do initialization
+      for(i=0; i<MAX_ENG; i++) {
+        engs[i].in_use.clear();
+        engs[i].set_key(key);	//initialize the key, in future can just compare the key
+      }
+
+      //open the door
+      inited = 1;
+    }
+  }
+
+  while(inited != 1){} //wait for the door to be opened
+
+  //find free engine
+  for(i=(last_i+1)%MAX_ENG;;i=(i+1)%MAX_ENG) {
+    if(!engs[i].in_use.test_and_set()){  //found a free one and already accupied by me after this line
+      last_i = i;                        //i may not be the lastest one, but worthless to make it accurate
+      engs[i].set_key(key);
+      break;
+    }
+  }
+  return &engs[i];
+}
+
+void IPSECCryptoAccel::put_engine(CryptoEngine* eng)
+{
+  IPSECCryptoEngine* ipsec = (IPSECCryptoEngine*)eng;
+  ipsec->in_use.clear();
+}
+
+bool IPSECCryptoAccel::flush(CryptoEngine* engine)
+{
+  IPSECCryptoEngine* ipsec_engine = (IPSECCryptoEngine *)engine;
+  if (!ipsec_engine || !ipsec_engine->m_mgr)
+    return false;
+
+  while (IMB_FLUSH_JOB(ipsec_engine->m_mgr))
+    ;
+  return true;
+}
+
+bool IPSECCryptoAccel::cbc_encrypt_mb(CryptoEngine* engine, unsigned char* out, const unsigned char* in, size_t size,
+  const unsigned char(&iv)[AES_256_IVSIZE])
+{
+  struct IMB_JOB* job;
+  int err;
+  IPSECCryptoEngine* ipsec_engine = (IPSECCryptoEngine *)engine;
+  if (!ipsec_engine || !ipsec_engine->m_mgr)
+    return false;
+
+  job = IMB_GET_NEXT_JOB(ipsec_engine->m_mgr);
+  if (job == NULL)
+    return false;
+  job->cipher_direction = IMB_DIR_ENCRYPT;
+  job->chain_order = IMB_ORDER_CIPHER_HASH;
+  job->dst = out;
+  job->src = in;
+  job->cipher_mode = IMB_CIPHER_CBC;
+  job->enc_keys = ipsec_engine->enc_keys;
+  job->dec_keys = ipsec_engine->dec_keys;
+  job->key_len_in_bytes = AES_256_KEYSIZE;
+
+  job->iv = &iv[0];
+  job->iv_len_in_bytes = AES_256_IVSIZE;
+  job->cipher_start_src_offset_in_bytes = 0;
+  job->msg_len_to_cipher_in_bytes = size;
+  job->hash_alg = IMB_AUTH_NULL;
+  job = IMB_SUBMIT_JOB(ipsec_engine->m_mgr);
+  if (job == NULL) {
+    /* no job returned - check for error */
+    err = imb_get_errno(ipsec_engine->m_mgr);
+    if (err != 0) {
+      return false;
+    }
+  }
+  else {
+    if (job->status != STS_COMPLETED) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool IPSECCryptoAccel::cbc_decrypt_mb(CryptoEngine* engine, unsigned char* out, const unsigned char* in, size_t size,
+  const unsigned char(&iv)[AES_256_IVSIZE])
+{
+  struct IMB_JOB* job;
+  int err;
+  IPSECCryptoEngine* ipsec_engine = (IPSECCryptoEngine*)engine;
+  if (!ipsec_engine || !ipsec_engine->m_mgr)
+    return false;
+
+  job = IMB_GET_NEXT_JOB(ipsec_engine->m_mgr);
+  if (job == NULL)
+    return false;
+  job->cipher_direction = IMB_DIR_DECRYPT;
+  job->chain_order = IMB_ORDER_HASH_CIPHER;
+  job->dst = out;
+  job->src = in;
+  job->cipher_mode = IMB_CIPHER_CBC;
+  job->enc_keys = ipsec_engine->enc_keys;
+  job->dec_keys = ipsec_engine->dec_keys;
+  job->key_len_in_bytes = AES_256_KEYSIZE;
+
+  job->iv = &iv[0];
+  job->iv_len_in_bytes = AES_256_IVSIZE;
+  job->cipher_start_src_offset_in_bytes = 0;
+  job->msg_len_to_cipher_in_bytes = size;
+  job->hash_alg = IMB_AUTH_NULL;
+  job = IMB_SUBMIT_JOB(ipsec_engine->m_mgr);
+  if (job == NULL) {
+    /* no job returned - check for error */
+    err = imb_get_errno(ipsec_engine->m_mgr);
+    if (err != 0) {
+      return false;
+    }
+  }
+  else {
+    if (job->status != STS_COMPLETED) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/crypto/ipsec_mb/ipsec_crypto_accel.h
+++ b/src/crypto/ipsec_mb/ipsec_crypto_accel.h
@@ -1,0 +1,64 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2021 Intel Corporation
+ *
+ * Author: Liang Fang <liang.a.fang@intel.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+#ifndef IPSEC_CRYPTO_ACCEL_H
+#define IPSEC_CRYPTO_ACCEL_H
+#include <atomic>
+#include "crypto/crypto_accel.h"
+#include "crypto/ipsec_mb/intel-ipsec-mb/lib/intel-ipsec-mb.h"
+
+class IPSECCryptoEngine : public CryptoEngine {
+ public:
+  alignas(16) uint32_t enc_keys[15 * 4];
+  alignas(16) uint32_t dec_keys[15 * 4];
+
+  IMB_MGR* m_mgr = NULL;
+  std::atomic_flag in_use;
+ private:
+  bool detect_arch_and_init_mgr();
+ public:
+  IPSECCryptoEngine();
+  IPSECCryptoEngine(const unsigned char(&key)[AES_256_KEYSIZE]);
+  virtual ~IPSECCryptoEngine();
+  void set_key(const unsigned char(&key)[AES_256_KEYSIZE]);
+};
+
+class IPSECCryptoAccel : public CryptoAccel {
+ public:
+  IPSECCryptoAccel() {}
+  virtual ~IPSECCryptoAccel() {}
+
+  bool cbc_encrypt(unsigned char* out, const unsigned char* in, size_t size,
+                   const unsigned char (&iv)[AES_256_IVSIZE],
+                   const unsigned char (&key)[AES_256_KEYSIZE]) override;
+  bool cbc_decrypt(unsigned char* out, const unsigned char* in, size_t size,
+                   const unsigned char (&iv)[AES_256_IVSIZE],
+                   const unsigned char (&key)[AES_256_KEYSIZE]) override;
+
+  /*
+  * Below is the multi-buffer version interface. Comparing with traditional interface listed above:
+  * - In the platform that CPU contains AVX512 instruction set, there's about 6 times
+  *   performance boost.
+  * - In the platform with lasted CPU (e.g. Intel Icelake Xeon) that contains VAES instruction set,
+  *   there's about 10 times performance boost.
+  */
+  CryptoEngine* get_engine(const unsigned char(&key)[AES_256_KEYSIZE]) override;
+  void put_engine(CryptoEngine* eng) override;
+  bool flush(CryptoEngine* engine) override;
+  bool cbc_encrypt_mb(CryptoEngine* engine, unsigned char* out, const unsigned char* in, size_t size,
+    const unsigned char(&iv)[AES_256_IVSIZE]) override;
+  bool cbc_decrypt_mb(CryptoEngine* engine, unsigned char* out, const unsigned char* in, size_t size,
+    const unsigned char(&iv)[AES_256_IVSIZE]) override;
+};
+#endif

--- a/src/crypto/ipsec_mb/ipsec_crypto_plugin.cc
+++ b/src/crypto/ipsec_mb/ipsec_crypto_plugin.cc
@@ -1,0 +1,34 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2021 Intel Corporation
+ *
+ * Author: Liang Fang <liang.a.fang@intel.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+
+// -----------------------------------------------------------------------------
+#include "crypto/ipsec_mb/ipsec_crypto_plugin.h"
+
+#include "ceph_ver.h"
+// -----------------------------------------------------------------------------
+
+const char *__ceph_plugin_version()
+{
+  return CEPH_GIT_NICE_VER;
+}
+
+int __ceph_plugin_init(CephContext *cct,
+                       const std::string& type,
+                       const std::string& name)
+{
+  auto instance = cct->get_plugin_registry();
+
+  return instance->add(type, name, new IPSECCryptoPlugin(cct));
+}

--- a/src/crypto/ipsec_mb/ipsec_crypto_plugin.h
+++ b/src/crypto/ipsec_mb/ipsec_crypto_plugin.h
@@ -1,0 +1,47 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2021 Intel Corporation
+ *
+ * Author: Liang Fang <liang.a.fang@intel.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+#ifndef IPSEC_CRYPTO_PLUGIN_H
+#define IPSEC_CRYPTO_PLUGIN_H
+// -----------------------------------------------------------------------------
+#include "crypto/crypto_plugin.h"
+#include "crypto/ipsec_mb/ipsec_crypto_accel.h"
+#include "arch/intel.h"
+#include "arch/probe.h"
+// -----------------------------------------------------------------------------
+
+
+class IPSECCryptoPlugin : public CryptoPlugin {
+
+public:
+
+  explicit IPSECCryptoPlugin(CephContext* cct) : CryptoPlugin(cct)
+  {}
+  ~IPSECCryptoPlugin()
+  {}
+  virtual int factory(CryptoAccelRef *cs,
+                      std::ostream *ss)
+  {
+    if (cryptoaccel == nullptr)
+    {
+      ceph_arch_probe();
+      if (ceph_arch_intel_aesni && ceph_arch_intel_sse41) {
+        cryptoaccel = CryptoAccelRef(new IPSECCryptoAccel);
+      }
+    }
+    *cs = cryptoaccel;
+    return 0;
+  }
+};
+#endif

--- a/src/crypto/test_crypto_plugins.cc
+++ b/src/crypto/test_crypto_plugins.cc
@@ -1,0 +1,158 @@
+/*
+	- put this file under ceph/src/crypto/..
+	- build:  g++ test_crypto_plugins.cc -o test_crypto_plugins -I.. -I../.. -I../../src -I../../build/include -I../../build/boost/include -std=c++17 -L../../build/lib -lceph_crypto_openssl -lceph_crypto_isal -lceph_crypto_ipsec -lceph-common -lpthread
+	- export LD_LIBRARY_PATH=../../build/lib
+	- ./test_crypto_plugins 
+*/
+#include <iostream>
+#include <string.h>
+#include <sys/time.h>
+#include "openssl/openssl_crypto_accel.h"
+#include "isa-l/isal_crypto_accel.h"
+#include "ipsec_mb/ipsec_crypto_accel.h"
+using namespace std;
+
+//use the same memory for all the tests, this is to make every tests fair
+size_t textlen = (4*1024);
+size_t loop_cnt = (1024*1024*2);
+
+unsigned char* in;
+unsigned char* out_encrypted;
+unsigned char* out_decrypted;
+unsigned char iv[CryptoAccel::AES_256_IVSIZE];
+unsigned char key[CryptoAccel::AES_256_KEYSIZE];
+
+void print_result(struct timeval &tv1, struct timeval &tv2,
+					size_t textlen, size_t loop_cnt,
+					bool encrypt, bool result)
+{
+	unsigned long du = (1000000 * tv2.tv_sec + tv2.tv_usec)-(1000000 * tv1.tv_sec + tv1.tv_usec);
+	printf("%s [%s], len:%ld, loop_cnt:%ld, duration=%ld us, throughput:%ld MB/s\n",
+		encrypt ? "Encryption" : "Decryption",
+		result ? "success" : "fail",
+		textlen,
+		loop_cnt,
+		du,
+		du ? (textlen*loop_cnt/du) : -1
+		);
+}
+
+#define print_data() printf("Data: in[0] 0x%X, encrypt_out[0] 0x%X, decrypt_out[0] 0x%X\n", in[0], out_encrypted[0], out_decrypted[0])
+
+void test_one_accel(CryptoAccel *accel)
+{
+	struct timeval tv1, tv2;
+	bool b;
+
+	memset(out_encrypted, 0, textlen);
+	memset(out_decrypted, 0, textlen);
+	
+	print_data();
+	gettimeofday(&tv1,NULL);
+	for(size_t i = 0; i<loop_cnt; i++)
+	{
+		b = accel->cbc_encrypt(out_encrypted, in, textlen, iv, key);
+	}
+	gettimeofday(&tv2,NULL);
+	print_result(tv1, tv2, textlen, loop_cnt, true, b);
+	print_data();
+
+	gettimeofday(&tv1,NULL);
+	for(size_t i = 0; i<loop_cnt; i++)
+	{
+		b = accel->cbc_decrypt(out_decrypted, out_encrypted, textlen, iv, key);
+	}
+	gettimeofday(&tv2,NULL);
+	print_result(tv1, tv2, textlen, loop_cnt, false, b);
+	print_data();
+}
+
+void test_one_accel_mb(CryptoAccel *accel)
+{
+	struct timeval tv1, tv2;
+	bool b;
+	CryptoEngine *engine = accel->get_engine(key);
+    	//std::unique_ptr<CryptoEngine> eng(engine);
+
+	memset(out_encrypted, 0, textlen);
+	memset(out_decrypted, 0, textlen);
+	
+	print_data();
+	gettimeofday(&tv1,NULL);
+	for(size_t i = 0; i<loop_cnt; i++)
+	{
+		b = accel->cbc_encrypt_mb(engine, out_encrypted, in, textlen, iv);
+	}
+	accel->flush(engine);
+	gettimeofday(&tv2,NULL);
+	print_result(tv1, tv2, textlen, loop_cnt, true, b);
+	print_data();
+
+	gettimeofday(&tv1,NULL);
+	for(size_t i = 0; i<loop_cnt; i++)
+	{
+		b = accel->cbc_decrypt_mb(engine, out_decrypted, out_encrypted, textlen, iv);
+	}
+	accel->flush(engine);
+	gettimeofday(&tv2,NULL);
+	print_result(tv1, tv2, textlen, loop_cnt, false, b);
+	print_data();
+
+	accel->put_engine(engine);
+}
+
+int main(int argc, char *argv[])
+{
+	int i;
+
+	if (argc == 2 && !strcmp(argv[1], "-h"))
+	{
+		printf("cmd: test textlen loop_cnt\n");
+		return 0;
+	}
+
+	if (argc == 3)
+	{
+		textlen = atoi(argv[1]);
+		loop_cnt = atoi(argv[2]);
+	}
+
+	OpenSSLCryptoAccel accel_openssl;
+	ISALCryptoAccel accel_isal;
+	IPSECCryptoAccel accel_ipsec;
+
+	in = (unsigned char*)malloc(textlen);
+	out_encrypted = (unsigned char*)malloc(textlen);
+	out_decrypted = (unsigned char*)malloc(textlen);
+
+	// initialize key
+	for(i = 0; i<CryptoAccel::AES_256_KEYSIZE; i++) {
+		key[i] = i*3;
+	}
+	// initialize IV
+	for(i = 0; i<CryptoAccel::AES_256_IVSIZE; i++) {
+		iv[i] = i*5;
+	}
+	// initialize the input plain text
+	for(i = 0; i<textlen; i++) {
+		in[i] = i;
+	}
+
+	printf("---------- testing crypto plugin - openssl -------------\n");
+	test_one_accel(&accel_openssl);
+
+	printf("---------- testing crypto plugin - isal ----------------\n");
+	test_one_accel(&accel_isal);
+
+	printf("---------- testing crypto plugin - ipsec ---------------\n");
+	test_one_accel(&accel_ipsec);
+
+	printf("---------- testing crypto plugin - openssl mb ----------\n");
+	test_one_accel_mb(&accel_openssl);
+
+	printf("---------- testing crypto plugin - isal mb -------------\n");
+	test_one_accel_mb(&accel_isal);
+
+	printf("---------- testing crypto plugin - ipsec mb ------------\n");
+	test_one_accel_mb(&accel_ipsec);
+}


### PR DESCRIPTION
Currently we have 3 types of crypto accelerators: isa-l/openssl/QAT, this PR is trying to introduce the fourth crypto accelerator: ipsec_mb. Like isa-l and openssl, ipsec_mb is just a software accelerator. The big advantage is: ipsec_mb module can leverage latest instruction set(VAES) of processor, this can significantly improve encryption/decryption speed.

Performance comparison (AES-CBC per CPU core):

    [encryption]
    - crypto/ipsec_mb with VAES: ~12GB/s
    - crypto/isa-l: ~1.2GB/s
    - crypto/openssl: ~1.2GB/s

    [decryption]
    - crypto/ipsec_mb with VAES: ~14GB/s
    - crypto/isa-l: ~6GB/s
    - crypto/openssl: ~6GB/s

So ipsec_mb has about 10 times performance gain comparing with existing accelerators (isa-l and openssl) in encryption, and more than 2 times in decryption.

* Measured via test_crypto_plugins.cc in this PR, may vary on different platforms

Regarding the performance gain in RGW, it depends on platforms. Using minio/warp to do the test, you may see ~7% gain in Xeon(R) Gold 6139. But you may can only see 1% or even cannot see obvious performance gain in some platforms. This may be caused by: the frequency of CPU core which running avx512 will be slightly drop down, e.g. 3.2GHz->3.1GHz. The ideal use model would be let this plugin running in a seperate thread(cpu core), so the frequency of other CPU core would remain un-impacted.

Signed-off-by: Liang Fang <liang.a.fang@intel.com>
