### PR TITLE
nautilus: mon: ensure progress is [0,1] before printing

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3063,8 +3063,14 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
       for (auto& i : pem) {
 	ss << "    " << i.second.message << "\n";
 	ss << "      [";
+	unsigned p;
+	if (i.second.progress >= 0.0 && i.second.progress <= 1.0) {
+	  p = (unsigned)(i.second.progress * 30.0);
+	} else {
+	  p = 0;
+	}
 	unsigned j;
-	for (j = 0; j < (unsigned)(i.second.progress * 30.0); ++j) {
+	for (j = 0; j < p; ++j) {
 	  ss << '=';
 	}
 	for (; j < 30; ++j) {


### PR DESCRIPTION
Ensure that progress is in the expected range [0,1] before
rendering a progress bar.

Nautilus only because this is avoided in future releases thanks
to 5f95ec4457059889bc4dbc2ad25cdc0537255f69.

Related-to: https://tracker.ceph.com/issues/50587
Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>