### PR TITLE
mgr/dashboard: Fix iSCSI menu entry should indicate how many gateways are down

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -210,7 +210,10 @@
             class="tc_submenuitem tc_submenuitem_block_iscsi"
             *ngIf="permissions.iscsi.read && enabledFeature.iscsi">
           <a i18n
-             routerLink="/block/iscsi">iSCSI</a>
+             routerLink="/block/iscsi">iSCSI
+            <small *ngIf="healthData.iscsi_daemons.down > 0"
+                   class="badge badge-danger">{{healthData.iscsi_daemons.down}}</small>
+          </a>
         </li>
       </ul>
     </li>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -212,7 +212,7 @@
           <a i18n
              routerLink="/block/iscsi">iSCSI
             <small *ngIf="healthData.iscsi_daemons.down > 0"
-                   class="badge badge-danger">{{healthData.iscsi_daemons.down}}</small>
+                   class="badge badge-danger">{{iscsi_daemons.down}}</small>
           </a>
         </li>
       </ul>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.ts
@@ -25,7 +25,7 @@ export class NavigationComponent implements OnInit, OnDestroy {
   @HostBinding('class') get class(): string {
     return 'top-notification-' + this.notifications.length;
   }
-  healthData: any;
+  iscsi_daemons: any;
   interval = new Subscription();
   permissions: Permissions;
   enabledFeature$: FeatureTogglesMap$;
@@ -85,8 +85,8 @@ export class NavigationComponent implements OnInit, OnDestroy {
   }
 
   getHealth() {
-    this.healthService.getMinimalHealth().subscribe((data: any) => {
-      this.healthData = data;
+    this.healthService.getMinimalHealth().subscribe((data) => {
+      this.iscsi_daemons = data.iscsi_daemons;
     });
   }
   blockHealthColor() {


### PR DESCRIPTION
Added the menu entry with warning for all iscsi health down > 0.
Also added the refresh interval service to make sure it syncs with the dashboard.


https://tracker.ceph.com/issues/42937
Signed-off-by: Navin Barnwal <knbarnwal@gmail.com>
