### PR TITLE
crimson/os/seastore: formal extended attributes support

### DIFF
--- a/src/crimson/os/alienstore/alien_store.h
+++ b/src/crimson/os/alienstore/alien_store.h
@@ -59,7 +59,7 @@ public:
 						 uint32_t op_flags = 0) final;
 					      
 
-  get_attr_errorator::future<ceph::bufferptr> get_attr(CollectionRef c,
+  get_attr_errorator::future<ceph::bufferlist> get_attr(CollectionRef c,
                                             const ghobject_t& oid,
                                             std::string_view name) const final;
   get_attrs_ertr::future<attrs_t> get_attrs(CollectionRef c,

--- a/src/crimson/os/cyanstore/cyan_object.h
+++ b/src/crimson/os/cyanstore/cyan_object.h
@@ -21,7 +21,7 @@ struct Object : public boost::intrusive_ref_counter<
   bufferlist data;
   // use transparent comparator for better performance, see
   // https://en.cppreference.com/w/cpp/utility/functional/less_void
-  std::map<std::string,bufferptr,std::less<>> xattr;
+  std::map<std::string,bufferlist,std::less<>> xattr;
   bufferlist omap_header;
   std::map<std::string,bufferlist> omap;
 

--- a/src/crimson/os/cyanstore/cyan_store.h
+++ b/src/crimson/os/cyanstore/cyan_store.h
@@ -89,7 +89,7 @@ public:
     interval_set<uint64_t>& m,
     uint32_t op_flags = 0) final;
 
-  get_attr_errorator::future<ceph::bufferptr> get_attr(
+  get_attr_errorator::future<ceph::bufferlist> get_attr(
     CollectionRef c,
     const ghobject_t& oid,
     std::string_view name) const final;
@@ -172,7 +172,7 @@ private:
     const std::string &last);
   int _truncate(const coll_t& cid, const ghobject_t& oid, uint64_t size);
   int _setattrs(const coll_t& cid, const ghobject_t& oid,
-                std::map<std::string,bufferptr>& aset);
+                std::map<std::string,bufferlist>& aset);
   int _rm_attr(const coll_t& cid, const ghobject_t& oid,
 	       string_view name);
   int _create_collection(const coll_t& cid, int bits);

--- a/src/crimson/os/futurized_store.h
+++ b/src/crimson/os/futurized_store.h
@@ -89,14 +89,14 @@ public:
   using get_attr_errorator = crimson::errorator<
     crimson::ct_error::enoent,
     crimson::ct_error::enodata>;
-  virtual get_attr_errorator::future<ceph::bufferptr> get_attr(
+  virtual get_attr_errorator::future<ceph::bufferlist> get_attr(
     CollectionRef c,
     const ghobject_t& oid,
     std::string_view name) const = 0;
 
   using get_attrs_ertr = crimson::errorator<
     crimson::ct_error::enoent>;
-  using attrs_t = std::map<std::string, ceph::bufferptr, std::less<>>;
+  using attrs_t = std::map<std::string, ceph::bufferlist, std::less<>>;
   virtual get_attrs_ertr::future<attrs_t> get_attrs(
     CollectionRef c,
     const ghobject_t& oid) = 0;

--- a/src/crimson/os/seastore/omap_manager.h
+++ b/src/crimson/os/seastore/omap_manager.h
@@ -71,6 +71,13 @@ public:
     const std::string &key,
     const ceph::bufferlist &value) = 0;
 
+  using omap_set_keys_ertr = base_ertr;
+  using omap_set_keys_ret = omap_set_keys_ertr::future<>;
+  virtual omap_set_keys_ret omap_set_keys(
+    omap_root_t &omap_root,
+    Transaction &t,
+    std::map<std::string, ceph::bufferlist>&& keys) = 0;
+
   /**
    * remove key value mapping in omap tree
    *

--- a/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.cc
+++ b/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.cc
@@ -106,6 +106,22 @@ BtreeOMapManager::omap_get_value(
   });
 }
 
+BtreeOMapManager::omap_set_keys_ret
+BtreeOMapManager::omap_set_keys(
+  omap_root_t &omap_root,
+  Transaction &t,
+  std::map<std::string, ceph::bufferlist>&& keys)
+{
+  return seastar::do_with(std::move(keys), [&, this](auto& keys) {
+    return crimson::do_for_each(
+      keys.begin(),
+      keys.end(),
+      [&, this](auto &p) {
+      return omap_set_key(omap_root, t, p.first, p.second);
+    });
+  });
+}
+
 BtreeOMapManager::omap_set_key_ret
 BtreeOMapManager::omap_set_key(
   omap_root_t &omap_root,

--- a/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.h
+++ b/src/crimson/os/seastore/omap_manager/btree/btree_omap_manager.h
@@ -77,6 +77,11 @@ public:
     Transaction &t,
     const std::string &key, const ceph::bufferlist &value) final;
 
+  omap_set_keys_ret omap_set_keys(
+    omap_root_t &omap_root,
+    Transaction &t,
+    std::map<std::string, ceph::bufferlist>&& keys) final;
+
   omap_rm_key_ret omap_rm_key(
     omap_root_t &omap_root,
     Transaction &t,

--- a/src/crimson/os/seastore/onode.h
+++ b/src/crimson/os/seastore/onode.h
@@ -32,6 +32,7 @@ struct onode_layout_t {
   ceph_le32 oi_size{0};
   ceph_le32 ss_size{0};
   omap_root_le_t omap_root;
+  omap_root_le_t xattr_root;
 
   object_data_le_t object_data;
 

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -62,7 +62,7 @@ public:
     const ghobject_t& oid,
     interval_set<uint64_t>& m,
     uint32_t op_flags = 0) final;
-  get_attr_errorator::future<ceph::bufferptr> get_attr(
+  get_attr_errorator::future<ceph::bufferlist> get_attr(
     CollectionRef c,
     const ghobject_t& oid,
     std::string_view name) const final;
@@ -254,7 +254,7 @@ private:
   tm_ret _setattrs(
     internal_context_t &ctx,
     OnodeRef &onode,
-    std::map<std::string,bufferptr> &&aset);
+    std::map<std::string,bufferlist>&& aset);
   tm_ret _create_collection(
     internal_context_t &ctx,
     const coll_t& cid, int bits);

--- a/src/crimson/osd/ops_executer.cc
+++ b/src/crimson/osd/ops_executer.cc
@@ -653,11 +653,9 @@ static PG::interruptible_future<hobject_t> pgls_filter(
     logger().debug("pgls_filter: filter is interested in xattr={} for obj={}",
                    xattr, sobj);
     return backend.getxattr(sobj, xattr).safe_then_interruptible(
-      [&filter, sobj] (ceph::bufferptr bp) {
+      [&filter, sobj] (ceph::bufferlist val) {
         logger().debug("pgls_filter: got xvalue for obj={}", sobj);
 
-        ceph::bufferlist val;
-        val.push_back(std::move(bp));
         const bool filtered = filter.filter(sobj, val);
         return seastar::make_ready_future<hobject_t>(filtered ? sobj : hobject_t{});
       }, PGBackend::get_attr_errorator::all_same_way([&filter, sobj] {

--- a/src/crimson/osd/pg_backend.cc
+++ b/src/crimson/osd/pg_backend.cc
@@ -77,8 +77,7 @@ PGBackend::load_metadata(const hobject_t& oid)
       [oid](auto &&attrs) -> load_metadata_ertr::future<loaded_object_md_t::ref>{
 	loaded_object_md_t::ref ret(new loaded_object_md_t());
 	if (auto oiiter = attrs.find(OI_ATTR); oiiter != attrs.end()) {
-	  bufferlist bl;
-	  bl.push_back(std::move(oiiter->second));
+	  bufferlist bl = std::move(oiiter->second);
 	  ret->os = ObjectState(
 	    object_info_t(bl),
 	    true);
@@ -91,8 +90,7 @@ PGBackend::load_metadata(const hobject_t& oid)
 	
 	if (oid.is_head()) {
 	  if (auto ssiter = attrs.find(SS_ATTR); ssiter != attrs.end()) {
-	    bufferlist bl;
-	    bl.push_back(std::move(ssiter->second));
+	    bufferlist bl = std::move(ssiter->second);
 	    ret->ss = SnapSet(bl);
 	  } else {
 	    /* TODO: add support for writing out snapsets
@@ -793,17 +791,14 @@ PGBackend::get_attr_ierrorator::future<> PGBackend::getxattr(
   }
   logger().debug("getxattr on obj={} for attr={}", os.oi.soid, name);
   return getxattr(os.oi.soid, name).safe_then_interruptible(
-    [&osd_op] (ceph::bufferptr val) {
-    osd_op.outdata.clear();
-    osd_op.outdata.push_back(std::move(val));
+    [&osd_op] (ceph::bufferlist&& val) {
+    osd_op.outdata = std::move(val);
     osd_op.op.xattr.value_len = osd_op.outdata.length();
     return get_attr_errorator::now();
-    //ctx->delta_stats.num_rd_kb += shift_round_up(osd_op.outdata.length(), 10);
   });
-  //ctx->delta_stats.num_rd++;
 }
 
-PGBackend::get_attr_ierrorator::future<ceph::bufferptr>
+PGBackend::get_attr_ierrorator::future<ceph::bufferlist>
 PGBackend::getxattr(
   const hobject_t& soid,
   std::string_view key) const

--- a/src/crimson/osd/pg_backend.h
+++ b/src/crimson/osd/pg_backend.h
@@ -181,7 +181,7 @@ public:
   get_attr_ierrorator::future<> getxattr(
     const ObjectState& os,
     OSDOp& osd_op) const;
-  get_attr_ierrorator::future<ceph::bufferptr> getxattr(
+  get_attr_ierrorator::future<ceph::bufferlist> getxattr(
     const hobject_t& soid,
     std::string_view key) const;
   get_attr_ierrorator::future<> get_xattrs(

--- a/src/crimson/osd/replicated_recovery_backend.cc
+++ b/src/crimson/osd/replicated_recovery_backend.cc
@@ -453,8 +453,8 @@ ReplicatedRecoveryBackend::read_metadata_for_push_op(
       return eversion_t{};
     }
     push_op->omap_header.claim_append(std::move(bl));
-    for (auto&& [key, val] : std::move(attrs)) {
-      push_op->attrset[key].push_back(val);
+    for (auto&& [key, val] : attrs) {
+      push_op->attrset.emplace(std::move(key), std::move(val));
     }
     logger().debug("read_metadata_for_push_op: {}", push_op->attrset[OI_ATTR]);
     object_info_t oi;

--- a/src/test/crimson/seastore/test_seastore.cc
+++ b/src/test/crimson/seastore/test_seastore.cc
@@ -177,20 +177,31 @@ struct seastore_test_t :
       EXPECT_EQ(contents.length(), st.st_size);
     }
 
-    void set_attr_oi(
+    void set_attr(
       SeaStore &seastore,
+      std::string key,
       bufferlist& val) {
       CTransaction t;
-      t.setattr(cid, oid, OI_ATTR, val);
+      t.setattr(cid, oid, key, val);
       seastore.do_transaction(
         coll,
         std::move(t)).get0();
     }
 
-    SeaStore::attrs_t get_attr_oi(
+    SeaStore::attrs_t get_attrs(
       SeaStore &seastore) {
-      return seastore.get_attrs(
-        coll, oid).handle_error(SeaStore::get_attrs_ertr::discard_all{}).get();
+      return seastore.get_attrs(coll, oid)
+		     .handle_error(SeaStore::get_attrs_ertr::discard_all{})
+		     .get();
+    }
+
+    ceph::bufferlist get_attr(
+      SeaStore& seastore,
+      std::string_view name) {
+      return seastore.get_attr(coll, oid, name)
+		      .handle_error(
+			SeaStore::get_attr_errorator::discard_all{})
+		      .get();
     }
 
     void check_omap_key(
@@ -350,16 +361,64 @@ TEST_F(seastore_test_t, attr)
 {
   run_async([this] {
     auto& test_obj = get_object(make_oid(0));
-    std::string s("asdfasdfasdf");
+
+    std::string oi("asdfasdfasdf");
     bufferlist bl;
-    encode(s, bl);
-    test_obj.set_attr_oi(*seastore, bl);
-    auto attrs = test_obj.get_attr_oi(*seastore);
-    std::string s2;
-    bufferlist bl2;
-    bl2.push_back(attrs[OI_ATTR]);
-    decode(s2, bl);
-    EXPECT_EQ(s, s2);
+    encode(oi, bl);
+    test_obj.set_attr(*seastore, OI_ATTR, bl);
+
+    std::string ss("fdsfdsfs");
+    bl.clear();
+    encode(ss, bl);
+    test_obj.set_attr(*seastore, SS_ATTR, bl);
+
+    std::string test_val("ssssssssssss");
+    bl.clear();
+    encode(test_val, bl);
+    test_obj.set_attr(*seastore, "test_key", bl);
+
+    auto attrs = test_obj.get_attrs(*seastore);
+    std::string oi2;
+    bufferlist bl2 = attrs[OI_ATTR];
+    decode(oi2, bl2);
+    bl2.clear();
+    bl2 = attrs[SS_ATTR];
+    std::string ss2;
+    decode(ss2, bl2);
+    std::string test_val2;
+    bl2.clear();
+    bl2 = attrs["test_key"];
+    decode(test_val2, bl2);
+    EXPECT_EQ(ss, ss2);
+    EXPECT_EQ(oi, oi2);
+    EXPECT_EQ(test_val, test_val2);
+
+    bl2.clear();
+    bl2 = test_obj.get_attr(*seastore, "test_key");
+    test_val2.clear();
+    decode(test_val2, bl2);
+    EXPECT_EQ(test_val, test_val2);
+
+    std::cout << "test_key passed" << std::endl;
+    char ss_array[256] = {0};
+    std::string ss_str(&ss_array[0], 256);
+    bl.clear();
+    encode(ss_str, bl);
+    test_obj.set_attr(*seastore, SS_ATTR, bl);
+
+    attrs = test_obj.get_attrs(*seastore);
+    std::cout << "got attr" << std::endl;
+    bl2.clear();
+    bl2 = attrs[SS_ATTR];
+    std::string ss_str2;
+    decode(ss_str2, bl2);
+    EXPECT_EQ(ss_str, ss_str2);
+
+    bl2.clear();
+    ss_str2.clear();
+    bl2 = test_obj.get_attr(*seastore, SS_ATTR);
+    decode(ss_str2, bl2);
+    EXPECT_EQ(ss_str, ss_str2);
   });
 }
 


### PR DESCRIPTION
Signed-off-by: Xuehan Xu <xxhdx1985126@gmail.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
