### PR TITLE
osd: fix reference leak when ManifestOp is not used

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3539,7 +3539,7 @@ bool PrimaryLogPG::inc_refcount_by_set(OpContext* ctx, object_manifest_t& set_ch
     refs);
   bool need_inc_ref = false;
   if (!refs.is_empty()) {
-    ManifestOpRef mop = std::make_shared<ManifestOp>(new RefCountCallback(ctx, osd_op));
+    ManifestOpRef mop(std::make_shared<ManifestOp>());
     for (auto c : set_chunk.chunk_map) {
       auto p = refs.find(c.second.oid);
       if (p == refs.end()) {
@@ -3578,6 +3578,7 @@ bool PrimaryLogPG::inc_refcount_by_set(OpContext* ctx, object_manifest_t& set_ch
       }
     }
     if (mop->tids.size()) {
+      mop->cb = new RefCountCallback(ctx, osd_op);
       manifest_ops[ctx->obs->oi.soid] = mop;
       manifest_ops[ctx->obs->oi.soid]->op = ctx->op;
     }
@@ -10356,7 +10357,7 @@ int PrimaryLogPG::start_dedup(OpRequestRef op, ObjectContextRef obc)
    * The operations to make dedup chunks are tracked by a ManifestOp.
    * This op will be finished if all the operations are completed.
    */
-  ManifestOpRef mop(std::make_shared<ManifestOp>(nullptr));
+  ManifestOpRef mop(std::make_shared<ManifestOp>());
 
   // cdc
   std::map<uint64_t, bufferlist> chunks; 

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -259,8 +259,8 @@ public:
 
   friend struct RefCountCallback;
   struct ManifestOp {
-    RefCountCallback *cb;
-    ceph_tid_t objecter_tid;
+    RefCountCallback *cb = nullptr;
+    ceph_tid_t objecter_tid = 0;
     OpRequestRef op;
     std::map<uint64_t, int> results;
     std::map<uint64_t, ceph_tid_t> tids; 
@@ -270,7 +270,8 @@ public:
     
 
     ManifestOp(RefCountCallback* cb)
-      : cb(cb), objecter_tid(0) {}
+      : cb(cb) {}
+    ManifestOp() = default;
   };
   typedef std::shared_ptr<ManifestOp> ManifestOpRef;
   std::map<hobject_t, ManifestOpRef> manifest_ops;


### PR DESCRIPTION

fixes: https://tracker.ceph.com/issues/50299

Signed-off-by: Myoungwon Oh <myoungwon.oh@samsung.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
