### PR TITLE
ceph-volume,cephadm: Allow not mounting tmpfs on osd activate

### DIFF
--- a/doc/man/8/ceph-volume.rst
+++ b/doc/man/8/ceph-volume.rst
@@ -116,6 +116,10 @@ Optional arguments:
 
    Do not enable or create any systemd units
 
+.. option:: --no-tmpfs
+
+   Skip mountng a tmpfs filesystem when activating the OSD even if a mounted one is not detected
+
 .. option:: --osds-per-device
 
    Provision more than 1 (the default) OSD per device

--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -140,7 +140,7 @@ def get_osd_device_path(osd_lvs, device_type, dmcrypt_secret=None):
     raise RuntimeError('could not find %s with uuid %s' % (device_type, device_uuid))
 
 
-def activate_bluestore(osd_lvs, no_systemd=False):
+def activate_bluestore(osd_lvs, no_systemd=False, no_tmpfs=False):
     for lv in osd_lvs:
         if lv.tags.get('ceph.type') == 'block':
             osd_block_lv = lv
@@ -157,8 +157,8 @@ def activate_bluestore(osd_lvs, no_systemd=False):
     # mount on tmpfs the osd directory
     osd_path = '/var/lib/ceph/osd/%s-%s' % (conf.cluster, osd_id)
     if not system.path_is_mounted(osd_path):
-        # mkdir -p and mount as tmpfs
-        prepare_utils.create_osd_path(osd_id, tmpfs=True)
+        # mkdir -p and mount as tmpfs unless forced not to
+        prepare_utils.create_osd_path(osd_id, tmpfs=(not no_tmpfs))
     # XXX This needs to be removed once ceph-bluestore-tool can deal with
     # symlinks that exist in the osd dir
     for link_name in ['block', 'block.db', 'block.wal']:
@@ -289,9 +289,9 @@ class Activate(object):
             logger.info('unable to find a journal associated with the OSD, '
                         'assuming bluestore')
 
-            return activate_bluestore(lvs, args.no_systemd)
+            return activate_bluestore(lvs, args.no_systemd, args.no_tmpfs)
         if args.bluestore:
-            activate_bluestore(lvs, args.no_systemd)
+            activate_bluestore(lvs, args.no_systemd, args.no_tmpfs)
         elif args.filestore:
             activate_filestore(lvs, args.no_systemd)
 
@@ -355,6 +355,12 @@ class Activate(object):
             dest='no_systemd',
             action='store_true',
             help='Skip creating and enabling systemd units and starting OSD services',
+        )
+        parser.add_argument(
+            '--no-tmpfs',
+            dest='no_tmpfs',
+            action='store_true',
+            help='Do not create a tmpfs for the OSD directory',
         )
         if len(self.argv) == 0:
             print(sub_command_help)

--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -360,7 +360,8 @@ class Activate(object):
             '--no-tmpfs',
             dest='no_tmpfs',
             action='store_true',
-            help='Do not create a tmpfs for the OSD directory',
+            help='Skip mountng a tmpfs filesystem when activating the OSD '
+                 'even if a mounted one is not detected.',
         )
         if len(self.argv) == 0:
             print(sub_command_help)

--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -257,6 +257,13 @@ class Batch(object):
             help='Skip creating and enabling systemd units and starting OSD services',
         )
         parser.add_argument(
+            '--no-tmpfs',
+            dest='no_tmpfs',
+            action='store_true',
+            help=('Skip mountng a tmpfs filesystem when activating the OSD '
+                 'even if a mounted one is not detected.'),
+        )
+        parser.add_argument(
             '--osds-per-device',
             type=int,
             default=1,

--- a/src/ceph-volume/ceph_volume/devices/lvm/common.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/common.py
@@ -79,6 +79,12 @@ common_args = {
         'action': 'store_true',
         'help': 'Skip creating and enabling systemd units and starting OSD services when activating',
     },
+    '--no-tmpfs': {
+        'dest': 'no_tmpfs',
+        'action': 'store_true',
+        'help': ('Skip mountng a tmpfs filesystem when activating the OSD '
+                 'even if a mounted one is not detected.'),
+    },
 }
 
 bluestore_args = {

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
@@ -13,6 +13,7 @@ class Args(object):
         self.filestore = False
         self.no_systemd = False
         self.auto_detect_objectstore = None
+        self.no_tmpfs = False
         for k, v in kw.items():
             setattr(self, k, v)
 
@@ -322,6 +323,22 @@ class TestActivateFlags(object):
         parsed_args = capture.calls[0]['args'][0]
         assert parsed_args.filestore is False
         assert parsed_args.bluestore is True
+
+    def test_no_tmpfs(self, capture):
+        args = ['--no-tmpfs', '0', 'asdf-ljh-asdf']
+        activation = activate.Activate(args)
+        activation.activate = capture
+        activation.main()
+        parsed_args = capture.calls[0]['args'][0]
+        assert parsed_args.no_tmpfs is True
+
+    def test_default_no_tmpfs(self, capture):
+        args = ['0', 'asdf-ljh-asdf']
+        activation = activate.Activate(args)
+        activation.activate = capture
+        activation.main()
+        parsed_args = capture.calls[0]['args'][0]
+        assert parsed_args.no_tmpfs is False
 
 
 class TestActivateAll(object):

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -4569,7 +4569,7 @@ def command_ceph_volume(ctx):
         image=ctx.image,
         entrypoint='/usr/sbin/ceph-volume',
         envs=ctx.env,
-        args=ctx.command,
+        args=ctx.command + ["--no-tmpfs"],
         privileged=True,
         volume_mounts=mounts,
     )

--- a/src/cephadm/cephadm
+++ b/src/cephadm/cephadm
@@ -2708,7 +2708,8 @@ def deploy_daemon_units(
                     args=[
                         'lvm', 'activate',
                         str(daemon_id), osd_fsid,
-                        '--no-systemd'
+                        '--no-systemd',
+                        '--no-tmpfs'
                     ],
                     privileged=True,
                     volume_mounts=get_container_mounts(ctx, fsid, daemon_type, daemon_id),


### PR DESCRIPTION
When running on a container, we don't want to mount a tmpfs on the osd
directory no matter what, this makes sure that will not happen by introducing a
new flag and using it from the cephadm perspective.

Fixes: https://tracker.ceph.com/issues/50604
Signed-off-by: David Caro <david@dcaro.es>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>