### PR TITLE
pacific: ceph-volume: fix raw listing when finding OSDs from different clusters

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/raw/list.py
+++ b/src/ceph-volume/ceph_volume/devices/raw/list.py
@@ -78,13 +78,13 @@ class List(object):
                 # ignore non-main devices, for now
                 continue
             whoami = oj[dev]['whoami']
-            result[whoami] = {
+            result[oj[dev]['osd_uuid']] = {
                 'type': 'bluestore',
                 'osd_id': int(whoami),
+                'osd_uuid': oj[dev]['osd_uuid'],
+                'ceph_fsid': oj[dev]['ceph_fsid'],
+                'dev': dev
             }
-            for f in ['osd_uuid', 'ceph_fsid']:
-                result[whoami][f] = oj[dev][f]
-            result[whoami]['device'] = dev
         return result
 
     @decorators.needs_root


### PR DESCRIPTION
When listing OSDs on host with 2 OSDs with the same ID, the output gets
overwritten with the last listed device. So a single OSD will show up.
See the ceph-volume.log which correctly parsed both disks:

```
[2021-04-22 09:44:21,391][ceph_volume.devices.raw.list][DEBUG ] Examining /dev/sda1
[2021-04-22 09:44:21,391][ceph_volume.process][INFO  ] Running command: /usr/bin/ceph-bluestore-tool show-label --dev /dev/sda1
[2021-04-22 09:44:21,418][ceph_volume.process][INFO  ] stdout {
[2021-04-22 09:44:21,418][ceph_volume.process][INFO  ] stdout "/dev/sda1": {
[2021-04-22 09:44:21,418][ceph_volume.process][INFO  ] stdout "osd_uuid": "423bf64d-f241-4f4b-a589-25a66fc836d1",
[2021-04-22 09:44:21,418][ceph_volume.process][INFO  ] stdout "size": 6442450944,
[2021-04-22 09:44:21,418][ceph_volume.process][INFO  ] stdout "btime": "2021-04-22T09:32:55.894961+0000",
[2021-04-22 09:44:21,418][ceph_volume.process][INFO  ] stdout "description": "main",
[2021-04-22 09:44:21,418][ceph_volume.process][INFO  ] stdout "bfm_blocks": "1572864",
[2021-04-22 09:44:21,418][ceph_volume.process][INFO  ] stdout "bfm_blocks_per_key": "128",
[2021-04-22 09:44:21,418][ceph_volume.process][INFO  ] stdout "bfm_bytes_per_block": "4096",
[2021-04-22 09:44:21,418][ceph_volume.process][INFO  ] stdout "bfm_size": "6442450944",
[2021-04-22 09:44:21,418][ceph_volume.process][INFO  ] stdout "bluefs": "1",
[2021-04-22 09:44:21,419][ceph_volume.process][INFO  ] stdout "ceph_fsid": "d3cd4b72-5342-4fd3-96ec-a6e581261eab",
[2021-04-22 09:44:21,419][ceph_volume.process][INFO  ] stdout "kv_backend": "rocksdb",
[2021-04-22 09:44:21,419][ceph_volume.process][INFO  ] stdout "magic": "ceph osd volume v026",
[2021-04-22 09:44:21,419][ceph_volume.process][INFO  ] stdout "mkfs_done": "yes",
[2021-04-22 09:44:21,419][ceph_volume.process][INFO  ] stdout "osd_key": "AQDGQoFg+XHqJBAAw9ZQmtrnotHCLI0Nc2to6A==",
[2021-04-22 09:44:21,419][ceph_volume.process][INFO  ] stdout "ready": "ready",
[2021-04-22 09:44:21,419][ceph_volume.process][INFO  ] stdout "whoami": "0"
[2021-04-22 09:44:21,419][ceph_volume.process][INFO  ] stdout }
[2021-04-22 09:44:21,419][ceph_volume.process][INFO  ] stdout }
[2021-04-22 09:44:21,419][ceph_volume.devices.raw.list][DEBUG ] Examining /dev/sda2
[2021-04-22 09:44:21,419][ceph_volume.process][INFO  ] Running command: /usr/bin/ceph-bluestore-tool show-label --dev /dev/sda2
[2021-04-22 09:44:21,445][ceph_volume.process][INFO  ] stdout {
[2021-04-22 09:44:21,445][ceph_volume.process][INFO  ] stdout "/dev/sda2": {
[2021-04-22 09:44:21,445][ceph_volume.process][INFO  ] stdout "osd_uuid": "c7c66bbd-7b38-4dcd-ad6d-3769c516f2fe",
[2021-04-22 09:44:21,446][ceph_volume.process][INFO  ] stdout "size": 6442450944,
[2021-04-22 09:44:21,446][ceph_volume.process][INFO  ] stdout "btime": "2021-04-22T09:32:21.814768+0000",
[2021-04-22 09:44:21,446][ceph_volume.process][INFO  ] stdout "description": "main",
[2021-04-22 09:44:21,446][ceph_volume.process][INFO  ] stdout "bfm_blocks": "1572864",
[2021-04-22 09:44:21,446][ceph_volume.process][INFO  ] stdout "bfm_blocks_per_key": "128",
[2021-04-22 09:44:21,446][ceph_volume.process][INFO  ] stdout "bfm_bytes_per_block": "4096",
[2021-04-22 09:44:21,446][ceph_volume.process][INFO  ] stdout "bfm_size": "6442450944",
[2021-04-22 09:44:21,446][ceph_volume.process][INFO  ] stdout "bluefs": "1",
[2021-04-22 09:44:21,446][ceph_volume.process][INFO  ] stdout "ceph_fsid": "69c40cb1-22af-42e4-9d59-4a4468a2f58f",
[2021-04-22 09:44:21,446][ceph_volume.process][INFO  ] stdout "kv_backend": "rocksdb",
[2021-04-22 09:44:21,446][ceph_volume.process][INFO  ] stdout "magic": "ceph osd volume v026",
[2021-04-22 09:44:21,446][ceph_volume.process][INFO  ] stdout "mkfs_done": "yes",
[2021-04-22 09:44:21,446][ceph_volume.process][INFO  ] stdout "osd_key": "AQCkQoFgre9SKBAANgHH6scIb+IiyKxh6MhY0A==",
[2021-04-22 09:44:21,446][ceph_volume.process][INFO  ] stdout "ready": "ready",
[2021-04-22 09:44:21,446][ceph_volume.process][INFO  ] stdout "require_osd_release": "16",
[2021-04-22 09:44:21,446][ceph_volume.process][INFO  ] stdout "whoami": "0"
[2021-04-22 09:44:21,446][ceph_volume.process][INFO  ] stdout }
[2021-04-22 09:44:21,446][ceph_volume.process][INFO  ] stdout }
```

However, a single OSD gets listed by `ceph-volume raw list`:

```
[root@2b5a3b8bf31c /]# ceph-volume raw list
{
    "0": {
        "ceph_fsid": "69c40cb1-22af-42e4-9d59-4a4468a2f58f",
        "device": "/dev/sda2",
        "osd_id": 0,
        "osd_uuid": "c7c66bbd-7b38-4dcd-ad6d-3769c516f2fe",
        "type": "bluestore"
    }
}
```

We now use the osd_uuid so the output will never conflict:

```
[root@2b5a3b8bf31c /]# ceph-volume raw list
{
    "423bf64d-f241-4f4b-a589-25a66fc836d1": {
        "ceph_fsid": "d3cd4b72-5342-4fd3-96ec-a6e581261eab",
        "dev": "/dev/sda1",
        "osd_id": 0,
        "osd_uuid": "423bf64d-f241-4f4b-a589-25a66fc836d1",
        "type": "bluestore"
    },
    "c7c66bbd-7b38-4dcd-ad6d-3769c516f2fe": {
        "ceph_fsid": "69c40cb1-22af-42e4-9d59-4a4468a2f58f",
        "dev": "/dev/sda2",
        "osd_id": 0,
        "osd_uuid": "c7c66bbd-7b38-4dcd-ad6d-3769c516f2fe",
        "type": "bluestore"
    }
}
```

Fixes: https://tracker.ceph.com/issues/50478
Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit ec0f5f3b22d24754c16131a1996e42b787e4255f)


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>

Backport of https://github.com/ceph/ceph/pull/40979