### PR TITLE
mgr/dashboard: Generate NPM dependencies manifest

### DIFF
--- a/src/script/generate-npm-manifest.sh
+++ b/src/script/generate-npm-manifest.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+this_script=$(basename "$0")
+
+function usage {
+    cat <<EOM >&2
+
+This script file is used to generate a .txt file which contains all the npm
+dependencies and its version, from the package-lock.json file.
+
+Usage:
+    ${this_script} path/to/package-lock.json path/for/manifest-file.txt
+
+Example:
+    ${this_script} ../pybind/mgr/dashboard/frontend/package-lock.json ../pybind/mgr/dashboard/manifest.txt
+
+EOM
+}
+
+empty=""
+if [ "$1" == "--help" ] || [ -z $1 ]
+then
+    usage
+    exit
+fi
+
+DEP_PATH=$1
+OUT_PATH=$2
+
+#check if package-lock.json exists
+if [ -e "$DEP_PATH" ]
+then
+    cat $DEP_PATH | jq -r '.dependencies | to_entries[] | "\(.key)  \(.value.version)  \(.value.resolved)"' > $OUT_PATH
+    echo "Manifest generated..."
+else
+    echo "Invalid path..."
+fi


### PR DESCRIPTION
A txt file with all the dependencies and its version & url link.

How to run?

 ```
 ./generate-npm-manifest.sh ../pybind/mgr/dashboard/frontend/package-lock.json ../pybind/mgr/dashboard/manifest.txt
 ```

Fixes: https://tracker.ceph.com/issues/50515
Signed-off-by: Nizamudeen A <nia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
