### PR TITLE
ceph-volume: It is not neccessary to zap partition when zap raw device.

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -254,8 +254,8 @@ class Zap(object):
             )
 
         # look for partitions and zap those
-        for part_name in device.sys_api.get('partitions', {}).keys():
-            self.zap_partition(Device('/dev/%s' % part_name))
+        #for part_name in device.sys_api.get('partitions', {}).keys():
+        #    self.zap_partition(Device('/dev/%s' % part_name))
 
         wipefs(device.abspath)
         zap_data(device.abspath)


### PR DESCRIPTION
For example:
  There is a raw device '/dev/sdf' whose size is 500G. But it has a '/dev/sdf1' partition of 1M. When exec ceph-volume lvm zap /dev/sdf --destroy, it will raise an error of 'error writing /dev/sdf1: No space left on device'.

Signed-off-by: jianglong01 <jianglong01@qianxin.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
