### PR TITLE
Revert "cmake: Add an option for enabling rook client in dashboard"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -652,8 +652,9 @@ endif()
 set(DASHBOARD_FRONTEND_LANGS "" CACHE STRING
   "List of comma separated ceph-dashboard frontend languages to build. \
   Use value `ALL` to build all languages")
-CMAKE_DEPENDENT_OPTION(WITH_MGR_ROOK_CLIENT "Enable Rook support in the dashboard" ON
-  "WITH_MGR_DASHBOARD_FRONTEND" OFF)
+
+# TODO: make this an option and set it to the same value as WITH_MGR_DASHBOARD_FRONTEND
+set(WITH_MGR_ROOK_CLIENT WITH_MGR_DASHBOARD_FRONTEND)
 
 include_directories(SYSTEM ${PROJECT_BINARY_DIR}/include)
 


### PR DESCRIPTION
Current master: https://pulpito.ceph.com/sage-2021-04-18_12:58:03-rados-master-distro-basic-smithi/
With revert: https://pulpito.ceph.com/sage-2021-04-16_19:04:25-rados-wip-sage4-testing-2021-04-16-1139-distro-basic-smithi/

```
2021-04-18T13:18:32.797 INFO:tasks.ceph.mgr.y.smithi175.stderr:2021-04-18T13:18:32.797+0000 7fda7ad40d00 -1 mgr[py] Module not found: 'rook'
2021-04-18T13:18:32.798 INFO:tasks.ceph.mgr.y.smithi175.stderr:2021-04-18T13:18:32.797+0000 7fda7ad40d00 -1 mgr[py] Traceback (most recent call last):
2021-04-18T13:18:32.798 INFO:tasks.ceph.mgr.y.smithi175.stderr:  File "/usr/share/ceph/mgr/rook/__init__.py", line 2, in <module>
2021-04-18T13:18:32.799 INFO:tasks.ceph.mgr.y.smithi175.stderr:    from .module import RookOrchestrator
2021-04-18T13:18:32.799 INFO:tasks.ceph.mgr.y.smithi175.stderr:  File "/usr/share/ceph/mgr/rook/module.py", line 38, in <module>
2021-04-18T13:18:32.799 INFO:tasks.ceph.mgr.y.smithi175.stderr:    from .rook_cluster import RookCluster
2021-04-18T13:18:32.799 INFO:tasks.ceph.mgr.y.smithi175.stderr:  File "/usr/share/ceph/mgr/rook/rook_cluster.py", line 38, in <module>
2021-04-18T13:18:32.800 INFO:tasks.ceph.mgr.y.smithi175.stderr:    from .rook_client.ceph import cephfilesystem as cfs
2021-04-18T13:18:32.800 INFO:tasks.ceph.mgr.y.smithi175.stderr:ModuleNotFoundError: No module named 'rook.rook_client.ceph'
2021-04-18T13:18:32.800 INFO:tasks.ceph.mgr.y.smithi175.stderr:
2021-04-18T13:18:32.800 INFO:tasks.ceph.mgr.y.smithi175.stderr:2021-04-18T13:18:32.798+0000 7fda7ad40d00 -1 mgr[py] Class not found in module 'rook'
2021-04-18T13:18:32.801 INFO:tasks.ceph.mgr.y.smithi175.stderr:2021-04-18T13:18:32.798+0000 7fda7ad40d00 -1 mgr[py] Error loading module 'rook': (2) No such file or directory
```