### PR TITLE
mgr/progress: ensure progress stays between [0,1]

### DIFF
--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -371,8 +371,14 @@ class PgRecoveryEvent(Event):
 
         self._pgs = list(set(self._pgs) ^ complete)
         completed_pgs = self._original_pg_count - len(self._pgs)
-        self._progress = (completed_pgs + complete_accumulate)\
-            / self._original_pg_count
+        completed_pgs = max(completed_pgs, 0)
+        try:
+            prog = (completed_pgs + complete_accumulate)\
+                / self._original_pg_count
+        except ZeroDivisionError:
+            prog = 0.0
+
+        self._progress = min(max(prog, 0.0), 1.0)
 
         self._refresh()
         log.info("Updated progress to %s", self.summary())


### PR DESCRIPTION
If _original_pg_count is 0 then progress can be negative.

Fixes: https://tracker.ceph.com/issues/50591
Related-to: https://tracker.ceph.com/issues/50587
Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>
