### PR TITLE
nautilus: mgr/dashboard: filesystem pool size should use stored stat

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -222,7 +222,7 @@ class CephFS(RESTController):
             pools_table.append({
                 "pool": pools[pool_id]['pool_name'],
                 "type": pool_type,
-                "used": stats['bytes_used'],
+                "used": stats['stored'],
                 "avail": stats['max_avail']
             })
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50417

---

backport of https://github.com/ceph/ceph/pull/40874
parent tracker: https://tracker.ceph.com/issues/50195

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh