### PR TITLE
common/pick_address: filter out loopback addresses

### DIFF
--- a/src/common/options/global.yaml.in
+++ b/src/common/options/global.yaml.in
@@ -1173,13 +1173,6 @@ options:
   fmt_desc: Throttles total size of messages waiting to be dispatched.
   default: 100_M
   with_legacy: true
-- name: ms_bind_exclude_lo_iface
-  type: bool
-  level: advanced
-  desc: Allow servers to bind loopback network interfaces (lo)
-  default: true
-  flags:
-  - startup
 - name: ms_bind_ipv4
   type: bool
   level: advanced

--- a/src/common/pick_address.h
+++ b/src/common/pick_address.h
@@ -88,7 +88,6 @@ const struct sockaddr *find_ip_in_subnet_list(
   unsigned ipv,
   const std::string &networks,
   const std::string &interfaces,
-  bool exclude_lo_iface,
   int numa_node=-1);
 
 int get_iface_numa_node(

--- a/src/test/test_ipaddr.cc
+++ b/src/test/test_ipaddr.cc
@@ -780,7 +780,6 @@ TEST(pick_address, filtering)
 			   CEPH_PICK_ADDRESS_IPV4 |
 			   CEPH_PICK_ADDRESS_MSGR1,
 			   &one, &av);
-    cout << av << std::endl;
     ASSERT_EQ(0, r);
     ASSERT_EQ(1u, av.v.size());
     ASSERT_EQ(string("v1:0.0.0.0:0/0"), stringify(av.v[0]));
@@ -791,7 +790,6 @@ TEST(pick_address, filtering)
 			   CEPH_PICK_ADDRESS_IPV6 |
 			   CEPH_PICK_ADDRESS_MSGR1,
 			   &one, &av);
-    cout << av << std::endl;
     ASSERT_EQ(0, r);
     ASSERT_EQ(1u, av.v.size());
     ASSERT_EQ(string("v1:[::]:0/0"), stringify(av.v[0]));
@@ -803,7 +801,6 @@ TEST(pick_address, filtering)
 			   CEPH_PICK_ADDRESS_IPV4 |
 			   CEPH_PICK_ADDRESS_MSGR1,
 			   &one, &av);
-    cout << av << std::endl;
     ASSERT_EQ(0, r);
     ASSERT_EQ(1u, av.v.size());
     ASSERT_EQ(string("v1:10.2.1.123:0/0"), stringify(av.v[0]));
@@ -817,7 +814,6 @@ TEST(pick_address, filtering)
 			   CEPH_PICK_ADDRESS_IPV4 |
 			   CEPH_PICK_ADDRESS_MSGR2,
 			   &one, &av);
-    cout << av << std::endl;
     ASSERT_EQ(0, r);
     ASSERT_EQ(1u, av.v.size());
     ASSERT_EQ(string("v2:10.2.1.123:0/0"), stringify(av.v[0]));
@@ -832,7 +828,6 @@ TEST(pick_address, filtering)
 			   CEPH_PICK_ADDRESS_IPV4 |
 			   CEPH_PICK_ADDRESS_MSGR2,
 			   &one, &av);
-    cout << av << std::endl;
     ASSERT_EQ(0, r);
     ASSERT_EQ(1u, av.v.size());
     ASSERT_EQ(string("v2:10.2.1.123:0/0"), stringify(av.v[0]));
@@ -847,7 +842,6 @@ TEST(pick_address, filtering)
 			   CEPH_PICK_ADDRESS_IPV4 |
 			   CEPH_PICK_ADDRESS_MSGR1,
 			   &one, &av);
-    cout << av << std::endl;
     ASSERT_EQ(0, r);
     ASSERT_EQ(1u, av.v.size());
     ASSERT_EQ(string("v1:10.1.1.2:0/0"), stringify(av.v[0]));
@@ -862,7 +856,6 @@ TEST(pick_address, filtering)
 			   CEPH_PICK_ADDRESS_IPV6 |
 			   CEPH_PICK_ADDRESS_MSGR2,
 			   &one, &av);
-    cout << av << std::endl;
     ASSERT_EQ(0, r);
     ASSERT_EQ(1u, av.v.size());
     ASSERT_EQ(string("v2:[2001:1234:5678:90ab::cdef]:0/0"), stringify(av.v[0]));
@@ -877,7 +870,6 @@ TEST(pick_address, filtering)
 			   CEPH_PICK_ADDRESS_IPV6 |
 			   CEPH_PICK_ADDRESS_MSGR2,
 			   &one, &av);
-    cout << av << std::endl;
     ASSERT_EQ(0, r);
     ASSERT_EQ(2u, av.v.size());
     ASSERT_EQ(string("v2:[2001:1234:5678:90ab::cdef]:0/0"), stringify(av.v[0]));
@@ -895,7 +887,6 @@ TEST(pick_address, filtering)
 			   CEPH_PICK_ADDRESS_MSGR1 |
 			   CEPH_PICK_ADDRESS_PREFER_IPV4,
 			   &one, &av);
-    cout << av << std::endl;
     ASSERT_EQ(0, r);
     ASSERT_EQ(2u, av.v.size());
     ASSERT_EQ(string("v1:10.2.1.123:0/0"), stringify(av.v[0]));
@@ -912,7 +903,6 @@ TEST(pick_address, filtering)
 			   CEPH_PICK_ADDRESS_MSGR1 |
 			   CEPH_PICK_ADDRESS_MSGR2,
 			   &one, &av);
-    cout << av << std::endl;
     ASSERT_EQ(0, r);
     ASSERT_EQ(2u, av.v.size());
     ASSERT_EQ(string("v2:[2001:1234:5678:90ab::cdef]:0/0"), stringify(av.v[0]));
@@ -927,7 +917,6 @@ TEST(pick_address, filtering)
 			   CEPH_PICK_ADDRESS_MSGR1 |
 			   CEPH_PICK_ADDRESS_MSGR2,
 			   &one, &av);
-    cout << av << std::endl;
     ASSERT_EQ(0, r);
     ASSERT_EQ(2u, av.v.size());
     ASSERT_EQ(string("v2:0.0.0.0:0/0"), stringify(av.v[0]));
@@ -963,7 +952,6 @@ TEST(pick_address, ipv4_ipv6_enabled)
 			   CEPH_PICK_ADDRESS_PUBLIC |
 			   CEPH_PICK_ADDRESS_MSGR1,
 			   &one, &av);
-    cout << av << std::endl;
     ASSERT_EQ(-1, r);
   }
 }
@@ -996,7 +984,6 @@ TEST(pick_address, ipv4_ipv6_enabled2)
 			   CEPH_PICK_ADDRESS_PUBLIC |
 			   CEPH_PICK_ADDRESS_MSGR1,
 			   &one, &av);
-    cout << av << std::endl;
     ASSERT_EQ(-1, r);
   }
 }

--- a/src/test/test_ipaddr.cc
+++ b/src/test/test_ipaddr.cc
@@ -13,6 +13,7 @@
 #endif
 #include <arpa/inet.h>
 #include <ifaddrs.h>
+#include <net/if.h>
 
 static void ipv4(struct sockaddr_in *addr, const char *s) {
   int err;
@@ -190,10 +191,12 @@ TEST(CommonIPAddr, TestV4_SkipLoopback)
   one.ifa_name = lo;
 
   two.ifa_next = &three;
+  two.ifa_flags = IFF_UP;
   two.ifa_addr = (struct sockaddr*)&a_two;
   two.ifa_name = lo0;
 
   three.ifa_next = NULL;
+  three.ifa_flags = IFF_UP;
   three.ifa_addr = (struct sockaddr*)&a_three;
   three.ifa_name = eth0;
 
@@ -202,21 +205,18 @@ TEST(CommonIPAddr, TestV4_SkipLoopback)
   ipv4(&a_three, "10.1.2.3");
 
   const struct sockaddr *result = nullptr;
+  // we prefer the non-loopback address despite the loopback addresses
   result =
     find_ip_in_subnet_list(nullptr, (struct ifaddrs*)&one,
                            CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6,
-                           "10.0.0.0/8", "", true);
+                           "", "");
   ASSERT_EQ((struct sockaddr*)&a_three, result);
+  // the subnet criteria leaves us no choice but the UP loopback address
   result =
     find_ip_in_subnet_list(nullptr, (struct ifaddrs*)&one,
                            CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6,
-                           "127.0.0.0/8", "", true);
-  ASSERT_EQ(nullptr, result);
-  result =
-    find_ip_in_subnet_list(nullptr, (struct ifaddrs*)&one,
-                           CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6,
-                           "127.0.0.0/8", "", false);
-  ASSERT_EQ((struct sockaddr*)&a_one, result);
+                           "127.0.0.0/8", "");
+  ASSERT_EQ((struct sockaddr*)&a_two, result);
 }
 
 TEST(CommonIPAddr, TestV6_Simple)
@@ -316,43 +316,37 @@ TEST(CommonIPAddr, TestV6_SkipLoopback)
   struct sockaddr_in6 a_one;
   struct sockaddr_in6 a_two;
   struct sockaddr_in6 a_three;
-  struct sockaddr_in6 net;
-
-  memset(&net, 0, sizeof(net));
 
   one.ifa_next = &two;
+  ipv6(&a_one, "::1");
   one.ifa_addr = (struct sockaddr*)&a_one;
   one.ifa_name = lo;
 
   two.ifa_next = &three;
+  two.ifa_flags = IFF_UP;
+  ipv6(&a_two, "::1");
   two.ifa_addr = (struct sockaddr*)&a_two;
   two.ifa_name = lo0;
 
   three.ifa_next = NULL;
+  three.ifa_flags = IFF_UP;
+  ipv6(&a_three, "2001:1234:5678:90ab::beef");
   three.ifa_addr = (struct sockaddr*)&a_three;
   three.ifa_name = eth0;
 
-  ipv6(&a_one, "::1");
-  ipv6(&a_two, "::1");
-  ipv6(&a_three, "2001:1234:5678:90ab::beef");
-  ipv6(&net, "ff00::1");
-
   const struct sockaddr *result = nullptr;
+  // we prefer the non-loopback address despite the loopback addresses
   result =
     find_ip_in_subnet_list(nullptr, (struct ifaddrs*)&one,
                            CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6,
-                           "2001:1234:5678:90ab::0/64", "", true);
+                           "", "");
   ASSERT_EQ((struct sockaddr*)&a_three, result);
+  // the subnet criteria leaves us no choice but the UP loopback address
   result =
     find_ip_in_subnet_list(nullptr, (struct ifaddrs*)&one,
                            CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6,
-                           "::1/128", "", true);
-  ASSERT_EQ(nullptr, result);
-  result =
-    find_ip_in_subnet_list(nullptr, (struct ifaddrs*)&one,
-                           CEPH_PICK_ADDRESS_IPV4 | CEPH_PICK_ADDRESS_IPV6,
-                           "::1/128", "", false);
-  ASSERT_EQ((struct sockaddr*)&a_one, result);
+                           "::1/128", "");
+  ASSERT_EQ((struct sockaddr*)&a_two, result);
 }
 
 TEST(CommonIPAddr, ParseNetwork_Empty)
@@ -709,8 +703,7 @@ TEST(pick_address, find_ip_in_subnet_list)
     &one,
     CEPH_PICK_ADDRESS_IPV4,
     "10.1.0.0/16",
-    "eth0",
-    true);
+    "eth0");
   ASSERT_EQ((struct sockaddr*)&a_one, result);
 
   result = find_ip_in_subnet_list(
@@ -718,8 +711,7 @@ TEST(pick_address, find_ip_in_subnet_list)
     &one,
     CEPH_PICK_ADDRESS_IPV4,
     "10.2.0.0/16",
-    "eth1",
-    true);
+    "eth1");
   ASSERT_EQ((struct sockaddr*)&a_two, result);
 
   // match by eth name
@@ -728,8 +720,7 @@ TEST(pick_address, find_ip_in_subnet_list)
     &one,
     CEPH_PICK_ADDRESS_IPV4,
     "10.0.0.0/8",
-    "eth0",
-    true);
+    "eth0");
   ASSERT_EQ((struct sockaddr*)&a_one, result);
 
   result = find_ip_in_subnet_list(
@@ -737,8 +728,7 @@ TEST(pick_address, find_ip_in_subnet_list)
     &one,
     CEPH_PICK_ADDRESS_IPV4,
     "10.0.0.0/8",
-    "eth1",
-    true);
+    "eth1");
   ASSERT_EQ((struct sockaddr*)&a_two, result);
 
   result = find_ip_in_subnet_list(
@@ -746,8 +736,7 @@ TEST(pick_address, find_ip_in_subnet_list)
     &one,
     CEPH_PICK_ADDRESS_IPV6,
     "2001::/16",
-    "eth1",
-    true);
+    "eth1");
   ASSERT_EQ((struct sockaddr*)&a_three, result);
 }
 


### PR DESCRIPTION
instead of filtering out loopback ifaces, check for loopback addresses.

before this change, iface named "lo" is filtered out by default,
and "lo" is allowed if `ms_bind_exclude_lo_iface` is false.

after this change, iface with loopback address of "127.0.0.1" is
filtered out. also, the iface marked down is not considered.

the option of "ms_bind_exclude_lo_iface" is removed. the tests are
updated accordingly.

Fixes: https://tracker.ceph.com/issues/50456
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
