### PR TITLE
mgr/cephadm: set host crush location based on HostSpec

### DIFF
--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1359,25 +1359,18 @@ class CephadmOrchestrator(orchestrator.Orchestrator, MgrModule,
             )
         ]
 
-    def _add_host(self, spec):
-        # type: (HostSpec) -> str
-        """
-        Add a host to be managed by the orchestrator.
-
-        :param host: host name
-        """
-        assert_valid_host(spec.hostname)
+    def _check_valid_addr(self, host: str, addr: str) -> None:
         # make sure hostname is resolvable before trying to make a connection
         try:
-            utils.resolve_ip(spec.addr)
+            utils.resolve_ip(addr)
         except OrchestratorError as e:
             msg = str(e) + f'''
-You may need to supply an address for {spec.addr}
+You may need to supply an address for {addr}
 
 Please make sure that the host is reachable and accepts connections using the cephadm SSH key
 To add the cephadm SSH key to the host:
 > ceph cephadm get-pub-key > ~/ceph.pub
-> ssh-copy-id -f -i ~/ceph.pub {self.ssh_user}@{spec.addr}
+> ssh-copy-id -f -i ~/ceph.pub {self.ssh_user}@{addr}
 
 To check that the host is reachable open a new shell with the --no-hosts flag:
 > cephadm shell --no-hosts
@@ -1386,19 +1379,30 @@ Then run the following:
 > ceph cephadm get-ssh-config > ssh_config
 > ceph config-key get mgr/cephadm/ssh_identity_key > ~/cephadm_private_key
 > chmod 0600 ~/cephadm_private_key
-> ssh -F ssh_config -i ~/cephadm_private_key {self.ssh_user}@{spec.addr}'''
+> ssh -F ssh_config -i ~/cephadm_private_key {self.ssh_user}@{addr}'''
             raise OrchestratorError(msg)
 
-        out, err, code = CephadmServe(self)._run_cephadm(spec.hostname, cephadmNoImage, 'check-host',
-                                                         ['--expect-hostname', spec.hostname],
-                                                         addr=spec.addr,
-                                                         error_ok=True, no_fsid=True)
+        out, err, code = CephadmServe(self)._run_cephadm(
+            host, cephadmNoImage, 'check-host',
+            ['--expect-hostname', host],
+            addr=addr,
+            error_ok=True, no_fsid=True)
         if code:
             # err will contain stdout and stderr, so we filter on the message text to
             # only show the errors
             errors = [_i.replace("ERROR: ", "") for _i in err if _i.startswith('ERROR')]
-            raise OrchestratorError('New host %s (%s) failed check(s): %s' % (
-                spec.hostname, spec.addr, errors))
+            raise OrchestratorError('Host %s (%s) failed check(s): %s' % (
+                host, addr, errors))
+
+    def _add_host(self, spec):
+        # type: (HostSpec) -> str
+        """
+        Add a host to be managed by the orchestrator.
+
+        :param host: host name
+        """
+        assert_valid_host(spec.hostname)
+        self._check_valid_addr(spec.hostname, spec.addr)
 
         # prime crush map?
         if spec.location:
@@ -1438,6 +1442,7 @@ Then run the following:
 
     @handle_orch_error
     def update_host_addr(self, host: str, addr: str) -> str:
+        self._check_valid_addr(host, addr)
         self.inventory.set_addr(host, addr)
         self._reset_con(host)
         self.event.set()  # refresh stray health check

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1409,8 +1409,9 @@ Then run the following:
                 'args': [f'{k}={v}' for k, v in spec.location.items()],
             })
 
+        if spec.hostname not in self.inventory:
+            self.cache.prime_empty_host(spec.hostname)
         self.inventory.add_host(spec)
-        self.cache.prime_empty_host(spec.hostname)
         self.offline_hosts_remove(spec.hostname)
         self.event.set()  # refresh stray health check
         self.log.info('Added host %s' % spec.hostname)

--- a/src/pybind/mgr/cephadm/module.py
+++ b/src/pybind/mgr/cephadm/module.py
@@ -1400,6 +1400,15 @@ Then run the following:
             raise OrchestratorError('New host %s (%s) failed check(s): %s' % (
                 spec.hostname, spec.addr, errors))
 
+        # prime crush map?
+        if spec.location:
+            self.check_mon_command({
+                'prefix': 'osd crush add-bucket',
+                'name': spec.hostname,
+                'type': 'host',
+                'args': [f'{k}={v}' for k, v in spec.location.items()],
+            })
+
         self.inventory.add_host(spec)
         self.cache.prime_empty_host(spec.hostname)
         self.offline_hosts_remove(spec.hostname)

--- a/src/python-common/ceph/deployment/hostspec.py
+++ b/src/python-common/ceph/deployment/hostspec.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 import errno
 try:
-    from typing import Optional, List, Any
+    from typing import Optional, List, Any, Dict
 except ImportError:
     pass  # just for type checking
 
@@ -23,10 +23,11 @@ class HostSpec(object):
     Information about hosts. Like e.g. ``kubectl get nodes``
     """
     def __init__(self,
-                 hostname,  # type: str
-                 addr=None,  # type: Optional[str]
-                 labels=None,  # type: Optional[List[str]]
-                 status=None,  # type: Optional[str]
+                 hostname: str,
+                 addr: Optional[str] = None,
+                 labels: Optional[List[str]] = None,
+                 status: Optional[str] = None,
+                 location: Optional[Dict[str, str]] = None,
                  ):
         self.service_type = 'host'
 
@@ -42,34 +43,57 @@ class HostSpec(object):
         #: human readable status
         self.status = status or ''  # type: str
 
-    def to_json(self) -> dict:
-        return {
+        self.location = location
+
+    def to_json(self) -> Dict[str, Any]:
+        r: Dict[str, Any] = {
             'hostname': self.hostname,
             'addr': self.addr,
             'labels': list(OrderedDict.fromkeys((self.labels))),
             'status': self.status,
         }
+        if self.location:
+            r['location'] = self.location
+        return r
 
     @classmethod
     def from_json(cls, host_spec: dict) -> 'HostSpec':
         host_spec = cls.normalize_json(host_spec)
-        _cls = cls(host_spec['hostname'],
-                   host_spec['addr'] if 'addr' in host_spec else None,
-                   list(OrderedDict.fromkeys(
-                       host_spec['labels'])) if 'labels' in host_spec else None,
-                   host_spec['status'] if 'status' in host_spec else None)
+        _cls = cls(
+            host_spec['hostname'],
+            host_spec['addr'] if 'addr' in host_spec else None,
+            list(OrderedDict.fromkeys(
+                host_spec['labels'])) if 'labels' in host_spec else None,
+            host_spec['status'] if 'status' in host_spec else None,
+            host_spec.get('location'),
+        )
         return _cls
 
     @staticmethod
     def normalize_json(host_spec: dict) -> dict:
         labels = host_spec.get('labels')
-        if labels is None:
-            return host_spec
-        if isinstance(labels, list):
-            return host_spec
-        if not isinstance(labels, str):
-            raise SpecValidationError(f'Labels ({labels}) must be a string or list of strings')
-        host_spec['labels'] = [labels]
+        if labels is not None:
+            if isinstance(labels, str):
+                host_spec['labels'] = [labels]
+            elif (
+                    not isinstance(labels, list)
+                    or any(not isinstance(v, str) for v in labels)
+            ):
+                raise SpecValidationError(
+                    f'Labels ({labels}) must be a string or list of strings'
+                )
+
+        loc = host_spec.get('location')
+        if loc is not None:
+            if (
+                    not isinstance(loc, dict)
+                    or any(not isinstance(k, str) for k in loc.keys())
+                    or any(not isinstance(v, str) for v in loc.values())
+            ):
+                raise SpecValidationError(
+                    f'Location ({loc}) must be a dictionary of strings to strings'
+                )
+
         return host_spec
 
     def __repr__(self) -> str:
@@ -80,6 +104,8 @@ class HostSpec(object):
             args.append(self.labels)
         if self.status:
             args.append(self.status)
+        if self.location:
+            args.append(self.location)
 
         return "HostSpec({})".format(', '.join(map(repr, args)))
 
@@ -92,4 +118,5 @@ class HostSpec(object):
         # Let's omit `status` for the moment, as it is still the very same host.
         return self.hostname == other.hostname and \
                self.addr == other.addr and \
-               self.labels == other.labels
+               sorted(self.labels) == sorted(other.labels) and \
+               self.location == other.location

--- a/src/python-common/ceph/tests/test_hostspec.py
+++ b/src/python-common/ceph/tests/test_hostspec.py
@@ -1,0 +1,40 @@
+# flake8: noqa
+import json
+import yaml
+
+import pytest
+
+from ceph.deployment.hostspec import HostSpec, SpecValidationError
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        ({"hostname": "foo"}, HostSpec('foo')),
+        ({"hostname": "foo", "labels": "l1"}, HostSpec('foo', labels=['l1'])),
+        ({"hostname": "foo", "labels": ["l1", "l2"]}, HostSpec('foo', labels=['l1', 'l2'])),
+        ({"hostname": "foo", "location": {"rack": "foo"}}, HostSpec('foo', location={'rack': 'foo'})),
+    ]
+)
+def test_parse_host_specs(test_input, expected):
+    hs = HostSpec.from_json(test_input)
+    assert hs == expected
+
+
+@pytest.mark.parametrize(
+    "bad_input",
+    [
+        ({"hostname": "foo", "labels": 124}),
+        ({"hostname": "foo", "labels": {"a", "b"}}),
+        ({"hostname": "foo", "labels": {"a", "b"}}),
+        ({"hostname": "foo", "labels": ["a", 2]}),
+        ({"hostname": "foo", "location": "rack=bar"}),
+        ({"hostname": "foo", "location": ["a"]}),
+        ({"hostname": "foo", "location": {"rack", 1}}),
+        ({"hostname": "foo", "location": {1: "rack"}}),
+    ]
+)
+def test_parse_host_specs(bad_input):
+    with pytest.raises(SpecValidationError):
+        hs = HostSpec.from_json(bad_input)
+    


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>