### PR TITLE
pacific: common/options/global.yaml.in: increase default value of bluestore_cache_trim_max_skip_pinned

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4527,7 +4527,7 @@ std::vector<Option> get_global_options() {
     .set_description("How frequently we trim the bluestore cache"),
 
     Option("bluestore_cache_trim_max_skip_pinned", Option::TYPE_UINT, Option::LEVEL_DEV)
-    .set_default(64)
+    .set_default(1000)
     .set_description("Max pinned cache entries we consider before giving up"),
 
     Option("bluestore_cache_type", Option::TYPE_STR, Option::LEVEL_DEV)


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50402

---

backport of https://github.com/ceph/ceph/pull/40732
parent tracker: https://tracker.ceph.com/issues/50217

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh