### PR TITLE
test/rgw: Removing unrecognized option from bootstrap file

### DIFF
--- a/src/test/rgw/bucket_notification/bootstrap
+++ b/src/test/rgw/bucket_notification/bootstrap
@@ -25,7 +25,7 @@ if [ -f /etc/redhat-release ]; then
     fi
 fi
 
-virtualenv -p python3 --system-site-packages --distribute virtualenv
+virtualenv -p python3 --system-site-packages virtualenv
 
 # avoid pip bugs
 ./virtualenv/bin/pip install --upgrade pip


### PR DESCRIPTION
Removing '--distribute' option from a command in bootstrap file which seemed to be the reason of failure in:
http://qa-proxy.ceph.com/teuthology/dang-2021-04-19_12:28:43-rgw-wip-dang-zipper-sysobj-distro-basic-smithi/6059513/teuthology.log

Signed-off-by: Kalpesh Pandya <kapandya@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
