### PR TITLE
 mgr/dashboard: RGW buckets async validator performance enhancement and name constraints

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/cypress/integration/rgw/buckets.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/cypress/integration/rgw/buckets.po.ts
@@ -129,7 +129,10 @@ export class BucketsPageHelper extends PageHelper {
       .and('have.class', 'ng-invalid');
 
     // Check that error message was printed under name input field
-    cy.get('#bid + .invalid-feedback').should('have.text', 'The value is not valid.');
+    cy.get('#bid + .invalid-feedback').should(
+      'have.text',
+      'Bucket names must be 3 to 63 characters long.'
+    );
 
     // Test invalid owner input
     // select some valid option. The owner drop down error message will not appear unless a valid user was selected at

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.html
@@ -50,6 +50,21 @@
             <span class="invalid-feedback"
                   *ngIf="bucketForm.showError('bid', frm, 'bucketNameExists')"
                   i18n>The chosen name is already in use.</span>
+            <span class="invalid-feedback"
+                  *ngIf="bucketForm.showError('bid', frm, 'containsUpperCase')"
+                  i18n>Bucket names must not contain uppercase characters or underscores.</span>
+            <span class="invalid-feedback"
+                  *ngIf="bucketForm.showError('bid', frm, 'lowerCaseOrNumber')"
+                  i18n>Each label must start and end with a lowercase letter or a number.</span>
+            <span class="invalid-feedback"
+                  *ngIf="bucketForm.showError('bid', frm, 'ipAddress')"
+                  i18n>Bucket names cannot be formatted as IP address.</span>
+            <span class="invalid-feedback"
+                  *ngIf="bucketForm.showError('bid', frm, 'onlyLowerCaseAndNumbers')"
+                  i18n>Bucket names can only contain lowercase letters, numbers, and hyphens.</span>
+            <span class="invalid-feedback"
+                  *ngIf="bucketForm.showError('bid', frm, 'shouldBeInRange')"
+                  i18n>Bucket names must be 3 to 63 characters long.</span>
           </div>
         </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
@@ -162,14 +162,14 @@ describe('RgwUserFormComponent', () => {
     it('should validate that username is valid', fakeAsync(() => {
       spyOn(rgwUserService, 'get').and.returnValue(throwError('foo'));
       formHelper.setValue('user_id', 'ab', true);
-      tick(500);
+      tick();
       formHelper.expectValid('user_id');
     }));
 
     it('should validate that username is invalid', fakeAsync(() => {
       spyOn(rgwUserService, 'get').and.returnValue(observableOf({}));
       formHelper.setValue('user_id', 'abc', true);
-      tick(500);
+      tick();
       formHelper.expectError('user_id', 'notUnique');
     }));
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.spec.ts
@@ -80,7 +80,7 @@ describe('RgwBucketService', () => {
     service.exists('foo').subscribe((resp) => {
       result = resp;
     });
-    const req = httpTesting.expectOne(`api/rgw/bucket?${RgwHelper.DAEMON_QUERY_PARAM}`);
+    const req = httpTesting.expectOne(`api/rgw/bucket/foo?${RgwHelper.DAEMON_QUERY_PARAM}`);
     expect(req.request.method).toBe('GET');
     req.flush(['foo', 'bar']);
     expect(result).toBe(true);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
@@ -348,29 +348,26 @@ export class CdValidators {
     serviceFn: existsServiceFn,
     serviceFnThis: any = null,
     usernameFn?: Function,
-    uidfield = false,
-    dueTime = 500
+    uidField = false
   ): AsyncValidatorFn {
-    let uname: string;
+    let uName: string;
     return (control: AbstractControl): Observable<ValidationErrors | null> => {
       // Exit immediately if user has not interacted with the control yet
       // or the control value is empty.
       if (control.pristine || isEmptyInputValue(control.value)) {
         return observableOf(null);
       }
-      uname = control.value;
+      uName = control.value;
       if (_.isFunction(usernameFn) && usernameFn() !== null && usernameFn() !== '') {
-        if (uidfield) {
-          uname = `${control.value}$${usernameFn()}`;
+        if (uidField) {
+          uName = `${control.value}$${usernameFn()}`;
         } else {
-          uname = `${usernameFn()}$${control.value}`;
+          uName = `${usernameFn()}$${control.value}`;
         }
       }
 
-      // Forgot previous requests if a new one arrives within the specified
-      // delay time.
-      return observableTimer(dueTime).pipe(
-        switchMapTo(serviceFn.call(serviceFnThis, uname)),
+      return observableTimer().pipe(
+        switchMapTo(serviceFn.call(serviceFnThis, uName)),
         map((resp: boolean) => {
           if (!resp) {
             return null;


### PR DESCRIPTION
The rgw bucket creation form has the Name field which have an async
validator. The validator calls all the bucket name and check if the
entered name is unique or not. This happens on every keystroke. So if
100 or more buckets are there, then the async validation can be real
slow and causes misvalidations in different fields.

I changed the validation logic and did some cleanups to improve the
performance of the async validation.

**BEFORE**


https://user-images.githubusercontent.com/71764184/116041569-fa4d4e00-a68a-11eb-99cd-55b1505da7ba.mp4


**AFTER**

https://user-images.githubusercontent.com/71764184/116041593-02a58900-a68b-11eb-983a-6419db0d61fa.mp4


Also explains the rgw bucket name constrains for each bucket name validation
errors.

Fixes: https://tracker.ceph.com/issues/50514
Fixes: https://tracker.ceph.com/issues/50516
Signed-off-by: Nizamudeen A <nia@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
