### PR TITLE
pacific: rbd: --source-spec-file should be --source-spec-path

### DIFF
--- a/doc/rbd/rbd-live-migration.rst
+++ b/doc/rbd/rbd-live-migration.rst
@@ -116,7 +116,7 @@ The import-only live-migration process is initiated by running the same
 and providing a JSON-encoded ``source-spec`` to describe how to access
 the source image data. This ``source-spec`` can either be passed
 directly via the `--source-spec` optional, or via a file or STDIN via the
-`--source-spec-file` optional::
+`--source-spec-path` optional::
 
         $ rbd migration prepare --import-only --source-spec "<JSON>" migration_target
 

--- a/src/tools/rbd/action/Migration.cc
+++ b/src/tools/rbd/action/Migration.cc
@@ -177,8 +177,8 @@ int execute_prepare(const po::variables_map &vm,
 
   std::string source_spec;
   if (vm.count("source-spec") && vm.count("source-spec-path")) {
-    std::cerr << "rbd: cannot specify both source-image-spec and "
-              << "source-spec/source-spec-file" << std::endl;
+    std::cerr << "rbd: cannot specify both source-spec and source-spec-path"
+              << std::endl;
     return -EINVAL;
   } else if (vm.count("source-spec-path")) {
     std::string source_spec_path = vm["source-spec-path"].as<std::string>();


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/41085