### PR TITLE
pacific: mgr/Dashboard: Remove erroneous elements in hosts-overview Grafana dashboard 

### DIFF
--- a/monitoring/grafana/dashboards/hosts-overview.json
+++ b/monitoring/grafana/dashboards/hosts-overview.json
@@ -131,7 +131,6 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "decimals": 0,
       "description": "Average CPU busy across all hosts (OSD, RGW, MON etc) within the cluster",
       "decimals": 2,
       "format": "percentunit",
@@ -215,7 +214,6 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "decimals": 0,
       "description": "Average Memory Usage across all hosts in the cluster (excludes buffer/cache usage)",
       "decimals": 2,
       "format": "percentunit",


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50427

---

backport of https://github.com/ceph/ceph/pull/40899
parent tracker: https://tracker.ceph.com/issues/50410

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh