### PR TITLE
monitoring: Use Instance in grafana dashb. Mult Ceph/single Prometheus

### DIFF
--- a/monitoring/grafana/dashboards/ceph-cluster.json
+++ b/monitoring/grafana/dashboards/ceph-cluster.json
@@ -38,8 +38,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": null,
-  "iteration": 1525415495309,
+  "iteration": 1619478790308,
   "links": [],
   "panels": [
     {
@@ -54,6 +53,12 @@
       "datasource": "$datasource",
       "editable": false,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -104,13 +109,13 @@
         "lineColor": "rgb(31, 120, 193)",
         "show": false
       },
-      "tableColumn": "",
       "targets": [
         {
-          "expr": "ceph_health_status{instance=~'$instance'}",
+          "expr": "ceph_health_status{instance=~\"$instance.*\"}",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
+          "legendFormat": "",
           "refId": "A",
           "step": 60
         }
@@ -118,7 +123,6 @@
       "thresholds": "1,2",
       "timeFrom": null,
       "title": "Health Status",
-      "transparent": false,
       "type": "singlestat",
       "valueFontSize": "50%",
       "valueMaps": [
@@ -151,6 +155,28 @@
       "cornerRadius": 0,
       "datasource": "$datasource",
       "displayName": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
       "flipCard": false,
       "flipTime": 5,
       "fontFormat": "Regular",
@@ -166,6 +192,7 @@
       "isHideAlertsOnDisable": false,
       "isIgnoreOKColors": false,
       "links": [],
+      "pluginVersion": "7.0.3",
       "targets": [
         {
           "aggregation": "Last",
@@ -174,8 +201,9 @@
           "displayAliasType": "Always",
           "displayType": "Regular",
           "displayValueWithAlias": "When Alias Displayed",
-          "expr": "count(ceph_osd_metadata{instance=~\"$instance\"})",
+          "expr": "count(ceph_osd_metadata{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "All",
           "refId": "A",
@@ -189,8 +217,9 @@
           "displayAliasType": "Always",
           "displayType": "Regular",
           "displayValueWithAlias": "When Alias Displayed",
-          "expr": "sum(ceph_osds_in{instance=~\"$instance\"})",
+          "expr": "sum(ceph_osds_in{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "In",
           "refId": "B",
@@ -204,7 +233,7 @@
           "displayAliasType": "Warning / Critical",
           "displayType": "Regular",
           "displayValueWithAlias": "When Alias Displayed",
-          "expr": "sum(ceph_osd_in{instance=~\"$instance\"} == bool 0)",
+          "expr": "sum(ceph_osd_in{instance=~\"$instance.*\"} == bool 0)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -221,8 +250,9 @@
           "displayAliasType": "Always",
           "displayType": "Regular",
           "displayValueWithAlias": "When Alias Displayed",
-          "expr": "sum(ceph_osd_up{instance=~\"$instance\"})",
+          "expr": "sum(ceph_osd_up{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Up",
           "refId": "D",
@@ -237,8 +267,9 @@
           "displayAliasType": "Warning / Critical",
           "displayType": "Regular",
           "displayValueWithAlias": "When Alias Displayed",
-          "expr": "sum(ceph_osd_up{instance=~\"$instance\"} == bool 0)",
+          "expr": "sum(ceph_osd_up{instance=~\"$instance.*\"} == bool 0)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Down",
           "refId": "E",
@@ -261,6 +292,12 @@
       ],
       "datasource": "$datasource",
       "decimals": 2,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "percentunit",
       "gauge": {
         "maxValue": 100,
@@ -309,11 +346,12 @@
         "lineColor": "rgb(31, 120, 193)",
         "show": true
       },
-      "tableColumn": "",
+      "tableColumn": "Used",
       "targets": [
         {
-          "expr": "sum(ceph_osd_stat_bytes_used{instance=~\"$instance\"})/sum(ceph_osd_stat_bytes{instance=~\"$instance\"})",
+          "expr": "sum(ceph_osd_stat_bytes_used{instance=~\"$instance.*\"})/sum(ceph_osd_stat_bytes{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Used",
           "refId": "A"
@@ -338,13 +376,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 8,
         "x": 8,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 53,
       "legend": {
         "avg": false,
@@ -359,6 +405,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -403,50 +452,57 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(ceph_pg_total)",
+          "expr": "sum(ceph_pg_total{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Total",
           "refId": "A"
         },
         {
-          "expr": "sum(ceph_pg_active)",
+          "expr": "sum(ceph_pg_active{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Active",
           "refId": "B"
         },
         {
-          "expr": "sum(ceph_pg_total - ceph_pg_active)",
+          "expr": "sum(ceph_pg_total{instance=~\"$instance.*\"} - ceph_pg_active{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Inactive",
           "refId": "G"
         },
         {
-          "expr": "sum(ceph_pg_undersized)",
+          "expr": "sum(ceph_pg_undersized{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Undersized",
           "refId": "F"
         },
         {
-          "expr": "sum(ceph_pg_degraded)",
+          "expr": "sum(ceph_pg_degraded{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Degraded",
           "refId": "C"
         },
         {
-          "expr": "sum(ceph_pg_inconsistent)",
+          "expr": "sum(ceph_pg_inconsistent{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Inconsistent",
           "refId": "D"
         },
         {
-          "expr": "sum(ceph_pg_down)",
+          "expr": "sum(ceph_pg_down{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Down",
           "refId": "E"
@@ -454,6 +510,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "PG States",
       "tooltip": {
@@ -486,7 +543,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -494,13 +555,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 6,
         "w": 8,
         "x": 16,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 66,
       "legend": {
         "avg": false,
@@ -515,6 +584,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -530,29 +602,33 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "quantile(0.95, ceph_osd_apply_latency_ms{instance=~\"$instance\"})",
+          "expr": "quantile(0.95, ceph_osd_apply_latency_ms{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Apply Latency P_95",
           "refId": "A"
         },
         {
-          "expr": "quantile(0.95, ceph_osd_commit_latency_ms{instance=~\"$instance\"})",
+          "expr": "quantile(0.95, ceph_osd_commit_latency_ms{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Commit Latency P_95",
           "refId": "B"
         },
         {
-          "expr": "avg(ceph_osd_apply_latency_ms{instance=~\"$instance\"})",
+          "expr": "avg(ceph_osd_apply_latency_ms{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Avg Apply Latency",
           "refId": "C"
         },
         {
-          "expr": "avg(ceph_osd_commit_latency_ms{instance=~\"$instance\"})",
+          "expr": "avg(ceph_osd_commit_latency_ms{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Avg Commit Latency",
           "refId": "D"
@@ -560,6 +636,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "OSD Latencies",
       "tooltip": {
@@ -592,7 +669,11 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "clusterName": "",
@@ -606,6 +687,12 @@
       "cornerRadius": 1,
       "datasource": "$datasource",
       "displayName": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "flipCard": false,
       "flipTime": 5,
       "fontFormat": "Regular",
@@ -629,7 +716,7 @@
           "displayAliasType": "Always",
           "displayType": "Regular",
           "displayValueWithAlias": "When Alias Displayed",
-          "expr": "sum(ceph_mon_quorum_status{instance=~\"$instance\"})",
+          "expr": "sum(ceph_mon_quorum_status{instance=~\"$instance.*\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -646,8 +733,9 @@
           "displayAliasType": "Always",
           "displayType": "Regular",
           "displayValueWithAlias": "When Alias Displayed",
-          "expr": "count(ceph_mon_quorum_status{instance=~\"$instance\"})",
+          "expr": "count(ceph_mon_quorum_status{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Total",
           "refId": "B",
@@ -663,8 +751,9 @@
           "displayAliasType": "Warning / Critical",
           "displayType": "Annotation",
           "displayValueWithAlias": "Never",
-          "expr": "count(ceph_mon_quorum_status{instance=~\"$instance\"}) / sum(ceph_mon_quorum_status{instance=~\"$instance\"})",
+          "expr": "count(ceph_mon_quorum_status{instance=~\"$instance.*\"}) / sum(ceph_mon_quorum_status{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "MONs out of Quorum",
           "refId": "C",
@@ -687,6 +776,12 @@
       "cornerRadius": 0,
       "datasource": "$datasource",
       "displayName": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "flipCard": false,
       "flipTime": 5,
       "fontFormat": "Regular",
@@ -710,8 +805,9 @@
           "displayAliasType": "Always",
           "displayType": "Regular",
           "displayValueWithAlias": "When Alias Displayed",
-          "expr": "ceph_mds_server_handle_client_session{instance=~\"$instance\"}",
+          "expr": "ceph_mds_server_handle_client_session{instance=~\"$instance.*\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Clients",
           "refId": "A",
@@ -728,13 +824,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
         "y": 6
       },
+      "hiddenSeries": false,
       "id": 45,
       "legend": {
         "avg": false,
@@ -749,6 +853,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 0.5,
       "points": false,
@@ -764,15 +871,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(ceph_osd_op_w_in_bytes{instance=~\"$instance\"}[1m]))",
+          "expr": "sum(irate(ceph_osd_op_w_in_bytes{instance=~\"$instance.*\"}[1m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Writes",
           "refId": "A"
         },
         {
-          "expr": "sum(irate(ceph_osd_op_r_out_bytes{instance=~\"$instance\"}[1m]))",
+          "expr": "sum(irate(ceph_osd_op_r_out_bytes{instance=~\"$instance.*\"}[1m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Reads",
           "refId": "B"
@@ -780,6 +889,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Cluster I/O",
       "tooltip": {
@@ -812,7 +922,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -820,13 +934,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 12,
         "y": 6
       },
+      "hiddenSeries": false,
       "id": 62,
       "legend": {
         "avg": false,
@@ -841,6 +963,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -851,14 +976,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(deriv(ceph_pool_stored{instance=~\"$instance\"}[1m]))",
+          "expr": "sum(deriv(ceph_pool_stored{instance=~\"$instance.*\"}[1m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
+          "legendFormat": "",
           "refId": "A"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "In-/Egress",
       "tooltip": {
@@ -891,7 +1019,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "cards": {
@@ -908,6 +1040,12 @@
       },
       "dataFormat": "timeseries",
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 9,
         "w": 6,
@@ -915,16 +1053,18 @@
         "y": 15
       },
       "heatmap": {},
+      "hideZeroBuckets": false,
       "highlightCards": true,
       "id": 55,
       "legend": {
         "show": true
       },
       "links": [],
+      "reverseYBuckets": false,
       "span": 12,
       "targets": [
         {
-          "expr": "ceph_osd_stat_bytes_used{instance=~'$instance'} / ceph_osd_stat_bytes{instance=~'$instance'}",
+          "expr": "ceph_osd_stat_bytes_used{instance=~\"$instance.*\"} / ceph_osd_stat_bytes{instance=~\"$instance.*\"}",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,
@@ -954,6 +1094,7 @@
         "show": true,
         "splitFactor": null
       },
+      "yBucketBound": "auto",
       "yBucketNumber": null,
       "yBucketSize": null
     },
@@ -971,6 +1112,12 @@
       },
       "dataFormat": "timeseries",
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 9,
         "w": 6,
@@ -978,16 +1125,19 @@
         "y": 15
       },
       "heatmap": {},
+      "hideZeroBuckets": false,
       "highlightCards": true,
       "id": 59,
       "legend": {
         "show": true
       },
       "links": [],
+      "reverseYBuckets": false,
       "targets": [
         {
-          "expr": "ceph_osd_numpg{instance=~\"$instance\"}",
+          "expr": "ceph_osd_numpg{instance=~\"$instance.*\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "#PGs",
           "refId": "A"
@@ -1013,6 +1163,7 @@
         "show": true,
         "splitFactor": null
       },
+      "yBucketBound": "auto",
       "yBucketNumber": null,
       "yBucketSize": null
     },
@@ -1022,13 +1173,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 12,
         "y": 15
       },
+      "hiddenSeries": false,
       "id": 64,
       "legend": {
         "avg": false,
@@ -1043,6 +1202,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -1053,8 +1215,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(ceph_osd_recovery_ops[1m]))",
+          "expr": "sum(irate(ceph_osd_recovery_ops{instance=~\"$instance.*\"}[1m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Op/s",
           "refId": "A"
@@ -1062,6 +1225,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Recovery Rate",
       "tooltip": {
@@ -1094,11 +1258,15 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 16,
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [
     "ceph",
@@ -1107,13 +1275,21 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
         "hide": 0,
+        "includeAll": false,
         "label": null,
+        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "type": "datasource"
       },
       {
@@ -1121,6 +1297,7 @@
         "auto_count": 10,
         "auto_min": "1m",
         "current": {
+          "selected": false,
           "text": "auto",
           "value": "$__auto_interval_interval"
         },
@@ -1189,13 +1366,15 @@
         ],
         "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
         "refresh": 2,
+        "skipUrlSync": false,
         "type": "interval"
       },
       {
         "allFormat": "glob",
         "allValue": null,
-        "current": {},
+        "current": {}
         "datasource": "$datasource",
+        "definition": "label_values(ceph_health_status, instance)",
         "hide": 0,
         "hideLabel": false,
         "includeAll": true,
@@ -1206,7 +1385,8 @@
         "options": [],
         "query": "label_values(ceph_health_status, instance)",
         "refresh": 1,
-        "regex": "",
+        "regex": "([^:]*).*",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
@@ -1247,5 +1427,5 @@
   },
   "timezone": "browser",
   "title": "Ceph - Cluster",
-  "version": 13
-    }
+  "version": 6
+}

--- a/monitoring/grafana/dashboards/cephfs-overview.json
+++ b/monitoring/grafana/dashboards/cephfs-overview.json
@@ -302,8 +302,7 @@
       "30d"
     ]
   },
-  "timezone": "",
+  "timezone": "browser",
   "title": "MDS Performance",
-  "uid": "tbO9LAiZz",
   "version": 2
 }

--- a/monitoring/grafana/dashboards/host-details.json
+++ b/monitoring/grafana/dashboards/host-details.json
@@ -36,11 +36,11 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": null,
-  "iteration": 1557386759572,
+  "iteration": 1619480057794,
   "links": [],
   "panels": [
     {
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -61,6 +61,12 @@
         "rgba(50, 172, 45, 0.97)"
       ],
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -91,7 +97,7 @@
         }
       ],
       "maxDataPoints": "",
-      "minSpan": 4,
+      "maxPerRow": 6,
       "nullPointMode": "connected",
       "nullText": null,
       "postfix": "",
@@ -148,13 +154,21 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "Shows the CPU breakdown. When multiple servers are selected, only the first host's cpu data is shown",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 6,
         "x": 3,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 9,
       "legend": {
         "alignAsTable": false,
@@ -169,8 +183,11 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "minSpan": 12,
+      "maxPerRow": 2,
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -193,6 +210,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "CPU Utilization",
       "tooltip": {
@@ -244,13 +262,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 6,
         "x": 9,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 14,
       "legend": {
         "avg": false,
@@ -265,6 +291,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -316,6 +345,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "RAM Usage",
       "tooltip": {
@@ -361,13 +391,21 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "Show the network load (rx,tx) across all interfaces (excluding loopback 'lo')",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 10,
         "w": 6,
         "x": 15,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 10,
       "legend": {
         "alignAsTable": false,
@@ -384,8 +422,11 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "minSpan": 12,
+      "maxPerRow": 2,
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -420,6 +461,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Network Load",
       "tooltip": {
@@ -464,13 +506,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 3,
         "x": 21,
         "y": 1
       },
+      "hiddenSeries": false,
       "hideTimeOverride": true,
       "id": 18,
       "legend": {
@@ -486,6 +536,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -518,6 +571,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Network drop rate",
       "tooltip": {
@@ -568,6 +622,12 @@
       "datasource": "$datasource",
       "decimals": 0,
       "description": "Each OSD consists of a Journal/WAL partition and a data partition. The RAW Capacity shown is the sum of the data partitions across all OSDs on the selected OSD hosts.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "bytes",
       "gauge": {
         "maxValue": 100,
@@ -598,7 +658,7 @@
         }
       ],
       "maxDataPoints": "",
-      "minSpan": 4,
+      "maxPerRow": 6,
       "nullPointMode": "connected",
       "nullText": null,
       "postfix": "",
@@ -621,9 +681,11 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(ceph_osd_stat_bytes and on (ceph_daemon) ceph_disk_occupation{instance=~\"($ceph_hosts).*\"})",
+          "expr": "sum(ceph_osd_stat_bytes and on (ceph_daemon) ceph_disk_occupation{exported_instance=~\"($ceph_hosts).*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
+          "legendFormat": "",
           "refId": "A",
           "step": 40,
           "textEditor": true
@@ -648,13 +710,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 3,
         "x": 21,
         "y": 6
       },
+      "hiddenSeries": false,
       "hideTimeOverride": true,
       "id": 19,
       "legend": {
@@ -670,6 +740,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -702,6 +775,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Network error rate",
       "tooltip": {
@@ -742,6 +816,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -761,13 +836,21 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "For any OSD devices on the host, this chart shows the iops per physical device. Each device is shown by it's name and corresponding OSD id value",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 11,
         "x": 0,
         "y": 12
       },
+      "hiddenSeries": false,
       "id": 6,
       "legend": {
         "avg": false,
@@ -781,8 +864,11 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "minSpan": 12,
+      "maxPerRow": 2,
       "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -798,8 +884,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "label_replace(\n  (\n    irate(node_disk_writes_completed{instance=~\"($ceph_hosts).*\"}[5m]) or\n    irate(node_disk_writes_completed_total{instance=~\"($ceph_hosts).*\"}[5m])\n  ),\n  \"instance\",\n  \"$1\",\n  \"instance\",\n  \"([^:.]*).*\"\n)\n* on(instance, device) group_left(ceph_daemon)\n  label_replace(\n    label_replace(\n      ceph_disk_occupation,\n      \"device\",\n      \"$1\",\n      \"device\",\n      \"/dev/(.*)\"\n    ),\n    \"instance\",\n    \"$1\",\n    \"instance\",\n    \"([^:.]*).*\"\n  )",
+          "expr": "label_replace(\n  (\n    irate(node_disk_writes_completed{instance=~\"($ceph_hosts).*\"}[5m]) or\n    irate(node_disk_writes_completed_total{instance=~\"($ceph_hosts).*\"}[5m])\n  ),\n  \"instance\",\n  \"$1\",\n  \"instance\",\n  \"([^:.]*).*\"\n)\n* on(instance, device) group_left(ceph_daemon)\n  label_replace(\n    label_replace(\n      ceph_disk_occupation,\n      \"device\",\n      \"$1\",\n      \"device\",\n      \"/dev/(.*)\"\n    ),\n    \"instance\",\n    \"$1\",\n    \"exported_instance\",\n    \"([^:.]*).*\"\n  )",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{device}}({{ceph_daemon}}) writes",
           "refId": "A",
@@ -807,9 +894,10 @@
           "textEditor": true
         },
         {
-          "expr": "label_replace(\n    (irate(node_disk_reads_completed{instance=~\"($ceph_hosts).*\"}[5m]) or irate(node_disk_reads_completed_total{instance=~\"($ceph_hosts).*\"}[5m])),\n    \"instance\",\n    \"$1\",\n    \"instance\",\n    \"([^:.]*).*\"\n)\n* on(instance, device) group_left(ceph_daemon)\n  label_replace(\n    label_replace(\n      ceph_disk_occupation,\n      \"device\",\n      \"$1\",\n      \"device\",\n      \"/dev/(.*)\"\n    ),\n    \"instance\",\n    \"$1\",\n    \"instance\",\n    \"([^:.]*).*\"\n  )",
+          "expr": "label_replace(\n    (irate(node_disk_reads_completed{instance=~\"($ceph_hosts).*\"}[5m]) or irate(node_disk_reads_completed_total{instance=~\"($ceph_hosts).*\"}[5m])),\n    \"instance\",\n    \"$1\",\n    \"instance\",\n    \"([^:.]*).*\"\n)\n* on(instance, device) group_left(ceph_daemon)\n  label_replace(\n    label_replace(\n      ceph_disk_occupation,\n      \"device\",\n      \"$1\",\n      \"device\",\n      \"/dev/(.*)\"\n    ),\n    \"instance\",\n    \"$1\",\n    \"exported_instance\",\n    \"([^:.]*).*\"\n  )",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{device}}({{ceph_daemon}}) reads",
           "refId": "B"
@@ -817,6 +905,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "$ceph_hosts Disk IOPS",
       "tooltip": {
@@ -862,13 +951,21 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "For OSD hosts, this chart shows the disk bandwidth (read bytes/sec + write bytes/sec) of the physical OSD device. Each device is shown by device name, and corresponding OSD id",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 11,
         "x": 12,
         "y": 12
       },
+      "hiddenSeries": false,
       "id": 8,
       "legend": {
         "avg": false,
@@ -882,8 +979,11 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "minSpan": 12,
+      "maxPerRow": 2,
       "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -899,15 +999,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "label_replace((irate(node_disk_bytes_written{instance=~\"($ceph_hosts).*\"}[5m]) or irate(node_disk_written_bytes_total{instance=~\"($ceph_hosts).*\"}[5m])), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\") * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\")",
+          "expr": "label_replace((irate(node_disk_bytes_written{instance=~\"($ceph_hosts).*\"}[5m]) or irate(node_disk_written_bytes_total{instance=~\"($ceph_hosts).*\"}[5m])), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\") * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"exported_instance\", \"([^:.]*).*\")",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{device}}({{ceph_daemon}}) write",
           "refId": "B"
         },
         {
-          "expr": "label_replace((irate(node_disk_bytes_read{instance=~\"($ceph_hosts).*\"}[5m]) or irate(node_disk_read_bytes_total{instance=~\"($ceph_hosts).*\"}[5m])), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\") * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\")",
+          "expr": "label_replace((irate(node_disk_bytes_read{instance=~\"($ceph_hosts).*\"}[5m]) or irate(node_disk_read_bytes_total{instance=~\"($ceph_hosts).*\"}[5m])), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\") * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"exported_instance\", \"([^:.]*).*\")",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{device}}({{ceph_daemon}}) read",
           "refId": "C"
@@ -915,6 +1017,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "$ceph_hosts Throughput by Disk",
       "tooltip": {
@@ -960,13 +1063,21 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "For OSD hosts, this chart shows the latency at the physical drive. Each drive is shown by device name, with it's corresponding OSD id",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 11,
         "x": 0,
         "y": 21
       },
+      "hiddenSeries": false,
       "id": 7,
       "legend": {
         "avg": false,
@@ -980,8 +1091,11 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "minSpan": 12,
+      "maxPerRow": 2,
       "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -992,9 +1106,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max by(instance,device) (label_replace((irate(node_disk_write_time_seconds_total{ instance=~\"($ceph_hosts).*\"}[5m]) )  / clamp_min(irate(node_disk_writes_completed_total{ instance=~\"($ceph_hosts).*\"}[5m]), 0.001) or   (irate(node_disk_read_time_seconds_total{ instance=~\"($ceph_hosts).*\"}[5m]) )  / clamp_min(irate(node_disk_reads_completed_total{ instance=~\"($ceph_hosts).*\"}[5m]), 0.001), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\")) *  on(instance,device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation{instance=~\"($ceph_hosts).*\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\")",
+          "expr": "max by(instance,device) (label_replace((irate(node_disk_write_time_seconds_total{ instance=~\"($ceph_hosts).*\"}[5m]) )  / clamp_min(irate(node_disk_writes_completed_total{ instance=~\"($ceph_hosts).*\"}[5m]), 0.001) or   (irate(node_disk_read_time_seconds_total{ instance=~\"($ceph_hosts).*\"}[5m]) )  / clamp_min(irate(node_disk_reads_completed_total{ instance=~\"($ceph_hosts).*\"}[5m]), 0.001), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\")) *  on(instance,device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation{exported_instance=~\"($ceph_hosts).*\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"exported_instance\", \"([^:.]*).*\")",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{device}}({{ceph_daemon}})",
           "refId": "D"
@@ -1002,6 +1117,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "$ceph_hosts Disk Latency",
       "tooltip": {
@@ -1047,6 +1163,12 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "Show disk utilization % (util) of any OSD devices on the host by the physical device name and associated OSD id.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1055,6 +1177,7 @@
         "x": 12,
         "y": 21
       },
+      "hiddenSeries": false,
       "id": 5,
       "legend": {
         "avg": false,
@@ -1083,9 +1206,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "label_replace(((irate(node_disk_io_time_ms{instance=~\"($ceph_hosts).*\"}[5m]) / 10 ) or  irate(node_disk_io_time_seconds_total{instance=~\"($ceph_hosts).*\"}[5m]) * 100), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\") * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation{instance=~\"($ceph_hosts).*\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\")",
+          "expr": "label_replace(((irate(node_disk_io_time_ms{instance=~\"($ceph_hosts).*\"}[5m]) / 10 ) or  irate(node_disk_io_time_seconds_total{instance=~\"($ceph_hosts).*\"}[5m]) * 100), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\") * on(instance, device) group_left(ceph_daemon) label_replace(label_replace(ceph_disk_occupation{exported_instance=~\"($ceph_hosts).*\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"exported_instance\", \"([^:.]*).*\")",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{device}}({{ceph_daemon}})",
           "refId": "A"
@@ -1134,7 +1258,7 @@
     }
   ],
   "refresh": "10s",
-  "schemaVersion": 16,
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [
     "overview"
@@ -1143,11 +1267,14 @@
     "list": [
       {
         "current": {
+          "selected": false,
           "text": "default",
           "value": "default"
         },
         "hide": 0,
+        "includeAll": false,
         "label": "Data Source",
+        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
@@ -1158,8 +1285,9 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {}
         "datasource": "$datasource",
+        "definition": "label_values(node_scrape_collector_success, instance) ",
         "hide": 0,
         "includeAll": false,
         "label": "Hostname",
@@ -1168,7 +1296,7 @@
         "options": [],
         "query": "label_values(node_scrape_collector_success, instance) ",
         "refresh": 1,
-        "regex": "([^.:]*).*",
+        "regex": "([^:]*).*",
         "skipUrlSync": false,
         "sort": 3,
         "tagValuesQuery": "",
@@ -1185,7 +1313,6 @@
   },
   "timepicker": {
     "refresh_intervals": [
-      "5s",
       "10s",
       "30s",
       "1m",
@@ -1210,6 +1337,5 @@
   },
   "timezone": "browser",
   "title": "Host Details",
-  "uid": "rtOg0AiWz",
-  "version": 4
+  "version": 7
 }

--- a/monitoring/grafana/dashboards/hosts-overview.json
+++ b/monitoring/grafana/dashboards/hosts-overview.json
@@ -36,8 +36,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": null,
-  "iteration": 1557393917915,
+  "iteration": 1619480467138,
   "links": [],
   "panels": [
     {
@@ -50,6 +49,12 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -101,10 +106,12 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(sum by (hostname) (ceph_osd_metadata))",
+          "expr": "count(sum by (hostname) (ceph_osd_metadata{instance=~\"$instance.*\"}))",
           "format": "time_series",
           "instant": true,
+          "interval": "",
           "intervalFactor": 1,
+          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -131,8 +138,14 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "description": "Average CPU busy across all hosts (OSD, RGW, MON etc) within the cluster",
       "decimals": 2,
+      "description": "Average CPU busy across all hosts (OSD, RGW, MON etc) within the cluster",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "percentunit",
       "gauge": {
         "maxValue": 100,
@@ -187,7 +200,9 @@
           "expr": "avg(\n  1 - (\n    avg by(instance) \n      (irate(node_cpu_seconds_total{mode='idle',instance=~\"($osd_hosts|$mon_hosts|$mds_hosts|$rgw_hosts).*\"}[1m]) or\n       irate(node_cpu{mode='idle',instance=~\"($osd_hosts|$mon_hosts|$mds_hosts|$rgw_hosts).*\"}[1m]))\n    )\n  )",
           "format": "time_series",
           "instant": true,
+          "interval": "",
           "intervalFactor": 1,
+          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -214,8 +229,14 @@
         "#d44a3a"
       ],
       "datasource": "$datasource",
-      "description": "Average Memory Usage across all hosts in the cluster (excludes buffer/cache usage)",
       "decimals": 2,
+      "description": "Average Memory Usage across all hosts in the cluster (excludes buffer/cache usage)",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "percentunit",
       "gauge": {
         "maxValue": 100,
@@ -298,6 +319,12 @@
       ],
       "datasource": "$datasource",
       "description": "IOPS Load at the device as reported by the OS on all OSD hosts",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -380,6 +407,12 @@
       ],
       "datasource": "$datasource",
       "description": "Average Disk utilization for all OSD data devices (i.e. excludes journal/WAL)",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "percent",
       "gauge": {
         "maxValue": 100,
@@ -431,10 +464,12 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr" : "avg (\n  label_replace((irate(node_disk_io_time_ms[5m]) / 10 ) or\n   (irate(node_disk_io_time_seconds_total[5m]) * 100), \"instance\", \"$1\", \"instance\", \"([^.:]*).*\"\n  ) *\n  on(instance, device) label_replace(label_replace(ceph_disk_occupation{instance=~\"($osd_hosts).*\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"instance\", \"([^.:]*).*\")\n)",
+          "expr": "avg (\n  label_replace((irate(node_disk_io_time_ms[5m]) / 10 ) or\n   (irate(node_disk_io_time_seconds_total[5m]) * 100), \"instance\", \"$1\", \"instance\", \"([^.:]*).*\"\n  ) *\n  on(instance, device) label_replace(label_replace(ceph_disk_occupation{exported_instance=~\"($osd_hosts).*\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"exported_instance\", \"([^.:]*).*\")\n)",
           "format": "time_series",
           "instant": true,
+          "interval": "",
           "intervalFactor": 1,
+          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -463,6 +498,12 @@
       "datasource": "$datasource",
       "decimals": 0,
       "description": "Total send/receive network load across all hosts in the ceph cluster",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "bytes",
       "gauge": {
         "maxValue": 100,
@@ -541,13 +582,21 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "Show the top 10 busiest hosts by cpu",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
         "y": 5
       },
+      "hiddenSeries": false,
       "id": 13,
       "legend": {
         "avg": false,
@@ -562,6 +611,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -574,6 +626,7 @@
         {
           "expr": "topk(10,100 * ( 1 - (\n    avg by(instance) \n      (irate(node_cpu_seconds_total{mode='idle',instance=~\"($osd_hosts|$mon_hosts|$mds_hosts|$rgw_hosts).*\"}[1m]) or\n       irate(node_cpu{mode='idle',instance=~\"($osd_hosts|$mon_hosts|$mds_hosts|$rgw_hosts).*\"}[1m]))\n    )\n  )\n)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -628,13 +681,21 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "Top 10 hosts by network load",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 12,
         "y": 5
       },
+      "hiddenSeries": false,
       "id": 19,
       "legend": {
         "avg": false,
@@ -649,6 +710,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -710,7 +774,7 @@
     }
   ],
   "refresh": "10s",
-  "schemaVersion": 16,
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -721,7 +785,9 @@
           "value": "default"
         },
         "hide": 0,
+        "includeAll": false,
         "label": "Data Source",
+        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
@@ -732,15 +798,20 @@
       },
       {
         "allValue": "",
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "$datasource",
+        "definition": "label_values(ceph_disk_occupation{instance=~\"$instance.*\"}, exported_instance)",
         "hide": 2,
         "includeAll": true,
         "label": null,
         "multi": false,
         "name": "osd_hosts",
         "options": [],
-        "query": "label_values(ceph_disk_occupation, exported_instance)",
+        "query": "label_values(ceph_disk_occupation{instance=~\"$instance.*\"}, exported_instance)",
         "refresh": 1,
         "regex": "([^.]*).*",
         "skipUrlSync": false,
@@ -753,15 +824,20 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "$datasource",
+        "definition": "label_values(ceph_mon_metadata{instance=~\"$instance.*\"}, ceph_daemon)",
         "hide": 2,
         "includeAll": true,
         "label": null,
         "multi": false,
         "name": "mon_hosts",
         "options": [],
-        "query": "label_values(ceph_mon_metadata, ceph_daemon)",
+        "query": "label_values(ceph_mon_metadata{instance=~\"$instance.*\"}, ceph_daemon)",
         "refresh": 1,
         "regex": "mon.(.*)",
         "skipUrlSync": false,
@@ -774,15 +850,20 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "$datasource",
+        "definition": "label_values(ceph_mds_inodes{instance=~\"$instance.*\"}, ceph_daemon)",
         "hide": 2,
         "includeAll": true,
         "label": null,
         "multi": false,
         "name": "mds_hosts",
         "options": [],
-        "query": "label_values(ceph_mds_inodes, ceph_daemon)",
+        "query": "label_values(ceph_mds_inodes{instance=~\"$instance.*\"}, ceph_daemon)",
         "refresh": 1,
         "regex": "mds.(.*)",
         "skipUrlSync": false,
@@ -795,17 +876,47 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "$datasource",
+        "definition": "label_values(ceph_rgw_qlen{instance=~\"$instance.*\"}, ceph_daemon)",
         "hide": 2,
         "includeAll": true,
         "label": null,
         "multi": false,
         "name": "rgw_hosts",
         "options": [],
-        "query": "label_values(ceph_rgw_qlen, ceph_daemon)",
+        "query": "label_values(ceph_rgw_qlen{instance=~\"$instance.*\"}, ceph_daemon)",
         "refresh": 1,
         "regex": "rgw.(.*)",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "default",
+          "value": "default"
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(ceph_health_status, instance)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Instance",
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": "label_values(ceph_health_status, instance)",
+        "refresh": 1,
+        "regex": "([^:]*).*",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
@@ -845,8 +956,7 @@
       "30d"
     ]
   },
-  "timezone": "",
+  "timezone": "browser",
   "title": "Host Overview",
-  "uid": "y0KGL0iZz",
   "version": 3
 }

--- a/monitoring/grafana/dashboards/osd-device-details.json
+++ b/monitoring/grafana/dashboards/osd-device-details.json
@@ -30,12 +30,12 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": null,
-  "iteration": 1557395861896,
+  "iteration": 1619480824956,
   "links": [],
   "panels": [
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -53,13 +53,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 6,
         "x": 0,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 2,
       "legend": {
         "avg": false,
@@ -74,6 +82,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -89,15 +100,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(ceph_osd_op_r_latency_sum{ceph_daemon=~\"$osd\"}[1m]) / on (ceph_daemon) irate(ceph_osd_op_r_latency_count[1m])",
+          "expr": "irate(ceph_osd_op_r_latency_sum{ceph_daemon=~\"$osd\", instance=~\"$instance.*\"}[1m]) / on (ceph_daemon) irate(ceph_osd_op_r_latency_count{instance=~\"$instance.*\"}[1m])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "read",
           "refId": "A"
         },
         {
-          "expr": "irate(ceph_osd_op_w_latency_sum{ceph_daemon=~\"$osd\"}[1m]) / on (ceph_daemon) irate(ceph_osd_op_w_latency_count[1m])",
+          "expr": "irate(ceph_osd_op_w_latency_sum{ceph_daemon=~\"$osd\", instance=~\"$instance.*\"}[1m]) / on (ceph_daemon) irate(ceph_osd_op_w_latency_count{instance=~\"$instance.*\"}[1m])",
           "format": "time_series",
+          "hide": true,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "write",
           "refId": "B"
@@ -105,6 +119,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "$osd Latency",
       "tooltip": {
@@ -149,13 +164,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 6,
         "x": 6,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 8,
       "legend": {
         "avg": false,
@@ -170,6 +193,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -185,15 +211,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(ceph_osd_op_r{ceph_daemon=~\"$osd\"}[1m])",
+          "expr": "irate(ceph_osd_op_r{ceph_daemon=~\"$osd\", instance=~\"$instance.*\"}[1m])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Reads",
           "refId": "A"
         },
         {
-          "expr": "irate(ceph_osd_op_w{ceph_daemon=~\"$osd\"}[1m])",
+          "expr": "irate(ceph_osd_op_w{ceph_daemon=~\"$osd\", instance=~\"$instance.*\"}[1m])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Writes",
           "refId": "B"
@@ -201,6 +229,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "$osd R/W IOPS",
       "tooltip": {
@@ -245,13 +274,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 6,
         "x": 12,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 7,
       "legend": {
         "avg": false,
@@ -266,6 +303,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -281,15 +321,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(ceph_osd_op_r_out_bytes{ceph_daemon=~\"$osd\"}[1m])",
+          "expr": "irate(ceph_osd_op_r_out_bytes{ceph_daemon=~\"$osd\", instance=~\"$instance.*\"}[1m])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Read Bytes",
           "refId": "A"
         },
         {
-          "expr": "irate(ceph_osd_op_w_in_bytes{ceph_daemon=~\"$osd\"}[1m])",
+          "expr": "irate(ceph_osd_op_w_in_bytes{ceph_daemon=~\"$osd\", instance=~\"$instance.*\"}[1m])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Write Bytes",
           "refId": "B"
@@ -297,6 +339,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "$osd R/W Bytes",
       "tooltip": {
@@ -337,6 +380,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -354,13 +398,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 6,
         "x": 0,
         "y": 11
       },
+      "hiddenSeries": false,
       "id": 9,
       "legend": {
         "avg": false,
@@ -375,6 +427,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -390,15 +445,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(label_replace(irate(node_disk_read_time_seconds_total[1m]) / irate(node_disk_reads_completed_total[1m]), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\") and on (instance, device) label_replace(label_replace(ceph_disk_occupation{ceph_daemon=~\"$osd\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\"))",
+          "expr": "(label_replace(irate(node_disk_read_time_seconds_total{instance=~\"$instance.*\"}[1m]) / irate(node_disk_reads_completed_total{instance=~\"$instance.*\"}[1m]), \"instance\", \"$1\", \"instance\", \"([^:]*).*\") and on (instance, device) label_replace(label_replace(ceph_disk_occupation{ceph_daemon=~\"$osd\", instance=~\"$instance.*\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"instance\", \"([^:]*).*\"))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{instance}}/{{device}} Reads",
           "refId": "A"
         },
         {
-          "expr": "(label_replace(irate(node_disk_write_time_seconds_total[1m]) / irate(node_disk_writes_completed_total[1m]), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\") and on (instance, device) label_replace(label_replace(ceph_disk_occupation{ceph_daemon=~\"$osd\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\"))",
+          "expr": "(label_replace(irate(node_disk_write_time_seconds_total{instance=~\"$instance.*\"}[1m]) / irate(node_disk_writes_completed_total{instance=~\"$instance.*\"}[1m]), \"instance\", \"$1\", \"instance\", \"([^:]*).*\") and on (instance, device) label_replace(label_replace(ceph_disk_occupation{ceph_daemon=~\"$osd\", instance=~\"$instance.*\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"instance\", \"([^:]*).*\"))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{instance}}/{{device}} Writes",
           "refId": "B"
@@ -406,6 +463,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Physical Device Latency for $osd",
       "tooltip": {
@@ -450,13 +508,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 6,
         "x": 6,
         "y": 11
       },
+      "hiddenSeries": false,
       "id": 5,
       "legend": {
         "avg": false,
@@ -471,6 +537,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -486,15 +555,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "label_replace(irate(node_disk_writes_completed_total[1m]), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\") and on (instance, device) label_replace(label_replace(ceph_disk_occupation{ceph_daemon=~\"$osd\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\")",
+          "expr": "label_replace(irate(node_disk_writes_completed_total{instance=~\"$instance.*\"}[1m]), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\") and on (instance, device) label_replace(label_replace(ceph_disk_occupation{ceph_daemon=~\"$osd\", instance=~\"$instance.*\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\")",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{device}} on {{instance}} Writes",
           "refId": "A"
         },
         {
-          "expr": "label_replace(irate(node_disk_reads_completed_total[1m]), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\") and on (instance, device) label_replace(label_replace(ceph_disk_occupation{ceph_daemon=~\"$osd\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\")",
+          "expr": "label_replace(irate(node_disk_reads_completed_total{instance=~\"$instance.*\"}[1m]), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\") and on (instance, device) label_replace(label_replace(ceph_disk_occupation{ceph_daemon=~\"$osd\", instance=~\"$instance.*\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\")",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{device}} on {{instance}} Reads",
           "refId": "B"
@@ -502,6 +573,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Physical Device R/W IOPS for $osd",
       "tooltip": {
@@ -546,13 +618,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 6,
         "x": 12,
         "y": 11
       },
+      "hiddenSeries": false,
       "id": 10,
       "legend": {
         "avg": false,
@@ -567,6 +647,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -582,15 +665,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "label_replace(irate(node_disk_read_bytes_total[1m]), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\") and on (instance, device) label_replace(label_replace(ceph_disk_occupation{ceph_daemon=~\"$osd\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\")",
+          "expr": "label_replace(irate(node_disk_read_bytes_total{instance=~\"$instance.*\"}[1m]), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\") and on (instance, device) label_replace(label_replace(ceph_disk_occupation{ceph_daemon=~\"$osd\", instance=~\"$instance.*\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\")",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{instance}} {{device}} Reads",
           "refId": "A"
         },
         {
-          "expr": "label_replace(irate(node_disk_written_bytes_total[1m]), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\") and on (instance, device) label_replace(label_replace(ceph_disk_occupation{ceph_daemon=~\"$osd\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\")",
+          "expr": "label_replace(irate(node_disk_written_bytes_total{instance=~\"$instance.*\"}[1m]), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\") and on (instance, device) label_replace(label_replace(ceph_disk_occupation{ceph_daemon=~\"$osd\", instance=~\"$instance.*\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\")",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{instance}} {{device}} Writes",
           "refId": "B"
@@ -598,6 +683,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Physical Device R/W Bytes for $osd",
       "tooltip": {
@@ -642,13 +728,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 6,
         "x": 18,
         "y": 11
       },
+      "hiddenSeries": false,
       "id": 4,
       "legend": {
         "avg": false,
@@ -663,6 +757,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -673,8 +770,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "label_replace(irate(node_disk_io_time_seconds_total[1m]), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\") and on (instance, device) label_replace(label_replace(ceph_disk_occupation{ceph_daemon=~\"$osd\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\")",
+          "expr": "label_replace(irate(node_disk_io_time_seconds_total{instance=~\"$instance.*\"}[1m]), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\") and on (instance, device) label_replace(label_replace(ceph_disk_occupation{ceph_daemon=~\"$osd\", instance=~\"$instance.*\"}, \"device\", \"$1\", \"device\", \"/dev/(.*)\"), \"instance\", \"$1\", \"instance\", \"([^:.]*).*\")",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{device}} on {{instance}}",
           "refId": "A"
@@ -682,6 +780,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Physical Device Util% for $osd",
       "tooltip": {
@@ -721,21 +820,21 @@
       }
     }
   ],
-  "schemaVersion": 16,
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "default",
-          "value": "default"
-        },
+        "current": {},
         "hide": 0,
+        "includeAll": false,
         "label": "Data Source",
+        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
+        "queryValue": "",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -743,17 +842,41 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {}
+        },
         "datasource": "$datasource",
+        "definition": "label_values(ceph_osd_metadata{instance=~\"$instance.*\"},ceph_daemon)",
         "hide": 0,
         "includeAll": false,
         "label": "OSD",
         "multi": false,
         "name": "osd",
         "options": [],
-        "query": "label_values(ceph_osd_metadata,ceph_daemon)",
+        "query": "label_values(ceph_osd_metadata{instance=~\"$instance.*\"},ceph_daemon)",
         "refresh": 1,
         "regex": "(.*)",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "$datasource",
+        "definition": "label_values(ceph_health_status, instance)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Instance",
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": "label_values(ceph_health_status, instance)",
+        "refresh": 1,
+        "regex": "([^:]*).*",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
@@ -793,8 +916,7 @@
       "30d"
     ]
   },
-  "timezone": "",
+  "timezone": "browser",
   "title": "OSD device details",
-  "uid": "CrAHE0iZz",
   "version": 3
 }

--- a/monitoring/grafana/dashboards/osds-overview.json
+++ b/monitoring/grafana/dashboards/osds-overview.json
@@ -1,5 +1,4 @@
 {
-
   "__requires": [
     {
       "type": "grafana",
@@ -42,8 +41,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": null,
-  "iteration": 1538083987689,
+  "iteration": 1619481178972,
   "links": [],
   "panels": [
     {
@@ -54,13 +52,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 0,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 12,
       "legend": {
         "avg": false,
@@ -75,6 +81,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -85,22 +94,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg (irate(ceph_osd_op_r_latency_sum[1m]) / on (ceph_daemon) irate(ceph_osd_op_r_latency_count[1m]) * 1000)",
+          "expr": "avg (irate(ceph_osd_op_r_latency_sum{instance=~\"$instance.*\"}[1m]) / on (ceph_daemon) irate(ceph_osd_op_r_latency_count{instance=~\"$instance.*\"}[1m]) * 1000)",
           "format": "time_series",
+          "instant": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "AVG read",
           "refId": "A"
         },
         {
-          "expr": "max (irate(ceph_osd_op_r_latency_sum[1m]) / on (ceph_daemon) irate(ceph_osd_op_r_latency_count[1m]) * 1000)",
+          "expr": "max (irate(ceph_osd_op_r_latency_sum{instance=~\"$instance.*\"}[1m]) / on (ceph_daemon) irate(ceph_osd_op_r_latency_count{instance=~\"$instance.*\"}[1m]) * 1000)",
           "format": "time_series",
+          "hide": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "MAX read",
           "refId": "B"
         },
         {
-          "expr": "quantile(0.95,\n  (irate(ceph_osd_op_r_latency_sum[1m]) / on (ceph_daemon) irate(ceph_osd_op_r_latency_count[1m]) * 1000)\n)",
+          "expr": "quantile(0.95,\n  (irate(ceph_osd_op_r_latency_sum{instance=~\"$instance.*\"}[1m]) / on (ceph_daemon) irate(ceph_osd_op_r_latency_count{instance=~\"$instance.*\"}[1m]) * 1000)\n)",
           "format": "time_series",
+          "hide": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "@95%ile",
           "refId": "C"
@@ -108,6 +123,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "OSD Read Latencies",
       "tooltip": {
@@ -140,12 +156,22 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "columns": [],
       "datasource": "$datasource",
       "description": "This table shows the osd's that are delivering the 10 highest read latencies within the cluster",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fontSize": "100%",
       "gridPos": {
         "h": 8,
@@ -160,11 +186,12 @@
       "showHeader": true,
       "sort": {
         "col": 2,
-        "desc": true
+        "desc": false
       },
       "styles": [
         {
           "alias": "OSD ID",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -180,6 +207,7 @@
         },
         {
           "alias": "Latency (ms)",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -195,6 +223,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -211,9 +240,10 @@
       ],
       "targets": [
         {
-          "expr": "topk(10,\n  (sort(\n    (irate(ceph_osd_op_r_latency_sum[1m]) / on (ceph_daemon) irate(ceph_osd_op_r_latency_count[1m]) * 1000)\n  ))\n)\n\n",
+          "expr": "topk(10,\n  (sort(\n    (irate(ceph_osd_op_r_latency_sum{instance=~\"$instance.*\"}[1m]) / on (ceph_daemon) irate(ceph_osd_op_r_latency_count{instance=~\"$instance.*\"}[1m]) * 1000)\n  ))\n)\n\n",
           "format": "table",
           "instant": true,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "",
           "refId": "A"
@@ -221,7 +251,7 @@
       ],
       "title": "Highest READ Latencies",
       "transform": "table",
-      "type": "table"
+      "type": "table-old"
     },
     {
       "aliasColors": {
@@ -231,13 +261,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 12,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 13,
       "legend": {
         "avg": false,
@@ -252,6 +290,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -262,22 +303,25 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg (irate(ceph_osd_op_w_latency_sum[1m]) / on (ceph_daemon) irate(ceph_osd_op_w_latency_count[1m]) * 1000)",
+          "expr": "avg (irate(ceph_osd_op_w_latency_sum{instance=~\"$instance.*\"}[1m]) / on (ceph_daemon) irate(ceph_osd_op_w_latency_count{instance=~\"$instance.*\"}[1m]) * 1000)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "AVG write",
           "refId": "A"
         },
         {
-          "expr": "max (irate(ceph_osd_op_w_latency_sum[1m]) / on (ceph_daemon) irate(ceph_osd_op_w_latency_count[1m]) * 1000)",
+          "expr": "max (irate(ceph_osd_op_w_latency_sum{instance=~\"$instance.*\"}[1m]) / on (ceph_daemon) irate(ceph_osd_op_w_latency_count{instance=~\"$instance.*\"}[1m]) * 1000)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "MAX write",
           "refId": "B"
         },
         {
-          "expr": "quantile(0.95,\n (irate(ceph_osd_op_w_latency_sum[1m]) / on (ceph_daemon) irate(ceph_osd_op_w_latency_count[1m]) * 1000)\n)",
+          "expr": "quantile(0.95,\n (irate(ceph_osd_op_w_latency_sum{instance=~\"$instance.*\"}[1m]) / on (ceph_daemon) irate(ceph_osd_op_w_latency_count{instance=~\"$instance.*\"}[1m]) * 1000)\n)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "@95%ile write",
           "refId": "C"
@@ -285,6 +329,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "OSD Write Latencies",
       "tooltip": {
@@ -317,12 +362,22 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "columns": [],
       "datasource": "$datasource",
       "description": "This table shows the osd's that are delivering the 10 highest write latencies within the cluster",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fontSize": "100%",
       "gridPos": {
         "h": 8,
@@ -337,11 +392,12 @@
       "showHeader": true,
       "sort": {
         "col": 2,
-        "desc": true
+        "desc": false
       },
       "styles": [
         {
           "alias": "OSD ID",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -357,6 +413,7 @@
         },
         {
           "alias": "Latency (ms)",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -372,6 +429,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -388,9 +446,10 @@
       ],
       "targets": [
         {
-          "expr": "topk(10,\n  (sort(\n    (irate(ceph_osd_op_w_latency_sum[1m]) / on (ceph_daemon) irate(ceph_osd_op_w_latency_count[1m]) * 1000)\n  ))\n)\n\n",
+          "expr": "topk(10,\n  (sort(\n    (irate(ceph_osd_op_w_latency_sum{instance=~\"$instance.*\"}[1m]) / on (ceph_daemon) irate(ceph_osd_op_w_latency_count{instance=~\"$instance.*\"}[1m]) * 1000)\n  ))\n)\n\n",
           "format": "table",
           "instant": true,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "",
           "refId": "A"
@@ -398,7 +457,7 @@
       ],
       "title": "Highest WRITE Latencies",
       "transform": "table",
-      "type": "table"
+      "type": "table-old"
     },
     {
       "aliasColors": {},
@@ -409,6 +468,12 @@
         "threshold": 0
       },
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fontSize": "80%",
       "format": "none",
       "gridPos": {
@@ -431,8 +496,9 @@
       "strokeWidth": 1,
       "targets": [
         {
-          "expr": "count by (device_class) (ceph_osd_metadata)",
+          "expr": "count by (device_class) (ceph_osd_metadata{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{device_class}}",
           "refId": "A"
@@ -453,6 +519,12 @@
         "threshold": 0
       },
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fontSize": "80%",
       "format": "none",
       "gridPos": {
@@ -473,30 +545,33 @@
       "legendType": "Under graph",
       "links": [],
       "maxDataPoints": "1",
-      "minSpan": 4,
+      "maxPerRow": 6,
       "nullPointMode": "connected",
       "pieType": "pie",
       "strokeWidth": 1,
       "targets": [
         {
-          "expr": "count(ceph_bluefs_wal_total_bytes)",
+          "expr": "count(ceph_bluefs_wal_total_bytes{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "bluestore",
           "refId": "A",
           "step": 240
         },
         {
-          "expr": "count(ceph_osd_metadata) - count(ceph_bluefs_wal_total_bytes)",
+          "expr": "count(ceph_osd_metadata{instance=~\"$instance.*\"}) - count(ceph_bluefs_wal_total_bytes{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "filestore",
           "refId": "B",
           "step": 240
         },
         {
-          "expr": "absent(ceph_bluefs_wal_total_bytes)*count(ceph_osd_metadata)",
+          "expr": "absent(ceph_bluefs_wal_total_bytes{instance=~\"$instance.*\"})*count(ceph_osd_metadata{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "filestore",
           "refId": "C",
@@ -519,6 +594,12 @@
       },
       "datasource": "$datasource",
       "description": "The pie chart shows the various OSD sizes used within the cluster",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fontSize": "80%",
       "format": "none",
       "gridPos": {
@@ -542,82 +623,103 @@
       "legendType": "Under graph",
       "links": [],
       "maxDataPoints": "",
-      "minSpan": 6,
+      "maxPerRow": 4,
       "nullPointMode": "connected",
       "pieType": "pie",
       "strokeWidth": "1",
       "targets": [
         {
-          "expr": "count(ceph_osd_stat_bytes < 1099511627776)",
+          "expr": "count(ceph_osd_stat_bytes{instance=~\"$instance.*\"} < 1099511627776)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "<1 TB",
           "refId": "A",
           "step": 2
         },
         {
-          "expr": "count(ceph_osd_stat_bytes >= 1099511627776 < 2199023255552)",
+          "expr": "count(ceph_osd_stat_bytes {instance=~\"$instance.*\"}>= 1099511627776 < 2199023255552)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "<2 TB",
           "refId": "B",
           "step": 2
         },
         {
-          "expr": "count(ceph_osd_stat_bytes >= 2199023255552 < 3298534883328)",
+          "expr": "count(ceph_osd_stat_bytes{instance=~\"$instance.*\"} >= 2199023255552 < 3298534883328)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "<3TB",
+          "legendFormat": "<3 TB",
           "refId": "C",
           "step": 2
         },
         {
-          "expr": "count(ceph_osd_stat_bytes >= 3298534883328 < 4398046511104)",
+          "expr": "count(ceph_osd_stat_bytes{instance=~\"$instance.*\"} >= 3298534883328 < 4398046511104)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "<4TB",
+          "legendFormat": "<4 TB",
           "refId": "D",
           "step": 2
         },
         {
-          "expr": "count(ceph_osd_stat_bytes >= 4398046511104 < 6597069766656)",
+          "expr": "count(ceph_osd_stat_bytes{instance=~\"$instance.*\"} >= 4398046511104 < 6597069766656)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "<6TB",
+          "legendFormat": "<6 TB",
           "refId": "E",
           "step": 2
         },
         {
-          "expr": "count(ceph_osd_stat_bytes >= 6597069766656 < 8796093022208)",
+          "expr": "count(ceph_osd_stat_bytes{instance=~\"$instance.*\"} >= 6597069766656 < 8796093022208)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "<8TB",
+          "legendFormat": "<8 TB",
           "refId": "F",
           "step": 2
         },
         {
-          "expr": "count(ceph_osd_stat_bytes >= 8796093022208 < 10995116277760)",
+          "expr": "count(ceph_osd_stat_bytes{instance=~\"$instance.*\"} >= 8796093022208 < 10995116277760)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "<10TB",
+          "legendFormat": "<10 TB",
           "refId": "G",
           "step": 2
         },
         {
-          "expr": "count(ceph_osd_stat_bytes >= 10995116277760 < 13194139533312)",
+          "expr": "count(ceph_osd_stat_bytes{instance=~\"$instance.*\"} >= 10995116277760 < 13194139533312)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "<12TB",
+          "legendFormat": "<12 TB",
           "refId": "H",
           "step": 2
         },
         {
-          "expr": "count(ceph_osd_stat_bytes >= 13194139533312)",
+          "expr": "count(ceph_osd_stat_bytes{instance=~\"$instance.*\"} >= 13194139533312 < 15393162788864)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "12TB+",
+          "legendFormat": "<14 TB",
           "refId": "I",
           "step": 2
+        },
+        {
+          "expr": "count(ceph_osd_stat_bytes{instance=~\"$instance.*\"} >= 15393162788864 < 17592186044416)",
+          "interval": "",
+          "legendFormat": "<16TB",
+          "refId": "J"
+        },
+        {
+          "expr": "count(ceph_osd_stat_bytes{instance=~\"$instance.*\"} >= 17592186044416)",
+          "interval": "",
+          "legendFormat": "16 TB+",
+          "refId": "K"
         }
       ],
       "timeFrom": null,
@@ -633,13 +735,21 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "Each bar indicates the number of OSD's that have a PG count in a specific range as shown on the x axis.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
         "y": 8
       },
+      "hiddenSeries": false,
       "id": 6,
       "legend": {
         "alignAsTable": false,
@@ -658,6 +768,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -668,9 +781,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ceph_osd_numpg\n",
+          "expr": "ceph_osd_numpg{instance=~\"$instance.*\"}\n",
           "format": "time_series",
           "instant": true,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "PGs per OSD",
           "refId": "A"
@@ -678,6 +792,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Distribution of PGs per OSD",
       "tooltip": {
@@ -713,10 +828,15 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -735,13 +855,21 @@
       "dashes": false,
       "datasource": "$datasource",
       "description": "Show the read/write workload profile overtime",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 24,
         "x": 0,
         "y": 17
       },
+      "hiddenSeries": false,
       "id": 10,
       "legend": {
         "avg": false,
@@ -756,6 +884,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -766,15 +897,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "round(sum(irate(ceph_pool_rd[30s])))",
+          "expr": "round(sum(irate(ceph_pool_rd{instance=~\"$instance.*\"}[30s])))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Reads",
           "refId": "A"
         },
         {
-          "expr": "round(sum(irate(ceph_pool_wr[30s])))",
+          "expr": "round(sum(irate(ceph_pool_wr{instance=~\"$instance.*\"}[30s])))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Writes",
           "refId": "B"
@@ -782,6 +915,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Read/Write Profile",
       "tooltip": {
@@ -814,30 +948,58 @@
           "min": null,
           "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": "10s",
-  "schemaVersion": 16,
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
-        {
-          "current": {
-          "tags": [],
+      {
+        "current": {
           "text": "default",
           "value": "default"
-          },
-          "hide": 0,
-          "label": "Data Source",
-          "name": "datasource",
-          "options": [],
-          "query": "prometheus",
-          "refresh": 1,
-          "regex": "",
-          "type": "datasource"
-        }
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "$datasource",
+        "definition": "label_values(ceph_health_status, instance)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Instance",
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": "label_values(ceph_health_status, instance)",
+        "refresh": 1,
+        "regex": "([^:]*).*",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
     ]
   },
   "time": {
@@ -871,6 +1033,5 @@
   },
   "timezone": "",
   "title": "OSD Overview",
-  "uid": "lo02I1Aiz",
-  "version": 3
+  "version": 6
 }

--- a/monitoring/grafana/dashboards/pool-detail.json
+++ b/monitoring/grafana/dashboards/pool-detail.json
@@ -36,8 +36,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": null,
-  "iteration": 1551858875941,
+  "iteration": 1619481771816,
   "links": [],
   "panels": [
     {
@@ -51,6 +50,12 @@
       ],
       "datasource": "$datasource",
       "decimals": 2,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "percentunit",
       "gauge": {
         "maxValue": 1,
@@ -99,12 +104,13 @@
         "lineColor": "rgb(31, 120, 193)",
         "show": true
       },
-      "tableColumn": "",
       "targets": [
         {
-          "expr": "(ceph_pool_stored / (ceph_pool_stored + ceph_pool_max_avail)) * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"}",
+          "expr": "(ceph_pool_stored{instance=~\"$instance.*\"} / (ceph_pool_stored{instance=~\"$instance.*\"} + ceph_pool_max_avail{instance=~\"$instance.*\"} )) * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\", instance=~\"$instance.*\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
+          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -132,6 +138,12 @@
       ],
       "datasource": "$datasource",
       "description": "Time till pool is full assuming the average fill rate of the last 6 hours",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "s",
       "gauge": {
         "maxValue": 100,
@@ -180,12 +192,13 @@
         "lineColor": "rgb(31, 120, 193)",
         "show": false
       },
-      "tableColumn": "",
       "targets": [
         {
-          "expr": "(ceph_pool_max_avail / deriv(ceph_pool_stored[6h])) * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"} > 0",
+          "expr": "(ceph_pool_max_avail{instance=~\"$instance.*\"} / deriv(ceph_pool_stored{instance=~\"$instance.*\"}[6h])) * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\", instance=~\"$instance.*\"} > 0",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
+          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -216,13 +229,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 12,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 10,
       "legend": {
         "avg": false,
@@ -236,8 +257,11 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "minSpan": 12,
+      "maxPerRow": 2,
       "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -248,8 +272,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "deriv(ceph_pool_objects[1m]) * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"}",
+          "expr": "deriv(ceph_pool_objects{instance=~\"$instance.*\"}[1m]) * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\", instance=~\"$instance.*\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Objects per second",
           "refId": "B"
@@ -257,6 +282,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "$pool_name Object Ingress/Egress",
       "tooltip": {
@@ -304,13 +330,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 0,
         "y": 7
       },
+      "hiddenSeries": false,
       "id": 6,
       "legend": {
         "avg": false,
@@ -324,8 +358,11 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "minSpan": 12,
+      "maxPerRow": 2,
       "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -341,15 +378,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(ceph_pool_rd[1m]) * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"}",
+          "expr": "irate(ceph_pool_rd{instance=~\"$instance.*\"}[1m]) * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\", instance=~\"$instance.*\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "reads",
           "refId": "B"
         },
         {
-          "expr": "irate(ceph_pool_wr[1m]) * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"}",
+          "expr": "irate(ceph_pool_wr{instance=~\"$instance.*\"}[1m]) * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\", instance=~\"$instance.*\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "writes",
           "refId": "C"
@@ -357,6 +396,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "$pool_name Client IOPS",
       "tooltip": {
@@ -404,13 +444,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 12,
         "y": 7
       },
+      "hiddenSeries": false,
       "id": 7,
       "legend": {
         "avg": false,
@@ -424,8 +472,11 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "minSpan": 12,
+      "maxPerRow": 2,
       "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -441,15 +492,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(ceph_pool_rd_bytes[1m]) + on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"}",
+          "expr": "irate(ceph_pool_rd_bytes{instance=~\"$instance.*\"}[1m]) + on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\", instance=~\"$instance.*\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "reads",
           "refId": "A"
         },
         {
-          "expr": "irate(ceph_pool_wr_bytes[1m]) + on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"}",
+          "expr": "irate(ceph_pool_wr_bytes{instance=~\"$instance.*\"}[1m]) + on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\", instance=~\"$instance.*\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "writes",
           "refId": "C"
@@ -457,6 +510,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "$pool_name Client Throughput",
       "tooltip": {
@@ -504,13 +558,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 0,
         "y": 14
       },
+      "hiddenSeries": false,
       "id": 8,
       "legend": {
         "avg": false,
@@ -524,8 +586,11 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "minSpan": 12,
+      "maxPerRow": 2,
       "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -536,8 +601,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "ceph_pool_objects * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\"}",
+          "expr": "ceph_pool_objects{instance=~\"$instance.*\"} * on(pool_id) group_left(instance,name) ceph_pool_metadata{name=~\"$pool_name\", instance=~\"$instance.*\"}",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Number of Objects",
           "refId": "B"
@@ -545,6 +611,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "$pool_name Objects",
       "tooltip": {
@@ -585,18 +652,20 @@
     }
   ],
   "refresh": "15s",
-  "schemaVersion": 16,
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "text": "Prometheus admin.virt1.home.fajerski.name:9090",
-          "value": "Prometheus admin.virt1.home.fajerski.name:9090"
+          "text": "default",
+          "value": "default"
         },
         "hide": 0,
+        "includeAll": false,
         "label": "Data Source",
+        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
@@ -609,17 +678,40 @@
         "allValue": null,
         "current": {},
         "datasource": "$datasource",
+        "definition": "label_values(ceph_pool_metadata{instance=~\"$instance.*\"},name)",
         "hide": 0,
         "includeAll": false,
         "label": "Pool Name",
         "multi": false,
         "name": "pool_name",
         "options": [],
-        "query": "label_values(ceph_pool_metadata,name)",
+        "query": "label_values(ceph_pool_metadata{instance=~\"$instance.*\"},name)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "$datasource",
+        "definition": "label_values(ceph_health_status, instance)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Instance",
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": "label_values(ceph_health_status, instance)",
+        "refresh": 1,
+        "regex": "([^:]*).*",
+        "skipUrlSync": false,
+        "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",
@@ -660,6 +752,5 @@
   },
   "timezone": "browser",
   "title": "Ceph Pool Details",
-  "uid": "-xyV8KCiz",
-  "version": 1
+  "version": 11
 }

--- a/monitoring/grafana/dashboards/pool-overview.json
+++ b/monitoring/grafana/dashboards/pool-overview.json
@@ -15,7 +15,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1551789900270,
+  "iteration": 1619482563168,
   "links": [],
   "panels": [
     {
@@ -24,13 +24,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 1
+        "y": 0
       },
+      "hiddenSeries": false,
       "id": 1,
       "legend": {
         "avg": false,
@@ -44,8 +52,11 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "minSpan": 12,
+      "maxPerRow": 2,
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -61,16 +72,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk($topk,rate(ceph_pool_rd[1m]) + on(pool_id) group_left(instance,name) ceph_pool_metadata) ",
+          "expr": "topk($topk,rate(ceph_pool_rd{instance=~\"$instance.*\"}[1m]) + on(pool_id) group_left(instance,name) ceph_pool_metadata{instance=~\"$instance.*\"}) ",
           "format": "time_series",
           "hide": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{name}} - read",
           "refId": "F"
         },
         {
-          "expr": "topk($topk,rate(ceph_pool_wr[1m]) + on(pool_id) group_left(instance,name) ceph_pool_metadata) ",
+          "expr": "topk($topk,rate(ceph_pool_wr{instance=~\"$instance.*\"}[1m]) + on(pool_id) group_left(instance,name) ceph_pool_metadata{instance=~\"$instance.*\"}) ",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{name}} - write",
           "refId": "A"
@@ -78,6 +91,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Top $topk Client IOPS by Pool",
       "tooltip": {
@@ -122,13 +136,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 1
+        "y": 0
       },
+      "hiddenSeries": false,
       "id": 2,
       "legend": {
         "avg": false,
@@ -142,8 +164,11 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "minSpan": 12,
+      "maxPerRow": 2,
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -159,16 +184,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk($topk,rate(ceph_pool_rd_bytes[1m]) + on(pool_id) group_left(instance,name) ceph_pool_metadata)",
+          "expr": "topk($topk,rate(ceph_pool_rd_bytes{instance=~\"$instance.*\"}[1m]) + on(pool_id) group_left(instance,name) ceph_pool_metadata{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{name}} - read",
           "refId": "A",
           "textEditor": true
         },
         {
-          "expr": "topk($topk,rate(ceph_pool_wr_bytes[1m]) + on(pool_id) group_left(instance,name) ceph_pool_metadata)",
+          "expr": "topk($topk,rate(ceph_pool_wr_bytes{instance=~\"$instance.*\"}[1m]) + on(pool_id) group_left(instance,name) ceph_pool_metadata{instance=~\"$instance.*\"})",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{name}} - write",
           "refId": "B"
@@ -176,6 +203,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Top $topk Client Throughput by Pool",
       "tooltip": {
@@ -222,16 +250,22 @@
         }
       ],
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fontSize": "100%",
       "gridPos": {
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 9
+        "y": 7
       },
       "id": 3,
       "links": [],
-      "minSpan": 12,
+      "maxPerRow": 2,
       "pageSize": null,
       "scroll": true,
       "showHeader": true,
@@ -242,6 +276,7 @@
       "styles": [
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -257,6 +292,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -272,6 +308,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -287,6 +324,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -302,6 +340,7 @@
         },
         {
           "alias": "Pool Name",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -317,6 +356,7 @@
         },
         {
           "alias": "Pool ID",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -332,6 +372,7 @@
         },
         {
           "alias": "IOPS (R+W)",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -348,17 +389,19 @@
       ],
       "targets": [
         {
-          "expr": "topk($topk,((irate(ceph_pool_rd[1m]) + irate(ceph_pool_wr[1m])) + on(pool_id) group_left(instance,name) ceph_pool_metadata))",
+          "expr": "topk($topk,((irate(ceph_pool_rd{instance=~\"$instance.*\"}[1m]) + irate(ceph_pool_wr{instance=~\"$instance.*\"}[1m])) + on(pool_id) group_left(instance,name) ceph_pool_metadata{instance=~\"$instance.*\"}))",
           "format": "table",
           "instant": true,
+          "interval": "",
           "intervalFactor": 2,
+          "legendFormat": "",
           "refId": "A",
           "textEditor": true
         }
       ],
       "title": "Top $topk Pools by Client IOPS",
       "transform": "table",
-      "type": "table"
+      "type": "table-old"
     },
     {
       "columns": [
@@ -368,16 +411,22 @@
         }
       ],
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fontSize": "100%",
       "gridPos": {
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 9
+        "y": 7
       },
       "id": 4,
       "links": [],
-      "minSpan": 12,
+      "maxPerRow": 2,
       "pageSize": null,
       "scroll": true,
       "showHeader": true,
@@ -388,12 +437,14 @@
       "styles": [
         {
           "alias": "Time",
+          "align": "auto",
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "pattern": "Time",
           "type": "hidden"
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -409,6 +460,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -424,6 +476,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -439,6 +492,7 @@
         },
         {
           "alias": "Pool Name",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -454,6 +508,7 @@
         },
         {
           "alias": "Pool ID",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -469,6 +524,7 @@
         },
         {
           "alias": "Throughput",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -485,31 +541,39 @@
       ],
       "targets": [
         {
-          "expr": "topk($topk,(irate(ceph_pool_rd_bytes[1m]) + irate(ceph_pool_wr_bytes[1m])) + on(pool_id) group_left(instance,name) ceph_pool_metadata) ",
+          "expr": "topk($topk,(irate(ceph_pool_rd_bytes{instance=~\"$instance.*\"}[1m]) + irate(ceph_pool_wr_bytes{instance=~\"$instance.*\"}[1m])) + on(pool_id) group_left(instance,name) ceph_pool_metadata{instance=~\"$instance.*\"}) ",
           "format": "table",
           "instant": true,
+          "interval": "",
           "intervalFactor": 2,
+          "legendFormat": "",
           "refId": "A",
           "textEditor": true
         }
       ],
       "title": "Top $topk Pools by Throughput",
       "transform": "table",
-      "type": "table"
+      "type": "table-old"
     },
     {
       "columns": [],
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fontSize": "100%",
       "gridPos": {
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 9
+        "y": 7
       },
       "id": 5,
       "links": [],
-      "minSpan": 8,
+      "maxPerRow": 3,
       "pageSize": null,
       "scroll": true,
       "showHeader": true,
@@ -520,6 +584,7 @@
       "styles": [
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -535,6 +600,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -550,6 +616,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -565,6 +632,7 @@
         },
         {
           "alias": "Pool Name",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -580,6 +648,7 @@
         },
         {
           "alias": "Pool ID",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -595,6 +664,7 @@
         },
         {
           "alias": "Capacity Used",
+          "align": "auto",
           "colorMode": "value",
           "colors": [
             "rgba(50, 172, 45, 0.97)",
@@ -614,10 +684,11 @@
       ],
       "targets": [
         {
-          "expr": "topk($topk,((ceph_pool_stored / (ceph_pool_stored + ceph_pool_max_avail)) * on(pool_id) group_left(name) ceph_pool_metadata))",
+          "expr": "topk($topk,((ceph_pool_stored{instance=~\"$instance.*\"} / (ceph_pool_stored{instance=~\"$instance.*\"} + ceph_pool_max_avail{instance=~\"$instance.*\"})) * on(pool_id) group_left(name) ceph_pool_metadata{instance=~\"$instance.*\"}))",
           "format": "table",
           "hide": false,
           "instant": true,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "",
           "refId": "D"
@@ -625,22 +696,24 @@
       ],
       "title": "Top $topk Pools By Capacity Used",
       "transform": "table",
-      "type": "table"
+      "type": "table-old"
     }
   ],
   "refresh": "15s",
-  "schemaVersion": 16,
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "text": "Prometheus admin.virt1.home.fajerski.name:9090",
-          "value": "Prometheus admin.virt1.home.fajerski.name:9090"
+          "text": "default",
+          "value": "default"
         },
         "hide": 0,
+        "includeAll": false,
         "label": "Data Source",
+        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
@@ -666,6 +739,28 @@
         "query": "15",
         "skipUrlSync": false,
         "type": "textbox"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "$datasource",
+        "definition": "label_values(ceph_health_status, instance)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Instance",
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": "label_values(ceph_health_status, instance)",
+        "refresh": 1,
+        "regex": "([^:]*).*",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },
@@ -701,6 +796,5 @@
   },
   "timezone": "browser",
   "title": "Ceph Pools Overview",
-  "uid": "z99hzWtmk",
-  "version": 1
+  "version": 4
 }

--- a/monitoring/grafana/dashboards/radosgw-detail.json
+++ b/monitoring/grafana/dashboards/radosgw-detail.json
@@ -484,8 +484,7 @@
       "30d"
     ]
   },
-  "timezone": "",
+  "timezone": "browser",
   "title": "RGW Instance Detail",
-  "uid": "x5ARzZtmk",
   "version": 2
 }

--- a/monitoring/grafana/dashboards/radosgw-overview.json
+++ b/monitoring/grafana/dashboards/radosgw-overview.json
@@ -623,8 +623,7 @@
       "30d"
     ]
   },
-  "timezone": "",
+  "timezone": "browser",
   "title": "RGW Overview",
-  "uid": "WAkugZpiz",
   "version": 2
 }

--- a/monitoring/grafana/dashboards/rbd-details.json
+++ b/monitoring/grafana/dashboards/rbd-details.json
@@ -31,8 +31,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": null,
-  "iteration": 1584428820779,
+  "iteration": 1619482841690,
   "links": [],
   "panels": [
     {
@@ -40,30 +39,45 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$Datasource",
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
-        "h": 9,
-        "w": 8,
+        "h": 12,
+        "w": 24,
         "x": 0,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 6,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
-        "current": false,
+        "current": true,
         "hideEmpty": false,
         "hideZero": false,
         "max": false,
         "min": false,
+        "rightSide": true,
         "show": true,
+        "sort": "current",
+        "sortDesc": false,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -74,22 +88,25 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(ceph_rbd_write_ops{pool=\"$Pool\", image=\"$Image\"}[30s])",
+          "expr": "irate(ceph_rbd_write_ops{pool=~\"$pool\", image=~\"$image\", instance=~\"$instance.*\"}[30s]) * -1",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Write",
+          "legendFormat": "Write {{image}}",
           "refId": "A"
         },
         {
-          "expr": "irate(ceph_rbd_read_ops{pool=\"$Pool\", image=\"$Image\"}[30s])",
+          "expr": "irate(ceph_rbd_read_ops{pool=~\"$pool\", image=~\"$image\", instance=~\"$instance.*\"}[30s])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Read",
+          "legendFormat": "Read {{image}}",
           "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "IOPS",
       "tooltip": {
@@ -111,7 +128,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": "0",
+          "min": null,
           "show": true
         },
         {
@@ -133,28 +150,41 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$Datasource",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 8,
-        "y": 0
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
       },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "hiddenSeries": false,
       "id": 4,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
-        "current": false,
+        "current": true,
         "max": false,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -165,22 +195,25 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(ceph_rbd_write_bytes{pool=\"$Pool\", image=\"$Image\"}[30s])",
+          "expr": "irate(ceph_rbd_write_bytes{pool=~\"$pool\", image=~\"$image\", instance=~\"$instance.*\"}[30s]) * -1",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Write",
+          "legendFormat": "Write {{image}}",
           "refId": "A"
         },
         {
-          "expr": "irate(ceph_rbd_read_bytes{pool=\"$Pool\", image=\"$Image\"}[30s])",
+          "expr": "irate(ceph_rbd_read_bytes{pool=~\"$pool\", image=~\"$image\", instance=~\"$instance.*\"}[30s])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Read",
+          "legendFormat": "Read {{image}}",
           "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Throughput",
       "tooltip": {
@@ -202,7 +235,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": "0",
+          "min": null,
           "show": true
         },
         {
@@ -224,28 +257,41 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "$Datasource",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 16,
-        "y": 0
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
       },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "hiddenSeries": false,
       "id": 2,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
-        "current": false,
+        "current": true,
         "max": false,
         "min": false,
+        "rightSide": true,
         "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -256,22 +302,25 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(ceph_rbd_write_latency_sum{pool=\"$Pool\", image=\"$Image\"}[30s]) / irate(ceph_rbd_write_latency_count{pool=\"$Pool\", image=\"$Image\"}[30s])",
+          "expr": "(irate(ceph_rbd_write_latency_sum{pool=~\"$pool\", image=~\"$image\", instance=~\"$instance.*\"}[30s]) / irate(ceph_rbd_write_latency_count{pool=~\"$pool\", image=~\"$image\", instance=~\"$instance.*\"}[30s])) * -1",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Write",
+          "legendFormat": "Write {{image}}",
           "refId": "A"
         },
         {
-          "expr": "irate(ceph_rbd_read_latency_sum{pool=\"$Pool\", image=\"$Image\"}[30s]) / irate(ceph_rbd_read_latency_count{pool=\"$Pool\", image=\"$Image\"}[30s])",
+          "expr": "irate(ceph_rbd_read_latency_sum{pool=~\"$pool\", image=~\"$image\", instance=~\"$instance.*\"}[30s]) / irate(ceph_rbd_read_latency_count{pool=\"$pool\", image=~\"$image\", instance=~\"$instance.*\"}[30s])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Read",
+          "legendFormat": "Read {{image}}",
           "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Average Latency",
       "tooltip": {
@@ -293,7 +342,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": "0",
+          "min": null,
           "show": true
         },
         {
@@ -311,8 +360,8 @@
       }
     }
   ],
-  "refresh": false,
-  "schemaVersion": 16,
+  "refresh": "10s",
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -320,8 +369,10 @@
       {
         "current": {},
         "hide": 0,
+        "includeAll": false,
         "label": null,
-        "name": "Datasource",
+        "multi": false,
+        "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
@@ -332,14 +383,41 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "$Datasource",
+        "datasource": "$datasource",
+        "definition": "label_values(ceph_rbd_read_bytes{instance=~\"$instance.*\"}, pool)",
         "hide": 0,
-        "includeAll": false,
-        "label": null,
+        "includeAll": true,
+        "label": "Pool",
         "multi": false,
-        "name": "Pool",
+        "name": "pool",
         "options": [],
-        "query": "label_values(pool)",
+        "query": "label_values(ceph_rbd_read_bytes{instance=~\"$instance.*\"}, pool)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(ceph_rbd_read_bytes{instance=~\"$instance.*\"}, image)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Image",
+        "multi": false,
+        "name": "image",
+        "options": [],
+        "query": "label_values(ceph_rbd_read_bytes{instance=~\"$instance.*\"}, image)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -354,15 +432,16 @@
         "allValue": null,
         "current": {},
         "datasource": "$Datasource",
+        "definition": "label_values(ceph_health_status, instance)",
         "hide": 0,
         "includeAll": false,
-        "label": null,
+        "label": "Instance",
         "multi": false,
-        "name": "Image",
+        "name": "instance",
         "options": [],
-        "query": "label_values(image)",
+        "query": "label_values(ceph_health_status, instance)",
         "refresh": 1,
-        "regex": "",
+        "regex": "([^:]*).*",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
@@ -402,8 +481,7 @@
       "30d"
     ]
   },
-  "timezone": "",
+  "timezone": "browser",
   "title": "RBD Details",
-  "uid": "YhCYGcuZz",
   "version": 7
 }

--- a/monitoring/grafana/dashboards/rbd-overview.json
+++ b/monitoring/grafana/dashboards/rbd-overview.json
@@ -42,8 +42,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": null,
-  "iteration": 1547242766440,
+  "iteration": 1619534670825,
   "links": [],
   "panels": [
     {
@@ -52,13 +51,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
         "x": 0,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 2,
       "legend": {
         "avg": false,
@@ -73,6 +80,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -83,14 +93,15 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "round(sum(irate(ceph_rbd_write_ops[30s])))",
+          "expr": "round(sum(irate(ceph_rbd_write_ops{instance=~\"$instance.*\"}[30s]))) * -1",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Writes",
           "refId": "A"
         },
         {
-          "expr": "round(sum(irate(ceph_rbd_read_ops[30s])))",
+          "expr": "round(sum(irate(ceph_rbd_read_ops{instance=~\"$instance.*\"}[30s])))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -145,13 +156,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
         "x": 8,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 4,
       "legend": {
         "avg": false,
@@ -166,6 +185,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -176,15 +198,16 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "round(sum(irate(ceph_rbd_write_bytes[30s])))",
+          "expr": "round(sum(irate(ceph_rbd_write_bytes{instance=~\"$instance.*\"}[30s]))) * -1",
           "format": "time_series",
           "instant": false,
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Write",
           "refId": "A"
         },
         {
-          "expr": "round(sum(irate(ceph_rbd_read_bytes[30s])))",
+          "expr": "round(sum(irate(ceph_rbd_read_bytes{instance=~\"$instance.*\"}[30s])))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -240,13 +263,21 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
         "x": 16,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 6,
       "legend": {
         "avg": false,
@@ -261,6 +292,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -271,14 +305,15 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "round(sum(irate(ceph_rbd_write_latency_sum[30s])) / sum(irate(ceph_rbd_write_latency_count[30s])))",
+          "expr": "round(sum(irate(ceph_rbd_write_latency_sum{instance=~\"$instance.*\"}[30s])) / sum(irate(ceph_rbd_write_latency_count{instance=~\"$instance.*\"}[30s]))) * -1",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Write",
           "refId": "A"
         },
         {
-          "expr": "round(sum(irate(ceph_rbd_read_latency_sum[30s])) / sum(irate(ceph_rbd_read_latency_count[30s])))",
+          "expr": "round(sum(irate(ceph_rbd_read_latency_sum{instance=~\"$instance.*\"}[30s])) / sum(irate(ceph_rbd_read_latency_count{instance=~\"$instance.*\"}[30s])))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -330,6 +365,12 @@
     {
       "columns": [],
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fontSize": "100%",
       "gridPos": {
         "h": 7,
@@ -350,6 +391,7 @@
       "styles": [
         {
           "alias": "Pool",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -367,6 +409,7 @@
         },
         {
           "alias": "Image",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -383,6 +426,7 @@
         },
         {
           "alias": "IOPS",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -399,6 +443,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -426,11 +471,17 @@
       ],
       "title": "Highest IOPS",
       "transform": "table",
-      "type": "table"
+      "type": "table-old"
     },
     {
       "columns": [],
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fontSize": "100%",
       "gridPos": {
         "h": 7,
@@ -450,6 +501,7 @@
       "styles": [
         {
           "alias": "Pool",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -466,6 +518,7 @@
         },
         {
           "alias": "Image",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -482,6 +535,7 @@
         },
         {
           "alias": "Throughput",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -498,6 +552,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -522,11 +577,17 @@
       ],
       "title": "Highest Throughput",
       "transform": "table",
-      "type": "table"
+      "type": "table-old"
     },
     {
       "columns": [],
       "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fontSize": "100%",
       "gridPos": {
         "h": 7,
@@ -546,6 +607,7 @@
       "styles": [
         {
           "alias": "Pool",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -562,6 +624,7 @@
         },
         {
           "alias": "Image",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -578,6 +641,7 @@
         },
         {
           "alias": "Latency",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -594,6 +658,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -620,11 +685,11 @@
       ],
       "title": "Highest Latency",
       "transform": "table",
-      "type": "table"
+      "type": "table-old"
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 16,
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [
     "overview"
@@ -637,7 +702,9 @@
           "value": "default"
         },
         "hide": 0,
+        "includeAll": false,
         "label": "Data Source",
+        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
@@ -645,11 +712,33 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "$datasource",
+        "definition": "label_values(ceph_health_status, instance)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Instance",
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": "label_values(ceph_health_status, instance)",
+        "refresh": 0,
+        "regex": "([^:]*).*",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {
@@ -678,8 +767,7 @@
       "30d"
     ]
   },
-  "timezone": "",
+  "timezone": "browser",
   "title": "RBD Overview",
-  "uid": "41FrpeUiz",
-  "version": 8
+  "version": 3
 }


### PR DESCRIPTION
Use Instance filter for multiple Ceph Clusters under single Prometheus source;
All Grafana templates use same timezone (browser)
Remove enforced uid's and or default values (hostname)

Signed-off-by: Justas Balcas juztas@gmail.com