### PR TITLE
qa: increase the pg_num for cephfs_data/metadata pools

### DIFF
--- a/qa/suites/fs/functional/tasks/mds-full.yaml
+++ b/qa/suites/fs/functional/tasks/mds-full.yaml
@@ -12,6 +12,8 @@ overrides:
       - is full \(reached quota
       - POOL_FULL
       - POOL_BACKFILLFULL
+      - PG_RECOVERY_FULL
+      - PG_DEGRADED
     conf:
       mon:
         mon osd nearfull ratio: 0.6

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -676,6 +676,9 @@ class Filesystem(MDSCluster):
 
         self.getinfo(refresh = True)
 
+        # wait pgs to be clean
+        self.mon_manager.wait_for_clean()
+
     def run_client_payload(self, cmd):
         # avoid circular dep by importing here:
         from tasks.cephfs.fuse_mount import FuseMount

--- a/qa/tasks/cephfs/test_admin.py
+++ b/qa/tasks/cephfs/test_admin.py
@@ -74,7 +74,8 @@ class TestAddDataPool(TestAdminCommands):
         """
         pool_name = "foo"
         mon_cmd = self.fs.mon_manager.raw_cluster_cmd
-        mon_cmd('osd', 'pool', 'create', pool_name, str(self.fs.pgs_per_fs_pool))
+        mon_cmd('osd', 'pool', 'create', pool_name, '--pg_num_min',
+                str(self.fs.pg_num_min))
         # Check whether https://tracker.ceph.com/issues/43061 is fixed
         mon_cmd('osd', 'pool', 'application', 'enable', pool_name, 'cephfs')
         self.fs.add_data_pool(pool_name, create=False)
@@ -207,7 +208,7 @@ class TestFsNew(TestAdminCommands):
         pool_names = [fs_name+'-'+key for key in keys]
         mon_cmd = self.fs.mon_manager.raw_cluster_cmd
         for p in pool_names:
-            mon_cmd('osd', 'pool', 'create', p, str(self.fs.pgs_per_fs_pool))
+            mon_cmd('osd', 'pool', 'create', p, '--pg_num_min', str(self.fs.pg_num_min))
             mon_cmd('osd', 'pool', 'application', 'enable', p, 'cephfs')
         mon_cmd('fs', 'new', fs_name, pool_names[0], pool_names[1])
         for i in range(2):

--- a/qa/tasks/cephfs/test_data_scan.py
+++ b/qa/tasks/cephfs/test_data_scan.py
@@ -545,7 +545,7 @@ class TestDataScan(CephFSTestCase):
             pgs_to_files[pgid].append(file_path)
             log.info("{0}: {1}".format(file_path, pgid))
 
-        pg_count = self.fs.pgs_per_fs_pool
+        pg_count = self.fs.get_pool_pg_num(self.fs.get_data_pool_name())
         for pg_n in range(0, pg_count):
             pg_str = "{0}.{1:x}".format(self.fs.get_data_pool_id(), pg_n)
             out = self.fs.data_scan(["pg_files", "mydir", pg_str])

--- a/qa/tasks/cephfs/test_full.py
+++ b/qa/tasks/cephfs/test_full.py
@@ -132,7 +132,7 @@ class FullnessTestCase(CephFSTestCase):
         else:
             log.info("Writing file B succeeded (full status will happen soon)")
             self.wait_until_true(lambda: self.is_full(),
-                                 timeout=osd_mon_report_interval * 5)
+                                 timeout=osd_mon_report_interval * 120)
 
         # Attempting to write more data should give me ENOSPC
         with self.assertRaises(CommandFailedError) as ar:
@@ -167,7 +167,7 @@ class FullnessTestCase(CephFSTestCase):
         # * The MDS to purge the stray folder and execute object deletions
         #  * The OSDs to inform the mon that they are no longer full
         self.wait_until_true(lambda: not self.is_full(),
-                             timeout=osd_mon_report_interval * 5)
+                             timeout=osd_mon_report_interval * 120)
 
         # Wait for the MDS to see the latest OSD map so that it will reliably
         # be applying the free space policy

--- a/qa/tasks/cephfs/test_full.py
+++ b/qa/tasks/cephfs/test_full.py
@@ -125,7 +125,7 @@ class FullnessTestCase(CephFSTestCase):
         # how soon the cluster recognises its own fullness
         self.mount_a.write_n_mb("large_file_a", self.fill_mb // 2)
         try:
-            self.mount_a.write_n_mb("large_file_b", self.fill_mb // 2)
+            self.mount_a.write_n_mb("large_file_b", (self.fill_mb * 1.1) // 2)
         except CommandFailedError:
             log.info("Writing file B failed (full status happened already)")
             assert self.is_full()
@@ -395,9 +395,7 @@ class TestClusterFull(FullnessTestCase):
         super(TestClusterFull, self).setUp()
 
         if self.pool_capacity is None:
-            max_avail = self.fs.get_pool_df(self._data_pool_name())['max_avail']
-            full_ratio = float(self.fs.get_config("mon_osd_full_ratio", service_type="mon"))
-            TestClusterFull.pool_capacity = int(max_avail * full_ratio)
+            TestClusterFull.pool_capacity = self.fs.get_pool_df(self._data_pool_name())['max_avail']
             TestClusterFull.fill_mb = (self.pool_capacity // (1024 * 1024))
 
 # Hide the parent class so that unittest.loader doesn't try to run it.

--- a/qa/tasks/cephfs/test_full.py
+++ b/qa/tasks/cephfs/test_full.py
@@ -25,9 +25,8 @@ class FullnessTestCase(CephFSTestCase):
     pool_capacity = None  # type: Optional[int]
     fill_mb = None
 
-    # Subclasses define what fullness means to them
     def is_full(self):
-        raise NotImplementedError()
+        return self.fs.is_full()
 
     def setUp(self):
         CephFSTestCase.setUp(self)
@@ -373,9 +372,6 @@ class TestQuotaFull(FullnessTestCase):
         self.fs.mon_manager.raw_cluster_cmd("osd", "pool", "set-quota", pool_name,
                                             "max_bytes", "{0}".format(self.pool_capacity))
 
-    def is_full(self):
-        return self.fs.is_full()
-
 
 class TestClusterFull(FullnessTestCase):
     """
@@ -392,9 +388,6 @@ class TestClusterFull(FullnessTestCase):
             full_ratio = float(self.fs.get_config("mon_osd_full_ratio", service_type="mon"))
             TestClusterFull.pool_capacity = int(max_avail * full_ratio)
             TestClusterFull.fill_mb = (self.pool_capacity // (1024 * 1024))
-
-    def is_full(self):
-        return self.fs.is_full()
 
 # Hide the parent class so that unittest.loader doesn't try to run it.
 del globals()['FullnessTestCase']

--- a/qa/tasks/cephfs/test_full.py
+++ b/qa/tasks/cephfs/test_full.py
@@ -325,8 +325,13 @@ class FullnessTestCase(CephFSTestCase):
                     bytes += os.write(f, b'x' * 1024 * 1024)
                     print("wrote bytes via buffered write, moving on to fsync")
                 except OSError as e:
-                    print("Unexpected error %s from write() instead of fsync()" % e)
-                    raise
+                    if {is_fuse}:
+                        print("Unexpected error %s from write() instead of fsync()" % e)
+                        raise
+                    else:
+                        print("Reached fullness after %.2f MB" % (bytes / (1024.0 * 1024.0)))
+                        full = True
+                        break
 
                 try:
                     os.fsync(f)

--- a/qa/tasks/cephfs/test_full.py
+++ b/qa/tasks/cephfs/test_full.py
@@ -213,9 +213,13 @@ class FullnessTestCase(CephFSTestCase):
             log.warning("This test may run rather slowly unless you decrease"
                      "osd_mon_report_interval (5 is a good setting)!")
 
+        # set the object_size to 1MB to make the objects destributed more evenly
+        # among the OSDs to fix Tracker#45434
+        file_layout = "stripe_unit=1048576 stripe_count=1 object_size=1048576"
         self.mount_a.run_python(template.format(
             fill_mb=self.fill_mb,
             file_path=file_path,
+            file_layout=file_layout,
             full_wait=full_wait,
             is_fuse=isinstance(self.mount_a, FuseMount)
         ))
@@ -233,6 +237,7 @@ class FullnessTestCase(CephFSTestCase):
             print("writing some data through which we expect to succeed")
             bytes = 0
             f = os.open("{file_path}", os.O_WRONLY | os.O_CREAT)
+            os.setxattr("{file_path}", 'ceph.file.layout', b'{file_layout}')
             bytes += os.write(f, b'a' * 512 * 1024)
             os.fsync(f)
             print("fsync'ed data successfully, will now attempt to fill fs")
@@ -304,6 +309,7 @@ class FullnessTestCase(CephFSTestCase):
             print("writing some data through which we expect to succeed")
             bytes = 0
             f = os.open("{file_path}", os.O_WRONLY | os.O_CREAT)
+            os.setxattr("{file_path}", 'ceph.file.layout', b'{file_layout}')
             bytes += os.write(f, b'a' * 4096)
             os.fsync(f)
             print("fsync'ed data successfully, will now attempt to fill fs")

--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -82,7 +82,7 @@ class TestMisc(CephFSTestCase):
                                             '--yes-i-really-really-mean-it')
         self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create',
                                             self.fs.metadata_pool_name,
-                                            self.fs.pgs_per_fs_pool.__str__())
+                                            '--pg_num_min', str(self.fs.pg_num_min))
 
         # insert a garbage object
         self.fs.radosm(["put", "foo", "-"], stdin=StringIO("bar"))
@@ -119,7 +119,7 @@ class TestMisc(CephFSTestCase):
                                             '--yes-i-really-really-mean-it')
         self.fs.mon_manager.raw_cluster_cmd('osd', 'pool', 'create',
                                             self.fs.metadata_pool_name,
-                                            self.fs.pgs_per_fs_pool.__str__())
+                                            '--pg_num_min', str(self.fs.pg_num_min))
         self.fs.mon_manager.raw_cluster_cmd('fs', 'new', self.fs.name,
                                             self.fs.metadata_pool_name,
                                             data_pool_name)


### PR DESCRIPTION
Setting the pg_num to 8 is too small that some osds maybe not covered by the
pools, some osds maybe overloaded.

Fixes: https://tracker.ceph.com/issues/50984
Fixes: https://tracker.ceph.com/issues/45434
Signed-off-by: Xiubo Li <xiubli@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
