### PR TITLE
crimson/net: Refactor conn::send() 

### DIFF
--- a/src/common/RefCountedObj.h
+++ b/src/common/RefCountedObj.h
@@ -193,6 +193,14 @@ static inline void intrusive_ptr_add_ref(const RefCountedObject *p) {
 static inline void intrusive_ptr_release(const RefCountedObject *p) {
   p->put();
 }
+struct UniquePtrDeleter
+{
+  void operator()(RefCountedObject *p) const
+  {
+    // Don't expect a call to `get()` in the ctor as we manually set nref to 1
+    p->put();
+  }
+};
 }
 using RefCountedPtr = ceph::ref_t<TOPNSPC::common::RefCountedObject>;
 

--- a/src/crimson/admin/admin_socket.cc
+++ b/src/crimson/admin/admin_socket.cc
@@ -131,10 +131,10 @@ seastar::future<> AdminSocket::handle_command(crimson::net::ConnectionRef conn,
   return execute_command(m->cmd, std::move(m->get_data())).then(
     [conn, tid=m->get_tid()](auto result) {
     auto [ret, err, out] = std::move(result);
-    auto reply = make_message<MCommandReply>(ret, err);
+    auto reply = crimson::net::make_message<MCommandReply>(ret, err);
     reply->set_tid(tid);
     reply->set_data(out);
-    return conn->send(reply);
+    return conn->send(std::move(reply));
   });
 }
 

--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -202,7 +202,7 @@ Connection::create_auth(crimson::auth::method_t protocol,
 seastar::future<std::optional<Connection::auth_result_t>>
 Connection::do_auth_single(Connection::request_t what)
 {
-  auto m = make_message<MAuth>();
+  auto m = crimson::net::make_message<MAuth>();
   m->protocol = auth->get_protocol();
   auth->prepare_build_request();
   switch (what) {
@@ -220,7 +220,7 @@ Connection::do_auth_single(Connection::request_t what)
     assert(0);
   }
   logger().info("sending {}", *m);
-  return conn->send(m).then([this] {
+  return conn->send(std::move(m)).then([this] {
     logger().info("waiting");
     return reply.get_shared_future();
   }).then([this] (Ref<MAuthReply> m) {
@@ -265,7 +265,7 @@ Connection::do_auth(Connection::request_t what) {
 seastar::future<Connection::auth_result_t> Connection::authenticate_v2()
 {
   auth_start = seastar::lowres_system_clock::now();
-  return conn->send(make_message<MMonGetMap>()).then([this] {
+  return conn->send(crimson::net::make_message<MMonGetMap>()).then([this] {
     auth_done.emplace();
     return auth_done->get_future();
   });

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -91,7 +91,7 @@ public:
   get_version_t get_version(const std::string& map);
   command_result_t run_command(std::string&& cmd,
                                bufferlist&& bl);
-  seastar::future<> send_message(MessageRef);
+  seastar::future<> send_message(MessageURef);
   bool sub_want(const std::string& what, version_t start, unsigned flags);
   void sub_got(const std::string& what, version_t have);
   void sub_unwant(const std::string& what);
@@ -180,8 +180,8 @@ private:
 
   // messages that are waiting for the active_con to be available
   struct pending_msg_t {
-    pending_msg_t(MessageRef& m) : msg(m) {}
-    MessageRef msg;
+    pending_msg_t(MessageURef m) : msg(std::move(m)) {}
+    MessageURef msg;
     seastar::promise<> pr;
   };
   std::deque<pending_msg_t> pending_messages;

--- a/src/crimson/net/Connection.h
+++ b/src/crimson/net/Connection.h
@@ -126,6 +126,8 @@ class Connection : public seastar::enable_shared_from_this<Connection> {
 #endif
 
   /// send a message over a connection that has completed its handshake
+  virtual seastar::future<> send(MessageURef msg) = 0;
+  // The version with MessageRef will be dropped in the future
   virtual seastar::future<> send(MessageRef msg) = 0;
 
   /// send a keepalive message over a connection that has completed its

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -69,6 +69,12 @@ bool SocketConnection::peer_wins() const
   return (messenger.get_myaddr() > peer_addr || policy.server);
 }
 
+seastar::future<> SocketConnection::send(MessageURef msg)
+{
+  assert(seastar::this_shard_id() == shard_id());
+  return protocol->send(MessageRef{msg.release()});
+}
+
 seastar::future<> SocketConnection::send(MessageRef msg)
 {
   assert(seastar::this_shard_id() == shard_id());

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -70,6 +70,7 @@ class SocketConnection : public Connection {
   bool peer_wins() const;
 #endif
 
+  seastar::future<> send(MessageURef msg) override;
   seastar::future<> send(MessageRef msg) override;
 
   seastar::future<> keepalive() override;

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -421,10 +421,10 @@ void Heartbeat::Connection::reset()
   }
 }
 
-seastar::future<> Heartbeat::Connection::send(MessageRef msg)
+seastar::future<> Heartbeat::Connection::send(MessageURef msg)
 {
   assert(is_connected);
-  return conn->send(msg);
+  return conn->send(std::move(msg));
 }
 
 void Heartbeat::Connection::validate()

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -279,7 +279,7 @@ seastar::future<> Heartbeat::handle_ping(crimson::net::ConnectionRef conn,
   auto min_message = static_cast<uint32_t>(
     local_conf()->osd_heartbeat_min_size);
   auto reply =
-    make_message<MOSDPing>(
+    crimson::net::make_message<MOSDPing>(
       m->fsid,
       service.get_osdmap_service().get_map()->get_epoch(),
       MOSDPing::PING_REPLY,
@@ -288,7 +288,7 @@ seastar::future<> Heartbeat::handle_ping(crimson::net::ConnectionRef conn,
       service.get_mnow(),
       service.get_osdmap_service().get_up_epoch(),
       min_message);
-  return conn->send(reply);
+  return conn->send(std::move(reply));
 }
 
 seastar::future<> Heartbeat::handle_reply(crimson::net::ConnectionRef conn,
@@ -613,7 +613,7 @@ void Heartbeat::Peer::do_send_heartbeat(
   for_each_conn([&, this] (auto& conn) {
     auto min_message = static_cast<uint32_t>(
       local_conf()->osd_heartbeat_min_size);
-    auto ping = make_message<MOSDPing>(
+    auto ping = crimson::net::make_message<MOSDPing>(
       heartbeat.monc.get_fsid(),
       heartbeat.service.get_osdmap_service().get_map()->get_epoch(),
       MOSDPing::PING,
@@ -641,14 +641,14 @@ bool Heartbeat::FailingPeers::add_pending(
       now - failed_since).count();
   auto osdmap = heartbeat.service.get_osdmap_service().get_map();
   auto failure_report =
-      make_message<MOSDFailure>(heartbeat.monc.get_fsid(),
+      crimson::net::make_message<MOSDFailure>(heartbeat.monc.get_fsid(),
                                 peer,
                                 osdmap->get_addrs(peer),
                                 static_cast<int>(failed_for),
                                 osdmap->get_epoch());
   failure_pending.emplace(peer, failure_info_t{failed_since,
                                                osdmap->get_addrs(peer)});
-  futures.push_back(heartbeat.monc.send_message(failure_report));
+  futures.push_back(heartbeat.monc.send_message(std::move(failure_report)));
   logger().info("{}: osd.{} failed for {}", __func__, peer, failed_for);
   return true;
 }
@@ -668,7 +668,7 @@ seastar::future<>
 Heartbeat::FailingPeers::send_still_alive(
     osd_id_t osd, const entity_addrvec_t& addrs)
 {
-  auto still_alive = make_message<MOSDFailure>(
+  auto still_alive = crimson::net::make_message<MOSDFailure>(
     heartbeat.monc.get_fsid(),
     osd,
     addrs,
@@ -676,5 +676,5 @@ Heartbeat::FailingPeers::send_still_alive(
     heartbeat.service.get_osdmap_service().get_map()->get_epoch(),
     MOSDFailure::FLAG_ALIVE);
   logger().info("{}: osd.{}", __func__, osd);
-  return heartbeat.monc.send_message(still_alive);
+  return heartbeat.monc.send_message(std::move(still_alive));
 }

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -189,7 +189,7 @@ class Heartbeat::Connection {
   void accepted(crimson::net::ConnectionRef);
   void replaced();
   void reset();
-  seastar::future<> send(MessageRef msg);
+  seastar::future<> send(MessageURef msg);
   void validate();
   // retry connection if still pending
   void retry();

--- a/src/crimson/osd/osd_operations/client_request.cc
+++ b/src/crimson/osd/osd_operations/client_request.cc
@@ -172,7 +172,7 @@ ClientRequest::process_op(Ref<PG> &pg)
       [this, pg](bool completed, int ret) mutable
       -> PG::load_obc_iertr::future<> {
       if (completed) {
-        auto reply = make_message<MOSDOpReply>(
+        auto reply = crimson::net::make_message<MOSDOpReply>(
           m.get(), ret, pg->get_osdmap_epoch(),
           CEPH_OSD_FLAG_ACK | CEPH_OSD_FLAG_ONDISK, false);
         return conn->send(std::move(reply));
@@ -231,7 +231,7 @@ ClientRequest::do_process(Ref<PG>& pg, crimson::osd::ObjectContextRef obc)
       return seastar::now();
     } else if (const hobject_t& hoid = m->get_hobj();
                !pg->get_peering_state().can_serve_replica_read(hoid)) {
-      auto reply = make_message<MOSDOpReply>(
+      auto reply = crimson::net::make_message<MOSDOpReply>(
 	m.get(), -EAGAIN, pg->get_osdmap_epoch(),
 	m->get_flags() & (CEPH_OSD_FLAG_ACK|CEPH_OSD_FLAG_ONDISK),
 	!m->has_flag(CEPH_OSD_FLAG_RETURNVEC));

--- a/src/crimson/osd/pg_recovery.cc
+++ b/src/crimson/osd/pg_recovery.cc
@@ -403,7 +403,7 @@ void PGRecovery::request_replica_scan(
   const hobject_t& end)
 {
   logger().debug("{}: target.osd={}", __func__, target.osd);
-  auto msg = make_message<MOSDPGScan>(
+  auto msg = crimson::net::make_message<MOSDPGScan>(
     MOSDPGScan::OP_SCAN_GET_DIGEST,
     pg->get_pg_whoami(),
     pg->get_osdmap_epoch(),
@@ -488,7 +488,7 @@ void PGRecovery::update_peers_last_backfill(
     if (const pg_info_t& pinfo = pg->get_peering_state().get_peer_info(bt);
         new_last_backfill > pinfo.last_backfill) {
       pg->get_peering_state().update_peer_last_backfill(bt, new_last_backfill);
-      auto m = make_message<MOSDPGBackfill>(
+      auto m = crimson::net::make_message<MOSDPGBackfill>(
         pinfo.last_backfill.is_max() ? MOSDPGBackfill::OP_BACKFILL_FINISH
                                      : MOSDPGBackfill::OP_BACKFILL_PROGRESS,
         pg->get_osdmap_epoch(),

--- a/src/crimson/osd/recovery_backend.cc
+++ b/src/crimson/osd/recovery_backend.cc
@@ -72,7 +72,7 @@ void RecoveryBackend::handle_backfill_finish(
   logger().debug("{}", __func__);
   ceph_assert(!pg.is_primary());
   ceph_assert(crimson::common::local_conf()->osd_kill_backfill_at != 1);
-  auto reply = make_message<MOSDPGBackfill>(
+  auto reply = crimson::net::make_message<MOSDPGBackfill>(
     MOSDPGBackfill::OP_BACKFILL_FINISH_ACK,
     pg.get_osdmap_epoch(),
     m.query_epoch,
@@ -234,7 +234,7 @@ RecoveryBackend::handle_scan_get_digest(
   ).then_interruptible([this,
           query_epoch=m.query_epoch,
           conn=m.get_connection()] (auto backfill_interval) {
-    auto reply = make_message<MOSDPGScan>(
+    auto reply = crimson::net::make_message<MOSDPGScan>(
       MOSDPGScan::OP_SCAN_DIGEST,
       pg.get_pg_whoami(),
       pg.get_osdmap_epoch(),

--- a/src/crimson/osd/replicated_backend.cc
+++ b/src/crimson/osd/replicated_backend.cc
@@ -67,7 +67,7 @@ ReplicatedBackend::_submit_transaction(std::set<pg_shard_t>&& pg_shards,
       if (pg_shard == whoami) {
         return shard_services.get_store().do_transaction(coll,std::move(txn));
       } else {
-        auto m = make_message<MOSDRepOp>(req_id, whoami,
+        auto m = crimson::net::make_message<MOSDRepOp>(req_id, whoami,
                                          spg_t{pgid, pg_shard.shard}, hoid,
                                          CEPH_OSD_FLAG_ACK | CEPH_OSD_FLAG_ONDISK,
                                          map_epoch, min_epoch,

--- a/src/crimson/osd/shard_services.cc
+++ b/src/crimson/osd/shard_services.cc
@@ -85,8 +85,10 @@ void ShardServices::handle_conf_change(const ConfigProxy& conf,
   }
 }
 
-seastar::future<> ShardServices::send_to_osd(
-  int peer, Ref<Message> m, epoch_t from_epoch) {
+template<class MsgT>
+seastar::future<> ShardServices::do_send_to_osd(
+  int peer, MsgT m, epoch_t from_epoch)
+{
   if (osdmap->is_down(peer)) {
     logger().info("{}: osd.{} is_down", __func__, peer);
     return seastar::now();
@@ -97,8 +99,20 @@ seastar::future<> ShardServices::send_to_osd(
   } else {
     auto conn = cluster_msgr.connect(
         osdmap->get_cluster_addrs(peer).front(), CEPH_ENTITY_TYPE_OSD);
-    return conn->send(m);
+    return conn->send(std::move(m));
   }
+}
+
+seastar::future<> ShardServices::send_to_osd(
+  int peer, MessageRef m, epoch_t from_epoch) 
+{
+  return do_send_to_osd(peer, std::move(m), from_epoch);
+}
+
+seastar::future<> ShardServices::send_to_osd(
+  int peer, MessageURef m, epoch_t from_epoch) 
+{
+  return do_send_to_osd(peer, std::move(m), from_epoch);
 }
 
 seastar::future<> ShardServices::dispatch_context_transaction(

--- a/src/crimson/osd/shard_services.h
+++ b/src/crimson/osd/shard_services.h
@@ -59,6 +59,9 @@ class ShardServices : public md_config_obs_t {
   const char** get_tracked_conf_keys() const final;
   void handle_conf_change(const ConfigProxy& conf,
                           const std::set <std::string> &changed) final;
+  template<class MsgT>
+  seastar::future<> do_send_to_osd(int peer, MsgT m, epoch_t from_epoch);
+
 public:
   ShardServices(
     OSDMapService &osdmap_service,
@@ -72,6 +75,11 @@ public:
   seastar::future<> send_to_osd(
     int peer,
     MessageRef m,
+    epoch_t from_epoch);
+
+  seastar::future<> send_to_osd(
+    int peer,
+    MessageURef m,
     epoch_t from_epoch);
 
   crimson::os::FuturizedStore &get_store() {

--- a/src/crimson/osd/watch.cc
+++ b/src/crimson/osd/watch.cc
@@ -36,7 +36,7 @@ seastar::future<> Watch::connect(crimson::net::ConnectionRef conn, bool)
 seastar::future<> Watch::send_notify_msg(NotifyRef notify)
 {
   logger().info("{} for notify(id={})", __func__, notify->ninfo.notify_id);
-  return conn->send(make_message<MWatchNotify>(
+  return conn->send(crimson::net::make_message<MWatchNotify>(
     winfo.cookie,
     notify->user_version,
     notify->ninfo.notify_id,
@@ -75,7 +75,7 @@ seastar::future<> Watch::send_disconnect_msg()
     return seastar::now();
   }
   ceph::bufferlist empty;
-  return conn->send(make_message<MWatchNotify>(
+  return conn->send(crimson::net::make_message<MWatchNotify>(
     winfo.cookie,
     0,
     0,
@@ -183,7 +183,7 @@ seastar::future<> Notify::send_completion(
   logger().debug("{} sending notify replies: {}", __func__, notify_replies);
 
   ceph::bufferlist empty;
-  auto reply = make_message<MWatchNotify>(
+  auto reply = crimson::net::make_message<MWatchNotify>(
     ninfo.cookie,
     user_version,
     ninfo.notify_id,

--- a/src/messages/MCacheExpire.h
+++ b/src/messages/MCacheExpire.h
@@ -105,6 +105,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 WRITE_CLASS_ENCODER(MCacheExpire::realm)

--- a/src/messages/MClientCapRelease.h
+++ b/src/messages/MClientCapRelease.h
@@ -52,6 +52,8 @@ class MClientCapRelease final : public SafeMessage {
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 
   static constexpr int HEAD_VERSION = 2;
   static constexpr int COMPAT_VERSION = 1;

--- a/src/messages/MClientCaps.h
+++ b/src/messages/MClientCaps.h
@@ -342,6 +342,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MClientLease.h
+++ b/src/messages/MClientLease.h
@@ -90,6 +90,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MClientMetrics.h
+++ b/src/messages/MClientMetrics.h
@@ -49,6 +49,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif // CEPH_MDS_CLIENT_METRICS_H

--- a/src/messages/MClientQuota.h
+++ b/src/messages/MClientQuota.h
@@ -49,6 +49,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MClientReclaim.h
+++ b/src/messages/MClientReclaim.h
@@ -61,6 +61,8 @@ private:
 
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MClientReclaimReply.h
+++ b/src/messages/MClientReclaimReply.h
@@ -67,6 +67,8 @@ private:
 
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MClientReconnect.h
+++ b/src/messages/MClientReconnect.h
@@ -170,6 +170,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -400,6 +400,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MClientRequest.h
+++ b/src/messages/MClientRequest.h
@@ -322,6 +322,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 WRITE_CLASS_ENCODER(MClientRequest::Release)

--- a/src/messages/MClientRequestForward.h
+++ b/src/messages/MClientRequestForward.h
@@ -67,6 +67,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MClientSession.h
+++ b/src/messages/MClientSession.h
@@ -94,6 +94,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MClientSnap.h
+++ b/src/messages/MClientSnap.h
@@ -66,6 +66,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MDentryLink.h
+++ b/src/messages/MDentryLink.h
@@ -75,6 +75,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MDentryUnlink.h
+++ b/src/messages/MDentryUnlink.h
@@ -66,6 +66,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MDirUpdate.h
+++ b/src/messages/MDirUpdate.h
@@ -93,6 +93,8 @@ private:
   static constexpr int COMPAT_VERSION = 1;
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MDiscover.h
+++ b/src/messages/MDiscover.h
@@ -95,6 +95,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MDiscoverReply.h
+++ b/src/messages/MDiscoverReply.h
@@ -210,6 +210,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportCaps.h
+++ b/src/messages/MExportCaps.h
@@ -59,6 +59,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportCapsAck.h
+++ b/src/messages/MExportCapsAck.h
@@ -53,6 +53,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDir.h
+++ b/src/messages/MExportDir.h
@@ -61,6 +61,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDirAck.h
+++ b/src/messages/MExportDirAck.h
@@ -53,6 +53,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDirCancel.h
+++ b/src/messages/MExportDirCancel.h
@@ -53,6 +53,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDirDiscover.h
+++ b/src/messages/MExportDirDiscover.h
@@ -68,6 +68,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDirDiscoverAck.h
+++ b/src/messages/MExportDirDiscoverAck.h
@@ -64,6 +64,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDirFinish.h
+++ b/src/messages/MExportDirFinish.h
@@ -58,6 +58,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDirNotify.h
+++ b/src/messages/MExportDirNotify.h
@@ -85,6 +85,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDirNotifyAck.h
+++ b/src/messages/MExportDirNotifyAck.h
@@ -57,7 +57,9 @@ public:
   }
 private:
   template<class T, typename... Args>
-  friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);  
+  friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDirPrep.h
+++ b/src/messages/MExportDirPrep.h
@@ -88,6 +88,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MExportDirPrepAck.h
+++ b/src/messages/MExportDirPrepAck.h
@@ -59,6 +59,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MGatherCaps.h
+++ b/src/messages/MGatherCaps.h
@@ -34,6 +34,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MHeartbeat.h
+++ b/src/messages/MHeartbeat.h
@@ -61,6 +61,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MInodeFileCaps.h
+++ b/src/messages/MInodeFileCaps.h
@@ -58,6 +58,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MLock.h
+++ b/src/messages/MLock.h
@@ -101,6 +101,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSBeacon.h
+++ b/src/messages/MMDSBeacon.h
@@ -317,6 +317,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSCacheRejoin.h
+++ b/src/messages/MMDSCacheRejoin.h
@@ -343,6 +343,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 
   static constexpr int HEAD_VERSION = 2;
   static constexpr int COMPAT_VERSION = 1;

--- a/src/messages/MMDSFindIno.h
+++ b/src/messages/MMDSFindIno.h
@@ -50,6 +50,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSFindInoReply.h
+++ b/src/messages/MMDSFindInoReply.h
@@ -50,6 +50,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSFragmentNotify.h
+++ b/src/messages/MMDSFragmentNotify.h
@@ -70,7 +70,9 @@ public:
   }
 private:
   template<class T, typename... Args>
-  friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);  
+  friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);  
 };
 
 #endif

--- a/src/messages/MMDSFragmentNotifyAck.h
+++ b/src/messages/MMDSFragmentNotifyAck.h
@@ -57,6 +57,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSLoadTargets.h
+++ b/src/messages/MMDSLoadTargets.h
@@ -58,6 +58,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSMap.h
+++ b/src/messages/MMDSMap.h
@@ -84,6 +84,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSMetrics.h
+++ b/src/messages/MMDSMetrics.h
@@ -48,6 +48,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif // CEPH_MDS_METRICS_H

--- a/src/messages/MMDSOpenIno.h
+++ b/src/messages/MMDSOpenIno.h
@@ -54,6 +54,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSOpenInoReply.h
+++ b/src/messages/MMDSOpenInoReply.h
@@ -59,6 +59,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSPeerRequest.h
+++ b/src/messages/MMDSPeerRequest.h
@@ -228,6 +228,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSPing.h
+++ b/src/messages/MMDSPing.h
@@ -45,6 +45,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif // CEPH_MESSAGES_MMDSPING_H

--- a/src/messages/MMDSResolve.h
+++ b/src/messages/MMDSResolve.h
@@ -148,6 +148,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 inline std::ostream& operator<<(std::ostream& out, const MMDSResolve::peer_request&) {

--- a/src/messages/MMDSResolveAck.h
+++ b/src/messages/MMDSResolveAck.h
@@ -60,6 +60,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSScrub.h
+++ b/src/messages/MMDSScrub.h
@@ -121,7 +121,9 @@ protected:
   ~MMDSScrub() override {}
 private:
   template<class T, typename... Args>
-    friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 
   static constexpr unsigned FLAG_INTERNAL_TAG	= 1<<0;
   static constexpr unsigned FLAG_FORCE		= 1<<1;

--- a/src/messages/MMDSScrubStats.h
+++ b/src/messages/MMDSScrubStats.h
@@ -75,6 +75,8 @@ private:
 
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSSnapUpdate.h
+++ b/src/messages/MMDSSnapUpdate.h
@@ -58,6 +58,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMDSTableRequest.h
+++ b/src/messages/MMDSTableRequest.h
@@ -65,6 +65,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMgrConfigure.h
+++ b/src/messages/MMgrConfigure.h
@@ -81,6 +81,8 @@ private:
   using RefCountedObject::get;
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMgrDigest.h
+++ b/src/messages/MMgrDigest.h
@@ -53,6 +53,8 @@ private:
   using RefCountedObject::get;
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMgrMap.h
+++ b/src/messages/MMgrMap.h
@@ -53,6 +53,8 @@ private:
   using RefCountedObject::get;
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMgrOpen.h
+++ b/src/messages/MMgrOpen.h
@@ -92,6 +92,8 @@ private:
   using RefCountedObject::get;
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMgrReport.h
+++ b/src/messages/MMgrReport.h
@@ -197,6 +197,8 @@ private:
   using RefCountedObject::get;
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MMonElection.h
+++ b/src/messages/MMonElection.h
@@ -138,7 +138,7 @@ public:
   }
 private:
   template<class T, typename... Args>
-  friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);  
+  friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
 };
 
 #endif

--- a/src/messages/MRemoveSnaps.h
+++ b/src/messages/MRemoveSnaps.h
@@ -51,6 +51,8 @@ public:
 private:
   template<class T, typename... Args>
   friend boost::intrusive_ptr<T> ceph::make_message(Args&&... args);
+  template<class T, typename... Args>
+  friend MURef<T> crimson::net::make_message(Args&&... args);
 };
 
 #endif

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -553,4 +553,10 @@ ceph::ref_t<T> make_message(Args&&... args) {
 }
 }
 
+namespace crimson::net {
+template<class T, typename... Args>
+MURef<T> make_message(Args&&... args) {
+  return {new T(std::forward<Args>(args)...), TOPNSPC::common::UniquePtrDeleter{}};
+}
+}
 #endif

--- a/src/msg/MessageRef.h
+++ b/src/msg/MessageRef.h
@@ -16,14 +16,18 @@
 #define CEPH_MESSAGEREF_H
  
 #include <boost/intrusive_ptr.hpp>
+#include "common/RefCountedObj.h"
 
 template<typename T>
 using MRef = boost::intrusive_ptr<T>;
 template<typename T>
 using MConstRef = boost::intrusive_ptr<T const>;
+template<typename T>
+using MURef = std::unique_ptr<T, TOPNSPC::common::UniquePtrDeleter>;
 
 using MessageRef = MRef<class Message>;
 using MessageConstRef = MConstRef<class Message>;
+using MessageURef = MURef<class Message>;
 
 /* cd src/messages/ && for f in *; do printf 'class '; basename "$f" .h | tr -d '\n'; printf ';\n'; done >> ../msg/MessageRef.h */
 


### PR DESCRIPTION
This is an effort to refactor connection:send() such that it takes a `std::unique_ptr` instead of a `boost::intrusive_ptr`. It is important to note that in the future, when we start working on m:n mapping, we might switch to `seastar::foreign_ptr`, therefore this PR should make any future changes easier.
There is more refactoring that needs to be done, specifically in wrapper functions to `conn::send()` but before I continue I would like to get some early review.

Signed-off-by: Amnon Hanuhov <ahanukov@redhat.com>