### PR TITLE
python-common: use OrderedDict instead of Set to remove duplicates from host labels list

### DIFF
--- a/src/python-common/ceph/deployment/hostspec.py
+++ b/src/python-common/ceph/deployment/hostspec.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import errno
 try:
     from typing import Optional, List, Any
@@ -45,7 +46,7 @@ class HostSpec(object):
         return {
             'hostname': self.hostname,
             'addr': self.addr,
-            'labels': list(set((self.labels))),
+            'labels': list(OrderedDict.fromkeys((self.labels))),
             'status': self.status,
         }
 
@@ -54,7 +55,8 @@ class HostSpec(object):
         host_spec = cls.normalize_json(host_spec)
         _cls = cls(host_spec['hostname'],
                    host_spec['addr'] if 'addr' in host_spec else None,
-                   list(set(host_spec['labels'])) if 'labels' in host_spec else None,
+                   list(OrderedDict.fromkeys(
+                       host_spec['labels'])) if 'labels' in host_spec else None,
                    host_spec['status'] if 'status' in host_spec else None)
         return _cls
 


### PR DESCRIPTION
this preserves the order of the list instead of randomizing the order

before:
![image](https://user-images.githubusercontent.com/22037319/115453668-e074bc80-a1ed-11eb-819d-edc01c56416e.png)

after:
![image](https://user-images.githubusercontent.com/22037319/115454205-845e6800-a1ee-11eb-8ac1-9c5c330adb2d.png)


fixes: https://tracker.ceph.com/issues/50444
Signed-off-by: Daniel Pivonka <dpivonka@redhat.com>


