### PR TITLE
doc/rgw: update to python3 print syntax

### DIFF
--- a/doc/radosgw/STSLite.rst
+++ b/doc/radosgw/STSLite.rst
@@ -159,10 +159,10 @@ Keystone.
     bucket = s3client.create_bucket(Bucket='my-new-shiny-bucket')
     response = s3client.list_buckets()
     for bucket in response["Buckets"]:
-        print "{name}\t{created}".format(
+        print("{name}\t{created}".format(
                     name = bucket['Name'],
                     created = bucket['CreationDate'],
-    )
+        ))
 
 Similar steps can be performed for using GetSessionToken with LDAP.
 

--- a/doc/radosgw/s3/python.rst
+++ b/doc/radosgw/s3/python.rst
@@ -33,10 +33,10 @@ This also prints out the bucket name and creation date of each bucket.
 .. code-block:: python
 
 	for bucket in conn.get_all_buckets():
-		print "{name}\t{created}".format(
+		print("{name}\t{created}".format(
 			name = bucket.name,
 			created = bucket.creation_date,
-		)
+		))
 
 The output will look something like this::
 
@@ -65,11 +65,11 @@ modified date.
 .. code-block:: python
 
 	for key in bucket.list():
-		print "{name}\t{size}\t{modified}".format(
+		print("{name}\t{size}\t{modified}".format(
 			name = key.name,
 			size = key.size,
 			modified = key.last_modified,
-			)
+		))
 
 The output will look something like this::
 
@@ -158,11 +158,11 @@ URL will stop working).
 
 	hello_key = bucket.get_key('hello.txt')
 	hello_url = hello_key.generate_url(0, query_auth=False, force_http=True)
-	print hello_url
+	print(hello_url)
 
 	plans_key = bucket.get_key('secret_plans.txt')
 	plans_url = plans_key.generate_url(3600, query_auth=True, force_http=True)
-	print plans_url
+	print(plans_url)
 
 The output of this will look something like::
 
@@ -177,7 +177,7 @@ For example, unordered list of objects could be fetched using:
 
 .. code-block:: python
 
-    print conn.list_objects(Bucket='my-new-bucket', AllowUnordered=True)
+    print(conn.list_objects(Bucket='my-new-bucket', AllowUnordered=True))
 
 
 Without the extensions file, in the above example, boto3 would complain that the ``AllowUnordered`` argument is invalid.

--- a/doc/radosgw/swift/python.rst
+++ b/doc/radosgw/swift/python.rst
@@ -54,7 +54,7 @@ This gets a list of containers that you own, and prints out the container name:
 .. code-block:: python
 
 	for container in conn.get_account()[1]:
-		print container['name']
+		print(container['name'])
 
 The output will look something like this::
 
@@ -71,7 +71,7 @@ object's name, the file size, and last modified date:
 .. code-block:: python
 
 	for data in conn.get_container(container_name)[1]:
-		print '{0}\t{1}\t{2}'.format(data['name'], data['bytes'], data['last_modified'])
+		print('{0}\t{1}\t{2}'.format(data['name'], data['bytes'], data['last_modified']))
 
 The output will look something like this::
 

--- a/doc/radosgw/swift/tempurl.rst
+++ b/doc/radosgw/swift/tempurl.rst
@@ -95,7 +95,7 @@ A sample python script to demonstrate the above is given below:
    sig = hmac.new(key, hmac_body, sha1).hexdigest()
    rest_uri = "{host}{path}?temp_url_sig={sig}&temp_url_expires={expires}".format(
 		host=host, path=path, sig=sig, expires=expires)
-   print rest_uri
+   print(rest_uri)
 
    # Example Output
    # https://objectstore.example.com/swift/v1/your-bucket/your-object?temp_url_sig=ff4657876227fc6025f04fcf1e82818266d022c6&temp_url_expires=1423200992


### PR DESCRIPTION
python3 requires parens for a `print` statement

Signed-off-by: Michael Fritch <mfritch@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
