### PR TITLE
mgr/cephadm: reimplement ceph.conf pushing; push client keyrings too

### DIFF
--- a/doc/cephadm/host-management.rst
+++ b/doc/cephadm/host-management.rst
@@ -37,7 +37,7 @@ To add each new host to the cluster, perform two steps:
 
    .. prompt:: bash #
 
-     ceph orch host add *newhost*
+     ceph orch host add *newhost* [*<label1> ...*]
 
    For example:
 
@@ -45,7 +45,16 @@ To add each new host to the cluster, perform two steps:
 
      ceph orch host add host2
      ceph orch host add host3
-     
+
+   One or more labels can also be included to immediately label the
+   new host.  For example, by default the ``_admin`` label will make
+   cephadm maintain a copy of the ``ceph.conf`` file and a
+   ``client.admin`` keyring file in ``/etc/ceph``:
+
+   .. prompt:: bash #
+
+       ceph orch host add host4 _admin
+
 .. _cephadm-removing-hosts:
 
 Removing Hosts

--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -148,11 +148,14 @@ This command will:
   host.
 * Generate a new SSH key for the Ceph cluster and add it to the root
   user's ``/root/.ssh/authorized_keys`` file.
+* Write a copy of the public key to ``/etc/ceph/ceph.pub``.
 * Write a minimal configuration file to ``/etc/ceph/ceph.conf``. This
   file is needed to communicate with the new cluster.
 * Write a copy of the ``client.admin`` administrative (privileged!)
   secret key to ``/etc/ceph/ceph.client.admin.keyring``.
-* Write a copy of the public key to ``/etc/ceph/ceph.pub``.
+* Add the ``_admin`` label to the bootstrap host.  By default, any host
+  with this label will (also) get a copy of ``/etc/ceph/ceph.conf`` and
+  ``/etc/ceph/ceph.client.admin.keyring``.
 
 Further information about cephadm bootstrap 
 -------------------------------------------
@@ -271,6 +274,16 @@ Adding Hosts
 ============
 
 Next, add all hosts to the cluster by following :ref:`cephadm-adding-hosts`.
+
+By default, a ``ceph.conf`` file and a copy of the ``client.admin`` keyring
+are maintained in ``/etc/ceph`` on all hosts with the ``_admin`` label, which is initially
+applied only to the bootstrap host. We usually recommend that one or more other hosts be
+given the ``_admin`` label so that the Ceph CLI (e.g., via ``cephadm shell``) is easily
+accessible on multiple hosts.  To add the ``_admin`` label to additional host(s),
+
+  .. prompt:: bash #
+
+    ceph orch host label add *<host>* _admin
 
 Adding additional MONs
 ======================

--- a/doc/cephadm/install.rst
+++ b/doc/cephadm/install.rst
@@ -184,7 +184,13 @@ available options.
 
 * You can pass any initial Ceph configuration options to the new
   cluster by putting them in a standard ini-style configuration file
-  and using the ``--config *<config-file>*`` option.
+  and using the ``--config *<config-file>*`` option.  For example::
+
+      $ cat <<EOF > initial-ceph.conf
+      [global]
+      osd crush chooseleaf type = 0
+      EOF
+      $ ./cephadm bootstrap --config initial-ceph.conf ...
 
 * The ``--ssh-user *<user>*`` option makes it possible to choose which ssh
   user cephadm will use to connect to hosts. The associated ssh key will be

--- a/doc/cephadm/operations.rst
+++ b/doc/cephadm/operations.rst
@@ -318,6 +318,14 @@ hosts, please enable this by running::
 
   ceph config set mgr mgr/cephadm/manage_etc_ceph_ceph_conf true
 
+If enabled, by default cephadm will update ``ceph.conf`` on all cluster hosts. To
+change the set of hosts that get a managed config file, you can update the
+``mgr/cephadm/manage_etc_ceph_ceph_conf_hosts`` setting to a different placement
+spec (see :ref:`orchestrator-cli-placement-spec`).  For example, to limit config
+file updates to hosts with the ``foo`` label::
+
+  ceph config set mgr mgr/cephadm/manage_etc_ceph_ceph_conf_host label:foo
+
 To set up an initial configuration before bootstrapping
 the cluster, create an initial ``ceph.conf`` file. For example::
 

--- a/doc/cephadm/operations.rst
+++ b/doc/cephadm/operations.rst
@@ -306,7 +306,7 @@ Cephadm can distribute copies of the ``ceph.conf`` and client keyring
 files to hosts.  For example, it is usually a good idea to store a
 copy of the config and ``client.admin`` keyring on any hosts that will
 be used to administer the cluster via the CLI.  By default, cephadm will do
-this for any nodes with the ``admin`` label (which normally includes the bootstrap
+this for any nodes with the ``_admin`` label (which normally includes the bootstrap
 host).
 
 When a client keyring is placed under management, cephadm will:
@@ -330,7 +330,7 @@ To place a keyring under management::
 
 - By default, the *path* will be ``/etc/ceph/client.{entity}.keyring``, which is where
   Ceph looks by default.  Be careful specifying alternate locations as existing files
-  maybe overwritten.
+  may be overwritten.
 - A placement of ``*`` (all hosts) is common.
 - The mode defaults to ``0600`` and ownership to ``0:0`` (user root, group root).
 

--- a/qa/suites/rados/cephadm/smoke-roleless/2-services/client-keyring.yaml
+++ b/qa/suites/rados/cephadm/smoke-roleless/2-services/client-keyring.yaml
@@ -1,0 +1,40 @@
+tasks:
+- cephadm.shell:
+    host.a:
+      - ceph orch host label add `hostname` foo
+      - ceph auth get-or-create client.foo mon 'allow r'
+      - ceph orch client-keyring set client.foo label:foo --mode 770 --owner 11111:22222
+- exec:
+    host.a:
+      - while ! test -e /etc/ceph/ceph.client.foo.keyring ; do sleep 1 ; done
+      - ls -al /etc/ceph/ceph.client.foo.keyring | grep rwxrwx---
+      - ls -al /etc/ceph/ceph.client.foo.keyring | grep 11111
+      - ls -al /etc/ceph/ceph.client.foo.keyring | grep 22222
+      - test -e /etc/ceph/ceph.conf
+- exec:
+    host.b:
+      - test ! -e /etc/ceph/ceph.client.foo.keyring
+- cephadm.shell:
+    host.b:
+      - ceph orch host label add `hostname` foo
+- exec:
+    host.b:
+      - while ! test -e /etc/ceph/ceph.client.foo.keyring ; do sleep 1 ; done
+      - ls -al /etc/ceph/ceph.client.foo.keyring | grep rwxrwx---
+      - ls -al /etc/ceph/ceph.client.foo.keyring | grep 11111
+      - ls -al /etc/ceph/ceph.client.foo.keyring | grep 22222
+- cephadm.shell:
+    host.b:
+      - ceph orch host label rm `hostname` foo
+- exec:
+    host.b:
+      - while test -e /etc/ceph/ceph.client.foo.keyring ; do sleep 1 ; done
+- exec:
+    host.a:
+      - test -e /etc/ceph/ceph.client.foo.keyring
+- cephadm.shell:
+    host.a:
+      - ceph orch client-keyring rm client.foo
+- exec:
+    host.a:
+      - while test -e /etc/ceph/ceph.client.foo.keyring ; do sleep 1 ; done

--- a/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-centos_8.3-octopus.yaml
+++ b/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-centos_8.3-octopus.yaml
@@ -14,6 +14,7 @@ tasks:
     allow_ptrace: false
     # deploy additional mons the "old" (octopus) way
     add_mons_via_daemon_add: true
+    avoid_pacific_features: true
 
 
 roles:

--- a/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-ubuntu_20.04-15.2.9.yaml
+++ b/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-ubuntu_20.04-15.2.9.yaml
@@ -10,6 +10,7 @@ tasks:
     allow_ptrace: false
     # deploy additional mons the "old" (octopus) way
     add_mons_via_daemon_add: true
+    avoid_pacific_features: true
 
 roles:
 - - mon.a

--- a/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-ubuntu_20.04.yaml
+++ b/qa/suites/rados/cephadm/upgrade/1-start-distro/1-start-ubuntu_20.04.yaml
@@ -10,6 +10,7 @@ tasks:
     allow_ptrace: false
     # deploy additional mons the "old" (octopus) way
     add_mons_via_daemon_add: true
+    avoid_pacific_features: true
 
 roles:
 - - mon.a

--- a/qa/suites/upgrade/octopus-x/parallel/1-tasks.yaml
+++ b/qa/suites/upgrade/octopus-x/parallel/1-tasks.yaml
@@ -14,6 +14,7 @@ tasks:
         osd_class_default_list: "*"
     # deploy additional mons the "old" (octopus) way
     add_mons_via_daemon_add: true
+    avoid_pacific_features: true
 - print: "**** done end installing octopus cephadm ..."
 
 - cephadm.shell:

--- a/qa/suites/upgrade/octopus-x/stress-split/1-start.yaml
+++ b/qa/suites/upgrade/octopus-x/stress-split/1-start.yaml
@@ -13,6 +13,7 @@ tasks:
         osd_class_default_list: "*"
     # deploy additional mons the "old" (octopus) way
     add_mons_via_daemon_add: true
+    avoid_pacific_features: true
 
 - cephadm.shell:
     mon.a:

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4128,6 +4128,14 @@ def command_bootstrap(ctx):
     if not ctx.skip_dashboard:
         prepare_dashboard(ctx, uid, gid, cli, wait_for_mgr_restart)
 
+    if ctx.output_config == '/etc/ceph/ceph.conf' and not ctx.skip_admin_label:
+        logger.info('Enabling client.admin keyring and conf on hosts with "admin" label')
+        try:
+            cli(['orch', 'client-keyring', 'set', 'client.admin', 'label:_admin'])
+            cli(['orch', 'host', 'label', 'add', get_hostname(), '_admin'])
+        except Exception:
+            logger.info('Unable to set up "admin" label; assuming older version of Ceph')
+
     if ctx.apply_spec:
         logger.info('Applying %s to cluster' % ctx.apply_spec)
 
@@ -7665,6 +7673,10 @@ def _get_parser():
     parser_bootstrap.add_argument(
         '--output-pub-ssh-key',
         help="location to write the cluster's public SSH key")
+    parser_bootstrap.add_argument(
+        '--skip-admin-label',
+        action='store_true',
+        help='do not create admin label for ceph.conf and client.admin keyring distribution')
     parser_bootstrap.add_argument(
         '--skip-ssh',
         action='store_true',

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -284,6 +284,12 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             desc='Manage and own /etc/ceph/ceph.conf on the hosts.',
         ),
         Option(
+            'manage_etc_ceph_ceph_conf_hosts',
+            type='str',
+            default='*',
+            desc='PlacementSpec describing on which hosts to manage /etc/ceph/ceph.conf',
+        ),
+        Option(
             'registry_url',
             type='str',
             default=None,
@@ -366,6 +372,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             self.migration_current: Optional[int] = None
             self.config_dashboard = True
             self.manage_etc_ceph_ceph_conf = True
+            self.manage_etc_ceph_ceph_conf_hosts = '*'
             self.registry_url: Optional[str] = None
             self.registry_username: Optional[str] = None
             self.registry_password: Optional[str] = None

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -56,7 +56,7 @@ from .services.monitoring import GrafanaService, AlertmanagerService, Prometheus
     NodeExporterService
 from .services.exporter import CephadmExporter, CephadmExporterConfig
 from .schedule import HostAssignment
-from .inventory import Inventory, SpecStore, HostCache, EventStore
+from .inventory import Inventory, SpecStore, HostCache, EventStore, ClientKeyringStore, ClientKeyringSpec
 from .upgrade import CephadmUpgrade
 from .template import TemplateMgr
 from .utils import CEPH_TYPES, GATEWAY_TYPES, forall_hosts, cephadmNoImage
@@ -416,6 +416,9 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
 
         self.spec_store = SpecStore(self)
         self.spec_store.load()
+
+        self.keys = ClientKeyringStore(self)
+        self.keys.load()
 
         # ensure the host lists are in sync
         for h in self.inventory.keys():
@@ -1197,6 +1200,67 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             return self.osd_service.deploy_osd_daemons_for_existing_osds(h, 'osd')
 
         return HandleCommandResult(stdout='\n'.join(run(host)))
+
+    @orchestrator._cli_read_command('orch client-keyring ls')
+    def _client_keyring_ls(self, format: Format = Format.plain) -> HandleCommandResult:
+        if format != Format.plain:
+            output = to_format(self.keys.keys.values(), format, many=True, cls=ClientKeyringSpec)
+        else:
+            table = PrettyTable(
+                ['ENTITY', 'PLACEMENT', 'MODE', 'OWNER', 'PATH'],
+                border=False)
+            table.align = 'l'
+            table.left_padding_width = 0
+            table.right_padding_width = 2
+            for ks in sorted(self.keys.keys.values(), key=lambda ks: ks.entity):
+                table.add_row((
+                    ks.entity, ks.placement.pretty_str(),
+                    utils.file_mode_to_str(ks.mode),
+                    f'{ks.uid}:{ks.gid}',
+                    ks.path,
+                ))
+            output = table.get_string()
+        return HandleCommandResult(stdout=output)
+
+    @orchestrator._cli_write_command('orch client-keyring set')
+    def _client_keyring_set(
+            self,
+            entity: str,
+            placement: str,
+            owner: Optional[str] = None,
+            mode: Optional[str] = None,
+    ) -> HandleCommandResult:
+        if not entity.startswith('client.'):
+            raise OrchestratorError('entity must start with client.')
+        if owner:
+            try:
+                uid, gid = map(int, owner.split(':'))
+            except Exception:
+                raise OrchestratorError('owner must look like "<uid>:<gid>", e.g., "0:0"')
+        else:
+            uid = 0
+            gid = 0
+        if mode:
+            try:
+                imode = int(mode, 8)
+            except Exception:
+                raise OrchestratorError('mode must be an octal mode, e.g. "600"')
+        else:
+            imode = 0o600
+        pspec = PlacementSpec.from_string(placement)
+        ks = ClientKeyringSpec(entity, pspec, mode=imode, uid=uid, gid=gid)
+        self.keys.update(ks)
+        self._kick_serve_loop()
+        return HandleCommandResult()
+
+    @orchestrator._cli_write_command('orch client-keyring rm')
+    def _client_keyring_rm(
+            self,
+            entity: str,
+    ) -> HandleCommandResult:
+        self.keys.rm(entity)
+        self._kick_serve_loop()
+        return HandleCommandResult()
 
     def _get_connection(self, host: str) -> Tuple['remoto.backends.BaseConnection',
                                                   'remoto.backends.LegacyModuleExecute']:

--- a/src/pybind/mgr/cephadm/remotes.py
+++ b/src/pybind/mgr/cephadm/remotes.py
@@ -26,6 +26,25 @@ def choose_python():
     return None
 
 
+def write_file(path: str, content: bytes, mode: int, uid: int, gid: int,
+               mkdir_p: bool = True) -> Optional[str]:
+    try:
+        if mkdir_p:
+            dirname = os.path.dirname(path)
+            if not os.path.exists(dirname):
+                os.makedirs(dirname)
+        tmp_path = path + '.new'
+        with open(tmp_path, 'wb') as f:
+            os.fchown(f.fileno(), uid, gid)
+            os.fchmod(f.fileno(), mode)
+            f.write(content)
+            os.fsync(f.fileno())
+        os.rename(tmp_path, path)
+    except Exception as e:
+        return str(e)
+    return None
+
+
 if __name__ == '__channelexec__':
     for item in channel:  # type: ignore # noqa: F821
         channel.send(eval(item))  # type: ignore # noqa: F821

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -386,22 +386,10 @@ class CephadmServe:
         config = self.mgr.get_minimal_ceph_conf()
 
         try:
-            with self._remote_connection(host) as tpl:
-                conn, connr = tpl
-                out, err, code = remoto.process.check(
-                    conn,
-                    ['mkdir', '-p', '/etc/ceph'])
-                if code:
-                    return f'failed to create /etc/ceph on {host}: {err}'
-                out, err, code = remoto.process.check(
-                    conn,
-                    ['dd', 'of=/etc/ceph/ceph.conf'],
-                    stdin=config.encode('utf-8')
-                )
-                if code:
-                    return f'failed to create /etc/ceph/ceph.conf on {host}: {err}'
-                self.mgr.cache.update_last_etc_ceph_ceph_conf(host)
-                self.mgr.cache.save_host(host)
+            self._write_remote_file(host, '/etc/ceph/ceph.conf',
+                                    config.encode('utf-8'), 0o644, 0, 0)
+            self.mgr.cache.update_last_etc_ceph_ceph_conf(host)
+            self.mgr.cache.save_host(host)
         except OrchestratorError as e:
             return f'failed to create /etc/ceph/ceph.conf on {host}: {str(e)}'
         return None

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -1139,6 +1139,24 @@ class CephadmServe:
             self.log.warning(msg)
             raise OrchestratorError(msg)
 
+    def _write_remote_file(self,
+                           host: str,
+                           path: str,
+                           content: bytes,
+                           mode: int,
+                           uid: int,
+                           gid: int) -> None:
+        with self._remote_connection(host) as tpl:
+            conn, connr = tpl
+            try:
+                errmsg = connr.write_file(path, content, mode, uid, gid)
+                if errmsg is not None:
+                    raise OrchestratorError(errmsg)
+            except Exception as e:
+                msg = f"Unable to write {host}:{path}: {e}"
+                self.log.warning(msg)
+                raise OrchestratorError(msg)
+
     @contextmanager
     def _remote_connection(self,
                            host: str,

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1,6 +1,5 @@
 import json
 from contextlib import contextmanager
-from unittest.mock import ANY
 
 import pytest
 
@@ -1028,9 +1027,11 @@ class TestCephadm(object):
 
     @mock.patch("cephadm.module.CephadmOrchestrator._get_connection")
     @mock.patch("remoto.process.check")
-    def test_etc_ceph(self, _check, _get_connection, cephadm_module):
+    @mock.patch("cephadm.module.CephadmServe._write_remote_file")
+    def test_etc_ceph(self, _write_file, _check, _get_connection, cephadm_module):
         _get_connection.return_value = mock.Mock(), mock.Mock()
         _check.return_value = '{}', '', 0
+        _write_file.return_value = None
 
         assert cephadm_module.manage_etc_ceph_ceph_conf is False
 
@@ -1043,15 +1044,16 @@ class TestCephadm(object):
             assert cephadm_module.manage_etc_ceph_ceph_conf is True
 
             CephadmServe(cephadm_module)._refresh_hosts_and_daemons()
-            _check.assert_called_with(ANY, ['dd', 'of=/etc/ceph/ceph.conf'], stdin=b'')
+            _write_file.assert_called_with('test', '/etc/ceph/ceph.conf', b'',
+                                           0o644, 0, 0)
 
             assert not cephadm_module.cache.host_needs_new_etc_ceph_ceph_conf('test')
 
             # set extra config and expect that we deploy another ceph.conf
             cephadm_module._set_extra_ceph_conf('[mon]\nk=v')
             CephadmServe(cephadm_module)._refresh_hosts_and_daemons()
-            _check.assert_called_with(
-                ANY, ['dd', 'of=/etc/ceph/ceph.conf'], stdin=b'\n\n[mon]\nk=v\n')
+            _write_file.assert_called_with('test', '/etc/ceph/ceph.conf',
+                                           b'\n\n[mon]\nk=v\n', 0o644, 0, 0)
 
             # reload
             cephadm_module.cache.last_etc_ceph_ceph_conf = {}

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -1036,7 +1036,7 @@ class TestCephadm(object):
         assert cephadm_module.manage_etc_ceph_ceph_conf is False
 
         with with_host(cephadm_module, 'test'):
-            assert not cephadm_module.cache.host_needs_new_etc_ceph_ceph_conf('test')
+            assert '/etc/ceph/ceph.conf' not in cephadm_module.cache.get_host_client_files('test')
 
         with with_host(cephadm_module, 'test'):
             cephadm_module.set_module_option('manage_etc_ceph_ceph_conf', True)
@@ -1047,7 +1047,7 @@ class TestCephadm(object):
             _write_file.assert_called_with('test', '/etc/ceph/ceph.conf', b'',
                                            0o644, 0, 0)
 
-            assert not cephadm_module.cache.host_needs_new_etc_ceph_ceph_conf('test')
+            assert '/etc/ceph/ceph.conf' in cephadm_module.cache.get_host_client_files('test')
 
             # set extra config and expect that we deploy another ceph.conf
             cephadm_module._set_extra_ceph_conf('[mon]\nk=v')
@@ -1056,21 +1056,17 @@ class TestCephadm(object):
                                            b'\n\n[mon]\nk=v\n', 0o644, 0, 0)
 
             # reload
-            cephadm_module.cache.last_etc_ceph_ceph_conf = {}
+            cephadm_module.cache.last_client_files = {}
             cephadm_module.cache.load()
 
-            assert not cephadm_module.cache.host_needs_new_etc_ceph_ceph_conf('test')
+            assert '/etc/ceph/ceph.conf' in cephadm_module.cache.get_host_client_files('test')
 
             # Make sure, _check_daemons does a redeploy due to monmap change:
-            cephadm_module.mock_store_set('_ceph_get', 'mon_map', {
-                'modified': datetime_to_str(datetime_now()),
-                'fsid': 'foobar',
-            })
-            cephadm_module.notify('mon_map', mock.MagicMock())
-            assert cephadm_module.cache.host_needs_new_etc_ceph_ceph_conf('test')
-            cephadm_module.cache.last_etc_ceph_ceph_conf = {}
-            cephadm_module.cache.load()
-            assert cephadm_module.cache.host_needs_new_etc_ceph_ceph_conf('test')
+            before_digest = cephadm_module.cache.get_host_client_files('test')['/etc/ceph/ceph.conf'][0]
+            cephadm_module._set_extra_ceph_conf('[mon]\nk2=v2')
+            CephadmServe(cephadm_module)._refresh_hosts_and_daemons()
+            after_digest = cephadm_module.cache.get_host_client_files('test')['/etc/ceph/ceph.conf'][0]
+            assert before_digest != after_digest
 
     def test_etc_ceph_init(self):
         with with_cephadm_module({'manage_etc_ceph_ceph_conf': True}) as m:

--- a/src/pybind/mgr/cephadm/utils.py
+++ b/src/pybind/mgr/cephadm/utils.py
@@ -119,3 +119,14 @@ def resolve_ip(hostname: str) -> str:
 
 def ceph_release_to_major(release: str) -> int:
     return ord(release[0]) - ord('a') + 1
+
+
+def file_mode_to_str(mode: int) -> str:
+    r = ''
+    for shift in range(0, 9, 3):
+        r = (
+            f'{"r" if (mode >> shift) & 4 else "-"}'
+            f'{"w" if (mode >> shift) & 2 else "-"}'
+            f'{"x" if (mode >> shift) & 1 else "-"}'
+        ) + r
+    return r


### PR DESCRIPTION
- Add a config option to control which hosts (by default, *) get a ceph.conf (if the bool manage_etc_ceph_ceph_conf option is enabled).
- Add ``ceph orch client-keyring {ls,set,rm}`` commands to manage which client keyrings (and associated configs) to push where
- Refactor a bit to use a cleaner, safer, more efficient method for writing remote files.