### PR TITLE
cephfs-mirror: sanitize `daemons status` JSON

### DIFF
--- a/doc/cephfs/cephfs-mirroring.rst
+++ b/doc/cephfs/cephfs-mirroring.rst
@@ -166,26 +166,32 @@ Mirroring Status
 CephFS mirroring module provides `mirror daemon status` interface to check mirror daemon status::
 
   $ ceph fs snapshot mirror daemon status <fs_name>
-  "14135": {
-    "1": {
-      "name": "a",
-      "directory_count": 0,
-      "peers": {
-        "ae3f22e6-1c72-4a81-8d5d-eebca3bfd29d": {
-          "remote": {
-            "client_name": "client.mirror_remote",
-            "cluster_name": "site-remote",
-            "fs_name": "backup_fs"
-          },
-          "stats": {
-            "failure_count": 0,
-            "recovery_count": 0
+  [
+    {
+      "daemon_id": 284167,
+      "filesystems": [
+        {
+          "filesystem_id": 1,
+          "name": "a",
+          "directory_count": 1,
+          "peers": [
+            {
+              "uuid": "02117353-8cd1-44db-976b-eb20609aa160",
+              "remote": {
+                "client_name": "client.mirror_remote",
+                "cluster_name": "ceph",
+                "fs_name": "backup_fs"
+              },
+              "stats": {
+                "failure_count": 1,
+                "recovery_count": 0
+              }
             }
-          }
+          ]
         }
-      }
+      ]
     }
-  }
+  ]
 
 An entry per mirror daemon instance is displayed along with information such as configured
 peers and basic stats. For more detailed stats, use the admin socket interface as detailed

--- a/doc/dev/cephfs-mirroring.rst
+++ b/doc/dev/cephfs-mirroring.rst
@@ -220,27 +220,32 @@ status::
 E.g::
 
   $ ceph fs snapshot mirror daemon status a | jq
-  {
-  "14135": {
-    "1": {
-      "name": "a",
-      "directory_count": 0,
-      "peers": {
-        "ae3f22e6-1c72-4a81-8d5d-eebca3bfd29d": {
-          "remote": {
-            "client_name": "client.mirror_remote",
-            "cluster_name": "site-remote",
-            "fs_name": "backup_fs"
-          },
-          "stats": {
-            "failure_count": 0,
-            "recovery_count": 0
+  [
+    {
+      "daemon_id": 284167,
+      "filesystems": [
+        {
+          "filesystem_id": 1,
+          "name": "a",
+          "directory_count": 1,
+          "peers": [
+            {
+              "uuid": "02117353-8cd1-44db-976b-eb20609aa160",
+              "remote": {
+                "client_name": "client.mirror_remote",
+                "cluster_name": "ceph",
+                "fs_name": "backup_fs"
+              },
+              "stats": {
+                "failure_count": 1,
+                "recovery_count": 0
+              }
             }
-          }
+          ]
         }
-      }
+      ]
     }
-  }
+  ]
 
 An entry per mirror daemon instance is displayed along with information such as configured
 peers and basic stats. For more detailed stats, use the admin socket interface as detailed


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
