### PR TITLE
Fix ssd cache full related bugs

### DIFF
--- a/src/librbd/cache/pwl/ssd/WriteLog.cc
+++ b/src/librbd/cache/pwl/ssd/WriteLog.cc
@@ -132,9 +132,10 @@ bool WriteLog<I>::initialize_pool(Context *on_finish,
     m_cache_state->clean = true;
     m_cache_state->empty = true;
     /* new pool, calculate and store metadata */
-    size_t small_write_size = MIN_WRITE_ALLOC_SSD_SIZE + sizeof(struct WriteLogCacheEntry);
+    size_t small_write_size = MIN_WRITE_ALLOC_SSD_SIZE * 2;
 
-    uint64_t num_small_writes = (uint64_t)(this->m_log_pool_config_size / small_write_size);
+    uint64_t m_log_pool_ring_buffer_size = this->m_log_pool_config_size - DATA_RING_BUFFER_OFFSET;
+    uint64_t num_small_writes = (uint64_t)(m_log_pool_ring_buffer_size / small_write_size);
     if (num_small_writes > MAX_LOG_ENTRIES) {
       num_small_writes = MAX_LOG_ENTRIES;
     }
@@ -146,7 +147,6 @@ bool WriteLog<I>::initialize_pool(Context *on_finish,
     m_first_free_entry = DATA_RING_BUFFER_OFFSET;
     m_first_valid_entry = DATA_RING_BUFFER_OFFSET;
 
-    pool_size = this->m_log_pool_config_size;
     auto new_root = std::make_shared<WriteLogPoolRoot>(pool_root);
     new_root->pool_size = this->m_log_pool_config_size;
     new_root->flushed_sync_gen = this->m_flushed_sync_gen;
@@ -158,14 +158,10 @@ bool WriteLog<I>::initialize_pool(Context *on_finish,
 
     r = update_pool_root_sync(new_root);
     if (r != 0) {
-      this->m_total_log_entries = 0;
-      this->m_free_log_entries = 0;
       lderr(m_image_ctx.cct) << "failed to initialize pool ("
                              << this->m_log_pool_name << ")" << dendl;
       on_finish->complete(r);
     }
-    this->m_total_log_entries = new_root->num_log_entries;
-    this->m_free_log_entries = new_root->num_log_entries - 1;
   } else {
     m_cache_state->present = true;
     bdev = BlockDevice::create(
@@ -178,19 +174,6 @@ bool WriteLog<I>::initialize_pool(Context *on_finish,
       return false;
     }
     load_existing_entries(later);
-    if (m_first_free_entry < m_first_valid_entry) {
-      /* Valid entries wrap around the end of the ring, so first_free is lower
-       * than first_valid.  If first_valid was == first_free+1, the entry at
-       * first_free would be empty. The last entry is never used, so in
-       * that case there would be zero free log entries. */
-      this->m_free_log_entries = this->m_total_log_entries -
-        (m_first_valid_entry - m_first_free_entry) - 1;
-    } else {
-      /* first_valid is <= first_free. If they are == we have zero valid log
-       * entries, and n-1 free log entries */
-      this->m_free_log_entries = this->m_total_log_entries -
-        (m_first_free_entry - m_first_valid_entry) - 1;
-    }
     m_cache_state->clean = this->m_dirty_log_entries.empty();
     m_cache_state->empty = m_log_entries.empty();
   }
@@ -242,7 +225,6 @@ void WriteLog<I>::load_existing_entries(pwl::DeferredContexts &later) {
   pool_root = current_pool_root;
   m_first_free_entry = first_free_entry;
   m_first_valid_entry = next_log_pos;
-  this->m_total_log_entries = current_pool_root.num_log_entries;
   this->m_flushed_sync_gen = current_pool_root.flushed_sync_gen;
   this->m_log_pool_actual_size = current_pool_root.pool_size;
 
@@ -288,6 +270,7 @@ void WriteLog<I>::load_existing_entries(pwl::DeferredContexts &later) {
 template <typename I>
 bool WriteLog<I>::alloc_resources(C_BlockIORequestT *req) {
   bool alloc_succeeds = true;
+  bool no_space = false;
   uint64_t bytes_allocated = 0;
   uint64_t bytes_cached = 0;
   uint64_t bytes_dirtied = 0;
@@ -295,17 +278,22 @@ bool WriteLog<I>::alloc_resources(C_BlockIORequestT *req) {
   uint64_t num_unpublished_reserves = 0;
   uint64_t num_log_entries = 0;
 
-  // Setup buffer, and get all the number of required resources
   req->setup_buffer_resources(&bytes_cached, &bytes_dirtied, &bytes_allocated,
                               &num_lanes, &num_log_entries,
                               &num_unpublished_reserves);
 
   bytes_allocated += num_log_entries * MIN_WRITE_ALLOC_SSD_SIZE;
 
-  alloc_succeeds = this->check_allocation(req, bytes_cached, bytes_dirtied,
-                                          bytes_allocated, num_lanes,
-                                          num_log_entries,
-                                          num_unpublished_reserves);
+  this->check_allocation(req, bytes_cached, bytes_dirtied,
+                         bytes_allocated, num_lanes,
+                         num_log_entries,
+                         num_unpublished_reserves,
+                         this->m_bytes_allocated_cap,
+                         alloc_succeeds, no_space);
+  this->m_bytes_allocated += bytes_allocated;
+  this->m_bytes_cached += bytes_cached;
+  this->m_bytes_dirty += bytes_dirtied;
+
   req->set_allocated(alloc_succeeds);
   return alloc_succeeds;
 }
@@ -455,7 +443,7 @@ void WriteLog<I>::append_op_log_entries(GenericLogOperations &ops) {
       }
     });
   // Append logs and update first_free_update
-  uint64_t bytes_allocated_updated;
+  uint64_t bytes_allocated_updated = 0;
   append_ops(ops, append_ctx, new_first_free_entry, bytes_allocated_updated);
 
   {
@@ -538,9 +526,7 @@ void WriteLog<I>::process_work() {
   bool wake_up_requested = false;
   uint64_t aggressive_high_water_bytes =
       this->m_bytes_allocated_cap * AGGRESSIVE_RETIRE_HIGH_WATER;
-  uint64_t aggressive_high_water_entries = this->m_total_log_entries * AGGRESSIVE_RETIRE_HIGH_WATER;
   uint64_t high_water_bytes = this->m_bytes_allocated_cap * RETIRE_HIGH_WATER;
-  uint64_t high_water_entries = this->m_total_log_entries * RETIRE_HIGH_WATER;
 
   ldout(cct, 20) << dendl;
 
@@ -550,18 +536,15 @@ void WriteLog<I>::process_work() {
       this->m_wake_up_requested = false;
     }
     if (this->m_alloc_failed_since_retire || (this->m_shutting_down) ||
-        this->m_invalidating || m_bytes_allocated > high_water_bytes ||
-        (m_log_entries.size() > high_water_entries)) {
+        this->m_invalidating || m_bytes_allocated > high_water_bytes) {
       ldout(m_image_ctx.cct, 10) << "alloc_fail=" << this->m_alloc_failed_since_retire
                                  << ", allocated > high_water="
                                  << (m_bytes_allocated > high_water_bytes)
                                  << ", allocated_entries > high_water="
-                                 << (m_log_entries.size() > high_water_entries)
                                  << dendl;
       retire_entries((this->m_shutting_down || this->m_invalidating ||
-                    (m_bytes_allocated > aggressive_high_water_bytes) ||
-                    (m_log_entries.size() > aggressive_high_water_entries))
-                    ? MAX_ALLOC_PER_TRANSACTION : MAX_FREE_PER_TRANSACTION);
+                     (m_bytes_allocated > aggressive_high_water_bytes))
+                     ? MAX_ALLOC_PER_TRANSACTION : MAX_FREE_PER_TRANSACTION);
     }
     this->dispatch_deferred_writes();
     this->process_writeback_dirty_entries();
@@ -626,12 +609,14 @@ bool WriteLog<I>::retire_entries(const unsigned long int frees_per_tx) {
             }
             break;
           } else {
+            ldout(cct, 20) << "retiring subentries" << dendl;
             retiring_subentries.push_back(*it);
             if ((*it)->is_write_entry()) {
               data_length += (*it)->get_aligned_data_size();
             }
           }
         } else {
+	  ldout(cct, 20) << "clearing subentries" << dendl;
           retiring_subentries.clear();
           break;
         }
@@ -677,7 +662,7 @@ bool WriteLog<I>::retire_entries(const unsigned long int frees_per_tx) {
     }
     if (first_valid_entry >= this->m_log_pool_config_size) {
       first_valid_entry = first_valid_entry % this->m_log_pool_config_size +
-          DATA_RING_BUFFER_OFFSET;
+        DATA_RING_BUFFER_OFFSET;
     }
     ceph_assert(first_valid_entry != initial_first_valid_entry);
     auto new_root = std::make_shared<WriteLogPoolRoot>(pool_root);
@@ -709,7 +694,6 @@ bool WriteLog<I>::retire_entries(const unsigned long int frees_per_tx) {
           std::lock_guard locker(m_lock);
           m_first_valid_entry = first_valid_entry;
           ceph_assert(m_first_valid_entry % MIN_WRITE_ALLOC_SSD_SIZE == 0);
-          this->m_free_log_entries += retiring_entries.size();
           ceph_assert(this->m_bytes_allocated >= allocated_bytes);
           this->m_bytes_allocated -= allocated_bytes;
           ceph_assert(this->m_bytes_cached >= cached_bytes);
@@ -750,7 +734,6 @@ void WriteLog<I>::append_ops(GenericLogOperations &ops, Context *ctx,
   GenericLogEntriesVector log_entries;
   CephContext *cct = m_image_ctx.cct;
   uint64_t span_payload_len = 0;
-  bytes_allocated = 0;
   ldout(cct, 20) << "Appending " << ops.size() << " log entries." << dendl;
 
   AioTransContext* aio = new AioTransContext(cct, ctx);


### PR DESCRIPTION
- Move code related to `m_free_lanes` and `m_free_log_entries` to rwl
- Remove unnecessary `m_log_entries` check in `process_work` function

Signed-off-by: Mahati Chamarthy <mahati.chamarthy@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
