### PR TITLE
mgr/dashboard: disable NFSv3 support in dashboard

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.html
@@ -322,7 +322,8 @@
                      class="custom-control-input"
                      id="protocolNfsv3"
                      name="protocolNfsv3"
-                     formControlName="protocolNfsv3">
+                     formControlName="protocolNfsv3"
+                     disabled>
               <label i18n
                      class="custom-control-label"
                      for="protocolNfsv3">NFSv3</label>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.spec.ts
@@ -98,7 +98,7 @@ describe('NfsFormComponent', () => {
       daemons: [],
       fsal: { fs_name: 'a', name: '', rgw_user_id: '', user_id: '' },
       path: '',
-      protocolNfsv3: true,
+      protocolNfsv3: false,
       protocolNfsv4: true,
       pseudo: '',
       sec_label_xattr: 'security.selinux',
@@ -143,6 +143,15 @@ describe('NfsFormComponent', () => {
     component.isEdit = true;
     component.ngOnInit();
     expect(component.nfsForm.get('cluster_id').disabled).toBeTruthy();
+  });
+
+  it('should mark NFSv4 protocol as required', () => {
+    component.nfsForm.patchValue({
+      protocolNfsv4: false
+    });
+    component.nfsForm.updateValueAndValidity({ emitEvent: false });
+    expect(component.nfsForm.valid).toBeFalsy();
+    expect(component.nfsForm.get('protocolNfsv4').hasError('required')).toBeTruthy();
   });
 
   describe('should submit request', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/nfs/nfs-form/nfs-form.component.ts
@@ -174,7 +174,7 @@ export class NfsFormComponent extends CdForm implements OnInit {
         })
       }),
       path: new FormControl(''),
-      protocolNfsv3: new FormControl(true, {
+      protocolNfsv3: new FormControl(false, {
         validators: [
           CdValidators.requiredIf({ protocolNfsv4: false }, (value: boolean) => {
             return !value;


### PR DESCRIPTION
The v3 checkbox is disabled. The v3 checkbox is unchecked and v4 is checked by default. The form can not be submitted if both protocols are unchecked.

Fixes: https://tracker.ceph.com/issues/49718
Related to: https://github.com/ceph/ceph/pull/40154

According to https://github.com/ceph/ceph/pull/40154#issuecomment-807268485 there is a bigger refactoring ongoing, but the issue must be backported to Octopus, so a simple cleanup would be easier to backport.

Signed-off-by: Volker Theile <vtheile@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
