### PR TITLE
cls/rgw: look for plain entries in non-ascii plain namespace too

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -56,6 +56,9 @@ static std::string bucket_index_prefixes[] = { "", /* special handling for the o
                                           /* this must be the last index */
                                           "9999_",};
 
+static const std::string BI_PREFIX_END = string(1, BI_PREFIX_CHAR) +
+    bucket_index_prefixes[BI_BUCKET_LAST_INDEX];
+
 static bool bi_is_objs_index(const string& s) {
   return ((unsigned char)s[0] != BI_PREFIX_CHAR);
 }
@@ -2442,18 +2445,14 @@ static int rgw_bi_put_op(cls_method_context_t hctx, bufferlist *in, bufferlist *
 }
 
 static int list_plain_entries(cls_method_context_t hctx,
-			      const string& name,
-			      const string& marker,
-			      uint32_t max,
+                              const string& filter,
+                              const string& start_after_key,
+                              const string& end_key,
+                              uint32_t max,
                               list<rgw_cls_bi_entry> *entries,
-			      bool *pmore)
+                              bool *end_key_reached,
+                              bool *pmore)
 {
-  string filter = name;
-  string start_after_key = marker;
-
-  string end_key; // stop listing at bi_log_prefix
-  bi_log_prefix(end_key);
-
   int count = 0;
   map<string, bufferlist> keys;
   int ret = cls_cxx_map_get_vals(hctx, start_after_key, filter, max,
@@ -2462,12 +2461,12 @@ static int list_plain_entries(cls_method_context_t hctx,
     return ret;
   }
 
+  *end_key_reached = false;
+
   for (auto iter = keys.begin(); iter != keys.end(); ++iter) {
-    if (iter->first >= end_key) {
-      /* past the end of plain namespace */
-      if (pmore) {
-	*pmore = false;
-      }
+    if (!end_key.empty() && iter->first >= end_key) {
+      *end_key_reached = true;
+      *pmore = true;
       return count;
     }
 
@@ -2486,13 +2485,12 @@ static int list_plain_entries(cls_method_context_t hctx,
       return -EIO;
     }
 
-    CLS_LOG(20, "%s(): entry.idx=%s e.key.name=%s", __func__, escape_str(entry.idx).c_str(), escape_str(e.key.name).c_str());
+    CLS_LOG(20, "%s(): entry.idx=%s e.key.name=%s", __func__,
+            escape_str(entry.idx).c_str(), escape_str(e.key.name).c_str());
 
-    if (!name.empty() && e.key.name != name) {
+    if (!filter.empty() && e.key.name != filter) {
       /* we are skipping the rest of the entries */
-      if (pmore) {
-	*pmore = false;
-      }
+      *pmore = false;
       return count;
     }
 
@@ -2501,10 +2499,52 @@ static int list_plain_entries(cls_method_context_t hctx,
     if (count >= (int)max) {
       return count;
     }
-    start_after_key = entry.idx;
   }
 
   return count;
+}
+
+static int list_plain_entries(cls_method_context_t hctx,
+                              const string& name,
+                              const string& marker,
+                              uint32_t max,
+                              list<rgw_cls_bi_entry> *entries,
+                              bool *pmore) {
+  string start_after_key = marker;
+  string end_key;
+  bi_log_prefix(end_key);
+  int r;
+  bool end_key_reached;
+  bool more;
+
+  if (start_after_key < end_key) {
+    // listing ascii plain namespace
+    int r = list_plain_entries(hctx, name, start_after_key, end_key, max,
+                               entries, &end_key_reached, &more);
+    if (r < 0) {
+      return r;
+    }
+    if (r >= (int)max || !end_key_reached || !more) {
+      if (pmore) {
+	*pmore = more;
+      }
+      return r;
+    }
+    start_after_key = BI_PREFIX_END;
+    max = max - r;
+  }
+
+  // listing non-ascii plain namespace
+  r = list_plain_entries(hctx, name, start_after_key, {}, max, entries,
+                         &end_key_reached, &more);
+  if (r < 0) {
+    return r;
+  }
+  if (pmore) {
+    *pmore = more;
+  }
+
+  return r;
 }
 
 static int list_instance_entries(cls_method_context_t hctx,

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -580,7 +580,7 @@ TEST_F(cls_rgw, bi_list)
   uint64_t num_objs = 35;
 
   for (uint64_t i = 0; i < num_objs; i++) {
-    string obj = str_int("obj", i);
+    string obj = str_int(i % 4 ? "obj" : "об'єкт", i);
     string tag = str_int("tag", i);
     string loc = str_int("loc", i);
     index_prepare(ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, obj, loc,

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -596,8 +596,8 @@ TEST_F(cls_rgw, bi_list)
   ret = cls_rgw_bi_list(ioctx, bucket_oid, name, marker, num_objs + 10, &entries,
 			    &is_truncated);
   ASSERT_EQ(ret, 0);
-  if (cct->_conf->osd_max_omap_entries_per_request < num_objs) {
-    ASSERT_EQ(entries.size(), cct->_conf->osd_max_omap_entries_per_request);
+  if (is_truncated) {
+    ASSERT_LT(entries.size(), num_objs);
   } else {
     ASSERT_EQ(entries.size(), num_objs);
   }
@@ -610,8 +610,7 @@ TEST_F(cls_rgw, bi_list)
 			  &is_truncated);
     ASSERT_EQ(ret, 0);
     if (is_truncated) {
-      ASSERT_EQ(entries.size(),
-		std::min(max, cct->_conf->osd_max_omap_entries_per_request));
+      ASSERT_LT(entries.size(), num_objs - num_entries);
     } else {
       ASSERT_EQ(entries.size(), num_objs - num_entries);
     }
@@ -635,7 +634,7 @@ TEST_F(cls_rgw, bi_list)
 			    &is_truncated);
       ASSERT_EQ(ret, 0);
       if (is_truncated) {
-	ASSERT_EQ(entries.size(), cct->_conf->osd_max_omap_entries_per_request);
+	ASSERT_LT(entries.size(), num_objs - num_entries);
       } else {
 	ASSERT_EQ(entries.size(), num_objs - num_entries);
       }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/50415
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
