### PR TITLE
ceph-volume:  Division preserves decimal parts, not integers

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -612,7 +612,7 @@ class VolumeGroup(object):
         if b_to_ext < int(self.vg_free_count):
             # return bytes in extents if there is more space
             return b_to_ext
-        elif b_to_ext / int(self.vg_free_count) - 1 < 0.01:
+        elif float(b_to_ext) / int(self.vg_free_count) - 1 < 0.01:
             # return vg_fre_count if its less then 1% off
             logger.info(
                 'bytes_to_extents results in {} but only {} '


### PR DESCRIPTION
According to the comments, size/extent_size is within 1% of the actual free extents, But when the code implements it, it doesn't keep decimal parts, only integers.

Signed-off-by: wangtengfei <wangtengfei@inspur.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
