### PR TITLE
osd/PG.cc: only set auto_repair=true when deep scrub is triggered by repair

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1452,7 +1452,7 @@ bool PG::verify_periodic_scrub_mode(bool allow_deep_scrub,
       is_time_for_deep(allow_deep_scrub, allow_regular_scrub, has_deep_errors, planned);
 
     if (try_to_auto_repair) {
-      if (planned.time_for_deep) {
+      if (planned.time_for_deep && (has_deep_errors || planned.need_auto)) {
 	dout(20) << __func__ << ": auto repair with deep scrubbing" << dendl;
 	planned.auto_repair = true;
       } else if (allow_regular_scrub) {


### PR DESCRIPTION
We should not be setting auto_repair=true when is_time_for_deep() is true due to
reasons unrelated to deep scrub errors or need_auto. This adds a misleading
repair flag to the PG state.

Fixes: https://tracker.ceph.com/issues/50446
Signed-off-by: Neha Ojha <nojha@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
