### PR TITLE
mgr/Dashboard: Remove erroneous elements in hosts-overview Grafana dashboard

### DIFF
--- a/monitoring/grafana/dashboards/hosts-overview.json
+++ b/monitoring/grafana/dashboards/hosts-overview.json
@@ -131,7 +131,6 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "decimals": 0,
       "description": "Average CPU busy across all hosts (OSD, RGW, MON etc) within the cluster",
       "decimals": 2,
       "format": "percentunit",
@@ -215,7 +214,6 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "decimals": 0,
       "description": "Average Memory Usage across all hosts in the cluster (excludes buffer/cache usage)",
       "decimals": 2,
       "format": "percentunit",


### PR DESCRIPTION
monitoring/grafana: Remove erroneous elements in hosts-overview Grafana dashboard
    
The hosts-overview Grafana dashboard json file contains a repeated element, making it invalid JSON. Some JSON parsers handle this. However, this prevents Jsonnet from parsing the dashboard, which prevents the deployment of this dashboard via Jsonnet.
    
Fixes: https://tracker.ceph.com/issues/50410
Signed-off-by: Malcolm Holmes <mdh@odoko.co.uk>
