### PR TITLE
os/FileStore: fix to handle readdir error correctly

### DIFF
--- a/src/os/filestore/BtrfsFileStoreBackend.cc
+++ b/src/os/filestore/BtrfsFileStoreBackend.cc
@@ -326,7 +326,17 @@ int BtrfsFileStoreBackend::list_checkpoints(list<string>& ls)
   list<string> snaps;
   char path[PATH_MAX];
   struct dirent *de;
-  while ((de = ::readdir(dir))) {
+  while (true) {
+    errno = 0;
+    de = ::readdir(dir);
+    if (de == nullptr) {
+      if (errno != 0) {
+        err = -errno;
+        dout(0) << "list_checkpoints: readdir '" << get_basedir_path() << "' failed: "
+                << cpp_strerror(err) << dendl;
+      }
+      break;
+    }
     snprintf(path, sizeof(path), "%s/%s", get_basedir_path().c_str(), de->d_name);
 
     struct stat st;

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -4987,7 +4987,17 @@ int FileStore::list_collections(vector<coll_t>& ls, bool include_temp)
   }
 
   struct dirent *de = nullptr;
-  while ((de = ::readdir(dir))) {
+  while (true) {
+    errno = 0;
+    de = ::readdir(dir);
+    if (de == nullptr) {
+      if (errno != 0) {
+        r = -errno;
+        derr << "readdir failed " << fn << ": " << cpp_strerror(-r) << dendl;
+        if (r == -EIO && m_filestore_fail_eio) handle_eio();
+      }
+      break;
+    }
     if (de->d_type == DT_UNKNOWN) {
       // d_type not supported (non-ext[234], btrfs), must stat
       struct stat sb;


### PR DESCRIPTION
Currently filestore code does not handle readdir error.
As man readdir(3) says, we need to check errno after readdir
returns NULL to determine if error happens or not.

This patch fixes the all readdir() calls to check errono and
handle it appropriately:
 - FileStore.cc ... abort if EIO error happens
 - BtrfsFileStoreBAckend.cc/LFNindex.cc
                ... return error to upper layer

Without this fixes, primary PG could fail to correctly perform
backfill operation and could lead data loss propagation described
in #50558.

Fixes: https://tracker.ceph.com/issues/50558
Signed-off-by: Misono Tomohiro <misono.tomohiro@jp.fujitsu.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
