### PR TITLE
common/options,doc: extract formatted desc into .yaml.in 

### DIFF
--- a/doc/_ext/ceph_confval.py
+++ b/doc/_ext/ceph_confval.py
@@ -1,12 +1,178 @@
+import io
+from typing import Any, Dict, List, Union
+
+from docutils.parsers.rst import directives
+from docutils.parsers.rst import Directive
+
 from sphinx.domains.python import PyField
 from sphinx.locale import _
+from sphinx.util import logging, status_iterator
 from sphinx.util.docfields import Field
 
+import jinja2
+import jinja2.filters
+import yaml
 
-def setup(app):
+
+logger = logging.getLogger(__name__)
+
+
+TEMPLATE = '''
+.. confval_option:: {{ opt.name }}
+{% if desc | length > 1 %}
+   {{ desc | wordwrap(70) | indent(3) }}
+{% endif %}
+   :type: ``{{opt.type}}``
+{%- if default %}
+  {%- if opt.type == 'size' %}
+   :default: ``{{ default | eval_size | filesizeformat(true) }}``
+  {%- elif opt.type == 'secs' %}
+   :default: ``{{ default | readable_duration(opt.type) }}``
+  {%- elif opt.type in ('uint', 'int', 'float') %}
+   :default: ``{{ default | readable_num(opt.type) }}``
+  {%- elif opt.type == 'millisecs' %}
+   :default: ``{{ default }}`` milliseconds
+  {%- elif opt.type == 'bool' %}
+   :default: ``{{ default | string | lower }}``
+  {%- else %}
+   :default: ``{{ default }}``
+  {%- endif -%}
+{%- endif %}
+'''
+
+
+def eval_size(value) -> int:
+    try:
+        return int(value)
+    except ValueError:
+        times = dict(_K=1 << 10,
+                     _M=1 << 20,
+                     _G=1 << 30,
+                     _T=1 << 40)
+        for unit, m in times.items():
+            if value.endswith(unit):
+                return int(value[:-len(unit)]) * m
+        raise ValueError(f'unknown value: {value}')
+
+
+def readable_duration(value: str, typ: str) -> str:
+    try:
+        if typ == 'sec':
+            v = int(value)
+            postfix = 'second' if v == 1 else 'seconds'
+            return f'{v} {postfix}'
+        elif typ == 'float':
+            return str(float(value))
+        else:
+            return str(int(value))
+    except ValueError:
+        times = dict(_min=['minute', 'minutes'],
+                     _hr=['hour', 'hours'],
+                     _day=['day', 'days'])
+        for unit, readables in times.items():
+            if value.endswith(unit):
+                v = int(value[:-len(unit)])
+                postfix = readables[0 if v == 1 else 1]
+                return f'{v} {postfix}'
+        raise ValueError(f'unknown value: {value}')
+
+
+def do_plain_num(value: str, typ: str) -> str:
+    if typ == 'float':
+        return str(float(value))
+    else:
+        return str(int(value))
+
+
+def do_fileize_num(value: str, typ: str) -> str:
+    v = eval_size(value)
+    return jinja2.filters.do_filesizeformat(v)
+
+
+def readable_num(value: str, typ: str) -> str:
+    e = ValueError()
+    for eval_func in [do_plain_num,
+                      readable_duration,
+                      do_fileize_num]:
+        try:
+            return eval_func(value, typ)
+        except ValueError as ex:
+            e = ex
+    raise e
+
+
+def jinja_template() -> jinja2.Template:
+    env = jinja2.Environment()
+    env.filters['eval_size'] = eval_size
+    env.filters['readable_duration'] = readable_duration
+    env.filters['readable_num'] = readable_num
+    return env.from_string(TEMPLATE)
+
+
+FieldValueT = Union[bool, float, int, str]
+
+
+class CephOption(Directive):
+    """
+    emit option loaded from given command/options/<name>.yaml.in file
+    """
+    has_content = True
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = False
+    option_spec = {'default': directives.unchanged}
+
+    template = jinja_template()
+    opts: Dict[str, Dict[str, FieldValueT]] = {}
+
+    def _load_yaml(self) -> Dict[str, Dict[str, FieldValueT]]:
+        if CephOption.opts:
+            return CephOption.opts
+        env = self.state.document.settings.env
+        opts = []
+        for fn in status_iterator(env.config.ceph_confval_imports,
+                                  'loading options...', 'red',
+                                  len(env.config.ceph_confval_imports),
+                                  env.app.verbosity):
+            env.note_dependency(fn)
+            try:
+                with open(fn, 'r') as f:
+                    yaml_in = io.StringIO()
+                    for line in f:
+                        if '@' not in line:
+                            yaml_in.write(line)
+                    yaml_in.seek(0)
+                    opts += yaml.safe_load(yaml_in)['options']
+            except OSError as e:
+                message = f'Unable to open option file "{fn}": {e}'
+                raise self.error(message)
+        CephOption.opts = dict((opt['name'], opt) for opt in opts)
+        return CephOption.opts
+
+    def run(self) -> List[Any]:
+        name = self.arguments[0]
+        opt = self._load_yaml().get(name)
+        if opt is None:
+            raise self.error(f'Option "{name}" not found!')
+        desc = opt.get('fmt_desc') or opt.get('long_desc') or opt.get('desc')
+        opt_default = opt.get('default')
+        default = self.options.get('default', opt_default)
+        rendered = self.template.render(opt=opt, desc=desc, default=default)
+        lineno = self.lineno - self.state_machine.input_offset - 1
+        source = self.state_machine.input_lines.source(lineno)
+        self.state_machine.insert_input(rendered.split('\n'), source)
+        return []
+
+
+def setup(app) -> Dict[str, Any]:
+    app.add_config_value('ceph_confval_imports',
+                         default=[],
+                         rebuild='html',
+                         types=[str])
+    app.add_directive('confval', CephOption)
     app.add_object_type(
-        'confval',
-        'confval',
+        'confval_option',
+        'confval_option',
         objname='configuration value',
         indextemplate='pair: %s; configuration value',
         doc_field_types=[
@@ -48,6 +214,7 @@ def setup(app):
                 has_arg=False,
             )]
     )
+
     return {
         'version': 'builtin',
         'parallel_read_safe': True,

--- a/doc/_ext/ceph_confval.py
+++ b/doc/_ext/ceph_confval.py
@@ -36,6 +36,18 @@ def setup(app):
             )
         ]
     )
+    app.add_object_type(
+        'confval_section',
+        'confval_section',
+        objname='configuration section',
+        indextemplate='pair: %s; configuration section',
+        doc_field_types=[
+            Field(
+                'example',
+                label=_('Example'),
+                has_arg=False,
+            )]
+    )
     return {
         'version': 'builtin',
         'parallel_read_safe': True,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -226,6 +226,18 @@ for c in pybinds:
 openapi_logger = sphinx.util.logging.getLogger('sphinxcontrib.openapi.openapi30')
 openapi_logger.setLevel(logging.WARNING)
 
+# ceph_confval
+ceph_confval_imports = [os.path.join(top_level,
+                                     'src/common/options',
+                                     yaml + '.yaml.in')
+                        for yaml in ['global',
+                                     'immutable-object-cache',
+                                     'mds',
+                                     'mds-client',
+                                     'rbd',
+                                     'rbd-mirror',
+                                     'rgw']]
+
 
 # handles edit-on-github and old version warning display
 def setup(app):

--- a/doc/rados/configuration/auth-config-ref.rst
+++ b/doc/rados/configuration/auth-config-ref.rst
@@ -145,37 +145,8 @@ Enablement
 
 
 .. confval:: auth_cluster_required
-
-   If enabled, the Ceph Storage Cluster daemons (i.e., ``ceph-mon``,
-   ``ceph-osd``, ``ceph-mds`` and ``ceph-mgr``) must authenticate with
-   each other. Valid settings are ``cephx`` or ``none``.
-
-  :type: String
-  :required: No
-  :default: ``cephx``.
-
-
 .. confval:: auth_service_required
-
-   If enabled, the Ceph Storage Cluster daemons require Ceph Clients
-   to authenticate with the Ceph Storage Cluster in order to access
-   Ceph services. Valid settings are ``cephx`` or ``none``.
-
-   :type: String
-   :required: No
-   :default: ``cephx``.
-
-
 .. confval:: auth_client_required
-
-   If enabled, the Ceph Client requires the Ceph Storage Cluster to
-   authenticate with the Ceph Client. Valid settings are ``cephx``
-   or ``none``.
-
-   :type: String
-   :required: No
-   :default: ``cephx``.
-
 
 .. index:: keys; keyring
 
@@ -205,33 +176,10 @@ To perform this step manually, execute the following::
 You may specify the key itself in the Ceph configuration file using the ``key``
 setting (not recommended), or a path to a keyfile using the ``keyfile`` setting.
 
-
 .. confval:: keyring
-
-   The path to the keyring file.
-
-  :type: String
-  :required: No
-  :default: ``/etc/ceph/$cluster.$name.keyring,/etc/ceph/$cluster.keyring,/etc/ceph/keyring,/etc/ceph/keyring.bin``
-
-
+   :default: /etc/ceph/$cluster.$name.keyring,/etc/ceph/$cluster.keyring,/etc/ceph/keyring,/etc/ceph/keyring.bin
 .. confval:: keyfile
-
-   The path to a key file (i.e,. a file containing only the key).
-
-   :type: String
-   :required: No
-   :default: None
-
-
 .. confval:: key
-
-   The key (i.e., the text string of the key itself). Not recommended.
-
-   :type: String
-   :required: No
-   :default: None
-
 
 Daemon Keyrings
 ---------------
@@ -299,61 +247,14 @@ Note that even with signatures enabled data is not encrypted in
 flight.
 
 .. confval:: cephx_require_signatures
-
-   If set to ``true``, Ceph requires signatures on all message
-   traffic between the Ceph Client and the Ceph Storage Cluster, and
-   between daemons comprising the Ceph Storage Cluster.
-
-   Ceph Argonaut and Linux kernel versions prior to 3.19 do
-   not support signatures; if such clients are in use this
-   option can be turned off to allow them to connect.
-
-  :type: Boolean
-  :required: No
-  :default: ``false``
-
-
 .. confval:: cephx_cluster_require_signatures
-
-   If set to ``true``, Ceph requires signatures on all message
-   traffic between Ceph daemons comprising the Ceph Storage Cluster.
-
-   :type: Boolean
-   :required: No
-   :default: ``false``
-
-
 .. confval:: cephx_service_require_signatures
-
-   If set to ``true``, Ceph requires signatures on all message
-   traffic between Ceph Clients and the Ceph Storage Cluster.
-
-   :type: Boolean
-   :required: No
-   :default: ``false``
-
-
 .. confval:: cephx_sign_messages
-
-   If the Ceph version supports message signing, Ceph will sign
-   all messages so they are more difficult to spoof.
-
-   :type: Boolean
-   :default: ``true``
-
 
 Time to Live
 ------------
 
 .. confval:: auth_service_ticket_ttl
-
-   When the Ceph Storage Cluster sends a Ceph Client a ticket for
-   authentication, the Ceph Storage Cluster assigns the ticket a
-   time to live.
-
-   :type: Double
-   :default: ``60*60``
-
 
 .. _Monitor Bootstrapping: ../../../install/manual-deployment#monitor-bootstrapping
 .. _Operating a Cluster: ../../operations/operating

--- a/doc/rados/configuration/ceph-conf.rst
+++ b/doc/rados/configuration/ceph-conf.rst
@@ -119,14 +119,14 @@ they apply to.
 
 These sections include:
 
-.. confval:: global
+.. confval_section:: global
 
    Settings under ``global`` affect all daemons and clients
    in a Ceph Storage Cluster.
 
    :example: ``log_file = /var/log/ceph/$cluster-$type.$id.log``
 
-.. confval:: mon
+.. confval_section:: mon
 
    Settings under ``mon`` affect all ``ceph-mon`` daemons in
    the Ceph Storage Cluster, and override the same setting in
@@ -134,7 +134,7 @@ These sections include:
 
    :example: ``mon_cluster_log_to_syslog = true``
 
-.. confval:: mgr
+.. confval_section:: mgr
 
    Settings in the ``mgr`` section affect all ``ceph-mgr`` daemons in
    the Ceph Storage Cluster, and override the same setting in
@@ -142,7 +142,7 @@ These sections include:
 
    :example: ``mgr_stats_period = 10``
 
-.. confval:: osd
+.. confval_section:: osd
 
    Settings under ``osd`` affect all ``ceph-osd`` daemons in
    the Ceph Storage Cluster, and override the same setting in
@@ -150,7 +150,7 @@ These sections include:
 
    :example: ``osd_op_queue = wpq``
 
-.. confval:: mds
+.. confval_section:: mds
 
    Settings in the ``mds`` section affect all ``ceph-mds`` daemons in
    the Ceph Storage Cluster, and override the same setting in
@@ -158,7 +158,7 @@ These sections include:
 
    :example: ``mds_cache_memory_limit = 10G``
 
-.. confval:: client
+.. confval_section:: client
 
    Settings under ``client`` affect all Ceph Clients
    (e.g., mounted Ceph File Systems, mounted Ceph Block Devices,

--- a/doc/rados/configuration/ceph-conf.rst
+++ b/doc/rados/configuration/ceph-conf.rst
@@ -198,7 +198,7 @@ configuration value is used. Ceph metavariables are similar to variable expansio
 
 Ceph supports the following metavariables: 
 
-.. confval:: $cluster
+.. describe:: $cluster
 
    Expands to the Ceph Storage Cluster name. Useful when running
    multiple Ceph Storage Clusters on the same hardware.
@@ -206,13 +206,13 @@ Ceph supports the following metavariables:
    :example: ``/etc/ceph/$cluster.keyring``
    :default: ``ceph``
 
-.. confval:: $type
+.. describe:: $type
 
    Expands to a daemon or process type (e.g., ``mds``, ``osd``, or ``mon``)
 
    :example: ``/var/lib/ceph/$type``
 
-.. confval:: $id
+.. describe:: $id
 
    Expands to the daemon or client identifier. For
    ``osd.0``, this would be ``0``; for ``mds.a``, it would
@@ -220,17 +220,17 @@ Ceph supports the following metavariables:
 
    :example: ``/var/lib/ceph/$type/$cluster-$id``
 
-.. confval:: $host
+.. describe:: $host
 
    Expands to the host name where the process is running.
 
-.. confval:: $name
+.. describe:: $name
 
    Expands to ``$type.$id``.
 
    :example: ``/var/run/ceph/$cluster-$name.asok``
 
-.. confval:: $pid
+.. describe:: $pid
 
    Expands to daemon pid.
 

--- a/doc/rados/configuration/journal-ref.rst
+++ b/doc/rados/configuration/journal-ref.rst
@@ -30,93 +30,10 @@ Filestore is preferred for new deployments.
 
 Ceph OSD Daemons recognize the following journal settings: 
 
-
 .. confval:: journal_dio
-
-   Enables direct i/o to the journal. Requires ``journal block
-   align`` set to ``true``.
-
-   :type: Boolean
-   :required: Yes when using ``aio``.
-   :default: ``true``
-
-
-
 .. confval:: journal_aio
-
-   .. versionchanged:: 0.61 Cuttlefish
-
-   Enables using ``libaio`` for asynchronous writes to the journal.
-   Requires ``journal dio`` set to ``true``.
-
-   :type: Boolean
-   :required: No.
-   :default: Version 0.61 and later, ``true``. Version 0.60 and earlier, ``false``.
-
-
 .. confval:: journal_block_align
-
-   Block aligns write operations. Required for ``dio`` and ``aio``.
-
-   :type: Boolean
-   :required: Yes when using ``dio`` and ``aio``.
-   :default: ``true``
-
-
 .. confval:: journal_max_write_bytes
-
-   The maximum number of bytes the journal will write at
-   any one time.
-
-   :type: Integer
-   :required: No
-   :default: ``10 << 20``
-
-
 .. confval:: journal_max_write_entries
-
-   The maximum number of entries the journal will write at
-   any one time.
-
-   :type: Integer
-   :required: No
-   :default: ``100``
-
-
-.. confval:: journal_queue_max_ops
-
-   The maximum number of operations allowed in the queue at
-   any one time.
-
-   :type: Integer
-   :required: No
-   :default: ``500``
-
-
-.. confval:: journal_queue_max_bytes
-
-   The maximum number of bytes allowed in the queue at
-   any one time.
-
-   :type: Integer
-   :required: No
-   :default: ``10 << 20``
-
-
 .. confval:: journal_align_min_size
-
-   Align data payloads greater than the specified minimum.
-
-   :type: Integer
-   :required: No
-   :default: ``64 << 10``
-
-
 .. confval:: journal_zero_on_create
-
-   Causes the file store to overwrite the entire journal with
-   ``0``'s during ``mkfs``.
-
-   :type: Boolean
-   :required: No
-   :default: ``false``

--- a/doc/rados/configuration/mon-osd-interaction.rst
+++ b/doc/rados/configuration/mon-osd-interaction.rst
@@ -217,180 +217,29 @@ section of your configuration file.
 Monitor Settings
 ----------------
 
-``mon osd min up ratio``
-
-:Description: The minimum ratio of ``up`` Ceph OSD Daemons before Ceph will
-              mark Ceph OSD Daemons ``down``.
-
-:Type: Double
-:Default: ``.3``
-
-
-``mon osd min in ratio``
-
-:Description: The minimum ratio of ``in`` Ceph OSD Daemons before Ceph will
-              mark Ceph OSD Daemons ``out``.
-
-:Type: Double
-:Default: ``.75``
-
-
-``mon osd laggy halflife``
-
-:Description: The number of seconds laggy estimates will decay.
-:Type: Integer
-:Default: ``60*60``
-
-
-``mon osd laggy weight``
-
-:Description: The weight for new samples in laggy estimation decay.
-:Type: Double
-:Default: ``0.3``
-
-
-
-``mon osd laggy max interval``
-
-:Description: Maximum value of ``laggy_interval`` in laggy estimations (in seconds).
-              Monitor uses an adaptive approach to evaluate the ``laggy_interval`` of
-              a certain OSD. This value will be used to calculate the grace time for
-              that OSD.
-:Type: Integer
-:Default: 300
-
-``mon osd adjust heartbeat grace``
-
-:Description: If set to ``true``, Ceph will scale based on laggy estimations.
-:Type: Boolean
-:Default: ``true``
-
-
-``mon osd adjust down out interval``
-
-:Description: If set to ``true``, Ceph will scaled based on laggy estimations.
-:Type: Boolean
-:Default: ``true``
-
-
-``mon osd auto mark in``
-
-:Description: Ceph will mark any booting Ceph OSD Daemons as ``in``
-              the Ceph Storage Cluster.
-
-:Type: Boolean
-:Default: ``false``
-
-
-``mon osd auto mark auto out in``
-
-:Description: Ceph will mark booting Ceph OSD Daemons auto marked ``out``
-              of the Ceph Storage Cluster as ``in`` the cluster.
-
-:Type: Boolean
-:Default: ``true``
-
-
-``mon osd auto mark new in``
-
-:Description: Ceph will mark booting new Ceph OSD Daemons as ``in`` the
-              Ceph Storage Cluster.
-
-:Type: Boolean
-:Default: ``true``
-
-
-``mon osd down out interval``
-
-:Description: The number of seconds Ceph waits before marking a Ceph OSD Daemon
-              ``down`` and ``out`` if it doesn't respond.
-
-:Type: 32-bit Integer
-:Default: ``600``
-
-
-``mon osd down out subtree limit``
-
-:Description: The smallest :term:`CRUSH` unit type that Ceph will **not**
-              automatically mark out. For instance, if set to ``host`` and if
-              all OSDs of a host are down, Ceph will not automatically mark out
-              these OSDs.
-
-:Type: String
-:Default: ``rack``
-
-
-``mon osd report timeout``
-
-:Description: The grace period in seconds before declaring
-              unresponsive Ceph OSD Daemons ``down``.
-
-:Type: 32-bit Integer
-:Default: ``900``
-
-``mon osd min down reporters``
-
-:Description: The minimum number of Ceph OSD Daemons required to report a
-              ``down`` Ceph OSD Daemon.
-
-:Type: 32-bit Integer
-:Default: ``2``
-
-
-``mon_osd_reporter_subtree_level``
-
-:Description: In which level of parent bucket the reporters are counted. The OSDs
-              send failure reports to monitors if they find a peer that is not responsive.
-              Monitors mark the reported ``OSD`` out and then ``down`` after a grace period.
-:Type: String
-:Default: ``host``
-
+.. confval:: mon_osd_min_up_ratio
+.. confval:: mon_osd_min_in_ratio
+.. confval:: mon_osd_laggy_halflife
+.. confval:: mon_osd_laggy_weight
+.. confval:: mon_osd_laggy_max_interval
+.. confval:: mon_osd_adjust_heartbeat_grace
+.. confval:: mon_osd_adjust_down_out_interval
+.. confval:: mon_osd_auto_mark_in
+.. confval:: mon_osd_auto_mark_auto_out_in
+.. confval:: mon_osd_auto_mark_new_in
+.. confval:: mon_osd_down_out_interval
+.. confval:: mon_osd_down_out_subtree_limit
+.. confval:: mon_osd_report_timeout
+.. confval:: mon_osd_min_down_reporters
+.. confval:: mon_osd_reporter_subtree_level
 
 .. index:: OSD hearbeat
 
 OSD Settings
 ------------
 
-``osd_heartbeat_interval``
-
-:Description: How often an Ceph OSD Daemon pings its peers (in seconds).
-:Type: 32-bit Integer
-:Default: ``6``
-
-
-``osd_heartbeat_grace``
-
-:Description: The elapsed time when a Ceph OSD Daemon hasn't shown a heartbeat
-              that the Ceph Storage Cluster considers it ``down``.
-              This setting must be set in both the [mon] and [osd] or [global]
-              sections so that it is read by both monitor and OSD daemons.
-:Type: 32-bit Integer
-:Default: ``20``
-
-
-``osd_mon_heartbeat_interval``
-
-:Description: How often the Ceph OSD Daemon pings a Ceph Monitor if it has no
-              Ceph OSD Daemon peers.
-
-:Type: 32-bit Integer
-:Default: ``30``
-
-
-``osd_mon_heartbeat_stat_stale``
-
-:Description: Stop reporting on heartbeat ping times which haven't been updated for
-              this many seconds.  Set to zero to disable this action.
-
-:Type: 32-bit Integer
-:Default: ``3600``
-
-
-``osd_mon_report_interval``
-
-:Description: The number of seconds a Ceph OSD Daemon may wait
-              from startup or another reportable event before reporting
-              to a Ceph Monitor.
-
-:Type: 32-bit Integer
-:Default: ``5``
+.. confval:: osd_heartbeat_interval
+.. confval:: osd_heartbeat_grace
+.. confval:: osd_mon_heartbeat_interval
+.. confval:: osd_mon_heartbeat_stat_stale
+.. confval:: osd_mon_report_interval

--- a/doc/rados/configuration/network-config-ref.rst
+++ b/doc/rados/configuration/network-config-ref.rst
@@ -288,25 +288,7 @@ addresses or override ``public_network`` settings using the ``public_addr``
 setting for a specific daemon.
 
 .. confval:: public_network
-
-   The IP address and netmask of the public (front-side) network
-   (e.g., ``192.168.0.0/24``). Set in ``[global]``. You may specify
-   comma-separated subnets.
-
-   :type: ``{ip-address}/{netmask} [, {ip-address}/{netmask}]``
-   :required: No
-   :default: N/A
-
 .. confval:: public_addr
-
-   The IP address for the public (front-side) network.
-   Set for each daemon.
-
-   :type: IP Address
-   :required: No
-   :default: N/A
-
-
 
 Cluster Network
 ---------------
@@ -318,25 +300,7 @@ settings using the ``cluster_addr`` setting for specific OSD daemons.
 
 
 .. confval:: cluster_network
-
-   The IP address and netmask of the cluster (back-side) network
-   (e.g., ``10.0.0.0/24``).  Set in ``[global]``. You may specify
-   comma-separated subnets.
-
-   :type: ``{ip-address}/{netmask} [, {ip-address}/{netmask}]``
-   :required: No
-   :default: N/A
-
-
 .. confval:: cluster_addr
-
-   The IP address for the cluster (back-side) network.
-   Set for each daemon.
-
-   :type: Address
-   :required: No
-   :default: N/A
-
 
 Bind
 ----
@@ -348,83 +312,19 @@ allows you to use the configured port range.
 You may also enable Ceph daemons to bind to IPv6 addresses instead of IPv4
 addresses.
 
-
 .. confval:: ms_bind_port_min
-
-   The minimum port number to which an OSD or MDS daemon will bind.
-
-   :type: 32-bit Integer
-   :default: ``6800``
-   :required: No
-
 .. confval:: ms_bind_port_max
-
-   The maximum port number to which an OSD or MDS daemon will bind.
-
-   :type: 32-bit Integer
-   :default: ``7300``
-   :required: No
-
 .. confval:: ms_bind_ipv4
-
-   Enables Ceph daemons to bind to IPv4 addresses.
-
-   :type: Boolean
-   :default: ``true``
-   :Required: No
-
 .. confval:: ms_bind_ipv6
-
-   Enables Ceph daemons to bind to IPv6 addresses.
-
-   :type: Boolean
-   :default: ``false``
-   :required: No
-
 .. confval:: public_bind_addr
-
-   In some dynamic deployments the Ceph MON daemon might bind
-   to an IP address locally that is different from the ``public_addr``
-   advertised to other peers in the network. The environment must ensure
-   that routing rules are set correctly. If ``public_bind_addr`` is set
-   the Ceph Monitor daemon will bind to it locally and use ``public_addr``
-   in the monmaps to advertise its address to peers. This behavior is limited
-   to the Monitor daemon.
-
-   :type: IP Address
-   :required: No
-   :default: N/A
-
-
 
 TCP
 ---
 
 Ceph disables TCP buffering by default.
 
-
 .. confval:: ms_tcp_nodelay
-
-   Ceph enables ``ms_tcp_nodelay`` so that each request is sent
-   immediately (no buffering). Disabling `Nagle's algorithm`_
-   increases network traffic, which can introduce latency. If you
-   experience large numbers of small packets, you may try
-   disabling ``ms_tcp_nodelay``.
-
-   :type: Boolean
-   :required: No
-   :default: ``true``
-
-
 .. confval:: ms_tcp_rcvbuf
-
-   The size of the socket buffer on the receiving end of a network
-   connection. Disable by default.
-
-   :type: 32-bit Integer
-   :required: No
-   :default: ``0``
-
 
 .. _Scalability and High Availability: ../../../architecture#scalability-and-high-availability
 .. _Hardware Recommendations - Networks: ../../../start/hardware-recommendations#networks

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -29,6 +29,8 @@ options:
   type: addr
   level: basic
   desc: public-facing address to bind to
+  fmt_desc: The IP address for the public (front-side) network.
+   Set for each daemon.
   services:
   - mon
   - mds
@@ -56,11 +58,20 @@ options:
   - mon
   flags:
   - startup
+  fmt_desc: In some dynamic deployments the Ceph MON daemon might bind
+   to an IP address locally that is different from the ``public_addr``
+   advertised to other peers in the network. The environment must ensure
+   that routing rules are set correctly. If ``public_bind_addr`` is set
+   the Ceph Monitor daemon will bind to it locally and use ``public_addr``
+   in the monmaps to advertise its address to peers. This behavior is limited
+   to the Monitor daemon.
   with_legacy: true
 - name: cluster_addr
   type: addr
   level: basic
   desc: cluster-facing address to bind to
+  fmt_desc: The IP address for the cluster (back-side) network.
+   Set for each daemon.
   tags:
   - network
   services:
@@ -72,6 +83,10 @@ options:
   type: str
   level: advanced
   desc: Network(s) from which to choose a public address to bind to
+  fmt_desc: The IP address and netmask of the public (front-side) network
+   (e.g., ``192.168.0.0/24``). Set in ``[global]``. You may specify
+   comma-separated subnets. The format of it looks like
+   ``{ip-address}/{netmask} [, {ip-address}/{netmask}]``
   tags:
   - network
   services:
@@ -102,6 +117,10 @@ options:
   type: str
   level: advanced
   desc: Network(s) from which to choose a cluster address to bind to
+  fmt_desc: The IP address and netmask of the cluster (back-side) network
+   (e.g., ``10.0.0.0/24``).  Set in ``[global]``. You may specify
+   comma-separated subnets. The format of it looks like
+   ``{ip-address}/{netmask} [, {ip-address}/{netmask}]``
   tags:
   - network
   services:
@@ -846,6 +865,7 @@ options:
   desc: Authentication key
   long_desc: A CephX authentication key, base64 encoded.  It normally looks something
     like 'AQAtut9ZdMbNJBAAHz6yBAWyJyz2yYRyeMWDag=='.
+  fmt_desc: The key (i.e., the text string of the key itself). Not recommended.
   see_also:
   - keyfile
   - keyring
@@ -859,6 +879,7 @@ options:
   desc: Path to a file containing a key
   long_desc: The file should contain a CephX authentication key and optionally a trailing
     newline, but nothing else.
+  fmt_desc: The path to a key file (i.e,. a file containing only the key).
   see_also:
   - key
   flags:
@@ -872,6 +893,9 @@ options:
   long_desc: A keyring file is an INI-style formatted file where the section names
     are client or daemon names (e.g., 'osd.0') and each section contains a 'key' property
     with CephX authentication key as the value.
+  # please note, document are generated without accessing to the CMake
+  # variables, so please update the document manually with a representive
+  # default value using the ":default:" option of ".. confval::" directive.
   default: @keyring_paths@
   see_also:
   - key
@@ -1022,12 +1046,19 @@ options:
   type: bool
   level: advanced
   desc: Disable Nagle's algorithm and send queued network traffic immediately
+  fmt_desc: Ceph enables ``ms_tcp_nodelay`` so that each request is sent
+   immediately (no buffering). Disabling `Nagle's algorithm`_
+   increases network traffic, which can introduce latency. If you
+   experience large numbers of small packets, you may try
+   disabling ``ms_tcp_nodelay``.
   default: true
   with_legacy: true
 - name: ms_tcp_rcvbuf
   type: size
   level: advanced
   desc: Size of TCP socket receive buffer
+  fmt_desc: The size of the socket buffer on the receiving end of a network
+   connection. Disable by default.
   default: 0
   with_legacy: true
 - name: ms_tcp_prefetch_max_size
@@ -1109,6 +1140,7 @@ options:
   type: bool
   level: advanced
   desc: Bind servers to IPv4 address(es)
+  fmt_desc: Enables Ceph daemons to bind to IPv4 addresses.
   default: true
   see_also:
   - ms_bind_ipv6
@@ -1116,6 +1148,7 @@ options:
   type: bool
   level: advanced
   desc: Bind servers to IPv6 address(es)
+  fmt_desc: Enables Ceph daemons to bind to IPv6 addresses.
   default: false
   see_also:
   - ms_bind_ipv4
@@ -1143,12 +1176,14 @@ options:
   type: int
   level: advanced
   desc: Lowest port number to bind daemon(s) to
+  fmt_desc: The minimum port number to which an OSD or MDS daemon will bind.
   default: 6800
   with_legacy: true
 - name: ms_bind_port_max
   type: int
   level: advanced
   desc: Highest port number to bind daemon(s) to
+  fmt_desc: The maximum port number to which an OSD or MDS daemon will bind.
   default: 7300
   with_legacy: true
 # FreeBSD does not use SO_REAUSEADDR so allow for a bit more time per default
@@ -3055,6 +3090,9 @@ options:
   type: str
   level: advanced
   desc: authentication methods required by the cluster
+  fmt_desc: If enabled, the Ceph Storage Cluster daemons (i.e., ``ceph-mon``,
+   ``ceph-osd``, ``ceph-mds`` and ``ceph-mgr``) must authenticate with
+   each other. Valid settings are ``cephx`` or ``none``.
   default: cephx
   with_legacy: true
 # required by daemons of clients
@@ -3062,6 +3100,9 @@ options:
   type: str
   level: advanced
   desc: authentication methods required by service daemons
+  fmt_desc: If enabled, the Ceph Storage Cluster daemons require Ceph Clients
+   to authenticate with the Ceph Storage Cluster in order to access
+   Ceph services. Valid settings are ``cephx`` or ``none``.
   default: cephx
   with_legacy: true
 # what clients require of daemons
@@ -3069,6 +3110,9 @@ options:
   type: str
   level: advanced
   desc: authentication methods allowed by clients
+  fmt_desc: If enabled, the Ceph Client requires the Ceph Storage Cluster to
+   authenticate with the Ceph Client. Valid settings are ``cephx``
+   or ``none``.
   default: cephx, none
   with_legacy: true
 # deprecated; default value for above if they are not defined.
@@ -3097,6 +3141,13 @@ options:
   type: bool
   level: advanced
   default: false
+  fmt_desc: If set to ``true``, Ceph requires signatures on all message
+   traffic between the Ceph Client and the Ceph Storage Cluster, and
+   between daemons comprising the Ceph Storage Cluster.
+
+   Ceph Argonaut and Linux kernel versions prior to 3.19 do
+   not support signatures; if such clients are in use this
+   option can be turned off to allow them to connect.
   with_legacy: true
 - name: cephx_require_version
   type: int
@@ -3108,6 +3159,8 @@ options:
   type: bool
   level: advanced
   default: false
+  fmt_desc:    If set to ``true``, Ceph requires signatures on all message
+   traffic between Ceph daemons comprising the Ceph Storage Cluster.
   with_legacy: true
 - name: cephx_cluster_require_version
   type: int
@@ -3119,6 +3172,8 @@ options:
   type: bool
   level: advanced
   default: false
+  fmt_desc: If set to ``true``, Ceph requires signatures on all message
+   traffic between Ceph Clients and the Ceph Storage Cluster.
   with_legacy: true
 - name: cephx_service_require_version
   type: int
@@ -3131,6 +3186,8 @@ options:
   type: bool
   level: advanced
   default: true
+  fmt_desc: If the Ceph version supports message signing, Ceph will sign
+   all messages so they are more difficult to spoof.
   with_legacy: true
 - name: auth_mon_ticket_ttl
   type: float
@@ -3142,6 +3199,9 @@ options:
   type: float
   level: advanced
   default: 1_hr
+  fmt_desc: When the Ceph Storage Cluster sends a Ceph Client a ticket for
+   authentication, the Ceph Storage Cluster assigns the ticket a
+   time to live.
   with_legacy: true
 - name: auth_allow_insecure_global_id_reclaim
   type: bool
@@ -7675,11 +7735,16 @@ options:
   type: bool
   level: dev
   default: true
+  fmt_desc: Enables direct i/o to the journal. Requires ``journal block
+   align`` set to ``true``.
   with_legacy: true
 - name: journal_aio
   type: bool
   level: dev
   default: true
+  fmt_desc: Enables using ``libaio`` for asynchronous writes to the journal.
+   Requires ``journal dio`` set to ``true``. Version 0.61 and later, ``true``.
+   Version 0.60 and earlier, ``false``.
   with_legacy: true
 - name: journal_force_aio
   type: bool
@@ -7695,6 +7760,7 @@ options:
   type: bool
   level: dev
   default: true
+  fmt_desc: Block aligns write operations. Required for ``dio`` and ``aio``.
   with_legacy: true
 - name: journal_write_header_frequency
   type: uint
@@ -7705,12 +7771,16 @@ options:
   type: size
   level: advanced
   desc: Max bytes in flight to journal
+  fmt_desc: The maximum number of bytes the journal will write at
+   any one time.
   default: 10_M
   with_legacy: true
 - name: journal_max_write_entries
   type: int
   level: advanced
   desc: Max IOs in flight to journal
+  fmt_desc: The maximum number of entries the journal will write at
+   any one time.
   default: 100
   with_legacy: true
 # Target range for journal fullness
@@ -7741,6 +7811,7 @@ options:
   type: size
   level: dev
   default: 64_K
+  fmt_desc: Align data payloads greater than the specified minimum.
   with_legacy: true
 - name: journal_replay_from
   type: int
@@ -7760,6 +7831,8 @@ options:
   type: bool
   level: dev
   default: false
+  fmt_desc: Causes the file store to overwrite the entire journal with
+   ``0``'s during ``mkfs``.
   with_legacy: true
 # assume journal is not corrupt
 - name: journal_ignore_corruption

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -1729,6 +1729,7 @@ options:
   type: int
   level: advanced
   desc: halflife of OSD 'lagginess' factor
+  fmt_desc: The number of seconds laggy estimates will decay.
   default: 1_hr
   services:
   - mon
@@ -1740,6 +1741,7 @@ options:
   long_desc: 1.0 means that an OSD marking itself back up (because it was marked down
     but not actually dead) means a 100% laggy_probability; 0.0 effectively disables
     tracking of laggy_probability.
+  fmt_desc: The weight for new samples in laggy estimation decay.
   default: 0.3
   services:
   - mon
@@ -1750,6 +1752,10 @@ options:
   type: int
   level: advanced
   desc: cap value for period for OSD to be marked for laggy_interval calculation
+  fmt_desc: Maximum value of ``laggy_interval`` in laggy estimations (in seconds).
+              Monitor uses an adaptive approach to evaluate the ``laggy_interval`` of
+              a certain OSD. This value will be used to calculate the grace time for
+              that OSD.
   default: 5_min
   services:
   - mon
@@ -1765,6 +1771,7 @@ options:
     that it isn't marked down again.  laggy_probability is an estimated probability
     that the given OSD is down because it is laggy (not actually down), and laggy_interval
     is an estiate on how long it stays down when it is laggy.
+  fmt_desc: If set to ``true``, Ceph will scale based on laggy estimations.
   default: true
   services:
   - mon
@@ -1777,6 +1784,7 @@ options:
   type: bool
   level: advanced
   desc: increase the mon_osd_down_out_interval if an OSD appears to be laggy
+  fmt_desc: If set to ``true``, Ceph will scaled based on laggy estimations.
   default: true
   services:
   - mon
@@ -1787,6 +1795,8 @@ options:
   type: bool
   level: advanced
   desc: mark any OSD that comes up 'in'
+  fmt_desc: Ceph will mark any booting Ceph OSD Daemons as ``in``
+              the Ceph Storage Cluster.
   default: false
   services:
   - mon
@@ -1795,6 +1805,8 @@ options:
   type: bool
   level: advanced
   desc: mark any OSD that comes up that was automatically marked 'out' back 'in'
+  fmt_desc: Ceph will mark booting Ceph OSD Daemons auto marked ``out``
+              of the Ceph Storage Cluster as ``in`` the cluster.
   default: true
   services:
   - mon
@@ -1805,6 +1817,8 @@ options:
   type: bool
   level: advanced
   desc: mark any new OSD that comes up 'in'
+  fmt_desc: Ceph will mark booting new Ceph OSD Daemons as ``in`` the
+              Ceph Storage Cluster.
   default: true
   services:
   - mon
@@ -1821,6 +1835,8 @@ options:
   type: int
   level: advanced
   desc: mark any OSD 'out' that has been 'down' for this long (seconds)
+  fmt_desc: The number of seconds Ceph waits before marking a Ceph OSD Daemon
+              ``down`` and ``out`` if it doesn't respond.
   default: 10_min
   services:
   - mon
@@ -1830,6 +1846,10 @@ options:
   level: advanced
   desc: do not automatically mark OSDs 'out' if an entire subtree of this size is
     down
+  fmt_desc: The smallest :term:`CRUSH` unit type that Ceph will **not**
+              automatically mark out. For instance, if set to ``host`` and if
+              all OSDs of a host are down, Ceph will not automatically mark out
+              these OSDs.
   default: rack
   services:
   - mon
@@ -1841,6 +1861,8 @@ options:
   type: float
   level: advanced
   desc: do not automatically mark OSDs 'out' if fewer than this many OSDs are 'up'
+  fmt_desc: The minimum ratio of ``up`` Ceph OSD Daemons before Ceph will
+              mark Ceph OSD Daemons ``down``.
   default: 0.3
   services:
   - mon
@@ -1851,6 +1873,8 @@ options:
   type: float
   level: advanced
   desc: do not automatically mark OSDs 'out' if fewer than this many OSDs are 'in'
+  fmt_desc: The minimum ratio of ``in`` Ceph OSD Daemons before Ceph will
+              mark Ceph OSD Daemons ``out``.
   default: 0.75
   services:
   - mon
@@ -2244,6 +2268,8 @@ options:
   type: int
   level: advanced
   desc: time before OSDs who do not report to the mons are marked down (seconds)
+  fmt_desc: The grace period in seconds before declaring
+              unresponsive Ceph OSD Daemons ``down``.
   default: 15_min
   services:
   - mon
@@ -2708,6 +2734,8 @@ options:
   level: advanced
   desc: number of OSDs from different subtrees who need to report a down OSD for it
     to count
+  fmt_desc: The minimum number of Ceph OSD Daemons required to report a
+              ``down`` Ceph OSD Daemon.
   default: 2
   services:
   - mon
@@ -2717,6 +2745,9 @@ options:
   type: str
   level: advanced
   desc: in which level of parent bucket the reporters are counted
+  fmt_desc: In which level of parent bucket the reporters are counted. The OSDs
+              send failure reports to monitors if they find a peer that is not responsive.
+              Monitors mark the reported ``OSD`` out and then ``down`` after a grace period.
   default: host
   services:
   - mon
@@ -4484,6 +4515,7 @@ options:
   type: int
   level: dev
   desc: Interval (in seconds) between peer pings
+  fmt_desc: How often an Ceph OSD Daemon pings its peers (in seconds).
   default: 6
   min: 1
   max: 1_min
@@ -4494,6 +4526,10 @@ options:
   type: int
   level: advanced
   default: 20
+  fmt_desc: The elapsed time when a Ceph OSD Daemon hasn't shown a heartbeat
+              that the Ceph Storage Cluster considers it ``down``.
+              This setting must be set in both the [mon] and [osd] or [global]
+              sections so that it is read by both monitor and OSD daemons.
   with_legacy: true
 - name: osd_heartbeat_stale
   type: int
@@ -4547,18 +4583,25 @@ options:
   type: int
   level: advanced
   default: 30
+  fmt_desc: How often the Ceph OSD Daemon pings a Ceph Monitor if it has no
+              Ceph OSD Daemon peers.
   with_legacy: true
 - name: osd_mon_heartbeat_stat_stale
   type: int
   level: advanced
   desc: Stop reporting on heartbeat ping times not updated for this many seconds.
   long_desc: Stop reporting on old heartbeat information unless this is set to zero
+  fmt_desc: Stop reporting on heartbeat ping times which haven't been updated for
+              this many seconds.  Set to zero to disable this action.
   default: 1_hr
 # failures, up_thru, boot.
 - name: osd_mon_report_interval
   type: int
   level: advanced
   desc: Frequency of OSD reports to mon for peer failures, fullness status changes
+  fmt_desc: The number of seconds a Ceph OSD Daemon may wait
+              from startup or another reportable event before reporting
+              to a Ceph Monitor.
   default: 5
   with_legacy: true
 # max updates in flight


### PR DESCRIPTION
this is the third step:

- [x] common: extract options into yaml. finished in #40731
- [x] add an option to the .yaml.in files for generating the corresponding entries in `legacy_config_opts.h`, and expand `y2c.py` to interpret this and generate `legacy_config_opts.h` accordingly. 
- [x] add a sphinx extension to extract and render the basic and advanced options as part of document.
- [ ] use "see_also" to reference other options. 
- [ ] migrate more options under `doc/rados/configuration` to use the `.confval::` directive.
- [ ] split the options groups by its readers / service types. so, for example, mds will be linked against the mds options only. the same applies to all daemons and clients
- [x] use comments in the .yaml.in for the descriptions of some options which don't have desc field yet. // optional.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
