### PR TITLE
rgw: Improve error message on email id reuse

### DIFF
--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -239,7 +239,7 @@ static void set_err_msg(std::string *sink, std::string msg)
 /*
  * Dump either the full user info or a subset to a formatter.
  *
- * NOTE: It is the caller's respnsibility to ensure that the
+ * NOTE: It is the caller's responsibility to ensure that the
  * formatter is flushed at the correct time.
  */
 
@@ -354,6 +354,43 @@ static void dump_user_info(Formatter *f, RGWUserInfo &info,
   f->close_section();
 }
 
+static int user_add_helper(RGWUserAdminOpState& op_state, std::string *err_msg)
+{
+  int ret = 0;
+  const rgw_user& uid = op_state.get_user_id();
+  std::string user_email = op_state.get_user_email();
+  std::string display_name = op_state.get_display_name();
+
+  // fail if the user exists already
+  if (op_state.has_existing_user()) {
+    if (op_state.found_by_email) {
+      set_err_msg(err_msg, "email: " + user_email +
+          " is the email address of an existing user");
+      ret = -ERR_EMAIL_EXIST;
+    } else if (op_state.found_by_key) {
+      set_err_msg(err_msg, "duplicate key provided");
+      ret = -ERR_KEY_EXIST;
+    } else {
+      set_err_msg(err_msg, "user: " + uid.to_str() + " exists");
+      ret = -EEXIST;
+    }
+    return ret;
+  }
+
+  // fail if the user_info has already been populated
+  if (op_state.is_populated()) {
+    set_err_msg(err_msg, "cannot overwrite already populated user");
+    return -EEXIST;
+  }
+
+  // fail if the display name was not included
+  if (display_name.empty()) {
+    set_err_msg(err_msg, "no display name specified");
+    return -EINVAL;
+  }
+
+  return ret;
+}
 
 RGWAccessKeyPool::RGWAccessKeyPool(RGWUser* usr)
 {
@@ -1063,7 +1100,7 @@ int RGWSubUserPool::check_op(RGWUserAdminOpState& op_state,
   }
 
   if (op_state.get_subuser_perm() == RGW_PERM_INVALID) {
-    set_err_msg(err_msg, "invaild subuser access");
+    set_err_msg(err_msg, "invalid subuser access");
     return -EINVAL;
   }
 
@@ -1581,28 +1618,22 @@ int RGWUser::update(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state
 
 int RGWUser::check_op(RGWUserAdminOpState& op_state, std::string *err_msg)
 {
-  bool same_id;
-  bool populated;
-  const rgw_user& op_id = op_state.get_user_id();
+  int ret = 0;
+  const rgw_user& uid = op_state.get_user_id();
 
-  RGWUserInfo user_info;
-
-  same_id = (user_id.compare(op_id) == 0);
-  populated = is_populated();
-
-  if (op_id.compare(RGW_USER_ANON_ID) == 0) {
+  if (uid.compare(RGW_USER_ANON_ID) == 0) {
     set_err_msg(err_msg, "unable to perform operations on the anonymous user");
     return -EINVAL;
   }
 
-  if (populated && !same_id) {
-    set_err_msg(err_msg, "user id mismatch, operation id: " + op_id.to_str()
+  if (is_populated() && user_id.compare(uid) != 0) {
+    set_err_msg(err_msg, "user id mismatch, operation id: " + uid.to_str()
             + " does not match: " + user_id.to_str());
 
     return -EINVAL;
   }
 
-  int ret = rgw_validate_tenant_name(op_id.tenant);
+  ret = rgw_validate_tenant_name(uid.tenant);
   if (ret) {
     set_err_msg(err_msg,
 		"invalid tenant only alphanumeric and _ characters are allowed");
@@ -1741,46 +1772,12 @@ int RGWUser::execute_rename(const DoutPrefixProvider *dpp, RGWUserAdminOpState& 
 int RGWUser::execute_add(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state, std::string *err_msg,
 			 optional_yield y)
 {
-  std::string subprocess_msg;
-  int ret = 0;
-  bool defer_user_update = true;
-
-  RGWUserInfo user_info;
-
   const rgw_user& uid = op_state.get_user_id();
   std::string user_email = op_state.get_user_email();
   std::string display_name = op_state.get_display_name();
 
-  // fail if the user exists already
-  if (op_state.has_existing_user()) {
-    if (op_state.found_by_email) {
-      set_err_msg(err_msg, "email: " + user_email +
-		  " is the email address an existing user");
-      ret = -ERR_EMAIL_EXIST;
-    } else if (op_state.found_by_key) {
-      set_err_msg(err_msg, "duplicate key provided");
-      ret = -ERR_KEY_EXIST;
-    } else {
-      set_err_msg(err_msg, "user: " + uid.to_str() + " exists");
-      ret = -EEXIST;
-    }
-    return ret;
-  }
-
-  // fail if the user_info has already been populated
-  if (op_state.is_populated()) {
-    set_err_msg(err_msg, "cannot overwrite already populated user");
-    return -EEXIST;
-  }
-
-  // fail if the display name was not included
-  if (display_name.empty()) {
-    set_err_msg(err_msg, "no display name specified");
-    return -EINVAL;
-  }
-
-		
   // set the user info
+  RGWUserInfo user_info;
   user_id = uid;
   user_info.user_id = user_id;
   user_info.display_name = display_name;
@@ -1837,13 +1834,15 @@ int RGWUser::execute_add(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_
   op_state.set_populated();
 
   // update the helper objects
-  ret = init_members(op_state);
+  int ret = init_members(op_state);
   if (ret < 0) {
     set_err_msg(err_msg, "unable to initialize user");
     return ret;
   }
 
   // see if we need to add an access key
+  std::string subprocess_msg;
+  bool defer_user_update = true;
   if (op_state.has_key_op()) {
     ret = keys.add(dpp, op_state, &subprocess_msg, defer_user_update, y);
     if (ret < 0) {
@@ -1868,11 +1867,14 @@ int RGWUser::execute_add(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_
   return 0;
 }
 
-
 int RGWUser::add(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state, optional_yield y, std::string *err_msg)
 {
   std::string subprocess_msg;
-  int ret;
+  int ret = user_add_helper(op_state, &subprocess_msg);
+  if (ret != 0) {
+    set_err_msg(err_msg, "unable to parse parameters, " + subprocess_msg);
+    return ret;
+  }
 
   ret = check_op(op_state, &subprocess_msg);
   if (ret < 0) {
@@ -2142,14 +2144,7 @@ int RGWUser::modify(const DoutPrefixProvider *dpp, RGWUserAdminOpState& op_state
 
   ret = check_op(op_state, &subprocess_msg);
   if (ret < 0) {
-    if (is_populated() && (user_id.compare(op_state.get_user_id()) != 0)) {
-      set_err_msg(err_msg, "unable to create user " + user_id.to_str()
-		  + " because user id " + op_state.get_user_id().to_str()
-		  + " already exists with email "
-		  + op_state.get_user_email());
-    } else {
-      set_err_msg(err_msg, "unable to parse parameters, " + subprocess_msg);
-    }
+    set_err_msg(err_msg, "unable to parse parameters, " + subprocess_msg);
     return ret;
   }
 


### PR DESCRIPTION
This corrects the patch in PR https://github.com/ceph/ceph/pull/39293

Fixes: https://tracker.ceph.com/issues/50554

The reproducer noted in PR https://github.com/ceph/ceph/pull/39293 is same here and has been verified with a local build.

Signed-off-by: Ponnuvel Palaniyappan <ponnuvel.palaniyappan@canonical.com>

Fixes: https://tracker.ceph.com/issues/50554

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
