### PR TITLE
common/options: fix several out of date defaults and options added during yaml conversion

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -6507,7 +6507,7 @@ options:
   type: float
   level: dev
   desc: Ratio of bluestore cache to devote to metadata
-  default: 0.4
+  default: 0.45
   see_also:
   - bluestore_cache_size
   with_legacy: true
@@ -6515,7 +6515,7 @@ options:
   type: float
   level: dev
   desc: Ratio of bluestore cache to devote to kv database (rocksdb)
-  default: 0
+  default: 0.45
   see_also:
   - bluestore_cache_size
   with_legacy: true
@@ -6523,7 +6523,7 @@ options:
   type: float
   level: dev
   desc: Ratio of bluestore cache to devote to kv onode column family (rocksdb)
-  default: 0
+  default: 0.04
   see_also:
   - bluestore_cache_size
 - name: bluestore_cache_autotune

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -1688,7 +1688,6 @@ options:
   default: 10
   services:
   - mon
-  - mon
   with_legacy: true
 - name: mon_osd_laggy_halflife
   type: int

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -1981,7 +1981,7 @@ options:
   level: advanced
   desc: The difference in connection score allowed before a peon stops ignoring out-of-quorum
     PROPOSEs
-  default: 0
+  default: 0.0005
   services:
   - mon
 - name: mon_warn_on_degraded_stretch_mode
@@ -1995,10 +1995,10 @@ options:
   type: float
   level: advanced
   desc: the ratio of up OSDs at which a degraded stretch cluster enters recovery
-  default: 0
+  default: 0.6
   services:
   - mon
-  min: 0
+  min: 0.51
   max: 1
 - name: mon_stretch_recovery_min_wait
   type: float
@@ -4234,7 +4234,7 @@ options:
     OSD for rotational device type. This is considered by the mclock_scheduler to
     set an additional cost factor in QoS calculations. Only considered for osd_op_queue
     = mclock_scheduler
-  default: 5
+  default: 5.2
   flags:
   - runtime
 - name: osd_mclock_cost_per_byte_usec_ssd
@@ -4245,7 +4245,7 @@ options:
     OSD for solid state device type. This is considered by the mclock_scheduler to
     set an additional cost factor in QoS calculations. Only considered for osd_op_queue
     = mclock_scheduler
-  default: 0
+  default: 0.011
   flags:
   - runtime
 - name: osd_mclock_max_capacity_iops
@@ -4478,7 +4478,7 @@ options:
 - name: osd_heartbeat_min_healthy_ratio
   type: float
   level: advanced
-  default: 0
+  default: 0.33
   with_legacy: true
 # (seconds) how often to ping monitor if no peers
 - name: osd_mon_heartbeat_interval

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -6018,46 +6018,11 @@ options:
   flags:
   - create
   with_legacy: true
-- name: bluestore_bluefs_min
-  type: size
-  level: advanced
-  desc: minimum disk space allocated to BlueFS (e.g., at mkfs)
-  default: 1_G
-- name: bluestore_bluefs_min_free
-  type: size
-  level: advanced
-  default: 1_G
-  desc: minimum free space allocated to BlueFS
 - name: bluestore_bluefs_max_free
   type: size
   level: advanced
   default: 10_G
   desc: Maximum free space allocated to BlueFS
-- name: bluestore_bluefs_min_ratio
-  type: float
-  level: advanced
-  default: 0.02
-  desc: Minimum fraction of free space devoted to BlueFS
-- name: bluestore_bluefs_max_ratio
-  type: float
-  level: advanced
-  default: 0.9
-  desc: Maximum fraction of free storage devoted to BlueFS
-- name: bluestore_bluefs_gift_ratio
-  type: float
-  level: advanced
-  default: 0.02
-  desc: Maximum fraction of free space to give to BlueFS at once
-- name: bluestore_bluefs_reclaim_ratio
-  type: float
-  level: advanced
-  default: 0.2
-  desc: Maximum fraction of free space to reclaim from BlueFS at once
-- name: bluestore_bluefs_balance_interval
-  type: float
-  level: advanced
-  default: 1
-  desc: How frequently (in seconds) to balance free space between BlueFS and BlueStore
 - name: bluestore_bluefs_alloc_failure_dump_interval
   type: float
   level: advanced

--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -4517,18 +4517,6 @@ options:
   level: advanced
   default: 500
   with_legacy: true
-- name: osd_mon_ack_timeout
-  type: float
-  level: advanced
-  default: 30
-- name: osd_stats_ack_timeout_factor
-  type: float
-  level: advanced
-  default: 2
-- name: osd_stats_ack_timeout_decay
-  type: float
-  level: advanced
-  default: 0.9
 # Max number of snap intervals to report to mgr in pg_stat_t
 - name: osd_max_snap_prune_intervals_per_epoch
   type: uint

--- a/src/common/options/immutable-object-cache.yaml.in
+++ b/src/common/options/immutable-object-cache.yaml.in
@@ -41,7 +41,7 @@ options:
   type: float
   level: advanced
   desc: immutable object cache water mark
-  default: 0.1
+  default: 0.9
   services:
   - immutable-object-cache
 - name: immutable_object_cache_qos_schedule_tick_min

--- a/src/common/options/y2c.py
+++ b/src/common/options/y2c.py
@@ -128,7 +128,7 @@ def set_enum_allowed(values):
     if values is None:
         return ''
     param = ', '.join(f'"{v}"' for v in values)
-    return f'.set_enum_allowed({{{param}}})'
+    return f'.set_enum_allowed({{{param}}})\n'
 
 
 def add_flags(flags):


### PR DESCRIPTION
Some of these got reset to old values (or old options were added back when they didn't exist anymore).

The ones most likely to have caused issues are the bluestore cache options.