### PR TITLE
pybind/rados: Document that timeout arg is ignored by connect

### DIFF
--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -660,6 +660,8 @@ Rados object in state %s." % self.state)
     def connect(self, timeout: int = 0):
         """
         Connect to the cluster.  Use shutdown() to release resources.
+
+        :param timeout: Any supplied timeout value is currently ignored.
         """
         self.require_state("configuring")
         # NOTE(sileht): timeout was supported by old python API,


### PR DESCRIPTION
While this argument is accepted it has always been ignored. To avoid
confusion it should at least be called out in the documentation.

Signed-off-by: Lee Yarwood <lyarwood@redhat.com>
