### PR TITLE
mgr/dashboard: fix rename inventory to disks

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -107,7 +107,7 @@
             class="tc_submenuitem tc_submenuitem_cluster_inventory"
             *ngIf="permissions.hosts.read">
           <a i18n
-             routerLink="/inventory">Inventory</a>
+             routerLink="/inventory">Physical disks</a>
         </li>
         <li routerLinkActive="active"
             class="tc_submenuitem tc_submenuitem_cluster_monitor"


### PR DESCRIPTION
Changed the Navigation menu name from 'Inventory'  to 'Physical disks'

Fixes: https://tracker.ceph.com/issues/50314
Signed-off-by: Navin Barnwal <knbarnwal@gmail.com>
