### PR TITLE
pacific: mgr/dashboard: OSDs placement text is unreadable

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/placement.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/placement.pipe.spec.ts
@@ -59,10 +59,10 @@ describe('PlacementPipe', () => {
     expect(
       pipe.transform({
         placement: {
-          host_pattern: '*'
+          host_pattern: 'abc.ceph.xyz.com'
         }
       })
-    ).toBe('*');
+    ).toBe('abc.ceph.xyz.com');
   });
 
   it('transforms placement (6)', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/placement.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/placement.pipe.ts
@@ -34,7 +34,7 @@ export class PlacementPipe implements PipeTransform {
       kv.push($localize`label:${label}`);
     }
     if (_.isString(hostPattern)) {
-      kv.push(...hostPattern);
+      kv.push(hostPattern);
     }
     return kv.join(';');
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
@@ -104,7 +104,7 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
       {
         name: $localize`Container image ID`,
         prop: 'status.container_image_id',
-        flexGrow: 3,
+        flexGrow: 1.5,
         cellTransformation: CellTemplate.truncate,
         customTemplateConfig: {
           length: 12
@@ -114,7 +114,7 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
         name: $localize`Placement`,
         prop: '',
         pipe: new PlacementPipe(),
-        flexGrow: 1
+        flexGrow: 2
       },
       {
         name: $localize`Running`,


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50583

---

backport of https://github.com/ceph/ceph/pull/41083
parent tracker: https://tracker.ceph.com/issues/50580

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh