### PR TITLE
mgr/dashboard: fix RBD namespace validation

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-namespace-form/rbd-namespace-form-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-namespace-form/rbd-namespace-form-modal.component.html
@@ -53,6 +53,7 @@
           <div class="cd-col-form-input">
             <input class="form-control"
                    type="text"
+                   autocomplete="off"
                    placeholder="Namespace name..."
                    id="namespace"
                    name="namespace"


### PR DESCRIPTION
mgr/dashboard: fix RBD namespace validation
Just adding autocomplete: "off" prevented incorrect suggestions in Firefox.

Fixes: https://tracker.ceph.com/issues/46369
Signed-off-by: Navin Barnwal knbarnwal@gmail.com
