### PR TITLE
librbd: 32-bit and libc++ portability fixups

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -7996,7 +7996,7 @@ int namespace_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
  */
 int sparsify(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 {
-  size_t sparse_size;
+  uint64_t sparse_size;
   bool remove_empty;
   try {
     auto iter = in->cbegin();

--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -2974,7 +2974,7 @@ int namespace_list(librados::IoCtx *ioctx,
   return namespace_list_finish(&iter, entries);
 }
 
-void sparsify(librados::ObjectWriteOperation *op, size_t sparse_size,
+void sparsify(librados::ObjectWriteOperation *op, uint64_t sparse_size,
               bool remove_empty)
 {
   bufferlist bl;
@@ -2983,7 +2983,7 @@ void sparsify(librados::ObjectWriteOperation *op, size_t sparse_size,
   op->exec("rbd", "sparsify", bl);
 }
 
-int sparsify(librados::IoCtx *ioctx, const std::string &oid, size_t sparse_size,
+int sparsify(librados::IoCtx *ioctx, const std::string &oid, uint64_t sparse_size,
              bool remove_empty)
 {
   librados::ObjectWriteOperation op;

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -652,9 +652,9 @@ int sparse_copyup(librados::IoCtx *ioctx, const std::string &oid,
                   const std::map<uint64_t, uint64_t> &extent_map,
                   ceph::buffer::list data);
 
-void sparsify(librados::ObjectWriteOperation *op, size_t sparse_size,
+void sparsify(librados::ObjectWriteOperation *op, uint64_t sparse_size,
               bool remove_empty);
-int sparsify(librados::IoCtx *ioctx, const std::string &oid, size_t sparse_size,
+int sparsify(librados::IoCtx *ioctx, const std::string &oid, uint64_t sparse_size,
              bool remove_empty);
 
 } // namespace cls_client

--- a/src/librbd/WatchNotifyTypes.h
+++ b/src/librbd/WatchNotifyTypes.h
@@ -410,10 +410,10 @@ struct MigratePayload : public AsyncRequestPayloadBase {
 };
 
 struct SparsifyPayload : public AsyncRequestPayloadBase {
-  size_t sparse_size = 0;
+  uint64_t sparse_size = 0;
 
   SparsifyPayload() {}
-  SparsifyPayload(const AsyncRequestId &id, size_t sparse_size)
+  SparsifyPayload(const AsyncRequestId &id, uint64_t sparse_size)
     : AsyncRequestPayloadBase(id), sparse_size(sparse_size) {
   }
 

--- a/src/librbd/object_map/DiffRequest.cc
+++ b/src/librbd/object_map/DiffRequest.cc
@@ -175,7 +175,7 @@ void DiffRequest<I>::handle_load_object_map(int r) {
     m_object_map.resize(num_objs);
   }
 
-  size_t prev_object_diff_state_size = m_object_diff_state->size();
+  uint64_t prev_object_diff_state_size = m_object_diff_state->size();
   if (prev_object_diff_state_size < num_objs) {
     // the diff state should be the largest of all snapshots in the set
     m_object_diff_state->resize(num_objs);


### PR DESCRIPTION
the size of `size_t` varies from architecture to architecture. the
C++ standard only requires it to be able to represent the maximum possible
size of object of any type. on 32-bit architectures, it's very likely a
32-bit unsigned integer. to ensure the interoperability between the
64-bit systems and 32-bit systems, we should use a type with explicitly
defined size.

also, we don't define the dencoder for size_t. so on systems where
size_t is not backed by uint32_t or uint64_t, the tree does not compile.

in this change, use uint64_t for sparse_size. and leave
`C_SparsifyObject::m_sparse_size` intact. as the latter should be able
to promoted to uint64_t when necessary.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
