### PR TITLE
crimson/os/seastore: track retired extents until in-progress transactions complete

### DIFF
--- a/src/crimson/os/seastore/cache.cc
+++ b/src/crimson/os/seastore/cache.cc
@@ -114,7 +114,7 @@ void Cache::replace_extent(CachedExtentRef next, CachedExtentRef prev)
     intrusive_ptr_release(&*prev);
     add_to_dirty(next);
   } else if (prev->is_dirty()) {
-    assert(prev->dirty_from == next->dirty_from);
+    assert(prev->get_dirty_from() == next->get_dirty_from());
     assert(prev->primary_ref_list_hook.is_linked());
     auto prev_it = dirty.iterator_to(*prev);
     dirty.insert(prev_it, *next);
@@ -454,17 +454,18 @@ Cache::get_next_dirty_extents_ret Cache::get_next_dirty_extents(
        i != dirty.end() && bytes_so_far < max_bytes;
        ++i) {
     CachedExtentRef cand;
-    if (i->dirty_from != journal_seq_t() && i->dirty_from < seq) {
+    if (i->get_dirty_from() != journal_seq_t() && i->get_dirty_from() < seq) {
       logger().debug(
 	"Cache::get_next_dirty_extents: next {}",
 	*i);
-      if (!(ret.empty() || ret.back()->dirty_from <= i->dirty_from)) {
+      if (!(ret.empty() ||
+	    ret.back()->get_dirty_from() <= i->get_dirty_from())) {
 	logger().debug(
 	  "Cache::get_next_dirty_extents: last {}, next {}",
 	  *ret.back(),
 	  *i);
       }
-      assert(ret.empty() || ret.back()->dirty_from <= i->dirty_from);
+      assert(ret.empty() || ret.back()->get_dirty_from() <= i->get_dirty_from());
       bytes_so_far += i->get_length();
       ret.push_back(&*i);
     } else {

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -496,7 +496,7 @@ public:
     return out;
   }
 
-  /// returns extents with dirty_from < seq
+  /// returns extents with get_dirty_from() < seq
   using get_next_dirty_extents_ertr = crimson::errorator<>;
   using get_next_dirty_extents_ret = get_next_dirty_extents_ertr::future<
     std::vector<CachedExtentRef>>;
@@ -504,12 +504,12 @@ public:
     journal_seq_t seq,
     size_t max_bytes);
 
-  /// returns std::nullopt if no dirty extents or dirty_from for oldest
+  /// returns std::nullopt if no dirty extents or get_dirty_from() for oldest
   std::optional<journal_seq_t> get_oldest_dirty_from() const {
     if (dirty.empty()) {
       return std::nullopt;
     } else {
-      auto oldest = dirty.begin()->dirty_from;
+      auto oldest = dirty.begin()->get_dirty_from();
       if (oldest == journal_seq_t()) {
 	return std::nullopt;
       } else {
@@ -526,7 +526,7 @@ private:
   /**
    * dirty
    *
-   * holds refs to dirty extents.  Ordered by CachedExtent::dirty_from.
+   * holds refs to dirty extents.  Ordered by CachedExtent::get_dirty_from().
    */
   CachedExtent::list dirty;
 

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -548,8 +548,14 @@ private:
   /// Add dirty extent to dirty list
   void add_to_dirty(CachedExtentRef ref);
 
+  /// Remove from dirty list
+  void remove_from_dirty(CachedExtentRef ref);
+
   /// Remove extent from extents handling dirty and refcounting
   void remove_extent(CachedExtentRef ref);
+
+  /// Retire extent, move reference to retired_extent_gate
+  void retire_extent(CachedExtentRef ref);
 
   /// Replace prev with next
   void replace_extent(CachedExtentRef next, CachedExtentRef prev);

--- a/src/crimson/os/seastore/cache.h
+++ b/src/crimson/os/seastore/cache.h
@@ -90,6 +90,22 @@ public:
   Cache(SegmentManager &segment_manager);
   ~Cache();
 
+  /// Creates empty transaction
+  TransactionRef create_transaction() {
+    return std::make_unique<Transaction>(
+      get_dummy_ordering_handle(),
+      false
+    );
+  }
+
+  /// Creates empty weak transaction
+  TransactionRef create_weak_transaction() {
+    return std::make_unique<Transaction>(
+      get_dummy_ordering_handle(),
+      true
+    );
+  }
+
   /**
    * drop_from_cache
    *

--- a/src/crimson/os/seastore/cached_extent.cc
+++ b/src/crimson/os/seastore/cached_extent.cc
@@ -46,6 +46,8 @@ std::ostream &operator<<(std::ostream &out, CachedExtent::extent_state_t state)
     return out << "CLEAN";
   case CachedExtent::extent_state_t::DIRTY:
     return out << "DIRTY";
+  case CachedExtent::extent_state_t::RETIRED:
+    return out << "RETIRED";
   case CachedExtent::extent_state_t::INVALID:
     return out << "INVALID";
   default:

--- a/src/crimson/os/seastore/cached_extent.h
+++ b/src/crimson/os/seastore/cached_extent.h
@@ -415,15 +415,11 @@ protected:
    * reference.
    */
   paddr_t maybe_generate_relative(paddr_t addr) {
-    if (!addr.is_relative()) {
-      return addr;
-    } else if (is_mutation_pending()) {
-      assert(addr.is_record_relative());
-      return addr;
-    } else {
-      ceph_assert(is_initial_pending());
-      ceph_assert(get_paddr().is_record_relative());
+    if (is_initial_pending() && addr.is_record_relative()) {
       return addr - get_paddr();
+    } else {
+      ceph_assert(!addr.is_record_relative() || is_mutation_pending());
+      return addr;
     }
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fwd.h
@@ -19,7 +19,6 @@ namespace crimson::os::seastore::onode {
 
 using crimson::os::seastore::Transaction;
 using crimson::os::seastore::TransactionRef;
-using crimson::os::seastore::make_transaction;
 using crimson::os::seastore::laddr_t;
 using crimson::os::seastore::L_ADDR_MIN;
 using crimson::os::seastore::L_ADDR_NULL;

--- a/src/crimson/os/seastore/seastore.cc
+++ b/src/crimson/os/seastore/seastore.cc
@@ -70,7 +70,7 @@ seastar::future<> SeaStore::mkfs(uuid_d new_osd_fsid)
   return transaction_manager->mkfs(
   ).safe_then([this] {
     return seastar::do_with(
-      make_transaction(),
+      transaction_manager->create_transaction(),
       [this](auto &t) {
 	return onode_manager->mkfs(*t
 	).safe_then([this, &t] {
@@ -139,7 +139,7 @@ seastar::future<std::vector<coll_t>> SeaStore::list_collections()
       return repeat_eagain([this, &ret] {
 
 	return seastar::do_with(
-	  make_transaction(),
+	  transaction_manager->create_transaction(),
 	  [this, &ret](auto &t) {
 	    return transaction_manager->read_collection_root(*t
 	    ).safe_then([this, &ret, &t](auto coll_root) {

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -158,9 +158,9 @@ private:
     return seastar::do_with(
       internal_context_t{ ch, std::move(t) },
       std::forward<F>(f),
-      [](auto &ctx, auto &f) {
+      [this](auto &ctx, auto &f) {
 	return repeat_eagain([&]() {
-	  ctx.reset(make_transaction());
+	  ctx.reset(transaction_manager->create_transaction());
 	  return std::invoke(f, ctx);
 	}).handle_error(
 	  crimson::ct_error::eagain::pass_further{},
@@ -184,7 +184,7 @@ private:
       std::forward<F>(f),
       [=](auto &oid, auto &ret, auto &t, auto &onode, auto &f) {
 	return repeat_eagain([&, this] {
-	  t = make_transaction();
+	  t = transaction_manager->create_transaction();
 	  return onode_manager->get_onode(
 	    *t, oid
 	  ).safe_then([&, this](auto onode_ret) {

--- a/src/crimson/os/seastore/seastore_types.cc
+++ b/src/crimson/os/seastore/seastore_types.cc
@@ -65,6 +65,8 @@ std::ostream &operator<<(std::ostream &out, extent_types_t t)
     return out << "COLL_BLOCK";
   case extent_types_t::OBJECT_DATA_BLOCK:
     return out << "OBJECT_DATA_BLOCK";
+  case extent_types_t::RETIRED_PLACEHOLDER:
+    return out << "RETIRED_PLACEHOLDER";
   case extent_types_t::TEST_BLOCK:
     return out << "TEST_BLOCK";
   case extent_types_t::TEST_BLOCK_PHYSICAL:

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -335,6 +335,7 @@ enum class extent_types_t : uint8_t {
   ONODE_BLOCK_STAGED = 6,
   COLL_BLOCK = 7,
   OBJECT_DATA_BLOCK = 8,
+  RETIRED_PLACEHOLDER = 9,
 
   // Test Block Types
   TEST_BLOCK = 0xF0,

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -59,7 +59,7 @@ std::ostream &segment_to_stream(std::ostream &, const segment_id_t &t);
 // may be negative for relative offsets
 using segment_off_t = int32_t;
 constexpr segment_off_t NULL_SEG_OFF =
-  std::numeric_limits<segment_id_t>::max();
+  std::numeric_limits<segment_off_t>::max();
 
 std::ostream &offset_to_stream(std::ostream &, const segment_off_t &t);
 

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -243,6 +243,10 @@ struct journal_seq_t {
 };
 WRITE_CMP_OPERATORS_2(journal_seq_t, segment_seq, offset)
 WRITE_EQ_OPERATORS_2(journal_seq_t, segment_seq, offset)
+constexpr journal_seq_t JOURNAL_SEQ_MIN{
+  0,
+  paddr_t{0, 0}
+};
 
 std::ostream &operator<<(std::ostream &out, const journal_seq_t &seq);
 

--- a/src/crimson/os/seastore/seastore_types.h
+++ b/src/crimson/os/seastore/seastore_types.h
@@ -36,6 +36,8 @@ struct seastore_meta_t {
 
 // Identifies segment location on disk, see SegmentManager,
 using segment_id_t = uint32_t;
+constexpr segment_id_t MAX_SEG_ID =
+  std::numeric_limits<segment_id_t>::max();
 constexpr segment_id_t NULL_SEG_ID =
   std::numeric_limits<segment_id_t>::max() - 1;
 /* Used to denote relative paddr_t */
@@ -60,6 +62,8 @@ std::ostream &segment_to_stream(std::ostream &, const segment_id_t &t);
 using segment_off_t = int32_t;
 constexpr segment_off_t NULL_SEG_OFF =
   std::numeric_limits<segment_off_t>::max();
+constexpr segment_off_t MAX_SEG_OFF =
+  std::numeric_limits<segment_off_t>::max();
 
 std::ostream &offset_to_stream(std::ostream &, const segment_off_t &t);
 
@@ -67,6 +71,8 @@ std::ostream &offset_to_stream(std::ostream &, const segment_off_t &t);
  * the incarnation of a segment */
 using segment_seq_t = uint32_t;
 static constexpr segment_seq_t NULL_SEG_SEQ =
+  std::numeric_limits<segment_seq_t>::max();
+static constexpr segment_seq_t MAX_SEG_SEQ =
   std::numeric_limits<segment_seq_t>::max();
 
 // Offset of delta within a record
@@ -192,6 +198,10 @@ WRITE_CMP_OPERATORS_2(paddr_t, segment, offset)
 WRITE_EQ_OPERATORS_2(paddr_t, segment, offset)
 constexpr paddr_t P_ADDR_NULL = paddr_t{};
 constexpr paddr_t P_ADDR_MIN = paddr_t{0, 0};
+constexpr paddr_t P_ADDR_MAX = paddr_t{
+  MAX_SEG_ID,
+  MAX_SEG_OFF
+};
 constexpr paddr_t make_record_relative_paddr(segment_off_t off) {
   return paddr_t{RECORD_REL_SEG_ID, off};
 }
@@ -246,6 +256,10 @@ WRITE_EQ_OPERATORS_2(journal_seq_t, segment_seq, offset)
 constexpr journal_seq_t JOURNAL_SEQ_MIN{
   0,
   paddr_t{0, 0}
+};
+constexpr journal_seq_t JOURNAL_SEQ_MAX{
+  MAX_SEG_SEQ,
+  P_ADDR_MAX
 };
 
 std::ostream &operator<<(std::ostream &out, const journal_seq_t &seq);

--- a/src/crimson/os/seastore/segment_cleaner.cc
+++ b/src/crimson/os/seastore/segment_cleaner.cc
@@ -266,7 +266,7 @@ SegmentCleaner::gc_trim_journal_ret SegmentCleaner::gc_trim_journal()
   return repeat_eagain(
     [this] {
       return seastar::do_with(
-	make_transaction(),
+	ecb->create_transaction(),
 	[this](auto &t) {
 	  return rewrite_dirty(*t, get_dirty_tail()
 	  ).safe_then([this, &t] {
@@ -310,7 +310,7 @@ SegmentCleaner::gc_reclaim_space_ret SegmentCleaner::gc_reclaim_space()
 	    "SegmentCleaner::gc_reclaim_space: processing {} extents",
 	    extents.size());
 	  return seastar::do_with(
-	    make_transaction(),
+	    ecb->create_transaction(),
 	    [this, &extents](auto &t) mutable {
 	      return crimson::do_for_each(
 		extents,

--- a/src/crimson/os/seastore/segment_cleaner.h
+++ b/src/crimson/os/seastore/segment_cleaner.h
@@ -625,7 +625,6 @@ private:
     }
 
     void maybe_wake_on_space_used() {
-      cleaner.log_gc_state("GCProcess::maybe_wake_on_space_used");
       if (cleaner.gc_should_run()) {
 	wake();
       }

--- a/src/crimson/os/seastore/segment_cleaner.h
+++ b/src/crimson/os/seastore/segment_cleaner.h
@@ -251,6 +251,9 @@ public:
   class ExtentCallbackInterface {
   public:
     virtual ~ExtentCallbackInterface() = default;
+
+    virtual TransactionRef create_transaction() = 0;
+
     /**
      * get_next_dirty_extent
      *

--- a/src/crimson/os/seastore/transaction.h
+++ b/src/crimson/os/seastore/transaction.h
@@ -113,8 +113,7 @@ public:
 
 private:
   friend class Cache;
-  friend Ref make_transaction();
-  friend Ref make_weak_transaction();
+  friend Ref make_test_transaction();
 
   /**
    * If set, *this may not be used to perform writes and will not provide
@@ -155,17 +154,12 @@ public:
 };
 using TransactionRef = Transaction::Ref;
 
-inline TransactionRef make_transaction() {
+/// Should only be used with dummy staged-fltree node extent manager
+inline TransactionRef make_test_transaction() {
   return std::make_unique<Transaction>(
     get_dummy_ordering_handle(),
     false
   );
-}
-
-inline TransactionRef make_weak_transaction() {
-  return std::make_unique<Transaction>(
-    get_dummy_ordering_handle(),
-    true);
 }
 
 }

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -83,9 +83,9 @@ TransactionManager::mount_ertr::future<> TransactionManager::mount()
           return lba_manager->scan_mapped_space(
             *t,
             [this](paddr_t addr, extent_len_t len) {
-              logger().debug("TransactionManager::mount: marking {}~{} used",
-                           addr,
-                           len);
+              logger().trace("TransactionManager::mount: marking {}~{} used",
+			     addr,
+			     len);
               segment_cleaner->mark_space_used(
                 addr,
                 len ,

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -73,7 +73,7 @@ TransactionManager::mount_ertr::future<> TransactionManager::mount()
   }).safe_then([this](auto addr) {
     segment_cleaner->set_journal_head(addr);
     return seastar::do_with(
-      make_weak_transaction(),
+      create_weak_transaction(),
       [this](auto &t) {
 	return cache->init_cached_extents(*t, [this](auto &t, auto &e) {
 	  return lba_manager->init_cached_extent(t, e);

--- a/src/crimson/os/seastore/transaction_manager.cc
+++ b/src/crimson/os/seastore/transaction_manager.cc
@@ -160,7 +160,7 @@ TransactionManager::ref_ret TransactionManager::dec_ref(
       logger().debug(
 	"TransactionManager::dec_ref: offset {} refcount 0",
 	offset);
-      return cache->retire_extent_if_cached(
+      return cache->retire_extent(
 	t, result.addr, result.length
       ).safe_then([] {
 	return ref_ret(

--- a/src/crimson/os/seastore/transaction_manager.h
+++ b/src/crimson/os/seastore/transaction_manager.h
@@ -86,13 +86,13 @@ public:
   close_ertr::future<> close();
 
   /// Creates empty transaction
-  TransactionRef create_transaction() {
-    return make_transaction();
+  TransactionRef create_transaction() final {
+    return cache->create_transaction();
   }
 
-  /// Creates weak transaction
+  /// Creates empty weak transaction
   TransactionRef create_weak_transaction() {
-    return make_weak_transaction();
+    return cache->create_weak_transaction();
   }
 
   /**

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -137,7 +137,7 @@ TEST_F(a_basic_test_t, 2_node_sizes)
 {
   run_async([this] {
     auto nm = NodeExtentManager::create_dummy(IS_DUMMY_SYNC);
-    auto t = make_transaction();
+    auto t = make_test_transaction();
     ValueBuilderImpl<TestValue> vb;
     context_t c{*nm, vb, *t};
     std::array<std::pair<NodeImplURef, NodeExtentMutable>, 16> nodes = {
@@ -181,7 +181,7 @@ struct b_dummy_tree_test_t : public seastar_test_suite_t {
 
   b_dummy_tree_test_t()
     : moved_nm{NodeExtentManager::create_dummy(IS_DUMMY_SYNC)},
-      ref_t{make_transaction()},
+      ref_t{make_test_transaction()},
       t{*ref_t},
       c{*moved_nm, vb, t},
       tree{std::move(moved_nm)} {}
@@ -403,7 +403,7 @@ class TestTree {
  public:
   TestTree()
     : moved_nm{NodeExtentManager::create_dummy(IS_DUMMY_SYNC)},
-      ref_t{make_transaction()},
+      ref_t{make_test_transaction()},
       t{*ref_t},
       c{*moved_nm, vb, t},
       tree{std::move(moved_nm)},
@@ -457,7 +457,7 @@ class TestTree {
                           const split_expectation_t& expected) {
     return seastar::async([this, key, value, expected] {
       TestBtree tree_clone(NodeExtentManager::create_dummy(IS_DUMMY_SYNC));
-      auto ref_t_clone = make_transaction();
+      auto ref_t_clone = make_test_transaction();
       Transaction& t_clone = *ref_t_clone;
       tree_clone.test_clone_from(t_clone, t, tree).unsafe_get0();
 
@@ -966,7 +966,7 @@ class DummyChildPool {
   std::optional<TestBtree> p_btree;
   NodeExtentManager* p_nm = nullptr;
   ValueBuilderImpl<TestValue> vb;
-  TransactionRef ref_t = make_transaction();
+  TransactionRef ref_t = make_test_transaction();
 
   std::random_device rd;
   std::set<Ref<DummyChild>> splitable_nodes;

--- a/src/test/crimson/seastore/test_btree_lba_manager.cc
+++ b/src/test/crimson/seastore/test_btree_lba_manager.cc
@@ -78,7 +78,7 @@ struct btree_lba_manager_test :
       return journal.open_for_write();
     }).safe_then([this](auto addr) {
       return seastar::do_with(
-	make_transaction(),
+	cache.create_transaction(),
 	[this](auto &transaction) {
 	  cache.init();
 	  return cache.mkfs(*transaction
@@ -121,7 +121,7 @@ struct btree_lba_manager_test :
 
   auto create_transaction() {
     auto t = test_transaction_t{
-      make_transaction(),
+      cache.create_transaction(),
       test_lba_mappings
     };
     cache.alloc_new_extent<TestBlockPhysical>(*t.t, TestBlockPhysical::SIZE);
@@ -130,7 +130,7 @@ struct btree_lba_manager_test :
 
   auto create_weak_transaction() {
     auto t = test_transaction_t{
-      make_weak_transaction(),
+      cache.create_weak_transaction(),
       test_lba_mappings
     };
     return t;

--- a/src/test/crimson/seastore/test_seastore_cache.cc
+++ b/src/test/crimson/seastore/test_seastore_cache.cc
@@ -66,7 +66,7 @@ struct cache_test_t : public seastar_test_suite_t {
   }
 
   auto get_transaction() {
-    return make_transaction();
+    return cache.create_transaction();
   }
 
   seastar::future<> set_up_fut() final {
@@ -74,7 +74,7 @@ struct cache_test_t : public seastar_test_suite_t {
     ).safe_then(
       [this] {
 	return seastar::do_with(
-	  make_transaction(),
+	  cache.create_transaction(),
 	  [this](auto &transaction) {
 	    cache.init();
 	    return cache.mkfs(*transaction).safe_then(


### PR DESCRIPTION
<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
