### PR TITLE
pacific: mgr/dashboard: set required env. variables in run-backend-api-tests.sh 

### DIFF
--- a/src/pybind/mgr/dashboard/run-backend-api-tests.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-tests.sh
@@ -122,7 +122,9 @@ run_teuthology_tests() {
         pybind_dir+=":$LOCAL_BUILD_DIR/src/pybind"
     fi
     export PYTHONPATH=$source_dir/qa:$LOCAL_BUILD_DIR/lib/cython_modules/lib.3/:$pybind_dir:$python_common_dir:${COVERAGE_PATH}
-    export RGW=${RGW:-1}
+    export DASHBOARD_SSL=1
+    export NFS=0
+    export RGW=1
 
     export COVERAGE_ENABLED=true
     export COVERAGE_FILE=.coverage.mgr.dashboard


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50498

---

backport of https://github.com/ceph/ceph/pull/40986
parent tracker: https://tracker.ceph.com/issues/50484

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh