### PR TITLE
mgr/dashboard: OSDs placement text is unreadable

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/placement.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/placement.pipe.spec.ts
@@ -59,10 +59,10 @@ describe('PlacementPipe', () => {
     expect(
       pipe.transform({
         placement: {
-          host_pattern: '*'
+          host_pattern: 'abc.ceph.xyz.com'
         }
       })
-    ).toBe('*');
+    ).toBe('abc.ceph.xyz.com');
   });
 
   it('transforms placement (6)', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/placement.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/placement.pipe.ts
@@ -34,7 +34,7 @@ export class PlacementPipe implements PipeTransform {
       kv.push($localize`label:${label}`);
     }
     if (_.isString(hostPattern)) {
-      kv.push(...hostPattern);
+      kv.push(hostPattern);
     }
     return kv.join(';');
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
@@ -104,7 +104,7 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
       {
         name: $localize`Container image ID`,
         prop: 'status.container_image_id',
-        flexGrow: 3,
+        flexGrow: 1.5,
         cellTransformation: CellTemplate.truncate,
         customTemplateConfig: {
           length: 12
@@ -114,7 +114,7 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
         name: $localize`Placement`,
         prop: '',
         pipe: new PlacementPipe(),
-        flexGrow: 1
+        flexGrow: 2
       },
       {
         name: $localize`Running`,


### PR DESCRIPTION
While displaying the host pattern in the OSDs placement tab, it gets splited with semi-colons. Also adjusted the column size of Container Image ID and Placement columns.

Fixes: https://tracker.ceph.com/issues/50580
Signed-off-by: Aashish Sharma <aasharma@redhat.com>

Before:
![Screenshot from 2021-04-29 18-41-10](https://user-images.githubusercontent.com/66050535/116556150-cb4d0b80-a91a-11eb-890c-c654c86206d1.png)

After:
![Screenshot from 2021-04-29 18-18-24](https://user-images.githubusercontent.com/66050535/116556173-d2741980-a91a-11eb-834c-0ac508ef858c.png)


<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
