### PR TITLE
include: define AT_REMOVEDIR on Windows

### DIFF
--- a/src/include/win32/fs_compat.h
+++ b/src/include/win32/fs_compat.h
@@ -31,5 +31,6 @@
 #define LOCK_RW    192
 
 #define AT_SYMLINK_NOFOLLOW 0x100
+#define AT_REMOVEDIR        0x200
 
 #define MAXSYMLINKS  65000


### PR DESCRIPTION
include: define AT_REMOVEDIR on Windows

The AT_REMOVEDIR flag is used by a recent change [1] but isn't
defined on Windows.

This commit will add the missing definition. Note that it won't be
passed to OS functions, only being used at the CephFS level.

[1] https://github.com/ceph/ceph/pull/40810