### PR TITLE
rgw/rgw_rest_sts: return local variable w/o std::move()

### DIFF
--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -89,7 +89,7 @@ WebTokenEngine::get_provider(const DoutPrefixProvider *dpp, const string& role_a
   if (ret < 0) {
     return nullptr;
   }
-  return std::move(provider);
+  return provider;
 }
 
 bool


### PR DESCRIPTION
in C++17, the C++ standard ensures that the return value in this case
can be optimized with copy elision, adding std::move() is not necessary,
and prevents copy elision from happening.

this change also silences the warning of:

../src/rgw/rgw_rest_sts.cc: In member function 'std::unique_ptr<rgw::sal::RGWOIDCProvider> rgw::auth::sts::WebTokenEngine::get_provider(const DoutPrefixProvider*, const string&, const string&) const':
../src/rgw/rgw_rest_sts.cc:92:19: warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
   92 |   return std::move(provider);
      |          ~~~~~~~~~^~~~~~~~~~
../src/rgw/rgw_rest_sts.cc:92:19: note: remove 'std::move' call

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
