### PR TITLE
doc/cephadm: osd: rewrite "additional opts"

### DIFF
--- a/doc/cephadm/osd.rst
+++ b/doc/cephadm/osd.rst
@@ -432,18 +432,15 @@ Filters
 -------
 
 .. note::
-   Filters are applied using a `AND` gate by default. This essentially means that a drive needs to fulfill all filter
-   criteria in order to get selected.
-   If you wish to change this behavior you can adjust this behavior by setting
+   Filters are applied using an `AND` gate by default. This means that a drive
+   must fulfill all filter criteria in order to get selected. This behavior can
+   be adjusted by setting ``filter_logic: OR`` in the OSD specification. 
 
-    `filter_logic: OR`  # valid arguments are `AND`, `OR`
+Filters are used to assign disks to groups, using their attributes to group
+them. 
 
-   in the OSD Specification.
-
-You can assign disks to certain groups by their attributes using filters.
-
-The attributes are based off of ceph-volume's disk query. You can retrieve the information
-with
+The attributes are based off of ceph-volume's disk query. You can retrieve
+information about the attributes with this command:
 
 .. code-block:: bash
 
@@ -452,7 +449,7 @@ with
 Vendor or Model:
 ^^^^^^^^^^^^^^^^
 
-You can target specific disks by their Vendor or by their Model
+Specific disks can be targeted by vendor or model:
 
 .. code-block:: yaml
 
@@ -468,7 +465,7 @@ or
 Size:
 ^^^^^
 
-You can also match by disk `Size`.
+Specific disks can be targeted by `Size`:
 
 .. code-block:: yaml
 
@@ -477,7 +474,7 @@ You can also match by disk `Size`.
 Size specs:
 ___________
 
-Size specification of format can be of form:
+Size specifications can be of the following forms:
 
 * LOW:HIGH
 * :HIGH
@@ -486,34 +483,34 @@ Size specification of format can be of form:
 
 Concrete examples:
 
-Includes disks of an exact size
+To include disks of an exact size
 
 .. code-block:: yaml
 
     size: '10G'
 
-Includes disks which size is within the range
+To include disks within a given range of size: 
 
 .. code-block:: yaml
 
     size: '10G:40G'
 
-Includes disks less than or equal to 10G in size
+To include disks that are less than or equal to 10G in size:
 
 .. code-block:: yaml
 
     size: ':10G'
 
-
-Includes disks equal to or greater than 40G in size
+To include disks equal to or greater than 40G in size:
 
 .. code-block:: yaml
 
     size: '40G:'
 
-Sizes don't have to be exclusively in Gigabyte(G).
+Sizes don't have to be specified exclusively in Gigabytes(G).
 
-Supported units are Megabyte(M), Gigabyte(G) and Terrabyte(T). Also appending the (B) for byte is supported. MB, GB, TB
+Other units of size are supported: Megabyte(M), Gigabyte(G) and Terrabyte(T).
+Appending the (B) for byte is also supported: ``MB``, ``GB``, ``TB``.
 
 
 Rotational:
@@ -545,14 +542,14 @@ Note: This is exclusive for the data_devices section.
 Limiter:
 ^^^^^^^^
 
-When you specified valid filters but want to limit the amount of matching disks you can use the 'limit' directive.
+If you have specified some valid filters but want to limit the number of disks that they match, use the ``limit`` directive:
 
 .. code-block:: yaml
 
     limit: 2
 
-For example, if you used `vendor` to match all disks that are from `VendorA` but only want to use the first two
-you could use `limit`.
+For example, if you used `vendor` to match all disks that are from `VendorA`
+but want to use only the first two, you could use `limit`:
 
 .. code-block:: yaml
 
@@ -560,7 +557,7 @@ you could use `limit`.
     vendor: VendorA
     limit: 2
 
-Note: Be aware that `limit` is really just a last resort and shouldn't be used if it can be avoided.
+Note: `limit` is a last resort and shouldn't be used if it can be avoided.
 
 
 Additional Options


### PR DESCRIPTION
This PR rewrites the "Additional Options"
subsection of the OSD chapter of the cephadm
guide.

Signed-off-by: Zac Dover <zac.dover@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
