### PR TITLE
blk/zoned: Add reset_zones functionality for zoned devices

### DIFF
--- a/src/blk/BlockDevice.h
+++ b/src/blk/BlockDevice.h
@@ -200,6 +200,11 @@ public:
     return conventional_region_size;
   }
 
+  virtual uint64_t reset_zones(uint64_t zone_num_start, uint64_t zone_num_end) {
+    ceph_assert(is_smr());
+    return 0;
+  }
+
   virtual void aio_submit(IOContext *ioc) = 0;
 
   void set_no_exclusive_lock() {

--- a/src/blk/zoned/HMSMRDevice.h
+++ b/src/blk/zoned/HMSMRDevice.h
@@ -41,6 +41,7 @@ class HMSMRDevice final : public BlockDevice {
   string vdo_name;
 
   std::string devname;  ///< kernel dev name (/sys/block/$devname), if any
+  int zbd_dev; /// zbd_open File Descriptor
 
   ceph::mutex debug_lock = ceph::make_mutex("HMSMRDevice::debug_lock");
   interval_set<uint64_t> debug_inflight;
@@ -134,6 +135,8 @@ public:
   int get_devices(std::set<std::string> *ls) const final;
 
   bool is_smr() const final { return true; }
+
+  uint64_t reset_zones(uint64_t zone_num_start, uint64_t zone_num_end);
 
   bool get_thin_utilization(uint64_t *total, uint64_t *avail) const final;
 


### PR DESCRIPTION
Signed-off-by: Rishabh Chawla <rishabhchawla1995@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
