### PR TITLE
nautilus: vstart.sh: disable "auth_allow_insecure_global_id_reclaim"

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -633,6 +633,7 @@ $CMONDEBUG
 $extra_conf
         mon cluster log file = $CEPH_OUT_DIR/cluster.mon.\$id.log
         osd pool default erasure code profile = plugin=jerasure technique=reed_sol_van k=2 m=1 crush-failure-domain=osd
+        auth allow insecure global id reclaim = false
 EOF
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50459

---

backport of https://github.com/ceph/ceph/pull/40873
parent tracker: https://tracker.ceph.com/issues/50374

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh