### PR TITLE
octopus: make-dist: refuse to run if script path contains a colon

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -1,7 +1,21 @@
 #!/bin/bash -e
 
+SCRIPTNAME="$(basename "${0}")"
+BASEDIR="$(readlink -f "$(dirname "${0}")")"
+
 if [ ! -d .git ]; then
-    echo "no .git present.  run this from the base dir of the git checkout."
+    echo "$SCRIPTNAME: Full path to the script: $BASEDIR/$SCRIPTNAME"
+    echo "$SCRIPTNAME: No .git present. Run this from the base dir of the git checkout."
+    exit 1
+fi
+
+# Running the script from a directory containing a colon anywhere in the path
+# will expose us to the dreaded "[BUG] npm run [command] failed if the directory
+# path contains colon" bug https://github.com/npm/cli/issues/633
+# (see https://tracker.ceph.com/issues/39556 for details)
+if [[ "$BASEDIR" == *:* ]] ; then
+    echo "$SCRIPTNAME: Full path to the script: $BASEDIR/$SCRIPTNAME"
+    echo "$SCRIPTNAME: The path to the script contains a colon. Their presence has been known to break the script."
     exit 1
 fi
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50357

---

backport of https://github.com/ceph/ceph/pull/40614
parent tracker: https://tracker.ceph.com/issues/39556

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh