### PR TITLE
core: fix compiler warning due to difference in order of struct members

### DIFF
--- a/src/global/pidfile.cc
+++ b/src/global/pidfile.cc
@@ -164,12 +164,12 @@ int pidfh::open(std::string_view pid_file)
   // Default Windows file share flags prevent other processes from writing
   // to this file.
   #ifndef _WIN32
-  struct flock l = {
-    .l_type = F_WRLCK,
-    .l_whence = SEEK_SET,
-    .l_start = 0,
-    .l_len = 0
-  };
+  struct flock l;
+  l.l_type = F_WRLCK;
+  l.l_whence = SEEK_SET;
+  l.l_start = 0;
+  l.l_len = 0;
+  
   int r = ::fcntl(pf_fd, F_SETLK, &l);
   if (r < 0) {
     if (errno == EAGAIN || errno == EACCES) {


### PR DESCRIPTION
Clang on FreeBSD reports:
```
Building CXX object src/global/CMakeFiles/libglobal_objs.dir/pidfile.cc.o
../src/global/pidfile.cc:170:5: warning: ISO C++ requires field designators to be specified in declaration order; field 'l_whence' will be initialized after field 'l_start' [-Wreorder-init-list]
    .l_start = 0,
    ^~~~~~~~~~~~
../src/global/pidfile.cc:169:17: note: previous initialization for field 'l_whence' is here
    .l_whence = SEEK_SET,
                ^~~~~~~~
```
And Linux and BSD have different orders in their `struct flock`

<!--
Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>