### PR TITLE
RGW Zipper consistent load/store APIs for User

### DIFF
--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -682,7 +682,7 @@ namespace rgw {
     const DoutPrefix dp(store->ctx(), dout_subsys, "librgw: ");
     std::unique_ptr<rgw::sal::User> user = store->get_user(uid);
     /* object exists, but policy is broken */
-    int ret = user->load_by_id(&dp, null_yield);
+    int ret = user->load_user(&dp, null_yield);
     if (ret < 0) {
       derr << "ERROR: failed reading user info: uid=" << uid << " ret="
 	   << ret << dendl;

--- a/src/rgw/rgw_acl_s3.cc
+++ b/src/rgw/rgw_acl_s3.cc
@@ -313,7 +313,7 @@ static int parse_grantee_str(const DoutPrefixProvider *dpp, rgw::sal::Store* sto
     grant.set_canon(user->get_id(), user->get_display_name(), rgw_perm);
   } else if (strcasecmp(id_type.c_str(), "id") == 0) {
     std::unique_ptr<rgw::sal::User> user = store->get_user(rgw_user(id_val));
-    ret = user->load_by_id(dpp, null_yield);
+    ret = user->load_user(dpp, null_yield);
     if (ret < 0)
       return ret;
 
@@ -492,7 +492,7 @@ int RGWAccessControlPolicy_S3::rebuild(const DoutPrefixProvider *dpp,
   }
 
   std::unique_ptr<rgw::sal::User> user = store->get_user(owner->get_id());
-  if (user->load_by_id(dpp, null_yield) < 0) {
+  if (user->load_user(dpp, null_yield) < 0) {
     ldout(cct, 10) << "owner info does not exist" << dendl;
     err_msg = "Invalid id";
     return -EINVAL;
@@ -546,7 +546,7 @@ int RGWAccessControlPolicy_S3::rebuild(const DoutPrefixProvider *dpp,
     
         if (grant_user.user_id.empty()) {
 	  user = store->get_user(uid);
-	  if (user->load_by_id(dpp, null_yield) < 0) {
+	  if (user->load_user(dpp, null_yield) < 0) {
 	    ldout(cct, 10) << "grant user does not exist:" << uid << dendl;
 	    err_msg = "Invalid id";
 	    return -EINVAL;

--- a/src/rgw/rgw_acl_swift.cc
+++ b/src/rgw/rgw_acl_swift.cc
@@ -123,7 +123,7 @@ static ACLGrant user_to_grant(const DoutPrefixProvider *dpp,
   std::unique_ptr<rgw::sal::User> user;
 
   user = store->get_user(rgw_user(uid));
-  if (user->load_by_id(dpp, null_yield) < 0) {
+  if (user->load_user(dpp, null_yield) < 0) {
     ldout(cct, 10) << "grant user does not exist: " << uid << dendl;
     /* skipping silently */
     grant.set_canon(user->get_id(), std::string(), perm);
@@ -316,7 +316,7 @@ void RGWAccessControlPolicy_SWIFTAcct::add_grants(const DoutPrefixProvider *dpp,
     } else  {
       std::unique_ptr<rgw::sal::User> user = store->get_user(rgw_user(uid));
 
-      if (user->load_by_id(dpp, null_yield) < 0) {
+      if (user->load_user(dpp, null_yield) < 0) {
         ldout(cct, 10) << "grant user does not exist:" << uid << dendl;
         /* skipping silently */
         grant.set_canon(user->get_id(), std::string(), perm);

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -376,7 +376,7 @@ void rgw::auth::WebIdentityApplier::create_account(const DoutPrefixProvider* dpp
   rgw_apply_default_bucket_quota(user->get_info().bucket_quota, cct->_conf);
   rgw_apply_default_user_quota(user->get_info().user_quota, cct->_conf);
 
-  int ret = user->store_info(dpp, null_yield, true);
+  int ret = user->store_user(dpp, null_yield, true);
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: failed to store new user info: user="
                   << user << " ret=" << ret << dendl;
@@ -394,7 +394,7 @@ void rgw::auth::WebIdentityApplier::load_acct_info(const DoutPrefixProvider* dpp
   std::unique_ptr<rgw::sal::User> user = store->get_user(federated_user);
 
   //Check in oidc namespace
-  if (user->load_by_id(dpp, null_yield) >= 0) {
+  if (user->load_user(dpp, null_yield) >= 0) {
     /* Succeeded. */
     user_info = user->get_info();
     return;
@@ -402,7 +402,7 @@ void rgw::auth::WebIdentityApplier::load_acct_info(const DoutPrefixProvider* dpp
 
   user->clear_ns();
   //Check for old users which wouldn't have been created in oidc namespace
-  if (user->load_by_id(dpp, null_yield) >= 0) {
+  if (user->load_user(dpp, null_yield) >= 0) {
     /* Succeeded. */
     user_info = user->get_info();
     return;
@@ -602,7 +602,7 @@ void rgw::auth::RemoteApplier::create_account(const DoutPrefixProvider* dpp,
   rgw_apply_default_user_quota(user->get_info().user_quota, cct->_conf);
   user_info = user->get_info();
 
-  int ret = user->store_info(dpp, null_yield, true);
+  int ret = user->store_user(dpp, null_yield, true);
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: failed to store new user info: user="
                   << user << " ret=" << ret << dendl;
@@ -645,7 +645,7 @@ void rgw::auth::RemoteApplier::load_acct_info(const DoutPrefixProvider* dpp, RGW
     const rgw_user tenanted_uid(acct_user.id, acct_user.id);
     user = store->get_user(tenanted_uid);
 
-    if (user->load_by_id(dpp, null_yield) >= 0) {
+    if (user->load_user(dpp, null_yield) >= 0) {
       /* Succeeded. */
       user_info = user->get_info();
       return;
@@ -656,7 +656,7 @@ void rgw::auth::RemoteApplier::load_acct_info(const DoutPrefixProvider* dpp, RGW
 
   if (split_mode && implicit_tenant)
 	;	/* suppress lookup for id used by "other" protocol */
-  else if (user->load_by_id(dpp, null_yield) >= 0) {
+  else if (user->load_user(dpp, null_yield) >= 0) {
     /* Succeeded. */
     user_info = user->get_info();
     return;

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -376,8 +376,7 @@ void rgw::auth::WebIdentityApplier::create_account(const DoutPrefixProvider* dpp
   rgw_apply_default_bucket_quota(user->get_info().bucket_quota, cct->_conf);
   rgw_apply_default_user_quota(user->get_info().user_quota, cct->_conf);
 
-  int ret = user->store_info(dpp, null_yield,
-			     RGWUserCtl::PutParams().set_exclusive(true));
+  int ret = user->store_info(dpp, null_yield, true);
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: failed to store new user info: user="
                   << user << " ret=" << ret << dendl;
@@ -603,8 +602,7 @@ void rgw::auth::RemoteApplier::create_account(const DoutPrefixProvider* dpp,
   rgw_apply_default_user_quota(user->get_info().user_quota, cct->_conf);
   user_info = user->get_info();
 
-  int ret = user->store_info(dpp, null_yield,
-			     RGWUserCtl::PutParams().set_exclusive(true));
+  int ret = user->store_info(dpp, null_yield, true);
   if (ret < 0) {
     ldpp_dout(dpp, 0) << "ERROR: failed to store new user info: user="
                   << user << " ret=" << ret << dendl;

--- a/src/rgw/rgw_auth_filters.h
+++ b/src/rgw/rgw_auth_filters.h
@@ -185,7 +185,7 @@ void ThirdPartyAccountApplier<T>::load_acct_info(const DoutPrefixProvider* dpp, 
       const rgw_user tenanted_uid(acct_user_override.id, acct_user_override.id);
       user = store->get_user(tenanted_uid);
 
-      if (user->load_by_id(dpp, null_yield) >= 0) {
+      if (user->load_user(dpp, null_yield) >= 0) {
 	user_info = user->get_info();
         /* Succeeded. */
         return;
@@ -193,7 +193,7 @@ void ThirdPartyAccountApplier<T>::load_acct_info(const DoutPrefixProvider* dpp, 
     }
 
     user = store->get_user(acct_user_override);
-    const int ret = user->load_by_id(dpp, null_yield);
+    const int ret = user->load_user(dpp, null_yield);
     if (ret < 0) {
       /* We aren't trying to recover from ENOENT here. It's supposed that creating
        * someone else's account isn't a thing we want to support in this filter. */
@@ -263,7 +263,7 @@ void SysReqApplier<T>::load_acct_info(const DoutPrefixProvider* dpp, RGWUserInfo
        * reasons. rgw_get_user_info_by_uid doesn't trigger the operator=() but
        * calls ::decode instead. */
       std::unique_ptr<rgw::sal::User> user = store->get_user(effective_uid);
-      if (user->load_by_id(dpp, null_yield) < 0) {
+      if (user->load_user(dpp, null_yield) < 0) {
         //ldpp_dout(dpp, 0) << "User lookup failed!" << dendl;
         throw -EACCES;
       }

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -487,7 +487,7 @@ int RGWBucket::init(rgw::sal::Store* _store, RGWBucketAdminOpState& op_state,
   op_state.set_bucket(bucket->clone());
 
   if (!rgw::sal::User::empty(user.get())) {
-    r = user->load_by_id(dpp, y);
+    r = user->load_user(dpp, y);
     if (r < 0) {
       set_err_msg(err_msg, "failed to fetch user info");
       return r;

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -1005,8 +1005,7 @@ namespace rgw {
 	if (token.valid() && (ldh->auth(token.id, token.key) == 0)) {
 	  /* try to store user if it doesn't already exist */
 	  if (user->load_by_id(dpp, null_yield) < 0) {
-	    int ret = user->store_info(dpp, null_yield, RGWUserCtl::PutParams()
-                                                  .set_exclusive(true));
+	    int ret = user->store_info(dpp, null_yield, true);
 	    if (ret < 0) {
 	      lsubdout(get_context(), rgw, 10)
 		<< "NOTICE: failed to store new user's info: ret=" << ret

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -1004,8 +1004,8 @@ namespace rgw {
 	}
 	if (token.valid() && (ldh->auth(token.id, token.key) == 0)) {
 	  /* try to store user if it doesn't already exist */
-	  if (user->load_by_id(dpp, null_yield) < 0) {
-	    int ret = user->store_info(dpp, null_yield, true);
+	  if (user->load_user(dpp, null_yield) < 0) {
+	    int ret = user->store_user(dpp, null_yield, true);
 	    if (ret < 0) {
 	      lsubdout(get_context(), rgw, 10)
 		<< "NOTICE: failed to store new user's info: ret=" << ret

--- a/src/rgw/rgw_frontend.h
+++ b/src/rgw/rgw_frontend.h
@@ -249,7 +249,7 @@ public:
     rgw_user uid(uid_str);
     std::unique_ptr<rgw::sal::User> user = env.store->get_user(uid);
 
-    int ret = user->load_by_id(this, null_yield);
+    int ret = user->load_user(this, null_yield);
     if (ret < 0) {
       derr << "ERROR: failed reading user info: uid=" << uid << " ret="
 	   << ret << dendl;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -227,7 +227,7 @@ int rgw_op_get_bucket_policy_from_attr(const DoutPrefixProvider *dpp,
     ldpp_dout(dpp, 0) << "WARNING: couldn't find acl header for bucket, generating default" << dendl;
     std::unique_ptr<rgw::sal::User> user = store->get_user(bucket_info.owner);
     /* object exists, but policy is broken */
-    int r = user->load_by_id(dpp, y);
+    int r = user->load_user(dpp, y);
     if (r < 0)
       return r;
 
@@ -261,7 +261,7 @@ static int get_obj_policy_from_attr(const DoutPrefixProvider *dpp,
     /* object exists, but policy is broken */
     ldpp_dout(dpp, 0) << "WARNING: couldn't find acl header for object, generating default" << dendl;
     std::unique_ptr<rgw::sal::User> user = store->get_user(bucket_info.owner);
-    ret = user->load_by_id(dpp, y);
+    ret = user->load_user(dpp, y);
     if (ret < 0)
       return ret;
 
@@ -1298,7 +1298,7 @@ int RGWOp::init_quota()
   if (s->user->get_id() == s->bucket_owner.get_id()) {
     user = s->user.get();
   } else {
-    int r = owner_user->load_by_id(this, s->yield);
+    int r = owner_user->load_user(this, s->yield);
     if (r < 0)
       return r;
     user = owner_user.get();
@@ -4408,7 +4408,7 @@ int RGWPutMetadataAccount::verify_permission(optional_yield y)
 void RGWPutMetadataAccount::execute(optional_yield y)
 {
   /* Params have been extracted earlier. See init_processing(). */
-  op_ret = s->user->load_by_id(this, y);
+  op_ret = s->user->load_user(this, y);
   if (op_ret < 0) {
     return;
   }
@@ -4428,7 +4428,7 @@ void RGWPutMetadataAccount::execute(optional_yield y)
   /* We are passing here the current (old) user info to allow the function
    * optimize-out some operations. */
   s->user->set_attrs(attrs);
-  op_ret = s->user->store_info(this, y, false, &s->user->get_info());
+  op_ret = s->user->store_user(this, y, false, &s->user->get_info());
 }
 
 int RGWPutMetadataBucket::verify_permission(optional_yield y)

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -802,7 +802,6 @@ protected:
   std::string end_marker;
   int64_t limit;
   uint64_t limit_max;
-  rgw::sal::Attrs attrs;
   bool is_truncated;
 
   RGWUsageStats global_stats;
@@ -1347,8 +1346,6 @@ protected:
   std::map<int, std::string> temp_url_keys;
   RGWQuotaInfo new_quota;
   bool new_quota_extracted;
-
-  RGWObjVersionTracker acct_op_tracker;
 
   RGWAccessControlPolicy policy;
   bool has_policy;

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1849,9 +1849,8 @@ int RGWHandler_REST::init_permissions(RGWOp* op, optional_yield y)
     // We don't need user policies in case of STS token returned by AssumeRole, hence the check for user type
     if (! s->user->get_id().empty() && s->auth.identity->get_identity_type() != TYPE_ROLE) {
       try {
-	rgw::sal::Attrs uattrs;
-        if (auto ret = s->user->read_attrs(s, y, &uattrs); ! ret) {
-          auto user_policies = get_iam_user_policy_from_attr(s->cct, uattrs, s->user->get_tenant());
+        if (auto ret = s->user->read_attrs(s, y); ! ret) {
+          auto user_policies = get_iam_user_policy_from_attr(s->cct, s->user->get_attrs(), s->user->get_tenant());
           s->iam_user_policies.insert(s->iam_user_policies.end(),
                                       std::make_move_iterator(user_policies.begin()),
                                       std::make_move_iterator(user_policies.end()));

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -6042,7 +6042,7 @@ rgw::auth::s3::STSEngine::authenticate(
   user = store->get_user(token.user);
   if (! token.user.empty() && token.acct_type != TYPE_ROLE) {
     // get user info
-    int ret = user->load_by_id(dpp, y);
+    int ret = user->load_user(dpp, y);
     if (ret < 0) {
       ldpp_dout(dpp, 5) << "ERROR: failed reading user info: uid=" << token.user << dendl;
       return result_t::reject(-EPERM);

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -175,7 +175,7 @@ void RGWListBuckets_ObjStore_SWIFT::send_response_begin(bool has_buckets)
     dump_account_metadata(s,
             global_stats,
             policies_stats,
-            attrs,
+            s->user->get_attrs(),
             s->user->get_info().user_quota,
             static_cast<RGWAccessControlPolicy_SWIFTAcct&>(*s->user_acl));
     dump_errno(s);
@@ -281,7 +281,7 @@ void RGWListBuckets_ObjStore_SWIFT::send_response_end()
     dump_account_metadata(s,
             global_stats,
             policies_stats,
-            attrs,
+            s->user->get_attrs(),
             s->user->get_info().user_quota,
             static_cast<RGWAccessControlPolicy_SWIFTAcct&>(*s->user_acl));
     dump_errno(s);
@@ -545,7 +545,8 @@ static void dump_container_metadata(struct req_state *s,
 void RGWStatAccount_ObjStore_SWIFT::execute(optional_yield y)
 {
   RGWStatAccount_ObjStore::execute(y);
-  op_ret = s->user->read_attrs(s, s->yield, &attrs);
+  op_ret = s->user->read_attrs(s, s->yield);
+  attrs = s->user->get_attrs();
 }
 
 void RGWStatAccount_ObjStore_SWIFT::send_response()

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -2083,7 +2083,7 @@ void RGWFormPost::get_owner_info(const req_state* const s,
       const rgw_user tenanted_uid(uid.id, uid.id);
       user = store->get_user(tenanted_uid);
 
-      if (user->load_by_id(s, s->yield) >= 0) {
+      if (user->load_user(s, s->yield) >= 0) {
         /* Succeeded. */
         found = true;
       }
@@ -2091,7 +2091,7 @@ void RGWFormPost::get_owner_info(const req_state* const s,
 
     if (!found) {
       user = store->get_user(uid);
-      if (user->load_by_id(s, s->yield) < 0) {
+      if (user->load_user(s, s->yield) < 0) {
 	throw -EPERM;
       }
     }
@@ -2108,7 +2108,7 @@ void RGWFormPost::get_owner_info(const req_state* const s,
                  << dendl;
 
   user = store->get_user(bucket->get_info().owner);
-  if (user->load_by_id(s, s->yield) < 0) {
+  if (user->load_user(s, s->yield) < 0) {
     throw -EPERM;
   }
 

--- a/src/rgw/rgw_rest_user_policy.cc
+++ b/src/rgw/rgw_rest_user_policy.cc
@@ -120,7 +120,7 @@ void RGWPutUserPolicy::execute(optional_yield y)
 
   std::unique_ptr<rgw::sal::User> user = store->get_user(rgw_user(user_name));
 
-  op_ret = user->load_by_id(s, s->yield);
+  op_ret = user->load_user(s, s->yield);
   if (op_ret < 0) {
     op_ret = -ERR_NO_SUCH_ENTITY;
     return;
@@ -151,7 +151,7 @@ void RGWPutUserPolicy::execute(optional_yield y)
     encode(policies, in_bl);
     user->get_attrs()[RGW_ATTR_USER_POLICY] = in_bl;
 
-    op_ret = user->store_info(s, s->yield, false);
+    op_ret = user->store_user(s, s->yield, false);
     if (op_ret < 0) {
       op_ret = -ERR_INTERNAL_ERROR;
     }
@@ -320,7 +320,7 @@ void RGWDeleteUserPolicy::execute(optional_yield y)
   }
 
   std::unique_ptr<rgw::sal::User> user = store->get_user(rgw_user(user_name));
-  op_ret = user->load_by_id(s, s->yield);
+  op_ret = user->load_user(s, s->yield);
   if (op_ret < 0) {
     op_ret = -ERR_NO_SUCH_ENTITY;
     return;
@@ -355,7 +355,7 @@ void RGWDeleteUserPolicy::execute(optional_yield y)
       encode(policies, in_bl);
       user->get_attrs()[RGW_ATTR_USER_POLICY] = in_bl;
 
-      op_ret = user->store_info(s, s->yield, false);
+      op_ret = user->store_user(s, s->yield, false);
       if (op_ret < 0) {
         op_ret = -ERR_INTERNAL_ERROR;
       }

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -242,6 +242,7 @@ class User {
   protected:
     RGWUserInfo info;
     RGWObjVersionTracker objv_tracker;
+    Attrs attrs;
 
   public:
     User() : info() {}
@@ -270,7 +271,7 @@ class User {
     const RGWUserCaps& get_caps() const { return info.caps; }
     static bool empty(User* u) { return (!u || u->info.user_id.id.empty()); }
     static bool empty(std::unique_ptr<User>& u) { return (!u || u->info.user_id.id.empty()); }
-    virtual int read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs* uattrs, RGWObjVersionTracker* tracker = nullptr) = 0;
+    virtual int read_attrs(const DoutPrefixProvider* dpp, optional_yield y) = 0;
     virtual int read_stats(optional_yield y, RGWStorageStats* stats,
 			   ceph::real_time* last_stats_sync = nullptr,
 			   ceph::real_time* last_stats_update = nullptr) = 0;
@@ -281,10 +282,12 @@ class User {
 			   map<rgw_user_bucket, rgw_usage_log_entry>& usage) = 0;
     virtual int trim_usage(uint64_t start_epoch, uint64_t end_epoch) = 0;
     virtual RGWObjVersionTracker& get_version_tracker() { return objv_tracker; }
+    virtual Attrs& get_attrs() { return attrs; }
+    virtual void set_attrs(Attrs& _attrs) { attrs = _attrs; }
 
     /* Placeholders */
     virtual int load_by_id(const DoutPrefixProvider* dpp, optional_yield y) = 0;
-    virtual int store_info(const DoutPrefixProvider* dpp, optional_yield y, const RGWUserCtl::PutParams& params = {}) = 0;
+    virtual int store_info(const DoutPrefixProvider* dpp, optional_yield y, bool exclusive, RGWUserInfo* old_info = nullptr) = 0;
     virtual int remove_info(const DoutPrefixProvider* dpp, optional_yield y, const RGWUserCtl::RemoveParams& params = {}) = 0;
 
     /* dang temporary; will be removed when User is complete */

--- a/src/rgw/rgw_sal.h
+++ b/src/rgw/rgw_sal.h
@@ -285,10 +285,9 @@ class User {
     virtual Attrs& get_attrs() { return attrs; }
     virtual void set_attrs(Attrs& _attrs) { attrs = _attrs; }
 
-    /* Placeholders */
-    virtual int load_by_id(const DoutPrefixProvider* dpp, optional_yield y) = 0;
-    virtual int store_info(const DoutPrefixProvider* dpp, optional_yield y, bool exclusive, RGWUserInfo* old_info = nullptr) = 0;
-    virtual int remove_info(const DoutPrefixProvider* dpp, optional_yield y, const RGWUserCtl::RemoveParams& params = {}) = 0;
+    virtual int load_user(const DoutPrefixProvider* dpp, optional_yield y) = 0;
+    virtual int store_user(const DoutPrefixProvider* dpp, optional_yield y, bool exclusive, RGWUserInfo* old_info = nullptr) = 0;
+    virtual int remove_user(const DoutPrefixProvider* dpp, optional_yield y) = 0;
 
     /* dang temporary; will be removed when User is complete */
     RGWUserInfo& get_info() { return info; }

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -82,7 +82,7 @@ static int rgw_op_get_bucket_policy_from_attr(const DoutPrefixProvider* dpp,
   } else {
     ldout(store->ctx(), 0) << "WARNING: couldn't find acl header for bucket, generating default" << dendl;
     /* object exists, but policy is broken */
-    int r = user.load_by_id(dpp, y);
+    int r = user.load_user(dpp, y);
     if (r < 0)
       return r;
 
@@ -188,12 +188,12 @@ int RadosUser::trim_usage(uint64_t start_epoch, uint64_t end_epoch)
   return store->getRados()->trim_usage(get_id(), bucket_name, start_epoch, end_epoch);
 }
 
-int RadosUser::load_by_id(const DoutPrefixProvider* dpp, optional_yield y)
+int RadosUser::load_user(const DoutPrefixProvider* dpp, optional_yield y)
 {
     return store->ctl()->user->get_info_by_uid(dpp, info.user_id, &info, y, RGWUserCtl::GetParams().set_objv_tracker(&objv_tracker));
 }
 
-int RadosUser::store_info(const DoutPrefixProvider* dpp, optional_yield y, bool exclusive, RGWUserInfo* old_info)
+int RadosUser::store_user(const DoutPrefixProvider* dpp, optional_yield y, bool exclusive, RGWUserInfo* old_info)
 {
     return store->ctl()->user->store_info(dpp, info, y,
 					  RGWUserCtl::PutParams().set_objv_tracker(&objv_tracker)
@@ -202,9 +202,10 @@ int RadosUser::store_info(const DoutPrefixProvider* dpp, optional_yield y, bool 
 					  .set_old_info(old_info));
 }
 
-int RadosUser::remove_info(const DoutPrefixProvider* dpp, optional_yield y, const RGWUserCtl::RemoveParams& params)
+int RadosUser::remove_user(const DoutPrefixProvider* dpp, optional_yield y)
 {
-    return store->ctl()->user->remove_info(dpp, info, y, params);
+    return store->ctl()->user->remove_info(dpp, info, y,
+					  RGWUserCtl::RemoveParams().set_objv_tracker(&objv_tracker));
 }
 
 /* Placeholder */

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -148,9 +148,9 @@ Bucket* RadosUser::create_bucket(rgw_bucket& bucket,
   return NULL;
 }
 
-int RadosUser::read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs* uattrs, RGWObjVersionTracker* tracker)
+int RadosUser::read_attrs(const DoutPrefixProvider* dpp, optional_yield y)
 {
-  return store->ctl()->user->get_attrs_by_uid(dpp, get_id(), uattrs, y, tracker);
+  return store->ctl()->user->get_attrs_by_uid(dpp, get_id(), &attrs, y, &objv_tracker);
 }
 
 int RadosUser::read_stats(optional_yield y, RGWStorageStats* stats,
@@ -193,9 +193,13 @@ int RadosUser::load_by_id(const DoutPrefixProvider* dpp, optional_yield y)
     return store->ctl()->user->get_info_by_uid(dpp, info.user_id, &info, y, RGWUserCtl::GetParams().set_objv_tracker(&objv_tracker));
 }
 
-int RadosUser::store_info(const DoutPrefixProvider* dpp, optional_yield y, const RGWUserCtl::PutParams& params)
+int RadosUser::store_info(const DoutPrefixProvider* dpp, optional_yield y, bool exclusive, RGWUserInfo* old_info)
 {
-    return store->ctl()->user->store_info(dpp, info, y, params);
+    return store->ctl()->user->store_info(dpp, info, y,
+					  RGWUserCtl::PutParams().set_objv_tracker(&objv_tracker)
+					  .set_exclusive(exclusive)
+					  .set_attrs(&attrs)
+					  .set_old_info(old_info));
 }
 
 int RadosUser::remove_info(const DoutPrefixProvider* dpp, optional_yield y, const RGWUserCtl::RemoveParams& params)

--- a/src/rgw/rgw_sal_rados.h
+++ b/src/rgw/rgw_sal_rados.h
@@ -63,10 +63,9 @@ class RadosUser : public User {
 			   map<rgw_user_bucket, rgw_usage_log_entry>& usage) override;
     virtual int trim_usage(uint64_t start_epoch, uint64_t end_epoch) override;
 
-    /* Placeholders */
-    virtual int load_by_id(const DoutPrefixProvider* dpp, optional_yield y) override;
-    virtual int store_info(const DoutPrefixProvider* dpp, optional_yield y, bool exclusive, RGWUserInfo* old_info = nullptr) override;
-    virtual int remove_info(const DoutPrefixProvider* dpp, optional_yield y, const RGWUserCtl::RemoveParams& params = {}) override;
+    virtual int load_user(const DoutPrefixProvider* dpp, optional_yield y) override;
+    virtual int store_user(const DoutPrefixProvider* dpp, optional_yield y, bool exclusive, RGWUserInfo* old_info = nullptr) override;
+    virtual int remove_user(const DoutPrefixProvider* dpp, optional_yield y) override;
 
     friend class RadosBucket;
 };

--- a/src/rgw/rgw_sal_rados.h
+++ b/src/rgw/rgw_sal_rados.h
@@ -52,7 +52,7 @@ class RadosUser : public User {
 		     uint64_t max, bool need_stats, BucketList& buckets,
 		     optional_yield y) override;
     virtual Bucket* create_bucket(rgw_bucket& bucket, ceph::real_time creation_time) override;
-    virtual int read_attrs(const DoutPrefixProvider* dpp, optional_yield y, Attrs* uattrs, RGWObjVersionTracker* tracker) override;
+    virtual int read_attrs(const DoutPrefixProvider* dpp, optional_yield y) override;
     virtual int read_stats(optional_yield y, RGWStorageStats* stats,
 			   ceph::real_time* last_stats_sync = nullptr,
 			   ceph::real_time* last_stats_update = nullptr) override;
@@ -65,7 +65,7 @@ class RadosUser : public User {
 
     /* Placeholders */
     virtual int load_by_id(const DoutPrefixProvider* dpp, optional_yield y) override;
-    virtual int store_info(const DoutPrefixProvider* dpp, optional_yield y, const RGWUserCtl::PutParams& params = {}) override;
+    virtual int store_info(const DoutPrefixProvider* dpp, optional_yield y, bool exclusive, RGWUserInfo* old_info = nullptr) override;
     virtual int remove_info(const DoutPrefixProvider* dpp, optional_yield y, const RGWUserCtl::RemoveParams& params = {}) override;
 
     friend class RadosBucket;

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -316,13 +316,13 @@ int STSService::storeARN(const DoutPrefixProvider *dpp, string& arn, optional_yi
 {
   int ret = 0;
   std::unique_ptr<rgw::sal::User> user = store->get_user(user_id);
-  if ((ret = user->load_by_id(dpp, y)) < 0) {
+  if ((ret = user->load_user(dpp, y)) < 0) {
     return -ERR_NO_SUCH_ENTITY;
   }
 
   user->get_info().assumed_role_arn = arn;
 
-  ret = user->store_info(dpp, y, false, &user->get_info());
+  ret = user->store_user(dpp, y, false, &user->get_info());
   if (ret < 0) {
     return -ERR_INTERNAL_ERROR;
   }

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -322,9 +322,7 @@ int STSService::storeARN(const DoutPrefixProvider *dpp, string& arn, optional_yi
 
   user->get_info().assumed_role_arn = arn;
 
-  ret = user->store_info(dpp, y, RGWUserCtl::PutParams()
-			    .set_old_info(&user->get_info())
-			    .set_exclusive(false));
+  ret = user->store_info(dpp, y, false, &user->get_info());
   if (ret < 0) {
     return -ERR_INTERNAL_ERROR;
   }

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -92,7 +92,7 @@ void TempURLEngine::get_owner_info(const DoutPrefixProvider* dpp, const req_stat
     if (uid.tenant.empty()) {
       rgw_user tenanted_uid(uid.id, uid.id);
       user = store->get_user(tenanted_uid);
-      if (user->load_by_id(dpp, s->yield) >= 0) {
+      if (user->load_user(dpp, s->yield) >= 0) {
 	/* Succeeded */
 	found = true;
       }
@@ -100,7 +100,7 @@ void TempURLEngine::get_owner_info(const DoutPrefixProvider* dpp, const req_stat
 
     if (!found) {
       user = store->get_user(uid);
-      if (user->load_by_id(dpp, s->yield) < 0) {
+      if (user->load_user(dpp, s->yield) < 0) {
 	throw -EPERM;
       }
     }
@@ -122,7 +122,7 @@ void TempURLEngine::get_owner_info(const DoutPrefixProvider* dpp, const req_stat
 
   std::unique_ptr<rgw::sal::User> user;
   user = store->get_user(bucket->get_info().owner);
-  if (user->load_by_id(dpp, s->yield) < 0) {
+  if (user->load_user(dpp, s->yield) < 0) {
     throw -EPERM;
   }
 

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1565,9 +1565,8 @@ int RGWUser::update(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state
 
   RGWUserInfo *pold_info = (is_populated() ? &old_info : nullptr);
 
-  ret = user->store_info(dpp, y, RGWUserCtl::PutParams()
-			 .set_old_info(pold_info)
-			 .set_objv_tracker(&op_state.objv));
+  ret = user->store_info(dpp, y, false, pold_info);
+  op_state.objv = user->get_version_tracker();
   if (ret < 0) {
     set_err_msg(err_msg, "unable to store user info");
     return ret;
@@ -1663,12 +1662,9 @@ int RGWUser::execute_rename(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
   std::unique_ptr<rgw::sal::User> user;
   user = store->get_user(new_user->get_id());
 
-  RGWObjVersionTracker objv;
   const bool exclusive = !op_state.get_overwrite_new_user(); // overwrite if requested
 
-  ret = user->store_info(dpp, y, RGWUserCtl::PutParams()
-			    .set_objv_tracker(&objv)
-			    .set_exclusive(exclusive));
+  ret = user->store_info(dpp, y, exclusive);
   if (ret == -EEXIST) {
     set_err_msg(err_msg, "user name given by --new-uid already exists");
     return ret;
@@ -1731,7 +1727,7 @@ int RGWUser::execute_rename(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
   // associated index objects
   RGWUserInfo& user_info = op_state.get_user_info();
   user_info.user_id = new_user->get_id();
-  op_state.objv = objv;
+  op_state.objv = user->get_version_tracker();
 
   rename_swift_keys(new_user->get_id(), user_info.swift_keys);
 

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1491,7 +1491,7 @@ int RGWUser::init(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state, 
 
   if (!user_id.empty() && (user_id.compare(RGW_USER_ANON_ID) != 0)) {
     user = store->get_user(user_id);
-    found = (user->load_by_id(dpp, y) >= 0);
+    found = (user->load_user(dpp, y) >= 0);
     op_state.found_by_uid = found;
   }
   if (store->ctx()->_conf.get_val<bool>("rgw_user_unique_email")) {
@@ -1565,7 +1565,7 @@ int RGWUser::update(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state
 
   RGWUserInfo *pold_info = (is_populated() ? &old_info : nullptr);
 
-  ret = user->store_info(dpp, y, false, pold_info);
+  ret = user->store_user(dpp, y, false, pold_info);
   op_state.objv = user->get_version_tracker();
   if (ret < 0) {
     set_err_msg(err_msg, "unable to store user info");
@@ -1664,7 +1664,7 @@ int RGWUser::execute_rename(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
 
   const bool exclusive = !op_state.get_overwrite_new_user(); // overwrite if requested
 
-  ret = user->store_info(dpp, y, exclusive);
+  ret = user->store_user(dpp, y, exclusive);
   if (ret == -EEXIST) {
     set_err_msg(err_msg, "user name given by --new-uid already exists");
     return ret;
@@ -1947,7 +1947,7 @@ int RGWUser::execute_remove(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
 
   } while (buckets.is_truncated());
 
-  ret = user->remove_info(dpp, y, RGWUserCtl::RemoveParams().set_objv_tracker(&op_state.objv));
+  ret = user->remove_user(dpp, y);
   if (ret < 0) {
     set_err_msg(err_msg, "unable to remove user from RADOS");
     return ret;

--- a/src/test/rgw/test_rgw_lua.cc
+++ b/src/test/rgw/test_rgw_lua.cc
@@ -58,15 +58,15 @@ public:
     return 0;
   }
 
-  virtual int load_by_id(const DoutPrefixProvider *dpp, optional_yield y) override {
+  virtual int load_user(const DoutPrefixProvider *dpp, optional_yield y) override {
     return 0;
   }
 
-  virtual int store_info(const DoutPrefixProvider *dpp, optional_yield y, const RGWUserCtl::PutParams& params) override {
+  virtual int store_user(const DoutPrefixProvider* dpp, optional_yield y, bool exclusive, RGWUserInfo* old_info) override {
     return 0;
   }
 
-  virtual int remove_info(const DoutPrefixProvider *dpp, optional_yield y, const RGWUserCtl::RemoveParams& params) override {
+  virtual int remove_user(const DoutPrefixProvider* dpp, optional_yield y) override {
     return 0;
   }
 

--- a/src/test/rgw/test_rgw_lua.cc
+++ b/src/test/rgw/test_rgw_lua.cc
@@ -34,7 +34,7 @@ public:
     return nullptr;
   }
 
-  virtual int read_attrs(const DoutPrefixProvider *dpp, optional_yield y, sal::Attrs* uattrs, RGWObjVersionTracker* tracker) override {
+  virtual int read_attrs(const DoutPrefixProvider *dpp, optional_yield y) override {
     return 0;
   }
 


### PR DESCRIPTION
The Zipper User had a mismash of APIs for loading/storing.  Create a consistent, usable API for these operations.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
