### PR TITLE
common: make y2c.py choke on duplicate keys

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -5208,7 +5208,6 @@ options:
   level: advanced
   default: 30
   with_legacy: true
-  with_legacy: true
 - name: osd_delete_sleep
   type: float
   level: advanced


### PR DESCRIPTION
Commit 5505fc0 ("common: generate legacy_config_opts.h from
.yaml.in files") inadvertently reverted a change of a default value by
adding a second "default" key with the old value.  This was corrected
in commit 75e07f8 ("common/options/global: correct default of
auth_mon_ticket_ttl"), but highlights that mis-merging a yaml file
is rather easy.

To prevent this happening again, fail the build if duplicate keys
exist in any of src/common/options/*.yaml.in files.