### PR TITLE
librbd/image: stop supporting v1_image

### DIFF
--- a/src/librbd/image/RemoveRequest.cc
+++ b/src/librbd/image/RemoveRequest.cc
@@ -416,50 +416,6 @@ template<typename I>
 void RemoveRequest<I>::remove_image() {
   ldout(m_cct, 20) << dendl;
 
-  if (m_old_format || m_unknown_format) {
-    remove_v1_image();
-  } else {
-    remove_v2_image();
-  }
-}
-
-template<typename I>
-void RemoveRequest<I>::remove_v1_image() {
-  ldout(m_cct, 20) << dendl;
-
-  Context *ctx = new LambdaContext([this] (int r) {
-      r = tmap_rm(m_ioctx, m_image_name);
-      handle_remove_v1_image(r);
-    });
-
-  m_op_work_queue->queue(ctx, 0);
-}
-
-template<typename I>
-void RemoveRequest<I>::handle_remove_v1_image(int r) {
-  ldout(m_cct, 20) << "r=" << r << dendl;
-
-  m_old_format = (r == 0);
-  if (r == 0 || (r < 0 && !m_unknown_format)) {
-    if (r < 0 && r != -ENOENT) {
-      lderr(m_cct) << "error removing image from v1 directory: "
-                   << cpp_strerror(r) << dendl;
-    }
-
-    m_on_finish->complete(r);
-    delete this;
-    return;
-  }
-
-  if (!m_old_format) {
-    remove_v2_image();
-  }
-}
-
-template<typename I>
-void RemoveRequest<I>::remove_v2_image() {
-  ldout(m_cct, 20) << dendl;
-
   if (m_image_id.empty()) {
     dir_get_image_id();
     return;

--- a/src/librbd/image/RemoveRequest.h
+++ b/src/librbd/image/RemoveRequest.h
@@ -169,11 +169,6 @@ private:
 
   void remove_image();
 
-  void remove_v1_image();
-  void handle_remove_v1_image(int r);
-
-  void remove_v2_image();
-
   void dir_get_image_id();
   void handle_dir_get_image_id(int r);
 


### PR DESCRIPTION
cleanup: v1_image has been 100% depreciated and replaced by v2_image.
fixes: https://tracker.ceph.com/issues/16044

Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
