### PR TITLE
mgr/cephadm: stable nfs-ganesha ranks; nfs + ingress support

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -28,6 +28,20 @@
   support an NFS export of both ``rgw`` and ``cephfs`` from a single
   NFS cluster instance.
 
+* The ``nfs cluster update`` command has been removed.  You can modify
+  the placement of an existing NFS service (and/or its associated
+  ingress service) using ``orch ls --export`` and ``orch apply -i
+  ...``.
+
+* The ``orch apply nfs`` command no longer requires a pool or
+  namespace argument. We strongly encourage users to use the defaults
+  so that the ``nfs cluster ls`` and related commands will work
+  properly.
+
+* The ``nfs cluster delete`` and ``nfs export delete`` commands are
+  deprecated; please use ``nfs cluster rm`` and ``nfs export rm``
+  instead.
+
 * mgr-pg_autoscaler: Autoscaler will now start out by scaling each
   pool to have a full complements of pgs from the start and will only
   decrease it when other pools need more pgs due to increased usage.

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -39,8 +39,8 @@
   properly.
 
 * The ``nfs cluster delete`` and ``nfs export delete`` commands are
-  deprecated; please use ``nfs cluster rm`` and ``nfs export rm``
-  instead.
+  deprecated and will be removed in a future release.  Please use
+  ``nfs cluster rm`` and ``nfs export rm`` instead.
 
 * mgr-pg_autoscaler: Autoscaler will now start out by scaling each
   pool to have a full complements of pgs from the start and will only

--- a/doc/cephadm/nfs.rst
+++ b/doc/cephadm/nfs.rst
@@ -16,17 +16,14 @@ To deploy a NFS Ganesha gateway, run the following command:
 
 .. prompt:: bash #
 
-    ceph orch apply nfs *<svc_id>* *<pool>* *<namespace>* --placement="*<num-daemons>* [*<host1>* ...]"
+    ceph orch apply nfs *<svc_id>* [--port *<port>*] [--placement ...]
 
-For example, to deploy NFS with a service id of *foo* that will use the RADOS
-pool *nfs-ganesha* and the namespace *nfs-ns*, run this command:
+For example, to deploy NFS with a service id of *foo* on the default
+port 2049 with the default placement of a single daemon:
 
 .. prompt:: bash #
 
-   ceph orch apply nfs foo nfs-ganesha nfs-ns
-
-.. note::
-   If the *nfs-ganesha* pool doesn't exist, create it.
+   ceph orch apply nfs foo
 
 See :ref:`orchestrator-cli-placement-spec` for the details of the placement
 specification.
@@ -35,9 +32,6 @@ Service Specification
 =====================
 
 Alternatively, an NFS service can be applied using a YAML specification. 
-
-A service of type ``nfs`` requires a pool name and can contain
-an optional namespace:
 
 .. code-block:: yaml
 
@@ -48,12 +42,10 @@ an optional namespace:
         - host1
         - host2
     spec:
-      pool: mypool
-      namespace: mynamespace
+      port: 12345
 
-In this example, ``pool`` is a RADOS pool where NFS client recovery data is
-stored and ``namespace`` is a RADOS namespace where NFS client recovery data
-is stored.
+In this example, we run the server on the non-default ``port`` of
+12345 (instead of the default 2049) on ``host1`` and ``host2``.
 
 The specification can then be applied by running the following command:
 

--- a/doc/cephadm/nfs.rst
+++ b/doc/cephadm/nfs.rst
@@ -1,16 +1,22 @@
+.. _deploy-cephadm-nfs-ganesha:
+
 ===========
 NFS Service
 ===========
 
 .. note:: Only the NFSv4 protocol is supported.
 
-.. _deploy-cephadm-nfs-ganesha:
+The simplest way to manage NFS is via the ``ceph nfs cluster ...``
+commands; see :ref:`cephfs-nfs`.  This document covers how to manage the
+cephadm services directly, which should only be necessary for unusual NFS
+configurations.
 
 Deploying NFS ganesha
 =====================
 
-Cephadm deploys NFS Ganesha using a pre-defined RADOS *pool*
-and optional *namespace*.
+Cephadm deploys NFS Ganesha daemon (or set of daemons).  The configuration for
+NFS is stored in the ``nfs-ganesha`` pool and exports are managed via the
+``ceph nfs export ...`` commands and via the dashboard.
 
 To deploy a NFS Ganesha gateway, run the following command:
 
@@ -52,3 +58,56 @@ The specification can then be applied by running the following command:
 .. prompt:: bash #
 
    ceph orch apply -i nfs.yaml
+
+
+High-availability NFS
+=====================
+
+Deploying an *ingress* service for an existing *nfs* service will provide:
+
+* a stable, virtual IP that can be used to access the NFS server
+* fail-over between hosts if there is a host failure
+* load distribution across multiple NFS gateways (although this is rarely necessary)
+
+Ingress for NFS can be deployed for an existing NFS service
+(``nfs.mynfs`` in this example) with the following specification:
+
+.. code-block:: yaml
+
+    service_type: ingress
+    service_id: nfs.mynfs
+    placement:
+      count: 2
+    spec:
+      backend_service: nfs.mynfs
+      frontend_port: 2049
+      monitor_port: 9000
+      virtual_ip: 10.0.0.123/24
+
+A few notes:
+
+  * The *virtual_ip* must include a CIDR prefix length, as in the
+    example above.  The virtual IP will normally be configured on the
+    first identified network interface that has an existing IP in the
+    same subnet.  You can also specify a *virtual_interface_networks*
+    property to match against IPs in other networks; see
+    :ref:`ingress-virtual-ip` for more information.
+  * The *monitor_port* is used to access the haproxy load status
+    page.  The user is ``admin`` by default, but can be modified by
+    via an *admin* property in the spec.  If a password is not
+    specified via a *password* property in the spec, the auto-generated password
+    can be found with:
+
+    .. prompt:: bash #
+
+	ceph config-key get mgr/cephadm/ingress.*{svc_id}*/monitor_password
+
+    For example:
+
+    .. prompt:: bash #
+
+	ceph config-key get mgr/cephadm/ingress.nfs.myfoo/monitor_password
+	
+  * The backend service (``nfs.mynfs`` in this example) should include
+    a *port* property that is not 2049 to avoid conflicting with the
+    ingress service, which could be placed on the same host(s).

--- a/doc/cephadm/rgw.rst
+++ b/doc/cephadm/rgw.rst
@@ -112,18 +112,21 @@ elected as master, and the virtual IP will be moved to that node.
 The active haproxy acts like a load balancer, distributing all RGW requests
 between all the RGW daemons available.
 
-**Prerequisites:**
+Prerequisites
+-------------
 
 * An existing RGW service, without SSL.  (If you want SSL service, the certificate
   should be configured on the ingress service, not the RGW service.)
 
-**Deploy of the high availability service for RGW**
+Deploying
+---------
 
 Use the command::
 
     ceph orch apply -i <ingress_spec_file>
 
-**Service specification file:**
+Service specification
+---------------------
 
 It is a yaml format file with the following properties:
 
@@ -171,7 +174,10 @@ where the properties of this service specification are:
     SSL certificate, if SSL is to be enabled. This must contain the both the certificate and
     private key blocks in .pem format.
 
-**Selecting ethernet interfaces for the virtual IP:**
+.. _ingress-virtual-ip:
+
+Selecting ethernet interfaces for the virtual IP
+------------------------------------------------
 
 You cannot simply provide the name of the network interface on which
 to configure the virtual IP because interface names tend to vary
@@ -204,7 +210,8 @@ configuring a "dummy" IP address is an unroutable network on the correct interfa
 and reference that dummy network in the networks list (see above).
 
 
-**Useful hints for ingress:**
+Useful hints for ingress
+------------------------
 
-* Good to have at least 3 RGW daemons
-* Use at least 3 hosts for the ingress
+* It is good to have at least 3 RGW daemons.
+* We recommend at least 3 hosts for the ingress service.

--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -67,7 +67,7 @@ Delete NFS Ganesha Cluster
 
 .. code:: bash
 
-    $ ceph nfs cluster delete <clusterid>
+    $ ceph nfs cluster rm <clusterid>
 
 This deletes the deployed cluster.
 
@@ -194,7 +194,7 @@ Delete CephFS Export
 
 .. code:: bash
 
-    $ ceph nfs export delete <clusterid> <binding>
+    $ ceph nfs export rm <clusterid> <binding>
 
 This deletes an export in an NFS Ganesha cluster, where:
 

--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -53,15 +53,6 @@ cluster)::
 For more details, refer :ref:`orchestrator-cli-placement-spec` but keep
 in mind that specifying the placement via a YAML file is not supported.
 
-Update NFS Ganesha Cluster
-==========================
-
-.. code:: bash
-
-    $ ceph nfs cluster update <clusterid> <placement>
-
-This updates the deployed cluster according to the placement value.
-
 Delete NFS Ganesha Cluster
 ==========================
 

--- a/doc/cephfs/fs-nfs-exports.rst
+++ b/doc/cephfs/fs-nfs-exports.rst
@@ -21,7 +21,7 @@ Create NFS Ganesha Cluster
 
 .. code:: bash
 
-    $ ceph nfs cluster create <clusterid> [<placement>]
+    $ ceph nfs cluster create <clusterid> [<placement>] [--ingress --virtual-ip <ip>]
 
 This creates a common recovery pool for all NFS Ganesha daemons, new user based on
 ``clusterid``, and a common NFS Ganesha config RADOS object.
@@ -49,6 +49,11 @@ on nodes host1 and host2 (for a total of two NFS Ganesha daemons in the
 cluster)::
 
     "2 host1,host2"
+
+To deploy NFS with an HA front-end (virtual IP and load balancer), add the
+``--ingress`` flag and specify a virtual IP address. This will deploy a combination
+of keepalived and haproxy to provide an high-availability NFS frontend for the NFS
+service.
 
 For more details, refer :ref:`orchestrator-cli-placement-spec` but keep
 in mind that specifying the placement via a YAML file is not supported.

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress.yaml
@@ -1,0 +1,68 @@
+tasks:
+- vip:
+
+# make sure cephadm notices the new IP
+- cephadm.shell:
+    host.a:
+      - ceph orch device ls --refresh
+
+# stop kernel nfs server, if running
+- vip.exec:
+    all-hosts:
+      - systemctl stop nfs-server
+
+- cephadm.shell:
+    host.a:
+      - ceph fs volume create foofs
+
+# deploy nfs + ingress
+- cephadm.apply:
+    specs:
+      - service_type: nfs
+        service_id: foo
+        placement:
+          count: 2
+        spec:
+          port: 12049
+      - service_type: ingress
+        service_id: nfs.foo
+        spec:
+          backend_service: nfs.foo
+          frontend_port: 2049
+          monitor_port: 9002
+          virtual_ip: "{{VIP0}}/{{VIPPREFIXLEN}}"
+- cephadm.wait_for_service:
+    service: nfs.foo
+- cephadm.wait_for_service:
+    service: ingress.nfs.foo
+
+## export and mount
+
+- cephadm.shell:
+    host.a:
+      - ceph nfs export create cephfs foofs foo --binding /fake
+
+- vip.exec:
+    host.a:
+      - mkdir /mnt/foo
+      - sleep 5
+      - mount -t nfs {{VIP0}}:/fake /mnt/foo
+      - echo test > /mnt/foo/testfile
+      - sync
+
+# take each gateway down in turn and ensure things still work
+- cephadm.shell:
+    volumes:
+      - /mnt/foo:/mnt/foo
+    host.a:
+      - |
+        echo "Check with each haproxy down in turn..."
+        for haproxy in `ceph orch ps | grep ^haproxy.nfs.foo. | awk '{print $1}'`; do
+          ceph orch daemon stop $haproxy
+          while ! ceph orch ps | grep $haproxy | grep stopped; do sleep 1 ; done
+          cat /mnt/foo/testfile
+          echo $haproxy > /mnt/foo/testfile
+          sync
+          ceph orch daemon start $haproxy
+          while ! ceph orch ps | grep $haproxy | grep running; do sleep 1 ; done
+        done

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress2.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs-ingress2.yaml
@@ -1,0 +1,50 @@
+tasks:
+- vip:
+
+# make sure cephadm notices the new IP
+- cephadm.shell:
+    host.a:
+      - ceph orch device ls --refresh
+
+# stop kernel nfs server, if running
+- vip.exec:
+    all-hosts:
+      - systemctl stop nfs-server
+
+- cephadm.shell:
+    host.a:
+      - ceph fs volume create foofs
+      - ceph nfs cluster create foo --ingress --virtual-ip {{VIP0}}/{{VIPPREFIXLEN}}
+      - ceph nfs export create cephfs foofs foo --binding /fake
+
+- cephadm.wait_for_service:
+    service: nfs.foo
+- cephadm.wait_for_service:
+    service: ingress.nfs.foo
+
+## export and mount
+
+- vip.exec:
+    host.a:
+      - mkdir /mnt/foo
+      - sleep 5
+      - mount -t nfs {{VIP0}}:/fake /mnt/foo
+      - echo test > /mnt/foo/testfile
+      - sync
+
+# take each gateway down in turn and ensure things still work
+- cephadm.shell:
+    volumes:
+      - /mnt/foo:/mnt/foo
+    host.a:
+      - |
+        echo "Check with each haproxy down in turn..."
+        for haproxy in `ceph orch ps | grep ^haproxy.nfs.foo. | awk '{print $1}'`; do
+          ceph orch daemon stop $haproxy
+          while ! ceph orch ps | grep $haproxy | grep stopped; do sleep 1 ; done
+          cat /mnt/foo/testfile
+          echo $haproxy > /mnt/foo/testfile
+          sync
+          ceph orch daemon start $haproxy
+          while ! ceph orch ps | grep $haproxy | grep running; do sleep 1 ; done
+        done

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs.yaml
@@ -1,0 +1,13 @@
+tasks:
+
+# stop kernel nfs server, if running
+- vip.exec:
+    all-hosts:
+      - systemctl stop nfs-server
+
+- cephadm.apply:
+    specs:
+      - service_type: nfs
+        service_id: foo
+- cephadm.wait_for_service:
+    service: nfs.foo

--- a/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs2.yaml
+++ b/qa/suites/orch/cephadm/smoke-roleless/2-services/nfs2.yaml
@@ -1,0 +1,12 @@
+tasks:
+
+# stop kernel nfs server, if running
+- vip.exec:
+    all-hosts:
+      - systemctl stop nfs-server
+
+- cephadm.shell:
+    host.a:
+      - ceph nfs cluster create foo
+- cephadm.wait_for_service:
+    service: nfs.foo

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -986,11 +986,11 @@ def shell(ctx, config):
     """
     cluster_name = config.get('cluster', 'ceph')
 
-    env = []
-    if 'env' in config:
-        for k in config['env']:
-            env.extend(['-e', k + '=' + ctx.config.get(k, '')])
-        del config['env']
+    args = []
+    for k in config.pop('env', []):
+        args.extend(['-e', k + '=' + ctx.config.get(k, '')])
+    for k in config.pop('volumes', []):
+        args.extend(['-v', k])
 
     if 'all-roles' in config and len(config) == 1:
         a = config['all-roles']
@@ -1008,12 +1008,12 @@ def shell(ctx, config):
             for c in cmd:
                 _shell(ctx, cluster_name, remote,
                        ['bash', '-c', subst_vip(ctx, c)],
-                       extra_cephadm_args=env)
+                       extra_cephadm_args=args)
         else:
             assert isinstance(cmd, str)
             _shell(ctx, cluster_name, remote,
                    ['bash', '-ex', '-c', subst_vip(ctx, cmd)],
-                   extra_cephadm_args=env)
+                   extra_cephadm_args=args)
 
 
 def apply(ctx, config):

--- a/qa/tasks/cephfs/test_nfs.py
+++ b/qa/tasks/cephfs/test_nfs.py
@@ -127,7 +127,7 @@ class TestNFS(MgrTestCase):
         '''
         Test deletion of a single nfs cluster.
         '''
-        self._nfs_cmd('cluster', 'delete', self.cluster_id)
+        self._nfs_cmd('cluster', 'rm', self.cluster_id)
         self._check_nfs_cluster_status('No daemons reported',
                                        'NFS Ganesha cluster could not be deleted')
 
@@ -179,7 +179,7 @@ class TestNFS(MgrTestCase):
         '''
         Delete an export.
         '''
-        self._nfs_cmd('export', 'delete', self.cluster_id, self.pseudo_path)
+        self._nfs_cmd('export', 'rm', self.cluster_id, self.pseudo_path)
         self._check_auth_ls()
 
     def _test_list_export(self):
@@ -297,7 +297,7 @@ class TestNFS(MgrTestCase):
         Test idempotency of cluster create and delete commands.
         '''
         self._test_idempotency(self._test_create_cluster, ['nfs', 'cluster', 'create', self.cluster_id])
-        self._test_idempotency(self._test_delete_cluster, ['nfs', 'cluster', 'delete', self.cluster_id])
+        self._test_idempotency(self._test_delete_cluster, ['nfs', 'cluster', 'rm', self.cluster_id])
 
     def test_create_cluster_with_invalid_cluster_id(self):
         '''
@@ -333,7 +333,7 @@ class TestNFS(MgrTestCase):
         self._test_idempotency(self._create_default_export, ['nfs', 'export', 'create', 'cephfs',
                                                              self.fs_name, self.cluster_id,
                                                              self.pseudo_path])
-        self._test_idempotency(self._delete_export, ['nfs', 'export', 'delete', self.cluster_id,
+        self._test_idempotency(self._delete_export, ['nfs', 'export', 'rm', self.cluster_id,
                                                      self.pseudo_path])
         self._test_delete_cluster()
 

--- a/qa/tasks/vip.py
+++ b/qa/tasks/vip.py
@@ -3,6 +3,7 @@ import ipaddress
 import logging
 import re
 
+from teuthology import misc as teuthology
 from teuthology.config import config as teuth_config
 
 log = logging.getLogger(__name__)
@@ -32,6 +33,38 @@ def echo(ctx, config):
     """
     for remote in ctx.cluster.remotes.keys():
         log.info(subst_vip(ctx, config))
+
+
+def exec(ctx, config):
+    """
+    This is similar to the standard 'exec' task, but does the VIP substitutions.
+    """
+    assert isinstance(config, dict), "task exec got invalid config"
+
+    testdir = teuthology.get_testdir(ctx)
+
+    if 'all-roles' in config and len(config) == 1:
+        a = config['all-roles']
+        roles = teuthology.all_roles(ctx.cluster)
+        config = dict((id_, a) for id_ in roles if not id_.startswith('host.'))
+    elif 'all-hosts' in config and len(config) == 1:
+        a = config['all-hosts']
+        roles = teuthology.all_roles(ctx.cluster)
+        config = dict((id_, a) for id_ in roles if id_.startswith('host.'))
+
+    for role, ls in config.items():
+        (remote,) = ctx.cluster.only(role).remotes.keys()
+        log.info('Running commands on role %s host %s', role, remote.name)
+        for c in ls:
+            c.replace('$TESTDIR', testdir)
+            remote.run(
+                args=[
+                    'sudo',
+                    'TESTDIR={tdir}'.format(tdir=testdir),
+                    'bash',
+                    '-c',
+                    subst_vip(ctx, c)],
+                )
 
 
 def map_vips(mip, count):

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -492,43 +492,6 @@ class NFSGanesha(object):
                 os.fchown(f.fileno(), uid, gid)
                 f.write(self.rgw.get('keyring', ''))
 
-    def get_rados_grace_container(self, action):
-        # type: (str) -> CephContainer
-        """Container for a ganesha action on the grace db"""
-        entrypoint = '/usr/bin/ganesha-rados-grace'
-
-        assert self.pool
-        args = ['--pool', self.pool]
-        if self.namespace:
-            args += ['--ns', self.namespace]
-        if self.userid:
-            args += ['--userid', self.userid]
-
-        meta = json.loads(self.ctx.meta_json)
-        if 'service_name' in meta and 'rank' in meta:
-            nodeid = f"{meta['service_name']}.{meta['rank']}"
-        else:
-            nodeid = self.daemon_id
-
-        args += [action, nodeid]
-
-        data_dir = get_data_dir(self.fsid, self.ctx.data_dir,
-                                self.daemon_type, self.daemon_id)
-        volume_mounts = self.get_container_mounts(data_dir)
-        envs = self.get_container_envs()
-
-        logger.info('Creating RADOS grace for action: %s' % action)
-        c = CephContainer(
-            self.ctx,
-            image=self.image,
-            entrypoint=entrypoint,
-            args=args,
-            volume_mounts=volume_mounts,
-            cname=self.get_container_name(desc='grace-%s' % action),
-            envs=envs
-        )
-        return c
-
 ##################################
 
 
@@ -2754,11 +2717,6 @@ def deploy_daemon_units(
                     memory_limit=ctx.memory_limit,
                 )
                 _write_container_cmd_to_bash(ctx, f, prestart, 'LVM OSDs use ceph-volume lvm activate')
-        elif daemon_type == NFSGanesha.daemon_type:
-            # add nfs to the rados grace db
-            nfs_ganesha = NFSGanesha.init(ctx, fsid, daemon_id)
-            prestart = nfs_ganesha.get_rados_grace_container('add')
-            _write_container_cmd_to_bash(ctx, f, prestart, 'add daemon to rados grace')
         elif daemon_type == CephIscsi.daemon_type:
             f.write(' '.join(CephIscsi.configfs_mount_umount(data_dir, mount=True)) + '\n')
             ceph_iscsi = CephIscsi.init(ctx, fsid, daemon_id)
@@ -2807,11 +2765,6 @@ def deploy_daemon_units(
                                                     daemon_id),
             )
             _write_container_cmd_to_bash(ctx, f, poststop, 'deactivate osd')
-        elif daemon_type == NFSGanesha.daemon_type:
-            # remove nfs from the rados grace db
-            nfs_ganesha = NFSGanesha.init(ctx, fsid, daemon_id)
-            poststop = nfs_ganesha.get_rados_grace_container('remove')
-            _write_container_cmd_to_bash(ctx, f, poststop, 'remove daemon from rados grace')
         elif daemon_type == CephIscsi.daemon_type:
             # make sure we also stop the tcmu container
             ceph_iscsi = CephIscsi.init(ctx, fsid, daemon_id)

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4365,8 +4365,8 @@ def command_deploy(ctx):
                       ports=daemon_ports)
 
     elif daemon_type == NFSGanesha.daemon_type:
-        if not ctx.reconfig and not redeploy:
-            daemon_ports.extend(NFSGanesha.port_map.values())
+        if not ctx.reconfig and not redeploy and not daemon_ports:
+            daemon_ports = list(NFSGanesha.port_map.values())
 
         config, keyring = get_config_and_keyring(ctx)
         # TODO: extract ganesha uid/gid (997, 994) ?

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4478,6 +4478,10 @@ def command_shell(ctx):
                                             os.path.join(home, f))
             mounts[home] = '/root'
 
+    for i in ctx.volume:
+        a, b = i.split(':', 1)
+        mounts[a] = b
+
     c = CephContainer(
         ctx,
         image=ctx.image,
@@ -7650,6 +7654,11 @@ def _get_parser():
         nargs='+')
     parser_shell.add_argument(
         '--env', '-e',
+        action='append',
+        default=[],
+        help='set environment variable')
+    parser_shell.add_argument(
+        '--volume', '-v',
         action='append',
         default=[],
         help='set environment variable')

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -3091,6 +3091,10 @@ class CephContainer:
             'run',
             '--rm',
             '--ipc=host',
+            # some containers (ahem, haproxy) override this, but we want a fast
+            # shutdown always (and, more importantly, a successful exit even if we
+            # fall back to SIGKILL).
+            '--stop-signal=SIGTERM',
         ]
 
         if isinstance(self.ctx.container_engine, Podman):

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -503,7 +503,14 @@ class NFSGanesha(object):
             args += ['--ns', self.namespace]
         if self.userid:
             args += ['--userid', self.userid]
-        args += [action, self.get_daemon_name()]
+
+        meta = json.loads(self.ctx.meta_json)
+        if 'service_name' in meta and 'rank' in meta:
+            nodeid = f"{meta['service_name']}.{meta['rank']}"
+        else:
+            nodeid = self.daemon_id
+
+        args += [action, nodeid]
 
         data_dir = get_data_dir(self.fsid, self.ctx.data_dir,
                                 self.daemon_type, self.daemon_id)

--- a/src/common/options/mgr.yaml.in
+++ b/src/common/options/mgr.yaml.in
@@ -126,7 +126,7 @@ options:
     first started after installation, to populate the list of enabled manager modules.  Subsequent
     updates are done using the 'mgr module [enable|disable]' commands.  List may be
     comma or space separated.
-  default: restful iostat
+  default: restful iostat nfs
   services:
   - mon
   - common

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -122,6 +122,7 @@ class Inventory:
 
 class SpecDescription(NamedTuple):
     spec: ServiceSpec
+    rank_map: Optional[Dict[int, Dict[int, Optional[str]]]]
     created: datetime.datetime
     deleted: Optional[datetime.datetime]
 
@@ -131,6 +132,8 @@ class SpecStore():
         # type: (CephadmOrchestrator) -> None
         self.mgr = mgr
         self._specs = {}  # type: Dict[str, ServiceSpec]
+        # service_name -> rank -> gen -> daemon_id
+        self._rank_maps = {}    # type: Dict[str, Dict[int, Dict[int, Optional[str]]]]
         self.spec_created = {}  # type: Dict[str, datetime.datetime]
         self.spec_deleted = {}  # type: Dict[str, datetime.datetime]
         self.spec_preview = {}  # type: Dict[str, ServiceSpec]
@@ -149,6 +152,7 @@ class SpecStore():
         if name not in self._specs:
             raise OrchestratorError(f'Service {name} not found.')
         return SpecDescription(self._specs[name],
+                               self._rank_maps.get(name),
                                self.spec_created[name],
                                self.spec_deleted.get(name, None))
 
@@ -171,6 +175,25 @@ class SpecStore():
                     deleted = str_to_datetime(cast(str, j['deleted']))
                     self.spec_deleted[service_name] = deleted
 
+                if 'rank_map' in j and isinstance(j['rank_map'], dict):
+                    self._rank_maps[service_name] = {}
+                    for rank_str, m in j['rank_map'].items():
+                        try:
+                            rank = int(rank_str)
+                        except ValueError:
+                            logger.exception(f"failed to parse rank in {j['rank_map']}")
+                            continue
+                        if isinstance(m, dict):
+                            self._rank_maps[service_name][rank] = {}
+                            for gen_str, name in m.items():
+                                try:
+                                    gen = int(gen_str)
+                                except ValueError:
+                                    logger.exception(f"failed to parse gen in {j['rank_map']}")
+                                    continue
+                                if isinstance(name, str) or m is None:
+                                    self._rank_maps[service_name][rank][gen] = name
+
                 self.mgr.log.debug('SpecStore: loaded spec for %s' % (
                     service_name))
             except Exception as e:
@@ -178,7 +201,11 @@ class SpecStore():
                     service_name, e))
                 pass
 
-    def save(self, spec: ServiceSpec, update_create: bool = True) -> None:
+    def save(
+            self,
+            spec: ServiceSpec,
+            update_create: bool = True,
+    ) -> None:
         name = spec.service_name()
         if spec.preview_only:
             self.spec_preview[name] = spec
@@ -187,11 +214,21 @@ class SpecStore():
 
         if update_create:
             self.spec_created[name] = datetime_now()
+        self._save(name)
 
-        data = {
-            'spec': spec.to_json(),
+    def save_rank_map(self,
+                      name: str,
+                      rank_map: Dict[int, Dict[int, Optional[str]]]) -> None:
+        self._rank_maps[name] = rank_map
+        self._save(name)
+
+    def _save(self, name: str) -> None:
+        data: Dict[str, Any] = {
+            'spec': self._specs[name].to_json(),
             'created': datetime_to_str(self.spec_created[name]),
         }
+        if name in self._rank_maps:
+            data['rank_map'] = self._rank_maps[name]
         if name in self.spec_deleted:
             data['deleted'] = datetime_to_str(self.spec_deleted[name])
 
@@ -199,7 +236,9 @@ class SpecStore():
             SPEC_STORE_PREFIX + name,
             json.dumps(data, sort_keys=True),
         )
-        self.mgr.events.for_service(spec, OrchestratorEvent.INFO, 'service was created')
+        self.mgr.events.for_service(self._specs[name],
+                                    OrchestratorEvent.INFO,
+                                    'service was created')
 
     def rm(self, service_name: str) -> bool:
         if service_name not in self._specs:
@@ -218,6 +257,8 @@ class SpecStore():
         found = service_name in self._specs
         if found:
             del self._specs[service_name]
+            if service_name in self._rank_maps:
+                del self._rank_maps[service_name]
             del self.spec_created[service_name]
             if service_name in self.spec_deleted:
                 del self.spec_deleted[service_name]

--- a/src/pybind/mgr/cephadm/inventory.py
+++ b/src/pybind/mgr/cephadm/inventory.py
@@ -167,7 +167,7 @@ class SpecStore():
                 self._specs[service_name] = spec
                 self.spec_created[service_name] = created
 
-                if 'deleted' in v:
+                if 'deleted' in j:
                     deleted = str_to_datetime(cast(str, j['deleted']))
                     self.spec_deleted[service_name] = deleted
 

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -584,7 +584,7 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         Generate a unique random service name
         """
         suffix = daemon_type not in [
-            'mon', 'crash', 'nfs',
+            'mon', 'crash',
             'prometheus', 'node-exporter', 'grafana', 'alertmanager',
             'container', 'cephadm-exporter',
         ]

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2255,7 +2255,7 @@ Then run the following:
             'service_name': spec.service_name(),
             'service_type': spec.service_type,
             'add': [hs.hostname for hs in to_add],
-            'remove': [d.hostname for d in to_remove]
+            'remove': [d.name() for d in to_remove]
         }
 
     @handle_orch_error

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -570,9 +570,16 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
         # cephadm
         self._kick_serve_loop()
 
-    def get_unique_name(self, daemon_type, host, existing, prefix=None,
-                        forcename=None):
-        # type: (str, str, List[orchestrator.DaemonDescription], Optional[str], Optional[str]) -> str
+    def get_unique_name(
+            self,
+            daemon_type: str,
+            host: str,
+            existing: List[orchestrator.DaemonDescription],
+            prefix: Optional[str] = None,
+            forcename: Optional[str] = None,
+            rank: Optional[int] = None,
+            rank_generation: Optional[int] = None,
+    ) -> str:
         """
         Generate a unique random service name
         """
@@ -594,6 +601,8 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
                 name = prefix + '.'
             else:
                 name = ''
+            if rank is not None and rank_generation is not None:
+                name += f'{rank}.{rank_generation}.'
             name += host
             if suffix:
                 name += '.' + ''.join(random.choice(string.ascii_lowercase)

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -2241,12 +2241,14 @@ Then run the following:
                     'service_type': spec.service_type,
                     'data': self._preview_osdspecs(osdspecs=[cast(DriveGroupSpec, spec)])}
 
+        svc = self.cephadm_services[spec.service_type]
         ha = HostAssignment(
             spec=spec,
             hosts=self._schedulable_hosts(),
             networks=self.cache.networks,
             daemons=self.cache.get_daemons_by_service(spec.service_name()),
-            allow_colo=self.cephadm_services[spec.service_type].allow_colo(),
+            allow_colo=svc.allow_colo(),
+            rank_map=self.spec_store[spec.service_name()].rank_map if svc.ranked() else None
         )
         ha.validate()
         hosts, to_add, to_remove = ha.place()

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1704,7 +1704,7 @@ Then run the following:
                          refresh: bool = False) -> List[orchestrator.ServiceDescription]:
         if refresh:
             self._invalidate_daemons_and_kick_serve()
-            self.log.info('Kicked serve() loop to refresh all services')
+            self.log.debug('Kicked serve() loop to refresh all services')
 
         sm: Dict[str, orchestrator.ServiceDescription] = {}
 
@@ -1788,7 +1788,7 @@ Then run the following:
                      refresh: bool = False) -> List[orchestrator.DaemonDescription]:
         if refresh:
             self._invalidate_daemons_and_kick_serve(host)
-            self.log.info('Kicked serve() loop to refresh all daemons')
+            self.log.debug('Kicked serve() loop to refresh all daemons')
 
         result = []
         for h, dm in self.cache.get_daemons_with_volatile_status():
@@ -1954,13 +1954,15 @@ Then run the following:
         if refresh:
             if host_filter and host_filter.hosts:
                 for h in host_filter.hosts:
+                    self.log.debug(f'will refresh {h} devs')
                     self.cache.invalidate_host_devices(h)
             else:
                 for h in self.cache.get_hosts():
+                    self.log.debug(f'will refresh {h} devs')
                     self.cache.invalidate_host_devices(h)
 
             self.event.set()
-            self.log.info('Kicked serve() loop to refresh devices')
+            self.log.debug('Kicked serve() loop to refresh devices')
 
         result = []
         for host, dls in self.cache.devices.items():

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -28,8 +28,7 @@ class DaemonPlacement(NamedTuple):
         if self.name:
             other.append(f'name={self.name}')
         if self.ports:
-            other.append(
-                f'{self.ip or "*"}:{self.ports[0] if len(self.ports) == 1 else ",".join(map(str, self.ports))}')
+            other.append(f'{self.ip or "*"}:{",".join(map(str, self.ports))}')
         if other:
             res += '(' + ' '.join(other) + ')'
         return res

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import random
 from typing import List, Optional, Callable, TypeVar, Tuple, NamedTuple, Dict
@@ -308,7 +309,10 @@ class HostAssignment(object):
 
         # shuffle for pseudo random selection
         # gen seed off of self.spec to make shuffling deterministic
-        seed = hash(self.spec.service_name())
-        random.Random(seed).shuffle(ls)
-
+        seed = int(
+            hashlib.sha1(self.spec.service_name().encode('utf-8')).hexdigest(),
+            16
+        ) % (2 ** 32)
+        final = sorted(ls)
+        random.Random(seed).shuffle(final)
         return ls

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -19,10 +19,14 @@ class DaemonPlacement(NamedTuple):
     name: str = ''
     ip: Optional[str] = None
     ports: List[int] = []
+    rank: Optional[int] = None
+    rank_generation: Optional[int] = None
 
     def __str__(self) -> str:
         res = self.daemon_type + ':' + self.hostname
         other = []
+        if self.rank is not None:
+            other.append(f'rank={self.rank}.{self.rank_generation}')
         if self.network:
             other.append(f'network={self.network}')
         if self.name:
@@ -41,6 +45,8 @@ class DaemonPlacement(NamedTuple):
             self.name,
             self.ip,
             [p + n for p in self.ports],
+            self.rank,
+            self.rank_generation,
         )
 
     def matches_daemon(self, dd: DaemonDescription) -> bool:

--- a/src/pybind/mgr/cephadm/schedule.py
+++ b/src/pybind/mgr/cephadm/schedule.py
@@ -49,6 +49,52 @@ class DaemonPlacement(NamedTuple):
             self.rank_generation,
         )
 
+    def assign_rank(self, rank: int, gen: int) -> 'DaemonPlacement':
+        return DaemonPlacement(
+            self.daemon_type,
+            self.hostname,
+            self.network,
+            self.name,
+            self.ip,
+            self.ports,
+            rank,
+            gen,
+        )
+
+    def assign_name(self, name: str) -> 'DaemonPlacement':
+        return DaemonPlacement(
+            self.daemon_type,
+            self.hostname,
+            self.network,
+            name,
+            self.ip,
+            self.ports,
+            self.rank,
+            self.rank_generation,
+        )
+
+    def assign_rank_generation(
+            self,
+            rank: int,
+            rank_map: Dict[int, Dict[int, Optional[str]]]
+    ) -> 'DaemonPlacement':
+        if rank not in rank_map:
+            rank_map[rank] = {}
+            gen = 0
+        else:
+            gen = max(rank_map[rank].keys()) + 1
+        rank_map[rank][gen] = None
+        return DaemonPlacement(
+            self.daemon_type,
+            self.hostname,
+            self.network,
+            self.name,
+            self.ip,
+            self.ports,
+            rank,
+            gen,
+        )
+
     def matches_daemon(self, dd: DaemonDescription) -> bool:
         if self.daemon_type != dd.daemon_type:
             return False
@@ -64,6 +110,31 @@ class DaemonPlacement(NamedTuple):
                 return False
         return True
 
+    def matches_rank_map(
+            self,
+            dd: DaemonDescription,
+            rank_map: Optional[Dict[int, Dict[int, Optional[str]]]],
+            ranks: List[int]
+    ) -> bool:
+        if rank_map is None:
+            # daemon should have no rank
+            return dd.rank is None
+
+        if dd.rank is None:
+            return False
+
+        if dd.rank not in rank_map:
+            return False
+        if dd.rank not in ranks:
+            return False
+
+        # must be the highest/newest rank_generation
+        if dd.rank_generation != max(rank_map[dd.rank].keys()):
+            return False
+
+        # must be *this* daemon
+        return rank_map[dd.rank][dd.rank_generation] == dd.daemon_id
+
 
 class HostAssignment(object):
 
@@ -76,6 +147,7 @@ class HostAssignment(object):
                  allow_colo: bool = False,
                  primary_daemon_type: Optional[str] = None,
                  per_host_daemon_type: Optional[str] = None,
+                 rank_map: Optional[Dict[int, Dict[int, Optional[str]]]] = None,
                  ):
         assert spec
         self.spec = spec  # type: ServiceSpec
@@ -88,6 +160,7 @@ class HostAssignment(object):
         self.allow_colo = allow_colo
         self.per_host_daemon_type = per_host_daemon_type
         self.ports_start = spec.get_port_start()
+        self.rank_map = rank_map
 
     def hosts_by_label(self, label: str) -> List[orchestrator.HostSpec]:
         return [h for h in self.hosts if label in h.labels]
@@ -195,12 +268,18 @@ class HostAssignment(object):
             per_host = 1 + ((count - 1) // len(candidates))
             candidates = expand_candidates(candidates, per_host)
 
-        # consider active (primary) daemons first
-        daemons = [
-            d for d in self.daemons if d.is_active and d.daemon_type == self.primary_daemon_type
-        ] + [
-            d for d in self.daemons if not d.is_active and d.daemon_type == self.primary_daemon_type
-        ]
+        # consider (preserve) existing daemons in a particular order...
+        daemons = sorted(
+            [
+                d for d in self.daemons if d.daemon_type == self.primary_daemon_type
+            ],
+            key=lambda d: (
+                not d.is_active,               # active before standby
+                d.rank is not None,            # ranked first, then non-ranked
+                d.rank,                        # low ranks
+                0 - (d.rank_generation or 0),  # newer generations first
+            )
+        )
 
         # sort candidates into existing/used slots that already have a
         # daemon, and others (the rest)
@@ -208,16 +287,21 @@ class HostAssignment(object):
         existing_standby: List[orchestrator.DaemonDescription] = []
         existing_slots: List[DaemonPlacement] = []
         to_remove: List[orchestrator.DaemonDescription] = []
-        others = candidates.copy()
+        ranks: List[int] = list(range(len(candidates)))
+        others: List[DaemonPlacement] = candidates.copy()
         for dd in daemons:
             found = False
             for p in others:
-                if p.matches_daemon(dd):
+                if p.matches_daemon(dd) and p.matches_rank_map(dd, self.rank_map, ranks):
                     others.remove(p)
                     if dd.is_active:
                         existing_active.append(dd)
                     else:
                         existing_standby.append(dd)
+                    if dd.rank is not None:
+                        assert dd.rank_generation is not None
+                        p = p.assign_rank(dd.rank, dd.rank_generation)
+                        ranks.remove(dd.rank)
                     existing_slots.append(p)
                     found = True
                     break
@@ -226,22 +310,34 @@ class HostAssignment(object):
 
         existing = existing_active + existing_standby
 
+        # build to_add
+        if not count:
+            to_add = others
+        else:
+            # The number of new slots that need to be selected in order to fulfill count
+            need = count - len(existing)
+
+            # we don't need any additional placements
+            if need <= 0:
+                to_remove.extend(existing[count:])
+                del existing_slots[count:]
+                return self.place_per_host_daemons(existing_slots, [], to_remove)
+
+            if need > 0:
+                to_add = others[:need]
+
+        if self.rank_map is not None:
+            # assign unused ranks (and rank_generations) to to_add
+            assert len(ranks) >= len(to_add)
+            for i in range(len(to_add)):
+                to_add[i] = to_add[i].assign_rank_generation(ranks[i], self.rank_map)
+
         # If we don't have <count> the list of candidates is definitive.
         if count is None:
-            logger.debug('Provided hosts: %s' % candidates)
-            return self.place_per_host_daemons(candidates, others, to_remove)
+            final = existing_slots + to_add
+            logger.debug('Provided hosts: %s' % final)
+            return self.place_per_host_daemons(final, to_add, to_remove)
 
-        # The number of new slots that need to be selected in order to fulfill count
-        need = count - len(existing)
-
-        # we don't need any additional placements
-        if need <= 0:
-            to_remove.extend(existing[count:])
-            del existing_slots[count:]
-            return self.place_per_host_daemons(existing_slots, [], to_remove)
-
-        # ask the scheduler to select additional slots
-        to_add = others[:need]
         logger.debug('Combine hosts with existing daemons %s + new hosts %s' % (
             existing, to_add))
         return self.place_per_host_daemons(existing_slots + to_add, to_add, to_remove)

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -782,10 +782,10 @@ class CephadmServe:
                 self._create_daemon(daemon_spec)
                 r = True
             except (RuntimeError, OrchestratorError) as e:
-                self.mgr.events.for_service(
-                    spec, 'ERROR',
-                    f"Failed while placing {slot.daemon_type}.{daemon_id} "
-                    f"on {slot.hostname}: {e}")
+                msg = (f"Failed while placing {slot.daemon_type}.{daemon_id} "
+                       f"on {slot.hostname}: {e}")
+                self.mgr.events.for_service(spec, 'ERROR', msg)
+                self.mgr.log.error(msg)
                 # only return "no change" if no one else has already succeeded.
                 # later successes will also change to True
                 if r is None:

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -840,6 +840,10 @@ class CephadmServe:
             if spec and spec.unmanaged:
                 continue
 
+            # ignore daemons for deleted services
+            if dd.service_name() in self.mgr.spec_store.spec_deleted:
+                continue
+
             # These daemon types require additional configs after creation
             if dd.daemon_type in ['grafana', 'iscsi', 'prometheus', 'alertmanager', 'nfs']:
                 daemons_post[dd.daemon_type].append(dd)

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -664,6 +664,9 @@ class CephadmServe:
             )
             return False
 
+        rank_map = None
+        if svc.ranked():
+            rank_map = self.mgr.spec_store[spec.service_name()].rank_map or {}
         ha = HostAssignment(
             spec=spec,
             hosts=self.mgr._schedulable_hosts(),
@@ -676,6 +679,7 @@ class CephadmServe:
             allow_colo=svc.allow_colo(),
             primary_daemon_type=svc.primary_daemon_type(),
             per_host_daemon_type=svc.per_host_daemon_type(),
+            rank_map=rank_map,
         )
 
         try:
@@ -703,6 +707,40 @@ class CephadmServe:
         self.log.debug('Hosts that will receive new daemons: %s' % slots_to_add)
         self.log.debug('Daemons that will be removed: %s' % daemons_to_remove)
 
+        # assign names
+        for i in range(len(slots_to_add)):
+            slot = slots_to_add[i]
+            slot = slot.assign_name(self.mgr.get_unique_name(
+                slot.daemon_type,
+                slot.hostname,
+                daemons,
+                prefix=spec.service_id,
+                forcename=slot.name,
+                rank=slot.rank,
+                rank_generation=slot.rank_generation,
+            ))
+            slots_to_add[i] = slot
+            if rank_map is not None:
+                assert slot.rank is not None
+                assert slot.rank_generation is not None
+                assert rank_map[slot.rank][slot.rank_generation] is None
+                rank_map[slot.rank][slot.rank_generation] = slot.name
+
+        if rank_map:
+            # record the rank_map before we make changes so that if we fail the
+            # next mgr will clean up.
+            self.mgr.spec_store.save_rank_map(spec.service_name(), rank_map)
+
+            # remove daemons now, since we are going to fence them anyway
+            for d in daemons_to_remove:
+                assert d.hostname is not None
+                self._remove_daemon(d.name(), d.hostname)
+            daemons_to_remove = []
+
+            # fence them
+            svc.fence_old_ranks(spec, rank_map, len(all_slots))
+
+        # create daemons
         for slot in slots_to_add:
             # first remove daemon on conflicting port?
             if slot.ports:
@@ -723,13 +761,7 @@ class CephadmServe:
                     break
 
             # deploy new daemon
-            daemon_id = self.mgr.get_unique_name(
-                slot.daemon_type,
-                slot.hostname,
-                daemons,
-                prefix=spec.service_id,
-                forcename=slot.name)
-
+            daemon_id = slot.name
             if not did_config:
                 svc.config(spec, daemon_id)
                 did_config = True

--- a/src/pybind/mgr/cephadm/serve.py
+++ b/src/pybind/mgr/cephadm/serve.py
@@ -420,6 +420,8 @@ class CephadmServe:
             sd.version = d.get('version')
             sd.ports = d.get('ports')
             sd.ip = d.get('ip')
+            sd.rank = int(d['rank']) if d.get('rank') is not None else None
+            sd.rank_generation = int(d['rank_generation']) if d.get('rank_generation') is not None else None
             if sd.daemon_type == 'osd':
                 sd.osdspec_affinity = self.mgr.osd_service.get_osdspec_affinity(sd.daemon_id)
             if 'state' in d:
@@ -737,6 +739,8 @@ class CephadmServe:
                 daemon_type=slot.daemon_type,
                 ports=slot.ports,
                 ip=slot.ip,
+                rank=slot.rank,
+                rank_generation=slot.rank_generation,
             )
             self.log.debug('Placing %s.%s on host %s' % (
                 slot.daemon_type, daemon_id, slot.hostname))
@@ -966,6 +970,8 @@ class CephadmServe:
                             'ports': daemon_spec.ports,
                             'ip': daemon_spec.ip,
                             'deployed_by': self.mgr.get_active_mgr_digests(),
+                            'rank': daemon_spec.rank,
+                            'rank_generation': daemon_spec.rank_generation,
                         }),
                         '--config-json', '-',
                     ] + daemon_spec.extra_args,

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -34,7 +34,9 @@ class CephadmDaemonDeploySpec:
                  extra_files: Optional[Dict[str, Any]] = None,
                  daemon_type: Optional[str] = None,
                  ip: Optional[str] = None,
-                 ports: Optional[List[int]] = None):
+                 ports: Optional[List[int]] = None,
+                 rank: Optional[int] = None,
+                 rank_generation: Optional[int] = None):
         """
         A data struction to encapsulate `cephadm deploy ...
         """
@@ -66,6 +68,9 @@ class CephadmDaemonDeploySpec:
         self.final_config: Dict[str, Any] = {}
         self.deps: List[str] = []
 
+        self.rank: Optional[int] = rank
+        self.rank_generation: Optional[int] = rank_generation
+
     def name(self) -> str:
         return '%s.%s' % (self.daemon_type, self.daemon_id)
 
@@ -88,6 +93,8 @@ class CephadmDaemonDeploySpec:
             service_name=dd.service_name(),
             ip=dd.ip,
             ports=dd.ports,
+            rank=dd.rank,
+            rank_generation=dd.rank_generation,
         )
 
     def to_daemon_description(self, status: DaemonDescriptionStatus, status_desc: str) -> DaemonDescription:
@@ -100,6 +107,8 @@ class CephadmDaemonDeploySpec:
             status_desc=status_desc,
             ip=self.ip,
             ports=self.ports,
+            rank=self.rank,
+            rank_generation=self.rank_generation,
         )
 
 
@@ -137,13 +146,16 @@ class CephadmService(metaclass=ABCMeta):
         return None
 
     def make_daemon_spec(
-            self, host: str,
+            self,
+            host: str,
             daemon_id: str,
             network: str,
             spec: ServiceSpecs,
             daemon_type: Optional[str] = None,
             ports: Optional[List[int]] = None,
             ip: Optional[str] = None,
+            rank: Optional[int] = None,
+            rank_generation: Optional[int] = None,
     ) -> CephadmDaemonDeploySpec:
         return CephadmDaemonDeploySpec(
             host=host,
@@ -153,6 +165,8 @@ class CephadmService(metaclass=ABCMeta):
             daemon_type=daemon_type,
             ports=ports,
             ip=ip,
+            rank=rank,
+            rank_generation=rank_generation,
         )
 
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -116,13 +116,24 @@ class CephadmService(metaclass=ABCMeta):
         self.mgr: "CephadmOrchestrator" = mgr
 
     def allow_colo(self) -> bool:
+        """
+        Return True if multiple daemons of the same type can colocate on
+        the same host.
+        """
         return False
 
-    def per_host_daemon_type(self) -> Optional[str]:
-        return None
-
     def primary_daemon_type(self) -> str:
+        """
+        This is the type of the primary (usually only) daemon to be deployed.
+        """
         return self.TYPE
+
+    def per_host_daemon_type(self) -> Optional[str]:
+        """
+        If defined, this type of daemon will be deployed once for each host
+        containing one or more daemons of the primary type.
+        """
+        return None
 
     def make_daemon_spec(
             self, host: str,

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -145,6 +145,19 @@ class CephadmService(metaclass=ABCMeta):
         """
         return None
 
+    def ranked(self) -> bool:
+        """
+        If True, we will assign a stable rank (0, 1, ...) and monotonically increasing
+        generation (0, 1, ...) to each daemon we create/deploy.
+        """
+        return False
+
+    def fence_old_ranks(self,
+                        spec: ServiceSpec,
+                        rank_map: Dict[int, Dict[int, Optional[str]]],
+                        num_ranks: int) -> None:
+        assert False
+
     def make_daemon_spec(
             self,
             host: str,

--- a/src/pybind/mgr/cephadm/services/cephadmservice.py
+++ b/src/pybind/mgr/cephadm/services/cephadmservice.py
@@ -94,6 +94,7 @@ class CephadmDaemonDeploySpec:
         return DaemonDescription(
             daemon_type=self.daemon_type,
             daemon_id=self.daemon_id,
+            service_name=self.service_name,
             hostname=self.host,
             status=status,
             status_desc=status_desc,

--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -6,7 +6,7 @@ from typing import List, Dict, Any, Tuple, cast, Optional
 
 from ceph.deployment.service_spec import IngressSpec
 from cephadm.utils import resolve_ip
-
+from orchestrator import OrchestratorError
 from cephadm.services.cephadmservice import CephadmDaemonDeploySpec, CephService
 
 logger = logging.getLogger(__name__)
@@ -209,7 +209,9 @@ class IngressService(CephService):
                     )
                     break
         if not interface:
-            interface = 'eth0'
+            raise OrchestratorError(
+                "Unable to identify interface for {spec.virtual_ip} on {host}"
+            )
 
         # script to monitor health
         script = '/usr/bin/false'

--- a/src/pybind/mgr/cephadm/services/ingress.py
+++ b/src/pybind/mgr/cephadm/services/ingress.py
@@ -210,7 +210,7 @@ class IngressService(CephService):
                     break
         if not interface:
             raise OrchestratorError(
-                "Unable to identify interface for {spec.virtual_ip} on {host}"
+                f"Unable to identify interface for {spec.virtual_ip} on {host}"
             )
 
         # script to monitor health

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -55,9 +55,11 @@ class NFSService(CephService):
                         self.mgr.spec_store.save_rank_map(spec.service_name(), rank_map)
 
     def config(self, spec: NFSServiceSpec, daemon_id: str) -> None:  # type: ignore
+        from nfs.cluster import create_ganesha_pool
+
         assert self.TYPE == spec.service_type
         assert spec.pool
-        self.mgr._check_pool_exists(spec.pool, spec.service_name())
+        create_ganesha_pool(self.mgr, spec.pool)
 
     def prepare_create(self, daemon_spec: CephadmDaemonDeploySpec) -> CephadmDaemonDeploySpec:
         assert self.TYPE == daemon_spec.daemon_type

--- a/src/pybind/mgr/cephadm/services/nfs.py
+++ b/src/pybind/mgr/cephadm/services/nfs.py
@@ -82,12 +82,17 @@ class NFSService(CephService):
 
         # generate the ganesha config
         def get_ganesha_conf() -> str:
-            context = dict(user=rados_user,
-                           nodeid=f'{daemon_spec.service_name}.{daemon_spec.rank}',
-                           pool=spec.pool,
-                           namespace=spec.namespace if spec.namespace else '',
-                           rgw_user=rgw_user,
-                           url=spec.rados_config_location())
+            context = {
+                "user": rados_user,
+                "nodeid": f'{daemon_spec.service_name}.{daemon_spec.rank}',
+                "pool": spec.pool,
+                "namespace": spec.namespace if spec.namespace else '',
+                "rgw_user": rgw_user,
+                "url": spec.rados_config_location(),
+                # fall back to default NFS port if not present in daemon_spec
+                "port": daemon_spec.ports[0] if daemon_spec.ports else 2049,
+                "bind_addr": daemon_spec.ip if daemon_spec.ip else '',
+            }
             return self.mgr.template.render('services/nfs/ganesha.conf.j2', context)
 
         # generate the cephadm config json

--- a/src/pybind/mgr/cephadm/templates/services/ingress/haproxy.cfg.j2
+++ b/src/pybind/mgr/cephadm/templates/services/ingress/haproxy.cfg.j2
@@ -19,24 +19,34 @@ global
 {% endif %}
 
 defaults
-    mode                    http
+    mode                    {{ mode }}
     log                     global
+{% if mode == 'http' %}
     option                  httplog
     option                  dontlognull
     option http-server-close
     option forwardfor       except 127.0.0.0/8
     option                  redispatch
     retries                 3
-    timeout http-request    1s
     timeout queue           20s
     timeout connect         5s
+    timeout http-request    1s
+    timeout http-keep-alive 5s
     timeout client          1s
     timeout server          1s
-    timeout http-keep-alive 5s
     timeout check           5s
+{% endif %}
+{% if mode == 'tcp' %}
+    timeout queue           1m
+    timeout connect         10s
+    timeout client          1m
+    timeout server          1m
+    timeout check           10s
+{% endif %}
     maxconn                 8000
 
 frontend stats
+    mode http
     bind {{ ip }}:{{ monitor_port }}
     stats enable
     stats uri /stats
@@ -54,9 +64,19 @@ frontend frontend
     default_backend backend
 
 backend backend
+{% if mode == 'http' %}
     option forwardfor
     balance static-rr
     option httpchk HEAD / HTTP/1.0
     {% for server in servers %}
     server {{ server.name }} {{ server.ip }}:{{ server.port }} check weight 100
     {% endfor %}
+{% endif %}
+{% if mode == 'tcp' %}
+    mode        tcp
+    balance     source
+    hash-type   consistent
+    {% for server in servers %}
+    server {{ server.name }} {{ server.ip }}:{{ server.port }}
+    {% endfor %}
+{% endif %}

--- a/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
+++ b/src/pybind/mgr/cephadm/templates/services/nfs/ganesha.conf.j2
@@ -3,6 +3,10 @@ NFS_CORE_PARAM {
         Enable_NLM = false;
         Enable_RQUOTA = false;
         Protocols = 4;
+        NFS_Port = {{ port }};
+{% if bind_addr %}
+        Bind_addr = {{ bind_addr }};
+{% endif %}
 }
 
 MDCACHE {

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -918,6 +918,8 @@ class TestCephadm(object):
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.services.nfs.NFSService.run_grace_tool", mock.MagicMock())
     @mock.patch("cephadm.services.nfs.NFSService.create_rados_config_obj", mock.MagicMock())
+    @mock.patch("cephadm.services.nfs.NFSService.purge", mock.MagicMock())
+    @mock.patch("subprocess.run", mock.MagicMock())
     def test_apply_save(self, spec: ServiceSpec, meth, cephadm_module: CephadmOrchestrator):
         with with_host(cephadm_module, 'test'):
             with with_service(cephadm_module, spec, meth, 'test'):

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -117,6 +117,7 @@ class TestCephadm(object):
 
                 assert [remove_id_events(dd) for dd in wait(cephadm_module, c)] == [
                     {
+                        'service_name': 'mds.name',
                         'daemon_type': 'mds',
                         'hostname': 'test',
                         'status': 1,

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -755,6 +755,7 @@ class TestCephadm(object):
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.services.nfs.NFSService.run_grace_tool", mock.MagicMock())
+    @mock.patch("cephadm.services.nfs.NFSService.purge", mock.MagicMock())
     @mock.patch("cephadm.services.nfs.NFSService.create_rados_config_obj", mock.MagicMock())
     def test_nfs(self, cephadm_module):
         with with_host(cephadm_module, 'test'):

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -755,7 +755,7 @@ class TestCephadm(object):
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.services.nfs.NFSService.run_grace_tool", mock.MagicMock())
-    @mock.patch("cephadm.module.CephadmOrchestrator.rados", mock.MagicMock())
+    @mock.patch("cephadm.services.nfs.NFSService.create_rados_config_obj", mock.MagicMock())
     def test_nfs(self, cephadm_module):
         with with_host(cephadm_module, 'test'):
             ps = PlacementSpec(hosts=['test'], count=1)
@@ -917,6 +917,7 @@ class TestCephadm(object):
     @mock.patch("subprocess.run", None)
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
     @mock.patch("cephadm.services.nfs.NFSService.run_grace_tool", mock.MagicMock())
+    @mock.patch("cephadm.services.nfs.NFSService.create_rados_config_obj", mock.MagicMock())
     def test_apply_save(self, spec: ServiceSpec, meth, cephadm_module: CephadmOrchestrator):
         with with_host(cephadm_module, 'test'):
             with with_service(cephadm_module, spec, meth, 'test'):

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -290,7 +290,7 @@ class TestCephadm(object):
                 _run_cephadm.assert_called_with(
                     'test', 'mon.test', 'deploy', [
                         '--name', 'mon.test',
-                        '--meta-json', '{"service_name": "mon", "ports": [], "ip": null, "deployed_by": []}',
+                        '--meta-json', '{"service_name": "mon", "ports": [], "ip": null, "deployed_by": [], "rank": null, "rank_generation": null}',
                         '--config-json', '-',
                         '--reconfig',
                     ],

--- a/src/pybind/mgr/cephadm/tests/test_cephadm.py
+++ b/src/pybind/mgr/cephadm/tests/test_cephadm.py
@@ -754,6 +754,7 @@ class TestCephadm(object):
                 })
 
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.services.nfs.NFSService.run_grace_tool", mock.MagicMock())
     @mock.patch("cephadm.module.CephadmOrchestrator.rados", mock.MagicMock())
     def test_nfs(self, cephadm_module):
         with with_host(cephadm_module, 'test'):
@@ -915,6 +916,7 @@ class TestCephadm(object):
     @mock.patch("cephadm.serve.CephadmServe._deploy_cephadm_binary", _deploy_cephadm_binary('test'))
     @mock.patch("subprocess.run", None)
     @mock.patch("cephadm.serve.CephadmServe._run_cephadm", _run_cephadm('{}'))
+    @mock.patch("cephadm.services.nfs.NFSService.run_grace_tool", mock.MagicMock())
     def test_apply_save(self, spec: ServiceSpec, meth, cephadm_module: CephadmOrchestrator):
         with with_host(cephadm_module, 'test'):
             with with_service(cephadm_module, spec, meth, 'test'):

--- a/src/pybind/mgr/cephadm/tests/test_scheduling.py
+++ b/src/pybind/mgr/cephadm/tests/test_scheduling.py
@@ -2,7 +2,7 @@
 
 # fmt: off
 
-from typing import NamedTuple, List, Dict
+from typing import NamedTuple, List, Dict, Optional
 import pytest
 
 from ceph.deployment.hostspec import HostSpec
@@ -379,12 +379,14 @@ class NodeAssignmentTest(NamedTuple):
     placement: PlacementSpec
     hosts: List[str]
     daemons: List[DaemonDescription]
+    rank_map: Optional[Dict[int, Dict[int, Optional[str]]]]
+    post_rank_map: Optional[Dict[int, Dict[int, Optional[str]]]]
     expected: List[str]
     expected_add: List[str]
     expected_remove: List[DaemonDescription]
 
 
-@pytest.mark.parametrize("service_type,placement,hosts,daemons,expected,expected_add,expected_remove",
+@pytest.mark.parametrize("service_type,placement,hosts,daemons,rank_map,post_rank_map,expected,expected_add,expected_remove",
     [   # noqa: E128
         # just hosts
         NodeAssignmentTest(
@@ -392,6 +394,7 @@ class NodeAssignmentTest(NamedTuple):
             PlacementSpec(hosts=['smithi060']),
             ['smithi060'],
             [],
+            None, None,
             ['mgr:smithi060'], ['mgr:smithi060'], []
         ),
         # all_hosts
@@ -403,6 +406,7 @@ class NodeAssignmentTest(NamedTuple):
                 DaemonDescription('mgr', 'a', 'host1'),
                 DaemonDescription('mgr', 'b', 'host2'),
             ],
+            None, None,
             ['mgr:host1', 'mgr:host2', 'mgr:host3'],
             ['mgr:host3'],
             []
@@ -416,6 +420,7 @@ class NodeAssignmentTest(NamedTuple):
                 DaemonDescription('mds', 'a', 'host1'),
                 DaemonDescription('mds', 'b', 'host2'),
             ],
+            None, None,
             ['mds:host1', 'mds:host2', 'mds:host3', 'mds:host1', 'mds:host2', 'mds:host3'],
             ['mds:host3', 'mds:host1', 'mds:host2', 'mds:host3'],
             []
@@ -427,6 +432,7 @@ class NodeAssignmentTest(NamedTuple):
             PlacementSpec(count=4),
             'host1 host2 host3'.split(),
             [],
+            None, None,
             ['mgr:host1', 'mgr:host2', 'mgr:host3'],
             ['mgr:host1', 'mgr:host2', 'mgr:host3'],
             []
@@ -437,6 +443,7 @@ class NodeAssignmentTest(NamedTuple):
             PlacementSpec(count=6),
             'host1 host2 host3'.split(),
             [],
+            None, None,
             ['mds:host1', 'mds:host2', 'mds:host3', 'mds:host1', 'mds:host2', 'mds:host3'],
             ['mds:host1', 'mds:host2', 'mds:host3', 'mds:host1', 'mds:host2', 'mds:host3'],
             []
@@ -450,6 +457,7 @@ class NodeAssignmentTest(NamedTuple):
                 DaemonDescription('mgr', 'a', 'host1'),
                 DaemonDescription('mgr', 'b', 'host2'),
             ],
+            None, None,
             ['mgr:host3'],
             ['mgr:host3'],
             ['mgr.a', 'mgr.b']
@@ -463,6 +471,7 @@ class NodeAssignmentTest(NamedTuple):
                 DaemonDescription('mds', 'a', 'host1'),
                 DaemonDescription('mds', 'b', 'host2'),
             ],
+            None, None,
             ['mds:host3', 'mds:host3', 'mds:host3'],
             ['mds:host3', 'mds:host3', 'mds:host3'],
             ['mds.a', 'mds.b']
@@ -476,6 +485,7 @@ class NodeAssignmentTest(NamedTuple):
                 DaemonDescription('mgr', 'a', 'host1'),
                 DaemonDescription('mgr', 'b', 'host2'),
             ],
+            None, None,
             ['mgr:host3'],
             ['mgr:host3'],
             ['mgr.a', 'mgr.b']
@@ -488,6 +498,7 @@ class NodeAssignmentTest(NamedTuple):
             [
                 DaemonDescription('mgr', 'a', 'host1'),
             ],
+            None, None,
             ['mgr:host3'],
             ['mgr:host3'],
             ['mgr.a']
@@ -500,6 +511,7 @@ class NodeAssignmentTest(NamedTuple):
             [
                 DaemonDescription('mgr', 'a', 'host1'),
             ],
+            None, None,
             ['mgr:host1'],
             [],
             []
@@ -512,6 +524,7 @@ class NodeAssignmentTest(NamedTuple):
             [
                 DaemonDescription('mgr', 'a', 'host2'),
             ],
+            None, None,
             ['mgr:host1'],
             ['mgr:host1'],
             ['mgr.a']
@@ -522,6 +535,7 @@ class NodeAssignmentTest(NamedTuple):
             PlacementSpec(label='foo'),
             'host1 host2 host3'.split(),
             [],
+            None, None,
             ['mgr:host1', 'mgr:host2', 'mgr:host3'],
             ['mgr:host1', 'mgr:host2', 'mgr:host3'],
             []
@@ -532,6 +546,7 @@ class NodeAssignmentTest(NamedTuple):
             PlacementSpec(count=4, label='foo'),
             'host1 host2 host3'.split(),
             [],
+            None, None,
             ['mgr:host1', 'mgr:host2', 'mgr:host3'],
             ['mgr:host1', 'mgr:host2', 'mgr:host3'],
             []
@@ -542,6 +557,7 @@ class NodeAssignmentTest(NamedTuple):
             PlacementSpec(count=6, label='foo'),
             'host1 host2 host3'.split(),
             [],
+            None, None,
             ['mds:host1', 'mds:host2', 'mds:host3', 'mds:host1', 'mds:host2', 'mds:host3'],
             ['mds:host1', 'mds:host2', 'mds:host3', 'mds:host1', 'mds:host2', 'mds:host3'],
             []
@@ -552,6 +568,7 @@ class NodeAssignmentTest(NamedTuple):
             PlacementSpec(label='foo', count_per_host=3),
             'host1 host2 host3'.split(),
             [],
+            None, None,
             ['mds:host1', 'mds:host2', 'mds:host3', 'mds:host1', 'mds:host2', 'mds:host3',
              'mds:host1', 'mds:host2', 'mds:host3'],
             ['mds:host1', 'mds:host2', 'mds:host3', 'mds:host1', 'mds:host2', 'mds:host3',
@@ -564,6 +581,7 @@ class NodeAssignmentTest(NamedTuple):
             PlacementSpec(host_pattern='mgr*'),
             'mgrhost1 mgrhost2 datahost'.split(),
             [],
+            None, None,
             ['mgr:mgrhost1', 'mgr:mgrhost2'],
             ['mgr:mgrhost1', 'mgr:mgrhost2'],
             []
@@ -574,6 +592,7 @@ class NodeAssignmentTest(NamedTuple):
             PlacementSpec(host_pattern='mds*', count_per_host=3),
             'mdshost1 mdshost2 datahost'.split(),
             [],
+            None, None,
             ['mds:mdshost1', 'mds:mdshost2', 'mds:mdshost1', 'mds:mdshost2', 'mds:mdshost1', 'mds:mdshost2'],
             ['mds:mdshost1', 'mds:mdshost2', 'mds:mdshost1', 'mds:mdshost2', 'mds:mdshost1', 'mds:mdshost2'],
             []
@@ -584,6 +603,7 @@ class NodeAssignmentTest(NamedTuple):
             PlacementSpec(count=6, label='foo'),
             'host1 host2 host3'.split(),
             [],
+            None, None,
             ['rgw:host1(*:80)', 'rgw:host2(*:80)', 'rgw:host3(*:80)',
              'rgw:host1(*:81)', 'rgw:host2(*:81)', 'rgw:host3(*:81)'],
             ['rgw:host1(*:80)', 'rgw:host2(*:80)', 'rgw:host3(*:80)',
@@ -600,6 +620,7 @@ class NodeAssignmentTest(NamedTuple):
                 DaemonDescription('rgw', 'b', 'host2', ports=[80]),
                 DaemonDescription('rgw', 'c', 'host1', ports=[82]),
             ],
+            None, None,
             ['rgw:host1(*:80)', 'rgw:host2(*:80)', 'rgw:host3(*:80)',
              'rgw:host1(*:81)', 'rgw:host2(*:81)', 'rgw:host3(*:81)'],
             ['rgw:host1(*:80)', 'rgw:host3(*:80)',
@@ -615,12 +636,186 @@ class NodeAssignmentTest(NamedTuple):
                 DaemonDescription('mgr', 'y', 'host1'),
                 DaemonDescription('mgr', 'x', 'host2'),
             ],
+            None, None,
             ['mgr:host1(name=y)', 'mgr:host2(name=x)'],
             [], []
         ),
+
+        # note: host -> rank mapping is psuedo-random based on svc name, so these
+        # host/rank pairs may seem random but they match the nfs.mynfs seed used by
+        # the test.
+
+        # ranked, fresh
+        NodeAssignmentTest(
+            'nfs',
+            PlacementSpec(count=3),
+            'host1 host2 host3'.split(),
+            [],
+            {},
+            {0: {0: None}, 1: {0: None}, 2: {0: None}},
+            ['nfs:host1(rank=0.0)', 'nfs:host2(rank=1.0)', 'nfs:host3(rank=2.0)'],
+            ['nfs:host1(rank=0.0)', 'nfs:host2(rank=1.0)', 'nfs:host3(rank=2.0)'],
+            []
+        ),
+        # 21: ranked, exist
+        NodeAssignmentTest(
+            'nfs',
+            PlacementSpec(count=3),
+            'host1 host2 host3'.split(),
+            [
+                DaemonDescription('nfs', '0.1', 'host1', rank=0, rank_generation=1),
+            ],
+            {0: {1: '0.1'}},
+            {0: {1: '0.1'}, 1: {0: None}, 2: {0: None}},
+            ['nfs:host1(rank=0.1)', 'nfs:host2(rank=1.0)', 'nfs:host3(rank=2.0)'],
+            ['nfs:host2(rank=1.0)', 'nfs:host3(rank=2.0)'],
+            []
+        ),
+        # ranked, exist, different ranks
+        NodeAssignmentTest(
+            'nfs',
+            PlacementSpec(count=3),
+            'host1 host2 host3'.split(),
+            [
+                DaemonDescription('nfs', '0.1', 'host1', rank=0, rank_generation=1),
+                DaemonDescription('nfs', '1.1', 'host2', rank=1, rank_generation=1),
+            ],
+            {0: {1: '0.1'}, 1: {1: '1.1'}},
+            {0: {1: '0.1'}, 1: {1: '1.1'}, 2: {0: None}},
+            ['nfs:host1(rank=0.1)', 'nfs:host2(rank=1.1)', 'nfs:host3(rank=2.0)'],
+            ['nfs:host3(rank=2.0)'],
+            []
+        ),
+        # ranked, exist, different ranks (2)
+        NodeAssignmentTest(
+            'nfs',
+            PlacementSpec(count=3),
+            'host1 host2 host3'.split(),
+            [
+                DaemonDescription('nfs', '0.1', 'host1', rank=0, rank_generation=1),
+                DaemonDescription('nfs', '1.1', 'host3', rank=1, rank_generation=1),
+            ],
+            {0: {1: '0.1'}, 1: {1: '1.1'}},
+            {0: {1: '0.1'}, 1: {1: '1.1'}, 2: {0: None}},
+            ['nfs:host1(rank=0.1)', 'nfs:host3(rank=1.1)', 'nfs:host2(rank=2.0)'],
+            ['nfs:host2(rank=2.0)'],
+            []
+        ),
+        # ranked, exist, extra ranks
+        NodeAssignmentTest(
+            'nfs',
+            PlacementSpec(count=3),
+            'host1 host2 host3'.split(),
+            [
+                DaemonDescription('nfs', '0.5', 'host1', rank=0, rank_generation=5),
+                DaemonDescription('nfs', '1.5', 'host2', rank=1, rank_generation=5),
+                DaemonDescription('nfs', '4.5', 'host2', rank=4, rank_generation=5),
+            ],
+            {0: {5: '0.5'}, 1: {5: '1.5'}},
+            {0: {5: '0.5'}, 1: {5: '1.5'}, 2: {0: None}},
+            ['nfs:host1(rank=0.5)', 'nfs:host2(rank=1.5)', 'nfs:host3(rank=2.0)'],
+            ['nfs:host3(rank=2.0)'],
+            ['nfs.4.5']
+        ),
+        # 25: ranked, exist, extra ranks (scale down: kill off high rank)
+        NodeAssignmentTest(
+            'nfs',
+            PlacementSpec(count=2),
+            'host3 host2 host1'.split(),
+            [
+                DaemonDescription('nfs', '0.5', 'host1', rank=0, rank_generation=5),
+                DaemonDescription('nfs', '1.5', 'host2', rank=1, rank_generation=5),
+                DaemonDescription('nfs', '2.5', 'host3', rank=2, rank_generation=5),
+            ],
+            {0: {5: '0.5'}, 1: {5: '1.5'}, 2: {5: '2.5'}},
+            {0: {5: '0.5'}, 1: {5: '1.5'}, 2: {5: '2.5'}},
+            ['nfs:host1(rank=0.5)', 'nfs:host2(rank=1.5)'],
+            [],
+            ['nfs.2.5']
+        ),
+        # ranked, exist, extra ranks (scale down hosts)
+        NodeAssignmentTest(
+            'nfs',
+            PlacementSpec(count=2),
+            'host1 host3'.split(),
+            [
+                DaemonDescription('nfs', '0.5', 'host1', rank=0, rank_generation=5),
+                DaemonDescription('nfs', '1.5', 'host2', rank=1, rank_generation=5),
+                DaemonDescription('nfs', '2.5', 'host3', rank=4, rank_generation=5),
+            ],
+            {0: {5: '0.5'}, 1: {5: '1.5'}, 2: {5: '2.5'}},
+            {0: {5: '0.5'}, 1: {5: '1.5', 6: None}, 2: {5: '2.5'}},
+            ['nfs:host1(rank=0.5)', 'nfs:host3(rank=1.6)'],
+            ['nfs:host3(rank=1.6)'],
+            ['nfs.2.5', 'nfs.1.5']
+        ),
+        # ranked, exist, duplicate rank
+        NodeAssignmentTest(
+            'nfs',
+            PlacementSpec(count=3),
+            'host1 host2 host3'.split(),
+            [
+                DaemonDescription('nfs', '0.0', 'host1', rank=0, rank_generation=0),
+                DaemonDescription('nfs', '1.1', 'host2', rank=1, rank_generation=1),
+                DaemonDescription('nfs', '1.2', 'host3', rank=1, rank_generation=2),
+            ],
+            {0: {0: '0.0'}, 1: {2: '1.2'}},
+            {0: {0: '0.0'}, 1: {2: '1.2'}, 2: {0: None}},
+            ['nfs:host1(rank=0.0)', 'nfs:host3(rank=1.2)', 'nfs:host2(rank=2.0)'],
+            ['nfs:host2(rank=2.0)'],
+            ['nfs.1.1']
+        ),
+        # 28: ranked, all gens stale (failure during update cycle)
+        NodeAssignmentTest(
+            'nfs',
+            PlacementSpec(count=2),
+            'host1 host2 host3'.split(),
+            [
+                DaemonDescription('nfs', '0.2', 'host1', rank=0, rank_generation=2),
+                DaemonDescription('nfs', '1.2', 'host2', rank=1, rank_generation=2),
+            ],
+            {0: {2: '0.2'}, 1: {2: '1.2', 3: '1.3'}},
+            {0: {2: '0.2'}, 1: {2: '1.2', 3: '1.3', 4: None}},
+            ['nfs:host1(rank=0.2)', 'nfs:host2(rank=1.4)'],
+            ['nfs:host2(rank=1.4)'],
+            ['nfs.1.2']
+        ),
+        # ranked, not enough hosts
+        NodeAssignmentTest(
+            'nfs',
+            PlacementSpec(count=4),
+            'host1 host2 host3'.split(),
+            [
+                DaemonDescription('nfs', '0.2', 'host1', rank=0, rank_generation=2),
+                DaemonDescription('nfs', '1.2', 'host2', rank=1, rank_generation=2),
+            ],
+            {0: {2: '0.2'}, 1: {2: '1.2'}},
+            {0: {2: '0.2'}, 1: {2: '1.2'}, 2: {0: None}},
+            ['nfs:host1(rank=0.2)', 'nfs:host2(rank=1.2)', 'nfs:host3(rank=2.0)'],
+            ['nfs:host3(rank=2.0)'],
+            []
+        ),
+        # ranked, scale down
+        NodeAssignmentTest(
+            'nfs',
+            PlacementSpec(hosts=['host2']),
+            'host1 host2'.split(),
+            [
+                DaemonDescription('nfs', '0.2', 'host1', rank=0, rank_generation=2),
+                DaemonDescription('nfs', '1.2', 'host2', rank=1, rank_generation=2),
+                DaemonDescription('nfs', '2.2', 'host3', rank=2, rank_generation=2),
+            ],
+            {0: {2: '0.2'}, 1: {2: '1.2'}, 2: {2: '2.2'}},
+            {0: {2: '0.2', 3: None}, 1: {2: '1.2'}, 2: {2: '2.2'}},
+            ['nfs:host2(rank=0.3)'],
+            ['nfs:host2(rank=0.3)'],
+            ['nfs.0.2', 'nfs.1.2', 'nfs.2.2']
+        ),
+
     ])
-def test_node_assignment(service_type, placement, hosts, daemons,
+def test_node_assignment(service_type, placement, hosts, daemons, rank_map, post_rank_map,
                          expected, expected_add, expected_remove):
+    spec = None
     service_id = None
     allow_colo = False
     if service_type == 'rgw':
@@ -629,17 +824,27 @@ def test_node_assignment(service_type, placement, hosts, daemons,
     elif service_type == 'mds':
         service_id = 'myfs'
         allow_colo = True
+    elif service_type == 'nfs':
+        service_id = 'mynfs'
+        spec = ServiceSpec(service_type=service_type,
+                           service_id=service_id,
+                           placement=placement,
+                           pool='foo')
 
-    spec = ServiceSpec(service_type=service_type,
-                       service_id=service_id,
-                       placement=placement)
+    if not spec:
+        spec = ServiceSpec(service_type=service_type,
+                           service_id=service_id,
+                           placement=placement)
 
     all_slots, to_add, to_remove = HostAssignment(
         spec=spec,
         hosts=[HostSpec(h, labels=['foo']) for h in hosts],
         daemons=daemons,
         allow_colo=allow_colo,
+        rank_map=rank_map,
     ).place()
+
+    assert rank_map == post_rank_map
 
     got = [str(p) for p in all_slots]
     num_wildcard = 0

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -86,16 +86,6 @@ class NFSCluster:
             return exception_handler(e, f"NFS Cluster {cluster_id} could not be created")
 
     @cluster_setter
-    def update_nfs_cluster(self, cluster_id, placement):
-        try:
-            if cluster_id in available_clusters(self.mgr):
-                self._call_orch_apply_nfs(placement)
-                return 0, "NFS Cluster Updated Successfully", ""
-            raise ClusterNotFound()
-        except Exception as e:
-            return exception_handler(e, f"NFS Cluster {cluster_id} could not be updated")
-
-    @cluster_setter
     def delete_nfs_cluster(self, cluster_id):
         try:
             cluster_list = available_clusters(self.mgr)

--- a/src/pybind/mgr/nfs/cluster.py
+++ b/src/pybind/mgr/nfs/cluster.py
@@ -2,7 +2,7 @@ import logging
 import socket
 import json
 import re
-from typing import cast, Dict, List, Any, Union
+from typing import cast, Dict, List, Any, Union, Optional
 
 from ceph.deployment.service_spec import NFSServiceSpec, PlacementSpec, IngressSpec
 from cephadm.utils import resolve_ip
@@ -89,8 +89,16 @@ class NFSCluster:
                  f"{self.pool_ns}")
 
     @cluster_setter
-    def create_nfs_cluster(self, cluster_id, placement, virtual_ip):
+    def create_nfs_cluster(self,
+                           cluster_id: str,
+                           placement: Optional[str],
+                           virtual_ip: Optional[str],
+                           ingress: Optional[bool] = None):
         try:
+            if virtual_ip and not ingress:
+                raise NFSInvalidOperation('virtual_ip can only be provided with ingress enabled')
+            if not virtual_ip and ingress:
+                raise NFSInvalidOperation('ingress currently requires a virtual_ip')
             invalid_str = re.search('[^A-Za-z0-9-_.]', cluster_id)
             if invalid_str:
                 raise NFSInvalidOperation(f"cluster id {cluster_id} is invalid. "
@@ -143,7 +151,7 @@ class NFSCluster:
                             "ip": cluster.ip or resolve_ip(cluster.hostname),
                             "port": cluster.ports[0]
                             })
-                except OrchestratorError:
+                except orchestrator.OrchestratorError:
                     continue
 
         r: Dict[str, Any] = {

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -1,8 +1,8 @@
 import logging
 import threading
-from typing import Tuple
+from typing import Tuple, Optional, List
 
-from mgr_module import MgrModule, CLICommand
+from mgr_module import MgrModule, CLICommand, Option
 import orchestrator
 
 from .export import ExportMgr
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 
 class Module(orchestrator.OrchestratorClientMixin, MgrModule):
-    MODULE_OPTIONS = []
+    MODULE_OPTIONS: List[Option] = []
 
     def __init__(self, *args, **kwargs):
         self.inited = False
@@ -79,7 +79,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.nfs.list_nfs_cluster()
 
     @CLICommand('nfs cluster info', perm='r')
-    def _cmd_nfs_cluster_info(self, clusterid: str = None) -> Tuple[int, str, str]:
+    def _cmd_nfs_cluster_info(self, clusterid: Optional[str] = None) -> Tuple[int, str, str]:
         """Displays NFS Cluster info"""
         return self.nfs.show_nfs_cluster_info(cluster_id=clusterid)
 

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -70,14 +70,8 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                 ingress: Optional[bool]=None,
                                 virtual_ip: Optional[str]=None) -> Tuple[int, str, str]:
         """Create an NFS Cluster"""
-        if virtual_ip and not ingress:
-            return (-errno.EINVAL, '',
-                    '--virtual-ip can only be provided with --ingress')
-        if ingress and not virtual_ip:
-            return (-errno.EINVAL, '',
-                    '--ingress current requires --virtual-ip')
         return self.nfs.create_nfs_cluster(cluster_id=clusterid, placement=placement,
-                                           virtual_ip=virtual_ip)
+                                           virtual_ip=virtual_ip, ingress=ingress)
 
     @CLICommand('nfs cluster rm', perm='rw')
     def _cmd_nfs_cluster_rm(self, clusterid: str) -> Tuple[int, str, str]:

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -68,11 +68,6 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         """Create an NFS Cluster"""
         return self.nfs.create_nfs_cluster(cluster_id=clusterid, placement=placement)
 
-    @CLICommand('nfs cluster update', perm='rw')
-    def _cmd_nfs_cluster_update(self, clusterid: str, placement: str) -> Tuple[int, str, str]:
-        """Updates an NFS Cluster"""
-        return self.nfs.update_nfs_cluster(cluster_id=clusterid, placement=placement)
-
     @CLICommand('nfs cluster rm', perm='rw')
     def _cmd_nfs_cluster_rm(self, clusterid: str) -> Tuple[int, str, str]:
         """Removes an NFS Cluster"""

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -63,10 +63,13 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         return self.export_mgr.update_export(export_config=inbuf)
 
     @CLICommand('nfs cluster create', perm='rw')
-    def _cmd_nfs_cluster_create(self, clusterid: str,
-                                placement: str = None) -> Tuple[int, str, str]:
+    def _cmd_nfs_cluster_create(self,
+                                clusterid: str,
+                                placement: Optional[str]=None,
+                                virtual_ip: Optional[str]=None) -> Tuple[int, str, str]:
         """Create an NFS Cluster"""
-        return self.nfs.create_nfs_cluster(cluster_id=clusterid, placement=placement)
+        return self.nfs.create_nfs_cluster(cluster_id=clusterid, placement=placement,
+                                           virtual_ip=virtual_ip)
 
     @CLICommand('nfs cluster rm', perm='rw')
     def _cmd_nfs_cluster_rm(self, clusterid: str) -> Tuple[int, str, str]:

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -36,9 +36,14 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
                                              cluster_id=clusterid, pseudo_path=binding,
                                              read_only=readonly, path=path)
 
+    @CLICommand('nfs export rm', perm='rw')
+    def _cmd_nfs_export_rm(self, clusterid: str, binding: str) -> Tuple[int, str, str]:
+        """Remove a cephfs export"""
+        return self.export_mgr.delete_export(cluster_id=clusterid, pseudo_path=binding)
+
     @CLICommand('nfs export delete', perm='rw')
     def _cmd_nfs_export_delete(self, clusterid: str, binding: str) -> Tuple[int, str, str]:
-        """Delete a cephfs export"""
+        """Delete a cephfs export (DEPRECATED)"""
         return self.export_mgr.delete_export(cluster_id=clusterid, pseudo_path=binding)
 
     @CLICommand('nfs export ls', perm='r')
@@ -68,9 +73,14 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         """Updates an NFS Cluster"""
         return self.nfs.update_nfs_cluster(cluster_id=clusterid, placement=placement)
 
+    @CLICommand('nfs cluster rm', perm='rw')
+    def _cmd_nfs_cluster_rm(self, clusterid: str) -> Tuple[int, str, str]:
+        """Removes an NFS Cluster"""
+        return self.nfs.delete_nfs_cluster(cluster_id=clusterid)
+
     @CLICommand('nfs cluster delete', perm='rw')
     def _cmd_nfs_cluster_delete(self, clusterid: str) -> Tuple[int, str, str]:
-        """Deletes an NFS Cluster"""
+        """Removes an NFS Cluster (DEPRECATED)"""
         return self.nfs.delete_nfs_cluster(cluster_id=clusterid)
 
     @CLICommand('nfs cluster ls', perm='r')

--- a/src/pybind/mgr/nfs/module.py
+++ b/src/pybind/mgr/nfs/module.py
@@ -1,3 +1,4 @@
+import errno
 import logging
 import threading
 from typing import Tuple, Optional, List
@@ -66,8 +67,15 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
     def _cmd_nfs_cluster_create(self,
                                 clusterid: str,
                                 placement: Optional[str]=None,
+                                ingress: Optional[bool]=None,
                                 virtual_ip: Optional[str]=None) -> Tuple[int, str, str]:
         """Create an NFS Cluster"""
+        if virtual_ip and not ingress:
+            return (-errno.EINVAL, '',
+                    '--virtual-ip can only be provided with --ingress')
+        if ingress and not virtual_ip:
+            return (-errno.EINVAL, '',
+                    '--ingress current requires --virtual-ip')
         return self.nfs.create_nfs_cluster(cluster_id=clusterid, placement=placement,
                                            virtual_ip=virtual_ip)
 

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -794,6 +794,8 @@ class DaemonDescription(object):
                  ports: Optional[List[int]] = None,
                  ip: Optional[str] = None,
                  deployed_by: Optional[List[str]] = None,
+                 rank: Optional[int] = None,
+                 rank_generation: Optional[int] = None,
                  ) -> None:
 
         # Host is at the same granularity as InventoryHost
@@ -815,6 +817,10 @@ class DaemonDescription(object):
         # This is the <foo> in mds.<foo>, the ID that will appear
         # in the FSMap/ServiceMap.
         self.daemon_id: Optional[str] = daemon_id
+
+        # Some daemon types have a numeric rank assigned
+        self.rank: Optional[int] = rank
+        self.rank_generation: Optional[int] = rank_generation
 
         self._service_name: Optional[str] = service_name
 
@@ -960,6 +966,8 @@ class DaemonDescription(object):
         out['is_active'] = self.is_active
         out['ports'] = self.ports
         out['ip'] = self.ip
+        out['rank'] = self.rank
+        out['rank_generation'] = self.rank_generation
 
         for k in ['last_refresh', 'created', 'started', 'last_deployed',
                   'last_configured']:

--- a/src/pybind/mgr/orchestrator/_interface.py
+++ b/src/pybind/mgr/orchestrator/_interface.py
@@ -943,6 +943,7 @@ class DaemonDescription(object):
         out: Dict[str, Any] = OrderedDict()
         out['daemon_type'] = self.daemon_type
         out['daemon_id'] = self.daemon_id
+        out['service_name'] = self._service_name
         out['hostname'] = self.hostname
         out['container_id'] = self.container_id
         out['container_image_id'] = self.container_image_id

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1121,10 +1121,10 @@ Usage:
     @_cli_write_command('orch apply nfs')
     def _apply_nfs(self,
                    svc_id: str,
-                   pool: str,
-                   namespace: Optional[str] = None,
                    placement: Optional[str] = None,
                    format: Format = Format.plain,
+                   pool: Optional[str] = None,
+                   namespace: Optional[str] = None,
                    port: Optional[int] = None,
                    dry_run: bool = False,
                    unmanaged: bool = False,

--- a/src/pybind/mgr/orchestrator/module.py
+++ b/src/pybind/mgr/orchestrator/module.py
@@ -1125,6 +1125,7 @@ Usage:
                    namespace: Optional[str] = None,
                    placement: Optional[str] = None,
                    format: Format = Format.plain,
+                   port: Optional[int] = None,
                    dry_run: bool = False,
                    unmanaged: bool = False,
                    no_overwrite: bool = False,
@@ -1137,6 +1138,7 @@ Usage:
             service_id=svc_id,
             pool=pool,
             namespace=namespace,
+            port=port,
             placement=PlacementSpec.from_string(placement),
             unmanaged=unmanaged,
             preview_only=dry_run

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -947,6 +947,9 @@ class IngressSpec(ServiceSpec):
                 'Cannot add ingress: No virtual_ip provided')
 
 
+yaml.add_representer(IngressSpec, ServiceSpec.yaml_representer)
+
+
 class CustomContainerSpec(ServiceSpec):
     def __init__(self,
                  service_type: str = 'container',

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -660,16 +660,18 @@ yaml.add_representer(ServiceSpec, ServiceSpec.yaml_representer)
 
 
 class NFSServiceSpec(ServiceSpec):
+    DEFAULT_POOL = 'nfs-ganesha'
+
     def __init__(self,
                  service_type: str = 'nfs',
                  service_id: Optional[str] = None,
-                 pool: Optional[str] = None,
-                 namespace: Optional[str] = None,
                  placement: Optional[PlacementSpec] = None,
                  unmanaged: bool = False,
                  preview_only: bool = False,
                  config: Optional[Dict[str, str]] = None,
                  networks: Optional[List[str]] = None,
+                 pool: Optional[str] = None,
+                 namespace: Optional[str] = None,
                  port: Optional[int] = None,
                  ):
         assert service_type == 'nfs'
@@ -679,10 +681,10 @@ class NFSServiceSpec(ServiceSpec):
             config=config, networks=networks)
 
         #: RADOS pool where NFS client recovery data is stored.
-        self.pool = pool
+        self.pool = pool or self.DEFAULT_POOL
 
         #: RADOS namespace where NFS client recovery data is stored in the pool.
-        self.namespace = namespace
+        self.namespace = namespace or self.service_id
 
         self.port = port
 

--- a/src/python-common/ceph/deployment/service_spec.py
+++ b/src/python-common/ceph/deployment/service_spec.py
@@ -670,6 +670,7 @@ class NFSServiceSpec(ServiceSpec):
                  preview_only: bool = False,
                  config: Optional[Dict[str, str]] = None,
                  networks: Optional[List[str]] = None,
+                 port: Optional[int] = None,
                  ):
         assert service_type == 'nfs'
         super(NFSServiceSpec, self).__init__(
@@ -682,6 +683,13 @@ class NFSServiceSpec(ServiceSpec):
 
         #: RADOS namespace where NFS client recovery data is stored in the pool.
         self.namespace = namespace
+
+        self.port = port
+
+    def get_port_start(self) -> List[int]:
+        if self.port:
+            return [self.port]
+        return []
 
     def validate(self) -> None:
         super(NFSServiceSpec, self).validate()


### PR DESCRIPTION
- Assign each ganesha daemon a stable rank id (0, 1, ...).
- Ensure that no more than one daemon at a time is running on a single rank.  For now, this relies on revoking the old daemon's auth key. In the future, we can additionally fence it, but that infrastructure isn't in tree yet.
- Add NFS support for ingress: haproxy with consistent hashing
- Update mgr/nfs to optionally deploy ingress (when VIP is provided)
- Update mgr/nfs cluster ls output to include stable endpoint separate from backend server instances
- Make everything default to pool ``nfs-ganesha`` and namespace matching the service_id
- Update mgr/nfs commands to use ``rm`` instead of ``delete`` for consistency with the rest of the CLI