### PR TITLE
librbd: fix spelling in immutable-object-cache conn error

### DIFF
--- a/src/librbd/cache/ParentCacheObjectDispatch.cc
+++ b/src/librbd/cache/ParentCacheObjectDispatch.cc
@@ -206,7 +206,7 @@ void ParentCacheObjectDispatch<I>::create_cache_session(Context* on_finish,
   Context* connect_ctx = new LambdaContext(
     [this, cct, register_ctx](int ret) {
     if (ret < 0) {
-      lderr(cct) << "Parent cache fail to connect RO daeomn." << dendl;
+      lderr(cct) << "Parent cache fail to connect RO daemon." << dendl;
       register_ctx->complete(ret);
       return;
     }


### PR DESCRIPTION
`daeomn` -> `daemon`