### PR TITLE
crimson/seastore: add perfcounters in seastore

### DIFF
--- a/src/crimson/os/seastore/journal.cc
+++ b/src/crimson/os/seastore/journal.cc
@@ -160,7 +160,7 @@ bool Journal::validate_metadata(const bufferlist &bl)
     ceph::encoded_sizeof_bounded<record_header_t>(),
     -1);
   ceph_le32 recorded_crc_le;
-  ::decode(recorded_crc_le, bliter);
+  decode(recorded_crc_le, bliter);
   uint32_t recorded_crc = recorded_crc_le;
   test_crc = bliter.crc32c(
     bliter.get_remaining(),

--- a/src/crimson/os/seastore/seastore.h
+++ b/src/crimson/os/seastore/seastore.h
@@ -22,6 +22,7 @@
 #include "crimson/os/seastore/onode_manager.h"
 #include "crimson/os/seastore/omap_manager.h"
 #include "crimson/os/seastore/collection_manager.h"
+#include "crimson/os/seastore/seastore_perf_counters.h"
 
 namespace crimson::os::seastore {
 
@@ -37,11 +38,15 @@ public:
     SegmentManagerRef sm,
     TransactionManagerRef tm,
     CollectionManagerRef cm,
-    OnodeManagerRef om
+    OnodeManagerRef om,
+    PerfServiceRef p_service
   ) : segment_manager(std::move(sm)),
       transaction_manager(std::move(tm)),
       collection_manager(std::move(cm)),
-      onode_manager(std::move(om)) {}
+      onode_manager(std::move(om)),
+      perf_service(std::move(p_service)) {
+    perf_service->add_to_collection();
+  }
 
   ~SeaStore();
     
@@ -246,6 +251,7 @@ private:
   TransactionManagerRef transaction_manager;
   CollectionManagerRef collection_manager;
   OnodeManagerRef onode_manager;
+  PerfServiceRef perf_service;
 
   using tm_ertr = TransactionManager::base_ertr;
   using tm_ret = tm_ertr::future<>;

--- a/src/crimson/os/seastore/seastore_perf_counters.h
+++ b/src/crimson/os/seastore/seastore_perf_counters.h
@@ -1,0 +1,77 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#pragma once
+
+#include "crimson/common/perf_counters_collection.h"
+
+namespace crimson::os::seastore {
+
+using PerfCountersRef = std::unique_ptr<PerfCounters>;
+enum {
+  seastore_perfcounters_first = 30000,
+  ss_tm_extents_mutated_total,
+  ss_tm_extents_mutated_bytes,
+  ss_tm_extents_retired_total,
+  ss_tm_extents_retired_bytes,
+  ss_tm_extents_allocated_total,
+  ss_tm_extents_allocated_bytes,
+  ss_sm_bytes_written,
+  ss_sm_segments_released,
+  ss_sm_bytes_released,
+  seastore_perfcounters_last,
+};
+
+class PerfService {
+  PerfCountersRef build_seastore_perf() {
+    std::string name = fmt::format("seastore::shard-{}", seastar::this_shard_id());
+    PerfCountersBuilder ss_plb(nullptr, name, seastore_perfcounters_first,
+                               seastore_perfcounters_last);
+    ss_plb.add_u64_counter(
+      ss_tm_extents_mutated_total, "extents_mutated_num",
+      "the number of extents which have been mutated");
+    ss_plb.add_u64_counter(
+      ss_tm_extents_mutated_bytes, "extents_mutated_bytes",
+      "the total bytes of extents which have been mutated");
+    ss_plb.add_u64_counter(
+      ss_tm_extents_retired_total, "extents_retired_num",
+      "the number of extents which have been retired");
+    ss_plb.add_u64_counter(
+      ss_tm_extents_retired_bytes, "extents_retired_bytes",
+      "the total bytes of extents which have been retired");
+    ss_plb.add_u64_counter(
+      ss_tm_extents_allocated_total, "extents_allocated_num",
+      "the number of extents which have been allocated");
+    ss_plb.add_u64_counter(
+      ss_tm_extents_allocated_bytes, "extents_allocated_bytes",
+      "the total bytes of extents which have been allocated");
+    ss_plb.add_u64_counter(
+      ss_sm_bytes_written, "sm_bytes_written",
+      "the number of bytes written by segmentmanager");
+    ss_plb.add_u64_counter(
+      ss_sm_segments_released, "sm_segments_released",
+      "the number of segments released by segmentmanager");
+    ss_plb.add_u64_counter(
+      ss_sm_bytes_released, "sm_bytes_released",
+      "the number of bytes released by segmentmanager");
+    return PerfCountersRef(ss_plb.create_perf_counters());
+  }
+
+  PerfCountersRef ss_perf = nullptr;
+public:
+  PerfService()
+  : ss_perf(build_seastore_perf()) {}
+
+  ~PerfService() {}
+
+  PerfCounters& get_counters() {
+    return *ss_perf;
+  }
+  void add_to_collection() {
+    crimson::common::local_perf_coll().get_perf_collection()->add(ss_perf.get());
+  }
+  void remove_from_collection() {
+    crimson::common::local_perf_coll().get_perf_collection()->remove(ss_perf.get());
+  }
+};
+using PerfServiceRef = std::unique_ptr<PerfService>;
+}

--- a/src/crimson/tools/store_nbd/tm_driver.cc
+++ b/src/crimson/tools/store_nbd/tm_driver.cc
@@ -133,7 +133,7 @@ void TMDriver::init()
 {
   auto segment_cleaner = std::make_unique<SegmentCleaner>(
     SegmentCleaner::config_t::get_default(),
-    false /* detailed */);
+    perf_service->get_counters(), false /* detailed */);
   segment_cleaner->mount(*segment_manager);
   auto journal = std::make_unique<Journal>(*segment_manager);
   auto cache = std::make_unique<Cache>(*segment_manager);
@@ -146,7 +146,8 @@ void TMDriver::init()
     std::move(segment_cleaner),
     std::move(journal),
     std::move(cache),
-    std::move(lba_manager));
+    std::move(lba_manager),
+    perf_service->get_counters());
 }
 
 void TMDriver::clear()
@@ -162,6 +163,7 @@ size_t TMDriver::get_size() const
 seastar::future<> TMDriver::mkfs()
 {
   assert(config.path);
+  perf_service->add_to_collection();
   segment_manager = std::make_unique<
     segment_manager::block::BlockSegmentManager
     >(*config.path);
@@ -184,6 +186,7 @@ seastar::future<> TMDriver::mkfs()
     logger().debug("sm close");
     return segment_manager->close();
   }).safe_then([this] {
+    perf_service->remove_from_collection();
     clear();
     logger().debug("mkfs complete");
     return TransactionManager::mkfs_ertr::now();

--- a/src/crimson/tools/store_nbd/tm_driver.h
+++ b/src/crimson/tools/store_nbd/tm_driver.h
@@ -4,6 +4,7 @@
 #include "block_driver.h"
 
 #include "crimson/os/seastore/cache.h"
+#include "crimson/os/seastore/seastore_perf_counters.h"
 #include "crimson/os/seastore/segment_cleaner.h"
 #include "crimson/os/seastore/segment_manager.h"
 #include "crimson/os/seastore/segment_manager/block.h"
@@ -41,6 +42,9 @@ private:
 
   using TransactionManager = crimson::os::seastore::TransactionManager;
   std::unique_ptr<TransactionManager> tm;
+  using PerfServiceRef = crimson::os::seastore::PerfServiceRef;
+  using PerfService = crimson::os::seastore::PerfService;
+  PerfServiceRef perf_service = PerfServiceRef(new PerfService());
 
   seastar::future<> mkfs();
   void init();

--- a/src/test/crimson/seastore/test_transaction_manager.cc
+++ b/src/test/crimson/seastore/test_transaction_manager.cc
@@ -60,7 +60,6 @@ struct transaction_manager_test_t :
 
   transaction_manager_test_t()
     : gen(rd()) {
-    init();
   }
 
   laddr_t get_random_laddr(size_t block_size, laddr_t limit) {


### PR DESCRIPTION
Signed-off-by: chunmei-liu <chunmei.liu@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
