### PR TITLE
Add per-inode fscrypt_priv opaque field 

### DIFF
--- a/src/include/fs_types.h
+++ b/src/include/fs_types.h
@@ -50,6 +50,15 @@ class JSONObj;
 // --------------------------------------
 // ino
 
+/*
+ * The MDS provides some (opaque) per-inode storage that fscrypt-enabled
+ * clients can stash data in.  The Linux fscrypt sources define
+ * FS_CRYPTO_BLOCK_SIZE as 16 bytes, which is a minimum blocksize for
+ * encryption. Allow one block per inode for this, so that that data can
+ * be encrypted.
+ */
+#define CEPH_FSCRYPT_PRIVATE_SIZE	16
+
 typedef uint64_t _inodeno_t;
 
 struct inodeno_t {

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -4043,6 +4043,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
     encode(file_i->rstat.rsnaps, bl);
     encode(snap_metadata, bl);
     encode(file_i->fscrypt, bl);
+    encode_raw(file_i->fscrypt_priv, bl);
     ENCODE_FINISH(bl);
   }
   else {

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -1734,7 +1734,7 @@ void CInode::decode_lock_idft(bufferlist::const_iterator& p)
 {
   inode_ptr _inode;
 
-  DECODE_START(1, p);
+  DECODE_START(2, p);
   if (is_auth()) {
     bool replica_dirty;
     decode(replica_dirty, p);
@@ -1786,7 +1786,7 @@ void CInode::decode_lock_idft(bufferlist::const_iterator& p)
 
 void CInode::encode_lock_ifile(bufferlist& bl)
 {
-  ENCODE_START(1, 1, bl);
+  ENCODE_START(2, 1, bl);
   if (is_auth()) {
     encode(get_inode()->version, bl); 
     encode(get_inode()->ctime, bl); 
@@ -1800,6 +1800,7 @@ void CInode::encode_lock_ifile(bufferlist& bl)
       encode(get_inode()->truncate_size, bl); 
       encode(get_inode()->client_ranges, bl); 
       encode(get_inode()->inline_data, bl); 
+      encode_raw(get_inode()->fscrypt_priv, bl);
     }    
   } else {
     // treat flushing as dirty when rejoining cache
@@ -1852,6 +1853,8 @@ void CInode::decode_lock_ifile(bufferlist::const_iterator& p)
       decode(_inode->truncate_size, p);
       decode(_inode->client_ranges, p);
       decode(_inode->inline_data, p);
+      if (struct_v >= 2)
+	decode_raw(_inode->fscrypt_priv, p);
     }
   } else {
     bool replica_dirty;

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -3693,6 +3693,7 @@ void Locker::_update_cap_fields(CInode *in, int dirty, const cref_t<MClientCaps>
 	      << " for " << *in << dendl;
       pi->size = size;
       pi->rstat.rbytes = size;
+      memcpy(pi->fscrypt_priv, m->fscrypt_priv, sizeof(pi->fscrypt_priv));
     }
     if (in->is_file() &&
         (dirty & CEPH_CAP_FILE_WR) &&

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4980,6 +4980,12 @@ void Server::handle_client_setattr(MDRequestRef& mdr)
   __u32 mask = req->head.args.setattr.mask;
   __u32 access_mask = MAY_WRITE;
 
+  // No changes to encrypted inodes from legacy clients
+  if (cur->get_inode()->fscrypt && req->get_header().version < 6) {
+    respond_to_request(mdr, -CEPHFS_EPERM);
+    return;
+  }
+
   // xlock inode
   if (mask & (CEPH_SETATTR_MODE|CEPH_SETATTR_UID|CEPH_SETATTR_GID|CEPH_SETATTR_BTIME|CEPH_SETATTR_KILL_SGUID))
     lov.add_xlock(&cur->authlock);
@@ -5063,6 +5069,10 @@ void Server::handle_client_setattr(MDRequestRef& mdr)
       pi.inode->size = req->head.args.setattr.size;
       pi.inode->rstat.rbytes = pi.inode->size;
     }
+    if (req->get_header().version >= 6) {
+      memcpy(pi.inode->fscrypt_priv, req->fscrypt_priv, sizeof(pi.inode->fscrypt_priv));
+    }
+
     pi.inode->mtime = mdr->get_op_stamp();
 
     // adjust client's max_size?

--- a/src/messages/MClientCaps.h
+++ b/src/messages/MClientCaps.h
@@ -22,7 +22,7 @@
 class MClientCaps final : public SafeMessage {
 private:
 
-  static constexpr int HEAD_VERSION = 11;
+  static constexpr int HEAD_VERSION = 12;
   static constexpr int COMPAT_VERSION = 1;
 
  public:
@@ -58,6 +58,8 @@ private:
 
   /* advisory CLIENT_CAPS_* flags to send to mds */
   unsigned flags = 0;
+
+  uint8_t fscrypt_priv[CEPH_FSCRYPT_PRIVATE_SIZE] = {0};
 
   int      get_caps() const { return head.caps; }
   int      get_wanted() const { return head.wanted; }
@@ -270,6 +272,9 @@ public:
       decode(nfiles, p);
       decode(nsubdirs, p);
     }
+    if (header.version >= 12) {
+      decode_raw(fscrypt_priv, p);
+    }
   }
   void encode_payload(uint64_t features) override {
     using ceph::encode;
@@ -338,6 +343,7 @@ public:
     encode(flags, payload);
     encode(nfiles, payload);
     encode(nsubdirs, payload);
+    encode_raw(fscrypt_priv, payload);
   }
 private:
   template<class T, typename... Args>

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -126,6 +126,7 @@ struct InodeStat {
   uint64_t size = 0, max_size = 0;
   uint64_t change_attr = 0;
   uint64_t truncate_size = 0;
+  uint8_t fscrypt_priv[CEPH_FSCRYPT_PRIVATE_SIZE] = {0};
   uint32_t truncate_seq = 0;
   uint32_t mode = 0, uid = 0, gid = 0, nlink = 0;
   frag_info_t dirstat;
@@ -157,7 +158,7 @@ struct InodeStat {
   void decode(ceph::buffer::list::const_iterator &p, const uint64_t features) {
     using ceph::decode;
     if (features == (uint64_t)-1) {
-      DECODE_START(6, p);
+      DECODE_START(7, p);
       decode(vino.ino, p);
       decode(vino.snapid, p);
       decode(rdev, p);
@@ -213,6 +214,9 @@ struct InodeStat {
       }
       if (struct_v >= 6) {
         decode(fscrypt, p);
+      }
+      if (struct_v >= 7) {
+	decode_raw(fscrypt_priv, p);
       }
       DECODE_FINISH(p);
     }

--- a/src/messages/MClientRequest.h
+++ b/src/messages/MClientRequest.h
@@ -67,7 +67,7 @@ WRITE_CLASS_ENCODER(SnapPayload)
 
 class MClientRequest final : public MMDSOp {
 private:
-  static constexpr int HEAD_VERSION = 5;
+  static constexpr int HEAD_VERSION = 6;
   static constexpr int COMPAT_VERSION = 1;
 
 public:
@@ -100,6 +100,9 @@ public:
   filepath path, path2;
   std::string alternate_name;
   std::vector<uint64_t> gid_list;
+
+  // extra setattr info
+  uint8_t fscrypt_priv[CEPH_FSCRYPT_PRIVATE_SIZE] = {0};
 
   /* XXX HACK */
   mutable bool queued_for_replay = false;
@@ -240,6 +243,8 @@ public:
       decode(gid_list, p);
     if (header.version >= 5)
       decode(alternate_name, p);
+    if (header.version >= 6)
+      decode_raw(fscrypt_priv, p);
   }
 
   void encode_payload(uint64_t features) override {
@@ -262,6 +267,7 @@ public:
     encode(stamp, payload);
     encode(gid_list, payload);
     encode(alternate_name, payload);
+    encode_raw(fscrypt_priv, payload);
   }
 
   std::string_view get_type_name() const override { return "creq"; }


### PR DESCRIPTION
This is still a very rough draft at this point, but should be enough for a PoC. The kernel client side of this is still a WIP.

This basically adds a 16-byte opaque field to inode_t and teaches the MDS to shlep it around alongside the size. The client will use this field to keep track of the "real size" of the inode, and it will always round up the traditional size field to the end of the last fscrypt block.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
