### PR TITLE
cephfs-mirror: allow connecting to local cluster using mon address

### DIFF
--- a/src/tools/cephfs_mirror/FSMirror.cc
+++ b/src/tools/cephfs_mirror/FSMirror.cc
@@ -141,7 +141,7 @@ void FSMirror::init(Context *on_finish) {
 
   std::scoped_lock locker(m_lock);
   int r = connect(g_ceph_context->_conf->name.to_str(),
-                  g_ceph_context->_conf->cluster, &m_cluster);
+                  g_ceph_context->_conf->cluster, &m_cluster, "", "", m_args);
   if (r < 0) {
     m_init_failed = true;
     on_finish->complete(r);

--- a/src/tools/cephfs_mirror/Utils.cc
+++ b/src/tools/cephfs_mirror/Utils.cc
@@ -18,7 +18,8 @@ namespace cephfs {
 namespace mirror {
 
 int connect(std::string_view client_name, std::string_view cluster_name,
-            RadosRef *cluster, std::string_view mon_host, std::string_view cephx_key) {
+            RadosRef *cluster, std::string_view mon_host, std::string_view cephx_key,
+            std::vector<const char *> args) {
   dout(20) << ": connecting to cluster=" << cluster_name << ", client=" << client_name
            << ", mon_host=" << mon_host << dendl;
 
@@ -40,12 +41,13 @@ int connect(std::string_view client_name, std::string_view cluster_name,
 
   cct->_conf.parse_env(cct->get_module_type());
 
-  std::vector<const char*> args;
-  r = cct->_conf.parse_argv(args);
-  if (r < 0) {
-    derr << ": could not parse environment: " << cpp_strerror(r) << dendl;
-    cct->put();
-    return r;
+  if (!args.empty()) {
+    r = cct->_conf.parse_argv(args);
+    if (r < 0) {
+      derr << ": could not parse command line args: " << cpp_strerror(r) << dendl;
+      cct->put();
+      return r;
+    }
   }
   cct->_conf.parse_env(cct->get_module_type());
 
@@ -65,6 +67,8 @@ int connect(std::string_view client_name, std::string_view cluster_name,
       return r;
     }
   }
+
+  dout(10) << ": using mon addr=" << cct->_conf.get_val<std::string>("mon_host") << dendl;
 
   cluster->reset(new librados::Rados());
 

--- a/src/tools/cephfs_mirror/Utils.h
+++ b/src/tools/cephfs_mirror/Utils.h
@@ -10,7 +10,8 @@ namespace cephfs {
 namespace mirror {
 
 int connect(std::string_view client_name, std::string_view cluster_name,
-            RadosRef *cluster, std::string_view mon_host={}, std::string_view cephx_key={});
+            RadosRef *cluster, std::string_view mon_host={}, std::string_view cephx_key={},
+            std::vector<const char *> args={});
 
 int mount(RadosRef cluster, const Filesystem &filesystem, bool cross_check_fscid,
           MountRef *mount);

--- a/src/tools/cephfs_mirror/main.cc
+++ b/src/tools/cephfs_mirror/main.cc
@@ -18,7 +18,9 @@
 void usage() {
   std::cout << "usage: cephfs-mirror [options...]" << std::endl;
   std::cout << "options:\n";
-  std::cout << "  --log-file=<logfile>  file to log debug output\n";
+  std::cout << "  --mon-host monaddress[:port]  connect to specified monitor\n";
+  std::cout << "  --keyring=<path>              path to keyring for local cluster\n";
+  std::cout << "  --log-file=<logfile>          file to log debug output\n";
   std::cout << "  --debug-cephfs-mirror=<log-level>/<memory-level>  set cephfs-mirror debug level\n";
   generic_server_usage();
 }


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/50581
Signed-off-by: Venky Shankar <vshankar@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
