### PR TITLE
msgr/async: fix unsafe access in unregister_conn()

### DIFF
--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -311,6 +311,7 @@ private:
     if (p->second->is_unregistered()) {
       std::lock_guard l{deleted_lock};
       if (deleted_conns.erase(p->second)) {
+	p->second->get_perf_counter()->dec(l_msgr_active_connections);
 	conns.erase(p);
 	return nullref;
       }
@@ -399,8 +400,6 @@ public:
    */
   void unregister_conn(const AsyncConnectionRef& conn) {
     std::lock_guard l{deleted_lock};
-    if (!accepting_conns.count(conn) || anon_conns.count(conn))
-      conn->get_perf_counter()->dec(l_msgr_active_connections);
     deleted_conns.emplace(std::move(conn));
     conn->unregister();
 


### PR DESCRIPTION
We were looking at anon_conns and accepting_conns without holding
the lock (deleted_lock is not sufficient).

Drop this test.

Replace all of the active_connections count updates with a set() set
conns.size() + anon_conns.size() (size() is cheap on a set<>) and the
invariant is clear and easy to maintain.

Fixes: https://tracker.ceph.com/issues/49237
Signed-off-by: Sage Weil <sage@newdream.net>