### PR TITLE
libcephfs, cephfs-mirror: configurable mount timeout

### DIFF
--- a/doc/cephfs/cephfs-mirroring.rst
+++ b/doc/cephfs/cephfs-mirroring.rst
@@ -307,6 +307,19 @@ synchronization.
 When mirroring is disabled, the respective `fs mirror status` command for the file system
 will not show up in command help.
 
+Configuration Options
+---------------------
+
+.. confval:: cephfs_mirror_max_concurrent_directory_syncs
+.. confval:: cephfs_mirror_action_update_interval
+.. confval:: cephfs_mirror_restart_mirror_on_blocklist_interval
+.. confval:: cephfs_mirror_max_snapshot_sync_per_cycle
+.. confval:: cephfs_mirror_directory_scan_interval
+.. confval:: cephfs_mirror_max_consecutive_failures_per_directory
+.. confval:: cephfs_mirror_retry_failed_directories_interval
+.. confval:: cephfs_mirror_restart_mirror_on_failure_interval
+.. confval:: cephfs_mirror_mount_timeout
+
 Re-adding Peers
 ---------------
 

--- a/src/common/options/cephfs-mirror.yaml.in
+++ b/src/common/options/cephfs-mirror.yaml.in
@@ -80,3 +80,15 @@ options:
   services:
   - cephfs-mirror
   min: 0
+- name: cephfs_mirror_mount_timeout
+  type: secs
+  level: advanced
+  desc: timeout for mounting primary/seconday ceph file system
+  long_desc: Timeout in seconds for mounting primary or secondary (remote) ceph file system
+    by the cephfs-mirror daemon. Setting this to a higher value could result in the mirror
+    daemon getting stalled when mounting a file system if the cluster is not reachable. This
+    option is used to override the usual client_mount_timeout.
+  default: 10
+  services:
+  - cephfs-mirror
+  min: 0

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -456,6 +456,15 @@ int ceph_conf_parse_env(struct ceph_mount_info *cmount, const char *var);
  */
 int ceph_conf_set(struct ceph_mount_info *cmount, const char *option, const char *value);
 
+/** Set mount timeout.
+ *
+ * @param cmount mount handle to set the configuration value on
+ * @param timeout mount timeout interval
+ *
+ * @returns 0 on success, negative error code otherwise.
+ */
+int ceph_set_mount_timeout(struct ceph_mount_info *cmount, uint32_t timeout);
+
 /**
  * Gets the configuration value as a string.
  *

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -27,6 +27,7 @@
 #include "common/version.h"
 #include "mon/MonClient.h"
 #include "include/str_list.h"
+#include "include/stringify.h"
 #include "messages/MMonMap.h"
 #include "msg/Messenger.h"
 #include "include/ceph_assert.h"
@@ -502,6 +503,15 @@ extern "C" int ceph_conf_get(struct ceph_mount_info *cmount, const char *option,
     return -EINVAL;
   }
   return cmount->conf_get(option, buf, len);
+}
+
+extern "C" int ceph_set_mount_timeout(struct ceph_mount_info *cmount, uint32_t timeout) {
+  if (cmount->is_mounted()) {
+    return -EINVAL;
+  }
+
+  auto timeout_str = stringify(timeout);
+  return ceph_conf_set(cmount, "client_mount_timeout", timeout_str.c_str());
 }
 
 extern "C" int ceph_mds_command(struct ceph_mount_info *cmount,

--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -50,6 +50,7 @@ cdef extern from "cephfs/libcephfs.h" nogil:
     int ceph_conf_parse_argv(ceph_mount_info *cmount, int argc, const char **argv)
     int ceph_conf_get(ceph_mount_info *cmount, const char *option, char *buf, size_t len)
     int ceph_conf_set(ceph_mount_info *cmount, const char *option, const char *value)
+    int ceph_set_mount_timeout(ceph_mount_info *cmount, uint32_t timeout)
 
     int ceph_mount(ceph_mount_info *cmount, const char *root)
     int ceph_select_filesystem(ceph_mount_info *cmount, const char *fs_name)

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -622,6 +622,24 @@ cdef class LibCephFS(object):
         if ret != 0:
             raise make_ex(ret, "error calling conf_set")
 
+    def set_mount_timeout(self, timeout):
+        """
+        Set mount timeout
+
+        :param timeout: mount timeout
+        """
+        self.require_state("configuring", "initialized")
+        if not isinstance(timeout, int):
+            raise TypeError('timeout must be an integer')
+        if timeout < 0:
+            raise make_ex(CEPHFS_EINVAL, 'timeout must be greater than or equal to 0')
+        cdef:
+            uint32_t _timeout = timeout
+        with nogil:
+            ret = ceph_set_mount_timeout(self.cluster, _timeout)
+        if ret != 0:
+            raise make_ex(ret, "error setting mount timeout")
+
     def init(self):
         """
         Initialize the filesystem client (but do not mount the filesystem yet)

--- a/src/pybind/cephfs/mock_cephfs.pxi
+++ b/src/pybind/cephfs/mock_cephfs.pxi
@@ -63,6 +63,8 @@ cdef nogil:
         pass
     int ceph_conf_set(ceph_mount_info *cmount, const char *option, const char *value):
         pass
+    int ceph_set_mount_timeout(ceph_mount_info *cmount, uint32_t timeout):
+        pass
 
     int ceph_mount(ceph_mount_info *cmount, const char *root):
         pass

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -3520,3 +3520,25 @@ TEST(LibCephFS, LookupMdsPrivateInos) {
 
   ceph_shutdown(cmount);
 }
+
+TEST(LibCephFS, SetMountTimeoutPostMount) {
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(ceph_mount(cmount, NULL), 0);
+
+  ASSERT_EQ(-EINVAL, ceph_set_mount_timeout(cmount, 5));
+  ceph_shutdown(cmount);
+}
+
+TEST(LibCephFS, SetMountTimeout) {
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(0, ceph_set_mount_timeout(cmount, 5));
+  ASSERT_EQ(ceph_mount(cmount, NULL), 0);
+
+  ceph_shutdown(cmount);
+}

--- a/src/test/pybind/test_cephfs.py
+++ b/src/test/pybind/test_cephfs.py
@@ -888,3 +888,19 @@ def test_snapshot_info():
 
     # remove directory
     cephfs.rmdir("/dir-1")
+
+@with_setup(setup_test)
+def test_set_mount_timeout_post_mount():
+    assert_raises(libcephfs.LibCephFSStateError, cephfs.set_mount_timeout, 5)
+
+@with_setup(setup_test)
+def test_set_mount_timeout():
+    cephfs.unmount()
+    cephfs.set_mount_timeout(5)
+    cephfs.mount()
+
+@with_setup(setup_test)
+def test_set_mount_timeout_lt0():
+    cephfs.unmount()
+    assert_raises(libcephfs.InvalidValue, cephfs.set_mount_timeout, -5)
+    cephfs.mount()

--- a/src/tools/cephfs_mirror/Utils.cc
+++ b/src/tools/cephfs_mirror/Utils.cc
@@ -108,6 +108,15 @@ int mount(RadosRef cluster, const Filesystem &filesystem, bool cross_check_fscid
     return r;
   }
 
+  // mount timeout applies for local and remote mounts.
+  auto mount_timeout = g_ceph_context->_conf.get_val<std::chrono::seconds>
+    ("cephfs_mirror_mount_timeout").count();
+  r = ceph_set_mount_timeout(cmi, mount_timeout);
+  if (r < 0) {
+    derr << ": mount error: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
   r = ceph_init(cmi);
   if (r < 0) {
     derr << ": mount error: " << cpp_strerror(r) << dendl;


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
