### PR TITLE
octopus: mgr/dashboard: OSDs placement text is unreadable 

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/placement.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/placement.pipe.spec.ts
@@ -73,10 +73,10 @@ describe('PlacementPipe', () => {
     expect(
       pipe.transform({
         placement: {
-          host_pattern: '*'
+          host_pattern: 'abc.ceph.xyz.com'
         }
       })
-    ).toBe('*');
+    ).toBe('abc.ceph.xyz.com');
   });
 
   it('transforms placement (6)', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/placement.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/placement.pipe.ts
@@ -37,7 +37,7 @@ export class PlacementPipe implements PipeTransform {
       kv.push(this.i18n('label:{{label}}', { label }));
     }
     if (_.isString(hostPattern)) {
-      kv.push(...hostPattern);
+      kv.push(hostPattern);
     }
     return kv.join(';');
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/services/services.component.ts
@@ -98,7 +98,7 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
       {
         name: this.i18n('Container image ID'),
         prop: 'status.container_image_id',
-        flexGrow: 3,
+        flexGrow: 1.5,
         cellTransformation: CellTemplate.truncate,
         customTemplateConfig: {
           length: 12
@@ -108,7 +108,7 @@ export class ServicesComponent extends ListWithDetails implements OnChanges, OnI
         name: this.i18n('Placement'),
         prop: '',
         pipe: new PlacementPipe(this.i18n),
-        flexGrow: 1
+        flexGrow: 2
       },
       {
         name: this.i18n('Running'),


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/50582

---

backport of https://github.com/ceph/ceph/pull/41083
parent tracker: https://tracker.ceph.com/issues/50580

this backport was staged using ceph-backport.sh version 16.0.0.6848
find the latest version at https://github.com/ceph/ceph/blob/master/src/script/ceph-backport.sh