### PR TITLE
pacific: mon/MonClient: reset authenticate_err in _reopen_session()

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -678,18 +678,6 @@ void MonClient::_finish_auth(int auth_err)
     _check_auth_tickets();
   }
   auth_cond.notify_all();
-
-  if (!auth_err) {
-    Context *cb = nullptr;
-    if (session_established_context) {
-      cb = session_established_context.release();
-    }
-    if (cb) {
-      monc_lock.unlock();
-      cb->complete(0);
-      monc_lock.lock();
-    }
-  }
 }
 
 // ---------

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -577,7 +577,6 @@ int MonClient::authenticate(double timeout)
   until += ceph::make_timespan(timeout);
   if (timeout > 0.0)
     ldout(cct, 10) << "authenticate will time out at " << until << dendl;
-  authenticate_err = 1;  // == in progress
   while (!active_con && authenticate_err >= 0) {
     if (timeout > 0.0) {
       auto r = auth_cond.wait_until(lock, until);
@@ -709,6 +708,8 @@ void MonClient::_reopen_session(int rank)
 
   active_con.reset();
   pending_cons.clear();
+
+  authenticate_err = 1;  // == in progress
 
   _start_hunting();
 

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -340,7 +340,6 @@ private:
 
   std::list<MessageRef> waiting_for_session;
   utime_t last_rotating_renew_sent;
-  std::unique_ptr<Context> session_established_context;
   bool had_a_connection;
   double reopen_interval_multiplier;
 
@@ -504,18 +503,9 @@ public:
     send_mon_message(MessageRef{m, false});
   }
   void send_mon_message(MessageRef m);
-  /**
-   * If you specify a callback, you should not call
-   * reopen_session() again until it has been triggered. The MonClient
-   * will behave, but the first callback could be triggered after
-   * the session has been killed and the MonClient has started trying
-   * to reconnect to another monitor.
-   */
-  void reopen_session(Context *cb=NULL) {
+
+  void reopen_session() {
     std::lock_guard l(monc_lock);
-    if (cb) {
-      session_established_context.reset(cb);
-    }
     _reopen_session();
   }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50505

---

backport of https://github.com/ceph/ceph/pull/40978
parent tracker: https://tracker.ceph.com/issues/50477