### PR TITLE
crimson/common: print the address that caused the fault on SIGSEGV.

### DIFF
--- a/src/crimson/common/fatal_signal.cc
+++ b/src/crimson/common/fatal_signal.cc
@@ -50,7 +50,7 @@ void FatalSignal::install_oneshot_signal_handler()
 }
 
 
-static void print_with_backtrace(std::string_view cause) {
+static void print_backtrace(std::string_view cause) {
   std::cerr << cause;
   if (seastar::engine_is_ready()) {
     std::cerr << " on shard " << seastar::this_shard_id();
@@ -66,13 +66,13 @@ void FatalSignal::signaled(const int signum)
 {
   switch (signum) {
   case SIGSEGV:
-    print_with_backtrace("Aborting");
+    print_backtrace("Aborting");
     break;
   case SIGABRT:
-    print_with_backtrace("Segmentation fault");
+    print_backtrace("Segmentation fault");
     break;
   default:
-    print_with_backtrace(fmt::format("Signal {}", signum));
+    print_backtrace(fmt::format("Signal {}", signum));
     break;
   }
 }

--- a/src/crimson/common/fatal_signal.cc
+++ b/src/crimson/common/fatal_signal.cc
@@ -66,10 +66,10 @@ void FatalSignal::signaled(const int signum)
 {
   switch (signum) {
   case SIGSEGV:
-    print_backtrace("Aborting");
+    print_backtrace("Segmentation fault");
     break;
   case SIGABRT:
-    print_backtrace("Segmentation fault");
+    print_backtrace("Aborting");
     break;
   default:
     print_backtrace(fmt::format("Signal {}", signum));

--- a/src/crimson/common/fatal_signal.h
+++ b/src/crimson/common/fatal_signal.h
@@ -9,7 +9,6 @@ public:
 
 private:
   static void signaled(int signum);
-  static void print_backtrace(int signum);
 
   template <int... SigNums>
   void install_oneshot_signals_handler();

--- a/src/crimson/common/fatal_signal.h
+++ b/src/crimson/common/fatal_signal.h
@@ -3,12 +3,14 @@
 
 #pragma once
 
+#include <csignal>
+
 class FatalSignal {
 public:
   FatalSignal();
 
 private:
-  static void signaled(int signum);
+  static void signaled(int signum, const siginfo_t* siginfo);
 
   template <int... SigNums>
   void install_oneshot_signals_handler();


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
