### PR TITLE
cephfs-mirror: disallow adding a active peer back to source

### DIFF
--- a/qa/tasks/cephfs/test_mirroring.py
+++ b/qa/tasks/cephfs/test_mirroring.py
@@ -26,6 +26,7 @@ class TestMirroring(CephFSTestCase):
         self.primary_fs_name = self.fs.name
         self.primary_fs_id = self.fs.id
         self.secondary_fs_name = self.backup_fs.name
+        self.secondary_fs_id = self.backup_fs.id
         self.enable_mirroring_module()
 
     def tearDown(self):
@@ -1147,5 +1148,21 @@ class TestMirroring(CephFSTestCase):
         self.check_peer_status(self.primary_fs_name, self.primary_fs_id,
                                "client.mirror_remote@ceph", f'/{repo_path}', 'snap_b', 2)
         self.verify_snapshot(repo_path, 'snap_b')
+
+        self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)
+
+    def test_cephfs_mirror_peer_add_primary(self):
+        self.enable_mirroring(self.primary_fs_name, self.primary_fs_id)
+        self.peer_add(self.primary_fs_name, self.primary_fs_id, "client.mirror_remote@ceph", self.secondary_fs_name)
+
+        # try adding the primary file system as a peer to secondary file
+        # system
+        try:
+            self.peer_add(self.secondary_fs_name, self.secondary_fs_id, "client.mirror_remote@ceph", self.primary_fs_name)
+        except CommandFailedError as ce:
+            if ce.exitstatus != errno.EINVAL:
+                raise RuntimeError('invalid errno when adding a primary file system')
+        else:
+            raise RuntimeError('adding peer should fail')
 
         self.disable_mirroring(self.primary_fs_name, self.primary_fs_id)

--- a/src/pybind/cephfs/c_cephfs.pxd
+++ b/src/pybind/cephfs/c_cephfs.pxd
@@ -46,6 +46,7 @@ cdef extern from "cephfs/libcephfs.h" nogil:
     void ceph_shutdown(ceph_mount_info *cmount)
 
     int ceph_getaddrs(ceph_mount_info* cmount, char** addrs)
+    int64_t ceph_get_fs_cid(ceph_mount_info *cmount)
     int ceph_conf_read_file(ceph_mount_info *cmount, const char *path_list)
     int ceph_conf_parse_argv(ceph_mount_info *cmount, int argc, const char **argv)
     int ceph_conf_get(ceph_mount_info *cmount, const char *option, char *buf, size_t len)

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -481,6 +481,17 @@ cdef class LibCephFS(object):
             for key, value in conf.items():
                 self.conf_set(key, value)
 
+    def get_fscid(self):
+        """
+        Return the file system id for this fs client.
+        """
+        self.require_state("mounted")
+        with nogil:
+            ret = ceph_get_fs_cid(self.cluster)
+        if ret < 0:
+            raise make_ex(ret, "error fetching fscid")
+        return ret
+
     def get_addrs(self):
         """
         Get associated client addresses with this RADOS session.

--- a/src/pybind/cephfs/mock_cephfs.pxi
+++ b/src/pybind/cephfs/mock_cephfs.pxi
@@ -55,6 +55,8 @@ cdef nogil:
 
     int ceph_getaddrs(ceph_mount_info* cmount, char** addrs):
         pass
+    int64_t ceph_get_fs_cid(ceph_mount_info *cmount):
+        pass
     int ceph_conf_read_file(ceph_mount_info *cmount, const char *path_list):
         pass
     int ceph_conf_parse_argv(ceph_mount_info *cmount, int argc, const char **argv):


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
