### PR TITLE
pybind/mirroring: fix directory path removal when no cephfs-mirror daemons are available

### DIFF
--- a/src/pybind/mgr/mirroring/fs/dir_map/policy.py
+++ b/src/pybind/mgr/mirroring/fs/dir_map/policy.py
@@ -79,16 +79,14 @@ class Policy:
                 self.dir_states[dir_path] = DirectoryState(instance_id, dir_map['last_shuffled'])
                 dir_state = self.dir_states[dir_path]
                 state = State.INITIALIZING if instance_id else State.ASSOCIATING
-                if instance_id:
-                    purging = dir_mapping.get('purging', False)
-                    if purging:
-                        dir_state.purging = True
-                        state = State.DISASSOCIATING
-                    else:
-                        state = State.INITIALIZING
-                else:
-                    state = State.ASSOCIATING
-                log.debug(f'starting state: {dir_path} {state}')
+                purging = dir_map.get('purging', 0)
+                if purging:
+                    dir_state.purging = True
+                    state = State.DISASSOCIATING
+                    if not instance_id:
+                        dir_state.transition = StateTransition.transit(state,
+                                                                       dir_state.transition.action_type)
+                log.debug(f'starting state: {dir_path} {state}: {dir_state}')
                 self.set_state(dir_state, state)
                 log.debug(f'init dir_state: {dir_state}')
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
