### PR TITLE
mgr/dashboard: fix duplicated rows when creating NFS export.

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -975,6 +975,7 @@ scopes are:
 - **iscsi**: includes all features related to iSCSI management.
 - **rgw**: includes all features related to RADOS Gateway (RGW) management.
 - **cephfs**: includes all features related to CephFS management.
+- **nfs-ganesha**: includes all features related to NFS Ganesha management.
 - **manager**: include all features related to Ceph Manager
   management.
 - **log**: include all features related to Ceph logs management.
@@ -1211,7 +1212,26 @@ A log entry may look like this::
 NFS-Ganesha Management
 ----------------------
 
-The Ceph Dashboard can manage `NFS Ganesha <http://nfs-ganesha.github.io/>`_ exports that use
+Support for NFS-Ganesha Clusters Deployed by the Orchestrator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Ceph Dashboard can be used to manage NFS-Ganesha clusters deployed by the
+Orchestrator and will detect them automatically. For more details
+on deploying NFS-Ganesha clusters with the Orchestrator, please see:
+
+- Cephadm backend: :ref:`orchestrator-cli-stateless-services`. Or particularly, see
+  :ref:`deploy-cephadm-nfs-ganesha`.
+- Rook backend: `Ceph NFS Gateway CRD <https://rook.github.io/docs/rook/master/ceph-nfs-crd.html>`_.
+
+Support for NFS-Ganesha Clusters Defined by the User
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. note::
+
+    This configuration only applies for user-defined clusters,
+    NOT for Orchestrator-deployed clusters.
+
+The Ceph Dashboard can manage `NFS Ganesha <https://nfs-ganesha.github.io/>`_ exports that use
 CephFS or RGW as their backstore.
 
 To enable this feature in Ceph Dashboard there are some assumptions that need
@@ -1282,16 +1302,6 @@ NFS-Ganesha cluster.
 
 When configuring the Ceph Dashboard with multiple NFS-Ganesha clusters, the
 Web UI will allow you to choose to which cluster an export belongs.
-
-
-Support for NFS-Ganesha Clusters Deployed by the Orchestrator
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The Ceph Dashboard can be used to manage NFS-Ganesha clusters deployed by the
-Orchestrator and will detect them automatically. For more details
-on deploying NFS-Ganesha clusters with the Orchestrator, please see :ref:`orchestrator-cli-stateless-services`.
-Or particularly, see :ref:`deploy-cephadm-nfs-ganesha` for how to deploy
-NFS-Ganesha clusters with the Cephadm backend.
 
 
 Plug-ins

--- a/src/pybind/mgr/dashboard/controllers/nfsganesha.py
+++ b/src/pybind/mgr/dashboard/controllers/nfsganesha.py
@@ -13,7 +13,8 @@ from ..services.cephfs import CephFS
 from ..services.cephx import CephX
 from ..services.exception import DashboardException, serialize_dashboard_exception
 from ..services.ganesha import Ganesha, GaneshaConf, NFSException
-from ..services.rgw_client import RgwClient
+from ..services.rgw_client import NoCredentialsException, \
+    NoRgwDaemonsException, RequestException, RgwClient
 from . import ApiController, BaseController, ControllerDoc, Endpoint, \
     EndpointDoc, ReadPermission, RESTController, Task, UiApiController
 
@@ -307,7 +308,11 @@ class NFSGaneshaUi(BaseController):
     @Endpoint('GET', '/rgw/buckets')
     @ReadPermission
     def buckets(self, user_id=None):
-        return RgwClient.instance(user_id).get_buckets()
+        try:
+            return RgwClient.instance(user_id).get_buckets()
+        except (DashboardException, NoCredentialsException, RequestException,
+                NoRgwDaemonsException):
+            return []
 
     @Endpoint('GET', '/clusters')
     @ReadPermission

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1202,15 +1202,11 @@ EOF
 
         prun env CEPH_CONF="${conf_fn}" ganesha-rados-grace --userid $test_user -p $pool_name -n $namespace
 
-        if $with_mgr_dashboard; then
-            $CEPH_BIN/rados -p $pool_name put "conf-$name" "$ganesha_dir/ganesha-$name.conf"
-        fi
-
         echo "$test_user ganesha daemon $name started on port: $port"
     done
 
     if $with_mgr_dashboard; then
-        ceph_adm dashboard set-ganesha-clusters-rados-pool-namespace $pool_name
+        ceph_adm dashboard set-ganesha-clusters-rados-pool-namespace "$cluster_id:$pool_name/$cluster_id"
     fi
 }
 


### PR DESCRIPTION
- Show an error message if the same pool & namespace is used by more than 1 cluster.
- Fix error handling when no rgw daemons found.
- Update documentation:
  - You learn first that orchestrator-managed clusters are detected automatically (therefore the documentation that follows is exclusively for user-defined clusters).
  - Include nfs-ganesha in the security scope list.

Fixes: https://tracker.ceph.com/issues/50440
Signed-off-by: Alfonso Martínez <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
