### PR TITLE
mgr/dashboard: fix set-ssl-certificate{,-key} commands

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -14,9 +14,16 @@ import sys
 import tempfile
 import threading
 import time
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from mgr_module import CLIWriteCommand, MgrModule, MgrStandbyModule, Option, _get_localized_key
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 8):
+        from typing import Literal
+    else:
+        from typing_extensions import Literal
+
+from mgr_module import CLIWriteCommand, HandleCommandResult, MgrModule, \
+    MgrStandbyModule, Option, _get_localized_key
 from mgr_util import ServerConfigException, create_self_signed_cert, \
     get_default_addr, verify_tls_files
 
@@ -214,6 +221,10 @@ class CherryPyConfig(object):
                 return uri
 
 
+if TYPE_CHECKING:
+    SslConfigKey = Literal['crt', 'key']
+
+
 class Module(MgrModule, CherryPyConfig):
     """
     dashboard module entrypoint
@@ -357,31 +368,36 @@ class Module(MgrModule, CherryPyConfig):
         logger.info('Stopping engine...')
         self.shutdown_event.set()
 
-    @CLIWriteCommand("dashboard set-ssl-certificate")
-    def set_ssl_certificate(self,
-                            mgr_id: Optional[str] = None,
-                            inbuf: Optional[bytes] = None):
+    def _set_ssl_item(self, item_label: str, item_key: 'SslConfigKey' = 'crt',
+                      mgr_id: Optional[str] = None, inbuf: Optional[str] = None):
         if inbuf is None:
-            return -errno.EINVAL, '',\
-                'Please specify the certificate file with "-i" option'
+            return -errno.EINVAL, '', f'Please specify the {item_label} with "-i" option'
+
         if mgr_id is not None:
-            self.set_store(_get_localized_key(mgr_id, 'crt'), inbuf.decode())
+            self.set_store(_get_localized_key(mgr_id, item_key), inbuf)
         else:
-            self.set_store('crt', inbuf.decode())
-        return 0, 'SSL certificate updated', ''
+            self.set_store(item_key, inbuf)
+        return 0, f'SSL {item_label} updated', ''
+
+    @CLIWriteCommand("dashboard set-ssl-certificate")
+    def set_ssl_certificate(self, mgr_id: Optional[str] = None, inbuf: Optional[str] = None):
+        return self._set_ssl_item('certificate', 'crt', mgr_id, inbuf)
 
     @CLIWriteCommand("dashboard set-ssl-certificate-key")
-    def set_ssl_certificate_key(self,
-                                mgr_id: Optional[str] = None,
-                                inbuf: Optional[bytes] = None):
-        if inbuf is None:
-            return -errno.EINVAL, '',\
-                'Please specify the certificate key file with "-i" option'
-        if mgr_id is not None:
-            self.set_store(_get_localized_key(mgr_id, 'key'), inbuf.decode())
-        else:
-            self.set_store('key', inbuf.decode())
-        return 0, 'SSL certificate key updated', ''
+    def set_ssl_certificate_key(self, mgr_id: Optional[str] = None, inbuf: Optional[str] = None):
+        return self._set_ssl_item('certificate key', 'key', mgr_id, inbuf)
+
+    @CLIWriteCommand("dashboard create-self-signed-cert")
+    def set_mgr_created_self_signed_cert(self):
+        cert, pkey = create_self_signed_cert('IT', 'ceph-dashboard')
+        result = HandleCommandResult(*self.set_ssl_certificate(inbuf=cert))
+        if result.retval != 0:
+            return result
+
+        result = HandleCommandResult(*self.set_ssl_certificate_key(inbuf=pkey))
+        if result.retval != 0:
+            return result
+        return 0, 'Self-signed certificate created', ''
 
     def handle_command(self, inbuf, cmd):
         # pylint: disable=too-many-return-statements
@@ -397,20 +413,12 @@ class Module(MgrModule, CherryPyConfig):
         if cmd['prefix'] == 'dashboard get-jwt-token-ttl':
             ttl = self.get_module_option('jwt_token_ttl', JwtManager.JWT_TOKEN_TTL)
             return 0, str(ttl), ''
-        if cmd['prefix'] == 'dashboard create-self-signed-cert':
-            self.create_self_signed_cert()
-            return 0, 'Self-signed certificate created', ''
         if cmd['prefix'] == 'dashboard grafana dashboards update':
             push_local_dashboards()
             return 0, 'Grafana dashboards updated', ''
 
         return (-errno.EINVAL, '', 'Command not found \'{0}\''
                 .format(cmd['prefix']))
-
-    def create_self_signed_cert(self):
-        cert, pkey = create_self_signed_cert('IT', 'ceph-dashboard')
-        self.set_store('crt', cert)
-        self.set_store('key', pkey)
 
     def notify(self, notify_type, notify_id):
         NotificationQueue.new_notification(notify_type, notify_id)

--- a/src/pybind/mgr/dashboard/tests/test_ssl.py
+++ b/src/pybind/mgr/dashboard/tests/test_ssl.py
@@ -1,0 +1,28 @@
+import errno
+import unittest
+
+from ..tests import CLICommandTestMixin, CmdException
+
+
+class SslTest(unittest.TestCase, CLICommandTestMixin):
+
+    def test_ssl_certificate_and_key(self):
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('set-ssl-certificate', inbuf='', mgr_id='x')
+        self.assertEqual(ctx.exception.retcode, -errno.EINVAL)
+        self.assertEqual(str(ctx.exception), 'Please specify the certificate with "-i" option')
+
+        result = self.exec_cmd('set-ssl-certificate', inbuf='content', mgr_id='x')
+        self.assertEqual(result, 'SSL certificate updated')
+
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('set-ssl-certificate-key', inbuf='', mgr_id='x')
+        self.assertEqual(ctx.exception.retcode, -errno.EINVAL)
+        self.assertEqual(str(ctx.exception), 'Please specify the certificate key with "-i" option')
+
+        result = self.exec_cmd('set-ssl-certificate-key', inbuf='content', mgr_id='x')
+        self.assertEqual(result, 'SSL certificate key updated')
+
+    def test_set_mgr_created_self_signed_cert(self):
+        result = self.exec_cmd('create-self-signed-cert')
+        self.assertEqual(result, 'Self-signed certificate created')

--- a/src/pybind/mgr/dashboard/tests/test_sso.py
+++ b/src/pybind/mgr/dashboard/tests/test_sso.py
@@ -5,13 +5,11 @@ from __future__ import absolute_import
 import errno
 import unittest
 
-from ..services.sso import handle_sso_command, load_sso_db
-from . import CmdException  # pylint: disable=no-name-in-module
-from . import KVStoreMockMixin  # pylint: disable=no-name-in-module
-from . import exec_dashboard_cmd  # pylint: disable=no-name-in-module
+from ..services.sso import load_sso_db
+from . import CLICommandTestMixin, CmdException  # pylint: disable=no-name-in-module
 
 
-class AccessControlTest(unittest.TestCase, KVStoreMockMixin):
+class AccessControlTest(unittest.TestCase, CLICommandTestMixin):
     IDP_METADATA = '''<?xml version="1.0"?>
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
                      xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
@@ -63,10 +61,6 @@ class AccessControlTest(unittest.TestCase, KVStoreMockMixin):
     def setUp(self):
         self.mock_kv_store()
         load_sso_db()
-
-    @classmethod
-    def exec_cmd(cls, cmd, **kwargs):
-        return exec_dashboard_cmd(handle_sso_command, cmd, **kwargs)
 
     def validate_onelogin_settings(self, onelogin_settings, ceph_dashboard_base_url, uid,
                                    sp_x509cert, sp_private_key, signature_enabled):


### PR DESCRIPTION
- Now create-self-signed-cert command relies on set-ssl-certificate{,-key} commands.
- Simplify the command testing and increase the test coverage.

Fixes: https://tracker.ceph.com/issues/50519
Signed-off-by: Alfonso Martínez <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
