### PR TITLE
mds: completed_requests -> num_completed_requests and dump num_completed_flushes

### DIFF
--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -590,6 +590,7 @@ void Session::dump(Formatter *f, bool cap_dump) const
   f->dump_float("uptime", get_session_uptime());
   f->dump_unsigned("requests_in_flight", get_request_count());
   f->dump_unsigned("num_completed_requests", get_num_completed_requests());
+  f->dump_unsigned("num_completed_flushes", get_num_completed_flushes());
   f->dump_bool("reconnecting", reconnecting);
   f->dump_object("recall_caps", recall_caps);
   f->dump_object("release_caps", release_caps);

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -589,7 +589,7 @@ void Session::dump(Formatter *f, bool cap_dump) const
   }
   f->dump_float("uptime", get_session_uptime());
   f->dump_unsigned("requests_in_flight", get_request_count());
-  f->dump_unsigned("completed_requests", get_num_completed_requests());
+  f->dump_unsigned("num_completed_requests", get_num_completed_requests());
   f->dump_bool("reconnecting", reconnecting);
   f->dump_object("recall_caps", recall_caps);
   f->dump_object("release_caps", release_caps);


### PR DESCRIPTION
Rename this in the session dump so we don't collide with the completed_requests dump in mdstypes session_info_t::dump.

Also dump num_completed_flushes which is useful to debug client failing to advance tid.

Fixes: https://tracker.ceph.com/issues/50559