### PR TITLE
rgw/acl: set_acl shouldn't overwrite bucket attrs

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -3032,25 +3032,6 @@ int RGWBucketCtl::do_unlink_bucket(RGWSI_Bucket_EP_Ctx& ctx,
   return svc.bucket->store_bucket_entrypoint_info(ctx, meta_key, ep, false, real_time(), &attrs, &ot, y, dpp);
 }
 
-int RGWBucketCtl::set_acl(ACLOwner& owner, rgw_bucket& bucket,
-                          RGWBucketInfo& bucket_info, bufferlist& bl,
-                          optional_yield y,
-                          const DoutPrefixProvider *dpp)
-{
-  // set owner and acl
-  bucket_info.owner = owner.get_id();
-  std::map<std::string, bufferlist> attrs{{RGW_ATTR_ACL, bl}};
-
-  int r = store_bucket_instance_info(bucket, bucket_info, y, dpp,
-                                     BucketInstance::PutParams().set_attrs(&attrs));
-  if (r < 0) {
-    cerr << "ERROR: failed to set bucket owner: " << cpp_strerror(-r) << std::endl;
-    return r;
-  }
-  
-  return 0;
-}
-
 // TODO: remove RGWRados dependency for bucket listing
 int RGWBucketCtl::chown(rgw::sal::Store* store, rgw::sal::Bucket* bucket,
                         const rgw_user& user_id, const std::string& display_name,

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -694,10 +694,6 @@ public:
             const rgw_user& user_id, const std::string& display_name,
             const std::string& marker, optional_yield y, const DoutPrefixProvider *dpp);
 
-  int set_acl(ACLOwner& owner, rgw_bucket& bucket,
-              RGWBucketInfo& bucket_info, bufferlist& bl, optional_yield y,
-              const DoutPrefixProvider *dpp);
-
   int read_buckets_stats(map<string, RGWBucketEnt>& m,
                          optional_yield y,
                          const DoutPrefixProvider *dpp);

--- a/src/rgw/rgw_sal_rados.cc
+++ b/src/rgw/rgw_sal_rados.cc
@@ -538,8 +538,20 @@ int RadosBucket::set_acl(const DoutPrefixProvider* dpp, RGWAccessControlPolicy &
 
   acls = acl;
   acl.encode(aclbl);
+  map<string, bufferlist>& attrs = get_attrs();
 
-  return store->ctl()->bucket->set_acl(acl.get_owner(), info.bucket, info, aclbl, y, dpp);
+  attrs[RGW_ATTR_ACL] = aclbl;
+  info.owner = acl.get_owner().get_id();
+
+  int r = store->ctl()->bucket->store_bucket_instance_info(info.bucket,
+                 info, y, dpp,
+                 RGWBucketCtl::BucketInstance::PutParams().set_attrs(&attrs));
+  if (r < 0) {
+    cerr << "ERROR: failed to set bucket owner: " << cpp_strerror(-r) << std::endl;
+    return r;
+  }
+  
+  return 0;
 }
 
 std::unique_ptr<Object> RadosBucket::get_object(const rgw_obj_key& k)


### PR DESCRIPTION
set_acl should update only  'RGW_ATTR_ACL' attr and preserve all the other bucket attrs

Signed-off-by: Soumya Koduri <skoduri@redhat.com>

