### PR TITLE
mgr/dashboard: RESTful API add recursive remove directory #50419

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -421,6 +421,16 @@ class CephFS(RESTController):
         cfs = self._cephfs_instance(fs_id)
         cfs.rm_dir(path)
 
+    @RESTController.Resource('DELETE', path='/tree')
+    def recursive_rm_tree(self, fs_id, path):
+        """
+        Recursive remove a directory.
+        :param fs_id: The filesystem identifier.
+        :param path: The path of the directory.
+        """
+        cfs = self._cephfs_instance(fs_id)
+        cfs.recursive_rm_dir(path)
+
     @RESTController.Resource('PUT', path='/quota')
     @allow_empty_body
     def quota(self, fs_id, path, max_bytes=None, max_files=None):


### PR DESCRIPTION
mgr/Dashboard: RESTful API add recursive remove directory

When you want to remove a cephfs directory through RESTful API of dashboard, you need remove data in the directory at first, then you can remove the directory. Well, we need a simple operation to remove recursively.

Fixes: https://tracker.ceph.com/issues/50419
Signed-off-by: bob zhou zhoubofsy@hotmail.com