### PR TITLE
crimson/onode-staged-tree: implement/validate features to erase values from tree

### DIFF
--- a/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/fltree_onode_manager.cc
@@ -105,7 +105,7 @@ FLTreeOnodeManager::write_dirty_ret FLTreeOnodeManager::write_dirty(
 	return seastar::now();
       }
       case FLTreeOnode::status_t::DELETED: {
-	return tree.erase(trans, flonode).safe_then([](auto) {});
+	return tree.erase(trans, flonode);
       }
       case FLTreeOnode::status_t::STABLE: {
 	return seastar::now();

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -286,10 +286,24 @@ Node::Node(NodeImplURef&& impl) : impl{std::move(impl)} {}
 Node::~Node()
 {
   // XXX: tolerate failure between allocate() and as_child()
-  if (is_root()) {
-    super->do_untrack_root(*this);
+  if (!super && !_parent_info.has_value()) {
+    // To erase a node:
+    // 1. I'm not tracking any children or cursors
+    // 2. unlink parent/super --ptr-> me
+    // 3. unlink me --ref-> parent/super
+    // 4. extent is retired
+    assert(!impl->is_extent_valid());
+
+    // TODO: maybe its possible when eagain happens internally, we should
+    // revisit to make sure tree operations can be aborted normally,
+    // without resource leak or hitting unexpected asserts.
   } else {
-    _parent_info->ptr->do_untrack_child(*this);
+    assert(impl->is_extent_valid());
+    if (is_root()) {
+      super->do_untrack_root(*this);
+    } else {
+      _parent_info->ptr->do_untrack_child(*this);
+    }
   }
 }
 
@@ -458,12 +472,12 @@ template void Node::as_child<true>(const search_position_t&, Ref<InternalNode>);
 template void Node::as_child<false>(const search_position_t&, Ref<InternalNode>);
 
 node_future<> Node::apply_split_to_parent(
-    context_t c, Ref<Node> split_right)
+    context_t c, Ref<Node> split_right, bool update_right_index)
 {
   assert(!is_root());
   // TODO(cross-node string dedup)
   return parent_info().ptr->apply_child_split(
-      c, this, split_right);
+      c, this, split_right, update_right_index);
 }
 
 node_future<Ref<tree_cursor_t>>
@@ -472,6 +486,122 @@ Node::get_next_cursor_from_parent(context_t c)
   assert(!impl->is_level_tail());
   assert(!is_root());
   return parent_info().ptr->get_next_cursor(c, parent_info().position);
+}
+
+node_future<>
+Node::try_merge_adjacent(context_t c, bool update_parent_index)
+{
+  impl->validate_non_empty();
+  assert(!is_root());
+  Ref<Node> this_ref = this;
+  if (!impl->is_size_underflow()) {
+    if (update_parent_index) {
+      return fix_parent_index(c);
+    } else {
+      parent_info().ptr->validate_child_tracked(*this);
+      return node_ertr::now();
+    }
+  }
+
+  return parent_info().ptr->get_child_peers(c, parent_info().position
+  ).safe_then([c, this_ref = std::move(this_ref), this,
+               update_parent_index] (auto lr_nodes) mutable -> node_future<> {
+    auto& [lnode, rnode] = lr_nodes;
+    Ref<Node> left_for_merge;
+    Ref<Node> right_for_merge;
+    bool is_left;
+    if (!lnode && !rnode) {
+      // XXX: this is possible before node rebalance is implemented,
+      // when its parent cannot merge with its peers and has only one child
+      // (this node).
+    } else if (!lnode) {
+      left_for_merge = std::move(this_ref);
+      right_for_merge = std::move(rnode);
+      is_left = true;
+    } else if (!rnode) {
+      left_for_merge = std::move(lnode);
+      right_for_merge = std::move(this_ref);
+      is_left = false;
+    } else { // lnode && rnode
+      if (lnode->impl->free_size() > rnode->impl->free_size()) {
+        left_for_merge = std::move(lnode);
+        right_for_merge = std::move(this_ref);
+        is_left = false;
+      } else { // lnode free size <= rnode free size
+        left_for_merge = std::move(this_ref);
+        right_for_merge = std::move(rnode);
+        is_left = true;
+      }
+    }
+
+    if (left_for_merge) {
+      assert(right_for_merge);
+      auto [merge_stage, merge_size] = left_for_merge->impl->evaluate_merge(
+          *right_for_merge->impl);
+      if (merge_size <= left_for_merge->impl->total_size()) {
+        // proceed merge
+        bool update_index_after_merge;
+        if (is_left) {
+          update_index_after_merge = false;
+        } else {
+          update_index_after_merge = update_parent_index;
+        }
+        logger().info("OTree::Node::MergeAdjacent: merge {} and {} "
+                      "at merge_stage={}, merge_size={}B, update_index={} ...",
+                      left_for_merge->get_name(), right_for_merge->get_name(),
+                      merge_stage, merge_size, update_index_after_merge);
+        // we currently cannot generate delta depends on another extent content,
+        // so use rebuild_extent() as a workaround to rebuild the node from a
+        // fresh extent, thus no need to generate delta.
+        return left_for_merge->rebuild_extent(c
+        ).safe_then([c, merge_stage, merge_size, update_index_after_merge,
+                     left_for_merge = std::move(left_for_merge),
+                     right_for_merge = std::move(right_for_merge)] (auto left_mut) mutable {
+          if (left_for_merge->impl->node_type() == node_type_t::LEAF) {
+            auto& left = *static_cast<LeafNode*>(left_for_merge.get());
+            left.on_layout_change();
+          }
+          search_position_t left_last_pos = left_for_merge->impl->merge(
+              left_mut, *right_for_merge->impl, merge_stage, merge_size);
+          left_for_merge->track_merge(right_for_merge, merge_stage, left_last_pos);
+          return left_for_merge->parent_info().ptr->apply_children_merge(
+              c, std::move(left_for_merge),
+              std::move(right_for_merge), update_index_after_merge);
+        });
+      } else {
+        // size will overflow if merge
+      }
+    }
+
+    // cannot merge
+    if (update_parent_index) {
+      return fix_parent_index(c);
+    } else {
+      parent_info().ptr->validate_child_tracked(*this);
+      return node_ertr::now();
+    }
+    // XXX: rebalance
+  });
+}
+
+node_future<> Node::erase_node(context_t c, Ref<Node>&& this_ref)
+{
+  assert(this_ref.get() == this);
+  assert(!is_tracking());
+  assert(!is_root());
+  assert(this_ref->use_count() == 1);
+  return parent_info().ptr->erase_child(c, std::move(this_ref));
+}
+
+node_future<> Node::fix_parent_index(context_t c)
+{
+  assert(!is_root());
+  auto& parent = parent_info().ptr;
+  // one-way unlink
+  parent->do_untrack_child(*this);
+  // the rest of parent tracks should be correct
+  parent->validate_tracked_children();
+  return parent->fix_index(c, this);
 }
 
 node_future<Ref<Node>> Node::load(
@@ -494,6 +624,44 @@ node_future<Ref<Node>> Node::load(
       ceph_abort("impossible path");
     }
   });
+}
+
+node_future<NodeExtentMutable> Node::rebuild_extent(context_t c)
+{
+  logger().debug("OTree::Node::Rebuild: {} ...", get_name());
+  assert(!is_root());
+  // assume I'm already ref counted by caller
+
+  // note: laddr can be changed after rebuild, but we don't fix the parent
+  // mapping as it is part of the merge process.
+  return impl->rebuild_extent(c);
+}
+
+node_future<> Node::retire(context_t c, Ref<Node>&& this_ref)
+{
+  logger().debug("OTree::Node::Retire: {} ...", get_name());
+  assert(this_ref.get() == this);
+  assert(!is_tracking());
+  assert(!super);
+  // make sure the parent also has untracked this node
+  assert(!_parent_info.has_value());
+  assert(this_ref->use_count() == 1);
+
+  return impl->retire_extent(c
+  ).safe_then([this_ref = std::move(this_ref)]{ /* deallocate node */});
+}
+
+void Node::make_tail(context_t c)
+{
+  assert(!impl->is_level_tail());
+  assert(!impl->is_keys_empty());
+  logger().debug("OTree::Node::MakeTail: {} ...", get_name());
+  impl->prepare_mutate(c);
+  auto tail_pos = impl->make_tail();
+  if (impl->node_type() == node_type_t::INTERNAL) {
+    auto& node = *static_cast<InternalNode*>(this);
+    node.track_make_tail(tail_pos);
+  }
 }
 
 /*
@@ -530,7 +698,8 @@ InternalNode::get_next_cursor(context_t c, const search_position_t& pos)
 }
 
 node_future<> InternalNode::apply_child_split(
-    context_t c, Ref<Node> left_child, Ref<Node> right_child)
+    context_t c, Ref<Node> left_child, Ref<Node> right_child,
+    bool update_right_index)
 {
   auto& left_pos = left_child->parent_info().position;
 
@@ -540,69 +709,379 @@ node_future<> InternalNode::apply_child_split(
   if (left_pos.is_end()) {
     assert(impl->is_level_tail());
     assert(right_child->impl->is_level_tail());
+    assert(!update_right_index);
   }
 #endif
 
   impl->prepare_mutate(c);
 
-  auto left_key = *left_child->impl->get_pivot_index();
+  logger().debug("OTree::Internal::ApplyChildSplit: apply {}'s child "
+                 "{} to split to {}, update_index={} ...",
+                 get_name(), left_child->get_name(),
+                 right_child->get_name(), update_right_index);
+
+  // update layout from left_pos => left_child_addr to right_child_addr
   auto left_child_addr = left_child->impl->laddr();
-  auto op_right_key = right_child->impl->get_pivot_index();
   auto right_child_addr = right_child->impl->laddr();
-  if (op_right_key.has_value()) {
-    logger().debug("OTree::Internal::Insert: "
-                   "left_pos({}), left_child({}, {:#x}), right_child({}, {:#x}) ...",
-                   left_pos, left_key, left_child_addr, *op_right_key, right_child_addr);
-  } else {
-    logger().debug("OTree::Internal::Insert: "
-                   "left_pos({}), left_child({}, {:#x}), right_child(N/A, {:#x}) ...",
-                   left_pos, left_key, left_child_addr, right_child_addr);
-  }
-  // update left_pos => left_child to left_pos => right_child
   impl->replace_child_addr(left_pos, right_child_addr, left_child_addr);
-  replace_track(right_child, left_child);
 
-  search_position_t insert_pos = left_pos;
-  auto [insert_stage, insert_size] = impl->evaluate_insert(
-      left_key, left_child_addr, insert_pos);
-  auto free_size = impl->free_size();
-  if (free_size >= insert_size) {
-    // insert
-    [[maybe_unused]] auto p_value = impl->insert(
-        left_key, left_child_addr, insert_pos, insert_stage, insert_size);
-    assert(impl->free_size() == free_size - insert_size);
-    assert(insert_pos <= left_pos);
-    assert(p_value->value == left_child_addr);
-    track_insert(insert_pos, insert_stage, left_child, right_child);
-    validate_tracked_children();
-    return node_ertr::now();
-  }
-  // split and insert
+  // update track from left_pos => left_child to right_child
+  replace_track(right_child, left_child, update_right_index);
+
+  auto left_key = *left_child->impl->get_pivot_index();
   Ref<InternalNode> this_ref = this;
-  return (is_root() ? upgrade_root(c) : node_ertr::now()
-  ).safe_then([this, c] {
-    return InternalNode::allocate(
-        c, impl->field_type(), impl->is_level_tail(), impl->level());
-  }).safe_then([this_ref, this, c, left_key, left_child, right_child,
-                insert_pos, insert_stage=insert_stage, insert_size=insert_size](auto fresh_right) mutable {
-    auto right_node = fresh_right.node;
-    auto left_child_addr = left_child->impl->laddr();
-    auto [split_pos, is_insert_left, p_value] = impl->split_insert(
-        fresh_right.mut, *right_node->impl, left_key, left_child_addr,
-        insert_pos, insert_stage, insert_size);
-    assert(p_value->value == left_child_addr);
-    track_split(split_pos, right_node);
-    if (is_insert_left) {
-      track_insert(insert_pos, insert_stage, left_child);
+  return insert_or_split(
+      c, left_pos, left_key, left_child,
+      (update_right_index ? right_child : nullptr)
+  ).safe_then([this, c, this_ref = std::move(this_ref)] (auto split_right) {
+    if (split_right) {
+      // even if update_right_index could be true,
+      // we haven't fixed the right_child index of this node yet,
+      // so my parent index should be correct now.
+      return apply_split_to_parent(c, split_right, false);
     } else {
-      right_node->track_insert(insert_pos, insert_stage, left_child);
+      return node_ertr::now();
     }
-    validate_tracked_children();
-    right_node->validate_tracked_children();
+  }).safe_then([c, update_right_index, right_child] {
+    if (update_right_index) {
+      // right_child must be already untracked by insert_or_split()
+      return right_child->parent_info().ptr->fix_index(c, right_child);
+    } else {
+      // there is no need to call try_merge_adjacent() because
+      // the filled size of the inserted node or the split right node
+      // won't be reduced if update_right_index is false.
+      return node_ertr::now();
+    }
+  });
+}
 
-    return apply_split_to_parent(c, right_node);
-    // TODO (optimize)
-    // try to acquire space from siblings before split... see btrfs
+node_future<> InternalNode::erase_child(context_t c, Ref<Node>&& child_ref)
+{
+  // this is a special version of recursive merge
+  impl->validate_non_empty();
+  assert(child_ref->use_count() == 1);
+  validate_child_tracked(*child_ref);
+
+  // fix the child's previous node as the new tail,
+  // and trigger prv_child_ref->try_merge_adjacent() at the end
+  bool fix_tail = (child_ref->parent_info().position.is_end() &&
+                   !impl->is_keys_empty());
+  return node_ertr::now().safe_then([c, this, fix_tail] {
+    if (fix_tail) {
+      search_position_t new_tail_pos;
+      const laddr_packed_t* new_tail_p_addr = nullptr;
+      impl->get_largest_slot(&new_tail_pos, nullptr, &new_tail_p_addr);
+      return get_or_track_child(c, new_tail_pos, new_tail_p_addr->value);
+    } else {
+      return node_ertr::make_ready_future<Ref<Node>>();
+    }
+  }).safe_then([c, this, child_ref = std::move(child_ref)]
+               (auto&& new_tail_child) mutable {
+    auto child_pos = child_ref->parent_info().position;
+    if (new_tail_child) {
+      logger().info("OTree::Internal::EraseChild: erase {}'s child {} at pos({}), "
+                    "and fix new child tail {} at pos({}) ...",
+                    get_name(), child_ref->get_name(), child_pos,
+                    new_tail_child->get_name(),
+                    new_tail_child->parent_info().position);
+      assert(!new_tail_child->impl->is_level_tail());
+      new_tail_child->make_tail(c);
+      assert(new_tail_child->impl->is_level_tail());
+      if (new_tail_child->impl->node_type() == node_type_t::LEAF) {
+        // no need to proceed merge because the filled size is not changed
+        new_tail_child.reset();
+      }
+    } else {
+      logger().info("OTree::Internal::EraseChild: erase {}'s child {} at pos({}) ...",
+                    get_name(), child_ref->get_name(), child_pos);
+    }
+
+    do_untrack_child(*child_ref);
+    Ref<InternalNode> this_ref = this;
+    child_ref->_parent_info.reset();
+    return child_ref->retire(c, std::move(child_ref)
+    ).safe_then([c, this, child_pos, this_ref = std::move(this_ref)] () mutable {
+      if ((impl->is_level_tail() && impl->is_keys_empty()) ||
+          (!impl->is_level_tail() && impl->is_keys_one())) {
+        // there is only one value left
+        // fast path without mutating the extent
+        logger().debug("OTree::Internal::EraseChild: {} has one value left, erase ...",
+                       get_name());
+#ifndef NDEBUG
+        if (impl->is_level_tail()) {
+          assert(child_pos.is_end());
+        } else {
+          assert(child_pos == search_position_t::begin());
+        }
+#endif
+
+        if (is_root()) {
+          // Note: if merge/split works as expected, we should never encounter the
+          // situation when the internal root has <=1 children:
+          //
+          // A newly created internal root (see Node::upgrade_root()) will have 2
+          // children after split is finished.
+          //
+          // When merge happens, children will try to merge each other, and if the
+          // root detects there is only one child left, the root will be
+          // down-graded to the only child.
+          //
+          // In order to preserve the invariant, we need to make sure the new
+          // internal root also has at least 2 children.
+          ceph_abort("trying to erase the last item from the internal root node");
+        }
+
+        // track erase
+        assert(tracked_child_nodes.empty());
+
+        // no child should be referencing this node now, this_ref is the last one.
+        assert(this_ref->use_count() == 1);
+        Ref<Node> node_ref = this_ref;
+        this_ref.reset();
+        return Node::erase_node(c, std::move(node_ref));
+      }
+
+      impl->prepare_mutate(c);
+      auto [erase_stage, next_or_last_pos] = impl->erase(child_pos);
+      if (child_pos.is_end()) {
+        // next_or_last_pos as last_pos
+        track_make_tail(next_or_last_pos);
+      } else {
+        // next_or_last_pos as next_pos
+        track_erase(child_pos, erase_stage);
+      }
+      validate_tracked_children();
+
+      if (is_root()) {
+        return try_downgrade_root(c, std::move(this_ref));
+      } else {
+        bool update_parent_index;
+        if (impl->is_level_tail()) {
+          update_parent_index = false;
+        } else {
+          // next_or_last_pos as next_pos
+          next_or_last_pos.is_end() ? update_parent_index = true
+                                    : update_parent_index = false;
+        }
+        return try_merge_adjacent(c, update_parent_index);
+      }
+    }).safe_then([c, new_tail_child = std::move(new_tail_child)] {
+      // finally, check if the new tail child needs to merge
+      if (new_tail_child && !new_tail_child->is_root()) {
+        assert(new_tail_child->impl->is_level_tail());
+        return new_tail_child->try_merge_adjacent(c, false);
+      } else {
+        return node_ertr::now();
+      }
+    });
+  });
+}
+
+node_future<> InternalNode::fix_index(context_t c, Ref<Node> child)
+{
+  impl->validate_non_empty();
+
+  auto& child_pos = child->parent_info().position;
+  // child must already be untracked before calling fix_index()
+  assert(tracked_child_nodes.find(child_pos) == tracked_child_nodes.end());
+  validate_child_inconsistent(*child);
+
+  impl->prepare_mutate(c);
+
+  key_view_t new_key = *child->impl->get_pivot_index();
+  logger().debug("OTree::Internal::FixIndex: fix {}'s index of child {} at pos({}), "
+                 "new_key={} ...",
+                 get_name(), child->get_name(), child_pos, new_key);
+
+  // erase the incorrect item
+  auto [erase_stage, next_pos] = impl->erase(child_pos);
+  track_erase(child_pos, erase_stage);
+  validate_tracked_children();
+
+  // find out whether there is a need to fix parent index recursively
+  bool update_parent_index;
+  if (impl->is_level_tail()) {
+    update_parent_index = false;
+  } else {
+    next_pos.is_end() ? update_parent_index = true
+                      : update_parent_index = false;
+  }
+
+  Ref<InternalNode> this_ref = this;
+  return insert_or_split(c, next_pos, new_key, child
+  ).safe_then([this, c, update_parent_index,
+               this_ref = std::move(this_ref)] (auto split_right) {
+    if (split_right) {
+      // after split, the parent index to the split_right will be incorrect
+      // if update_parent_index is true.
+      return apply_split_to_parent(c, split_right, update_parent_index);
+    } else {
+      // no split path
+      if (is_root()) {
+        // no need to call try_downgrade_root() because the number of keys
+        // has not changed.
+        return node_ertr::now();
+      } else {
+        // for non-root, maybe need merge adjacent or fix parent,
+        // because the filled node size may be reduced.
+        return try_merge_adjacent(c, update_parent_index);
+      }
+    }
+  });
+}
+
+node_future<> InternalNode::apply_children_merge(
+    context_t c, Ref<Node>&& left_child,
+    Ref<Node>&& right_child, bool update_index)
+{
+  auto left_pos = left_child->parent_info().position;
+  auto left_addr = left_child->impl->laddr();
+  auto& right_pos = right_child->parent_info().position;
+  auto right_addr = right_child->impl->laddr();
+  logger().debug("OTree::Internal::ApplyChildMerge: apply {}'s child "
+                 "{} at pos({}), to merge with {} at pos({}), update_index={} ...",
+                 get_name(), left_child->get_name(), left_pos,
+                 right_child->get_name(), right_pos, update_index);
+
+#ifndef NDEBUG
+  assert(left_child->parent_info().ptr == this);
+  assert(!left_pos.is_end());
+  const laddr_packed_t* p_value_left;
+  impl->get_slot(left_pos, nullptr, &p_value_left);
+  assert(p_value_left->value == left_addr);
+
+  assert(right_child->use_count() == 1);
+  assert(right_child->parent_info().ptr == this);
+  const laddr_packed_t* p_value_right;
+  if (right_pos.is_end()) {
+    assert(right_child->impl->is_level_tail());
+    assert(left_child->impl->is_level_tail());
+    assert(impl->is_level_tail());
+    assert(!update_index);
+    p_value_right = impl->get_tail_value();
+  } else {
+    assert(!right_child->impl->is_level_tail());
+    assert(!left_child->impl->is_level_tail());
+    impl->get_slot(right_pos, nullptr, &p_value_right);
+  }
+  assert(p_value_right->value == right_addr);
+#endif
+
+  // XXX: we may jump to try_downgrade_root() without mutating this node.
+
+  // update layout from right_pos => right_addr to left_addr
+  impl->prepare_mutate(c);
+  impl->replace_child_addr(right_pos, left_addr, right_addr);
+
+  // update track from right_pos => right_child to left_child
+  do_untrack_child(*left_child);
+  replace_track(left_child, right_child, update_index);
+
+  // erase left_pos from layout
+  auto [erase_stage, next_pos] = impl->erase(left_pos);
+  track_erase<false>(left_pos, erase_stage);
+  assert(next_pos == left_child->parent_info().position);
+
+  // All good to retire the right_child.
+  // I'm already ref-counted by left_child.
+  return right_child->retire(c, std::move(right_child)
+  ).safe_then([c, this, update_index,
+               left_child = std::move(left_child)] () mutable {
+    Ref<InternalNode> this_ref = this;
+    if (update_index) {
+      return left_child->fix_parent_index(c
+      ).safe_then([c, this, this_ref = std::move(this_ref)] {
+        // I'm all good but:
+        // - my number of keys is reduced by 1
+        // - my size may underflow,
+        //   but try_merge_adjacent() is already part of fix_index()
+        if (is_root()) {
+          return try_downgrade_root(c, std::move(this_ref));
+        } else {
+          return node_ertr::now();
+        }
+      });
+    } else {
+      left_child.reset();
+      validate_tracked_children();
+      // I'm all good but:
+      // - my number of keys is reduced by 1
+      // - my size may underflow
+      if (is_root()) {
+        return try_downgrade_root(c, std::move(this_ref));
+      } else {
+        return try_merge_adjacent(c, false);
+      }
+    }
+  });
+}
+
+node_future<std::pair<Ref<Node>, Ref<Node>>> InternalNode::get_child_peers(
+    context_t c, const search_position_t& pos)
+{
+  // assume I'm already ref counted by caller
+  search_position_t prev_pos;
+  const laddr_packed_t* prev_p_child_addr = nullptr;
+  search_position_t next_pos;
+  const laddr_packed_t* next_p_child_addr = nullptr;
+
+  if (pos.is_end()) {
+    assert(impl->is_level_tail());
+    if (!impl->is_keys_empty()) {
+      // got previous child only
+      impl->get_largest_slot(&prev_pos, nullptr, &prev_p_child_addr);
+      assert(prev_pos < pos);
+      assert(prev_p_child_addr != nullptr);
+    } else {
+      // no keys, so no peer children
+    }
+  } else { // !pos.is_end()
+    if (pos != search_position_t::begin()) {
+      // got previous child
+      prev_pos = pos;
+      impl->get_prev_slot(prev_pos, nullptr, &prev_p_child_addr);
+      assert(prev_pos < pos);
+      assert(prev_p_child_addr != nullptr);
+    } else {
+      // is already the first child, so no previous child
+    }
+
+    next_pos = pos;
+    impl->get_next_slot(next_pos, nullptr, &next_p_child_addr);
+    if (next_pos.is_end()) {
+      if (impl->is_level_tail()) {
+        // the next child is the tail
+        next_p_child_addr = impl->get_tail_value();
+        assert(pos < next_pos);
+        assert(next_p_child_addr != nullptr);
+      } else {
+        // next child doesn't exist
+        assert(next_p_child_addr == nullptr);
+      }
+    } else {
+      // got the next child
+      assert(pos < next_pos);
+      assert(next_p_child_addr != nullptr);
+    }
+  }
+
+  return node_ertr::now().safe_then([this, c, prev_pos, prev_p_child_addr] {
+    if (prev_p_child_addr != nullptr) {
+      return get_or_track_child(c, prev_pos, prev_p_child_addr->value);
+    } else {
+      return node_ertr::make_ready_future<Ref<Node>>();
+    }
+  }).safe_then([this, c, next_pos, next_p_child_addr] (Ref<Node> lnode) {
+    if (next_p_child_addr != nullptr) {
+      return get_or_track_child(c, next_pos, next_p_child_addr->value
+      ).safe_then([lnode] (Ref<Node> rnode) {
+        return node_ertr::make_ready_future<std::pair<Ref<Node>, Ref<Node>>>(
+            lnode, rnode);
+      });
+    } else {
+      return node_ertr::make_ready_future<std::pair<Ref<Node>, Ref<Node>>>(
+          lnode, nullptr);
+    }
   });
 }
 
@@ -708,6 +1187,60 @@ node_future<> InternalNode::do_get_tree_stats(
   );
 }
 
+void InternalNode::track_merge(
+    Ref<Node> _right_node, match_stage_t stage, search_position_t& left_last_pos)
+{
+  assert(level() == _right_node->level());
+  assert(impl->node_type() == _right_node->impl->node_type());
+  auto& right_node = *static_cast<InternalNode*>(_right_node.get());
+  if (right_node.tracked_child_nodes.empty()) {
+    return;
+  }
+
+  match_stage_t curr_stage = STAGE_BOTTOM;
+
+  // prepare the initial left_last_pos for offset
+  while (curr_stage < stage) {
+    left_last_pos.index_by_stage(curr_stage) = 0;
+    ++curr_stage;
+  }
+  ++left_last_pos.index_by_stage(curr_stage);
+
+  // fix the tracked child nodes of right_node, stage by stage.
+  auto& right_tracked_children = right_node.tracked_child_nodes;
+  auto rit = right_tracked_children.begin();
+  while (curr_stage <= STAGE_TOP) {
+    auto right_pos_until = search_position_t::begin();
+    right_pos_until.index_by_stage(curr_stage) = INDEX_UPPER_BOUND;
+    auto rend = right_tracked_children.lower_bound(right_pos_until);
+    while (rit != rend) {
+      auto new_pos = rit->second->parent_info().position;
+      assert(new_pos == rit->first);
+      assert(rit->second->parent_info().ptr == &right_node);
+      new_pos += left_last_pos;
+      auto p_child = rit->second;
+      rit = right_tracked_children.erase(rit);
+      p_child->as_child(new_pos, this);
+    }
+    left_last_pos.index_by_stage(curr_stage) = 0;
+    ++curr_stage;
+  }
+
+  // fix the end tracked child node of right_node, if exists.
+  if (rit != right_tracked_children.end()) {
+    assert(rit->first == search_position_t::end());
+    assert(rit->second->parent_info().position == search_position_t::end());
+    assert(right_node.impl->is_level_tail());
+    assert(impl->is_level_tail());
+    auto p_child = rit->second;
+    rit = right_tracked_children.erase(rit);
+    p_child->as_child(search_position_t::end(), this);
+  }
+  assert(right_tracked_children.empty());
+
+  validate_tracked_children();
+}
+
 node_future<> InternalNode::test_clone_root(
     context_t c_other, RootNodeTracker& tracker_other) const
 {
@@ -736,6 +1269,125 @@ node_future<> InternalNode::test_clone_root(
         return kv.second->test_clone_non_root(c_other, cloned_root);
       }
     );
+  });
+}
+
+node_future<> InternalNode::try_downgrade_root(
+    context_t c, Ref<Node>&& this_ref)
+{
+  assert(this_ref.get() == this);
+  assert(is_root());
+  assert(impl->is_level_tail());
+  if (!impl->is_keys_empty()) {
+    // I have more than 1 values, no need to downgrade
+    return node_ertr::now();
+  }
+
+  // proceed downgrade root to the only child
+  laddr_t child_addr = impl->get_tail_value()->value;
+  return get_or_track_child(c, search_position_t::end(), child_addr
+  ).safe_then([c, this, this_ref = std::move(this_ref)] (auto child) mutable {
+    logger().info("OTree::Internal::DownGradeRoot: downgrade {} to new root {}",
+                  get_name(), child->get_name());
+    // Invariant, see InternalNode::erase_child()
+    // the new internal root should have at least 2 children.
+    assert(child->impl->is_level_tail());
+    if (child->impl->node_type() == node_type_t::INTERNAL) {
+      ceph_assert(!child->impl->is_keys_empty());
+    }
+
+    this->super->do_untrack_root(*this);
+    assert(tracked_child_nodes.size() == 1);
+    do_untrack_child(*child);
+    child->_parent_info.reset();
+    child->make_root_from(c, std::move(this->super), impl->laddr());
+    return retire(c, std::move(this_ref));
+  });
+}
+
+node_future<Ref<InternalNode>> InternalNode::insert_or_split(
+    context_t c,
+    const search_position_t& pos,
+    const key_view_t& insert_key,
+    Ref<Node> insert_child,
+    Ref<Node> outdated_child)
+{
+  // XXX: check the insert_child is unlinked from this node
+#ifndef NDEBUG
+  auto _insert_key = *insert_child->impl->get_pivot_index();
+  assert(insert_key.compare_to(_insert_key) == MatchKindCMP::EQ);
+#endif
+  auto insert_value = insert_child->impl->laddr();
+  auto insert_pos = pos;
+  logger().debug("OTree::Internal::InsertSplit: insert {} "
+                 "with insert_key={}, insert_child={}, insert_pos({}), "
+                 "outdated_child={} ...",
+                 get_name(), insert_key, insert_child->get_name(),
+                 insert_pos, (outdated_child ? "True" : "False"));
+  auto [insert_stage, insert_size] = impl->evaluate_insert(
+      insert_key, insert_value, insert_pos);
+  auto free_size = impl->free_size();
+  if (free_size >= insert_size) {
+    // proceed to insert
+    [[maybe_unused]] auto p_value = impl->insert(
+        insert_key, insert_value, insert_pos, insert_stage, insert_size);
+    assert(impl->free_size() == free_size - insert_size);
+    assert(insert_pos <= pos);
+    assert(p_value->value == insert_value);
+    track_insert(insert_pos, insert_stage, insert_child);
+
+    if (outdated_child) {
+      // untrack the inaccurate child after updated its position
+      // before validate, and before fix_index()
+      validate_child_inconsistent(*outdated_child);
+      // we will need its parent_info valid for the following fix_index()
+      do_untrack_child(*outdated_child);
+    }
+
+    validate_tracked_children();
+    return node_ertr::make_ready_future<Ref<InternalNode>>(nullptr);
+  }
+
+  // proceed to split with insert
+  // assume I'm already ref-counted by caller
+  return (is_root() ? upgrade_root(c) : node_ertr::now()
+  ).safe_then([this, c] {
+    return InternalNode::allocate(
+        c, impl->field_type(), impl->is_level_tail(), impl->level());
+  }).safe_then([this, insert_key, insert_child, insert_pos,
+                insert_stage=insert_stage, insert_size=insert_size,
+                outdated_child](auto fresh_right) mutable {
+    // I'm the left_node and need to split into the right_node
+    auto right_node = fresh_right.node;
+    logger().info("OTree::Internal::InsertSplit: proceed split {} to fresh {} "
+                  "with insert_child={}, outdated_child={} ...",
+                  get_name(), right_node->get_name(),
+                  insert_child->get_name(),
+                  (outdated_child ? outdated_child->get_name() : "N/A"));
+    auto insert_value = insert_child->impl->laddr();
+    auto [split_pos, is_insert_left, p_value] = impl->split_insert(
+        fresh_right.mut, *right_node->impl, insert_key, insert_value,
+        insert_pos, insert_stage, insert_size);
+    assert(p_value->value == insert_value);
+    track_split(split_pos, right_node);
+    if (is_insert_left) {
+      track_insert(insert_pos, insert_stage, insert_child);
+    } else {
+      right_node->track_insert(insert_pos, insert_stage, insert_child);
+    }
+
+    if (outdated_child) {
+      // untrack the inaccurate child after updated its position
+      // before validate, and before fix_index()
+      auto& _parent = outdated_child->parent_info().ptr;
+      _parent->validate_child_inconsistent(*outdated_child);
+      // we will need its parent_info valid for the following fix_index()
+      _parent->do_untrack_child(*outdated_child);
+    }
+
+    validate_tracked_children();
+    right_node->validate_tracked_children();
+    return right_node;
   });
 }
 
@@ -801,16 +1453,28 @@ void InternalNode::track_insert(
 }
 
 void InternalNode::replace_track(
-    Ref<Node> new_child, Ref<Node> old_child)
+    Ref<Node> new_child, Ref<Node> old_child, bool is_new_child_outdated)
 {
   assert(old_child->parent_info().ptr == this);
   auto& pos = old_child->parent_info().position;
   do_untrack_child(*old_child);
-  new_child->as_child(pos, this);
+  if (is_new_child_outdated) {
+    // we need to keep track of the outdated child through
+    // insert and split.
+    new_child->as_child<false>(pos, this);
+  } else {
+    new_child->as_child(pos, this);
+  }
   // ok, safe to release ref
   old_child->_parent_info.reset();
 
-  validate_child_tracked(*new_child);
+#ifndef NDEBUG
+  if (is_new_child_outdated) {
+    validate_child_inconsistent(*new_child);
+  } else {
+    validate_child_tracked(*new_child);
+  }
+#endif
 }
 
 void InternalNode::track_split(
@@ -823,6 +1487,48 @@ void InternalNode::track_split(
     iter = tracked_child_nodes.erase(iter);
     new_pos -= split_pos;
     p_node->as_child<false>(new_pos, right_node);
+  }
+}
+
+template <bool VALIDATE>
+void InternalNode::track_erase(
+    const search_position_t& erase_pos, match_stage_t erase_stage)
+{
+  auto first = tracked_child_nodes.lower_bound(erase_pos);
+  assert(first == tracked_child_nodes.end() ||
+         first->first != erase_pos);
+  auto pos_upper_bound = erase_pos;
+  pos_upper_bound.index_by_stage(erase_stage) = INDEX_UPPER_BOUND;
+  auto last = tracked_child_nodes.lower_bound(pos_upper_bound);
+  std::vector<Node*> p_nodes;
+  std::for_each(first, last, [&p_nodes](auto& kv) {
+    p_nodes.push_back(kv.second);
+  });
+  tracked_child_nodes.erase(first, last);
+  for (auto& p_node: p_nodes) {
+    auto new_pos = p_node->parent_info().position;
+    assert(new_pos.index_by_stage(erase_stage) > 0);
+    --new_pos.index_by_stage(erase_stage);
+    p_node->as_child<VALIDATE>(new_pos, this);
+  }
+}
+
+void InternalNode::track_make_tail(const search_position_t& last_pos)
+{
+  // assume I'm ref counted by the caller.
+  assert(impl->is_level_tail());
+  assert(!last_pos.is_end());
+  assert(tracked_child_nodes.find(search_position_t::end()) ==
+         tracked_child_nodes.end());
+  auto last_it = tracked_child_nodes.find(last_pos);
+  if (last_it != tracked_child_nodes.end()) {
+    assert(std::next(last_it) == tracked_child_nodes.end());
+    auto p_last_child = last_it->second;
+    tracked_child_nodes.erase(last_it);
+    p_last_child->as_child(search_position_t::end(), this);
+  } else {
+    assert(tracked_child_nodes.lower_bound(last_pos) ==
+           tracked_child_nodes.end());
   }
 }
 
@@ -846,6 +1552,25 @@ void InternalNode::validate_child(const Node& child) const
   }
   // XXX(multi-type)
   assert(impl->field_type() <= child.impl->field_type());
+#endif
+}
+
+void InternalNode::validate_child_inconsistent(const Node& child) const
+{
+#ifndef NDEBUG
+  assert(impl->level() - 1 == child.impl->level());
+  assert(this == child.parent_info().ptr);
+  auto& child_pos = child.parent_info().position;
+  // the tail value has no key to fix
+  assert(!child_pos.is_end());
+  assert(!child.impl->is_level_tail());
+
+  key_view_t current_key;
+  const laddr_packed_t* p_value;
+  impl->get_slot(child_pos, &current_key, &p_value);
+  key_view_t new_key = *child.impl->get_pivot_index();
+  assert(current_key.compare_to(new_key) != MatchKindCMP::EQ);
+  assert(p_value->value == child.impl->laddr());
 #endif
 }
 
@@ -915,9 +1640,74 @@ LeafNode::get_next_cursor(context_t c, const search_position_t& pos)
 node_future<Ref<tree_cursor_t>>
 LeafNode::erase(context_t c, const search_position_t& pos, bool get_next)
 {
-  ceph_abort("not implemented");
-  return node_ertr::make_ready_future<Ref<tree_cursor_t>>(
-      tree_cursor_t::get_invalid());
+  assert(!pos.is_end());
+  assert(!impl->is_keys_empty());
+  Ref<LeafNode> this_ref = this;
+  logger().debug("OTree::Leaf::Erase: erase {}'s pos({}), get_next={} ...",
+                 get_name(), pos, get_next);
+
+  // get the next cursor
+  return node_ertr::now().safe_then([c, &pos, get_next, this] {
+    if (get_next) {
+      return get_next_cursor(c, pos);
+    } else {
+      return node_ertr::make_ready_future<Ref<tree_cursor_t>>();
+    }
+  }).safe_then([c, &pos, this_ref = std::move(this_ref),
+                this] (Ref<tree_cursor_t> next_cursor) {
+    if (next_cursor && next_cursor->is_end()) {
+      // reset the node reference from the end cursor
+      next_cursor.reset();
+    }
+    return node_ertr::now(
+    ).safe_then([c, &pos, this_ref = std::move(this_ref), this] () mutable {
+#ifndef NDEBUG
+      assert(!impl->is_keys_empty());
+      if (impl->is_keys_one()) {
+        assert(pos == search_position_t::begin());
+      }
+#endif
+      if (!is_root() && impl->is_keys_one()) {
+        // we need to keep the root as an empty leaf node
+        // fast path without mutating the extent
+        // track_erase
+        logger().debug("OTree::Leaf::Erase: {} has one value left, erase ...",
+                       get_name());
+        assert(tracked_cursors.size() == 1);
+        auto iter = tracked_cursors.begin();
+        assert(iter->first == pos);
+        iter->second->invalidate();
+        tracked_cursors.clear();
+
+        // no cursor should be referencing this node now, this_ref is the last one.
+        assert(this_ref->use_count() == 1);
+        Ref<Node> node_ref = this_ref;
+        this_ref.reset();
+        return Node::erase_node(c, std::move(node_ref));
+      }
+
+      on_layout_change();
+      impl->prepare_mutate(c);
+      auto [erase_stage, next_pos] = impl->erase(pos);
+      track_erase(pos, erase_stage);
+      validate_tracked_cursors();
+
+      if (is_root()) {
+        return node_ertr::now();
+      } else {
+        bool update_parent_index;
+        if (impl->is_level_tail()) {
+          update_parent_index = false;
+        } else {
+          next_pos.is_end() ? update_parent_index = true
+                            : update_parent_index = false;
+        }
+        return try_merge_adjacent(c, update_parent_index);
+      }
+    }).safe_then([next_cursor] {
+      return next_cursor;
+    });
+  });
 }
 
 node_future<> LeafNode::extend_value(
@@ -1003,6 +1793,49 @@ node_future<> LeafNode::do_get_tree_stats(context_t, tree_stats_t& stats)
   return node_ertr::now();
 }
 
+void LeafNode::track_merge(
+    Ref<Node> _right_node, match_stage_t stage, search_position_t& left_last_pos)
+{
+  assert(level() == _right_node->level());
+  // assert(impl->node_type() == _right_node->impl->node_type());
+  auto& right_node = *static_cast<LeafNode*>(_right_node.get());
+  if (right_node.tracked_cursors.empty()) {
+    return;
+  }
+
+  match_stage_t curr_stage = STAGE_BOTTOM;
+
+  // prepare the initial left_last_pos for offset
+  while (curr_stage < stage) {
+    left_last_pos.index_by_stage(curr_stage) = 0;
+    ++curr_stage;
+  }
+  ++left_last_pos.index_by_stage(curr_stage);
+
+  // fix the tracked child nodes of right_node, stage by stage.
+  auto& right_tracked_cursors = right_node.tracked_cursors;
+  auto rit = right_tracked_cursors.begin();
+  while (curr_stage <= STAGE_TOP) {
+    auto right_pos_until = search_position_t::begin();
+    right_pos_until.index_by_stage(curr_stage) = INDEX_UPPER_BOUND;
+    auto rend = right_tracked_cursors.lower_bound(right_pos_until);
+    while (rit != rend) {
+      auto new_pos = rit->second->get_position();
+      assert(new_pos == rit->first);
+      assert(rit->second->get_leaf_node().get() == &right_node);
+      new_pos += left_last_pos;
+      auto p_cursor = rit->second;
+      rit = right_tracked_cursors.erase(rit);
+      p_cursor->update_track<true>(this, new_pos);
+    }
+    left_last_pos.index_by_stage(curr_stage) = 0;
+    ++curr_stage;
+  }
+  assert(right_tracked_cursors.empty());
+
+  validate_tracked_cursors();
+}
+
 node_future<> LeafNode::test_clone_root(
     context_t c_other, RootNodeTracker& tracker_other) const
 {
@@ -1078,7 +1911,7 @@ node_future<Ref<tree_cursor_t>> LeafNode::insert_value(
     validate_tracked_cursors();
     right_node->validate_tracked_cursors();
 
-    return apply_split_to_parent(c, right_node
+    return apply_split_to_parent(c, right_node, false
     ).safe_then([ret] {
       return ret;
     });
@@ -1169,6 +2002,33 @@ void LeafNode::track_split(
     iter = tracked_cursors.erase(iter);
     new_pos -= split_pos;
     p_cursor->update_track<false>(right_node, new_pos);
+  }
+}
+
+void LeafNode::track_erase(
+    const search_position_t& erase_pos, match_stage_t erase_stage)
+{
+  // erase tracking and invalidate the erased cursor
+  auto to_erase = tracked_cursors.find(erase_pos);
+  assert(to_erase != tracked_cursors.end());
+  to_erase->second->invalidate();
+  auto first = tracked_cursors.erase(to_erase);
+
+  // update cursor position
+  assert(first == tracked_cursors.lower_bound(erase_pos));
+  auto pos_upper_bound = erase_pos;
+  pos_upper_bound.index_by_stage(erase_stage) = INDEX_UPPER_BOUND;
+  auto last = tracked_cursors.lower_bound(pos_upper_bound);
+  std::vector<tree_cursor_t*> p_cursors;
+  std::for_each(first, last, [&p_cursors](auto& kv) {
+    p_cursors.push_back(kv.second);
+  });
+  tracked_cursors.erase(first, last);
+  for (auto& p_cursor : p_cursors) {
+    search_position_t new_pos = p_cursor->get_position();
+    assert(new_pos.index_by_stage(erase_stage) > 0);
+    --new_pos.index_by_stage(erase_stage);
+    p_cursor->update_track<true>(this, new_pos);
   }
 }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -744,15 +744,14 @@ void InternalNode::replace_track(
 void InternalNode::track_split(
     const search_position_t& split_pos, Ref<InternalNode> right_node)
 {
-  auto first = tracked_child_nodes.lower_bound(split_pos);
-  auto iter = first;
+  auto iter = tracked_child_nodes.lower_bound(split_pos);
   while (iter != tracked_child_nodes.end()) {
-    search_position_t new_pos = iter->first;
+    auto new_pos = iter->first;
+    auto p_node = iter->second;
+    iter = tracked_child_nodes.erase(iter);
     new_pos -= split_pos;
-    iter->second->as_child<false>(new_pos, right_node);
-    ++iter;
+    p_node->as_child<false>(new_pos, right_node);
   }
-  tracked_child_nodes.erase(first, tracked_child_nodes.end());
 }
 
 void InternalNode::validate_child(const Node& child) const
@@ -1082,15 +1081,14 @@ void LeafNode::track_split(
     const search_position_t& split_pos, Ref<LeafNode> right_node)
 {
   // update cursor ownership and position
-  auto first = tracked_cursors.lower_bound(split_pos);
-  auto iter = first;
+  auto iter = tracked_cursors.lower_bound(split_pos);
   while (iter != tracked_cursors.end()) {
-    search_position_t new_pos = iter->first;
+    auto new_pos = iter->first;
+    auto p_cursor = iter->second;
+    iter = tracked_cursors.erase(iter);
     new_pos -= split_pos;
-    iter->second->update_track<false>(right_node, new_pos);
-    ++iter;
+    p_cursor->update_track<false>(right_node, new_pos);
   }
-  tracked_cursors.erase(first, tracked_cursors.end());
 }
 
 node_future<LeafNode::fresh_node_t> LeafNode::allocate(

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.cc
@@ -370,6 +370,11 @@ std::ostream& Node::dump_brief(std::ostream& os) const
   return impl->dump_brief(os);
 }
 
+const std::string& Node::get_name() const
+{
+  return impl->get_name();
+}
+
 void Node::test_make_destructable(
     context_t c, NodeExtentMutable& mut, Super::URef&& _super)
 {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -572,6 +572,7 @@ class InternalNode final : public Node {
   // XXX: extract a common tracker for InternalNode to track Node,
   // and LeafNode to track tree_cursor_t.
   node_future<Ref<Node>> get_or_track_child(context_t, const search_position_t&, laddr_t);
+  template <bool VALIDATE = true>
   void track_insert(
       const search_position_t&, match_stage_t, Ref<Node>, Ref<Node> nxt_child = nullptr);
   void replace_track(Ref<Node> new_child, Ref<Node> old_child, bool);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -128,6 +128,9 @@ class tree_cursor_t final
   /// Check that this is next to prv
   void assert_next_to(const tree_cursor_t&, value_magic_t) const;
 
+  /// Erases the key-value pair from tree.
+  future<Ref<tree_cursor_t>> erase(context_t, bool get_next);
+
   MatchKindCMP compare_to(const tree_cursor_t&, value_magic_t) const;
 
   // public to Value
@@ -352,6 +355,15 @@ class Node
   node_future<std::pair<Ref<tree_cursor_t>, bool>> insert(
       context_t, const key_hobj_t&, value_config_t);
 
+  /**
+   * erase
+   *
+   * Removes a key-value pair from the sub-tree formed by this node.
+   *
+   * Returns the number of erased key-value pairs (0 or 1).
+   */
+  node_future<std::size_t> erase(context_t, const key_hobj_t&);
+
   /// Recursively collects the statistics of the sub-tree formed by this node
   node_future<tree_stats_t> get_tree_stats(context_t);
 
@@ -558,6 +570,17 @@ class LeafNode final : public Node {
   const char* read() const;
   std::tuple<key_view_t, const value_header_t*> get_kv(const search_position_t&) const;
   node_future<Ref<tree_cursor_t>> get_next_cursor(context_t, const search_position_t&);
+
+  /**
+   * erase
+   *
+   * Removes a key-value pair from the position.
+   *
+   * If get_next is true, returns the cursor pointing to the next key-value
+   * pair that followed the erased element, which can be nullptr if is end.
+   */
+  node_future<Ref<tree_cursor_t>> erase(
+      context_t, const search_position_t&, bool get_next);
 
   template <bool VALIDATE>
   void do_track_cursor(tree_cursor_t& cursor) {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -436,7 +436,7 @@ class Node
   node_future<> try_merge_adjacent(context_t, bool);
   node_future<> erase_node(context_t, Ref<Node>&&);
   template <bool FORCE_MERGE = false>
-  node_future<> fix_parent_index(context_t);
+  node_future<> fix_parent_index(context_t, bool);
   node_future<NodeExtentMutable> rebuild_extent(context_t);
   node_future<> retire(context_t, Ref<Node>&&);
   void make_tail(context_t);
@@ -520,7 +520,7 @@ class InternalNode final : public Node {
   node_future<> erase_child(context_t, Ref<Node>&&);
 
   template <bool FORCE_MERGE = false>
-  node_future<> fix_index(context_t, Ref<Node>);
+  node_future<> fix_index(context_t, Ref<Node>, bool);
 
   template <bool FORCE_MERGE = false>
   node_future<> apply_children_merge(

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -430,13 +430,13 @@ class Node
   };
   const parent_info_t& parent_info() const { return *_parent_info; }
 
-  node_future<> apply_split_to_parent(context_t, Ref<Node>, bool);
+  node_future<> apply_split_to_parent(context_t, Ref<Node>&&, Ref<Node>&&, bool);
   node_future<Ref<tree_cursor_t>> get_next_cursor_from_parent(context_t);
   template <bool FORCE_MERGE = false>
-  node_future<> try_merge_adjacent(context_t, bool);
+  node_future<> try_merge_adjacent(context_t, bool, Ref<Node>&&);
   node_future<> erase_node(context_t, Ref<Node>&&);
   template <bool FORCE_MERGE = false>
-  node_future<> fix_parent_index(context_t, bool);
+  node_future<> fix_parent_index(context_t, Ref<Node>&&, bool);
   node_future<NodeExtentMutable> rebuild_extent(context_t);
   node_future<> retire(context_t, Ref<Node>&&);
   void make_tail(context_t);
@@ -485,7 +485,7 @@ class InternalNode final : public Node {
 
   node_future<Ref<tree_cursor_t>> get_next_cursor(context_t, const search_position_t&);
 
-  node_future<> apply_child_split(context_t, Ref<Node> left, Ref<Node> right, bool);
+  node_future<> apply_child_split(context_t, Ref<Node>&& left, Ref<Node>&& right, bool);
 
   template <bool VALIDATE>
   void do_track_child(Node& child) {
@@ -520,7 +520,7 @@ class InternalNode final : public Node {
   node_future<> erase_child(context_t, Ref<Node>&&);
 
   template <bool FORCE_MERGE = false>
-  node_future<> fix_index(context_t, Ref<Node>, bool);
+  node_future<> fix_index(context_t, Ref<Node>&&, bool);
 
   template <bool FORCE_MERGE = false>
   node_future<> apply_children_merge(

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -129,6 +129,7 @@ class tree_cursor_t final
   void assert_next_to(const tree_cursor_t&, value_magic_t) const;
 
   /// Erases the key-value pair from tree.
+  template <bool FORCE_MERGE = false>
   future<Ref<tree_cursor_t>> erase(context_t, bool get_next);
 
   MatchKindCMP compare_to(const tree_cursor_t&, value_magic_t) const;
@@ -431,6 +432,7 @@ class Node
 
   node_future<> apply_split_to_parent(context_t, Ref<Node>, bool);
   node_future<Ref<tree_cursor_t>> get_next_cursor_from_parent(context_t);
+  template <bool FORCE_MERGE = false>
   node_future<> try_merge_adjacent(context_t, bool);
   node_future<> erase_node(context_t, Ref<Node>&&);
   node_future<> fix_parent_index(context_t);
@@ -626,6 +628,7 @@ class LeafNode final : public Node {
    * If get_next is true, returns the cursor pointing to the next key-value
    * pair that followed the erased element, which can be nullptr if is end.
    */
+  template <bool FORCE_MERGE>
   node_future<Ref<tree_cursor_t>> erase(
       context_t, const search_position_t&, bool get_next);
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -50,10 +50,10 @@ class InternalNode;
 using layout_version_t = uint32_t;
 struct node_version_t {
   layout_version_t layout;
-  bool is_duplicate;
+  nextent_state_t state;
 
   bool operator==(const node_version_t& rhs) const {
-    return (layout == rhs.layout && is_duplicate == rhs.is_duplicate);
+    return (layout == rhs.layout && state == rhs.state);
   }
   bool operator!=(const node_version_t& rhs) const {
     return !(*this == rhs);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -373,6 +373,9 @@ class Node
   /// Returns an ostream containing an one-line summary of this node.
   std::ostream& dump_brief(std::ostream&) const;
 
+  /// Print the node name
+  const std::string& get_name() const;
+
   /// Initializes the tree by allocating an empty root node.
   static node_future<> mkfs(context_t, RootNodeTracker&);
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -435,6 +435,7 @@ class Node
   template <bool FORCE_MERGE = false>
   node_future<> try_merge_adjacent(context_t, bool);
   node_future<> erase_node(context_t, Ref<Node>&&);
+  template <bool FORCE_MERGE = false>
   node_future<> fix_parent_index(context_t);
   node_future<NodeExtentMutable> rebuild_extent(context_t);
   node_future<> retire(context_t, Ref<Node>&&);
@@ -518,8 +519,10 @@ class InternalNode final : public Node {
 
   node_future<> erase_child(context_t, Ref<Node>&&);
 
+  template <bool FORCE_MERGE = false>
   node_future<> fix_index(context_t, Ref<Node>);
 
+  template <bool FORCE_MERGE = false>
   node_future<> apply_children_merge(
       context_t, Ref<Node>&& left, Ref<Node>&& right, bool update_index);
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node.h
@@ -524,7 +524,7 @@ class InternalNode final : public Node {
 
   template <bool FORCE_MERGE = false>
   node_future<> apply_children_merge(
-      context_t, Ref<Node>&& left, Ref<Node>&& right, bool update_index);
+      context_t, Ref<Node>&& left, laddr_t, Ref<Node>&& right, bool update_index);
 
   void validate_child_tracked(const Node& child) const {
     validate_child(child);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
@@ -329,6 +329,15 @@ class NodeExtentAccessorT {
     return state;
   }
 
+  bool is_valid() const {
+    if (extent) {
+      assert(extent->is_valid());
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   // must be called before any mutate attempes.
   // for the safety of mixed read and mutate, call before read.
   void prepare_mutate(context_t c) {
@@ -487,7 +496,49 @@ class NodeExtentAccessorT {
     std::memcpy(to.get_write(), extent->get_read(), extent->get_length());
   }
 
+  using ertr = NodeExtentManager::tm_ertr;
+  ertr::future<NodeExtentMutable> rebuild(context_t c) {
+    assert(extent->is_valid());
+    if (state == nextent_state_t::FRESH) {
+      assert(extent->is_initial_pending());
+      // already fresh and no need to record
+      return ertr::make_ready_future<NodeExtentMutable>(*mut);
+    }
+    assert(!extent->is_initial_pending());
+    return c.nm.alloc_extent(c.t, node_stage_t::EXTENT_SIZE
+    ).safe_then([this, c] (auto fresh_extent) {
+      logger().debug("OTree::Extent::Rebuild: update addr from {:#x} to {:#x} ...",
+                     extent->get_laddr(), fresh_extent->get_laddr());
+      assert(fresh_extent->is_initial_pending());
+      assert(fresh_extent->get_recorder() == nullptr);
+      assert(extent->get_length() == fresh_extent->get_length());
+      auto fresh_mut = fresh_extent->get_mutable();
+      std::memcpy(fresh_mut.get_write(), extent->get_read(), extent->get_length());
+      NodeExtentRef to_discard = extent;
+
+      extent = fresh_extent;
+      node_stage = node_stage_t(
+          reinterpret_cast<const FieldType*>(extent->get_read()));
+      state = nextent_state_t::FRESH;
+      mut.emplace(fresh_mut);
+      recorder = nullptr;
+
+      return c.nm.retire_extent(c.t, to_discard);
+    }).safe_then([this] {
+      return *mut;
+    });
+  }
+
+  ertr::future<> retire(context_t c) {
+    assert(extent->is_valid());
+    return c.nm.retire_extent(c.t, std::move(extent));
+  }
+
  private:
+  static seastar::logger& logger() {
+    return crimson::get_logger(ceph_subsys_filestore);
+  }
+
   NodeExtentRef extent;
   node_stage_t node_stage;
   nextent_state_t state;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_accessor.h
@@ -244,6 +244,8 @@ class DeltaRecorderT final: public DeltaRecorder {
  * This component is responsible to reference and mutate the underlying
  * NodeExtent, record mutation parameters when needed, and apply the recorded
  * modifications for a specific node layout.
+ *
+ * For possible internal states, see node_types.h.
  */
 template <typename FieldType, node_type_t NODE_TYPE>
 class NodeExtentAccessorT {
@@ -260,18 +262,21 @@ class NodeExtentAccessorT {
   NodeExtentAccessorT(NodeExtentRef extent)
       : extent{extent},
         node_stage{reinterpret_cast<const FieldType*>(extent->get_read())} {
-    if (no_recording()) {
+    if (extent->is_initial_pending()) {
+      state = nextent_state_t::FRESH;
       mut.emplace(extent->get_mutable());
       assert(extent->get_recorder() == nullptr);
       recorder = nullptr;
-    } else if (needs_recording()) {
+    } else if (extent->is_mutation_pending()) {
+      state = nextent_state_t::MUTATION_PENDING;
       mut.emplace(extent->get_mutable());
       auto p_recorder = extent->get_recorder();
       assert(p_recorder != nullptr);
       assert(p_recorder->node_type() == NODE_TYPE);
       assert(p_recorder->field_type() == FIELD_TYPE);
       recorder = static_cast<recorder_t*>(p_recorder);
-    } else if (needs_mutate()) {
+    } else if (!extent->is_pending() && extent->is_valid()) {
+      state = nextent_state_t::READ_ONLY;
       // mut is empty
       assert(extent->get_recorder() == nullptr ||
              extent->get_recorder()->is_empty());
@@ -294,26 +299,30 @@ class NodeExtentAccessorT {
 
   const node_stage_t& read() const { return node_stage; }
   laddr_t get_laddr() const { return extent->get_laddr(); }
-  bool is_duplicate() const {
-    // we cannot rely on whether the extent state is MUTATION_PENDING because
-    // we may access the extent (internally) after it becomes DIRTY after
-    // transaction submission.
-    return recorder != nullptr;
+  nextent_state_t get_state() const {
+    assert(extent->is_valid());
+    // we cannot rely on the underlying extent state because
+    // FRESH/MUTATION_PENDING can become DIRTY after transaction submission.
+    return state;
   }
 
   // must be called before any mutate attempes.
   // for the safety of mixed read and mutate, call before read.
   void prepare_mutate(context_t c) {
-    if (needs_mutate()) {
+    assert(extent->is_valid());
+    if (state == nextent_state_t::READ_ONLY) {
+      assert(!extent->is_pending());
       auto ref_recorder = recorder_t::create_for_encode(c.vb);
       recorder = static_cast<recorder_t*>(ref_recorder.get());
       extent = extent->mutate(c, std::move(ref_recorder));
-      assert(needs_recording());
+      state = nextent_state_t::MUTATION_PENDING;
+      assert(extent->is_mutation_pending());
       node_stage = node_stage_t(
           reinterpret_cast<const FieldType*>(extent->get_read()));
       assert(recorder == static_cast<recorder_t*>(extent->get_recorder()));
       mut.emplace(extent->get_mutable());
     }
+    assert(extent->is_pending());
   }
 
   template <KeyT KT>
@@ -323,8 +332,9 @@ class NodeExtentAccessorT {
       position_t& insert_pos,
       match_stage_t& insert_stage,
       node_offset_t& insert_size) {
-    assert(!needs_mutate());
-    if (needs_recording()) {
+    assert(extent->is_pending());
+    assert(state != nextent_state_t::READ_ONLY);
+    if (state == nextent_state_t::MUTATION_PENDING) {
       recorder->template encode_insert<KT>(
           key, value, insert_pos, insert_stage, insert_size);
     }
@@ -343,8 +353,9 @@ class NodeExtentAccessorT {
   }
 
   void split_replayable(StagedIterator& split_at) {
-    assert(!needs_mutate());
-    if (needs_recording()) {
+    assert(extent->is_pending());
+    assert(state != nextent_state_t::READ_ONLY);
+    if (state == nextent_state_t::MUTATION_PENDING) {
       recorder->encode_split(split_at, read().p_start());
     }
 #ifndef NDEBUG
@@ -365,8 +376,9 @@ class NodeExtentAccessorT {
       position_t& insert_pos,
       match_stage_t& insert_stage,
       node_offset_t& insert_size) {
-    assert(!needs_mutate());
-    if (needs_recording()) {
+    assert(extent->is_pending());
+    assert(state != nextent_state_t::READ_ONLY);
+    if (state == nextent_state_t::MUTATION_PENDING) {
       recorder->template encode_split_insert<KT>(
           split_at, key, value, insert_pos, insert_stage, insert_size,
           read().p_start());
@@ -388,8 +400,9 @@ class NodeExtentAccessorT {
 
   void update_child_addr_replayable(
       const laddr_t new_addr, laddr_packed_t* p_addr) {
-    assert(!needs_mutate());
-    if (needs_recording()) {
+    assert(extent->is_pending());
+    assert(state != nextent_state_t::READ_ONLY);
+    if (state == nextent_state_t::MUTATION_PENDING) {
       recorder->encode_update_child_addr(new_addr, p_addr, read().p_start());
     }
 #ifndef NDEBUG
@@ -406,7 +419,7 @@ class NodeExtentAccessorT {
   prepare_mutate_value_payload(context_t c) {
     prepare_mutate(c);
     ValueDeltaRecorder* p_value_recorder = nullptr;
-    if (needs_recording()) {
+    if (state == nextent_state_t::MUTATION_PENDING) {
       p_value_recorder = recorder->get_value_recorder();
     }
     return {*mut, p_value_recorder};
@@ -418,26 +431,9 @@ class NodeExtentAccessorT {
   }
 
  private:
-  /**
-   * Possible states with CachedExtent::extent_state_t:
-   *   INITIAL_WRITE_PENDING -- can mutate, no recording
-   *   MUTATION_PENDING      -- can mutate, needs recording
-   *   CLEAN/DIRTY           -- pending mutate
-   *   INVALID               -- impossible
-   */
-  bool no_recording() const {
-    return extent->is_initial_pending();
-  }
-  bool needs_recording() const {
-    return extent->is_mutation_pending();
-  }
-  bool needs_mutate() const {
-    assert(extent->is_valid());
-    return !extent->is_pending();
-  }
-
   NodeExtentRef extent;
   node_stage_t node_stage;
+  nextent_state_t state;
   std::optional<NodeExtentMutable> mut;
   // owned by extent
   recorder_t* recorder;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
@@ -41,8 +41,6 @@ class NodeExtent : public LogicalCachedExtent {
   NodeExtent(T&&... t) : LogicalCachedExtent(std::forward<T>(t)...) {}
 
   NodeExtentMutable do_get_mutable() {
-    assert(is_pending() || // during mutation
-           is_clean());    // during replay
     return NodeExtentMutable(get_bptr().c_str(), get_length());
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager.h
@@ -72,6 +72,7 @@ class NodeExtentManager {
   virtual tm_future<NodeExtentRef> read_extent(
       Transaction&, laddr_t, extent_len_t) = 0;
   virtual tm_future<NodeExtentRef> alloc_extent(Transaction&, extent_len_t) = 0;
+  virtual tm_future<> retire_extent(Transaction&, NodeExtentRef) = 0;
   virtual tm_future<Super::URef> get_super(Transaction&, RootNodeTracker&) = 0;
   virtual std::ostream& print(std::ostream& os) const = 0;
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
@@ -71,6 +71,8 @@ class DummyNodeExtentManager final: public NodeExtentManager {
   static constexpr size_t ALIGNMENT = 4096;
  public:
   ~DummyNodeExtentManager() override = default;
+  std::size_t size() const { return allocate_map.size(); }
+
  protected:
   bool is_read_isolated() const override { return false; }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/dummy.h
@@ -27,7 +27,7 @@ class DummySuper final: public Super {
  protected:
   laddr_t get_root_laddr() const override { return *p_root_laddr; }
   void write_root_laddr(context_t, laddr_t addr) override {
-    logger().info("OTree::Dummy: update root {:#x} ...", addr);
+    logger().debug("OTree::Dummy: update root {:#x} ...", addr);
     *p_root_laddr = addr;
   }
  private:
@@ -175,7 +175,7 @@ class DummyNodeExtentManager final: public NodeExtentManager {
 
   tm_future<Super::URef> get_super_sync(
       Transaction& t, RootNodeTracker& tracker) {
-    logger().debug("OTree::Dummy: got root {:#x}", root_laddr);
+    logger().trace("OTree::Dummy: got root {:#x}", root_laddr);
     return tm_ertr::make_ready_future<Super::URef>(
         Super::URef(new DummySuper(t, tracker, &root_laddr)));
   }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.cc
@@ -51,7 +51,7 @@ static DeltaRecorderURef create_replay_recorder(
 
 void SeastoreSuper::write_root_laddr(context_t c, laddr_t addr)
 {
-  logger().info("OTree::Seastore: update root {:#x} ...", addr);
+  logger().debug("OTree::Seastore: update root {:#x} ...", addr);
   root_addr = addr;
   auto nm = static_cast<SeastoreNodeExtentManager*>(&c.nm);
   nm->get_tm().write_onode_root(c.t, addr);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.cc
@@ -84,7 +84,6 @@ void SeastoreNodeExtent::apply_delta(const ceph::bufferlist& bl)
     assert(recorder->field_type() == field_type);
 #endif
   }
-  assert(is_clean());
   auto node = do_get_mutable();
   auto p = bl.cbegin();
   while (p != bl.end()) {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
@@ -74,7 +74,7 @@ class SeastoreNodeExtentManager final: public NodeExtentManager {
 
   tm_future<NodeExtentRef> read_extent(
       Transaction& t, laddr_t addr, extent_len_t len) override {
-    logger().debug("OTree::Seastore: reading {}B at {:#x} ...", len, addr);
+    logger().trace("OTree::Seastore: reading {}B at {:#x} ...", len, addr);
     return tm.read_extent<SeastoreNodeExtent>(t, addr, len
     ).safe_then([addr, len](auto&& e) {
       logger().trace("OTree::Seastore: read {}B at {:#x}",
@@ -116,7 +116,7 @@ class SeastoreNodeExtentManager final: public NodeExtentManager {
       Transaction& t, RootNodeTracker& tracker) override {
     logger().trace("OTree::Seastore: get root ...");
     return tm.read_onode_root(t).safe_then([this, &t, &tracker](auto root_addr) {
-      logger().debug("OTree::Seastore: got root {:#x}", root_addr);
+      logger().trace("OTree::Seastore: got root {:#x}", root_addr);
       return Super::URef(new SeastoreSuper(t, tracker, root_addr, tm));
     });
   }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
@@ -100,6 +100,18 @@ class SeastoreNodeExtentManager final: public NodeExtentManager {
     });
   }
 
+  tm_future<> retire_extent(
+      Transaction& t, NodeExtentRef _extent) override {
+    LogicalCachedExtentRef extent = _extent;
+    auto addr = extent->get_laddr();
+    auto len = extent->get_length();
+    logger().debug("OTree::Seastore: retiring {}B at {:#x} ...", len, addr);
+    return tm.dec_ref(t, extent).safe_then([addr, len] (unsigned cnt) {
+      assert(cnt == 0);
+      logger().trace("OTree::Seastore: retired {}B at {:#x} ...", len, addr);
+    });
+  }
+
   tm_future<Super::URef> get_super(
       Transaction& t, RootNodeTracker& tracker) override {
     logger().trace("OTree::Seastore: get root ...");

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_extent_manager/seastore.h
@@ -89,7 +89,7 @@ class SeastoreNodeExtentManager final: public NodeExtentManager {
 
   tm_future<NodeExtentRef> alloc_extent(
       Transaction& t, extent_len_t len) override {
-    logger().debug("OTree::Seastore: allocating {}B ...", len);
+    logger().trace("OTree::Seastore: allocating {}B ...", len);
     return tm.alloc_extent<SeastoreNodeExtent>(t, addr_min, len
     ).safe_then([len](auto extent) {
       logger().debug("OTree::Seastore: allocated {}B at {:#x}",

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.cc
@@ -11,7 +11,7 @@ last_split_info_t last_split = {};
 #endif
 
 // XXX: branchless allocation
-InternalNodeImpl::alloc_ertr::future<InternalNodeImpl::fresh_impl_t>
+InternalNodeImpl::ertr::future<InternalNodeImpl::fresh_impl_t>
 InternalNodeImpl::allocate(
     context_t c, field_type_t type, bool is_level_tail, level_t level)
 {
@@ -28,7 +28,7 @@ InternalNodeImpl::allocate(
   }
 }
 
-LeafNodeImpl::alloc_ertr::future<LeafNodeImpl::fresh_impl_t>
+LeafNodeImpl::ertr::future<LeafNodeImpl::fresh_impl_t>
 LeafNodeImpl::allocate(
     context_t c, field_type_t type, bool is_level_tail)
 {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
@@ -71,7 +71,7 @@ class NodeImpl {
   virtual field_type_t field_type() const = 0;
   virtual laddr_t laddr() const = 0;
   virtual const char* read() const = 0;
-  virtual bool is_duplicate() const = 0;
+  virtual nextent_state_t get_extent_state() const = 0;
   virtual void prepare_mutate(context_t) = 0;
   virtual bool is_level_tail() const = 0;
   virtual bool is_empty() const = 0;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
@@ -91,6 +91,7 @@ class NodeImpl {
   virtual node_stats_t get_stats() const = 0;
   virtual std::ostream& dump(std::ostream&) const = 0;
   virtual std::ostream& dump_brief(std::ostream&) const = 0;
+  virtual const std::string& get_name() const = 0;
   virtual void validate_layout() const = 0;
 
   virtual void test_copy_to(NodeExtentMutable&) const = 0;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_impl.h
@@ -74,7 +74,16 @@ class NodeImpl {
   virtual nextent_state_t get_extent_state() const = 0;
   virtual void prepare_mutate(context_t) = 0;
   virtual bool is_level_tail() const = 0;
-  virtual bool is_empty() const = 0;
+
+  /* Invariants for num_keys and num_values:
+   * - for leaf node and non-tail internal node, num_keys == num_values;
+   * - for tail internal node, num_keys + 1 == num_values;
+   * - all node must have at least 1 value, except the root leaf node;
+   * - the root internal node must have more than 1 values;
+   */
+  virtual void validate_non_empty() const = 0;
+  virtual bool is_keys_empty() const = 0;
+
   virtual level_t level() const = 0;
   virtual node_offset_t free_size() const = 0;
   virtual std::optional<key_view_t> get_pivot_index() const = 0;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -802,7 +802,6 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
       node_offset_t insert_size;
       if (unlikely(is_keys_empty())) {
         assert(insert_pos.is_end());
-        assert(is_level_tail());
         insert_stage = STAGE;
         insert_size = STAGE_T::template insert_size<KeyT::VIEW>(key, value);
       } else {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -359,10 +359,8 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
     assert(_right_impl.field_type() == FIELD_TYPE);
     auto& right_impl = dynamic_cast<NodeLayoutT&>(_right_impl);
     logger().info("OTree::Layout::Split: begin at "
-                  "insert_pos({}), insert_stage={}, insert_size={}B, "
-                  "{:#x}=>{:#x} ...",
-                  _insert_pos, insert_stage, insert_size,
-                  laddr(), right_impl.laddr());
+                  "insert_pos({}), insert_stage={}, insert_size={}B ...",
+                  _insert_pos, insert_stage, insert_size);
     if (unlikely(logger().is_enabled(seastar::log_level::debug))) {
       std::ostringstream sos;
       dump(sos);
@@ -591,6 +589,9 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
   void replace_child_addr(
       const search_position_t& pos, laddr_t dst, laddr_t src) override {
     if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
+      logger().debug("OTree::Layout::ReplaceChildAddr: "
+                     "update from {:#x} to {:#x} at pos({}) ...",
+                     src, dst, pos);
       const laddr_packed_t* p_value;
       if (pos.is_end()) {
         assert(is_level_tail());

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -90,7 +90,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
   field_type_t field_type() const override { return FIELD_TYPE; }
   laddr_t laddr() const override { return extent.get_laddr(); }
   const char* read() const override { return extent.read().p_start(); }
-  bool is_duplicate() const override { return extent.is_duplicate(); }
+  nextent_state_t get_extent_state() const override { return extent.get_state(); }
   void prepare_mutate(context_t c) override { return extent.prepare_mutate(c); }
   bool is_level_tail() const override { return extent.read().is_level_tail(); }
   bool is_empty() const override { return extent.read().keys() == 0; }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -386,7 +386,7 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
        *    the estimated left_node_size <= target_split_size;
        * B. the fair one takes a further step to calculate the next slot of
        *    P KiB, and if left_node_size + P/2 < target_split_size, compensate
-       *    the split position to include the next slot; (TODO)
+       *    the split position to include the next slot;
        *
        * Say that the node_block_size = N KiB, the largest allowed
        * insert_size = 1/I * N KiB (I > 1). We want to identify the minimal 'I'

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -378,7 +378,24 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
   void get_prev_slot(search_position_t& pos,
                      key_view_t* p_index_key = nullptr,
                      const value_t** pp_value = nullptr) const override {
-    ceph_abort("not implemented");
+    assert(!is_keys_empty());
+    assert(!pos.is_end());
+    auto& _pos = cast_down<STAGE>(pos);
+#ifndef NDEBUG
+    auto nxt_pos = _pos;
+#endif
+    if (!p_index_key && pp_value) {
+      STAGE_T::template get_prev_slot<false, true>(
+          extent.read(), _pos, nullptr, pp_value);
+    } else {
+      ceph_abort("not implemented");
+    }
+#ifndef NDEBUG
+    auto _nxt_pos = _pos;
+    STAGE_T::template get_next_slot<false, false>(
+        extent.read(), _nxt_pos, nullptr, nullptr);
+    assert(nxt_pos == _nxt_pos);
+#endif
   }
 
   void get_next_slot(search_position_t& pos,

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout.h
@@ -108,14 +108,13 @@ class NodeLayoutT final : public InternalNodeImpl, public LeafNodeImpl {
   node_offset_t free_size() const override { return extent.read().free_size(); }
 
   std::optional<key_view_t> get_pivot_index() const override {
-    if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
-      if (is_level_tail()) {
-        return std::nullopt;
-      }
+    if (is_level_tail()) {
+      return std::nullopt;
     }
     assert(!is_keys_empty());
     key_view_t pivot_index;
-    get_largest_slot(nullptr, &pivot_index, nullptr);
+    STAGE_T::template get_largest_slot<false, true, false>(
+        extent.read(), nullptr, &pivot_index, nullptr);
     return {pivot_index};
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout_replayable.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout_replayable.h
@@ -71,6 +71,22 @@ struct NodeLayoutReplayableT {
     assert(NODE_TYPE == node_type_t::INTERNAL);
     mut.copy_in_absolute(p_addr, new_addr);
   }
+
+  static std::tuple<match_stage_t, position_t> erase(
+      NodeExtentMutable& mut,
+      const node_stage_t& node_stage,
+      const position_t& _erase_pos) {
+    // TODO
+    ceph_abort("not implemented");
+  }
+
+  static position_t make_tail(
+      NodeExtentMutable& mut,
+      const node_stage_t& node_stage) {
+    assert(!node_stage.is_level_tail());
+    // TODO
+    ceph_abort("not implemented");
+  }
 };
 
 }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout_replayable.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout_replayable.h
@@ -76,8 +76,18 @@ struct NodeLayoutReplayableT {
       NodeExtentMutable& mut,
       const node_stage_t& node_stage,
       const position_t& _erase_pos) {
-    // TODO
-    ceph_abort("not implemented");
+    if (_erase_pos.is_end()) {
+      // must be internal node
+      assert(node_stage.is_level_tail());
+      // return erase_stage, last_pos
+      return update_last_to_tail(mut, node_stage);
+    }
+
+    assert(node_stage.keys() != 0);
+    position_t erase_pos = _erase_pos;
+    auto erase_stage = STAGE_T::erase(mut, node_stage, erase_pos);
+    // return erase_stage, next_pos
+    return {erase_stage, erase_pos};
   }
 
   static position_t make_tail(
@@ -86,6 +96,36 @@ struct NodeLayoutReplayableT {
     assert(!node_stage.is_level_tail());
     // TODO
     ceph_abort("not implemented");
+  }
+
+ private:
+  static std::tuple<match_stage_t, position_t> update_last_to_tail(
+      NodeExtentMutable& mut,
+      const node_stage_t& node_stage) {
+    if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
+      assert(node_stage.keys() != 0);
+      position_t last_pos;
+      laddr_t last_value;
+      {
+        const laddr_packed_t* p_last_value;
+        STAGE_T::template get_largest_slot<true, false, true>(
+            node_stage, &last_pos, nullptr, &p_last_value);
+        last_value = p_last_value->value;
+      }
+
+      auto erase_pos = last_pos;
+      auto erase_stage = STAGE_T::erase(mut, node_stage, erase_pos);
+      assert(erase_pos.is_end());
+
+      node_stage_t::update_is_level_tail(mut, node_stage, true);
+      auto p_last_value = const_cast<laddr_packed_t*>(
+          node_stage.get_end_p_laddr());
+      mut.copy_in_absolute(p_last_value, last_value);
+      // return erase_stage, last_pos
+      return {erase_stage, last_pos};
+    } else {
+      ceph_abort("impossible path");
+    }
   }
 };
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout_replayable.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_layout_replayable.h
@@ -94,8 +94,15 @@ struct NodeLayoutReplayableT {
       NodeExtentMutable& mut,
       const node_stage_t& node_stage) {
     assert(!node_stage.is_level_tail());
-    // TODO
-    ceph_abort("not implemented");
+    if constexpr (NODE_TYPE == node_type_t::INTERNAL) {
+      auto [r_stage, r_last_pos] = update_last_to_tail(mut, node_stage);
+      std::ignore = r_stage;
+      return r_last_pos;
+    } else {
+      node_stage_t::update_is_level_tail(mut, node_stage, true);
+      // no need to calculate the last pos
+      return position_t::end();
+    }
   }
 
  private:

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_types.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_types.h
@@ -66,6 +66,8 @@ enum class node_delta_op_t : uint8_t {
   SPLIT,
   SPLIT_INSERT,
   UPDATE_CHILD_ADDR,
+  ERASE,
+  MAKE_TAIL,
   SUBOP_UPDATE_VALUE = 0xff,
 };
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/node_types.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/node_types.h
@@ -69,4 +69,41 @@ enum class node_delta_op_t : uint8_t {
   SUBOP_UPDATE_VALUE = 0xff,
 };
 
+/** nextent_state_t
+ *
+ * The possible states of tree node extent(NodeExtentAccessorT).
+ *
+ * State transition implies the following capabilities is changed:
+ * - mutability is changed;
+ * - whether to record;
+ * - memory has been copied;
+ *
+ * load()----+
+ *           |
+ * alloc()   v
+ *  |        +--> [READ_ONLY] ---------+
+ *  |        |         |               |
+ *  |        |   prepare_mutate()      |
+ *  |        |         |               |
+ *  |        v         v               v
+ *  |        +--> [MUTATION_PENDING]---+
+ *  |        |                         |
+ *  |        |                     rebuild()
+ *  |        |                         |
+ *  |        v                         v
+ *  +------->+--> [FRESH] <------------+
+ *
+ * Note that NodeExtentAccessorT might still be MUTATION_PENDING/FRESH while
+ * the internal extent has become DIRTY after the transaction submission is
+ * started while nodes destruction and validation has not been completed yet.
+ */
+enum class nextent_state_t : uint8_t {
+  READ_ONLY = 0,       // requires mutate for recording
+                       //   CLEAN/DIRTY
+  MUTATION_PENDING,    // can mutate, needs recording
+                       //   MUTATION_PENDING
+  FRESH,               // can mutate, no recording
+                       //   INITIAL_WRITE_PENDING
+};
+
 }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.cc
@@ -103,6 +103,22 @@ ITER_TEMPLATE(node_type_t::INTERNAL);
 
 template <node_type_t NODE_TYPE>
 template <KeyT KT>
+APPEND_T::Appender(NodeExtentMutable* p_mut,
+                   const item_iterator_t& iter,
+                   bool open) : p_mut{p_mut}
+{
+  assert(!iter.has_next());
+  if (open) {
+    p_append = const_cast<char*>(iter.get_key().p_start());
+    p_offset_while_open = const_cast<char*>(iter.item_range.p_end);
+  } else {
+    // XXX: this doesn't need to advance the iter to last
+    p_append = const_cast<char*>(iter.p_items_start);
+  }
+}
+
+template <node_type_t NODE_TYPE>
+template <KeyT KT>
 bool APPEND_T::append(const ITER_T& src, index_t& items)
 {
   auto p_end = src.p_end();

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.cc
@@ -82,6 +82,19 @@ node_offset_t ITER_T::trim_at(
   return trim_size;
 }
 
+template <node_type_t NODE_TYPE>
+node_offset_t ITER_T::erase(
+    NodeExtentMutable& mut, const ITER_T& iter, const char* p_left_bound)
+{
+  node_offset_t erase_size = iter.p_end() - iter.p_start();
+  const char* p_shift_start = p_left_bound;
+  assert(p_left_bound <= iter.p_start());
+  extent_len_t shift_len = iter.p_start() - p_left_bound;
+  int shift_off = erase_size;
+  mut.shift_absolute(p_shift_start, shift_len, shift_off);
+  return erase_size;
+}
+
 #define ITER_TEMPLATE(NT) template class ITER_INST(NT)
 ITER_TEMPLATE(node_type_t::LEAF);
 ITER_TEMPLATE(node_type_t::INTERNAL);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.h
@@ -169,6 +169,7 @@ class item_iterator_t<NODE_TYPE>::Appender {
  public:
   Appender(NodeExtentMutable* p_mut, char* p_append)
     : p_mut{p_mut}, p_append{p_append} {}
+  Appender(NodeExtentMutable*, const item_iterator_t&, bool open);
   bool append(const item_iterator_t<NODE_TYPE>& src, index_t& items);
   char* wrap() { return p_append; }
   std::tuple<NodeExtentMutable*, char*> open_nxt(const key_get_type&);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/item_iterator_stage.h
@@ -138,6 +138,9 @@ class item_iterator_t {
   static node_offset_t trim_at(
       NodeExtentMutable&, const item_iterator_t<NODE_TYPE>&, node_offset_t trimmed);
 
+  static node_offset_t erase(
+      NodeExtentMutable&, const item_iterator_t<NODE_TYPE>&, const char*);
+
   template <KeyT KT>
   class Appender;
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.cc
@@ -176,6 +176,22 @@ node_offset_t NODE_T::trim_at(
   return 0;
 }
 
+template <typename FieldType, node_type_t NODE_TYPE>
+node_offset_t NODE_T::erase_at(
+    NodeExtentMutable& mut, const node_extent_t& node,
+    index_t index, const char* p_left_bound)
+{
+  if constexpr (FIELD_TYPE == field_type_t::N0 ||
+                FIELD_TYPE == field_type_t::N1) {
+    assert(node.keys() > 0);
+    assert(index < node.keys());
+    assert(p_left_bound == node.p_left_bound());
+    return FieldType::erase_at(mut, node.fields(), index, p_left_bound);
+  } else {
+    ceph_abort("not implemented");
+  }
+}
+
 #define NODE_TEMPLATE(FT, NT) template class NODE_INST(FT, NT)
 NODE_TEMPLATE(node_fields_0_t, node_type_t::INTERNAL);
 NODE_TEMPLATE(node_fields_1_t, node_type_t::INTERNAL);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
@@ -175,6 +175,9 @@ class node_extent_t {
   static node_offset_t trim_at(NodeExtentMutable&, const node_extent_t&,
                         index_t index, node_offset_t trimmed);
 
+  static node_offset_t erase_at(NodeExtentMutable&, const node_extent_t&,
+                                index_t index, const char* p_left_bound);
+
   template <KeyT KT>
   class Appender;
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage.h
@@ -201,6 +201,7 @@ class node_extent_t<FieldType, NODE_TYPE>::Appender {
     p_append_left = p_start + FieldType::HEADER_SIZE;
     p_append_right = p_start + FieldType::SIZE;
   }
+  Appender(NodeExtentMutable*, const node_extent_t&, bool open = false);
   void append(const node_extent_t& src, index_t from, index_t items);
   void append(const full_key_t<KT>&, const value_input_t&, const value_t*&);
   char* wrap();

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.cc
@@ -36,6 +36,13 @@ void F013_T::update_size_at(
     NodeExtentMutable& mut, const me_t& node, index_t index, int change)
 {
   assert(index <= node.num_keys);
+#ifndef NDEBUG
+  // check underflow
+  if (change < 0 && index != node.num_keys) {
+    assert(node.get_item_start_offset(index) <
+           node.get_item_end_offset(index));
+  }
+#endif
   for (const auto* p_slot = &node.slots[index];
        p_slot < &node.slots[node.num_keys];
        ++p_slot) {
@@ -44,6 +51,14 @@ void F013_T::update_size_at(
         (void*)&(p_slot->right_offset),
         node_offset_t(offset - change));
   }
+#ifndef NDEBUG
+  // check overflow
+  if (change > 0 && index != node.num_keys) {
+    assert(node.num_keys > 0);
+    assert(node.get_key_start_offset(node.num_keys) <=
+           node.slots[node.num_keys - 1].right_offset);
+  }
+#endif
 }
 
 template <typename SlotType>

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.cc
@@ -103,6 +103,30 @@ IA_TEMPLATE(slot_0_t, KeyT::HOBJ);
 IA_TEMPLATE(slot_1_t, KeyT::HOBJ);
 IA_TEMPLATE(slot_3_t, KeyT::HOBJ);
 
+template <typename SlotType>
+node_offset_t F013_T::erase_at(
+    NodeExtentMutable& mut, const me_t& node, index_t index, const char* p_left_bound)
+{
+  auto offset_item_start = node.get_item_start_offset(index);
+  auto offset_item_end = node.get_item_end_offset(index);
+  assert(offset_item_start < offset_item_end);
+  auto erase_size = offset_item_end - offset_item_start;
+  // fix and shift the left part
+  update_size_at(mut, node, index + 1, -erase_size);
+  const char* p_shift_start = fields_start(node) + node.get_key_start_offset(index + 1);
+  extent_len_t shift_len = sizeof(SlotType) * (node.num_keys - index - 1);
+  int shift_off = -(int)sizeof(SlotType);
+  mut.shift_absolute(p_shift_start, shift_len, shift_off);
+  // shift the right part
+  p_shift_start = p_left_bound;
+  shift_len = fields_start(node) + offset_item_start - p_left_bound;
+  shift_off = erase_size;
+  mut.shift_absolute(p_shift_start, shift_len, shift_off);
+  // fix num_keys
+  mut.copy_in_absolute((void*)&node.num_keys, num_keys_t(node.num_keys - 1));
+  return erase_size;
+}
+
 #define F013_TEMPLATE(ST) template struct F013_INST(ST)
 F013_TEMPLATE(slot_0_t);
 F013_TEMPLATE(slot_1_t);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/node_stage_layout.h
@@ -171,6 +171,7 @@ struct _node_fields_013_t {
   static void insert_at(
       NodeExtentMutable&, const full_key_t<KT>& key,
       const me_t& node, index_t index, node_offset_t size_right);
+  static node_offset_t erase_at(NodeExtentMutable&, const me_t&, index_t, const char*);
   static void update_size_at(
       NodeExtentMutable&, const me_t& node, index_t index, int change);
   static void append_key(

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
@@ -858,8 +858,20 @@ struct staged {
 
   static bool is_keys_one(
       const container_t& container) {      // IN
-    // TODO
-    ceph_abort("not implemented");
+    auto iter = iterator_t(container);
+    iter.seek_last();
+    if (iter.index() == 0) {
+      if constexpr (IS_BOTTOM) {
+        // ok, there is only 1 key
+        return true;
+      } else {
+        auto nxt_container = iter.get_nxt_container();
+        return NXT_STAGE_T::is_keys_one(nxt_container);
+      }
+    } else {
+      // more than 1 keys
+      return false;
+    }
   }
 
   template <bool GET_KEY>

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
@@ -335,7 +335,7 @@ struct staged {
 
     template <typename T = void>
     std::enable_if_t<!IS_BOTTOM, T>
-    update_size(NodeExtentMutable& mut, node_offset_t insert_size) {
+    update_size(NodeExtentMutable& mut, int insert_size) {
       assert(!is_end());
       container_t::update_size_at(mut, container, _index, insert_size);
     }
@@ -627,7 +627,7 @@ struct staged {
           mut, container, key, is_end(), size, p_left_bound);
     }
 
-    void update_size(NodeExtentMutable& mut, node_offset_t insert_size) {
+    void update_size(NodeExtentMutable& mut, int insert_size) {
       assert(!is_end());
       container_t::update_size(mut, container, insert_size);
     }

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage.h
@@ -856,6 +856,12 @@ struct staged {
    * Lookup internals (hide?)
    */
 
+  static bool is_keys_one(
+      const container_t& container) {      // IN
+    // TODO
+    ceph_abort("not implemented");
+  }
+
   template <bool GET_KEY>
   static result_t smallest_result(
       const iterator_t& iter, full_key_t<KeyT::VIEW>* p_index_key) {
@@ -2110,6 +2116,13 @@ struct staged {
       auto& iter = trim_at.get();
       iter.trim_until(mut);
     }
+  }
+
+  static std::tuple<match_stage_t, node_offset_t> evaluate_merge(
+      const full_key_t<KeyT::VIEW>& left_pivot_index,
+      const container_t& right_container) {
+    // TODO
+    ceph_abort("not implemented");
   }
 };
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/stage_types.h
@@ -194,6 +194,14 @@ struct staged_position_t {
     return *this;
   }
 
+  me_t& operator+=(const me_t& o) {
+    assert(is_valid_index(index));
+    assert(is_valid_index(o.index));
+    index += o.index;
+    nxt += o.nxt;
+    return *this;
+  }
+
   void encode(ceph::bufferlist& encoded) const {
     ceph::encode(index, encoded);
     nxt.encode(encoded);
@@ -266,6 +274,13 @@ struct staged_position_t<STAGE_BOTTOM> {
       assert(is_valid_index(index));
       index -= o.index;
     }
+    return *this;
+  }
+
+  me_t& operator+=(const me_t& o) {
+    assert(is_valid_index(index));
+    assert(is_valid_index(o.index));
+    index += o.index;
     return *this;
   }
 

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.cc
@@ -196,8 +196,75 @@ template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
 
 template <KeyT KT>
+void leaf_sub_items_t::Appender<KT>::append(
+    const leaf_sub_items_t& src, index_t from, index_t items)
+{
+  if (p_append) {
+    // append from empty
+    assert(cnt <= APPENDER_LIMIT);
+    assert(from <= src.keys());
+    if (items == 0) {
+      return;
+    }
+    if (op_src) {
+      assert(*op_src == src);
+    } else {
+      op_src = src;
+    }
+    assert(from < src.keys());
+    assert(from + items <= src.keys());
+    appends[cnt] = range_items_t{from, items};
+    ++cnt;
+  } else {
+    // append from existing
+    assert(op_dst.has_value());
+    assert(!p_appended);
+    assert(from == 0);
+    assert(items);
+    assert(items == src.keys());
+
+    num_keys_t num_keys = op_dst->keys();
+    node_offset_t compensate = op_dst->get_offset(num_keys - 1).value;
+    const char* p_items_start = op_dst->p_start();
+    const char* p_items_end = op_dst->p_items_end;
+
+    // update dst num_keys
+    num_keys += items;
+    p_mut->copy_in_absolute((char*)op_dst->p_num_keys, num_keys);
+
+    // shift dst items
+    std::size_t src_offsets_size = sizeof(node_offset_t) * items;
+    p_mut->shift_absolute(p_items_start,
+                          p_items_end - p_items_start,
+                          -(int)src_offsets_size);
+
+    // fill offsets from src
+    node_offset_t offset;
+    char* p_cur_offset = const_cast<char*>(p_items_end);
+    for (auto i = from; i < from + items; ++i) {
+      offset = src.get_offset(i).value + compensate;
+      p_cur_offset -= sizeof(node_offset_t);
+      p_mut->copy_in_absolute(p_cur_offset, offset);
+    }
+
+    // fill items from src
+    auto p_src_items_start = src.get_item_end(from + items);
+    std::size_t src_items_size = src.get_item_end(from) - p_src_items_start;
+    p_appended = const_cast<char*>(p_items_start) - src_offsets_size - src_items_size;
+    p_mut->copy_in_absolute(p_appended, p_src_items_start, src_items_size);
+  }
+}
+
+template <KeyT KT>
 char* leaf_sub_items_t::Appender<KT>::wrap()
 {
+  if (op_dst.has_value()) {
+    // append from existing
+    assert(p_appended);
+    return p_appended;
+  }
+  // append from empty
+  assert(p_append);
   auto p_cur = p_append;
   num_keys_t num_keys = 0;
   for (auto i = 0u; i < cnt; ++i) {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.h
@@ -110,6 +110,9 @@ class internal_sub_items_t {
 
   static node_offset_t trim_until(NodeExtentMutable&, internal_sub_items_t&, index_t);
 
+  static node_offset_t erase_at(
+      NodeExtentMutable&, const internal_sub_items_t&, index_t, const char*);
+
   template <KeyT KT>
   class Appender;
 
@@ -269,6 +272,9 @@ class leaf_sub_items_t {
       index_t index, node_offset_t size, const char* p_left_bound);
 
   static node_offset_t trim_until(NodeExtentMutable&, leaf_sub_items_t&, index_t index);
+
+  static node_offset_t erase_at(
+      NodeExtentMutable&, const leaf_sub_items_t&, index_t, const char*);
 
   template <KeyT KT>
   class Appender;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/stages/sub_items_stage.h
@@ -126,6 +126,11 @@ class internal_sub_items_t::Appender {
  public:
   Appender(NodeExtentMutable* p_mut, char* p_append)
     : p_mut{p_mut}, p_append{p_append} {}
+  Appender(NodeExtentMutable* p_mut, const internal_sub_items_t& sub_items)
+    : p_mut{p_mut},
+      p_append{(char*)(sub_items.p_first_item + 1 - sub_items.keys())} {
+    assert(sub_items.keys());
+  }
   void append(const internal_sub_items_t& src, index_t from, index_t items);
   void append(const full_key_t<KT>&, const laddr_t&, const laddr_packed_t*&);
   char* wrap() { return p_append; }
@@ -304,25 +309,16 @@ class leaf_sub_items_t::Appender {
   Appender(NodeExtentMutable* p_mut, char* p_append)
     : p_mut{p_mut}, p_append{p_append} {
   }
-
-  void append(const leaf_sub_items_t& src, index_t from, index_t items) {
-    assert(cnt <= APPENDER_LIMIT);
-    assert(from <= src.keys());
-    if (items == 0) {
-      return;
-    }
-    if (op_src) {
-      assert(*op_src == src);
-    } else {
-      op_src = src;
-    }
-    assert(from < src.keys());
-    assert(from + items <= src.keys());
-    appends[cnt] = range_items_t{from, items};
-    ++cnt;
+  Appender(NodeExtentMutable* p_mut, const leaf_sub_items_t& sub_items)
+    : p_mut{p_mut} , op_dst(sub_items) {
+    assert(sub_items.keys());
   }
+
+  void append(const leaf_sub_items_t& src, index_t from, index_t items);
   void append(const full_key_t<KT>& key,
               const value_config_t& value, const value_header_t*& p_value) {
+    // append from empty
+    assert(p_append);
     assert(pp_value == nullptr);
     assert(cnt <= APPENDER_LIMIT);
     appends[cnt] = kv_item_t{&key, value};
@@ -332,12 +328,16 @@ class leaf_sub_items_t::Appender {
   char* wrap();
 
  private:
+  NodeExtentMutable* p_mut;
+  // append from empty
   std::optional<leaf_sub_items_t> op_src;
   const value_header_t** pp_value = nullptr;
-  NodeExtentMutable* p_mut;
-  char* p_append;
+  char* p_append = nullptr;
   var_t appends[APPENDER_LIMIT];
   index_t cnt = 0;
+  // append from existing
+  std::optional<leaf_sub_items_t> op_dst;
+  char* p_appended = nullptr;
 };
 
 template <node_type_t> struct _sub_items_t;

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree.h
@@ -110,10 +110,11 @@ class Btree {
       });
     }
 
+    template <bool FORCE_MERGE = false>
     btree_future<Cursor> erase(Transaction& t) {
       assert(!is_end());
       auto this_obj = *this;
-      return p_cursor->erase(p_tree->get_context(t), true
+      return p_cursor->erase<FORCE_MERGE>(p_tree->get_context(t), true
       ).safe_then([this_obj, this] (Ref<tree_cursor_t> next_cursor) {
         assert(p_cursor->is_invalid());
         if (next_cursor) {

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/tree_utils.h
@@ -132,6 +132,22 @@ class KVPool {
     std::random_shuffle(random_p_kvs.begin(), random_p_kvs.end());
   }
 
+  void erase_from_random(iterator_t begin, iterator_t end) {
+    random_p_kvs.erase(begin, end);
+    kv_vector_t new_kvs;
+    for (auto p_kv : random_p_kvs) {
+      new_kvs.emplace_back(*p_kv);
+    }
+    std::sort(new_kvs.begin(), new_kvs.end(), [](auto& l, auto& r) {
+      return l.key < r.key;
+    });
+
+    kvs.swap(new_kvs);
+    serial_p_kvs.resize(kvs.size());
+    random_p_kvs.resize(kvs.size());
+    init();
+  }
+
   static KVPool create_raw_range(
       const std::vector<size_t>& str_sizes,
       const std::vector<size_t>& value_sizes,
@@ -188,6 +204,10 @@ class KVPool {
  private:
   KVPool(kv_vector_t&& _kvs)
       : kvs(std::move(_kvs)), serial_p_kvs(kvs.size()), random_p_kvs(kvs.size()) {
+    init();
+  }
+
+  void init() {
     std::transform(kvs.begin(), kvs.end(), serial_p_kvs.begin(),
                    [] (kv_t& item) { return &item; });
     std::transform(kvs.begin(), kvs.end(), random_p_kvs.begin(),
@@ -278,12 +298,15 @@ class TreeBuilder {
     auto cursors = seastar::make_lw_shared<std::vector<BtreeCursor>>();
     logger().warn("start inserting {} kvs ...", kvs.size());
     auto start_time = mono_clock::now();
-    return crimson::do_until([&t, this, cursors, ref_kv_iter]() -> future<bool> {
+    return crimson::do_until([&t, this, cursors, ref_kv_iter,
+                              start_time]() -> future<bool> {
       if (*ref_kv_iter == kvs.random_end()) {
+        std::chrono::duration<double> duration = mono_clock::now() - start_time;
+        logger().warn("Insert done! {}s", duration.count());
         return ertr::template make_ready_future<bool>(true);
       }
       auto p_kv = **ref_kv_iter;
-      logger().debug("[{}] {} -> {}",
+      logger().debug("[{}] insert {} -> {}",
                      (*ref_kv_iter) - kvs.random_begin(),
                      key_hobj_t{p_kv->key},
                      p_kv->value);
@@ -313,9 +336,7 @@ class TreeBuilder {
         return ertr::template make_ready_future<bool>(false);
 #endif
       });
-    }).safe_then([&t, this, start_time, cursors, ref_kv_iter] {
-      std::chrono::duration<double> duration = mono_clock::now() - start_time;
-      logger().warn("Insert done! {}s", duration.count());
+    }).safe_then([&t, this, cursors, ref_kv_iter] {
       if (!cursors->empty()) {
         logger().info("Verifing tracked cursors ...");
         *ref_kv_iter = kvs.random_begin();
@@ -346,11 +367,103 @@ class TreeBuilder {
     });
   }
 
+  future<> erase(Transaction& t, std::size_t erase_size) {
+    assert(erase_size <= kvs.size());
+    kvs.shuffle();
+    auto begin = kvs.random_begin();
+    auto end = begin + erase_size;
+    auto ref_kv_iter = seastar::make_lw_shared<iterator_t>();
+    auto cursors = seastar::make_lw_shared<std::map<ghobject_t, BtreeCursor>>();
+    return ertr::now().safe_then([&t, this, cursors, ref_kv_iter] {
+      if constexpr (TRACK) {
+        logger().info("Tracking cursors before erase ...");
+        *ref_kv_iter = kvs.begin();
+        auto start_time = mono_clock::now();
+        return crimson::do_until([&t, this, cursors, ref_kv_iter, start_time] () -> future<bool> {
+          if (*ref_kv_iter == kvs.end()) {
+            std::chrono::duration<double> duration = mono_clock::now() - start_time;
+            logger().info("Track done! {}s", duration.count());
+            return ertr::template make_ready_future<bool>(true);
+          }
+          auto p_kv = **ref_kv_iter;
+          return tree->find(t, p_kv->key).safe_then([this, cursors, ref_kv_iter](auto cursor) {
+            auto p_kv = **ref_kv_iter;
+            validate_cursor_from_item(p_kv->key, p_kv->value, cursor);
+            cursors->emplace(p_kv->key, cursor);
+            ++(*ref_kv_iter);
+            return ertr::template make_ready_future<bool>(false);
+          });
+        });
+      } else {
+        return ertr::now();
+      }
+    }).safe_then([&t, this, ref_kv_iter, begin, end] {
+      *ref_kv_iter = begin;
+      logger().warn("start erasing {}/{} kvs ...", end - begin, kvs.size());
+      auto start_time = mono_clock::now();
+      return crimson::do_until([&t, this, ref_kv_iter,
+                                start_time, begin, end] () -> future<bool> {
+        if (*ref_kv_iter == end) {
+          std::chrono::duration<double> duration = mono_clock::now() - start_time;
+          logger().warn("Erase done! {}s", duration.count());
+          return ertr::template make_ready_future<bool>(true);
+        }
+        auto p_kv = **ref_kv_iter;
+        logger().debug("[{}] erase {} -> {}",
+                       (*ref_kv_iter) - begin,
+                       key_hobj_t{p_kv->key},
+                       p_kv->value);
+        return tree->erase(t, p_kv->key).safe_then([&t, this, ref_kv_iter] (auto size) {
+          ceph_assert(size == 1);
+#ifndef NDEBUG
+          auto p_kv = **ref_kv_iter;
+          return tree->contains(t, p_kv->key).safe_then([ref_kv_iter] (bool ret) {
+            ceph_assert(ret == false);
+            ++(*ref_kv_iter);
+            return ertr::template make_ready_future<bool>(false);
+          });
+#else
+          ++(*ref_kv_iter);
+          return ertr::template make_ready_future<bool>(false);
+#endif
+        });
+      });
+    }).safe_then([this, cursors, ref_kv_iter, begin, end] {
+      if constexpr (TRACK) {
+        logger().info("Verifing tracked cursors ...");
+        *ref_kv_iter = begin;
+        while (*ref_kv_iter != end) {
+          auto p_kv = **ref_kv_iter;
+          auto c_it = cursors->find(p_kv->key);
+          ceph_assert(c_it != cursors->end());
+          ceph_assert(c_it->second.is_end());
+          cursors->erase(c_it);
+          ++(*ref_kv_iter);
+        }
+      }
+      kvs.erase_from_random(begin, end);
+      if constexpr (TRACK) {
+        *ref_kv_iter = kvs.begin();
+        for (auto& [k, c] : *cursors) {
+          assert(*ref_kv_iter != kvs.end());
+          auto p_kv = **ref_kv_iter;
+          validate_cursor_from_item(p_kv->key, p_kv->value, c);
+          ++(*ref_kv_iter);
+        }
+        logger().info("Verify done!");
+      }
+    });
+  }
+
   future<> get_stats(Transaction& t) {
     return tree->get_stats_slow(t
     ).safe_then([this](auto stats) {
       logger().warn("{}", stats);
     });
+  }
+
+  future<std::size_t> height(Transaction& t) {
+    return tree->height(t);
   }
 
   void reload(NodeExtentManagerURef&& nm) {
@@ -359,7 +472,7 @@ class TreeBuilder {
 
   future<> validate(Transaction& t) {
     return seastar::async([this, &t] {
-      logger().info("Verifing insertion ...");
+      logger().info("Verifing inserted ...");
       for (auto& p_kv : kvs) {
         auto cursor = tree->find(t, p_kv->key).unsafe_get0();
         validate_cursor_from_item(p_kv->key, p_kv->value, cursor);

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.cc
@@ -34,8 +34,15 @@ Value::Value(NodeExtentManager& nm,
 
 Value::~Value() {}
 
+bool Value::is_tracked() const
+{
+  assert(!p_cursor->is_end());
+  return p_cursor->is_tracked();
+}
+
 future<> Value::extend(Transaction& t, value_size_t extend_size)
 {
+  assert(is_tracked());
   [[maybe_unused]] auto target_size = get_payload_size() + extend_size;
   return p_cursor->extend_value(get_context(t), extend_size)
 #ifndef NDEBUG
@@ -48,6 +55,7 @@ future<> Value::extend(Transaction& t, value_size_t extend_size)
 
 future<> Value::trim(Transaction& t, value_size_t trim_size)
 {
+  assert(is_tracked());
   assert(get_payload_size() > trim_size);
   [[maybe_unused]] auto target_size = get_payload_size() - trim_size;
   return p_cursor->trim_value(get_context(t), trim_size)

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
@@ -233,6 +233,9 @@ class Value {
   NodeExtentManager& nm;
   const ValueBuilder& vb;
   Ref<tree_cursor_t> p_cursor;
+
+  template <typename ValueImpl>
+  friend class Btree;
 };
 
 /**

--- a/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
+++ b/src/crimson/os/seastore/onode_manager/staged-fltree/value.h
@@ -177,8 +177,12 @@ class Value {
   Value& operator=(const Value&) = delete;
   Value& operator=(Value&&) = delete;
 
+  /// Returns whether the Value is still tracked in tree.
+  bool is_tracked() const;
+
   /// Returns the value payload size.
   value_size_t get_payload_size() const {
+    assert(is_tracked());
     return read_value_header()->payload_size;
   }
 
@@ -198,6 +202,7 @@ class Value {
   template <typename PayloadT, typename ValueDeltaRecorderT>
   std::pair<NodeExtentMutable&, ValueDeltaRecorderT*>
   prepare_mutate_payload(Transaction& t) {
+    assert(is_tracked());
     assert(sizeof(PayloadT) <= get_payload_size());
 
     auto value_mutable = do_prepare_mutate_payload(t);
@@ -211,6 +216,7 @@ class Value {
   /// Get the latest payload pointer for read.
   template <typename PayloadT>
   const PayloadT* read_payload() const {
+    assert(is_tracked());
     // see Value documentation
     static_assert(alignof(PayloadT) == 1);
     assert(sizeof(PayloadT) <= get_payload_size());

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -710,7 +710,7 @@ class DummyChildPool {
     field_type_t field_type() const override { return field_type_t::N0; }
     const char* read() const override {
       ceph_abort("impossible path"); }
-    bool is_duplicate() const override {
+    nextent_state_t get_extent_state() const override {
       ceph_abort("impossible path"); }
     level_t level() const override { return 0u; }
     void prepare_mutate(context_t) override {

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -686,6 +686,7 @@ class DummyChildPool {
     DummyChildImpl(const std::set<ghobject_t>& keys, bool is_level_tail, laddr_t laddr)
         : keys{keys}, _is_level_tail{is_level_tail}, _laddr{laddr} {
       std::tie(key_view, p_mem_key_view) = build_key_view(*keys.crbegin());
+      build_name();
     }
     ~DummyChildImpl() override {
       std::free(p_mem_key_view);
@@ -698,12 +699,14 @@ class DummyChildPool {
       _is_level_tail = level_tail;
       std::free(p_mem_key_view);
       std::tie(key_view, p_mem_key_view) = build_key_view(*keys.crbegin());
+      build_name();
     }
 
    public:
     laddr_t laddr() const override { return _laddr; }
     bool is_level_tail() const override { return _is_level_tail; }
     std::optional<key_view_t> get_pivot_index() const override { return {key_view}; }
+    const std::string& get_name() const override { return name; }
 
    protected:
     node_type_t node_type() const override { return node_type_t::LEAF; }
@@ -735,9 +738,20 @@ class DummyChildPool {
       ceph_abort("impossible path"); }
 
    private:
+    void build_name() {
+      std::ostringstream sos;
+      sos << "DummyNode"
+          << "@0x" << std::hex << laddr() << std::dec
+          << "Lv" << (unsigned)level()
+          << (is_level_tail() ? "$" : "")
+          << "(" << key_view << ")";
+      name = sos.str();
+    }
+
     std::set<ghobject_t> keys;
     bool _is_level_tail;
     laddr_t _laddr;
+    std::string name;
 
     key_view_t key_view;
     void* p_mem_key_view;

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -937,7 +937,9 @@ class DummyChildPool {
       if (right_child->can_split()) {
         splitable_nodes.insert(right_child);
       }
-      return apply_split_to_parent(c, right_child, false);
+      Ref<Node> this_ref = this;
+      return apply_split_to_parent(
+          c, std::move(this_ref), std::move(right_child), false);
     }
 
     node_future<> insert_and_split(
@@ -989,7 +991,8 @@ class DummyChildPool {
       std::set<ghobject_t> new_keys;
       new_keys.insert(new_key);
       impl->reset(new_keys, impl->is_level_tail());
-      return fix_parent_index<true>(c, false);
+      Ref<Node> this_ref = this;
+      return fix_parent_index<true>(c, std::move(this_ref), false);
     }
 
     bool match_pos(const search_position_t& pos) const {

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -715,7 +715,9 @@ class DummyChildPool {
     level_t level() const override { return 0u; }
     void prepare_mutate(context_t) override {
       ceph_abort("impossible path"); }
-    bool is_empty() const override {
+    void validate_non_empty() const override {
+      ceph_abort("impossible path"); }
+    bool is_keys_empty() const override {
       ceph_abort("impossible path"); }
     node_offset_t free_size() const override {
       ceph_abort("impossible path"); }

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -1214,16 +1214,19 @@ TEST_F(d_seastore_tm_test_t, 6_random_insert_leaf_node)
       auto t = tm->create_transaction();
       tree->bootstrap(*t).unsafe_get();
       tm->submit_transaction(std::move(t)).unsafe_get();
+      segment_cleaner->run_until_halt().get0();
     }
     {
       auto t = tm->create_transaction();
       tree->insert(*t).unsafe_get();
       tm->submit_transaction(std::move(t)).unsafe_get();
+      segment_cleaner->run_until_halt().get0();
     }
     {
       auto t = tm->create_transaction();
       tree->get_stats(*t).unsafe_get();
       tm->submit_transaction(std::move(t)).unsafe_get();
+      segment_cleaner->run_until_halt().get0();
     }
     if constexpr (TEST_SEASTORE) {
       logger().info("seastore replay begin");

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -989,7 +989,7 @@ class DummyChildPool {
       std::set<ghobject_t> new_keys;
       new_keys.insert(new_key);
       impl->reset(new_keys, impl->is_level_tail());
-      return fix_parent_index<true>(c);
+      return fix_parent_index<true>(c, false);
     }
 
     bool match_pos(const search_position_t& pos) const {

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -706,7 +706,13 @@ class DummyChildPool {
     laddr_t laddr() const override { return _laddr; }
     bool is_level_tail() const override { return _is_level_tail; }
     std::optional<key_view_t> get_pivot_index() const override { return {key_view}; }
+    bool is_extent_valid() const override { return true; }
     const std::string& get_name() const override { return name; }
+    search_position_t make_tail() override {
+      _is_level_tail = true;
+      build_name();
+      return search_position_t::end();
+    }
 
    protected:
     node_type_t node_type() const override { return node_type_t::LEAF; }
@@ -722,7 +728,23 @@ class DummyChildPool {
       ceph_abort("impossible path"); }
     bool is_keys_empty() const override {
       ceph_abort("impossible path"); }
+    bool is_keys_one() const override {
+      ceph_abort("impossible path"); }
     node_offset_t free_size() const override {
+      ceph_abort("impossible path"); }
+    node_offset_t total_size() const override {
+      ceph_abort("impossible path"); }
+    bool is_size_underflow() const override {
+      ceph_abort("impossible path"); }
+    std::tuple<match_stage_t, search_position_t> erase(const search_position_t&) override {
+      ceph_abort("impossible path"); }
+    std::tuple<match_stage_t, std::size_t> evaluate_merge(NodeImpl&) override {
+      ceph_abort("impossible path"); }
+    search_position_t merge(NodeExtentMutable&, NodeImpl&, match_stage_t, node_offset_t) override {
+      ceph_abort("impossible path"); }
+    ertr::future<NodeExtentMutable> rebuild_extent(context_t) override {
+      ceph_abort("impossible path"); }
+    ertr::future<> retire_extent(context_t) override {
       ceph_abort("impossible path"); }
     node_stats_t get_stats() const override {
       ceph_abort("impossible path"); }
@@ -787,7 +809,7 @@ class DummyChildPool {
       if (right_child->can_split()) {
         splitable_nodes.insert(right_child);
       }
-      return apply_split_to_parent(c, right_child);
+      return apply_split_to_parent(c, right_child, false);
     }
 
     node_future<> insert_and_split(
@@ -862,6 +884,10 @@ class DummyChildPool {
         context_t, const key_hobj_t&, MatchHistory&) override {
       ceph_abort("impossible path"); }
     node_future<> do_get_tree_stats(context_t, tree_stats_t&) override {
+      ceph_abort("impossible path"); }
+    bool is_tracking() const override {
+      ceph_abort("impossible path"); }
+    void track_merge(Ref<Node>, match_stage_t, search_position_t&) override {
       ceph_abort("impossible path"); }
 
    private:

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -1071,7 +1071,7 @@ class DummyChildPool {
       }
       left->impl->reset(*p_keys, left_is_tail);
       return left->parent_info().ptr->apply_children_merge<true>(
-          c, std::move(left), std::move(right), !stole_key);
+          c, std::move(left), left->impl->laddr(), std::move(right), !stole_key);
     }
 
     DummyChildImpl* impl;

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -1514,7 +1514,7 @@ struct d_seastore_tm_test_t :
   }
 };
 
-TEST_F(d_seastore_tm_test_t, 6_random_insert_leaf_node)
+TEST_F(d_seastore_tm_test_t, 6_random_tree_insert_erase)
 {
   run_async([this] {
     constexpr bool TEST_SEASTORE = true;
@@ -1523,15 +1523,19 @@ TEST_F(d_seastore_tm_test_t, 6_random_insert_leaf_node)
         {8, 11, 64, 256, 301, 320},
         {8, 16, 128, 512, 576, 640},
         {0, 32}, {0, 10}, {0, 4});
-    auto tree = std::make_unique<TreeBuilder<TRACK_CURSORS, test_item_t>>(kvs,
-        (TEST_SEASTORE ? NodeExtentManager::create_seastore(*tm)
-                       : NodeExtentManager::create_dummy(IS_DUMMY_SYNC)));
+    auto moved_nm = (TEST_SEASTORE ? NodeExtentManager::create_seastore(*tm)
+                                   : NodeExtentManager::create_dummy(IS_DUMMY_SYNC));
+    auto p_nm = moved_nm.get();
+    auto tree = std::make_unique<TreeBuilder<TRACK_CURSORS, test_item_t>>(
+        kvs, std::move(moved_nm));
     {
       auto t = tm->create_transaction();
       tree->bootstrap(*t).unsafe_get();
       tm->submit_transaction(std::move(t)).unsafe_get();
       segment_cleaner->run_until_halt().get0();
     }
+
+    // test insert
     {
       auto t = tm->create_transaction();
       tree->insert(*t).unsafe_get();
@@ -1541,19 +1545,67 @@ TEST_F(d_seastore_tm_test_t, 6_random_insert_leaf_node)
     {
       auto t = tm->create_transaction();
       tree->get_stats(*t).unsafe_get();
-      tm->submit_transaction(std::move(t)).unsafe_get();
-      segment_cleaner->run_until_halt().get0();
     }
     if constexpr (TEST_SEASTORE) {
-      logger().info("seastore replay begin");
+      logger().info("seastore replay insert begin");
       restart();
       tree->reload(NodeExtentManager::create_seastore(*tm));
-      logger().info("seastore replay end");
+      logger().info("seastore replay insert end");
     }
     {
       // Note: tm->create_weak_transaction() can also work, but too slow.
       auto t = tm->create_transaction();
       tree->validate(*t).unsafe_get();
+    }
+
+    // test erase 3/4
+    {
+      auto t = tm->create_transaction();
+      tree->erase(*t, kvs.size() / 4 * 3).unsafe_get();
+      tm->submit_transaction(std::move(t)).unsafe_get();
+      segment_cleaner->run_until_halt().get0();
+    }
+    {
+      auto t = tm->create_transaction();
+      tree->get_stats(*t).unsafe_get();
+    }
+    if constexpr (TEST_SEASTORE) {
+      logger().info("seastore replay erase-1 begin");
+      restart();
+      tree->reload(NodeExtentManager::create_seastore(*tm));
+      logger().info("seastore replay erase-1 end");
+    }
+    {
+      auto t = tm->create_transaction();
+      tree->validate(*t).unsafe_get();
+    }
+
+    // test erase remaining
+    {
+      auto t = tm->create_transaction();
+      tree->erase(*t, kvs.size()).unsafe_get();
+      tm->submit_transaction(std::move(t)).unsafe_get();
+      segment_cleaner->run_until_halt().get0();
+    }
+    {
+      auto t = tm->create_transaction();
+      tree->get_stats(*t).unsafe_get();
+    }
+    if constexpr (TEST_SEASTORE) {
+      logger().info("seastore replay erase-2 begin");
+      restart();
+      tree->reload(NodeExtentManager::create_seastore(*tm));
+      logger().info("seastore replay erase-2 end");
+    }
+    {
+      auto t = tm->create_transaction();
+      tree->validate(*t).unsafe_get();
+      EXPECT_EQ(tree->height(*t).unsafe_get0(), 1);
+    }
+
+    if constexpr (!TEST_SEASTORE) {
+      auto p_dummy = static_cast<DummyManager*>(p_nm);
+      EXPECT_EQ(p_dummy->size(), 1);
     }
     tree.reset();
   });

--- a/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
+++ b/src/test/crimson/seastore/onode_tree/test_staged_fltree.cc
@@ -771,7 +771,7 @@ class DummyChildPool {
       if (right_child->can_split()) {
         splitable_nodes.insert(right_child);
       }
-      return insert_parent(c, *impl->get_pivot_index(), right_child);
+      return apply_split_to_parent(c, right_child);
     }
 
     node_future<> insert_and_split(

--- a/src/tools/crimson/perf_staged_fltree.cc
+++ b/src/tools/crimson/perf_staged_fltree.cc
@@ -35,12 +35,14 @@ class PerfTree : public TMTestState {
           auto t = tm->create_transaction();
           tree->bootstrap(*t).unsafe_get();
           tm->submit_transaction(std::move(t)).unsafe_get();
+          segment_cleaner->run_until_halt().get0();
         }
         {
           auto t = tm->create_transaction();
           tree->insert(*t).unsafe_get();
           auto start_time = mono_clock::now();
           tm->submit_transaction(std::move(t)).unsafe_get();
+          segment_cleaner->run_until_halt().get0();
           std::chrono::duration<double> duration = mono_clock::now() - start_time;
           logger().warn("submit_transaction() done! {}s", duration.count());
         }
@@ -48,6 +50,7 @@ class PerfTree : public TMTestState {
           auto t = tm->create_transaction();
           tree->get_stats(*t).unsafe_get();
           tm->submit_transaction(std::move(t)).unsafe_get();
+          segment_cleaner->run_until_halt().get0();
         }
         {
           // Note: tm->create_weak_transaction() can also work, but too slow.


### PR DESCRIPTION
@athanatos I finally decided to add independent states back at the level of `NodeExtentAccessorT` in https://github.com/ceph/ceph/commit/03292204e7cc943b80d0e93407b8e683256ace28, as discussed in https://github.com/ceph/ceph/pull/36986#discussion_r533849350. These accessor-level states are logically associated with accessor-level operations like `preprare_mutate[_value_payload]()` and `rebuild()` which may operate on multiple `LogicalCachedExtent`s internally. And `Cursor` needs to be aware of accessor-level states in order to keep its cache up-to-date.

TODOs  (will be in separate PRs)
---
- [x] Onode manager level integration and tests (see #41075);
- [ ] Work with the interruptive eagain and other errors;
- [ ] Node size adjustments

Further works
---
- Optimize key/value alignments;
- Cross-node "ns-oid" deduplication;

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
