### PR TITLE
test: extend retry timeout from 150s to 300s

### DIFF
--- a/src/test/librados/tier_cxx.cc
+++ b/src/test/librados/tier_cxx.cc
@@ -179,12 +179,12 @@ void is_intended_refcount_state(librados::IoCtx& src_ioctx,
     }
     dst_refcount = refs.count();
   }
-  for (int tries = 0; tries < 10; ++tries) {
+  for (int tries = 0; tries < 15; ++tries) {
     r = cls_cas_references_chunk(src_ioctx, src_oid, dst_oid);
     if (r == -ENOENT || r == -ENOLINK) {
       src_refcount = 0;
     } else if (r == -EBUSY) {
-      sleep(15);
+      sleep(20);
       continue;
     } else {
       src_refcount = r;


### PR DESCRIPTION
Manifest objects try to recover their clones if the clones
are unreadable when calculating ref. count.
In some case, the recovery takes more time than 150s,
so this commit extends time from 150s to 300s.

Fixes: https://tracker.ceph.com/issues/50352

Signed-off-by: Myoungwon Oh <myoungwon.oh@samsung.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
