### PR TITLE
crimson: make backtraces more human-readable with boost::stacktrace and addr2line

### DIFF
--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -15,6 +15,7 @@ set(crimson_common_srcs
   common/assert.cc
   common/buffer_io.cc
   common/config_proxy.cc
+  common/fatal_signal.cc
   common/formatter.cc
   common/perf_counters_collection.cc
   common/log.cc

--- a/src/crimson/common/fatal_signal.cc
+++ b/src/crimson/common/fatal_signal.cc
@@ -3,7 +3,7 @@
 
 #include "fatal_signal.h"
 
-#include <signal.h>
+#include <csignal>
 #include <iostream>
 #include <string_view>
 
@@ -11,21 +11,43 @@
 
 FatalSignal::FatalSignal()
 {
-  auto fatal_signals = {SIGSEGV,
-                        SIGABRT,
-                        SIGBUS,
-                        SIGILL,
-                        SIGFPE,
-                        SIGXCPU,
-                        SIGXFSZ,
-                        SIGSYS};
-
-  for (auto signum : fatal_signals) {
-    seastar::engine().handle_signal(signum, [signum, this] {
-      signaled(signum);
-    });
-  }
+  install_oneshot_signals_handler<SIGSEGV,
+                                  SIGABRT,
+                                  SIGBUS,
+                                  SIGILL,
+                                  SIGFPE,
+                                  SIGXCPU,
+                                  SIGXFSZ,
+                                  SIGSYS>();
 }
+
+template <int... SigNums>
+void FatalSignal::install_oneshot_signals_handler()
+{
+  (install_oneshot_signal_handler<SigNums>() , ...);
+}
+
+template <int SigNum>
+void FatalSignal::install_oneshot_signal_handler()
+{
+  struct sigaction sa;
+  sa.sa_sigaction = [](int sig, siginfo_t *info, void *p) {
+    static std::atomic_bool handled = false;
+    if (handled.exchange(true)) {
+      return;
+    }
+    FatalSignal::signaled(sig);
+    ::signal(sig, SIG_DFL);
+  };
+  sigfillset(&sa.sa_mask);
+  sa.sa_flags = SA_SIGINFO | SA_RESTART;
+  if constexpr (SigNum == SIGSEGV) {
+      sa.sa_flags |= SA_ONSTACK;
+  }
+  [[maybe_unused]] auto r = ::sigaction(SigNum, &sa, nullptr);
+  assert(r);
+}
+
 
 static void print_with_backtrace(std::string_view cause) {
   std::cerr << cause;
@@ -43,9 +65,6 @@ static void print_with_backtrace(std::string_view cause) {
 
 void FatalSignal::signaled(int signum)
 {
-  if (handled.exchange(true)) {
-    return;
-  }
   switch (signum) {
   case SIGSEGV:
     print_with_backtrace("Aborting");
@@ -57,5 +76,4 @@ void FatalSignal::signaled(int signum)
     print_with_backtrace(fmt::format("Signal {}", signum));
     break;
   }
-  signal(signum, SIG_DFL);
 }

--- a/src/crimson/common/fatal_signal.cc
+++ b/src/crimson/common/fatal_signal.cc
@@ -58,5 +58,4 @@ void FatalSignal::signaled(int signum)
     break;
   }
   signal(signum, SIG_DFL);
-  seastar::engine().exit(1);
 }

--- a/src/crimson/common/fatal_signal.cc
+++ b/src/crimson/common/fatal_signal.cc
@@ -1,0 +1,62 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "fatal_signal.h"
+
+#include <signal.h>
+#include <iostream>
+#include <string_view>
+
+#include <seastar/core/reactor.hh>
+
+FatalSignal::FatalSignal()
+{
+  auto fatal_signals = {SIGSEGV,
+                        SIGABRT,
+                        SIGBUS,
+                        SIGILL,
+                        SIGFPE,
+                        SIGXCPU,
+                        SIGXFSZ,
+                        SIGSYS};
+
+  for (auto signum : fatal_signals) {
+    seastar::engine().handle_signal(signum, [signum, this] {
+      signaled(signum);
+    });
+  }
+}
+
+static void print_with_backtrace(std::string_view cause) {
+  std::cerr << cause;
+  if (seastar::engine_is_ready()) {
+    std::cerr << " on shard " << seastar::this_shard_id();
+  }
+  std::cerr << ".\nBacktrace:\n";
+#if 0
+  std::cerr << symbolized::current_backtrace_tasklocal();
+#endif
+  std::cerr << std::flush;
+  // TODO: dump crash related meta data to $crash_dir
+  //       see handle_fatal_signal()
+}
+
+void FatalSignal::signaled(int signum)
+{
+  if (handled.exchange(true)) {
+    return;
+  }
+  switch (signum) {
+  case SIGSEGV:
+    print_with_backtrace("Aborting");
+    break;
+  case SIGABRT:
+    print_with_backtrace("Segmentation fault");
+    break;
+  default:
+    print_with_backtrace(fmt::format("Signal {}", signum));
+    break;
+  }
+  signal(signum, SIG_DFL);
+  seastar::engine().exit(1);
+}

--- a/src/crimson/common/fatal_signal.h
+++ b/src/crimson/common/fatal_signal.h
@@ -1,0 +1,16 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <atomic>
+
+class FatalSignal {
+public:
+  FatalSignal();
+
+private:
+  void signaled(int signum);
+  static void print_backtrace(int signum);
+  std::atomic<bool> handled = false;
+};

--- a/src/crimson/common/fatal_signal.h
+++ b/src/crimson/common/fatal_signal.h
@@ -3,14 +3,17 @@
 
 #pragma once
 
-#include <atomic>
-
 class FatalSignal {
 public:
   FatalSignal();
 
 private:
-  void signaled(int signum);
+  static void signaled(int signum);
   static void print_backtrace(int signum);
-  std::atomic<bool> handled = false;
+
+  template <int... SigNums>
+  void install_oneshot_signals_handler();
+
+  template <int SigNum>
+  void install_oneshot_signal_handler();
 };

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -16,6 +16,7 @@
 #include "common/ceph_argparse.h"
 #include "crimson/common/buffer_io.h"
 #include "crimson/common/config_proxy.h"
+#include "crimson/common/fatal_signal.h"
 #include "crimson/mon/MonClient.h"
 #include "crimson/net/Messenger.h"
 #include "global/pidfile.h"
@@ -198,6 +199,7 @@ int main(int argc, char* argv[])
       [&, &ceph_args=ceph_args] {
       auto& config = app.configuration();
       return seastar::async([&] {
+        FatalSignal fatal_signal;
 	if (config.count("debug")) {
 	    seastar::global_logger_registry().set_all_loggers_level(
 	      seastar::log_level::debug


### PR DESCRIPTION
This frees a developer from the need to pass the backtrace through `seastar-addr2line`. After the change:

```
[rzarzynski@o06 build]$ ./bin/unittest-seastar-errorator --smp 1 
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from errorator_test_t
[ RUN      ] errorator_test_t.basic
Aborting on shard 0.
Backtrace:
 0# print_with_backtrace(std::basic_string_view<char, std::char_traits<char> >) at /home/rzarzynski/ceph1/src/crimson/common/fatal_signal.cc:59
 1# FatalSignal::signaled(int) at /home/rzarzynski/ceph1/src/crimson/common/fatal_signal.cc:78
 2# FatalSignal::install_oneshot_signal_handler<11>()::{lambda(int, siginfo_t*, void*)#1}::_FUN(int, siginfo_t*, void*) at /home/rzarzynski/ceph1/src/crimson/common/fatal_signal.cc:41
 3# 0x00007F5640897B30 in /lib64/libpthread.so.0
 4# auto crimson::do_until<errorator_test_t::test_do_until()::{lambda()#1}>(errorator_test_t::test_do_until()::{lambda()#1}) at /home/rzarzynski/ceph1/src/test/crimson/test_errorator.cc:21
 5# seastar::noncopyable_function<void ()>::direct_vtable_for<seastar::async<errorator_test_t_basic_Test::TestBody()::{lambda()#1}>(seastar::thread_attributes, std::decay&&, (std::decay<errorator_test_t_basic_Test::TestBody()::{lambda()#1}>::type&&)...)::{lambda()#1}>::call(seastar::noncopyable_function<void ()> const*) at /home/rzarzynski/ceph1/src/seastar/include/seastar/core/future.hh:1473
 6# seastar::thread_context::main() at /home/rzarzynski/ceph1/src/seastar/include/seastar/core/future.hh:924
Segmentation fault (core dumped)
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
